### PR TITLE
Using `ConsulConfiguration` subclass instead of the parent one.

### DIFF
--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/ConsulServiceInstanceList.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/ConsulServiceInstanceList.java
@@ -16,7 +16,6 @@
 
 package io.micronaut.discovery.consul;
 
-import io.micronaut.discovery.client.DiscoveryClientConfiguration;
 import io.micronaut.discovery.client.DiscoveryServerInstanceList;
 import io.micronaut.discovery.consul.client.v1.ConsulClient;
 import io.micronaut.discovery.consul.condition.RequiresConsul;
@@ -44,7 +43,7 @@ public class ConsulServiceInstanceList extends DiscoveryServerInstanceList {
      * @param configuration The discovery config
      * @param instanceConfiguration The instance config
      */
-    public ConsulServiceInstanceList(DiscoveryClientConfiguration configuration, ApplicationConfiguration.InstanceConfiguration instanceConfiguration) {
+    public ConsulServiceInstanceList(ConsulConfiguration configuration, ApplicationConfiguration.InstanceConfiguration instanceConfiguration) {
         super(configuration, instanceConfiguration);
     }
 


### PR DESCRIPTION
When using Consul discovery in a cloud environment, there can be multiple
instances of a bean with type `DiscoveryClientConfiguration` (eg:
`Route53ClientDiscoveryConfiguration` and `ConsulConfiguration`. In this
scenario, Micronaut will fail to build the application context because
it won't be able to wire a `DiscoveryClientConfiguration` candidate in
`ConsulServiceInstanceList` when there's more than one bean of that type.