### PR TITLE
Fix duplicate primary bean handling

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/primary/C.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/primary/C.java
@@ -1,0 +1,4 @@
+package io.micronaut.inject.qualifiers.primary;
+
+public interface C {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/primary/C1.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/primary/C1.java
@@ -1,0 +1,10 @@
+package io.micronaut.inject.qualifiers.primary;
+
+import io.micronaut.context.annotation.Primary;
+
+import javax.inject.Singleton;
+
+@Primary
+@Singleton
+public class C1 implements C {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/primary/C2.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/primary/C2.java
@@ -1,0 +1,10 @@
+package io.micronaut.inject.qualifiers.primary;
+
+import io.micronaut.context.annotation.Primary;
+
+import javax.inject.Singleton;
+
+@Primary
+@Singleton
+public class C2 implements C {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/primary/PrimarySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/primary/PrimarySpec.groovy
@@ -16,6 +16,7 @@
 package io.micronaut.inject.qualifiers.primary
 
 import io.micronaut.context.BeanContext
+import io.micronaut.context.exceptions.NonUniqueBeanException
 import spock.lang.Specification
 /**
  * Created by graemerocher on 26/05/2017.
@@ -35,5 +36,16 @@ class PrimarySpec extends Specification {
         b.all.any() { it instanceof A1 }
         b.all.any() { it instanceof A2 }
         b.a instanceof A2
+    }
+
+    void "test duplicate @Primary bean throws exception"() {
+        given:
+        BeanContext context = BeanContext.run()
+
+        when:
+        C c = context.getBean(C)
+
+        then:
+        thrown(NonUniqueBeanException)
     }
 }

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -2070,9 +2070,7 @@ public class DefaultBeanContext implements BeanContext {
                     return Optional.empty();
                 }
 
-                Optional<BeanDefinition<T>> primary = beanDefinitionList.stream()
-                        .findFirst();
-                definition = primary.orElseGet(() -> lastChanceResolve(beanType, qualifier, throwNonUnique, beanDefinitionList));
+                definition = lastChanceResolve(beanType, qualifier, throwNonUnique, beanDefinitionList);
             } else {
                 candidates.removeIf(BeanDefinition::isAbstract);
                 if (candidates.size() == 1) {
@@ -2082,14 +2080,7 @@ public class DefaultBeanContext implements BeanContext {
                     if (LOG.isDebugEnabled()) {
                         LOG.debug("Searching for @Primary for type [{}] from candidates: {} ", beanType.getName(), candidates);
                     }
-                    Optional<BeanDefinition<T>> primary = candidates.stream()
-                            .filter(BeanDefinition::isPrimary)
-                            .findFirst();
-                    if (primary.isPresent()) {
-                        definition = primary.get();
-                    } else {
-                        definition = lastChanceResolve(beanType, null, throwNonUnique, candidates);
-                    }
+                    definition = lastChanceResolve(beanType, null, throwNonUnique, candidates);
                 }
             }
         }
@@ -2146,6 +2137,14 @@ public class DefaultBeanContext implements BeanContext {
     }
 
     private <T> BeanDefinition<T> lastChanceResolve(Class<T> beanType, Qualifier<T> qualifier, boolean throwNonUnique, Collection<BeanDefinition<T>> candidates) {
+        if (candidates.size() > 1) {
+            List<BeanDefinition<T>> primary = candidates.stream()
+                    .filter(BeanDefinition::isPrimary)
+                    .collect(Collectors.toList());
+            if (!primary.isEmpty()) {
+                candidates = primary;
+            }
+        }
         if (candidates.size() == 1) {
             return candidates.iterator().next();
         } else {


### PR DESCRIPTION
I discovered that multiple `@Primary` beans won't create `NonUniqueBeanException` on injection, but they should.