### PR TITLE
the configuration entry for @Property must exist; and it does not handle default values.

### DIFF
--- a/src/main/docs/guide/config/valueAnnotation.adoc
+++ b/src/main/docs/guide/config/valueAnnotation.adoc
@@ -89,7 +89,7 @@ If you wish to inject a specific property name then you may be better off using 
 String url;
 ----
 
-The above will instead inject the value of the `my.url` property resolved from application configuration. You can also use this feature to resolve sub maps. For example, consider the following configuration:
+The above will instead inject the value of the `my.url` property resolved from application configuration. Note that the configuration values for `@Property` must exist and no default value can be defined. You can also use this feature to resolve sub maps. For example, consider the following configuration:
 
 .Example `application.yml` configuration
 [source,yaml]

--- a/src/main/docs/guide/config/valueAnnotation.adoc
+++ b/src/main/docs/guide/config/valueAnnotation.adoc
@@ -89,7 +89,9 @@ If you wish to inject a specific property name then you may be better off using 
 String url;
 ----
 
-The above will instead inject the value of the `my.url` property resolved from application configuration. Note that the configuration values for `@Property` must exist and no default value can be defined. You can also use this feature to resolve sub maps. For example, consider the following configuration:
+The above will instead inject the value of the `my.url` property resolved from application configuration. If the property can not be found in configuration, an exception will be thrown. As with other types of injection, the injection point can also be annotated with `@Nullable` to make the injection optional.
+
+You can also use this feature to resolve sub maps. For example, consider the following configuration:
 
 .Example `application.yml` configuration
 [source,yaml]


### PR DESCRIPTION
At least that is, what I figured out (maybe I'm mistaken):
- the configuration key/value in the YML/whatever file must exist (exception thrown otherwise)
- no default value can be specified (in contrast to @Value)

If it is correct, what I tried for myself, it would be nice to state this in the documentation.