### PR TITLE
when release, update static-website

### DIFF
--- a/travis-build.sh
+++ b/travis-build.sh
@@ -71,6 +71,23 @@ if [[ $EXIT_STATUS -eq 0 ]]; then
         git push origin HEAD || true
       }
       cd ..
+
+      rm -rf gh-pages
+
+      if [[ -n $TRAVIS_TAG ]]; then
+        echo "set released version in static website"
+        git clone https://${GH_TOKEN}@github.com/micronaut-projects/micronaut-projects/static-website.git -b master static-website-master --single-branch > /dev/null
+        cd static-website-master
+        version="$TRAVIS_TAG"
+        version=${version:1}
+        ./release.sh $version
+        git commit -a -m "Updating micronaut version at static website for Travis build: https://travis-ci.org/$TRAVIS_REPO_SLUG/builds/$TRAVIS_BUILD_ID" && {
+          git push origin HEAD || true
+        }
+        cd ..
+        rm -r static-website-master
+      fi
+
     fi
 fi
 


### PR DESCRIPTION
When TRAVIS_TAG, update the `static-website` file `releases.yml`

https://github.com/micronaut-projects/static-website/blob/master/main/src/main/resources/releases.yml

via this script: 

https://github.com/micronaut-projects/static-website/blob/master/release.sh

