### PR TITLE
add String to Byte converter to DefaultConversionService

### DIFF
--- a/core/src/main/java/io/micronaut/core/convert/DefaultConversionService.java
+++ b/core/src/main/java/io/micronaut/core/convert/DefaultConversionService.java
@@ -392,6 +392,17 @@ public class DefaultConversionService implements ConversionService<DefaultConver
             }
         });
 
+        // String -> Byte
+        addConverter(CharSequence.class, Byte.class, (CharSequence object, Class<Byte> targetType, ConversionContext context) -> {
+            try {
+                Byte converted = Byte.valueOf(object.toString());
+                return Optional.of(converted);
+            } catch (NumberFormatException e) {
+                context.reject(object, e);
+                return Optional.empty();
+            }
+        });
+
         // String -> BigDecimal
         addConverter(CharSequence.class, BigDecimal.class, (CharSequence object, Class<BigDecimal> targetType, ConversionContext context) -> {
             try {

--- a/core/src/test/groovy/io/micronaut/core/convert/DefaultConversionServiceSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/convert/DefaultConversionServiceSpec.groovy
@@ -44,6 +44,7 @@ class DefaultConversionServiceSpec extends Specification {
         10                     | Float       | 10.0f
         10                     | String      | "10"
         "1,2"                  | int[]       | [1, 2] as int[]
+        "10"                   | Byte        | 10
         "10"                   | Integer     | 10
         "${5 + 5}"             | Integer     | 10
         "yes"                  | Boolean     | true


### PR DESCRIPTION
Added a String to Byte converter to DefaultConversionService, which also makes possible to use Byte as a parameter in controllers, like this:

```kotlin
@Get("/county/{id}")
fun getCountyById(id: Byte): Maybe<County>
```

Without the newly added converter, you can't pass a valid value to functions with Byte params, through a HTTP request.