### PR TITLE
Allow inner configuration properties of @EachProperty to be singletons

### DIFF
--- a/discovery-client/src/main/java/io/micronaut/discovery/client/DiscoveryClientCacheConfiguration.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/client/DiscoveryClientCacheConfiguration.java
@@ -18,7 +18,6 @@ package io.micronaut.discovery.client;
 import static io.micronaut.discovery.client.DiscoveryClientCacheConfiguration.CACHE_NAME;
 
 import io.micronaut.cache.CacheConfiguration;
-import io.micronaut.cache.DefaultCacheConfiguration;
 import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.util.StringUtils;

--- a/discovery-client/src/main/java/io/micronaut/discovery/client/DiscoveryClientCacheConfiguration.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/client/DiscoveryClientCacheConfiguration.java
@@ -35,9 +35,9 @@ import java.time.Duration;
  * @since 1.0
  */
 @Named(CACHE_NAME)
-@ConfigurationProperties(CACHE_NAME)
+@ConfigurationProperties(CacheConfiguration.PREFIX + "." + CACHE_NAME)
 @Requires(property = DiscoveryClientCacheConfiguration.SETTING_ENABLED, notEquals = StringUtils.FALSE)
-public class DiscoveryClientCacheConfiguration extends DefaultCacheConfiguration implements Toggleable {
+public class DiscoveryClientCacheConfiguration extends CacheConfiguration implements Toggleable {
 
     /**
      * The prefix to use for all discovery client settings.

--- a/http-client/src/main/java/io/micronaut/http/client/ServiceHttpClientConfiguration.java
+++ b/http-client/src/main/java/io/micronaut/http/client/ServiceHttpClientConfiguration.java
@@ -21,6 +21,7 @@ import io.micronaut.context.annotation.Parameter;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.runtime.ApplicationConfiguration;
 
+import javax.annotation.Nullable;
 import java.net.URI;
 import java.time.Duration;
 import java.util.Collections;
@@ -78,11 +79,15 @@ public class ServiceHttpClientConfiguration extends HttpClientConfiguration {
      */
     public ServiceHttpClientConfiguration(
             @Parameter String serviceId,
-            ServiceConnectionPoolConfiguration connectionPoolConfiguration,
+            @Nullable ServiceConnectionPoolConfiguration connectionPoolConfiguration,
             ApplicationConfiguration applicationConfiguration) {
         super(applicationConfiguration);
         this.serviceId = serviceId;
-        this.connectionPoolConfiguration = connectionPoolConfiguration;
+        if (connectionPoolConfiguration != null) {
+            this.connectionPoolConfiguration = connectionPoolConfiguration;
+        } else {
+            this.connectionPoolConfiguration = new ServiceConnectionPoolConfiguration();
+        }
     }
 
     /**

--- a/http-client/src/test/groovy/io/micronaut/http/client/services/ManualHttpServiceDefinitionSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/services/ManualHttpServiceDefinitionSpec.groovy
@@ -50,7 +50,7 @@ class ManualHttpServiceDefinitionSpec extends Specification {
                 'micronaut.http.services.bar.health-check':true,
                 'micronaut.http.services.bar.health-check-interval':'100ms',
                 'micronaut.http.services.bar.read-timeout':'10s',
-                'micronaut.http.services.bar.pool.enabled':false
+                'micronaut.http.services.bar.pool.enabled':true
         )
         TestClientFoo tcFoo = clientApp.getBean(TestClientFoo)
         TestClientBar tcBar = clientApp.getBean(TestClientBar)
@@ -76,7 +76,7 @@ class ManualHttpServiceDefinitionSpec extends Specification {
 
         then:
         config.readTimeout.get() == Duration.ofSeconds(10)
-        !config.getConnectionPoolConfiguration().isEnabled()
+        config.getConnectionPoolConfiguration().isEnabled()
 
         when:
         client = clientApp.getBean(RxHttpClient, Qualifiers.byName("bar"))

--- a/inject-java/src/test/groovy/io/micronaut/inject/configproperties/inheritance/ParentEachProps.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configproperties/inheritance/ParentEachProps.java
@@ -1,0 +1,41 @@
+package io.micronaut.inject.configproperties.inheritance;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.context.annotation.EachProperty;
+
+@EachProperty("teams")
+public class ParentEachProps {
+
+    private Integer wins;
+    private ManagerProps managerProps;
+
+    public Integer getWins() {
+        return wins;
+    }
+
+    public void setWins(Integer wins) {
+        this.wins = wins;
+    }
+
+    public ManagerProps getManager() {
+        return managerProps;
+    }
+
+    public void setManager(ManagerProps managerProps) {
+        this.managerProps = managerProps;
+    }
+
+    @ConfigurationProperties("manager")
+    public static class ManagerProps {
+
+        private Integer age;
+
+        public Integer getAge() {
+            return age;
+        }
+
+        public void setAge(Integer age) {
+            this.age = age;
+        }
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/configproperties/inheritance/ParentEachPropsCtor.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configproperties/inheritance/ParentEachPropsCtor.java
@@ -1,0 +1,60 @@
+package io.micronaut.inject.configproperties.inheritance;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.context.annotation.EachProperty;
+import io.micronaut.context.annotation.Parameter;
+
+import javax.annotation.Nullable;
+
+@EachProperty("teams")
+public class ParentEachPropsCtor {
+
+    private Integer wins;
+    private final String name;
+    private ManagerProps managerProps;
+
+    ParentEachPropsCtor(@Parameter String name,
+                        @Nullable ManagerProps managerProps) {
+        this.name = name;
+        this.managerProps = managerProps;
+    }
+
+    public Integer getWins() {
+        return wins;
+    }
+
+    public void setWins(Integer wins) {
+        this.wins = wins;
+    }
+
+    public ManagerProps getManager() {
+        return managerProps;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @ConfigurationProperties("manager")
+    public static class ManagerProps {
+
+        private final String name;
+        private Integer age;
+
+        ManagerProps(@Parameter String name) {
+            this.name = name;
+        }
+
+        public Integer getAge() {
+            return age;
+        }
+
+        public void setAge(Integer age) {
+            this.age = age;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/AbstractBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractBeanDefinition.java
@@ -751,7 +751,8 @@ public class AbstractBeanDefinition<T> extends AbstractBeanContextConditional im
                 Class argumentType = argument.getType();
 
                 if (isInnerConfiguration(argumentType)) {
-                    return ((DefaultBeanContext) context).createBean(resolutionContext, argumentType, null);
+                    Qualifier qualifier = resolveQualifier(resolutionContext, argument, true);
+                    return ((DefaultBeanContext) context).getBean(resolutionContext, argumentType, qualifier);
                 } else {
                     String argumentName = argument.getName();
                     String valString = resolvePropertyValueName(resolutionContext, injectionPoint.getAnnotationMetadata(), argument, valueAnnStr);
@@ -976,7 +977,7 @@ public class AbstractBeanDefinition<T> extends AbstractBeanContextConditional im
                 path.pushConstructorResolve(this, argument);
                 try {
                     Object bean;
-                    Qualifier qualifier = resolveQualifier(resolutionContext, argument);
+                    Qualifier qualifier = resolveQualifier(resolutionContext, argument, isInnerConfiguration(argumentType));
                     //noinspection unchecked
                     bean = ((DefaultBeanContext) context).getBean(resolutionContext, argumentType, qualifier);
                     path.pop();
@@ -1170,7 +1171,8 @@ public class AbstractBeanDefinition<T> extends AbstractBeanContextConditional im
                 String valueAnnVal = annotationMetadata.getValue(Value.class, String.class).orElse(null);
                 Class<?> fieldType = injectionPoint.getType();
                 if (isInnerConfiguration(fieldType)) {
-                    return context.createBean(fieldType);
+                    Qualifier qualifier = resolveQualifier(resolutionContext, injectionPoint.asArgument(), true);
+                    return ((DefaultBeanContext) context).getBean(resolutionContext, fieldType, qualifier);
                 } else {
                     String valString = resolvePropertyValueName(resolutionContext, injectionPoint, valueAnnVal, annotationMetadata);
                     Argument fieldArgument = injectionPoint.asArgument();
@@ -1340,7 +1342,7 @@ public class AbstractBeanDefinition<T> extends AbstractBeanContextConditional im
             path.pushFieldResolve(this, injectionPoint);
 
             try {
-                Qualifier qualifier = resolveQualifier(resolutionContext, injectionPoint);
+                Qualifier qualifier = resolveQualifier(resolutionContext, injectionPoint.asArgument());
                 @SuppressWarnings("unchecked") Object bean = ((DefaultBeanContext) context).getBean(resolutionContext, beanType, qualifier);
                 path.pop();
                 return bean;
@@ -1706,7 +1708,7 @@ public class AbstractBeanDefinition<T> extends AbstractBeanContextConditional im
 
         try {
             Optional<Class> genericType = injectionPoint.getType().isArray() ? Optional.of(injectionPoint.getType().getComponentType()) : injectionPoint.asArgument().getFirstTypeVariable().map(Argument::getType);
-            Qualifier qualifier = resolveQualifier(resolutionContext, injectionPoint);
+            Qualifier qualifier = resolveQualifier(resolutionContext, injectionPoint.asArgument());
             @SuppressWarnings("unchecked") B bean = (B) beanResolver.resolveBean(genericType.orElse(injectionPoint.getType()), qualifier);
             path.pop();
             return bean;
@@ -1719,11 +1721,11 @@ public class AbstractBeanDefinition<T> extends AbstractBeanContextConditional im
         return isConfigurationProperties;
     }
 
-    private Qualifier resolveQualifier(BeanResolutionContext resolutionContext, FieldInjectionPoint injectionPoint) {
-        return resolveQualifier(resolutionContext, injectionPoint.asArgument());
+    private Qualifier resolveQualifier(BeanResolutionContext resolutionContext, Argument argument) {
+        return resolveQualifier(resolutionContext, argument, false);
     }
 
-    private Qualifier resolveQualifier(BeanResolutionContext resolutionContext, Argument argument) {
+    private Qualifier resolveQualifier(BeanResolutionContext resolutionContext, Argument argument, boolean innerConfiguration) {
         Qualifier qualifier = null;
         AnnotationMetadata annotationMetadata = argument.getAnnotationMetadata();
         Optional<Class<? extends Annotation>> qualifierType = annotationMetadata.getAnnotationTypeByStereotype(javax.inject.Qualifier.class);
@@ -1742,12 +1744,13 @@ public class AbstractBeanDefinition<T> extends AbstractBeanContextConditional im
                 Optional<Qualifier> optional = resolutionContext.get(javax.inject.Qualifier.class.getName(), Map.class)
                         .map(map -> (Qualifier) map.get(argument));
                 qualifier = optional.orElse(null);
-                if (qualifier == null && isIterable() && argument.isAnnotationPresent(Parameter.class)) {
-
-                    qualifier = optional.orElseGet(() -> {
-                        final Optional<String> n = resolutionContext.get(Named.class.getName(), String.class);
-                        return n.map(Qualifiers::byName).orElse(null);
-                    });
+                if (qualifier == null && isIterable()) {
+                    if (argument.isAnnotationPresent(Parameter.class) || innerConfiguration) {
+                        qualifier = optional.orElseGet(() -> {
+                            final Optional<String> n = resolutionContext.get(Named.class.getName(), String.class);
+                            return n.map(Qualifiers::byName).orElse(null);
+                        });
+                    }
                 }
             }
         }

--- a/inject/src/main/java/io/micronaut/context/BeanDefinitionDelegate.java
+++ b/inject/src/main/java/io/micronaut/context/BeanDefinitionDelegate.java
@@ -165,7 +165,14 @@ class BeanDefinitionDelegate<T> extends AbstractBeanContextConditional implement
 
     @Override
     public T build(BeanResolutionContext resolutionContext, BeanContext context, BeanDefinition<T> definition) throws BeanInstantiationException {
-        resolutionContext.putAll(attributes);
+        LinkedHashMap<String, Object> oldAttributes = new LinkedHashMap<>();
+        for (Map.Entry<String, Object> entry: attributes.entrySet()) {
+            String key = entry.getKey();
+            if (resolutionContext.containsKey(key)) {
+                oldAttributes.put(key, resolutionContext.get(key));
+            }
+            resolutionContext.put(key, entry.getValue());
+        }
         try {
             if (this.definition instanceof ParametrizedBeanFactory) {
                 ParametrizedBeanFactory<T> parametrizedBeanFactory = (ParametrizedBeanFactory<T>) this.definition;
@@ -199,6 +206,7 @@ class BeanDefinitionDelegate<T> extends AbstractBeanContextConditional implement
             for (String key : attributes.keySet()) {
                 resolutionContext.remove(key);
             }
+            resolutionContext.putAll(oldAttributes);
         }
     }
 

--- a/inject/src/main/java/io/micronaut/context/BeanDefinitionDelegate.java
+++ b/inject/src/main/java/io/micronaut/context/BeanDefinitionDelegate.java
@@ -165,14 +165,18 @@ class BeanDefinitionDelegate<T> extends AbstractBeanContextConditional implement
 
     @Override
     public T build(BeanResolutionContext resolutionContext, BeanContext context, BeanDefinition<T> definition) throws BeanInstantiationException {
-        LinkedHashMap<String, Object> oldAttributes = new LinkedHashMap<>();
-        for (Map.Entry<String, Object> entry: attributes.entrySet()) {
-            String key = entry.getKey();
-            if (resolutionContext.containsKey(key)) {
-                oldAttributes.put(key, resolutionContext.get(key));
+        LinkedHashMap<String, Object> oldAttributes = null;
+        if (!attributes.isEmpty()) {
+            oldAttributes = new LinkedHashMap<>(attributes.size());
+            for (Map.Entry<String, Object> entry: attributes.entrySet()) {
+                String key = entry.getKey();
+                if (resolutionContext.containsKey(key)) {
+                    oldAttributes.put(key, resolutionContext.get(key));
+                }
+                resolutionContext.put(key, entry.getValue());
             }
-            resolutionContext.put(key, entry.getValue());
         }
+
         try {
             if (this.definition instanceof ParametrizedBeanFactory) {
                 ParametrizedBeanFactory<T> parametrizedBeanFactory = (ParametrizedBeanFactory<T>) this.definition;
@@ -206,7 +210,9 @@ class BeanDefinitionDelegate<T> extends AbstractBeanContextConditional implement
             for (String key : attributes.keySet()) {
                 resolutionContext.remove(key);
             }
-            resolutionContext.putAll(oldAttributes);
+            if (oldAttributes != null) {
+                resolutionContext.putAll(oldAttributes);
+            }
         }
     }
 

--- a/runtime/src/main/java/io/micronaut/cache/DefaultSyncCache.java
+++ b/runtime/src/main/java/io/micronaut/cache/DefaultSyncCache.java
@@ -46,27 +46,13 @@ import java.util.function.Supplier;
  * @author Graeme Rocher
  * @since 1.0
  */
-@EachBean(DefaultCacheConfiguration.class)
+@EachBean(CacheConfiguration.class)
 public class DefaultSyncCache implements SyncCache<com.github.benmanes.caffeine.cache.Cache> {
 
     private final CacheConfiguration cacheConfiguration;
     private final com.github.benmanes.caffeine.cache.Cache cache;
     private final ApplicationContext applicationContext;
     private final ConversionService<?> conversionService;
-
-    /**
-     * Construct a sync cache implementation with given configurations.
-     *
-     * @param cacheConfiguration The cache configurations
-     * @param applicationContext The application context
-     * @param conversionService To convert the value from the cache into given required type
-     */
-    @Inject public DefaultSyncCache(
-            DefaultCacheConfiguration cacheConfiguration,
-            ApplicationContext applicationContext,
-            ConversionService<?> conversionService) {
-        this((CacheConfiguration) cacheConfiguration, applicationContext, conversionService);
-    }
 
     /**
      * Construct a sync cache implementation with given configurations.

--- a/runtime/src/main/java/io/micronaut/cache/DefaultSyncCache.java
+++ b/runtime/src/main/java/io/micronaut/cache/DefaultSyncCache.java
@@ -62,6 +62,21 @@ public class DefaultSyncCache implements SyncCache<com.github.benmanes.caffeine.
      * @param conversionService To convert the value from the cache into given required type
      */
     public DefaultSyncCache(
+            DefaultCacheConfiguration cacheConfiguration,
+            ApplicationContext applicationContext,
+            ConversionService<?> conversionService) {
+        this((CacheConfiguration) cacheConfiguration, applicationContext, conversionService);
+    }
+
+    /**
+     * Construct a sync cache implementation with given configurations.
+     *
+     * @param cacheConfiguration The cache configurations
+     * @param applicationContext The application context
+     * @param conversionService To convert the value from the cache into given required type
+     */
+    @Inject
+    public DefaultSyncCache(
             CacheConfiguration cacheConfiguration,
             ApplicationContext applicationContext,
             ConversionService<?> conversionService) {


### PR DESCRIPTION
This PR resolves a couple issues

1. It is not possible to retrieve inner configuration properties of `@EachProperty` as beans directly
2. It is not possible to inject the inner configuration instance into the parent `@EachProperty` constructor