### PR TITLE
Fix client introduction advice issues

### DIFF
--- a/http-client/src/test/groovy/io/micronaut/http/client/aop/HateosCrudSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/aop/HateosCrudSpec.groovy
@@ -143,7 +143,7 @@ class HateosCrudSpec extends Specification {
 
     static interface BookApi {
 
-        @Get(value = "/{id}", produces = MediaType.APPLICATION_HAL_JSON)
+        @Get(value = "/{id}", processes = MediaType.APPLICATION_HAL_JSON)
         Book get(Long id)
 
         @Get
@@ -152,13 +152,13 @@ class HateosCrudSpec extends Specification {
         @Delete("/{id}")
         void delete(Long id)
 
-        @Post(produces = MediaType.APPLICATION_HAL_JSON)
+        @Post(processes = MediaType.APPLICATION_HAL_JSON)
         Book save(String title)
 
-        @Post(value= '/{id}/{embedded}', produces = MediaType.APPLICATION_HAL_JSON)
+        @Post(value= '/{id}/{embedded}', processes = MediaType.APPLICATION_HAL_JSON)
         Book save(Long id, String embedded)
 
-        @Patch(value = "/{id}", produces = MediaType.APPLICATION_HAL_JSON)
+        @Patch(value = "/{id}", processes = MediaType.APPLICATION_HAL_JSON)
         Book update(Long id, String title)
     }
 


### PR DESCRIPTION
Fixes #581

Also the handling of consumes/produces was backwards in the client advice. Consumes was being used to set the content type and Produces to set the accept header.