### PR TITLE
Fix env var name from GRADLE_OPTS to optsEnvironmentVar variable (enabled only macOS)

### DIFF
--- a/cli/src/main/resources/unixStartScript.txt
+++ b/cli/src/main/resources/unixStartScript.txt
@@ -106,7 +106,7 @@ fi
 
 # For Darwin, add options to specify how the application appears in the dock
 if \$darwin; then
-    GRADLE_OPTS="\$GRADLE_OPTS \\"-Xdock:name=\$APP_NAME\\" \\"-Xdock:icon=\$APP_HOME/media/mn.icns\\""
+    ${optsEnvironmentVar}="\$${optsEnvironmentVar} \\"-Xdock:name=\$APP_NAME\\" \\"-Xdock:icon=\$APP_HOME/media/mn.icns\\""
 fi
 
 # For Cygwin, switch paths to Windows format before running java


### PR DESCRIPTION
Fix hardcoded environment variable name `GRADLE_OPTS` to dynamic variable name `optsEnvironmentVar`.
(The `optsEnironmentVar` will replace to `NM_OPTS`)
