### PR TITLE
Factory bean scope cleanup

### DIFF
--- a/configurations/hibernate-validator/src/main/java/io/micronaut/configuration/hibernate/validator/ValidatorFactoryProvider.java
+++ b/configurations/hibernate-validator/src/main/java/io/micronaut/configuration/hibernate/validator/ValidatorFactoryProvider.java
@@ -15,7 +15,6 @@
  */
 package io.micronaut.configuration.hibernate.validator;
 
-import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.annotation.Value;

--- a/configurations/hibernate-validator/src/main/java/io/micronaut/configuration/hibernate/validator/ValidatorFactoryProvider.java
+++ b/configurations/hibernate-validator/src/main/java/io/micronaut/configuration/hibernate/validator/ValidatorFactoryProvider.java
@@ -68,7 +68,6 @@ public class ValidatorFactoryProvider {
      * @return validator factory
      */
     @Singleton
-    @Bean
     @Requires(classes = HibernateValidator.class)
     ValidatorFactory validatorFactory(Optional<Environment> environment) {
         Configuration validatorConfiguration = Validation.byDefaultProvider()

--- a/function-client/src/main/java/io/micronaut/function/client/aws/AWSLambdaAsyncClientFactory.java
+++ b/function-client/src/main/java/io/micronaut/function/client/aws/AWSLambdaAsyncClientFactory.java
@@ -44,7 +44,6 @@ public class AWSLambdaAsyncClientFactory {
      * The client returned from a builder.
      * @return client object
      */
-    @Bean
     @Refreshable
     @Requires(beans = AWSLambdaConfiguration.class)
     AWSLambdaAsync awsLambdaAsyncClient() {

--- a/function-client/src/main/java/io/micronaut/function/client/aws/AWSLambdaAsyncClientFactory.java
+++ b/function-client/src/main/java/io/micronaut/function/client/aws/AWSLambdaAsyncClientFactory.java
@@ -17,7 +17,6 @@ package io.micronaut.function.client.aws;
 
 import com.amazonaws.services.lambda.AWSLambdaAsync;
 import com.amazonaws.services.lambda.AWSLambdaAsyncClientBuilder;
-import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.runtime.context.scope.Refreshable;

--- a/http-client/src/test/groovy/io/micronaut/http/client/convert/TypeConverters.java
+++ b/http-client/src/test/groovy/io/micronaut/http/client/convert/TypeConverters.java
@@ -24,7 +24,6 @@ import javax.inject.Singleton;
 @Factory
 public class TypeConverters {
 
-    @Bean
     @Singleton
     public TypeConverter<String, Bar> stringToBarConverter() {
         return TypeConverter.of(
@@ -34,7 +33,6 @@ public class TypeConverters {
         );
     }
 
-    @Bean
     @Singleton
     public TypeConverter<String, Foo> stringToFooConverter() {
         return TypeConverter.of(

--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/NettyThreadFactory.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/NettyThreadFactory.java
@@ -61,7 +61,6 @@ public class NettyThreadFactory {
      *
      * @return The thread factory
      */
-    @Bean
     @Singleton
     @Named(NAME)
     ThreadFactory nettyThreadFactory() {

--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/NettyThreadFactory.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/NettyThreadFactory.java
@@ -15,7 +15,6 @@
  */
 package io.micronaut.http.netty.channel;
 
-import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.core.annotation.TypeHint;
 import io.netty.channel.nio.NioEventLoopGroup;

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
@@ -86,7 +86,6 @@ import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.TooLongFrameException;
 import io.netty.handler.codec.http.*;
-import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.multipart.Attribute;
 import io.netty.handler.codec.http.multipart.FileUpload;
 import io.netty.handler.codec.http.multipart.HttpData;

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/converters/ByteBufConverters.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/converters/ByteBufConverters.java
@@ -15,7 +15,6 @@
  */
 package io.micronaut.http.server.netty.converters;
 
-import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.convert.TypeConverter;

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/converters/ByteBufConverters.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/converters/ByteBufConverters.java
@@ -42,7 +42,6 @@ public class ByteBufConverters {
      * @return A converter that converts bytebufs to strings
      */
     @Singleton
-    @Bean
     TypeConverter<ByteBuf, CharSequence> byteBufCharSequenceTypeConverter() {
         return (object, targetType, context) -> Optional.of(object.toString(context.getCharset()));
     }
@@ -51,7 +50,6 @@ public class ByteBufConverters {
      * @return A converter that converts composite bytebufs to strings
      */
     @Singleton
-    @Bean
     TypeConverter<CompositeByteBuf, CharSequence> compositeByteBufCharSequenceTypeConverter() {
         return (object, targetType, context) -> Optional.of(object.toString(context.getCharset()));
     }
@@ -60,7 +58,6 @@ public class ByteBufConverters {
      * @return A converter that converts bytebufs to byte arrays
      */
     @Singleton
-    @Bean
     TypeConverter<ByteBuf, byte[]> byteBufToArrayTypeConverter() {
         return (object, targetType, context) -> Optional.of(ByteBufUtil.getBytes(object));
     }
@@ -69,7 +66,6 @@ public class ByteBufConverters {
      * @return A converter that converts bytebufs to byte arrays
      */
     @Singleton
-    @Bean
     TypeConverter<byte[], ByteBuf> byteArrayToByteBuffTypeConverter() {
         return (object, targetType, context) -> Optional.of(Unpooled.wrappedBuffer(object));
     }
@@ -78,7 +74,6 @@ public class ByteBufConverters {
      * @return A converter that converts composite bytebufs to byte arrays
      */
     @Singleton
-    @Bean
     TypeConverter<CompositeByteBuf, byte[]> compositeByteBufTypeConverter() {
         return (object, targetType, context) -> Optional.of(ByteBufUtil.getBytes(object));
     }

--- a/http/src/main/java/io/micronaut/http/bind/DefaultRequestBinderRegistry.java
+++ b/http/src/main/java/io/micronaut/http/bind/DefaultRequestBinderRegistry.java
@@ -29,7 +29,6 @@ import io.micronaut.http.HttpParameters;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.Body;
-import io.micronaut.http.bind.binders.RequestAttributeAnnotationBinder;
 import io.micronaut.http.bind.binders.*;
 import io.micronaut.http.cookie.Cookie;
 import io.micronaut.http.cookie.Cookies;

--- a/http/src/main/java/io/micronaut/http/resource/ResourceLoaderFactory.java
+++ b/http/src/main/java/io/micronaut/http/resource/ResourceLoaderFactory.java
@@ -15,7 +15,6 @@
  */
 package io.micronaut.http.resource;
 
-import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.env.Environment;

--- a/http/src/main/java/io/micronaut/http/resource/ResourceLoaderFactory.java
+++ b/http/src/main/java/io/micronaut/http/resource/ResourceLoaderFactory.java
@@ -74,7 +74,6 @@ public class ResourceLoaderFactory {
      * @return The class path resource loader
      */
     @Singleton
-    @Bean
     @BootstrapContextCompatible
     protected @Nonnull ClassPathResourceLoader getClassPathResourceLoader() {
         return new DefaultClassPathResourceLoader(classLoader);

--- a/inject-groovy/src/test/groovy/io/micronaut/aop/factory/ConcreteClassFactory.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/aop/factory/ConcreteClassFactory.groovy
@@ -16,9 +16,9 @@
 package io.micronaut.aop.factory
 
 import io.micronaut.aop.interceptors.Mutating
-import io.micronaut.context.annotation.Bean
 import io.micronaut.context.annotation.Factory
 import io.micronaut.context.annotation.Primary
+import io.micronaut.context.annotation.Prototype
 
 import javax.inject.Named
 
@@ -28,14 +28,15 @@ import javax.inject.Named
  */
 @Factory
 class ConcreteClassFactory {
-    @Bean
+
+    @Prototype
     @Mutating("name")
     @Primary
     ConcreteClass concreteClass() {
         return new ConcreteClass(new AnotherClass())
     }
 
-    @Bean
+    @Prototype
     @Mutating("name")
     @Named("another")
     ConcreteClass anotherImpl() {

--- a/inject-groovy/src/test/groovy/io/micronaut/aop/factory/InterfaceFactory.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/aop/factory/InterfaceFactory.groovy
@@ -16,9 +16,9 @@
 package io.micronaut.aop.factory
 
 import io.micronaut.aop.interceptors.Mutating
-import io.micronaut.context.annotation.Bean
 import io.micronaut.context.annotation.Factory
 import io.micronaut.context.annotation.Primary
+import io.micronaut.context.annotation.Prototype
 
 import javax.inject.Named
 
@@ -29,14 +29,14 @@ import javax.inject.Named
 @Factory
 class InterfaceFactory {
 
-    @Bean
+    @Prototype
     @Mutating("name")
     @Primary
     InterfaceClass interfaceClass() {
         return new InterfaceImpl()
     }
 
-    @Bean
+    @Prototype
     @Mutating("name")
     @Named("another")
     InterfaceClass anotherImpl() {

--- a/inject-groovy/src/test/groovy/io/micronaut/aop/factory/SessionFactoryFactory.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/aop/factory/SessionFactoryFactory.groovy
@@ -16,8 +16,8 @@
 package io.micronaut.aop.factory
 
 import io.micronaut.aop.interceptors.Mutating
-import io.micronaut.context.annotation.Bean
 import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Prototype
 import org.hibernate.SessionFactory
 import org.hibernate.engine.spi.SessionFactoryDelegatingImpl
 
@@ -29,7 +29,7 @@ import org.hibernate.engine.spi.SessionFactoryDelegatingImpl
 class SessionFactoryFactory {
 
     @Mutating("name")
-    @Bean
+    @Prototype
     SessionFactory sessionFactory() {
         return new SessionFactoryDelegatingImpl(null)
     }

--- a/inject-groovy/src/test/groovy/io/micronaut/docs/config/builder/EngineFactory.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/docs/config/builder/EngineFactory.groovy
@@ -15,11 +15,7 @@
  */
 package io.micronaut.docs.config.builder
 
-import io.micronaut.context.annotation.Bean
-import io.micronaut.context.annotation.Factory
-
 // tag::imports[]
-import io.micronaut.context.annotation.Bean
 import io.micronaut.context.annotation.Factory
 
 import javax.inject.Singleton
@@ -33,7 +29,6 @@ import javax.inject.Singleton
 @Factory
 class EngineFactory {
 
-    @Bean
     @Singleton
     EngineImpl buildEngine(EngineConfig engineConfig) {
         engineConfig.builder.build(engineConfig.crankShaft, engineConfig.sparkPlug)

--- a/inject-groovy/src/test/groovy/io/micronaut/docs/events/factory/EngineFactory.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/docs/events/factory/EngineFactory.groovy
@@ -37,7 +37,6 @@ class EngineFactory {
         engine = new V8Engine(rodLength: rodLength) // <2>
     }
 
-    @Bean
     @Singleton
     Engine v8Engine() {
         return engine // <3>

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/factory/BeanInitializingWithFactorySpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/factory/BeanInitializingWithFactorySpec.groovy
@@ -19,6 +19,7 @@ import io.micronaut.context.BeanContext
 import io.micronaut.context.DefaultBeanContext
 import io.micronaut.context.annotation.Bean
 import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Prototype
 import io.micronaut.context.event.BeanInitializedEventListener
 import io.micronaut.context.event.BeanInitializingEvent
 import spock.lang.Specification
@@ -83,7 +84,7 @@ class BeanInitializingWithFactorySpec extends Specification {
             name = name.toUpperCase()
         }
 
-        @Bean
+        @Prototype
         B get() {
             getCalled = true
             return new B(name: name )

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/factory/FactorySpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/factory/FactorySpec.groovy
@@ -19,6 +19,7 @@ import io.micronaut.context.BeanContext
 import io.micronaut.context.DefaultBeanContext
 import io.micronaut.context.annotation.Bean
 import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Prototype
 import spock.lang.Specification
 
 import javax.annotation.PostConstruct
@@ -90,7 +91,6 @@ class FactorySpec extends Specification {
             name = name.toUpperCase()
         }
 
-        @Bean
         @Singleton
         B get() {
             assert postConstructCalled : "post construct should have been called"
@@ -100,7 +100,7 @@ class FactorySpec extends Specification {
             return new B(name: name )
         }
 
-        @Bean
+        @Prototype
         C buildC(B b) {
             return new C(b:b)
         }

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/factory/ParametrizedFactorySpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/factory/ParametrizedFactorySpec.groovy
@@ -20,6 +20,7 @@ import io.micronaut.context.DefaultBeanContext
 import io.micronaut.context.annotation.Parameter
 import io.micronaut.context.annotation.Bean
 import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Prototype
 import io.micronaut.context.exceptions.BeanInstantiationException
 import spock.lang.Specification
 
@@ -121,7 +122,6 @@ class ParametrizedFactorySpec extends Specification  {
             name = name.toUpperCase()
         }
 
-        @Bean
         @Singleton
         B get() {
             assert postConstructCalled : "post construct should have been called"
@@ -131,7 +131,7 @@ class ParametrizedFactorySpec extends Specification  {
             return new B(name: name )
         }
 
-        @Bean
+        @Prototype
         C buildC(B b, @Parameter int count) {
             return new C(b, count)
         }

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/value/FactoryWithValueSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/value/FactoryWithValueSpec.groovy
@@ -16,8 +16,8 @@
 package io.micronaut.inject.value
 
 import io.micronaut.context.ApplicationContext
-import io.micronaut.context.annotation.Bean
 import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Prototype
 import io.micronaut.context.annotation.Value
 import spock.lang.Specification
 
@@ -58,12 +58,13 @@ class FactoryWithValueSpec extends Specification {
 
     @Factory
     static class MyFactory {
-        @Bean
+
+        @Prototype
         A newA(@Value('${foo.bar}') int port) {
             return new A(port)
         }
 
-        @Bean
+        @Prototype
         B newB(A a, @Value('${foo.bar}') int port) {
             return new B(a, port)
         }

--- a/inject-java/src/test/groovy/io/micronaut/aop/factory/ConcreteClassFactory.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/factory/ConcreteClassFactory.java
@@ -16,9 +16,9 @@
 package io.micronaut.aop.factory;
 
 import io.micronaut.aop.simple.Mutating;
-import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Primary;
+import io.micronaut.context.annotation.Prototype;
 
 import javax.inject.Named;
 
@@ -28,14 +28,15 @@ import javax.inject.Named;
  */
 @Factory
 public class ConcreteClassFactory {
-    @Bean
+
+    @Prototype
     @Mutating("name")
     @Primary
     ConcreteClass concreteClass() {
         return new ConcreteClass(new AnotherClass());
     }
 
-    @Bean
+    @Prototype
     @Mutating("name")
     @Named("another")
     ConcreteClass anotherImpl() {

--- a/inject-java/src/test/groovy/io/micronaut/aop/factory/InterfaceFactory.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/factory/InterfaceFactory.java
@@ -19,6 +19,7 @@ import io.micronaut.aop.simple.Mutating;
 import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Primary;
+import io.micronaut.context.annotation.Prototype;
 
 import javax.inject.Named;
 
@@ -29,14 +30,14 @@ import javax.inject.Named;
 @Factory
 public class InterfaceFactory {
 
-    @Bean
+    @Prototype
     @Mutating("name")
     @Primary
     InterfaceClass interfaceClass() {
         return new InterfaceImpl();
     }
 
-    @Bean
+    @Prototype
     @Mutating("name")
     @Named("another")
     InterfaceClass anotherImpl() {

--- a/inject-java/src/test/groovy/io/micronaut/aop/factory/SessionFactoryFactory.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/factory/SessionFactoryFactory.java
@@ -15,8 +15,8 @@
  */
 package io.micronaut.aop.factory;
 
-import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Prototype;
 import org.hibernate.SessionFactory;
 import org.hibernate.engine.spi.SessionFactoryDelegatingImpl;
 import io.micronaut.aop.simple.Mutating;
@@ -29,7 +29,7 @@ import io.micronaut.aop.simple.Mutating;
 public class SessionFactoryFactory {
 
     @Mutating("name")
-    @Bean
+    @Prototype
     SessionFactory sessionFactory() {
         return new SessionFactoryDelegatingImpl(null);
     }

--- a/inject-java/src/test/groovy/io/micronaut/inject/factory/beanwithfactory/BFactory.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/factory/beanwithfactory/BFactory.java
@@ -15,8 +15,8 @@
  */
 package io.micronaut.inject.factory.beanwithfactory;
 
-import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Prototype;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
@@ -60,7 +60,7 @@ public class BFactory  {
         name = name.toUpperCase();
     }
 
-    @Bean
+    @Prototype
     public B get() {
         getCalled = true;
         B b = new B();

--- a/inject-java/src/test/groovy/io/micronaut/inject/factory/factorydefinition/BFactory.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/factory/factorydefinition/BFactory.java
@@ -15,8 +15,8 @@
  */
 package io.micronaut.inject.factory.factorydefinition;
 
-import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Prototype;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
@@ -69,7 +69,7 @@ public class BFactory {
         return b;
     }
 
-    @Bean
+    @Prototype
     public C buildC(B b) {
         C c = new C();
         c.setB(b);

--- a/inject-java/src/test/groovy/io/micronaut/inject/factory/inject/MyFactory.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/factory/inject/MyFactory.java
@@ -15,8 +15,8 @@
  */
 package io.micronaut.inject.factory.inject;
 
-import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Prototype;
 
 import javax.inject.Inject;
 
@@ -27,7 +27,7 @@ public class MyFactory {
     MyService myService;
 
 
-    @Bean
+    @Prototype
     MyService myService() {
         return new MyService();
     }

--- a/inject-java/src/test/groovy/io/micronaut/inject/factory/named/TemplateFactory.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/factory/named/TemplateFactory.java
@@ -15,21 +15,21 @@
  */
 package io.micronaut.inject.factory.named;
 
-import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Prototype;
 
 import javax.inject.Named;
 
 @Factory
 public class TemplateFactory {
 
-    @Bean
+    @Prototype
     @Named("csw-test-template")
     public Template cswTemplate() {
         return new CSWTestTemplate();
     }
 
-    @Bean
+    @Prototype
     @Named("ias-test-template")
     public Template iasTemplate() {
         return new IASTestTemplate();

--- a/inject-java/src/test/groovy/io/micronaut/inject/factory/named/TestCacheFactory.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/factory/named/TestCacheFactory.java
@@ -38,14 +38,12 @@ public class TestCacheFactory {
             .expireAfterWrite(30, TimeUnit.DAYS)
             .build();
 
-    @Bean
     @Singleton
     @Named("orgRepositoryCache")
     public Cache<String, Flowable<String>> orgRepositoryCache() {
         return orgRepoCache;
     }
 
-    @Bean
     @Singleton
     @Named("repositoryCache")
     public Cache<String, Maybe<String>> repositoryCache() {

--- a/inject-java/src/test/groovy/io/micronaut/inject/factory/parameterizedfactory/BFactory.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/factory/parameterizedfactory/BFactory.java
@@ -18,6 +18,7 @@ package io.micronaut.inject.factory.parameterizedfactory;
 import io.micronaut.context.annotation.Parameter;
 import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Prototype;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
@@ -67,7 +68,7 @@ public class BFactory {
         return b;
     }
 
-    @Bean
+    @Prototype
     C buildC(B b, @Parameter int count) {
         return new C(b, count);
     }

--- a/inject-java/src/test/groovy/io/micronaut/inject/value/factorywithvalue/MyFactory.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/value/factorywithvalue/MyFactory.java
@@ -15,18 +15,19 @@
  */
 package io.micronaut.inject.value.factorywithvalue;
 
-import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Prototype;
 import io.micronaut.context.annotation.Value;
 
 @Factory
 public class MyFactory {
-    @Bean
+
+    @Prototype
     public A newA(@Value("${foo.bar}") int port) {
         return new A(port);
     }
 
-    @Bean
+    @Prototype
     public B newB(A a, @Value("${foo.bar}") int port) {
         return new B(a, port);
     }

--- a/inject/src/main/java/io/micronaut/inject/annotation/DefaultAnnotationMetadata.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/DefaultAnnotationMetadata.java
@@ -16,7 +16,6 @@
 package io.micronaut.inject.annotation;
 
 import io.micronaut.core.annotation.*;
-import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.TypeConverter;
 import io.micronaut.core.convert.value.ConvertibleValues;

--- a/runtime/src/main/java/io/micronaut/discovery/cloud/gcp/GoogleComputeInstanceMetadataResolver.java
+++ b/runtime/src/main/java/io/micronaut/discovery/cloud/gcp/GoogleComputeInstanceMetadataResolver.java
@@ -35,7 +35,6 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.micronaut.discovery.cloud.ComputeInstanceMetadataResolverUtils.*;
-import static io.micronaut.discovery.cloud.ComputeInstanceMetadataResolverUtils.readMetadataUrl;
 
 /**
  * Resolves {@link ComputeInstanceMetadata} for Google Cloud Platform.

--- a/runtime/src/main/java/io/micronaut/jackson/ObjectMapperFactory.java
+++ b/runtime/src/main/java/io/micronaut/jackson/ObjectMapperFactory.java
@@ -74,7 +74,6 @@ public class ObjectMapperFactory {
      * @param jsonFactory          The JSON factory
      * @return The {@link ObjectMapper}
      */
-    @Bean
     @Singleton
     @Primary
     @BootstrapContextCompatible

--- a/runtime/src/main/java/io/micronaut/runtime/context/scope/ThreadLocal.java
+++ b/runtime/src/main/java/io/micronaut/runtime/context/scope/ThreadLocal.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.runtime.context.scope;
 
+import io.micronaut.context.annotation.Bean;
+
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;

--- a/runtime/src/main/java/io/micronaut/runtime/context/scope/ThreadLocal.java
+++ b/runtime/src/main/java/io/micronaut/runtime/context/scope/ThreadLocal.java
@@ -15,8 +15,6 @@
  */
 package io.micronaut.runtime.context.scope;
 
-import io.micronaut.context.annotation.Bean;
-
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;

--- a/runtime/src/main/java/io/micronaut/runtime/http/codec/MediaTypeCodecRegistryFactory.java
+++ b/runtime/src/main/java/io/micronaut/runtime/http/codec/MediaTypeCodecRegistryFactory.java
@@ -15,7 +15,6 @@
  */
 package io.micronaut.runtime.http.codec;
 
-import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Primary;

--- a/runtime/src/main/java/io/micronaut/runtime/http/codec/MediaTypeCodecRegistryFactory.java
+++ b/runtime/src/main/java/io/micronaut/runtime/http/codec/MediaTypeCodecRegistryFactory.java
@@ -41,7 +41,6 @@ public class MediaTypeCodecRegistryFactory {
      */
     @Singleton
     @Primary
-    @Bean
     @BootstrapContextCompatible
     MediaTypeCodecRegistry mediaTypeCodecRegistry(List<MediaTypeCodec> codecs) {
         return MediaTypeCodecRegistry.of(codecs);

--- a/runtime/src/main/java/io/micronaut/scheduling/executor/DefaultThreadFactory.java
+++ b/runtime/src/main/java/io/micronaut/scheduling/executor/DefaultThreadFactory.java
@@ -35,7 +35,6 @@ public class DefaultThreadFactory {
     /**
      * @return The default thread factory
      */
-    @Bean
     @Singleton
     @Primary
     ThreadFactory threadFactory() {

--- a/runtime/src/main/java/io/micronaut/scheduling/executor/DefaultThreadFactory.java
+++ b/runtime/src/main/java/io/micronaut/scheduling/executor/DefaultThreadFactory.java
@@ -15,7 +15,6 @@
  */
 package io.micronaut.scheduling.executor;
 
-import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Primary;
 

--- a/runtime/src/main/java/io/micronaut/scheduling/executor/IOExecutorServiceConfig.java
+++ b/runtime/src/main/java/io/micronaut/scheduling/executor/IOExecutorServiceConfig.java
@@ -15,7 +15,6 @@
  */
 package io.micronaut.scheduling.executor;
 
-import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.scheduling.TaskExecutors;

--- a/runtime/src/main/java/io/micronaut/scheduling/executor/IOExecutorServiceConfig.java
+++ b/runtime/src/main/java/io/micronaut/scheduling/executor/IOExecutorServiceConfig.java
@@ -37,7 +37,6 @@ public class IOExecutorServiceConfig {
      * @return The default thread pool configurations
      */
     @Singleton
-    @Bean
     @Named(TaskExecutors.IO)
     ExecutorConfiguration configuration() {
         return UserExecutorConfiguration.of(ExecutorType.CACHED);

--- a/runtime/src/main/java/io/micronaut/scheduling/executor/ScheduledExecutorServiceConfig.java
+++ b/runtime/src/main/java/io/micronaut/scheduling/executor/ScheduledExecutorServiceConfig.java
@@ -15,7 +15,6 @@
  */
 package io.micronaut.scheduling.executor;
 
-import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.scheduling.TaskExecutors;

--- a/runtime/src/main/java/io/micronaut/scheduling/executor/ScheduledExecutorServiceConfig.java
+++ b/runtime/src/main/java/io/micronaut/scheduling/executor/ScheduledExecutorServiceConfig.java
@@ -38,7 +38,6 @@ public class ScheduledExecutorServiceConfig {
      * @return The executor configurations
      */
     @Singleton
-    @Bean
     @Named(TaskExecutors.SCHEDULED)
     ExecutorConfiguration configuration() {
         return UserExecutorConfiguration.of(ExecutorType.SCHEDULED);

--- a/runtime/src/test/groovy/io/micronaut/cache/jcache/JCacheSyncCacheSpec.groovy
+++ b/runtime/src/test/groovy/io/micronaut/cache/jcache/JCacheSyncCacheSpec.groovy
@@ -138,7 +138,6 @@ class JCacheSyncCacheSpec extends Specification {
     static class CacheFactory {
 
         @Singleton
-        @Bean
         @Requires(property = JCacheManager.JCACHE_ENABLED, value = "true")
         CacheManager cacheManager() {
             def cacheManager = Caching.getCachingProvider().cacheManager

--- a/runtime/src/test/groovy/io/micronaut/runtime/MicronautSpec.groovy
+++ b/runtime/src/test/groovy/io/micronaut/runtime/MicronautSpec.groovy
@@ -16,8 +16,8 @@
 package io.micronaut.runtime
 
 import io.micronaut.context.ApplicationContext
-import io.micronaut.context.annotation.Bean
 import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Prototype
 import spock.lang.Specification
 
 /**
@@ -42,7 +42,7 @@ class MicronautSpec extends Specification {
             Micronaut.run(Application, args)
         }
 
-        @Bean
+        @Prototype
         A a() { new A() }
     }
 

--- a/runtime/src/test/groovy/io/micronaut/runtime/context/scope/ThreadLocalScopeSpec.groovy
+++ b/runtime/src/test/groovy/io/micronaut/runtime/context/scope/ThreadLocalScopeSpec.groovy
@@ -243,7 +243,7 @@ class A2Impl implements IA2 {
 
 @Factory
 class  IA2Factory {
-    @Bean
+
     @ThreadLocal
     IA2 a() {
         return new A2Impl()

--- a/src/main/docs/guide/aop/aroundAdvice.adoc
+++ b/src/main/docs/guide/aop/aroundAdvice.adoc
@@ -68,7 +68,7 @@ This behaviour is more efficient as only one instance of the bean is required, h
 The semantics of AOP advice when applied to <<factories,Bean Factories>> differs to regular beans, with the following rules applying:
 
 1. AOP advice applied at the class level of a ann:context.annotation.Factory[] bean will apply the advice to the factory itself and not to any beans defined with the ann:context.annotation.Bean[] annotation.
-2. AOP advice applied on a method annotated with ann:context.annotation.Bean[] will apply the AOP advice to the bean that the factory produces.
+2. AOP advice applied on a method annotated with a bean scope will apply the AOP advice to the bean that the factory produces.
 
 Consider the following two examples:
 
@@ -79,7 +79,7 @@ Consider the following two examples:
 @Factory
 class MyFactory {
 
-    @Bean
+    @Prototype
     MyBean myBean() {
         return new MyBean();
     }
@@ -96,7 +96,7 @@ Now consider this example:
 @Factory
 class MyFactory {
 
-    @Bean
+    @Prototype
     @Cacheable("my-cache")
     MyBean myBean() {
         return new MyBean();

--- a/src/main/docs/guide/ioc/factories.adoc
+++ b/src/main/docs/guide/ioc/factories.adoc
@@ -1,14 +1,17 @@
 In many cases, you may want to make available as a bean a class that is not part of your codebase such as those provided by third-party libraries. In this case, you cannot annotate the already compiled class. Instead, you should implement a link:{api}/io/micronaut/context/annotation/Factory.html[Factory].
 
-A factory is a class annotated with the link:{api}/io/micronaut/context/annotation/Factory.html[Factory] annotation that provides 1 or more methods annotated with the link:{api}/io/micronaut/context/annotation/Bean.html[Bean] annotation.
+A factory is a class annotated with the link:{api}/io/micronaut/context/annotation/Factory.html[Factory] annotation that provides 1 or more methods annotated with a bean scope annotation. Which annotation you use depends on what scope you want the bean to be in. See the section on <<scopes, bean scopes>> for more information.
 
-The return types of methods annotated with `@Bean` are the bean types. This is best illustrated by an example:
+The return types of methods annotated with a bean scope annotation are the bean types. This is best illustrated by an example:
 
 snippet::io.micronaut.docs.factories.CrankShaft,io.micronaut.docs.factories.V8Engine,io.micronaut.docs.factories.EngineFactory[tags="class",indent=0]
 
-In this case, the `V8Engine` is built by the `EngineFactory` class' `v8Engine` method. Note that you can inject parameters into the method and these parameters will be resolved as beans.
+In this case, the `V8Engine` is built by the `EngineFactory` class' `v8Engine` method. Note that you can inject parameters into the method and these parameters will be resolved as beans. The resulting `V8Engine` bean will be a singleton.
 
-A factory can also have multiple methods annotated with link:{api}/io/micronaut/context/annotation/Bean.html[@Bean] each one returning a distinct bean type.
+A factory can have multiple methods annotated with bean scope annotations, each one returning a distinct bean type.
 
-NOTE: If you take this approach, then you should not invoke other methods annotated with `@Bean` internally within the class. Instead, inject the types via parameters.
+NOTE: If you take this approach, then you should not invoke other bean methods internally within the class. Instead, inject the types via parameters.
+
+TIP: To allow the resulting bean to participate in the application context shutdown process, annotate the method with link:{api}/io/micronaut/context/annotation/Bean.html[@Bean] and set the `preDestroy` argument to the name of the method that should be called to close the bean.
+
 

--- a/src/main/docs/guide/ioc/scopes/builtInScopes.adoc
+++ b/src/main/docs/guide/ioc/scopes/builtInScopes.adoc
@@ -16,6 +16,8 @@
 |`@Refreshable` scope is a custom scope that allows a bean's state to be refreshed via the `/refresh` endpoint.
 |===
 
+NOTE: The link:{api}/io/micronaut/context/annotation/Prototype.html[@Prototype] annotation is a synonym for link:{api}/io/micronaut/context/annotation/Bean.html[@Bean] because the default scope is prototype.
+
 Additional scopes can be added by defining a `@Singleton` bean that implements the link:{api}/io/micronaut/context/scope/CustomScope.html[CustomScope] interface.
 
 Note that with Micronaut when starting a api:context.ApplicationContext[] by default `@Singleton` scoped beans are created lazily and on demand. This is by design and to optimize startup time.

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/factories/EngineFactory.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/factories/EngineFactory.groovy
@@ -28,7 +28,6 @@ import javax.inject.Singleton
 @Factory
 class EngineFactory {
 
-    @Bean
     @Singleton
     Engine v8Engine(CrankShaft crankShaft) {
         new V8Engine(crankShaft)

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/whatsNew/CacheFactory.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/whatsNew/CacheFactory.groovy
@@ -15,7 +15,6 @@ import javax.inject.Singleton
 class CacheFactory {
 
     @Singleton
-    @Bean
     CacheManager cacheManager() {
         CacheManager cacheManager = Caching.cachingProvider.cacheManager
         cacheManager.createCache("my-cache", new MutableConfiguration())

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/factories/EngineFactory.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/factories/EngineFactory.kt
@@ -28,7 +28,6 @@ import javax.inject.Singleton
 @Factory
 internal class EngineFactory {
 
-    @Bean
     @Singleton
     fun v8Engine(crankShaft: CrankShaft): Engine {
         return V8Engine(crankShaft)

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/whatsNew/CacheFactory.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/whatsNew/CacheFactory.kt
@@ -15,7 +15,6 @@ import javax.inject.Singleton
 class CacheFactory {
 
     @Singleton
-    @Bean
     fun cacheManager(): CacheManager {
         val cacheManager = Caching.getCachingProvider().cacheManager
         cacheManager.createCache("my-cache", MutableConfiguration<Any, Any>())

--- a/test-suite/src/test/java/io/micronaut/docs/factories/EngineFactory.java
+++ b/test-suite/src/test/java/io/micronaut/docs/factories/EngineFactory.java
@@ -28,7 +28,6 @@ import javax.inject.Singleton;
 @Factory
 class EngineFactory {
 
-    @Bean
     @Singleton
     Engine v8Engine(CrankShaft crankShaft) {
         return new V8Engine(crankShaft);

--- a/test-suite/src/test/java/io/micronaut/docs/whatsNew/CacheFactory.java
+++ b/test-suite/src/test/java/io/micronaut/docs/whatsNew/CacheFactory.java
@@ -15,7 +15,6 @@ import javax.inject.Singleton;
 class CacheFactory {
 
     @Singleton
-    @Bean
     CacheManager cacheManager() {
         CacheManager cacheManager = Caching.getCachingProvider()
                 .getCacheManager();

--- a/tracing/src/main/java/io/micronaut/tracing/brave/BraveTracerFactory.java
+++ b/tracing/src/main/java/io/micronaut/tracing/brave/BraveTracerFactory.java
@@ -19,10 +19,7 @@ import brave.CurrentSpanCustomizer;
 import brave.SpanCustomizer;
 import brave.Tracing;
 import brave.opentracing.BraveTracer;
-import io.micronaut.context.annotation.Bean;
-import io.micronaut.context.annotation.Factory;
-import io.micronaut.context.annotation.Primary;
-import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.annotation.*;
 import io.opentracing.Tracer;
 import io.opentracing.util.GlobalTracer;
 import zipkin2.Span;
@@ -91,7 +88,6 @@ public class BraveTracerFactory {
      * @param tracing The {@link Tracing} bean
      * @return The Open Tracing {@link Tracer} bean
      */
-    @Bean
     @Singleton
     @Requires(classes = {BraveTracer.class, Tracer.class})
     @Primary
@@ -109,7 +105,7 @@ public class BraveTracerFactory {
      * @param configuration The configuration
      * @return The {@link AsyncReporter} bean
      */
-    @Bean
+    @Prototype
     @Requires(beans = AsyncReporterConfiguration.class)
     @Requires(missingBeans = Reporter.class)
     AsyncReporter<Span> asyncReporter(AsyncReporterConfiguration configuration) {

--- a/tracing/src/main/java/io/micronaut/tracing/brave/instrument/http/HttpTracingFactory.java
+++ b/tracing/src/main/java/io/micronaut/tracing/brave/instrument/http/HttpTracingFactory.java
@@ -17,7 +17,6 @@ package io.micronaut.tracing.brave.instrument.http;
 
 import brave.Tracing;
 import brave.http.*;
-import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.HttpAttributes;

--- a/tracing/src/main/java/io/micronaut/tracing/brave/instrument/http/HttpTracingFactory.java
+++ b/tracing/src/main/java/io/micronaut/tracing/brave/instrument/http/HttpTracingFactory.java
@@ -47,7 +47,6 @@ public class HttpTracingFactory {
      * @param tracing The {@link Tracing} bean
      * @return The {@link HttpTracing} bean
      */
-    @Bean
     @Singleton
     @Requires(missingBeans = HttpTracing.class)
     HttpTracing httpTracing(Tracing tracing) {
@@ -60,7 +59,6 @@ public class HttpTracingFactory {
      * @param httpTracing The {@link HttpTracing} bean
      * @return The {@link HttpClientHandler} bean
      */
-    @Bean
     @Singleton
     HttpClientHandler<HttpRequest<?>, HttpResponse<?>> httpClientHandler(HttpTracing httpTracing) {
         return HttpClientHandler.create(httpTracing, new HttpClientAdapter<HttpRequest<?>, HttpResponse<?>>() {
@@ -110,7 +108,6 @@ public class HttpTracingFactory {
      * @param httpTracing The {@link HttpTracing} bean
      * @return The {@link HttpServerHandler} bean
      */
-    @Bean
     @Singleton
     HttpServerHandler<HttpRequest<?>, HttpResponse<?>> httpServerHandler(HttpTracing httpTracing) {
         return HttpServerHandler.create(httpTracing, new HttpServerAdapter<HttpRequest<?>, HttpResponse<?>>() {

--- a/tracing/src/main/java/io/micronaut/tracing/brave/sender/HttpClientSenderFactory.java
+++ b/tracing/src/main/java/io/micronaut/tracing/brave/sender/HttpClientSenderFactory.java
@@ -49,7 +49,6 @@ public class HttpClientSenderFactory {
      * @param loadBalancerResolver A resolver capable of resolving references to services into a concrete loadbalance
      * @return The {@link Sender}
      */
-    @Bean
     @Singleton
     @Requires(missingBeans = Sender.class)
     Sender zipkinSender(Provider<LoadBalancerResolver> loadBalancerResolver) {

--- a/tracing/src/main/java/io/micronaut/tracing/brave/sender/HttpClientSenderFactory.java
+++ b/tracing/src/main/java/io/micronaut/tracing/brave/sender/HttpClientSenderFactory.java
@@ -15,7 +15,6 @@
  */
 package io.micronaut.tracing.brave.sender;
 
-import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.client.LoadBalancerResolver;


### PR DESCRIPTION
Remove duplicate @Bean/@Singleton annotations on factories. 
Replace @Bean without preDestroy with @Prototype to be more explicit. 
Closes #1288