### PR TITLE
Use https GitHub link in cloning instructions

### DIFF
--- a/src/main/docs/guide/quickStart/buildCLI.adoc
+++ b/src/main/docs/guide/quickStart/buildCLI.adoc
@@ -3,7 +3,7 @@ If you have not installed Micronaut on your local machine, you can build the dis
 Clone the repository:
 
 ----
-> git clone git@github.com:micronaut-projects/micronaut-core.git
+> git clone https://github.com/micronaut-projects/micronaut-core.git
 ----
 
 


### PR DESCRIPTION
This is the URL shown by GitHub to anon users.