### PR TITLE
#1265 correct snippet for StubExample

### DIFF
--- a/src/main/docs/guide/aop/introductionAdvice.adoc
+++ b/src/main/docs/guide/aop/introductionAdvice.adoc
@@ -26,7 +26,7 @@ snippet::io.micronaut.docs.aop.introduction.StubIntroduction[tags="imports,class
 
 To now use this introduction advice in an application you simply annotate your abstract classes or interfaces with `@Stub`:
 
-snippet::io.micronaut.docs.aop.introduction.StubIntroduction[tags="class", indent=0, title="StubExample"]
+snippet::io.micronaut.docs.aop.introduction.StubExample[tags="class", indent=0, title="StubExample"]
 
 All abstract methods will delegate to the `StubIntroduction` class to be implemented.
 


### PR DESCRIPTION
`snippet::io.micronaut.docs.aop.introduction.StubIntroduction` is repeated
Correct snippet for StubExample is:
`snippet::io.micronaut.docs.aop.introduction.StubExample`