### PR TITLE
Allow factory methods to return null

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/factory/nullreturn/FactoryConstructor.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/factory/nullreturn/FactoryConstructor.java
@@ -1,0 +1,9 @@
+package io.micronaut.inject.factory.nullreturn;
+
+import io.micronaut.context.annotation.Factory;
+
+@Factory
+public class FactoryConstructor {
+
+    FactoryConstructor(E e) {}
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/factory/nullreturn/NullReturnFactorySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/factory/nullreturn/NullReturnFactorySpec.groovy
@@ -1,0 +1,73 @@
+package io.micronaut.inject.factory.nullreturn
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.BeanContext
+import io.micronaut.context.exceptions.BeanContextException
+import io.micronaut.context.exceptions.NoSuchBeanException
+import spock.lang.Specification
+
+class NullReturnFactorySpec extends Specification {
+
+    void "test factory that returns null"() {
+        given:
+        BeanContext beanContext = ApplicationContext.run()
+        NullableFactory factory = beanContext.getBean(NullableFactory)
+
+        when:
+        beanContext.createBean(A, "null")
+
+        then:
+        thrown(NoSuchBeanException)
+
+        when:
+        A a = beanContext.createBean(A, "hello")
+
+        then:
+        a != null
+
+        when:
+        Collection<B> bs = beanContext.getBeansOfType(B)
+
+        then:
+        bs.size() == 2
+        bs.any { it.name == "two" }
+        bs.any { it.name == "three" }
+        factory.bCalls == 3
+
+        when:
+        Collection<C> cs = beanContext.getBeansOfType(C)
+
+        then:
+        cs.size() == 1
+        cs[0].name == "three"
+        factory.cCalls == 2
+        factory.bCalls == 3
+
+        expect:
+        beanContext.getBeansOfType(D).size() == 1
+        factory.bCalls == 3
+        factory.cCalls == 2
+        factory.dCalls == 1
+
+        when:
+        beanContext.getBean(E)
+
+        then:
+        thrown(NoSuchBeanException)
+
+        when:
+        beanContext.getBean(F)
+
+        then:
+        thrown(BeanContextException)
+
+        when:
+        beanContext.getBean(FactoryConstructor)
+
+        then:
+        thrown(BeanContextException)
+
+        cleanup:
+        beanContext.close()
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/factory/nullreturn/NullableFactory.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/factory/nullreturn/NullableFactory.java
@@ -1,0 +1,93 @@
+package io.micronaut.inject.factory.nullreturn;
+
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Prototype;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+@Factory
+public class NullableFactory {
+
+    public int bCalls = 0;
+    public int cCalls = 0;
+    public int dCalls = 0;
+
+    @Prototype
+    A getA(@Parameter String name) {
+        if (name.equals("null")) {
+            return null;
+        } else {
+            return new A();
+        }
+    }
+
+    @Singleton
+    @Named("one")
+    B getBOne() {
+        bCalls++;
+        return null;
+    }
+
+    @Singleton
+    @Named("two")
+    B getBTwo() {
+        bCalls++;
+        return new B("two");
+    }
+
+    @Singleton
+    @Named("three")
+    B getBThree() {
+        bCalls++;
+        return new B("three");
+    }
+
+    @EachBean(B.class)
+    C getC(B b) {
+        cCalls++;
+        if (b.name.equals("three")) {
+            return new C(b.name);
+        } else {
+            return null;
+        }
+    }
+
+    @EachBean(C.class)
+    D getD(C c) {
+        dCalls++;
+        return new D();
+    }
+
+    @Singleton
+    E getE() {
+        return null;
+    }
+
+    @Singleton
+    F getF(E e) {
+        return new F();
+    }
+
+}
+
+class A {}
+class B {
+    public final String name;
+
+    B(String name) {
+        this.name = name;
+    }
+}
+class C {
+    public final String name;
+
+    C(String name) {
+        this.name = name;
+    }
+}
+class D {}
+class E {}
+class F {}

--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
@@ -293,24 +293,27 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
                             }
 
                             optional.ifPresent(qualifier -> {
-                                    String qualifierKey = javax.inject.Qualifier.class.getName();
-                                    Argument<?>[] arguments = candidate.getConstructor().getArguments();
-                                    for (Argument<?> argument : arguments) {
-                                        if (argument.getType().equals(dependentType)) {
-                                            Map<? extends Argument<?>, Qualifier> qualifedArg = Collections.singletonMap(argument, qualifier);
-                                            delegate.put(qualifierKey, qualifedArg);
-                                            break;
-                                        }
-                                    }
-
-                                    if (qualifier instanceof Named) {
-                                        delegate.put(Named.class.getName(), ((Named) qualifier).getName());
-                                    }
-                                    if (delegate.isEnabled(this)) {
-                                        transformedCandidates.add((BeanDefinition<T>) delegate);
+                                BeanRegistration beanRegistration = getActiveBeanRegistration(dependentCandidate, qualifier);
+                                if (beanRegistration != null && beanRegistration.bean == null) {
+                                    return;
+                                }
+                                String qualifierKey = javax.inject.Qualifier.class.getName();
+                                Argument<?>[] arguments = candidate.getConstructor().getArguments();
+                                for (Argument<?> argument : arguments) {
+                                    if (argument.getType().equals(dependentType)) {
+                                        Map<? extends Argument<?>, Qualifier> qualifedArg = Collections.singletonMap(argument, qualifier);
+                                        delegate.put(qualifierKey, qualifedArg);
+                                        break;
                                     }
                                 }
-                            );
+
+                                if (qualifier instanceof Named) {
+                                    delegate.put(Named.class.getName(), ((Named) qualifier).getName());
+                                }
+                                if (delegate.isEnabled(this)) {
+                                    transformedCandidates.add((BeanDefinition<T>) delegate);
+                                }
+                            });
                         }
                     }
                 } else {

--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
@@ -293,27 +293,28 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
                             }
 
                             optional.ifPresent(qualifier -> {
-                                BeanRegistration beanRegistration = getActiveBeanRegistration(dependentCandidate, qualifier);
-                                if (beanRegistration != null && beanRegistration.bean == null) {
-                                    return;
-                                }
-                                String qualifierKey = javax.inject.Qualifier.class.getName();
-                                Argument<?>[] arguments = candidate.getConstructor().getArguments();
-                                for (Argument<?> argument : arguments) {
-                                    if (argument.getType().equals(dependentType)) {
-                                        Map<? extends Argument<?>, Qualifier> qualifedArg = Collections.singletonMap(argument, qualifier);
-                                        delegate.put(qualifierKey, qualifedArg);
-                                        break;
+                                    BeanRegistration beanRegistration = getActiveBeanRegistration(dependentCandidate, qualifier);
+                                    if (beanRegistration != null && beanRegistration.bean == null) {
+                                        return;
+                                    }
+                                    String qualifierKey = javax.inject.Qualifier.class.getName();
+                                    Argument<?>[] arguments = candidate.getConstructor().getArguments();
+                                    for (Argument<?> argument : arguments) {
+                                        if (argument.getType().equals(dependentType)) {
+                                            Map<? extends Argument<?>, Qualifier> qualifedArg = Collections.singletonMap(argument, qualifier);
+                                            delegate.put(qualifierKey, qualifedArg);
+                                            break;
+                                        }
+                                    }
+
+                                    if (qualifier instanceof Named) {
+                                        delegate.put(Named.class.getName(), ((Named) qualifier).getName());
+                                    }
+                                    if (delegate.isEnabled(this)) {
+                                        transformedCandidates.add((BeanDefinition<T>) delegate);
                                     }
                                 }
-
-                                if (qualifier instanceof Named) {
-                                    delegate.put(Named.class.getName(), ((Named) qualifier).getName());
-                                }
-                                if (delegate.isEnabled(this)) {
-                                    transformedCandidates.add((BeanDefinition<T>) delegate);
-                                }
-                            });
+                            );
                         }
                     }
                 } else {

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -780,7 +780,8 @@ public class DefaultBeanContext implements BeanContext {
      * Find an active {@link javax.inject.Singleton} bean for the given definition and qualifier.
      *
      * @param beanDefinition The bean definition
-     * @param qualifier The qualifier
+     * @param qualifier      The qualifier
+     * @param <T>            The bean generic type
      * @return The bean registration
      */
     @Nullable

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -777,6 +777,21 @@ public class DefaultBeanContext implements BeanContext {
     }
 
     /**
+     * Find an active {@link javax.inject.Singleton} bean for the given definition and qualifier.
+     *
+     * @param beanDefinition The bean definition
+     * @param qualifier The qualifier
+     * @return The bean registration
+     */
+    @Nullable
+    protected <T> BeanRegistration<T> getActiveBeanRegistration(BeanDefinition<T> beanDefinition, Qualifier qualifier) {
+        if (beanDefinition == null) {
+            return null;
+        }
+        return singletonObjects.get(new BeanKey(beanDefinition, qualifier));
+    }
+
+    /**
      * Creates a bean.
      *
      * @param resolutionContext The bean resolution context
@@ -1409,7 +1424,8 @@ public class DefaultBeanContext implements BeanContext {
     }
 
     /**
-     * Execution the creation of a bean.
+     * Execution the creation of a bean. The returned value can be null if a
+     * factory method returned null.
      *
      * @param resolutionContext The {@link BeanResolutionContext}
      * @param beanDefinition    The {@link BeanDefinition}
@@ -1419,7 +1435,7 @@ public class DefaultBeanContext implements BeanContext {
      * @param <T>               The bean generic type
      * @return The created bean
      */
-    protected @Nonnull <T> T doCreateBean(@Nullable BeanResolutionContext resolutionContext,
+    protected @Nullable <T> T doCreateBean(@Nullable BeanResolutionContext resolutionContext,
                                  @Nonnull BeanDefinition<T> beanDefinition,
                                  @Nullable Qualifier<T> qualifier,
                                  boolean isSingleton,
@@ -1484,7 +1500,9 @@ public class DefaultBeanContext implements BeanContext {
                     bean = beanFactory.build(resolutionContext, this, beanDefinition);
 
                     if (bean == null) {
-                        throw new BeanInstantiationException(resolutionContext, "Bean Factory [" + beanFactory + "] returned null");
+                        if (!beanDefinition.getAnnotationMetadata().hasAnnotation(Factory.class)) {
+                            throw new BeanInstantiationException(resolutionContext, "Bean Factory [" + beanFactory + "] returned null");
+                        }
                     } else {
                         if (bean instanceof Qualified) {
                             ((Qualified) bean).$withBeanQualifier(declaredQualifier);
@@ -1522,28 +1540,31 @@ public class DefaultBeanContext implements BeanContext {
             inject(resolutionContext, null, bean);
         }
 
-        if (!BeanCreatedEventListener.class.isInstance(bean)) {
-            if (CollectionUtils.isNotEmpty(beanCreationEventListeners)) {
-                BeanKey beanKey = new BeanKey(beanDefinition, qualifier);
-                for (BeanRegistration<BeanCreatedEventListener> registration : beanCreationEventListeners) {
-                    BeanDefinition<BeanCreatedEventListener> definition = registration.getBeanDefinition();
-                    List<Argument<?>> typeArguments = definition.getTypeArguments(BeanCreatedEventListener.class);
-                    if (CollectionUtils.isEmpty(typeArguments) || typeArguments.get(0).getType().isAssignableFrom(beanType)) {
-                        BeanCreatedEventListener listener = registration.getBean();
-                        bean = (T) listener.onCreated(new BeanCreatedEvent(this, beanDefinition, beanKey, bean));
-                        if (bean == null) {
-                            throw new BeanInstantiationException(resolutionContext, "Listener [" + listener + "] returned null from onCreated event");
+        if (bean != null) {
+            if (!BeanCreatedEventListener.class.isInstance(bean)) {
+                if (CollectionUtils.isNotEmpty(beanCreationEventListeners)) {
+                    BeanKey beanKey = new BeanKey(beanDefinition, qualifier);
+                    for (BeanRegistration<BeanCreatedEventListener> registration : beanCreationEventListeners) {
+                        BeanDefinition<BeanCreatedEventListener> definition = registration.getBeanDefinition();
+                        List<Argument<?>> typeArguments = definition.getTypeArguments(BeanCreatedEventListener.class);
+                        if (CollectionUtils.isEmpty(typeArguments) || typeArguments.get(0).getType().isAssignableFrom(beanType)) {
+                            BeanCreatedEventListener listener = registration.getBean();
+                            bean = (T) listener.onCreated(new BeanCreatedEvent(this, beanDefinition, beanKey, bean));
+                            if (bean == null) {
+                                throw new BeanInstantiationException(resolutionContext, "Listener [" + listener + "] returned null from onCreated event");
+                            }
                         }
                     }
                 }
             }
+            if (beanDefinition instanceof ValidatedBeanDefinition) {
+                bean = ((ValidatedBeanDefinition<T>) beanDefinition).validate(resolutionContext, bean);
+            }
+            if (LOG_LIFECYCLE.isDebugEnabled()) {
+                LOG_LIFECYCLE.debug("Created bean [{}] from definition [{}] with qualifier [{}]", bean, beanDefinition, qualifier);
+            }
         }
-        if (beanDefinition instanceof ValidatedBeanDefinition) {
-            bean = ((ValidatedBeanDefinition<T>) beanDefinition).validate(resolutionContext, bean);
-        }
-        if (LOG_LIFECYCLE.isDebugEnabled()) {
-            LOG_LIFECYCLE.debug("Created bean [{}] from definition [{}] with qualifier [{}]", bean, beanDefinition, qualifier);
-        }
+
         return bean;
     }
 
@@ -1781,10 +1802,15 @@ public class DefaultBeanContext implements BeanContext {
 
         BeanRegistration<T> beanRegistration = singletonObjects.get(beanKey);
         if (beanRegistration != null) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Resolved existing bean [{}] for type [{}] and qualifier [{}]", beanRegistration.bean, beanType, qualifier);
+            T bean = beanRegistration.bean;
+            if (bean == null && throwNoSuchBean) {
+                throw new NoSuchBeanException(beanType, qualifier);
+            } else {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Resolved existing bean [{}] for type [{}] and qualifier [{}]", beanRegistration.bean, beanType, qualifier);
+                }
+                return bean;
             }
-            return beanRegistration.bean;
         } else if (LOG.isTraceEnabled()) {
             LOG.trace("No existing bean found for bean key: {}", beanKey);
         }
@@ -1816,7 +1842,12 @@ public class DefaultBeanContext implements BeanContext {
                     }
                     return null;
                 } else {
-                    return getBeanForDefinition(resolutionContext, beanType, qualifier, throwNoSuchBean, definition);
+                    bean = getBeanForDefinition(resolutionContext, beanType, qualifier, throwNoSuchBean, definition);
+                    if (bean == null && throwNoSuchBean) {
+                        throw new NoSuchBeanException(beanType, qualifier);
+                    } else {
+                        return bean;
+                    }
                 }
 
             } else {
@@ -2193,7 +2224,7 @@ public class DefaultBeanContext implements BeanContext {
         boolean isNotProxyTarget = qualifier != PROXY_TARGET_QUALIFIER;
         if (isNotProxyTarget) {
 
-            Class<?> createdType = createdBean.getClass();
+            Class<?> createdType = createdBean != null ? createdBean.getClass() : beanType;
             boolean createdTypeDiffers = !createdType.equals(beanType);
 
             BeanKey createdBeanKey = new BeanKey(createdType, qualifier);
@@ -2489,7 +2520,9 @@ public class DefaultBeanContext implements BeanContext {
             bean = getScopedBeanForDefinition(resolutionContext, beanType, qualifier, true, candidate);
         }
 
-        beansOfTypeList.add(bean);
+        if (bean != null) {
+            beansOfTypeList.add(bean);
+        }
     }
 
     private <T> boolean isCandidatePresent(Class<T> beanType, Qualifier<T> qualifier) {


### PR DESCRIPTION
This PR is not supporting Optional for a several reasons

1. It would no longer be possible to create beans of type `Optional` in a factory (unlikely I'm aware)
2. It would require changes to byte code generation for the bean definitions to set the bean type to the generic
3. It would require additional logic in many places to unwrap the optional anytime a bean is retrieved
4. Optional is really meant for an API the user will call. Factory methods should never be called directly so there is no benefit other than satisfying a feature that users may expect to work