### PR TITLE
Fix issues with multiple validation errors response

### DIFF
--- a/validation/src/main/java/io/micronaut/validation/exceptions/ConstraintExceptionHandler.java
+++ b/validation/src/main/java/io/micronaut/validation/exceptions/ConstraintExceptionHandler.java
@@ -52,46 +52,38 @@ public class ConstraintExceptionHandler implements ExceptionHandler<ConstraintVi
 
         if (constraintViolations.size() == 1) {
             ConstraintViolation<?> violation = constraintViolations.iterator().next();
-            StringBuilder message = new StringBuilder();
-            Path propertyPath = violation.getPropertyPath();
-            boolean first = true;
-            Iterator<Path.Node> i = propertyPath.iterator();
-            while (i.hasNext()) {
-                Path.Node node = i.next();
-                if (first) {
-                    first = false;
-                    continue;
-                }
-                message.append(node);
-                if (i.hasNext()) {
-                    message.append('.');
-                }
-            }
-            message.append(": ").append(violation.getMessage());
-            JsonError error = new JsonError(message.toString());
+            JsonError error = new JsonError(createMessage(violation));
             error.link(Link.SELF, Link.of(request.getUri()));
             return HttpResponse.badRequest(error);
         } else {
             JsonError error = new JsonError(HttpStatus.BAD_REQUEST.getReason());
             List<Resource> errors = new ArrayList<>();
             for (ConstraintViolation<?> violation : constraintViolations) {
-
-                StringBuilder message = new StringBuilder();
-                Path propertyPath = violation.getPropertyPath();
-                boolean first = true;
-                for (Path.Node node : propertyPath) {
-                    if (first) {
-                        first = false;
-                        continue;
-                    }
-                    message.append(node).append('.');
-                }
-                message.append(':').append(violation.getMessage());
-                errors.add(new JsonError(message.toString()));
+                errors.add(new JsonError(createMessage(violation)));
             }
             error.embedded(Resource.EMBEDDED, errors);
             error.link(Link.SELF, Link.of(request.getUri()));
             return HttpResponse.badRequest(error);
         }
+    }
+
+    protected String createMessage(ConstraintViolation violation) {
+        Path propertyPath = violation.getPropertyPath();
+        StringBuilder message = new StringBuilder();
+        boolean first = true;
+        Iterator<Path.Node> i = propertyPath.iterator();
+        while (i.hasNext()) {
+            Path.Node node = i.next();
+            if (first) {
+                first = false;
+                continue;
+            }
+            message.append(node);
+            if (i.hasNext()) {
+                message.append('.');
+            }
+        }
+        message.append(": ").append(violation.getMessage());
+        return message.toString();
     }
 }

--- a/validation/src/main/java/io/micronaut/validation/exceptions/ConstraintExceptionHandler.java
+++ b/validation/src/main/java/io/micronaut/validation/exceptions/ConstraintExceptionHandler.java
@@ -52,22 +52,22 @@ public class ConstraintExceptionHandler implements ExceptionHandler<ConstraintVi
 
         if (constraintViolations.size() == 1) {
             ConstraintViolation<?> violation = constraintViolations.iterator().next();
-            JsonError error = new JsonError(createMessage(violation));
+            JsonError error = new JsonError(buildMessage(violation));
             error.link(Link.SELF, Link.of(request.getUri()));
             return HttpResponse.badRequest(error);
         } else {
             JsonError error = new JsonError(HttpStatus.BAD_REQUEST.getReason());
             List<Resource> errors = new ArrayList<>();
             for (ConstraintViolation<?> violation : constraintViolations) {
-                errors.add(new JsonError(createMessage(violation)));
+                errors.add(new JsonError(buildMessage(violation)));
             }
-            error.embedded(Resource.EMBEDDED, errors);
+            error.embedded("errors", errors);
             error.link(Link.SELF, Link.of(request.getUri()));
             return HttpResponse.badRequest(error);
         }
     }
 
-    protected String createMessage(ConstraintViolation violation) {
+    protected String buildMessage(ConstraintViolation violation) {
         Path propertyPath = violation.getPropertyPath();
         StringBuilder message = new StringBuilder();
         boolean first = true;

--- a/validation/src/test/groovy/io/micronaut/validation/Pojo.java
+++ b/validation/src/test/groovy/io/micronaut/validation/Pojo.java
@@ -1,11 +1,15 @@
 package io.micronaut.validation;
 
 import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
 
 public class Pojo {
 
     @Email(message = "Email should be valid")
     private String email;
+
+    @NotBlank
+    private String name;
 
     public String getEmail() {
         return email;
@@ -13,5 +17,13 @@ public class Pojo {
 
     public void setEmail(String email) {
         this.email = email;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 }


### PR DESCRIPTION
This PR fix some but not all of the issues described in https://github.com/micronaut-projects/micronaut-core/issues/980

- Remove extra dot after property paths. This issue is only visible (in 1.0.1) when there are multiple violations.
- Change extra nested "_embedded" key to "errors". I'm not sure if this can be fixed on the 1.0.x branch as it alters the JSON response. I hope no one depends on the wrong structure in 1.0.1. 