### PR TITLE
#904 - HashiCorp Vault integration

### DIFF
--- a/discovery-client/src/main/java/io/micronaut/discovery/vault/VaultClientConfiguration.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/vault/VaultClientConfiguration.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.discovery.vault;
+
+import io.micronaut.context.annotation.BootstrapContextCompatible;
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.discovery.config.ConfigDiscoveryConfiguration;
+import io.micronaut.discovery.vault.condition.RequiresVaultClientConfig;
+import io.micronaut.http.client.HttpClientConfiguration;
+import io.micronaut.runtime.ApplicationConfiguration;
+
+import javax.inject.Inject;
+
+/**
+ *  A {@link HttpClientConfiguration} for Vault Client.
+ *
+ *  @author thiagolocatelli
+ *  @author graemerocher
+ *  @since 1.1.1
+ */
+@RequiresVaultClientConfig
+@ConfigurationProperties(VaultClientConstants.PREFIX)
+@BootstrapContextCompatible
+public class VaultClientConfiguration extends HttpClientConfiguration {
+
+    /**
+     * Vault Server Endpoint.
+     */
+    public static final String VAULT_CLIENT_CONFIG_ENDPOINT = "${" + VaultClientConstants.PREFIX + ".uri}";
+
+    /**
+     * Vault Backend Secret Engine versions.
+     */
+    public enum VaultKvVersion { V1, V2 };
+
+    private final VaultClientConnectionPoolConfiguration vaultClientConnectionPoolConfiguration;
+    private final VaultClientDiscoveryConfiguration vaultClientDiscoveryConfiguration = new VaultClientDiscoveryConfiguration();
+
+    private String uri = "http://locahost:8200";
+    private String token;
+    private VaultKvVersion kvVersion = VaultKvVersion.V2;
+    private String backend = "secret";
+    private boolean failFast;
+
+    /**
+     * @param vaultClientConnectionPoolConfiguration Vault Client Connection Pool Configuration
+     * @param applicationConfiguration Application Configuration
+     */
+    @Inject
+    public VaultClientConfiguration(VaultClientConnectionPoolConfiguration vaultClientConnectionPoolConfiguration, ApplicationConfiguration applicationConfiguration) {
+        super(applicationConfiguration);
+        this.vaultClientConnectionPoolConfiguration = vaultClientConnectionPoolConfiguration;
+    }
+
+    @Override
+    public ConnectionPoolConfiguration getConnectionPoolConfiguration() {
+        return vaultClientConnectionPoolConfiguration;
+    }
+
+    /**
+     * @return The discovery service configuration
+     */
+    public VaultClientDiscoveryConfiguration getDiscoveryConfiguration() {
+        return vaultClientDiscoveryConfiguration;
+    }
+
+    /**
+     * @return The Vault Server Uri
+     */
+    public String getUri() {
+        return uri;
+    }
+
+    /**
+     * Set the Vault Server Uri.
+     *
+     * @param uri Vault Server Uri
+     */
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
+    /**
+     * @return The Vault authentication token
+     */
+    public String getToken() {
+        return token;
+    }
+
+    /**
+     * Set the Vault authentication token.
+     *
+     * @param token Vault authentication token
+     */
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    /**
+     * @return The Backend Secret engine version
+     */
+    public VaultKvVersion getKvVersion() {
+        return kvVersion;
+    }
+
+    /**
+     * Set the version of the Backend Secret engine.
+     *
+     * @param kvVersion The version of the Backend Secret engine
+     */
+    public void setKvVersion(VaultKvVersion kvVersion) {
+        this.kvVersion = kvVersion;
+    }
+
+    /**
+     * @return The Backend Secret engine name
+     */
+    public String getBackend() {
+        return backend;
+    }
+
+    /**
+     * Set the name of the Backend Secret engine.
+     *
+     * @param backend Backend Secret engine name
+     */
+    public void setBackend(String backend) {
+        this.backend = backend;
+    }
+
+    /**
+     * @return Flag to indicate that failure to connect to HashiCorp Vault is fatal (default false).
+     */
+    public boolean isFailFast() {
+        return failFast;
+    }
+
+    /**
+     * Set flag to indicate that failure to connect to HashiCorp Vault is fatal.
+     *
+     * @param failFast Flag to fail fast
+     */
+    public void setFailFast(boolean failFast) {
+        this.failFast = failFast;
+    }
+
+    /**
+     * The Http Pool Connection Configuration class for Vault.
+     */
+    @ConfigurationProperties(ConnectionPoolConfiguration.PREFIX)
+    @BootstrapContextCompatible
+    public static class VaultClientConnectionPoolConfiguration extends ConnectionPoolConfiguration { }
+
+    /**
+     * The Discovery Configuration class for Vault.
+     */
+    @ConfigurationProperties(ConfigDiscoveryConfiguration.PREFIX)
+    @BootstrapContextCompatible
+    public static class VaultClientDiscoveryConfiguration extends ConfigDiscoveryConfiguration { }
+
+}

--- a/discovery-client/src/main/java/io/micronaut/discovery/vault/VaultClientConstants.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/vault/VaultClientConstants.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.discovery.vault;
+
+/**
+ *  Vault Client Constants.
+ *
+ *  @author thiagolocatelli
+ *  @author graemerocher
+ *  @since 1.1.1
+ */
+public class VaultClientConstants {
+
+    public static final String PREFIX = "vault.client";
+    public static final String X_VAULT_TOKEN_HEADER = "X-Vault-Token";
+
+}

--- a/discovery-client/src/main/java/io/micronaut/discovery/vault/condition/RequiresVaultClientConfig.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/vault/condition/RequiresVaultClientConfig.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.discovery.vault.condition;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.discovery.config.ConfigDiscoveryConfiguration;
+import io.micronaut.discovery.vault.VaultClientConstants;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.annotation.ElementType;
+
+
+/**
+ * <p>Meta annotation for Vault Client Config requirements</p>.
+ *
+ *  @author thiagolocatelli
+ *  @author graemerocher
+ *  @since 1.1.1
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PACKAGE, ElementType.TYPE})
+@Requires(property = VaultClientConstants.PREFIX)
+@Requires(property = VaultClientConstants.PREFIX + "." + ConfigDiscoveryConfiguration.PREFIX + ".enabled", value = "true")
+public @interface RequiresVaultClientConfig { }

--- a/discovery-client/src/main/java/io/micronaut/discovery/vault/condition/package-info.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/vault/condition/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Vault Client Configuration.
+ *
+ *  @author thiagolocatelli
+ *  @author graemerocher
+ *  @since 1.1.1
+ */
+package io.micronaut.discovery.vault.condition;

