### PR TITLE
Environment order

### DIFF
--- a/inject/src/main/java/io/micronaut/context/env/AbstractPropertySourceLoader.java
+++ b/inject/src/main/java/io/micronaut/context/env/AbstractPropertySourceLoader.java
@@ -15,8 +15,6 @@
  */
 package io.micronaut.context.env;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.core.io.ResourceLoader;
 import io.micronaut.core.order.Ordered;
@@ -24,7 +22,6 @@ import io.micronaut.core.util.Toggleable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.InputStream;

--- a/inject/src/main/java/io/micronaut/context/env/AbstractPropertySourceLoader.java
+++ b/inject/src/main/java/io/micronaut/context/env/AbstractPropertySourceLoader.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.context.env;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.core.io.ResourceLoader;
 import io.micronaut.core.order.Ordered;
@@ -22,6 +24,8 @@ import io.micronaut.core.util.Toggleable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
@@ -38,7 +42,6 @@ import java.util.Set;
  */
 public abstract class AbstractPropertySourceLoader implements PropertySourceLoader, Toggleable, Ordered {
 
-
     /**
      * Default position for the property source loader.
      */
@@ -52,29 +55,32 @@ public abstract class AbstractPropertySourceLoader implements PropertySourceLoad
     }
 
     @Override
