### PR TITLE
Adding snippets for Kotlin in Server - Error Handling

### DIFF
--- a/src/main/docs/guide/httpServer/errorHandling.adoc
+++ b/src/main/docs/guide/httpServer/errorHandling.adoc
@@ -13,10 +13,7 @@ TIP: When defining an error handler for an exception, you can specify the except
 For example the following method will handling JSON parse exceptions from Jackson for the scope of the declaring controller:
 
 .Local exception handler
-[source,java]
-----
-include::{testsuite}/server/json/PersonController.java[tags=localError, indent=0]
-----
+snippet::io.micronaut.docs.server.error.PersonController[tags="localError", indent=0]
 
 <1> A method that explicitly handles `JsonParseException` is declared
 <2> An instance of api:http.hateoas.JsonError[] is returned.

--- a/src/main/docs/guide/httpServer/errorHandling.adoc
+++ b/src/main/docs/guide/httpServer/errorHandling.adoc
@@ -20,39 +20,27 @@ snippet::io.micronaut.docs.server.error.PersonController[tags="localError", inde
 <3> A custom response is returned to handle the error
 
 .Local status handler
-[source,java]
-----
-@Error(status = HttpStatus.NOT_FOUND)
-include::{testsuite}/server/json/PersonController.java[tags=statusError, indent=0]
-----
+snippet::io.micronaut.docs.server.error.PersonController[tags="statusError", indent=0]
 
 <1> The api:http.annotation.Error[] declares which api:http.HttpStatus[] error code to handle (in this case 404)
 <2> A api:http.hateoas.JsonError[] instance is returned for all 404 responses
-<3> An api:http.HttpStatus#NOT_FOUND[] response is returned
+<3> A api:http.HttpStatus#NOT_FOUND[] response is returned
 
 == Global Error Handling
 
 .Global error handler
-[source,java]
-----
-@Error(global = true) // <1>
-include::{testsuite}/server/json/PersonController.java[tags=globalError, indent=0]
-----
+snippet::io.micronaut.docs.server.error.PersonController[tags="globalError", indent=0]
 
 <1> The api:http.annotation.Error[] is used to declare the method a global error handler
 <2> A api:http.hateoas.JsonError[] instance is returned for all errors
 <3> An api:http.HttpStatus#INTERNAL_SERVER_ERROR[] response is returned
 
 .Global status handler
-[source,java]
-----
-@Error(status = HttpStatus.NOT_FOUND, global = true)
-include::{testsuite}/server/json/PersonController.java[tags=statusError, indent=0]
-----
+snippet::io.micronaut.docs.server.error.PersonController[tags="statusError", indent=0]
 
 <1> The api:http.annotation.Error[] declares which api:http.HttpStatus[] error code to handle (in this case 404)
 <2> A api:http.hateoas.JsonError[] instance is returned for all 404 responses
-<3> An api:http.HttpStatus#NOT_FOUND[] response is returned
+<3> A api:http.HttpStatus#NOT_FOUND[] response is returned
 
 IMPORTANT: A few things to note about the api:http.annotation.Error[] annotation. Two identical `@Error` annotations that are
 global cannot be declared. Two identical `@Error` annotations that are non-global cannot be declared in the same controller.

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/error/PersonController.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/error/PersonController.kt
@@ -24,4 +24,21 @@ class PersonController {
     }
     // end::localError[]
 
+    // tag::globalError[]
+    @Error // <1>
+    fun error(request: HttpRequest<String>, e: Throwable): HttpResponse<JsonError> {
+        val error = JsonError("Bad Things Happened: ${e.message}") // <2>
+        return HttpResponse.serverError<JsonError>().body(error) // <3>
+    }
+    // end::globalError[]
+
+    // tag::statusError[]
+    @Error(status = HttpStatus.NOT_FOUND)
+    fun notFound(request: HttpRequest<String>): HttpResponse<JsonError> { // <1>
+        val error = JsonError("Page Not Found") // <2>
+            .link(Link.SELF, Link.of(request.uri))
+
+        return HttpResponse.notFound<JsonError>().body(error) // <3>
+    }
+    // end::statusError[]
 }

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/error/PersonController.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/error/PersonController.kt
@@ -1,0 +1,27 @@
+package io.micronaut.docs.server.error
+
+import com.fasterxml.jackson.core.JsonParseException
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Error
+import io.micronaut.http.hateoas.JsonError
+import io.micronaut.http.hateoas.Link
+
+@Controller("/people")
+class PersonController {
+
+    // tag::localError[]
+    @Error
+    fun jsonError(
+        request: HttpRequest<String>,
+        jsonParseException: JsonParseException
+    ): HttpResponse<JsonError> { // <1>
+        val error = JsonError("Invalid JSON: ${jsonParseException.message}") // <2>
+            .link(Link.SELF, Link.of(request.uri))
+        return HttpResponse.status<JsonError>(HttpStatus.BAD_REQUEST, "Fix your JSON").body(error) // <3>
+    }
+    // end::localError[]
+
+}

