### PR TITLE
fixed delayed resolve error type mirror for @Inject fields and method return types

### DIFF
--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -1986,6 +1986,11 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
         }
     }
 
-    private static class PostponeToNextRoundException extends RuntimeException {}
+    /**
+     * Exception to indicate postponing processing to next round
+     */
+    private static class PostponeToNextRoundException extends RuntimeException {
+
+    }
 
 }

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -1987,7 +1987,7 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
     }
 
     /**
-     * Exception to indicate postponing processing to next round
+     * Exception to indicate postponing processing to next round.
      */
     private static class PostponeToNextRoundException extends RuntimeException {
 

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -182,16 +182,16 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                 if (processed.add(className)) {
                     final TypeElement refreshedClassElement = elementUtils.getTypeElement(className);
                     final AnnBeanElementVisitor visitor = new AnnBeanElementVisitor(refreshedClassElement);
-                    refreshedClassElement.accept(visitor, className);
-                    if (visitor.processNextRound) {
-                        processed.remove(className);
-                    } else {
+                    try {
+                        refreshedClassElement.accept(visitor, className);
                         visitor.getBeanDefinitionWriters().forEach((name, writer) -> {
                             String beanDefinitionName = writer.getBeanDefinitionName();
                             if (processed.add(beanDefinitionName)) {
                                 processBeanDefinitions(refreshedClassElement, writer);
                             }
                         });
+                    } catch (PostponeToNextRoundException e) {
+                        processed.remove(className);
                     }
                 }
             });
@@ -311,7 +311,6 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
         private ConfigurationMetadata configurationMetadata;
         private ExecutableElementParamInfo constructorParameterInfo;
         private AtomicInteger adaptedMethodIndex = new AtomicInteger(0);
-        private boolean processNextRound;
 
         /**
          * @param concreteClass The {@link TypeElement}
@@ -576,8 +575,13 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
 
             AnnotationMetadata methodAnnotationMetadata = annotationUtils.getAnnotationMetadata(method);
 
+            TypeKind returnKind = method.getReturnType().getKind();
+            if ((returnKind == TypeKind.ERROR) && !processingOver) {
+                throw new PostponeToNextRoundException();
+            }
+
             // handle @Bean annotation for @Factory class
-            if (isFactoryType && methodAnnotationMetadata.hasDeclaredStereotype(Bean.class, Scope.class) && method.getReturnType().getKind() == TypeKind.DECLARED) {
+            if (isFactoryType && methodAnnotationMetadata.hasDeclaredStereotype(Bean.class, Scope.class) && returnKind == TypeKind.DECLARED) {
                 visitBeanFactoryMethod(method);
                 return null;
             }
@@ -1414,6 +1418,10 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                 }
 
                 TypeMirror type = variable.asType();
+                if ((type.getKind() == TypeKind.ERROR) && !processingOver) {
+                    throw new PostponeToNextRoundException();
+                }
+
                 Object fieldType = modelUtils.resolveTypeReference(type);
 
                 if (isValue) {
@@ -1849,6 +1857,9 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
 
                 TypeMirror typeMirror = paramElement.asType();
                 TypeKind kind = typeMirror.getKind();
+                if ((kind == TypeKind.ERROR) && !processingOver) {
+                    throw new PostponeToNextRoundException();    
+                }
 
                 switch (kind) {
                     case ARRAY:
@@ -1912,10 +1923,8 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                             }
                             Object argType = modelUtils.classOfPrimitiveFor(typeName);
                             params.addParameter(argName, argType, argType);
-                        } else if (processingOver) {
-                            error(element, "Unprocessable element type [%s] for param [%s] of element %s", kind, paramElement, element);
                         } else {
-                            processNextRound = true;
+                            error(element, "Unprocessable element type [%s] for param [%s] of element %s", kind, paramElement, element);
                         }
                 }
             });
@@ -1976,4 +1985,7 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
             return name.hashCode();
         }
     }
+
+    private static class PostponeToNextRoundException extends RuntimeException {}
+
 }


### PR DESCRIPTION
Continuation of #1694. Injected fields and factory methods using types not yet generated were not handled. 

Separate but related note: these two cases are being silently ignored rather than failing with an error, like what happens for constructor parameters. It is probably not a problem as for legitimate cases, the compilation should fail anyway, but it did throw me off until I realised that the fix was incomplete. Some tests were failing with strange errors.

The inject case gets resolved to void in case of an error typemirror and ends up with V.class in the BeanDefinition, leading to a NoClassDefFound for V. I thought I was going insane the first time I saw it. It  is now fixed for the case when the injected field type is generated in a subsequent annotation processing round.

The bean method case silently drops the bean definition leading to an error that no bean exists for that type, which again caused me to triple check that the annotation processor is executing before realising it is yet another case of the same issue, and it is now also fixed.