### PR TITLE
Uri template helper constructor

### DIFF
--- a/http/src/main/java/io/micronaut/http/uri/UriTemplate.java
+++ b/http/src/main/java/io/micronaut/http/uri/UriTemplate.java
@@ -93,11 +93,11 @@ public class UriTemplate implements Comparable<UriTemplate> {
      *
      * @param baseUrl Base Url
      * @param queryParameters Query Parameters
-     * @param skipEmpty If true for a map such as [offset: 0, max: 10, empty: ''], keys will be consider [offset, max]
+     * @param skipEmptyKeys If true for a map such as [offset: 0, max: 10, empty: ''], keys will be consider [offset, max]
      */
-    public UriTemplate(@Nonnull CharSequence baseUrl, @Nonnull Map<String, Object> queryParameters, boolean skipEmpty) {
+    public UriTemplate(@Nonnull CharSequence baseUrl, @Nonnull Map<String, Object> queryParameters, boolean skipEmptyKeys) {
         this(baseUrl, queryParameters.keySet().stream().filter(queryParam -> {
-            if (skipEmpty) {
+            if (skipEmptyKeys) {
                 Object value = queryParameters.get(queryParam);
                 if (value == null) {
                     return false;
@@ -243,6 +243,20 @@ public class UriTemplate implements Comparable<UriTemplate> {
      */
     public String expand(Object bean) {
         return expand(BeanMap.of(bean));
+    }
+
+    /**
+     *
+     * Expand a base url with a list of query parameters.
+     * e.g. ('http://localhost',[offset: 0, max: 10, empty: ''], true) expands to 'http://example.com:8080/?x=1024&y=768'
+     *
+     * @param baseUrl The Base Url
+     * @param queryParameters URL query parameters
+     * @param skipEmptyKeys If true for a map such as [offset: 0, max: 10, empty: ''], keys will be consider [offset, max]
+     * @return The expanded URI.
+     */
+    public static String expand(String baseUrl, Map<String, Object> queryParameters, boolean skipEmptyKeys) {
+        return new UriTemplate(baseUrl, queryParameters, skipEmptyKeys).expand(queryParameters);
     }
 
     @Override

--- a/http/src/test/groovy/io/micronaut/http/uri/UriTemplateSpec.groovy
+++ b/http/src/test/groovy/io/micronaut/http/uri/UriTemplateSpec.groovy
@@ -505,4 +505,19 @@ class UriTemplateSpec extends Specification {
         'http://example.com:8080/{&keys}'             | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | 'http://example.com:8080/&keys=semi,%3B,dot,.,comma,%2C'
         'http://example.com:8080/{&keys*}'            | [keys: ['semi': ';', 'dot': '.', comma: ',']]      | 'http://example.com:8080/&semi=%3B&dot=.&comma=%2C'
     }
+
+    @Unroll("new UriTemplate(http://example.com:8080,#m, #skipEmpty) => #expected")
+    def "verify new UriTemplate(http://localhost,[offset: 0, max: 10]) is equivalent to new UriTemplate(http://localhost?{offset,max})"() {
+        when:
+        String result = new UriTemplate('http://example.com:8080/', m as Map<String, Object>,  skipEmpty).expand(m)
+
+        then:
+        result == expected
+
+        where:
+        m                               | skipEmpty | expected
+        [x: 1024, y: 768, empty: '']    | false     | 'http://example.com:8080/?x=1024&y=768&empty='
+        [x: 1024, y: 768, empty: '']    | true      | 'http://example.com:8080/?x=1024&y=768'
+        [:]                             | true      | 'http://example.com:8080'
+    }
 }

--- a/http/src/test/groovy/io/micronaut/http/uri/UriTemplateSpec.groovy
+++ b/http/src/test/groovy/io/micronaut/http/uri/UriTemplateSpec.groovy
@@ -509,15 +509,18 @@ class UriTemplateSpec extends Specification {
     @Unroll("new UriTemplate(http://example.com:8080,#m, #skipEmpty) => #expected")
     def "verify new UriTemplate(http://localhost,[offset: 0, max: 10]) is equivalent to new UriTemplate(http://localhost?{offset,max})"() {
         when:
-        String result = new UriTemplate('http://example.com:8080/', m as Map<String, Object>,  skipEmpty).expand(m)
+        String result = new UriTemplate(baseUrl, m as Map<String, Object>,  skipEmpty).expand(m)
 
         then:
         result == expected
 
+        and:
+        UriTemplate.expand(baseUrl, m, skipEmpty) == expected
+
         where:
-        m                               | skipEmpty | expected
-        [x: 1024, y: 768, empty: '']    | false     | 'http://example.com:8080/?x=1024&y=768&empty='
-        [x: 1024, y: 768, empty: '']    | true      | 'http://example.com:8080/?x=1024&y=768'
-        [:]                             | true      | 'http://example.com:8080'
+        baseUrl                    | m                               | skipEmpty | expected
+        'http://example.com:8080/' | [x: 1024, y: 768, empty: '']    | false     | 'http://example.com:8080/?x=1024&y=768&empty='
+        'http://example.com:8080/' | [x: 1024, y: 768, empty: '']    | true      | 'http://example.com:8080/?x=1024&y=768'
+        'http://example.com:8080/' | [:]                             | true      | 'http://example.com:8080'
     }
 }


### PR DESCRIPTION
Provides another constructor so that you can invoke 

```groovy
def skipEmpty = true
new UriTemplate('http://localhost',[offset: 0, max: 10, empty: ''], skipEmpty)
```

equivalent to `new UriTemplate('http://localhost?{offset,max}')`

and a static method so that you can do:

`UriTemplate.expand('http://localhost',[offset: 0, max: 10, , empty: ''], skipEmpty) == 'http:localhost:8080?offset=0&max=10'`