### PR TITLE
Fix typo in Kotlin example with httpclient

### DIFF
--- a/src/main/docs/guide/httpClient/lowLevelHttpClient/clientBasics.adoc
+++ b/src/main/docs/guide/httpClient/lowLevelHttpClient/clientBasics.adoc
@@ -12,7 +12,7 @@ The above example will inject a client that targets the Twitter API.
 
 [source,kotlin]
 ----
-@Client("\${myapp.api.twitter.url}") @Inject httpClient: RxHttpClient
+@field:Client("\${myapp.api.twitter.url}") @Inject lateinit var httpClient: RxHttpClient
 ----
 
 The above Kotlin example will inject a client that targets the Twitter API using a configuration path. Note the required escaping (backslash) on `"\${path.to.config}"` which is required due to Kotlin string interpolation.


### PR DESCRIPTION
I recreated the PR on 1.2.x, and I'll close the old PR.