### PR TITLE
Add instructions on how to install CLI via MacPorts

### DIFF
--- a/src/main/docs/guide/quickStart/buildCLI/installMacPorts.adoc
+++ b/src/main/docs/guide/quickStart/buildCLI/installMacPorts.adoc
@@ -1,0 +1,25 @@
+Before installing it is recommended to sync the latest Portfiles.
+
+[source,bash]
+----
+$ sudo port sync
+----
+
+In order to install Micronaut, run following command:
+
+[source,bash]
+----
+$ sudo port install micronaut
+----
+
+You can find more information about MacPorts usage on their https://www.macports.org[homepage].
+
+You should now be able to run the Micronaut CLI.
+
+[source,bash]
+----
+$ mn
+| Starting interactive mode...
+| Enter a command name to run. Use TAB for completion:
+mn>
+----

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -7,6 +7,7 @@ quickStart:
     title: Build/Install the CLI
     installSdkman: Install with Sdkman
     installHomebrew: Install with Homebrew
+    installMacPorts: Install with MacPorts
     installWindows: Install through Binary on Windows
     buildSource: Building from Source
   creatingServer: Creating a Server Application


### PR DESCRIPTION
I maintain the Micronaut CLI port for [MacPorts](https://www.macports.org). This PR adds instructions for installing the Micronaut CLI using MacPorts.