### PR TITLE
Fix for unsafe wrapping of different body-payloads in same response object in reactive stream

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/DefaultHttpClient.java
@@ -36,6 +36,7 @@ import io.micronaut.core.order.OrderUtil;
 import io.micronaut.core.reflect.InstantiationUtils;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.*;
+import io.micronaut.http.HttpResponseWrapper;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.MutableHttpHeaders;
@@ -827,8 +828,12 @@ public class DefaultHttpClient implements RxWebSocketClient, RxHttpClient, RxStr
                         traceBody("Response", byteBuf);
                     }
                     ByteBuffer<?> byteBuffer = byteBufferFactory.wrap(byteBuf);
-                    nettyStreamedHttpResponse.setBody(byteBuffer);
-                    return nettyStreamedHttpResponse;
+                    return new HttpResponseWrapper<ByteBuffer<?>>(nettyStreamedHttpResponse) {
+                        @Override
+                        public Optional<ByteBuffer<?>> getBody() {
+                            return Optional.of(byteBuffer);
+                        }
+                    };
                 });
             });
         };

--- a/http-client/src/test/groovy/io/micronaut/http/client/DataStreamSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/DataStreamSpec.groovy
@@ -131,6 +131,24 @@ class DataStreamSpec extends Specification {
 
     }
 
+    void "test that stream response is free of race conditions"() {
+        given:
+        RxStreamingHttpClient client = context.createBean(RxStreamingHttpClient,embeddedServer.getURL())
+
+        when:
+        List<byte[]> arrays = client.exchangeStream(HttpRequest.GET(
+                '/datastream/books'
+        )).blockingIterable().toList().collect { res -> res.body.get().toByteArray() }
+
+        then:
+        arrays.size() == 2
+        new String(arrays[0]) == 'The Stand'
+        new String(arrays[1]) == 'The Shining'
+
+        cleanup:
+        client.stop()
+
+    }
     @Controller("/datastream/books")
     static class BookController {
 

--- a/http/src/main/java/io/micronaut/http/HttpResponseWrapper.java
+++ b/http/src/main/java/io/micronaut/http/HttpResponseWrapper.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017-2018 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.http;
+
+/**
+ * A wrapper around a {@link HttpResponse}.
+ *
+ * @param <B> The Http body type
+ * @since 1.0.1
+ */
+public class HttpResponseWrapper<B> extends HttpMessageWrapper<B> implements HttpResponse<B> {
+
+    /**
+     * @param delegate The Http Request
+     */
+    public HttpResponseWrapper(HttpResponse<B> delegate) {
+        super(delegate);
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return getDelegate().getStatus();
+    }
+
+    @Override
+    public HttpResponse<B> getDelegate() {
+        return (HttpResponse<B>) super.getDelegate();
+    }
+
+}


### PR DESCRIPTION
### Steps to Reproduce

1. Call the streaming DefaultHttpClient.exchangeStream()
2. Drain the published info into temporary storage (e.g. by blockingIterable, buffer, etc.), or consume them in an asynchronous fashion.
3. See that the bodies are mixed up

### Expected Behaviour

Each returned result from the Flowable should be independent from the others

### Actual Behaviour

Each returned result from the Flowable is the same object, but the contained body is exchanged between each "next".

### Environment Information

- **Operating System**: All
- **Micronaut Version:** 1.0.0
- **JDK Version:** All

### Example Application

Added as an instructive test case in `io.micronaut.http.client.DataStreamSpec#test that stream response is free of race conditions`. Without the fix, this happens:
```
Condition not satisfied:

new String(arrays[0]) == 'The Stand'
|          |     |    |
The Shining|     |    false
           |     |    5 differences (54% similarity)
           |     |    The S(hi)n(ing)
           |     |    The S(ta)n(d--)
           |     [84, 104, 101, 32, 83, 104, 105, 110, 105, 110, 103]
           [[84, 104, 101, 32, 83, 104, 105, 110, 105, 110, 103], [84, 104, 101, 32, 83, 104, 105, 110, 105, 110, 103]]

Expected :The Stand

Actual   :The Shining
```