### PR TITLE
pulled up RequestArgumentSatisfier to http-server module #367

### DIFF
--- a/http-server-netty/build.gradle
+++ b/http-server-netty/build.gradle
@@ -1,7 +1,6 @@
 dependencies {
     compile project(":http-server")
     compile project(":http-netty")
-    compile project(":router")
 
     compileOnly project(":inject-java")
 

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
@@ -30,6 +30,7 @@ import io.micronaut.discovery.event.ServiceShutdownEvent;
 import io.micronaut.discovery.event.ServiceStartedEvent;
 import io.micronaut.http.codec.MediaTypeCodecRegistry;
 import io.micronaut.http.netty.channel.NettyThreadFactory;
+import io.micronaut.http.server.binding.RequestArgumentSatisfier;
 import io.micronaut.http.server.binding.RequestBinderRegistry;
 import io.micronaut.http.server.exceptions.ServerStartupException;
 import io.micronaut.http.server.netty.configuration.NettyHttpServerConfiguration;
@@ -110,7 +111,7 @@ public class NettyHttpServer implements EmbeddedServer {
     private final StaticResourceResolver staticResourceResolver;
     private final Environment environment;
     private final Router router;
-    private final RequestBinderRegistry binderRegistry;
+    private final RequestArgumentSatisfier requestArgumentSatisfier;
     private final BeanLocator beanLocator;
     private final ThreadFactory threadFactory;
     private volatile int serverPort;
@@ -125,7 +126,7 @@ public class NettyHttpServer implements EmbeddedServer {
      * @param serverConfiguration                     The Netty HTTP server configuration
      * @param applicationContext                      The application context
      * @param router                                  The router
-     * @param binderRegistry                          The request binder registry
+     * @param requestArgumentSatisfier                The request argument satisfier
      * @param mediaTypeCodecRegistry                  The Media type codec registry
      * @param customizableResponseTypeHandlerRegistry The Netty customizable response type handler registry
      * @param resourceResolver                        The static resource resolver
@@ -141,7 +142,7 @@ public class NettyHttpServer implements EmbeddedServer {
         NettyHttpServerConfiguration serverConfiguration,
         ApplicationContext applicationContext,
         Router router,
-        RequestBinderRegistry binderRegistry,
+        RequestArgumentSatisfier requestArgumentSatisfier,
         MediaTypeCodecRegistry mediaTypeCodecRegistry,
         NettyCustomizableResponseTypeHandlerRegistry customizableResponseTypeHandlerRegistry,
         StaticResourceResolver resourceResolver,
@@ -167,7 +168,7 @@ public class NettyHttpServer implements EmbeddedServer {
         this.executorSelector = executorSelector;
         OrderUtil.sort(outboundHandlers);
         this.outboundHandlers = outboundHandlers;
-        this.binderRegistry = binderRegistry;
+        this.requestArgumentSatisfier = requestArgumentSatisfier;
         this.staticResourceResolver = resourceResolver;
         this.sslContext = nettyServerSslBuilder.build();
         this.threadFactory = threadFactory;
@@ -202,8 +203,6 @@ public class NettyHttpServer implements EmbeddedServer {
                     protected void initChannel(Channel ch) throws Exception {
                         ChannelPipeline pipeline = ch.pipeline();
 
-                        RequestBinderRegistry binderRegistry = NettyHttpServer.this.binderRegistry;
-
                         sslContext.ifPresent(ctx -> pipeline.addLast(ctx.newHandler(ch.alloc())));
 
                         serverConfiguration.getLogLevel().ifPresent(logLevel -> pipeline.addLast(new LoggingHandler(logLevel)));
@@ -231,7 +230,7 @@ public class NettyHttpServer implements EmbeddedServer {
                             customizableResponseTypeHandlerRegistry,
                             staticResourceResolver,
                             serverConfiguration,
-                            binderRegistry,
+                            requestArgumentSatisfier,
                             executorSelector,
                             ioExecutor
                         ));

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyRequestArgumentSatisfier.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyRequestArgumentSatisfier.java
@@ -1,0 +1,37 @@
+package io.micronaut.http.server.netty;
+
+import io.micronaut.context.annotation.Primary;
+import io.micronaut.core.type.Argument;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.server.binding.RequestArgumentSatisfier;
+import io.micronaut.http.server.binding.RequestBinderRegistry;
+
+import javax.inject.Singleton;
+import java.util.Optional;
+
+/**
+ * A class containing methods to aid in satisfying arguments of a {@link io.micronaut.web.router.Route}.
+ *
+ * Contains Netty specific extensions - setting the body required for blocking binders.
+ *
+ * @author Graeme Rocher
+ * @author Vladimir Orany
+ * @since 1.0
+ */
+@Primary
+@Singleton
+public class NettyRequestArgumentSatisfier extends RequestArgumentSatisfier {
+
+    public NettyRequestArgumentSatisfier(RequestBinderRegistry requestBinderRegistry) {
+        super(requestBinderRegistry);
+    }
+
+    @Override
+    protected Optional<Object> getValueForArgument(Argument argument, HttpRequest<?> request, boolean satisfyOptionals) {
+        if (request instanceof NettyHttpRequest) {
+            NettyHttpRequest nettyHttpRequest = (NettyHttpRequest) request;
+            nettyHttpRequest.setBodyRequired(true);
+        }
+        return super.getValueForArgument(argument, request, satisfyOptionals);
+    }
+}

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
@@ -47,7 +47,7 @@ import io.micronaut.http.netty.NettyMutableHttpResponse;
 import io.micronaut.http.netty.buffer.NettyByteBufferFactory;
 import io.micronaut.http.netty.content.HttpContentUtil;
 import io.micronaut.http.netty.stream.StreamedHttpRequest;
-import io.micronaut.http.server.binding.RequestBinderRegistry;
+import io.micronaut.http.server.binding.RequestArgumentSatisfier;
 import io.micronaut.http.server.exceptions.ExceptionHandler;
 import io.micronaut.http.server.exceptions.InternalServerException;
 import io.micronaut.http.server.netty.async.ContextCompletionAwareSubscriber;
@@ -141,7 +141,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
      * @param customizableResponseTypeHandlerRegistry The customizable response type handler registry
      * @param staticResourceResolver                  The static resource resolver
      * @param serverConfiguration                     The Netty HTTP server configuration
-     * @param binderRegistry                          The Request binder registry
+     * @param requestArgumentSatisfier                The Request argument satisfier
      * @param executorSelector                        The executor selector
      * @param ioExecutor                              The IO executor
      */
@@ -152,7 +152,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
         NettyCustomizableResponseTypeHandlerRegistry customizableResponseTypeHandlerRegistry,
         StaticResourceResolver staticResourceResolver,
         NettyHttpServerConfiguration serverConfiguration,
-        RequestBinderRegistry binderRegistry,
+        RequestArgumentSatisfier requestArgumentSatisfier,
         ExecutorSelector executorSelector,
         ExecutorService ioExecutor) {
 
@@ -163,7 +163,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
         this.ioExecutor = ioExecutor;
         this.executorSelector = executorSelector;
         this.router = router;
-        this.requestArgumentSatisfier = new RequestArgumentSatisfier(binderRegistry);
+        this.requestArgumentSatisfier = requestArgumentSatisfier;
         this.serverConfiguration = serverConfiguration;
     }
 

--- a/http-server/build.gradle
+++ b/http-server/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'com.github.johnrengelman.plugin-shadow'
 dependencies {
     shadowCompile project(":runtime")
     compile project(":runtime")
+    compile project(":router")
     compileOnly project(":inject-java")
 }
 shadowJar {


### PR DESCRIPTION
Pulled up RequestArgumentSatisfier to `http-server` module to simplify the creation of own http server implementation #367. to achieve this `http-server` now depends also on `routes`. other option would be to create a separate module just for the satisfier which doesn't make much sense to me as router seems crucial for the HTTP server anyway. I'm not sure about the `shadowJar` settings in `http-server` after adding `router` dependency