### PR TITLE
Oneof features & Lang flag

### DIFF
--- a/cli/src/main/groovy/io/micronaut/cli/profile/AbstractProfile.groovy
+++ b/cli/src/main/groovy/io/micronaut/cli/profile/AbstractProfile.groovy
@@ -66,6 +66,8 @@ abstract class AbstractProfile implements Profile {
     protected List<Feature> features = []
     protected Set<String> defaultFeaturesNames = []
     protected Set<String> requiredFeatureNames = []
+    protected Set<String> oneOfFeatureNames = []
+    protected String defaultOneOfFeatureName = null
     protected String parentTargetFolder
     protected final ClassLoader classLoader
     protected ExclusionDependencySelector exclusionDependencySelector = new ExclusionDependencySelector()
@@ -154,6 +156,8 @@ abstract class AbstractProfile implements Profile {
             def featureList = (List) featureMap.get("provided") ?: Collections.emptyList()
             def defaultFeatures = (List) featureMap.get("defaults") ?: Collections.emptyList()
             def requiredFeatures = (List) featureMap.get("required") ?: Collections.emptyList()
+            def oneOfFeatures = (List) featureMap.get("oneOf") ?: Collections.emptyList()
+            def defaultOneOfFeatures = featureMap.get("defaultOneOf") ?: null
             for (fn in featureList) {
                 def featureData = profileDir.createRelative("features/${fn}/feature.yml")
                 if (featureData.exists()) {
@@ -164,6 +168,8 @@ abstract class AbstractProfile implements Profile {
 
             defaultFeaturesNames.addAll(defaultFeatures)
             requiredFeatureNames.addAll(requiredFeatures)
+            oneOfFeatureNames.addAll(oneOfFeatures)
+            defaultOneOfFeatureName = defaultOneOfFeatures
         }
 
 
@@ -249,6 +255,17 @@ abstract class AbstractProfile implements Profile {
     Iterable<Feature> getDefaultFeatures() {
         getFeatures().findAll() { Feature f -> defaultFeaturesNames.contains(f.name) }
     }
+
+    @Override
+    Iterable<Feature> getOneOfFeatures() {
+        getFeatures().findAll() { Feature f -> oneOfFeatureNames.contains(f.name) }
+    }
+
+    @Override
+    Feature getDefaultOneOfFeature() {
+        getFeatures().find() { Feature f -> f.name == defaultOneOfFeatureName } as Feature
+    }
+
 
     @Override
     Iterable<Feature> getRequiredFeatures() {

--- a/cli/src/main/groovy/io/micronaut/cli/profile/Profile.java
+++ b/cli/src/main/groovy/io/micronaut/cli/profile/Profile.java
@@ -77,6 +77,16 @@ public interface Profile {
     Iterable<Feature> getDefaultFeatures();
 
     /**
+     * @return The defaultOneOf feature for this profile
+     */
+    Feature getDefaultOneOfFeature();
+
+    /**
+     * @return The oneOf features for this profile
+     */
+    Iterable<Feature> getOneOfFeatures();
+
+    /**
      * @return The required features for this profile
      */
     Iterable<Feature> getRequiredFeatures();

--- a/cli/src/main/groovy/io/micronaut/cli/profile/commands/CreateAppCommand.groovy
+++ b/cli/src/main/groovy/io/micronaut/cli/profile/commands/CreateAppCommand.groovy
@@ -291,7 +291,7 @@ class CreateAppCommand extends ArgumentCompletingCommand implements ProfileRepos
             Files.walkFileTree(projectDir.absoluteFile.toPath(), new SimpleFileVisitor<Path>() {
                 @Override
                 public FileVisitResult visitFile(Path path, BasicFileAttributes mainAtts)
-                    throws IOException {
+                        throws IOException {
                     if (path.fileName.toString() == fileName) {
                         files.add(path.toFile())
                     }
@@ -419,19 +419,19 @@ class CreateAppCommand extends ArgumentCompletingCommand implements ProfileRepos
 
         List<String> features = [langFeature]
         List<String> commandLineFeatures = commandLine.optionValue(FEATURES_FLAG)?.toString()?.split(',')?.toList()
-        if(commandLineFeatures) features.addAll(commandLineFeatures)
+        if (commandLineFeatures) features.addAll(commandLineFeatures)
 
         String build = commandLine.hasOption(BUILD_FLAG) ? commandLine.optionValue(BUILD_FLAG) : "gradle"
 
         CreateServiceCommandObject cmd = new CreateServiceCommandObject(
-            appName: appName,
-            baseDir: executionContext.baseDir,
-            profileName: profileName,
-            micronautVersion: VersionInfo.getVersion(MicronautCli),
-            features: features,
-            inplace: inPlace,
-            build: build,
-            console: executionContext.console
+                appName: appName,
+                baseDir: executionContext.baseDir,
+                profileName: profileName,
+                micronautVersion: VersionInfo.getVersion(MicronautCli),
+                features: features,
+                inplace: inPlace,
+                build: build,
+                console: executionContext.console
         )
 
         return this.handle(cmd)
@@ -487,22 +487,22 @@ class CreateAppCommand extends ArgumentCompletingCommand implements ProfileRepos
             tokens = new MavenBuildTokens().getTokens(profile, features)
         }
 
-        if(tokens) {
+        if (tokens) {
             List<String> requestedFeatureNames = features.findAll { it.requested }*.name
             List<String> allFeatureNames = features*.name
             String testFramework = null
             String sourceLanguage = null
 
-            if(requestedFeatureNames) {
+            if (requestedFeatureNames) {
                 testFramework = evaulateTestFramework(requestedFeatureNames)
                 sourceLanguage = evaulateSourceLanguage(requestedFeatureNames)
             }
 
-            if(!testFramework) {
+            if (!testFramework) {
                 testFramework = evaulateTestFramework(allFeatureNames)
             }
 
-            if(!sourceLanguage) {
+            if (!sourceLanguage) {
                 sourceLanguage = evaulateSourceLanguage(allFeatureNames)
             }
 
@@ -513,8 +513,12 @@ class CreateAppCommand extends ArgumentCompletingCommand implements ProfileRepos
         ant.replace(dir: targetDirectory) {
             tokens.each { k, v ->
                 replacefilter {
-                    if (k) {replacetoken("@${k}@".toString()) }
-                    if (v) { replacevalue(v) }
+                    if (k) {
+                        replacetoken("@${k}@".toString())
+                    }
+                    if (v) {
+                        replacevalue(v)
+                    }
                 }
             }
             variables.each { k, v ->
@@ -528,11 +532,11 @@ class CreateAppCommand extends ArgumentCompletingCommand implements ProfileRepos
 
     protected String evaulateTestFramework(List<String> features) {
         String testFramework = null
-        if(features.contains("spock"))
+        if (features.contains("spock"))
             testFramework = "spock"
-        else if(features.contains("junit"))
+        else if (features.contains("junit"))
             testFramework = "junit"
-        else if(features.contains("spek"))
+        else if (features.contains("spek"))
             testFramework = "spek"
 
         testFramework
@@ -540,11 +544,11 @@ class CreateAppCommand extends ArgumentCompletingCommand implements ProfileRepos
 
     protected String evaulateSourceLanguage(List<String> features) {
         String sourceLanguage = null
-        if(features.contains("groovy"))
+        if (features.contains("groovy"))
             sourceLanguage = "groovy"
-        else if(features.contains("kotlin"))
+        else if (features.contains("kotlin"))
             sourceLanguage = "kotlin"
-        else if(features.contains("java"))
+        else if (features.contains("java"))
             sourceLanguage = "java"
 
         sourceLanguage
@@ -559,7 +563,7 @@ class CreateAppCommand extends ArgumentCompletingCommand implements ProfileRepos
     }
 
     protected String resolveLang(CommandLine commandLine) {
-        if(!lang) lang = commandLine.optionValue(LANG_FLAG) ?: LANG_DEFAULT
+        if (!lang) lang = commandLine.optionValue(LANG_FLAG) ?: LANG_DEFAULT
         lang
     }
 
@@ -592,7 +596,7 @@ class CreateAppCommand extends ArgumentCompletingCommand implements ProfileRepos
 
         features.addAll(profile.requiredFeatures)
 
-        if(profile.oneOfFeatures.size() > 0) {
+        if (profile.oneOfFeatures.size() > 0) {
             Set<Feature> oneOfFeatures = features.findAll { profile.oneOfFeatures.contains(it) }
 
             if (!oneOfFeatures) {
@@ -604,9 +608,19 @@ class CreateAppCommand extends ArgumentCompletingCommand implements ProfileRepos
             features.addAll(features[i].getDependentFeatures(profile))
         }
 
-        if(validRequestedFeatureNames) {
+        if (profile.oneOfFeatures.size() > 0) {
+            Iterable<Feature> includedOneOfFeatures = features.findAll { Feature f -> profile.oneOfFeatures.contains(f) }
+
+            if (includedOneOfFeatures.size() > 1) {
+                List<String> names = includedOneOfFeatures*.name
+                StringBuilder warning = new StringBuilder("Features ${names.join(", ")} should not be used together!")
+                MicronautConsole.getInstance().warn(warning.toString())
+            }
+        }
+
+        if (validRequestedFeatureNames) {
             features = features.collect { feature ->
-                if(validRequestedFeatureNames.contains(feature.name)) {
+                if (validRequestedFeatureNames.contains(feature.name)) {
                     feature.setRequested(true)
                 }
 

--- a/src/main/docs/guide/cli/createProject.adoc
+++ b/src/main/docs/guide/cli/createProject.adoc
@@ -8,7 +8,7 @@ In addition, there are specialty commands for creating a "federation" of multipl
 |Command|Description|Arguments|Example
 
 |`create-app`
-|Creates a basic Micronaut application, using the `service` profile by default.
+|Creates a basic Micronaut Java application, using the `service` profile by default.
 | `profile`, `features`, `build`, `inplace`
 |`mn create-app my-project -features mongo-reactive,security-jwt  -build maven`
 
@@ -39,6 +39,10 @@ The `create-app` command will generate a basic Micronaut project, with optional 
 .Create-App Flags
 |===
 |Flag|Description|Example
+
+|`lang`
+|Language to use for the application (one of `java`, `groovy`, `kotlin` - default is `java`)
+|`-lang groovy`
 
 |`build`
 |Build tool (one of `gradle`, `maven` - default is `gradle`)
@@ -91,22 +95,22 @@ NOTE: The values in `micronaut-cli.yml` are used by the CLI for code generation 
 
 ==== Groovy
 
-To create an app with Groovy & Spock support, supply the appropriate features via the `feature` flag:
+To create an app with Groovy & Spock support, supply the appropriate feature via the `lang` flag:
 
 [source,bash]
 ----
-mn> create-app my-groovy-app -features groovy, spock
+mn> create-app my-groovy-app -lang groovy
 ----
 
 This will include the Groovy & Spock dependencies in your project, and write the appropriates values in `micronaut-cli.yml`.
 
 ==== Kotlin
 
-To create an app with Kotlin & Spek support, supply the appropriate features via the `feature` flag:
+To create an app with Kotlin & Spek support, supply the appropriate feature via the `lang` flag:
 
 [source,bash]
 ----
-mn> create-app my-groovy-app -features kotlin, spek
+mn> create-app my-groovy-app -lang kotlin
 ----
 
 This will include the Kotlin & Spek dependencies in your project, and write the appropriates values in `micronaut-cli.yml`.

--- a/src/main/docs/guide/languageSupport/groovy.adoc
+++ b/src/main/docs/guide/languageSupport/groovy.adoc
@@ -23,12 +23,12 @@ The most common module you will need is `inject-groovy`, which enables DI and AO
 
 == Groovy Support in the CLI
 
-The <<cli, Command Line Interface>> for Micronaut also includes special support for Groovy. To create Groovy application use the `groovy` feature. For example:
+The <<cli, Command Line Interface>> for Micronaut includes special support for Groovy. To create a Groovy application use the `groovy` lang option. For example:
 
 [source,bash]
 .Create a Micronaut Groovy application
 ----
-$ mn create-app hello-world --features groovy
+$ mn create-app hello-world -lang groovy
 ----
 
 The above will generate a Groovy project, built with Gradle. You can use the `-build maven` flag to generate a project built with Maven instead.

--- a/src/main/docs/guide/languageSupport/kotlin.adoc
+++ b/src/main/docs/guide/languageSupport/kotlin.adoc
@@ -1,3 +1,6 @@
+TIP: The <<cli, Command Line Interface>> for Micronaut includes special support for Kotlin. To create a Kotlin application use the `kotlin` lang option. For example:
+
+
 Support for Kotlin in Micronaut is built upon the https://kotlinlang.org/docs/reference/kapt.html[Kapt] compiler plugin, which includes support for Java annotation processors. To use Kotlin in your Micronaut application, you will simply need to add the proper dependencies to configure and run kapt on your `kt` source files. Kapt will create Java "stub" classes for each of your Kotlin classes, which can then be processed by Micronaut's Java annotation processor. The stubs are not included in the final compiled application.
 
 TIP: Learn more about kapt and its features from the https://kotlinlang.org/docs/reference/kapt.html[official documentation.]


### PR DESCRIPTION
Added support for OneOf and DefaultOneOf features. Immediate use case is to allow the use of `application-[lang]` features so that Groovy projects have an `Application.groovy` class, Kotlin projects have a `Application.kt` class. Select `defaultOneOf` if no selection was made. Warn if multiple `oneOf` features are selected,.

Example:

```
description: The service profile
features:
    defaultOneOf: application-java
    oneOf:
        - application-java
        - application-groovy
        - application-kotlin
```

Also added a `-lang` flag which services as a shortcut to specifying the `application-[lang]` feature.

```
> mn create-app my-groovy-app -lang groovy //same as -features application-groovy 
```

Updated the docs to reflect the new CLI usage.

Corresponding PR in the profiles project: https://github.com/micronaut-projects/micronaut-profiles/pull/32