### PR TITLE
Fixing EventListenerSpec

### DIFF
--- a/spring/src/test/groovy/io/micronaut/spring/tx/EventListenerSpec.groovy
+++ b/spring/src/test/groovy/io/micronaut/spring/tx/EventListenerSpec.groovy
@@ -8,6 +8,7 @@ class EventListenerSpec extends Specification {
     void "test a transactional event listener is invoked once"() {
         given:
         ApplicationContext ctx = ApplicationContext.run()
+        ctx.publishEvent(new FakeEvent())
 
         when:
         TransactionalListener t = ctx.getBean(TransactionalListener)

--- a/spring/src/test/groovy/io/micronaut/spring/tx/FakeEvent.groovy
+++ b/spring/src/test/groovy/io/micronaut/spring/tx/FakeEvent.groovy
@@ -1,0 +1,5 @@
+package io.micronaut.spring.tx
+
+class FakeEvent {
+
+}

--- a/spring/src/test/groovy/io/micronaut/spring/tx/TransactionalListener.java
+++ b/spring/src/test/groovy/io/micronaut/spring/tx/TransactionalListener.java
@@ -1,32 +1,20 @@
 package io.micronaut.spring.tx;
 
-import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.event.ApplicationEventListener;
-import io.micronaut.context.event.StartupEvent;
-import io.micronaut.scheduling.annotation.Async;
 import io.micronaut.spring.tx.annotation.Transactional;
 
 import javax.inject.Singleton;
 
 @Singleton
-public class TransactionalListener implements ApplicationEventListener<StartupEvent> {
+public class TransactionalListener implements ApplicationEventListener<FakeEvent> {
 
     private static int invokeCount = 0;
 
-    public TransactionalListener(ApplicationContext ctx) {
-
-    }
-
     @Override
     @Transactional
-    public void onApplicationEvent(StartupEvent event) {
+    public void onApplicationEvent(FakeEvent event) {
         invokeCount++;
         System.out.println("Hello");
-    }
-
-    @Async
-    void asyncMethod() {
-
     }
 
     public int invokeCount() {


### PR DESCRIPTION
Tackling #919 and now `EventListenerSpec` is agnostic of `StartupEvent` by making it rely on a custom event instead.