### PR TITLE
Issue #1846 Heartbeat event is disabled by default

### DIFF
--- a/runtime/src/main/java/io/micronaut/health/HeartbeatDiscoveryClientCondition.java
+++ b/runtime/src/main/java/io/micronaut/health/HeartbeatDiscoveryClientCondition.java
@@ -25,6 +25,8 @@ import io.micronaut.inject.BeanDefinition;
 
 import java.util.Collection;
 
+import static java.lang.Boolean.TRUE;
+
 /**
  * Custom condition to conditionally enable the heart beat.
  *
@@ -36,8 +38,8 @@ public final class HeartbeatDiscoveryClientCondition implements Condition {
     @Override
     public boolean matches(ConditionContext context) {
         final ApplicationContext beanContext = (ApplicationContext) context.getBeanContext();
-        final Boolean enabled = beanContext.getProperty(HeartbeatConfiguration.ENABLED, Boolean.class).orElse(null);
-        if (enabled != null && enabled) {
+        final Boolean enabled = beanContext.getProperty(HeartbeatConfiguration.ENABLED, Boolean.class).orElse(TRUE);
+        if (enabled) {
             return true;
         }
 

--- a/runtime/src/test/groovy/io/micronaut/health/HeartbeatDiscoveryClientConditionSpec.groovy
+++ b/runtime/src/test/groovy/io/micronaut/health/HeartbeatDiscoveryClientConditionSpec.groovy
@@ -1,0 +1,63 @@
+package io.micronaut.health
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.condition.ConditionContext
+import io.micronaut.discovery.DiscoveryClient
+import io.micronaut.inject.BeanDefinition
+import spock.lang.Specification
+
+import static java.lang.Boolean.FALSE
+
+class HeartbeatDiscoveryClientConditionSpec extends Specification {
+
+    HeartbeatDiscoveryClientCondition heartbeatDiscoveryClientCondition = new HeartbeatDiscoveryClientCondition()
+
+    def "matches should return true when micronaut.heartbeat.enabled is not defined"() {
+
+        given:
+        ConditionContext conditionContext = Mock(ConditionContext)
+        ApplicationContext  beanContext = Mock(ApplicationContext)
+
+        when:
+        Boolean matches = heartbeatDiscoveryClientCondition.matches(conditionContext)
+
+        then:
+        matches
+        1 * conditionContext.getBeanContext() >> beanContext
+        1 * beanContext.getProperty(HeartbeatConfiguration.ENABLED, Boolean.class) >> Optional.empty()
+    }
+
+    def "matches should return false when micronaut.heartbeat.enabled is defined as false and there are no discovery clients"() {
+
+        given:
+        ConditionContext conditionContext = Mock(ConditionContext)
+        ApplicationContext  beanContext = Mock(ApplicationContext)
+
+        when:
+        Boolean matches = heartbeatDiscoveryClientCondition.matches(conditionContext)
+
+        then:
+        !matches
+        1 * conditionContext.getBeanContext() >> beanContext
+        1 * beanContext.getProperty(HeartbeatConfiguration.ENABLED, Boolean.class) >> Optional.of(FALSE)
+        1 * beanContext.getBeanDefinitions(DiscoveryClient.class) >> []
+    }
+
+    def "matches should return true when micronaut.heartbeat.enabled is defined as false and there are discovery clients"() {
+
+        given:
+        ConditionContext conditionContext = Mock(ConditionContext)
+        ApplicationContext  beanContext = Mock(ApplicationContext)
+        def beanDefinition = Mock(BeanDefinition)
+
+        when:
+        Boolean matches = heartbeatDiscoveryClientCondition.matches(conditionContext)
+
+        then:
+        matches
+        1 * conditionContext.getBeanContext() >> beanContext
+        1 * beanContext.getProperty(HeartbeatConfiguration.ENABLED, Boolean.class) >> Optional.of(FALSE)
+        1 * beanDefinition.getBeanType() >> DiscoveryClient.class
+        1 * beanContext.getBeanDefinitions(DiscoveryClient.class) >> [beanDefinition]
+    }
+}


### PR DESCRIPTION
This PR fixes the issue in Micronaut 1.1.3 in which Heartbeat is disabled if not explicitly enabled in the config. This contradicts the documentation which states that Heartbeat is enabled by default.
See #1846 for full details