### PR TITLE
#639 Ability to specify and merge additional Swagger files

### DIFF
--- a/configurations/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
+++ b/configurations/openapi/src/main/java/io/micronaut/openapi/visitor/OpenApiApplicationVisitor.java
@@ -32,12 +32,19 @@ import io.swagger.v3.oas.annotations.servers.Server;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.Writer;
 import java.lang.annotation.Annotation;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -52,6 +59,10 @@ public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements
      * System property that enables setting the target file to write to.
      */
     public static final String MICRONAUT_OPENAPI_TARGET_FILE = "micronaut.openapi.target.file";
+    /**
+     * System property that specifies the location of additional swagger YAML files to read from.
+     */
+    public static final String MICRONAUT_OPENAPI_ADDITIONAL_FILES = "micronaut.openapi.additional.files";
 
     private ClassElement classElement;
 
@@ -73,6 +84,7 @@ public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements
             context.put(ATTR_OPENAPI, openAPI);
         }
 
+        mergeAdditionalSwaggerFiles(element, context, openAPI);
         // handle type level tags
         List<io.swagger.v3.oas.models.tags.Tag> tagList = processOpenApiAnnotation(
                 element,
@@ -111,6 +123,59 @@ public class OpenApiApplicationVisitor extends AbstractOpenApiVisitor implements
         }
 
         this.classElement = element;
