### PR TITLE
#1265 converts qualifiers.adoc to snippets

### DIFF
--- a/src/main/docs/guide/ioc/qualifiers.adoc
+++ b/src/main/docs/guide/ioc/qualifiers.adoc
@@ -8,8 +8,6 @@ To qualify by name you can use the link:{jeeapi}/javax/inject/Named.html[Named] 
 
 snippet::io.micronaut.docs.inject.qualifiers.named.Engine,io.micronaut.docs.inject.qualifiers.named.V6Engine,io.micronaut.docs.inject.qualifiers.named.V8Engine,io.micronaut.docs.inject.qualifiers.named.Vehicle[tags="class",indent=0]
 
-
-
 <1> The `Engine` interface defines the common contract
 <2> The `V6Engine` class is the first implementation
 <3> The `V8Engine` class is the second implementation
@@ -22,19 +20,11 @@ You can also declare link:{jeeapi}/javax/inject/Named.html[@Named] at the class 
 
 In addition to being able to qualify by name, you can build your own qualifiers using the link:{jeeapi}/javax/inject/Qualifier.html[Qualifier] annotation. For example, consider the following annotation:
 
-[source,groovy]
-----
-include::{testsdir}/qualifiers/annotation/V8.groovy[tags=imports, indent=0]
-
-include::{testsdir}/qualifiers/annotation/V8.groovy[tags=class, indent=0]
-----
+snippet::io.micronaut.docs.qualifiers.annotation.V8[tags="imports,class",indent=0]
 
 The above annotation is itself annotated with the `@Qualifier` annotation to designate it as a qualifier. You can then use the annotation at any injection point in your code. For example:
 
-[source,groovy]
-----
-include::{testsdir}/qualifiers/annotation/Vehicle.groovy[tags=constructor, indent=0]
-----
+snippet::io.micronaut.docs.qualifiers.annotation.Vehicle[tags="constructor",indent=0]
 
 == Primary and Secondary Beans
 
@@ -42,39 +32,19 @@ api:context.annotation.Primary[] is a qualifier that indicates that a bean is th
 
 Consider the following example:
 
-[source,java]
-----
-include::{testshttpservernetty}/context/annotation/primary/ColorPicker.groovy[tags=clazz, indent=0]
-----
+snippet::io.micronaut.docs.context.annotation.primary.ColorPicker[tags=clazz, indent=0]
 
 Given a common interface called `ColorPicker` that is implemented by multiple classes.
 
-.The Primary Bean
-[source,java]
-----
-include::{testshttpservernetty}/context/annotation/primary/Green.groovy[tags=imports, indent=0]
-
-include::{testshttpservernetty}/context/annotation/primary/Green.groovy[tags=clazz, indent=0]
-----
+snippet::io.micronaut.docs.context.annotation.primary.Green[tags="imports,clazz", indent=0, title="The Primary Bean"]
 
 The `Green` bean is a `ColorPicker`, but is annotated with `@Primary`.
 
-.Another Bean of the Same Type
-[source,java]
-----
-include::{testshttpservernetty}/context/annotation/primary/Blue.groovy[tags=imports, indent=0]
-
-include::{testshttpservernetty}/context/annotation/primary/Blue.groovy[tags=clazz, indent=0]
-----
+snippet::io.micronaut.docs.context.annotation.primary.Blue[tags="imports,clazz", indent=0, title="Another Bean of the Same Type"]
 
 The `Blue` bean is also a `ColorPicker` and hence you have two possible candidates when injecting the `ColorPicker` interface. Since `Green` is the primary it will always be favoured.
 
-
-
-[source,java]
-----
-include::{testshttpservernetty}/context/annotation/primary/TestController.groovy[tags=clazz, indent=0]
-----
+snippet::io.micronaut.docs.context.annotation.primary.TestController[tags="clazz", indent=0]
 
 <1> Although there are two `ColorPicker` beans, `Green` gets injected due to the `@Primary` annotation.
 

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/context/annotation/primary/Blue.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/context/annotation/primary/Blue.groovy
@@ -1,0 +1,22 @@
+package io.micronaut.docs.context.annotation.primary
+
+import io.micronaut.context.annotation.Requires
+
+//tag::imports[]
+
+import javax.inject.Singleton
+
+//end::imports[]
+
+@Requires(property = 'spec.name', value = 'primaryspec')
+//tag::clazz[]
+@Singleton
+public class Blue implements ColorPicker {
+
+    @Override
+    public String color() {
+        return "blue";
+    }
+}
+//end::clazz[]
+

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/context/annotation/primary/Blue.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/context/annotation/primary/Blue.groovy
@@ -11,11 +11,11 @@ import javax.inject.Singleton
 @Requires(property = 'spec.name', value = 'primaryspec')
 //tag::clazz[]
 @Singleton
