### PR TITLE
Restore prior server request context after wrapping execution

### DIFF
--- a/http/src/main/java/io/micronaut/http/context/ServerRequestContext.java
+++ b/http/src/main/java/io/micronaut/http/context/ServerRequestContext.java
@@ -15,11 +15,14 @@
  */
 package io.micronaut.http.context;
 
-import io.micronaut.http.HttpRequest;
-
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import io.micronaut.http.HttpRequest;
 
 /**
  * The holder for the current {@link HttpRequest} that is bound to instrumented threads.
@@ -35,6 +38,14 @@ public final class ServerRequestContext {
     private ServerRequestContext() {
     }
 
+    private static void set(@Nullable HttpRequest request) {
+        if (request == null) {
+            REQUEST.remove();
+        } else {
+            REQUEST.set(request);
+        }
+    }
+
     /**
      * Wrap the execution of the given runnable in request context processing.
      *
@@ -47,12 +58,12 @@ public final class ServerRequestContext {
         try {
             if (request != existing) {
                 isSet = true;
-                REQUEST.set(request);
+                set(request);
             }
             runnable.run();
         } finally {
             if (isSet) {
-                REQUEST.remove();
+                set(existing);
             }
         }
     }
@@ -82,12 +93,12 @@ public final class ServerRequestContext {
         try {
             if (request != existing) {
                 isSet = true;
-                REQUEST.set(request);
+                set(request);
             }
             return callable.get();
         } finally {
             if (isSet) {
-                REQUEST.remove();
+                set(existing);
             }
         }
     }
@@ -107,12 +118,12 @@ public final class ServerRequestContext {
         try {
             if (request != existing) {
                 isSet = true;
-                REQUEST.set(request);
+                set(request);
             }
             return callable.call();
         } finally {
             if (isSet) {
-                REQUEST.remove();
+                set(existing);
             }
         }
     }

--- a/http/src/main/java/io/micronaut/http/context/ServerRequestContext.java
+++ b/http/src/main/java/io/micronaut/http/context/ServerRequestContext.java
@@ -52,7 +52,7 @@ public final class ServerRequestContext {
      * @param request  The request
      * @param runnable The runnable
      */
