### PR TITLE
Fix profile-info padding

### DIFF
--- a/cli/src/main/groovy/io/micronaut/cli/profile/commands/ProfileInfoCommand.groovy
+++ b/cli/src/main/groovy/io/micronaut/cli/profile/commands/ProfileInfoCommand.groovy
@@ -92,7 +92,8 @@ class ProfileInfoCommand extends ArgumentCompletingCommand implements ProfileRep
                 console.log('--------------------')
                 Iterable<Command> commands = findCommands(profile, console).toUnique { Command c -> c.name }.sort { it.name }
                 if (!commands.empty) {
-                    int width = Math.min(20, commands.collect { it.name }.sort { it.length() }.last().length())
+                    int padding = commands.collect { it.name }.max { it.length() }.length()
+                    int width = Math.min(padding, commands.collect { it.name }.sort { it.length() }.last().length())
                     String separator = String.format('%n').padRight(width) // in case of multi-line command description
                     for (cmd in commands) {
                         def spec = cmd.commandSpec
@@ -104,8 +105,8 @@ class ProfileInfoCommand extends ArgumentCompletingCommand implements ProfileRep
                 console.log('--------------------')
                 def features = profile.features.sort { it.name }
                 if (!features.empty) {
-                    int width = Math.min(20, features.collect { it.name }.sort { it.length() }.last().length())
-
+                    int padding = features.collect { it.name }.max { it.length() }.length()
+                    int width = Math.min(padding, features.collect { it.name }.sort { it.length() }.last().length())
                     for (feature in features) {
                         console.log("  ${feature.name.padRight(width)}  ${feature.description}")
                     }


### PR DESCRIPTION
Fix the padding for the `profile-info` command on the CLI.

On the right the current oputput, on the left the one after applying this PR:

![cli-profile-info](https://user-images.githubusercontent.com/559192/57215347-d94a4900-6fec-11e9-9dcb-5785958883df.png)
