### PR TITLE
Expose declarative HTTP client MethodInvocationContext

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/interceptor/HttpClientIntroductionAdvice.java
+++ b/http-client/src/main/java/io/micronaut/http/client/interceptor/HttpClientIntroductionAdvice.java
@@ -360,6 +360,7 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
                 }
             }
 
+            request.setAttribute(HttpAttributes.INVOCATION_CONTEXT, context);
             // Set the URI template used to make the request for tracing purposes
             request.setAttribute(HttpAttributes.URI_TEMPLATE, resolveTemplate(clientAnnotation, uriTemplate.toString()));
             String serviceId = clientAnnotation.getValue(String.class).orElse(null);

--- a/http/src/main/java/io/micronaut/http/HttpAttributes.java
+++ b/http/src/main/java/io/micronaut/http/HttpAttributes.java
@@ -61,7 +61,12 @@ public enum HttpAttributes implements CharSequence {
     /**
      * Attribute used to store the MediaTypeCodec. Used to override the registered codec per-request.
      */
-    MEDIA_TYPE_CODEC(Constants.PREFIX + ".mediaType.codec");
+    MEDIA_TYPE_CODEC(Constants.PREFIX + ".mediaType.codec"),
+
+    /**
+     * Attribute used to store the MethodInvocationContext by declarative client.
+     */
+    INVOCATION_CONTEXT(Constants.PREFIX + ".invocationContext");
 
     private final String name;
 


### PR DESCRIPTION
This patch adds MethodInvocationContext to request attributes generated by HttpClientIntroductionAdvice. Primary motivation is to allow HttpClientFilter access executed method metadata, e.g. annotations.