### PR TITLE
Add support for Oracle Cloud hosting environment

### DIFF
--- a/discovery-client/src/test/groovy/io/micronaut/discovery/cloud/OracleCloudMetadataResolverSpec.groovy
+++ b/discovery-client/src/test/groovy/io/micronaut/discovery/cloud/OracleCloudMetadataResolverSpec.groovy
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.discovery.cloud
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.micronaut.context.env.ComputePlatform
+import io.micronaut.context.env.Environment
+import io.micronaut.discovery.cloud.oraclecloud.OracleCloudInstanceMetadata
+import io.micronaut.discovery.cloud.oraclecloud.OracleCloudMetadataConfiguration
+import io.micronaut.discovery.cloud.oraclecloud.OracleCloudMetadataResolver
+import io.micronaut.discovery.cloud.oraclecloud.OracleCloudNetworkInterface
+import spock.lang.Specification
+
+import java.nio.file.Paths
+
+class OracleCloudMetadataResolverSpec extends Specification {
+
+    void "test building oracle cloud compute metadata"() {
+        given:
+        Environment environment = Mock(Environment)
+        OracleCloudMetadataResolver resolver = buildResolver()
+        Optional<OracleCloudInstanceMetadata> computeInstanceMetadata = resolver.resolve(environment) as Optional<OracleCloudInstanceMetadata>
+
+        expect:
+        computeInstanceMetadata.isPresent()
+        computeInstanceMetadata.get().computePlatform == ComputePlatform.ORACLE_CLOUD
+        computeInstanceMetadata.get().instanceId == "ocid1.instance.oc1.phx.abyhqljrg2v5zuydab6r5nbsywedkjvtwd57opwmuhfc5hg5jrxgs3jmg3ga"
+        computeInstanceMetadata.get().name == "micronaut-env"
+        computeInstanceMetadata.get().region == "us-phoenix-1"
+    }
+
+
+    private OracleCloudMetadataResolver buildResolver() {
+        def configuration = new OracleCloudMetadataConfiguration()
+        String currentPath = Paths.get("").toAbsolutePath().toString()
+        configuration.url = "file:///${currentPath}/src/test/groovy/io/micronaut/discovery/cloud/oracleCloudInstanceMetadata.json"
+
+        return new OracleCloudMetadataResolver(new ObjectMapper(), configuration)
+    }
+}

--- a/discovery-client/src/test/groovy/io/micronaut/discovery/cloud/oracleCloudInstanceMetadata.json
+++ b/discovery-client/src/test/groovy/io/micronaut/discovery/cloud/oracleCloudInstanceMetadata.json
@@ -7,7 +7,7 @@
   "image" : "ocid1.image.oc1.phx.aaaaaaaapxvrtwbpgy3lchk2usn462ekarljwg4zou2acmundxlkzdty4bjq",
   "metadata" : {
     "ssh_authorized_keys" : "ssh-rsa redacted",
-    "user_data" : "dW5kZWZpbmVk"
+    "user_data" : "redacted"
   },
   "region" : "phx",
   "canonicalRegionName" : "us-phoenix-1",

--- a/discovery-client/src/test/groovy/io/micronaut/discovery/cloud/oracleCloudInstanceMetadata.json
+++ b/discovery-client/src/test/groovy/io/micronaut/discovery/cloud/oracleCloudInstanceMetadata.json
@@ -1,0 +1,20 @@
+{
+  "availabilityDomain" : "odti:PHX-AD-1",
+  "faultDomain" : "FAULT-DOMAIN-2",
+  "compartmentId" : "ocid1.compartment.oc1..aaaaaaaa7lzppsdxt6j56zhpvy6u5gyrenwyc2e2h4fak5ydvv6kt7anizbq",
+  "displayName" : "micronaut-env",
+  "id" : "ocid1.instance.oc1.phx.abyhqljrg2v5zuydab6r5nbsywedkjvtwd57opwmuhfc5hg5jrxgs3jmg3ga",
+  "image" : "ocid1.image.oc1.phx.aaaaaaaapxvrtwbpgy3lchk2usn462ekarljwg4zou2acmundxlkzdty4bjq",
+  "metadata" : {
+    "ssh_authorized_keys" : "ssh-rsa redacted",
+    "user_data" : "dW5kZWZpbmVk"
+  },
+  "region" : "phx",
+  "canonicalRegionName" : "us-phoenix-1",
+  "shape" : "VM.Standard2.1",
+  "state" : "Running",
+  "timeCreated" : 1555331099543,
+  "agentConfig" : {
+    "monitoringDisabled" : false
+  }
+}

