### PR TITLE
Link to Build/Install CLI from the CLI usage area

### DIFF
--- a/src/main/docs/guide/cli.adoc
+++ b/src/main/docs/guide/cli.adoc
@@ -1,6 +1,6 @@
 The Micronaut CLI is the recommended way to create new Micronaut projects. The CLI includes commands for generating specific categories of projects, allowing you to choose between build tools, test frameworks, and even pick the language you wish to use in your application. The CLI also provides commands for generating artifacts such as controllers, client interfaces, and serverless functions.
 
-When Micronaut is installed on your computer, you can call the CLI with the `mn` command.
+When <<buildCLI, Micronaut is installed on your computer>>, you can call the CLI with the `mn` command.
 
 [source,bash]
 ----


### PR DESCRIPTION
Guides like the http://guides.micronaut.io/creating-your-first-micronaut-app-groovy/guide/index.html#tests link to this CLI page, but there is no description on how to install the CLI.  This will make it easier for someone writing their first micronaut app to get up and running