### PR TITLE
#1703 Updated JavaMethodElement

### DIFF
--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaMethodElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaMethodElement.java
@@ -17,6 +17,7 @@ package io.micronaut.annotation.processing.visitor;
 
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.inject.annotation.DefaultAnnotationMetadata;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.MethodElement;
 import io.micronaut.inject.ast.ParameterElement;
@@ -82,8 +83,13 @@ class JavaMethodElement extends AbstractJavaElement implements MethodElement {
     @Override
     public ParameterElement[] getParameters() {
         List<? extends VariableElement> parameters = executableElement.getParameters();
-        return parameters.stream().map((Function<VariableElement, ParameterElement>) variableElement ->
-                new JavaParameterElement(declaringClass, variableElement, visitorContext.getAnnotationUtils().getAnnotationMetadata(variableElement), visitorContext)
+        return parameters.stream().map((Function<VariableElement, ParameterElement>) variableElement -> {
+                    AnnotationMetadata annotationMetadata = visitorContext.getAnnotationUtils().getAnnotationMetadata(variableElement);
+                    if (annotationMetadata.hasDeclaredAnnotation("org.jetbrains.annotations.Nullable")) {
+                        annotationMetadata = DefaultAnnotationMetadata.mutateMember(annotationMetadata, "javax.annotation.Nullable", Collections.emptyMap());
+                    }
+                    return new JavaParameterElement(declaringClass, variableElement, annotationMetadata, visitorContext);
+                }
         ).toArray(ParameterElement[]::new);
     }
 


### PR DESCRIPTION
Map `org.jetbrains.annotations.Nullable` to `javax.annotation.Nullable`.