### PR TITLE
Add more functionality to JwtTokenValidator

### DIFF
--- a/security-jwt/src/main/java/io/micronaut/security/token/jwt/validator/ExpirationJwtClaimsValidator.java
+++ b/security-jwt/src/main/java/io/micronaut/security/token/jwt/validator/ExpirationJwtClaimsValidator.java
@@ -33,7 +33,7 @@ import java.util.Date;
  */
 @Singleton
 @Requires(property = JwtClaimsValidator.PREFIX + ".expiration", notEquals = StringUtils.FALSE)
-public class ExpirationJwtClaimsValidator implements JwtClaimsValidator {
+public class ExpirationJwtClaimsValidator implements GenericJwtClaimsValidator {
 
     private static final Logger LOG = LoggerFactory.getLogger(ExpirationJwtClaimsValidator.class);
 

--- a/security-jwt/src/main/java/io/micronaut/security/token/jwt/validator/GenericJwtClaimsValidator.java
+++ b/security-jwt/src/main/java/io/micronaut/security/token/jwt/validator/GenericJwtClaimsValidator.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017-2018 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.security.token.jwt.validator;
+
+/**
+ * Any {@link JwtTokenValidator} which should be verified for any JWT should implement this interface.
+ *
+ * @author Sergio del Amo
+ * @since 1.1.0
+ */
+public interface GenericJwtClaimsValidator extends JwtClaimsValidator {
+}

--- a/security-jwt/src/main/java/io/micronaut/security/token/jwt/validator/JwtTokenValidator.java
+++ b/security-jwt/src/main/java/io/micronaut/security/token/jwt/validator/JwtTokenValidator.java
@@ -43,6 +43,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * @see <a href="https://connect2id.com/products/nimbus-jose-jwt/examples/validating-jwt-access-tokens">Validating JWT Access Tokens</a>
@@ -57,22 +58,22 @@ public class JwtTokenValidator implements TokenValidator {
 
     protected final List<SignatureConfiguration> signatureConfigurations = new ArrayList<>();
     protected final List<EncryptionConfiguration> encryptionConfigurations = new ArrayList<>();
-    protected final List<JwtClaimsValidator> jwtClaimsValidators = new ArrayList<>();
+    protected final List<GenericJwtClaimsValidator> genericJwtClaimsValidators = new ArrayList<>();
 
     /**
      * Constructor.
      *
      * @param signatureConfigurations List of Signature configurations which are used to attempt validation.
      * @param encryptionConfigurations List of Encryption configurations which are used to attempt validation.
-     * @param jwtClaimsValidators JWT Claims validators.
+     * @param genericJwtClaimsValidators Generic JWT Claims validators which should be used to validate any JWT.
      */
     @Inject
     public JwtTokenValidator(Collection<SignatureConfiguration> signatureConfigurations,
                              Collection<EncryptionConfiguration> encryptionConfigurations,
-                             Collection<JwtClaimsValidator> jwtClaimsValidators) {
+                             Collection<GenericJwtClaimsValidator> genericJwtClaimsValidators) {
         this.signatureConfigurations.addAll(signatureConfigurations);
         this.encryptionConfigurations.addAll(encryptionConfigurations);
-        this.jwtClaimsValidators.addAll(jwtClaimsValidators);
+        this.genericJwtClaimsValidators.addAll(genericJwtClaimsValidators);
     }
 
     /**
@@ -91,41 +92,35 @@ public class JwtTokenValidator implements TokenValidator {
                 Collections.singleton(new ExpirationJwtClaimsValidator()));
     }
 
+
+
     /**
-     *
+     * Validates the Signature of a plain JWT.
      * @param jwt a JWT Token
-     * @return an Authentication if validation was successful or empty if not.
-     * @throws ParseException it may throw a ParseException while retrieving the JWT claims
+     * @return empty if signature configurations exists, Optional.of(jwt) if no signature configuration is available.
      */
-    protected Publisher<Authentication> validatePlainJWT(JWT jwt) throws ParseException {
+    protected Optional<JWT> validatePlainJWTSignature(JWT jwt) {
         if (signatureConfigurations.isEmpty()) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("JWT is not signed and no signature configurations -> verified");
             }
+            return Optional.of(jwt);
         } else {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("A non-signed JWT cannot be accepted as signature configurations have been defined");
             }
-            return Flowable.empty();
+            return Optional.empty();
         }
-        if (!verifyClaims(jwt.getJWTClaimsSet())) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("JWT Claims verification failed: {}", jwt.getJWTClaimsSet().toString());
-            }
-            return Flowable.empty();
-        }
-        return createAuthentication(jwt);
     }
 
     /**
      *
-     * Validates a Signed JWT.
+     * Validates a Signed JWT signature.
      *
      * @param signedJWT a Signed JWT Token
-     * @return an Authentication if validation was successful or empty if not.
-     * @throws ParseException it may throw a ParseException while retrieving the JWT claims
+     * @return empty if signature validation fails
      */
