### PR TITLE
using path for matching filters instead of URI.toString()

### DIFF
--- a/router/src/main/java/io/micronaut/web/router/DefaultFilterRoute.java
+++ b/router/src/main/java/io/micronaut/web/router/DefaultFilterRoute.java
@@ -77,7 +77,7 @@ class DefaultFilterRoute implements FilterRoute {
         if (httpMethods != null && !httpMethods.contains(method)) {
             return Optional.empty();
         }
-        String uriStr = uri.toString();
+        String uriStr = uri.getPath();
         for (String pattern : patterns) {
             if (PathMatcher.ANT.matches(pattern, uriStr)) {
                 HttpFilter filter = getFilter();


### PR DESCRIPTION
if the URI is absolute then the filter won' match