### PR TITLE
Tests and fixes for various @MockBean scenarios

### DIFF
--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1730,9 +1730,7 @@ public class DefaultBeanContext implements BeanContext {
                             if (type != null) {
                                 final Optional qualified = Qualifiers.<T>byName(qualifier)
                                         .qualify(type, Stream.of(definition));
-                                if (qualified.isPresent()) {
-                                    return true;
-                                }
+                                return qualified.isPresent();
                             }
                         }
                     }
@@ -1788,10 +1786,12 @@ public class DefaultBeanContext implements BeanContext {
             }
             if (defaultImpl.filter(impl -> impl == bt).isPresent()) {
                 return (clazz) -> clazz.isAssignableFrom(bt);
+            } else {
+                return (clazz) -> clazz == bt;
             }
         }
 
-        return (clazz) -> clazz == bt;
+        return (clazz) -> clazz != Object.class && clazz.isAssignableFrom(bt);
     }
 
     private <T> void doInject(BeanResolutionContext resolutionContext, T instance, BeanDefinition definition) {

--- a/inject/src/main/java/io/micronaut/context/annotation/DefaultImplementation.java
+++ b/inject/src/main/java/io/micronaut/context/annotation/DefaultImplementation.java
@@ -16,6 +16,8 @@
 
 package io.micronaut.context.annotation;
 
+import io.micronaut.core.annotation.Experimental;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -57,6 +59,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Documented
 @Retention(RUNTIME)
 @Target(ElementType.TYPE)
+@Experimental
 public @interface DefaultImplementation {
 
     /**

--- a/test-suite/src/test/java/io/micronaut/test/replaces/InterfaceA.java
+++ b/test-suite/src/test/java/io/micronaut/test/replaces/InterfaceA.java
@@ -1,0 +1,6 @@
+package io.micronaut.test.replaces;
+
+public interface InterfaceA {
+
+    String doStuff();
+}

--- a/test-suite/src/test/java/io/micronaut/test/replaces/InterfaceAImpl.java
+++ b/test-suite/src/test/java/io/micronaut/test/replaces/InterfaceAImpl.java
@@ -1,0 +1,11 @@
+package io.micronaut.test.replaces;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class InterfaceAImpl implements InterfaceA {
+    @Override
+    public String doStuff() {
+        return "real-bean";
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/test/replaces/InterfaceB.java
+++ b/test-suite/src/test/java/io/micronaut/test/replaces/InterfaceB.java
@@ -1,0 +1,5 @@
+package io.micronaut.test.replaces;
+
+public interface InterfaceB {
+    String doStuff();
+}

--- a/test-suite/src/test/java/io/micronaut/test/replaces/InterfaceBImpl.java
+++ b/test-suite/src/test/java/io/micronaut/test/replaces/InterfaceBImpl.java
@@ -1,0 +1,11 @@
+package io.micronaut.test.replaces;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class InterfaceBImpl implements InterfaceB {
+    @Override
+    public String doStuff() {
+        return "real";
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/test/replaces/InterfaceC.java
+++ b/test-suite/src/test/java/io/micronaut/test/replaces/InterfaceC.java
@@ -1,0 +1,5 @@
+package io.micronaut.test.replaces;
+
+public interface InterfaceC {
+    String doStuff();
+}

--- a/test-suite/src/test/java/io/micronaut/test/replaces/InterfaceCFactory.java
+++ b/test-suite/src/test/java/io/micronaut/test/replaces/InterfaceCFactory.java
@@ -1,0 +1,13 @@
+package io.micronaut.test.replaces;
+
+import io.micronaut.context.annotation.Factory;
+import org.testcontainers.shaded.javax.inject.Singleton;
+
+@Factory
+public class InterfaceCFactory {
+
+    @Singleton
+    InterfaceC interfaceC() {
+        return () -> "real";
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/test/replaces/MockBeanTest.java
+++ b/test-suite/src/test/java/io/micronaut/test/replaces/MockBeanTest.java
@@ -1,0 +1,57 @@
+package io.micronaut.test.replaces;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.test.annotation.MicronautTest;
+import io.micronaut.test.annotation.MockBean;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+
+@MicronautTest
+class MockBeanTest {
+
+    @Inject
+    ApplicationContext applicationContext;
+
+    @Inject
+    InterfaceA interfaceA;
+
+    @Inject
+    InterfaceC interfaceC;
+
+    @Inject
+    InterfaceB interfaceB;
+
+
+    @Test
+    void testMockConcretePrimaryBean() {
+        assertEquals("mocked A", interfaceA.doStuff());
+    }
+
+    @Test
+    void testMockInterfaceImplPrimary() {
+        assertEquals("mocked B", interfaceB.doStuff());
+    }
+
+    @Test
+    void testMockInterfaceFromFactory() {
+        assertEquals("mocked C", interfaceC.doStuff());
+    }
+
+    @MockBean(InterfaceAImpl.class)
+    InterfaceA conreteBeanMock() {
+        return () -> "mocked A";
+    }
+
+    @MockBean(InterfaceB.class)
+    InterfaceB interfaceDefaultImplMock() {
+        return () -> "mocked B";
+    }
+
+
+    @MockBean(InterfaceC.class)
+    InterfaceC interfaceFactoryMock() {
+        return () -> "mocked C";
+    }
+}


### PR DESCRIPTION
This change alters the behaviour of `@Replaces` to use `isAssignableFrom`

This may constitute a breaking change in certain scenarios but fixes what is considered in a bug in the functioning of `@MockBean` and is less surprising than the current behaviour.

This is currently a PR as it may only be included in 1.3 rather than 1.2