--- a/discovery-client/src/main/java/io/micronaut/discovery/vault/config/client/AbstractVaultConfigConfigurationClient.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/vault/config/client/AbstractVaultConfigConfigurationClient.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.discovery.vault.config.client;
+
+import io.micronaut.context.env.Environment;
+import io.micronaut.context.env.PropertySource;
+import io.micronaut.discovery.config.ConfigurationClient;
+import io.micronaut.discovery.vault.VaultClientConfiguration;
+import io.micronaut.runtime.ApplicationConfiguration;
+import io.reactivex.Flowable;
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+
+/**
+ *  A {@link ConfigurationClient} for Vault Configuration.
+ *
+ *  @author thiagolocatelli
+ *  @author graemerocher
+ *  @since 1.1.1
+ */
+public abstract class AbstractVaultConfigConfigurationClient implements ConfigurationClient {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractVaultConfigConfigurationClient.class);
+
+    private VaultClientConfiguration vaultClientConfiguration;
+    private ApplicationConfiguration applicationConfiguration;
+    private Environment environment;
+    private ExecutorService executorService;
+
+    /**
+     * Default Constructor.
+     *
+     * @param vaultClientConfiguration  Vault Client Configuration
+     * @param applicationConfiguration  The application configuration
+     * @param environment               The environment
+     * @param executorService           Executor Service
+     */
+    public AbstractVaultConfigConfigurationClient(final VaultClientConfiguration vaultClientConfiguration,
+                                                  final ApplicationConfiguration applicationConfiguration,
+                                                  final Environment environment,
+                                                  final ExecutorService executorService) {
+
+        this.vaultClientConfiguration = vaultClientConfiguration;
+        this.applicationConfiguration = applicationConfiguration;
+        this.environment = environment;
+        this.executorService = executorService;
+    }
+
+    @Override
+    public Publisher<PropertySource> getPropertySources(Environment environment) {
+        if (!vaultClientConfiguration.getDiscoveryConfiguration().isEnabled()) {
+            return Flowable.empty();
+        }
+
+        final String applicationName = applicationConfiguration.getName().get();
+        final Set<String> activeNames = environment.getActiveNames();
+
+        if (LOG.isInfoEnabled()) {
+            LOG.info("Vault server endpoint: {}, secret engine version: {}", vaultClientConfiguration.getUri(),
+                    vaultClientConfiguration.getKvVersion());
+            LOG.info("Application name: {}, application profiles: {}", applicationName, activeNames);
+        }
+
+        activeNames.add(applicationName);
+        Flowable<PropertySource> propertySourceFlowable = getProperySources(activeNames);
+
+        if (executorService != null) {
+            return propertySourceFlowable.subscribeOn(io.reactivex.schedulers.Schedulers.from(
+                    executorService
+            ));
+        } else {
+            return propertySourceFlowable;
+        }
+    }
+
+    /**
+     * Builds the property source name.
+     *
+     * @param activeNames Active environment names
+     * @param currentActiveName Current environment name being processed
+     * @return property source name
+     */
+    protected String getVaultSourceName(Set<String> activeNames, String currentActiveName) {
+        for (String activeName : activeNames) {
+            if (activeName.equals(currentActiveName) && !activeName.equals(getApplicationConfiguration().getName().get())) {
+                return "/" + getApplicationConfiguration().getName().get() + "/" + activeName;
+            }
+        }
+        return "/" + getApplicationConfiguration().getName().get();
+    }
+
+    /**
+     * @param activeNames Active environment names
+     * @return The property sources
+     */
+    protected abstract Flowable<PropertySource> getProperySources(Set<String> activeNames);
+
+    /**
+     * @return The Application Configuration
+     */
+    public ApplicationConfiguration getApplicationConfiguration() {
+        return this.applicationConfiguration;
+    }
+
+    /**
+     * @return The Vault Client configuration
+     */
+    public VaultClientConfiguration getVaultClientConfiguration() {
+        return this.vaultClientConfiguration;
+    }
+
+    /**
+     * @return The Environment
+     */
+    public Environment getEnvironment() {
+        return this.environment;
+    }
+
+    /**
+     * Object holding a pair of objects.
+     *
+     * @param <L> Left object
+     * @param <R> Right object
+     */
+    public class Pair<L, R> {
+
+        private L left;
+        private R right;
+
+        /**
+         * Default Constructor.
+         *
+         * @param left the left object
+         * @param right the right object
+         */
+        protected Pair(L left, R right) {
+            this.left = left;
+            this.right = right;
+        }
+
+        /**
+         * @return The left object
+         */
+        public L getLeft() {
+            return left;
+        }
+
+        /**
+         * @return The right object
+         */
+        public R getRight() {
+            return right;
+        }
+
+    }
+}

--- a/discovery-client/src/main/java/io/micronaut/discovery/vault/config/client/AbstractVaultResponse.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/vault/config/client/AbstractVaultResponse.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.discovery.vault.config.client;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.concurrent.Immutable;
+import java.util.List;
+import java.util.Map;
+
+/**
+ *  Vault Response Envelope.
+ *
+ *  @param <T> type of the generic
+ *
+ *  @author thiagolocatelli
+ *  @author graemerocher
+ *  @since 1.1.1
+ */
+@Immutable
+public abstract class AbstractVaultResponse<T> {
+
+    private T data;
+
+    @JsonProperty("lease_duration")
+    private Long leaseDuration;
+
+    @JsonProperty("lease_id")
+    private String leaseId;
+
+    @JsonProperty("request_id")
+    private String requestId;
+
+    @JsonProperty("wrap_info")
+    private Map<String, String> wrapInfo;
+
+    private boolean renewable;
+
+    private List<String> warnings;
+
+    /**
+     * Constructor for AbstractVaultResponse.
+     *
+     * @param data The data object
+     * @param leaseDuration The token lease duration
+     * @param leaseId The token lease id
+     * @param requestId The vault request id
+     * @param wrapInfo The wrap info object
+     * @param renewable The flag indicating the vault token is renewable
+     * @param warnings The list of warnings
+     */
+    public AbstractVaultResponse(final T data,
+                                 final Long leaseDuration,
+                                 final String leaseId,
+                                 final String requestId,
+                                 final Map<String, String> wrapInfo,
+                                 final boolean renewable,
+                                 final List<String> warnings) {
+        this.data = data;
+        this.leaseDuration = leaseDuration;
+        this.leaseId = leaseId;
+        this.requestId = requestId;
+        this.wrapInfo = wrapInfo;
+        this.renewable = renewable;
+        this.warnings = warnings;
+    }
+
+    /**
+     * @return The data object
+     */
+    public T getData() {
+        return data;
+    }
+
+    /**
+     * Set the data object.
+     *
+     * @param data the data object
+     */
+    public void setData(final T data) {
+        this.data = data;
+    }
+
+    /**
+     * @return The token lease duration
+     */
+    public Long getLeaseDuration() {
+        return leaseDuration;
+    }
+
+    /**
+     * Set the token lease duration.
+     *
+     * @param leaseDuration token lease duration
+     */
+    public void setLeaseDuration(final Long leaseDuration) {
+        this.leaseDuration = leaseDuration;
+    }
+
+    /**
+     * @return The token lease id
+     */
+    public String getLeaseId() {
+        return leaseId;
+    }
+
+    /**
+     * Set the token release id.
+     *
+     * @param leaseId token release id
+     */
+    public void setLeaseId(final String leaseId) {
+        this.leaseId = leaseId;
+    }
+
+    /**
+     * @return The vault request id
+     */
+    public String getRequestId() {
+        return requestId;
+    }
+
+    /**
+     * Set the vault request id.
+     *
+     * @param requestId vault request id
+     */
+    public void setRequestId(final String requestId) {
+        this.requestId = requestId;
+    }
+
+    /**
+     * @return The wrap info object
+     */
+    public Map<String, String> getWrapInfo() {
+        return wrapInfo;
+    }
+
+    /**
+     * Set the wrap info object.
+     *
+     * @param wrapInfo wrap info object
+     */
+    public void setWrapInfo(final Map<String, String> wrapInfo) {
+        this.wrapInfo = wrapInfo;
+    }
+
+    /**
+     * @return The flag indicating the vault token is renewable
+     */
+    public boolean isRenewable() {
+        return renewable;
+    }
+
+    /**
+     * Set the flag indicating the vault token is renewable.
+     *
+     * @param renewable flag indicating the vault token is renewable
+     */
+    public void setRenewable(final boolean renewable) {
+        this.renewable = renewable;
+    }
+
+    /**
+     * @return List of warning
+     */
+    public List<String> getWarnings() {
+        return warnings;
+    }
+
+    /**
+     * Set the list of warnings.
+     *
+     * @param warnings list of warning
+     */
+    public void setWarnings(final List<String> warnings) {
+        this.warnings = warnings;
+    }
+}

--- a/discovery-client/src/main/java/io/micronaut/discovery/vault/config/client/filter/VaultHttpClientFilter.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/vault/config/client/filter/VaultHttpClientFilter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.discovery.vault.config.client.filter;
+
+import io.micronaut.context.annotation.BootstrapContextCompatible;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.annotation.Value;
+import io.micronaut.discovery.vault.VaultClientConstants;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.MutableHttpRequest;
+import io.micronaut.http.annotation.Filter;
+import io.micronaut.http.filter.ClientFilterChain;
+import io.micronaut.http.filter.HttpClientFilter;
+import org.reactivestreams.Publisher;
+
+/**
+ *  Vault Http Filter used to set auth token header.
+ *
+ *  @author thiagolocatelli
+ *  @author graemerocher
+ *  @since 1.1.1
+ */
+@Filter("/v1/**")
+@Requires(property = VaultClientConstants.PREFIX + ".token")
+@BootstrapContextCompatible
+public class VaultHttpClientFilter implements HttpClientFilter {
+
+    private String vaultToken;
+
+    /**
+     * @param vaultToken the vault token
+     */
+    public VaultHttpClientFilter(@Value("${vault.client.token}") final String vaultToken) {
+        this.vaultToken = vaultToken;
+    }
+
+    @Override
+    public Publisher<? extends HttpResponse<?>> doFilter(
+            final MutableHttpRequest<?> request,
+            final ClientFilterChain chain) {
+
+        return chain.proceed(request.header(VaultClientConstants.X_VAULT_TOKEN_HEADER, vaultToken));
+    }
+}

