### PR TITLE
Resolve issue with security-session putting user details in the session

### DIFF
--- a/security-session/src/main/java/io/micronaut/security/session/SessionLoginHandler.java
+++ b/security-session/src/main/java/io/micronaut/security/session/SessionLoginHandler.java
@@ -20,6 +20,7 @@ import io.micronaut.core.convert.value.MutableConvertibleValues;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.security.authentication.AuthenticationFailed;
+import io.micronaut.security.authentication.AuthenticationUserDetailsAdapter;
 import io.micronaut.security.authentication.UserDetails;
 import io.micronaut.security.handlers.LoginHandler;
 import io.micronaut.security.filters.SecurityFilter;
@@ -57,7 +58,7 @@ public class SessionLoginHandler implements LoginHandler {
     @Override
     public HttpResponse loginSuccess(UserDetails userDetails, HttpRequest<?> request) {
         Session session = findSession(request);
-        session.put(SecurityFilter.AUTHENTICATION, userDetails);
+        session.put(SecurityFilter.AUTHENTICATION, new AuthenticationUserDetailsAdapter(userDetails));
         try {
             URI location = new URI(securitySessionConfiguration.getLoginSuccessTargetUrl());
             return HttpResponse.seeOther(location);

--- a/security/src/main/java/io/micronaut/security/authentication/DefaultAuthentication.java
+++ b/security/src/main/java/io/micronaut/security/authentication/DefaultAuthentication.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017-2018 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.security.authentication;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.concurrent.Immutable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A default implementation of the Authentication interface.
+ *
+ * @author James Kleeh
+ * @since 1.0.1
+ */
+@Immutable
+public class DefaultAuthentication implements Authentication {
+
+    private final String name;
+    private final Map<String, Object> attributes;
+
+    /**
+     *
+     * @param name The name of the authentication
+     * @param attributes The attributes for the authentication
+     */
+    @JsonCreator
+    public DefaultAuthentication(@JsonProperty("name") String name,
+                                 @JsonProperty("attributes") Map<String, Object> attributes) {
+        this.name = name;
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return new HashMap<>(attributes);
+    }
+}

--- a/security/src/main/java/io/micronaut/security/authentication/PrincipalArgumentBinder.java
+++ b/security/src/main/java/io/micronaut/security/authentication/PrincipalArgumentBinder.java
@@ -49,7 +49,7 @@ public class PrincipalArgumentBinder implements TypedRequestArgumentBinder<Princ
             MutableConvertibleValues<Object> attrs = source.getAttributes();
             Optional<Authentication> existing = attrs.get(SecurityFilter.AUTHENTICATION, Authentication.class);
             if (existing.isPresent()) {
-                return () -> existing.map(e -> (Principal) e::getName);
+                return () -> existing.map(Principal.class::cast);
             }
         }
 

--- a/security/src/main/java/io/micronaut/security/authentication/jackson/SecurityJacksonModule.java
+++ b/security/src/main/java/io/micronaut/security/authentication/jackson/SecurityJacksonModule.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017-2018 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.security.authentication.jackson;
+
+import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import io.micronaut.security.authentication.Authentication;
+import io.micronaut.security.authentication.DefaultAuthentication;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Singleton;
+
+/**
+ * A module to extend Jackson for security related classes.
+ *
+ * @author James Kleeh
+ * @since 1.0
+ */
+@Singleton
+public class SecurityJacksonModule extends SimpleModule {
+
+    /**
+     * Default constructor.
+     */
+    public SecurityJacksonModule() {
+        super("micronaut.security");
+    }
+
+    @PostConstruct
+    protected void customize() {
+        SimpleAbstractTypeResolver resolver = new SimpleAbstractTypeResolver();
+        resolver.addMapping(Authentication.class, DefaultAuthentication.class);
+        this.setAbstractTypes(resolver);
+    }
+}


### PR DESCRIPTION
The initial concern is that the UserDetails object was being put into the session. Given that the default implementation is in memory, and the only external implementation didn't work, I think the risk of causing issues with existing session data is low. The only way that would happen is if the user implemented their own external session store that uses serialization.