### PR TITLE
InterceptUrlMapRule by exact match on both method and URI

### DIFF
--- a/security/src/main/java/io/micronaut/security/rules/InterceptUrlMapRule.java
+++ b/security/src/main/java/io/micronaut/security/rules/InterceptUrlMapRule.java
@@ -88,7 +88,7 @@ abstract class InterceptUrlMapRule extends AbstractSecurityRule {
         final HttpMethod httpMethod = request.getMethod();
 
         Predicate<InterceptUrlMapPattern> exactMatch = p -> pathMatcher.matches(p.getPattern(), path) && p.getHttpMethod().isPresent() && httpMethod.equals(p.getHttpMethod().get());
-        Predicate<InterceptUrlMapPattern> uriPatternMatch = p -> pathMatcher.matches(p.getPattern(), path) && p.getHttpMethod().map(method -> method.equals(httpMethod)).orElse(true);
+        Predicate<InterceptUrlMapPattern> uriPatternMatchOnly = p -> pathMatcher.matches(p.getPattern(), path) && !p.getHttpMethod().isPresent();
 
         Optional<InterceptUrlMapPattern> matchedPattern = getPatternList()
                 .stream()
@@ -99,7 +99,7 @@ abstract class InterceptUrlMapRule extends AbstractSecurityRule {
         if (!matchedPattern.isPresent()) {
             matchedPattern = getPatternList()
                     .stream()
-                    .filter(uriPatternMatch)
+                    .filter(uriPatternMatchOnly)
                     .findFirst();
         }
 

--- a/security/src/test/groovy/io/micronaut/security/rules/InterceptUrlMapRuleSpec.groovy
+++ b/security/src/test/groovy/io/micronaut/security/rules/InterceptUrlMapRuleSpec.groovy
@@ -18,7 +18,9 @@ package io.micronaut.security.rules
 import io.micronaut.http.HttpMethod
 import io.micronaut.http.HttpRequest
 import io.micronaut.security.config.InterceptUrlMapPattern
+import io.micronaut.security.token.DefaultRolesFinder
 import io.micronaut.security.token.config.TokenConfiguration
+import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -50,5 +52,48 @@ class InterceptUrlMapRuleSpec extends Specification {
         '/foo'          || SecurityRuleResult.ALLOWED
         '/foo?bar=true' || SecurityRuleResult.ALLOWED
         '/foo/bar'      || SecurityRuleResult.UNKNOWN
+    }
+
+    @Issue("https://github.com/micronaut-projects/micronaut-core/issues/1511")
+    @Unroll
+    void "An http #request.method request to '#request.uri' should result in the security result '#expectedResult'"() {
+
+        given: 'a token configuration'
+        TokenConfiguration configuration = Mock()
+
+        and: 'the expected mock behaviour'
+        (0..1) * configuration.rolesName >> "roles"
+        0 * _
+
+        and: ''
+        SecurityRule rule = new InterceptUrlMapRule(new DefaultRolesFinder(configuration)) {
+            @Override
+            protected List<InterceptUrlMapPattern> getPatternList() {
+                [
+                        new InterceptUrlMapPattern("/v1/sessions/**", ["isAuthenticated()"], null),
+                        new InterceptUrlMapPattern("/v1/sessions/**", ["isAnonymous()"], HttpMethod.OPTIONS)
+                ]
+            }
+        }
+
+        expect:
+        rule.check(request, null, null) == expectedResult
+
+        where:
+        request                                       || expectedResult
+        HttpRequest.OPTIONS('/v1/sessions/123')       || SecurityRuleResult.ALLOWED
+        HttpRequest.OPTIONS('/v1/sessions/')          || SecurityRuleResult.ALLOWED
+        HttpRequest.GET('/v1/sessions/123')           || SecurityRuleResult.REJECTED
+        HttpRequest.GET('/v1/sessions/')              || SecurityRuleResult.REJECTED
+        HttpRequest.POST('/v1/sessions/123', 'body')  || SecurityRuleResult.REJECTED
+        HttpRequest.POST('/v1/sessions/', 'body')     || SecurityRuleResult.REJECTED
+        HttpRequest.PUT('/v1/sessions/123', 'body')   || SecurityRuleResult.REJECTED
+        HttpRequest.PUT('/v1/sessions/', 'body')      || SecurityRuleResult.REJECTED
+        HttpRequest.DELETE('/v1/sessions/123')        || SecurityRuleResult.REJECTED
+        HttpRequest.DELETE('/v1/sessions/')           || SecurityRuleResult.REJECTED
+        HttpRequest.HEAD('/v1/sessions/123')          || SecurityRuleResult.REJECTED
+        HttpRequest.HEAD('/v1/sessions/')             || SecurityRuleResult.REJECTED
+        HttpRequest.PATCH('/v1/sessions/123', 'body') || SecurityRuleResult.REJECTED
+        HttpRequest.PATCH('/v1/sessions/', 'body')    || SecurityRuleResult.REJECTED
     }
 }

--- a/src/main/docs/guide/security/securityRule/interceptUrlMap.adoc
+++ b/src/main/docs/guide/security/securityRule/interceptUrlMap.adoc
@@ -12,9 +12,9 @@ include::{testssecurity}/security/securityRule/intercepturlmap/InterceptUrlMapSp
 As you see in the previous code listing, any endpoint is identified by a combination of pattern
 and an optional HTTP method.
 
-Furthermore it is possible to declare multiple access rules for the an URI pattern. The example below defines that
-all HTTP requests to URIs matching the pattern `/v1/myResource/**` and using HTTP method `OPTIONS` will be accessible to everyone.
-Requests matching the same URI pattern but using a different HTTP method than `OPTIONS` require fully authenticated access.
+If a given request URI matches more than one intercept url map, the one that specifies an http method that matches the request method will be used. If there are multiple mappings that do not specify a method and match the request URI, then the first mapping will be used. For example:
+
+The example below defines that all HTTP requests to URIs matching the pattern `/v1/myResource/**` and using HTTP method `GET` will be accessible to everyone. Requests matching the same URI pattern but using a different HTTP method than `GET` require fully authenticated access.
 
 [source, yaml]
 ----
@@ -23,12 +23,12 @@ micronaut:
     enabled: true
     intercept-url-map:
       - pattern: /v1/myResource/**
-        httpMethod: OPTIONS // <1>
+        httpMethod: GET // <1>
         access:
           - isAnonymous()
       - pattern: /v1/myResource/**
         access:
           - isAuthenticated() // <2>
 ----
-<1> allow anonymous access to this path when accessing with HTTP method `OPTIONS`.
-<2> all other requests have to be fully authenticated for that path.
+<1> Accessing `/v1/myResource/**` with a GET request does not require authentication.
+<2> Accessing `/v1/myResource/**` with a request that isn't GET requires authentication.

--- a/src/main/docs/guide/security/securityRule/interceptUrlMap.adoc
+++ b/src/main/docs/guide/security/securityRule/interceptUrlMap.adoc
@@ -10,4 +10,25 @@ include::{testssecurity}/security/securityRule/intercepturlmap/InterceptUrlMapSp
 <3> Enable access for users who are granted any of the specified roles.
 
 As you see in the previous code listing, any endpoint is identified by a combination of pattern
-and an optional HTTP Method
+and an optional HTTP method.
+
+Furthermore it is possible to declare multiple access rules for the an URI pattern. The example below defines that
+all HTTP requests to URIs matching the pattern `/v1/myResource/**` and using HTTP method `OPTIONS` will be accessible to everyone.
+Requests matching the same URI pattern but using a different HTTP method than `OPTIONS` require fully authenticated access.
+
+[source, yaml]
+----
+micronaut:
+  security:
+    enabled: true
+    intercept-url-map:
+      - pattern: /v1/myResource/**
+        httpMethod: OPTIONS // <1>
+        access:
+          - isAnonymous()
+      - pattern: /v1/myResource/**
+        access:
+          - isAuthenticated() // <2>
+----
+<1> allow anonymous access to this path when accessing with HTTP method `OPTIONS`.
+<2> all other requests have to be fully authenticated for that path.


### PR DESCRIPTION
This PR fixes #1511 by first trying to find  url rules that **exactly match** the http **request method** and the **uri pattern**. 
If there is no match the code falls back to the original behaviour by finding by uri pattern.