### PR TITLE
Make JWT cookie path configurable

### DIFF
--- a/security-jwt/src/main/java/io/micronaut/security/token/jwt/cookie/JwtCookieConfiguration.java
+++ b/security-jwt/src/main/java/io/micronaut/security/token/jwt/cookie/JwtCookieConfiguration.java
@@ -32,6 +32,12 @@ public interface JwtCookieConfiguration extends Toggleable {
     String getCookieName();
 
     /**
+     * cookiePath getter.
+     * @return a String with the Cookie path
+     */
+    String getCookiePath();
+
+    /**
      *
      * @return String to be parsed into a URI which represents where the user is redirected to after a successful login.
      */

--- a/security-jwt/src/main/java/io/micronaut/security/token/jwt/cookie/JwtCookieConfigurationProperties.java
+++ b/security-jwt/src/main/java/io/micronaut/security/token/jwt/cookie/JwtCookieConfigurationProperties.java
@@ -42,6 +42,12 @@ public class JwtCookieConfigurationProperties implements JwtCookieConfiguration 
     public static final String DEFAULT_COOKIENAME = "JWT";
 
     /**
+     * The default cookie path.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static final String DEFAULT_COOKIEPATH = null;
+
+    /**
      * The default logout target URL.
      */
     @SuppressWarnings("WeakerAccess")
@@ -61,6 +67,7 @@ public class JwtCookieConfigurationProperties implements JwtCookieConfiguration 
     private boolean enabled = DEFAULT_ENABLED;
     private String logoutTargetUrl = DEFAULT_LOGOUTTARGETURL;
     private String cookieName = DEFAULT_COOKIENAME;
+    private String cookiePath = DEFAULT_COOKIEPATH;
     private String loginSuccessTargetUrl = DEFAULT_LOGINSUCCESSTARGETURL;
     private String loginFailureTargetUrl = DEFAULT_LOGINFAILURETARGETURL;
 
@@ -98,6 +105,15 @@ public class JwtCookieConfigurationProperties implements JwtCookieConfiguration 
     }
 
     /**
+     * cookiePath getter.
+     * @return a String with the Cookie path
+     */
+    @Override
+    public String getCookiePath() {
+        return cookiePath;
+    }
+
+    /**
      * Sets whether JWT cookie based security is enabled. Default value ({@value #DEFAULT_ENABLED}).
      *
      * @param enabled True if it is enabled
@@ -123,6 +139,18 @@ public class JwtCookieConfigurationProperties implements JwtCookieConfiguration 
     public void setCookieName(String cookieName) {
         if (StringUtils.isNotEmpty(cookieName)) {
             this.cookieName = cookieName;
+        }
+    }
+
+    /**
+     * Sets the cookie path to use. Default value ({@value #DEFAULT_COOKIEPATH}).
+     * @param cookiePath The cookie path
+     */
+    public void setCookiePath(String cookiePath) {
+        if (StringUtils.isNotEmpty(cookiePath)) {
+            this.cookiePath = cookiePath;
+        } else {
+            this.cookiePath = null;
         }
     }
 

--- a/security-jwt/src/main/java/io/micronaut/security/token/jwt/cookie/JwtCookieLoginHandler.java
+++ b/security-jwt/src/main/java/io/micronaut/security/token/jwt/cookie/JwtCookieLoginHandler.java
@@ -61,6 +61,7 @@ public class JwtCookieLoginHandler implements LoginHandler {
         Optional<AccessRefreshToken> accessRefreshTokenOptional = accessRefreshTokenGenerator.generate(userDetails);
         if (accessRefreshTokenOptional.isPresent()) {
             Cookie cookie = Cookie.of(jwtCookieConfiguration.getCookieName(), accessRefreshTokenOptional.get().getAccessToken());
+            cookie.path(jwtCookieConfiguration.getCookiePath());
             cookie.maxAge(jwtGeneratorConfiguration.getAccessTokenExpiration());
             cookie.httpOnly(true).secure(request.isSecure());
             try {

--- a/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/cookie/JwtCookieAuthenticationSpec.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/cookie/JwtCookieAuthenticationSpec.groovy
@@ -121,6 +121,7 @@ class JwtCookieAuthenticationSpec extends GebSpec {
         then:
         cookie
         cookie.contains('JWT=')
+        !cookie.contains('Path=/')
 
         when:
         String sessionId = cookie.substring('JWT='.size(), cookie.indexOf(';'))
@@ -192,7 +193,3 @@ class JwtCookieAuthenticationSpec extends GebSpec {
     }
 }
 
-class LoginForm {
-    String username
-    String password
-}

--- a/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/cookie/JwtCookiePathSpec.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/cookie/JwtCookiePathSpec.groovy
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017-2018 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.security.token.jwt.cookie
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.env.Environment
+
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MediaType
+import io.micronaut.http.client.RxHttpClient
+import io.micronaut.http.cookie.Cookie
+import io.micronaut.runtime.server.EmbeddedServer
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class JwtCookiePathSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    ApplicationContext context = ApplicationContext.run(
+            [
+                    'spec.name': 'jwtcookie',
+                    'micronaut.http.client.followRedirects': false,
+                    'micronaut.security.enabled': true,
+                    'micronaut.security.endpoints.login.enabled': true,
+                    'micronaut.security.token.jwt.enabled': true,
+                    'micronaut.security.token.jwt.bearer.enabled': false,
+                    'micronaut.security.token.jwt.cookie.enabled': true,
+                    'micronaut.security.token.jwt.cookie.cookie-path': "/",
+                    'micronaut.security.token.jwt.signatures.secret.generator.secret': 'qrD6h8K6S9503Q06Y6Rfk21TErImPYqa',
+            ], Environment.TEST)
+
+    @Shared
+    @AutoCleanup
+    EmbeddedServer embeddedServer = context.getBean(EmbeddedServer).start()
+
+    @Shared
+    @AutoCleanup
+    RxHttpClient client = embeddedServer.applicationContext.createBean(RxHttpClient, embeddedServer.getURL())
+
+    def "verify jwt cookie path is set from configuration"() {
+
+        when:
+        HttpRequest loginRequest = HttpRequest.POST('/login', new LoginForm(username: 'sherlock', password: 'password'))
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE)
+
+        HttpResponse<String> loginRsp = client.toBlocking().exchange(loginRequest, String)
+
+        then:
+        loginRsp.status().code == 303
+
+        when:
+        String cookie = loginRsp.getHeaders().get('Set-Cookie')
+        println cookie
+        then:
+        cookie
+        cookie.contains('JWT=')
+        cookie.contains('Path=/;')
+
+        when:
+        String sessionId = cookie.substring('JWT='.size(), cookie.indexOf(';'))
+        HttpRequest request = HttpRequest.GET('/').cookie(Cookie.of('JWT', sessionId).path("/"))
+        HttpResponse<String> rsp = client.toBlocking().exchange(request, String)
+
+        then:
+        rsp.status().code == 200
+        rsp.body()
+        rsp.body().contains('sherlock')
+    }
+
+}

--- a/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/cookie/LoginForm.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/cookie/LoginForm.groovy
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017-2018 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.security.token.jwt.cookie
+
+class LoginForm {
+    String username
+    String password
+}


### PR DESCRIPTION
Fixes #798 

I wanted to set the default cookie path to / but that would alter the current behavior. But I think the current behavior is wrong. Discuss.