### PR TITLE
HttpClientResponseException prints null when the body cannot be converted to JSONError

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/exceptions/HttpClientResponseException.java
+++ b/http-client/src/main/java/io/micronaut/http/client/exceptions/HttpClientResponseException.java
@@ -57,7 +57,7 @@ public class HttpClientResponseException extends HttpClientException {
     @Override
     public String getMessage() {
         Optional<JsonError> body = getResponse().getBody(JsonError.class);
-        if (body.isPresent()) {
+        if (body.isPresent() && body.get().getMessage() != null) {
             return body.get().getMessage();
         } else {
             return super.getMessage();


### PR DESCRIPTION
A HttpClientResponseException is thrown when a HttpClient makes a call to a server and the server returns an error (a 400 for instance). However, when the server returns some message as part of the body the exception prints null in the console. That makes very difficult to debug those requests without enabling TRACE log level.

When the response's body is not empty but it cannot be converted to JsonError the method getMessage() get a JsonError with a null message. So instead of printing the exception message it prints null.

This PR fixes that by checking if the JsonError's message is null and in that case it prints the exception's message instead.

A better solution could be to modify FullNettyClientHttpResponse to return an empty Optional in this case instead of returning a new JSONError without any value. I decided not to change that because I'm not sure how that might affect other parts of the framework.