+    }
+
+    /**
+     * Merge the OpenAPI YAML files into one single file.
+     *
+     * @param element The element
+     * @param context The visitor context
+     * @param openAPI The {@link OpenAPI} object for the application
+     */
+    private void mergeAdditionalSwaggerFiles(ClassElement element, VisitorContext context, OpenAPI openAPI) {
+        String additionalSwaggerFiles = System.getProperty(MICRONAUT_OPENAPI_ADDITIONAL_FILES);
+        if (StringUtils.isNotEmpty(additionalSwaggerFiles)) {
+            Path directory = Paths.get(additionalSwaggerFiles);
+            if (Files.isDirectory(directory)) {
+                context.info("Merging Swagger OpenAPI YAML files from location :" + additionalSwaggerFiles);
+                try {
+                    Files.newDirectoryStream(directory,
+                            path -> path.toString().endsWith(".yml"))
+                            .forEach(path -> {
+                                context.info("Reading Swagger OpenAPI YAML file " + path.getFileName());
+                                OpenAPI parsedOpenApi = null;
+                                try {
+                                    parsedOpenApi = yamlMapper.readValue(path.toFile(), OpenAPI.class);
+                                } catch (IOException e) {
+                                    context.warn("Unable to read file " + path.getFileName() + ": " + e.getMessage() , classElement);
+                                }
+                                if (parsedOpenApi != null) {
+                                    if (!parsedOpenApi.getOpenapi().equals(openAPI.getOpenapi())) {
+                                        context.warn("The OpenAPI version " + parsedOpenApi.getOpenapi() + " in the file doesn't match the OpenAPI version " + openAPI.getOpenapi() + " of application", element);
+                                        return;
+                                    }
+                                    Optional.ofNullable(parsedOpenApi.getServers()).ifPresent(servers -> servers.forEach(openAPI::addServersItem));
+                                    Optional.ofNullable(parsedOpenApi.getPaths()).ifPresent(paths -> paths.forEach(openAPI::path));
+                                    Optional.ofNullable(parsedOpenApi.getComponents()).ifPresent(components -> {
+                                        Map<String, Schema> schemas = components.getSchemas();
+                                        if (schemas != null && !schemas.isEmpty()) {
+                                            schemas.forEach(openAPI::schema);
+                                        }
+                                        Map<String, SecurityScheme> securitySchemes = components.getSecuritySchemes();
+                                        if (securitySchemes != null && !securitySchemes.isEmpty()) {
+                                            securitySchemes.forEach(openAPI::schemaRequirement);
+                                        }
+                                    });
+                                    Optional.ofNullable(parsedOpenApi.getSecurity()).ifPresent(securityRequirements -> securityRequirements.forEach(openAPI::addSecurityItem));
+                                    Optional.ofNullable(parsedOpenApi.getTags()).ifPresent(tags -> tags.forEach(openAPI::addTagsItem));
+                                    Optional.ofNullable(parsedOpenApi.getExtensions()).ifPresent(extensions -> extensions.forEach(openAPI::addExtension));
+                                }
+                            });
+                } catch (IOException e) {
+                    context.warn("Unable to read  file from "+ directory.getFileName() + ": " + e.getMessage() , classElement);
+                }
+            }
+        }
     }
 
     private <T, A extends Annotation> List<T> processOpenApiAnnotation(ClassElement element, VisitorContext context, Class<A> annotationType, Class<T> modelType, List<T> tagList) {

--- a/configurations/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiMergeSchemaSpec.groovy
+++ b/configurations/openapi/src/test/groovy/io/micronaut/openapi/visitor/OpenApiMergeSchemaSpec.groovy
@@ -1,0 +1,126 @@
+package io.micronaut.openapi.visitor
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.Operation
+import spock.util.environment.RestoreSystemProperties
+
+class OpenApiMergeSchemaSpec extends AbstractTypeElementSpec {
+
+    @RestoreSystemProperties
+    void "test merging of additional OpenAPI schema"() {
+        given:"An API definition"
+        System.setProperty(AbstractOpenApiVisitor.ATTR_TEST_MODE, "true")
+        String additionalSwaggerFilesDir= new File("src/test/resources/swagger").absolutePath
+        System.setProperty(OpenApiApplicationVisitor.MICRONAUT_OPENAPI_ADDITIONAL_FILES, additionalSwaggerFilesDir)
+
+        when:
+        buildBeanDefinition('test.MyBean', '''
+package test;
+
+import io.reactivex.Maybe;
+import io.reactivex.Single;
+import io.micronaut.http.annotation.*;
+import java.util.List;
+import io.swagger.v3.oas.annotations.*;
+import io.swagger.v3.oas.annotations.info.*;
+import io.swagger.v3.oas.annotations.tags.*;
+import io.swagger.v3.oas.annotations.servers.*;
+import io.swagger.v3.oas.annotations.security.*;
+
+@OpenAPIDefinition(
+        info = @Info(
+                title = "the title",
+                version = "0.0",
+                description = "My API",
+                license = @License(name = "Apache 2.0", url = "http://foo.bar"),
+                contact = @Contact(url = "http://gigantic-server.com", name = "Fred", email = "Fred@gigagantic-server.com")
+        ),
+        tags = {
+                @Tag(name = "Tag 1", description = "desc 1", externalDocs = @ExternalDocumentation(description = "docs desc")),
+                @Tag(name = "Tag 2", description = "desc 2", externalDocs = @ExternalDocumentation(description = "docs desc 2")),
+                @Tag(name = "Tag 3")
+        },
+        externalDocs = @ExternalDocumentation(description = "definition docs desc"),
+        security = {
+                @SecurityRequirement(name = "req 1", scopes = {"a", "b"}),
+                @SecurityRequirement(name = "req 2", scopes = {"b", "c"})
+        },
+        servers = {
+                @Server(
+                        description = "server 1",
+                        url = "http://foo",
+                        variables = {
+                                @ServerVariable(name = "var1", description = "var 1", defaultValue = "1", allowableValues = {"1", "2"}),
+                                @ServerVariable(name = "var2", description = "var 2", defaultValue = "1", allowableValues = {"1", "2"})
+                        })
+        }
+)
+class Application {
+
+}
+
+
+@javax.inject.Singleton
+class MyBean {}
+''')
+        then:"the state is correct"
+        AbstractOpenApiVisitor.testReference != null
+
+        when:"the /pets path is retrieved"
+        OpenAPI openAPI = AbstractOpenApiVisitor.testReference
+
+        then:"it is included in the OpenAPI doc"
+        openAPI.info != null
+        openAPI.info.title == 'the title'
+        openAPI.info.version == '0.0'
+        openAPI.info.description == 'My API'
+        openAPI.info.license.name == 'Apache 2.0'
+        openAPI.info.contact.name == 'Fred'
+        openAPI.tags.size() == 3
+        openAPI.tags.first().name == 'Tag 1'
+        openAPI.tags.first().description == 'desc 1'
+        openAPI.externalDocs.description == 'definition docs desc'
+        openAPI.security.size() == 2
+        openAPI.security.first().name[0] == 'req 1'
+        openAPI.servers.size() == 2
+        openAPI.servers[0].description == 'server 1'
+        openAPI.servers[0].url == 'http://foo'
+        openAPI.servers[0].variables.size() == 2
+        openAPI.servers[0].variables.var1.description == 'var 1'
+        openAPI.servers[0].variables.var1.default == '1'
+        openAPI.servers[1].url == 'http://petstore.swagger.io/v1'
+        openAPI.paths.size() == 2
+
+        when:
+        Operation operation = openAPI.paths.get("/pets").get
+
+        then:
+        operation.tags.size() == 1
+        operation.tags[0] == "pets"
+        operation.summary == "List all pets"
+
+        when:
+        operation = openAPI.paths.get("/pets").post
+
+        then:
+        operation.tags.size() == 1
+        operation.tags[0] == "pets"
+        operation.summary == "Create a pet"
+
+        when:
+        operation = openAPI.paths.get("/pets/{petId}").get
+
+        then:
+        operation.tags.size() == 1
+        operation.tags[0] == "pets"
+        operation.summary == "Info for a specific pet"
+
+        when:
+        Components components = openAPI.components
+
+        then:
+        components.schemas.size() == 3
+    }
+}

--- a/configurations/openapi/src/test/resources/swagger/petstore.yml
+++ b/configurations/openapi/src/test/resources/swagger/petstore.yml
@@ -1,0 +1,109 @@
+openapi: "3.0.1"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        200:
+          description: An paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      responses:
+        201:
+          description: Null response
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /pets/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        200:
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+    Pets:
+      type: array
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string


### PR DESCRIPTION
* System property `micronaut.openapi.additional.files` to read additional Swagger YAML files from disk.
* Updated OpenApiApplicationVisitor to parse and merge additional swagger files into the application `OpenAPI` object.