### PR TITLE
Add support to Freemarker views

### DIFF
--- a/src/main/docs/guide/httpServer/views/freemarker.adoc
+++ b/src/main/docs/guide/httpServer/views/freemarker.adoc
@@ -1,0 +1,21 @@
+Micronaut includes api:views.freemarker.FreemarkerViewsRenderer[] which uses
+the https://freemarker.apache.org[Apache Freemarker] Java-based template engine.
+
+In addition to the <<views, Views>> dependency, add the following dependency on your classpath.
+
+dependency:freemarker[groupsId="org.freemarker",scope="runtime",version="2.3.28"]
+
+Freemarker integration instantiates a freemarker https://freemarker.apache.org/docs/api/freemarker/template/Configuration.html[`Configuration`].
+
+All configurable properties are extracted from https://freemarker.apache.org/docs/api/freemarker/template/Configuration.html[`Configuration`] and
+https://freemarker.apache.org/docs/api/freemarker/core/Configurable.html[`Configurable`]. All Freemarker properties names are reused in the micronaut configuration.
+
+If a value is not declared and is null, the default configuration from Freemarker is used. The expected format of each value is the same from Freemarker, and no conversion or validation is done by Micronaut. You can find in https://freemarker.apache.org/docs/pgui_config.html[Freemarker documentation] how to configure each one.
+
+The example shown in the <<views, Views>> section, could be rendered with the following Freemarker template:
+
+[source,html]
+.src/main/resources/views/home.ftl
+----
+include::{testsviews}/../../../../resources/views/home.ftl[]
+----

--- a/src/main/docs/guide/httpServer/views/freemarker.adoc
+++ b/src/main/docs/guide/httpServer/views/freemarker.adoc
@@ -3,14 +3,7 @@ the https://freemarker.apache.org[Apache Freemarker] Java-based template engine.
 
 In addition to the <<views, Views>> dependency, add the following dependency on your classpath.
 
-dependency:freemarker[groupsId="org.freemarker",scope="runtime",version="2.3.28"]
-
-Freemarker integration instantiates a freemarker https://freemarker.apache.org/docs/api/freemarker/template/Configuration.html[`Configuration`].
-
-All configurable properties are extracted from https://freemarker.apache.org/docs/api/freemarker/template/Configuration.html[`Configuration`] and
-https://freemarker.apache.org/docs/api/freemarker/core/Configurable.html[`Configurable`]. All Freemarker properties names are reused in the micronaut configuration.
-
-If a value is not declared and is null, the default configuration from Freemarker is used. The expected format of each value is the same from Freemarker, and no conversion or validation is done by Micronaut. You can find in https://freemarker.apache.org/docs/pgui_config.html[Freemarker documentation] how to configure each one.
+dependency:freemarker[groupId="org.freemarker",scope="runtime",version="2.3.28"]
 
 The example shown in the <<views, Views>> section, could be rendered with the following Freemarker template:
 
@@ -19,3 +12,10 @@ The example shown in the <<views, Views>> section, could be rendered with the fo
 ----
 include::{testsviews}/../../../../resources/views/home.ftl[]
 ----
+
+Freemarker integration instantiates a freemarker https://freemarker.apache.org/docs/api/freemarker/template/Configuration.html[`Configuration`].
+
+All configurable properties are extracted from https://freemarker.apache.org/docs/api/freemarker/template/Configuration.html[`Configuration`] and
+https://freemarker.apache.org/docs/api/freemarker/core/Configurable.html[`Configurable`], and properties names are reused in the micronaut configuration.
+
+If a value is not declared and is null, the default configuration from Freemarker is used. The expected format of each value is the same from Freemarker, and no conversion or validation is done by Micronaut. You can find in https://freemarker.apache.org/docs/pgui_config.html[Freemarker documentation] how to configure each one.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -101,6 +101,7 @@ httpServer:
     thymeleaf: Thymeleaf
     handlebars: Handlebars.java
     velocity: Apache Velocity
+    freemarker: Apache Freemarker
   openapi: OpenAPI / Swagger Support
 httpClient:
   title: The HTTP Client

