### PR TITLE
Remove extra escape character in cli base usage

### DIFF
--- a/cli/src/main/groovy/io/micronaut/cli/MicronautCli.groovy
+++ b/cli/src/main/groovy/io/micronaut/cli/MicronautCli.groovy
@@ -206,7 +206,7 @@ class MicronautCli {
     }
 
     private int getBaseUsage() {
-        System.out.println "Usage: \n\t $APP_USAGE_MESSAGE \n\t $CLI_APP_USAGE_MESSAGE \\n\\t $FEDERATION_USAGE_MESSAGE \n\t $FUNCTION_USAGE_MESSAGE  \n\n"
+        System.out.println "Usage: \n\t $APP_USAGE_MESSAGE \n\t $CLI_APP_USAGE_MESSAGE \n\t $FEDERATION_USAGE_MESSAGE \n\t $FUNCTION_USAGE_MESSAGE  \n\n"
         this.execute "list-profiles"
         System.out.println "\nType 'mn help' or 'mn -h' for more information."
 


### PR DESCRIPTION
There is a "\n\t" in usage outout:
```
λ  mn profile-list
Usage:
         create-app [NAME]
         create-cli-app [NAME] \n\t create-federation [NAME] --services SERVICE_NAME[,SERVICE_NAME]...
         create-function [NAME]
```