### PR TITLE
Sorting of endpoint data (fix for #1295)

### DIFF
--- a/management/src/main/java/io/micronaut/management/endpoint/beans/BeansEndpoint.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/beans/BeansEndpoint.java
@@ -16,12 +16,16 @@
 package io.micronaut.management.endpoint.beans;
 
 import io.micronaut.context.BeanContext;
+import io.micronaut.inject.BeanDefinition;
 import io.micronaut.management.endpoint.annotation.Endpoint;
 import io.micronaut.management.endpoint.annotation.Read;
 import io.reactivex.Flowable;
 import io.reactivex.Single;
 
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * <p>Exposes an {@link Endpoint} to provide information about the beans of the application.</p>
@@ -49,8 +53,12 @@ public class BeansEndpoint {
      */
     @Read
     public Single getBeans() {
+        List<BeanDefinition<?>> beanDefinitions = beanContext.getAllBeanDefinitions()
+                .stream()
+                .sorted(Comparator.comparing((BeanDefinition<?> bd) -> bd.getClass().getName()))
+                .collect(Collectors.toList());
         return Flowable
-            .fromPublisher(beanDefinitionDataCollector.getData(beanContext.getAllBeanDefinitions()))
+            .fromPublisher(beanDefinitionDataCollector.getData(beanDefinitions))
             .first(Collections.emptyMap());
     }
 }

--- a/management/src/main/java/io/micronaut/management/endpoint/beans/impl/DefaultBeanDefinitionData.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/beans/impl/DefaultBeanDefinitionData.java
@@ -60,7 +60,7 @@ public class DefaultBeanDefinitionData implements BeanDefinitionData<Map<String,
      * @return A list of dependencies for the bean definition
      */
     protected List getDependencies(BeanDefinition<?> beanDefinition) {
-        return beanDefinition.getRequiredComponents().stream().map(Class::getName).collect(Collectors.toList());
+        return beanDefinition.getRequiredComponents().stream().map(Class::getName).sorted().collect(Collectors.toList());
     }
 
     /**

--- a/management/src/main/java/io/micronaut/management/endpoint/beans/impl/RxJavaBeanDefinitionDataCollector.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/beans/impl/RxJavaBeanDefinitionDataCollector.java
@@ -31,7 +31,6 @@ import javax.inject.Singleton;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 
 /**
@@ -72,7 +71,7 @@ public class RxJavaBeanDefinitionDataCollector implements BeanDefinitionDataColl
      * @return A {@link Single} that wraps a Map
      */
     protected Single<Map<String, Object>> getBeans(Collection<BeanDefinition<?>> definitions) {
-        Map<String, Object> beans = new ConcurrentHashMap<>(definitions.size());
+        Map<String, Object> beans = new LinkedHashMap<>(definitions.size());
 
         return Flowable
             .fromIterable(definitions)

--- a/management/src/main/java/io/micronaut/management/endpoint/loggers/LoggerConfiguration.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/loggers/LoggerConfiguration.java
@@ -15,7 +15,7 @@
  */
 package io.micronaut.management.endpoint.loggers;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -70,7 +70,7 @@ public class LoggerConfiguration {
      * @return a Map of data to emit (less the name)
      */
     public Map<String, Object> getData() {
-        Map<String, Object> data = new HashMap<>(2);
+        Map<String, Object> data = new LinkedHashMap<>(2);
         data.put(CONFIGURED_LEVEL, getConfiguredLevel());
         data.put(EFFECTIVE_LEVEL, getEffectiveLevel());
         return data;

--- a/management/src/main/java/io/micronaut/management/endpoint/loggers/impl/DefaultLoggersManager.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/loggers/impl/DefaultLoggersManager.java
@@ -39,7 +39,7 @@ public class DefaultLoggersManager implements LoggersManager<Map<String, Object>
 
     @Override
     public Publisher<Map<String, Object>> getLoggers(LoggingSystem loggingSystem) {
-        Map<String, Object> data = new HashMap<>(2);
+        Map<String, Object> data = new LinkedHashMap<>(2);
 
         data.put(LEVELS, getLogLevels());
         data.put(LOGGERS, getLoggerData(loggingSystem.getLoggers()));
@@ -68,7 +68,9 @@ public class DefaultLoggersManager implements LoggersManager<Map<String, Object>
                 .stream()
                 .collect(Collectors.toMap(
                         LoggerConfiguration::getName,
-                        LoggerConfiguration::getData));
+                        LoggerConfiguration::getData,
+                        (l1, l2) -> l1,
+                        LinkedHashMap::new));
     }
 
     /**

--- a/management/src/main/java/io/micronaut/management/endpoint/routes/RoutesEndpoint.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/routes/RoutesEndpoint.java
@@ -18,7 +18,11 @@ package io.micronaut.management.endpoint.routes;
 import io.micronaut.management.endpoint.annotation.Endpoint;
 import io.micronaut.management.endpoint.annotation.Read;
 import io.micronaut.web.router.Router;
+import io.micronaut.web.router.UriRoute;
 import io.reactivex.Single;
+
+import java.util.Comparator;
+import java.util.stream.Stream;
 
 /**
  * <p>Exposes an {@link Endpoint} to display application routes.</p>
@@ -47,6 +51,10 @@ public class RoutesEndpoint {
      */
     @Read
     public Single getRoutes() {
-        return Single.fromPublisher(routeDataCollector.getData(router.uriRoutes()));
+        Stream<UriRoute> uriRoutes = router.uriRoutes()
+                .sorted(Comparator
+                        .comparing((UriRoute r) -> r.getUriMatchTemplate().toPathString())
+                        .thenComparing((UriRoute r) -> r.getHttpMethod().ordinal()));
+        return Single.fromPublisher(routeDataCollector.getData(uriRoutes));
     }
 }

--- a/management/src/main/java/io/micronaut/management/endpoint/routes/impl/RxJavaRouteDataCollector.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/routes/impl/RxJavaRouteDataCollector.java
@@ -28,9 +28,9 @@ import org.reactivestreams.Publisher;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -61,7 +61,7 @@ public class RxJavaRouteDataCollector implements RouteDataCollector<Map<String, 
     @Override
     public Publisher<Map<String, Object>> getData(Stream<UriRoute> routes) {
         List<UriRoute> routeList = routes.collect(Collectors.toList());
-        Map<String, Object> routeMap = new ConcurrentHashMap<>(routeList.size());
+        Map<String, Object> routeMap = new LinkedHashMap<>(routeList.size());
 
         return Flowable
             .fromIterable(routeList)


### PR DESCRIPTION
This PR consistently sorts beans, loggers and routes endpoint data by using `LinkedHashMap`s and sorting collections. Fix for #1295.