### PR TITLE
Allow JSON streaming in the body of a HTTP request

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/jackson/JsonHttpContentSubscriberFactory.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/jackson/JsonHttpContentSubscriberFactory.java
@@ -34,7 +34,7 @@ import java.util.Optional;
  * @author Graeme Rocher
  * @since 1.0
  */
-@Consumes(MediaType.APPLICATION_JSON)
+@Consumes({MediaType.APPLICATION_JSON_STREAM,MediaType.APPLICATION_JSON})
 @Singleton
 @Internal
 public class JsonHttpContentSubscriberFactory implements HttpContentSubscriberFactory {


### PR DESCRIPTION
With asynchronous request handling.

The test is a little funny, with the semaphore to ensure that the sending and receiving really happens concurrently. That could be taken out.