### PR TITLE
Use AuthenticationRequest instead of UsernamePasswordCredentials in Authenticator

### DIFF
--- a/security/src/main/java/io/micronaut/security/authentication/Authenticator.java
+++ b/security/src/main/java/io/micronaut/security/authentication/Authenticator.java
@@ -54,7 +54,7 @@ public class Authenticator {
      * @param credentials The credentials to authenticate with
      * @return A publisher that emits {@link AuthenticationResponse} objects
      */
-    public Publisher<AuthenticationResponse> authenticate(UsernamePasswordCredentials credentials) {
+    public Publisher<AuthenticationResponse> authenticate(AuthenticationRequest credentials) {
         if (this.authenticationProviders == null) {
             return Flowable.empty();
         }
@@ -72,7 +72,7 @@ public class Authenticator {
     }
 
     private Flowable<AuthenticationResponse> attemptAuthenticationRequest(
-        UsernamePasswordCredentials credentials,
+            AuthenticationRequest credentials,
         Iterator<AuthenticationProvider> providerIterator,
         Flowable<AuthenticationProvider> providerFlowable, AtomicReference<AuthenticationResponse> lastFailure) {
 


### PR DESCRIPTION
The `Authenticator` class use `UsernamePasswordCredentials` for the credentials when it really should be `AuthenticationRequest`. Otherwise it's not possible to make a custom class that implements `AuthenticationRequest` but don't extend `UsernamePasswordCredentials`.
Fixes #649