--- a/discovery-client/src/main/java/io/micronaut/discovery/vault/config/client/filter/package-info.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/vault/config/client/filter/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  Vault Client Configuration.
+ *
+ *  @author thiagolocatelli
+ *  @author graemerocher
+ *  @since 1.1.1
+ */
+package io.micronaut.discovery.vault.config.client.filter;

--- a/discovery-client/src/main/java/io/micronaut/discovery/vault/config/client/package-info.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/vault/config/client/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  Vault Client Configuration.
+ *
+ *  @author thiagolocatelli
+ *  @author graemerocher
+ *  @since 1.1.1
+ */
+package io.micronaut.discovery.vault.config.client;

--- a/discovery-client/src/main/java/io/micronaut/discovery/vault/config/client/v1/VaultConfigConfigurationClientV1.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/vault/config/client/v1/VaultConfigConfigurationClientV1.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.discovery.vault.config.client.v1;
+
+import io.micronaut.context.annotation.BootstrapContextCompatible;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.annotation.Value;
+import io.micronaut.context.env.Environment;
+import io.micronaut.context.env.PropertySource;
+import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.discovery.config.ConfigurationClient;
+import io.micronaut.discovery.vault.VaultClientConfiguration;
+import io.micronaut.discovery.vault.condition.RequiresVaultClientConfig;
+import io.micronaut.discovery.vault.config.client.AbstractVaultConfigConfigurationClient;
+import io.micronaut.discovery.vault.config.client.v1.condition.RequiresVaultClientConfigV1;
+import io.micronaut.discovery.vault.config.client.v1.response.VaultResponseV1;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.client.exceptions.HttpClientResponseException;
+import io.micronaut.runtime.ApplicationConfiguration;
+import io.micronaut.scheduling.TaskExecutors;
+import io.reactivex.BackpressureStrategy;
+import io.reactivex.Flowable;
+import io.reactivex.functions.Function;
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+/**
+ *  A {@link ConfigurationClient} for Vault Configuration.
+ *
+ *  @author thiagolocatelli
+ *  @author graemerocher
+ *  @since 1.1.1
+ */
+@Singleton
+@RequiresVaultClientConfig
+@RequiresVaultClientConfigV1
+@Requires(property = ConfigurationClient.ENABLED, value = "true", defaultValue = "false")
+@BootstrapContextCompatible
+public class VaultConfigConfigurationClientV1 extends AbstractVaultConfigConfigurationClient {
+
+    private static final Logger LOG = LoggerFactory.getLogger(VaultConfigConfigurationClientV1.class);
+
+    private final VaultConfigHttpClientV1 vaultConfigClientV1;
+    private final String vaultUri;
+
+    /**
+     * Default Constructor.
+     *
+     * @param vaultConfigClientV1       Vault Config Http Client
+     * @param vaultClientConfiguration  Vault Client Configuration
+     * @param applicationConfiguration  The application configuration
+     * @param environment               The environment
+     * @param vaultUri                  Vault endpoint uri
+     * @param executorService           Executor Service
+     */
+    public VaultConfigConfigurationClientV1(final VaultConfigHttpClientV1 vaultConfigClientV1,
+                                            final VaultClientConfiguration vaultClientConfiguration,
+                                            final ApplicationConfiguration applicationConfiguration,
+                                            final Environment environment,
+                                            @Value(VaultClientConfiguration.VAULT_CLIENT_CONFIG_ENDPOINT) final String vaultUri,
+                                            @Named(TaskExecutors.IO) @Nullable final ExecutorService executorService) {
+
+        super(vaultClientConfiguration, applicationConfiguration, environment, executorService);
+        this.vaultConfigClientV1 = vaultConfigClientV1;
+        this.vaultUri = vaultUri;
+    }
+
+    @Override
+    protected Flowable<PropertySource> getProperySources(Set<String> activeNames) {
+
+        final AtomicInteger sourceCount = new AtomicInteger(0);
+        final List<String> activeNamesList = new ArrayList<>(activeNames);
+
+        final Function<Throwable, Publisher<? extends VaultResponseV1>> errorHandler = getErrorHandler(sourceCount);
+        final List<PairVaultResponse> configurationValuesList = retrieveVaultProperties(activeNames);
+
+        return Flowable.fromIterable(configurationValuesList).concatMapEager(pairVaultResponse -> {
+            return pairVaultResponse.getRight().onErrorResumeNext(errorHandler)
+                    .flatMap(vaultResponse -> Flowable.create(emitter -> {
+
+                        String vaultSourceName = getVaultSourceName(activeNames, pairVaultResponse.getLeft());
+                        Map<String, Object> vaultResponseData = vaultResponse.getData();
+
+                        synchronized (sourceCount) {
+                            sourceCount.getAndIncrement();
+                        }
+
+                        if (!CollectionUtils.isEmpty(vaultResponseData)) {
+                            if (LOG.isInfoEnabled()) {
+                                LOG.info("Obtained property source from Vault, source={}", vaultSourceName);
+                            }
+                            emitter.onNext(PropertySource.of(vaultSourceName,
+                                    vaultResponseData, Integer.MAX_VALUE - activeNamesList.indexOf(
+                                            pairVaultResponse.getLeft())));
+                        }
+
+                        //if all items have been processed, emit onComplete
+                        if (sourceCount.get() == configurationValuesList.size()) {
+                            emitter.onComplete();
+                        }
+            }, BackpressureStrategy.ERROR));
+        });
+    }
+
+    /**
+     * @param activeNames active environment names
+     * @return list of responses from vault
+     */
+    private List<PairVaultResponse> retrieveVaultProperties(Set<String> activeNames) {
+        final String applicationName = getApplicationConfiguration().getName().get();
+
+        return activeNames.stream().map(activeName -> new PairVaultResponse(activeName,
+                    activeName.equals(applicationName) ?
+                        Flowable.fromPublisher(
+                                vaultConfigClientV1.readConfigurationValues(
+                                    getVaultClientConfiguration().getBackend(), applicationName)) :
+                        Flowable.fromPublisher(
+                                vaultConfigClientV1.readConfigurationValues(
+                                    getVaultClientConfiguration().getBackend(), applicationName, activeName))
+                )).collect(Collectors.toList());
+    }
+
+    /**
+     * @param sourceCount total of property sources from vault
+     * @return the error handler to handle vault failed requests
+     */
+    private Function<Throwable, Publisher<? extends VaultResponseV1>> getErrorHandler(AtomicInteger sourceCount) {
+        return throwable -> {
+
+            synchronized (sourceCount) {
+                sourceCount.getAndIncrement();
+            }
+
+            if (throwable instanceof HttpClientResponseException) {
+                HttpClientResponseException httpClientResponseException = (HttpClientResponseException) throwable;
+                if (httpClientResponseException.getStatus() == HttpStatus.NOT_FOUND) {
+                    if (getVaultClientConfiguration().isFailFast()) {
+                        return Flowable.error(new IllegalStateException(
+                                "Could not locate PropertySource and the fail fast property is set",
+                                throwable));
+                    }
+                    LOG.warn("Could not locate PropertySource: ", throwable);
+                    return Flowable.empty();
+                }
+            }
+            return Flowable.error(throwable);
+        };
+    }
+
+    @Override
+    public String getDescription() {
+        return VaultConfigHttpClientV1.CLIENT_DESCRIPTION;
+    }
+
+    /**
+     * Wrapper for Vault Response.
+     */
+    private class PairVaultResponse extends Pair<String, Flowable<VaultResponseV1>> {
+        public PairVaultResponse(String left, Flowable<VaultResponseV1> right) {
+            super(left, right);
+        }
+    }
+}

