### PR TITLE
SecurityRule evaluation to its own bean

### DIFF
--- a/security/src/main/java/io/micronaut/security/filters/SecurityFilter.java
+++ b/security/src/main/java/io/micronaut/security/filters/SecurityFilter.java
@@ -23,21 +23,23 @@ import io.micronaut.http.filter.OncePerRequestHttpServerFilter;
 import io.micronaut.http.filter.ServerFilterChain;
 import io.micronaut.security.authentication.Authentication;
 import io.micronaut.security.handlers.RejectionHandler;
+import io.micronaut.security.rules.DefaultSecurityRuleEvaluator;
 import io.micronaut.security.rules.SecurityRule;
+import io.micronaut.security.rules.SecurityRuleEvaluation;
+import io.micronaut.security.rules.SecurityRuleEvaluator;
 import io.micronaut.security.rules.SecurityRuleResult;
-import io.micronaut.web.router.RouteMatch;
-import io.micronaut.web.router.RouteMatchUtils;
 import io.reactivex.Flowable;
 import io.reactivex.Maybe;
-import io.reactivex.functions.Function;
+import io.reactivex.annotations.NonNull;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+import javax.inject.Inject;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -67,11 +69,12 @@ public class SecurityFilter extends OncePerRequestHttpServerFilter {
      */
     protected final Integer order;
 
-    protected final Collection<SecurityRule> securityRules;
     protected final Collection<AuthenticationFetcher> authenticationFetchers;
     protected final RejectionHandler rejectionHandler;
+    protected final SecurityRuleEvaluator securityRuleEvaluator;
 
     /**
+     * @deprecated Use {@link #SecurityFilter(Collection, RejectionHandler, SecurityFilterOrderProvider, SecurityRuleEvaluator)} instead
      * @param securityRules               The list of rules that will allow or reject the request
      * @param authenticationFetchers      List of {@link AuthenticationFetcher} beans in the context.
      * @param rejectionHandler            Bean which handles routes which need to be rejected
@@ -81,10 +84,24 @@ public class SecurityFilter extends OncePerRequestHttpServerFilter {
                           Collection<AuthenticationFetcher> authenticationFetchers,
                           RejectionHandler rejectionHandler,
                           @Nullable SecurityFilterOrderProvider securityFilterOrderProvider) {
-        this.securityRules = securityRules;
+        this(authenticationFetchers, rejectionHandler, securityFilterOrderProvider, new DefaultSecurityRuleEvaluator(securityRules));
+    }
+
+    /**
+     * @param authenticationFetchers      List of {@link AuthenticationFetcher} beans in the context.
+     * @param rejectionHandler            Bean which handles routes which need to be rejected
+     * @param securityFilterOrderProvider filter order provider
+     * @param securityRuleEvaluator securityRuleEvaluator
+     */
+    @Inject
+    public SecurityFilter(Collection<AuthenticationFetcher> authenticationFetchers,
+                          RejectionHandler rejectionHandler,
+                          @Nullable SecurityFilterOrderProvider securityFilterOrderProvider,
+                          SecurityRuleEvaluator securityRuleEvaluator) {
         this.authenticationFetchers = authenticationFetchers;
         this.rejectionHandler = rejectionHandler;
         this.order = securityFilterOrderProvider != null ? securityFilterOrderProvider.getOrder() : 0;
+        this.securityRuleEvaluator = securityRuleEvaluator;
     }
 
     @Override
@@ -94,67 +111,55 @@ public class SecurityFilter extends OncePerRequestHttpServerFilter {
 
     @Override
     protected Publisher<MutableHttpResponse<?>> doFilterOnce(HttpRequest<?> request, ServerFilterChain chain) {
-        String method = request.getMethod().toString();
-        String path = request.getPath();
-
         Maybe<Authentication> authentication = Flowable.fromIterable(authenticationFetchers)
             .flatMap(authenticationFetcher -> authenticationFetcher.fetchAuthentication(request))
             .firstElement();
 
-        return authentication.toFlowable().flatMap((Function<Authentication, Publisher<MutableHttpResponse<?>>>) authentication1 -> {
-            request.setAttribute(AUTHENTICATION, authentication1);
-            Map<String, Object> attributes = authentication1.getAttributes();
-            Optional<RouteMatch> routeMatch = RouteMatchUtils.findRouteMatchAtRequest(request);
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Attributes: {}", attributes
+        return authentication.toFlowable().flatMap(auth -> process(request, chain, auth, true))
+                .switchIfEmpty(Flowable.just("").flatMap(i -> process(request, chain, null, false)));
+    }
+
+    private void logResult(HttpRequest<?> request, @NonNull SecurityRuleEvaluation evaluation) {
+        if (LOG.isDebugEnabled()) {
+            String msg = "";
+            if (evaluation.getResult() == SecurityRuleResult.REJECTED) {
+                msg = "Unauthorized request {} {}. The rule provider {} rejected the request.";
+            } else if (evaluation.getResult() == SecurityRuleResult.ALLOWED) {
+                msg = "Authorized request {} {}. The rule provider {} authorized the request.";
+            }
+            LOG.debug(msg,
+                    request.getMethod().toString(),
+                    request.getPath(),
+                    evaluation.getRule().getClass().getName());
+        }
+    }
+
+    private Publisher<MutableHttpResponse<?>> process(HttpRequest<?> request,
+                                                                ServerFilterChain chain,
+                                                                @Nullable Authentication authentication,
+                                                                boolean forbidden) {
+        request.setAttribute(AUTHENTICATION, authentication);
+        Map<String, Object> attributes = authentication != null ? authentication.getAttributes() : null;
+        if (attributes != null && LOG.isDebugEnabled()) {
+            LOG.debug("Attributes: {}", attributes
                     .entrySet()
                     .stream()
                     .map((entry) -> entry.getKey() + "=>" + entry.getValue().toString())
                     .collect(Collectors.joining(", ")));
+        }
+        SecurityRuleEvaluation evaluation = securityRuleEvaluator.findFirst(request, attributes, Arrays.asList(SecurityRuleResult.ALLOWED, SecurityRuleResult.REJECTED)).orElse(null);
+        if (evaluation != null) {
+            SecurityRuleResult result = evaluation.getResult();
+            logResult(request, evaluation);
+            if (result == SecurityRuleResult.REJECTED) {
+                return rejectionHandler.reject(request, forbidden);
             }
-            for (SecurityRule rule : securityRules) {
-                SecurityRuleResult result = rule.check(request, routeMatch.orElse(null), attributes);
-                if (result == SecurityRuleResult.REJECTED) {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Unauthorized request {} {}. The rule provider {} rejected the request.", method, path, rule.getClass().getName());
-                    }
-                    return rejectionHandler.reject(request, true);
-                }
-                if (result == SecurityRuleResult.ALLOWED) {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Authorized request {} {}. The rule provider {} authorized the request.", method, path, rule.getClass().getName());
-                    }
-                    return chain.proceed(request);
-                }
+            if (result == SecurityRuleResult.ALLOWED) {
+                return chain.proceed(request);
             }
+        }
 
-            //no rule found for the given request, reject
-            return rejectionHandler.reject(request, true);
-        }).switchIfEmpty(Flowable.just(securityRules).flatMap(securityRules -> {
-            request.setAttribute(AUTHENTICATION, null);
-            Optional<RouteMatch> routeMatch = RouteMatchUtils.findRouteMatchAtRequest(request);
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Failure to authenticate request. {} {}.", method, path);
-            }
-
-            for (SecurityRule rule : securityRules) {
-                SecurityRuleResult result = rule.check(request, routeMatch.orElse(null), null);
-                if (result == SecurityRuleResult.REJECTED) {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Unauthorized request {} {}. The rule provider {} rejected the request.", method, path, rule.getClass().getName());
-                    }
-                    return rejectionHandler.reject(request, false);
-                }
-                if (result == SecurityRuleResult.ALLOWED) {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Authorized request {} {}. The rule provider {} authorized the request.", method, path, rule.getClass().getName());
-                    }
-                    return chain.proceed(request);
-                }
-            }
-
-            //no rule found for the given request, reject
-            return rejectionHandler.reject(request, false);
-        }));
+    //no rule found for the given request, reject
+        return rejectionHandler.reject(request, forbidden);
     }
 }

