### PR TITLE
Fix compilation issue with Eclipse APT implementation

### DIFF
--- a/inject/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -83,11 +83,21 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
      */
     public AnnotationMetadata build(T element) {
         DefaultAnnotationMetadata annotationMetadata = new DefaultAnnotationMetadata();
-        AnnotationMetadata metadata = buildInternal(null, element, annotationMetadata, true);
-        if (metadata.isEmpty()) {
-            return AnnotationMetadata.EMPTY_METADATA;
+
+        try {
+            AnnotationMetadata metadata = buildInternal(null, element, annotationMetadata, true);
+            if (metadata.isEmpty()) {
+                return AnnotationMetadata.EMPTY_METADATA;
+            }
+            return metadata;
+        } catch(RuntimeException e) {
+            if("org.eclipse.jdt.internal.compiler.problem.AbortCompilation".equals(e.getClass().getName())) {
+                // workaround for a bug in the Eclipse APT implementation. See bug 541466 on their Bugzilla.
+                return AnnotationMetadata.EMPTY_METADATA;
+            } else {
+                throw e;
+            }
         }
-        return metadata;
     }
 
     /**


### PR DESCRIPTION
Fix https://github.com/micronaut-projects/micronaut-test/issues/

Original issue: https://github.com/redhat-developer/vscode-java/issues/693

Workarround until https://bugs.eclipse.org/bugs/show_bug.cgi?id=541466 is fixed.

This should work for any JVM based language since I fixed it in `inject` directly instead of `inject-java`.

# Reproduction

from @graemerocher reproduction in original issue

With VS code and [Java Extension Pack](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-pack) extension installed

* Clone the repo https://github.com/micronaut-projects/micronaut-examples
* cd hello-world-java
* Remove the build.gradle (so that VSC uses the pom.xml)
* Run code .
* Run any test from VS Code

Observation: the test has been skipped

# Acceptance test

* Clone this repo
* Run `./gradlew pTML` from the created folder
* Go back to VS Code on hello-world-java
* Replace in the hello-world-java's `pom.xml` the micronaut-core version by `1.1.0.BUILD-SNAPSHOT` and save
* Run any test from VS Code

The test should be executed and should be OK.

As usual, I'll be happy to receive any criticism.
I could add some tests for validating that:
* An exception having the same package and class name will be ignored
* Any other exception will be thrown as usual

I found it to be overkill.

I also can add a comment `TODO(any): remove this workarround when the issue is fixed on Eclipse side` since it should be only temporary.

Just let me know, or feel free to edit it yourself 👍.
Thank you for your review !