### PR TITLE
Issue 1167 - FileInputStream / FileOutputStream Considered Harmful

### DIFF
--- a/cli/src/main/groovy/io/micronaut/cli/io/support/FileSystemResource.java
+++ b/cli/src/main/groovy/io/micronaut/cli/io/support/FileSystemResource.java
@@ -17,13 +17,13 @@
 package io.micronaut.cli.io.support;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.net.URL;
+import java.nio.file.Files;
 
 /**
  * Based on Spring FileSystemResource implementation.
@@ -96,7 +96,7 @@ public class FileSystemResource implements Resource {
      */
     @Override
     public InputStream getInputStream() throws IOException {
-        return new FileInputStream(file);
+        return Files.newInputStream(file.toPath());
     }
 
     /**

--- a/cli/src/main/groovy/io/micronaut/cli/io/support/FileSystemResource.java
+++ b/cli/src/main/groovy/io/micronaut/cli/io/support/FileSystemResource.java
@@ -17,7 +17,6 @@
 package io.micronaut.cli.io.support;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -193,7 +192,7 @@ public class FileSystemResource implements Resource {
      * @see java.io.FileOutputStream
      */
     public OutputStream getOutputStream() throws IOException {
-        return new FileOutputStream(file);
+        return Files.newOutputStream(file.toPath());
     }
 
     /**

--- a/cli/src/main/groovy/io/micronaut/cli/io/support/SpringIOUtils.java
+++ b/cli/src/main/groovy/io/micronaut/cli/io/support/SpringIOUtils.java
@@ -30,7 +30,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -188,7 +187,7 @@ public class SpringIOUtils {
         for (Resource resource : resources) {
             final InputStream input = resource.getInputStream();
             final File target = new File(targetDir, resource.getURL().toString().substring(baseUrl.toString().length()));
-            copy(new BufferedInputStream(input), new BufferedOutputStream(new FileOutputStream(target)));
+            copy(new BufferedInputStream(input), new BufferedOutputStream(Files.newOutputStream(target.toPath())));
         }
     }
 
@@ -204,7 +203,7 @@ public class SpringIOUtils {
         assert in != null : "No input File specified";
         assert out != null : "No output File specified";
         return copy(new BufferedInputStream(Files.newInputStream(in.toPath())),
-            new BufferedOutputStream(new FileOutputStream(out)));
+            new BufferedOutputStream(Files.newOutputStream(out.toPath())));
     }
 
     /**
@@ -219,7 +218,7 @@ public class SpringIOUtils {
         assert in != null : "No input File specified";
         assert out != null : "No output File specified";
         return copy(new BufferedInputStream(in.getInputStream()),
-            new BufferedOutputStream(new FileOutputStream(out)));
+            new BufferedOutputStream(Files.newOutputStream(out.toPath())));
     }
 
     /**
@@ -233,7 +232,7 @@ public class SpringIOUtils {
         assert in != null : "No input byte array specified";
         assert out != null : "No output File specified";
         ByteArrayInputStream inStream = new ByteArrayInputStream(in);
-        OutputStream outStream = new BufferedOutputStream(new FileOutputStream(out));
+        OutputStream outStream = new BufferedOutputStream(Files.newOutputStream(out.toPath()));
         copy(inStream, outStream);
     }
 

--- a/cli/src/main/groovy/io/micronaut/cli/io/support/SpringIOUtils.java
+++ b/cli/src/main/groovy/io/micronaut/cli/io/support/SpringIOUtils.java
@@ -30,7 +30,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -40,6 +39,7 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.lang.reflect.Array;
 import java.net.URL;
+import java.nio.file.Files;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
@@ -118,7 +118,7 @@ public class SpringIOUtils {
     }
 
     private static byte[] compute(File f, String algorithm) throws IOException {
-        InputStream is = new FileInputStream(f);
+        InputStream is = Files.newInputStream(f.toPath());
 
         try {
             MessageDigest md = getMessageDigest(algorithm);
@@ -203,7 +203,7 @@ public class SpringIOUtils {
     public static int copy(File in, File out) throws IOException {
         assert in != null : "No input File specified";
         assert out != null : "No output File specified";
-        return copy(new BufferedInputStream(new FileInputStream(in)),
+        return copy(new BufferedInputStream(Files.newInputStream(in.toPath())),
             new BufferedOutputStream(new FileOutputStream(out)));
     }
 
@@ -247,7 +247,7 @@ public class SpringIOUtils {
     public static byte[] copyToByteArray(File in) throws IOException {
         assert in != null : "No input File specified";
 
-        return copyToByteArray(new BufferedInputStream(new FileInputStream(in)));
+        return copyToByteArray(new BufferedInputStream(Files.newInputStream(in.toPath())));
     }
 
     //---------------------------------------------------------------------

--- a/core/src/main/java/io/micronaut/core/io/Streamable.java
+++ b/core/src/main/java/io/micronaut/core/io/Streamable.java
@@ -18,11 +18,11 @@ package io.micronaut.core.io;
 
 import javax.annotation.Nullable;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 
 /**
  * Interface for types that can be written to an {@link java.io.OutputStream}.
@@ -48,7 +48,7 @@ public interface Streamable {
      * @throws IOException if an error occurred while outputting data to the writer
      */
     default void writeTo(File file) throws IOException {
-        try (FileOutputStream outputStream = new FileOutputStream(file)) {
+        try (OutputStream outputStream = Files.newOutputStream(file.toPath())) {
             writeTo(outputStream);
         }
     }

--- a/core/src/main/java/io/micronaut/core/io/Writable.java
+++ b/core/src/main/java/io/micronaut/core/io/Writable.java
@@ -18,13 +18,13 @@ package io.micronaut.core.io;
 
 import javax.annotation.Nullable;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 
 /**
  * <p>An interface for classes to implement that are capable of writing themselves to a {@link Writer}</p>.
@@ -58,7 +58,7 @@ public interface Writable extends Streamable {
      * @throws IOException if an error occurred while outputting data to the writer
      */
     default void writeTo(File file) throws IOException {
-        try (FileOutputStream outputStream = new FileOutputStream(file)) {
+        try (OutputStream outputStream = Files.newOutputStream(file.toPath())) {
             writeTo(outputStream);
         }
     }

--- a/core/src/main/java/io/micronaut/core/io/file/DefaultFileSystemResourceLoader.java
+++ b/core/src/main/java/io/micronaut/core/io/file/DefaultFileSystemResourceLoader.java
@@ -19,11 +19,12 @@ package io.micronaut.core.io.file;
 import io.micronaut.core.io.ResourceLoader;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -62,8 +63,8 @@ public class DefaultFileSystemResourceLoader implements FileSystemResourceLoader
     public Optional<InputStream> getResourceAsStream(String path) {
         File file = getFile(normalize(path));
         try {
-            return Optional.of(new FileInputStream(file));
-        } catch (FileNotFoundException e) {
+            return Optional.of(Files.newInputStream(file.toPath()));
+        } catch (IOException e) {
             return Optional.empty();
         }
     }

--- a/core/src/main/java/io/micronaut/core/io/scan/ClassPathAnnotationScanner.java
+++ b/core/src/main/java/io/micronaut/core/io/scan/ClassPathAnnotationScanner.java
@@ -22,7 +22,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.JarURLConnection;
@@ -199,7 +198,7 @@ public class ClassPathAnnotationScanner implements AnnotationScanner {
         if (fileName.endsWith(".class")) {
             // ignore generated classes
             if (fileName.indexOf('$') == -1) {
-                try (FileInputStream inputStream = new FileInputStream(file)) {
+                try (InputStream inputStream = Files.newInputStream(file.toPath())) {
                     scanInputStream(annotation, inputStream, classes);
                 } catch (IOException e) {
                     if (LOG.isDebugEnabled()) {

--- a/inject/src/main/java/io/micronaut/inject/writer/AbstractClassFileWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/AbstractClassFileWriter.java
@@ -28,9 +28,9 @@ import org.objectweb.asm.commons.Method;
 
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -519,7 +519,7 @@ public abstract class AbstractClassFileWriter implements Opcodes {
             File targetFile = new File(targetDir, fileName);
             targetFile.getParentFile().mkdirs();
 
-            try (FileOutputStream outputStream = new FileOutputStream(targetFile)) {
+            try (OutputStream outputStream = Files.newOutputStream(targetFile.toPath())) {
                 writeClassToDisk(outputStream, classWriter);
             }
         }

--- a/inject/src/main/java/io/micronaut/inject/writer/DirectoryClassWriterOutputVisitor.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/DirectoryClassWriterOutputVisitor.java
@@ -19,9 +19,9 @@ package io.micronaut.inject.writer;
 import io.micronaut.core.annotation.Internal;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.Optional;
 
 /**
@@ -49,7 +49,7 @@ public class DirectoryClassWriterOutputVisitor extends AbstractClassWriterOutput
         if (!parentDir.exists() && !parentDir.mkdirs()) {
             throw new IOException("Cannot create parent directory: " + targetFile.getParentFile());
         }
-        return new FileOutputStream(targetFile);
+        return Files.newOutputStream(targetFile.toPath());
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/inject/writer/FileBackedGeneratedFile.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/FileBackedGeneratedFile.java
@@ -19,7 +19,6 @@ package io.micronaut.inject.writer;
 import io.micronaut.core.annotation.Internal;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.FileWriter;
@@ -61,7 +60,7 @@ class FileBackedGeneratedFile implements GeneratedFile {
     @Override
     public InputStream openInputStream() throws IOException {
         file.getParentFile().mkdirs();
-        return new FileInputStream(file);
+        return Files.newInputStream(file.toPath());
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/inject/writer/FileBackedGeneratedFile.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/FileBackedGeneratedFile.java
@@ -19,7 +19,6 @@ package io.micronaut.inject.writer;
 import io.micronaut.core.annotation.Internal;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -66,7 +65,7 @@ class FileBackedGeneratedFile implements GeneratedFile {
     @Override
     public OutputStream openOutputStream() throws IOException {
         file.getParentFile().mkdirs();
-        return new FileOutputStream(file);
+        return Files.newOutputStream(file.toPath());
     }
 
     @Override


### PR DESCRIPTION
Hello,

[issue 1167](https://github.com/micronaut-projects/micronaut-core/issues/1167) looked like a good first issue.
I replaced the constructor calls with calls to the factory methods. 

Using Path instead of File I left out as this would be a bigger change. To me it also looked like it would result in API breaking changes (for example in io.micronaut.cli.io.support.UrlResource.getFile())