### PR TITLE
Do not skip Graal type visitor if there is a base reflect.json file. Fixes #1391

### DIFF
--- a/graal/src/main/java/io/micronaut/graal/reflect/GraalTypeElementVisitor.java
+++ b/graal/src/main/java/io/micronaut/graal/reflect/GraalTypeElementVisitor.java
@@ -214,7 +214,7 @@ public class GraalTypeElementVisitor implements TypeElementVisitor<Object, Objec
                 json = new ArrayList<>();
             }
 
-            if (CollectionUtils.isEmpty(beans) && CollectionUtils.isEmpty(classes) && CollectionUtils.isEmpty(arrays)) {
+            if (CollectionUtils.isEmpty(beans) && CollectionUtils.isEmpty(classes) && CollectionUtils.isEmpty(arrays) && CollectionUtils.isEmpty(json)) {
                 return;
             }
 


### PR DESCRIPTION
Fixes #1391