### PR TITLE
Kafka - adding queryable state store bean, tests and docs

### DIFF
--- a/configurations/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/registry/KafkaStreamRegistryFactory.java
+++ b/configurations/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/registry/KafkaStreamRegistryFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017-2018 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.configuration.kafka.streams.registry;
+
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Factory;
+import org.apache.kafka.streams.KafkaStreams;
+
+import java.util.Set;
+
+/**
+ * A factory that constructs a {@link KafkaStreamsRegistry} and {@link QueryableStoreRegistry} beans.
+ *
+ * @author Christian Oestreich
+ * @since 1.0
+ */
+@Factory
+public class KafkaStreamRegistryFactory {
+
+    /**
+     * Exposes the {@link KafkaStreamsRegistry} as a bean.
+     *
+     * @param kafkaStreamsList The list of registered streams
+     * @return The kafka streams registry
+     */
+    @Bean
+    public KafkaStreamsRegistry kafkaStreamsRegistry(Set<KafkaStreams> kafkaStreamsList) {
+        return new KafkaStreamsRegistry(kafkaStreamsList);
+    }
+
+    /**
+     * Exposes the {@link QueryableStoreRegistry} as a bean.
+     *
+     * @param kafkaStreamsRegistry The bean that contains the list of registered streams
+     * @return The queryable store registry
+     */
+    @Bean
+    public QueryableStoreRegistry queryableStoreTypeRegistry(KafkaStreamsRegistry kafkaStreamsRegistry) {
+        return new QueryableStoreRegistry(kafkaStreamsRegistry);
+    }
+}

--- a/configurations/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/registry/KafkaStreamsRegistry.java
+++ b/configurations/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/registry/KafkaStreamsRegistry.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017-2018 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.configuration.kafka.streams.registry;
+
+import org.apache.kafka.streams.KafkaStreams;
+
+import java.util.Set;
+
+/**
+ * A bean to hold all the registered streams for use in activities like querying state stores, etc.
+ *
+ * @author Christian Oestreich
+ * @since 1.0
+ */
+class KafkaStreamsRegistry {
+
+    private final Set<KafkaStreams> kafkaStreams;
+
+    /**
+     * Constructor method for creating a KafkaStreamsRegistry.
+     *
+     * @param kafkaStreams A set of all the kafka streams
+     */
+    KafkaStreamsRegistry(Set<KafkaStreams> kafkaStreams) {
+        this.kafkaStreams = kafkaStreams;
+    }
+
+    /**
+     * Get all the registered {@link KafkaStreams} objects.
+     *
+     * @return set of {@link KafkaStreams} objects
+     */
+    Set<KafkaStreams> getKafkaStreams() {
+        return kafkaStreams;
+    }
+}

--- a/configurations/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/registry/QueryableStoreRegistry.java
+++ b/configurations/kafka-streams/src/main/java/io/micronaut/configuration/kafka/streams/registry/QueryableStoreRegistry.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017-2018 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.configuration.kafka.streams.registry;
+
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.errors.InvalidStateStoreException;
+import org.apache.kafka.streams.state.QueryableStoreType;
+
+/**
+ * A factory that constructs a {@link KafkaStreamsRegistry} and {@link QueryableStoreRegistry} beans.
+ *
+ * @author Christian Oestreich
+ * @since 1.0
+ */
+public class QueryableStoreRegistry {
+
+    private final KafkaStreamsRegistry kafkaStreamsRegistry;
+
+    /**
+     * Constructor method for creating a QueryableStoreRegistry.
+     *
+     * @param kafkaStreamsRegistry The bean containing all the registered streams
+     */
+    QueryableStoreRegistry(KafkaStreamsRegistry kafkaStreamsRegistry) {
+        this.kafkaStreamsRegistry = kafkaStreamsRegistry;
+    }
+
+    /**
+     * Retrieve and return a queryable store by name created in the application.
+     *
+     * @param storeName name of the queryable store
+     * @param storeType type of the queryable store
+     * @param <T>       generic queryable store
+     * @return queryable store.
+     */
+    public <T> T getQueryableStoreType(String storeName, QueryableStoreType<T> storeType) {
+        for (KafkaStreams kafkaStream : this.kafkaStreamsRegistry.getKafkaStreams()) {
+            try {
+                T store = kafkaStream.store(storeName, storeType);
+                if (store != null) {
+                    return store;
+                }
+            } catch (InvalidStateStoreException ignored) {
+                //pass through
+            }
+        }
+        return null;
+    }
+
+}

