### PR TITLE
Updated Green.kt for multi-lingual docs

### DIFF
--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/context/annotation/primary/Green.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/context/annotation/primary/Green.kt
@@ -17,3 +17,4 @@ class Green: ColorPicker {
         return "green"
     }
 }
+//end:clazz[]


### PR DESCRIPTION
Added missing `end::clazz[]` tag.