### PR TITLE
Fixes configBuilder visitor for private fields with public getters

### DIFF
--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/InjectTransform.groovy
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/InjectTransform.groovy
@@ -962,10 +962,10 @@ class InjectTransform implements ASTTransformation, CompilationUnitAware {
                         if (isConfigurationProperties && fieldAnnotationMetadata.hasStereotype(ConfigurationBuilder.class)) {
                             if(isPrivate) {
                                 // Using the field would throw a IllegalAccessError, use the method instead
-                                String fieldGetterName = NameUtils.getterNameFor(fieldNode.name, fieldType == Boolean)
-                                Optional<MethodNode> getterMethod = Optional.ofNullable(declaringClass.methods?.find { it.name == fieldGetterName})
-                                if(getterMethod.isPresent()) {
-                                    getBeanWriter().visitConfigBuilderMethod(fieldType, getterMethod.get().name, fieldAnnotationMetadata, configurationMetadataBuilder)
+                                String fieldGetterName = NameUtils.getterNameFor(fieldNode.name)
+                                MethodNode getterMethod = declaringClass.methods?.find { it.name == fieldGetterName}
+                                if(getterMethod != null) {
+                                    getBeanWriter().visitConfigBuilderMethod(fieldType, getterMethod.name, fieldAnnotationMetadata, configurationMetadataBuilder)
                                 } else {
                                     addError("ConfigurationBuilder applied to a private field must have a corresponding non-private getter method.", fieldNode)
                                 }

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/configuration/Engine.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/configuration/Engine.groovy
@@ -1,0 +1,30 @@
+package io.micronaut.inject.configuration
+
+public class Engine {
+    private final String manufacturer
+
+    public Engine(String manufacturer) {
+        this.manufacturer = manufacturer
+    }
+
+    public String getManufacturer() {
+        return manufacturer
+    }
+
+    static Builder builder() {
+        return new Builder()
+    }
+
+    public static final class Builder {
+        private String manufacturer = "Ford"
+
+        public Builder withManufacturer(String manufacturer) {
+            this.manufacturer = manufacturer
+            return this
+        }
+
+        Engine build() {
+            return new Engine(manufacturer)
+        }
+    }
+}

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/configuration/GroovyConfigBuilderSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/configuration/GroovyConfigBuilderSpec.groovy
@@ -1,0 +1,118 @@
+package io.micronaut.inject.configuration
+
+import io.micronaut.AbstractBeanDefinitionSpec
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.env.PropertySource
+import org.codehaus.groovy.GroovyBugError
+import org.codehaus.groovy.control.MultipleCompilationErrorsException
+
+class GroovyConfigBuilderSpec extends AbstractBeanDefinitionSpec {
+
+    void "test definition uses getter instead of field"() {
+        given:
+        ApplicationContext ctx = buildContext("test.TestProps", '''
+package test;
+
+import io.micronaut.context.annotation.*;
+
+@ConfigurationProperties("test.props")    
+final class TestProps {
+    @ConfigurationBuilder(prefixes = "with") 
+    private Engine.Builder builder = Engine.builder();
+
+    public final Engine.Builder getBuilder() {
+        return builder;
+    }
+}
+
+class Engine {
+    private final String manufacturer; 
+
+    public Engine(String manufacturer) {
+        this.manufacturer = manufacturer;
+    }
+    
+    public String getManufacturer() {
+        return manufacturer;    
+    }
+    
+    static Builder builder() {
+        return new Builder();
+    }
+
+    static final class Builder {
+        private String manufacturer = "Ford";
+
+        public Builder withManufacturer(String manufacturer) {
+            this.manufacturer = manufacturer;
+            return this;
+        }
+
+        Engine build() {
+            return new Engine(manufacturer);
+        }
+    }
+}
+''')
+        ctx.getEnvironment().addPropertySource(PropertySource.of(["test.props.manufacturer": "Toyota"]))
+
+        when:
+        Class testProps = ctx.classLoader.loadClass("test.TestProps")
+        def testPropBean = ctx.getBean(testProps)
+
+        then:
+        noExceptionThrown()
+        ctx.getProperty("test.props.manufacturer", String).get() == "Toyota"
+        testPropBean.getBuilder().build().getManufacturer() == "Toyota"
+    }
+
+    void "test private config field with no getter throws an error"() {
+        when:
+        ApplicationContext ctx = buildContext("test.TestProps", '''
+package test;
+
+import io.micronaut.context.annotation.*;
+
+@ConfigurationProperties("test.props")    
+final class TestProps {
+    @ConfigurationBuilder(prefixes = "with") 
+    private Engine.Builder builder = Engine.builder();
+}
+
+class Engine {
+    private final String manufacturer; 
+
+    public Engine(String manufacturer) {
+        this.manufacturer = manufacturer;
+    }
+    
+    public String getManufacturer() {
+        return manufacturer;    
+    }
+    
+    static Builder builder() {
+        return new Builder();
+    }
+
+    static final class Builder {
+        private String manufacturer = "Ford";
+
+        public Builder withManufacturer(String manufacturer) {
+            this.manufacturer = manufacturer;
+            return this;
+        }
+
+        Engine build() {
+            return new Engine(manufacturer);
+        }
+    }
+}
+''')
+
+        then:
+        MultipleCompilationErrorsException ex = thrown()
+        ex.message.contains("ConfigurationBuilder applied to a private field must have a corresponding non-private getter method.")
+        ex.message.contains("@ConfigurationBuilder(prefixes = \"with\")")
+
+    }
+}

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -614,7 +614,7 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                 if (methodAnnotationMetadata.hasStereotype(ConfigurationBuilder.class)) {
                     writer.visitConfigBuilderMethod(
                             fieldType,
-                            NameUtils.getterNameFor(parameter.getSimpleName().toString()),
+                            NameUtils.getterNameFor(NameUtils.getPropertyNameForSetter(method.getSimpleName().toString())),
                             methodAnnotationMetadata,
                             metadataBuilder);
                     try {

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -1411,13 +1411,13 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
 
                 String fieldName = field.getSimpleName().toString();
                 if (fieldAnnotationMetadata.hasStereotype(ConfigurationBuilder.class)) {
-                    if(modelUtils.isPrivate(field)) {
+                    if (modelUtils.isPrivate(field)) {
                         // Using the field would throw a IllegalAccessError, use the method instead
                         Optional<ExecutableElement> getterMethod = modelUtils.findGetterMethodFor(field);
-                        if(getterMethod.isPresent()) {
+                        if (getterMethod.isPresent()) {
                             writer.visitConfigBuilderMethod(fieldType, getterMethod.get().getSimpleName().toString(), fieldAnnotationMetadata, metadataBuilder);
                         } else {
-                            error(field,"ConfigurationBuilder applied to a private field must have a corresponding non-private getter method.");
+                            error(field, "ConfigurationBuilder applied to a private field must have a corresponding non-private getter method.");
                         }
                     } else {
                         writer.visitConfigBuilderField(fieldType, fieldName, fieldAnnotationMetadata, metadataBuilder);

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/ModelUtils.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/ModelUtils.java
@@ -114,6 +114,39 @@ public class ModelUtils {
      * @param field The field
      * @return An optional setter method
      */
+    Optional<ExecutableElement> findGetterMethodFor(Element field) {
+        String getterName = getterNameFor(field);
+        // FIXME refine this to discover one of possible overloaded methods with correct signature (i.e. single arg of field type)
+        TypeElement typeElement = classElementFor(field);
+        if (typeElement == null) {
+            return Optional.empty();
+        }
+
+        List<? extends Element> elements = typeElement.getEnclosedElements();
+        List<ExecutableElement> methods = ElementFilter.methodsIn(elements);
+        return methods.stream()
+                .filter(method -> {
+                    String methodName = method.getSimpleName().toString();
+                    if (getterName.equals(methodName)) {
+                        Set<Modifier> modifiers = method.getModifiers();
+                        return
+                                // it's not static
+                                !modifiers.contains(STATIC)
+                                        // it's either public or package visibility
+                                        && modifiers.contains(PUBLIC)
+                                        || !(modifiers.contains(PRIVATE) || modifiers.contains(PROTECTED));
+                    }
+                    return false;
+                })
+                .findFirst();
+    }
+
+    /**
+     * Resolves a setter method for a field.
+     *
+     * @param field The field
+     * @return An optional setter method
+     */
     Optional<ExecutableElement> findSetterMethodFor(Element field) {
         String name = field.getSimpleName().toString();
         if (field.asType().getKind() == TypeKind.BOOLEAN) {
@@ -145,6 +178,20 @@ public class ModelUtils {
                 return false;
             })
             .findFirst();
+    }
+
+    /**
+     * The name of a getter for the given field.
+     *
+     * @param field The field in question
+     * @return The getter name
+     */
+    String getterNameFor(Element field) {
+        String methodNamePrefix = "get";
+        if (field.asType().getKind() == TypeKind.BOOLEAN) {
+            methodNamePrefix = "is";
+        }
+        return methodNamePrefix + NameUtils.capitalize(field.getSimpleName().toString());
     }
 
     /**

--- a/inject-java/src/test/groovy/io/micronaut/inject/configuration/ConfigurationBuilderSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configuration/ConfigurationBuilderSpec.groovy
@@ -1,0 +1,116 @@
+package io.micronaut.inject.configuration
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.env.PropertySource
+import io.micronaut.inject.AbstractTypeElementSpec
+
+class ConfigurationBuilderSpec extends AbstractTypeElementSpec {
+
+    void "test definition uses getter instead of field"() {
+        given:
+        ApplicationContext ctx = buildContext("test.TestProps", '''
+package test;
+
+import io.micronaut.context.annotation.*;
+
+@ConfigurationProperties("test.props")    
+final class TestProps {
+    @ConfigurationBuilder(prefixes = "with") 
+    private Engine.Builder builder = Engine.builder();
+
+    public final Engine.Builder getBuilder() {
+        return builder;
+    }
+}
+
+class Engine {
+    private final String manufacturer; 
+
+    public Engine(String manufacturer) {
+        this.manufacturer = manufacturer;
+    }
+    
+    public String getManufacturer() {
+        return manufacturer;    
+    }
+    
+    static Builder builder() {
+        return new Builder();
+    }
+
+    static final class Builder {
+        private String manufacturer = "Ford";
+
+        public Builder withManufacturer(String manufacturer) {
+            this.manufacturer = manufacturer;
+            return this;
+        }
+
+        Engine build() {
+            return new Engine(manufacturer);
+        }
+    }
+}
+''')
+        ctx.getEnvironment().addPropertySource(PropertySource.of(["test.props.manufacturer": "Toyota"]))
+
+        when:
+        Class testProps = ctx.classLoader.loadClass("test.TestProps")
+        def testPropBean = ctx.getBean(testProps)
+
+        then:
+        noExceptionThrown()
+        ctx.getProperty("test.props.manufacturer", String).get() == "Toyota"
+        testPropBean.getBuilder().build().getManufacturer() == "Toyota"
+    }
+
+    void "test private config field with no getter throws an error"() {
+        when:
+        ApplicationContext ctx = buildContext("test.TestProps", '''
+package test;
+
+import io.micronaut.context.annotation.*;
+
+@ConfigurationProperties("test.props")    
+final class TestProps {
+    @ConfigurationBuilder(prefixes = "with") 
+    private Engine.Builder builder = Engine.builder();
+}
+
+class Engine {
+    private final String manufacturer; 
+
+    public Engine(String manufacturer) {
+        this.manufacturer = manufacturer;
+    }
+    
+    public String getManufacturer() {
+        return manufacturer;    
+    }
+    
+    static Builder builder() {
+        return new Builder();
+    }
+
+    static final class Builder {
+        private String manufacturer = "Ford";
+
+        public Builder withManufacturer(String manufacturer) {
+            this.manufacturer = manufacturer;
+            return this;
+        }
+
+        Engine build() {
+            return new Engine(manufacturer);
+        }
+    }
+}
+''')
+
+        then:
+        RuntimeException ex = thrown()
+        ex.message.contains("ConfigurationBuilder applied to a private field must have a corresponding non-private getter method.")
+        ex.message.contains("private Engine.Builder builder = Engine.builder();")
+
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/configuration/ConfigurationBuilderSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configuration/ConfigurationBuilderSpec.groovy
@@ -12,6 +12,7 @@ class ConfigurationBuilderSpec extends AbstractTypeElementSpec {
 package test;
 
 import io.micronaut.context.annotation.*;
+import io.micronaut.inject.configuration.Engine;
 
 @ConfigurationProperties("test.props")    
 final class TestProps {
@@ -20,35 +21,6 @@ final class TestProps {
 
     public final Engine.Builder getBuilder() {
         return builder;
-    }
-}
-
-class Engine {
-    private final String manufacturer; 
-
-    public Engine(String manufacturer) {
-        this.manufacturer = manufacturer;
-    }
-    
-    public String getManufacturer() {
-        return manufacturer;    
-    }
-    
-    static Builder builder() {
-        return new Builder();
-    }
-
-    static final class Builder {
-        private String manufacturer = "Ford";
-
-        public Builder withManufacturer(String manufacturer) {
-            this.manufacturer = manufacturer;
-            return this;
-        }
-
-        Engine build() {
-            return new Engine(manufacturer);
-        }
     }
 }
 ''')
@@ -70,40 +42,12 @@ class Engine {
 package test;
 
 import io.micronaut.context.annotation.*;
+import io.micronaut.inject.configuration.Engine;
 
 @ConfigurationProperties("test.props")    
 final class TestProps {
     @ConfigurationBuilder(prefixes = "with") 
     private Engine.Builder builder = Engine.builder();
-}
-
-class Engine {
-    private final String manufacturer; 
-
-    public Engine(String manufacturer) {
-        this.manufacturer = manufacturer;
-    }
-    
-    public String getManufacturer() {
-        return manufacturer;    
-    }
-    
-    static Builder builder() {
-        return new Builder();
-    }
-
-    static final class Builder {
-        private String manufacturer = "Ford";
-
-        public Builder withManufacturer(String manufacturer) {
-            this.manufacturer = manufacturer;
-            return this;
-        }
-
-        Engine build() {
-            return new Engine(manufacturer);
-        }
-    }
 }
 ''')
 
@@ -111,6 +55,41 @@ class Engine {
         RuntimeException ex = thrown()
         ex.message.contains("ConfigurationBuilder applied to a private field must have a corresponding non-private getter method.")
         ex.message.contains("private Engine.Builder builder = Engine.builder();")
+
+    }
+
+    void "test config field with setter abnormal paramater name"() {
+        given:
+        ApplicationContext ctx = buildContext("test.TestProps", '''
+package test;
+
+import io.micronaut.context.annotation.*;
+import io.micronaut.inject.configuration.Engine;
+
+@ConfigurationProperties("test.props")    
+final class TestProps { 
+    Engine.Builder builder = Engine.builder();
+    
+    Engine.Builder getBuilder() {
+        return this.builder;
+    }
+    
+    @ConfigurationBuilder(prefixes = "with")
+    void setBuilder(Engine.Builder p0) {
+        this.builder = p0;
+    }
+}
+''')
+        ctx.getEnvironment().addPropertySource(PropertySource.of(["test.props.manufacturer": "Toyota"]))
+
+        when:
+        Class testProps = ctx.classLoader.loadClass("test.TestProps")
+        def testPropBean = ctx.getBean(testProps)
+
+        then:
+        noExceptionThrown()
+        ctx.getProperty("test.props.manufacturer", String).get() == "Toyota"
+        testPropBean.getBuilder().build().getManufacturer() == "Toyota"
 
     }
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/configuration/Engine.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configuration/Engine.java
@@ -1,0 +1,30 @@
+package io.micronaut.inject.configuration;
+
+public class Engine {
+    private final String manufacturer;
+
+    public Engine(String manufacturer) {
+        this.manufacturer = manufacturer;
+    }
+
+    public String getManufacturer() {
+        return manufacturer;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private String manufacturer = "Ford";
+
+        public Builder withManufacturer(String manufacturer) {
+            this.manufacturer = manufacturer;
+            return this;
+        }
+
+        public Engine build() {
+            return new Engine(manufacturer);
+        }
+    }
+}


### PR DESCRIPTION
In working on #1265 I encountered an IllegalAccessorError caused by the AnnotationProcessor utilizing a private field when a public getter was the preferred accessor. @jameskleeh and I walked through reproducing the error (via the new ConfigurationBuilderSpec) and we were able to solve the bug.