--- a/security/src/main/java/io/micronaut/security/rules/DefaultSecurityRuleEvaluator.java
+++ b/security/src/main/java/io/micronaut/security/rules/DefaultSecurityRuleEvaluator.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.security.rules;
+
+import io.micronaut.http.HttpRequest;
+import io.micronaut.web.router.RouteMatch;
+import io.micronaut.web.router.RouteMatchUtils;
+import io.reactivex.annotations.NonNull;
+import io.reactivex.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Singleton;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Evaluates a {@link SecurityRule}s for a given request.
+ *
+ * @author Sergio del Amo
+ * @since 1.1.0
+ */
+@Singleton
+public class DefaultSecurityRuleEvaluator implements SecurityRuleEvaluator {
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultSecurityRuleEvaluator.class);
+
+    protected final Collection<SecurityRule> securityRules;
+
+    /**
+     * @param securityRules The list of rules that will allow or reject the request
+     */
+    public DefaultSecurityRuleEvaluator(Collection<SecurityRule> securityRules) {
+        this.securityRules = securityRules;
+    }
+
+    @Override
+    public Optional<SecurityRuleEvaluation> findFirst(@NonNull HttpRequest<?> request,
+                                            @Nullable Map<String, Object> claims,
+                                            @NonNull List<SecurityRuleResult> matchAnyResult) {
+        RouteMatch routeMatch = RouteMatchUtils.findRouteMatchAtRequest(request).orElse(null);
+        if (routeMatch == null) {
+            if (LOG.isWarnEnabled()) {
+                LOG.warn("could find a routeMatch for the request {} {}", request.getMethod(), request.getPath());
+            }
+        }
+        return securityRules.stream()
+                .map(rule -> new SecurityRuleEvaluation(rule, rule.check(request, routeMatch, claims)))
+                .filter(evaluation -> matchAnyResult.contains(evaluation.getResult()))
+                .findFirst();
+    }
+}