--- a/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
+++ b/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
@@ -74,6 +74,7 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
     private static final int DEFAULT_READ_TIMEOUT = 500;
     private static final int DEFAULT_CONNECT_TIMEOUT = 500;
     private static final String GOOGLE_COMPUTE_METADATA = "http://metadata.google.internal";
+    private static final String ORACLE_CLOUD_METADATA = "http://169.254.169.254/opc/v1/instance/";
     private static final String DO_SYS_VENDOR_FILE = "/sys/devices/virtual/dmi/id/sys_vendor";
     private static final Boolean DEDUCE_ENVIRONMENT_DEFAULT = true;
 
@@ -698,6 +699,10 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
                                 environments.add(AMAZON_EC2);
                                 environments.add(Environment.CLOUD);
                                 break;
+                            case ORACLE_CLOUD:
+                                environments.add(ORACLE_CLOUD);
+                                environments.add(Environment.CLOUD);
+                                break;
                             case AZURE:
                                 // not yet implemented
                                 environments.add(AZURE);
@@ -807,6 +812,10 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
             return ComputePlatform.GOOGLE_COMPUTE;
         }
 
+        if (isOracleCloud()) {
+            return ComputePlatform.ORACLE_CLOUD;
+        }
+
         if (isDigitalOcean()) {
             return ComputePlatform.DIGITAL_OCEAN;
         }
@@ -841,6 +850,21 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
 
         } catch (IOException e) {
             // well not google then
+        }
+        return false;
+    }
+
+    @SuppressWarnings("MagicNumber")
+    private static boolean isOracleCloud() {
+        try {
+            final HttpURLConnection con = createConnection(ORACLE_CLOUD_METADATA);
+            con.setRequestMethod("GET");
+            con.setDoOutput(true);
+            int responseCode = con.getResponseCode();
+            return responseCode == 200;
+
+        } catch (IOException e) {
+            // well not oracle then
         }
         return false;
     }

--- a/inject/src/main/java/io/micronaut/context/env/Environment.java
+++ b/inject/src/main/java/io/micronaut/context/env/Environment.java
@@ -146,6 +146,12 @@ public interface Environment extends PropertyResolver, LifeCycle<Environment>, C
     /**
      * Cloud provider Digital Ocean.
      */
+    String ORACLE_CLOUD = "oraclecloud";
+
+    /**
+     * Cloud provider Digital Ocean.
+     */
+
     String DIGITAL_OCEAN = "digitalocean";
     /**
      * Cloud or non cloud provider on bare metal (unknown).

--- a/runtime/src/main/java/io/micronaut/discovery/cloud/oraclecloud/OracleCloudInstanceMetadata.java
+++ b/runtime/src/main/java/io/micronaut/discovery/cloud/oraclecloud/OracleCloudInstanceMetadata.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.discovery.cloud.oraclecloud;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.micronaut.context.env.ComputePlatform;
+import io.micronaut.discovery.cloud.AbstractComputeInstanceMetadata;
+
+/**
+ * Represents {@link io.micronaut.discovery.cloud.ComputeInstanceMetadata} for Oracle Cloud.
+ *
+ * @author Todd Sharp
+ * @since 1.2
+ */
+public class OracleCloudInstanceMetadata extends AbstractComputeInstanceMetadata {
+
+    private final ComputePlatform computePlatform = ComputePlatform.ORACLE_CLOUD;
+
+    @Override
+    @JsonIgnore
+    public ComputePlatform getComputePlatform() {
+        return computePlatform;
+    }
+}

