### PR TITLE
Document how to build Graal native image without Docker

### DIFF
--- a/src/main/docs/guide/languageSupport/graal/graalServices.adoc
+++ b/src/main/docs/guide/languageSupport/graal/graalServices.adoc
@@ -12,7 +12,7 @@ The `graal-native-image` feature adds four important items:
 
 1. A `MicronautSubstitutions.java` file needed to recompute Netty and Caffeine's use of `Unsafe`.
 2. The `svm` and `graal` dependencies to your `build.gradle` (or `pom.xml` if `--build maven` is used).
-3. A `Dockerfile` which can be used to construct the native image using Docker.
+3. A `Dockerfile` which can be used to construct the native image using Docker and a script `docker-build.sh` to run it.
 4. A `build-native-image.sh` script to build the native image without using Docker.
 
 
@@ -26,6 +26,13 @@ $ docker build . -t hello-world
 $ docker run --network=host hello-world # <1>
 ----
 <1> Start the Docker container with `--network=host` makes the application uses the same network as the host so all ports are exposed automatically without needing to map them manually
+
+Or use the provided script:
+
+[source,bash]
+----
+$ ./docker-build.sh
+----
 
 
 ==== Build native image without using Docker

--- a/src/main/docs/guide/languageSupport/graal/graalServices.adoc
+++ b/src/main/docs/guide/languageSupport/graal/graalServices.adoc
@@ -8,20 +8,43 @@ To get started creating a Microservice that can be compiled into a native image,
 $ mn create-app hello-world --features graal-native-image
 ----
 
-The `graal-native-image` feature adds 3 important items:
+The `graal-native-image` feature adds four important items:
 
 1. A `MicronautSubstitutions.java` file needed to recompute Netty and Caffeine's use of `Unsafe`.
 2. The `svm` and `graal` dependencies to your `build.gradle` (or `pom.xml` if `--build maven` is used).
-3. A `Dockerfile` which can be used to construct the native image.
+3. A `Dockerfile` which can be used to construct the native image using Docker.
+4. A `build-native-image.sh` script to build the native image without using Docker.
 
+
+==== Build native image using Docker
 
 To build your native image using Docker simply run:
 
 [source,bash]
 ----
 $ docker build . -t hello-world
-$ docker run hello-world
+$ docker run --network=host hello-world # <1>
 ----
+<1> Start the Docker container with `--network=host` makes the application uses the same network as the host so all ports are exposed automatically without needing to map them manually
+
+
+==== Build native image without using Docker
+
+To build your native image without using Docker you need to install GraalVM SDK via the https://www.graalvm.org/docs/getting-started/[Getting Started] instructions or using SDKman:
+
+.Installing GraalVM 1.0.0-rc7 with SDKman
+[source,bash]
+----
+$ sdk install java 1.0.0-rc7-graal
+$ sdk use java 1.0.0-rc7-graal
+----
+
+.Creating native image
+[source,bash]
+----
+$ ./build-native-image.sh
+----
+
 
 === Understanding Micronaut and Graal
 


### PR DESCRIPTION
Now that Graal-RC7 is back in SDKMan and old releases won't be removed, at least until Graal 1.0 GA, we can also create native images without using Docker. This PR updates the documentation to explain users both options.

This needs to be merged with: https://github.com/micronaut-projects/micronaut-profiles/pull/84