--- a/discovery-client/src/main/java/io/micronaut/discovery/vault/config/client/v1/VaultConfigHttpClientV1.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/vault/config/client/v1/VaultConfigHttpClientV1.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.discovery.vault.config.client.v1;
+
+import io.micronaut.context.annotation.BootstrapContextCompatible;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.discovery.vault.VaultClientConfiguration;
+import io.micronaut.discovery.vault.config.client.v1.condition.RequiresVaultClientConfigV1;
+import io.micronaut.discovery.vault.config.client.v1.response.VaultResponseV1;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Produces;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.retry.annotation.Retryable;
+import org.reactivestreams.Publisher;
+
+import javax.annotation.Nonnull;
+
+/**
+ *  A non-blocking HTTP client for Vault - KV v2.
+ *
+ *  @author thiagolocatelli
+ *  @author graemerocher
+ *  @since 1.1.1
+ */
+@Client(value = VaultClientConfiguration.VAULT_CLIENT_CONFIG_ENDPOINT, configuration = VaultClientConfiguration.class)
+@Requires(beans = VaultClientConfiguration.class)
+@RequiresVaultClientConfigV1
+@BootstrapContextCompatible
+public interface VaultConfigHttpClientV1 {
+
+    /**
+     * Vault Http Client description.
+     */
+    String CLIENT_DESCRIPTION = "vault-config-client-v1";
+
+    /**
+     * Reads an application configuration from Spring Config Server.
+     *
+     * @param backend           The name of the secret engine in Vault
+     * @param applicationName   The application name
+     * @return A {@link Publisher} that emits a list of {@link VaultResponseV1}
+     */
+    @Get("/v1/{backend}/{applicationName}")
+    @Produces(single = true)
+    @Retryable(
+            attempts = "${" + VaultClientConfiguration.VaultClientConnectionPoolConfiguration.PREFIX + ".retry-count:3}",
+            delay = "${" + VaultClientConfiguration.VaultClientConnectionPoolConfiguration.PREFIX + ".retry-delay:1s}"
+    )
+    @Nonnull
+    Publisher<VaultResponseV1> readConfigurationValues(
+            @Nonnull String backend,
+            @Nonnull String applicationName);
+
+    /**
+     * Reads an application configuration from Spring Config Server.
+     *
+     * @param backend           The name of the secret engine in Vault
+     * @param applicationName   The application name
+     * @param profile           The active profiles
+     * @return A {@link Publisher} that emits a list of {@link VaultResponseV1}
+     */
+    @Get("/v1/{backend}/{applicationName}/{profile}")
+    @Produces(single = true)
+    @Retryable(
+            attempts = "${" + VaultClientConfiguration.VaultClientConnectionPoolConfiguration.PREFIX + ".retry-count:3}",
+            delay = "${" + VaultClientConfiguration.VaultClientConnectionPoolConfiguration.PREFIX + ".retry-delay:1s}"
+    )
+    @Nonnull Publisher<VaultResponseV1> readConfigurationValues(
+            @Nonnull String backend,
+            @Nonnull String applicationName,
+            @Nonnull String profile);
+}

--- a/discovery-client/src/main/java/io/micronaut/discovery/vault/config/client/v1/condition/RequiresVaultClientConfigV1.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/vault/config/client/v1/condition/RequiresVaultClientConfigV1.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.discovery.vault.config.client.v1.condition;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.discovery.vault.VaultClientConstants;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.annotation.ElementType;
+
+/**
+ *  <p>Meta annotation for Vault Client Config requirements</p>.
+ *
+ *  @author thiagolocatelli
+ *  @author graemerocher
+ *  @since 1.1.1
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PACKAGE, ElementType.TYPE})
+@Requires(property = VaultClientConstants.PREFIX)
+@Requires(property = VaultClientConstants.PREFIX + ".kv-version", value = "V1")
+public @interface RequiresVaultClientConfigV1 { }

--- a/discovery-client/src/main/java/io/micronaut/discovery/vault/config/client/v1/condition/package-info.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/vault/config/client/v1/condition/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  Vault Client Configuration.
+ *
+ *  @author thiagolocatelli
+ *  @author graemerocher
+ *  @since 1.1.1
+ */
+package io.micronaut.discovery.vault.config.client.v1.condition;

--- a/discovery-client/src/main/java/io/micronaut/discovery/vault/config/client/v1/package-info.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/vault/config/client/v1/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  Vault Client Configuration.
+ *
+ *  @author thiagolocatelli
+ *  @author graemerocher
+ *  @since 1.1.1
+ */
+package io.micronaut.discovery.vault.config.client.v1;

--- a/discovery-client/src/main/java/io/micronaut/discovery/vault/config/client/v1/response/VaultResponseV1.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/vault/config/client/v1/response/VaultResponseV1.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.discovery.vault.config.client.v1.response;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.discovery.vault.config.client.AbstractVaultResponse;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ *  Vault Response Envelope.
+ *
+ *  @author thiagolocatelli
+ *  @author graemerocher
+ *  @since 1.1.1
+ */
+public class VaultResponseV1 extends AbstractVaultResponse<Map<String, Object>> {
+
+    /**
+     * Constructor for VaultResponseV1.
+     *
+     * @param data The data object
+     * @param leaseDuration The token lease duration
+     * @param leaseId The token lease id
+     * @param requestId The vault request id
+     * @param wrapInfo The wrap info object
+     * @param renewable The flag indicating the vault token is renewable
+     * @param warnings The list of warnings
+     */
+    @JsonCreator
+    @Internal
+    public VaultResponseV1(
+            @JsonProperty("data") final Map<String, Object> data,
+            @JsonProperty("lease_duration") final Long leaseDuration,
+            @JsonProperty("lease_id") final String leaseId,
+            @JsonProperty("request_id") final String requestId,
+            @JsonProperty("wrap_info") final Map<String, String> wrapInfo,
+            @JsonProperty("renewable") final boolean renewable,
+            @JsonProperty("warnings") final List<String> warnings) {
+
+        super(data, leaseDuration, leaseId, requestId, wrapInfo, renewable,
+                warnings);
+    }
+}

--- a/discovery-client/src/main/java/io/micronaut/discovery/vault/config/client/v1/response/package-info.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/vault/config/client/v1/response/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  Vault Client Configuration.
+ *
+ *  @author thiagolocatelli
+ *  @author graemerocher
+ *  @since 1.1.1
+ */
+package io.micronaut.discovery.vault.config.client.v1.response;

