### PR TITLE
Improve multipage documentation rendering.

### DIFF
--- a/src/main/docs/resources/css/custom.css
+++ b/src/main/docs/resources/css/custom.css
@@ -236,3 +236,24 @@ a:hover,
     border-bottom-left-radius: 5px;
     border-bottom-right-radius: 5px;
 }
+
+/*
+
+Changes to make individual pages render properly
+
+*/
+#col1 {
+    padding-top: 100px;
+}
+
+#col2 {
+    display: none !important;
+}
+
+.corner-all #table-of-content {
+    display: none;
+}
+
+.corner-all .project {
+    display: none;
+}


### PR DESCRIPTION
When viewing documentation on a mobile device, it's helpful to have the documentation as individual pages.

Fortunately this is already available at:

https://docs.micronaut.io/latest/guide/introduction.html

However, it does not render properly.

This PR fixes the rendering.  

A link on the home page to the multipage version would be appreciated.