### PR TITLE
Fix multiple attempt to write metadata (Error:  Error occurred writing configuration metadata: Output stream or writer has already been opened.)

### DIFF
--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -192,22 +192,6 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                     }
                 }
             });
-
-            if (metadataBuilder.hasMetadata()) {
-                ServiceLoader<ConfigurationMetadataWriter> writers = ServiceLoader.load(ConfigurationMetadataWriter.class, getClass().getClassLoader());
-
-                try {
-                    for (ConfigurationMetadataWriter writer : writers) {
-                        try {
-                            writer.write(metadataBuilder, classWriterOutputVisitor);
-                        } catch (IOException e) {
-                            error("Error occurred writing configuration metadata: %s", e.getMessage());
-                        }
-                    }
-                } catch (ServiceConfigurationError e) {
-                    warning("Unable to load ConfigurationMetadataWriter due to : %s", e.getMessage());
-                }
-            }
             AnnotationUtils.invalidateCache();
         }
 
@@ -217,6 +201,7 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
         */
         if (processingOver) {
             try {
+                writeConfigurationMetadata();
                 writeBeanDefinitionsToMetaInf();
             } finally {
                 AnnotationUtils.invalidateCache();
@@ -225,6 +210,24 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
         }
 
         return false;
+    }
+
+    private void writeConfigurationMetadata() {
+        if (metadataBuilder.hasMetadata()) {
+            ServiceLoader<ConfigurationMetadataWriter> writers = ServiceLoader.load(ConfigurationMetadataWriter.class, getClass().getClassLoader());
+
+            try {
+                for (ConfigurationMetadataWriter writer : writers) {
+                    try {
+                        writer.write(metadataBuilder, classWriterOutputVisitor);
+                    } catch (IOException e) {
+                        error("Error occurred writing configuration metadata: %s", e.getMessage());
+                    }
+                }
+            } catch (ServiceConfigurationError e) {
+                warning("Unable to load ConfigurationMetadataWriter due to : %s", e.getMessage());
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Fix is similar to https://github.com/micronaut-projects/micronaut-core/pull/1339
Fixes https://github.com/micronaut-projects/micronaut-core/issues/1711 issue with using MapStruct and @ConfigurationProperties