### PR TITLE
Fix incorrect usage of Androids onTerminate() in doc

### DIFF
--- a/src/main/docs/guide/ioc/android.adoc
+++ b/src/main/docs/guide/ioc/android.adoc
@@ -74,15 +74,6 @@ public class BaseApplication extends Application { // <1>
             ... // shortened for brevity, it is not necessary to implement other methods
         });
     }
-
-    @Override
-    public void onTerminate() {
-        super.onTerminate();
-        if(ctx != null && ctx.isRunning()) { // <4>
-            ctx.stop();
-        }
-    }
-
 }
 
 ----
@@ -90,5 +81,4 @@ public class BaseApplication extends Application { // <1>
 <1> Extend the `android.app.Application` class
 <2> Run the `ApplicationContext` with the `ANDROID` environment
 <3> To allow dependency injection of Android `Activity` instances register a `ActivityLifecycleCallbacks` instance
-<4> Stop the `ApplicationContext` when the application terminates
 


### PR DESCRIPTION
A concept that is foreign for non-Android devs, is that there are a bunch of entry lifecycle points but no exit lifecycle for the whole _application_ (there is for `Activity` ie. the Android OS interface for creating views). So there is no concept of "exiting application", it just disappears from the heap at some point, the Android OS handles this. As developer you should therefore not rely on cleanup code in the `Application`, only in `Activities` (or similar) - which are also not guaranteed to be called (specifically `onDestroy()`).

In this particular case, this is even worse because `onTerminate()` is _only_ called in emulator environments (check out: https://developer.android.com/reference/android/app/Application.html#onTerminate())
which makes this example highly misleading. As the cleanup code is probably not useful to execute when Android OS decides to clear the app from the heap, it is redundant anyway.