### PR TITLE
HttpResponse - HTTP 202 Accepted (URI location)

### DIFF
--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/HttpResponseSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/HttpResponseSpec.groovy
@@ -64,6 +64,7 @@ class HttpResponseSpec extends AbstractMicronautSpec {
         "created-body"        | HttpStatus.CREATED            | '{"name":"blah","age":10}' | defaultHeaders + ['content-length': '24', 'content-type': 'application/json'] + [connection: 'close']
         "created-uri"         | HttpStatus.CREATED            | null                       | [connection: 'close', 'location': 'http://test.com']
         "accepted"            | HttpStatus.ACCEPTED           | null                       | [connection: 'close']
+        "accepted-uri"        | HttpStatus.ACCEPTED           | null                       | [connection: 'close', 'location': 'http://example.com']
         "disallow"            | HttpStatus.METHOD_NOT_ALLOWED | null                       | [connection: "close", 'allow': 'DELETE']
 
     }
@@ -96,6 +97,7 @@ class HttpResponseSpec extends AbstractMicronautSpec {
         "created-body"        | HttpStatus.CREATED           | '{"name":"blah","age":10}' | defaultHeaders + ['content-length': '24', 'content-type': 'application/json'] + [connection: 'close']
         "created-uri"         | HttpStatus.CREATED           | null                       | [connection: 'close', 'location': 'http://test.com']
         "accepted"            | HttpStatus.ACCEPTED          | null                       | [connection: 'close']
+        "accepted-uri"        | HttpStatus.ACCEPTED          | null                       | [connection: 'close', 'location': 'http://example.com']
     }
 
     void "test content encoding"() {

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/java/ResponseController.java
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/java/ResponseController.java
@@ -36,6 +36,11 @@ public class ResponseController {
         return HttpResponse.accepted();
     }
 
+    @Get("/accepted-uri")
+    public HttpResponse acceptedUri() {
+        return HttpResponse.accepted(HttpResponse.uri("http://example.com"));
+    }
+
     @Get("/created-uri")
     public HttpResponse createdUri() {
         return HttpResponse.created(HttpResponse.uri("http://test.com"));

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/resources/StaticResourceResolutionSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/resources/StaticResourceResolutionSpec.groovy
@@ -16,10 +16,9 @@
 
 package io.micronaut.http.server.netty.resources
 
-import io.micronaut.context.exceptions.ConfigurationException
+import io.micronaut.context.ApplicationContext
 import io.micronaut.context.exceptions.DependencyInjectionException
 import io.micronaut.http.HttpRequest
-import io.micronaut.context.ApplicationContext
 import io.micronaut.http.HttpStatus
 import io.micronaut.http.client.RxHttpClient
 import io.micronaut.http.server.netty.AbstractMicronautSpec
@@ -29,13 +28,9 @@ import java.nio.file.Paths
 import java.time.Instant
 import java.time.ZoneId
 import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
 
-import static io.micronaut.http.HttpHeaders.CACHE_CONTROL
-import static io.micronaut.http.HttpHeaders.CONTENT_LENGTH
-import static io.micronaut.http.HttpHeaders.CONTENT_TYPE
-import static io.micronaut.http.HttpHeaders.DATE
-import static io.micronaut.http.HttpHeaders.EXPIRES
-import static io.micronaut.http.HttpHeaders.LAST_MODIFIED
+import static io.micronaut.http.HttpHeaders.*
 
 class StaticResourceResolutionSpec extends AbstractMicronautSpec {
 
@@ -69,7 +64,7 @@ class StaticResourceResolutionSpec extends AbstractMicronautSpec {
         Integer.parseInt(response.header(CONTENT_LENGTH)) > 0
         response.headers.getDate(DATE) < response.headers.getDate(EXPIRES)
         response.header(CACHE_CONTROL) == "private, max-age=60"
-        response.headers.getDate(LAST_MODIFIED) == ZonedDateTime.ofInstant(Instant.ofEpochMilli(tempFile.lastModified()), ZoneId.of("GMT") )
+        response.headers.getDate(LAST_MODIFIED) == ZonedDateTime.ofInstant(Instant.ofEpochMilli(tempFile.lastModified()), ZoneId.of("GMT")).truncatedTo(ChronoUnit.SECONDS)
         response.body() == "<html><head></head><body>HTML Page from static file</body></html>"
     }
 
@@ -88,7 +83,7 @@ class StaticResourceResolutionSpec extends AbstractMicronautSpec {
         Integer.parseInt(response.header(CONTENT_LENGTH)) > 0
         response.headers.getDate(DATE) < response.headers.getDate(EXPIRES)
         response.header(CACHE_CONTROL) == "private, max-age=60"
-        response.headers.getDate(LAST_MODIFIED) == ZonedDateTime.ofInstant(Instant.ofEpochMilli(file.lastModified()), ZoneId.of("GMT") )
+        response.headers.getDate(LAST_MODIFIED) == ZonedDateTime.ofInstant(Instant.ofEpochMilli(file.lastModified()), ZoneId.of("GMT")).truncatedTo(ChronoUnit.SECONDS)
         response.body() == "<html><head></head><body>HTML Page from resources</body></html>"
     }
 
@@ -107,7 +102,7 @@ class StaticResourceResolutionSpec extends AbstractMicronautSpec {
         Integer.parseInt(response.header(CONTENT_LENGTH)) > 0
         response.headers.getDate(DATE) < response.headers.getDate(EXPIRES)
         response.header(CACHE_CONTROL) == "private, max-age=60"
-        response.headers.getDate(LAST_MODIFIED) == ZonedDateTime.ofInstant(Instant.ofEpochMilli(file.lastModified()), ZoneId.of("GMT") )
+        response.headers.getDate(LAST_MODIFIED) == ZonedDateTime.ofInstant(Instant.ofEpochMilli(file.lastModified()), ZoneId.of("GMT")).truncatedTo(ChronoUnit.SECONDS)
         response.body() == "<html><head></head><body>HTML Page from resources</body></html>"
     }
 
@@ -133,7 +128,7 @@ class StaticResourceResolutionSpec extends AbstractMicronautSpec {
         Integer.parseInt(response.header(CONTENT_LENGTH)) > 0
         response.headers.getDate(DATE) < response.headers.getDate(EXPIRES)
         response.header(CACHE_CONTROL) == "private, max-age=60"
-        response.headers.getDate(LAST_MODIFIED) == ZonedDateTime.ofInstant(Instant.ofEpochMilli(file.lastModified()), ZoneId.of("GMT") )
+        response.headers.getDate(LAST_MODIFIED) == ZonedDateTime.ofInstant(Instant.ofEpochMilli(file.lastModified()), ZoneId.of("GMT")).truncatedTo(ChronoUnit.SECONDS)
         response.body() == "<html><head></head><body>HTML Page from resources</body></html>"
 
         cleanup:
@@ -162,7 +157,7 @@ class StaticResourceResolutionSpec extends AbstractMicronautSpec {
         Integer.parseInt(response.header(CONTENT_LENGTH)) > 0
         response.headers.getDate(DATE) < response.headers.getDate(EXPIRES)
         response.header(CACHE_CONTROL) == "private, max-age=60"
-        response.headers.getDate(LAST_MODIFIED) == ZonedDateTime.ofInstant(Instant.ofEpochMilli(file.lastModified()), ZoneId.of("GMT") )
+        response.headers.getDate(LAST_MODIFIED) == ZonedDateTime.ofInstant(Instant.ofEpochMilli(file.lastModified()), ZoneId.of("GMT")).truncatedTo(ChronoUnit.SECONDS)
         response.body() == "<html><head></head><body>HTML Page from resources</body></html>"
 
         cleanup:
@@ -191,7 +186,7 @@ class StaticResourceResolutionSpec extends AbstractMicronautSpec {
         Integer.parseInt(response.header(CONTENT_LENGTH)) > 0
         response.headers.getDate(DATE) < response.headers.getDate(EXPIRES)
         response.header(CACHE_CONTROL) == "private, max-age=60"
-        response.headers.getDate(LAST_MODIFIED) == ZonedDateTime.ofInstant(Instant.ofEpochMilli(file.lastModified()), ZoneId.of("GMT") )
+        response.headers.getDate(LAST_MODIFIED) == ZonedDateTime.ofInstant(Instant.ofEpochMilli(file.lastModified()), ZoneId.of("GMT")).truncatedTo(ChronoUnit.SECONDS)
         response.body() == "<html><head></head><body>HTML Page from resources/foo</body></html>"
 
         cleanup:
@@ -208,4 +203,5 @@ class StaticResourceResolutionSpec extends AbstractMicronautSpec {
         then:
         thrown(DependencyInjectionException)
     }
+
 }

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/types/FileTypeHandlerSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/types/FileTypeHandlerSpec.groovy
@@ -36,16 +36,18 @@ import io.micronaut.http.server.types.files.SystemFileCustomizableResponseType
 import java.time.Instant
 import java.time.ZoneId
 import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
 
 import static io.micronaut.http.HttpHeaders.*
 
 class FileTypeHandlerSpec extends AbstractMicronautSpec {
 
     private static File tempFile
+    private static String tempFileContents = "<html><head></head><body>HTML Page</body></html>"
 
     static {
         tempFile = File.createTempFile("fileTypeHandlerSpec", ".html")
-        tempFile.write("<html><head></head><body>HTML Page</body></html>")
+        tempFile.write(tempFileContents)
         tempFile
     }
 
@@ -59,8 +61,8 @@ class FileTypeHandlerSpec extends AbstractMicronautSpec {
         Integer.parseInt(response.header(CONTENT_LENGTH)) > 0
         response.headers.getDate(DATE) < response.headers.getDate(EXPIRES)
         response.header(CACHE_CONTROL) == "private, max-age=60"
-        response.headers.getDate(LAST_MODIFIED) == ZonedDateTime.ofInstant(Instant.ofEpochMilli(tempFile.lastModified()), ZoneId.of("GMT") )
-        response.body() == "<html><head></head><body>HTML Page</body></html>"
+        response.headers.getDate(LAST_MODIFIED) == ZonedDateTime.ofInstant(Instant.ofEpochMilli(tempFile.lastModified()), ZoneId.of("GMT")).truncatedTo(ChronoUnit.SECONDS)
+        response.body() == tempFileContents
     }
 
     void "test 304 is returned if the correct header is sent"() {
@@ -100,8 +102,8 @@ class FileTypeHandlerSpec extends AbstractMicronautSpec {
         Integer.parseInt(response.header(CONTENT_LENGTH)) > 0
         response.headers.getDate(DATE) < response.headers.getDate(EXPIRES)
         response.header(CACHE_CONTROL) == "private, max-age=60"
-        response.headers.getDate(LAST_MODIFIED) == ZonedDateTime.ofInstant(Instant.ofEpochMilli(tempFile.lastModified()), ZoneId.of("GMT") )
-        response.body() == "<html><head></head><body>HTML Page</body></html>"
+        response.headers.getDate(LAST_MODIFIED) == ZonedDateTime.ofInstant(Instant.ofEpochMilli(tempFile.lastModified()), ZoneId.of("GMT")).truncatedTo(ChronoUnit.SECONDS)
+        response.body() == tempFileContents
     }
 
     void "test when an attached file is returned with a name"() {
@@ -115,8 +117,8 @@ class FileTypeHandlerSpec extends AbstractMicronautSpec {
         Integer.parseInt(response.header(CONTENT_LENGTH)) > 0
         response.headers.getDate(DATE) < response.headers.getDate(EXPIRES)
         response.header(CACHE_CONTROL) == "private, max-age=60"
-        response.headers.getDate(LAST_MODIFIED) == ZonedDateTime.ofInstant(Instant.ofEpochMilli(tempFile.lastModified()), ZoneId.of("GMT") )
-        response.body() == "<html><head></head><body>HTML Page</body></html>"
+        response.headers.getDate(LAST_MODIFIED) == ZonedDateTime.ofInstant(Instant.ofEpochMilli(tempFile.lastModified()), ZoneId.of("GMT")).truncatedTo(ChronoUnit.SECONDS)
+        response.body() == tempFileContents
     }
 
     void "test the content type is honored when an attached file response is returned"() {
@@ -130,8 +132,8 @@ class FileTypeHandlerSpec extends AbstractMicronautSpec {
         Integer.parseInt(response.header(CONTENT_LENGTH)) > 0
         response.headers.getDate(DATE) < response.headers.getDate(EXPIRES)
         response.header(CACHE_CONTROL) == "private, max-age=60"
-        response.headers.getDate(LAST_MODIFIED) == ZonedDateTime.ofInstant(Instant.ofEpochMilli(tempFile.lastModified()), ZoneId.of("GMT") )
-        response.body() == "<html><head></head><body>HTML Page</body></html>"
+        response.headers.getDate(LAST_MODIFIED) == ZonedDateTime.ofInstant(Instant.ofEpochMilli(tempFile.lastModified()), ZoneId.of("GMT")).truncatedTo(ChronoUnit.SECONDS)
+        response.body() == tempFileContents
     }
 
     void "test supports"() {

--- a/http/src/main/java/io/micronaut/http/HttpResponse.java
+++ b/http/src/main/java/io/micronaut/http/HttpResponse.java
@@ -187,7 +187,6 @@ public interface HttpResponse<B> extends HttpMessage<B> {
      * @return The response
      */
     static <T> MutableHttpResponse<T> serverError() {
-
         return HttpResponseFactory.INSTANCE.status(HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
@@ -199,6 +198,20 @@ public interface HttpResponse<B> extends HttpMessage<B> {
      */
     static <T> MutableHttpResponse<T> accepted() {
         return HttpResponseFactory.INSTANCE.status(HttpStatus.ACCEPTED);
+    }
+
+    /**
+     * Return an {@link HttpStatus#ACCEPTED} response with an empty body and a {@link HttpHeaders#LOCATION} header
+     *
+     * @param location the location in which the new resource will be available
+     * @param <T>      The response type
+     * @return The response
+     */
+    static <T> MutableHttpResponse<T> accepted(URI location) {
+        return HttpResponseFactory.INSTANCE.<T>status(HttpStatus.ACCEPTED)
+                .headers((headers) ->
+                    headers.location(location)
+                );
     }
 
     /**


### PR DESCRIPTION
- Added support for `location` URI header to be added to `HTTP 202 - ACCEPTED` response
- Fixed some unit tests which were failing due to last modified date comparison

Closes #532