### PR TITLE
Fix render more than one * asciidoc in config properties

### DIFF
--- a/build-projects/asciidoc-config-props/src/main/groovy/io/micronaut/documentation/asciidoc/AsciiDocPropertyReferenceWriter.java
+++ b/build-projects/asciidoc-config-props/src/main/groovy/io/micronaut/documentation/asciidoc/AsciiDocPropertyReferenceWriter.java
@@ -125,7 +125,7 @@ public class AsciiDocPropertyReferenceWriter implements ConfigurationMetadataWri
                                 }
 
                                 w.newLine();
-                                w.append("| `").append(path).append('`');
+                                w.append("| `+").append(path).append("+`");
                                 w.newLine();
                                 w.append("|").append(type);
                                 w.newLine();


### PR DESCRIPTION
With this change it is possible to render correctly config properties like `micronaut.caches.*.redis.caches.*.server`