### PR TITLE
AWS environment variables were not being resolved using camel case format

### DIFF
--- a/configurations/aws-common/src/main/java/io/micronaut/configuration/aws/EnvironmentAWSCredentialsProvider.java
+++ b/configurations/aws-common/src/main/java/io/micronaut/configuration/aws/EnvironmentAWSCredentialsProvider.java
@@ -35,27 +35,27 @@ public class EnvironmentAWSCredentialsProvider implements AWSCredentialsProvider
     /**
      * Environment variable name for the AWS access key ID.
      */
-    public static final String ACCESS_KEY_ENV_VAR = "aws.accessKeyId";
+    public static final String ACCESS_KEY_ENV_VAR = "aws.access-key-id";
 
     /**
      * Alternate environment variable name for the AWS access key ID.
      */
-    public static final String ALTERNATE_ACCESS_KEY_ENV_VAR = "aws.accessKey";
+    public static final String ALTERNATE_ACCESS_KEY_ENV_VAR = "aws.access-key";
 
     /**
      * Environment variable name for the AWS secret key.
      */
-    public static final String SECRET_KEY_ENV_VAR = "aws.secretKey";
+    public static final String SECRET_KEY_ENV_VAR = "aws.secret-key";
 
     /**
      * Alternate environment variable name for the AWS secret key.
      */
-    public static final String ALTERNATE_SECRET_KEY_ENV_VAR = "aws.secretAccessKey";
+    public static final String ALTERNATE_SECRET_KEY_ENV_VAR = "aws.secret-access-key";
 
     /**
      * Environment variable name for the AWS session token.
      */
-    public static final String AWS_SESSION_TOKEN_ENV_VAR = "aws.sessionToken";
+    public static final String AWS_SESSION_TOKEN_ENV_VAR = "aws.session-token";
 
     private final Environment environment;
 

--- a/configurations/aws-common/src/test/groovy/io/micronaut/configuration/aws/EnvironmentAWSCredentialsProviderTest.groovy
+++ b/configurations/aws-common/src/test/groovy/io/micronaut/configuration/aws/EnvironmentAWSCredentialsProviderTest.groovy
@@ -1,0 +1,92 @@
+package io.micronaut.configuration.aws
+
+import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.BasicSessionCredentials
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.env.Environment
+import io.micronaut.context.env.PropertySource
+import io.micronaut.core.util.CollectionUtils
+import spock.lang.Specification
+
+class EnvironmentAWSCredentialsProviderTest extends Specification {
+
+    String TEST_KEY_ID = "testKeyId"
+    String TEST_SECRET_KEY = "testSecretKey"
+    String TEST_SESSION_TOKEN = "testSessionToken"
+
+
+    def "AWS accessKeyId and secretKey can be read from environment"() {
+        given:
+        ApplicationContext applicationContext = ApplicationContext.run(
+                PropertySource.of(CollectionUtils.mapOf("aws.accessKeyId", "$TEST_KEY_ID", "aws" +
+                        ".secretKey", "$TEST_SECRET_KEY"))
+        )
+
+        Environment environment = applicationContext.getEnvironment()
+        EnvironmentAWSCredentialsProvider awsCredentialsProvider = new
+                EnvironmentAWSCredentialsProvider((environment))
+
+        when:
+        AWSCredentials awsCredentials = awsCredentialsProvider.getCredentials()
+
+        then:
+        awsCredentials.getAWSAccessKeyId().equals(TEST_KEY_ID)
+        awsCredentials.getAWSSecretKey().equals(TEST_SECRET_KEY)
+    }
+
+    def "AWS alternate accessKey and secretAccessKey can be read from environment"() {
+        given:
+        ApplicationContext applicationContext = ApplicationContext.run(
+                PropertySource.of(CollectionUtils.mapOf("aws.accessKey", "$TEST_KEY_ID", "aws" +
+                        ".secretAccessKey", "$TEST_SECRET_KEY"))
+        )
+
+        Environment environment = applicationContext.getEnvironment()
+        EnvironmentAWSCredentialsProvider awsCredentialsProvider = new
+                EnvironmentAWSCredentialsProvider((environment))
+
+        when:
+        AWSCredentials awsCredentials = awsCredentialsProvider.getCredentials()
+
+        then:
+        awsCredentials.getAWSAccessKeyId().equals(TEST_KEY_ID)
+        awsCredentials.getAWSSecretKey().equals(TEST_SECRET_KEY)
+    }
+
+    def "AWS accessKeyId, secretKey, and sessionToken can be read from environment"() {
+        given:
+        ApplicationContext applicationContext = ApplicationContext.run(
+                PropertySource.of(CollectionUtils.mapOf("aws.accessKeyId", "$TEST_KEY_ID", "aws" +
+                        ".secretKey", "$TEST_SECRET_KEY", "aws.sessionToken",
+                        "$TEST_SESSION_TOKEN")))
+
+        Environment environment = applicationContext.getEnvironment()
+        EnvironmentAWSCredentialsProvider awsCredentialsProvider = new
+                EnvironmentAWSCredentialsProvider((environment))
+
+        when:
+        BasicSessionCredentials awsCredentials = awsCredentialsProvider.getCredentials()
+
+        then:
+        awsCredentials.getAWSAccessKeyId().equals(TEST_KEY_ID)
+        awsCredentials.getAWSSecretKey().equals(TEST_SECRET_KEY)
+        awsCredentials.getSessionToken().equals(TEST_SESSION_TOKEN)
+    }
+
+    def "AWS accessKeyId, secretKey, and sessionToken can be read via yaml configuration"() {
+        given:
+        ApplicationContext applicationContext = ApplicationContext.run()
+        Environment environment = applicationContext.getEnvironment()
+        EnvironmentAWSCredentialsProvider awsCredentialsProvider = new
+                EnvironmentAWSCredentialsProvider((environment))
+
+        when:
+        BasicSessionCredentials awsCredentials = awsCredentialsProvider.getCredentials()
+
+        then:
+        awsCredentials.getAWSAccessKeyId().equals("yamlAccessKeyId")
+        awsCredentials.getAWSSecretKey().equals("yamlSecretKey")
+        awsCredentials.getSessionToken().equals("yamlSessionToken")
+    }
+
+}

