### PR TITLE
prevent String index out of range error

### DIFF
--- a/cli/src/main/groovy/io/micronaut/cli/profile/commands/CreateAppCommand.groovy
+++ b/cli/src/main/groovy/io/micronaut/cli/profile/commands/CreateAppCommand.groovy
@@ -404,7 +404,7 @@ class CreateAppCommand extends ArgumentCompletingCommand implements ProfileRepos
         List<String> validFlags = getFlags()
         commandLine.undeclaredOptions.each { String key, Object value ->
             if (!validFlags.contains(key)) {
-                List possibleSolutions = validFlags.findAll { it.substring(0, 2) == key.substring(0, 2) }
+                List possibleSolutions = validFlags.findAll { it.startsWith(key.take(2).toString()) }
                 StringBuilder warning = new StringBuilder("Unrecognized flag: ${key}.")
                 if (possibleSolutions) {
                     warning.append(" Possible solutions: ")
@@ -577,7 +577,7 @@ class CreateAppCommand extends ArgumentCompletingCommand implements ProfileRepos
             requestedFeatures.removeAll(allFeatureNames)
             requestedFeatures.each { String invalidFeature ->
                 List possibleSolutions = allFeatureNames.findAll {
-                    it.substring(0, 2) == invalidFeature.substring(0, 2)
+                    it.startsWith(invalidFeature.take(2).toString())
                 }
                 StringBuilder warning = new StringBuilder("Feature ${invalidFeature} does not exist in the profile ${profile.name}!")
                 if (possibleSolutions) {


### PR DESCRIPTION
when either calling `create-app` with a feature or flag with less than 2
chars, a RuntimeException was raised:
`Error occurred running Micronaut CLI: String index out of range: 2`.

The cli tries to give hints when misspelling flags or features, but this
only worked, when at least 2 chars where given. E.g.
`mn create-app foo -f groovy` and
`mn create-app foo -features g` both resulted in an error.