### PR TITLE
Added /caches endpoint

### DIFF
--- a/management/build.gradle
+++ b/management/build.gradle
@@ -1,3 +1,5 @@
+apply plugin: "com.github.johnrengelman.shadow"
+
 dependencies {
     compile project(":router")
     compile project(":runtime")
@@ -13,4 +15,12 @@ dependencies {
 
     compileOnly "ch.qos.logback:logback-classic:1.2.3"
 }
+
+shadowJar {
+    relocate "com.github.benmanes.caffeine", "io.micronaut.caffeine"
+}
+tasks.withType(com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation) { t ->
+    t.enabled = false
+}
+
 //compileTestGroovy.groovyOptions.forkOptions.jvmArgs = ['-Xdebug', '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005']

--- a/management/src/main/java/io/micronaut/management/endpoint/caches/CacheData.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/caches/CacheData.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.management.endpoint.caches;
+
+import io.micronaut.cache.SyncCache;
+
+/**
+ * Returns data for a given cache to be used for the {@link CachesEndpoint}.
+ *
+ * @param <T> The type
+ * @author Marcel Overdijk
+ * @since 1.1
+ */
+public interface CacheData<T> {
+
+    /**
+     * @param cache The cache
+     * @return Cache data
+     */
+    T getData(SyncCache cache);
+}

--- a/management/src/main/java/io/micronaut/management/endpoint/caches/CacheDataCollector.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/caches/CacheDataCollector.java
@@ -25,7 +25,7 @@ import java.util.List;
  *
  * @param <T> The type
  * @author Marcel Overdijk
- * @since 1.1
+ * @since 1.1.0
  */
 public interface CacheDataCollector<T> {
 
@@ -33,7 +33,7 @@ public interface CacheDataCollector<T> {
      * @param caches A java stream of caches
      * @return A publisher that returns data representing all of the given caches
      */
-    Publisher<T> getData(List<SyncCache> caches);
+    Publisher<T> getData(Publisher<SyncCache> caches);
 
     /**
      * @param cache The cache

--- a/management/src/main/java/io/micronaut/management/endpoint/caches/CacheDataCollector.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/caches/CacheDataCollector.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.management.endpoint.caches;
+
+import io.micronaut.cache.SyncCache;
+import org.reactivestreams.Publisher;
+
+import java.util.List;
+
+/**
+ * Used to respond with cache information used for the {@link CachesEndpoint}.
+ *
+ * @param <T> The type
+ * @author Marcel Overdijk
+ * @since 1.1
+ */
+public interface CacheDataCollector<T> {
+
+    /**
+     * @param caches A java stream of caches
+     * @return A publisher that returns data representing all of the given caches
+     */
+    Publisher<T> getData(List<SyncCache> caches);
+
+    /**
+     * @param cache The cache
+     * @return A publisher that returns data representing the given cache
+     */
+    Publisher<T> getData(SyncCache cache);
+}

--- a/management/src/main/java/io/micronaut/management/endpoint/caches/CachesEndpoint.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/caches/CachesEndpoint.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.management.endpoint.caches;
+
+import io.micronaut.cache.CacheManager;
+import io.micronaut.cache.SyncCache;
+import io.micronaut.management.endpoint.annotation.Delete;
+import io.micronaut.management.endpoint.annotation.Endpoint;
+import io.micronaut.management.endpoint.annotation.Read;
+import io.micronaut.management.endpoint.annotation.Selector;
+import io.reactivex.Maybe;
+import io.reactivex.Single;
+
+import javax.validation.constraints.NotBlank;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Exposes an {@link Endpoint} to manage caches.
+ *
+ * @author Marcel Overdijk
+ * @since 1.1
+ */
+@Endpoint(id = CachesEndpoint.NAME)
+public class CachesEndpoint {
+
+    /**
+     * Endpoint name.
+     */
+    public static final String NAME = "caches";
+
+    private final CacheManager cacheManager;
+    private final CacheDataCollector cacheDataCollector;
+
+    /**
+     * @param cacheManager       The {@link CacheManager}
+     * @param cacheDataCollector The {@link CacheDataCollector}
+     */
+    public CachesEndpoint(CacheManager cacheManager, CacheDataCollector cacheDataCollector) {
+        this.cacheManager = cacheManager;
+        this.cacheDataCollector = cacheDataCollector;
+    }
+
+    /**
+     * Returns the caches as a {@link Single}.
+     *
+     * @return The caches as a {@link Single}
+     */
+    @Read
+    public Single getCaches() {
+        return Single.fromPublisher(cacheDataCollector.getData(getSyncCaches()));
+    }
+
+    /**
+     * Returns the cache as a {@link Maybe}.
+     *
+     * @param name The name of the cache to retrieve
+     * @return The cache as a {@link Single}
+     */
+    @Read
+    public Maybe getCache(@NotBlank @Selector String name) {
+        Optional<SyncCache> cache = getSyncCache(name);
+        if (cache.isPresent()) {
+            return Maybe.just(cacheDataCollector.getData(cache.get()));
+        } else {
+            return Maybe.empty();
+        }
+    }
+
+    /**
+     * Invalidates all the caches.
+     */
+    @Delete
+    public void invalidateCaches() {
+        getSyncCaches().forEach(SyncCache::invalidateAll);
+    }
+
+    /**
+     * Invalidates the cache.
+     *
+     * @param name The name of the cache to invalidate
+     */
+    @Delete
+    public void invalidateCache(@NotBlank @Selector String name) {
+        getSyncCache(name).ifPresent(SyncCache::invalidateAll);
+    }
+
+    private List<SyncCache> getSyncCaches() {
+        return getCacheNames()
+                .stream()
+                .map((cacheName) -> cacheManager.getCache(cacheName))
+                .collect(Collectors.toList());
+    }
+
+    private Optional<SyncCache> getSyncCache(String name) {
+        return getCacheNames()
+                .stream()
+                .filter((cacheName) -> cacheName.equals(name))
+                .findFirst()
+                .map((cacheName) -> cacheManager.getCache(cacheName));
+    }
+
+    private List<String> getCacheNames() {
+        Set<String> cacheNames = cacheManager.getCacheNames();
+        return cacheNames.stream().sorted().collect(Collectors.toList());
+    }
+}

--- a/management/src/main/java/io/micronaut/management/endpoint/caches/impl/DefaultCacheData.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/caches/impl/DefaultCacheData.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.management.endpoint.caches.impl;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Policy;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import io.micronaut.cache.SyncCache;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.management.endpoint.caches.CacheData;
+import io.micronaut.management.endpoint.caches.CachesEndpoint;
+
+import javax.inject.Singleton;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Default cache data implementation.
+ *
+ * @author Marcel Overdijk
+ * @since 1.1
+ */
+@Singleton
+@Requires(beans = CachesEndpoint.class)
+public class DefaultCacheData implements CacheData<Map<String, Object>> {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Map<String, Object> getData(SyncCache cache) {
+
+        Map<String, Object> values = new LinkedHashMap<>(2);
+
+        values.put("implementationClass", cache.getNativeCache().getClass().getName());
+
+        if (cache.getNativeCache() instanceof Cache) {
+            values.put("caffeine", getCaffeineCacheData((Cache) cache.getNativeCache()));
+        }
+
+        return values;
+    }
+
+    private Map<String, Object> getCaffeineCacheData(Cache caffeineCache) {
+
+        Policy policy = caffeineCache.policy();
+        Policy.Eviction eviction = (Policy.Eviction) policy.eviction().orElse(null);
+        Policy.Expiration expireAfterAccess = (Policy.Expiration) policy.expireAfterAccess().orElse(null);
+        Policy.Expiration expireAfterWrite = (Policy.Expiration) policy.expireAfterWrite().orElse(null);
+        Long maximumSize = (!eviction.isWeighted() ? eviction.getMaximum() : null);
+        Long maximumWeight = (eviction.isWeighted() ? eviction.getMaximum() : null);
+        Long weightedSize = (eviction.weightedSize().isPresent() ? eviction.weightedSize().getAsLong() : null);
+        boolean isRecordingStats = policy.isRecordingStats();
+
+        Map<String, Object> values = new LinkedHashMap<>(8);
+
+        values.put("estimatedSize", caffeineCache.estimatedSize());
+        values.put("maximumSize", maximumSize);
+        values.put("maximumWeight", maximumWeight);
+        values.put("weightedSize", weightedSize);
+        values.put("expireAfterAccess", getExpiresAfter(expireAfterAccess));
+        values.put("expireAfterWrite", getExpiresAfter(expireAfterWrite));
+        values.put("recordingStats", isRecordingStats);
+
+        if (isRecordingStats) {
+            values.put("stats", getStatsData(caffeineCache.stats()));
+        }
+
+        return values;
+    }
+
+    private Long getExpiresAfter(Policy.Expiration expiration) {
+        return expiration != null ? expiration.getExpiresAfter(TimeUnit.MILLISECONDS) : null;
+    }
+
+    private Map<String, Object> getStatsData(CacheStats stats) {
+
+        Map<String, Object> values = new LinkedHashMap<>(13);
+
+        values.put("requestCount", stats.requestCount());
+        values.put("hitCount", stats.hitCount());
+        values.put("hitRate", stats.hitRate());
+        values.put("missCount", stats.missCount());
+        values.put("missRate", stats.missRate());
+        values.put("evictionCount", stats.evictionCount());
+        values.put("evictionWeight", stats.evictionWeight());
+
+        return values;
+    }
+}

--- a/management/src/main/java/io/micronaut/management/endpoint/caches/impl/DefaultCacheData.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/caches/impl/DefaultCacheData.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.micronaut.management.endpoint.caches.impl;
 
 import com.github.benmanes.caffeine.cache.Cache;
@@ -32,7 +33,7 @@ import java.util.concurrent.TimeUnit;
  * Default cache data implementation.
  *
  * @author Marcel Overdijk
- * @since 1.1
+ * @since 1.1.0
  */
 @Singleton
 @Requires(beans = CachesEndpoint.class)

--- a/management/src/main/java/io/micronaut/management/endpoint/caches/impl/RxJavaCacheDataCollector.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/caches/impl/RxJavaCacheDataCollector.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.management.endpoint.caches.impl;
+
+import io.micronaut.cache.SyncCache;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.management.endpoint.caches.CacheData;
+import io.micronaut.management.endpoint.caches.CacheDataCollector;
+import io.micronaut.management.endpoint.caches.CachesEndpoint;
+import io.micronaut.scheduling.TaskExecutors;
+import io.reactivex.Flowable;
+import io.reactivex.Single;
+import io.reactivex.schedulers.Schedulers;
+import org.reactivestreams.Publisher;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * A RxJava cache data collector.
+ *
+ * @author Marcel Overdijk
+ * @since 1.1
+ */
+@Singleton
+@Requires(beans = CachesEndpoint.class)
+public class RxJavaCacheDataCollector implements CacheDataCollector<Map<String, Object>> {
+
+    private final CacheData cacheData;
+    private final ExecutorService executorService;
+
+    /**
+     * @param cacheData       The {@link CacheData}
+     * @param executorService The {@link ExecutorService}
+     */
+    public RxJavaCacheDataCollector(CacheData cacheData, @Named(TaskExecutors.IO) ExecutorService executorService) {
+        this.cacheData = cacheData;
+        this.executorService = executorService;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Publisher<Map<String, Object>> getData(List<SyncCache> caches) {
+        return getCaches(caches)
+                .map((cacheMap) -> {
+                    Map<String, Object> cacheData = new LinkedHashMap<>(1);
+                    cacheData.put("caches", cacheMap);
+                    return cacheData;
+                }).toFlowable();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Publisher getData(final SyncCache cache) {
+        return Flowable.just(cacheData.getData(cache));
+    }
+
+    /**
+     * @param caches The caches
+     * @return A {@link Single} that wraps a Map
+     */
+    protected Single<Map<String, Object>> getCaches(List<SyncCache> caches) {
+        Map<String, Object> cacheMap = new LinkedHashMap<>(caches.size());
+
+        return Flowable
+                .fromIterable(caches)
+                .subscribeOn(Schedulers.from(executorService))
+                .collectInto(cacheMap, (map, cache) ->
+                        map.put(cache.getName(), cacheData.getData(cache))
+                );
+    }
+}

--- a/management/src/main/java/io/micronaut/management/endpoint/caches/impl/package-info.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/caches/impl/package-info.java
@@ -13,22 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.management.endpoint.caches;
-
-import io.micronaut.cache.SyncCache;
 
 /**
- * Returns data for a given cache to be used for the {@link CachesEndpoint}.
+ * Implementations for the cache endpoint
  *
- * @param <T> The type
  * @author Marcel Overdijk
  * @since 1.1.0
  */
-public interface CacheData<T> {
-
-    /**
-     * @param cache The cache
-     * @return Cache data
-     */
-    T getData(SyncCache cache);
-}
+package io.micronaut.management.endpoint.caches.impl;

--- a/management/src/main/java/io/micronaut/management/endpoint/caches/package-info.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/caches/package-info.java
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
  * Caches management endpoint.
  *
  * @author Marcel Overdijk
- * @since 1.1
+ * @since 1.1.0
  */
 package io.micronaut.management.endpoint.caches;

--- a/management/src/main/java/io/micronaut/management/endpoint/caches/package-info.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/caches/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Caches management endpoint.
+ *
+ * @author Marcel Overdijk
+ * @since 1.1
+ */
+package io.micronaut.management.endpoint.caches;

--- a/management/src/test/groovy/io/micronaut/management/endpoint/caches/CachesEndpointConfigurationSpec.groovy
+++ b/management/src/test/groovy/io/micronaut/management/endpoint/caches/CachesEndpointConfigurationSpec.groovy
@@ -16,6 +16,8 @@
 package io.micronaut.management.endpoint.caches
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.management.endpoint.caches.impl.DefaultCacheData
+import io.micronaut.management.endpoint.caches.impl.RxJavaCacheDataCollector
 import spock.lang.Specification
 
 /**
@@ -29,7 +31,9 @@ class CachesEndpointConfigurationSpec extends Specification {
         ApplicationContext context = ApplicationContext.run()
 
         expect:
-        context.containsBean(CachesEndpoint)
+        !context.containsBean(CachesEndpoint)
+        !context.containsBean(DefaultCacheData)
+        !context.containsBean(RxJavaCacheDataCollector)
 
         cleanup:
         context.close()
@@ -37,10 +41,12 @@ class CachesEndpointConfigurationSpec extends Specification {
 
     void "test caches endpoint can be disabled"() {
         given:
-        ApplicationContext context = ApplicationContext.run(["endpoints.caches.enabled": false])
+        ApplicationContext context = ApplicationContext.run(["endpoints.caches.enabled": true])
 
         expect:
-        !context.containsBean(CachesEndpoint)
+        context.containsBean(CachesEndpoint)
+        context.containsBean(DefaultCacheData)
+        context.containsBean(RxJavaCacheDataCollector)
 
         cleanup:
         context.close()

--- a/management/src/test/groovy/io/micronaut/management/endpoint/caches/CachesEndpointConfigurationSpec.groovy
+++ b/management/src/test/groovy/io/micronaut/management/endpoint/caches/CachesEndpointConfigurationSpec.groovy
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.management.endpoint.caches
+
+import io.micronaut.context.ApplicationContext
+import spock.lang.Specification
+
+/**
+ * @author Marcel Overdijk
+ * @since 1.1
+ */
+class CachesEndpointConfigurationSpec extends Specification {
+
+    void "test caches endpoint enabled"() {
+        given:
+        ApplicationContext context = ApplicationContext.run()
+
+        expect:
+        context.containsBean(CachesEndpoint)
+
+        cleanup:
+        context.close()
+    }
+
+    void "test caches endpoint can be disabled"() {
+        given:
+        ApplicationContext context = ApplicationContext.run(["endpoints.caches.enabled": false])
+
+        expect:
+        !context.containsBean(CachesEndpoint)
+
+        cleanup:
+        context.close()
+    }
+}

--- a/management/src/test/groovy/io/micronaut/management/endpoint/caches/CachesEndpointSpec.groovy
+++ b/management/src/test/groovy/io/micronaut/management/endpoint/caches/CachesEndpointSpec.groovy
@@ -33,7 +33,10 @@ class CachesEndpointSpec extends Specification {
 
     void "test no caches are returned from caches endpoint"() {
         given:
-        EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, ["endpoints.caches.sensitive": false], Environment.TEST)
+        EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
+                "endpoints.caches.enabled": true,
+                "endpoints.caches.sensitive": false
+        ], Environment.TEST)
         RxHttpClient rxClient = embeddedServer.applicationContext.createBean(RxHttpClient, embeddedServer.getURL())
 
         when:
@@ -53,6 +56,7 @@ class CachesEndpointSpec extends Specification {
         given:
         EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer,
                 [
+                        "endpoints.caches.enabled": true,
                         "endpoints.caches.sensitive": false,
                         "micronaut.caches.foo-cache.maximumSize": 10,
                         "micronaut.caches.foo-cache.recordStats": true,
@@ -122,6 +126,7 @@ class CachesEndpointSpec extends Specification {
         given:
         EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer,
                 [
+                        "endpoints.caches.enabled": true,
                         "endpoints.caches.sensitive": false,
                         "micronaut.caches.foo-cache.maximumSize": 10,
                         "micronaut.caches.bar-cache.maximumSize": 10
@@ -169,6 +174,7 @@ class CachesEndpointSpec extends Specification {
         given:
         EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer,
                 [
+                        "endpoints.caches.enabled": true,
                         "endpoints.caches.sensitive": false,
                         "micronaut.caches.foo-cache.maximumSize": 10,
                         "micronaut.caches.bar-cache.maximumSize": 10

--- a/management/src/test/groovy/io/micronaut/management/endpoint/caches/CachesEndpointSpec.groovy
+++ b/management/src/test/groovy/io/micronaut/management/endpoint/caches/CachesEndpointSpec.groovy
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.management.endpoint.caches
+
+import io.micronaut.cache.CacheManager
+import io.micronaut.cache.SyncCache
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.env.Environment
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.RxHttpClient
+import io.micronaut.runtime.server.EmbeddedServer
+import spock.lang.Specification
+
+/**
+ * @author Marcel Overdijk
+ * @since 1.1
+ */
+class CachesEndpointSpec extends Specification {
+
+    void "test no caches are returned from caches endpoint"() {
+        given:
+        EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, ["endpoints.caches.sensitive": false], Environment.TEST)
+        RxHttpClient rxClient = embeddedServer.applicationContext.createBean(RxHttpClient, embeddedServer.getURL())
+
+        when:
+        def response = rxClient.exchange("/caches", Map).blockingFirst()
+        Map result = response.body()
+
+        then:
+        response.code() == HttpStatus.OK.code
+        result == [:]
+
+        cleanup:
+        rxClient.close()
+        embeddedServer?.close()
+    }
+
+    void "test caches are returned from caches endpoint"() {
+        given:
+        EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer,
+                [
+                        "endpoints.caches.sensitive": false,
+                        "micronaut.caches.foo-cache.maximumSize": 10,
+                        "micronaut.caches.foo-cache.recordStats": true,
+                        "micronaut.caches.bar-cache.maximumWeight": 20
+                ],Environment.TEST)
+        RxHttpClient rxClient = embeddedServer.applicationContext.createBean(RxHttpClient, embeddedServer.getURL())
+        CacheManager cacheManager = embeddedServer.applicationContext.getBean(CacheManager)
+
+        SyncCache fooCache = cacheManager.getCache("foo-cache")
+        fooCache.put("foo1", "value1")
+        fooCache.put("foo2", "value2")
+        fooCache.get("foo1", Object)
+        fooCache.get("foo2", Object)
+        fooCache.get("foo2", Object)
+        fooCache.get("foo3", Object)
+
+        when:
+        def response = rxClient.exchange("/caches", Map).blockingFirst()
+        Map result = response.body()
+        Map<String, Map<String, Object>> caches = result.caches
+
+        then:
+        response.code() == HttpStatus.OK.code
+        caches.size() == 2
+        caches["bar-cache"].implementationClass == "com.github.benmanes.caffeine.cache.BoundedLocalCache\$BoundedLocalManualCache"
+        caches["bar-cache"].caffeine.estimatedSize == 0
+        caches["bar-cache"].caffeine.maximumWeight == 20
+        caches["bar-cache"].caffeine.weightedSize == 0
+        caches["bar-cache"].caffeine.recordingStats == false
+        caches["bar-cache"].caffeine.stats == null
+        caches["foo-cache"].caffeine.estimatedSize == 2
+        caches["foo-cache"].caffeine.maximumSize == 10
+        caches["foo-cache"].caffeine.recordingStats == true
+        caches["foo-cache"].caffeine.stats.requestCount == 4
+        caches["foo-cache"].caffeine.stats.hitCount == 3
+        caches["foo-cache"].caffeine.stats.hitRate == 0.75
+        caches["foo-cache"].caffeine.stats.missCount == 1
+        caches["foo-cache"].caffeine.stats.missRate == 0.25
+        caches["foo-cache"].caffeine.stats.evictionCount == 0
+        caches["foo-cache"].caffeine.stats.evictionWeight == 0
+
+        when:
+        response = rxClient.exchange("/caches/foo-cache", Map).blockingFirst()
+        result = response.body()
+
+        then:
+        response.code() == HttpStatus.OK.code
+        caches.size() == 2
+        result.implementationClass == "com.github.benmanes.caffeine.cache.BoundedLocalCache\$BoundedLocalManualCache"
+        result.caffeine.estimatedSize == 2
+        result.caffeine.maximumSize == 10
+        result.caffeine.recordingStats == true
+        result.caffeine.stats.requestCount == 4
+        result.caffeine.stats.hitCount == 3
+        result.caffeine.stats.hitRate == 0.75
+        result.caffeine.stats.missCount == 1
+        result.caffeine.stats.missRate == 0.25
+        result.caffeine.stats.evictionCount == 0
+        result.caffeine.stats.evictionWeight == 0
+
+        cleanup:
+        rxClient.close()
+        embeddedServer?.close()
+    }
+
+    void "test invalidate single cache"() {
+        given:
+        EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer,
+                [
+                        "endpoints.caches.sensitive": false,
+                        "micronaut.caches.foo-cache.maximumSize": 10,
+                        "micronaut.caches.bar-cache.maximumSize": 10
+                ],Environment.TEST)
+        RxHttpClient rxClient = embeddedServer.applicationContext.createBean(RxHttpClient, embeddedServer.getURL())
+        CacheManager cacheManager = embeddedServer.applicationContext.getBean(CacheManager)
+
+        SyncCache fooCache = cacheManager.getCache("foo-cache")
+        fooCache.put("foo1", "value1")
+        fooCache.put("foo2", "value2")
+
+        SyncCache barCache = cacheManager.getCache("bar-cache")
+        barCache.put("bar1", "value1")
+        barCache.put("bar2", "value2")
+
+        when:
+        def response = rxClient.exchange("/caches", Map).blockingFirst()
+        Map result = response.body()
+        Map<String, Map<String, Object>> caches = result.caches
+
+        then:
+        response.code() == HttpStatus.OK.code
+        caches.size() == 2
+        caches["bar-cache"].caffeine.estimatedSize == 2
+        caches["foo-cache"].caffeine.estimatedSize == 2
+
+        when:
+        rxClient.exchange(HttpRequest.DELETE("/caches/foo-cache")).blockingFirst()
+        response = rxClient.exchange("/caches", Map).blockingFirst()
+        result = response.body()
+        caches = result.caches
+
+        then:
+        response.code() == HttpStatus.OK.code
+        caches.size() == 2
+        caches["bar-cache"].caffeine.estimatedSize == 2
+        caches["foo-cache"].caffeine.estimatedSize == 0
+
+        cleanup:
+        rxClient.close()
+        embeddedServer?.close()
+    }
+
+    void "test invalidate all caches"() {
+        given:
+        EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer,
+                [
+                        "endpoints.caches.sensitive": false,
+                        "micronaut.caches.foo-cache.maximumSize": 10,
+                        "micronaut.caches.bar-cache.maximumSize": 10
+                ],Environment.TEST)
+        RxHttpClient rxClient = embeddedServer.applicationContext.createBean(RxHttpClient, embeddedServer.getURL())
+        CacheManager cacheManager = embeddedServer.applicationContext.getBean(CacheManager)
+
+        SyncCache fooCache = cacheManager.getCache("foo-cache")
+        fooCache.put("foo1", "value1")
+        fooCache.put("foo2", "value2")
+
+        SyncCache barCache = cacheManager.getCache("bar-cache")
+        barCache.put("bar1", "value1")
+        barCache.put("bar2", "value2")
+
+        when:
+        def response = rxClient.exchange("/caches", Map).blockingFirst()
+        Map result = response.body()
+        Map<String, Map<String, Object>> caches = result.caches
+
+        then:
+        response.code() == HttpStatus.OK.code
+        caches.size() == 2
+        caches["bar-cache"].caffeine.estimatedSize == 2
+        caches["foo-cache"].caffeine.estimatedSize == 2
+
+        when:
+        rxClient.exchange(HttpRequest.DELETE("/caches")).blockingFirst()
+        response = rxClient.exchange("/caches", Map).blockingFirst()
+        result = response.body()
+        caches = result.caches
+
+        then:
+        response.code() == HttpStatus.OK.code
+        caches.size() == 2
+        caches["bar-cache"].caffeine.estimatedSize == 0
+        caches["foo-cache"].caffeine.estimatedSize == 0
+
+        cleanup:
+        rxClient.close()
+        embeddedServer?.close()
+    }
+}

--- a/src/main/docs/guide/management/providedEndpoints.adoc
+++ b/src/main/docs/guide/management/providedEndpoints.adoc
@@ -8,13 +8,21 @@ When the `management` dependency is added to your project, the following built-i
 | `/beans`
 |Returns information about the loaded bean definitions in the application (see <<beansEndpoint, BeansEndpoint>>)
 
-|api:management.endpoint.info.InfoEndpoint[]
-| `/info`
-|Returns static information from the state of the application (see <<infoEndpoint, InfoEndpoint>>)
+|api:management.endpoint.caches.CachesEndpoint[]
+| `/caches`
+|Returns information about the caches and permits invalidating them (see <<cachesEndpoint, CachesEndpoint>>)
 
 |api:management.endpoint.health.HealthEndpoint[]
 | `/health`
 |Returns information about the "health" of the application (see <<healthEndpoint, HealthEndpoint>>)
+
+|api:management.endpoint.info.InfoEndpoint[]
+| `/info`
+|Returns static information from the state of the application (see <<infoEndpoint, InfoEndpoint>>)
+
+|api:management.endpoint.loggers.LoggersEndpoint[]
+| `/loggers`
+|Returns information about available loggers and permits changing the configured log level (see <<loggersEndpoint, LoggersEndpoint>>)
 
 |api:configuration.metrics.management.endpoint.MetricsEndpoint[]
 | `/metrics`
@@ -27,10 +35,6 @@ When the `management` dependency is added to your project, the following built-i
 |api:management.endpoint.routes.RoutesEndpoint[]
 | `/routes`
 |Returns information about URIs available to be called for your application (see <<routesEndpoint, RoutesEndpoint>>)
-
-|api:management.endpoint.loggers.LoggersEndpoint[]
-| `/loggers`
-|Returns information about available loggers and permits changing the configured log level (see <<loggersEndpoint, LoggersEndpoint>>)
 
 |===
 

--- a/src/main/docs/guide/management/providedEndpoints/cachesEndpoint.adoc
+++ b/src/main/docs/guide/management/providedEndpoints/cachesEndpoint.adoc
@@ -1,0 +1,59 @@
+
+The caches endpoint returns information about the caches in the application and
+permits invalidating them.
+
+To get a collection of all caches by name with their configuration, send a GET request to /caches.
+
+[source,bash]
+----
+$ curl http://localhost:8080/caches
+----
+
+To get the configuration of a particular cache, include the cache name in your GET request. For
+example, to access the configuration of the cache 'book-cache':
+
+[source,bash]
+----
+$ curl http://localhost:8080/caches/book-cache
+----
+
+To invalidate all cached values within a single cache, send a DELETE request to the named cache URL.
+
+[source,bash]
+----
+$ curl -X DELETE http://localhost:8080/caches/book-cache
+----
+
+To invalidate all caches, send a DELETE request to /caches.
+
+[source,bash]
+----
+$ curl -X DELETE http://localhost:8080/caches
+----
+
+== Configuration
+
+To configure the caches endpoint, supply configuration through `endpoints.caches`.
+
+.Caches Endpoint Configuration Example
+[source,yaml]
+----
+endpoints:
+    caches:
+        enabled: Boolean
+        sensitive: Boolean
+----
+
+== Customization
+
+The caches endpoint is composed of a cache data collector and a cache data implementation.
+The cache data collector (link:{api}/io/micronaut/management/endpoint/caches/CacheDataCollector.html[CacheDataCollector])
+is responsible for returning a publisher that will return the data used in the response.
+The cache data (link:{api}/io/micronaut/management/endpoint/caches/CacheData.html[CacheData]) is responsible for returning
+data about an individual cache.
+
+To override the default behavior for either of the helper classes, either extend the default implementations
+(link:{api}/io/micronaut/management/endpoint/caches/impl/RxJavaCacheDataCollector.html[RxJavaRouteDataCollector], link:{api}/io/micronaut/management/endpoint/caches/impl/DefaultCacheData.html[DefaultRouteData]),
+or implement the relevant interface directly.
+To ensure your implementation is used instead of the default, add the link:{api}/io/micronaut/context/annotation/Replaces.html[@Replaces]
+annotation to your class with the value being the default implementation.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -219,6 +219,7 @@ management:
     refreshEndpoint: The Refresh Endpoint
     routesEndpoint: The Routes Endpoint
     loggersEndpoint: The Loggers Endpoint
+    cachesEndpoint: The Caches Endpoint
     stopEndpoint: The Server Stop Endpoint
 security:
   title: Security


### PR DESCRIPTION
This PR adds a `/caches` endoint.
It contains the endpoint classes (took the same approach as existing endpoints), tests and docs.

Note: I had to include the shadow plugin to `management/build.gradle` to relocate the Caffeine classes. I have never done this before so good to check if what I have done is correct.