--- a/configurations/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/KafkaStreamsSpec.groovy
+++ b/configurations/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/KafkaStreamsSpec.groovy
@@ -11,12 +11,15 @@ import spock.util.concurrent.PollingConditions
 
 class KafkaStreamsSpec extends Specification {
 
-    @Shared @AutoCleanup ApplicationContext context = ApplicationContext.run(
+    @Shared
+    @AutoCleanup
+    ApplicationContext context = ApplicationContext.run(
             CollectionUtils.mapOf(
                     "kafka.bootstrap.servers", 'localhost:${random.port}',
                     AbstractKafkaConfiguration.EMBEDDED, true,
                     AbstractKafkaConfiguration.EMBEDDED_TOPICS, [WordCountStream.INPUT, WordCountStream.OUTPUT],
-                    'kafka.streams.my-stream.num.stream.threads',10
+                    'kafka.streams.my-stream.num.stream.threads', 10,
+                    'kafka.streams.state-stream.num.stream.threads', 10
             )
     )
 
@@ -27,12 +30,11 @@ class KafkaStreamsSpec extends Specification {
 
     void "test kafka stream application"() {
         given:
-
         PollingConditions conditions = new PollingConditions(timeout: 30, delay: 1)
 
         when:
-        WordCountClient wordCountClient = context.getBean(WordCountClient);
-        wordCountClient.publishSentence("The quick brown fox jumps over the lazy dog. THE QUICK BROWN FOX JUMPED OVER THE LAZY DOG'S BACK");
+        WordCountClient wordCountClient = context.getBean(WordCountClient)
+        wordCountClient.publishSentence("The quick brown fox jumps over the lazy dog. THE QUICK BROWN FOX JUMPED OVER THE LAZY DOG'S BACK")
 
         WordCountListener countListener = context.getBean(WordCountListener)
 
@@ -44,6 +46,5 @@ class KafkaStreamsSpec extends Specification {
         }
 
     }
-
 
 }

--- a/configurations/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/registry/KafkaStreamQueryableStoreSpec.groovy
+++ b/configurations/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/registry/KafkaStreamQueryableStoreSpec.groovy
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2017-2018 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.configuration.kafka.streams.registry
+
+import io.micronaut.configuration.kafka.config.AbstractKafkaConfiguration
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.util.CollectionUtils
+import org.apache.kafka.streams.state.QueryableStoreTypes
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
+
+class KafkaStreamQueryableStoreSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    ApplicationContext context = ApplicationContext.run(
+            CollectionUtils.mapOf(
+                    "kafka.bootstrap.servers", 'localhost:${random.port}',
+                    AbstractKafkaConfiguration.EMBEDDED, true,
+                    AbstractKafkaConfiguration.EMBEDDED_TOPICS, [WordCountStateStoreStream.INPUT, WordCountStateStoreStream.OUTPUT],
+                    'kafka.streams.my-stream.num.stream.threads', 10,
+                    'kafka.streams.state-stream.num.stream.threads', 10
+            )
+    )
+
+    void "test the number of streams registered"() {
+        when:
+        def kafkaStreamsRegistry = context.getBean(KafkaStreamsRegistry)
+        def queryableStoreRegistry = context.getBean(QueryableStoreRegistry)
+
+        then: 'Just make sure there are some streams in-case more stream tests are added messing up the count'
+        kafkaStreamsRegistry.kafkaStreams.size() >= 1
+
+        and:
+        queryableStoreRegistry
+    }
+
+    void "test kafka stream application state store query"() {
+        given:
+        PollingConditions conditions = new PollingConditions(timeout: 30, delay: 1)
+        WordCountStateStoreClient wordCountStateStoreClient = context.getBean(WordCountStateStoreClient)
+        QueryableStoreRegistry queryableStoreRegistry = context.getBean(QueryableStoreRegistry)
+
+        when:
+        wordCountStateStoreClient.publishSentence("The quick brown fox jumps over the lazy dog. THE QUICK BROWN FOX JUMPED OVER THE LAZY DOG'S BACK")
+
+        then:
+        conditions.eventually {
+            queryableStoreRegistry.getQueryableStoreType(WordCountStateStoreStream.STATE_STORE, QueryableStoreTypes.<String, Long> keyValueStore()).get("fox") > 0
+            queryableStoreRegistry.getQueryableStoreType(WordCountStateStoreStream.STATE_STORE, QueryableStoreTypes.keyValueStore()).get("fox") > 0
+        }
+    }
+
+    void "test kafka stream application state store query using example bean"() {
+        given:
+        PollingConditions conditions = new PollingConditions(timeout: 30, delay: 1)
+        WordCountStateStoreClient wordCountStateStoreClient = context.getBean(WordCountStateStoreClient)
+        QueryableStoreRegistryExample queryableStoreRegistryExample = context.getBean(QueryableStoreRegistryExample)
+
+        when:
+        wordCountStateStoreClient.publishSentence("The quick brown fox jumps over the lazy dog. THE QUICK BROWN FOX JUMPED OVER THE LAZY DOG'S BACK")
+
+        then:
+        conditions.eventually {
+            queryableStoreRegistryExample.getStore(WordCountStateStoreStream.STATE_STORE).get("fox") > 0
+            queryableStoreRegistryExample.getValue(WordCountStateStoreStream.STATE_STORE, "fox") > 0
+        }
+    }
+}

--- a/configurations/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/registry/KafkaStreamRegistryFactorySpec.groovy
+++ b/configurations/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/registry/KafkaStreamRegistryFactorySpec.groovy
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2018 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.configuration.kafka.streams.registry
+
+import spock.lang.Specification
+
+
+class KafkaStreamRegistryFactorySpec extends Specification {
+
+    def "construct factor and call bean methods"() {
+        expect:
+        new KafkaStreamRegistryFactory().kafkaStreamsRegistry([] as Set)
+        new KafkaStreamRegistryFactory().queryableStoreTypeRegistry(null)
+    }
+}

--- a/configurations/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/registry/KafkaStreamsRegistrySpec.groovy
+++ b/configurations/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/registry/KafkaStreamsRegistrySpec.groovy
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2018 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.configuration.kafka.streams.registry
+
+import org.apache.kafka.streams.KafkaStreams
+import spock.lang.Specification
+
+
+class KafkaStreamsRegistrySpec extends Specification {
+
+    def "test getKafkaStreams"() {
+        expect:
+        new KafkaStreamsRegistry([Mock(KafkaStreams)] as Set).getKafkaStreams().size() == 1
+    }
+}

--- a/configurations/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/registry/QueryableStoreRegistryExample.java
+++ b/configurations/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/registry/QueryableStoreRegistryExample.java
@@ -1,0 +1,25 @@
+package io.micronaut.configuration.kafka.streams.registry;
+
+import org.apache.kafka.streams.state.QueryableStoreTypes;
+import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class QueryableStoreRegistryExample {
+
+    private final QueryableStoreRegistry queryableStoreRegistry;
+
+    public QueryableStoreRegistryExample(QueryableStoreRegistry queryableStoreRegistry) { // <1>
+        this.queryableStoreRegistry = queryableStoreRegistry;
+    }
+
+    public <K, V> ReadOnlyKeyValueStore<K, V> getStore(String storeName) { // <2>
+        return queryableStoreRegistry.getQueryableStoreType(storeName, QueryableStoreTypes.keyValueStore());
+    }
+
+    public <K, V> V getValue(String storeName, K key) { // <3>
+        ReadOnlyKeyValueStore<K, V> readOnlyKeyValueStore = getStore(storeName);
+        return readOnlyKeyValueStore != null ? readOnlyKeyValueStore.get(key) : null;
+    }
+}

--- a/configurations/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/registry/QueryableStoreRegistrySpec.groovy
+++ b/configurations/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/registry/QueryableStoreRegistrySpec.groovy
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2018 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.configuration.kafka.streams.registry
+
+import org.apache.kafka.streams.KafkaStreams
+import org.apache.kafka.streams.state.QueryableStoreType
+import org.apache.kafka.streams.state.QueryableStoreTypes
+import org.apache.kafka.streams.state.ReadOnlyKeyValueStore
+import spock.lang.Specification
+
+class QueryableStoreRegistrySpec extends Specification {
+
+    def "test getQueryableStoreType"() {
+        given:
+        ReadOnlyKeyValueStore readOnlyKeyValueStore = Mock(ReadOnlyKeyValueStore)
+        KafkaStreams kafkaStreams = Mock(KafkaStreams)
+        KafkaStreamsRegistry kafkaStreamsRegistry = new KafkaStreamsRegistry([kafkaStreams] as Set)
+        QueryableStoreRegistry queryableStoreRegistry = new QueryableStoreRegistry(kafkaStreamsRegistry)
+
+        when:
+        def queryableStoreType = queryableStoreRegistry.getQueryableStoreType("foo", QueryableStoreTypes.keyValueStore())
+
+        then:
+        1 * kafkaStreams.store("foo", _ as QueryableStoreType) >> readOnlyKeyValueStore
+
+        when:
+        def get = queryableStoreType.get("bar")
+
+        then:
+        get == 10
+        1 * readOnlyKeyValueStore.get("bar") >> 10
+
+    }
+}

--- a/configurations/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/registry/WordCountStateStoreClient.java
+++ b/configurations/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/registry/WordCountStateStoreClient.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2018 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.configuration.kafka.streams.registry;
+
+import io.micronaut.configuration.kafka.annotation.KafkaClient;
+import io.micronaut.configuration.kafka.annotation.Topic;
+
+@KafkaClient
+public interface WordCountStateStoreClient {
+
+    @Topic(WordCountStateStoreStream.INPUT)
+    void publishSentence(String sentence);
+}

--- a/configurations/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/registry/WordCountStateStoreStream.java
+++ b/configurations/kafka-streams/src/test/groovy/io/micronaut/configuration/kafka/streams/registry/WordCountStateStoreStream.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017-2018 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.configuration.kafka.streams.registry;
+
+// tag::imports[]
+
+import io.micronaut.configuration.kafka.streams.ConfiguredStreamBuilder;
+import io.micronaut.context.annotation.Factory;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.Produced;
+
+import javax.inject.Singleton;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Properties;
+// end::imports[]
+
+// tag::clazz[]
+@Factory
+public class WordCountStateStoreStream {
+
+    public static final String INPUT = "statestore-plaintext-input"; // <1>
+    public static final String OUTPUT = "statestore-wordcount-output"; // <2>
+    public static final String STATE_STORE = "queryable-store-name"; // <3>
+// end::clazz[]
+
+    // tag::stateStoreStream[]
+    @Singleton
+    KStream<String, String> stateStoreStream(ConfiguredStreamBuilder builder) {
+
+        // end::stateStoreStream[]
+        // set default serdes
+        Properties props = builder.getConfiguration();
+        props.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
+        props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+        KStream<String, String> source = builder.stream(INPUT);
+        // tag::stateStore[]
+        KTable<String, Long> counts = source
+                .flatMapValues(value -> Arrays.asList(value.toLowerCase(Locale.getDefault()).split(" ")))
+                .groupBy((key, value) -> value)
+                .count(Materialized.as("queryable-store-name")); // <1>
+        // end::stateStore[]
+        // need to override value serde to Long type
+        counts.toStream().to(OUTPUT, Produced.with(Serdes.String(), Serdes.Long()));
+        return source;
+    }
+}

--- a/src/main/docs/guide/messaging/kafka/kafkaStream.adoc
+++ b/src/main/docs/guide/messaging/kafka/kafkaStream.adoc
@@ -110,3 +110,33 @@ You can then inject a api:configuration.kafka.streams.ConfiguredStreamBuilder[] 
 include::{testskafkastreams}/WordCountStream.java[tags=namedStream, indent=0]
 }
 ----
