### PR TITLE
Fix configuration example for static resources

### DIFF
--- a/src/main/docs/guide/httpServer/staticResources.adoc
+++ b/src/main/docs/guide/httpServer/staticResources.adoc
@@ -11,13 +11,12 @@ Here is what an example YAML configuration might look like (note that the `route
 
 [source,yaml]
 ----
-micronaut:
-    router:
-        static:
-            resources:
-                enabled: true
-                mapping: /static/**
-                paths: classpath:public
+router:
+    static:
+        resources:
+            enabled: true
+            mapping: /static/**
+            paths: classpath:public
 ----
 
 TIP: `index.html` will be resolved by default. In the above example a request to `/static` will attempt to retrieve `src/main/resources/public/index.html`.


### PR DESCRIPTION
according to StaticResourceConfiguration "router" is a top level key