### PR TITLE
Scheduled issues

### DIFF
--- a/src/main/docs/guide/aop/scheduling.adoc
+++ b/src/main/docs/guide/aop/scheduling.adoc
@@ -40,6 +40,18 @@ include::{testsuite}/aop/scheduled/ScheduledExample.java[tags=cron, indent=0]
 
 The above example will run the task every Monday morning at 10:15AM.
 
+=== Scheduling with only an Initial Delay
+
+To schedule a task so that is runs a single time after the server starts, use the `initialDelay` member:
+
+.Initial Delay Example
+[source,java]
+----
+include::{testsuite}/aop/scheduled/ScheduledExample.java[tags=initialDelay, indent=0]
+----
+
+The above example will only run a single time 1 minute after the server starts.
+
 == Programmatically Scheduling Tasks
 
 If you wish to programmatically schedule tasks, then you can use the api:scheduling.TaskScheduler[] bean which can be injected as follows:

--- a/test-suite/src/test/groovy/io/micronaut/docs/aop/scheduled/ScheduledExample.java
+++ b/test-suite/src/test/groovy/io/micronaut/docs/aop/scheduled/ScheduledExample.java
@@ -48,6 +48,13 @@ public class ScheduledExample {
     }
     // end::cron[]
 
+    // tag::initialDelay[]
+    @Scheduled(initialDelay = "1m" )
+    void onceOneMinuteAfterStartup() {
+        System.out.println("Executing onceOneMinuteAfterStartup()");
+    }
+    // end::initialDelay[]
+
     // tag::configured[]
     @Scheduled( fixedRate = "${my.task.rate:5m}",
                 initialDelay = "${my.task.delay:1m}" )


### PR DESCRIPTION
This technically has an improvement, which is adding support for only specifying an `initialDelay` in the scheduled annotation.

What could be considered a breaking change is throwing an exception when the task could not be scheduled due to no configuration ie just `@Scheduled` on the method with no members. I think its incorrect behavior to simply ignore the annotation in that case.