### PR TITLE
GORM for MongoDB database name

### DIFF
--- a/src/main/docs/guide/configurations/dataAccess/mongoSupport.adoc
+++ b/src/main/docs/guide/configurations/dataAccess/mongoSupport.adoc
@@ -115,6 +115,8 @@ To add support for GORM for MongoDB, first configure the MongoDB connection as p
 compile "io.micronaut.configuration:mongo-gorm"
 ----
 
+WARNING: For GORM for MongoDB you will need to configure the database name separately as the `grails.mongodb.datataseName` property in `application.yml`.
+
 The following should be noted regarding using GORM for MongoDB in Micronaut:
 
 * Each class you wish to be a GORM entity should be annotated with the `grails.gorm.annotation.Entity` annotation.


### PR DESCRIPTION
Add a note instructing how to specify the database when using
GORM for MongoDB.  It has to be specified in the
`grails.mongodb.databaseName` property instead of the
expected `mongodb.uri` property.