### PR TITLE
Using @QueryValue annotation for binding request parameters to POJO

### DIFF
--- a/test-suite/src/test/groovy/io/micronaut/docs/server/binding/BookmarkController.java
+++ b/test-suite/src/test/groovy/io/micronaut/docs/server/binding/BookmarkController.java
@@ -36,7 +36,7 @@ public class BookmarkController {
 
     // tag::listBooks[]
     @Get("/bookmarks/list{?paginationCommand*}")
-    public HttpStatus list(@Valid @Nullable PaginationCommand paginationCommand) {
+    public HttpStatus list(@Valid @Nullable @QueryValue PaginationCommand paginationCommand) {
         return HttpStatus.OK;
     }
     // end::listBooks[]


### PR DESCRIPTION
we have to use @QueryValue annotation for binding request parameters to POJO