### PR TITLE
Tuesday should be Monday

### DIFF
--- a/src/main/docs/guide/aop/scheduling.adoc
+++ b/src/main/docs/guide/aop/scheduling.adoc
@@ -38,7 +38,7 @@ To schedule a https://en.wikipedia.org/wiki/Cron[Cron] task use the `cron` membe
 include::{testsuite}/aop/scheduled/ScheduledExample.java[tags=cron, indent=0]
 ----
 
-The above example will run the task every Tuesday morning at 10:15AM.
+The above example will run the task every Monday morning at 10:15AM.
 
 == Programmatically Scheduling Tasks
 


### PR DESCRIPTION
Technically, every day should be Saturday, but in this particular case, "Tuesday" should be "Monday" to match the code.