### PR TITLE
Issue 2228: fix missing cleanup code

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/DefaultHttpClient.java
@@ -1806,13 +1806,134 @@ public class DefaultHttpClient implements RxWebSocketClient, RxHttpClient, RxStr
                     } catch (IllegalArgumentException e) {
                         if (complete.compareAndSet(false, true)) {
                             emitter.onError(e);
-                        } else {
-                            getLog().warn("unsupported http status after completion", e);
+                        } else if (LOG.isWarnEnabled()) {
+                            LOG.warn("Unsupported http status after handler completed: " + e.getMessage(), e);
                         }
                         return;
                     }
 
-                    handleResponse(fullResponse, status, statusCode, httpStatus);
+                    try {
+                        HttpHeaders headers = fullResponse.headers();
+                        if (log.isTraceEnabled()) {
+                            log.trace("HTTP Client Response Received for Request: {} {}", request.getMethod(), request.getUri());
+                            log.trace("Status Code: {}", status);
+                            traceHeaders(headers);
+                            traceBody("Response", fullResponse.content());
+                        }
+
+                        // it is a redirect
+                        if (statusCode > 300 && statusCode < 400 && configuration.isFollowRedirects() && headers.contains(HttpHeaderNames.LOCATION)) {
+                            String location = headers.get(HttpHeaderNames.LOCATION);
+                            Flowable<io.micronaut.http.HttpResponse<O>> redirectedRequest = exchange(io.micronaut.http.HttpRequest.GET(location), bodyType);
+                            redirectedRequest.first(io.micronaut.http.HttpResponse.notFound())
+                                    .subscribe((oHttpResponse, throwable) -> {
+                                        if (throwable != null) {
+                                            emitter.onError(throwable);
+
+                                        } else {
+                                            emitter.onNext(oHttpResponse);
+                                            emitter.onComplete();
+                                        }
+                                    });
+                            return;
+                        }
+                        if (statusCode == HttpStatus.NO_CONTENT.getCode()) {
+                            // normalize the NO_CONTENT header, since http content aggregator adds it even if not present in the response
+                            headers.remove(HttpHeaderNames.CONTENT_LENGTH);
+                        }
+                        boolean errorStatus = statusCode >= 400;
+                        FullNettyClientHttpResponse<O> response
+                                = new FullNettyClientHttpResponse<>(fullResponse, httpStatus, mediaTypeCodecRegistry, byteBufferFactory, bodyType, errorStatus);
+
+                        if (complete.compareAndSet(false, true)) {
+                            if (errorStatus) {
+                                try {
+                                    HttpClientResponseException clientError;
+                                    if (errorType != HttpClient.DEFAULT_ERROR_TYPE) {
+                                        clientError = new HttpClientResponseException(
+                                                status.reasonPhrase(),
+                                                null,
+                                                response,
+                                                new HttpClientErrorDecoder() {
+                                                    @Override
+                                                    public Argument<?> getErrorType(MediaType mediaType) {
+                                                        return errorType;
+                                                    }
+                                                }
+                                        );
+                                    } else {
+                                        clientError = new HttpClientResponseException(
+                                                status.reasonPhrase(),
+                                                response
+                                        );
+                                    }
+                                    try {
+                                        emitter.onError(clientError);
+                                    } finally {
+                                        response.onComplete();
+                                    }
+                                } catch (Throwable t) {
+                                    if (t instanceof HttpClientResponseException) {
+                                        try {
+                                            emitter.onError(t);
+                                        } finally {
+                                            response.onComplete();
+                                        }
+                                    } else {
+                                        response.onComplete();
+                                        FullNettyClientHttpResponse<Object> errorResponse = new FullNettyClientHttpResponse<>(
+                                                fullResponse,
+                                                httpStatus,
+                                                mediaTypeCodecRegistry,
+                                                byteBufferFactory,
+                                                null,
+                                                true
+                                        );
+                                        errorResponse.onComplete();
+                                        HttpClientResponseException clientResponseError = new HttpClientResponseException(
+                                                "Error decoding HTTP error response body: " + t.getMessage(),
+                                                t,
+                                                errorResponse,
+                                                null
+                                        );
+                                        emitter.onError(clientResponseError);
+                                    }
+                                }
+                            } else {
+                                emitter.onNext(response);
+                                response.onComplete();
+                                emitter.onComplete();
+                            }
+                        }
+                    } catch (Throwable t) {
+                        if (complete.compareAndSet(false, true)) {
+                            if (t instanceof HttpClientResponseException) {
+                                emitter.onError(t);
+                            } else {
+                                FullNettyClientHttpResponse<Object> response = new FullNettyClientHttpResponse<>(fullResponse, httpStatus, mediaTypeCodecRegistry, byteBufferFactory, null, true);
+                                HttpClientResponseException clientResponseError = new HttpClientResponseException(
+                                        "Error decoding HTTP response body: " + t.getMessage(),
+                                        t,
+                                        response,
+                                        new HttpClientErrorDecoder() {
+                                            @Override
+                                            public Argument<?> getErrorType(MediaType mediaType) {
+                                                return errorType;
+                                            }
+                                        }
+                                );
+                                try {
+                                    emitter.onError(clientResponseError);
+                                } finally {
+                                    response.onComplete();
+                                }
+                            }
+                        } else {
+                            if (LOG.isWarnEnabled()) {
+                                LOG.warn("Exception fired after handler completed: " + t.getMessage(), t);
+                            }
+                        }
+                    }
                 } finally {
                     if (fullResponse.refCnt() > 0) {
                         try {
@@ -1828,131 +1949,6 @@ public class DefaultHttpClient implements RxWebSocketClient, RxHttpClient, RxStr
                     }
                     pipeline.remove(this);
 
-                }
-            }
-
-            private void handleResponse(FullHttpResponse fullResponse, HttpResponseStatus status, int statusCode, HttpStatus httpStatus) {
-                try {
-                    HttpHeaders headers = fullResponse.headers();
-                    if (log.isTraceEnabled()) {
-                        log.trace("HTTP Client Response Received for Request: {} {}", request.getMethod(), request.getUri());
-                        log.trace("Status Code: {}", status);
-                        traceHeaders(headers);
-                        traceBody("Response", fullResponse.content());
-                    }
-
-                    // it is a redirect
-                    if (statusCode > 300 && statusCode < 400 && configuration.isFollowRedirects() && headers.contains(HttpHeaderNames.LOCATION)) {
-                        String location = headers.get(HttpHeaderNames.LOCATION);
-                        Flowable<io.micronaut.http.HttpResponse<O>> redirectedRequest = exchange(io.micronaut.http.HttpRequest.GET(location), bodyType);
-                        redirectedRequest.first(io.micronaut.http.HttpResponse.notFound())
-                                .subscribe((oHttpResponse, throwable) -> {
-                                    if (throwable != null) {
-                                        emitter.onError(throwable);
-
-                                    } else {
-                                        emitter.onNext(oHttpResponse);
-                                        emitter.onComplete();
-                                    }
-                                });
-                        return;
-                    }
-                    if (statusCode == HttpStatus.NO_CONTENT.getCode()) {
-                        // normalize the NO_CONTENT header, since http content aggregator adds it even if not present in the response
-                        headers.remove(HttpHeaderNames.CONTENT_LENGTH);
-                    }
-                    boolean errorStatus = statusCode >= 400;
-                    FullNettyClientHttpResponse<O> response
-                            = new FullNettyClientHttpResponse<>(fullResponse, httpStatus, mediaTypeCodecRegistry, byteBufferFactory, bodyType, errorStatus);
-
-                    if (complete.compareAndSet(false, true)) {
-                        if (errorStatus) {
-                            try {
-                                HttpClientResponseException clientError;
-                                if (errorType != HttpClient.DEFAULT_ERROR_TYPE) {
-                                    clientError = new HttpClientResponseException(
-                                            status.reasonPhrase(),
-                                            null,
-                                            response,
-                                            new HttpClientErrorDecoder() {
-                                                @Override
-                                                public Argument<?> getErrorType(MediaType mediaType) {
-                                                    return errorType;
-                                                }
-                                            }
-                                    );
-                                } else {
-                                    clientError = new HttpClientResponseException(
-                                            status.reasonPhrase(),
-                                            response
-                                    );
-                                }
-                                try {
-                                    emitter.onError(clientError);
-                                } finally {
-                                    response.onComplete();
-                                }
-                            } catch (Throwable t) {
-                                if (t instanceof HttpClientResponseException) {
-                                    try {
-                                        emitter.onError(t);
-                                    } finally {
-                                        response.onComplete();
-                                    }
-                                } else {
-                                    response.onComplete();
-                                    FullNettyClientHttpResponse<Object> errorResponse = new FullNettyClientHttpResponse<>(
-                                            fullResponse,
-                                            httpStatus,
-                                            mediaTypeCodecRegistry,
-                                            byteBufferFactory,
-                                            null,
-                                            true
-                                    );
-                                    errorResponse.onComplete();
-                                    HttpClientResponseException clientResponseError = new HttpClientResponseException(
-                                            "Error decoding HTTP error response body: " + t.getMessage(),
-                                            t,
-                                            errorResponse,
-                                            null
-                                    );
-                                    emitter.onError(clientResponseError);
-                                }
-                            }
-                        } else {
-                            emitter.onNext(response);
-                            response.onComplete();
-                            emitter.onComplete();
-                        }
-                    }
-                } catch (Throwable t) {
-                    if (complete.compareAndSet(false, true)) {
-                        if (t instanceof HttpClientResponseException) {
-                            emitter.onError(t);
-                        } else {
-                            FullNettyClientHttpResponse<Object> response = new FullNettyClientHttpResponse<>(fullResponse, httpStatus, mediaTypeCodecRegistry, byteBufferFactory, null, true);
-                            HttpClientResponseException clientResponseError = new HttpClientResponseException(
-                                    "Error decoding HTTP response body: " + t.getMessage(),
-                                    t,
-                                    response,
-                                    new HttpClientErrorDecoder() {
-                                        @Override
-                                        public Argument<?> getErrorType(MediaType mediaType) {
-                                            return errorType;
-                                        }
-                                    }
-                            );
-                            try {
-                                emitter.onError(clientResponseError);
-                            } finally {
-                                response.onComplete();
-                            }
-                        }
-                    } else {
-                        if (LOG.isWarnEnabled()) {
-                            LOG.warn("Exception fired after handler completed: " + t.getMessage(), t);
-                        }
-                    }
                 }
             }
 

--- a/http-client/src/main/java/io/micronaut/http/client/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/DefaultHttpClient.java
@@ -1804,7 +1804,11 @@ public class DefaultHttpClient implements RxWebSocketClient, RxHttpClient, RxStr
                     try {
                         httpStatus = HttpStatus.valueOf(statusCode);
                     } catch (IllegalArgumentException e) {
-                        emitter.onError(e);
+                        if (complete.compareAndSet(false, true)) {
+                            emitter.onError(e);
+                        } else {
+                            getLog().warn("unsupported http status after completion", e);
+                        }
                         return;
                     }
 


### PR DESCRIPTION
Unsupported http status emits exception, but does not remove the pipeline handler... leaving `ReadTimeoutHandler` still attached and active!
