### PR TITLE
Fix "colon" detection when validating property names. Fixes #1217

### DIFF
--- a/core/src/main/java/io/micronaut/core/naming/NameUtils.java
+++ b/core/src/main/java/io/micronaut/core/naming/NameUtils.java
@@ -41,7 +41,7 @@ public class NameUtils {
     private static final String PREFIX_GET = "get";
     private static final String PREFIX_SET = "set";
     private static final Pattern ENVIRONMENT_VAR_SEQUENCE = Pattern.compile("^[\\p{Lu}_{0-9}]+");
-    private static final Pattern KEBAB_CASE_SEQUENCE = Pattern.compile("^(([a-z0-9])+(\\-|\\.)?)*([a-z0-9])+$");
+    private static final Pattern KEBAB_CASE_SEQUENCE = Pattern.compile("^(([a-z0-9])+(\\-|\\.|:)?)*([a-z0-9])+$");
 
 
     /**

--- a/validation/src/test/groovy/io/micronaut/validation/properties/MixedCasePropertySpec.groovy
+++ b/validation/src/test/groovy/io/micronaut/validation/properties/MixedCasePropertySpec.groovy
@@ -251,7 +251,7 @@ import javax.inject.Singleton;
 class MyService {
 
     @Value(\"\${some-value:anotherThing:`this:goes:together`}\")
-    private String serverAddress;
+    private String foo;
 }
 
 """)
@@ -259,5 +259,69 @@ class MyService {
         then:
         def e = thrown(RuntimeException)
         e.message.contains("Value 'some-value:anotherThing' is not valid property placeholder. Please use kebab-case notation, for example 'some-value:another-thing'.")
+    }
+
+    void "test that escaping : works with more than one property when all property names are correct"() {
+        when:
+        buildTypeElement("""
+package test;
+
+import io.micronaut.context.annotation.Value;
+import javax.inject.Singleton;
+
+@Singleton
+class MyService {
+
+    @Value(\"\${some-value:another-thing:foo-bar:`this:goes:together`}\")
+    private String foo;
+}
+
+""")
+
+        then:
+        notThrown(Exception)
+    }
+
+    void "test that escaping : works with the last property name"() {
+        when:
+        buildTypeElement("""
+package test;
+
+import io.micronaut.context.annotation.Value;
+import javax.inject.Singleton;
+
+@Singleton
+class MyService {
+
+    @Value(\"\${some-value:another-thing:fooBar:`this:goes:together`}\")
+    private String foo;
+}
+
+""")
+
+        then:
+        def e = thrown(RuntimeException)
+        e.message.contains("Value 'some-value:another-thing:fooBar' is not valid property placeholder. Please use kebab-case notation, for example 'some-value:another-thing:foo-bar'.")
+    }
+
+    void "test that escaping : works with more than one property when all property names are correct and default value is not checked"() {
+        when:
+        buildTypeElement("""
+package test;
+
+import io.micronaut.context.annotation.Value;
+import javax.inject.Singleton;
+
+@Singleton
+class MyService {
+
+    @Value(\"\${some-value:another-thing:foo-bar:`this:goes:together:AndDoesNtMATtteR`}\")
+    private String foo;
+}
+
+""")
+
+        then:
+        notThrown(Exception)
     }
 }


### PR DESCRIPTION
I've added a few more test cases that were missing and fixed the regular expression to property detect `:`