### PR TITLE
BeanDefinitionInjectProcessor works with Mapstruct

### DIFF
--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -110,7 +110,6 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
     private JavaConfigurationMetadataBuilder metadataBuilder;
     private Map<String, AnnBeanElementVisitor> beanDefinitionWriters;
     private Set<String> processed = new HashSet<>();
-    private boolean executed = false;
 
     @Override
     public final synchronized void init(ProcessingEnvironment processingEnv) {
@@ -121,10 +120,6 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
 
     @Override
     public final boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
-        if (executed) {
-            return false;
-        }
-        executed = true;
 
         annotations = annotations
                 .stream()
@@ -189,13 +184,6 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                     });
                 });
 
-                try {
-                    classWriterOutputVisitor.finish();
-                } catch (Exception e) {
-                    String message = e.getMessage();
-                    error("Error occurred writing META-INF files: %s", message != null ? message : e);
-                }
-
                 if (metadataBuilder.hasMetadata()) {
                     ServiceLoader<ConfigurationMetadataWriter> writers = ServiceLoader.load(ConfigurationMetadataWriter.class, getClass().getClassLoader());
 
@@ -211,12 +199,32 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                         warning("Unable to load ConfigurationMetadataWriter due to : %s", e.getMessage());
                     }
                 }
-
                 AnnotationUtils.invalidateCache();
             }
         }
         AnnotationUtils.invalidateCache();
+
+        /*
+        Since the underlying Filer expects us to write only once into a file we need to make sure it happens in the last
+        processing round.
+        */
+        if (roundEnv.processingOver()) {
+            writeBeanDefinitionsToMetaInf();
+        }
+
         return false;
+    }
+
+    /**
+     * Writes {@link io.micronaut.inject.BeanDefinitionReference} into /META-INF/services/io.micronaut.inject.BeanDefinitionReference
+     */
+    private void writeBeanDefinitionsToMetaInf() {
+        try {
+            classWriterOutputVisitor.finish();
+        } catch (Exception e) {
+            String message = e.getMessage();
+            error("Error occurred writing META-INF files: %s", message != null ? message : e);
+        }
     }
 
     private void processBeanDefinitions(TypeElement beanClassElement, BeanDefinitionVisitor beanDefinitionWriter) {


### PR DESCRIPTION
The following PR contains a fix for https://github.com/micronaut-projects/micronaut-core/issues/1309 and makes sure that Micronauts `BeanDefinitionInjectProcessor` in **version 1.0.4** participates on every processing round.

Therefore Micronaut includes e.g. `@Singleton` classes that were generated by other third party annotation processors.

- This PR removes the `executed` flag that made sure the processor runs only in round 1.
- And moves the generation of the `/META-INF/services/io.micronaut.inject.BeanDefinitionReference` to the last processing round.

Fixes https://github.com/micronaut-projects/micronaut-core/issues/1309