### PR TITLE
Added cache configuration option to record stats.

### DIFF
--- a/runtime/src/main/java/io/micronaut/cache/CacheConfiguration.java
+++ b/runtime/src/main/java/io/micronaut/cache/CacheConfiguration.java
@@ -38,6 +38,12 @@ public class CacheConfiguration {
     public static final String PREFIX = "micronaut.caches";
 
     /**
+     * The default record stats value.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static final boolean DEFAULT_RECORD_STATS = false;
+
+    /**
      * The default test mode value.
      */
     @SuppressWarnings("WeakerAccess")
@@ -50,6 +56,7 @@ public class CacheConfiguration {
     private Long maximumWeight;
     private Duration expireAfterWrite;
     private Duration expireAfterAccess;
+    private boolean recordStats = DEFAULT_RECORD_STATS;
     private boolean testMode = DEFAULT_TESTMODE;
     private final String cacheName;
 
@@ -111,6 +118,15 @@ public class CacheConfiguration {
     }
 
     /**
+     * Some caches support recording statistics. For example to record hit and miss ratio's fine tune the cache characteristics.
+     *
+     * @return True if record stats is enabled
+     */
+    public boolean isRecordStats() {
+        return recordStats;
+    }
+
+    /**
      * @return The charset used to serialize and deserialize values
      */
     public Charset getCharset() {
@@ -154,6 +170,15 @@ public class CacheConfiguration {
      */
     public void setExpireAfterAccess(Duration expireAfterAccess) {
         this.expireAfterAccess = expireAfterAccess;
+    }
+
+    /**
+     * Set whether record stats is enabled. Default value ({@value #DEFAULT_RECORD_STATS}).
+     *
+     * @param recordStats True if record status is enabled
+     */
+    public void setRecordStats(final boolean recordStats) {
+        this.recordStats = recordStats;
     }
 
     /**

--- a/runtime/src/main/java/io/micronaut/cache/DefaultSyncCache.java
+++ b/runtime/src/main/java/io/micronaut/cache/DefaultSyncCache.java
@@ -151,7 +151,9 @@ public class DefaultSyncCache implements SyncCache<com.github.benmanes.caffeine.
             builder.maximumWeight(weight);
             builder.weigher(findWeigher());
         });
-
+        if (cacheConfiguration.isRecordStats()) {
+            builder.recordStats();
+        }
         if (cacheConfiguration.isTestMode()) {
             // run commands on same thread
             builder.executor(Runnable::run);


### PR DESCRIPTION
Many cache implementation - like Caffeine - support recording statistics to get cache insights regarding hit/miss ratio's. With these insights the application's caches can be fine tuned / optimised. 

Caffeine has `recrodStats` method to enable recording the statistics.

```
Cache<Key, Graph> graphs = Caffeine.newBuilder()
    .maximumSize(10_000)
    .recordStats()
    .build();
```

This PR adds configuration support for enabling recording statistics of Micronaut caches.