### PR TITLE
Use a Map in the interface instead of JWTClaimsSet

### DIFF
--- a/security-jwt/src/main/java/io/micronaut/security/token/jwt/generator/claims/JwtClaimsSetAdapter.java
+++ b/security-jwt/src/main/java/io/micronaut/security/token/jwt/generator/claims/JwtClaimsSetAdapter.java
@@ -16,47 +16,43 @@
 
 package io.micronaut.security.token.jwt.generator.claims;
 
+import com.nimbusds.jwt.JWTClaimsSet;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Set;
 
 /**
- * @see <a href="https://tools.ietf.org/html/rfc7519#section-4.1">Registered Claims Names</a>
+ * Adapts from {@link JWTClaimsSet} to {@link JwtClaims}.
+ *
+ * @author Sergio del Amo
+ * @since 1.1.0
  */
-public interface JwtClaims {
-    String ISSUER          = "iss";
+public class JwtClaimsSetAdapter implements JwtClaims {
 
-    String SUBJECT         = "sub";
-
-    String EXPIRATION_TIME = "exp";
-
-    String NOT_BEFORE      = "nbf";
-
-    String ISSUED_AT       = "iat";
-
-    String JWT_ID          = "jti";
-
-    String AUDIENCE        = "aud";
+    private final JWTClaimsSet jwtClaimsSet;
 
     /**
-     *
-     * @param claimName the JWT Claim name
-     * @return {@code null} if the claim not exist or the Claim value.
+     * Constructor.
+     * @param jwtClaimsSet a JWT Claims set
      */
+    public JwtClaimsSetAdapter(JWTClaimsSet jwtClaimsSet) {
+        this.jwtClaimsSet = jwtClaimsSet;
+    }
+
     @Nullable
-    Object get(String claimName);
+    @Override
+    public Object get(String claimName) {
+        return jwtClaimsSet.getClaim(claimName);
+    }
 
-    /**
-     *
-     * @return All claim names.
-     */
     @Nonnull
-    Set<String> names();
+    @Override
+    public Set<String> names() {
+        return jwtClaimsSet.getClaims().keySet();
+    }
 
-    /**
-     *
-     * @param claimName the JWT Claim name
-     * @return {@code false} if the claim does not exist.
-     */
-    boolean contains(String claimName);
+    @Override
+    public boolean contains(String claimName) {
+        return jwtClaimsSet.getClaims().containsKey(claimName);
+    }
 }

--- a/security-jwt/src/main/java/io/micronaut/security/token/jwt/validator/ExpirationJwtClaimsValidator.java
+++ b/security-jwt/src/main/java/io/micronaut/security/token/jwt/validator/ExpirationJwtClaimsValidator.java
@@ -19,13 +19,13 @@ package io.micronaut.security.token.jwt.validator;
 import com.nimbusds.jwt.JWTClaimsSet;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.util.StringUtils;
+import io.micronaut.security.token.jwt.generator.claims.JwtClaims;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.inject.Singleton;
 import java.util.Date;
-import java.util.Map;
 
 /**
  * Validate JWT is not expired.
@@ -59,7 +59,7 @@ public class ExpirationJwtClaimsValidator implements GenericJwtClaimsValidator {
     }
 
     @Override
-    public boolean validate(Map<String, Object> claims) {
+    public boolean validate(JwtClaims claims) {
         return validate(JWTClaimsSetUtils.jwtClaimsSetFromClaims(claims));
     }
 }

--- a/security-jwt/src/main/java/io/micronaut/security/token/jwt/validator/ExpirationJwtClaimsValidator.java
+++ b/security-jwt/src/main/java/io/micronaut/security/token/jwt/validator/ExpirationJwtClaimsValidator.java
@@ -22,8 +22,10 @@ import io.micronaut.core.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
 import javax.inject.Singleton;
 import java.util.Date;
+import java.util.Map;
 
 /**
  * Validate JWT is not expired.
@@ -37,8 +39,12 @@ public class ExpirationJwtClaimsValidator implements GenericJwtClaimsValidator {
 
     private static final Logger LOG = LoggerFactory.getLogger(ExpirationJwtClaimsValidator.class);
 
-    @Override
-    public boolean validate(JWTClaimsSet claimsSet) {
+    /**
+     *
+     * @param claimsSet The JWT Claims
+     * @return true if the expiration claim denotes a date after now.
+     */
+    protected boolean validate(@Nonnull JWTClaimsSet claimsSet) {
         final Date expTime = claimsSet.getExpirationTime();
         if (expTime != null) {
             final Date now = new Date();
@@ -50,5 +56,10 @@ public class ExpirationJwtClaimsValidator implements GenericJwtClaimsValidator {
             }
         }
         return true;
+    }
+
+    @Override
+    public boolean validate(Map<String, Object> claims) {
+        return validate(JWTClaimsSetUtils.jwtClaimsSetFromClaims(claims));
     }
 }

