### PR TITLE
Adding testAnnotationProcessor in dependencies

### DIFF
--- a/src/main/docs/guide/ioc.adoc
+++ b/src/main/docs/guide/ioc.adoc
@@ -37,7 +37,7 @@ dependencies {
 <1> Apply the Annotation Processing plugin
 <2> Include the minimal dependencies required to perform dependency injection
 
-NOTE: For the Groovy language you should include `micronaut-inject-groovy` in the `compileOnly` scope.
+NOTE: For the Groovy language you should include `micronaut-inject-groovy` in the `compileOnly` and `testCompileOnly` scopes.
 
 The entry point for IoC is then the api:context.ApplicationContext[] interface, which includes a `run` method. The following example demonstrates using it:
 

--- a/src/main/docs/guide/ioc.adoc
+++ b/src/main/docs/guide/ioc.adoc
@@ -28,6 +28,8 @@ dependencies {
     annotationProcessor "io.micronaut:micronaut-inject-java:{version}" // <2>
     compile "io.micronaut:micronaut-inject:{version}"
     ...
+    testAnnotationProcessor "io.micronaut:micronaut-inject-java:{version}"
+    ...
 }
 
 ----


### PR DESCRIPTION
Developers, not using micronaut-cli, are often not aware of the need to add `testAnnotationProcessor` in the dependencies.