### PR TITLE
Add topological sorting to beans before closing

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/close/A.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/close/A.java
@@ -1,0 +1,20 @@
+package io.micronaut.inject.close;
+
+import io.micronaut.context.annotation.Requires;
+
+import javax.annotation.PreDestroy;
+import javax.inject.Singleton;
+import java.io.IOException;
+
+@Requires(property = "spec.name", value = "BeanCloseOrderSpec")
+@Singleton
+public class A implements AutoCloseable {
+
+    public A(B b) {}
+
+    @PreDestroy
+    @Override
+    public void close() throws IOException {
+        BeanCloseOrderSpec.getClosed().add(A.class);
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/close/B.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/close/B.java
@@ -1,0 +1,4 @@
+package io.micronaut.inject.close;
+
+public interface B {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/close/BImpl.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/close/BImpl.java
@@ -1,0 +1,20 @@
+package io.micronaut.inject.close;
+
+import io.micronaut.context.annotation.Requires;
+
+import javax.annotation.PreDestroy;
+import javax.inject.Singleton;
+import java.io.IOException;
+
+@Requires(property = "spec.name", value = "BeanCloseOrderSpec")
+@Singleton
+public class BImpl implements AutoCloseable, B {
+
+    public BImpl(C c) {}
+
+    @PreDestroy
+    @Override
+    public void close() throws IOException {
+        BeanCloseOrderSpec.getClosed().add(B.class);
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/close/BeanCloseOrderSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/close/BeanCloseOrderSpec.groovy
@@ -1,0 +1,24 @@
+package io.micronaut.inject.close
+
+import io.micronaut.context.ApplicationContext
+import spock.lang.Specification
+
+class BeanCloseOrderSpec extends Specification {
+
+    static List<Class> closed = []
+
+    void "test close order"() {
+        given:
+        ApplicationContext ctx = ApplicationContext.run(["spec.name": getClass().simpleName])
+        ctx.getBean(A)
+        ctx.getBean(B)
+        ctx.getBean(C)
+        ctx.getBean(D)
+
+        when:
+        ctx.close()
+
+        then:
+        closed == [A,B,C,D]
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/close/C.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/close/C.java
@@ -1,0 +1,20 @@
+package io.micronaut.inject.close;
+
+import io.micronaut.context.annotation.Requires;
+
+import javax.annotation.PreDestroy;
+import javax.inject.Singleton;
+import java.io.IOException;
+
+@Requires(property = "spec.name", value = "BeanCloseOrderSpec")
+@Singleton
+public class C implements AutoCloseable {
+
+    public C(D d) {}
+
+    @PreDestroy
+    @Override
+    public void close() throws IOException {
+        BeanCloseOrderSpec.getClosed().add(C.class);
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/close/D.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/close/D.java
@@ -1,0 +1,21 @@
+package io.micronaut.inject.close;
+
+import io.micronaut.context.annotation.Requires;
+
+import javax.annotation.PreDestroy;
+import javax.inject.Singleton;
+import java.io.IOException;
+
+@Requires(property = "spec.name", value = "BeanCloseOrderSpec")
+@Singleton
+public class D implements AutoCloseable {
+
+    public D() {}
+
+    @PreDestroy
+    @Override
+    public void close() throws IOException {
+        BeanCloseOrderSpec.getClosed().add(D.class);
+    }
+}
+

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -190,20 +190,9 @@ public class DefaultBeanContext implements BeanContext {
                 LOG.debug("Stopping BeanContext");
             }
             publishEvent(new ShutdownEvent(this));
+
             // need to sort registered singletons so that beans with that require other beans appear first
-            ArrayList<BeanRegistration> objects = new ArrayList<>(singletonObjects.values());
-            objects.sort((o1, o2) -> {
-                        BeanDefinition bd1 = o1.beanDefinition;
-                        BeanDefinition bd2 = o2.beanDefinition;
-
-                        Collection requiredComponents1 = bd1.getRequiredComponents();
-                        Collection requiredComponents2 = bd2.getRequiredComponents();
-                        Integer requiredComponentCount1 = requiredComponents1.size();
-                        Integer requiredComponentCount2 = requiredComponents2.size();
-                        return requiredComponentCount1.compareTo(requiredComponentCount2);
-                    }
-            );
-
+            List<BeanRegistration> objects = topologicalSort(singletonObjects.values());
 
             Set<Integer> processed = new HashSet<>();
             for (BeanRegistration beanRegistration : objects) {
@@ -2267,6 +2256,51 @@ public class DefaultBeanContext implements BeanContext {
             return stream.count() > 0;
         }
         return false;
+    }
+
+    private List<BeanRegistration> topologicalSort(Collection<BeanRegistration> beans) {
+        List<BeanRegistration> sorted = new ArrayList<>();
+        List<BeanRegistration> unsorted = new ArrayList<>(beans);
+
+        //loop until all items have been sorted
+        while (!unsorted.isEmpty()) {
+            boolean acyclic = false;
+
+            Iterator<BeanRegistration> i = unsorted.iterator();
+            while (i.hasNext()) {
+                BeanRegistration bean = i.next();
+                boolean found = false;
+
+                //determine if any components are in the unsorted list
+                Collection<Class> components = bean.getBeanDefinition().getRequiredComponents();
+                for (Class<?> clazz: components) {
+                    if (unsorted.stream()
+                            .map(BeanRegistration::getBeanDefinition)
+                            .map(BeanDefinition::getBeanType)
+                            .anyMatch(bt -> clazz.isAssignableFrom(bt))) {
+                        found = true;
+                        break;
+                    }
+                }
+
+                //none of the required components are in the unsorted list
+                //so it can be added to the sorted list
+                if (!found) {
+                    acyclic = true;
+                    i.remove();
+                    sorted.add(0, bean);
+                }
+            }
+
+            //rather than throw an exception here because there is a cyclical dependency
+            //just add the first item to the list and keep trying. It may be possible to
+            //see a cycle here because qualifiers are not taken into account.
+            if (!acyclic) {
+                sorted.add(0, unsorted.remove(0));
+            }
+        }
+
+        return sorted;
     }
 
     /**


### PR DESCRIPTION
I also noticed there isn't anything in the documentation about how to get a bean to participate in the closing of the context. Simply implementing Closeable or AutoCloseable isn't enough. One must either use the `@Bean(preDestroy =` for a factory bean or annotate a method with `@PreDestroy` for a bean class.