+
+=== Kafka Streams State Store
+
+You can use a state store in your stream and leverage the concept of a https://cwiki.apache.org/confluence/display/KAFKA/KIP-67%3A+Queryable+state+for+Kafka+Streams[state store].  Micronaut provides a bean of type `QueryableStoreRegistry` to allow you to query a state store.
+
+.Create Materialized Store For Stream
+To query the store you will first need to tell your stream to use a materialized store.
+
+.Kafka Streams Word Count w/Store
+[source,java]
+----
+include::{testskafkastreams}/registry/WordCountStateStoreStream.java[tags=stateStore, indent=0]
+----
+
+<1> Output the count to a state store
+
+.Query State Store
+You can query your store by using the `QueryableStoreRegistry` bean.  This contrived helper class illustrates how to inject the `QueryableStoreRegistry` bean, get a read only key value store and a value from the store.
+
+[NOTE]
+The `getQueryableStoreType` method can produce a null so make sure to check that a store was returned before invoking get operation.
+
+[source,java]
+----
+include::{testskafkastreams}/registry/QueryableStoreRegistryExample.java[]
+----
+
+<1> Inject the `QueryableStoreRegistry` bean
+<2> Method to get a ReadOnlyKeyValueStore
+<3> Get the store and lookup value


### PR DESCRIPTION
This is a feature that is provided by spring cloud streams binder kafka https://docs.spring.io/spring-cloud-stream/docs/current/reference/htmlsingle/#_interactive_queries

