### PR TITLE
Changing equals method to be case insensitive as per rfc2045

### DIFF
--- a/http/src/main/java/io/micronaut/http/MediaType.java
+++ b/http/src/main/java/io/micronaut/http/MediaType.java
@@ -549,7 +549,7 @@ public class MediaType implements CharSequence {
     /**
      * {@inheritDoc}
      * <p>
-     * Beware that the parameters are not taken into account.
+     * Only the name is matched. Parameters are not included.
      */
     @Override
     public boolean equals(Object o) {

--- a/http/src/main/java/io/micronaut/http/MediaType.java
+++ b/http/src/main/java/io/micronaut/http/MediaType.java
@@ -519,7 +519,7 @@ public class MediaType implements CharSequence {
     public boolean isTextBased() {
         boolean matches = textTypePatterns.stream().anyMatch((p) -> p.matcher(name).matches());
         if (!matches) {
-            matches = subtype.equals("json") || subtype.equals("xml");
+            matches = subtype.equalsIgnoreCase("json") || subtype.equalsIgnoreCase("xml");
         }
         return matches;
     }
@@ -546,6 +546,11 @@ public class MediaType implements CharSequence {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Beware that the parameters are not taken into account.
+     */
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -557,7 +562,7 @@ public class MediaType implements CharSequence {
 
         MediaType mediaType = (MediaType) o;
 
-        return name.equals(mediaType.name);
+        return name.equalsIgnoreCase(mediaType.name);
     }
 
     @Override

--- a/http/src/test/groovy/io/micronaut/http/MediaTypeSpec.groovy
+++ b/http/src/test/groovy/io/micronaut/http/MediaTypeSpec.groovy
@@ -48,6 +48,24 @@ class MediaTypeSpec extends Specification {
         "text/html;charset=utf-8"   | null  | null       | "text/html"            | 'html'      | [charset: "utf-8"] | 1.0     | 'html'     | "text"
     }
 
+    void "test equals case insensitive"() {
+        given:
+        MediaType mediaType1 = new MediaType("application/json")
+        MediaType mediaType2 = new MediaType("application/JSON")
+
+        expect:
+        mediaType1 == mediaType2
+    }
+
+    void "test equals ignores params"() {
+        given:
+        MediaType mediaType1 = new MediaType("application/json")
+        MediaType mediaType2 = new MediaType("application/json;charset=utf-8")
+
+        expect:
+        mediaType1 == mediaType2
+    }
+
     @Unroll
     void "test #contentType is compressible = #expected"() {
         expect:


### PR DESCRIPTION
As per [rfc2045 Syntax of the Content-Type Header Field](https://tools.ietf.org/html/rfc2045#section-5.1):

```
In the Augmented BNF notation of RFC 822, a Content-Type header field
   value is defined as follows:

     content := "Content-Type" ":" type "/" subtype
                *(";" parameter)
                ; Matching of media type and subtype
                ; is ALWAYS case-insensitive.
```