### PR TITLE
Changed --features aws-api-proxy for --features aws-api-proxy

### DIFF
--- a/src/main/docs/guide/serverlessFunctions/writingFunctions.adoc
+++ b/src/main/docs/guide/serverlessFunctions/writingFunctions.adoc
@@ -52,7 +52,7 @@ When using this approach the FaaS system (in this case AWS Lambda) will directly
 [TIP]
 .Using the CLI
 ====
-You can create a AWS API Gateway service using `mn create-app myapp --features aws-api-proxy`
+You can create a AWS API Gateway service using `mn create-app myapp --features aws-api-gateway`
 ====
 
 Another approach to FaaS is to build a regular REST application and then deploy the application using tools offered by the FaaS system such as https://aws.amazon.com/api-gateway/[AWS API Gateway].


### PR DESCRIPTION
The feature aws-api-proxy indicated in the documentation doesn't exist. It should be aws-api-proxy as correctly indicated by the mn CLI:

```
Setting micronaut 1.1.0.M2 as default.
 codependent@xxxx  ~/git/codependent/github  mn create-app micronaut-aws-lambda-proxy --features aws-api-proxy -l kotlin

Resolving dependencies..
| Warning Feature aws-api-proxy does not exist in the profile service! Possible solutions: aws-api-gateway-graal, aws-api-gateway
```