--- a/security-jwt/src/main/java/io/micronaut/security/token/jwt/validator/JWTClaimsSetUtils.java
+++ b/security-jwt/src/main/java/io/micronaut/security/token/jwt/validator/JWTClaimsSetUtils.java
@@ -17,8 +17,7 @@
 package io.micronaut.security.token.jwt.validator;
 
 import com.nimbusds.jwt.JWTClaimsSet;
-
-import java.util.Map;
+import io.micronaut.security.token.jwt.generator.claims.JwtClaims;
 
 /**
  * Utils class to instantiate a JWClaimsSet give a map of claims.
@@ -30,12 +29,12 @@ public class JWTClaimsSetUtils {
 
     /**
      *
-     * @param claims Map of Claims
+     * @param claims JWT claims
      * @return A JWTClaimsSet
      */
-    public static JWTClaimsSet jwtClaimsSetFromClaims(Map<String, Object> claims) {
+    public static JWTClaimsSet jwtClaimsSetFromClaims(JwtClaims claims) {
         JWTClaimsSet.Builder claimsSetBuilder = new JWTClaimsSet.Builder();
-        for (String k : claims.keySet()) {
+        for (String k : claims.names()) {
             claimsSetBuilder.claim(k, claims.get(k));
         }
         return claimsSetBuilder.build();

--- a/security-jwt/src/main/java/io/micronaut/security/token/jwt/validator/JWTClaimsSetUtils.java
+++ b/security-jwt/src/main/java/io/micronaut/security/token/jwt/validator/JWTClaimsSetUtils.java
@@ -16,24 +16,28 @@
 
 package io.micronaut.security.token.jwt.validator;
 
-import io.micronaut.security.token.jwt.config.JwtConfigurationProperties;
+import com.nimbusds.jwt.JWTClaimsSet;
 
 import java.util.Map;
 
 /**
- * Provides a contract to create custom JWT claims validations.
+ * Utils class to instantiate a JWClaimsSet give a map of claims.
  *
  * @author Sergio del Amo
  * @since 1.1.0
  */
-public interface JwtClaimsValidator {
-
-    String PREFIX = JwtConfigurationProperties.PREFIX + ".claims-validators";
+public class JWTClaimsSetUtils {
 
     /**
      *
-     * @param claims JWT Claims
-     * @return whether the JWT claims pass validation.
+     * @param claims Map of Claims
+     * @return A JWTClaimsSet
      */
-    boolean validate(Map<String, Object> claims);
+    public static JWTClaimsSet jwtClaimsSetFromClaims(Map<String, Object> claims) {
+        JWTClaimsSet.Builder claimsSetBuilder = new JWTClaimsSet.Builder();
+        for (String k : claims.keySet()) {
+            claimsSetBuilder.claim(k, claims.get(k));
+        }
+        return claimsSetBuilder.build();
+    }
 }

--- a/security-jwt/src/main/java/io/micronaut/security/token/jwt/validator/JwtClaimsValidator.java
+++ b/security-jwt/src/main/java/io/micronaut/security/token/jwt/validator/JwtClaimsValidator.java
@@ -17,8 +17,7 @@
 package io.micronaut.security.token.jwt.validator;
 
 import io.micronaut.security.token.jwt.config.JwtConfigurationProperties;
-
-import java.util.Map;
+import io.micronaut.security.token.jwt.generator.claims.JwtClaims;
 
 /**
  * Provides a contract to create custom JWT claims validations.
@@ -35,5 +34,5 @@ public interface JwtClaimsValidator {
      * @param claims JWT Claims
      * @return whether the JWT claims pass validation.
      */
-    boolean validate(Map<String, Object> claims);
+    boolean validate(JwtClaims claims);
 }

--- a/security-jwt/src/main/java/io/micronaut/security/token/jwt/validator/JwtTokenValidator.java
+++ b/security-jwt/src/main/java/io/micronaut/security/token/jwt/validator/JwtTokenValidator.java
@@ -29,6 +29,7 @@ import com.nimbusds.jwt.PlainJWT;
 import com.nimbusds.jwt.SignedJWT;
 import io.micronaut.security.authentication.Authentication;
 import io.micronaut.security.token.jwt.encryption.EncryptionConfiguration;
+import io.micronaut.security.token.jwt.generator.claims.JwtClaimsSetAdapter;
 import io.micronaut.security.token.jwt.signature.SignatureConfiguration;
 import io.micronaut.security.token.validator.TokenValidator;
 import io.reactivex.Flowable;
@@ -165,7 +166,7 @@ public class JwtTokenValidator implements TokenValidator {
      */
     protected boolean verifyClaims(JWTClaimsSet jwtClaimsSet, Collection<? extends JwtClaimsValidator> claimsValidators) {
         return claimsValidators.stream()
-                .allMatch(jwtClaimsValidator -> jwtClaimsValidator.validate(jwtClaimsSet.getClaims()));
+                .allMatch(jwtClaimsValidator -> jwtClaimsValidator.validate(new JwtClaimsSetAdapter(jwtClaimsSet)));
     }
 
     /**

--- a/security-jwt/src/main/java/io/micronaut/security/token/jwt/validator/JwtTokenValidator.java
+++ b/security-jwt/src/main/java/io/micronaut/security/token/jwt/validator/JwtTokenValidator.java
@@ -165,7 +165,7 @@ public class JwtTokenValidator implements TokenValidator {
      */
     protected boolean verifyClaims(JWTClaimsSet jwtClaimsSet, Collection<? extends JwtClaimsValidator> claimsValidators) {
         return claimsValidators.stream()
-                .allMatch(jwtClaimsValidator -> jwtClaimsValidator.validate(jwtClaimsSet));
+                .allMatch(jwtClaimsValidator -> jwtClaimsValidator.validate(jwtClaimsSet.getClaims()));
     }
 
     /**

--- a/security-jwt/src/main/java/io/micronaut/security/token/jwt/validator/SubjectNotNullJwtClaimsValidator.java
+++ b/security-jwt/src/main/java/io/micronaut/security/token/jwt/validator/SubjectNotNullJwtClaimsValidator.java
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Singleton;
+import java.util.Map;
 
 /**
  * Validate JWT subject claim is not null.
@@ -41,7 +42,6 @@ public class SubjectNotNullJwtClaimsValidator implements GenericJwtClaimsValidat
      * @param claimsSet JWT Claims
      * @return True if the JWT subject claim is not null
      */
-    @Override
     public boolean validate(JWTClaimsSet claimsSet) {
         final String subject = claimsSet.getSubject();
         boolean hasSubject = subject != null;
@@ -51,5 +51,10 @@ public class SubjectNotNullJwtClaimsValidator implements GenericJwtClaimsValidat
             }
         }
         return hasSubject;
+    }
+
+    @Override
+    public boolean validate(Map<String, Object> claims) {
+        return validate(JWTClaimsSetUtils.jwtClaimsSetFromClaims(claims));
     }
 }

--- a/security-jwt/src/main/java/io/micronaut/security/token/jwt/validator/SubjectNotNullJwtClaimsValidator.java
+++ b/security-jwt/src/main/java/io/micronaut/security/token/jwt/validator/SubjectNotNullJwtClaimsValidator.java
@@ -19,11 +19,10 @@ package io.micronaut.security.token.jwt.validator;
 import com.nimbusds.jwt.JWTClaimsSet;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.util.StringUtils;
+import io.micronaut.security.token.jwt.generator.claims.JwtClaims;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import javax.inject.Singleton;
-import java.util.Map;
 
 /**
  * Validate JWT subject claim is not null.
@@ -54,7 +53,7 @@ public class SubjectNotNullJwtClaimsValidator implements GenericJwtClaimsValidat
     }
 
     @Override
-    public boolean validate(Map<String, Object> claims) {
+    public boolean validate(JwtClaims claims) {
         return validate(JWTClaimsSetUtils.jwtClaimsSetFromClaims(claims));
     }
 }


### PR DESCRIPTION
To avoid coupling to the class `JWTClaimsSet` which comes from the dependency used for JWT right now which is Nimbus JOSE+JWT.

Please, note that `JwtTokenValidator.java` does not exist in `1.0.x`