### PR TITLE
Fixed issue when running from .jar file with view/handlebars.

### DIFF
--- a/views/src/main/java/io/micronaut/views/handlebars/HandlebarsViewsRenderer.java
+++ b/views/src/main/java/io/micronaut/views/handlebars/HandlebarsViewsRenderer.java
@@ -95,8 +95,8 @@ public class HandlebarsViewsRenderer implements ViewsRenderer {
         if (viewsConfiguration.getFolder() != null) {
             sb.append(viewsConfiguration.getFolder());
         }
-        sb.append(FILE_SEPARATOR);
-        sb.append(name.replace("/", FILE_SEPARATOR));
+        sb.append("/");
+        sb.append(name);
         int index = sb.indexOf(extension());
         if (index != -1) {
             return sb.substring(0, index);


### PR DESCRIPTION
When running an application from the .jar file, the views are not found.  This results in nothing returned and a 404 HTTP error.  Tested manually with micronaut 1.0.0 issue on Windows 7, JDK 1.8.0_191 using the gradle build command:  'gradlew distZip'.  Let me know if I should log a bug for this issue. 

I switched to using only forward slash (/), which seems to work with .jar files and folder-based execution.  

Tested the fix manually on Linux and Windows.  I could not find a way to automate the tests to run from a .jar file.