-    public static void with(HttpRequest request, Runnable runnable) {
+    public static void with(@Nullable HttpRequest request, @Nonnull Runnable runnable) {
         HttpRequest existing = REQUEST.get();
         boolean isSet = false;
         try {
@@ -75,7 +75,7 @@ public final class ServerRequestContext {
      * @param runnable The runnable
      * @return The newly instrumented runnable
      */
-    public static Runnable instrument(HttpRequest request, Runnable runnable) {
+    public static Runnable instrument(@Nullable HttpRequest request, @Nonnull Runnable runnable) {
         return () -> with(request, runnable);
     }
 
@@ -87,7 +87,7 @@ public final class ServerRequestContext {
      * @param <T>      The return type of the callable
      * @return The return value of the callable
      */
-    public static <T> T with(HttpRequest request, Supplier<T> callable) {
+    public static <T> T with(@Nullable HttpRequest request, @Nonnull Supplier<T> callable) {
         HttpRequest existing = REQUEST.get();
         boolean isSet = false;
         try {
@@ -112,7 +112,7 @@ public final class ServerRequestContext {
      * @return The return value of the callable
      * @throws Exception If the callable throws an exception
      */
-    public static <T> T with(HttpRequest request, Callable<T> callable) throws Exception {
+    public static <T> T with(@Nullable HttpRequest request, @Nonnull Callable<T> callable) throws Exception {
         HttpRequest existing = REQUEST.get();
         boolean isSet = false;
         try {

--- a/http/src/test/groovy/io/micronaut/http/context/ServerRequestContextSpec.groovy
+++ b/http/src/test/groovy/io/micronaut/http/context/ServerRequestContextSpec.groovy
@@ -1,0 +1,284 @@
+package io.micronaut.http.context
+
+import io.micronaut.http.HttpRequest
+import spock.lang.Specification
+
+import java.util.concurrent.Callable
+import java.util.function.Supplier
+
+class ServerRequestContextSpec extends Specification {
+
+    def "runnable is instrumented with request"() {
+        given:
+        HttpRequest request = HttpRequest.GET("/")
+
+        when:
+        Optional<HttpRequest> instrumentedRequest = null
+        ServerRequestContext.with(request, {
+            instrumentedRequest = ServerRequestContext.currentRequest()
+        } as Runnable)
+
+        then:
+        instrumentedRequest.isPresent()
+        instrumentedRequest.get() is request
+        !ServerRequestContext.currentRequest().isPresent()
+    }
+
+    def "runnable instrumentation restores original request"() {
+        given:
+        HttpRequest firstRequest = HttpRequest.GET("/a")
+        HttpRequest secondRequest = HttpRequest.GET("/b")
+
+        when:
+        Optional<HttpRequest> firstInstrumentedRequest = null
+        Optional<HttpRequest> secondInstrumentedRequest = null
+        Optional<HttpRequest> firstInstrumentedRequestRestored = null
+        ServerRequestContext.with(firstRequest, {
+            firstInstrumentedRequest = ServerRequestContext.currentRequest()
+            ServerRequestContext.with(secondRequest, {
+                secondInstrumentedRequest = ServerRequestContext.currentRequest()
+            } as Runnable)
+            firstInstrumentedRequestRestored = ServerRequestContext.currentRequest()
+        } as Runnable)
+
+        then:
+        firstInstrumentedRequest.isPresent()
+        firstInstrumentedRequest.get() is firstRequest
+        secondInstrumentedRequest.isPresent()
+        secondInstrumentedRequest.get() is secondRequest
+        firstInstrumentedRequestRestored.isPresent()
+        firstInstrumentedRequest.get() is firstRequest
+        !ServerRequestContext.currentRequest().isPresent()
+    }
+
+    def "runnable instrumentation restores empty"() {
+        given:
+        HttpRequest secondRequest = HttpRequest.GET("/b")
+
+        when:
+        Optional<HttpRequest> firstInstrumentedRequest = null
+        Optional<HttpRequest> secondInstrumentedRequest = null
+        Optional<HttpRequest> firstInstrumentedRequestRestored = null
+        ServerRequestContext.with(null, {
+            firstInstrumentedRequest = ServerRequestContext.currentRequest()
+            ServerRequestContext.with(secondRequest, {
+                secondInstrumentedRequest = ServerRequestContext.currentRequest()
+            } as Runnable)
+            firstInstrumentedRequestRestored = ServerRequestContext.currentRequest()
+        } as Runnable)
+
+        then:
+        !firstInstrumentedRequest.isPresent()
+        secondInstrumentedRequest.isPresent()
+        secondInstrumentedRequest.get() is secondRequest
+        !firstInstrumentedRequestRestored.isPresent()
+        !ServerRequestContext.currentRequest().isPresent()
+    }
+
+    def "runnable instrumentation overrides with empty"() {
+        given:
+        HttpRequest firstRequest = HttpRequest.GET("/a")
+
+        when:
+        Optional<HttpRequest> firstInstrumentedRequest = null
+        Optional<HttpRequest> secondInstrumentedRequest = null
+        Optional<HttpRequest> firstInstrumentedRequestRestored = null
+        ServerRequestContext.with(firstRequest, {
+            firstInstrumentedRequest = ServerRequestContext.currentRequest()
+            ServerRequestContext.with(null, {
+                secondInstrumentedRequest = ServerRequestContext.currentRequest()
+            } as Runnable)
+            firstInstrumentedRequestRestored = ServerRequestContext.currentRequest()
+        } as Runnable)
+
+        then:
+        firstInstrumentedRequest.isPresent()
+        firstInstrumentedRequest.get() is firstRequest
+        !secondInstrumentedRequest.isPresent()
+        firstInstrumentedRequestRestored.isPresent()
+        firstInstrumentedRequest.get() is firstRequest
+        !ServerRequestContext.currentRequest().isPresent()
+    }
+
+    def "supplier is instrumented with request"() {
+        given:
+        HttpRequest request = HttpRequest.GET("/")
+
+        when:
+        Optional<HttpRequest> instrumentedRequest = ServerRequestContext.with(request, {
+            ServerRequestContext.currentRequest()
+        } as Supplier<Optional<HttpRequest>>)
+
+        then:
+        instrumentedRequest.isPresent()
+        instrumentedRequest.get() is request
+        !ServerRequestContext.currentRequest().isPresent()
+    }
+
+    def "supplier instrumentation restores original request"() {
+        given:
+        HttpRequest firstRequest = HttpRequest.GET("/a")
+        HttpRequest secondRequest = HttpRequest.GET("/b")
+
+        when:
+        Optional<HttpRequest> firstInstrumentedRequest = null
+        Optional<HttpRequest> secondInstrumentedRequest = null
+        Optional<HttpRequest> firstInstrumentedRequestRestored = null
+        ServerRequestContext.with(firstRequest, {
+            firstInstrumentedRequest = ServerRequestContext.currentRequest()
+            ServerRequestContext.with(secondRequest, {
+                secondInstrumentedRequest = ServerRequestContext.currentRequest()
+            } as Supplier<Void>)
+            firstInstrumentedRequestRestored = ServerRequestContext.currentRequest()
+        } as Supplier<Void>)
+
+        then:
+        firstInstrumentedRequest.isPresent()
+        firstInstrumentedRequest.get() is firstRequest
+        secondInstrumentedRequest.isPresent()
+        secondInstrumentedRequest.get() is secondRequest
+        firstInstrumentedRequestRestored.isPresent()
+        firstInstrumentedRequest.get() is firstRequest
+        !ServerRequestContext.currentRequest().isPresent()
+    }
+
+    def "supplier instrumentation restores empty"() {
+        given:
+        HttpRequest secondRequest = HttpRequest.GET("/b")
+
+        when:
+        Optional<HttpRequest> firstInstrumentedRequest = null
+        Optional<HttpRequest> secondInstrumentedRequest = null
+        Optional<HttpRequest> firstInstrumentedRequestRestored = null
+        ServerRequestContext.with(null, {
+            firstInstrumentedRequest = ServerRequestContext.currentRequest()
+            ServerRequestContext.with(secondRequest, {
+                secondInstrumentedRequest = ServerRequestContext.currentRequest()
+            } as Supplier<Void>)
+            firstInstrumentedRequestRestored = ServerRequestContext.currentRequest()
+        } as Supplier<Void>)
+
+        then:
+        !firstInstrumentedRequest.isPresent()
+        secondInstrumentedRequest.isPresent()
+        secondInstrumentedRequest.get() is secondRequest
+        !firstInstrumentedRequestRestored.isPresent()
+        !ServerRequestContext.currentRequest().isPresent()
+    }
+
+    def "supplier instrumentation overrides with empty"() {
+        given:
+        HttpRequest firstRequest = HttpRequest.GET("/a")
+
+        when:
+        Optional<HttpRequest> firstInstrumentedRequest = null
+        Optional<HttpRequest> secondInstrumentedRequest = null
+        Optional<HttpRequest> firstInstrumentedRequestRestored = null
+        ServerRequestContext.with(firstRequest, {
+            firstInstrumentedRequest = ServerRequestContext.currentRequest()
+            ServerRequestContext.with(null, {
+                secondInstrumentedRequest = ServerRequestContext.currentRequest()
+            } as Supplier<Void>)
+            firstInstrumentedRequestRestored = ServerRequestContext.currentRequest()
+        } as Supplier<Void>)
+
+        then:
+        firstInstrumentedRequest.isPresent()
+        firstInstrumentedRequest.get() is firstRequest
+        !secondInstrumentedRequest.isPresent()
+        firstInstrumentedRequestRestored.isPresent()
+        firstInstrumentedRequest.get() is firstRequest
+        !ServerRequestContext.currentRequest().isPresent()
+    }
+
+    def "callable is instrumented with request"() {
+        given:
+        HttpRequest request = HttpRequest.GET("/")
+
+        when:
+        Optional<HttpRequest> instrumentedRequest = ServerRequestContext.with(request, {
+            ServerRequestContext.currentRequest()
+        } as Callable<Optional<HttpRequest>>)
+
+        then:
+        instrumentedRequest.isPresent()
+        instrumentedRequest.get() is request
+        !ServerRequestContext.currentRequest().isPresent()
+    }
+
+    def "callable instrumentation restores original request"() {
+        given:
+        HttpRequest firstRequest = HttpRequest.GET("/a")
+        HttpRequest secondRequest = HttpRequest.GET("/b")
+
+        when:
+        Optional<HttpRequest> firstInstrumentedRequest = null
+        Optional<HttpRequest> secondInstrumentedRequest = null
+        Optional<HttpRequest> firstInstrumentedRequestRestored = null
+        ServerRequestContext.with(firstRequest, {
+            firstInstrumentedRequest = ServerRequestContext.currentRequest()
+            ServerRequestContext.with(secondRequest, {
+                secondInstrumentedRequest = ServerRequestContext.currentRequest()
+            } as Callable<Void>)
+            firstInstrumentedRequestRestored = ServerRequestContext.currentRequest()
+        } as Callable<Void>)
+
+        then:
+        firstInstrumentedRequest.isPresent()
+        firstInstrumentedRequest.get() is firstRequest
+        secondInstrumentedRequest.isPresent()
+        secondInstrumentedRequest.get() is secondRequest
+        firstInstrumentedRequestRestored.isPresent()
+        firstInstrumentedRequest.get() is firstRequest
+        !ServerRequestContext.currentRequest().isPresent()
+    }
+
+    def "callable instrumentation restores empty"() {
+        given:
+        HttpRequest secondRequest = HttpRequest.GET("/b")
+
+        when:
+        Optional<HttpRequest> firstInstrumentedRequest = null
+        Optional<HttpRequest> secondInstrumentedRequest = null
+        Optional<HttpRequest> firstInstrumentedRequestRestored = null
+        ServerRequestContext.with(null, {
+            firstInstrumentedRequest = ServerRequestContext.currentRequest()
+            ServerRequestContext.with(secondRequest, {
+                secondInstrumentedRequest = ServerRequestContext.currentRequest()
+            } as Callable<Void>)
+            firstInstrumentedRequestRestored = ServerRequestContext.currentRequest()
+        } as Callable<Void>)
+
+        then:
+        !firstInstrumentedRequest.isPresent()
+        secondInstrumentedRequest.isPresent()
+        secondInstrumentedRequest.get() is secondRequest
+        !firstInstrumentedRequestRestored.isPresent()
+        !ServerRequestContext.currentRequest().isPresent()
+    }
+
+    def "callable instrumentation overrides with empty"() {
+        given:
+        HttpRequest firstRequest = HttpRequest.GET("/a")
+
+        when:
+        Optional<HttpRequest> firstInstrumentedRequest = null
+        Optional<HttpRequest> secondInstrumentedRequest = null
+        Optional<HttpRequest> firstInstrumentedRequestRestored = null
+        ServerRequestContext.with(firstRequest, {
+            firstInstrumentedRequest = ServerRequestContext.currentRequest()
+            ServerRequestContext.with(null, {
+                secondInstrumentedRequest = ServerRequestContext.currentRequest()
+            } as Callable<Void>)
+            firstInstrumentedRequestRestored = ServerRequestContext.currentRequest()
+        } as Callable<Void>)
+
+        then:
+        firstInstrumentedRequest.isPresent()
+        firstInstrumentedRequest.get() is firstRequest
+        !secondInstrumentedRequest.isPresent()
+        firstInstrumentedRequestRestored.isPresent()
+        firstInstrumentedRequest.get() is firstRequest
+        !ServerRequestContext.currentRequest().isPresent()
+    }
+}


### PR DESCRIPTION
Currently, all of the wrappers in `ServerRequestContext` will completely clear the request context after execution. This has the unexpected behavior of permanently losing the context after instrumenting any code with a request other than the original.

Restoring the prior context allows instrumenting code that should run under a different context or no context at all, without affecting the surrounding code.

Sorry if the spec is not idiomatic or confusing - I'm not very familiar with Spock nor even Groovy.