--- a/discovery-client/src/main/java/io/micronaut/discovery/vault/config/client/v2/VaultConfigConfigurationClientV2.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/vault/config/client/v2/VaultConfigConfigurationClientV2.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.discovery.vault.config.client.v2;
+
+import io.micronaut.context.annotation.BootstrapContextCompatible;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.annotation.Value;
+import io.micronaut.context.env.Environment;
+import io.micronaut.context.env.PropertySource;
+import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.discovery.config.ConfigurationClient;
+import io.micronaut.discovery.vault.VaultClientConfiguration;
+import io.micronaut.discovery.vault.condition.RequiresVaultClientConfig;
+import io.micronaut.discovery.vault.config.client.AbstractVaultConfigConfigurationClient;
+import io.micronaut.discovery.vault.config.client.v2.condition.RequiresVaultClientConfigV2;
+import io.micronaut.discovery.vault.config.client.v2.response.VaultResponseData;
+import io.micronaut.discovery.vault.config.client.v2.response.VaultResponseV2;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.client.exceptions.HttpClientResponseException;
+import io.micronaut.runtime.ApplicationConfiguration;
+import io.micronaut.scheduling.TaskExecutors;
+import io.reactivex.BackpressureStrategy;
+import io.reactivex.Flowable;
+import io.reactivex.functions.Function;
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+/**
+ *  A {@link ConfigurationClient} for Vault Configuration.
+ *
+ *  @author thiagolocatelli
+ *  @author graemerocher
+ *  @since 1.1.1
+ */
+@Singleton
+@RequiresVaultClientConfig
+@RequiresVaultClientConfigV2
+@Requires(property = ConfigurationClient.ENABLED, value = "true", defaultValue = "false")
+@BootstrapContextCompatible
+public class VaultConfigConfigurationClientV2 extends AbstractVaultConfigConfigurationClient {
+
+    private static final Logger LOG = LoggerFactory.getLogger(VaultConfigConfigurationClientV2.class);
+
+    private final VaultConfigHttpClientV2 vaultConfigClientV2;
+    private final String vaultUri;
+
+    /**
+     * Default Constructor.
+     *
+     * @param vaultConfigClientV2       Vault Config Http Client
+     * @param vaultClientConfiguration  Vault Client Configuration
+     * @param applicationConfiguration  The application configuration
+     * @param environment               The environment
+     * @param vaultUri                  Vault endpoint uri
+     * @param executorService           Executor Service
+     */
+    public VaultConfigConfigurationClientV2(final VaultConfigHttpClientV2 vaultConfigClientV2,
+                                            final VaultClientConfiguration vaultClientConfiguration,
+                                            final ApplicationConfiguration applicationConfiguration,
+                                            final Environment environment,
+                                            @Value(VaultClientConfiguration.VAULT_CLIENT_CONFIG_ENDPOINT) final String vaultUri,
+                                            @Named(TaskExecutors.IO) @Nullable final ExecutorService executorService) {
+
+        super(vaultClientConfiguration, applicationConfiguration, environment, executorService);
+        this.vaultConfigClientV2 = vaultConfigClientV2;
+        this.vaultUri = vaultUri;
+    }
+
+    @Override
+    protected Flowable<PropertySource> getProperySources(Set<String> activeNames) {
+
+        final AtomicInteger sourceCount = new AtomicInteger(0);
+        final List<String> activeNamesList = new ArrayList<>(activeNames);
+
+        Function<Throwable, Publisher<? extends VaultResponseV2>> errorHandler = getErrorHandler(sourceCount);
+        List<PairVaultResponse> configurationValuesList = retrieveVaultProperties(activeNames);
+
+        return Flowable.fromIterable(configurationValuesList).flatMap(pairVaultResponse -> {
+            return pairVaultResponse.getRight().onErrorResumeNext(errorHandler)
+                    .flatMap(vaultResponse -> Flowable.create(emitter -> {
+                VaultResponseData vaultResponseData = vaultResponse.getData();
+
+                synchronized (sourceCount) {
+                    sourceCount.getAndIncrement();
+                }
+
+                if (!CollectionUtils.isEmpty(vaultResponseData.getData())) {
+                    String vaultSourceName = getVaultSourceName(activeNames, pairVaultResponse.getLeft());
+
+                    if (LOG.isInfoEnabled()) {
+                        LOG.info("Obtained property source from Vault, source={}", vaultSourceName);
+                    }
+                    emitter.onNext(PropertySource.of(vaultSourceName,
+                            vaultResponseData.getData(), Integer.MAX_VALUE - activeNamesList.indexOf(pairVaultResponse.getLeft())));
+                }
+
+                //if all items have been processed, emit onComplete
+                if (sourceCount.get() == configurationValuesList.size()) {
+                    emitter.onComplete();
+                }
+            }, BackpressureStrategy.ERROR));
+        });
+    }
+
+    /**
+     * @param activeNames active environment names
+     * @return list of responses from vault
+     */
+    private List<PairVaultResponse> retrieveVaultProperties(Set<String> activeNames) {
+        final String applicationName = getApplicationConfiguration().getName().get();
+
+        return activeNames.stream().map(activeName -> new PairVaultResponse(activeName,
+                activeName.equals(applicationName) ?
+                        Flowable.fromPublisher(
+                                vaultConfigClientV2.readConfigurationValues(
+                                        getVaultClientConfiguration().getBackend(), applicationName)) :
+                        Flowable.fromPublisher(
+                                vaultConfigClientV2.readConfigurationValues(
+                                        getVaultClientConfiguration().getBackend(), applicationName, activeName))
+        )).collect(Collectors.toList());
+    }
+
+    /**
+     * @param sourceCount total of property sources from vault
+     * @return the error handler to handle vault failed requests
+     */
+    private Function<Throwable, Publisher<? extends VaultResponseV2>>  getErrorHandler(AtomicInteger sourceCount) {
+        return throwable -> {
+
+            synchronized (sourceCount) {
+                sourceCount.getAndIncrement();
+            }
+
+            if (throwable instanceof HttpClientResponseException) {
+                HttpClientResponseException httpClientResponseException = (HttpClientResponseException) throwable;
+                if (httpClientResponseException.getStatus() == HttpStatus.NOT_FOUND) {
+                    if (getVaultClientConfiguration().isFailFast()) {
+                        return Flowable.error(new IllegalStateException(
+                                "Could not locate PropertySource and the fail fast property is set",
+                                throwable));
+                    }
+                    LOG.warn("Could not locate PropertySource: ", throwable);
+                    return Flowable.empty();
+                }
+            }
+            return Flowable.error(throwable);
+        };
+    }
+
+    @Override
+    public String getDescription() {
+        return VaultConfigHttpClientV2.CLIENT_DESCRIPTION;
+    }
+
+    /**
+     * Wrapper for Vault Response.
+     */
+    private class PairVaultResponse extends Pair<String, Flowable<VaultResponseV2>> {
+        public PairVaultResponse(String left, Flowable<VaultResponseV2> right) {
+            super(left, right);
+        }
+    }
+
+}

--- a/discovery-client/src/main/java/io/micronaut/discovery/vault/config/client/v2/VaultConfigHttpClientV2.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/vault/config/client/v2/VaultConfigHttpClientV2.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.discovery.vault.config.client.v2;
+
+import io.micronaut.context.annotation.BootstrapContextCompatible;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.discovery.vault.VaultClientConfiguration;
+import io.micronaut.discovery.vault.config.client.v2.condition.RequiresVaultClientConfigV2;
+import io.micronaut.discovery.vault.config.client.v2.response.VaultResponseV2;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Produces;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.retry.annotation.Retryable;
+import org.reactivestreams.Publisher;
+
+import javax.annotation.Nonnull;
+
+/**
+ *  A non-blocking HTTP client for Vault - KV v2.
+ *
+ *  @author thiagolocatelli
+ *  @author graemerocher
+ *  @since 1.1.1
+ */
+@Client(value = VaultClientConfiguration.VAULT_CLIENT_CONFIG_ENDPOINT, configuration = VaultClientConfiguration.class)
+@Requires(beans = VaultClientConfiguration.class)
+@RequiresVaultClientConfigV2
+@BootstrapContextCompatible
+public interface VaultConfigHttpClientV2 {
+
+    /**
+     * Vault Http Client description.
+     */
+    String CLIENT_DESCRIPTION = "vault-config-client-v2";
+
+    /**
+     * Reads an application configuration from Spring Config Server.
+     *
+     * @param backend           The name of the secret engine in Vault
+     * @param applicationName   The application name
+     * @return A {@link Publisher} that emits a list of {@link VaultResponseV2}
+     */
+    @Get("/v1/{backend}/data/{applicationName}")
+    @Produces(single = true)
+    @Retryable(
+            attempts = "${" + VaultClientConfiguration.VaultClientConnectionPoolConfiguration.PREFIX + ".retry-count:3}",
+            delay = "${" + VaultClientConfiguration.VaultClientConnectionPoolConfiguration.PREFIX + ".retry-celay:1s}"
+    )
+    @Nonnull
+    Publisher<VaultResponseV2> readConfigurationValues(
+            @Nonnull String backend,
+            @Nonnull String applicationName);
+
+    /**
+     * Reads an application configuration from Spring Config Server.
+     *
+     * @param backend           The name of the secret engine in Vault
+     * @param applicationName   The application name
+     * @param profile           The active profiles
+     * @return A {@link Publisher} that emits a list of {@link VaultResponseV2}
+     */
+    @Get("/v1/{backend}/data/{applicationName}/{profile}")
+    @Produces(single = true)
+    @Retryable(
+            attempts = "${" + VaultClientConfiguration.VaultClientConnectionPoolConfiguration.PREFIX + ".retry-count:3}",
+            delay = "${" + VaultClientConfiguration.VaultClientConnectionPoolConfiguration.PREFIX + ".retry-delay:1s}"
+    )
+    @Nonnull Publisher<VaultResponseV2> readConfigurationValues(
+            @Nonnull String backend,
+            @Nonnull String applicationName,
+            @Nonnull String profile);
+}

