### PR TITLE
Adapt with bean from userdetails to authentication

### DIFF
--- a/security/src/main/java/io/micronaut/security/authentication/AuthenticationResponseToAuthenticationAdapter.java
+++ b/security/src/main/java/io/micronaut/security/authentication/AuthenticationResponseToAuthenticationAdapter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2018 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.security.authentication;
+
+/**
+ * Adapt from an Authentication response  as obtained from {@link AuthenticationProvider}s to {@link Authentication}.
+ *
+ * @author Sergio del Amo
+ * @since 1.0.0
+ */
+public interface AuthenticationResponseToAuthenticationAdapter {
+
+    /**
+     *
+     * @param authenticationResponse Authentication Response as obtained from {@link AuthenticationProvider}s.
+     * @return An authentication object
+     */
+    Authentication adapt(AuthenticationResponse authenticationResponse);
+}

--- a/security/src/main/java/io/micronaut/security/authentication/AuthenticationUserDetailsAdapter.java
+++ b/security/src/main/java/io/micronaut/security/authentication/AuthenticationUserDetailsAdapter.java
@@ -27,7 +27,12 @@ import java.util.Map;
  */
 public class AuthenticationUserDetailsAdapter implements Authentication {
 
+    private static final String DEFAULT_USERNAME = "username";
+    private static final String DEFAULT_ROLESNAME = "roles";
+
     private UserDetails userDetails;
+    private String username = DEFAULT_USERNAME;
+    private String rolesNames = DEFAULT_ROLESNAME;
 
     /**
      *
@@ -40,13 +45,53 @@ public class AuthenticationUserDetailsAdapter implements Authentication {
     @Override
     public Map<String, Object> getAttributes() {
         Map<String, Object> attributes = new HashMap<>();
-        attributes.put("roles", userDetails.getRoles());
-        attributes.put("username", userDetails.getUsername());
+        attributes.put(getRolesNames(), userDetails.getRoles());
+        attributes.put(getUsername(), userDetails.getUsername());
         return attributes;
     }
 
     @Override
     public String getName() {
         return userDetails.getUsername();
+    }
+
+    /**
+     *
+     * @param rolesName The key user for roles
+     */
+    public void setRolesNames(String rolesName) {
+        this.rolesNames = rolesName;
+    }
+
+    /**
+     *
+     * @return The key use for username
+     */
+    public String getUsername() {
+        return username;
+    }
+
+    /**
+     *
+     * @param username The key use for username
+     */
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    /**
+     *
+     * @return The key use for rolesNames T
+     */
+    public String getRolesNames() {
+        return rolesNames;
+    }
+
+    /**
+     *
+     * @return the original userDetails used to construct the object
+     */
+    public UserDetails getUserDetails() {
+        return userDetails;
     }
 }

--- a/security/src/main/java/io/micronaut/security/authentication/DefaultToAuthenticationUserDetailsAdapter.java
+++ b/security/src/main/java/io/micronaut/security/authentication/DefaultToAuthenticationUserDetailsAdapter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017-2018 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.security.authentication;
+
+import io.micronaut.security.token.config.TokenConfiguration;
+
+import javax.annotation.Nonnull;
+import javax.inject.Singleton;
+
+/**
+ * Default bean to adapt from User Details to {@link Authentication}.
+ *
+ * @author Sergio del Amo
+ * @since 1.0.0
+ */
+@Singleton
+public class DefaultToAuthenticationUserDetailsAdapter implements UserDetailsAuthenticationResponseToAuthenticationAdapter {
+
+    private final TokenConfiguration tokenConfiguration;
+
+    /**
+     *
+     * @param tokenConfiguration The Token configuration.
+     */
+    public DefaultToAuthenticationUserDetailsAdapter(TokenConfiguration tokenConfiguration) {
+        this.tokenConfiguration = tokenConfiguration;
+    }
+
+    @Nonnull
+    @Override
+    public Authentication adapt(AuthenticationResponse authenticationResponse) {
+        if (authenticationResponse instanceof UserDetails) {
+            AuthenticationUserDetailsAdapter adapter = new AuthenticationUserDetailsAdapter((UserDetails) authenticationResponse);
+            if (tokenConfiguration != null) {
+                adapter.setRolesNames(tokenConfiguration.getRolesName());
+            }
+            return adapter;
+        }
+        throw new IllegalArgumentException("authenticationResponse is not of type UserDetails");
+    }
+}

--- a/security/src/main/java/io/micronaut/security/authentication/UserDetailsAuthenticationResponseToAuthenticationAdapter.java
+++ b/security/src/main/java/io/micronaut/security/authentication/UserDetailsAuthenticationResponseToAuthenticationAdapter.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017-2018 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.security.authentication;
+
+/**
+ * Adapt from an User Details as obtained from an {@link AuthenticationProvider}s to {@link Authentication}.
+ *
+ * @author Sergio del Amo
+ * @since 1.0.0
+ */
+public interface UserDetailsAuthenticationResponseToAuthenticationAdapter extends AuthenticationResponseToAuthenticationAdapter {
+}

