### PR TITLE
Fix issue with oauth response not being 100% compliant

### DIFF
--- a/security-jwt/src/main/java/io/micronaut/security/token/jwt/render/AccessRefreshToken.java
+++ b/security-jwt/src/main/java/io/micronaut/security/token/jwt/render/AccessRefreshToken.java
@@ -16,6 +16,8 @@
 
 package io.micronaut.security.token.jwt.render;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * Stores the combination of access and refresh tokens.
  *
@@ -24,7 +26,10 @@ package io.micronaut.security.token.jwt.render;
  */
 public class AccessRefreshToken {
 
+    @JsonProperty("access_token")
     private String accessToken;
+
+    @JsonProperty("refresh_token")
     private String refreshToken;
 
     /**

--- a/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/render/AccessRefreshTokenSpec.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/render/AccessRefreshTokenSpec.groovy
@@ -1,0 +1,24 @@
+package io.micronaut.security.token.jwt.render
+
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import spock.lang.Specification
+
+import static com.fasterxml.jackson.databind.MapperFeature.SORT_PROPERTIES_ALPHABETICALLY
+
+class AccessRefreshTokenSpec extends Specification {
+    def "token json matches OAuth 2.0 RFC6749 specification"(){
+        given: "we have an jackson mapper that will give us consistent results"
+            ObjectMapper mapper = new ObjectMapper()
+            mapper.configure(SORT_PROPERTIES_ALPHABETICALLY, true)
+
+        and : "a fully populated token"
+            AccessRefreshToken token = new AccessRefreshToken("1234", "abcd")
+
+        when: "we serialize the object to json"
+            def rawJsonString = mapper.writeValueAsString(token)
+
+        then: "we will get an OAuth 2.0 RFC6749 compliant value"
+            rawJsonString == "{\"access_token\":\"1234\",\"refresh_token\":\"abcd\"}"
+    }
+}

--- a/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/render/BearerAccessRefreshTokenSpec.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/render/BearerAccessRefreshTokenSpec.groovy
@@ -1,0 +1,24 @@
+package io.micronaut.security.token.jwt.render
+
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import spock.lang.Specification
+
+import static com.fasterxml.jackson.databind.MapperFeature.SORT_PROPERTIES_ALPHABETICALLY
+
+class BearerAccessRefreshTokenSpec extends Specification {
+    def "token json matches OAuth 2.0 RFC6749 specification"(){
+        given: "we have an jackson mapper that will give us consistent results"
+            ObjectMapper mapper = new ObjectMapper()
+            mapper.configure(SORT_PROPERTIES_ALPHABETICALLY, true)
+
+        and : "a fully populated bearer token"
+            BearerAccessRefreshToken token = new BearerAccessRefreshToken("testing", ["admin", "superuser"], 3600, "1234", "abcd")
+
+        when: "we serialize the object to json"
+            def rawJsonString = mapper.writeValueAsString(token)
+
+        then: "we will get an OAuth 2.0 RFC6749 compliant value"
+            rawJsonString == "{\"access_token\":\"1234\",\"expires_in\":3600,\"refresh_token\":\"abcd\",\"roles\":[\"admin\",\"superuser\"],\"token_type\":\"Bearer\",\"username\":\"testing\"}"
+    }
+}


### PR DESCRIPTION
accessToken and refreshToken were camel case and did not use
underscores. Example in docs as well and RFC show it with underscore.
As well tooling (Postman) expects it to be underscore.

#607 