### PR TITLE
Expires in and token type properties included in AccessRefreshToken

### DIFF
--- a/security-jwt/src/main/java/io/micronaut/security/token/jwt/render/AccessRefreshToken.java
+++ b/security-jwt/src/main/java/io/micronaut/security/token/jwt/render/AccessRefreshToken.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.security.token.jwt.render;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -31,6 +32,13 @@ public class AccessRefreshToken {
     @JsonProperty("refresh_token")
     private String refreshToken;
 
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("expires_in")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Integer expiresIn;
+
     /**
      * Necessary for JSON serialization.
      */
@@ -40,14 +48,30 @@ public class AccessRefreshToken {
      *
      * @param accessToken JWT token
      * @param refreshToken JWT token
+     * @param tokenType Type of token
      */
-    public AccessRefreshToken(String accessToken, String refreshToken) {
+    public AccessRefreshToken(String accessToken, String refreshToken, String tokenType) {
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
+        this.tokenType = tokenType;
     }
 
     /**
-     * accesToken getter.
+     *
+     * @param accessToken JWT token
+     * @param refreshToken JWT token
+     * @param tokenType Type of token
+     * @param expiresIn Seconds until token expiration
+     */
+    public AccessRefreshToken(String accessToken, String refreshToken, String tokenType, Integer expiresIn) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+        this.tokenType = tokenType;
+        this.expiresIn = expiresIn;
+    }
+
+    /**
+     * accessToken getter.
      * @return The access token
      */
     public String getAccessToken() {
@@ -55,10 +79,26 @@ public class AccessRefreshToken {
     }
 
     /**
-     * accesToken setter.
+     * refreshToken getter.
      * @return The refresh token
      */
     public String getRefreshToken() {
         return refreshToken;
+    }
+
+    /**
+     * token type getter.
+     * @return TokenType e.g. Bearer
+     */
+    public String getTokenType() {
+        return tokenType;
+    }
+
+    /**
+     * token type getter.
+     * @return expiration time
+     */
+    public Integer getExpiresIn() {
+        return expiresIn;
     }
 }

--- a/security-jwt/src/main/java/io/micronaut/security/token/jwt/render/BearerAccessRefreshToken.java
+++ b/security-jwt/src/main/java/io/micronaut/security/token/jwt/render/BearerAccessRefreshToken.java
@@ -15,9 +15,6 @@
  */
 package io.micronaut.security.token.jwt.render;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import io.micronaut.http.HttpHeaderValues;
-
 import java.util.Collection;
 import java.util.List;
 
@@ -32,12 +29,6 @@ public class BearerAccessRefreshToken extends AccessRefreshToken {
     private String username;
     private Collection<String> roles;
 
-    @JsonProperty("expires_in")
-    private Integer expiresIn;
-
-    @JsonProperty("token_type")
-    private String tokenType = HttpHeaderValues.AUTHORIZATION_PREFIX_BEARER;
-
     /**
      * Necessary for JSON serialization.
      */
@@ -47,7 +38,7 @@ public class BearerAccessRefreshToken extends AccessRefreshToken {
      *
      * @param username a string e.g. admin
      * @param roles Collection of Strings e.g. ( [ROLE_USER, ROLE_ADMIN] )
-     * @param expiresIn Acccess Token expiration
+     * @param expiresIn Access Token expiration
      * @param accessToken JWT token
      * @param refreshToken  JWT token
      */
@@ -55,11 +46,12 @@ public class BearerAccessRefreshToken extends AccessRefreshToken {
                                     Collection<String> roles,
                                     Integer expiresIn,
                                     String accessToken,
-                                    String refreshToken) {
-        super(accessToken, refreshToken);
+                                    String refreshToken,
+                                    String tokenType
+    ) {
+        super(accessToken, refreshToken, tokenType, expiresIn);
         this.username = username;
         this.roles = roles;
-        this.expiresIn = expiresIn;
     }
 
     /**
@@ -92,37 +84,5 @@ public class BearerAccessRefreshToken extends AccessRefreshToken {
      */
     public void setRoles(List<String> roles) {
         this.roles = roles;
-    }
-
-    /**
-     *
-     * @return TokenType e.g. Bearer
-     */
-    public String getTokenType() {
-        return tokenType;
-    }
-
-    /**
-     * token type setter.
-     * @param tokenType e.g. Bearer
-     */
-    public void setTokenType(String tokenType) {
-        this.tokenType = tokenType;
-    }
-
-    /**
-     *
-     * @return expiration time
-     */
-    public Integer getExpiresIn() {
-        return expiresIn;
-    }
-
-    /**
-     *
-     * @param expiresIn expiration time
-     */
-    public void setExpiresIn(Integer expiresIn) {
-        this.expiresIn = expiresIn;
     }
 }

--- a/security-jwt/src/main/java/io/micronaut/security/token/jwt/render/BearerTokenRenderer.java
+++ b/security-jwt/src/main/java/io/micronaut/security/token/jwt/render/BearerTokenRenderer.java
@@ -15,7 +15,9 @@
  */
 package io.micronaut.security.token.jwt.render;
 
+import io.micronaut.http.HttpHeaderValues;
 import io.micronaut.security.authentication.UserDetails;
+
 import javax.inject.Singleton;
 
 /**
@@ -23,16 +25,19 @@ import javax.inject.Singleton;
  * @author Sergio del Amo
  * @since 1.0
  */
+
 @Singleton
 public class BearerTokenRenderer implements TokenRenderer {
 
+    private final String BEARER_TOKEN_TYPE = HttpHeaderValues.AUTHORIZATION_PREFIX_BEARER;
+
     @Override
     public AccessRefreshToken render(Integer expiresIn, String accessToken, String refreshToken) {
-        return new AccessRefreshToken(accessToken, refreshToken);
+        return new AccessRefreshToken(accessToken, refreshToken, BEARER_TOKEN_TYPE, expiresIn);
     }
 
     @Override
     public AccessRefreshToken render(UserDetails userDetails, Integer expiresIn, String accessToken, String refreshToken) {
-        return new BearerAccessRefreshToken(userDetails.getUsername(), userDetails.getRoles(), expiresIn, accessToken, refreshToken);
+        return new BearerAccessRefreshToken(userDetails.getUsername(), userDetails.getRoles(), expiresIn, accessToken, refreshToken, BEARER_TOKEN_TYPE);
     }
 }

--- a/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/endpoints/LoginControllerSpec.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/endpoints/LoginControllerSpec.groovy
@@ -78,6 +78,7 @@ class LoginControllerSpec extends Specification {
         rsp.body().username
         rsp.body().roles == null
         rsp.body().expiresIn
+        rsp.body().tokenType
     }
 
     def "invoking login with GET, returns unauthorized"() {

--- a/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/render/AccessRefreshTokenSpec.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/render/AccessRefreshTokenSpec.groovy
@@ -27,12 +27,12 @@ class AccessRefreshTokenSpec extends Specification {
             mapper.configure(SORT_PROPERTIES_ALPHABETICALLY, true)
 
         and : "a fully populated token"
-            AccessRefreshToken token = new AccessRefreshToken("1234", "abcd")
+            AccessRefreshToken token = new AccessRefreshToken("1234", "abcd", "Bearer")
 
         when: "we serialize the object to json"
             def rawJsonString = mapper.writeValueAsString(token)
 
         then: "we will get an OAuth 2.0 RFC6749 compliant value"
-            rawJsonString == "{\"access_token\":\"1234\",\"refresh_token\":\"abcd\"}"
+            rawJsonString == "{\"access_token\":\"1234\",\"refresh_token\":\"abcd\",\"token_type\":\"Bearer\"}"
     }
 }

--- a/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/render/BearerAccessRefreshTokenSpec.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/render/BearerAccessRefreshTokenSpec.groovy
@@ -27,7 +27,7 @@ class BearerAccessRefreshTokenSpec extends Specification {
             mapper.configure(SORT_PROPERTIES_ALPHABETICALLY, true)
 
         and : "a fully populated bearer token"
-            BearerAccessRefreshToken token = new BearerAccessRefreshToken("testing", ["admin", "superuser"], 3600, "1234", "abcd")
+            BearerAccessRefreshToken token = new BearerAccessRefreshToken("testing", ["admin", "superuser"], 3600, "1234", "abcd", "Bearer")
 
         when: "we serialize the object to json"
             def rawJsonString = mapper.writeValueAsString(token)

--- a/src/main/docs/guide/appendix/breaks.adoc
+++ b/src/main/docs/guide/appendix/breaks.adoc
@@ -4,8 +4,7 @@ This section will document breaking changes that may happen during milestone or 
 
 * link:{api}/io/micronaut/session/http/HttpSessionConfiguration.html[HttpSessionConfiguration] default value for `cookiePath` is `/`.
 
-* link:{api}/io/micronaut/security/token/jwt/render/AccessRefreshToken.html[AccessRefreshToken] includes `tokenType` and `expiresIn` to comply with refresh token responses specified in link:https://tools.ietf.org/html/rfc6749#section-4.1.4.html[RFC 6749].
-These properties are serialized respectively as `token_type` and `expires_in` in the refresh token response.
+* The link:{api}/io/micronaut/security/token/jwt/render/AccessRefreshToken.html[AccessRefreshToken] API has been changed to  include `tokenType` and `expiresIn`. This change was necessary to comply with the token response link:https://tools.ietf.org/html/rfc6749#section-4.1.4.html[RFC 6749].
 
 ==== 1.0.0.RC3
 

--- a/src/main/docs/guide/appendix/breaks.adoc
+++ b/src/main/docs/guide/appendix/breaks.adoc
@@ -4,6 +4,9 @@ This section will document breaking changes that may happen during milestone or 
 
 * link:{api}/io/micronaut/session/http/HttpSessionConfiguration.html[HttpSessionConfiguration] default value for `cookiePath` is `/`.
 
+* link:{api}/io/micronaut/security/token/jwt/render/AccessRefreshToken.html[AccessRefreshToken] includes `tokenType` and `expiresIn` to comply with refresh token responses specified in link:https://tools.ietf.org/html/rfc6749#section-4.1.4.html[RFC 6749].
+These properties are serialized respectively as `token_type` and `expires_in` in the refresh token response.
+
 ==== 1.0.0.RC3
 
 * All Micronaut modules have been renamed to include `micronaut-` prefix to make it easier to manage dependencies. If you are upgrading rename all references modules. Example `bom` -> `micronaut-bom`, `inject` -> `micronaut-inject` etc.


### PR DESCRIPTION
I'm trying to use the [Dart OAuth2 Client](https://pub.dartlang.org/packages/oauth2) to manage authentication with a providing Micronaut server. I'm running into issues when the (respective client attempts to refresh credentials because [there isn't a `token_type` field](https://github.com/dart-lang/oauth2/blob/master/lib/src/handle_access_token_response.dart#L65). It appears that the client expectations [comply with the specification](https://tools.ietf.org/html/rfc6749#section-4.1.4), prompting this PR to adjust the response.

Adding the fields to the `AccessRefreshToken` seemed like a reasonable implementation change to accommodate my clients requirements, let me know if something else would be preferred.

This changes the refresh token response from:
```
{
  "access_token": "xxx...",
  "refresh_token": "xxx..."
}
```

To:
```
{
  "access_token": "xxx...",
  "refresh_token": "xxx...",
  "token_type": "Bearer",
  "expires_in": 3600
}
```