### PR TITLE
mutable http parameters for mutable http request

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/NettyClientHttpRequest.java
+++ b/http-client/src/main/java/io/micronaut/http/client/NettyClientHttpRequest.java
@@ -23,8 +23,8 @@ import io.micronaut.core.convert.value.MutableConvertibleValues;
 import io.micronaut.core.convert.value.MutableConvertibleValuesMap;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.StringUtils;
-import io.micronaut.http.HttpParameters;
 import io.micronaut.http.MutableHttpHeaders;
+import io.micronaut.http.MutableHttpParameters;
 import io.micronaut.http.MutableHttpRequest;
 import io.micronaut.http.cookie.Cookie;
 import io.micronaut.http.cookie.Cookies;
@@ -137,7 +137,7 @@ class NettyClientHttpRequest<B> implements MutableHttpRequest<B> {
     }
 
     @Override
-    public HttpParameters getParameters() {
+    public MutableHttpParameters getParameters() {
         NettyHttpParameters httpParameters = this.httpParameters;
         if (httpParameters == null) {
             synchronized (this) { // double check

--- a/http/src/main/java/io/micronaut/http/MutableHttpParameters.java
+++ b/http/src/main/java/io/micronaut/http/MutableHttpParameters.java
@@ -1,0 +1,32 @@
+package io.micronaut.http;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Mutable version of {@link HttpParameters} which allows adding new parameters.
+ *
+ * @author Vladimir Orany
+ */
+public interface MutableHttpParameters extends HttpParameters {
+
+    /**
+     * Add new http parameter.
+     * @param name      the name of the parameter
+     * @param value     the value of the parameter
+     * @return self
+     */
+    default MutableHttpParameters add(CharSequence name, CharSequence value) {
+        add(name, Collections.singletonList(value));
+        return this;
+    }
+
+    /**
+     * Add new http parameter.
+     * @param name      the name of the parameter
+     * @param values    the values of the parameter
+     * @return self
+     */
+    MutableHttpParameters add(CharSequence name, List<CharSequence> values);
+
+}

--- a/http/src/main/java/io/micronaut/http/MutableHttpRequest.java
+++ b/http/src/main/java/io/micronaut/http/MutableHttpRequest.java
@@ -56,6 +56,9 @@ public interface MutableHttpRequest<B> extends HttpRequest<B>, MutableHttpMessag
     @Override
     MutableHttpHeaders getHeaders();
 
+    @Override
+    MutableHttpParameters getParameters();
+
     /**
      * Sets the acceptable {@link MediaType} instances via the {@link HttpHeaders#ACCEPT} header.
      *

--- a/http/src/main/java/io/micronaut/http/simple/SimpleHttpHeaders.java
+++ b/http/src/main/java/io/micronaut/http/simple/SimpleHttpHeaders.java
@@ -35,11 +35,20 @@ public class SimpleHttpHeaders implements MutableHttpHeaders {
 
     /**
      * Map-based implementation of {@link MutableHttpHeaders}.
+     * @param headers The headers
      * @param conversionService The conversion service
      */
-    SimpleHttpHeaders(ConversionService conversionService) {
-        this.headers = new LinkedHashMap<>();
+    public SimpleHttpHeaders(Map<String, String> headers, ConversionService conversionService) {
+        this.headers = headers;
         this.conversionService = conversionService;
+    }
+
+    /**
+     * Map-based implementation of {@link MutableHttpHeaders}.
+     * @param conversionService The conversion service
+     */
+    public SimpleHttpHeaders(ConversionService conversionService) {
+        this(new LinkedHashMap<>(), conversionService);
     }
 
     @Override

--- a/http/src/main/java/io/micronaut/http/simple/SimpleHttpParameters.java
+++ b/http/src/main/java/io/micronaut/http/simple/SimpleHttpParameters.java
@@ -20,34 +20,37 @@ import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.value.ConvertibleMultiValues;
 import io.micronaut.core.convert.value.ConvertibleMultiValuesMap;
-import io.micronaut.http.HttpParameters;
+import io.micronaut.http.MutableHttpParameters;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
- * Simple implementation of {@link HttpParameters}.
+ * Simple implementation of {@link MutableHttpParameters}.
  *
  * @author Graeme Rocher
  * @author Vladimir Orany
  *
  * @since 1.0
  */
-public class SimpleHttpParameters implements HttpParameters {
+public class SimpleHttpParameters implements MutableHttpParameters {
 
-    private final LinkedHashMap<CharSequence, List<String>> valuesMap;
+    private final Map<CharSequence, List<String>> valuesMap;
     private final ConvertibleMultiValues<String> values;
 
     /**
      * @param conversionService The conversion service
      */
-    public SimpleHttpParameters(ConversionService conversionService) {
-        this.valuesMap = new LinkedHashMap<>();
+    public SimpleHttpParameters(Map<CharSequence, List<String>> values, ConversionService conversionService) {
+        this.valuesMap = values;
         this.values = new ConvertibleMultiValuesMap<>(this.valuesMap, conversionService);
+    }
+
+    /**
+     * @param conversionService The conversion service
+     */
+    public SimpleHttpParameters(ConversionService conversionService) {
+        this(new LinkedHashMap<>(), conversionService);
     }
 
     @Override
@@ -75,23 +78,9 @@ public class SimpleHttpParameters implements HttpParameters {
         return values.get(name, conversionContext);
     }
 
-    /**
-     * Put new http parameter.
-     * @param name      the name of the parameter
-     * @param value     the value of the parameter
-     * @return the previous value of the parameter
-     */
-    public List<String> put(String name, String value) {
-        return valuesMap.put(name, Collections.singletonList(value));
-    }
-
-    /**
-     * Put new http parameter.
-     * @param name      the name of the parameter
-     * @param values    the values of the parameter
-     * @return the previous value of the parameter
-     */
-    public List<String> put(String name, List<String> values) {
-        return valuesMap.put(name, values);
+    @Override
+    public MutableHttpParameters add(CharSequence name, List<CharSequence> values) {
+        valuesMap.put(name, values.stream().map(v -> v == null ? null : v.toString()).collect(Collectors.toList()));
+        return this;
     }
 }

--- a/http/src/main/java/io/micronaut/http/simple/SimpleHttpRequest.java
+++ b/http/src/main/java/io/micronaut/http/simple/SimpleHttpRequest.java
@@ -19,10 +19,7 @@ package io.micronaut.http.simple;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.value.MutableConvertibleValues;
 import io.micronaut.core.convert.value.MutableConvertibleValuesMap;
-import io.micronaut.http.HttpMethod;
-import io.micronaut.http.HttpParameters;
-import io.micronaut.http.MutableHttpHeaders;
-import io.micronaut.http.MutableHttpRequest;
+import io.micronaut.http.*;
 import io.micronaut.http.cookie.Cookie;
 import io.micronaut.http.cookie.Cookies;
 import io.micronaut.http.simple.cookies.SimpleCookies;
@@ -95,7 +92,7 @@ public class SimpleHttpRequest<B> implements MutableHttpRequest<B> {
     }
 
     @Override
-    public HttpParameters getParameters() {
+    public MutableHttpParameters getParameters() {
         return parameters;
     }
 


### PR DESCRIPTION
This makes `MutableHttpRequest` _more mutable_

Additional changes requried for the custom HTTP server implementation:

* exposed `SimpleHttpHeaders` to implementing classes
* added constructors for `SimpleHttpHeaders` and `SimpleHttpParameters`
which accepts the original mutable map