### PR TITLE
Add support for netty server's native transport.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -264,7 +264,8 @@ ext {
                               'netty-codec-redis', 'netty-codec-smtp', 'netty-codec-socks', 'netty-codec-stomp',
                               'netty-codec-xml', 'netty-common', 'netty-dev-tools', 'netty-handler',
                               'netty-handler-proxy', 'netty-resolver', 'netty-resolver-dns', 'netty-transport',
-                              'netty-transport-rxtx', 'netty-transport-sctp', 'netty-transport-udt']
+                              'netty-transport-rxtx', 'netty-transport-sctp', 'netty-transport-udt',
+                              'netty-transport-native-epoll', 'netty-transport-native-kqueue']
             ],
             opentracing                : [
                     version: opentracingVersion,

--- a/http-server-netty/build.gradle
+++ b/http-server-netty/build.gradle
@@ -3,6 +3,8 @@ dependencies {
     compile project(":http-netty")
 
     compileOnly project(":inject-java")
+    compileOnly dependencyModuleVersion("netty", "netty-transport-native-epoll")
+    compileOnly dependencyModuleVersion("netty", "netty-transport-native-kqueue")
 
     testCompile project(":inject-groovy")
     testCompile project(":inject-java")

--- a/http-server-netty/build.gradle
+++ b/http-server-netty/build.gradle
@@ -13,6 +13,8 @@ dependencies {
     testCompile dependencyModuleVersion("groovy", "groovy-templates")
     testCompile dependencyVersion("rxjava2")
     testCompile dependencyVersion("reactor")
+    testCompile(dependencyModuleVersion("netty", "netty-transport-native-epoll") + ":linux-x86_64")
+    testCompile(dependencyModuleVersion("netty", "netty-transport-native-kqueue") + ":osx-x86_64")
 }
 
 //tasks.withType(Test) {

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/EpollAvailabilityCondition.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/EpollAvailabilityCondition.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.netty;
+
+import io.micronaut.context.condition.Condition;
+import io.micronaut.context.condition.ConditionContext;
+import io.micronaut.core.annotation.Internal;
+
+import io.netty.channel.epoll.Epoll;
+
+/**
+ * Checks if epoll is available.
+ * 
+ * @author croudet
+ */
+@Internal
+class EpollAvailabilityCondition implements Condition {
+
+    /**
+     * Checks if netty's epoll native transport is available.
+     * 
+     * @param context The ConditionContext.
+     * @return true if the epoll native transport is available.
+     */
+    public boolean matches(ConditionContext context) {
+        return Epoll.isAvailable();
+    }
+}

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/EpollEventLoopGroupFactory.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/EpollEventLoopGroupFactory.java
@@ -15,11 +15,10 @@
  */
 package io.micronaut.http.server.netty;
 
-import java.util.OptionalInt;
-
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadFactory;
 
+import javax.annotation.Nullable;
 import javax.inject.Singleton;
 
 import io.micronaut.context.annotation.Requires;
@@ -42,8 +41,10 @@ import io.netty.channel.epoll.EpollServerSocketChannel;
 @Internal
 class EpollEventLoopGroupFactory implements EventLoopGroupFactory {
 
-    private static EpollEventLoopGroup setIoRatio(EpollEventLoopGroup group, OptionalInt ioRatio) {
-        ioRatio.ifPresent(group::setIoRatio);
+    private static EpollEventLoopGroup withIoRatio(EpollEventLoopGroup group, @Nullable Integer ioRatio) {
+        if (ioRatio != null) {
+            group.setIoRatio(ioRatio);
+        }
         return group;
     }
     
@@ -55,8 +56,8 @@ class EpollEventLoopGroupFactory implements EventLoopGroupFactory {
      * @return An EpollEventLoopGroup.
      */
     @Override
-    public EventLoopGroup createEventLoopGroup(int threads, OptionalInt ioRatio) {
-        return setIoRatio(new EpollEventLoopGroup(threads), ioRatio);
+    public EventLoopGroup createEventLoopGroup(int threads, @Nullable Integer ioRatio) {
+        return withIoRatio(new EpollEventLoopGroup(threads), ioRatio);
     }
 
     /**
@@ -68,8 +69,8 @@ class EpollEventLoopGroupFactory implements EventLoopGroupFactory {
      * @return An EpollEventLoopGroup.
      */
     @Override
-    public EventLoopGroup createEventLoopGroup(int threads, ThreadFactory threadFactory, OptionalInt ioRatio) {
-        return setIoRatio(new EpollEventLoopGroup(threads, threadFactory), ioRatio);
+    public EventLoopGroup createEventLoopGroup(int threads, ThreadFactory threadFactory, @Nullable Integer ioRatio) {
+        return withIoRatio(new EpollEventLoopGroup(threads, threadFactory), ioRatio);
     }
 
     /**
@@ -81,8 +82,8 @@ class EpollEventLoopGroupFactory implements EventLoopGroupFactory {
      * @return An EpollEventLoopGroup.
      */
     @Override
-    public EventLoopGroup createEventLoopGroup(int threads, Executor executor, OptionalInt ioRatio) {
-        return setIoRatio(new EpollEventLoopGroup(threads, executor), ioRatio);
+    public EventLoopGroup createEventLoopGroup(int threads, Executor executor, @Nullable Integer ioRatio) {
+        return withIoRatio(new EpollEventLoopGroup(threads, executor), ioRatio);
     }
 
     /**
@@ -92,8 +93,8 @@ class EpollEventLoopGroupFactory implements EventLoopGroupFactory {
      * @return An EpollEventLoopGroup.
      */
     @Override
-    public EventLoopGroup createEventLoopGroup(OptionalInt ioRatio) {
-        return setIoRatio(new EpollEventLoopGroup(), ioRatio);
+    public EventLoopGroup createEventLoopGroup(@Nullable Integer ioRatio) {
+        return withIoRatio(new EpollEventLoopGroup(), ioRatio);
     }
 
     /**

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/EpollEventLoopGroupFactory.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/EpollEventLoopGroupFactory.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.netty;
+
+import java.util.OptionalInt;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadFactory;
+
+import javax.inject.Singleton;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.util.StringUtils;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.socket.ServerSocketChannel;
+import io.netty.channel.epoll.Epoll;
+import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.epoll.EpollServerSocketChannel;
+
+/**
+ * Factory for EpollEventLoopGroup.
+ * 
+ * @author croudet
+ */
+@Singleton
+@Requires(property = "micronaut.server.netty.use-native-transport", value = StringUtils.TRUE, defaultValue = StringUtils.FALSE)
+@Requires(classes = Epoll.class, condition = EpollAvailabilityCondition.class)
+@Internal
+class EpollEventLoopGroupFactory implements EventLoopGroupFactory {
+
+    private static EpollEventLoopGroup setIoRatio(EpollEventLoopGroup group, OptionalInt ioRatio) {
+        ioRatio.ifPresent(group::setIoRatio);
+        return group;
+    }
+    
+    /**
+     * Creates an EpollEventLoopGroup.
+     * 
+     * @param threads The number of threads to use.
+     * @param ioRatio The io ratio.
+     * @return An EpollEventLoopGroup.
+     */
+    @Override
+    public EventLoopGroup createEventLoopGroup(int threads, OptionalInt ioRatio) {
+        return setIoRatio(new EpollEventLoopGroup(threads), ioRatio);
+    }
+
+    /**
+     * Creates an EpollEventLoopGroup.
+     * 
+     * @param threads       The number of threads to use.
+     * @param threadFactory The thread factory.
+     * @param ioRatio       The io ratio.
+     * @return An EpollEventLoopGroup.
+     */
+    @Override
+    public EventLoopGroup createEventLoopGroup(int threads, ThreadFactory threadFactory, OptionalInt ioRatio) {
+        return setIoRatio(new EpollEventLoopGroup(threads, threadFactory), ioRatio);
+    }
+
+    /**
+     * Creates an EpollEventLoopGroup.
+     * 
+     * @param threads  The number of threads to use.
+     * @param executor An Executor.
+     * @param ioRatio  The io ratio.
+     * @return An EpollEventLoopGroup.
+     */
+    @Override
+    public EventLoopGroup createEventLoopGroup(int threads, Executor executor, OptionalInt ioRatio) {
+        return setIoRatio(new EpollEventLoopGroup(threads, executor), ioRatio);
+    }
+
+    /**
+     * Creates a default EpollEventLoopGroup.
+     * 
+     * @param ioRatio The io ratio.
+     * @return An EpollEventLoopGroup.
+     */
+    @Override
+    public EventLoopGroup createEventLoopGroup(OptionalInt ioRatio) {
+        return setIoRatio(new EpollEventLoopGroup(), ioRatio);
+    }
+
+    /**
+     * Returns the server channel class.
+     * 
+     * @return EpollServerSocketChannel.
+     */
+    public Class<? extends ServerSocketChannel> serverSocketChannelClass() {
+        return EpollServerSocketChannel.class;
+    }
+}

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/EventLoopGroupFactory.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/EventLoopGroupFactory.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.netty;
+
+import java.util.OptionalInt;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadFactory;
+
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.socket.ServerSocketChannel;
+
+/**
+ * Factory for EventLoopGroup.
+ * 
+ * @author croudet
+ */
+interface EventLoopGroupFactory {
+
+    /**
+     * Creates an EventLoopGroup.
+     * 
+     * @param threads  The number of threads to use.
+     * @param executor An Executor.
+     * @param ioRatio  The io ratio.
+     * @return An EventLoopGroup.
+     */
+    EventLoopGroup createEventLoopGroup(int threads, Executor executor, OptionalInt ioRatio);
+
+    /**
+     * Creates an EventLoopGroup.
+     * 
+     * @param threads The number of threads to use.
+     * @param ioRatio The io ratio.
+     * @return An EventLoopGroup.
+     */
+    EventLoopGroup createEventLoopGroup(int threads, OptionalInt ioRatio);
+
+    /**
+     * Creates an EventLoopGroup.
+     * 
+     * @param threads       The number of threads to use.
+     * @param threadFactory The thread factory.
+     * @param ioRatio       The io ratio.
+     * @return An EventLoopGroup.
+     */
+    EventLoopGroup createEventLoopGroup(int threads, ThreadFactory threadFactory, OptionalInt ioRatio);
+
+    /**
+     * Creates a default EventLoopGroup.
+     * 
+     * @param ioRatio The io ratio.
+     * @return An EventLoopGroup.
+     */
+    EventLoopGroup createEventLoopGroup(OptionalInt ioRatio);
+
+    /**
+     * Returns the server channel class.
+     * 
+     * @return A ServerChannelClass.
+     */
+    Class<? extends ServerSocketChannel> serverSocketChannelClass();
+}

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/EventLoopGroupFactory.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/EventLoopGroupFactory.java
@@ -13,9 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.http.server.netty;
 
-import java.util.OptionalInt;
+package io.micronaut.http.server.netty;
 
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadFactory;
@@ -23,12 +22,14 @@ import java.util.concurrent.ThreadFactory;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.ServerSocketChannel;
 
+import javax.annotation.Nullable;
+
 /**
  * Factory for EventLoopGroup.
  * 
  * @author croudet
  */
-interface EventLoopGroupFactory {
+public interface EventLoopGroupFactory {
 
     /**
      * Creates an EventLoopGroup.
@@ -38,7 +39,7 @@ interface EventLoopGroupFactory {
      * @param ioRatio  The io ratio.
      * @return An EventLoopGroup.
      */
-    EventLoopGroup createEventLoopGroup(int threads, Executor executor, OptionalInt ioRatio);
+    EventLoopGroup createEventLoopGroup(int threads, Executor executor, @Nullable Integer ioRatio);
 
     /**
      * Creates an EventLoopGroup.
@@ -47,7 +48,7 @@ interface EventLoopGroupFactory {
      * @param ioRatio The io ratio.
      * @return An EventLoopGroup.
      */
-    EventLoopGroup createEventLoopGroup(int threads, OptionalInt ioRatio);
+    EventLoopGroup createEventLoopGroup(int threads, @Nullable Integer ioRatio);
 
     /**
      * Creates an EventLoopGroup.
@@ -57,7 +58,7 @@ interface EventLoopGroupFactory {
      * @param ioRatio       The io ratio.
      * @return An EventLoopGroup.
      */
-    EventLoopGroup createEventLoopGroup(int threads, ThreadFactory threadFactory, OptionalInt ioRatio);
+    EventLoopGroup createEventLoopGroup(int threads, ThreadFactory threadFactory, @Nullable Integer ioRatio);
 
     /**
      * Creates a default EventLoopGroup.
@@ -65,7 +66,7 @@ interface EventLoopGroupFactory {
      * @param ioRatio The io ratio.
      * @return An EventLoopGroup.
      */
-    EventLoopGroup createEventLoopGroup(OptionalInt ioRatio);
+    EventLoopGroup createEventLoopGroup(@Nullable Integer ioRatio);
 
     /**
      * Returns the server channel class.

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/KQueueAvailabilityCondition.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/KQueueAvailabilityCondition.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.netty;
+
+import io.micronaut.context.condition.Condition;
+import io.micronaut.context.condition.ConditionContext;
+import io.micronaut.core.annotation.Internal;
+
+import io.netty.channel.kqueue.KQueue;
+
+/**
+ * Checks if kqueue is available.
+ * 
+ * @author croudet
+ */
+@Internal
+class KQueueAvailabilityCondition implements Condition {
+
+    /**
+     * Checks if netty's kqueue native transport is available.
+     * 
+     * @param context The ConditionContext.
+     * @return true if the kqueue native transport is available.
+     */
+    public boolean matches(ConditionContext context) {
+        return KQueue.isAvailable();
+    }
+}

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/KQueueEventLoopGroupFactory.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/KQueueEventLoopGroupFactory.java
@@ -13,20 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.http.server.netty;
 
-import java.util.OptionalInt;
+package io.micronaut.http.server.netty;
 
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadFactory;
 
+import javax.annotation.Nullable;
 import javax.inject.Singleton;
 
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.util.StringUtils;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.kqueue.KQueue;
 import io.netty.channel.kqueue.KQueueEventLoopGroup;
 import io.netty.channel.kqueue.KQueueServerSocketChannel;
@@ -43,8 +42,10 @@ import io.netty.channel.socket.ServerSocketChannel;
 @Internal
 class KQueueEventLoopGroupFactory implements EventLoopGroupFactory {
 
-    private static KQueueEventLoopGroup setIoRatio(KQueueEventLoopGroup group, OptionalInt ioRatio) {
-        ioRatio.ifPresent(group::setIoRatio);
+    private static KQueueEventLoopGroup withIoRatio(KQueueEventLoopGroup group, @Nullable Integer ioRatio) {
+        if (ioRatio != null) {
+            group.setIoRatio(ioRatio);
+        }
         return group;
     }
 
@@ -56,8 +57,8 @@ class KQueueEventLoopGroupFactory implements EventLoopGroupFactory {
      * @return A KQueueEventLoopGroup.
      */
     @Override
-    public EventLoopGroup createEventLoopGroup(int threads, OptionalInt ioRatio) {
-        return setIoRatio(new KQueueEventLoopGroup(threads), ioRatio);
+    public EventLoopGroup createEventLoopGroup(int threads, @Nullable Integer ioRatio) {
+        return withIoRatio(new KQueueEventLoopGroup(threads), ioRatio);
     }
 
     /**
@@ -69,8 +70,8 @@ class KQueueEventLoopGroupFactory implements EventLoopGroupFactory {
      * @return A KQueueEventLoopGroup.
      */
     @Override
-    public EventLoopGroup createEventLoopGroup(int threads, ThreadFactory threadFactory, OptionalInt ioRatio) {
-        return setIoRatio(new KQueueEventLoopGroup(threads, threadFactory), ioRatio);
+    public EventLoopGroup createEventLoopGroup(int threads, ThreadFactory threadFactory, @Nullable Integer ioRatio) {
+        return withIoRatio(new KQueueEventLoopGroup(threads, threadFactory), ioRatio);
     }
 
     /**
@@ -82,8 +83,8 @@ class KQueueEventLoopGroupFactory implements EventLoopGroupFactory {
      * @return A KQueueEventLoopGroup.
      */
     @Override
-    public EventLoopGroup createEventLoopGroup(int threads, Executor executor, OptionalInt ioRatio) {
-        return setIoRatio(new KQueueEventLoopGroup(threads, executor), ioRatio);
+    public EventLoopGroup createEventLoopGroup(int threads, Executor executor, @Nullable Integer ioRatio) {
+        return withIoRatio(new KQueueEventLoopGroup(threads, executor), ioRatio);
     }
 
     /**
@@ -93,8 +94,8 @@ class KQueueEventLoopGroupFactory implements EventLoopGroupFactory {
      * @return A KQueueEventLoopGroup.
      */
     @Override
-    public EventLoopGroup createEventLoopGroup(OptionalInt ioRatio) {
-        return setIoRatio(new KQueueEventLoopGroup(), ioRatio);
+    public EventLoopGroup createEventLoopGroup(@Nullable Integer ioRatio) {
+        return withIoRatio(new KQueueEventLoopGroup(), ioRatio);
     }
 
     /**

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/KQueueEventLoopGroupFactory.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/KQueueEventLoopGroupFactory.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.netty;
+
+import java.util.OptionalInt;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadFactory;
+
+import javax.inject.Singleton;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.util.StringUtils;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.kqueue.KQueue;
+import io.netty.channel.kqueue.KQueueEventLoopGroup;
+import io.netty.channel.kqueue.KQueueServerSocketChannel;
+import io.netty.channel.socket.ServerSocketChannel;
+
+/**
+ * Factory for KQueueEventLoopGroup.
+ * 
+ * @author croudet
+ */
+@Singleton
+@Requires(property = "micronaut.server.netty.use-native-transport", value = StringUtils.TRUE, defaultValue = StringUtils.FALSE)
+@Requires(classes = KQueue.class, condition = KQueueAvailabilityCondition.class)
+@Internal
+class KQueueEventLoopGroupFactory implements EventLoopGroupFactory {
+
+    private static KQueueEventLoopGroup setIoRatio(KQueueEventLoopGroup group, OptionalInt ioRatio) {
+        ioRatio.ifPresent(group::setIoRatio);
+        return group;
+    }
+
+    /**
+     * Creates a KQueueEventLoopGroup.
+     * 
+     * @param threads The number of threads to use.
+     * @param ioRatio The io ratio.
+     * @return A KQueueEventLoopGroup.
+     */
+    @Override
+    public EventLoopGroup createEventLoopGroup(int threads, OptionalInt ioRatio) {
+        return setIoRatio(new KQueueEventLoopGroup(threads), ioRatio);
+    }
+
+    /**
+     * Creates a KQueueEventLoopGroup.
+     * 
+     * @param threads       The number of threads to use.
+     * @param threadFactory The thread factory.
+     * @param ioRatio       The io ratio.
+     * @return A KQueueEventLoopGroup.
+     */
+    @Override
+    public EventLoopGroup createEventLoopGroup(int threads, ThreadFactory threadFactory, OptionalInt ioRatio) {
+        return setIoRatio(new KQueueEventLoopGroup(threads, threadFactory), ioRatio);
+    }
+
+    /**
+     * Creates a KQueueEventLoopGroup.
+     * 
+     * @param threads  The number of threads to use.
+     * @param executor An Executor.
+     * @param ioRatio  The io ratio.
+     * @return A KQueueEventLoopGroup.
+     */
+    @Override
+    public EventLoopGroup createEventLoopGroup(int threads, Executor executor, OptionalInt ioRatio) {
+        return setIoRatio(new KQueueEventLoopGroup(threads, executor), ioRatio);
+    }
+
+    /**
+     * Creates a default KQueueEventLoopGroup.
+     * 
+     * @param ioRatio The io ratio.
+     * @return A KQueueEventLoopGroup.
+     */
+    @Override
+    public EventLoopGroup createEventLoopGroup(OptionalInt ioRatio) {
+        return setIoRatio(new KQueueEventLoopGroup(), ioRatio);
+    }
+
+    /**
+     * Returns the server channel class.
+     * 
+     * @return KQueueServerSocketChannel.
+     */
+    public Class<? extends ServerSocketChannel> serverSocketChannelClass() {
+        return KQueueServerSocketChannel.class;
+    }
+}

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
@@ -470,21 +470,22 @@ public class NettyHttpServer implements EmbeddedServer, WebSocketSessionReposito
     private EventLoopGroup newEventLoopGroup(NettyHttpServerConfiguration.EventLoopConfig config) {
         if (config != null) {
             Optional<ExecutorService> executorService = config.getExecutorName().flatMap(name -> beanLocator.findBean(ExecutorService.class, Qualifiers.byName(name)));
-            EventLoopGroup group = executorService.map(service ->
-                eventLoopGroupFactory.createEventLoopGroup(config.getNumOfThreads(), service, config.getIoRatio())
+            int threads = config.getNumOfThreads();
+            Integer ioRatio = config.getIoRatio().orElse(null);
+            return executorService.map(service ->
+                eventLoopGroupFactory.createEventLoopGroup(threads, service, ioRatio)
             ).orElseGet(() -> {
                 if (threadFactory != null) {
-                    return eventLoopGroupFactory.createEventLoopGroup(config.getNumOfThreads(), threadFactory, config.getIoRatio());
+                    return eventLoopGroupFactory.createEventLoopGroup(threads, threadFactory, ioRatio);
                 } else {
-                    return eventLoopGroupFactory.createEventLoopGroup(config.getNumOfThreads(), config.getIoRatio());
+                    return eventLoopGroupFactory.createEventLoopGroup(threads, ioRatio);
                 }
             });
-            return group;
         } else {
             if (threadFactory != null) {
-                return eventLoopGroupFactory.createEventLoopGroup(NettyThreadFactory.DEFAULT_EVENT_LOOP_THREADS, threadFactory, OptionalInt.empty());
+                return eventLoopGroupFactory.createEventLoopGroup(NettyThreadFactory.DEFAULT_EVENT_LOOP_THREADS, threadFactory, null);
             } else {
-                return eventLoopGroupFactory.createEventLoopGroup(OptionalInt.empty());
+                return eventLoopGroupFactory.createEventLoopGroup(null);
             }
         }
     }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NioEventLoopGroupFactory.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NioEventLoopGroupFactory.java
@@ -15,17 +15,15 @@
  */
 package io.micronaut.http.server.netty;
 
-import java.util.OptionalInt;
-
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadFactory;
 
+import javax.annotation.Nullable;
 import javax.inject.Singleton;
 
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Internal;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.kqueue.KQueueEventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.ServerSocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
@@ -40,8 +38,10 @@ import io.netty.channel.socket.nio.NioServerSocketChannel;
 @Requires(missingBeans = { EpollEventLoopGroupFactory.class, KQueueEventLoopGroupFactory.class })
 class NioEventLoopGroupFactory implements EventLoopGroupFactory {
 
-    private static NioEventLoopGroup setIoRatio(NioEventLoopGroup group, OptionalInt ioRatio) {
-        ioRatio.ifPresent(group::setIoRatio);
+    private static NioEventLoopGroup withIoRatio(NioEventLoopGroup group, @Nullable Integer ioRatio) {
+        if (ioRatio != null) {
+            group.setIoRatio(ioRatio);
+        }
         return group;
     }
 
@@ -53,8 +53,8 @@ class NioEventLoopGroupFactory implements EventLoopGroupFactory {
      * @return A NioEventLoopGroup.
      */
     @Override
-    public EventLoopGroup createEventLoopGroup(int threads, OptionalInt ioRatio) {
-        return setIoRatio(new NioEventLoopGroup(threads), ioRatio);
+    public EventLoopGroup createEventLoopGroup(int threads, @Nullable Integer ioRatio) {
+        return withIoRatio(new NioEventLoopGroup(threads), ioRatio);
     }
 
     /**
@@ -66,8 +66,8 @@ class NioEventLoopGroupFactory implements EventLoopGroupFactory {
      * @return A NioEventLoopGroup.
      */
     @Override
-    public EventLoopGroup createEventLoopGroup(int threads, ThreadFactory threadFactory, OptionalInt ioRatio) {
-        return setIoRatio(new NioEventLoopGroup(threads, threadFactory), ioRatio);
+    public EventLoopGroup createEventLoopGroup(int threads, ThreadFactory threadFactory, @Nullable Integer ioRatio) {
+        return withIoRatio(new NioEventLoopGroup(threads, threadFactory), ioRatio);
     }
 
     /**
@@ -79,8 +79,8 @@ class NioEventLoopGroupFactory implements EventLoopGroupFactory {
      * @return A NioEventLoopGroup.
      */
     @Override
-    public EventLoopGroup createEventLoopGroup(int threads, Executor executor, OptionalInt ioRatio) {
-        return setIoRatio(new NioEventLoopGroup(threads, executor), ioRatio);
+    public EventLoopGroup createEventLoopGroup(int threads, Executor executor, @Nullable Integer ioRatio) {
+        return withIoRatio(new NioEventLoopGroup(threads, executor), ioRatio);
     }
 
     /**
@@ -90,8 +90,8 @@ class NioEventLoopGroupFactory implements EventLoopGroupFactory {
      * @return A NioEventLoopGroup.
      */
     @Override
-    public EventLoopGroup createEventLoopGroup(OptionalInt ioRatio) {
-        return setIoRatio(new NioEventLoopGroup(), ioRatio);
+    public EventLoopGroup createEventLoopGroup(@Nullable Integer ioRatio) {
+        return withIoRatio(new NioEventLoopGroup(), ioRatio);
     }
 
     /**

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NioEventLoopGroupFactory.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NioEventLoopGroupFactory.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.netty;
+
+import java.util.OptionalInt;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadFactory;
+
+import javax.inject.Singleton;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Internal;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.kqueue.KQueueEventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.ServerSocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+
+/**
+ * Factory for NioEventLoopGroup.
+ * 
+ * @author croudet
+ */
+@Singleton
+@Internal
+@Requires(missingBeans = { EpollEventLoopGroupFactory.class, KQueueEventLoopGroupFactory.class })
+class NioEventLoopGroupFactory implements EventLoopGroupFactory {
+
+    private static NioEventLoopGroup setIoRatio(NioEventLoopGroup group, OptionalInt ioRatio) {
+        ioRatio.ifPresent(group::setIoRatio);
+        return group;
+    }
+
+    /**
+     * Creates a NioEventLoopGroup.
+     * 
+     * @param threads The number of threads to use.
+     * @param ioRatio The io ratio.
+     * @return A NioEventLoopGroup.
+     */
+    @Override
+    public EventLoopGroup createEventLoopGroup(int threads, OptionalInt ioRatio) {
+        return setIoRatio(new NioEventLoopGroup(threads), ioRatio);
+    }
+
+    /**
+     * Creates a NioEventLoopGroup.
+     * 
+     * @param threads       The number of threads to use.
+     * @param threadFactory The thread factory.
+     * @param ioRatio       The io ratio.
+     * @return A NioEventLoopGroup.
+     */
+    @Override
+    public EventLoopGroup createEventLoopGroup(int threads, ThreadFactory threadFactory, OptionalInt ioRatio) {
+        return setIoRatio(new NioEventLoopGroup(threads, threadFactory), ioRatio);
+    }
+
+    /**
+     * Creates a NioEventLoopGroup.
+     * 
+     * @param threads  The number of threads to use.
+     * @param executor An Executor.
+     * @param ioRatio  The io ratio.
+     * @return A NioEventLoopGroup.
+     */
+    @Override
+    public EventLoopGroup createEventLoopGroup(int threads, Executor executor, OptionalInt ioRatio) {
+        return setIoRatio(new NioEventLoopGroup(threads, executor), ioRatio);
+    }
+
+    /**
+     * Creates a default NioEventLoopGroup.
+     * 
+     * @param ioRatio The io ratio.
+     * @return A NioEventLoopGroup.
+     */
+    @Override
+    public EventLoopGroup createEventLoopGroup(OptionalInt ioRatio) {
+        return setIoRatio(new NioEventLoopGroup(), ioRatio);
+    }
+
+    /**
+     * Returns the server channel class.
+     * 
+     * @return NioServerSocketChannel.
+     */
+    public Class<? extends ServerSocketChannel> serverSocketChannelClass() {
+        return NioServerSocketChannel.class;
+    }
+}

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/configuration/NettyHttpServerConfiguration.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/configuration/NettyHttpServerConfiguration.java
@@ -385,11 +385,11 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
         /**
          * @return The I/O ratio to use
          */
-        public OptionalInt getIoRatio() {
+        public Optional<Integer> getIoRatio() {
             if (ioRatio != null) {
-                return OptionalInt.of(ioRatio);
+                return Optional.of(ioRatio);
             }
-            return OptionalInt.empty();
+            return Optional.empty();
         }
 
         /**

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/configuration/NettyHttpServerConfiguration.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/configuration/NettyHttpServerConfiguration.java
@@ -38,6 +38,12 @@ import java.util.OptionalInt;
 public class NettyHttpServerConfiguration extends HttpServerConfiguration {
 
     /**
+     * The default use netty's native transport flag.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static final boolean DEFAULT_USE_NATIVE_TRANSPORT = false;
+
+    /**
      * The default max initial line length.
      */
     @SuppressWarnings("WeakerAccess")
@@ -91,6 +97,7 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
     private int initialBufferSize = DEFAULT_INITIALBUFFERSIZE;
     private LogLevel logLevel;
     private int compressionThreshold = DEFAULT_COMPRESSIONTHRESHOLD;
+    private boolean useNativeTransport = DEFAULT_USE_NATIVE_TRANSPORT;
 
     /**
      * Default empty constructor.
@@ -149,6 +156,15 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
      */
     public boolean isChunkedSupported() {
         return chunkedSupported;
+    }
+
+    /**
+     * Whether to use netty's native transport (epoll or kqueue) if available.
+     *
+     * @return To use netty's native transport (epoll or kqueue) if available.
+     */
+    public boolean isUseNativeTransport() {
+        return useNativeTransport;
     }
 
     /**
@@ -271,6 +287,14 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
      */
     public void setChunkedSupported(boolean chunkedSupported) {
         this.chunkedSupported = chunkedSupported;
+    }
+
+    /**
+     * Sets whether to use netty's native transport (epoll or kqueue) if available . Default value ({@value #DEFAULT_USE_NATIVE_TRANSPORT_IF_AVAILABLE}).
+     * @param useNativeTransport True if netty's native transport should be use if available.
+     */
+    public void setUseNativeTransport(boolean useNativeTransport) {
+        this.useNativeTransport = useNativeTransport;
     }
 
     /**

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/AbstractMicronautSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/AbstractMicronautSpec.groovy
@@ -31,12 +31,14 @@ abstract class AbstractMicronautSpec extends Specification {
     static final SPEC_NAME_PROPERTY = 'spec.name'
 
     @Shared File uploadDir = File.createTempDir()
-    @Shared @AutoCleanup EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer,
+    @Shared EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer,
             getConfiguration() << [(SPEC_NAME_PROPERTY):getClass().simpleName]
     )
     @Shared int serverPort = embeddedServer.getPort()
     @Shared URL server = embeddedServer.getURL()
-    @Shared @AutoCleanup RxHttpClient rxClient = embeddedServer.applicationContext.createBean(RxHttpClient, server)
+    @Shared @AutoCleanup ApplicationContext applicationContext = embeddedServer.applicationContext
+    @Shared @AutoCleanup RxHttpClient rxClient = applicationContext.createBean(RxHttpClient, server)
+
 
     Collection<String> configurationNames() {
         ['io.micronaut.configuration.jackson','io.micronaut.web.router']
@@ -49,4 +51,5 @@ abstract class AbstractMicronautSpec extends Specification {
     void cleanupSpec()  {
         uploadDir.delete()
     }
+
 }

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/nativetransport/LinuxNativeTransportSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/nativetransport/LinuxNativeTransportSpec.groovy
@@ -1,0 +1,29 @@
+package io.micronaut.http.server.netty.nativetransport
+
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.server.netty.AbstractMicronautSpec
+import io.micronaut.http.server.netty.EventLoopGroupFactory
+import io.netty.channel.epoll.EpollServerSocketChannel
+import spock.lang.Requires
+import spock.util.environment.OperatingSystem
+
+@Requires({ os.family == OperatingSystem.Family.LINUX })
+class LinuxNativeTransportSpec extends AbstractMicronautSpec {
+
+    void "test a basic request works with mac native transport"() {
+        when:
+        String body = rxClient.retrieve(HttpRequest.GET("/native-transport")).blockingFirst()
+
+        then:
+        noExceptionThrown()
+        body == "works"
+
+        expect:
+        applicationContext.getBean(EventLoopGroupFactory).serverSocketChannelClass() == EpollServerSocketChannel.class
+    }
+
+    @Override
+    Map<String, Object> getConfiguration() {
+        super.getConfiguration() << ['micronaut.server.netty.use-native-transport': true]
+    }
+}

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/nativetransport/MacNativeTransportSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/nativetransport/MacNativeTransportSpec.groovy
@@ -1,0 +1,29 @@
+package io.micronaut.http.server.netty.nativetransport
+
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.server.netty.AbstractMicronautSpec
+import io.micronaut.http.server.netty.EventLoopGroupFactory
+import io.netty.channel.kqueue.KQueueServerSocketChannel
+import spock.lang.Requires
+import spock.util.environment.OperatingSystem
+
+@Requires({ os.family == OperatingSystem.Family.MAC_OS })
+class MacNativeTransportSpec extends AbstractMicronautSpec {
+
+    void "test a basic request works with mac native transport"() {
+        when:
+        String body = rxClient.retrieve(HttpRequest.GET("/native-transport")).blockingFirst()
+
+        then:
+        noExceptionThrown()
+        body == "works"
+
+        expect:
+        applicationContext.getBean(EventLoopGroupFactory).serverSocketChannelClass() == KQueueServerSocketChannel.class
+    }
+
+    @Override
+    Map<String, Object> getConfiguration() {
+        super.getConfiguration() << ['micronaut.server.netty.use-native-transport': true]
+    }
+}

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/nativetransport/NativeTransportController.java
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/nativetransport/NativeTransportController.java
@@ -1,0 +1,13 @@
+package io.micronaut.http.server.netty.nativetransport;
+
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+
+@Controller("/native-transport")
+public class NativeTransportController {
+
+    @Get
+    String test() {
+        return "works";
+    }
+}


### PR DESCRIPTION
To enable netty server's native transport:
- set 'micronaut.server.netty.use-native-transport' to true in application.yml
- add one of netty's native transport dependency 'netty-transport-native-epoll' or 'netty-transport-native-kqueue' to your classpath.

Epoll.isAvailable() or KQueue.isAvailable() will be checked.
If native transport is not available, NioEventLoopGroup will be used.