### PR TITLE
fixed regression for BeanDefinitionInjectProcessor

### DIFF
--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -184,8 +184,8 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
             beanDefinitions.forEach(className -> {
                 if (processed.add(className)) {
                     final TypeElement refreshedClassElement = elementUtils.getTypeElement(className);
-                    final AnnBeanElementVisitor visitor = new AnnBeanElementVisitor(refreshedClassElement);
                     try {
+                        final AnnBeanElementVisitor visitor = new AnnBeanElementVisitor(refreshedClassElement);
                         refreshedClassElement.accept(visitor, className);
                         visitor.getBeanDefinitionWriters().forEach((name, writer) -> {
                             String beanDefinitionName = writer.getBeanDefinitionName();

--- a/settings.gradle
+++ b/settings.gradle
@@ -34,6 +34,7 @@ include "websocket"
 
 // test suites
 include "test-suite"
+include "test-suite-helper"
 include "test-suite-kotlin"
 include "test-suite-groovy"
 include "test-utils"

--- a/test-suite-helper/src/main/java/io/micronaut/testsuitehelper/TestGeneratingAnnotationProcessor.java
+++ b/test-suite-helper/src/main/java/io/micronaut/testsuitehelper/TestGeneratingAnnotationProcessor.java
@@ -19,33 +19,30 @@ import javax.tools.StandardLocation;
 @SupportedAnnotationTypes("*")
 @SupportedSourceVersion(RELEASE_8)
 public class TestGeneratingAnnotationProcessor extends AbstractProcessor {
-    
+
     private boolean executed = false;
-    
+
     @Override
     public boolean process(final Set<? extends TypeElement> annotations, final RoundEnvironment roundEnv) {
         if (executed) {
             return false;
         }
-        
+
         try {
             final String output = determineOutputPath();
             final File outputDir = new File(output);
-    
+
             switch (outputDir.getName()) {
                 case "main":
                 case "classes":
-                    return false;
+                    break;
                 case "test":
                 case "test-classes":
                     final JavaFileObject issue = processingEnv
                         .getFiler()
                         .createSourceFile("io.micronaut.test.generated.Example");
                     try (final Writer w = issue.openWriter()) {
-                        w.write(
-                            "package io.micronaut.test.generated;\n\n"
-                        );
-                        w.write("public interface Example {}");
+                        w.write("package io.micronaut.test.generated;\n\npublic interface Example {}");
                     }
                     break;
                 default:
@@ -54,7 +51,7 @@ public class TestGeneratingAnnotationProcessor extends AbstractProcessor {
         } catch (final IOException e) {
             throw new IllegalStateException(e);
         }
-        
+
         executed = true;
         return false;
     }
@@ -70,5 +67,5 @@ public class TestGeneratingAnnotationProcessor extends AbstractProcessor {
             resource.delete();
         }
     }
-    
+
 }

--- a/test-suite-helper/src/main/java/io/micronaut/testsuitehelper/TestGeneratingAnnotationProcessor.java
+++ b/test-suite-helper/src/main/java/io/micronaut/testsuitehelper/TestGeneratingAnnotationProcessor.java
@@ -1,0 +1,74 @@
+package io.micronaut.testsuitehelper;
+
+import static javax.lang.model.SourceVersion.RELEASE_8;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Set;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.tools.FileObject;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardLocation;
+
+@SupportedAnnotationTypes("*")
+@SupportedSourceVersion(RELEASE_8)
+public class TestGeneratingAnnotationProcessor extends AbstractProcessor {
+    
+    private boolean executed = false;
+    
+    @Override
+    public boolean process(final Set<? extends TypeElement> annotations, final RoundEnvironment roundEnv) {
+        if (executed) {
+            return false;
+        }
+        
+        try {
+            final String output = determineOutputPath();
+            final File outputDir = new File(output);
+    
+            switch (outputDir.getName()) {
+                case "main":
+                case "classes":
+                    return false;
+                case "test":
+                case "test-classes":
+                    final JavaFileObject issue = processingEnv
+                        .getFiler()
+                        .createSourceFile("io.micronaut.test.generated.Example");
+                    try (final Writer w = issue.openWriter()) {
+                        w.write(
+                            "package io.micronaut.test.generated;\n\n"
+                        );
+                        w.write("public interface Example {}");
+                    }
+                    break;
+                default:
+                    throw new IllegalStateException("Unknown builder for output " + outputDir);
+            }
+        } catch (final IOException e) {
+            throw new IllegalStateException(e);
+        }
+        
+        executed = true;
+        return false;
+    }
+
+    private String determineOutputPath() throws IOException {
+        // go write a file so as to figure out where we're running
+        final FileObject resource = processingEnv
+            .getFiler()
+            .createResource(StandardLocation.CLASS_OUTPUT, "", "tmp" + System.currentTimeMillis(), (Element[]) null);
+        try {
+            return new File(resource.toUri()).getCanonicalFile().getParent();
+        } finally {
+            resource.delete();
+        }
+    }
+    
+}

--- a/test-suite-helper/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/test-suite-helper/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+io.micronaut.testsuitehelper.TestGeneratingAnnotationProcessor

--- a/test-suite/build.gradle
+++ b/test-suite/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     compileOnly project(":inject-java")
     compile project(":inject")
 
+    testCompileOnly project(":test-suite-helper")
     testCompile project(":http-server-netty")
     testCompile project(":http-client")
     testCompile project(":validation")
@@ -52,6 +53,8 @@ dependencies {
     testRuntime dependencyVersion("h2")
     testRuntime "org.junit.vintage:junit-vintage-engine:$junit5Version"
     testRuntime "ch.qos.logback:logback-classic:1.2.3"
+
+    //testAnnotationProcessor project(":test-suite-helper")
 }
 
 apply from: "${rootProject.projectDir}/gradle/geb.gradle"

--- a/test-suite/build.gradle
+++ b/test-suite/build.gradle
@@ -53,8 +53,6 @@ dependencies {
     testRuntime dependencyVersion("h2")
     testRuntime "org.junit.vintage:junit-vintage-engine:$junit5Version"
     testRuntime "ch.qos.logback:logback-classic:1.2.3"
-
-    //testAnnotationProcessor project(":test-suite-helper")
 }
 
 apply from: "${rootProject.projectDir}/gradle/geb.gradle"

--- a/test-suite/src/test/java/io/micronaut/docs/aop/introduction/generics/GenericPublisher.java
+++ b/test-suite/src/test/java/io/micronaut/docs/aop/introduction/generics/GenericPublisher.java
@@ -1,0 +1,7 @@
+package io.micronaut.docs.aop.introduction.generics;
+
+public interface GenericPublisher<E> {
+    
+    String publish(E event);
+    
+}

--- a/test-suite/src/test/java/io/micronaut/docs/aop/introduction/generics/GenericsIntroductionSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/aop/introduction/generics/GenericsIntroductionSpec.java
@@ -1,0 +1,23 @@
+package io.micronaut.docs.aop.introduction.generics;
+
+import static org.junit.Assert.assertEquals;
+
+import io.micronaut.context.ApplicationContext;
+import org.junit.Test;
+
+public class GenericsIntroductionSpec {
+
+    @Test
+    public void testStubIntroduction() {
+        ApplicationContext applicationContext = ApplicationContext.run();
+
+        // tag::test[]
+        SpecificPublisher publisher = applicationContext.getBean(SpecificPublisher.class);
+
+        assertEquals("SpecificEvent", publisher.publish(new SpecificEvent()));
+        // end::test[]
+
+        applicationContext.stop();
+    }
+    
+}

--- a/test-suite/src/test/java/io/micronaut/docs/aop/introduction/generics/PublisherIntroduction.java
+++ b/test-suite/src/test/java/io/micronaut/docs/aop/introduction/generics/PublisherIntroduction.java
@@ -1,0 +1,45 @@
+package io.micronaut.docs.aop.introduction.generics;
+
+import io.micronaut.aop.MethodInterceptor;
+import io.micronaut.aop.MethodInvocationContext;
+import java.lang.reflect.Method;
+import javax.inject.Singleton;
+
+@Singleton
+public final class PublisherIntroduction implements MethodInterceptor<GenericPublisher<?>, Object> {
+
+    @Override
+    public Object intercept(final MethodInvocationContext<GenericPublisher<?>, Object> context) {
+        final Method method = context.getTargetMethod();
+        if (isEqualsMethod(method)) {
+            // Only consider equal when proxies are identical.
+            return context.getTarget() == context.getParameterValues()[0];
+
+        } else if (isHashCodeMethod(method)) {
+            return hashCode();
+
+        } else if (isToStringMethod(method)) {
+            return toString();
+            
+        } else {
+            return context.getArguments()[0].getType().getSimpleName();
+        }
+    }
+
+    private static boolean isEqualsMethod(final Method method) {
+        if ((method == null) || !"equals".equals(method.getName())) {
+            return false;
+        }
+        final Class<?>[] paramTypes = method.getParameterTypes();
+        return (paramTypes.length == 1) && (paramTypes[0] == Object.class);
+    }
+
+    private static boolean isHashCodeMethod(final Method method) {
+        return (method != null) && "hashCode".equals(method.getName()) && (method.getParameterTypes().length == 0);
+    }
+
+    private static boolean isToStringMethod(final Method method) {
+        return (method != null) && "toString".equals(method.getName()) && (method.getParameterTypes().length == 0);
+    }
+
+}

--- a/test-suite/src/test/java/io/micronaut/docs/aop/introduction/generics/PublisherIntroduction.java
+++ b/test-suite/src/test/java/io/micronaut/docs/aop/introduction/generics/PublisherIntroduction.java
@@ -20,9 +20,9 @@ public final class PublisherIntroduction implements MethodInterceptor<GenericPub
 
         } else if (isToStringMethod(method)) {
             return toString();
-            
+
         } else {
-            return context.getArguments()[0].getType().getSimpleName();
+            return context.getParameterValues()[0].getClass().getSimpleName();
         }
     }
 

--- a/test-suite/src/test/java/io/micronaut/docs/aop/introduction/generics/PublisherProxy.java
+++ b/test-suite/src/test/java/io/micronaut/docs/aop/introduction/generics/PublisherProxy.java
@@ -1,0 +1,20 @@
+package io.micronaut.docs.aop.introduction.generics;
+
+import io.micronaut.aop.Introduction;
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Type;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.inject.Singleton;
+
+@Introduction
+@Type(PublisherIntroduction.class)
+@Bean
+@Singleton
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface PublisherProxy {}

--- a/test-suite/src/test/java/io/micronaut/docs/aop/introduction/generics/SpecificEvent.java
+++ b/test-suite/src/test/java/io/micronaut/docs/aop/introduction/generics/SpecificEvent.java
@@ -1,0 +1,3 @@
+package io.micronaut.docs.aop.introduction.generics;
+
+public class SpecificEvent {}

--- a/test-suite/src/test/java/io/micronaut/docs/aop/introduction/generics/SpecificPublisher.java
+++ b/test-suite/src/test/java/io/micronaut/docs/aop/introduction/generics/SpecificPublisher.java
@@ -1,0 +1,4 @@
+package io.micronaut.docs.aop.introduction.generics;
+
+@PublisherProxy
+public interface SpecificPublisher extends GenericPublisher<SpecificEvent> {}

--- a/test-suite/src/test/java/io/micronaut/docs/inject/generated/MainBean.java
+++ b/test-suite/src/test/java/io/micronaut/docs/inject/generated/MainBean.java
@@ -1,0 +1,19 @@
+package io.micronaut.docs.inject.generated;
+
+import io.micronaut.test.generated.Example;
+import javax.inject.Singleton;
+
+@Singleton
+public class MainBean {
+
+    private final Example example;
+
+    public MainBean(Example example) {
+        this.example = example;
+    }
+
+    public boolean check() {
+        return example != null;
+    }
+
+}

--- a/test-suite/src/test/java/io/micronaut/docs/inject/generated/SomeBean.java
+++ b/test-suite/src/test/java/io/micronaut/docs/inject/generated/SomeBean.java
@@ -1,0 +1,7 @@
+package io.micronaut.docs.inject.generated;
+
+import io.micronaut.test.generated.Example;
+import javax.inject.Singleton;
+
+@Singleton
+public class SomeBean implements Example {}

--- a/test-suite/src/test/java/io/micronaut/docs/inject/generated/VerifyDefinitionInjectionSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/inject/generated/VerifyDefinitionInjectionSpec.java
@@ -1,0 +1,23 @@
+package io.micronaut.docs.inject.generated;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.micronaut.context.BeanContext;
+import org.junit.jupiter.api.Test;
+
+public class VerifyDefinitionInjectionSpec {
+
+    @Test
+    public void test() {
+        BeanContext beanContext = BeanContext.run();
+
+        // tag::test[]
+        MainBean mainBean = beanContext.getBean(MainBean.class);
+
+        assertTrue(mainBean.check());
+        // end::test[]
+
+        beanContext.stop();
+    }
+
+}

--- a/test-suite/src/test/java/io/micronaut/docs/inject/generated/VerifyDefinitionInjectionSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/inject/generated/VerifyDefinitionInjectionSpec.java
@@ -11,11 +11,9 @@ public class VerifyDefinitionInjectionSpec {
     public void test() {
         BeanContext beanContext = BeanContext.run();
 
-        // tag::test[]
         MainBean mainBean = beanContext.getBean(MainBean.class);
 
         assertTrue(mainBean.check());
-        // end::test[]
 
         beanContext.stop();
     }


### PR DESCRIPTION
fixed regression introduced in 8f539ac for BeanDefinitionInjectProcessor generating definitions of beans using interfaces generated in annotation processor.

Also added test cases for #1649 and #1667

