### PR TITLE
Added implemenation scope to Maven build token mappings.

### DIFF
--- a/cli/src/main/groovy/io/micronaut/cli/io/support/MavenBuildTokens.groovy
+++ b/cli/src/main/groovy/io/micronaut/cli/io/support/MavenBuildTokens.groovy
@@ -35,6 +35,7 @@ class MavenBuildTokens extends BuildTokens {
 
     static {
         scopeConversions.put("compile", "compile")
+        scopeConversions.put("implementation", "compile")
         scopeConversions.put("provided", "provided")
         scopeConversions.put("runtime", "runtime")
         scopeConversions.put("runtimeOnly", "provided")


### PR DESCRIPTION
See discussion: https://github.com/micronaut-projects/micronaut-profiles/issues/124

This change is required before merging the profiles PR: https://github.com/micronaut-projects/micronaut-profiles/pull/161