### PR TITLE
Add Homebrew install instructions

### DIFF
--- a/src/main/docs/guide/quickStart/buildCLI/installSdkman.adoc
+++ b/src/main/docs/guide/quickStart/buildCLI/installSdkman.adoc
@@ -21,6 +21,14 @@ $ sdk install micronaut {version}
 
 You can find more information about SDKMAN usage on the http://sdkman.io/usage.html[SDKMAN Docs]
 
+For Mac platforms, you can use HOMEBREW to install like so:
+
+[source,bash]
+====
+$ brew install micronaut {version}
+====
+
+
 You should now be able to run the Micronaut CLI.
 
 [source,bash]

--- a/src/main/docs/guide/quickStart/buildCLI/installSdkman.adoc
+++ b/src/main/docs/guide/quickStart/buildCLI/installSdkman.adoc
@@ -21,13 +21,21 @@ $ sdk install micronaut {version}
 
 You can find more information about SDKMAN usage on the http://sdkman.io/usage.html[SDKMAN Docs]
 
-For Mac platforms, you can use HOMEBREW to install like so:
+For Mac platforms, you can use https://brew.sh/[Homebrew] to install the CLI:
+
+Before updating make sure you have latest updates.
+
+[source,bash]
+----
+$ brew update
+----
+
+Then run the following:
 
 [source,bash,subs="attributes"]
 ----
 $ brew install micronaut {version}
 ----
-
 
 You should now be able to run the Micronaut CLI.
 

--- a/src/main/docs/guide/quickStart/buildCLI/installSdkman.adoc
+++ b/src/main/docs/guide/quickStart/buildCLI/installSdkman.adoc
@@ -23,10 +23,10 @@ You can find more information about SDKMAN usage on the http://sdkman.io/usage.h
 
 For Mac platforms, you can use HOMEBREW to install like so:
 
-[source,bash]
-====
+[source,bash,subs="attributes"]
+----
 $ brew install micronaut {version}
-====
+----
 
 
 You should now be able to run the Micronaut CLI.


### PR DESCRIPTION
How about adding a section for installation using Homebrew for Mac machines?
Like so ... 
[source,bash]
====
$ brew install micronaut {version}
====