### PR TITLE
Add gradle-versions-plugin to discover dependencies updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ buildscript {
 
 plugins {
     id 'com.github.hierynomus.license' version '0.15.0' apply false
-	id 'com.github.ben-manes.versions' version '0.21.0'
+    id 'com.github.ben-manes.versions' version '0.21.0'
 }
 
 apply plugin: "io.sdkman.vendors"

--- a/build.gradle
+++ b/build.gradle
@@ -770,14 +770,14 @@ htmlSanityCheck {
 docs.finalizedBy(htmlSanityCheck)
 
 dependencyUpdates.resolutionStrategy {
-	componentSelection { rules ->
-		rules.all { ComponentSelection selection ->
-			boolean rejected = ['alpha', 'beta', 'rc', 'cr', 'm', 'preview', 'b', 'ea'].any { qualifier ->
-				selection.candidate.version ==~ /(?i).*[.-]$qualifier[.\d-+]*/
-			}
-			if (rejected) {
-				selection.reject('Release candidate')
-			}
-		}
-	}
+    componentSelection { rules ->
+        rules.all { ComponentSelection selection ->
+            boolean rejected = ['alpha', 'beta', 'rc', 'cr', 'm', 'preview', 'b', 'ea'].any { qualifier ->
+                selection.candidate.version ==~ /(?i).*[.-]$qualifier[.\d-+]*/
+            }
+            if (rejected) {
+                selection.reject('Release candidate')
+            }
+        }
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ buildscript {
 
 plugins {
     id 'com.github.hierynomus.license' version '0.15.0' apply false
+	id 'com.github.ben-manes.versions' version '0.21.0'
 }
 
 apply plugin: "io.sdkman.vendors"
@@ -767,3 +768,16 @@ htmlSanityCheck {
 
 }
 docs.finalizedBy(htmlSanityCheck)
+
+dependencyUpdates.resolutionStrategy {
+	componentSelection { rules ->
+		rules.all { ComponentSelection selection ->
+			boolean rejected = ['alpha', 'beta', 'rc', 'cr', 'm', 'preview', 'b', 'ea'].any { qualifier ->
+				selection.candidate.version ==~ /(?i).*[.-]$qualifier[.\d-+]*/
+			}
+			if (rejected) {
+				selection.reject('Release candidate')
+			}
+		}
+	}
+}


### PR DESCRIPTION
This plugin provides a task to determine which dependencies have updates.
Additionally, the plugin checks for updates to Gradle itself. It has been
configured to disallow release candidates as upgradable versions.

More info available at:
https://github.com/ben-manes/gradle-versions-plugin

#gh-1079