### PR TITLE
Fix inconsistency in documentation describing how to enable api versioning

### DIFF
--- a/src/main/docs/guide/httpServer/apiVersioning.adoc
+++ b/src/main/docs/guide/httpServer/apiVersioning.adoc
@@ -33,20 +33,22 @@ By default Micronaut has 2 out-of-the-box strategies for resolving the version t
 micronaut:
     router:
         versioning:
+            enabled: true <1>
             parameter:
-                enabled: false # <1>
-                names: 'v,api-version' # <2>
+                enabled: false # <2>
+                names: 'v,api-version' # <3>
             header:
-                enabled: true # <3>
-                names: # <4>
+                enabled: true # <4>
+                names: # <5>
                     - 'X-API-VERSION'
                     - 'Accept-Version'
 ----
 
-<1> Enables or disables parameter based versioning
-<2> Specify the parameter names as a comma separated list
-<3> Enables or disables header based versioning
-<4> Specify the header names as a YAML list
+<1> Enables versioning
+<2> Enables or disables parameter based versioning
+<3> Specify the parameter names as a comma separated list
+<4> Enables or disables header based versioning
+<5> Specify the header names as a YAML list
 
 If this is not enough you can also implement the api:web.router.version.strategy.VersionExtractingStrategy[] interface which receives the api:http.HttpRequest[] and can implement any strategy you choose.
 


### PR DESCRIPTION
Api versioning example in the document is missing the part which enables versioning
Based on comments in https://github.com/micronaut-projects/micronaut-core/issues/997