--- a/views/build.gradle
+++ b/views/build.gradle
@@ -3,6 +3,7 @@ ext {
     velocityEngine = '2.0'
     handlebarsVersion='4.1.0'
     thymeleafVersion='3.0.9.RELEASE'
+    freemarkerVersion='2.3.28'
 }
 
 dependencies {
@@ -10,6 +11,7 @@ dependencies {
     compileOnly "org.apache.velocity:velocity-engine-core:$velocityEngine"
     compileOnly "com.github.jknack:handlebars:${handlebarsVersion}"
     compileOnly "org.thymeleaf:thymeleaf:$thymeleafVersion"
+    compileOnly "org.freemarker:freemarker:$freemarkerVersion"
     compileOnly project(":security")
 
     compile project(":runtime")
@@ -23,6 +25,7 @@ dependencies {
     testRuntime "org.apache.velocity:velocity-engine-core:$velocityEngine"
     testRuntime "com.github.jknack:handlebars:${handlebarsVersion}"
     testRuntime "org.thymeleaf:thymeleaf:$thymeleafVersion"
+    testRuntime "org.freemarker:freemarker:$freemarkerVersion"
 }
 
 bintray.pkg.name = "micronaut-views"

--- a/views/src/main/java/io/micronaut/views/freemarker/FreemarkerViewsRenderer.java
+++ b/views/src/main/java/io/micronaut/views/freemarker/FreemarkerViewsRenderer.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2017-2018 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.views.freemarker;
+
+import static freemarker.core.Configurable.*;
+import static freemarker.core.Configurable.AUTO_IMPORT_KEY;
+import static freemarker.core.Configurable.AUTO_INCLUDE_KEY;
+import static freemarker.template.Configuration.*;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.Supplier;
+
+import javax.annotation.Nullable;
+import javax.inject.Singleton;
+
+import freemarker.core.ParseException;
+import freemarker.template.Configuration;
+import freemarker.template.MalformedTemplateNameException;
+import freemarker.template.Template;
+import freemarker.template.TemplateException;
+import freemarker.template.Version;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.beans.BeanMap;
+import io.micronaut.core.io.Writable;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Produces;
+import io.micronaut.views.ViewsConfiguration;
+import io.micronaut.views.ViewsRenderer;
+import io.micronaut.views.exceptions.ViewRenderingException;
+
+/**
+ * Renders Views with with FreeMarker.
+ *
+ * @author Jerónimo López
+ * @see <a href= "https://freemarker.apache.org/">freemarker.apache.org</a>
+ * @since 1.0.2
+ */
+@Produces(MediaType.TEXT_HTML)
+@Requires(property = FreemarkerViewsRendererConfigurationProperties.PREFIX + ".enabled", notEquals = "false")
+@Requires(classes = Configuration.class)
+@Singleton
+public class FreemarkerViewsRenderer implements ViewsRenderer {
+
+    protected final ViewsConfiguration viewsConfiguration;
+    protected final FreemarkerViewsRendererConfiguration freemarkerMicronautConfiguration;
+    protected final Configuration freemarkerConfiguration;
+    protected final String extension;
+
+    /**
+     * @param viewsConfiguration               Views Configuration
+     * @param freemarkerMicronautConfiguration Freemarker Configuration
+     * @throws TemplateException               When template doesn't exist or can not be parsed
+     */
+    FreemarkerViewsRenderer(ViewsConfiguration viewsConfiguration,
+            FreemarkerViewsRendererConfiguration freemarkerMicronautConfiguration) throws TemplateException {
+        this.viewsConfiguration = viewsConfiguration;
+        this.freemarkerMicronautConfiguration = freemarkerMicronautConfiguration;
+        this.freemarkerConfiguration = createConfiguration(freemarkerMicronautConfiguration);
+        this.extension = extension(freemarkerMicronautConfiguration);
+    }
+
+    @Override
+    public Writable render(String view, @Nullable Object data) {
+        return (writer) -> {
+            Map<String, Object> context = context(data);
+            String viewName = viewName(view);
+            Template template = freemarkerConfiguration.getTemplate(viewName);
+            try {
+                template.process(context, writer);
+            } catch (TemplateException e) {
+                throw new ViewRenderingException(
+                        "Error rendering Freemarker view [" + viewName + "]: " + e.getMessage(), e);
+            }
+        };
+    }
+
+    @Override
+    public boolean exists(String view) {
+        try {
+            freemarkerConfiguration.getTemplate(viewName(view));
+        } catch (ParseException | MalformedTemplateNameException e) {
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
+        return true;
+    }
+
+    private Map<String, Object> context(@Nullable Object data) {
+        if (data == null) {
+            return new HashMap<>();
+        }
+        if (data instanceof Map) {
+            return (Map<String, Object>) data;
+        }
+        return BeanMap.of(data);
+    }
+
+    private String viewName(String name) {
+        if (!name.endsWith(extension)) {
+            return name + extension;
+        }
+        return name;
+    }
+
+    private String extension(FreemarkerViewsRendererConfiguration freemarkerMicronautConfiguration) {
+        return EXTENSION_SEPARATOR + freemarkerMicronautConfiguration.getDefaultExtension();
+    }
+
+    private Configuration createConfiguration(FreemarkerViewsRendererConfiguration micronautConfig)
+            throws TemplateException {
+        
+        Map<String, Supplier<String>> mapper = createConfigurationMapper(micronautConfig);
+        
+        String incompatibleImprovements = micronautConfig.getIncompatibleImprovements();
+        Version version = DEFAULT_INCOMPATIBLE_IMPROVEMENTS;
+        if (incompatibleImprovements != null) {
+            version = new Version(incompatibleImprovements);
+        }
+        Configuration freemarkerConfiguration = new Configuration(version);
+        freemarkerConfiguration.setClassForTemplateLoading(this.getClass(), "/" + viewsConfiguration.getFolder());
+
+        for (Entry<String, Supplier<String>> mapEntry : mapper.entrySet()) {
+            String value = mapEntry.getValue().get();
+            if (value != null) {
+                freemarkerConfiguration.setSetting(mapEntry.getKey(), value);
+            }
+        }
+        return freemarkerConfiguration;
+    }
+    
+    private Map<String, Supplier<String>> createConfigurationMapper(
+            FreemarkerViewsRendererConfiguration micronautConfig) {
+        Map<String, Supplier<String>> mapper = new HashMap<>();
+        mapper.put(LOCALE_KEY, micronautConfig::getLocale);
+        mapper.put(NUMBER_FORMAT_KEY, micronautConfig::getNumberFormat);
+        mapper.put(CUSTOM_NUMBER_FORMATS_KEY, micronautConfig::getCustomNumberFormats);
+        mapper.put(TIME_FORMAT_KEY, micronautConfig::getTimeFormat);
+        mapper.put(DATE_FORMAT_KEY, micronautConfig::getDateFormat);
+        mapper.put(CUSTOM_DATE_FORMATS_KEY, micronautConfig::getCustomDateFormats);
+        mapper.put(DATETIME_FORMAT_KEY, micronautConfig::getDatetimeFormat);
+        mapper.put(TIME_ZONE_KEY, micronautConfig::getTimeZone);
+        mapper.put(SQL_DATE_AND_TIME_TIME_ZONE_KEY, micronautConfig::getSqlDateAndTimeTimeZone);
+        mapper.put(CLASSIC_COMPATIBLE_KEY, micronautConfig::getClassicCompatible);
+        mapper.put(TEMPLATE_EXCEPTION_HANDLER_KEY, micronautConfig::getTemplateExceptionHandler);
+        mapper.put(ATTEMPT_EXCEPTION_REPORTER_KEY, micronautConfig::getAttemptExceptionReporter);
+        mapper.put(ARITHMETIC_ENGINE_KEY, micronautConfig::getArithmeticEngine);
+        mapper.put(OBJECT_WRAPPER_KEY, micronautConfig::getObjectWrapper);
+        mapper.put(BOOLEAN_FORMAT_KEY, micronautConfig::getBooleanFormat);
+        mapper.put(OUTPUT_ENCODING_KEY, micronautConfig::getOutputEncoding);
+        mapper.put(URL_ESCAPING_CHARSET_KEY, micronautConfig::getUrlEscapingCharset);
+        mapper.put(AUTO_FLUSH_KEY, micronautConfig::getAutoFlush);
+        mapper.put(NEW_BUILTIN_CLASS_RESOLVER_KEY, micronautConfig::getNewBuiltinClassResolver);
+        mapper.put(SHOW_ERROR_TIPS_KEY, micronautConfig::getShowErrorTips);
+        mapper.put(API_BUILTIN_ENABLED_KEY, micronautConfig::getApiBuiltinEnabled);
+        mapper.put(LOG_TEMPLATE_EXCEPTIONS_KEY, micronautConfig::getLogTemplateExceptions);
+        mapper.put(WRAP_UNCHECKED_EXCEPTIONS_KEY, micronautConfig::getWrapUncheckedExceptions);
+        mapper.put(LAZY_IMPORTS_KEY, micronautConfig::getLazyImports);
+        mapper.put(LAZY_AUTO_IMPORTS_KEY, micronautConfig::getLazyAutoImports);
+        mapper.put(AUTO_IMPORT_KEY, micronautConfig::getAutoImport);
+        mapper.put(AUTO_INCLUDE_KEY, micronautConfig::getAutoInclude);
+        mapper.put(DEFAULT_ENCODING_KEY, micronautConfig::getDefaultEncoding);
+        mapper.put(LOCALIZED_LOOKUP_KEY, micronautConfig::getLocalizedLookup);
+        mapper.put(WHITESPACE_STRIPPING_KEY, micronautConfig::getWhitespaceStripping);
+        mapper.put(REGISTERED_CUSTOM_OUTPUT_FORMATS_KEY, micronautConfig::getRegisteredCustomOutputFormats);
+        mapper.put(AUTO_ESCAPING_POLICY_KEY, micronautConfig::getAutoEscapingPolicy);
+        mapper.put(OUTPUT_FORMAT_KEY, micronautConfig::getOutputFormat);
+        mapper.put(RECOGNIZE_STANDARD_FILE_EXTENSIONS_KEY, micronautConfig::getRecognizeStandardFileExtensions);
+        mapper.put(CACHE_STORAGE_KEY, micronautConfig::getCacheStorage);
+        mapper.put(TEMPLATE_UPDATE_DELAY_KEY, micronautConfig::getTemplateUpdateDelay);
+        mapper.put(TAG_SYNTAX_KEY, micronautConfig::getTagSyntax);
+        mapper.put(INTERPOLATION_SYNTAX_KEY, micronautConfig::getInterpolationSyntax);
+        mapper.put(NAMING_CONVENTION_KEY, micronautConfig::getNamingConvention);
+        mapper.put(TAB_SIZE_KEY, micronautConfig::getTabSize);
+        mapper.put(TEMPLATE_LOADER_KEY, micronautConfig::getTemplateLoader);
+        mapper.put(TEMPLATE_LOOKUP_STRATEGY_KEY, micronautConfig::getTemplateLookupStrategy);
+        mapper.put(TEMPLATE_NAME_FORMAT_KEY, micronautConfig::getTemplateNameFormat);
+        mapper.put(TEMPLATE_CONFIGURATIONS_KEY, micronautConfig::getTemplateConfigurations);
+        return mapper;
+    }
+
+}

--- a/views/src/main/java/io/micronaut/views/freemarker/FreemarkerViewsRenderer.java
+++ b/views/src/main/java/io/micronaut/views/freemarker/FreemarkerViewsRenderer.java
@@ -46,11 +46,11 @@ import io.micronaut.views.ViewsRenderer;
 import io.micronaut.views.exceptions.ViewRenderingException;
 
 /**
- * Renders Views with with FreeMarker.
+ * Renders Views with FreeMarker Java template engine.
  *
  * @author Jerónimo López
  * @see <a href= "https://freemarker.apache.org/">freemarker.apache.org</a>
- * @since 1.0.2
+ * @since 1.1
  */
 @Produces(MediaType.TEXT_HTML)
 @Requires(property = FreemarkerViewsRendererConfigurationProperties.PREFIX + ".enabled", notEquals = "false")

--- a/views/src/main/java/io/micronaut/views/freemarker/FreemarkerViewsRendererConfiguration.java
+++ b/views/src/main/java/io/micronaut/views/freemarker/FreemarkerViewsRendererConfiguration.java
@@ -21,18 +21,8 @@ import io.micronaut.core.util.Toggleable;
 /**
  * Configuration for {@link FreemarkerViewsRenderer}.
  * 
- * All configured properties are extracted from {@link freemarker.template.Configuration} and
- * {@link freemarker.core.Configurable}. All Freemarker properties names are reused in the micronaut
- * configuration.
- * 
- * If a value is not declared and is null, the default configuration from Freemarker is used. The expected
- * format of each value is the same from Freemarker, and no conversion or validation is done by Micronaut.
- * 
- * All Freemarker configuration documentation is published in their
- * <a href="https://freemarker.apache.org/docs/pgui_config.html">site</a>.
- *
  * @author Jerónimo López
- * @since 1.0.2
+ * @since 1.1
  */
 public interface FreemarkerViewsRendererConfiguration extends Toggleable {
 

--- a/views/src/main/java/io/micronaut/views/freemarker/FreemarkerViewsRendererConfiguration.java
+++ b/views/src/main/java/io/micronaut/views/freemarker/FreemarkerViewsRendererConfiguration.java
@@ -1,0 +1,331 @@
+/*
+ * Copyright 2017-2018 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.views.freemarker;
+
+import io.micronaut.core.util.Toggleable;
+
+/**
+ * Configuration for {@link FreemarkerViewsRenderer}.
+ * 
+ * All configured properties are extracted from {@link freemarker.template.Configuration} and
+ * {@link freemarker.core.Configurable}. All Freemarker properties names are reused in the micronaut
+ * configuration.
+ * 
+ * If a value is not declared and is null, the default configuration from Freemarker is used. The expected
+ * format of each value is the same from Freemarker, and no conversion or validation is done by Micronaut.
+ * 
+ * All Freemarker configuration documentation is published in their
+ * <a href="https://freemarker.apache.org/docs/pgui_config.html">site</a>.
+ *
+ * @author Jerónimo López
+ * @since 1.0.2
+ */
+public interface FreemarkerViewsRendererConfiguration extends Toggleable {
+
+    /**
+     * @return Default extension for templates
+     */
+    String getDefaultExtension();
+
+    /*
+     * Configurations from {@link freemarker.core.Configurable}
+     */
+
+    /**
+     * @return the locale used for number and date formatting
+     * @see freemarker.core.Configurable#setLocale()
+     */
+    String getLocale();
+
+    /**
+     * @return the default number format used to convert numbers to strings
+     * @see freemarker.core.Configurable#setNumberFormat()
+     */
+    String getNumberFormat();
+
+    /**
+     * @return associated names with number formatter factories
+     * @see freemarker.core.Configurable#setCustomNumberFormats()
+     */
+    String getCustomNumberFormats();
+
+    /**
+     * @return the format used to convert {@link java.util.Date}s that are time values to string
+     * @see freemarker.core.Configurable#setTimeFormat()
+     */
+    String getTimeFormat();
+
+    /**
+     * @return the format used to convert {@link java.util.Date}s that are date-only values to string
+     * @see freemarker.core.Configurable#setDateFormat()
+     */
+    String getDateFormat();
+
+    /**
+     * @return associated names with date formatter factories
+     * @see freemarker.core.Configurable#setCustomDateFormats()
+     */
+    String getCustomDateFormats();
+
+    /**
+     * @return the format used to convert {@link java.util.Date}s that are date-time values to string
+     * @see freemarker.core.Configurable#setDateTimeFormat()
+     */
+    String getDatetimeFormat();
+
+    /**
+     * @return the time zone to use when formatting date/time values
+     * @see freemarker.core.Configurable#setTimeZone()
+     */
+    String getTimeZone();
+
+    /**
+     * @return the time zone used when dealing with Date and Time values
+     * @see freemarker.core.Configurable#setSQLDateAndTimeTimeZone()
+     */
+    String getSqlDateAndTimeTimeZone();
+
+    /**
+     * @return get the "Classic Compatible" mode
+     * @see freemarker.core.Configurable#setClassicCompatible()
+     */
+    String getClassicCompatible();
+
+    /**
+     * @return the exception handler used to handle exceptions occurring inside templates
+     * @see freemarker.core.Configurable#setTemplateExceptionHandler()
+     */
+    String getTemplateExceptionHandler();
+
+    /**
+     * @return how exceptions handled by an {@code #attempt} blocks
+     * @see freemarker.core.Configurable#setAttemptExceptionReporter()
+     */
+    String getAttemptExceptionReporter();
+
+    /**
+     * @return the arithmetic engine used to perform arithmetic operations
+     * @see freemarker.core.Configurable#setArithmeticEngine()
+     */
+    String getArithmeticEngine();
+
+    /**
+     * @return the object wrapper used to wrap objects to TemplateModels
+     * @see freemarker.core.Configurable#setObjectWrapper()
+     */
+    String getObjectWrapper();
+
+    /**
+     * @return the string value for the boolean {@code true} and {@code false} values, intended for human audience
+     * @see freemarker.core.Configurable#setBooleanFormat()
+     */
+    String getBooleanFormat();
+
+    /**
+     * @return the charset used for the output
+     * @see freemarker.core.Configurable#setOutputEncoding()
+     */
+    String getOutputEncoding();
+
+    /**
+     * @return the URL escaping charset
+     * @see freemarker.core.Configurable#setURLEscapingCharset()
+     */
+    String getUrlEscapingCharset();
+
+    /**
+     * @return whether the output {@link Writer} is automatically flushed at the end of Template render
+     * @see freemarker.core.Configurable#setAutoFlush()
+     */
+    String getAutoFlush();
+
+    /**
+     * @return the TemplateClassResolver that is used when the <code>new</code> built-in is called in a template
+     * @see freemarker.core.Configurable#setNewBuiltinClassResolver()
+     */
+    String getNewBuiltinClassResolver();
+
+    /**
+     * @return if tips should be shown in error messages of errors arising during template processing.
+     * @see freemarker.core.Configurable#setShowErrorTips()
+     */
+    String getShowErrorTips();
+
+    /**
+     * @return if {@code ?api} can be used in templates
+     * @see freemarker.core.Configurable#setAPIBuiltinEnabled()
+     */
+    String getApiBuiltinEnabled();
+
+    /**
+     * @return if TemplateExceptions thrown by template processing are logged by FreeMarker or not
+     * @see freemarker.core.Configurable#setLogTemplateExceptions()
+     */
+    String getLogTemplateExceptions();
+
+    /**
+     * @return if unchecked exceptions thrown during expression evaluation or during executing custom directives
+     *         will be wrapped into TemplateExceptions, or will bubble up to the caller
+     * @see freemarker.core.Configurable#setWrapUncheckedExceptions()
+     */
+    String getWrapUncheckedExceptions();
+
+    /**
+     * @return if {@code <#import ...>} should delay the loading and processing of the imported templates
+     * @see freemarker.core.Configurable#setLazyImports()
+     */
+    String getLazyImports();
+
+    /**
+     * @return lazy auto imports configuration
+     * @see freemarker.core.Configurable#setLazyAutoImports()
+     */
+    String getLazyAutoImports();
+
+    /**
+     * @return autoimport configuration
+     * @see freemarker.core.Configurable#setAutoImports()
+     */
+    String getAutoImport();
+
+    /**
+     * @return autoinclude configuration
+     * @see freemarker.core.Configurable#setAutoIncludes()
+     */
+    String getAutoInclude();
+
+    /*
+     * Configurations from {@link freemarker.template.Configuration}
+     */
+
+    /**
+     * @return Default encoding for templates
+     * @see freemarker.template.Configuration#setDefaultEncoding()
+     */
+    String getDefaultEncoding();
+
+    /**
+     * @return if localized template lookup is enabled or not
+     * @see freemarker.template.Configuration#setLocalizedLookup()
+     */
+    String getLocalizedLookup();
+
+    /**
+     * @return if the FTL parser will try to remove superfluous white-space around certain FTL tags
+     * @see freemarker.template.Configuration#setWhitespaceStripping()
+     */
+    String getWhitespaceStripping();
+
+    /**
+     * @return the custom output formats that can be referred by their unique name from templates
+     * @see freemarker.template.Configuration#setRegisteredCustomOutputFormats()
+     */
+    String getRegisteredCustomOutputFormats();
+
+    /**
+     * @return auto escaping policy
+     * @see freemarker.template.Configuration#setAutoEscapingPolicy()
+     */
+    String getAutoEscapingPolicy();
+
+    /**
+     * @return the default output format
+     * @see freemarker.template.Configuration#setOutputFormat()
+     */
+    String getOutputFormat();
+
+    /**
+     * @return if the "file" extension part of the source name will influence certain parsing settings
+     * @see freemarker.template.Configuration#setRecognizeStandardFileExtensions()
+     */
+    String getRecognizeStandardFileExtensions();
+
+    /**
+     * @return the CacheStorage used for caching Templates
+     * @see freemarker.template.Configuration#setCacheStorage()
+     */
+    String getCacheStorage();
+
+    /**
+     * @return the time that must elapse before checking whether there is a newer version of a template "file"
+     *         than the cached one
+     * @see freemarker.template.Configuration#setTemplateUpdateDelayMilliseconds()
+     */
+    String getTemplateUpdateDelay();
+
+    /**
+     * @return the tag syntax of the template files that has no {@code #ftl} header to decide that
+     * @see freemarker.template.Configuration#setTagSyntax()
+     */
+    String getTagSyntax();
+
+    /**
+     * @return the interpolation syntax of the template files
+     * @see freemarker.template.Configuration#setInterpolationSyntax()
+     */
+    String getInterpolationSyntax();
+
+    /**
+     * @return the naming convention used for the identifiers that are part of the template language
+     * @see freemarker.template.Configuration#setNamingConvention()
+     */
+    String getNamingConvention();
+
+    /**
+     * @return the assumed display width of the tab character (ASCII 9), which influences the column number shown
+     *         in error messages
+     * @see freemarker.template.Configuration#setTabSize()
+     */
+    String getTabSize();
+
+    /**
+     * @return which the version of the non-backward-compatible bugfixes/improvements should be enabled
+     * @see freemarker.template.Configuration#setIncompatibleImprovements()
+     */
+    String getIncompatibleImprovements();
+
+    /**
+     * @return the TemplateLoader that is used to look up and load templates
+     * @see freemarker.template.Configuration#setTemplateLoader()
+     */
+    String getTemplateLoader();
+
+    /**
+     * @return the TemplateLookupStrategy that is used to look up templates based on the requested name
+     * @see freemarker.template.Configuration#setTemplateLookupStrategy()
+     */
+    String getTemplateLookupStrategy();
+
+    /**
+     * @return the template name format used. The setup follows the properties configuration explained in
+     *         <a href= "https://freemarker.apache.org/docs/pgui_config_templateloading.html#autoid_42">
+     *         freemarker documentation</a>
+     * @see freemarker.template.Configuration#setTemplateNameFormat()
+     */
+    String getTemplateNameFormat();
+
+    /**
+     * @return the TemplateConfigurationFactory that will configure individual templates where their settings
+     *         differ from those coming from the common Configuration object. The setup follows the properties
+     *         configuration explained in
+     *         <a href= "https://freemarker.apache.org/docs/pgui_config_templateconfigurations.html"> freemarker
+     *         documentation</a>
+     * @see freemarker.template.Configuration#setTemplateConfigurations()
+     */
+    String getTemplateConfigurations();
+
+}

--- a/views/src/main/java/io/micronaut/views/freemarker/FreemarkerViewsRendererConfigurationProperties.java
+++ b/views/src/main/java/io/micronaut/views/freemarker/FreemarkerViewsRendererConfigurationProperties.java
@@ -1,0 +1,940 @@
+/*
+ * Copyright 2017-2018 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.views.freemarker;
+
+import freemarker.template.Configuration;
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.views.ViewsConfigurationProperties;
+
+/**
+ * {@link ConfigurationProperties} implementation of {@link FreemarkerViewsRendererConfiguration}.
+ *
+ * @author Jerónimo López
+ * @since 1.0.2
+ */
+@Requires(classes = freemarker.template.Configuration.class)
+@ConfigurationProperties(FreemarkerViewsRendererConfigurationProperties.PREFIX)
+public class FreemarkerViewsRendererConfigurationProperties implements FreemarkerViewsRendererConfiguration {
+
+    public static final String PREFIX = ViewsConfigurationProperties.PREFIX + ".freemarker";
+
+    /**
+     * The default extension.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static final String DEFAULT_EXTENSION = "ftl";
+
+    /**
+     * The default enable value.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static final boolean DEFAULT_ENABLED = true;
+
+    /**
+     * The default freemarker incompatible improvements version.
+     * 
+     * @see freemarker.template.Configuration#Configuration(freemarker.template.Version)
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static final String DEFAULT_INCOMPATIBLE_IMPROVEMENTS = Configuration.DEFAULT_INCOMPATIBLE_IMPROVEMENTS
+            .toString();
+
+    private boolean enabled = DEFAULT_ENABLED;
+
+    private String defaultExtension = DEFAULT_EXTENSION;
+
+    /*
+     * Configurations from {@link freemarker.core.Configurable}
+     */
+    private String locale;
+
+    private String numberFormat;
+
+    private String customNumberFormats;
+
+    private String timeFormat;
+
+    private String dateFormat;
+
+    private String customDateFormats;
+
+    private String datetimeFormat;
+
+    private String timeZone;
+
+    private String sqlDateAndTimeTimeZone;
+
+    private String classicCompatible;
+
+    private String templateExceptionHandler;
+
+    private String attemptExceptionReporter;
+
+    private String arithmeticEngine;
+
+    private String objectWrapper;
+
+    private String booleanFormat;
+
+    private String outputEncoding;
+
+    private String urlEscapingCharset;
+
+    private String autoFlush;
+
+    private String newBuiltinClassResolver;
+
+    private String showErrorTips;
+
+    private String apiBuiltinEnabled;
+
+    private String logTemplateExceptions;
+
+    private String wrapUncheckedExceptions;
+
+    private String lazyImports;
+
+    private String lazyAutoImports;
+
+    private String autoImport;
+
+    private String autoInclude;
+
+    /*
+     * Configurations from {@link freemarker.template.Configuration}
+     */
+    private String defaultEncoding;
+
+    private String localizedLookup;
+
+    private String whitespaceStripping;
+
+    private String registeredCustomOutputFormats;
+
+    private String autoEscapingPolicy;
+
+    private String outputFormat;
+
+    private String recognizeStandardFileExtensions;
+
+    private String cacheStorage;
+
+    private String templateUpdateDelay;
+
+    private String tagSyntax;
+
+    private String interpolationSyntax;
+
+    private String namingConvention;
+
+    private String tabSize;
+
+    private String incompatibleImprovements;
+
+    private String templateLoader;
+
+    private String templateLookupStrategy;
+
+    private String templateNameFormat;
+
+    private String templateConfigurations;
+
+    /**
+     * enabled getter.
+     *
+     * @return boolean flag indicating whether {@link FreemarkerViewsRenderer} is enabled.
+     */
+    @Override
+    public boolean isEnabled() {
+        return this.enabled;
+    }
+
+    /**
+     * @return Default extension for templates. By default {@value #DEFAULT_EXTENSION}.
+     */
+    @Override
+    public String getDefaultExtension() {
+        return defaultExtension;
+    }
+
+    /**
+     * @return the locale used for number and date formatting
+     * @see freemarker.core.Configurable#setLocale()
+     */
+    @Override
+    public String getLocale() {
+        return locale;
+    }
+
+    /**
+     * @return the default number format used to convert numbers to strings
+     * @see freemarker.core.Configurable#setNumberFormat()
+     */
+    @Override
+    public String getNumberFormat() {
+        return numberFormat;
+    }
+
+    /**
+     * @return associated names with number formatter factories
+     * @see freemarker.core.Configurable#setCustomNumberFormats()
+     */
+    @Override
+    public String getCustomNumberFormats() {
+        return customNumberFormats;
+    }
+
+    /**
+     * @return the format used to convert {@link java.util.Date}s that are time values to string
+     * @see freemarker.core.Configurable#setTimeFormat()
+     */
+    @Override
+    public String getTimeFormat() {
+        return timeFormat;
+    }
+
+    /**
+     * @return the format used to convert {@link java.util.Date}s that are date-only values to string
+     * @see freemarker.core.Configurable#setDateFormat()
+     */
+    @Override
+    public String getDateFormat() {
+        return dateFormat;
+    }
+
+    /**
+     * @return associated names with date formatter factories
+     * @see freemarker.core.Configurable#setCustomDateFormats()
+     */
+    @Override
+    public String getCustomDateFormats() {
+        return customDateFormats;
+    }
+
+    /**
+     * @return the format used to convert {@link java.util.Date}s that are date-time values to string
+     * @see freemarker.core.Configurable#setDateTimeFormat()
+     */
+    @Override
+    public String getDatetimeFormat() {
+        return datetimeFormat;
+    }
+
+    /**
+     * @return the time zone to use when formatting date/time values
+     * @see freemarker.core.Configurable#setTimeZone()
+     */
+    @Override
+    public String getTimeZone() {
+        return timeZone;
+    }
+
+    /**
+     * @return the time zone used when dealing with SQL Date and Time values
+     * @see freemarker.core.Configurable#setSQLDateAndTimeTimeZone()
+     */
+    @Override
+    public String getSqlDateAndTimeTimeZone() {
+        return sqlDateAndTimeTimeZone;
+    }
+
+    /**
+     * @return get the "Classic Compatible" mode
+     * @see freemarker.core.Configurable#setClassicCompatible()
+     */
+    @Override
+    public String getClassicCompatible() {
+        return classicCompatible;
+    }
+
+    /**
+     * @return the exception handler used to handle exceptions occurring inside templates
+     * @see freemarker.core.Configurable#setTemplateExceptionHandler()
+     */
+    @Override
+    public String getTemplateExceptionHandler() {
+        return templateExceptionHandler;
+    }
+
+    /**
+     * @return how exceptions handled by an {@code #attempt} blocks
+     * @see freemarker.core.Configurable#setAttemptExceptionReporter()
+     */
+    @Override
+    public String getAttemptExceptionReporter() {
+        return attemptExceptionReporter;
+    }
+
+    /**
+     * @return the arithmetic engine used to perform arithmetic operations
+     * @see freemarker.core.Configurable#setArithmeticEngine()
+     */
+    @Override
+    public String getArithmeticEngine() {
+        return arithmeticEngine;
+    }
+
+    /**
+     * @return the object wrapper used to wrap objects to TemplateModels
+     * @see freemarker.core.Configurable#setObjectWrapper()
+     */
+    @Override
+    public String getObjectWrapper() {
+        return objectWrapper;
+    }
+
+    /**
+     * @return the string value for the boolean {@code true} and {@code false} values, intended for human audience
+     * @see freemarker.core.Configurable#setBooleanFormat()
+     */
+    @Override
+    public String getBooleanFormat() {
+        return booleanFormat;
+    }
+
+    /**
+     * @return the charset used for the output
+     * @see freemarker.core.Configurable#setOutputEncoding()
+     */
+    @Override
+    public String getOutputEncoding() {
+        return outputEncoding;
+    }
+
+    /**
+     * @return the URL escaping charset
+     * @see freemarker.core.Configurable#setURLEscapingCharset()
+     */
+    @Override
+    public String getUrlEscapingCharset() {
+        return urlEscapingCharset;
+    }
+
+    /**
+     * @return whether the output {@link Writer} is automatically flushed at the end of Template render
+     * @see freemarker.core.Configurable#setAutoFlush()
+     */
+    @Override
+    public String getAutoFlush() {
+        return autoFlush;
+    }
+
+    /**
+     * @return the TemplateClassResolver that is used when the <code>new</code> built-in is called in a template
+     * @see freemarker.core.Configurable#setNewBuiltinClassResolver()
+     */
+    @Override
+    public String getNewBuiltinClassResolver() {
+        return newBuiltinClassResolver;
+    }
+
+    /**
+     * @return if tips should be shown in error messages of errors arising during template processing.
+     * @see freemarker.core.Configurable#setShowErrorTips()
+     */
+    @Override
+    public String getShowErrorTips() {
+        return showErrorTips;
+    }
+
+    /**
+     * @return if {@code ?api} can be used in templates
+     * @see freemarker.core.Configurable#setAPIBuiltinEnabled()
+     */
+    @Override
+    public String getApiBuiltinEnabled() {
+        return apiBuiltinEnabled;
+    }
+
+    /**
+     * @return if TemplateExceptions thrown by template processing are logged by FreeMarker or not
+     * @see freemarker.core.Configurable#setLogTemplateExceptions()
+     */
+    @Override
+    public String getLogTemplateExceptions() {
+        return logTemplateExceptions;
+    }
+
+    /**
+     * @return if unchecked exceptions thrown during expression evaluation or during executing custom directives
+     *         will be wrapped into TemplateExceptions, or will bubble up to the caller
+     * @see freemarker.core.Configurable#setWrapUncheckedExceptions()
+     */
+    @Override
+    public String getWrapUncheckedExceptions() {
+        return wrapUncheckedExceptions;
+    }
+
+    /**
+     * @return if {@code <#import ...>} should delay the loading and processing of the imported templates
+     * @see freemarker.core.Configurable#setLazyImports()
+     */
+    @Override
+    public String getLazyImports() {
+        return lazyImports;
+    }
+
+    /**
+     * @return lazy auto imports configuration
+     * @see freemarker.core.Configurable#setLazyAutoImports()
+     */
+    @Override
+    public String getLazyAutoImports() {
+        return lazyAutoImports;
+    }
+
+    /**
+     * @return autoimport configuration
+     * @see freemarker.core.Configurable#setAutoImports()
+     */
+    @Override
+    public String getAutoImport() {
+        return autoImport;
+    }
+
+    /**
+     * @return autoinclude configuration
+     * @see freemarker.core.Configurable#setAutoIncludes()
+     */
+    @Override
+    public String getAutoInclude() {
+        return autoInclude;
+    }
+
+    /**
+     * @return Default encoding for templates
+     * @see freemarker.template.Configuration#setDefaultEncoding()
+     */
+    @Override
+    public String getDefaultEncoding() {
+        return defaultEncoding;
+    }
+
+    /**
+     * @return if localized template lookup is enabled or not
+     * @see freemarker.template.Configuration#setLocalizedLookup()
+     */
+    @Override
+    public String getLocalizedLookup() {
+        return localizedLookup;
+    }
+
+    /**
+     * @return if the FTL parser will try to remove superfluous white-space around certain FTL tags
+     * @see freemarker.template.Configuration#setWhitespaceStripping()
+     */
+    @Override
+    public String getWhitespaceStripping() {
+        return whitespaceStripping;
+    }
+
+    /**
+     * @return the custom output formats that can be referred by their unique name from templates
+     * @see freemarker.template.Configuration#setRegisteredCustomOutputFormats()
+     */
+    @Override
+    public String getRegisteredCustomOutputFormats() {
+        return registeredCustomOutputFormats;
+    }
+
+    /**
+     * @return auto escaping policy
+     * @see freemarker.template.Configuration#setAutoEscapingPolicy()
+     */
+    @Override
+    public String getAutoEscapingPolicy() {
+        return autoEscapingPolicy;
+    }
+
+    /**
+     * @return the default output format
+     * @see freemarker.template.Configuration#setOutputFormat()
+     */
+    @Override
+    public String getOutputFormat() {
+        return outputFormat;
+    }
+
+    /**
+     * @return if the "file" extension part of the source name will influence certain parsing settings
+     * @see freemarker.template.Configuration#setRecognizeStandardFileExtensions()
+     */
+    @Override
+    public String getRecognizeStandardFileExtensions() {
+        return recognizeStandardFileExtensions;
+    }
+
+    /**
+     * @return the CacheStorage used for caching Templates
+     * @see freemarker.template.Configuration#setCacheStorage()
+     */
+    @Override
+    public String getCacheStorage() {
+        return cacheStorage;
+    }
+
+    /**
+     * @return the time that must elapse before checking whether there is a newer version of a template "file"
+     *         than the cached one
+     * @see freemarker.template.Configuration#setTemplateUpdateDelayMilliseconds()
+     */
+    @Override
+    public String getTemplateUpdateDelay() {
+        return templateUpdateDelay;
+    }
+
+    /**
+     * @return the tag syntax of the template files that has no {@code #ftl} header to decide that
+     * @see freemarker.template.Configuration#setTagSyntax()
+     */
+    @Override
+    public String getTagSyntax() {
+        return tagSyntax;
+    }
+
+    /**
+     * @return the interpolation syntax of the template files
+     * @see freemarker.template.Configuration#setInterpolationSyntax()
+     */
+    @Override
+    public String getInterpolationSyntax() {
+        return interpolationSyntax;
+    }
+
+    /**
+     * @return the naming convention used for the identifiers that are part of the template language
+     * @see freemarker.template.Configuration#setNamingConvention()
+     */
+    @Override
+    public String getNamingConvention() {
+        return namingConvention;
+    }
+
+    /**
+     * @return the assumed display width of the tab character (ASCII 9), which influences the column number shown
+     *         in error messages
+     * @see freemarker.template.Configuration#setTabSize()
+     */
+    @Override
+    public String getTabSize() {
+        return tabSize;
+    }
+
+    /**
+     * @return which version of the non-backward-compatible bugfixes/improvements should be enabled
+     * @see freemarker.template.Configuration#setIncompatibleImprovements()
+     */
+    @Override
+    public String getIncompatibleImprovements() {
+        return incompatibleImprovements;
+    }
+
+    /**
+     * @return the TemplateLoader that is used to look up and load templates
+     * @see freemarker.template.Configuration#setTemplateLoader()
+     */
+    @Override
+    public String getTemplateLoader() {
+        return templateLoader;
+    }
+
+    /**
+     * @return the TemplateLookupStrategy that is used to look up templates based on the requested name
+     * @see freemarker.template.Configuration#setTemplateLookupStrategy()
+     */
+    @Override
+    public String getTemplateLookupStrategy() {
+        return templateLookupStrategy;
+    }
+
+    /**
+     * @return the template name format used. The setup follows the properties configuration explained in
+     *         <a href= "https://freemarker.apache.org/docs/pgui_config_templateloading.html#autoid_42">
+     *         freemarker documentation</a>
+     * @see freemarker.template.Configuration#setTemplateNameFormat()
+     */
+    @Override
+    public String getTemplateNameFormat() {
+        return templateNameFormat;
+    }
+
+    /**
+     * @return the TemplateConfigurationFactory that will configure individual templates where their settings
+     *         differ from those coming from the common Configuration object. The setup follows the properties
+     *         configuration explained in
+     *         <a href= "https://freemarker.apache.org/docs/pgui_config_templateconfigurations.html"> freemarker
+     *         documentation</a>
+     * @see freemarker.template.Configuration#setTemplateConfigurations()
+     */
+    @Override
+    public String getTemplateConfigurations() {
+        return templateConfigurations;
+    }
+
+    /**
+     * Whether freemarker views are enabled. Default value ({@value #DEFAULT_ENABLED}).
+     *
+     * @param enabled True if they are
+     */
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    /**
+     * Sets the default extension to use for freemarker templates. Default value ({@value #DEFAULT_EXTENSION}).
+     *
+     * @param defaultExtension The default extension
+     */
+    public void setDefaultExtension(String defaultExtension) {
+        this.defaultExtension = defaultExtension;
+    }
+
+    /**
+     * @param locale The locale to use for number and date formatting
+     */
+    public void setLocale(String locale) {
+        this.locale = locale;
+    }
+
+    /**
+     * @param numberFormat The default number format used to convert numbers to strings
+     */
+    public void setNumberFormat(String numberFormat) {
+        this.numberFormat = numberFormat;
+    }
+
+    /**
+     * @param customNumberFormats The associated names with number formatter factories
+     */
+    public void setCustomNumberFormats(String customNumberFormats) {
+        this.customNumberFormats = customNumberFormats;
+    }
+
+    /**
+     * @param timeFormat The format used to convert {@link java.util.Date}s that are time values to string
+     */
+    public void setTimeFormat(String timeFormat) {
+        this.timeFormat = timeFormat;
+    }
+
+    /**
+     * @param dateFormat The format used to convert {@link java.util.Date}s that are date-only values to string
+     */
+    public void setDateFormat(String dateFormat) {
+        this.dateFormat = dateFormat;
+    }
+
+    /**
+     * @param customDateFormats The associated names with date formatter factories
+     */
+    public void setCustomDateFormats(String customDateFormats) {
+        this.customDateFormats = customDateFormats;
+    }
+
+    /**
+     * @param datetimeFormat The format used to convert {@link java.util.Date}s that are date-time values to
+     *                       string
+     */
+    public void setDatetimeFormat(String datetimeFormat) {
+        this.datetimeFormat = datetimeFormat;
+    }
+
+    /**
+     * @param timeZone The time zone to use when formatting date/time values
+     */
+    public void setTimeZone(String timeZone) {
+        this.timeZone = timeZone;
+    }
+
+    /**
+     * @param sqlDateAndTimeTimeZone The time zone used when dealing with SQL Date and Time values
+     */
+    public void setSqlDateAndTimeTimeZone(String sqlDateAndTimeTimeZone) {
+        this.sqlDateAndTimeTimeZone = sqlDateAndTimeTimeZone;
+    }
+
+    /**
+     * @param classicCompatible The "Classic Compatible" mode
+     */
+    public void setClassicCompatible(String classicCompatible) {
+        this.classicCompatible = classicCompatible;
+    }
+
+    /**
+     * @param templateExceptionHandler The exception handler used to handle exceptions occurring inside templates
+     */
+    public void setTemplateExceptionHandler(String templateExceptionHandler) {
+        this.templateExceptionHandler = templateExceptionHandler;
+    }
+
+    /**
+     * @param attemptExceptionReporter How exceptions handled by an {@code #attempt} blocks
+     */
+    public void setAttemptExceptionReporter(String attemptExceptionReporter) {
+        this.attemptExceptionReporter = attemptExceptionReporter;
+    }
+
+    /**
+     * @param arithmeticEngine The arithmetic engine used to perform arithmetic operations
+     */
+    public void setArithmeticEngine(String arithmeticEngine) {
+        this.arithmeticEngine = arithmeticEngine;
+    }
+
+    /**
+     * @param objectWrapper The object wrapper used to wrap objects to TemplateModels
+     */
+    public void setObjectWrapper(String objectWrapper) {
+        this.objectWrapper = objectWrapper;
+    }
+
+    /**
+     * @param booleanFormat The string value for the boolean {@code true} and {@code false} values, intended for
+     *                      human audience
+     */
+    public void setBooleanFormat(String booleanFormat) {
+        this.booleanFormat = booleanFormat;
+    }
+
+    /**
+     * @param outputEncoding The charset used for the output
+     */
+    public void setOutputEncoding(String outputEncoding) {
+        this.outputEncoding = outputEncoding;
+    }
+
+    /**
+     * @param urlEscapingCharset The URL escaping charset
+     */
+    public void setUrlEscapingCharset(String urlEscapingCharset) {
+        this.urlEscapingCharset = urlEscapingCharset;
+    }
+
+    /**
+     * @param autoFlush Whether the output {@link Writer} is automatically flushed at the end of Template render
+     */
+    public void setAutoFlush(String autoFlush) {
+        this.autoFlush = autoFlush;
+    }
+
+    /**
+     * @param newBuiltinClassResolver The TemplateClassResolver that is used when the <code>new</code> built-in is
+     *                                called in a template
+     */
+    public void setNewBuiltinClassResolver(String newBuiltinClassResolver) {
+        this.newBuiltinClassResolver = newBuiltinClassResolver;
+    }
+
+    /**
+     * @param showErrorTips If tips should be shown in error messages of errors arising during template
+     *                      processing.
+     */
+    public void setShowErrorTips(String showErrorTips) {
+        this.showErrorTips = showErrorTips;
+    }
+
+    /**
+     * @param apiBuiltinEnabled If {@code ?api} can be used in templates
+     */
+    public void setApiBuiltinEnabled(String apiBuiltinEnabled) {
+        this.apiBuiltinEnabled = apiBuiltinEnabled;
+    }
+
+    /**
+     * @param logTemplateExceptions If TemplateExceptions thrown by template processing are logged by FreeMarker
+     *                              or not
+     */
+    public void setLogTemplateExceptions(String logTemplateExceptions) {
+        this.logTemplateExceptions = logTemplateExceptions;
+    }
+
+    /**
+     * @param wrapUncheckedExceptions If unchecked exceptions thrown during expression evaluation or during
+     *                                executing custom directives will be wrapped into TemplateExceptions, or will
+     *                                bubble up to the caller
+     */
+    public void setWrapUncheckedExceptions(String wrapUncheckedExceptions) {
+        this.wrapUncheckedExceptions = wrapUncheckedExceptions;
+    }
+
+    /**
+     * @param lazyImports If {@code <#import ...>} should delay the loading and processing of the imported
+     *                    templates
+     */
+    public void setLazyImports(String lazyImports) {
+        this.lazyImports = lazyImports;
+    }
+
+    /**
+     * @param lazyAutoImports Lazy auto imports configuration
+     */
+    public void setLazyAutoImports(String lazyAutoImports) {
+        this.lazyAutoImports = lazyAutoImports;
+    }
+
+    /**
+     * @param autoImport Autoimport configuration
+     */
+    public void setAutoImport(String autoImport) {
+        this.autoImport = autoImport;
+    }
+
+    /**
+     * @param autoInclude Autoinclude configuration
+     */
+    public void setAutoInclude(String autoInclude) {
+        this.autoInclude = autoInclude;
+    }
+
+    /**
+     * @param defaultEncoding Default encoding for templates
+     */
+    public void setDefaultEncoding(String defaultEncoding) {
+        this.defaultEncoding = defaultEncoding;
+    }
+
+    /**
+     * @param localizedLookup If localized template lookup is enabled or not
+     */
+    public void setLocalizedLookup(String localizedLookup) {
+        this.localizedLookup = localizedLookup;
+    }
+
+    /**
+     * @param whitespaceStripping If the FTL parser will try to remove superfluous white-space around certain FTL
+     *                            tags
+     */
+    public void setWhitespaceStripping(String whitespaceStripping) {
+        this.whitespaceStripping = whitespaceStripping;
+    }
+
+    /**
+     * @param registeredCustomOutputFormats The custom output formats that can be referred by their unique name
+     *                                      from templates
+     */
+    public void setRegisteredCustomOutputFormats(String registeredCustomOutputFormats) {
+        this.registeredCustomOutputFormats = registeredCustomOutputFormats;
+    }
+
+    /**
+     * @param autoEscapingPolicy Auto escaping policy
+     */
+    public void setAutoEscapingPolicy(String autoEscapingPolicy) {
+        this.autoEscapingPolicy = autoEscapingPolicy;
+    }
+
+    /**
+     * @param outputFormat The default output format
+     */
+    public void setOutputFormat(String outputFormat) {
+        this.outputFormat = outputFormat;
+    }
+
+    /**
+     * @param recognizeStandardFileExtensions If the "file" extension part of the source name will influence
+     *                                        certain parsing settings
+     */
+    public void setRecognizeStandardFileExtensions(String recognizeStandardFileExtensions) {
+        this.recognizeStandardFileExtensions = recognizeStandardFileExtensions;
+    }
+
+    /**
+     * @param cacheStorage The CacheStorage used for caching Templates
+     */
+    public void setCacheStorage(String cacheStorage) {
+        this.cacheStorage = cacheStorage;
+    }
+
+    /**
+     * @param templateUpdateDelay The time that must elapse before checking whether there is a newer version of a
+     *                            template "file" than the cached one
+     */
+    public void setTemplateUpdateDelay(String templateUpdateDelay) {
+        this.templateUpdateDelay = templateUpdateDelay;
+    }
+
+    /**
+     * @param tagSyntax The tag syntax of the template files that has no {@code #ftl} header to decide that
+     */
+    public void setTagSyntax(String tagSyntax) {
+        this.tagSyntax = tagSyntax;
+    }
+
+    /**
+     * @param interpolationSyntax The interpolation syntax of the template files
+     */
+    public void setInterpolationSyntax(String interpolationSyntax) {
+        this.interpolationSyntax = interpolationSyntax;
+    }
+
+    /**
+     * @param namingConvention The naming convention used for the identifiers that are part of the template
+     *                         language
+     */
+    public void setNamingConvention(String namingConvention) {
+        this.namingConvention = namingConvention;
+    }
+
+    /**
+     * @param tabSize The assumed display width of the tab character (ASCII 9), which influences the column number
+     *                shown in error messages
+     */
+    public void setTabSize(String tabSize) {
+        this.tabSize = tabSize;
+    }
+
+    /**
+     * @param incompatibleImprovements Which version of the non-backward-compatible bugfixes/improvements should
+     *                                 be enabled
+     */
+    public void setIncompatibleImprovements(String incompatibleImprovements) {
+        this.incompatibleImprovements = incompatibleImprovements;
+    }
+
+    /**
+     * @param templateLoader The TemplateLoader that is used to look up and load templates
+     */
+    public void setTemplateLoader(String templateLoader) {
+        this.templateLoader = templateLoader;
+    }
+
+    /**
+     * @param templateLookupStrategy The TemplateLookupStrategy that is used to look up templates based on the
+     *                               requested name
+     */
+    public void setTemplateLookupStrategy(String templateLookupStrategy) {
+        this.templateLookupStrategy = templateLookupStrategy;
+    }
+
+    /**
+     * @param templateNameFormat The template name format used
+     */
+    public void setTemplateNameFormat(String templateNameFormat) {
+        this.templateNameFormat = templateNameFormat;
+    }
+
+    /**
+     * @param templateConfigurations The TemplateConfigurationFactory that will configure individual templates
+     *                               where their settings differ from those coming from the common Configuration
+     *                               object
+     */
+    public void setTemplateConfigurations(String templateConfigurations) {
+        this.templateConfigurations = templateConfigurations;
+    }
+
+}

--- a/views/src/main/java/io/micronaut/views/freemarker/FreemarkerViewsRendererConfigurationProperties.java
+++ b/views/src/main/java/io/micronaut/views/freemarker/FreemarkerViewsRendererConfigurationProperties.java
@@ -23,9 +23,19 @@ import io.micronaut.views.ViewsConfigurationProperties;
 
 /**
  * {@link ConfigurationProperties} implementation of {@link FreemarkerViewsRendererConfiguration}.
- *
+ * 
+ * All configured properties are extracted from {@link freemarker.template.Configuration} and
+ * {@link freemarker.core.Configurable}. All Freemarker properties names are reused in the micronaut
+ * configuration.
+ * 
+ * If a value is not declared and is null, the default configuration from Freemarker is used. The expected
+ * format of each value is the same from Freemarker, and no conversion or validation is done by Micronaut.
+ * 
+ * All Freemarker configuration documentation is published in their
+ * <a href="https://freemarker.apache.org/docs/pgui_config.html">site</a>.
+ * 
  * @author Jerónimo López
- * @since 1.0.2
+ * @since 1.1
  */
 @Requires(classes = freemarker.template.Configuration.class)
 @ConfigurationProperties(FreemarkerViewsRendererConfigurationProperties.PREFIX)
@@ -417,7 +427,7 @@ public class FreemarkerViewsRendererConfigurationProperties implements Freemarke
     }
 
     /**
-     * @return Default encoding for templates
+     * @return default encoding for templates
      * @see freemarker.template.Configuration#setDefaultEncoding()
      */
     @Override

--- a/views/src/main/java/io/micronaut/views/freemarker/package-info.java
+++ b/views/src/main/java/io/micronaut/views/freemarker/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2018 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contains classes specific to Views rendered with FreeMarker.
+ * @see <a href="https://freemarker.apache.org/">FreeMarker</a>
+ *
+ * @author Jerónimo López
+ * @since 1.0.2
+ */
+@Configuration
+@Requires(classes = freemarker.template.Configuration.class)
+package io.micronaut.views.freemarker;
+
+import io.micronaut.context.annotation.Configuration;
+import io.micronaut.context.annotation.Requires;

--- a/views/src/main/java/io/micronaut/views/freemarker/package-info.java
+++ b/views/src/main/java/io/micronaut/views/freemarker/package-info.java
@@ -19,7 +19,7 @@
  * @see <a href="https://freemarker.apache.org/">FreeMarker</a>
  *
  * @author Jerónimo López
- * @since 1.0.2
+ * @since 1.1
  */
 @Configuration
 @Requires(classes = freemarker.template.Configuration.class)

--- a/views/src/test/groovy/io/micronaut/docs/FreemarkerController.groovy
+++ b/views/src/test/groovy/io/micronaut/docs/FreemarkerController.groovy
@@ -1,0 +1,66 @@
+package io.micronaut.docs
+
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.util.CollectionUtils
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Produces
+import io.micronaut.views.ModelAndView
+import io.micronaut.views.View
+import io.reactivex.Single
+
+@Requires(property = "spec.name", value = "freemarker")
+@Controller("/freemarker")
+class FreemarkerController {
+
+    @View("home")
+    @Get("/")
+    HttpResponse index() {
+        return HttpResponse.ok(CollectionUtils.mapOf("loggedIn", true, "username", "sdelamo"));
+    }
+
+    @View("home.ftl")
+    @Get("/pogo")
+    HttpResponse<Person> pogo() {
+        HttpResponse.ok(new Person(loggedIn: true, username: 'sdelamo'))
+    }
+
+    @Get("/home")
+    HttpResponse<Person> home() {
+        HttpResponse.ok(new Person(loggedIn: true, username: 'sdelamo'))
+    }
+
+    @Produces(MediaType.TEXT_PLAIN)
+    @View("home.ftl")
+    @Get("/viewWithNoViewRendererForProduces")
+    Person viewWithNoViewRendererForProduces() {
+        new Person(loggedIn: true, username: 'sdelamo')
+    }
+
+    @View("home")
+    @Get("/reactive")
+    Single<Person> reactive() {
+        return Single.just(new Person(loggedIn: true, username: 'sdelamo'))
+    }
+
+    @Get("/modelAndView")
+    Single<ModelAndView> modelAndView() {
+        ModelAndView modelAndView = new ModelAndView("home",
+                new Person(loggedIn: true, username: 'sdelamo'))
+        return Single.just(modelAndView)
+    }
+
+    @View("bogus")
+    @Get("/bogus")
+    HttpResponse<Person> bogus() {
+        HttpResponse.ok(new Person(loggedIn: true, username: 'sdelamo'))
+    }
+
+    @View("/home")
+    @Get("/nullbody")
+    HttpResponse nullBody() {
+        HttpResponse.ok()
+    }
+}

--- a/views/src/test/groovy/io/micronaut/docs/FreemarkerViewRendererSpec.groovy
+++ b/views/src/test/groovy/io/micronaut/docs/FreemarkerViewRendererSpec.groovy
@@ -8,21 +8,21 @@ import io.micronaut.http.client.RxHttpClient
 import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.runtime.server.EmbeddedServer
 import io.micronaut.views.ViewsFilter
-import io.micronaut.views.velocity.VelocityViewsRenderer
+import io.micronaut.views.freemarker.FreemarkerViewsRenderer
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Specification
 
-class VelocityViewRendererSpec extends Specification {
+class FreemarkerViewRendererSpec extends Specification {
 
     @Shared
     @AutoCleanup
     EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer,
             [
-                    'spec.name': 'velocity',
+                    'spec.name': 'freemarker',
                     'micronaut.views.thymeleaf.enabled': false,
+                    'micronaut.views.velocity.enabled': false,
                     'micronaut.views.handlebars.enabled': false,
-                    'micronaut.views.freemarker.enabled': false,
             ],
             "test")
 
@@ -32,16 +32,16 @@ class VelocityViewRendererSpec extends Specification {
 
     def "bean is loaded"() {
         when:
-        embeddedServer.applicationContext.getBean(VelocityViewsRenderer)
+        embeddedServer.applicationContext.getBean(FreemarkerViewsRenderer)
         embeddedServer.applicationContext.getBean(ViewsFilter)
 
         then:
         noExceptionThrown()
     }
 
-    def "invoking /velocity/home does not specify @View, thus, regular JSON rendering is used"() {
+    def "invoking /freemarker/home does not specify @View, thus, regular JSON rendering is used"() {
         when:
-        HttpResponse<String> rsp = client.toBlocking().exchange('/velocity/home', String)
+        HttpResponse<String> rsp = client.toBlocking().exchange('/freemarker/home', String)
 
         then:
         noExceptionThrown()
@@ -57,9 +57,9 @@ class VelocityViewRendererSpec extends Specification {
         rsp.contentType.get() == MediaType.APPLICATION_JSON_TYPE
     }
 
-    def "invoking /velocity renders velocity template from a controller returning a map"() {
+    def "invoking /freemarker renders freemarker template from a controller returning a map"() {
         when:
-        HttpResponse<String> rsp = client.toBlocking().exchange('/velocity', String)
+        HttpResponse<String> rsp = client.toBlocking().exchange('/freemarker', String)
 
         then:
         noExceptionThrown()
@@ -73,9 +73,9 @@ class VelocityViewRendererSpec extends Specification {
         rsp.body().contains("<h1>username: <span>sdelamo</span></h1>")
     }
 
-    def "invoking /velocity/pogo renders velocity template from a controller returning a pogo"() {
+    def "invoking /freemarker/pogo renders freemarker template from a controller returning a pogo"() {
         when:
-        HttpResponse<String> rsp = client.toBlocking().exchange('/velocity/pogo', String)
+        HttpResponse<String> rsp = client.toBlocking().exchange('/freemarker/pogo', String)
 
         then:
         noExceptionThrown()
@@ -89,9 +89,9 @@ class VelocityViewRendererSpec extends Specification {
         rsp.body().contains("<h1>username: <span>sdelamo</span></h1>")
     }
 
-    def "invoking /velocity/reactive renders velocity template from a controller returning a reactive type"() {
+    def "invoking /freemarker/reactive renders freemarker template from a controller returning a reactive type"() {
         when:
-        HttpResponse<String> rsp = client.toBlocking().exchange('/velocity/reactive', String)
+        HttpResponse<String> rsp = client.toBlocking().exchange('/freemarker/reactive', String)
 
         then:
         noExceptionThrown()
@@ -105,9 +105,9 @@ class VelocityViewRendererSpec extends Specification {
         rsp.body().contains("<h1>username: <span>sdelamo</span></h1>")
     }
 
-    def "invoking /velocity/modelAndView renders velocity template from a controller returning a ModelAndView instance"() {
+    def "invoking /freemarker/modelAndView renders freemarker template from a controller returning a ModelAndView instance"() {
         when:
-        HttpResponse<String> rsp = client.toBlocking().exchange('/velocity/modelAndView', String)
+        HttpResponse<String> rsp = client.toBlocking().exchange('/freemarker/modelAndView', String)
 
         then:
         noExceptionThrown()
@@ -121,9 +121,9 @@ class VelocityViewRendererSpec extends Specification {
         rsp.body().contains("<h1>username: <span>sdelamo</span></h1>")
     }
 
-    def "invoking /velocity/viewWithNoViewRendererForProduces skips view rendering since controller specifies a media type with no available ViewRenderer"() {
+    def "invoking /freemarker/viewWithNoViewRendererForProduces skips view rendering since controller specifies a media type with no available ViewRenderer"() {
         when:
-        HttpResponse<String> rsp = client.toBlocking().exchange('/velocity/viewWithNoViewRendererForProduces', String)
+        HttpResponse<String> rsp = client.toBlocking().exchange('/freemarker/viewWithNoViewRendererForProduces', String)
 
         then:
         noExceptionThrown()
@@ -137,9 +137,9 @@ class VelocityViewRendererSpec extends Specification {
         rsp.body() == 'io.micronaut.docs.Person(sdelamo, true)'
     }
 
-    def "invoking /velocity/bogus returns 404 if you attempt to render a template which does not exist"() {
+    def "invoking /freemarker/bogus returns 404 if you attempt to render a template which does not exist"() {
         when:
-        client.toBlocking().exchange('/velocity/bogus', String)
+        client.toBlocking().exchange('/freemarker/bogus', String)
 
         then:
         def e = thrown(HttpClientResponseException)
@@ -148,9 +148,9 @@ class VelocityViewRendererSpec extends Specification {
         e.status == HttpStatus.NOT_FOUND
     }
 
-    def "invoking /velocity/nullbody renders view even if the response body is null"() {
+    def "invoking /freemarker/nullbody renders view even if the response body is null"() {
         when:
-        HttpResponse<String> rsp = client.toBlocking().exchange('/velocity/nullbody', String)
+        HttpResponse<String> rsp = client.toBlocking().exchange('/freemarker/nullbody', String)
 
         then:
         noExceptionThrown()

--- a/views/src/test/groovy/io/micronaut/docs/HandlebarsViewsRendererSpec.groovy
+++ b/views/src/test/groovy/io/micronaut/docs/HandlebarsViewsRendererSpec.groovy
@@ -26,6 +26,7 @@ class HandlebarsViewsRendererSpec extends Specification {
                     'micronaut.views.handlebars.enabled': true,
                     'micronaut.views.thymeleaf.enabled': false,
                     'micronaut.views.velocity.enabled': false,
+                    'micronaut.views.freemarker.enabled': false,
             ],
             "test")
 

--- a/views/src/test/groovy/io/micronaut/docs/ThymeleafViewRendererSpec.groovy
+++ b/views/src/test/groovy/io/micronaut/docs/ThymeleafViewRendererSpec.groovy
@@ -26,6 +26,7 @@ class ThymeleafViewRendererSpec extends Specification {
                     'spec.name': 'thymeleaf',
                     'micronaut.views.velocity.enabled': false,
                     'micronaut.views.handlebars.enabled': false,
+                    'micronaut.views.freemarker.enabled': false,
             ],
             "test")
 

--- a/views/src/test/groovy/io/micronaut/docs/ViewsFilterSpec.groovy
+++ b/views/src/test/groovy/io/micronaut/docs/ViewsFilterSpec.groovy
@@ -22,6 +22,7 @@ class ViewsFilterSpec extends Specification {
                     'micronaut.views.thymeleaf.enabled': false,
                     'micronaut.views.handlebars.enabled': false,
                     'micronaut.views.velocity.enabled': false,
+                    'micronaut.views.freemarker.enabled': false,
             ],
             "test")
 

--- a/views/src/test/resources/views/home.ftl
+++ b/views/src/test/resources/views/home.ftl
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Home</title>
+</head>
+<body>
+    <#if loggedIn??>
+    <h1>username: <span>${username}</span></h1>
+    <#else>
+    <h1>You are not logged in</h1>
+    </#if>
+</body>
+</html>


### PR DESCRIPTION
"Inspired" in the Velocity view implementation, add support for Freemarker.

All configuration defined by Freemarker is supported in the Micronaut configuration.

As another view, the same kind of tests and documentation are created.