### PR TITLE
More reasonable date format example

### DIFF
--- a/src/main/docs/guide/config/configurationProperties.adoc
+++ b/src/main/docs/guide/config/configurationProperties.adoc
@@ -149,7 +149,7 @@ The ann:io.micronaut.core.convert.format.Format[] annotation can be used on any 
 .Using `@Format` for Dates
 [source,java]
 ----
-public void setMyDate(@Format("yy-mm-dd") LocalDate date) {
+public void setMyDate(@Format("yyyy-MM-dd") LocalDate date) {
     this.myDate = date;
 }
 ----


### PR DESCRIPTION
The date format example provided was in two digit year, _minutes_, days. More likely if someone is using a LocalDate, they are likely to be expecting something similar to DateTimeFormatter#ISO_LOCAL_DATE, which is yyyy-MM-dd.