### PR TITLE
Fix so that specified environments will be logged and be the highest …

### DIFF
--- a/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
+++ b/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
@@ -122,20 +122,24 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
     @SuppressWarnings("MagicNumber")
     public DefaultEnvironment(ClassPathResourceLoader resourceLoader, ConversionService conversionService, String... names) {
         super(conversionService);
-        Set<String> specifiedNames = new LinkedHashSet<>(3);
-        specifiedNames.addAll(Arrays.asList(names));
+        Set<String> environments = new LinkedHashSet<>(3);
+        List<String> specifiedNames = Arrays.asList(names);
 
         if (!specifiedNames.contains(Environment.FUNCTION) && shouldDeduceEnvironments()) {
             EnvironmentsAndPackage environmentsAndPackage = getEnvironmentsAndPackage();
-            specifiedNames.addAll(environmentsAndPackage.enviroments);
+            environments.addAll(environmentsAndPackage.enviroments);
             String aPackage = environmentsAndPackage.aPackage;
             if (aPackage != null) {
                 packages.add(aPackage);
             }
         }
+        environments.addAll(specifiedNames);
 
         this.classLoader = resourceLoader.getClassLoader();
-        this.names = specifiedNames;
+        this.names = environments;
+        if (LOG.isInfoEnabled() && !environments.isEmpty()) {
+            LOG.info("Established active environments: {}", environments);
+        }
         conversionService.addConverter(
             CharSequence.class, Class.class, new StringToClassConverter(classLoader)
         );
@@ -617,10 +621,6 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
             .flatMap(s -> Arrays.stream(s.split(",")))
             .map(String::trim)
             .forEach(environments::add);
-
-        if (LOG.isInfoEnabled() && !environments.isEmpty()) {
-            LOG.info("Established active environments: {}", environments);
-        }
 
         return environmentsAndPackage;
     }

--- a/inject/src/test/groovy/io/micronaut/context/env/DefaultEnvironmentSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/env/DefaultEnvironmentSpec.groovy
@@ -296,7 +296,7 @@ class DefaultEnvironmentSpec extends Specification {
         def envNames = env.getActiveNames().toList()
 
         then: "env names should be in the same order as defined in micronaut.environment variable, with test env first"
-        envNames == ["x", "y", "test", "cloud", "ec2", "foo", "bar", "baz"]
+        envNames == ["test", "cloud", "ec2", "foo", "bar", "baz", "x", "y"]
     }
 
     @RestoreSystemProperties

--- a/inject/src/test/groovy/io/micronaut/context/env/DefaultEnvironmentSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/env/DefaultEnvironmentSpec.groovy
@@ -299,6 +299,35 @@ class DefaultEnvironmentSpec extends Specification {
         envNames == ["x", "y", "test", "cloud", "ec2", "foo", "bar", "baz"]
     }
 
+    @RestoreSystemProperties
+    void "test environments supplied should be a higher priority than deduced and system property"() {
+        when:
+        def env = new DefaultEnvironment()
+
+        then:
+        env.activeNames.size() == 1
+        env.activeNames[0] == "test"
+
+        when:
+        env = new DefaultEnvironment("explicit")
+
+        then:
+        env.activeNames.size() == 2
+        env.activeNames[0] == "test"
+        env.activeNames[1] == "explicit"
+
+        when:
+        System.setProperty("micronaut.environments", "system,property")
+        env = new DefaultEnvironment("explicit")
+
+        then:
+        env.activeNames.size() == 4
+        env.activeNames[0] == "test"
+        env.activeNames[1] == "system"
+        env.activeNames[2] == "property"
+        env.activeNames[3] == "explicit"
+    }
+
     private static Environment startEnv(String files) {
         new DefaultEnvironment("test") {
             protected String readPropertySourceListKeyFromEnvironment() {


### PR DESCRIPTION
Environments explicitly passed to the context builder should have a higher priority than deduced or system property environments. Also the current log statement doesn't take the explicit environments into account

This could be considered a breaking change, however I doubt anyone would expect the current behavior. If you think this should be delayed until 2.0.0, that is OK too