--- a/runtime/src/main/java/io/micronaut/discovery/cloud/oraclecloud/OracleCloudMetadataConfiguration.java
+++ b/runtime/src/main/java/io/micronaut/discovery/cloud/oraclecloud/OracleCloudMetadataConfiguration.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.discovery.cloud.oraclecloud;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.env.Environment;
+import io.micronaut.core.util.Toggleable;
+import io.micronaut.runtime.ApplicationConfiguration;
+
+/**
+ * Default configuration for retrieving Oracle Cloud metadata for {@link io.micronaut.context.env.ComputePlatform#ORACLE_CLOUD}.
+ *
+ * @author Todd Sharp
+ * @since 1.2
+ */
+@ConfigurationProperties(OracleCloudMetadataConfiguration.PREFIX)
+@Requires(env = Environment.ORACLE_CLOUD)
+public class OracleCloudMetadataConfiguration implements Toggleable {
+
+    /**
+     * Prefix for Oracle Cloud configuration metadata.
+     */
+    public static final String PREFIX = ApplicationConfiguration.PREFIX + "." + Environment.ORACLE_CLOUD + ".metadata";
+
+    /**
+     * The default enable value.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static final boolean DEFAULT_ENABLED = true;
+
+    /**
+     * The default url value.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static final String DEFAULT_URL = "http://169.254.169.254/opc/v1/instance/";
+
+    private String url = DEFAULT_URL;
+    private String metadataUrl;
+    private String instanceDocumentUrl;
+    private boolean enabled = DEFAULT_ENABLED;
+
+    /**
+     * @return Whether the Oracle Cloud configuration is enabled
+     */
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Default value ({@value #DEFAULT_ENABLED}).
+     * @param enabled Enable or disable the Oracle Cloud configuration
+     */
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    /**
+     * @return The Url
+     */
+    public String getUrl() {
+        return url;
+    }
+
+    /**
+     * Default value ({@value #DEFAULT_URL}).
+     * @param url The url
+     */
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    /**
+     * @return The metadata Url
+     */
+    public String getMetadataUrl() {
+        return url;
+    }
+
+    /**
+     * @param metadataUrl The metadata Url
+     */
+    public void setMetadataUrl(String metadataUrl) {
+        this.metadataUrl = metadataUrl;
+    }
+
+    /**
+     * @return The instance document Url
+     */
+    public String getInstanceDocumentUrl() {
+        return url;
+    }
+
+    /**
+     * @param instanceDocumentUrl The instance document Url
+     */
+    public void setInstanceDocumentUrl(String instanceDocumentUrl) {
+        this.instanceDocumentUrl = instanceDocumentUrl;
+    }
+}

--- a/runtime/src/main/java/io/micronaut/discovery/cloud/oraclecloud/OracleCloudMetadataKeys.java
+++ b/runtime/src/main/java/io/micronaut/discovery/cloud/oraclecloud/OracleCloudMetadataKeys.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.discovery.cloud.oraclecloud;
+
+/**
+ * Models common Oracle Cloud compute instance metadata keys.
+ *
+ * @author Todd Sharp
+ * @since 1.2
+ */
+public enum OracleCloudMetadataKeys {
+
+    AVAILABILITY_DOMAIN("availabilityDomain"),
+    FAULT_DOMAIN("faultDomain"),
+    ID("id"),
+    COMPARTMENT_ID("compartmentId"),
+    DISPLAY_NAME("displayName"),
+    IMAGE("image"),
+    REGION("region"),
+    CANONICAL_REGION_NAME("canonicalRegionName"),
+    SHAPE("shape"),
+    STATE("state"),
+    AGENT_CONFIG("agentConfig"),
+    MONITORING_DISABLED("monitoringDisabled"),
+    USER_METADATA("metadata"),
+    TIME_CREATED("timeCreated");
+
+    private final String name;
+
+    /**
+     * @param name The name of the metadata key represented in Oracle Cloud Metadata.
+     */
+    OracleCloudMetadataKeys(String name) {
+        this.name = name;
+    }
+
+    /**
+     * @return The name of the metadata key represented in Oracle Cloud Metadata.
+     */
+    public String getName() {
+        return name;
+    }
+}

--- a/runtime/src/main/java/io/micronaut/discovery/cloud/oraclecloud/OracleCloudMetadataResolver.java
+++ b/runtime/src/main/java/io/micronaut/discovery/cloud/oraclecloud/OracleCloudMetadataResolver.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.discovery.cloud.oraclecloud;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.env.Environment;
+import io.micronaut.discovery.cloud.ComputeInstanceMetadata;
+import io.micronaut.discovery.cloud.ComputeInstanceMetadataResolver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.*;
+
+import static io.micronaut.discovery.cloud.ComputeInstanceMetadataResolverUtils.populateMetadata;
+import static io.micronaut.discovery.cloud.ComputeInstanceMetadataResolverUtils.readMetadataUrl;
+import static io.micronaut.discovery.cloud.oraclecloud.OracleCloudMetadataKeys.*;
+
+/**
+ * Resolves {@link ComputeInstanceMetadata} for Oracle Cloud.
+ *
+ * @author Todd Sharp
+ * @since 1.2
+ */
+@Singleton
+@Requires(env = Environment.ORACLE_CLOUD)
+public class OracleCloudMetadataResolver implements ComputeInstanceMetadataResolver {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OracleCloudMetadataResolver.class);
+    private static final int READ_TIMEOUT_IN_MILLS = 5000;
+    private static final int CONNECTION_TIMEOUT_IN_MILLS = 5000;
+
+    private final ObjectMapper objectMapper;
+    private final OracleCloudMetadataConfiguration configuration;
+    private OracleCloudInstanceMetadata cachedMetadata;
+
+    /**
+     *
+     * @param objectMapper To read and write JSON
+     * @param configuration Oracle Cloud Metadata configuration
+     */
+    @Inject
+    public OracleCloudMetadataResolver(ObjectMapper objectMapper, OracleCloudMetadataConfiguration configuration) {
+        this.objectMapper = objectMapper;
+        this.configuration = configuration;
+    }
+
+    /**
+     * Construct with default settings.
+     */
+    public OracleCloudMetadataResolver() {
+        objectMapper = new ObjectMapper();
+        configuration = new OracleCloudMetadataConfiguration();
+    }
+
+    @Override
+    public Optional<ComputeInstanceMetadata> resolve(Environment environment) {
+        if (!configuration.isEnabled()) {
+            return Optional.empty();
+        }
+        if (cachedMetadata != null) {
+            cachedMetadata.setCached(true);
+            return Optional.of(cachedMetadata);
+        }
+
+        OracleCloudInstanceMetadata instanceMetadata = new OracleCloudInstanceMetadata();
+
+        try {
+            String metadataUrl = configuration.getUrl();
+            JsonNode metadataJson = readMetadataUrl(new URL(metadataUrl), CONNECTION_TIMEOUT_IN_MILLS, READ_TIMEOUT_IN_MILLS, objectMapper, new HashMap<>());
+            if (metadataJson != null) {
+                instanceMetadata.setInstanceId(textValue(metadataJson, ID));
+                instanceMetadata.setName(textValue(metadataJson, DISPLAY_NAME));
+                instanceMetadata.setRegion(textValue(metadataJson, CANONICAL_REGION_NAME));
+                instanceMetadata.setAvailabilityZone(textValue(metadataJson, AVAILABILITY_DOMAIN));
+                instanceMetadata.setImageId(textValue(metadataJson, IMAGE));
+                instanceMetadata.setMachineType(textValue(metadataJson, SHAPE));
+
+                Map<String, String> metadata = objectMapper.convertValue(metadataJson, Map.class);
+
+                JsonNode agentConfig = metadataJson.findValue(AGENT_CONFIG.getName());
+                metadata.put("timeCreated", textValue(metadataJson, TIME_CREATED));
+                metadata.put("monitoringDisabled", textValue(agentConfig, MONITORING_DISABLED));
+                JsonNode userMeta = metadataJson.findValue(USER_METADATA.getName());
+                Iterator<String> userMetaFieldNames = userMeta.fieldNames();
+                userMeta.forEach(userNode -> {
+                    String fieldName = userMetaFieldNames.next();
+                    metadata.put(fieldName, userNode.asText());
+                });
+                // override the 'region' in metadata in favor of canonicalRegionName
+                metadata.put(REGION.getName(), textValue(metadataJson, CANONICAL_REGION_NAME));
+                metadata.put("zone", textValue(metadataJson, AVAILABILITY_DOMAIN));
+
+                populateMetadata(instanceMetadata, metadata);
+                cachedMetadata = instanceMetadata;
+
+                return Optional.of(instanceMetadata);
+            }
+        } catch (MalformedURLException mue) {
+            if (LOG.isErrorEnabled()) {
+                LOG.error("Oracle Cloud metadataUrl value is invalid!: " + configuration.getUrl(), mue);
+            }
+        } catch (IOException ioe) {
+            if (LOG.isErrorEnabled()) {
+                LOG.error("Error connecting to" + configuration.getUrl() + "reading instance metadata", ioe);
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    private String textValue(JsonNode node, OracleCloudMetadataKeys key) {
+        JsonNode value = node.findValue(key.getName());
+        if (value != null) {
+            return value.asText();
+        } else {
+            return null;
+        }
+    }
+
+}

--- a/runtime/src/main/java/io/micronaut/discovery/cloud/oraclecloud/OracleCloudNetworkInterface.java
+++ b/runtime/src/main/java/io/micronaut/discovery/cloud/oraclecloud/OracleCloudNetworkInterface.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.discovery.cloud.oraclecloud;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.discovery.cloud.NetworkInterface;
+
+/**
+ * A {@link NetworkInterface} implementation for Google.
+ *
+ * @author Todd Sharp
+ * @since 1.2
+ */
+@Internal
+class OracleCloudNetworkInterface extends NetworkInterface {
+
+    @Override
+    protected void setIpv4(String ipv4) {
+        super.setIpv4(ipv4);
+    }
+
+    @Override
+    protected void setIpv6(String ipv6) {
+        super.setIpv6(ipv6);
+    }
+
+    @Override
+    protected void setName(String name) {
+        super.setName(name);
+    }
+
+    @Override
+    protected void setMac(String mac) {
+        super.setMac(mac);
+    }
+
+    @Override
+    protected void setId(String id) {
+        super.setId(id);
+    }
+
+    @Override
+    protected void setGateway(String gateway) {
+        super.setGateway(gateway);
+    }
+
+    @Override
+    protected void setNetwork(String network) {
+        super.setNetwork(network);
+    }
+
+    @Override
+    protected void setNetmask(String netmask) {
+        super.setNetmask(netmask);
+    }
+}

--- a/runtime/src/main/java/io/micronaut/discovery/cloud/oraclecloud/package-info.java
+++ b/runtime/src/main/java/io/micronaut/discovery/cloud/oraclecloud/package-info.java
@@ -13,51 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.context.env;
-
 /**
- * @author Ryan Vanderwerf
- * @since 1.0
+ * Oracle cloud configuration.
+ *
+ * @author Todd Sharp
+ * @since 1.2
  */
-public enum ComputePlatform {
+package io.micronaut.discovery.cloud.oraclecloud;
 
-    /**
-     * Google Compute Platform.
-     */
-    GOOGLE_COMPUTE,
-
-    /**
-     * Amazon EC2.
-     */
-    AMAZON_EC2,
-
-    /**
-     * Microsoft Azure.
-     */
-    AZURE,
-
-    /**
-     * Oracle Cloud.
-     */
-    ORACLE_CLOUD,
-
-    /**
-     * Digital Ocean.
-     */
-    DIGITAL_OCEAN,
-
-    /**
-     * Cloud or non cloud provider on bare metal (unknown).
-     */
-    BARE_METAL,
-
-    /**
-     * IBM Cloud.
-     */
-    IBM,
-
-    /**
-     * Other.
-     */
-    OTHER
-}

--- a/src/main/docs/guide/cloud/cloudConfiguration.adoc
+++ b/src/main/docs/guide/cloud/cloudConfiguration.adoc
@@ -65,6 +65,11 @@ The following table summarizes the constants provided by the api:context.env.Env
 |`@Requires(env = Environment.DIGITAL_OCEAN)`
 |`digitalocean`
 
+|api:context.env.Environment#ORACLE_CLOUD[]
+|Running on https://cloud.oracle.com/[Oracle Cloud]
+|`@Requires(env = Environment.ORACLE_CLOUD)`
+|`oraclecloud`
+
 |===
 
 Note that it may be the case that you have multiple active environment names since you may run Kubernetes on AWS for example.
@@ -79,7 +84,7 @@ TIP: Any configuration property in the api:context.env.Environment[] can also be
 
 When Micronaut detects it is running on any of the cloud platforms listed above, such as Google Compute or AWS EC2, upon startup Micronaut will populate the interface api:discovery.cloud.ComputeInstanceMetadata[].
 
-TIP: Depending on the environment you are running in the backing implementation will be either api:io.micronaut.discovery.cloud.gcp.GoogleComputeInstanceMetadata[], api:io.micronaut.discovery.cloud.aws.AmazonEC2InstanceMetadata[] or api:io.micronaut.discovery.cloud.digitalocean.DigitalOceanInstanceMetadata[] with metadata found from the cloud provider metadata services.
+TIP: Depending on the environment you are running in the backing implementation will be either api:io.micronaut.discovery.cloud.gcp.GoogleComputeInstanceMetadata[], api:io.micronaut.discovery.cloud.aws.AmazonEC2InstanceMetadata[],  api:io.micronaut.discovery.cloud.digitalocean.DigitalOceanInstanceMetadata[] or api:io.micronaut.discovery.cloud.oraclecloud.OracleCloudInstanceMetadata[] with metadata found from the cloud provider metadata services.
 
 All of this data is merged together into the `metadata` property for the running api:discovery.ServiceInstance[].
 
@@ -104,16 +109,17 @@ Flowable.fromPublisher(
 ----
 
 
-To obtain metadata for the locally running server use the api:runtime.server.EmbeddedServerInstance[] interface:
-
+To obtain metadata for the locally running server use an <<events,EventListener>> for the api:discovery.event.ServiceStartedEvent[]:
 
 .Obtaining Metadata for a Local Server
 [source,java]
 ----
-EmbeddedServerInstance serverInstance = applicationContext.getBean(EmbeddedServerInstance.class);
-ConvertibleValues<String> metaData = serverInstance.getMetadata();
+@EventListener
+void onServiceStarted(ServiceStartedEvent event) {
+    ServiceInstance serviceInstance = event.getSource()
+    ConvertibleValues<String> metadata = serviceInstance.metadata
+}
 ----
-
 
 
 


### PR DESCRIPTION
This PR adds support for Environment.ORACLE_CLOUD to provide compute instance metadata for Micronaut applications hosted on Oracle Cloud Infrastructure.