--- a/discovery-client/src/main/java/io/micronaut/discovery/vault/config/client/v2/condition/RequiresVaultClientConfigV2.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/vault/config/client/v2/condition/RequiresVaultClientConfigV2.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.discovery.vault.config.client.v2.condition;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.discovery.vault.VaultClientConstants;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.annotation.ElementType;
+
+/**
+ *  <p>Meta annotation for Vault Client Config requirements</p>.
+ *
+ *  @author thiagolocatelli
+ *  @author graemerocher
+ *  @since 1.1.1
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PACKAGE, ElementType.TYPE})
+@Requires(property = VaultClientConstants.PREFIX)
+@Requires(property = VaultClientConstants.PREFIX + ".kv-version", value = "V2")
+public @interface RequiresVaultClientConfigV2 { }

--- a/discovery-client/src/main/java/io/micronaut/discovery/vault/config/client/v2/condition/package-info.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/vault/config/client/v2/condition/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  Vault Client Configuration.
+ *
+ *  @author thiagolocatelli
+ *  @author graemerocher
+ *  @since 1.1.1
+ */
+package io.micronaut.discovery.vault.config.client.v2.condition;

--- a/discovery-client/src/main/java/io/micronaut/discovery/vault/config/client/v2/package-info.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/vault/config/client/v2/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  Vault Client Configuration.
+ *
+ *  @author thiagolocatelli
+ *  @author graemerocher
+ *  @since 1.1.1
+ */
+package io.micronaut.discovery.vault.config.client.v2;

--- a/discovery-client/src/main/java/io/micronaut/discovery/vault/config/client/v2/response/VaultResponseData.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/vault/config/client/v2/response/VaultResponseData.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.discovery.vault.config.client.v2.response;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.core.annotation.Internal;
+
+import javax.annotation.concurrent.Immutable;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ *  Vault Data object.
+ *
+ *  @author thiagolocatelli
+ *  @author graemerocher
+ *  @since 1.1.1
+ */
+@Immutable
+public class VaultResponseData {
+
+    private Map<String, Object> data;
+    private Map<String, Object> metadata;
+
+    /**
+     * Constructor for VaultResponseData.
+     *
+     * @param data The data map
+     * @param metadata The metadata map
+     */
+    @JsonCreator
+    @Internal
+    public VaultResponseData(@JsonProperty("data") final Map<String, Object> data,
+                             @JsonProperty("metadata") final Map<String, Object> metadata) {
+
+        this.data = data == null ? Collections.emptyMap() : Collections.unmodifiableMap(data);
+        this.metadata = metadata == null ? Collections.emptyMap() : Collections.unmodifiableMap(metadata);
+    }
+
+    /**
+     * @return The data map
+     */
+    public Map<String, Object> getData() {
+        return data;
+    }
+
+    /**
+     * Set the data map.
+     *
+     * @param data the data map
+     */
+    public void setData(final Map<String, Object> data) {
+        this.data = data;
+    }
+
+    /**
+     * @return The metadata map
+     */
+    public Map<String, Object> getMetadata() {
+        return metadata;
+    }
+
+    /**
+     * Set the metadata map.
+     *
+     * @param metadata the metadata map
+     */
+    public void setMetadata(final Map<String, Object> metadata) {
+        this.metadata = metadata;
+    }
+}

--- a/discovery-client/src/main/java/io/micronaut/discovery/vault/config/client/v2/response/VaultResponseV2.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/vault/config/client/v2/response/VaultResponseV2.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.discovery.vault.config.client.v2.response;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.discovery.vault.config.client.AbstractVaultResponse;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ *  Vault Response Envelope.
+ *
+ *  @author thiagolocatelli
+ *  @author graemerocher
+ *  @since 1.1.1
+ */
+public class VaultResponseV2 extends AbstractVaultResponse<VaultResponseData> {
+
+    /**
+     * Constructor for VaultResponseV2.
+     *
+     * @param data The data object
+     * @param leaseDuration The token lease duration
+     * @param leaseId The token lease id
+     * @param requestId The vault request id
+     * @param wrapInfo The wrap info object
+     * @param renewable The flag indicating the vault token is renewable
+     * @param warnings The list of warnings
+     */
+    @JsonCreator
+    @Internal
+    public VaultResponseV2(
+            @JsonProperty("data") final VaultResponseData data,
+            @JsonProperty("lease_duration") final Long leaseDuration,
+            @JsonProperty("lease_id") final String leaseId,
+            @JsonProperty("request_id") final String requestId,
+            @JsonProperty("wrap_info") final Map<String, String> wrapInfo,
+            @JsonProperty("renewable") final boolean renewable,
+            @JsonProperty("warnings") final List<String> warnings) {
+
+        super(data, leaseDuration, leaseId, requestId, wrapInfo, renewable,
+                warnings);
+    }
+}

--- a/discovery-client/src/main/java/io/micronaut/discovery/vault/config/client/v2/response/package-info.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/vault/config/client/v2/response/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  Vault Client Configuration.
+ *
+ *  @author thiagolocatelli
+ *  @author graemerocher
+ *  @since 1.1.1
+ */
+package io.micronaut.discovery.vault.config.client.v2.response;

--- a/discovery-client/src/main/java/io/micronaut/discovery/vault/config/package-info.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/vault/config/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  Vault Client Configuration.
+ *
+ *  @author thiagolocatelli
+ *  @author graemerocher
+ *  @since 1.1.1
+ */
+package io.micronaut.discovery.vault.config;

--- a/discovery-client/src/main/java/io/micronaut/discovery/vault/package-info.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/vault/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *  Vault Client Configuration.
+ *
+ *  @author thiagolocatelli
+ *  @author graemerocher
+ *  @since 1.1.1
+ */
+package io.micronaut.discovery.vault;

--- a/discovery-client/src/test/groovy/io/micronaut/discovery/vault/ApplicationTestController.java
+++ b/discovery-client/src/test/groovy/io/micronaut/discovery/vault/ApplicationTestController.java
@@ -1,0 +1,35 @@
+package io.micronaut.discovery.vault;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.annotation.Value;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Controller
+@Requires(property = ApplicationTestController.ENABLED)
+public class ApplicationTestController {
+
+    public static final String ENABLED = "enable.mock.application-controller";
+
+    @Value("${vault-backend-key-one:LOCAL}")
+    protected String vaultBackendKey;
+
+    @Value("${vault-backend-kv-version:LOCAL}")
+    protected String vaultBackendKvVersion;
+
+    @Value("${vault-backend-name:LOCAL}")
+    protected String vaultBackendName;
+
+    @Get("/test-vault")
+    Map<String, String> test() {
+        Map<String, String> response = new HashMap<>();
+        response.put("vault-backend-key-one", vaultBackendKey);
+        response.put("vault-backend-kv-version", vaultBackendKvVersion);
+        response.put("vault-backend-name", vaultBackendName);
+        return response;
+    }
+
+}

