### PR TITLE
Allow to override consul client full path #456

### DIFF
--- a/runtime/src/main/java/io/micronaut/discovery/config/ConfigDiscoveryConfiguration.java
+++ b/runtime/src/main/java/io/micronaut/discovery/config/ConfigDiscoveryConfiguration.java
@@ -40,6 +40,7 @@ public abstract class ConfigDiscoveryConfiguration implements Toggleable {
 
     private boolean enabled = true;
     private String path;
+    private boolean full_path = false;
     private Format format = Format.NATIVE;
 
     /**
@@ -86,6 +87,17 @@ public abstract class ConfigDiscoveryConfiguration implements Toggleable {
             this.format = format;
         }
     }
+
+    /**
+     *
+     * @return Return whether the given path is full or not
+     */
+    public boolean getFullPath() { return full_path; }
+
+    /**
+     * @param full_path The given path is full
+     */
+    public void setFullPath(boolean full_path) { this.full_path = full_path; }
 
     /**
      * The format the configuration is stored in.


### PR DESCRIPTION
Fixes #456 

This allows to add a Micronaut microservice in a already productive Consul environment that uses git2consul with the following k/v paths:

`<repository>/<branch>/<project>.yaml/`

Now it works great! The only caveat is that i must put @Values in my Config Bean as following:

```
package ai.foundrecruiting;

import io.micronaut.context.annotation.*;

import javax.inject.Singleton;
import javax.validation.constraints.NotBlank;

@Singleton
public class MailerConfig {
    @NotBlank @Value("${mail-user}")
    String MAIL_USER;

    @NotBlank @Value("${mail-host}")
    String MAIL_HOST;

    @NotBlank @Value("${app-environment}")
    String APP_ENVIRONMENT;
}
```