### PR TITLE
Update DefaultConversionService.java

### DIFF
--- a/core/src/main/java/io/micronaut/core/convert/DefaultConversionService.java
+++ b/core/src/main/java/io/micronaut/core/convert/DefaultConversionService.java
@@ -832,7 +832,7 @@ public class DefaultConversionService implements ConversionService<DefaultConver
                 ConvertiblePair pair = new ConvertiblePair(sourceSuperType, targetSuperType, formattingAnnotation);
                 typeConverter = typeConverters.get(pair);
                 if (typeConverter == null && hasFormatting) {
-                    ConvertiblePair pair = new ConvertiblePair(sourceSuperType, targetSuperType);
+                    pair = new ConvertiblePair(sourceSuperType, targetSuperType);
                     typeConverter = typeConverters.get(pair);
                 }
 

--- a/core/src/main/java/io/micronaut/core/convert/DefaultConversionService.java
+++ b/core/src/main/java/io/micronaut/core/convert/DefaultConversionService.java
@@ -831,21 +831,14 @@ public class DefaultConversionService implements ConversionService<DefaultConver
             for (Class targetSuperType : targetHierarchy) {
                 ConvertiblePair pair = new ConvertiblePair(sourceSuperType, targetSuperType, formattingAnnotation);
                 typeConverter = typeConverters.get(pair);
+                if (typeConverter == null && hasFormatting) {
+                    ConvertiblePair pair = new ConvertiblePair(sourceSuperType, targetSuperType);
+                    typeConverter = typeConverters.get(pair);
+                }
+
                 if (typeConverter != null) {
                     converterCache.put(pair, typeConverter);
                     return typeConverter;
-                }
-            }
-        }
-        if (hasFormatting) {
-            for (Class sourceSuperType : sourceHierarchy) {
-                for (Class targetSuperType : targetHierarchy) {
-                    ConvertiblePair pair = new ConvertiblePair(sourceSuperType, targetSuperType);
-                    typeConverter = typeConverters.get(pair);
-                    if (typeConverter != null) {
-                        converterCache.put(pair, typeConverter);
-                        return typeConverter;
-                    }
                 }
             }
         }


### PR DESCRIPTION
Removing repetitive code.

The changes are not valid when `typeConverter` with `formattingAnnotation` should be evaluated before `typeConverter` without `formattingAnnotation`.