### PR TITLE
Adds operating system for conditional beans

### DIFF
--- a/inject/src/main/java/io/micronaut/context/condition/LinuxOsCondition.java
+++ b/inject/src/main/java/io/micronaut/context/condition/LinuxOsCondition.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context.condition;
+
+/**
+ * A {@link Condition} that evaluates to true if the current operating system is in the Linux family.
+ *
+ * @since 1.2.4
+ */
+public class LinuxOsCondition implements Condition {
+    @Override
+    public boolean matches(ConditionContext context) {
+        return OperatingSystem.getCurrent().isLinux();
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/condition/MacOsCondition.java
+++ b/inject/src/main/java/io/micronaut/context/condition/MacOsCondition.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context.condition;
+
+/**
+ * A {@link Condition} that evaluates to true if the current operating system is in the MacOS family.
+ *
+ * @since 1.2.4
+ */
+public class MacOsCondition implements Condition {
+    @Override
+    public boolean matches(ConditionContext context) {
+        return OperatingSystem.getCurrent().isMacOs();
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/condition/OperatingSystem.java
+++ b/inject/src/main/java/io/micronaut/context/condition/OperatingSystem.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context.condition;
+
+/**
+ * Details of the current operating system.
+ */
+final class OperatingSystem {
+    private final Family family;
+
+    private OperatingSystem(Family family) {
+        this.family = family;
+    }
+
+    /**
+     * Resolves and returns the current operating system.
+     *
+     * @return the current operating system.
+     */
+    static OperatingSystem getCurrent() {
+        String osName = System.getenv("os.name").toLowerCase();
+        Family osFamily;
+        if (osName.contains("linux")) {
+            osFamily = Family.LINUX;
+        } else if (osName.contains("mac os")) {
+            osFamily = Family.MAC_OS;
+        } else if (osName.contains("windows")) {
+            osFamily = Family.WINDOWS;
+        } else if (osName.contains("sunos")) {
+            osFamily = Family.SOLARIS;
+        } else {
+            osFamily = Family.OTHER;
+        }
+        return new OperatingSystem(osFamily);
+    }
+
+    /**
+     * @return <code>true</code> if the current operating system is in the Linux family.
+     */
+    boolean isLinux() {
+        return family == Family.LINUX;
+    }
+
+    /**
+     * @return <code>true</code> if the current operating system is in the Linux family.
+     */
+    boolean isWindows() {
+        return family == Family.WINDOWS;
+    }
+
+    /**
+     * @return <code>true</code> if the current operating system is in the Linux family.
+     */
+    boolean isMacOs() {
+        return family == Family.MAC_OS;
+    }
+
+    /**
+     * @return <code>true</code> if the current operating system is in the Linux family.
+     */
+    boolean isSolaris() {
+        return family == Family.SOLARIS;
+    }
+
+    /**
+     * An operating system family.
+     */
+    enum Family {
+        LINUX, MAC_OS, WINDOWS, SOLARIS, OTHER
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/condition/SolarisOsCondition.java
+++ b/inject/src/main/java/io/micronaut/context/condition/SolarisOsCondition.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context.condition;
+
+/**
+ * A {@link Condition} that evaluates to true if the current operating system is in the Solaris family.
+ *
+ * @since 1.2.4
+ */
+public class SolarisOsCondition implements Condition {
+    @Override
+    public boolean matches(ConditionContext context) {
+        return OperatingSystem.getCurrent().isSolaris();
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/condition/WindowsOsCondition.java
+++ b/inject/src/main/java/io/micronaut/context/condition/WindowsOsCondition.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context.condition;
+
+/**
+ * A {@link Condition} that evaluates to true if the current operating system is in the Windows family.
+ *
+ * @since 1.2.4
+ */
+public class WindowsOsCondition implements Condition {
+    @Override
+    public boolean matches(ConditionContext context) {
+        return OperatingSystem.getCurrent().isWindows();
+    }
+}


### PR DESCRIPTION
Hopefully this is the direction of the changes required to close #1737. Not sure the extent of detail for the `OperatingSystem` so have kept it as minimum as required. Also I am not sure if you could think of any reuse of it and hence the `condition` package may not be the best place for it.

I couldn't find anything on which copyright to use and I have assumed the javadoc should have the `@since` annotation and I have just set it as the next version.

Let me know if you want anything updated 😄 