-    public Optional<PropertySource> load(String resourceName, ResourceLoader resourceLoader, String environmentName) {
+    public Optional<PropertySource> load(String resourceName, ResourceLoader resourceLoader, @Nullable String environmentName) {
+        if (environmentName != null) {
+            return loadEnv(resourceName, resourceLoader, ActiveEnvironment.of(environmentName, 0));
+        } else {
+            return load(resourceLoader, resourceName, getOrder());
+        }
+    }
+
+    @Override
+    public Optional<PropertySource> loadEnv(String resourceName, ResourceLoader resourceLoader, ActiveEnvironment activeEnvironment) {
+        return load(resourceLoader, resourceName + "-" + activeEnvironment.getName(), this.getOrder() + 1 + activeEnvironment.getPriority());
+    }
+
+    private Optional<PropertySource> load(ResourceLoader resourceLoader, String fileName, int order) {
         if (isEnabled()) {
             Set<String> extensions = getExtensions();
             for (String ext : extensions) {
-                String fileName = resourceName;
-                if (environmentName != null) {
-                    fileName += "-" + environmentName;
-                }
                 String qualifiedName = fileName;
                 fileName += "." + ext;
                 Map<String, Object> finalMap = loadProperties(resourceLoader, qualifiedName, fileName);
 
-                int order = this.getOrder();
-                if (environmentName != null) {
-                    order++; // higher precedence than the default
-                }
                 if (!finalMap.isEmpty()) {
-                    int finalOrder = order;
                     MapPropertySource newPropertySource = new MapPropertySource(qualifiedName, finalMap) {
                         @Override
                         public int getOrder() {
-
-                            return finalOrder;
+                            return order;
                         }
                     };
                     return Optional.of(newPropertySource);

--- a/inject/src/main/java/io/micronaut/context/env/ActiveEnvironment.java
+++ b/inject/src/main/java/io/micronaut/context/env/ActiveEnvironment.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.context.env;
+
+/**
+ * An environment that is active for the current execution
+ * of the application.
+ *
+ * @author James Kleeh
+ * @since 1.2.0
+ */
+public interface ActiveEnvironment {
+
+    /**
+     * @return The name of the environment
+     */
+    String getName();
+
+    /**
+     * A 0 based index representing the priority
+     * of the environment relative to other active
+     * environments.
+     *
+     * @return The priority
+     */
+    int getPriority();
+
+    /**
+     * Creates a new active environment for the given arguments.
+     *
+     * @param name     The environment name
+     * @param priority The priority
+     * @return The active environment
+     */
+    static ActiveEnvironment of(String name, int priority) {
+        return new ActiveEnvironment() {
+            @Override
+            public String getName() {
+                return name;
+            }
+
+            @Override
+            public int getPriority() {
+                return priority;
+            }
+        };
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
+++ b/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
@@ -578,12 +578,14 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
     }
 
     private void loadPropertySourceFromLoader(String name, PropertySourceLoader propertySourceLoader, List<PropertySource> propertySources) {
-        Optional<PropertySource> defaultPropertySource = propertySourceLoader.load(name, this, null);
+        Optional<PropertySource> defaultPropertySource = propertySourceLoader.load(name, this);
         defaultPropertySource.ifPresent(propertySources::add);
         Set<String> activeNames = getActiveNames();
-        for (String activeName : activeNames) {
-            Optional<PropertySource> propertySource = propertySourceLoader.load(name, this, activeName);
+        int i = 0;
+        for (String activeName: activeNames) {
+            Optional<PropertySource> propertySource = propertySourceLoader.loadEnv(name, this, ActiveEnvironment.of(activeName, i));
             propertySource.ifPresent(propertySources::add);
+            i++;
         }
     }
 

--- a/inject/src/main/java/io/micronaut/context/env/PropertySourceLoader.java
+++ b/inject/src/main/java/io/micronaut/context/env/PropertySourceLoader.java
@@ -18,6 +18,7 @@ package io.micronaut.context.env;
 import io.micronaut.core.io.ResourceLoader;
 import io.micronaut.core.util.Toggleable;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Optional;
 
@@ -37,7 +38,18 @@ public interface PropertySourceLoader extends Toggleable, PropertySourceLocator,
      */
     @Override
     default Optional<PropertySource> load(Environment environment) {
-        return load(Environment.DEFAULT_NAME, environment, null);
+        return load(Environment.DEFAULT_NAME, environment);
+    }
+
+    /**
+     * Load a {@link PropertySource} for the given {@link Environment}.
+     *
+     * @param resourceName    The resourceName of the resource to load
+     * @param resourceLoader  The {@link ResourceLoader} to retrieve the resource
+     * @return An optional of {@link PropertySource}
+     */
+    default Optional<PropertySource> load(String resourceName, ResourceLoader resourceLoader) {
+        return load(resourceName, resourceLoader, null);
     }
 
     /**
@@ -47,6 +59,20 @@ public interface PropertySourceLoader extends Toggleable, PropertySourceLocator,
      * @param resourceLoader  The {@link ResourceLoader} to retrieve the resource
      * @param environmentName The environment name to load. Null if the default environment is to be used
      * @return An optional of {@link PropertySource}
+     * @deprecated Use {@link #load(String, ResourceLoader)} or {@link #loadEnv(String, ResourceLoader, ActiveEnvironment)} (String, ResourceLoader, ActiveEnvironment)} instead
      */
+    @Deprecated
     Optional<PropertySource> load(String resourceName, ResourceLoader resourceLoader, @Nullable String environmentName);
+
+    /**
+     * Load a {@link PropertySource} for the given {@link Environment}.
+     *
+     * @param resourceName        The resourceName of the resource to load
+     * @param resourceLoader      The {@link ResourceLoader} to retrieve the resource
+     * @param activeEnvironment   The environment to load
+     * @return An optional of {@link PropertySource}
+     */
+    default Optional<PropertySource> loadEnv(String resourceName, ResourceLoader resourceLoader, ActiveEnvironment activeEnvironment) {
+        return load(resourceName, resourceLoader, activeEnvironment.getName());
+    }
 }

--- a/inject/src/main/java/io/micronaut/context/env/PropertySourceLoader.java
+++ b/inject/src/main/java/io/micronaut/context/env/PropertySourceLoader.java
@@ -18,7 +18,6 @@ package io.micronaut.context.env;
 import io.micronaut.core.io.ResourceLoader;
 import io.micronaut.core.util.Toggleable;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Optional;
 

--- a/inject/src/test/groovy/io/micronaut/context/env/EnvironmentOrderSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/env/EnvironmentOrderSpec.groovy
@@ -1,0 +1,26 @@
+package io.micronaut.context.env
+
+import spock.lang.Specification
+
+class EnvironmentOrderSpec extends Specification {
+
+    void "test the last environment has priority"() {
+        Environment env = new DefaultEnvironment("first", "second").start()
+
+        expect:
+        env.getRequiredProperty("environment.order", String) == "second"
+
+        cleanup:
+        env.close()
+    }
+
+    void "test the last environment has priority 2"() {
+        Environment env = new DefaultEnvironment("second", "first").start()
+
+        expect:
+        env.getRequiredProperty("environment.order", String) == "first"
+
+        cleanup:
+        env.close()
+    }
+}

--- a/inject/src/test/resources/application-first.yml
+++ b/inject/src/test/resources/application-first.yml
@@ -1,0 +1,1 @@
+environment.order: first

--- a/inject/src/test/resources/application-second.yml
+++ b/inject/src/test/resources/application-second.yml
@@ -1,0 +1,1 @@
+environment.order: second

--- a/management/src/main/java/io/micronaut/management/endpoint/info/source/PropertiesInfoSource.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/info/source/PropertiesInfoSource.java
@@ -61,7 +61,7 @@ public interface PropertiesInfoSource extends InfoSource {
         Optional<ResourceLoader> resourceLoader = resourceResolver.getSupportingLoader(propertiesPath);
         if (resourceLoader.isPresent()) {
             PropertiesPropertySourceLoader propertySourceLoader = new PropertiesPropertySourceLoader();
-            return propertySourceLoader.load(propertiesPath, resourceLoader.get(), null);
+            return propertySourceLoader.load(propertiesPath, resourceLoader.get());
         }
 
         return Optional.empty();


### PR DESCRIPTION
Support deterministic ordering of environment property sources

`-Dmicronaut.environments=a,b,c` will result in `c` having the highest precedence.