### PR TITLE
Handle preDestroy when method defined on superclass.  Fixes #1272

### DIFF
--- a/inject-java/src/main/java/io/micronaut/annotation/processing/ModelUtils.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/ModelUtils.java
@@ -202,7 +202,7 @@ public class ModelUtils {
      * @return The executable element
      */
     Optional<ExecutableElement> findAccessibleNoArgumentInstanceMethod(TypeElement classElement, String methodName) {
-        return ElementFilter.methodsIn(classElement.getEnclosedElements())
+        return ElementFilter.methodsIn(elementUtils.getAllMembers(classElement))
                 .stream().filter(m -> m.getSimpleName().toString().equals(methodName) && !isPrivate(m) && !isStatic(m))
                 .findFirst();
     }


### PR DESCRIPTION
The problem was that `MongoClient` implements `Closeable`, but the `close()` method implementation is on the superclass.

`TypeElement.getEnclosedElements` "Returns the fields, methods, constructors, and member types that are **directly declared** in this class or interface."  Thus, any `preDestroy` method declared on a superclass or extended interface would be missed.
