### PR TITLE
Stop log noise by handling interrupt on shutdown latch

### DIFF
--- a/runtime/src/main/java/io/micronaut/runtime/Micronaut.java
+++ b/runtime/src/main/java/io/micronaut/runtime/Micronaut.java
@@ -132,7 +132,11 @@ public class Micronaut extends DefaultApplicationContextBuilder implements Appli
                             }
                         }, SHUTDOWN_MONITOR_THREAD).start();
 
-                        countDownLatch.await();
+                        try {
+                            countDownLatch.await();
+                        } catch (InterruptedException e) {
+                            // ignore
+                        }
                         if (LOG.isInfoEnabled()) {
                             LOG.info("Embedded Application shutting down");
                         }


### PR DESCRIPTION
When using a GraalVM native image, at present you have to make your application class look like:

```
package com.example;

import io.micronaut.runtime.Micronaut;
import sun.misc.Signal;
import sun.misc.SignalHandler;

public class Application {
    public static void main(String[] args) {
        SignalHandler sh = sig -> System.exit(128 + sig.getNumber());
        Signal.handle(new Signal("INT"), sh);
        Signal.handle(new Signal("TERM"), sh);

        Micronaut.run(Application.class);
    }
}
```

in order to get the shutdown hooks to run, as at present there's no default signal handler in native images (https://github.com/oracle/graal/issues/465).

However when you do this, I think because native images are faster, you sometimes get this exception:
```
java.lang.InterruptedException: null
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.doAcquireSharedInterruptibly(AbstractQueuedSynchronizer.java:998)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireSharedInterruptibly(AbstractQueuedSynchronizer.java:1304)
	at java.util.concurrent.CountDownLatch.await(CountDownLatch.java:231)
	at io.micronaut.runtime.Micronaut.lambda$start$2(Micronaut.java:135)
	at java.util.Optional.ifPresent(Optional.java:159)
	at io.micronaut.runtime.Micronaut.start(Micronaut.java:73)
	at io.micronaut.runtime.Micronaut.run(Micronaut.java:303)
	at io.micronaut.runtime.Micronaut.run(Micronaut.java:289)
	at com.example.Application.main(Application.java:14)
```

I think it's just noise, but it doesn't look great in your logs.

This error might become more common once GraalVM (hopefully) starts having some way to create the default signal handlers: https://github.com/oracle/graal/issues/1592