### PR TITLE
WIP Add space in Basic and Bearer constants

### DIFF
--- a/http/src/main/java/io/micronaut/http/HttpHeaderValues.java
+++ b/http/src/main/java/io/micronaut/http/HttpHeaderValues.java
@@ -26,12 +26,12 @@ public interface HttpHeaderValues {
     /**
      * {@code "Bearer "}.
      */
-    String AUTHORIZATION_PREFIX_BEARER = "Bearer";
+    String AUTHORIZATION_PREFIX_BEARER = "Bearer ";
 
     /**
      * {@code "Basic "}.
      */
-    String AUTHORIZATION_PREFIX_BASIC = "Basic";
+    String AUTHORIZATION_PREFIX_BASIC = "Basic ";
 
     /**
      * @see <a href="https://tools.ietf.org/html/rfc7234#section-5.2.1.1">Rfc 7234 section-5.2.1.1</a>, <a href="https://tools.ietf.org/html/rfc7234#section-5.2.2.8">Rfc 7234 section-5.2.2.8</a>.

--- a/http/src/main/java/io/micronaut/http/HttpHeaderValues.java
+++ b/http/src/main/java/io/micronaut/http/HttpHeaderValues.java
@@ -24,14 +24,14 @@ package io.micronaut.http;
 public interface HttpHeaderValues {
 
     /**
-     * {@code "Bearer "}.
+     * {@code "Bearer"}.
      */
-    String AUTHORIZATION_PREFIX_BEARER = "Bearer ";
+    String AUTHORIZATION_PREFIX_BEARER = "Bearer";
 
     /**
-     * {@code "Basic "}.
+     * {@code "Basic"}.
      */
-    String AUTHORIZATION_PREFIX_BASIC = "Basic ";
+    String AUTHORIZATION_PREFIX_BASIC = "Basic";
 
     /**
      * @see <a href="https://tools.ietf.org/html/rfc7234#section-5.2.1.1">Rfc 7234 section-5.2.1.1</a>, <a href="https://tools.ietf.org/html/rfc7234#section-5.2.2.8">Rfc 7234 section-5.2.2.8</a>.


### PR DESCRIPTION
The Javadoc includes the space but the value doesn't.