### PR TITLE
DefaultCloseHandler needs to change context to read for keep-alive

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/async/DefaultCloseHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/async/DefaultCloseHandler.java
@@ -77,6 +77,8 @@ public class DefaultCloseHandler implements GenericFutureListener<ChannelFuture>
             }
         } else if (!request.getHeaders().isKeepAlive() || statusCode >= HttpStatus.MULTIPLE_CHOICES.getCode()) {
             future.channel().close();
+        } else {
+            context.read();
         }
     }
 }


### PR DESCRIPTION
This resolves issue #185 . Keep-Alive connections need handled on a close by switching the context to a read() mode.