### PR TITLE
Only first resolving strategy usage for route filtering fix

### DIFF
--- a/router/src/main/java/io/micronaut/web/router/version/RouteVersionFilter.java
+++ b/router/src/main/java/io/micronaut/web/router/version/RouteVersionFilter.java
@@ -71,7 +71,10 @@ public class RouteVersionFilter implements RouteMatchFilter {
 
         return (match) -> resolvingStrategies.stream()
                 .map(strategy -> strategy.resolve(request))
-                .anyMatch((opt) -> opt.map(s -> isVersionMatched(match, s)).orElse(true));
+                .filter(Optional::isPresent)
+                .findFirst()
+                .flatMap(opt -> opt.map(v -> isVersionMatched(match, v)))
+                .orElse(true);
     }
 
     private <T, R> boolean isVersionMatched(UriRouteMatch<T, R> routeMatch, String version) {

--- a/router/src/test/groovy/io/micronaut/web/router/version/DefaultVersionedUrlFilterSpec.groovy
+++ b/router/src/test/groovy/io/micronaut/web/router/version/DefaultVersionedUrlFilterSpec.groovy
@@ -153,4 +153,29 @@ class DefaultVersionedUrlFilterSpec extends Specification {
         matches.size() == 2
     }
 
+    def "should return only matched versions after using all version resolvers"() {
+        when:
+        def strategies = [
+                new ParameterVersionResolver(
+                    new ParameterVersionResolverConfiguration().with {
+                        names = ["version"]
+                        it
+                    }
+                ),
+                new HeaderVersionResolver(
+                    new HeaderVersionResolverConfiguration().with {
+                        names = ["API-VERSION"]
+                        it
+                    })
+        ]
+        def handler = new RouteVersionFilter(strategies)
+        def request = HttpRequest.GET("/versioned/hello").header("API-VERSION", "2")
+        def matches = routes.stream().filter(handler.filter(request)).collect(Collectors.toList())
+        then:
+        matches.size() == 2
+
+
+
+    }
+
 }


### PR DESCRIPTION
Found an issue in `RouteVersionFilter` with resolving strategies processing
This cleanup commit makes this bug more visible in code: https://github.com/micronaut-projects/micronaut-core/commit/f3432dfd9e9ba8b7f826b35a893ff69b0bf629b6

Description:
If the first resolving strategy in `resolvingStrategies` will return `Optional.empty()`
`opt.map(...).orElse(true)` will return `true` and `anyMatch` will return `true` immedialty.

A test case provided with this logic fixed.
Without the fix the test returns `matches.size() == 4` and is incorrect.
