### PR TITLE
Don't display Groovy version

### DIFF
--- a/cli/src/main/groovy/io/micronaut/cli/MicronautCli.groovy
+++ b/cli/src/main/groovy/io/micronaut/cli/MicronautCli.groovy
@@ -206,7 +206,6 @@ class MicronautCli {
         if (mainCommandLine.hasOption(CommandLine.VERSION_ARGUMENT) || mainCommandLine.hasOption('v')) {
             def console = MicronautConsole.instance
             console.addStatus("Micronaut Version: ${MicronautCli.getPackage().implementationVersion}")
-            console.addStatus("Groovy Version: ${GroovySystem.version}")
             console.addStatus("JVM Version: ${System.getProperty('java.version')}")
             exit(0)
         }


### PR DESCRIPTION
Now that we support several languages, it can be misleading to display the Groovy version, as folks might think that Groovy will be included.