### PR TITLE
Fix subproject name so IntelliJ Gradle integration doesn't complain

### DIFF
--- a/test-suite-kotlin/build.gradle
+++ b/test-suite-kotlin/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.30"
-    compile project(':http-server-netty:')
+    compile project(':http-server-netty')
     compile project(':runtime')
 
     testCompileOnly project(':inject-java')


### PR DESCRIPTION
Without this change, I get a complaint from IntelliJ on import of the Micronaut build.  