--- a/test-suite/src/test/java/io/micronaut/docs/server/error/PersonController.java
+++ b/test-suite/src/test/java/io/micronaut/docs/server/error/PersonController.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.server.error;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import io.micronaut.docs.server.json.Person;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.annotation.Error;
+import io.micronaut.http.annotation.*;
+import io.micronaut.http.hateoas.JsonError;
+import io.micronaut.http.hateoas.Link;
+import io.reactivex.Maybe;
+import io.reactivex.Single;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * @author Graeme Rocher
+ * @since 1.0
+ */
+// tag::class[]
+@Controller("/people")
+public class PersonController {
+
+    Map<String, Person> inMemoryDatastore = new LinkedHashMap<>();
+// end::class[]
+
+    @Get
+    public Collection<Person> index() {
+        return inMemoryDatastore.values();
+    }
+
+    @Get("/{name}")
+    public Maybe<Person> get(String name) {
+        if (inMemoryDatastore.containsKey(name)) {
+            return Maybe.just(inMemoryDatastore.get(name));
+        }
+        return Maybe.empty();
+    }
+
+    // tag::single[]
+    @Post
+    public Single<HttpResponse<Person>> save(@Body Single<Person> person) { // <1>
+        return person.map(p -> {
+                    inMemoryDatastore.put(p.getFirstName(), p); // <2>
+                    return HttpResponse.created(p); // <3>
+                }
+        );
+    }
+    // end::single[]
+
+
+    @Post("/saveWithArgs")
+    // tag::args[]
+    public HttpResponse<Person> save(String firstName, String lastName, Optional<Integer> age) {
+        Person p = new Person(firstName, lastName);
+        age.ifPresent(p::setAge);
+        inMemoryDatastore.put(p.getFirstName(), p);
+        return HttpResponse.created(p);
+    }
+    // end::args[]
+
+    // tag::future[]
+    public CompletableFuture<HttpResponse<Person>> save(@Body CompletableFuture<Person> person) {
+        return person.thenApply(p -> {
+                    inMemoryDatastore.put(p.getFirstName(), p);
+                    return HttpResponse.created(p);
+                }
+        );
+    }
+    // end::future[]
+
+    // tag::regular[]
+    public HttpResponse<Person> save(@Body Person person) {
+        inMemoryDatastore.put(person.getFirstName(), person);
+        return HttpResponse.created(person);
+    }
+    // end::regular[]
+
+    // tag::localError[]
+    @Error
+    public HttpResponse<JsonError> jsonError(HttpRequest request, JsonParseException jsonParseException) { // <1>
+        JsonError error = new JsonError("Invalid JSON: " + jsonParseException.getMessage()) // <2>
+                .link(Link.SELF, Link.of(request.getUri()));
+
+        return HttpResponse.<JsonError>status(HttpStatus.BAD_REQUEST, "Fix Your JSON")
+                .body(error); // <3>
+    }
+    // end::localError[]
+
+
+    @Get("/error")
+    public String throwError() {
+        throw new RuntimeException("Something went wrong");
+    }
+
+    @Error // <1>
+    // tag::globalError[]
+    public HttpResponse<JsonError> error(HttpRequest request, Throwable e) {
+        JsonError error = new JsonError("Bad Things Happened: " + e.getMessage()) // <2>
+                .link(Link.SELF, Link.of(request.getUri()));
+
+        return HttpResponse.<JsonError>serverError()
+                .body(error); // <3>
+    }
+    // end::globalError[]
+
+    @Error(status = HttpStatus.NOT_FOUND)
+    // tag::statusError[]
+    public HttpResponse<JsonError> notFound(HttpRequest request) { // <1>
+        JsonError error = new JsonError("Page Not Found") // <2>
+                .link(Link.SELF, Link.of(request.getUri()));
+
+        return HttpResponse.<JsonError>notFound()
+                .body(error); // <3>
+    }
+    // end::statusError[]
+}

--- a/test-suite/src/test/java/io/micronaut/docs/server/error/PersonController.java
+++ b/test-suite/src/test/java/io/micronaut/docs/server/error/PersonController.java
@@ -113,8 +113,8 @@ public class PersonController {
         throw new RuntimeException("Something went wrong");
     }
 
-    @Error // <1>
     // tag::globalError[]
+    @Error // <1>
     public HttpResponse<JsonError> error(HttpRequest request, Throwable e) {
         JsonError error = new JsonError("Bad Things Happened: " + e.getMessage()) // <2>
                 .link(Link.SELF, Link.of(request.getUri()));
@@ -124,8 +124,8 @@ public class PersonController {
     }
     // end::globalError[]
 
-    @Error(status = HttpStatus.NOT_FOUND)
     // tag::statusError[]
+    @Error(status = HttpStatus.NOT_FOUND)
     public HttpResponse<JsonError> notFound(HttpRequest request) { // <1>
         JsonError error = new JsonError("Page Not Found") // <2>
                 .link(Link.SELF, Link.of(request.getUri()));


### PR DESCRIPTION
Have migrated the `PersonController` examples in the *Server - Error Handling* part of the documentation to use the `snippet` function and added Kotlin examples