### PR TITLE
Jackson @JsonView support - alternate approach

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/jackson/JsonViewServerFilter.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/jackson/JsonViewServerFilter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017-2018 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.http.server.netty.jackson;
+
+import com.fasterxml.jackson.annotation.JsonView;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.http.HttpAttributes;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.MutableHttpResponse;
+import io.micronaut.http.annotation.Filter;
+import io.micronaut.http.filter.HttpServerFilter;
+import io.micronaut.http.filter.ServerFilterChain;
+import io.micronaut.jackson.JacksonConfiguration;
+import io.micronaut.jackson.serialize.JsonViewValueWrapper;
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+
+/**
+ * Jackson @JsonView filter.
+ */
+@Requires(beans = JacksonConfiguration.class)
+@Requires(property = "jackson.json-view-enabled")
+@Filter("/**")
+public class JsonViewServerFilter implements HttpServerFilter {
+    private static final Logger LOG = LoggerFactory.getLogger(JsonViewServerFilter.class);
+
+    @Override
+    public Publisher<MutableHttpResponse<?>> doFilter(HttpRequest<?> request, ServerFilterChain chain) {
+        Optional<AnnotationMetadata> routeMatch = request.getAttribute(HttpAttributes.ROUTE_MATCH, AnnotationMetadata.class);
+        if (routeMatch.isPresent()) {
+            AnnotationMetadata metadata = routeMatch.get();
+
+            Optional<Class> viewClass = metadata.classValue(JsonView.class);
+            if (viewClass.isPresent()) {
+                JsonViewValueWrapper wrapper = new JsonViewValueWrapper(viewClass.get());
+                request.setAttribute(HttpAttributes.MEDIA_TYPE_CODEC_DECORATOR, wrapper);
+            }
+        }
+
+        return chain.proceed(request);
+    }
+}

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/jackson/JsonViewController.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/jackson/JsonViewController.groovy
@@ -1,0 +1,36 @@
+package io.micronaut.http.server.netty.jackson
+
+import com.fasterxml.jackson.annotation.JsonView
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+
+@Controller("/jsonview")
+class JsonViewController {
+
+    static TestModel TEST_MODEL = new TestModel(firstName: "Bob", lastName: "Jones", birthdate: "08/01/1980", password: "secret")
+
+    @Get("/none")
+    HttpResponse<TestModel> none() {
+        return HttpResponse.ok(TEST_MODEL)
+    }
+
+    @JsonView(Views.Public)
+    @Get("/public")
+    HttpResponse<TestModel> publicView() {
+        return HttpResponse.ok(TEST_MODEL)
+    }
+
+    @JsonView(Views.Internal)
+    @Get("/internal")
+    HttpResponse<TestModel> internalView() {
+        return HttpResponse.ok(TEST_MODEL)
+    }
+
+    @JsonView(Views.Admin)
+    @Get("/admin")
+    HttpResponse<TestModel> adminView() {
+        return HttpResponse.ok(TEST_MODEL)
+    }
+
+}

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/jackson/JsonViewServerFilterSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/jackson/JsonViewServerFilterSpec.groovy
@@ -1,0 +1,63 @@
+package io.micronaut.http.server.netty.jackson
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.client.RxHttpClient
+import io.micronaut.runtime.server.EmbeddedServer
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class JsonViewServerFilterSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer,
+            [
+                    'jackson.jsonViewEnabled': true
+            ],
+            "test")
+
+    @Shared
+    @AutoCleanup
+    RxHttpClient client = embeddedServer.getApplicationContext().createBean(RxHttpClient, embeddedServer.getURL())
+
+
+    def "invoking /jsonview/none does not specify @JsonView, thus, all properties are returned"() {
+        when:
+        HttpResponse<TestModel> rsp = client.toBlocking().exchange('/jsonview/none', TestModel)
+
+        then:
+        rsp.body() == JsonViewController.TEST_MODEL
+    }
+
+    def "invoking /jsonview/public specifies 'public' @JsonView, thus, only public properties are returned"() {
+        when:
+        HttpResponse<TestModel> rsp = client.toBlocking().exchange('/jsonview/public', TestModel)
+
+        then:
+        rsp.body().firstName == JsonViewController.TEST_MODEL.firstName
+        rsp.body().lastName == JsonViewController.TEST_MODEL.lastName
+        rsp.body().birthdate == null
+        rsp.body().password == null
+    }
+
+    def "invoking /jsonview/internal specifies 'internal' @JsonView, thus, only internal properties are returned"() {
+        when:
+        HttpResponse<TestModel> rsp = client.toBlocking().exchange('/jsonview/internal', TestModel)
+
+        then:
+        rsp.body().firstName == JsonViewController.TEST_MODEL.firstName
+        rsp.body().lastName == JsonViewController.TEST_MODEL.lastName
+        rsp.body().birthdate == JsonViewController.TEST_MODEL.birthdate
+        rsp.body().password == null
+    }
+
+    def "invoking /jsonview/admin specifies 'admin' @JsonView, thus, admin (all) properties are returned"() {
+        when:
+        HttpResponse<TestModel> rsp = client.toBlocking().exchange('/jsonview/admin', TestModel)
+
+        then:
+        rsp.body() == JsonViewController.TEST_MODEL
+    }
+}

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/jackson/JsonViewSetupSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/jackson/JsonViewSetupSpec.groovy
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017-2018 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.netty.jackson
+
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.DefaultApplicationContext
+import io.micronaut.context.env.MapPropertySource
+import io.micronaut.jackson.JacksonConfiguration
+import spock.lang.Specification
+
+class JsonViewSetupSpec extends Specification {
+
+    void "verify default jackson setup with @JsonView disabled"() {
+
+        given:
+        ApplicationContext applicationContext = new DefaultApplicationContext("test").start()
+
+        expect:
+        applicationContext.containsBean(JacksonConfiguration)
+        !applicationContext.getBean(JacksonConfiguration).jsonViewEnabled
+        !applicationContext.containsBean(JsonViewServerFilter)
+
+        cleanup:
+        applicationContext?.close()
+    }
+
+
+    void "verify jackson setup with @JsonView enabled"() {
+
+        given:
+        ApplicationContext applicationContext = new DefaultApplicationContext("test")
+        applicationContext.environment.addPropertySource(MapPropertySource.of(
+                'jackson.jsonViewEnabled': true
+        ))
+        applicationContext.start()
+
+        expect:
+        applicationContext.containsBean(JacksonConfiguration)
+        applicationContext.getBean(JacksonConfiguration).jsonViewEnabled
+        applicationContext.containsBean(JsonViewServerFilter)
+
+        cleanup:
+        applicationContext?.close()
+    }
+}

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/jackson/TestModel.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/jackson/TestModel.groovy
@@ -1,0 +1,19 @@
+package io.micronaut.http.server.netty.jackson
+
+import com.fasterxml.jackson.annotation.JsonView
+import groovy.transform.EqualsAndHashCode
+
+@EqualsAndHashCode
+@JsonView(Views.Public)
+class TestModel {
+
+    String firstName
+
+    String lastName
+
+    @JsonView(Views.Internal)
+    String birthdate
+
+    @JsonView(Views.Admin)
+    String password
+}

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/jackson/Views.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/jackson/Views.groovy
@@ -1,0 +1,9 @@
+package io.micronaut.http.server.netty.jackson
+
+class Views {
+    static class Public {}
+
+    static class Internal extends Public {}
+
+    static class Admin extends Internal {}
+}

