### PR TITLE
Clarification to Mongo support documentation

### DIFF
--- a/src/main/docs/guide/configurations/dataAccess/mongoSupport.adoc
+++ b/src/main/docs/guide/configurations/dataAccess/mongoSupport.adoc
@@ -37,6 +37,8 @@ To use the blocking driver, add a dependency to your application to the mongo-ja
 compile "org.mongodb:mongo-java-driver"
 ----
 
+IMPORTANT: `"io.micronaut.configuration:micronaut-mongo-reactive"` dependency must be included as well
+
 Then the blocking http://mongodb.github.io/mongo-java-driver/3.7/javadoc/com/mongodb/MongoClient.html[MongoClient] will be available for injection.
 
 ==== Configuring the MongoDB Driver


### PR DESCRIPTION
I had an issue configuring Mongo with blocking driver. 
I added `org.mongodb:mongo-java-driver` dependency but still had an error:
`
No bean of type [com.mongodb.client.MongoClient] exists. Ensure the class is declared a bean and if you are using Java or Kotlin make sure you have enabled annotation processing.
`

In the [ticket](https://github.com/micronaut-projects/micronaut-core/issues/343) I was told to include `io.micronaut.configuration:micronaut-mongo-reactive` dependency as well to successfully use native driver.

I think that adding this note to Mongo support section would be beneficial to other people as well.