-public class Blue implements ColorPicker {
+class Blue implements ColorPicker {
 
     @Override
-    public String color() {
-        return "blue";
+    String color() {
+        return "blue"
     }
 }
 //end::clazz[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/context/annotation/primary/ColorPicker.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/context/annotation/primary/ColorPicker.groovy
@@ -1,0 +1,6 @@
+package io.micronaut.docs.context.annotation.primary
+//tag::clazz[]
+public interface ColorPicker {
+    String color()
+}
+//end::clazz[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/context/annotation/primary/ColorPicker.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/context/annotation/primary/ColorPicker.groovy
@@ -1,6 +1,6 @@
 package io.micronaut.docs.context.annotation.primary
 //tag::clazz[]
-public interface ColorPicker {
+interface ColorPicker {
     String color()
 }
 //end::clazz[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/context/annotation/primary/Green.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/context/annotation/primary/Green.groovy
@@ -1,0 +1,22 @@
+package io.micronaut.docs.context.annotation.primary
+
+import io.micronaut.context.annotation.Primary
+
+//tag::imports[]
+import io.micronaut.context.annotation.Requires
+import javax.inject.Singleton
+//end::imports[]
+
+@Requires(property = 'spec.name', value = 'primaryspec')
+//tag::clazz[]
+@Primary
+@Singleton
+public class Green implements ColorPicker {
+
+    @Override
+    public String color() {
+        return "green";
+    }
+}
+//end::clazz[]
+

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/context/annotation/primary/Green.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/context/annotation/primary/Green.groovy
@@ -11,11 +11,11 @@ import javax.inject.Singleton
 //tag::clazz[]
 @Primary
 @Singleton
-public class Green implements ColorPicker {
+class Green implements ColorPicker {
 
     @Override
-    public String color() {
-        return "green";
+    String color() {
+        return "green"
     }
 }
 //end::clazz[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/context/annotation/primary/PrimarySpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/context/annotation/primary/PrimarySpec.groovy
@@ -1,0 +1,37 @@
+package io.micronaut.docs.context.annotation.primary
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.env.Environment
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.RxHttpClient
+import io.micronaut.runtime.server.EmbeddedServer
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class PrimarySpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
+            'spec.name': 'primaryspec'
+    ], Environment.TEST)
+
+    @AutoCleanup
+    @Shared
+    RxHttpClient rxClient = embeddedServer.applicationContext.createBean(RxHttpClient, embeddedServer.getURL())
+
+    def "@Primary annotated beans gets injected in case of a collection"() {
+        expect:
+        embeddedServer.applicationContext.getBeansOfType(ColorPicker.class).size() == 2
+
+        when:
+        HttpResponse<String> rsp = rxClient.toBlocking().exchange(HttpRequest.GET('/test'), String)
+
+        then:
+        rsp.status() == HttpStatus.OK
+        rsp.body() == 'green'
+    }
+}

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/context/annotation/primary/TestController.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/context/annotation/primary/TestController.groovy
@@ -9,7 +9,7 @@ import io.micronaut.http.annotation.Get
 @Controller("/test")
 class TestController {
 
-    protected final ColorPicker colorPicker;
+    protected final ColorPicker colorPicker
 
     TestController(ColorPicker colorPicker) { // <1>
         this.colorPicker = colorPicker

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/context/annotation/primary/TestController.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/context/annotation/primary/TestController.groovy
@@ -7,17 +7,17 @@ import io.micronaut.http.annotation.Get
 @Requires(property = 'spec.name', value = 'primaryspec')
 //tag::clazz[]
 @Controller("/test")
-public class TestController {
+class TestController {
 
     protected final ColorPicker colorPicker;
 
-    public TestController(ColorPicker colorPicker) { // <1>
-        this.colorPicker = colorPicker;
+    TestController(ColorPicker colorPicker) { // <1>
+        this.colorPicker = colorPicker
     }
 
     @Get
-    public String index() {
-        return colorPicker.color();
+    String index() {
+        colorPicker.color()
     }
 }
 //end::clazz[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/context/annotation/primary/TestController.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/context/annotation/primary/TestController.groovy
@@ -1,0 +1,23 @@
+package io.micronaut.docs.context.annotation.primary
+
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+
+@Requires(property = 'spec.name', value = 'primaryspec')
+//tag::clazz[]
+@Controller("/test")
+public class TestController {
+
+    protected final ColorPicker colorPicker;
+
+    public TestController(ColorPicker colorPicker) { // <1>
+        this.colorPicker = colorPicker;
+    }
+
+    @Get
+    public String index() {
+        return colorPicker.color();
+    }
+}
+//end::clazz[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/qualifiers/annotation/Engine.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/qualifiers/annotation/Engine.groovy
@@ -1,0 +1,8 @@
+package io.micronaut.docs.qualifiers.annotation
+
+// tag::class[]
+interface Engine { // <1>
+    int getCylinders()
+    String start()
+}
+// end::class[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/qualifiers/annotation/V6Engine.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/qualifiers/annotation/V6Engine.groovy
@@ -1,0 +1,14 @@
+package io.micronaut.docs.qualifiers.annotation
+
+import javax.inject.Singleton
+
+// tag::class[]
+@Singleton
+class V6Engine implements Engine { // <2>
+    int cylinders = 6
+
+    String start() {
+        "Starting V6"
+    }
+}
+// end::class[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/qualifiers/annotation/V8.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/qualifiers/annotation/V8.groovy
@@ -1,0 +1,15 @@
+package io.micronaut.docs.qualifiers.annotation
+
+// tag::imports[]
+import javax.inject.Qualifier
+import java.lang.annotation.Retention
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME
+// end::imports[]
+
+// tag::class[]
+@Qualifier
+@Retention(RUNTIME)
+@interface V8 {
+}
+// end::class[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/qualifiers/annotation/V8Engine.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/qualifiers/annotation/V8Engine.groovy
@@ -1,0 +1,14 @@
+package io.micronaut.docs.qualifiers.annotation
+
+import javax.inject.Singleton
+
+// tag::class[]
+@Singleton
+class V8Engine implements Engine { // <3>
+    int cylinders = 8
+
+    String start() {
+        "Starting V8"
+    }
+}
+// end::class[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/qualifiers/annotation/Vehicle.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/qualifiers/annotation/Vehicle.groovy
@@ -1,0 +1,21 @@
+package io.micronaut.docs.qualifiers.annotation
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+// tag::class[]
+@Singleton
+class Vehicle {
+    final Engine engine
+
+    // tag::constructor[]
+    @Inject Vehicle(@V8 Engine engine) {
+        this.engine = engine
+    }
+    // end::constructor[]
+
+    String start() {
+        engine.start() // <5>
+    }
+}
+// end::class[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/qualifiers/annotation/VehicleSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/qualifiers/annotation/VehicleSpec.groovy
@@ -1,0 +1,20 @@
+package io.micronaut.docs.qualifiers.annotation
+
+import io.micronaut.context.DefaultBeanContext
+import spock.lang.Specification
+
+class VehicleSpec extends Specification {
+
+    void "test start vehicle"() {
+        when:
+        // tag::start[]
+        Vehicle vehicle = new DefaultBeanContext()
+                .start()
+                .getBean(Vehicle)
+        println( vehicle.start() )
+        // end::start[]
+
+        then:
+        vehicle.start() == "Starting V8"
+    }
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/config/builder/VehicleSpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/config/builder/VehicleSpec.kt
@@ -6,7 +6,7 @@ import io.micronaut.context.ApplicationContext
 
 internal class VehicleSpec : StringSpec({
 
-    "test start vehicle".config(enabled = false) {
+    "test start vehicle" {
         // tag::start[]
         val applicationContext = ApplicationContext.run(
                 mapOf(

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/context/annotation/primary/Blue.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/context/annotation/primary/Blue.kt
@@ -1,22 +1,18 @@
 package io.micronaut.docs.context.annotation.primary
 
 import io.micronaut.context.annotation.Requires
-
 //tag::imports[]
-import io.micronaut.context.annotation.Primary
+
 import javax.inject.Singleton
+
 //end::imports[]
 
-@Requires(property = 'spec.name', value = 'primaryspec')
+@Requires(property = "spec.name", value = "primaryspec")
 //tag::clazz[]
-@Primary
 @Singleton
-class Green implements ColorPicker {
-
-    @Override
-    String color() {
-        return "green"
+class Blue: ColorPicker {
+    override fun color(): String {
+        return "blue"
     }
 }
 //end::clazz[]
-

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/context/annotation/primary/ColorPicker.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/context/annotation/primary/ColorPicker.kt
@@ -1,0 +1,7 @@
+package io.micronaut.docs.context.annotation.primary
+
+//tag::clazz[]
+interface ColorPicker {
+    fun color(): String
+}
+//end::clazz[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/context/annotation/primary/Green.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/context/annotation/primary/Green.kt
@@ -5,18 +5,15 @@ import io.micronaut.context.annotation.Requires
 //tag::imports[]
 import io.micronaut.context.annotation.Primary
 import javax.inject.Singleton
+
 //end::imports[]
 
-@Requires(property = 'spec.name', value = 'primaryspec')
+@Requires(property = "spec.name", value = "primaryspec")
 //tag::clazz[]
 @Primary
 @Singleton
-class Green implements ColorPicker {
-
-    @Override
-    String color() {
+class Green: ColorPicker {
+    override fun color(): String {
         return "green"
     }
 }
-//end::clazz[]
-

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/context/annotation/primary/PrimarySpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/context/annotation/primary/PrimarySpec.kt
@@ -1,0 +1,29 @@
+package io.micronaut.docs.context.annotation.primary
+
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.StringSpec
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.env.Environment
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.RxHttpClient
+import io.micronaut.runtime.server.EmbeddedServer
+
+class PrimarySpec : StringSpec() {
+
+    val embeddedServer = autoClose(ApplicationContext.run(EmbeddedServer::class.java, mapOf(
+            "spec.name" to "primaryspec"
+    ), Environment.TEST))
+
+    val rxClient = autoClose(embeddedServer.applicationContext.createBean(RxHttpClient::class.java, embeddedServer.getURL()))
+
+    init {
+        "test @Primary annotated beans gets injected in case of a collection" {
+            embeddedServer.applicationContext.getBeansOfType(ColorPicker::class.java).size.shouldBe(2)
+            val rsp = rxClient.toBlocking().exchange(HttpRequest.GET<String>("/test"), String::class.java)
+
+            rsp.status.shouldBe(HttpStatus.OK)
+            rsp.body().shouldBe("green")
+        }
+    }
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/context/annotation/primary/TestController.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/context/annotation/primary/TestController.kt
@@ -1,0 +1,17 @@
+package io.micronaut.docs.context.annotation.primary
+
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+
+@Requires(property = "spec.name", value = "primaryspec")
+//tag::clazz[]
+@Controller("/test")
+class TestController(val colorPicker: ColorPicker) { // <1>
+
+    @Get
+    fun index(): String {
+        return colorPicker.color()
+    }
+}
+//end::clazz[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/qualifiers/annotation/Engine.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/qualifiers/annotation/Engine.kt
@@ -1,0 +1,8 @@
+package io.micronaut.docs.qualifiers.annotation
+
+// tag::class[]
+interface Engine { // <1>
+    val cylinders : Int
+    fun start(): String
+}
+// end::class[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/qualifiers/annotation/V6Engine.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/qualifiers/annotation/V6Engine.kt
@@ -1,0 +1,14 @@
+package io.micronaut.docs.qualifiers.annotation
+
+import javax.inject.Singleton
+
+// tag::class[]
+@Singleton
+class V6Engine : Engine { // <2>
+    override val cylinders = 6
+
+    override fun start(): String {
+        return "Starting V6"
+    }
+}
+// end::class[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/qualifiers/annotation/V8.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/qualifiers/annotation/V8.kt
@@ -1,0 +1,12 @@
+package io.micronaut.docs.qualifiers.annotation
+
+// tag::imports[]
+import javax.inject.Qualifier
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy.RUNTIME
+// end::imports[]
+// tag::class[]
+@Qualifier
+@Retention(RUNTIME)
+annotation class V8
+// end::class[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/qualifiers/annotation/V8Engine.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/qualifiers/annotation/V8Engine.kt
@@ -1,0 +1,14 @@
+package io.micronaut.docs.qualifiers.annotation
+
+import javax.inject.Singleton
+
+// tag::class[]
+@Singleton
+class V8Engine : Engine { // <2>
+    override val cylinders = 8
+
+    override fun start(): String {
+        return "Starting V8"
+    }
+}
+// end::class[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/qualifiers/annotation/Vehicle.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/qualifiers/annotation/Vehicle.kt
@@ -1,0 +1,16 @@
+package io.micronaut.docs.qualifiers.annotation
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+// tag::class[]
+@Singleton
+class Vehicle // tag::constructor[]
+@Inject constructor(@V8 val engine: Engine) {
+
+    // end::constructor[]
+    fun start(): String {
+        return engine.start() // <5>
+    }
+}
+// end::class[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/qualifiers/annotation/VehicleSpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/qualifiers/annotation/VehicleSpec.kt
@@ -1,0 +1,18 @@
+package io.micronaut.docs.qualifiers.annotation
+
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.StringSpec
+import io.micronaut.context.DefaultBeanContext
+
+
+class VehicleSpec : StringSpec({
+
+    "test vehicle start uses v8" {
+        // tag::start[]
+        val vehicle = DefaultBeanContext().start().getBean(Vehicle::class.java)
+        println(vehicle.start())
+        // end::start[]
+
+        vehicle.start().shouldBe("Starting V8")
+    }
+})

--- a/test-suite/src/test/java/io/micronaut/docs/context/annotation/primary/Blue.java
+++ b/test-suite/src/test/java/io/micronaut/docs/context/annotation/primary/Blue.java
@@ -1,0 +1,21 @@
+package io.micronaut.docs.context.annotation.primary;
+
+import io.micronaut.context.annotation.Requires;
+
+//tag::imports[]
+
+import javax.inject.Singleton;
+
+//end::imports[]
+
+@Requires(property = "spec.name", value = "primaryspec")
+//tag::clazz[]
+@Singleton
+public class Blue implements ColorPicker {
+
+    @Override
+    public String color() {
+        return "blue";
+    }
+}
+//end::clazz[]

--- a/test-suite/src/test/java/io/micronaut/docs/context/annotation/primary/ColorPicker.java
+++ b/test-suite/src/test/java/io/micronaut/docs/context/annotation/primary/ColorPicker.java
@@ -1,0 +1,7 @@
+package io.micronaut.docs.context.annotation.primary;
+
+//tag::clazz[]
+public interface ColorPicker {
+    String color();
+}
+//end::clazz[]

--- a/test-suite/src/test/java/io/micronaut/docs/context/annotation/primary/Green.java
+++ b/test-suite/src/test/java/io/micronaut/docs/context/annotation/primary/Green.java
@@ -1,0 +1,21 @@
+package io.micronaut.docs.context.annotation.primary;
+
+import io.micronaut.context.annotation.Primary;
+
+//tag::imports[]
+import io.micronaut.context.annotation.Requires;
+import javax.inject.Singleton;
+//end::imports[]
+
+@Requires(property = "spec.name", value = "primaryspec")
+//tag::clazz[]
+@Primary
+@Singleton
+class Green implements ColorPicker {
+
+    @Override
+    public String color() {
+        return "green";
+    }
+}
+//end::clazz[]

--- a/test-suite/src/test/java/io/micronaut/docs/context/annotation/primary/PrimarySpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/context/annotation/primary/PrimarySpec.java
@@ -1,0 +1,52 @@
+package io.micronaut.docs.context.annotation.primary;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.env.Environment;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.client.RxHttpClient;
+import io.micronaut.runtime.server.EmbeddedServer;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+
+public class PrimarySpec {
+
+    private static EmbeddedServer embeddedServer;
+
+    private static RxHttpClient rxClient;
+
+
+    @BeforeClass
+    public static void setup(){
+        embeddedServer = ApplicationContext.run(EmbeddedServer.class, new HashMap<String, Object>() {{
+            put("spec.name", "primaryspec");
+            put("spec.lang", "java");
+        }}, Environment.TEST);
+        rxClient = embeddedServer.getApplicationContext().createBean(RxHttpClient.class, embeddedServer.getURL());
+    }
+    @AfterClass
+    public static void teardown(){
+        if(rxClient != null){
+            rxClient.close();
+        }
+        if(embeddedServer != null){
+            embeddedServer.close();
+        }
+    }
+
+    @Test
+    public void testPrimaryAnnotatedBeanIsInjectedWhenMultipleOptionsExist() {
+        assertEquals(embeddedServer.getApplicationContext().getBeansOfType(ColorPicker.class).size(), 2);
+
+        HttpResponse<String> rsp = rxClient.toBlocking().exchange(HttpRequest.GET("/test"), String.class);
+
+        assertEquals(rsp.status(), HttpStatus.OK);
+        assertEquals(rsp.body(), "green");
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/docs/context/annotation/primary/TestController.java
+++ b/test-suite/src/test/java/io/micronaut/docs/context/annotation/primary/TestController.java
@@ -1,0 +1,23 @@
+package io.micronaut.docs.context.annotation.primary;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+
+@Requires(property = "spec.name", value = "primaryspec")
+//tag::clazz[]
+@Controller("/test")
+public class TestController {
+
+    protected final ColorPicker colorPicker;
+
+    public TestController(ColorPicker colorPicker) { // <1>
+        this.colorPicker = colorPicker;
+    }
+
+    @Get
+    public String index() {
+        return colorPicker.color();
+    }
+}
+//end::clazz[]

--- a/test-suite/src/test/java/io/micronaut/docs/qualifiers/annotation/Engine.java
+++ b/test-suite/src/test/java/io/micronaut/docs/qualifiers/annotation/Engine.java
@@ -1,0 +1,8 @@
+package io.micronaut.docs.qualifiers.annotation;
+
+// tag::class[]
+public interface Engine { // <1>
+    int getCylinders();
+    String start();
+}
+// end::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/qualifiers/annotation/V6Engine.java
+++ b/test-suite/src/test/java/io/micronaut/docs/qualifiers/annotation/V6Engine.java
@@ -1,0 +1,18 @@
+package io.micronaut.docs.qualifiers.annotation;
+
+import javax.inject.Singleton;
+
+// tag::class[]
+@Singleton
+public class V6Engine implements Engine { // <2>
+    private int cylinders = 6;
+
+    public int getCylinders() {
+        return cylinders;
+    }
+
+    public String start() {
+        return "Starting V6";
+    }
+}
+// end::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/qualifiers/annotation/V8.java
+++ b/test-suite/src/test/java/io/micronaut/docs/qualifiers/annotation/V8.java
@@ -1,0 +1,15 @@
+package io.micronaut.docs.qualifiers.annotation;
+
+// tag::imports[]
+import javax.inject.Qualifier;
+import java.lang.annotation.Retention;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+// end::imports[]
+
+// tag::class[]
+@Qualifier
+@Retention(RUNTIME)
+public @interface V8 {
+}
+// end::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/qualifiers/annotation/V8Engine.java
+++ b/test-suite/src/test/java/io/micronaut/docs/qualifiers/annotation/V8Engine.java
@@ -1,0 +1,18 @@
+package io.micronaut.docs.qualifiers.annotation;
+
+import javax.inject.Singleton;
+
+// tag::class[]
+@Singleton
+public class V8Engine implements Engine { // <2>
+    private int cylinders = 8;
+
+    public int getCylinders() {
+        return cylinders;
+    }
+
+    public String start() {
+        return "Starting V8";
+    }
+}
+// end::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/qualifiers/annotation/Vehicle.java
+++ b/test-suite/src/test/java/io/micronaut/docs/qualifiers/annotation/Vehicle.java
@@ -1,0 +1,21 @@
+package io.micronaut.docs.qualifiers.annotation;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+// tag::class[]
+@Singleton
+public class Vehicle {
+    final Engine engine;
+
+    // tag::constructor[]
+    @Inject Vehicle(@V8 Engine engine) {
+        this.engine = engine;
+    }
+    // end::constructor[]
+
+    String start() {
+        return engine.start(); // <5>
+    }
+}
+// end::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/qualifiers/annotation/VehicleSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/qualifiers/annotation/VehicleSpec.java
@@ -1,0 +1,21 @@
+package io.micronaut.docs.qualifiers.annotation;
+
+import io.micronaut.context.DefaultBeanContext;
+import io.micronaut.docs.inject.qualifiers.named.Vehicle;
+import org.codehaus.groovy.runtime.DefaultGroovyMethods;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class VehicleSpec {
+    @Test
+    public void testStartVehicle() {
+        // tag::start[]
+        io.micronaut.docs.inject.qualifiers.named.Vehicle vehicle = new DefaultBeanContext().start().getBean(Vehicle.class);
+        DefaultGroovyMethods.println(this, vehicle.start());
+        // end::start[]
+
+        assertEquals("Starting V8", vehicle.start());
+    }
+
+}


### PR DESCRIPTION
- Moves Groovy samples from inject-groovy to test-suite-groovy
- Adds Java and Kotlin corollaries for all files relevant to this section of the docs

Note that the titles will be lost for the snippets until https://github.com/micronaut-projects/micronaut-docs/pull/10 is built and utilized by the core project. Not sure how we should handle that