### PR TITLE
Update kafkaQuickStart.adoc

### DIFF
--- a/src/main/docs/guide/messaging/kafka/kafkaQuickStart.adoc
+++ b/src/main/docs/guide/messaging/kafka/kafkaQuickStart.adoc
@@ -13,7 +13,7 @@ Or with Maven:
 ----
 <dependency>
   <groupId>io.micronaut.configuration</groupId>
-  <artifactId>kafka</artifactId>
+  <artifactId>micronaut-kafka</artifactId>
 </dependency>
 ----
 


### PR DESCRIPTION
Changed to the right artifactId for io.micronaut.configuration for kafka used in RC3