### PR TITLE
Fixed #758 Default database empty configuration is not working

### DIFF
--- a/inject/src/main/java/io/micronaut/context/env/AbstractPropertySourceLoader.java
+++ b/inject/src/main/java/io/micronaut/context/env/AbstractPropertySourceLoader.java
@@ -139,7 +139,7 @@ public abstract class AbstractPropertySourceLoader implements PropertySourceLoad
             Map.Entry entry = (Map.Entry) o;
             String key = entry.getKey().toString();
             Object value = entry.getValue();
-            if (value instanceof Map) {
+            if (value instanceof Map && !((Map) value).isEmpty()) {
                 processMap(finalMap, (Map) value, prefix + key + '.');
             } else {
                 finalMap.put(prefix + key, value);


### PR DESCRIPTION
The value never being added to the `finalMap` if it's an empty `Map`. That's why `datasources.default: {}` does not initialize the default configurations for the database or in other words the `DataSource` bean.

However, it does work when the value is of type String as `datasources.default: ""` or `datasources.default: "{}"`.