### PR TITLE
Added support for jvmArgs token in CLI

### DIFF
--- a/cli/src/main/groovy/io/micronaut/cli/io/support/GradleBuildTokens.groovy
+++ b/cli/src/main/groovy/io/micronaut/cli/io/support/GradleBuildTokens.groovy
@@ -71,6 +71,13 @@ class GradleBuildTokens extends BuildTokens {
             "apply plugin:\"$name\""
         }
 
+        def jvmArgs = profile.jvmArgs
+        for (Feature f in features) {
+            jvmArgs.addAll(f.jvmArgs)
+        }
+
+        jvmArgs = jvmArgs.collect { String arg -> "'-${arg}'"}.join(',')
+
         for (Feature f in features) {
             buildPlugins.addAll f.buildPlugins.collect() { String name ->
                 "apply plugin:\"$name\""
@@ -79,6 +86,7 @@ class GradleBuildTokens extends BuildTokens {
 
         buildPlugins = buildPlugins.unique().join(ln)
 
+        tokens.put("jvmArgs", jvmArgs)
         tokens.put("buildPlugins", buildPlugins)
         tokens.put("dependencies", dependencies)
         tokens.put("buildDependencies", buildDependencies)

--- a/cli/src/main/groovy/io/micronaut/cli/io/support/MavenBuildTokens.groovy
+++ b/cli/src/main/groovy/io/micronaut/cli/io/support/MavenBuildTokens.groovy
@@ -93,6 +93,7 @@ class MavenBuildTokens extends BuildTokens {
 
         def dependenciesWriter = new StringWriter()
         MarkupBuilder dependenciesXml = new MarkupBuilder(dependenciesWriter)
+
         dependencies.each { Dependency dep ->
 
             def artifact = dep.artifact
@@ -117,6 +118,19 @@ class MavenBuildTokens extends BuildTokens {
             }
         }
 
+        def jvmArgsWriter = new StringWriter()
+        MarkupBuilder jvmArgsXml = new MarkupBuilder(jvmArgsWriter)
+
+        def arguments = profile.jvmArgs
+        for (Feature f in features) {
+            arguments.addAll(f.jvmArgs)
+        }
+
+        arguments.each { String arg ->
+            jvmArgsXml.argument("-${arg}")
+
+        }
+        tokens.put("arguments", prettyPrint(jvmArgsWriter.toString(), 12))
         tokens.put("dependencies", prettyPrint(dependenciesWriter.toString(), 8))
         tokens.put("repositories", prettyPrint(repositoriesWriter.toString(), 8))
         tokens.put("jdkversion", VersionInfo.getJdkVersion())

--- a/cli/src/main/groovy/io/micronaut/cli/profile/AbstractProfile.groovy
+++ b/cli/src/main/groovy/io/micronaut/cli/profile/AbstractProfile.groovy
@@ -55,6 +55,7 @@ abstract class AbstractProfile implements Profile {
     protected ProfileRepository profileRepository
     protected List<Dependency> dependencies = []
     protected List<String> repositories = []
+    protected List<String> jvmArgs = []
     protected List<String> parentNames = []
     protected List<String> buildRepositories = []
     protected List<String> buildPlugins = []
@@ -219,7 +220,7 @@ abstract class AbstractProfile implements Profile {
         }
 
         this.repositories = (List<String>) navigableConfig.get("repositories", [])
-
+        this.jvmArgs = (List<String>) navigableConfig.get("jvmArgs", [])
         this.buildRepositories = (List<String>) navigableConfig.get("build.repositories", [])
         this.buildPlugins = (List<String>) navigableConfig.get("build.plugins", [])
         this.buildExcludes = (List<String>) navigableConfig.get("build.excludes", [])
@@ -353,6 +354,12 @@ abstract class AbstractProfile implements Profile {
             calculatedRepositories.addAll(repositories)
         }
         return calculatedRepositories
+    }
+
+
+    @Override
+    List<String> getJvmArgs() {
+        jvmArgs
     }
 
     List<Dependency> getDependencies() {

--- a/cli/src/main/groovy/io/micronaut/cli/profile/DefaultFeature.groovy
+++ b/cli/src/main/groovy/io/micronaut/cli/profile/DefaultFeature.groovy
@@ -44,6 +44,7 @@ class DefaultFeature implements Feature {
     final NavigableMap configuration = new NavigableMap()
     final List<Dependency> dependencies = []
     final List<String> buildPlugins
+    final List<String> jvmArgs
     final List<String> dependentFeatures = []
     private Boolean requested = false
     final Integer minJava
@@ -86,6 +87,7 @@ class DefaultFeature implements Feature {
             }
         }
         this.buildPlugins = (List<String>) configuration.get("build.plugins", [])
+        this.jvmArgs = (List<String>) configuration.get("jvmArgs", [])
 
         this.minJava = (Integer) configuration.get("java.min") ?: null
         this.maxJava = (Integer) configuration.get("java.max") ?: null

--- a/cli/src/main/groovy/io/micronaut/cli/profile/Feature.groovy
+++ b/cli/src/main/groovy/io/micronaut/cli/profile/Feature.groovy
@@ -58,6 +58,12 @@ interface Feature {
      */
     List<String> getBuildPlugins()
 
+
+    /**
+     * @return The JVM args
+     */
+    List<String> getJvmArgs()
+
     /**
      * @return The configuration for the feature
      */

--- a/cli/src/main/groovy/io/micronaut/cli/profile/Profile.java
+++ b/cli/src/main/groovy/io/micronaut/cli/profile/Profile.java
@@ -104,6 +104,11 @@ public interface Profile {
     List<Dependency> getDependencies();
 
     /**
+     * @return The JVM args
+     */
+    List<String> getJvmArgs();
+
+    /**
      * @return The profiles configuration
      */
     NavigableMap getConfiguration();


### PR DESCRIPTION
This change allows profiles and features to specify JVM arguments (necessary to add support for Java agents - e.g. spring-loaded (#228)).

