### PR TITLE
Add micronaut.server.context-path

### DIFF
--- a/http-server/src/main/java/io/micronaut/http/server/HttpServerConfiguration.java
+++ b/http-server/src/main/java/io/micronaut/http/server/HttpServerConfiguration.java
@@ -110,6 +110,7 @@ public class HttpServerConfiguration {
     private boolean logHandledExceptions = DEFAULT_LOG_HANDLED_EXCEPTIONS;
     private HostResolutionConfiguration hostResolution;
     private String clientAddressHeader;
+    private String contextPath;
 
     private final ApplicationConfiguration applicationConfiguration;
     private Charset defaultCharset;
@@ -248,6 +249,13 @@ public class HttpServerConfiguration {
     }
 
     /**
+     * @return the context path for the web server
+     */
+    public String getContextPath() {
+        return contextPath;
+    }
+
+    /**
      * @param defaultCharset The default charset to use
      */
     public void setDefaultCharset(Charset defaultCharset) {
@@ -377,6 +385,16 @@ public class HttpServerConfiguration {
      */
     public void setClientAddressHeader(String clientAddressHeader) {
         this.clientAddressHeader = clientAddressHeader;
+    }
+
+    /**
+     * Sets the context path for the web server.
+     * The context should start with a "/" character but not end with a "/" character.
+     *
+     * @param contextPath the context path for the web server
+     */
+    public void setContextPath(String contextPath) {
+        this.contextPath = contextPath;
     }
 
     /**

--- a/http-server/src/main/java/io/micronaut/http/server/HttpServerConfiguration.java
+++ b/http-server/src/main/java/io/micronaut/http/server/HttpServerConfiguration.java
@@ -389,7 +389,6 @@ public class HttpServerConfiguration {
 
     /**
      * Sets the context path for the web server.
-     * The context should start with a "/" character but not end with a "/" character.
      *
      * @param contextPath the context path for the web server
      */

--- a/router/src/main/java/io/micronaut/web/router/naming/ConfigurableUriNamingStrategy.java
+++ b/router/src/main/java/io/micronaut/web/router/naming/ConfigurableUriNamingStrategy.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.web.router.naming;
+
+import io.micronaut.context.annotation.Primary;
+import io.micronaut.context.annotation.Replaces;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.annotation.Value;
+import io.micronaut.core.naming.conventions.PropertyConvention;
+import io.micronaut.inject.BeanDefinition;
+
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ * The configurable {@link io.micronaut.web.router.RouteBuilder.UriNamingStrategy}
+ * if property "micronaut.server.context-path" has been set.
+ *
+ * @author Andrey Tsarenko
+ * @since 1.2.0
+ */
+@Primary
+@Singleton
+@Replaces(HyphenatedUriNamingStrategy.class)
+@Requires(property = "micronaut.server.context-path")
+public class ConfigurableUriNamingStrategy extends HyphenatedUriNamingStrategy {
+
+    private final String contextPath;
+
+    /**
+     * Constructs a new uri naming strategy for the given property.
+     *
+     * @param contextPath the "micronaut.server.context-path" property value
+     */
+    @Inject
+    public ConfigurableUriNamingStrategy(@Value("${micronaut.server.context-path}") String contextPath) {
+        this.contextPath = contextPath;
+    }
+
+    @Override
+    public String resolveUri(Class type) {
+        return contextPath + super.resolveUri(type);
+    }
+
+    @Override
+    public @Nonnull String resolveUri(BeanDefinition<?> beanDefinition) {
+        return contextPath + super.resolveUri(beanDefinition);
+    }
+
+    @Override
+    public @Nonnull String resolveUri(String property) {
+        return contextPath + super.resolveUri(property);
+    }
+
+    @Override
+    public @Nonnull String resolveUri(Class type, PropertyConvention id) {
+        return contextPath + super.resolveUri(type, id);
+    }
+}

--- a/router/src/main/java/io/micronaut/web/router/naming/ConfigurableUriNamingStrategy.java
+++ b/router/src/main/java/io/micronaut/web/router/naming/ConfigurableUriNamingStrategy.java
@@ -48,7 +48,7 @@ public class ConfigurableUriNamingStrategy extends HyphenatedUriNamingStrategy {
      */
     @Inject
     public ConfigurableUriNamingStrategy(@Value("${micronaut.server.context-path}") String contextPath) {
-        this.contextPath = contextPath;
+        this.contextPath = normalizeContextPath(contextPath);
     }
 
     @Override
@@ -70,4 +70,15 @@ public class ConfigurableUriNamingStrategy extends HyphenatedUriNamingStrategy {
     public @Nonnull String resolveUri(Class type, PropertyConvention id) {
         return contextPath + super.resolveUri(type, id);
     }
+
+    private String normalizeContextPath(String contextPath) {
+        if (contextPath.charAt(0) != '/') {
+            contextPath = '/' + contextPath;
+        }
+        if (contextPath.charAt(contextPath.length() - 1) == '/') {
+            contextPath = contextPath.substring(0, contextPath.length() - 1);
+        }
+        return contextPath;
+    }
 }
+

--- a/router/src/test/groovy/io/micronaut/web/router/ConfigurableUriNamingStrategySpec.groovy
+++ b/router/src/test/groovy/io/micronaut/web/router/ConfigurableUriNamingStrategySpec.groovy
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.web.router
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.DefaultApplicationContext
+import io.micronaut.context.env.PropertySource
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.web.router.naming.ConfigurableUriNamingStrategy
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import static io.micronaut.http.HttpMethod.GET
+
+/**
+ * @author Andrey Tsarenko
+ * @since 1.2.0
+ */
+class ConfigurableUriNamingStrategySpec extends Specification {
+
+    void "By default ConfigurableUriNamingStrategy bean is not loaded"() {
+        given:
+        def applicationContext = new DefaultApplicationContext('test').start()
+
+        expect:
+        !applicationContext.containsBean(ConfigurableUriNamingStrategy)
+
+        cleanup:
+        applicationContext.close()
+    }
+
+    void "ConfigurableUriNamingStrategy bean is loaded if 'micronaut.server.context-path' specified"() {
+        given:
+        def applicationContext = ApplicationContext.run(
+                PropertySource.of(
+                        'test',
+                        ['micronaut.server.context-path': '/test']
+                )
+        )
+
+        expect:
+        applicationContext.containsBean(ConfigurableUriNamingStrategy)
+
+        cleanup:
+        applicationContext.close()
+    }
+
+    @Unroll
+    void "Test 'micronaut.server.context-path' matches with #route"() {
+        given:
+        def applicationContext = ApplicationContext.run(
+                PropertySource.of(
+                        'test',
+                        ['micronaut.server.context-path': '/test']
+                )
+        )
+                .start()
+        def router = applicationContext.getBean(Router)
+
+        expect:
+        router."$method"(route).isPresent()
+        router."$method"(route).get().invoke() == result
+
+        cleanup:
+        applicationContext.close()
+
+        where:
+        method | route                      | result
+        GET    | '/test/city'               | 'Hello city'
+        GET    | '/test/city/Madrid'        | 'City Madrid'
+        GET    | '/test/city/country/Spain' | 'Country Spain'
+    }
+
+    @Unroll
+    void "Test 'micronaut.server.context-path' not started with '/' and matches with #route"() {
+        given:
+        def applicationContext = ApplicationContext.run(
+                PropertySource.of(
+                        'test',
+                        ['micronaut.server.context-path': 'test']
+                )
+        )
+                .start()
+        def router = applicationContext.getBean(Router)
+
+        expect:
+        router."$method"(route).isPresent()
+        router."$method"(route).get().invoke() == result
+
+        cleanup:
+        applicationContext.close()
+
+        where:
+        method | route                      | result
+        GET    | '/test/city'               | 'Hello city'
+        GET    | '/test/city/Madrid'        | 'City Madrid'
+        GET    | '/test/city/country/Spain' | 'Country Spain'
+    }
+
+    @Unroll
+    void "Test 'micronaut.server.context-path' ending with '/' and matches with #route"() {
+        given:
+        def applicationContext = ApplicationContext.run(
+                PropertySource.of(
+                        'test',
+                        ['micronaut.server.context-path': 'test/']
+                )
+        )
+                .start()
+        def router = applicationContext.getBean(Router)
+
+        expect:
+        router."$method"(route).isPresent()
+        router."$method"(route).get().invoke() == result
+
+        cleanup:
+        applicationContext.close()
+
+        where:
+        method | route                      | result
+        GET    | '/test/city'               | 'Hello city'
+        GET    | '/test/city/Madrid'        | 'City Madrid'
+        GET    | '/test/city/country/Spain' | 'Country Spain'
+    }
+
+    @Unroll
+    void "Test 'micronaut.server.context-path' started and ending with '/' and matches with #route"() {
+        given:
+        def applicationContext = ApplicationContext.run(
+                PropertySource.of(
+                        'test',
+                        ['micronaut.server.context-path': '/test/']
+                )
+        )
+                .start()
+        def router = applicationContext.getBean(Router)
+
+        expect:
+        router."$method"(route).isPresent()
+        router."$method"(route).get().invoke() == result
+
+        cleanup:
+        applicationContext.close()
+
+        where:
+        method | route                      | result
+        GET    | '/test/city'               | 'Hello city'
+        GET    | '/test/city/Madrid'        | 'City Madrid'
+        GET    | '/test/city/country/Spain' | 'Country Spain'
+    }
+
+    @Controller('/city')
+    static class CityController {
+
+        @Get
+        String index() {
+            'Hello city'
+        }
+
+        @Get('/{name}')
+        String city(String name) {
+            "City $name"
+        }
+
+        @Get('country/{name}')
+        String country(String name) {
+            "Country $name"
+        }
+    }
+}


### PR DESCRIPTION
In my humble opinion it will be useful to be able to set server context path using property `micronaut.server.context-path` for all controllers.

Also the same ability is already present in Spring Boot [server.servlet.context-path](https://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html)

Motivated by [stackoverflow question](https://stackoverflow.com/q/56769848/8112217)