### PR TITLE
1.0.x Fix spaces form Javadoc for HttpHeaderValues

### DIFF
--- a/http/src/main/java/io/micronaut/http/HttpHeaderValues.java
+++ b/http/src/main/java/io/micronaut/http/HttpHeaderValues.java
@@ -25,12 +25,12 @@ package io.micronaut.http;
 public interface HttpHeaderValues {
 
     /**
-     * {@code "Bearer "}.
+     * {@code "Bearer"}.
      */
     String AUTHORIZATION_PREFIX_BEARER = "Bearer";
 
     /**
-     * {@code "Basic "}.
+     * {@code "Basic"}.
      */
     String AUTHORIZATION_PREFIX_BASIC = "Basic";
 }


### PR DESCRIPTION
Remove extra spaces from the Javadoc for `AUTHORIZATION_PREFIX_BEARER` and `AUTHORIZATION_PREFIX_BASIC`.