--- a/configurations/aws-common/src/test/groovy/io/micronaut/configuration/aws/EnvironmentAWSCredentialsProviderTest.groovy
+++ b/configurations/aws-common/src/test/groovy/io/micronaut/configuration/aws/EnvironmentAWSCredentialsProviderTest.groovy
@@ -18,8 +18,9 @@ class EnvironmentAWSCredentialsProviderTest extends Specification {
     def "AWS accessKeyId and secretKey can be read from environment"() {
         given:
         ApplicationContext applicationContext = ApplicationContext.run(
-                PropertySource.of(CollectionUtils.mapOf("aws.accessKeyId", "$TEST_KEY_ID", "aws" +
-                        ".secretKey", "$TEST_SECRET_KEY"))
+                PropertySource.of(CollectionUtils.mapOf(
+                        "aws.accessKeyId", "$TEST_KEY_ID",
+                        "aws.secretKey", "$TEST_SECRET_KEY"))
         )
 
         Environment environment = applicationContext.getEnvironment()
@@ -37,9 +38,12 @@ class EnvironmentAWSCredentialsProviderTest extends Specification {
     def "AWS alternate accessKey and secretAccessKey can be read from environment"() {
         given:
         ApplicationContext applicationContext = ApplicationContext.run(
-                PropertySource.of(CollectionUtils.mapOf("aws.accessKey", "$TEST_KEY_ID", "aws" +
-                        ".secretAccessKey", "$TEST_SECRET_KEY"))
-        )
+                PropertySource.of(CollectionUtils.mapOf(
+                        //  nulling out non alternate values so that alternates will get picked up
+                        "aws.accessKeyId", null,
+                        "aws.secretKey", null,
+                        "aws.accessKey", "$TEST_KEY_ID",
+                        "aws.secretAccessKey", "$TEST_SECRET_KEY")))
 
         Environment environment = applicationContext.getEnvironment()
         EnvironmentAWSCredentialsProvider awsCredentialsProvider = new
@@ -56,9 +60,10 @@ class EnvironmentAWSCredentialsProviderTest extends Specification {
     def "AWS accessKeyId, secretKey, and sessionToken can be read from environment"() {
         given:
         ApplicationContext applicationContext = ApplicationContext.run(
-                PropertySource.of(CollectionUtils.mapOf("aws.accessKeyId", "$TEST_KEY_ID", "aws" +
-                        ".secretKey", "$TEST_SECRET_KEY", "aws.sessionToken",
-                        "$TEST_SESSION_TOKEN")))
+                PropertySource.of(CollectionUtils.mapOf(
+                        "aws.accessKeyId", "$TEST_KEY_ID",
+                        "aws.secretKey", "$TEST_SECRET_KEY",
+                        "aws.sessionToken", "$TEST_SESSION_TOKEN")))
 
         Environment environment = applicationContext.getEnvironment()
         EnvironmentAWSCredentialsProvider awsCredentialsProvider = new

--- a/configurations/aws-common/src/test/resources/application.yml
+++ b/configurations/aws-common/src/test/resources/application.yml
@@ -1,0 +1,4 @@
+aws:
+  accessKeyId: yamlAccessKeyId
+  secretKey: yamlSecretKey
+  sessionToken: yamlSessionToken


### PR DESCRIPTION
AWS credentials: accessKeyId, accessKey, secretKey, secretAccessKey, and sessionToken were not being resolved using camel case env variable names.  I was only able to access them using hyphenated format.

From the Micronaut documentation it seems that variables can't be accessed using camel case:  https://docs.micronaut.io/latest/guide/index.html#environments