### PR TITLE
Enables support for http & https at the same time

### DIFF
--- a/http-server/src/main/java/io/micronaut/http/server/HttpServerConfiguration.java
+++ b/http-server/src/main/java/io/micronaut/http/server/HttpServerConfiguration.java
@@ -96,6 +96,12 @@ public class HttpServerConfiguration {
     @SuppressWarnings("WeakerAccess")
     public static final boolean DEFAULT_LOG_HANDLED_EXCEPTIONS = false;
 
+    /**
+     * The default value for enabling dual protocol (http/https).
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static final boolean DEFAULT_DUAL_PROTOCOL = false;
+
     private Integer port;
     private String host;
     private Integer readTimeout;
@@ -111,6 +117,7 @@ public class HttpServerConfiguration {
     private HostResolutionConfiguration hostResolution;
     private String clientAddressHeader;
     private String contextPath;
+    private boolean dualProtocol = DEFAULT_DUAL_PROTOCOL;
 
     private final ApplicationConfiguration applicationConfiguration;
     private Charset defaultCharset;
@@ -256,6 +263,13 @@ public class HttpServerConfiguration {
     }
 
     /**
+     * @return if dual protocol has been enabled or not
+     */
+    public boolean isDualProtocol() {
+        return dualProtocol;
+    }
+
+    /**
      * @param defaultCharset The default charset to use
      */
     public void setDefaultCharset(Charset defaultCharset) {
@@ -394,6 +408,13 @@ public class HttpServerConfiguration {
      */
     public void setContextPath(String contextPath) {
         this.contextPath = contextPath;
+    }
+
+    /**
+     * @param dualProtocol the dual protocol (http/https) configuration
+     */
+    public void setDualProtocol(boolean dualProtocol) {
+        this.dualProtocol = dualProtocol;
     }
 
     /**

--- a/src/main/docs/guide/httpServer/serverConfiguration/dualProtocol.adoc
+++ b/src/main/docs/guide/httpServer/serverConfiguration/dualProtocol.adoc
@@ -1,0 +1,15 @@
+Micronaut supports binding both HTTP and HTTPS out of the box. To enable
+dual protocol support, modify your configuration. For example with `application.yml`:
+
+.Dual Protocol Configuration Example
+[source,yaml]
+----
+micronaut:
+    ssl:
+        enabled: true
+        buildSelfSigned: true # <1>
+    server:
+        dualProtocol : true #<2>
+----
+<1> You will need to configure ssl for https to work. In this example we are just using self signed but see <<https, Securing the Server with HTTPS>> for other configurations
+<2> To enable http & https is an opt-in feature, setting the dualProtocol flag enables that, by default Micronaut will only enable one or the other

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -102,6 +102,7 @@ httpServer:
     threadPools: Configuring Server Thread Pools
     cors: Configuring CORS
     https: Securing the Server with HTTPS
+    dualProtocol: Enabling HTTP and HTTPS
   views:
     title: Server Side View Rendering
   openapi: OpenAPI / Swagger Support


### PR DESCRIPTION
Enables what was discussed here #1137. Adds on opt in flag `micronaut.server.dualProtocol` that will bind both http and https to different ports if enabled. 