-    protected  Publisher<Authentication> validateSignedJWT(SignedJWT signedJWT) throws ParseException {
+    protected  Optional<JWT> validateSignedJWTSignature(SignedJWT signedJWT) {
         if (LOG.isDebugEnabled()) {
             LOG.debug("JWT is signed");
         }
@@ -138,14 +133,7 @@ public class JwtTokenValidator implements TokenValidator {
                 }
                 try {
                     if (config.verify(signedJWT)) {
-                        if (verifyClaims(signedJWT.getJWTClaimsSet())) {
-                            return createAuthentication(signedJWT);
-                        } else {
-                            if (LOG.isDebugEnabled()) {
-                                LOG.debug("JWT Claims verification failed: {}", signedJWT.getJWTClaimsSet().toString());
-                            }
-                        }
-
+                        return Optional.of(signedJWT);
                     } else {
                         if (LOG.isDebugEnabled()) {
                             LOG.debug("JWT Signature verification failed: {}", signedJWT.getParsedString());
@@ -165,7 +153,7 @@ public class JwtTokenValidator implements TokenValidator {
         if (LOG.isDebugEnabled()) {
             LOG.debug("No signature algorithm found for JWT: {}", signedJWT.getParsedString());
         }
-        return Flowable.empty();
+        return Optional.empty();
     }
 
     /**
@@ -173,21 +161,20 @@ public class JwtTokenValidator implements TokenValidator {
      * @param jwtClaimsSet JWT Claims.
      * @return Whether the JWT claims pass every validation.
      */
-    protected boolean verifyClaims(JWTClaimsSet jwtClaimsSet) {
-        return this.jwtClaimsValidators.stream()
+    protected boolean verifyClaims(JWTClaimsSet jwtClaimsSet, Collection<? extends JwtClaimsValidator> claimsValidators) {
+        return claimsValidators.stream()
                 .allMatch(jwtClaimsValidator -> jwtClaimsValidator.validate(jwtClaimsSet));
     }
 
     /**
      *
-     * Validates a encrypted JWT.
+     * Validates a encrypted JWT Signature.
      *
      * @param encryptedJWT a encrytped JWT Token
      * @param token the JWT token as String
-     * @return an Authentication if validation was successful or empty if not.
-     * @throws ParseException it may throw a ParseException while retrieving the JWT claims
+     * @return empty if signature validation fails
      */
-    protected Publisher<Authentication> validateEncryptedJWT(EncryptedJWT encryptedJWT, String token) throws ParseException  {
+    protected Optional<JWT> validateEncryptedJWTSignature(EncryptedJWT encryptedJWT, String token) {
         if (LOG.isDebugEnabled()) {
             LOG.debug("JWT is encrypted");
         }
@@ -207,9 +194,9 @@ public class JwtTokenValidator implements TokenValidator {
                         if (LOG.isDebugEnabled()) {
                             LOG.debug("encrypted JWT could couldn't be converted to a signed JWT.");
                         }
-                        return Flowable.empty();
+                        return Optional.empty();
                     }
-                    return validateSignedJWT(signedJWT);
+                    return validateSignedJWTSignature(signedJWT);
 
                 } catch (final JOSEException e) {
                     if (LOG.isDebugEnabled()) {
@@ -221,48 +208,104 @@ public class JwtTokenValidator implements TokenValidator {
         if (LOG.isDebugEnabled()) {
             LOG.debug("No encryption algorithm found for JWT: {}", token);
         }
-        return Flowable.empty();
+        return Optional.empty();
     }
 
     /**
      *
      * @param token The token string.
-     * @return The authentication or empty if the validation fails.
+     * @return Publishes {@link Authentication} based on the JWT or empty if the validation fails.
      */
     @Override
     public Publisher<Authentication> validateToken(String token) {
+        Optional<Authentication> authentication = authenticationIfValidJwtSignatureAndClaims(token, genericJwtClaimsValidators);
+        if (authentication.isPresent()) {
+            return Flowable.just(authentication.get());
+        }
+        return Flowable.empty();
+    }
+
+    /**
+     * Authentication if JWT has valid signature and claims are verified.
+     *
+     * @param token A JWT token
+     * @param claimsValidators a Collection of claims Validators.
+     * @return empty if signature or claims verification failed, An Authentication otherwise.
+     */
+    public Optional<Authentication> authenticationIfValidJwtSignatureAndClaims(String token, Collection<? extends JwtClaimsValidator> claimsValidators) {
+        Optional<JWT> jwt = validateJwtSignatureAndClaims(token, claimsValidators);
+        if (jwt.isPresent()) {
+            try {
+                return Optional.of(createAuthentication(jwt.get()));
+            } catch (ParseException e) {
+                if (LOG.isErrorEnabled()) {
+                    LOG.error("ParseException creating authentication", e.getMessage());
+                }
+            }
+        }
+        return Optional.empty();
+
+    }
+    /**
+     * Validates JWT signature and Claims
+     *
+     * @param token A JWT token
+     * @param claimsValidators a Collection of claims Validators.
+     * @return empty if signature or claims verification failed, JWT otherwise.
+     */
+    public Optional<JWT> validateJwtSignatureAndClaims(String token, Collection<? extends JwtClaimsValidator> claimsValidators) {
+        Optional<JWT> jwt = parseJwtIfValidSignature(token);
+        if (jwt.isPresent()) {
+            try {
+                if (verifyClaims(jwt.get().getJWTClaimsSet(), claimsValidators)) {
+                    return jwt;
+                }
+            } catch (ParseException e) {
+                if (LOG.isErrorEnabled()) {
+                    LOG.error("ParseException creating authentication", e.getMessage());
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Retuns a JWT if the signature could be verified.
+     * @param token a JWT token
+     * @return Empty if JWT signature verification failed or JWT if valid signature.
+     */
+    protected Optional<JWT> parseJwtIfValidSignature(String token) {
         try {
             JWT jwt = JWTParser.parse(token);
 
             if (jwt instanceof PlainJWT) {
-                return validatePlainJWT(jwt);
+                return validatePlainJWTSignature(jwt);
 
             } else if (jwt instanceof EncryptedJWT) {
                 final EncryptedJWT encryptedJWT = (EncryptedJWT) jwt;
-                return validateEncryptedJWT(encryptedJWT, token);
+                return validateEncryptedJWTSignature(encryptedJWT, token);
 
             } else if (jwt instanceof SignedJWT) {
                 final SignedJWT signedJWT = (SignedJWT) jwt;
-                return validateSignedJWT(signedJWT);
+                return validateSignedJWTSignature(signedJWT);
             }
 
         } catch (final ParseException e) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Cannot decrypt / verify JWT: {}", e.getMessage());
+            if (LOG.isErrorEnabled()) {
+                LOG.error("Cannot decrypt / verify JWT: {}", e.getMessage());
             }
         }
-
-        return Flowable.empty();
+        return Optional.empty();
     }
 
     /**
      *
      * @param jwt a JWT token
-     * @return Publishes a {@link Authentication} based on the JWT.
+     * @return {@link Authentication} based on the JWT.
      * @throws ParseException it may throw a ParseException while retrieving the JWT claims
      */
-    protected Publisher<Authentication> createAuthentication(final JWT jwt) throws ParseException {
+    protected Authentication createAuthentication(final JWT jwt) throws ParseException {
         final JWTClaimsSet claimSet = jwt.getJWTClaimsSet();
-        return Flowable.just(new AuthenticationJWTClaimsSetAdapter(claimSet));
+        return new AuthenticationJWTClaimsSetAdapter(claimSet);
     }
 }

--- a/security-jwt/src/main/java/io/micronaut/security/token/jwt/validator/SubjectNotNullJwtClaimsValidator.java
+++ b/security-jwt/src/main/java/io/micronaut/security/token/jwt/validator/SubjectNotNullJwtClaimsValidator.java
@@ -32,7 +32,7 @@ import javax.inject.Singleton;
  */
 @Singleton
 @Requires(property = JwtClaimsValidator.PREFIX + ".subject-not-null", notEquals = StringUtils.FALSE)
-public class SubjectNotNullJwtClaimsValidator implements JwtClaimsValidator {
+public class SubjectNotNullJwtClaimsValidator implements GenericJwtClaimsValidator {
 
     private static final Logger LOG = LoggerFactory.getLogger(SubjectNotNullJwtClaimsValidator.class);
 


### PR DESCRIPTION
Note, this is not a breaking change. JWTValidator only had a public method. 

https://github.com/micronaut-projects/micronaut-core/blob/1.0.x/security-jwt/src/main/java/io/micronaut/security/token/jwt/validator/JwtTokenValidator.java

`    public Publisher<Authentication> validateToken(String token) {`

which is still in place. 

This PR adds a couple of public methods: 

`    public Optional<Authentication> authenticationIfValidJwtSignatureAndClaims(String token, Collection<? extends JwtClaimsValidator> claimsValidators)`

and:

` public Optional<JWT> validateJwtSignatureAndClaims(String token, Collection<? extends JwtClaimsValidator> claimsValidators) {`

which can be used to validate a particular JWT which needs extra Claims validations. For example, in an Open ID connect ID Token validation

I have created an interface with named `GenericJwtClaimsValidator` which should be always validated. E.g. expiration time or subject not null. 

That is not a breaking change either since those classes do not exist in 1.0.x

In case some of those generic JWT validations are not desired the user can turn them off. 

e.g. 

`micronaut.security.token.jwt..claims-validators.expiration: false`

