### PR TITLE
Added (missing) getProperties method to JpaConfiguration

### DIFF
--- a/configurations/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/JpaConfiguration.java
+++ b/configurations/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/JpaConfiguration.java
@@ -107,6 +107,13 @@ public class JpaConfiguration {
     }
 
     /**
+     * @return The JPA properties
+     */
+    public Map<String, Object> getProperties() {
+        return jpaProperties;
+    }
+
+    /**
      * Creates the default {@link BootstrapServiceRegistryBuilder}.
      *
      * @param integrator  The integrator to use. Can be null


### PR DESCRIPTION
As discussed on Gitter added `getProperties()` to `JpaConfiguration`.
This way properties can be added in e.g. a `BeanCreatedEventListener<JpaConfiguration>` bean event.