### PR TITLE
Optimize memory usage for JSON streaming

### DIFF
--- a/runtime/src/main/java/io/micronaut/jackson/parser/JacksonProcessor.java
+++ b/runtime/src/main/java/io/micronaut/jackson/parser/JacksonProcessor.java
@@ -279,7 +279,7 @@ public class JacksonProcessor extends SingleThreadedBufferingProcessor<byte[], J
     private JsonNode node(JsonNode node) {
         if (node instanceof ObjectNode) {
             return ((ObjectNode) node).putObject(currentFieldName);
-        } else if (node instanceof ArrayNode) {
+        } else if (node instanceof ArrayNode && !(streamArray && nodeStack.size() == 1)) {
             return ((ArrayNode) node).addObject();
         } else {
             return JsonNodeFactory.instance.objectNode();


### PR DESCRIPTION
In case we are streaming an array into a number of JSON values, all parsed and streamed nodes are added to the root array, but this array is later thrown away. In order to reduce memory usage and not hold on to every JSON value streamed, we can keep the root array empty and just have it as a stream-is-complete marker.