### PR TITLE
Adds HttpRequest to Unauthorized & forbidden

### DIFF
--- a/security-session/src/main/java/io/micronaut/security/session/SecuritySessionConfigurationProperties.java
+++ b/security-session/src/main/java/io/micronaut/security/session/SecuritySessionConfigurationProperties.java
@@ -18,6 +18,7 @@ package io.micronaut.security.session;
 
 import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.core.util.StringUtils;
+import io.micronaut.http.HttpRequest;
 import io.micronaut.security.config.SecurityConfigurationProperties;
 import io.micronaut.security.handlers.ForbiddenRejectionUriProvider;
 import io.micronaut.security.handlers.UnauthorizedRejectionUriProvider;
@@ -183,13 +184,27 @@ public class SecuritySessionConfigurationProperties implements SecuritySessionCo
         this.enabled = enabled;
     }
 
-    @Override
+    /**
+     * @return A uri to redirect to when a user tries to access a secured resource without authentication.
+     */
     public Optional<String> getUnauthorizedRedirectUri() {
         return Optional.ofNullable(unauthorizedTargetUrl);
     }
 
     @Override
+    public Optional<String> getUnauthorizedRedirectUri(HttpRequest<?> request) {
+        return getUnauthorizedRedirectUri();
+    }
+
+    /**
+     * @return A uri to redirect to when an authenticated user tries to access a resource for which he does not have the required authorization level.
+     */
     public Optional<String> getForbiddenRedirectUri() {
         return Optional.ofNullable(forbiddenTargetUrl);
+    }
+
+    @Override
+    public Optional<String> getForbiddenRedirectUri(HttpRequest<?> request) {
+        return getForbiddenRedirectUri();
     }
 }

--- a/security/src/main/java/io/micronaut/security/handlers/ForbiddenRejectionUriProvider.java
+++ b/security/src/main/java/io/micronaut/security/handlers/ForbiddenRejectionUriProvider.java
@@ -16,6 +16,8 @@
 
 package io.micronaut.security.handlers;
 
+import io.micronaut.http.HttpRequest;
+
 import java.util.Optional;
 
 /**
@@ -29,8 +31,8 @@ import java.util.Optional;
 public interface ForbiddenRejectionUriProvider {
 
     /**
-     *
+     * @param request {@link HttpRequest} being processed
      * @return A uri to redirect to when an authenticated user tries to access a resource for which he does not have the required authorization level.
      */
-    Optional<String> getForbiddenRedirectUri();
+    Optional<String> getForbiddenRedirectUri(HttpRequest<?> request);
 }

--- a/security/src/main/java/io/micronaut/security/handlers/RedirectRejectionHandler.java
+++ b/security/src/main/java/io/micronaut/security/handlers/RedirectRejectionHandler.java
@@ -75,7 +75,7 @@ public class RedirectRejectionHandler implements RejectionHandler {
         return Flowable.create(emitter -> {
             if (shouldHandleRequest(request)) {
                 try {
-                    String uri = getRedirectUri(forbidden).orElse("/");
+                    String uri = getRedirectUri(request, forbidden).orElse("/");
                     emitter.onNext(httpResponseWithUri(uri));
                 } catch (URISyntaxException e) {
                     emitter.onError(e);
@@ -126,12 +126,13 @@ public class RedirectRejectionHandler implements RejectionHandler {
     /**
      * Returns the redirection uri.
      *
+     * @param request {@link HttpRequest} being processed
      * @param forbidden if true indicates that although the user was authenticated he did not had the necessary access privileges.
      * @return the uri to redirect to
      */
-    protected Optional<String> getRedirectUri(boolean forbidden) {
-        Optional<String> uri = forbidden ? forbiddenRejectionUriProvider.getForbiddenRedirectUri() :
-                unauthorizedRejectionUriProvider.getUnauthorizedRedirectUri();
+    protected Optional<String> getRedirectUri(HttpRequest<?> request, boolean forbidden) {
+        Optional<String> uri = forbidden ? forbiddenRejectionUriProvider.getForbiddenRedirectUri(request) :
+                unauthorizedRejectionUriProvider.getUnauthorizedRedirectUri(request);
         if (LOG.isDebugEnabled()) {
             LOG.debug("redirect uri: {}", uri);
         }

--- a/security/src/main/java/io/micronaut/security/handlers/UnauthorizedRejectionUriProvider.java
+++ b/security/src/main/java/io/micronaut/security/handlers/UnauthorizedRejectionUriProvider.java
@@ -16,6 +16,8 @@
 
 package io.micronaut.security.handlers;
 
+import io.micronaut.http.HttpRequest;
+
 import java.util.Optional;
 
 /**
@@ -28,8 +30,8 @@ import java.util.Optional;
 public interface UnauthorizedRejectionUriProvider {
 
     /**
-     *
+     * @param request {@link HttpRequest} being processed
      * @return A uri to redirect to when a user tries to access a secured resource without authentication.
      */
-    Optional<String> getUnauthorizedRedirectUri();
+    Optional<String> getUnauthorizedRedirectUri(HttpRequest<?> request);
 }

--- a/security/src/test/groovy/io/micronaut/security/handlers/CustomForbiddenRejectionUriProvider.groovy
+++ b/security/src/test/groovy/io/micronaut/security/handlers/CustomForbiddenRejectionUriProvider.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.security.handlers
 
 import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpRequest
 
 import javax.inject.Singleton
 
@@ -9,7 +10,7 @@ import javax.inject.Singleton
 class CustomForbiddenRejectionUriProvider implements ForbiddenRejectionUriProvider {
 
     @Override
-    Optional<String> getForbiddenRedirectUri() {
+    Optional<String> getForbiddenRedirectUri(HttpRequest<?> request) {
         Optional.of("/forbidden")
     }
 }

--- a/security/src/test/groovy/io/micronaut/security/handlers/CustomUnauthorizedRejectionUriProvider.groovy
+++ b/security/src/test/groovy/io/micronaut/security/handlers/CustomUnauthorizedRejectionUriProvider.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.security.handlers
 
 import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpRequest
 
 import javax.inject.Singleton
 
@@ -9,7 +10,7 @@ import javax.inject.Singleton
 class CustomUnauthorizedRejectionUriProvider implements UnauthorizedRejectionUriProvider {
 
     @Override
-    Optional<String> getUnauthorizedRedirectUri() {
+    Optional<String> getUnauthorizedRedirectUri(HttpRequest<?> request) {
         Optional.of("/login")
     }
 }


### PR DESCRIPTION
It maybe useful to provide the current http request to both unauthorized and forbidden redirect uri providers. For example, you may choose to redirect to a url with a parameter containing a cookie value.  