--- a/http-server/src/main/java/io/micronaut/http/server/codec/TextStreamCodec.java
+++ b/http-server/src/main/java/io/micronaut/http/server/codec/TextStreamCodec.java
@@ -97,33 +97,33 @@ public class TextStreamCodec implements MediaTypeCodec {
     }
 
     @Override
-    public <T> T decode(Argument<T> type, InputStream inputStream) throws CodecException {
+    public <T> T decode(Argument<T> type, InputStream inputStream, Object... decorators) throws CodecException {
         throw new UnsupportedOperationException("This codec currently only supports encoding");
     }
 
     @Override
-    public <T> T decode(Class<T> type, InputStream inputStream) throws CodecException {
+    public <T> T decode(Class<T> type, InputStream inputStream, Object... decorators) throws CodecException {
         throw new UnsupportedOperationException("This codec currently only supports encoding");
     }
 
     @Override
-    public <T> void encode(T object, OutputStream outputStream) throws CodecException {
+    public <T> void encode(T object, OutputStream outputStream, Object... decorators) throws CodecException {
         try {
-            outputStream.write(encode(object));
+            outputStream.write(encode(object, decorators));
         } catch (IOException e) {
             throw new CodecException("I/O error occurred encoding object to output stream: " + e.getMessage(), e);
         }
     }
 
     @Override
-    public <T> byte[] encode(T object) throws CodecException {
-        ByteBuffer buffer = encode(object, byteBufferFactory);
+    public <T> byte[] encode(T object, Object... decorators) throws CodecException {
+        ByteBuffer buffer = encode(object, byteBufferFactory, decorators);
         return buffer.toByteArray();
     }
 
     @SuppressWarnings("MagicNumber")
     @Override
-    public <T> ByteBuffer encode(T object, ByteBufferFactory allocator) throws CodecException {
+    public <T> ByteBuffer encode(T object, ByteBufferFactory allocator, Object... decorators) throws CodecException {
         Event<Object> event;
         if (object instanceof Event) {
             event = (Event<Object>) object;
@@ -137,7 +137,7 @@ public class TextStreamCodec implements MediaTypeCodec {
         } else {
             MediaTypeCodec jsonCodec = resolveMediaTypeCodecRegistry().findCodec(MediaType.APPLICATION_JSON_TYPE)
                 .orElseThrow(() -> new CodecException("No possible JSON encoders found!"));
-            body = jsonCodec.encode(data, allocator);
+            body = jsonCodec.encode(data, allocator, decorators);
         }
         ByteBuffer eventData = allocator.buffer(body.readableBytes() + 10);
         writeAttribute(eventData, COMMENT_PREFIX, event.getComment());

--- a/http/src/main/java/io/micronaut/http/HttpAttributes.java
+++ b/http/src/main/java/io/micronaut/http/HttpAttributes.java
@@ -52,7 +52,12 @@ public enum HttpAttributes implements CharSequence {
     /**
      * Attribute used to store the service ID a client request is being sent to. Used for tracing purposes.
      */
-    SERVICE_ID(Constants.PREFIX + ".serviceId");
+    SERVICE_ID(Constants.PREFIX + ".serviceId"),
+
+    /**
+     * Attribute used to store a decorator to affect encoding or decoding via a MediaTypeCodec.
+     */
+    MEDIA_TYPE_CODEC_DECORATOR(Constants.PREFIX + ".mediaTypeCodec.decorator");
 
     private final String name;
 

--- a/http/src/main/java/io/micronaut/http/codec/MediaTypeCodec.java
+++ b/http/src/main/java/io/micronaut/http/codec/MediaTypeCodec.java
@@ -46,10 +46,11 @@ public interface MediaTypeCodec {
      * @param type        The type
      * @param inputStream The input stream
      * @param <T>         The generic type
+     * @param decorators Decorator objects that can affect decoding behavior
      * @return The decoded result
      * @throws CodecException When the result cannot be decoded
      */
-    <T> T decode(Argument<T> type, InputStream inputStream) throws CodecException;
+    <T> T decode(Argument<T> type, InputStream inputStream, Object... decorators) throws CodecException;
 
     /**
      * Encode the given type from the given {@link InputStream}.
@@ -57,9 +58,10 @@ public interface MediaTypeCodec {
      * @param object       The object to encode
      * @param outputStream The input stream
      * @param <T>          The generic type
+     * @param decorators Decorator objects that can affect encoding behavior
      * @throws CodecException When the result cannot be decoded
      */
-    <T> void encode(T object, OutputStream outputStream) throws CodecException;
+    <T> void encode(T object, OutputStream outputStream, Object... decorators) throws CodecException;
 
     /**
      * Encode the given type returning the object as a byte[].
@@ -67,9 +69,10 @@ public interface MediaTypeCodec {
      * @param object The object to encode
      * @param <T>    The generic type
      * @return The decoded result
+     * @param decorators Decorator objects that can affect encoding behavior
      * @throws CodecException When the result cannot be decoded
      */
-    <T> byte[] encode(T object) throws CodecException;
+    <T> byte[] encode(T object, Object... decorators) throws CodecException;
 
     /**
      * Encode the given type returning the object as a {@link ByteBuffer}.
@@ -77,10 +80,11 @@ public interface MediaTypeCodec {
      * @param object    The object to encode
      * @param allocator The allocator
      * @param <T>       The generic type
+     * @param decorators Decorator objects that can affect encoding behavior
      * @return The decoded result
      * @throws CodecException When the result cannot be decoded
      */
-    <T> ByteBuffer encode(T object, ByteBufferFactory allocator) throws CodecException;
+    <T> ByteBuffer encode(T object, ByteBufferFactory allocator, Object... decorators) throws CodecException;
 
     /**
      * Decode the given type from the given {@link InputStream}.
@@ -88,11 +92,12 @@ public interface MediaTypeCodec {
      * @param type        The type
      * @param inputStream The input stream
      * @param <T>         The generic type
+     * @param decorators Decorator objects that can affect decoding behavior
      * @return The decoded result
      * @throws CodecException When the result cannot be decoded
      */
-    default <T> T decode(Class<T> type, InputStream inputStream) throws CodecException {
-        return decode(Argument.of(type), inputStream);
+    default <T> T decode(Class<T> type, InputStream inputStream, Object... decorators) throws CodecException {
+        return decode(Argument.of(type), inputStream, decorators);
     }
 
     /**
@@ -101,11 +106,12 @@ public interface MediaTypeCodec {
      * @param type  The type
      * @param bytes The bytes
      * @param <T>   The decoded type
+     * @param decorators Decorator objects that can affect decoding behavior
      * @return The decoded result
      * @throws CodecException When the result cannot be decoded
      */
-    default <T> T decode(Class<T> type, byte[] bytes) throws CodecException {
-        return decode(type, new ByteArrayInputStream(bytes));
+    default <T> T decode(Class<T> type, byte[] bytes, Object... decorators) throws CodecException {
+        return decode(type, new ByteArrayInputStream(bytes), decorators);
     }
 
     /**
@@ -114,11 +120,12 @@ public interface MediaTypeCodec {
      * @param type  The type
      * @param bytes The bytes
      * @param <T>   The decoded type
+     * @param decorators Decorator objects that can affect decoding behavior
      * @return The decoded result
      * @throws CodecException When the result cannot be decoded
      */
-    default <T> T decode(Argument<T> type, byte[] bytes) throws CodecException {
-        return decode(type, new ByteArrayInputStream(bytes));
+    default <T> T decode(Argument<T> type, byte[] bytes, Object... decorators) throws CodecException {
+        return decode(type, new ByteArrayInputStream(bytes), decorators);
     }
 
     /**
@@ -128,11 +135,12 @@ public interface MediaTypeCodec {
      * @param type   The type
      * @param buffer the buffer
      * @param <T>    The decoded type
+     * @param decorators Decorator objects that can affect decoding behavior
      * @return The decoded result
      * @throws CodecException When the result cannot be decoded
      */
-    default <T> T decode(Class<T> type, ByteBuffer<?> buffer) throws CodecException {
-        return decode(type, buffer.toInputStream());
+    default <T> T decode(Class<T> type, ByteBuffer<?> buffer, Object... decorators) throws CodecException {
+        return decode(type, buffer.toInputStream(), decorators);
     }
 
     /**
@@ -142,11 +150,12 @@ public interface MediaTypeCodec {
      * @param type   The type
      * @param buffer the buffer
      * @param <T>    The decoded type
+     * @param decorators Decorator objects that can affect decoding behavior
      * @return The decoded result
      * @throws CodecException When the result cannot be decoded
      */
-    default <T> T decode(Argument<T> type, ByteBuffer<?> buffer) throws CodecException {
-        return decode(type, buffer.toInputStream());
+    default <T> T decode(Argument<T> type, ByteBuffer<?> buffer, Object... decorators) throws CodecException {
+        return decode(type, buffer.toInputStream(), decorators);
     }
 
     /**
@@ -155,11 +164,12 @@ public interface MediaTypeCodec {
      * @param type The type
      * @param data The data as a string
      * @param <T>  The decoded type
+     * @param decorators Decorator objects that can affect decoding behavior
      * @return The decoded result
      * @throws CodecException When the result cannot be decoded
      */
-    default <T> T decode(Class<T> type, String data) throws CodecException {
-        return decode(type, new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8)));
+    default <T> T decode(Class<T> type, String data, Object... decorators) throws CodecException {
+        return decode(type, new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8)), decorators);
     }
 
     /**
@@ -168,11 +178,12 @@ public interface MediaTypeCodec {
      * @param type The type
      * @param data The data as a string
      * @param <T>  The decoded type
+     * @param decorators Decorator objects that can affect decoding behavior
      * @return The decoded result
      * @throws CodecException When the result cannot be decoded
      */
-    default <T> T decode(Argument<T> type, String data) throws CodecException {
-        return decode(type, new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8)));
+    default <T> T decode(Argument<T> type, String data, Object... decorators) throws CodecException {
+        return decode(type, new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8)), decorators);
     }
 
     /**

--- a/runtime/src/main/java/io/micronaut/jackson/JacksonConfiguration.java
+++ b/runtime/src/main/java/io/micronaut/jackson/JacksonConfiguration.java
@@ -57,6 +57,7 @@ public class JacksonConfiguration {
     private Map<JsonGenerator.Feature, Boolean> generator = Collections.emptyMap();
     private JsonInclude.Include serializationInclusion = JsonInclude.Include.NON_EMPTY;
     private PropertyNamingStrategy propertyNamingStrategy = null;
+    private Boolean jsonViewEnabled = false;
 
     /**
      * @return The default serialization inclusion settings
@@ -133,6 +134,13 @@ public class JacksonConfiguration {
      */
     public PropertyNamingStrategy getPropertyNamingStrategy() {
         return propertyNamingStrategy;
+    }
+
+    /**
+     * @return True if JsonView annotation support is enabled.
+     */
+    public Boolean getJsonViewEnabled() {
+        return jsonViewEnabled;
     }
 
     /**
@@ -235,5 +243,13 @@ public class JacksonConfiguration {
      */
     public void setPropertyNamingStrategy(PropertyNamingStrategy propertyNamingStrategy) {
         this.propertyNamingStrategy = propertyNamingStrategy;
+    }
+
+    /**
+     * Enables or disables support for the JsonView annotation.
+     * @param jsonViewEnabled The boolean value
+     */
+    public void setJsonViewEnabled(Boolean jsonViewEnabled) {
+        this.jsonViewEnabled = jsonViewEnabled;
     }
 }

--- a/runtime/src/main/java/io/micronaut/jackson/serialize/JsonViewValueWrapper.java
+++ b/runtime/src/main/java/io/micronaut/jackson/serialize/JsonViewValueWrapper.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2018 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.jackson.serialize;
+
+/**
+ * Wraps the view class value of the Jackson @JsonView annotation.
+ */
+public final class JsonViewValueWrapper {
+
+    private final Class viewClass;
+
+    /**
+     * @param viewClass The view class specified by @JsonView
+     */
+    public JsonViewValueWrapper(Class viewClass) {
+        this.viewClass = viewClass;
+    }
+
+    /**
+     * @return The view class
+     */
+    public Class getViewClass() {
+        return viewClass;
+    }
+}

--- a/runtime/src/main/java/io/micronaut/runtime/http/codec/TextPlainCodec.java
+++ b/runtime/src/main/java/io/micronaut/runtime/http/codec/TextPlainCodec.java
@@ -87,7 +87,7 @@ public class TextPlainCodec implements MediaTypeCodec {
     }
 
     @Override
-    public <T> T decode(Argument<T> type, ByteBuffer<?> buffer) throws CodecException {
+    public <T> T decode(Argument<T> type, ByteBuffer<?> buffer, Object... decorators) throws CodecException {
         String text = buffer.toString(defaultCharset);
         return ConversionService.SHARED
             .convert(text, type)
@@ -95,7 +95,7 @@ public class TextPlainCodec implements MediaTypeCodec {
     }
 
     @Override
-    public <T> T decode(Argument<T> type, InputStream inputStream) throws CodecException {
+    public <T> T decode(Argument<T> type, InputStream inputStream, Object... decorators) throws CodecException {
         if (CharSequence.class.isAssignableFrom(type.getType())) {
             try {
                 return (T) IOUtils.readText(new BufferedReader(new InputStreamReader(inputStream, defaultCharset)));
@@ -107,8 +107,8 @@ public class TextPlainCodec implements MediaTypeCodec {
     }
 
     @Override
-    public <T> void encode(T object, OutputStream outputStream) throws CodecException {
-        byte[] bytes = encode(object);
+    public <T> void encode(T object, OutputStream outputStream, Object... decorators) throws CodecException {
+        byte[] bytes = encode(object, decorators);
         try {
             outputStream.write(bytes);
         } catch (IOException e) {
@@ -117,13 +117,13 @@ public class TextPlainCodec implements MediaTypeCodec {
     }
 
     @Override
-    public <T> byte[] encode(T object) throws CodecException {
+    public <T> byte[] encode(T object, Object... decorators) throws CodecException {
         return object.toString().getBytes(defaultCharset);
     }
 
     @Override
-    public <T> ByteBuffer encode(T object, ByteBufferFactory allocator) throws CodecException {
-        byte[] bytes = encode(object);
+    public <T> ByteBuffer encode(T object, ByteBufferFactory allocator, Object... decorators) throws CodecException {
+        byte[] bytes = encode(object, decorators);
         int len = bytes.length;
 
         return allocator.buffer(len, len).write(bytes);

--- a/runtime/src/test/groovy/io/micronaut/jackson/JacksonSetupSpec.groovy
+++ b/runtime/src/test/groovy/io/micronaut/jackson/JacksonSetupSpec.groovy
@@ -40,6 +40,7 @@ class JacksonSetupSpec extends Specification {
         applicationContext.containsBean(JacksonConfiguration)
         applicationContext.getBean(ObjectMapper.class).valueToTree([foo: 'bar']).get('foo').textValue() == 'bar'
         !applicationContext.getBean(JacksonConfiguration).propertyNamingStrategy
+        !applicationContext.getBean(JacksonConfiguration).jsonViewEnabled
 
         cleanup:
         applicationContext?.close()
@@ -52,7 +53,8 @@ class JacksonSetupSpec extends Specification {
         ApplicationContext applicationContext = new DefaultApplicationContext("test")
         applicationContext.environment.addPropertySource(MapPropertySource.of(
                 'jackson.dateFormat': 'yyMMdd',
-                'jackson.serialization.indentOutput': true
+                'jackson.serialization.indentOutput': true,
+                'jackson.jsonViewEnabled': true
         ))
         applicationContext.start()
 
@@ -63,6 +65,7 @@ class JacksonSetupSpec extends Specification {
         applicationContext.containsBean(JacksonConfiguration)
         applicationContext.getBean(JacksonConfiguration).dateFormat == 'yyMMdd'
         applicationContext.getBean(JacksonConfiguration).serializationSettings.get(SerializationFeature.INDENT_OUTPUT)
+        applicationContext.getBean(JacksonConfiguration).jsonViewEnabled
 
         cleanup:
         applicationContext?.close()


### PR DESCRIPTION
Last night I tried out this alternate approach to jackson `@JsonView` support (proposed in [a comment](https://github.com/micronaut-projects/micronaut-core/pull/1145#issuecomment-456199686) in #1145).

IMHO this is a better approach, but it does require changes to the existing `MediaTypeCodec` interface to allow decorator object params in the `encode` and `decode` methods.  Implementations of that interface need to change (including one in micronaut-grpc that I could change in a separate PR), but callers of those implementations do not, as the decorators are passed in as varargs in the last param.  This solution does still use a request attribute...I just don't see a way around that.

@graemerocher, if you have ideas for a cleaner solution, I'm happy to pitch in!