### PR TITLE
Use an Argument instead of Class for the error type. Fixes #2203

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/DefaultHttpClient.java
@@ -1851,8 +1851,8 @@ public class DefaultHttpClient implements RxWebSocketClient, RxHttpClient, RxStr
                                             response,
                                             new HttpClientErrorDecoder() {
                                                 @Override
-                                                public Class<?> getErrorType(MediaType mediaType) {
-                                                    return errorType.getType();
+                                                public Argument<?> getErrorType(MediaType mediaType) {
+                                                    return errorType;
                                                 }
                                             }
                                     );
@@ -1912,8 +1912,8 @@ public class DefaultHttpClient implements RxWebSocketClient, RxHttpClient, RxStr
                                     response,
                                     new HttpClientErrorDecoder() {
                                         @Override
-                                        public Class<?> getErrorType(MediaType mediaType) {
-                                            return errorType.getType();
+                                        public Argument<?> getErrorType(MediaType mediaType) {
+                                            return errorType;
                                         }
                                     }
                             );

--- a/http-client/src/main/java/io/micronaut/http/client/exceptions/HttpClientErrorDecoder.java
+++ b/http-client/src/main/java/io/micronaut/http/client/exceptions/HttpClientErrorDecoder.java
@@ -15,7 +15,9 @@
  */
 package io.micronaut.http.client.exceptions;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.naming.Described;
+import io.micronaut.core.type.Argument;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.hateoas.JsonError;
 import io.micronaut.http.hateoas.VndError;
@@ -28,6 +30,7 @@ import java.util.Optional;
  * @author graemerocher
  * @since 1.0
  */
+@Internal
 public interface HttpClientErrorDecoder {
 
     /**
@@ -62,13 +65,13 @@ public interface HttpClientErrorDecoder {
      * @param mediaType The media type
      * @return The error type
      */
-    default Class<?> getErrorType(MediaType mediaType) {
+    default Argument<?> getErrorType(MediaType mediaType) {
         if (mediaType.equals(MediaType.APPLICATION_JSON_TYPE)) {
-            return JsonError.class;
+            return Argument.of(JsonError.class);
         } else if (mediaType.equals(MediaType.APPLICATION_VND_ERROR_TYPE)) {
-            return VndError.class;
+            return Argument.of(VndError.class);
         } else {
-            return String.class;
+            return Argument.of(String.class);
         }
     }
 }

--- a/http-client/src/main/java/io/micronaut/http/client/exceptions/HttpClientResponseException.java
+++ b/http-client/src/main/java/io/micronaut/http/client/exceptions/HttpClientResponseException.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.http.client.exceptions;
 
+import io.micronaut.core.type.Argument;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.MediaType;
@@ -64,7 +65,7 @@ public class HttpClientResponseException extends HttpClientException implements 
 
     @Override
     public String getMessage() {
-        Optional<Class<?>> errorType = Optional.ofNullable(getErrorType(response));
+        Optional<Argument<?>> errorType = Optional.ofNullable(getErrorType(response));
         if (errorType.isPresent()) {
             return getResponse().getBody(errorType.get()).flatMap(errorDecoder::getMessage).orElse(super.getMessage());
         } else {
@@ -88,7 +89,7 @@ public class HttpClientResponseException extends HttpClientException implements 
 
     @SuppressWarnings("MagicNumber")
     private void initResponse(HttpResponse<?> response) {
-        Class<?> errorType = getErrorType(response);
+        Argument<?> errorType = getErrorType(response);
         if (errorType != null) {
             response.getBody(errorType);
         } else {
@@ -96,9 +97,9 @@ public class HttpClientResponseException extends HttpClientException implements 
         }
     }
 
-    private Class<?> getErrorType(HttpResponse<?> response) {
+    private Argument<?> getErrorType(HttpResponse<?> response) {
         Optional<MediaType> contentType = response.getContentType();
-        Class<?> errorType = null;
+        Argument<?> errorType = null;
         if (contentType.isPresent() && response.getStatus().getCode() > 399) {
             MediaType mediaType = contentType.get();
             if (errorDecoder != null) {


### PR DESCRIPTION
Submitting a PR because this introduces a breaking change in `HttpClientErrorDecoder`. The class isn't used in a context that allows for extension however it is not marked `@Internal`. I think the likelihood of anyone using this class directly is very low.