### PR TITLE
Support denoting a default implementation of an interface

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/A.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/A.java
@@ -1,0 +1,7 @@
+package io.micronaut.inject.qualifiers.replaces.defaultimpl;
+
+import io.micronaut.context.annotation.DefaultImplementation;
+
+@DefaultImplementation(A1.class)
+public interface A {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/A1.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/A1.java
@@ -1,0 +1,7 @@
+package io.micronaut.inject.qualifiers.replaces.defaultimpl;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class A1 implements A {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/A2.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/A2.java
@@ -1,0 +1,10 @@
+package io.micronaut.inject.qualifiers.replaces.defaultimpl;
+
+import io.micronaut.context.annotation.Replaces;
+
+import javax.inject.Singleton;
+
+@Singleton
+@Replaces(A.class)
+public class A2 implements A {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/B.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/B.java
@@ -1,0 +1,7 @@
+package io.micronaut.inject.qualifiers.replaces.defaultimpl;
+
+import io.micronaut.context.annotation.DefaultImplementation;
+
+@DefaultImplementation(name = "io.micronaut.inject.qualifiers.replaces.defaultimpl.B1")
+public interface B {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/B1.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/B1.java
@@ -1,0 +1,7 @@
+package io.micronaut.inject.qualifiers.replaces.defaultimpl;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class B1 implements B {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/B2.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/B2.java
@@ -1,0 +1,10 @@
+package io.micronaut.inject.qualifiers.replaces.defaultimpl;
+
+import io.micronaut.context.annotation.Replaces;
+
+import javax.inject.Singleton;
+
+@Singleton
+@Replaces(B.class)
+public class B2 implements B {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/B3.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/B3.java
@@ -1,0 +1,7 @@
+package io.micronaut.inject.qualifiers.replaces.defaultimpl;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class B3 implements B {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/C.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/C.java
@@ -1,0 +1,7 @@
+package io.micronaut.inject.qualifiers.replaces.defaultimpl;
+
+import io.micronaut.context.annotation.DefaultImplementation;
+
+@DefaultImplementation(C1.class)
+public interface C {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/C1.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/C1.java
@@ -1,0 +1,7 @@
+package io.micronaut.inject.qualifiers.replaces.defaultimpl;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class C1 implements C {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/C2.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/C2.java
@@ -1,0 +1,7 @@
+package io.micronaut.inject.qualifiers.replaces.defaultimpl;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class C2 implements C {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/C3.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/C3.java
@@ -1,0 +1,10 @@
+package io.micronaut.inject.qualifiers.replaces.defaultimpl;
+
+import io.micronaut.context.annotation.Replaces;
+
+import javax.inject.Singleton;
+
+@Singleton
+@Replaces(C2.class)
+public class C3 implements C {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/E.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/E.java
@@ -1,0 +1,7 @@
+package io.micronaut.inject.qualifiers.replaces.defaultimpl;
+
+import io.micronaut.context.annotation.DefaultImplementation;
+
+@DefaultImplementation(E1.class)
+public interface E {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/E1.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/E1.java
@@ -1,0 +1,7 @@
+package io.micronaut.inject.qualifiers.replaces.defaultimpl;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class E1 implements E {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/E2.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/E2.java
@@ -1,0 +1,10 @@
+package io.micronaut.inject.qualifiers.replaces.defaultimpl;
+
+import io.micronaut.context.annotation.Replaces;
+
+import javax.inject.Singleton;
+
+@Singleton
+@Replaces(E.class)
+public class E2 implements E {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/F.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/F.java
@@ -1,0 +1,7 @@
+package io.micronaut.inject.qualifiers.replaces.defaultimpl;
+
+import io.micronaut.context.annotation.DefaultImplementation;
+
+@DefaultImplementation(F1.class)
+public interface F extends E {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/F1.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/F1.java
@@ -1,0 +1,7 @@
+package io.micronaut.inject.qualifiers.replaces.defaultimpl;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class F1 implements F {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/F2.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/F2.java
@@ -1,0 +1,10 @@
+package io.micronaut.inject.qualifiers.replaces.defaultimpl;
+
+import io.micronaut.context.annotation.Replaces;
+
+import javax.inject.Singleton;
+
+@Singleton
+@Replaces(F.class)
+public class F2 implements F {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/ReplacesDefaultImplSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/defaultimpl/ReplacesDefaultImplSpec.groovy
@@ -1,0 +1,85 @@
+package io.micronaut.inject.qualifiers.replaces.defaultimpl
+
+import io.micronaut.context.BeanContext
+import io.micronaut.context.DefaultBeanContext
+import io.micronaut.context.exceptions.NonUniqueBeanException
+import spock.lang.Specification
+
+class ReplacesDefaultImplSpec extends Specification {
+
+    void "test A replacement"() {
+        given:
+        BeanContext context = new DefaultBeanContext().start()
+
+        when:"retrieve the interface"
+        A a = context.getBean(A)
+
+        then:"the default implementation is replaced"
+        noExceptionThrown()
+        a instanceof A2
+
+        cleanup:
+        context.close()
+    }
+
+    void "test B replacement"() {
+        given:
+        BeanContext context = new DefaultBeanContext().start()
+
+        when:"retrieve the interface"
+        List<B> bs = context.getBeansOfType(B).toList()
+
+        then:"the default implementation is replaced"
+        noExceptionThrown()
+        bs.size() == 2
+        bs.stream().noneMatch({ b -> b instanceof B1 })
+
+        cleanup:
+        context.close()
+    }
+
+    void "test nested default impls"() {
+        given:
+        BeanContext context = new DefaultBeanContext().start()
+
+        when:
+        F f = context.getBean(F)
+
+        then:
+        noExceptionThrown()
+        f instanceof F2
+
+        when:
+        context.getBean(E)
+
+        then:
+        thrown(NonUniqueBeanException)
+
+        when:
+        List<E> es = context.getBeansOfType(E).toList()
+
+        then:
+        es.size() == 2
+        es.stream().anyMatch({e -> e instanceof F2})
+        es.stream().anyMatch({e -> e instanceof E2})
+
+        cleanup:
+        context.close()
+    }
+
+    void "test normal replacement still works"() {
+        given:
+        BeanContext context = new DefaultBeanContext().start()
+
+        when:"retrieve the interface"
+        List<C> cs = context.getBeansOfType(C).toList()
+
+        then:"the target implementation is replaced"
+        noExceptionThrown()
+        cs.size() == 2
+        cs.stream().noneMatch({ c -> c instanceof C2 })
+
+        cleanup:
+        context.close()
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1740,6 +1740,15 @@ public class DefaultBeanContext implements BeanContext {
             Class<? super T> superclass = bt.getSuperclass();
             return (clazz) -> clazz == superclass || clazz == bt;
         }
+        if (annotationMetadata.hasAnnotation(DefaultImplementation.class)) {
+            Optional<Class> defaultImpl = annotationMetadata.getValue(DefaultImplementation.class, Class.class);
+            if (!defaultImpl.isPresent()) {
+                defaultImpl = annotationMetadata.getValue(DefaultImplementation.class, "name", Class.class);
+            }
+            if (defaultImpl.filter(impl -> impl == bt).isPresent()) {
+                return (clazz) -> clazz.isAssignableFrom(bt);
+            }
+        }
 
         return (clazz) -> clazz == bt;
     }

--- a/inject/src/main/java/io/micronaut/context/annotation/DefaultImplementation.java
+++ b/inject/src/main/java/io/micronaut/context/annotation/DefaultImplementation.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.context.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * <p>An annotation to apply to an interface to indicate which implementation
+ * is the default implementation. The initial use case is to redirect {@link Replaces}
+ * to another class to allow the replacement of an implementation that isn't
+ * accessible due to visibility restrictions.</p>
+ *
+ * <p>For example:</p>
+ *
+ * <pre class="code">
+ * &#064;DefaultImplementation(MyImpl.class)
+ * public interface SomeInterface {
+ *
+ * }
+ *
+ * class MyImpl implements SomeInterface {
+ *
+ * }
+ *
+ * &#064;Replaces(SomeInterface.class)
+ * class OtherImpl implements SomeInterface {
+ *
+ * }
+ * </pre>
+ *
+ * <p>In the above example the {@code OtherImpl} bean will replace the
+ * {@code MyImpl} bean because the class in the {@link Replaces} annotation
+ * has a default implementation.</p>
+ *
+ * @author James Kleeh
+ * @since 1.2.0
+ */
+@Documented
+@Retention(RUNTIME)
+@Target(ElementType.TYPE)
+public @interface DefaultImplementation {
+
+    /**
+     * @return The bean type that is the default implementation
+     */
+    Class value() default void.class;
+
+    /**
+     * @return The fully qualified bean type name that is the default implementation
+     */
+    String name() default "";
+}

--- a/src/main/docs/guide/ioc/replaces.adoc
+++ b/src/main/docs/guide/ioc/replaces.adoc
@@ -30,6 +30,8 @@ include::{testsjava}/replaces/MockBookService.java[tags=class, indent=0]
 
 <1> The `MockBookService` declares that it replaces `JdbcBookService`
 
+=== Factory Replacement
+
 The `@Replaces` annotation also supports a `factory` argument. That argument allows the replacement of factory beans in their entirety or specific types created by the factory.
 
 For example, it may be desired to replace all or part of the given factory class:
@@ -60,3 +62,22 @@ include::{testsjava}/replaces/TextBookFactory.java[tags=class, indent=0]
 
 The `BookFactory#novel()` method will not be replaced because the TextBook class is defined in the annotation.
 
+=== Default Implementation
+
+When exposing an API, it may be desirable for the default implementation of an interface to not be exposed as part of the public API. Doing so would prevent users from being able to replace the implementation because they would not be able to reference the class. The solution is to annotate the interface with api:context.annotation.DefaultImplementation[] to indicate which implementation should be replaced if a user creates a bean that `@Replaces(YourInterface.class)`.
+
+For example consider:
+
+A public API contract
+
+snippet::io.micronaut.docs.qualifiers.replaces.defaultimpl.ResponseStrategy[tags="clazz"]
+
+The default implementation
+
+snippet::io.micronaut.docs.qualifiers.replaces.defaultimpl.DefaultResponseStrategy[tags="clazz"]
+
+The custom implementation
+
+snippet::io.micronaut.docs.qualifiers.replaces.defaultimpl.CustomResponseStrategy[tags="clazz"]
+
+In the above example, the `CustomResponseStrategy` will replace the `DefaultResponseStrategy` because the api:context.annotation.DefaultImplementation[] annotation points to the `DefaultResponseStrategy`.

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/qualifiers/replaces/defaultimpl/CustomResponseStrategy.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/qualifiers/replaces/defaultimpl/CustomResponseStrategy.groovy
@@ -1,0 +1,12 @@
+package io.micronaut.docs.qualifiers.replaces.defaultimpl
+
+//tag::clazz[]
+import io.micronaut.context.annotation.Replaces
+import javax.inject.Singleton
+
+@Singleton
+@Replaces(ResponseStrategy)
+class CustomResponseStrategy implements ResponseStrategy {
+
+}
+//end::clazz[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/qualifiers/replaces/defaultimpl/DefaultImplementationSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/qualifiers/replaces/defaultimpl/DefaultImplementationSpec.groovy
@@ -1,0 +1,22 @@
+package io.micronaut.docs.qualifiers.replaces.defaultimpl
+
+import io.micronaut.context.BeanContext
+import io.micronaut.context.DefaultBeanContext
+import spock.lang.Specification
+
+class DefaultImplementationSpec extends Specification {
+
+    void "test the default is replaced"() {
+        given:
+        BeanContext ctx = new DefaultBeanContext().start()
+
+        when:
+        ResponseStrategy responseStrategy = ctx.getBean(ResponseStrategy)
+
+        then:
+        responseStrategy instanceof CustomResponseStrategy
+
+        cleanup:
+        ctx.close()
+    }
+}

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/qualifiers/replaces/defaultimpl/DefaultResponseStrategy.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/qualifiers/replaces/defaultimpl/DefaultResponseStrategy.groovy
@@ -1,0 +1,10 @@
+package io.micronaut.docs.qualifiers.replaces.defaultimpl
+
+//tag::clazz[]
+import javax.inject.Singleton
+
+@Singleton
+class DefaultResponseStrategy implements ResponseStrategy {
+
+}
+//end::clazz[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/qualifiers/replaces/defaultimpl/ResponseStrategy.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/qualifiers/replaces/defaultimpl/ResponseStrategy.groovy
@@ -1,0 +1,9 @@
+package io.micronaut.docs.qualifiers.replaces.defaultimpl
+
+//tag::clazz[]
+import io.micronaut.context.annotation.DefaultImplementation
+
+@DefaultImplementation(DefaultResponseStrategy)
+interface ResponseStrategy {
+}
+//end::clazz[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/qualifiers/replaces/defaultimpl/CustomResponseStrategy.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/qualifiers/replaces/defaultimpl/CustomResponseStrategy.kt
@@ -1,0 +1,10 @@
+package io.micronaut.docs.qualifiers.replaces.defaultimpl
+
+//tag::clazz[]
+import io.micronaut.context.annotation.Replaces
+import javax.inject.Singleton
+
+@Singleton
+@Replaces(ResponseStrategy::class)
+class CustomResponseStrategy : ResponseStrategy
+//end::clazz[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/qualifiers/replaces/defaultimpl/DefaultImplementationSpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/qualifiers/replaces/defaultimpl/DefaultImplementationSpec.kt
@@ -1,0 +1,15 @@
+package io.micronaut.docs.qualifiers.replaces.defaultimpl
+
+import io.kotlintest.matchers.types.shouldBeInstanceOf
+import io.kotlintest.specs.StringSpec
+import io.micronaut.context.DefaultBeanContext
+
+class DefaultImplementationSpec : StringSpec({
+
+    "test the default implementation is replaced" {
+        val ctx = DefaultBeanContext().start()
+        val responseStrategy = ctx.getBean(ResponseStrategy::class.java)
+
+        responseStrategy.shouldBeInstanceOf<CustomResponseStrategy>()
+    }
+})

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/qualifiers/replaces/defaultimpl/DefaultResponseStrategy.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/qualifiers/replaces/defaultimpl/DefaultResponseStrategy.kt
@@ -1,0 +1,8 @@
+package io.micronaut.docs.qualifiers.replaces.defaultimpl
+
+//tag::clazz[]
+import javax.inject.Singleton
+
+@Singleton
+internal class DefaultResponseStrategy : ResponseStrategy
+//end::clazz[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/qualifiers/replaces/defaultimpl/ResponseStrategy.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/qualifiers/replaces/defaultimpl/ResponseStrategy.kt
@@ -1,0 +1,8 @@
+package io.micronaut.docs.qualifiers.replaces.defaultimpl
+
+//tag::clazz[]
+import io.micronaut.context.annotation.DefaultImplementation
+
+@DefaultImplementation(DefaultResponseStrategy::class)
+interface ResponseStrategy
+//end::clazz[]

--- a/test-suite/src/test/java/io/micronaut/docs/qualifiers/replaces/defaultimpl/CustomResponseStrategy.java
+++ b/test-suite/src/test/java/io/micronaut/docs/qualifiers/replaces/defaultimpl/CustomResponseStrategy.java
@@ -1,0 +1,12 @@
+package io.micronaut.docs.qualifiers.replaces.defaultimpl;
+
+//tag::clazz[]
+import io.micronaut.context.annotation.Replaces;
+import javax.inject.Singleton;
+
+@Singleton
+@Replaces(ResponseStrategy.class)
+public class CustomResponseStrategy implements ResponseStrategy {
+
+}
+//end::clazz[]

--- a/test-suite/src/test/java/io/micronaut/docs/qualifiers/replaces/defaultimpl/DefaultImplementationSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/qualifiers/replaces/defaultimpl/DefaultImplementationSpec.java
@@ -1,0 +1,16 @@
+package io.micronaut.docs.qualifiers.replaces.defaultimpl;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.DefaultBeanContext;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class DefaultImplementationSpec {
+
+    @Test
+    void testTheDefaultIsReplaced() {
+        BeanContext ctx = new DefaultBeanContext().start();
+        Assertions.assertTrue(ctx.getBean(ResponseStrategy.class) instanceof CustomResponseStrategy);
+        ctx.close();
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/docs/qualifiers/replaces/defaultimpl/DefaultResponseStrategy.java
+++ b/test-suite/src/test/java/io/micronaut/docs/qualifiers/replaces/defaultimpl/DefaultResponseStrategy.java
@@ -1,0 +1,10 @@
+package io.micronaut.docs.qualifiers.replaces.defaultimpl;
+
+//tag::clazz[]
+import javax.inject.Singleton;
+
+@Singleton
+class DefaultResponseStrategy implements ResponseStrategy {
+
+}
+//end::clazz[]

--- a/test-suite/src/test/java/io/micronaut/docs/qualifiers/replaces/defaultimpl/ResponseStrategy.java
+++ b/test-suite/src/test/java/io/micronaut/docs/qualifiers/replaces/defaultimpl/ResponseStrategy.java
@@ -1,0 +1,10 @@
+package io.micronaut.docs.qualifiers.replaces.defaultimpl;
+
+//tag::clazz[]
+import io.micronaut.context.annotation.DefaultImplementation;
+
+@DefaultImplementation(DefaultResponseStrategy.class)
+public interface ResponseStrategy {
+
+}
+//end::clazz[]


### PR DESCRIPTION
The core issue this resolves is that to replace an implementation of an interface, that implementation must be part of the public API and known to the user. 

The issue is resolved with the `@DefaultImplementation` annotation that can be placed on an interface to designate its default implementation. Then users can simply `@Replace(TheInterface)` and the default implementation will be replaced.