### PR TITLE
Add @Introspected to EndpoointEnabledCondition

### DIFF
--- a/management/src/main/java/io/micronaut/management/endpoint/EndpointEnabledCondition.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/EndpointEnabledCondition.java
@@ -20,6 +20,7 @@ import io.micronaut.context.condition.Condition;
 import io.micronaut.context.condition.ConditionContext;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationMetadataProvider;
+import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.value.PropertyResolver;
 import io.micronaut.management.endpoint.annotation.Endpoint;
 
@@ -30,6 +31,7 @@ import java.util.Optional;
  *
  * @author James Kleeh
  */
+@Introspected
 public class EndpointEnabledCondition implements Condition {
 
     @Override


### PR DESCRIPTION
Fix to be able to start native-image application with management. Without this the application fails to start with:

```
 No BeanIntrospection found for bean type: class io.micronaut.management.endpoint.EndpointEnabledCondition
12:29:57.372 [main] DEBUG i.m.core.reflect.InstantiationUtils - Tried, but could not instantiate type: class io.micronaut.management.endpoint.EndpointEnabledCondition
java.lang.InstantiationException: Type `io.micronaut.management.endpoint.EndpointEnabledCondition` can not be instantiated reflectively as it does not have a no-parameter constructor or the no-parameter constructor has not been added explicitly to the native image.
	at java.lang.Class.newInstance(DynamicHub.java:699)
	at io.micronaut.core.reflect.InstantiationUtils.lambda$tryInstantiate$0(InstantiationUtils.java:76)
	at java.util.Optional.orElseGet(Optional.java:267)
	at io.micronaut.core.reflect.InstantiationUtils.tryInstantiate(InstantiationUtils.java:101)
	at io.micronaut.context.RequiresCondition.matchesCustomConditions(RequiresCondition.java:298)
	at io.micronaut.context.RequiresCondition.processPostStartRequirements(RequiresCondition.java:181)
	at io.micronaut.context.RequiresCondition.matches(RequiresCondition.java:79)
	at io.micronaut.context.AbstractBeanContextConditional.isEnabled(AbstractBeanContextConditional.java:53)
	at io.micronaut.context.AbstractBeanDefinition.isEnabled(AbstractBeanDefinition.java:89)
	at io.micronaut.context.DefaultBeanContext.lambda$getBeanDefinitions$13(DefaultBeanContext.java:900)
	at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:174)
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
	at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:175)
	at java.util.concurrent.ConcurrentLinkedQueue$CLQSpliterator.forEachRemaining(ConcurrentLinkedQueue.java:857)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:499)
	at io.micronaut.context.DefaultBeanContext.getBeanDefinitions(DefaultBeanContext.java:902)
	at io.micronaut.context.AnnotationProcessorListener.onCreated(AnnotationProcessorListener.java:58)
	at io.micronaut.context.AnnotationProcessorListener.onCreated(AnnotationProcessorListener.java:45)
	at io.micronaut.context.DefaultBeanContext.doCreateBean(DefaultBeanContext.java:1487)
	at io.micronaut.context.DefaultBeanContext.addCandidateToList(DefaultBeanContext.java:2419)
	at io.micronaut.context.DefaultBeanContext.getBeansOfTypeInternal(DefaultBeanContext.java:2347)
	at io.micronaut.context.DefaultBeanContext.getBeansOfType(DefaultBeanContext.java:833)
	at io.micronaut.context.AbstractBeanDefinition.lambda$getBeansOfTypeForConstructorArgument$10(AbstractBeanDefinition.java:1087)
	at io.micronaut.context.AbstractBeanDefinition.resolveBeanWithGenericsFromConstructorArgument(AbstractBeanDefinition.java:1695)
	at io.micronaut.context.AbstractBeanDefinition.getBeansOfTypeForConstructorArgument(AbstractBeanDefinition.java:1082)
	at io.micronaut.context.AbstractBeanDefinition.getBeanForConstructorArgument(AbstractBeanDefinition.java:961)
	at io.micronaut.web.router.$DefaultRouterDefinition.build(Unknown Source)
	at io.micronaut.context.DefaultBeanContext.doCreateBean(DefaultBeanContext.java:1442)
	at io.micronaut.context.DefaultBeanContext.createAndRegisterSingleton(DefaultBeanContext.java:2052)
	at io.micronaut.context.DefaultBeanContext.getBeanForDefinition(DefaultBeanContext.java:1781)
	at io.micronaut.context.DefaultBeanContext.getBeanInternal(DefaultBeanContext.java:1761)
	at io.micronaut.context.DefaultBeanContext.getBean(DefaultBeanContext.java:970)
	at io.micronaut.context.AbstractBeanDefinition.getBeanForConstructorArgument(AbstractBeanDefinition.java:981)
	at io.micronaut.http.server.netty.$NettyHttpServerDefinition.build(Unknown Source)
	at io.micronaut.context.DefaultBeanContext.doCreateBean(DefaultBeanContext.java:1442)
	at io.micronaut.context.DefaultBeanContext.createAndRegisterSingleton(DefaultBeanContext.java:2052)
	at io.micronaut.context.DefaultBeanContext.getBeanForDefinition(DefaultBeanContext.java:1781)
	at io.micronaut.context.DefaultBeanContext.getBeanInternal(DefaultBeanContext.java:1761)
	at io.micronaut.context.DefaultBeanContext.findBean(DefaultBeanContext.java:989)
	at io.micronaut.context.DefaultBeanContext.findBean(DefaultBeanContext.java:566)
	at io.micronaut.context.BeanLocator.findBean(BeanLocator.java:135)
	at io.micronaut.runtime.Micronaut.start(Micronaut.java:69)
	at io.micronaut.runtime.Micronaut.run(Micronaut.java:274)
	at io.micronaut.runtime.Micronaut.run(Micronaut.java:260)
	at example.micronaut.Application.main(Application.java:8)
```