### PR TITLE
Allow `@RequestScope` beans to get access to the request

### DIFF
--- a/http-server-netty/src/test/groovy/io/micronaut/runtime/http/scope/RequestScopeSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/runtime/http/scope/RequestScopeSpec.groovy
@@ -68,9 +68,6 @@ class RequestScopeSpec extends AbstractMicronautSpec {
         conditions.eventually {
             RequestBean.BEANS_CREATED.first().dead
         }
-
-        cleanup:
-        embeddedServer.stop()
     }
 
     void "test request scope bean that injects the request"() {

--- a/runtime/src/main/java/io/micronaut/runtime/http/scope/RequestAware.java
+++ b/runtime/src/main/java/io/micronaut/runtime/http/scope/RequestAware.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.runtime.http.scope;
+
+import io.micronaut.http.HttpRequest;
+
+/**
+ * An interface that may be implemented by {@link RequestScope} beans to allow
+ * access to the current request.
+ *
+ * @author James Kleeh
+ * @since 1.3.0
+ */
+public interface RequestAware {
+
+    /**
+     * Provides the request directly after bean creation.
+     *
+     * @param request The current request
+     */
+    void setRequest(HttpRequest<?> request);
+}

--- a/runtime/src/main/java/io/micronaut/runtime/http/scope/RequestCustomScope.java
+++ b/runtime/src/main/java/io/micronaut/runtime/http/scope/RequestCustomScope.java
@@ -88,6 +88,9 @@ class RequestCustomScope implements CustomScope<RequestScope>, LifeCycle<Request
                 bean = (T) scopedBeanMap.get(identifier);
                 if (bean == null) {
                     bean = provider.get();
+                    if (bean instanceof RequestAware) {
+                        ((RequestAware) bean).setRequest(httpRequest);
+                    }
                     scopedBeanMap.put(identifier, bean);
                 }
             }


### PR DESCRIPTION
The goal here is to reduce another lookup to the context holder since we already have access to the request and the bean it should not be necessary