### PR TITLE
Keep the property type instead of String

### DIFF
--- a/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
+++ b/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
@@ -339,7 +339,7 @@ public class PropertySourcePropertyResolver implements PropertyResolver {
                 if (value != null) {
                     String key = entry.getKey().substring(prefix.length());
                     key = keyConvention.format(key);
-                    properties.put(key, resolvePlaceHoldersIfNecessary(value.toString()));
+                    properties.put(key, resolvePlaceHoldersIfNecessary(value));
                 }
             });
 


### PR DESCRIPTION
When resolving properties, We lost the type found in the entries. In my opinion, it is necessary to keep the initial type to avoid unnecessary conversion later.