### PR TITLE
perf/cleanup: redundant if/else on return

### DIFF
--- a/cli/src/main/groovy/io/micronaut/cli/console/interactive/CandidateListCompletionHandler.java
+++ b/cli/src/main/groovy/io/micronaut/cli/console/interactive/CandidateListCompletionHandler.java
@@ -95,7 +95,7 @@ public class CandidateListCompletionHandler implements CompletionHandler {
         }
 
         // convert to an array for speed
-        String[] strings = candidates.toArray(new String[candidates.size()]);
+        String[] strings = candidates.toArray(new String[0]);
 
         String first = strings[0];
         StringBuilder candidate = new StringBuilder();

--- a/cli/src/main/groovy/io/micronaut/cli/console/logging/MicronautConsole.java
+++ b/cli/src/main/groovy/io/micronaut/cli/console/logging/MicronautConsole.java
@@ -1042,7 +1042,7 @@ public class MicronautConsole implements ConsoleLogger {
      * @return The line of text entered by the user
      */
     public String userInput(String message, List<String> validResponses) {
-        return userInput(message, validResponses.toArray(new String[validResponses.size()]));
+        return userInput(message, validResponses.toArray(new String[0]));
     }
 
     /**

--- a/cli/src/main/groovy/io/micronaut/cli/io/support/AntPathMatcher.java
+++ b/cli/src/main/groovy/io/micronaut/cli/io/support/AntPathMatcher.java
@@ -230,7 +230,7 @@ public class AntPathMatcher {
 
     private String[] tokenize(String pattern) {
         List<String> list = StringGroovyMethods.tokenize((CharSequence) pattern, (CharSequence) pathSeparator);
-        return list.toArray(new String[list.size()]);
+        return list.toArray(new String[0]);
     }
 
     /**

--- a/cli/src/main/groovy/io/micronaut/cli/io/support/PathMatchingResourcePatternResolver.java
+++ b/cli/src/main/groovy/io/micronaut/cli/io/support/PathMatchingResourcePatternResolver.java
@@ -267,7 +267,7 @@ public class PathMatchingResourcePatternResolver {
             URL url = resourceUrls.nextElement();
             result.add(convertClassLoaderURL(url));
         }
-        return result.toArray(new Resource[result.size()]);
+        return result.toArray(new Resource[0]);
     }
 
     /**
@@ -307,7 +307,7 @@ public class PathMatchingResourcePatternResolver {
                 result.addAll(doFindPathMatchingFileResources(rootDirResource, subPattern));
             }
         }
-        return result.toArray(new Resource[result.size()]);
+        return result.toArray(new Resource[0]);
     }
 
     /**

--- a/cli/src/main/groovy/io/micronaut/cli/io/support/ResourceUtils.java
+++ b/cli/src/main/groovy/io/micronaut/cli/io/support/ResourceUtils.java
@@ -445,7 +445,7 @@ public class ResourceUtils {
         if (collection == null) {
             return null;
         }
-        return collection.toArray(new String[collection.size()]);
+        return collection.toArray(new String[0]);
     }
 
     private static String deleteAny(String inString, String charsToDelete) {

--- a/core/src/main/java/io/micronaut/core/async/subscriber/SingleThreadedBufferingSubscriber.java
+++ b/core/src/main/java/io/micronaut/core/async/subscriber/SingleThreadedBufferingSubscriber.java
@@ -193,15 +193,14 @@ public abstract class SingleThreadedBufferingSubscriber<T> implements Subscriber
         if (demand <= 0) {
             illegalDemand();
             return false;
-        } else {
-            if (upstreamDemand < Long.MAX_VALUE) {
-                upstreamDemand += demand;
-                if (upstreamDemand < 0) {
-                    upstreamDemand = Long.MAX_VALUE;
-                }
-            }
-            return true;
         }
+        if (upstreamDemand < Long.MAX_VALUE) {
+            upstreamDemand += demand;
+            if (upstreamDemand < 0) {
+                upstreamDemand = Long.MAX_VALUE;
+            }
+        }
+        return true;
     }
 
     private void flushBuffer() {

--- a/core/src/main/java/io/micronaut/core/beans/PropertyDescriptor.java
+++ b/core/src/main/java/io/micronaut/core/beans/PropertyDescriptor.java
@@ -65,9 +65,8 @@ public class PropertyDescriptor implements Named {
     public Class<?> getBeanClass() {
         if (getter != null) {
             return getter.getDeclaringClass();
-        } else {
-            return setter.getDeclaringClass();
         }
+        return setter.getDeclaringClass();
     }
 
     /**
@@ -76,9 +75,8 @@ public class PropertyDescriptor implements Named {
     public Class<?> getType() {
         if (getter != null) {
             return getter.getReturnType();
-        } else {
-            return setter.getParameterTypes()[0];
         }
+        return setter.getParameterTypes()[0];
     }
 
     /**

--- a/core/src/main/java/io/micronaut/core/bind/annotation/AbstractAnnotatedArgumentBinder.java
+++ b/core/src/main/java/io/micronaut/core/bind/annotation/AbstractAnnotatedArgumentBinder.java
@@ -122,8 +122,7 @@ public abstract class AbstractAnnotatedArgumentBinder<A extends Annotation, T, S
         Optional<T> result = conversionService.convert(value, context);
         if (result.isPresent() && context.getArgument().getType() == Optional.class) {
             return () -> (Optional<T>) result.get();
-        } else {
-            return () -> result;
         }
+        return () -> result;
     }
 }

--- a/core/src/main/java/io/micronaut/core/cli/CommandLineParser.java
+++ b/core/src/main/java/io/micronaut/core/cli/CommandLineParser.java
@@ -268,6 +268,6 @@ class CommandLineParser implements CommandLine.Builder<CommandLineParser> {
         if (state == inQuote || state == inDoubleQuote) {
             throw new ParseException("unbalanced quotes in " + toProcess);
         }
-        return result.toArray(new String[result.size()]);
+        return result.toArray(new String[0]);
     }
 }

--- a/core/src/main/java/io/micronaut/core/convert/DefaultConversionService.java
+++ b/core/src/main/java/io/micronaut/core/convert/DefaultConversionService.java
@@ -119,12 +119,10 @@ public class DefaultConversionService implements ConversionService<DefaultConver
             if (typeConverter != null) {
                 converterCache.put(pair, typeConverter);
                 return true;
-            } else {
-                return false;
             }
-        } else {
-            return true;
+            return false;
         }
+        return true;
     }
 
     @Override
@@ -500,21 +498,20 @@ public class DefaultConversionService implements ConversionService<DefaultConver
                 AnnotationClassValue[] array = new AnnotationClassValue[1];
                 array[0] = (AnnotationClassValue) object;
                 return Optional.of(array);
-            } else {
-
-                String str = object.toString();
-                String[] strings = str.split(",");
-                Class<?> componentType = ReflectionUtils.getWrapperType(targetType.getComponentType());
-                Object newArray = Array.newInstance(componentType, strings.length);
-                for (int i = 0; i < strings.length; i++) {
-                    String string = strings[i];
-                    Optional<?> converted = convert(string, componentType);
-                    if (converted.isPresent()) {
-                        Array.set(newArray, i, converted.get());
-                    }
-                }
-                return Optional.of((Object[]) newArray);
             }
+
+            String str = object.toString();
+            String[] strings = str.split(",");
+            Class<?> componentType = ReflectionUtils.getWrapperType(targetType.getComponentType());
+            Object newArray = Array.newInstance(componentType, strings.length);
+            for (int i = 0; i < strings.length; i++) {
+                String string = strings[i];
+                Optional<?> converted = convert(string, componentType);
+                if (converted.isPresent()) {
+                    Array.set(newArray, i, converted.get());
+                }
+            }
+            return Optional.of((Object[]) newArray);
         });
 
         // String -> Int Array
@@ -569,25 +566,32 @@ public class DefaultConversionService implements ConversionService<DefaultConver
             Class targetNumberType = ReflectionUtils.getWrapperType(targetType);
             if (targetNumberType.isInstance(object)) {
                 return Optional.of(object);
-            } else if (targetNumberType == Integer.class) {
+            }
+            if (targetNumberType == Integer.class) {
                 return Optional.of(object.intValue());
-            } else if (targetNumberType == Long.class) {
+            }
+            if (targetNumberType == Long.class) {
                 return Optional.of(object.longValue());
-            } else if (targetNumberType == Short.class) {
+            }
+            if (targetNumberType == Short.class) {
                 return Optional.of(object.shortValue());
-            } else if (targetNumberType == Byte.class) {
+            }
+            if (targetNumberType == Byte.class) {
                 return Optional.of(object.byteValue());
-            } else if (targetNumberType == Float.class) {
+            }
+            if (targetNumberType == Float.class) {
                 return Optional.of(object.floatValue());
-            } else if (targetNumberType == Double.class) {
+            }
+            if (targetNumberType == Double.class) {
                 return Optional.of(object.doubleValue());
-            } else if (targetNumberType == BigInteger.class) {
+            } 
+            if (targetNumberType == BigInteger.class) {
                 if (object instanceof BigDecimal) {
                     return Optional.of(((BigDecimal) object).toBigInteger());
-                } else {
-                    return Optional.of(BigInteger.valueOf(object.longValue()));
                 }
-            } else if (targetNumberType == BigDecimal.class) {
+                return Optional.of(BigInteger.valueOf(object.longValue()));
+            }
+            if (targetNumberType == BigDecimal.class) {
                 return Optional.of(new BigDecimal(object.toString()));
             }
             return Optional.empty();
@@ -621,9 +625,8 @@ public class DefaultConversionService implements ConversionService<DefaultConver
             Optional converted = convert(object, targetComponentType, newContext);
             if (converted.isPresent()) {
                 return Optional.of(converted);
-            } else {
-                return Optional.of(Optional.empty());
             }
+            return Optional.of(Optional.empty());
         });
 
         addConverter(Object.class, OptionalInt.class, (object, targetType, context) -> {
@@ -644,9 +647,8 @@ public class DefaultConversionService implements ConversionService<DefaultConver
             if (ConvertibleValues.class.isAssignableFrom(targetType)) {
                 if (object instanceof ConvertibleValues) {
                     return Optional.of(object);
-                } else {
-                    return Optional.empty();
                 }
+                return Optional.empty();
             }
             Optional<Argument<?>> typeVariable = context.getFirstTypeVariable();
             Argument<?> componentType = typeVariable.orElse(Argument.OBJECT_ARGUMENT);
@@ -665,17 +667,16 @@ public class DefaultConversionService implements ConversionService<DefaultConver
                     }
                 }
                 return CollectionUtils.convertCollection((Class) targetType, list);
-            } else {
-                targetComponentType = Object.class;
-                List list = new ArrayList();
-                for (Object o : object) {
-                    Optional<?> converted = convert(o, targetComponentType, newContext);
-                    if (converted.isPresent()) {
-                        list.add(converted.get());
-                    }
-                }
-                return CollectionUtils.convertCollection((Class) targetType, list);
             }
+            targetComponentType = Object.class;
+            List list = new ArrayList();
+            for (Object o : object) {
+                Optional<?> converted = convert(o, targetComponentType, newContext);
+                if (converted.isPresent()) {
+                    list.add(converted.get());
+                }
+            }
+            return CollectionUtils.convertCollection((Class) targetType, list);
         });
 
         // Object[] -> String

--- a/core/src/main/java/io/micronaut/core/io/ResourceResolver.java
+++ b/core/src/main/java/io/micronaut/core/io/ResourceResolver.java
@@ -115,9 +115,8 @@ public class ResourceResolver {
         Optional<ResourceLoader> resourceLoader = getSupportingLoader(path);
         if (resourceLoader.isPresent()) {
             return resourceLoader.get().getResourceAsStream(path);
-        } else {
-            return Optional.empty();
         }
+        return Optional.empty();
     }
 
     /**
@@ -131,9 +130,8 @@ public class ResourceResolver {
         Optional<ResourceLoader> resourceLoader = getSupportingLoader(path);
         if (resourceLoader.isPresent()) {
             return resourceLoader.get().getResource(path);
-        } else {
-            return Optional.empty();
         }
+        return Optional.empty();
     }
 
     /**
@@ -147,8 +145,7 @@ public class ResourceResolver {
         Optional<ResourceLoader> resourceLoader = getSupportingLoader(path);
         if (resourceLoader.isPresent()) {
             return resourceLoader.get().getResources(path);
-        } else {
-            return Stream.empty();
         }
+        return Stream.empty();
     }
 }

--- a/core/src/main/java/io/micronaut/core/io/UrlReadable.java
+++ b/core/src/main/java/io/micronaut/core/io/UrlReadable.java
@@ -74,33 +74,32 @@ class UrlReadable implements Readable {
                 } catch (URISyntaxException ex) {
                     return new File(url.getFile()).exists();
                 }
-            } else {
-                URLConnection con = url.openConnection();
-                con.setUseCaches(true);
-                final boolean isHttp = con instanceof HttpURLConnection;
-                if (isHttp) {
-                    final HttpURLConnection httpURLConnection = (HttpURLConnection) con;
-                    httpURLConnection.setRequestMethod("HEAD");
-                    int code = httpURLConnection.getResponseCode();
-                    if (code == HttpURLConnection.HTTP_OK) {
-                        return true;
-                    } else if (code == HttpURLConnection.HTTP_NOT_FOUND) {
-                        return false;
-                    }
-                }
-                if (con.getContentLengthLong() >= 0) {
+            }
+            URLConnection con = url.openConnection();
+            con.setUseCaches(true);
+            final boolean isHttp = con instanceof HttpURLConnection;
+            if (isHttp) {
+                final HttpURLConnection httpURLConnection = (HttpURLConnection) con;
+                httpURLConnection.setRequestMethod("HEAD");
+                int code = httpURLConnection.getResponseCode();
+                if (code == HttpURLConnection.HTTP_OK) {
                     return true;
                 }
-                if (isHttp) {
-                    // No HTTP OK status, and no content-length header: give up
-                    ((HttpURLConnection) con).disconnect();
+                if (code == HttpURLConnection.HTTP_NOT_FOUND) {
                     return false;
-                } else {
-                    // Fall back to stream existence: can we open the stream?
-                    asInputStream().close();
-                    return true;
                 }
             }
+            if (con.getContentLengthLong() >= 0) {
+                return true;
+            }
+            if (isHttp) {
+                // No HTTP OK status, and no content-length header: give up
+                ((HttpURLConnection) con).disconnect();
+                return false;
+            }
+            // Fall back to stream existence: can we open the stream?
+            asInputStream().close();
+            return true;
         } catch (IOException ex) {
             return false;
         }

--- a/core/src/main/java/io/micronaut/core/io/scan/ClassPathAnnotationScanner.java
+++ b/core/src/main/java/io/micronaut/core/io/scan/ClassPathAnnotationScanner.java
@@ -92,10 +92,9 @@ public class ClassPathAnnotationScanner implements AnnotationScanner {
     public Stream<Class> scan(String annotation, String pkg) {
         if (pkg == null) {
             return Stream.empty();
-        } else {
-            List<Class> classes = doScan(annotation, pkg);
-            return classes.stream();
         }
+        List<Class> classes = doScan(annotation, pkg);
+        return classes.stream();
     }
 
     /**

--- a/core/src/main/java/io/micronaut/core/io/scan/DefaultClassPathResourceLoader.java
+++ b/core/src/main/java/io/micronaut/core/io/scan/DefaultClassPathResourceLoader.java
@@ -76,9 +76,8 @@ public class DefaultClassPathResourceLoader implements ClassPathResourceLoader {
     public Optional<InputStream> getResourceAsStream(String path) {
         if (!isDirectory(path)) {
             return Optional.ofNullable(classLoader.getResourceAsStream(prefixPath(path)));
-        } else {
-            return Optional.empty();
         }
+        return Optional.empty();
     }
 
     /**
@@ -205,12 +204,10 @@ public class DefaultClassPathResourceLoader implements ClassPathResourceLoader {
         if (basePath != null) {
             if (path.startsWith("/")) {
                 return basePath + path.substring(1);
-            } else {
-                return basePath + path;
             }
-        } else {
-            return path;
+            return basePath + path;
         }
+        return path;
     }
 
 }

--- a/core/src/main/java/io/micronaut/core/io/service/SoftServiceLoader.java
+++ b/core/src/main/java/io/micronaut/core/io/service/SoftServiceLoader.java
@@ -141,7 +141,8 @@ public final class SoftServiceLoader<S> implements Iterable<ServiceDefinition<S>
             public boolean hasNext() {
                 if (loaded.hasNext()) {
                     return true;
-                } else if (unloadedServices.hasNext()) {
+                }
+                if (unloadedServices.hasNext()) {
                     return true;
                 }
                 return false;
@@ -155,7 +156,8 @@ public final class SoftServiceLoader<S> implements Iterable<ServiceDefinition<S>
 
                 if (loaded.hasNext()) {
                     return loaded.next();
-                } else if (unloadedServices.hasNext()) {
+                }
+                if (unloadedServices.hasNext()) {
                     ServiceDefinition<S> nextService = unloadedServices.next();
                     loadedServices.put(nextService.getName(), nextService);
                     return nextService;

--- a/core/src/main/java/io/micronaut/core/naming/NameUtils.java
+++ b/core/src/main/java/io/micronaut/core/naming/NameUtils.java
@@ -237,9 +237,13 @@ public class NameUtils {
         int prefixLength = 0;
         if (methodName.startsWith("get")) {
             prefixLength = PREFIX_LENTGH;
-        }
-        if (methodName.startsWith("is")) {
+        } else if (methodName.startsWith("is")) {
             prefixLength = IS_LENTGH;
+        } else {
+            return false;
+        }
+        if (len > prefixLength) {
+            return Character.isUpperCase(methodName.charAt(prefixLength));
         }
         return false;
     }

--- a/core/src/main/java/io/micronaut/core/naming/NameUtils.java
+++ b/core/src/main/java/io/micronaut/core/naming/NameUtils.java
@@ -149,9 +149,8 @@ public class NameUtils {
         if (matcher.find()) {
             int position = matcher.start();
             return className.substring(0, position);
-        } else {
-            return "";
         }
+        return "";
     }
 
     /**
@@ -186,9 +185,8 @@ public class NameUtils {
         if (matcher.find()) {
             int position = matcher.start();
             return className.substring(position + 1);
-        } else {
-            return className;
         }
+        return className;
     }
 
     /**
@@ -239,13 +237,9 @@ public class NameUtils {
         int prefixLength = 0;
         if (methodName.startsWith("get")) {
             prefixLength = PREFIX_LENTGH;
-        } else if (methodName.startsWith("is")) {
-            prefixLength = IS_LENTGH;
-        } else {
-            return false;
         }
-        if (len > prefixLength) {
-            return Character.isUpperCase(methodName.charAt(prefixLength));
+        if (methodName.startsWith("is")) {
+            prefixLength = IS_LENTGH;
         }
         return false;
     }
@@ -261,7 +255,8 @@ public class NameUtils {
             int prefixLength = 0;
             if (getterName.startsWith("get")) {
                 prefixLength = PREFIX_LENTGH;
-            } else if (getterName.startsWith("is")) {
+            }
+            if (getterName.startsWith("is")) {
                 prefixLength = IS_LENTGH;
             }
             return decapitalize(getterName.substring(prefixLength));
@@ -387,9 +382,8 @@ public class NameUtils {
         int index = lastSeparator > extensionPos ? -1 : extensionPos;
         if (index == -1) {
             return "";
-        } else {
-            return filename.substring(index + 1);
         }
+        return filename.substring(index + 1);
     }
 
     /**
@@ -434,9 +428,8 @@ public class NameUtils {
         int index = lastSeparator > extensionPos ? path.length() : extensionPos;
         if (index == -1) {
             return "";
-        } else {
-            return path.substring(lastSeparator + 1, index);
         }
+        return path.substring(lastSeparator + 1, index);
     }
 
 }

--- a/core/src/main/java/io/micronaut/core/reflect/ClassUtils.java
+++ b/core/src/main/java/io/micronaut/core/reflect/ClassUtils.java
@@ -41,8 +41,8 @@ import java.util.*;
 public class ClassUtils {
 
     public static final int EMPTY_OBJECT_ARRAY_HASH_CODE = Arrays.hashCode(ArrayUtils.EMPTY_OBJECT_ARRAY);
-    public static final Map<String, Class> COMMON_CLASS_MAP = new HashMap<>(25);
-    public static final Map<String, Class> BASIC_TYPE_MAP = new HashMap<>(10);
+    public static final Map<String, Class> COMMON_CLASS_MAP = new HashMap<>(34);
+    public static final Map<String, Class> BASIC_TYPE_MAP = new HashMap<>(18);
     public static final String CLASS_EXTENSION = ".class";
     
     static final List<ClassLoadingReporter> CLASS_LOADING_REPORTERS;

--- a/core/src/main/java/io/micronaut/core/reflect/GenericTypeUtils.java
+++ b/core/src/main/java/io/micronaut/core/reflect/GenericTypeUtils.java
@@ -186,7 +186,8 @@ public class GenericTypeUtils {
         ParameterizedType pt;
         if (actualTypeArgument instanceof Class) {
             return Optional.of((Class) actualTypeArgument);
-        } else if (actualTypeArgument instanceof ParameterizedType) {
+        }
+        if (actualTypeArgument instanceof ParameterizedType) {
             pt = (ParameterizedType) actualTypeArgument;
             Type rawType = pt.getRawType();
             if (rawType instanceof Class) {

--- a/core/src/main/java/io/micronaut/core/reflect/ReflectionUtils.java
+++ b/core/src/main/java/io/micronaut/core/reflect/ReflectionUtils.java
@@ -118,9 +118,8 @@ public class ReflectionUtils {
     public static Class getWrapperType(Class primitiveType) {
         if (primitiveType.isPrimitive()) {
             return PRIMITIVES_TO_WRAPPERS.get(primitiveType);
-        } else {
-            return primitiveType;
         }
+        return primitiveType;
     }
 
     /**
@@ -133,9 +132,8 @@ public class ReflectionUtils {
         Class<?> wrapper = WRAPPER_TO_PRIMITIVE.get(wrapperType);
         if (wrapper != null) {
             return wrapper;
-        } else {
-            return wrapperType;
         }
+        return wrapperType;
     }
 
     /**

--- a/core/src/main/java/io/micronaut/core/serialize/JdkSerializer.java
+++ b/core/src/main/java/io/micronaut/core/serialize/JdkSerializer.java
@@ -105,9 +105,8 @@ public class JdkSerializer implements ObjectSerializer {
                 Optional<Class> aClass = ClassUtils.forName(desc.getName(), requiredType.getClassLoader());
                 if (aClass.isPresent()) {
                     return aClass.get();
-                } else {
-                    return super.resolveClass(desc);
                 }
+                return super.resolveClass(desc);
             }
         };
     }

--- a/core/src/main/java/io/micronaut/core/type/Argument.java
+++ b/core/src/main/java/io/micronaut/core/type/Argument.java
@@ -171,14 +171,13 @@ public interface Argument<T> extends TypeVariableResolver, Named, AnnotationMeta
     static Class[] toClassArray(Argument... arguments) {
         if (ArrayUtils.isEmpty(arguments)) {
             return ReflectionUtils.EMPTY_CLASS_ARRAY;
-        } else {
-            Class[] types = new Class[arguments.length];
-            for (int i = 0; i < arguments.length; i++) {
-                Argument argument = arguments[i];
-                types[i] = argument.getType();
-            }
-            return types;
         }
+        Class[] types = new Class[arguments.length];
+        for (int i = 0; i < arguments.length; i++) {
+            Argument argument = arguments[i];
+            types[i] = argument.getType();
+        }
+        return types;
     }
 
     /**
@@ -289,20 +288,19 @@ public interface Argument<T> extends TypeVariableResolver, Named, AnnotationMeta
     static <T> Argument<T> of(Class<T> type, @Nullable Class<?>... typeParameters) {
         if (typeParameters == null) {
             return of(type);
-        } else {
-
-            TypeVariable<Class<T>>[] parameters = type.getTypeParameters();
-            int len = typeParameters.length;
-            if (parameters.length != len) {
-                throw new IllegalArgumentException("Type parameter length does not match. Required: " + parameters.length + ", Specified: " + len);
-            }
-            Argument[] typeArguments = new Argument[len];
-            for (int i = 0; i < parameters.length; i++) {
-                TypeVariable<Class<T>> parameter = parameters[i];
-                typeArguments[i] = Argument.of(typeParameters[i], parameter.getName());
-            }
-            return new DefaultArgument<>(type, NameUtils.decapitalize(type.getSimpleName()), AnnotationMetadata.EMPTY_METADATA, typeArguments);
         }
+
+        TypeVariable<Class<T>>[] parameters = type.getTypeParameters();
+        int len = typeParameters.length;
+        if (parameters.length != len) {
+            throw new IllegalArgumentException("Type parameter length does not match. Required: " + parameters.length + ", Specified: " + len);
+        }
+        Argument[] typeArguments = new Argument[len];
+        for (int i = 0; i < parameters.length; i++) {
+            TypeVariable<Class<T>> parameter = parameters[i];
+            typeArguments[i] = Argument.of(typeParameters[i], parameter.getName());
+        }
+        return new DefaultArgument<>(type, NameUtils.decapitalize(type.getSimpleName()), AnnotationMetadata.EMPTY_METADATA, typeArguments);
     }
 
     /**

--- a/core/src/main/java/io/micronaut/core/type/ReturnType.java
+++ b/core/src/main/java/io/micronaut/core/type/ReturnType.java
@@ -41,7 +41,7 @@ public interface ReturnType<T> extends TypeVariableResolver, AnnotationSource {
      */
     default Argument<T> asArgument() {
         Collection<Argument<?>> values = getTypeVariables().values();
-        return Argument.of(getType(), values.toArray(new Argument[values.size()]));
+        return Argument.of(getType(), values.toArray(new Argument[0]));
     }
 
     /**

--- a/core/src/main/java/io/micronaut/core/type/TypeVariableResolver.java
+++ b/core/src/main/java/io/micronaut/core/type/TypeVariableResolver.java
@@ -39,7 +39,7 @@ public interface TypeVariableResolver {
     @SuppressWarnings("ToArrayCallWithZeroLengthArrayArgument")
     default Argument[] getTypeParameters() {
         Collection<Argument<?>> values = getTypeVariables().values();
-        return values.toArray(new Argument[values.size()]);
+        return values.toArray(new Argument[0]);
     }
 
     /**

--- a/core/src/main/java/io/micronaut/core/util/ArrayUtils.java
+++ b/core/src/main/java/io/micronaut/core/util/ArrayUtils.java
@@ -102,9 +102,8 @@ public class ArrayUtils {
     public static String toString(String delimiter, @Nullable Object[] array) {
         if (isEmpty(array)) {
             return "";
-        } else {
-            List<Object> list = Arrays.asList(array);
-            return CollectionUtils.toString(delimiter, list);
         }
+        List<Object> list = Arrays.asList(array);
+        return CollectionUtils.toString(delimiter, list);
     }
 }

--- a/core/src/main/java/io/micronaut/core/util/CollectionUtils.java
+++ b/core/src/main/java/io/micronaut/core/util/CollectionUtils.java
@@ -86,20 +86,22 @@ public class CollectionUtils {
         }
         if (iterableType.equals(Set.class)) {
             return Optional.of(new HashSet<>(collection));
-        } else if (iterableType.equals(Queue.class)) {
+        }
+        if (iterableType.equals(Queue.class)) {
             return Optional.of(new LinkedList<>(collection));
-        } else if (iterableType.equals(List.class)) {
+        }
+        if (iterableType.equals(List.class)) {
             return Optional.of(new ArrayList<>(collection));
-        } else if (!iterableType.isInterface()) {
+        }
+        if (!iterableType.isInterface()) {
             try {
                 Constructor<? extends Iterable<T>> constructor = iterableType.getConstructor(Collection.class);
                 return Optional.of(constructor.newInstance(collection));
             } catch (Throwable e) {
                 return Optional.empty();
             }
-        } else {
-            return Optional.empty();
         }
+        return Optional.empty();
     }
 
     /**
@@ -212,22 +214,19 @@ public class CollectionUtils {
     public static <T> List<T> iterableToList(Iterable<T> iterable) {
         if (iterable == null) {
             return Collections.emptyList();
-        } else {
-            if (iterable instanceof List) {
-                return (List<T>) iterable;
-            } else {
-                Iterator<T> i = iterable.iterator();
-                if (i.hasNext()) {
-                    List<T> list = new ArrayList<>();
-                    while (i.hasNext()) {
-                        list.add(i.next());
-                    }
-                    return list;
-                } else {
-                    return Collections.emptyList();
-                }
-            }
         }
+        if (iterable instanceof List) {
+            return (List<T>) iterable;
+        }
+        Iterator<T> i = iterable.iterator();
+        if (i.hasNext()) {
+            List<T> list = new ArrayList<>();
+            while (i.hasNext()) {
+                list.add(i.next());
+            }
+            return list;
+        }
+        return Collections.emptyList();
     }
 
     /**
@@ -240,22 +239,19 @@ public class CollectionUtils {
     public static <T> Set<T> iterableToSet(Iterable<T> iterable) {
         if (iterable == null) {
             return Collections.emptySet();
-        } else {
-            if (iterable instanceof Set) {
-                return (Set<T>) iterable;
-            } else {
-                Iterator<T> i = iterable.iterator();
-                if (i.hasNext()) {
-                    Set<T> list = new HashSet<>();
-                    while (i.hasNext()) {
-                        list.add(i.next());
-                    }
-                    return list;
-                } else {
-                    return Collections.emptySet();
-                }
-            }
         }
+        if (iterable instanceof Set) {
+            return (Set<T>) iterable;
+        }
+        Iterator<T> i = iterable.iterator();
+        if (i.hasNext()) {
+            Set<T> list = new HashSet<>();
+            while (i.hasNext()) {
+                list.add(i.next());
+            }
+            return list;
+        }
+        return Collections.emptySet();
     }
 
     /**

--- a/core/src/main/java/io/micronaut/core/util/StringUtils.java
+++ b/core/src/main/java/io/micronaut/core/util/StringUtils.java
@@ -130,7 +130,7 @@ public final class StringUtils {
             throw new IllegalArgumentException("Number of arguments should be an even number representing the keys and values");
         }
 
-        Map<String, Object> answer = new HashMap<>(len / 2);
+        Map<String, Object> answer = new HashMap<>((int) (len / 2 / 0.75));
         int i = 0;
         while (i < values.length - 1) {
             String key = values[i++].toString().intern();

--- a/core/src/main/java/io/micronaut/core/util/StringUtils.java
+++ b/core/src/main/java/io/micronaut/core/util/StringUtils.java
@@ -210,7 +210,7 @@ public final class StringUtils {
                 tokens.add(token);
             }
         }
-        return tokens.toArray(new String[tokens.size()]);
+        return tokens.toArray(new String[0]);
     }
 
     /**

--- a/core/src/main/java/io/micronaut/core/util/clhm/ConcurrentLinkedHashMap.java
+++ b/core/src/main/java/io/micronaut/core/util/clhm/ConcurrentLinkedHashMap.java
@@ -659,7 +659,8 @@ public final class ConcurrentLinkedHashMap<K, V> extends AbstractMap<K, V>
             if (prior == null) {
                 afterWrite(new AddTask(node, weight));
                 return null;
-            } else if (onlyIfAbsent) {
+            }
+            if (onlyIfAbsent) {
                 afterRead(prior);
                 return prior.getValue();
             }
@@ -749,7 +750,8 @@ public final class ConcurrentLinkedHashMap<K, V> extends AbstractMap<K, V>
             if (prior == null) {
                 afterWrite(new AddTask(node, weight));
                 return weightedValue.value;
-            } else if (onlyIfAbsent) {
+            }
+            if (onlyIfAbsent) {
                 afterRead(prior);
                 return prior.getValue();
             }
@@ -877,9 +879,8 @@ public final class ConcurrentLinkedHashMap<K, V> extends AbstractMap<K, V>
         if (ks == null) {
             keySet = new KeySet();
             return keySet;
-        } else {
-            return ks;
         }
+        return ks;
     }
 
     /**
@@ -997,9 +998,8 @@ public final class ConcurrentLinkedHashMap<K, V> extends AbstractMap<K, V>
         if (vs == null) {
             values = new Values();
             return values;
-        } else {
-            return vs;
         }
+        return vs;
     }
 
     @Override
@@ -1008,9 +1008,8 @@ public final class ConcurrentLinkedHashMap<K, V> extends AbstractMap<K, V>
         if (es == null) {
             entrySet = new EntrySet();
             return entrySet;
-        } else {
-            return es;
         }
+        return es;
     }
 
     /**

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/ObservableBodyBinder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/ObservableBodyBinder.java
@@ -70,7 +70,7 @@ public class ObservableBodyBinder extends DefaultBodyAnnotationBinder<Observable
         Collection<Argument<?>> typeVariables = context.getArgument().getTypeVariables().values();
 
         BindingResult<Publisher> result = publisherBodyBinder.bind(
-            ConversionContext.of(Argument.of(Publisher.class, (Argument[]) typeVariables.toArray(new Argument[typeVariables.size()]))),
+            ConversionContext.of(Argument.of(Publisher.class, (Argument[]) typeVariables.toArray(new Argument[0]))),
             source
         );
         if (result.isPresentAndSatisfied()) {

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/SingleBodyBinder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/SingleBodyBinder.java
@@ -70,7 +70,7 @@ public class SingleBodyBinder extends DefaultBodyAnnotationBinder<Single> implem
         Collection<Argument<?>> typeVariables = context.getArgument().getTypeVariables().values();
 
         BindingResult<Publisher> result = publisherBodyBinder.bind(
-            ConversionContext.of(Argument.of(Publisher.class, (Argument[]) typeVariables.toArray(new Argument[typeVariables.size()]))),
+            ConversionContext.of(Argument.of(Publisher.class, (Argument[]) typeVariables.toArray(new Argument[0]))),
             source
         );
         if (result.isPresentAndSatisfied()) {

--- a/inject/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadata.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadata.java
@@ -184,7 +184,7 @@ abstract class AbstractAnnotationMetadata implements AnnotationMetadata {
                     }
                 });
             }
-            return annotations.toArray(new Annotation[annotations.size()]);
+            return annotations.toArray(new Annotation[0]);
         }
 
         return AnnotationUtil.ZERO_ANNOTATIONS;

--- a/management/src/main/java/io/micronaut/management/endpoint/refresh/RefreshEndpoint.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/refresh/RefreshEndpoint.java
@@ -68,7 +68,7 @@ public class RefreshEndpoint {
                 eventPublisher.publishEvent(new RefreshEvent(changes));
             }
             Set<String> keys = changes.keySet();
-            return keys.toArray(new String[keys.size()]);
+            return keys.toArray(new String[0]);
         }
     }
 }

--- a/router/src/main/java/io/micronaut/web/router/DefaultRouter.java
+++ b/router/src/main/java/io/micronaut/web/router/DefaultRouter.java
@@ -260,7 +260,7 @@ public class DefaultRouter implements Router {
     private UriRoute[] finalizeRoutes(List<UriRoute> routes) {
         Collections.sort(routes);
         Collections.reverse(routes);
-        return routes.toArray(new UriRoute[routes.size()]);
+        return routes.toArray(new UriRoute[0]);
     }
 
     private <T> Optional<RouteMatch<T>> findRouteMatch(Map<ErrorRoute, RouteMatch<T>> matchedRoutes, Throwable error) {

--- a/runtime/src/main/java/io/micronaut/jackson/codec/JsonMediaTypeCodec.java
+++ b/runtime/src/main/java/io/micronaut/jackson/codec/JsonMediaTypeCodec.java
@@ -200,6 +200,6 @@ public class JsonMediaTypeCodec implements MediaTypeCodec {
                 javaTypes.add(typeFactory.constructType(argument.getType()));
             }
         }
-        return javaTypes.toArray(new JavaType[javaTypes.size()]);
+        return javaTypes.toArray(new JavaType[0]);
     }
 }


### PR DESCRIPTION
Remove redundant else / else if if a return is present. Saves a bytecode instruction and cleans up the code slightly for better reading. Note also that HashMap's max size is size * 0.75, so it needs to be sized at size / 0.75.