### PR TITLE
default simple implementation for http request and response

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/NettyClientHttpRequest.java
+++ b/http-client/src/main/java/io/micronaut/http/client/NettyClientHttpRequest.java
@@ -58,8 +58,6 @@ import java.util.Optional;
 @Internal
 class NettyClientHttpRequest<B> implements MutableHttpRequest<B> {
 
-    private static final int DEFAULT_HTTP_PORT = 80;
-
     private final NettyHttpHeaders headers = new NettyHttpHeaders();
     private final MutableConvertibleValues<Object> attributes = new MutableConvertibleValuesMap<>();
     private final io.micronaut.http.HttpMethod httpMethod;
@@ -162,34 +160,6 @@ class NettyClientHttpRequest<B> implements MutableHttpRequest<B> {
     @Override
     public URI getUri() {
         return uri;
-    }
-
-    @Override
-    public String getPath() {
-        return uri.getPath();
-    }
-
-    @Override
-    public InetSocketAddress getRemoteAddress() {
-        return getServerAddress();
-    }
-
-    @Override
-    public InetSocketAddress getServerAddress() {
-        String host = uri.getHost();
-        int port = uri.getPort();
-        return new InetSocketAddress(host != null ? host : "localhost", port > -1 ? port : DEFAULT_HTTP_PORT);
-    }
-
-    @Override
-    public String getServerName() {
-        return uri.getHost();
-    }
-
-    @Override
-    public boolean isSecure() {
-        String scheme = getUri().getScheme();
-        return scheme != null && scheme.equals("https");
     }
 
     private NettyHttpParameters decodeParameters(String uri) {

--- a/http/src/main/java/io/micronaut/http/HttpRequest.java
+++ b/http/src/main/java/io/micronaut/http/HttpRequest.java
@@ -60,27 +60,40 @@ public interface HttpRequest<B> extends HttpMessage<B> {
     /**
      * @return Get the path without any parameters
      */
-    String getPath();
+    default String getPath() {
+        return getUri().getPath();
+    }
 
     /**
      * @return Obtain the remote address
      */
-    InetSocketAddress getRemoteAddress();
+    default InetSocketAddress getRemoteAddress() {
+        return getServerAddress();
+    }
 
     /**
      * @return Obtain the server address
      */
-    InetSocketAddress getServerAddress();
+    default InetSocketAddress getServerAddress() {
+        String host = getUri().getHost();
+        int port = getUri().getPort();
+        return new InetSocketAddress(host != null ? host : "localhost", port > -1 ? port : 80);
+    }
 
     /**
      * @return The server host name
      */
-    String getServerName();
+    default String getServerName() {
+        return getUri().getHost();
+    }
 
     /**
      * @return Is the request an HTTPS request
      */
-    boolean isSecure();
+    default boolean isSecure() {
+        String scheme = getUri().getScheme();
+        return scheme != null && scheme.equals("https");
+    }
 
     @Override
     default HttpRequest<B> setAttribute(CharSequence name, Object value) {

--- a/http/src/main/java/io/micronaut/http/HttpRequestFactory.java
+++ b/http/src/main/java/io/micronaut/http/HttpRequestFactory.java
@@ -33,7 +33,7 @@ public interface HttpRequestFactory {
      * The default {@link io.micronaut.http.cookie.CookieFactory} instance.
      */
     Optional<HttpRequestFactory> INSTANCE = SoftServiceLoader.load(HttpRequestFactory.class)
-        .firstOr("io.micronaut.http.client.NettyClientHttpRequestFactory", HttpRequestFactory.class.getClassLoader())
+        .firstOr("io.micronaut.http.simple.SimpleHttpRequestFactory", HttpRequestFactory.class.getClassLoader())
         .map(ServiceDefinition::load);
 
     /**

--- a/http/src/main/java/io/micronaut/http/HttpResponseFactory.java
+++ b/http/src/main/java/io/micronaut/http/HttpResponseFactory.java
@@ -33,7 +33,7 @@ public interface HttpResponseFactory {
      * The default {@link io.micronaut.http.cookie.CookieFactory} instance.
      */
     Optional<HttpResponseFactory> INSTANCE = SoftServiceLoader.load(HttpResponseFactory.class)
-        .firstOr("io.micronaut.http.server.netty.NettyHttpResponseFactory", HttpResponseFactory.class.getClassLoader())
+        .firstOr("io.micronaut.http.simple.SimpleHttpResponseFactory", HttpResponseFactory.class.getClassLoader())
         .map(ServiceDefinition::load);
 
     /**

--- a/http/src/main/java/io/micronaut/http/cookie/CookieFactory.java
+++ b/http/src/main/java/io/micronaut/http/cookie/CookieFactory.java
@@ -32,7 +32,7 @@ public interface CookieFactory {
      */
     CookieFactory INSTANCE = SoftServiceLoader
         .load(CookieFactory.class)
-        .firstOr("io.micronaut.http.netty.cookies.NettyCookieFactory", CookieFactory.class.getClassLoader())
+        .firstOr("io.micronaut.http.simple.cookies.SimpleCookieFactory", CookieFactory.class.getClassLoader())
         .map(ServiceDefinition::load)
         .orElse(null);
 

--- a/http/src/main/java/io/micronaut/http/simple/SimpleHttpHeaders.java
+++ b/http/src/main/java/io/micronaut/http/simple/SimpleHttpHeaders.java
@@ -33,6 +33,10 @@ public class SimpleHttpHeaders implements MutableHttpHeaders {
     private final Map<String, String> headers;
     private final ConversionService conversionService;
 
+    /**
+     * Map-based implementation of {@link MutableHttpHeaders}.
+     * @param conversionService The conversion service
+     */
     SimpleHttpHeaders(ConversionService conversionService) {
         this.headers = new LinkedHashMap<>();
         this.conversionService = conversionService;

--- a/http/src/main/java/io/micronaut/http/simple/SimpleHttpHeaders.java
+++ b/http/src/main/java/io/micronaut/http/simple/SimpleHttpHeaders.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017-2018 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.http.simple;
+
+import io.micronaut.core.convert.ArgumentConversionContext;
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.http.MutableHttpHeaders;
+
+import java.util.*;
+
+/**
+ * Simple {@link MutableHttpHeaders} implementation.
+ *
+ * @author Vladimir Orany
+ * @since 1.0
+ */
+public class SimpleHttpHeaders implements MutableHttpHeaders {
+
+    private final Map<String, String> headers;
+    private final ConversionService conversionService;
+
+    SimpleHttpHeaders(ConversionService conversionService) {
+        this.headers = new LinkedHashMap<>();
+        this.conversionService = conversionService;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> Optional<T> get(CharSequence name, ArgumentConversionContext<T> conversionContext) {
+        String value = headers.get(name.toString());
+        if (value != null) {
+            return conversionService.convert(value, conversionContext);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public List<String> getAll(CharSequence name) {
+        return Collections.singletonList(headers.get(name.toString()));
+    }
+
+    @Override
+    public Set<String> names() {
+        return headers.keySet();
+    }
+
+    @Override
+    public Collection<List<String>> values() {
+        Set<String> names = names();
+        List<List<String>> values = new ArrayList<>();
+        for (String name : names) {
+            values.add(getAll(name));
+        }
+        return Collections.unmodifiableList(values);
+    }
+
+    @Override
+    public String get(CharSequence name) {
+        return headers.get(name.toString());
+    }
+
+    @Override
+    public MutableHttpHeaders add(CharSequence header, CharSequence value) {
+        headers.put(header.toString(), value == null ? null : value.toString());
+        return this;
+    }
+
+    @Override
+    public void remove(CharSequence header) {
+        headers.remove(header.toString());
+    }
+}

--- a/http/src/main/java/io/micronaut/http/simple/SimpleHttpParameters.java
+++ b/http/src/main/java/io/micronaut/http/simple/SimpleHttpParameters.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017-2018 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.http.simple;
+
+import io.micronaut.core.convert.ArgumentConversionContext;
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.convert.value.ConvertibleMultiValues;
+import io.micronaut.core.convert.value.ConvertibleMultiValuesMap;
+import io.micronaut.http.HttpParameters;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Simple implementation of {@link HttpParameters}.
+ *
+ * @author Graeme Rocher
+ * @author Vladimir Orany
+ *
+ * @since 1.0
+ */
+public class SimpleHttpParameters implements HttpParameters {
+
+    private final LinkedHashMap<CharSequence, List<String>> valuesMap;
+    private final ConvertibleMultiValues<String> values;
+
+    /**
+     * @param conversionService The conversion service
+     */
+    public SimpleHttpParameters(ConversionService conversionService) {
+        this.valuesMap = new LinkedHashMap<>();
+        this.values = new ConvertibleMultiValuesMap<>(this.valuesMap, conversionService);
+    }
+
+    @Override
+    public Set<String> names() {
+        return values.names();
+    }
+
+    @Override
+    public Collection<List<String>> values() {
+        return values.values();
+    }
+
+    @Override
+    public List<String> getAll(CharSequence name) {
+        return values.getAll(name);
+    }
+
+    @Override
+    public String get(CharSequence name) {
+        return values.get(name);
+    }
+
+    @Override
+    public <T> Optional<T> get(CharSequence name, ArgumentConversionContext<T> conversionContext) {
+        return values.get(name, conversionContext);
+    }
+
+    public List<String> put(String name, String value) {
+        return valuesMap.put(name, Collections.singletonList(value));
+    }
+
+    public List<String> put(String name, List<String> value) {
+        return valuesMap.put(name, value);
+    }
+}

--- a/http/src/main/java/io/micronaut/http/simple/SimpleHttpParameters.java
+++ b/http/src/main/java/io/micronaut/http/simple/SimpleHttpParameters.java
@@ -26,7 +26,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -76,11 +75,23 @@ public class SimpleHttpParameters implements HttpParameters {
         return values.get(name, conversionContext);
     }
 
+    /**
+     * Put new http parameter.
+     * @param name      the name of the parameter
+     * @param value     the value of the parameter
+     * @return the previous value of the parameter
+     */
     public List<String> put(String name, String value) {
         return valuesMap.put(name, Collections.singletonList(value));
     }
 
-    public List<String> put(String name, List<String> value) {
-        return valuesMap.put(name, value);
+    /**
+     * Put new http parameter.
+     * @param name      the name of the parameter
+     * @param values    the values of the parameter
+     * @return the previous value of the parameter
+     */
+    public List<String> put(String name, List<String> values) {
+        return valuesMap.put(name, values);
     }
 }

--- a/http/src/main/java/io/micronaut/http/simple/SimpleHttpRequest.java
+++ b/http/src/main/java/io/micronaut/http/simple/SimpleHttpRequest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2017-2018 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.http.simple;
+
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.convert.value.MutableConvertibleValues;
+import io.micronaut.core.convert.value.MutableConvertibleValuesMap;
+import io.micronaut.http.HttpMethod;
+import io.micronaut.http.HttpParameters;
+import io.micronaut.http.MutableHttpHeaders;
+import io.micronaut.http.MutableHttpRequest;
+import io.micronaut.http.cookie.Cookie;
+import io.micronaut.http.cookie.Cookies;
+import io.micronaut.http.simple.cookies.SimpleCookies;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Optional;
+
+/**
+ * Simple {@link MutableHttpRequest} implementation.
+ *
+ * @author Vladimir Orany
+ * @since 1.0
+ */
+public class SimpleHttpRequest<B> implements MutableHttpRequest<B> {
+
+    private final MutableConvertibleValues<Object> attributes = new MutableConvertibleValuesMap<>();
+    private final SimpleCookies cookies = new SimpleCookies(ConversionService.SHARED);
+    private final SimpleHttpHeaders headers = new SimpleHttpHeaders(ConversionService.SHARED);
+    private final SimpleHttpParameters parameters = new SimpleHttpParameters(ConversionService.SHARED);
+
+    private HttpMethod method;
+    private URI uri;
+    private B body;
+
+    public SimpleHttpRequest(HttpMethod method, String uri, B body) {
+        this.method = method;
+        try {
+            this.uri = new URI(uri);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Wrong URI", e);
+        }
+        this.body = body;
+    }
+
+    @Override
+    public MutableHttpRequest<B> cookie(Cookie cookie) {
+        cookies.put(cookie.getName(), cookie);
+        return this;
+    }
+
+    @Override
+    public MutableHttpRequest<B> uri(URI uri) {
+        this.uri = uri;
+        return this;
+    }
+
+    @Override
+    public MutableHttpRequest<B> body(B body) {
+        this.body = body;
+        return this;
+    }
+
+    @Override
+    public MutableHttpHeaders getHeaders() {
+        return headers;
+    }
+
+    @Override
+    public Cookies getCookies() {
+        return cookies;
+    }
+
+    @Override
+    public HttpParameters getParameters() {
+        return parameters;
+    }
+
+    @Override
+    public HttpMethod getMethod() {
+        return this.method;
+    }
+
+    @Override
+    public URI getUri() {
+        return this.uri;
+    }
+
+    @Override
+    public MutableConvertibleValues<Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Optional<B> getBody() {
+        return Optional.ofNullable(this.body);
+    }
+}

--- a/http/src/main/java/io/micronaut/http/simple/SimpleHttpRequest.java
+++ b/http/src/main/java/io/micronaut/http/simple/SimpleHttpRequest.java
@@ -34,6 +34,8 @@ import java.util.Optional;
 /**
  * Simple {@link MutableHttpRequest} implementation.
  *
+ * @param <B> the type of the body
+ *
  * @author Vladimir Orany
  * @since 1.0
  */
@@ -48,6 +50,12 @@ public class SimpleHttpRequest<B> implements MutableHttpRequest<B> {
     private URI uri;
     private B body;
 
+    /**
+     * Simple {@link MutableHttpRequest} implementation.
+     * @param method    the HTTP method
+     * @param uri       the URI of the request
+     * @param body      the optional body of the request
+     */
     public SimpleHttpRequest(HttpMethod method, String uri, B body) {
         this.method = method;
         try {

--- a/http/src/main/java/io/micronaut/http/simple/SimpleHttpRequestFactory.java
+++ b/http/src/main/java/io/micronaut/http/simple/SimpleHttpRequestFactory.java
@@ -19,7 +19,6 @@ package io.micronaut.http.simple;
 import io.micronaut.http.HttpMethod;
 import io.micronaut.http.HttpRequestFactory;
 import io.micronaut.http.MutableHttpRequest;
-import io.micronaut.http.cookie.CookieFactory;
 
 /**
  * Simple {@link HttpRequestFactory} implementation.
@@ -32,41 +31,41 @@ import io.micronaut.http.cookie.CookieFactory;
 public class SimpleHttpRequestFactory implements HttpRequestFactory {
     @Override
     public <T> MutableHttpRequest<T> get(String uri) {
-        return new SimpleHttpRequest<T>(HttpMethod.GET, uri, null);
+        return new SimpleHttpRequest<>(HttpMethod.GET, uri, null);
     }
 
     @Override
     public <T> MutableHttpRequest<T> post(String uri, T body) {
-        return new SimpleHttpRequest<T>(HttpMethod.POST, uri, body);
+        return new SimpleHttpRequest<>(HttpMethod.POST, uri, body);
     }
 
     @Override
     public <T> MutableHttpRequest<T> put(String uri, T body) {
-        return new SimpleHttpRequest<T>(HttpMethod.PUT, uri, body);
+        return new SimpleHttpRequest<>(HttpMethod.PUT, uri, body);
     }
 
     @Override
     public <T> MutableHttpRequest<T> patch(String uri, T body) {
-        return new SimpleHttpRequest<T>(HttpMethod.PATCH, uri, body);
+        return new SimpleHttpRequest<>(HttpMethod.PATCH, uri, body);
     }
 
     @Override
     public <T> MutableHttpRequest<T> head(String uri) {
-        return new SimpleHttpRequest<T>(HttpMethod.HEAD, uri, null);
+        return new SimpleHttpRequest<>(HttpMethod.HEAD, uri, null);
     }
 
     @Override
     public <T> MutableHttpRequest<T> options(String uri) {
-        return new SimpleHttpRequest<T>(HttpMethod.OPTIONS, uri, null);
+        return new SimpleHttpRequest<>(HttpMethod.OPTIONS, uri, null);
     }
 
     @Override
     public <T> MutableHttpRequest<T> delete(String uri, T body) {
-        return new SimpleHttpRequest<T>(HttpMethod.DELETE, uri, body);
+        return new SimpleHttpRequest<>(HttpMethod.DELETE, uri, body);
     }
 
     @Override
     public <T> MutableHttpRequest<T> create(HttpMethod httpMethod, String uri) {
-        return new SimpleHttpRequest<T>(httpMethod, uri, null);
+        return new SimpleHttpRequest<>(httpMethod, uri, null);
     }
 }

--- a/http/src/main/java/io/micronaut/http/simple/SimpleHttpRequestFactory.java
+++ b/http/src/main/java/io/micronaut/http/simple/SimpleHttpRequestFactory.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017-2018 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.http.simple;
+
+import io.micronaut.http.HttpMethod;
+import io.micronaut.http.HttpRequestFactory;
+import io.micronaut.http.MutableHttpRequest;
+import io.micronaut.http.cookie.CookieFactory;
+
+/**
+ * Simple {@link HttpRequestFactory} implementation.
+ *
+ * This is the default fallback factory.
+ *
+ * @author Vladimir Orany
+ * @since 1.0
+ */
+public class SimpleHttpRequestFactory implements HttpRequestFactory {
+    @Override
+    public <T> MutableHttpRequest<T> get(String uri) {
+        return new SimpleHttpRequest<T>(HttpMethod.GET, uri, null);
+    }
+
+    @Override
+    public <T> MutableHttpRequest<T> post(String uri, T body) {
+        return new SimpleHttpRequest<T>(HttpMethod.POST, uri, body);
+    }
+
+    @Override
+    public <T> MutableHttpRequest<T> put(String uri, T body) {
+        return new SimpleHttpRequest<T>(HttpMethod.PUT, uri, body);
+    }
+
+    @Override
+    public <T> MutableHttpRequest<T> patch(String uri, T body) {
+        return new SimpleHttpRequest<T>(HttpMethod.PATCH, uri, body);
+    }
+
+    @Override
+    public <T> MutableHttpRequest<T> head(String uri) {
+        return new SimpleHttpRequest<T>(HttpMethod.HEAD, uri, null);
+    }
+
+    @Override
+    public <T> MutableHttpRequest<T> options(String uri) {
+        return new SimpleHttpRequest<T>(HttpMethod.OPTIONS, uri, null);
+    }
+
+    @Override
+    public <T> MutableHttpRequest<T> delete(String uri, T body) {
+        return new SimpleHttpRequest<T>(HttpMethod.DELETE, uri, body);
+    }
+
+    @Override
+    public <T> MutableHttpRequest<T> create(HttpMethod httpMethod, String uri) {
+        return new SimpleHttpRequest<T>(httpMethod, uri, null);
+    }
+}

--- a/http/src/main/java/io/micronaut/http/simple/SimpleHttpResponse.java
+++ b/http/src/main/java/io/micronaut/http/simple/SimpleHttpResponse.java
@@ -32,6 +32,8 @@ import java.util.Optional;
 /**
  * Simple {@link MutableHttpResponse} implementation.
  *
+ * @param <B> the type of the body
+ *
  * @author Vladimir Orany
  * @since 1.0
  */

--- a/http/src/main/java/io/micronaut/http/simple/SimpleHttpResponse.java
+++ b/http/src/main/java/io/micronaut/http/simple/SimpleHttpResponse.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2017-2018 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.http.simple;
+
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.convert.value.MutableConvertibleValues;
+import io.micronaut.core.convert.value.MutableConvertibleValuesMap;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.MutableHttpHeaders;
+import io.micronaut.http.MutableHttpResponse;
+import io.micronaut.http.cookie.Cookie;
+import io.micronaut.http.cookie.Cookies;
+import io.micronaut.http.simple.cookies.SimpleCookies;
+
+import javax.annotation.Nullable;
+import java.util.Optional;
+
+/**
+ * Simple {@link MutableHttpResponse} implementation.
+ *
+ * @author Vladimir Orany
+ * @since 1.0
+ */
+class SimpleHttpResponse<B> implements MutableHttpResponse<B> {
+
+    private final MutableHttpHeaders headers = new SimpleHttpHeaders(ConversionService.SHARED);
+    private final SimpleCookies cookies = new SimpleCookies(ConversionService.SHARED);
+    private final MutableConvertibleValues<Object> attributes = new MutableConvertibleValuesMap<>();
+
+    private HttpStatus status = HttpStatus.OK;
+    private B body;
+
+    @Override
+    public MutableHttpResponse<B> cookie(Cookie cookie) {
+        cookies.put(cookie.getName(), cookie);
+        return this;
+    }
+
+    @Override
+    public MutableHttpHeaders getHeaders() {
+        return this.headers;
+    }
+
+    @Override
+    public MutableConvertibleValues<Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Optional<B> getBody() {
+        return Optional.ofNullable(body);
+    }
+
+    @Override
+    public MutableHttpResponse<B> body(@Nullable B body) {
+        this.body = body;
+        return this;
+    }
+
+    @Override
+    public MutableHttpResponse<B> status(HttpStatus status, CharSequence message) {
+        this.status = status;
+        return this;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return this.status;
+    }
+
+    public Cookies getCookies() {
+        return cookies;
+    }
+}

--- a/http/src/main/java/io/micronaut/http/simple/SimpleHttpResponseFactory.java
+++ b/http/src/main/java/io/micronaut/http/simple/SimpleHttpResponseFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2018 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.http.simple;
+
+import io.micronaut.http.HttpResponseFactory;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.MutableHttpResponse;
+
+/**
+ * Simple {@link HttpResponseFactory} implementation.
+ *
+ * This is the default fallback factory.
+ *
+ * @author Vladimir Orany
+ * @since 1.0
+ */
+public class SimpleHttpResponseFactory implements HttpResponseFactory {
+
+    @Override
+    public <T> MutableHttpResponse<T> ok(T body) {
+        return new SimpleHttpResponse<>();
+    }
+
+    @Override
+    public <T> MutableHttpResponse<T> status(HttpStatus status, String reason) {
+        return new SimpleHttpResponse<T>().status(status, reason);
+    }
+
+    @Override
+    public <T> MutableHttpResponse<T> status(HttpStatus status, T body) {
+        return new SimpleHttpResponse<T>().status(status).body(body);
+    }
+
+}

--- a/http/src/main/java/io/micronaut/http/simple/cookies/SimpleCookie.java
+++ b/http/src/main/java/io/micronaut/http/simple/cookies/SimpleCookie.java
@@ -18,6 +18,8 @@ package io.micronaut.http.simple.cookies;
 
 import io.micronaut.http.cookie.Cookie;
 
+import java.util.Objects;
+
 /**
  * Simple {@link Cookie} implementation.
  *
@@ -178,6 +180,11 @@ public class SimpleCookie implements Cookie {
         }
 
         return 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, domain, path);
     }
 
     @Override

--- a/http/src/main/java/io/micronaut/http/simple/cookies/SimpleCookie.java
+++ b/http/src/main/java/io/micronaut/http/simple/cookies/SimpleCookie.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2017-2018 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.http.simple.cookies;
+
+import io.micronaut.http.cookie.Cookie;
+
+/**
+ * Simple {@link Cookie} implementation.
+ *
+ * @author Vladimir Orany
+ * @since 1.0
+ */
+public class SimpleCookie implements Cookie {
+
+    private final String name;
+    private String value;
+    private String domain;
+    private String path;
+    private boolean httpOnly;
+    private boolean secure;
+    private long maxAge;
+
+    public SimpleCookie(String name, String value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String getDomain() {
+        return domain;
+    }
+
+    @Override
+    public String getPath() {
+        return path;
+    }
+
+    @Override
+    public boolean isHttpOnly() {
+        return httpOnly;
+    }
+
+    @Override
+    public boolean isSecure() {
+        return secure;
+    }
+
+    @Override
+    public long getMaxAge() {
+        return maxAge;
+    }
+
+    @Override
+    public Cookie maxAge(long maxAge) {
+        this.maxAge = maxAge;
+        return this;
+    }
+
+    @Override
+    public Cookie value(String value) {
+        this.value = value;
+        return this;
+    }
+
+    @Override
+    public Cookie domain(String domain) {
+        this.domain = domain;
+        return this;
+    }
+
+    @Override
+    public Cookie path(String path) {
+        this.path = path;
+        return this;
+    }
+
+    @Override
+    public Cookie secure(boolean secure) {
+        this.secure = secure;
+        return this;
+    }
+
+    @Override
+    public Cookie httpOnly(boolean httpOnly) {
+        this.httpOnly = httpOnly;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!(o instanceof Cookie)) {
+            return false;
+        }
+
+        Cookie that = (Cookie) o;
+        if (!getName().equals(that.getName())) {
+            return false;
+        }
+
+        if (getPath() == null) {
+            if (that.getPath() != null) {
+                return false;
+            }
+        } else if (that.getPath() == null) {
+            return false;
+        } else if (!getPath().equals(that.getPath())) {
+            return false;
+        }
+
+        if (getDomain() == null) {
+            if (that.getDomain() != null) {
+                return false;
+            }
+        } else {
+            return getDomain().equalsIgnoreCase(that.getDomain());
+        }
+
+        return true;
+    }
+
+    @Override
+    public int compareTo(Cookie c) {
+        int v = getName().compareTo(c.getName());
+        if (v != 0) {
+            return v;
+        }
+
+        if (getPath() == null) {
+            if (c.getPath() != null) {
+                return -1;
+            }
+        } else if (c.getPath() == null) {
+            return 1;
+        } else {
+            v = getPath().compareTo(c.getPath());
+            if (v != 0) {
+                return v;
+            }
+        }
+
+        if (getDomain() == null) {
+            if (c.getDomain() != null) {
+                return -1;
+            }
+        } else if (c.getDomain() == null) {
+            return 1;
+        } else {
+            v = getDomain().compareToIgnoreCase(c.getDomain());
+            return v;
+        }
+
+        return 0;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder buf = new StringBuilder()
+                .append(getName())
+                .append('=')
+                .append(getValue());
+        if (getDomain() != null) {
+            buf.append(", domain=")
+                    .append(getDomain());
+        }
+        if (getPath() != null) {
+            buf.append(", path=")
+                    .append(getPath());
+        }
+        if (getMaxAge() >= 0) {
+            buf.append(", maxAge=")
+                    .append(getMaxAge())
+                    .append('s');
+        }
+        if (isSecure()) {
+            buf.append(", secure");
+        }
+        if (isHttpOnly()) {
+            buf.append(", HTTPOnly");
+        }
+        return buf.toString();
+    }
+}

--- a/http/src/main/java/io/micronaut/http/simple/cookies/SimpleCookieFactory.java
+++ b/http/src/main/java/io/micronaut/http/simple/cookies/SimpleCookieFactory.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2018 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.http.simple.cookies;
+
+import io.micronaut.http.cookie.Cookie;
+import io.micronaut.http.cookie.CookieFactory;
+
+/**
+ * Simple {@link CookieFactory} implementation.
+ *
+ * This is the default fallback factory.
+ *
+ * @author Vladimir Orany
+ * @since 1.0
+ */
+public class SimpleCookieFactory implements CookieFactory {
+    @Override
+    public Cookie create(String name, String value) {
+        return new SimpleCookie(name, value);
+    }
+}

--- a/http/src/main/java/io/micronaut/http/simple/cookies/SimpleCookies.java
+++ b/http/src/main/java/io/micronaut/http/simple/cookies/SimpleCookies.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017-2018 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.http.simple.cookies;
+
+import io.micronaut.core.convert.ArgumentConversionContext;
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.http.cookie.Cookie;
+import io.micronaut.http.cookie.Cookies;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Simple {@link Cookies} implementation.
+ *
+ * @author Graeme Rocher
+ * @author Vladimir Orany
+ * @since 1.0
+ */
+public class SimpleCookies implements Cookies {
+
+    private final ConversionService<?> conversionService;
+    private final Map<CharSequence, Cookie> cookies;
+
+    /**
+     * @param conversionService The conversion service
+     */
+    public SimpleCookies(ConversionService conversionService) {
+        this.conversionService = conversionService;
+        this.cookies = new LinkedHashMap<>();
+    }
+
+    @Override
+    public Set<Cookie> getAll() {
+        return new HashSet<>(cookies.values());
+    }
+
+    @Override
+    public Optional<Cookie> findCookie(CharSequence name) {
+        Cookie cookie = cookies.get(name);
+        return cookie != null ? Optional.of(cookie) : Optional.empty();
+    }
+
+    @Override
+    public <T> Optional<T> get(CharSequence name, Class<T> requiredType) {
+        if (requiredType == Cookie.class || requiredType == Object.class) {
+            //noinspection unchecked
+            return (Optional<T>) findCookie(name);
+        } else {
+            return findCookie(name).flatMap((cookie -> conversionService.convert(cookie.getValue(), requiredType)));
+        }
+    }
+
+    @Override
+    public <T> Optional<T> get(CharSequence name, ArgumentConversionContext<T> conversionContext) {
+        return findCookie(name).flatMap((cookie -> conversionService.convert(cookie.getValue(), conversionContext)));
+    }
+
+    @Override
+    public Collection<Cookie> values() {
+        return Collections.unmodifiableCollection(cookies.values());
+    }
+
+    public Cookie put(CharSequence name, Cookie cookie) {
+        return cookies.put(name, cookie);
+    }
+}

--- a/http/src/main/java/io/micronaut/http/simple/cookies/SimpleCookies.java
+++ b/http/src/main/java/io/micronaut/http/simple/cookies/SimpleCookies.java
@@ -80,6 +80,12 @@ public class SimpleCookies implements Cookies {
         return Collections.unmodifiableCollection(cookies.values());
     }
 
+    /**
+     * Put a new cookie.
+     * @param name      the name of the cookie
+     * @param cookie    the cookie itself
+     * @return previous value for given name
+     */
     public Cookie put(CharSequence name, Cookie cookie) {
         return cookies.put(name, cookie);
     }

--- a/http/src/main/java/io/micronaut/http/simple/cookies/package-info.java
+++ b/http/src/main/java/io/micronaut/http/simple/cookies/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017-2018 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Simple HTTP cookies classes.
+ *
+ * @author Vladimir Orany
+ * @since 1.0
+ */
+package io.micronaut.http.simple.cookies;

--- a/http/src/main/java/io/micronaut/http/simple/package-info.java
+++ b/http/src/main/java/io/micronaut/http/simple/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017-2018 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Simple HTTP request and response classes.
+ *
+ * @author Vladimir Orany
+ * @since 1.0
+ */
+package io.micronaut.http.simple;


### PR DESCRIPTION
This is a default fallback implementation of `Cookie`, `HttpRequest` and `HttpResponse` if Netty implementation is not on the classpath. This is particularly useful for very simple unit tests and custom HTTP server implementations #367.