--- a/security/src/main/java/io/micronaut/security/handlers/RedirectRejectionHandler.java
+++ b/security/src/main/java/io/micronaut/security/handlers/RedirectRejectionHandler.java
@@ -1,6 +1,17 @@
-/**
- * @author Sergio del Amo
- * @since 1.0
+/*
+ * Copyright 2017-2018 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package io.micronaut.security.handlers;

--- a/views/src/test/groovy/io/micronaut/views/model/security/DefaultToAuthenticationUserDetailsAdapterReplacement.groovy
+++ b/views/src/test/groovy/io/micronaut/views/model/security/DefaultToAuthenticationUserDetailsAdapterReplacement.groovy
@@ -1,0 +1,32 @@
+package io.micronaut.views.model.security
+
+import io.micronaut.context.annotation.Replaces
+import io.micronaut.security.authentication.Authentication
+import io.micronaut.security.authentication.AuthenticationResponse
+import io.micronaut.security.authentication.DefaultToAuthenticationUserDetailsAdapter
+import io.micronaut.security.authentication.UserDetailsAuthenticationResponseToAuthenticationAdapter
+import io.micronaut.security.token.config.TokenConfiguration
+import javax.inject.Singleton
+
+@Replaces(DefaultToAuthenticationUserDetailsAdapter)
+@Singleton
+class DefaultToAuthenticationUserDetailsAdapterReplacement implements UserDetailsAuthenticationResponseToAuthenticationAdapter {
+
+    private final TokenConfiguration tokenConfiguration
+
+    /**
+     *
+     * @param tokenConfiguration The Token configuration.
+     */
+    DefaultToAuthenticationUserDetailsAdapterReplacement(TokenConfiguration tokenConfiguration) {
+        this.tokenConfiguration = tokenConfiguration
+    }
+
+    @Override
+    Authentication adapt(AuthenticationResponse authenticationResponse) {
+        if (authenticationResponse instanceof UserDetailsEmail) {
+            return new UserDetailsEmailAdapter(authenticationResponse)
+        }
+        throw new IllegalArgumentException("authenticationResponse is not of type UserDetailsEmail")
+    }
+}

--- a/views/src/test/groovy/io/micronaut/views/model/security/MockAuthenticationProvider.groovy
+++ b/views/src/test/groovy/io/micronaut/views/model/security/MockAuthenticationProvider.groovy
@@ -14,6 +14,6 @@ import javax.inject.Singleton
 class MockAuthenticationProvider implements AuthenticationProvider {
     @Override
     Publisher<AuthenticationResponse> authenticate(AuthenticationRequest authenticationRequest) {
-        return Flowable.just(new UserDetails(authenticationRequest.identity as String, ['email': 'john@email.com']))
+        return Flowable.just(new UserDetailsEmail(authenticationRequest.identity as String, [], 'john@email.com'))
     }
 }

--- a/views/src/test/groovy/io/micronaut/views/model/security/UserDetailsEmail.groovy
+++ b/views/src/test/groovy/io/micronaut/views/model/security/UserDetailsEmail.groovy
@@ -1,0 +1,11 @@
+package io.micronaut.views.model.security
+
+import groovy.transform.CompileStatic
+import groovy.transform.InheritConstructors
+import io.micronaut.security.authentication.UserDetails
+
+@InheritConstructors
+@CompileStatic
+class UserDetailsEmail extends UserDetails  {
+    String email
+}

--- a/views/src/test/groovy/io/micronaut/views/model/security/UserDetailsEmailAdapter.groovy
+++ b/views/src/test/groovy/io/micronaut/views/model/security/UserDetailsEmailAdapter.groovy
@@ -1,0 +1,22 @@
+package io.micronaut.views.model.security
+
+import io.micronaut.security.authentication.Authentication
+
+class UserDetailsEmailAdapter implements Authentication {
+
+    UserDetailsEmail userDetailsEmail
+
+    UserDetailsEmailAdapter(UserDetailsEmail userDetailsEmail) {
+        this.userDetailsEmail = userDetailsEmail
+    }
+
+    @Override
+    Map<String, Object> getAttributes() {
+        return [email: userDetailsEmail.email, roles: userDetailsEmail.roles]
+    }
+
+    @Override
+    String getName() {
+        return userDetailsEmail.username
+    }
+}


### PR DESCRIPTION
This will enable from users to return a class which inherit from User details in the Authentication providers and then adapt it authentication as they need via replacement of `DefaultToAuthenticationUserDetailsAdapter` as illustrated in the test in this commit.

Thoughts @jameskleeh @graemerocher 