### PR TITLE
Include base URI from @Client(uri="...") in request line for streamed request body

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/DefaultHttpClient.java
@@ -1424,6 +1424,11 @@ public class DefaultHttpClient implements RxWebSocketClient, RxHttpClient, RxStr
                         nettyRequest = clientHttpRequest.getStreamedRequest(
                                 requestBodyPublisher
                         );
+                        try {
+                            nettyRequest.setUri(requestURI.toURL().getFile());
+                        } catch (MalformedURLException e) {
+                            //should never happen
+                        }
                         return new NettyRequestWriter(nettyRequest, null);
                     } else if (bodyValue instanceof CharSequence) {
                         bodyContent = charSequenceToByteBuf((CharSequence) bodyValue, requestContentType);


### PR DESCRIPTION
Subject says it all -- when I added a test through a @Client (for completeness), it didn't match the controller's URI. Turns out there's an short-circuit return in the middle of io.micronaut.http.client.DefaultHttpClient#buildNettyRequest so it doesn't set the (file part of) the requestURI.

This took one me forever to hunt down, through umpteen publishers of request URIs, requests and whatnot... :-)