### PR TITLE
Dual port patch

### DIFF
--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/NettyHttpServerSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/NettyHttpServerSpec.groovy
@@ -16,15 +16,11 @@
 package io.micronaut.http.server.netty.binding
 
 import io.micronaut.context.ApplicationContext
-import io.micronaut.context.DefaultApplicationContext
 import io.micronaut.context.env.Environment
 import io.micronaut.context.env.PropertySource
+import io.micronaut.context.event.StartupEvent
 import io.micronaut.core.io.socket.SocketUtils
-import io.micronaut.http.HttpHeaders
-import io.micronaut.http.HttpMethod
-import io.micronaut.http.HttpRequest
-import io.micronaut.http.HttpResponse
-import io.micronaut.http.HttpStatus
+import io.micronaut.http.*
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Put
@@ -32,15 +28,17 @@ import io.micronaut.http.client.DefaultHttpClientConfiguration
 import io.micronaut.http.client.RxHttpClient
 import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.http.server.exceptions.ServerStartupException
-import io.micronaut.http.server.netty.configuration.NettyHttpServerConfiguration
 import io.micronaut.runtime.Micronaut
+import io.micronaut.runtime.event.annotation.EventListener
 import io.micronaut.runtime.server.EmbeddedServer
 import spock.lang.Retry
 import spock.lang.Specification
 import spock.lang.Stepwise
 
+import javax.inject.Singleton
 import java.time.Duration
 import java.time.temporal.ChronoUnit
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * @author Graeme Rocher
@@ -246,6 +244,50 @@ class NettyHttpServerSpec extends Specification {
         embeddedServer.applicationContext.stop()
     }
 
+    void "test non dual protocol Micronaut server only fires startup event once"() {
+        when:
+        PropertySource propertySource = PropertySource.of(
+                'micronaut.server.port': SocketUtils.findAvailableTcpPort(),
+                'micronaut.server.dualProtocol':false
+        )
+        EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, propertySource)
+
+        then:
+        EventCounter eventCounter = embeddedServer.applicationContext.getBean(EventCounter)
+        eventCounter.count as Integer == 1
+
+        cleanup:
+        embeddedServer.applicationContext.stop()
+    }
+
+    void "test dual protocol only fires startup event once"() {
+        when:
+        PropertySource propertySource = PropertySource.of(
+                'micronaut.server.port': SocketUtils.findAvailableTcpPort(),
+                'micronaut.ssl.port': SocketUtils.findAvailableTcpPort(),
+                'micronaut.ssl.enabled': true,
+                'micronaut.ssl.buildSelfSigned': true,
+                'micronaut.server.dualProtocol':true
+        )
+        EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, propertySource)
+
+        then:
+        EventCounter eventCounter = embeddedServer.applicationContext.getBean(EventCounter)
+        eventCounter.count as Integer == 1
+
+        cleanup:
+        embeddedServer.applicationContext.stop()
+    }
+
+    @Singleton
+    static class EventCounter {
+        AtomicInteger count = new AtomicInteger(0)
+
+        @EventListener
+        void receive(StartupEvent event) {
+            count.incrementAndGet()
+        }
+    }
 
     @Controller("/person")
     static class PersonController {


### PR DESCRIPTION
After getting this into real use in the micronaut-acme project found
that it was firing the startup event twice now. This is not ideal as it
triggered the certificate validation process twice.

Also it looks like if using a random port failed to bind and it retried
it would have also suffered from this
(Not sure much would have been affected by this other than tests cases)