### PR TITLE
Update example custom exception handling in docs

### DIFF
--- a/http-server-netty/src/test/groovy/io/micronaut/docs/http/server/exception/OutOfStockException.java
+++ b/http-server-netty/src/test/groovy/io/micronaut/docs/http/server/exception/OutOfStockException.java
@@ -16,6 +16,11 @@
 package io.micronaut.docs.http.server.exception;
 
 //tag::clazz[]
-public class OutOfStockException extends RuntimeException {
+public class OutOfStockException extends RuntimeException implements HttpResponseProvider {
+  
+    @Override
+    public HttpResponse<?> getResponse() {
+        return HttpResponse.ok(0);
+    }
 }
 //end::clazz[]

--- a/http-server-netty/src/test/groovy/io/micronaut/docs/http/server/exception/OutOfStockException.java
+++ b/http-server-netty/src/test/groovy/io/micronaut/docs/http/server/exception/OutOfStockException.java
@@ -15,9 +15,12 @@
  */
 package io.micronaut.docs.http.server.exception;
 
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpResponseProvider;
+
 //tag::clazz[]
 public class OutOfStockException extends RuntimeException implements HttpResponseProvider {
-  
+
     @Override
     public HttpResponse<?> getResponse() {
         return HttpResponse.ok(0);


### PR DESCRIPTION
Implementing a HttpResponseProvider ensures the metric reporter reports on the correct status code