--- a/security/src/main/java/io/micronaut/security/rules/SecurityRuleEvaluation.java
+++ b/security/src/main/java/io/micronaut/security/rules/SecurityRuleEvaluation.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.security.rules;
+
+/**
+ * Encapsulates the result of a Security Rule evaluation.
+ *
+ */
+public class SecurityRuleEvaluation {
+
+    private SecurityRuleResult result;
+
+    private SecurityRule rule;
+
+    /**
+     * Constructs a SecurityRule evaluation.
+     */
+    public SecurityRuleEvaluation() {
+
+    }
+
+    /**
+     *
+     * @param rule The evaluated Rule
+     * @param result Result of evaluation
+     */
+    public SecurityRuleEvaluation(SecurityRule rule, SecurityRuleResult result) {
+        this.rule = rule;
+        this.result = result;
+    }
+
+    /**
+     *
+     * @return Result of evaluation
+     */
+    public SecurityRuleResult getResult() {
+        return result;
+    }
+
+    /**
+     *
+     * @param result Result of evaluation
+     */
+    public void setResult(SecurityRuleResult result) {
+        this.result = result;
+    }
+
+    /**
+     *
+     * @return The evaluated Rule
+     */
+    public SecurityRule getRule() {
+        return rule;
+    }
+
+    /**
+     *
+     * @param rule The evaluated Rule
+     */
+    public void setRule(SecurityRule rule) {
+        this.rule = rule;
+    }
+}

--- a/security/src/main/java/io/micronaut/security/rules/SecurityRuleEvaluator.java
+++ b/security/src/main/java/io/micronaut/security/rules/SecurityRuleEvaluator.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.security.rules;
+
+import io.micronaut.http.HttpRequest;
+import io.reactivex.annotations.NonNull;
+import io.reactivex.annotations.Nullable;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Evaluates a {@link SecurityRule}s for a given request.
+ *
+ * @author Sergio del Amo
+ * @since 1.1.0
+ */
+public interface SecurityRuleEvaluator {
+
+    /**
+     * @param request        The HTTP request
+     * @param claims         The claims from the token. Null if not authenticated
+     * @param matchAnyResult List of {@link SecurityRuleResult} to match.
+     * @return Evaluation encapsulating the result and the first rule which matched any of the supplied results.
+     */
+    Optional<SecurityRuleEvaluation> findFirst(@NonNull HttpRequest<?> request,
+                                               @Nullable Map<String, Object> claims,
+                                               @NonNull List<SecurityRuleResult> matchAnyResult);
+}


### PR DESCRIPTION
Extract Security Rule evaluation to its own bean. Reduces complexity of Security Filter code splitting into several methods. 