### PR TITLE
Update clientBasics.adoc

### DIFF
--- a/src/main/docs/guide/httpClient/lowLevelHttpClient/clientBasics.adoc
+++ b/src/main/docs/guide/httpClient/lowLevelHttpClient/clientBasics.adoc
@@ -10,6 +10,13 @@ There are a few ways by which you can obtain a reference to a api:http.client.Ht
 
 The above example will inject a client that targets the Twitter API.
 
+[source,kotlin]
+----
+@Client("\${myapp.api.twitter.url}") @Inject httpClient: RxHttpClient
+----
+
+The above Kotlin example will inject a client that targets the Twitter API using a configuration path. Note the required escaping (backslash) on `"\${path.to.config}"` which is required due to Kotlin string interpolation.
+
 The api:http.client.Client[] annotation is also a custom scope that will manage the creation of api:http.client.HttpClient[] instances and ensure they are shutdown when the application shuts down.
 
 The value you pass to the api:http.client.Client[] annotation can be one of the following:


### PR DESCRIPTION
Add Kotlin example to show how to use the `${}` syntax for `@Client` where you need to escape the `$` to avoid string interpolation (I got hung up on this)