### PR TITLE
Fix JWT SecretEncryption constructor (Fixes Issue #1102)

### DIFF
--- a/security-jwt/src/main/java/io/micronaut/security/token/jwt/encryption/secret/SecretEncryption.java
+++ b/security-jwt/src/main/java/io/micronaut/security/token/jwt/encryption/secret/SecretEncryption.java
@@ -49,7 +49,7 @@ public class SecretEncryption extends AbstractEncryptionConfiguration {
         if (secretEncryptionConfiguration.getSecret() == null) {
             throw new ConfigurationException("Secret encryption Configuration 'secret' is required");
         }
-        if (supports(secretEncryptionConfiguration.getJweAlgorithm(), secretEncryptionConfiguration.getEncryptionMethod())) {
+        if (!supports(secretEncryptionConfiguration.getJweAlgorithm(), secretEncryptionConfiguration.getEncryptionMethod())) {
             StringBuilder sb = new StringBuilder();
             sb.append("Encryption Method: ");
             sb.append(secretEncryptionConfiguration.getEncryptionMethod().toString());


### PR DESCRIPTION
This fixes the issue for me locally, I was able to sign and encrypt a JWT using SecretEncryption, using JweAlgorithm=dir and EncryptionMethod=A128CBC-HS256.