### PR TITLE
Fix link for implementing custom version resolution

### DIFF
--- a/src/main/docs/guide/httpServer/apiVersioning.adoc
+++ b/src/main/docs/guide/httpServer/apiVersioning.adoc
@@ -48,7 +48,7 @@ micronaut:
 <3> Enables or disables header based versioning
 <4> Specify the header names as a YAML list
 
-If this is not enough you can also implement the api:web.router.version.strategy.VersionExtractingStrategy[] interface which receives the api:http.HttpRequest[] and can implement any strategy you choose.
+If this is not enough you can also implement the api:web.router.version.resolution.RequestVersionResolver[] interface which receives the api:http.HttpRequest[] and can implement any strategy you choose.
 
 === Versioning Client Requests
 


### PR DESCRIPTION
The custom version resolution text was pointing to the VersionExtractingStrategy class, which has been renamed and relocated to RequestVersionResolver.