### PR TITLE
Fixes #734 by examining the Java payload inside the streaming container.

### DIFF
--- a/http-client/src/test/groovy/io/micronaut/http/client/aop/StreamSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/aop/StreamSpec.groovy
@@ -27,6 +27,8 @@ import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.QueryValue
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.runtime.server.EmbeddedServer
+import io.netty.buffer.ByteBuf
+import io.netty.buffer.Unpooled
 import io.reactivex.Flowable
 import io.reactivex.Single
 import reactor.core.publisher.Flux
@@ -129,7 +131,7 @@ class StreamSpec extends Specification {
         expect:
         myClient.someJson(n) == '{"key":"value"}'
         where:
-        n << [1,2]
+        n << [1, 2, 3]
     }
 
     @Unroll
@@ -200,9 +202,18 @@ class StreamSpec extends Specification {
             return HttpResponse.ok(Flowable.just('{"key":"value"}'.getBytes(StandardCharsets.UTF_8)))
         }
 
+        @Get(value = "/someJson3", produces = MediaType.APPLICATION_JSON)
+        Flowable<ByteBuf> someJson3() {
+            return Flowable.just(byteBuf('{"key":'), byteBuf('"value"}'))
+        }
+
         @Get(value = "/someJsonCollection", produces = MediaType.APPLICATION_JSON)
         HttpResponse<Flowable<String>> someJsonCollection() {
             return HttpResponse.ok(Flowable.just('{"x":1}','{"x":2}'))
+        }
+
+        private static ByteBuf byteBuf(String s) {
+            Unpooled.wrappedBuffer(s.getBytes(StandardCharsets.UTF_8))
         }
 
     }

--- a/http-client/src/test/groovy/io/micronaut/http/client/aop/StreamSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/aop/StreamSpec.groovy
@@ -129,7 +129,15 @@ class StreamSpec extends Specification {
         expect:
         myClient.someJson(n) == '{"key":"value"}'
         where:
-        n << [1,2,3]
+        n << [1,2]
+    }
+
+    @Unroll
+    void "JSON can still be streamed using Flowable as container"() {
+        given:
+        StreamEchoClient myClient = context.getBean(StreamEchoClient)
+        expect:
+        myClient.someJsonCollection() == '[{"x":1},{"x":2}]'
     }
 
     @Client('/stream')
@@ -154,6 +162,9 @@ class StreamSpec extends Specification {
 
         @Get(value = "/someJson{n}", consumes = MediaType.APPLICATION_JSON)
         String someJson(int n);
+
+        @Get(value = "/someJsonCollection", consumes = MediaType.APPLICATION_JSON)
+        String someJsonCollection();
     }
 
     static class Elephant {
@@ -185,13 +196,13 @@ class StreamSpec extends Specification {
         }
 
         @Get(value = "/someJson2", produces = MediaType.APPLICATION_JSON)
-        Flowable<String> someJson2() {
-            return Flowable.just('{"key":"value"}')
+        HttpResponse<Flowable<byte[]>> someJson2() {
+            return HttpResponse.ok(Flowable.just('{"key":"value"}'.getBytes(StandardCharsets.UTF_8)))
         }
 
-        @Get(value = "/someJson3", produces = MediaType.APPLICATION_JSON)
-        HttpResponse<Flowable<String>> someJson3() {
-            return HttpResponse.ok(Flowable.just('{"key":"value"}'))
+        @Get(value = "/someJsonCollection", produces = MediaType.APPLICATION_JSON)
+        HttpResponse<Flowable<String>> someJsonCollection() {
+            return HttpResponse.ok(Flowable.just('{"x":1}','{"x":2}'))
         }
 
     }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
@@ -597,9 +597,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
     }
 
     private boolean isJsonFormattable(Class javaType) {
-        return ! (CharSequence.class.isAssignableFrom(javaType) ||
-                javaType == byte[].class ||
-                ByteBuffer.class.isAssignableFrom(javaType));
+        return !(javaType == byte[].class || ByteBuffer.class.isAssignableFrom(javaType));
     }
 
     private Subscriber<Object> buildSubscriber(NettyHttpRequest request,

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
@@ -597,7 +597,9 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
     }
 
     private boolean isJsonFormattable(Class javaType) {
-        return !(javaType == byte[].class || ByteBuffer.class.isAssignableFrom(javaType));
+        return !(javaType == byte[].class
+                || ByteBuffer.class.isAssignableFrom(javaType)
+                || ByteBuf.class.isAssignableFrom(javaType));
     }
 
     private Subscriber<Object> buildSubscriber(NettyHttpRequest request,


### PR DESCRIPTION
This refines the framing of JSON content by discriminating between payloads that are likely to be JSON formatted (such as beans handled by Jackson), and String og byte-ish constructs, ready for the Netty layer.