### PR TITLE
Add support for ProxySelector

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/DefaultHttpClient.java
@@ -1311,6 +1311,17 @@ public class DefaultHttpClient implements RxWebSocketClient, RxHttpClient, RxStr
         return filterList;
     }
 
+
+    /**
+     * Configures the HTTP proxy for the pipeline.
+     *
+     * @param pipeline The pipeline
+     * @param proxy    The proxy
+     */
+    protected void configureProxy(ChannelPipeline pipeline, Proxy proxy) {
+        configureProxy(pipeline, proxy.type(), proxy.address());
+    }
+
     /**
      * Configures the HTTP proxy for the pipeline.
      *
@@ -2097,11 +2108,9 @@ public class DefaultHttpClient implements RxWebSocketClient, RxHttpClient, RxStr
                 ch.config().setAutoRead(false);
             }
 
-            Optional<SocketAddress> proxy = configuration.getProxyAddress();
-            if (proxy.isPresent()) {
-                Type proxyType = configuration.getProxyType();
-                SocketAddress proxyAddress = proxy.get();
-                configureProxy(p, proxyType, proxyAddress);
+            Proxy proxy = configuration.resolveProxy(sslContext != null, host, port);
+            if (!Proxy.NO_PROXY.equals(proxy)) {
+                configureProxy(p, proxy);
             }
 
             if (sslContext != null) {

--- a/http-client/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
+++ b/http-client/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
@@ -23,8 +23,7 @@ import io.micronaut.runtime.ApplicationConfiguration;
 import io.netty.channel.ChannelOption;
 
 import javax.annotation.Nullable;
-import java.net.Proxy;
-import java.net.SocketAddress;
+import java.net.*;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -99,6 +98,8 @@ public abstract class HttpClientConfiguration {
     private String proxyUsername;
 
     private String proxyPassword;
+
+    private ProxySelector proxySelector;
 
     private Charset defaultCharset = StandardCharsets.UTF_8;
 
@@ -399,6 +400,53 @@ public abstract class HttpClientConfiguration {
      */
     public void setProxyPassword(String proxyPassword) {
         this.proxyPassword = proxyPassword;
+    }
+
+    /**
+     * Sets the proxy selector.
+     * ProxySelector decides what proxy to use and take precedence over {@link #setProxyAddress(SocketAddress)} and {@link #setProxyType(Proxy.Type)}.
+     *
+     * @param proxySelector The proxy selector to use
+     */
+    public void setProxySelector(ProxySelector proxySelector) {
+        this.proxySelector = proxySelector;
+    }
+
+    /**
+     * @return The proxy selector provided
+     */
+    public Optional<ProxySelector> getProxySelector() {
+        return Optional.ofNullable(proxySelector);
+    }
+
+    /**
+     * Resolves a proxy to use for connection.
+     *
+     * If ProxySelector is set by {@link #setProxySelector(ProxySelector)} then it constructs URI and pass it to {@link ProxySelector#select(URI)}.
+     * First proxy returned by proxy selector will be used. If no proxy is returned by select, then {@link Proxy#NO_PROXY} will be used.
+     *
+     * If ProxySelector is not set then parameters are ignored and a proxy as defined by {@link #setProxyAddress(SocketAddress)} and {@link #setProxyType(Proxy.Type)} will be returned.
+     * If no proxy is defined then parameters are ignored and {@link Proxy#NO_PROXY} is returned.
+     *
+     * @param isSsl is it http or https connection
+     * @param host connection host
+     * @param port connection port
+     * @return A non null proxy instance
+     */
+    public Proxy resolveProxy(boolean isSsl, String host, int port) {
+        try {
+            if (proxySelector != null) {
+                final URI uri = new URI(isSsl ? "https" : "http", null, host, port, null, null, null);
+                return getProxySelector()
+                        .flatMap(selector -> selector.select(uri).stream().findFirst())
+                        .orElse(Proxy.NO_PROXY);
+            } else if (proxyAddress != null) {
+                return new Proxy(getProxyType(), proxyAddress);
+            }
+            return  Proxy.NO_PROXY;
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**


### PR DESCRIPTION
Add a way to set ProxySelector that can dynamically pick a proxy based on host and port.

- it picks only the first proxy returned by ProxySelector.select method
- it never call ProxySelector.connectFailed
- it does not use default proxy selector as provided by Java. This would potentially be a breaking change, it can be considered for next major release.