### PR TITLE
Documentation error for consul.client.config.format: FILE

### DIFF
--- a/src/main/docs/guide/cloud/cloudConfiguration/distributedConfigurationConsul.adoc
+++ b/src/main/docs/guide/cloud/cloudConfiguration/distributedConfigurationConsul.adoc
@@ -117,7 +117,7 @@ Another option popular option is https://github.com/breser/git2consul[git2consul
 
 You can setup a Git repository that contains files like `application.yml`, `hello-world-test.json` etc. and the contents of these files are cloned to Consul.
 
-In this case each key in consul represents a file with an extension. For example `/config/application.yml` and you must configure the `FILES` format:
+In this case each key in consul represents a file with an extension. For example `/config/application.yml` and you must configure the `FILE` format:
 
 .application.yml
 [source,yaml]
@@ -125,5 +125,5 @@ In this case each key in consul represents a file with an extension. For example
 consul:
     client:
         config:
-            format: FILES
+            format: FILE
 ----


### PR DESCRIPTION
Update the documentation with the correct FILE (not FILES) setting for consul.client.config.format.