--- a/discovery-client/src/test/groovy/io/micronaut/discovery/vault/MockingVaultServerController.java
+++ b/discovery-client/src/test/groovy/io/micronaut/discovery/vault/MockingVaultServerController.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.discovery.vault;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.discovery.vault.config.client.v1.response.VaultResponseV1;
+import io.micronaut.discovery.vault.config.client.v2.response.VaultResponseData;
+import io.micronaut.discovery.vault.config.client.v2.response.VaultResponseV2;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.reactivex.Flowable;
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+@Controller("/")
+@Requires(property = MockingVaultServerController.ENABLED)
+public class MockingVaultServerController {
+
+    public static final String ENABLED = "enable.mock.vault-config";
+    final static Logger LOGGER = LoggerFactory.getLogger(MockingVaultServerController.class);
+
+    @Get("/v1/{backend}/{applicationName}")
+    public Publisher<VaultResponseV1> readConfigurationValues(@Nonnull String backend,
+                                                              @Nonnull String applicationName) {
+
+        return getVaultResponseV1(backend, applicationName, applicationName);
+    }
+
+    @Get("/v1/{backend}/{applicationName}/{profile}")
+    public Publisher<VaultResponseV1> readConfigurationValues(@Nonnull String backend,
+                                                              @Nonnull String applicationName,
+                                                              @Nonnull String profile) {
+
+        return getVaultResponseV1(backend, applicationName, profile);
+    }
+
+    @Get("/v1/{backend}/data/{applicationName}")
+    public Publisher<VaultResponseV2> readConfigurationValuesV2(@Nonnull String backend,
+                                                              @Nonnull String applicationName) {
+
+        return getVaultResponseV2(backend, applicationName, applicationName);
+    }
+
+    @Get("/v1/{backend}/data/{applicationName}/{profile}")
+    public Publisher<VaultResponseV2> readConfigurationValuesV2(@Nonnull String backend,
+                                                              @Nonnull String applicationName,
+                                                              @Nonnull String profile) {
+
+        return getVaultResponseV2(backend, applicationName, profile);
+    }
+
+
+    private Publisher<VaultResponseV1> getVaultResponseV1(@Nonnull String backend,
+                                                        @Nonnull String applicationName,
+                                                        @Nonnull String profile) {
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("vault-backend-key-one", applicationName + (StringUtils.isNotEmpty(profile) ? "-" + profile : ""));
+        properties.put("vault-backend-name", backend + (StringUtils.isNotEmpty(profile) ? "-" + profile : ""));
+        properties.put("vault-backend-kv-version", "v1" + (StringUtils.isNotEmpty(profile) ? "-" + profile : ""));
+
+        VaultResponseV1 response = new VaultResponseV1(properties,
+                null,
+                null,
+                null,
+                Collections.emptyMap(),
+                false,
+                Collections.emptyList());
+
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+            LOGGER.info(objectMapper.writeValueAsString(response));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+
+        return Flowable.just(response);
+    }
+
+    private Publisher<VaultResponseV2> getVaultResponseV2(@Nonnull String backend,
+                                                        @Nonnull String applicationName,
+                                                        @Nonnull String profile) {
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("vault-backend-key-one", applicationName + (StringUtils.isNotEmpty(profile) ? "-" + profile : ""));
+        properties.put("vault-backend-name", backend + (StringUtils.isNotEmpty(profile) ? "-" + profile : ""));
+        properties.put("vault-backend-kv-version", "v1" + (StringUtils.isNotEmpty(profile) ? "-" + profile : ""));
+
+        VaultResponseData vaultResponseData = new VaultResponseData(properties, Collections.emptyMap());
+
+        VaultResponseV2 response = new VaultResponseV2(vaultResponseData,
+                null,
+                null,
+                null,
+                Collections.emptyMap(),
+                false,
+                Collections.emptyList());
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+        try {
+            LOGGER.info(objectMapper.writeValueAsString(response));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+
+        return Flowable.just(response);
+    }
+
+}

--- a/discovery-client/src/test/groovy/io/micronaut/discovery/vault/VaultClientConfigTest.java
+++ b/discovery-client/src/test/groovy/io/micronaut/discovery/vault/VaultClientConfigTest.java
@@ -1,0 +1,123 @@
+package io.micronaut.discovery.vault;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.env.Environment;
+import io.micronaut.discovery.vault.config.client.v1.response.VaultResponseV1;
+import io.micronaut.discovery.vault.config.client.v2.response.VaultResponseV2;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.LoadBalancer;
+import io.micronaut.runtime.server.EmbeddedServer;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class VaultClientConfigTest {
+
+    private static EmbeddedServer vaultServer;
+    private static HttpClient vaultServerHttpClient;
+
+    private static EmbeddedServer applicationServer;
+    private static HttpClient applicationServerHttpClient;
+
+    @BeforeClass
+    public static void setupServer() {
+
+        System.setProperty(Environment.BOOTSTRAP_CONTEXT_PROPERTY, "true");
+
+        Map<String, Object> vaultServerPropertiesMap = new HashMap<>();
+        vaultServerPropertiesMap.put(MockingVaultServerController.ENABLED, true);
+        vaultServerPropertiesMap.put("micronaut.server.port", -1);
+        vaultServerPropertiesMap.put("micronaut.environments", "dev,test");
+        vaultServerPropertiesMap.put("vault.client.config.enabled", false);
+        vaultServer = ApplicationContext.run(EmbeddedServer.class, vaultServerPropertiesMap);
+
+        vaultServerHttpClient = vaultServer
+                .getApplicationContext()
+                .createBean(HttpClient.class, LoadBalancer.fixed(vaultServer.getURL()));
+
+        Map<String, Object> applicationServerPropertiesMap = new HashMap<>();
+        applicationServerPropertiesMap.put(ApplicationTestController.ENABLED, true);
+        applicationServerPropertiesMap.put("micronaut.environments", "dev");
+        applicationServerPropertiesMap.put("micronaut.application.name", "vault-config-sample");
+        applicationServerPropertiesMap.put("micronaut.config-client.enabled", true);
+        applicationServerPropertiesMap.put("vault.client.config.enabled", true);
+        applicationServerPropertiesMap.put("vault.client.kv-version", "V1");
+        applicationServerPropertiesMap.put("vault.client.token", "testtoken");
+        applicationServerPropertiesMap.put("vault.client.backend", "backendv1");
+        applicationServerPropertiesMap.put("vault.client.uri", vaultServer.getURI());
+        applicationServer = ApplicationContext.run(EmbeddedServer.class, applicationServerPropertiesMap);
+
+        applicationServerHttpClient = applicationServer
+                .getApplicationContext()
+                .createBean(HttpClient.class, LoadBalancer.fixed(applicationServer.getURL()));
+
+    }
+
+    @AfterClass
+    public static void stopServer() {
+        System.setProperty(Environment.BOOTSTRAP_CONTEXT_PROPERTY, "");
+        if (vaultServer != null) {
+            vaultServer.stop();
+        }
+        if (vaultServerHttpClient != null) {
+            vaultServerHttpClient.stop();
+        }
+
+        if (applicationServer != null) {
+            applicationServer.stop();
+        }
+        if (applicationServerHttpClient != null) {
+            applicationServerHttpClient.stop();
+        }
+    }
+
+    @Test
+    public void testReadValuesFromVaultServerV1() throws Exception {
+        HttpRequest request = HttpRequest.GET("/v1/backendv1/vault-config-sample/prod");
+        VaultResponseV1 response = vaultServerHttpClient.toBlocking().retrieve(request, VaultResponseV1.class);
+
+        assertNotNull(response);
+        assertTrue(response.getData().containsKey("vault-backend-key-one"));
+        assertEquals(response.getData().get("vault-backend-key-one"), "vault-config-sample-prod");
+
+        assertTrue(response.getData().containsKey("vault-backend-name"));
+        assertEquals(response.getData().get("vault-backend-name"), "backendv1-prod");
+    }
+
+    @Test
+    public void testReadValuesFromVaultServerV2() throws Exception {
+        HttpRequest request = HttpRequest.GET("/v1/backendv2/data/vault-config-sample/prod");
+        VaultResponseV2 response = vaultServerHttpClient.toBlocking().retrieve(request, VaultResponseV2.class);
+
+        assertNotNull(response);
+        assertNotNull(response.getData());
+
+        assertTrue(response.getData().getData().containsKey("vault-backend-key-one"));
+        assertEquals(response.getData().getData().get("vault-backend-key-one"), "vault-config-sample-prod");
+
+        assertTrue(response.getData().getData().containsKey("vault-backend-name"));
+        assertEquals(response.getData().getData().get("vault-backend-name"), "backendv2-prod");
+    }
+
+    @Test
+    public void testReadValuesFromApplicationController() throws Exception {
+
+        Map<String, String> responseType = new HashMap<>();
+
+        HttpRequest request = HttpRequest.GET("/test-vault");
+        Map<String, String> response = applicationServerHttpClient.toBlocking().retrieve(request, responseType.getClass());
+
+        assertNotNull(response);
+
+        assertTrue(response.containsKey("vault-backend-key-one"));
+        assertTrue(response.containsKey("vault-backend-kv-version"));
+        assertTrue(response.containsKey("vault-backend-name"));
+    }
+
+}

--- a/src/main/docs/guide/cloud/cloudConfiguration/distributedConfigurationVault.adoc
+++ b/src/main/docs/guide/cloud/cloudConfiguration/distributedConfigurationVault.adoc
@@ -1,0 +1,29 @@
+Since 1.1, Micronaut features a native https://www.vaultproject.io/[HashiCorp Vault] for those who have not switched to a dedicated more complete solution like Consul.
+
+To enable support for Vault Configuration simply add the following configuration to your `bootstrap.yml` file:
+
+.Integrating with HashiCorp Vault
+[source,yaml]
+----
+micronaut:
+    application:
+        name: hello-world
+    config-client:
+        enabled: true
+
+vault:
+    client:
+        config:
+            enabled: true
+        uri: http://192.168.1.88:8200   # default value: http://locahost:8200
+        token: ${VAULT_TOKEN}           # Usually set as environment variable
+        kv-version: V1                  # default value: V1
+        backend: backendv1              # default value: secret
+        fail-fast: false
+        retry-attempts: 4               # optional, number of times to retry
+        retry-delay: 2s                 # optional, delay between retries
+----
+
+Micronaut will use the configured `micronaut.application.name` to lookup property sources for the application from Vault configured via `vault.client.uri`.
+
+See the https://www.vaultproject.io/api/secret/kv/index.html[Documentation for HashiCorp Vault] for more information on how to setup the server.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -136,7 +136,8 @@ cloud:
   cloudConfiguration:
     title: Cloud Configuration
     distributedConfiguration: Distributed Configuration
-    distributedConfigurationConsul: Consul Support
+    distributedConfigurationConsul: HashiCorp Consul Support
+    distributedConfigurationVault: HashiCorp Vault Support
     distributedConfigurationSpringCloud: Spring Cloud Config Support
     distributedConfigurationAwsParameterStore: AWS Parameter Store Support
   serviceDiscovery:


### PR DESCRIPTION
This Pull Request addresses the issue #904 created by @alvarosanchez 

It contains the integration with Vault to load secrets from Vault as application properties. Vault is a little different from Spring Cloud Config, which returns properties for all property sources matched with the application name and environment names in one response. In Vault, for each environment name a request needs to be made. Also, the user can store secrets under the application name only, without any `profile`. For example, if the application name is `vault-config-sample` and the Micronaut environments are `dev` and `docker` and the user created the secrets in a KV store named `backendv1`, three requests need to be made:

- http://192.168.1.88:8200/v1/backendv1/vault-config-sample
- http://192.168.1.88:8200/v1/backendv1/vault-config-sample/dev
- http://192.168.1.88:8200/v1/backendv1/vault-config-sample/docker

At least one request is always made, using the application name. The vault client also respects the order, so in this example, dev takes precedence over docker which takes precedence over the application name. If one environment name, aka profile, does not exist in Vault, the error message is displayed in the logs and the next profiles are evaluated (considering `vault.client.fail-fast` is set to `false`). The logs might show a different order of profiles being retrieved from Vault, that's due to the `Flowable.flatMap()` that loses the order when processing items.


Some examples from a sample app I created (using native image on a Mac):

```
####################################################################################################################################################################################

[thiago@dropzone ~/dev/java/micronaut/vault-config-sample (master)] ./vault-config-sample
12:22:40.652 [main] INFO  i.m.context.DefaultBeanContext - Reading Startup environment from bootstrap.yml
12:22:41.442 [main] INFO  i.m.d.v.c.c.AbstractVaultConfigConfigurationClient - Vault server endpoint: http://127.0.0.1:8200, secret engine version: V1
12:22:41.443 [main] INFO  i.m.d.v.c.c.AbstractVaultConfigConfigurationClient - Application name: vault-config-sample, application profiles: []
12:22:41.968 [nioEventLoopGroup-2-2] INFO  i.m.d.v.c.c.v.VaultConfigConfigurationClientV1 - Obtained property source from Vault, source=/vault-config-sample
12:22:41.970 [main] INFO  i.m.d.c.c.DistributedPropertySourceLocator - Resolved 1 configuration sources from client: compositeConfigurationClient(vault-config-client-v1)
12:22:42.530 [main] INFO  io.micronaut.runtime.Micronaut - Startup completed in 2049ms. Server Running: http://localhost:8080

[tlocatellidasilva@C02Q61S3G8WL ~] http http://127.0.0.1:8080/test
HTTP/1.1 200 OK
Date: Mon, 13 May 2019 16:23:01 GMT
connection: keep-alive
content-length: 112
content-type: application/json

{
    "vault-backend-key-one": "vault-config-sample",
    "vault-backend-kv-version": "v1",
    "vault-backend-name": "backendv1"
}

####################################################################################################################################################################################

[thiago@dropzone ~/dev/java/micronaut/vault-config-sample (master)] MICRONAUT_ENVIRONMENTS=dev,docker ./vault-config-sample
12:15:10.496 [main] INFO  i.m.context.env.DefaultEnvironment - Established active environments: [dev, docker]
12:15:10.549 [main] INFO  i.m.context.DefaultBeanContext - Reading Startup environment from bootstrap.yml
12:15:10.551 [main] INFO  i.m.context.env.DefaultEnvironment - Established active environments: [dev, docker]
12:15:11.407 [main] INFO  i.m.d.v.c.c.AbstractVaultConfigConfigurationClient - Vault server endpoint: http://127.0.0.1:8200, secret engine version: V1
12:15:11.407 [main] INFO  i.m.d.v.c.c.AbstractVaultConfigConfigurationClient - Application name: vault-config-sample, application profiles: [dev, docker]
12:15:11.949 [nioEventLoopGroup-2-6] INFO  i.m.d.v.c.c.v.VaultConfigConfigurationClientV1 - Obtained property source from Vault, source=/vault-config-sample
12:15:11.949 [nioEventLoopGroup-2-5] INFO  i.m.d.v.c.c.v.VaultConfigConfigurationClientV1 - Obtained property source from Vault, source=/vault-config-sample/docker
12:15:11.949 [nioEventLoopGroup-2-4] INFO  i.m.d.v.c.c.v.VaultConfigConfigurationClientV1 - Obtained property source from Vault, source=/vault-config-sample/dev
12:15:11.950 [main] INFO  i.m.d.c.c.DistributedPropertySourceLocator - Resolved 3 configuration sources from client: compositeConfigurationClient(vault-config-client-v1)
12:15:12.508 [main] INFO  io.micronaut.runtime.Micronaut - Startup completed in 2151ms. Server Runningsimhttp://localhost:8080

[thiago@dropzone ~] http http://127.0.0.1:8080/test
HTTP/1.1 200 OK
Date: Mon, 13 May 2019 16:15:52 GMT
connection: keep-alive
content-length: 124
content-type: application/json

{
    "vault-backend-key-one": "vault-config-sample-dev",
    "vault-backend-kv-version": "v1-dev",
    "vault-backend-name": "backendv1-dev"
}

####################################################################################################################################################################################

[thiago@dropzone ~/dev/java/micronaut/vault-config-sample (master)] MICRONAUT_ENVIRONMENTS=docker,dev ./vault-config-sample
12:18:15.181 [main] INFO  i.m.context.env.DefaultEnvironment - Established active environments: [docker, dev]
12:18:15.229 [main] INFO  i.m.context.DefaultBeanContext - Reading Startup environment from bootstrap.yml
12:18:15.230 [main] INFO  i.m.context.env.DefaultEnvironment - Established active environments: [docker, dev]
12:18:16.022 [main] INFO  i.m.d.v.c.c.AbstractVaultConfigConfigurationClient - Vault server endpoint: http://127.0.0.1:8200, secret engine version: V1
12:18:16.022 [main] INFO  i.m.d.v.c.c.AbstractVaultConfigConfigurationClient - Application name: vault-config-sample, application profiles: [docker, dev]
12:18:16.562 [nioEventLoopGroup-2-4] INFO  i.m.d.v.c.c.v.VaultConfigConfigurationClientV1 - Obtained property source from Vault, source=/vault-config-sample
12:18:16.562 [nioEventLoopGroup-2-6] INFO  i.m.d.v.c.c.v.VaultConfigConfigurationClientV1 - Obtained property source from Vault, source=/vault-config-sample/dev
12:18:16.562 [nioEventLoopGroup-2-5] INFO  i.m.d.v.c.c.v.VaultConfigConfigurationClientV1 - Obtained property source from Vault, source=/vault-config-sample/docker
12:18:16.564 [main] INFO  i.m.d.c.c.DistributedPropertySourceLocator - Resolved 3 configuration sources from client: compositeConfigurationClient(vault-config-client-v1)
12:18:17.138 [main] INFO  io.micronaut.runtime.Micronaut - Startup completed in 2092ms. Server Running: http://localhost:8080

[thiago@dropzone ~] http http://127.0.0.1:8080/test
HTTP/1.1 200 OK
Date: Mon, 13 May 2019 16:18:28 GMT
connection: keep-alive
content-length: 133
content-type: application/json

{
    "vault-backend-key-one": "vault-config-sample-docker",
    "vault-backend-kv-version": "v1-docker",
    "vault-backend-name": "backendv1-docker"
}
```

I have also updated the documentation and included the entries for this feature.