### PR TITLE
Injection into parametrized bean fails if no arguments are provided

### DIFF
--- a/inject-groovy/src/test/groovy/io/micronaut/inject/factory/ParametrizedFactorySpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/factory/ParametrizedFactorySpec.groovy
@@ -54,7 +54,7 @@ class ParametrizedFactorySpec extends Specification  {
 
         then:
         def e = thrown(BeanInstantiationException)
-        e.message.contains(' Missing bean argument [int count]')
+        e.message.contains('Missing bean argument [int count] for type: io.micronaut.inject.factory.ParametrizedFactorySpec$C. Requires arguments: int count')
 
     }
 

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/factory/ParametrizedFactorySpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/factory/ParametrizedFactorySpec.groovy
@@ -17,9 +17,8 @@ package io.micronaut.inject.factory
 
 import io.micronaut.context.BeanContext
 import io.micronaut.context.DefaultBeanContext
-import io.micronaut.context.annotation.Parameter
-import io.micronaut.context.annotation.Bean
 import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Parameter
 import io.micronaut.context.annotation.Prototype
 import io.micronaut.context.exceptions.BeanInstantiationException
 import spock.lang.Specification
@@ -55,7 +54,7 @@ class ParametrizedFactorySpec extends Specification  {
 
         then:
         def e = thrown(BeanInstantiationException)
-        e.message.contains('Missing bean arguments for type: io.micronaut.inject.factory.ParametrizedFactorySpec$C')
+        e.message.contains(' Missing bean argument [int count]')
 
     }
 

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/factory/ParametrizedFactorySpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/factory/ParametrizedFactorySpec.groovy
@@ -54,7 +54,7 @@ class ParametrizedFactorySpec extends Specification  {
 
         then:
         def e = thrown(BeanInstantiationException)
-        e.message.contains('Missing bean argument [int count] for type: io.micronaut.inject.factory.ParametrizedFactorySpec$C. Requires arguments: int count')
+        e.message.contains('Missing bean argument [int count] for type: io.micronaut.inject.factory.ParametrizedFactorySpec$C. Required arguments: int count')
 
     }
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/factory/parameterizedfactory/D.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/factory/parameterizedfactory/D.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright 2017-2019 original authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.micronaut.inject.factory.parameterizedfactory;
+
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Prototype;
+
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+
+@Prototype
+public class D {
+
+    @Inject
+    public D(@Nullable @Parameter A someBean) {
+
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/factory/parameterizedfactory/ParametrizedFactorySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/factory/parameterizedfactory/ParametrizedFactorySpec.groovy
@@ -47,7 +47,7 @@ class ParametrizedFactorySpec extends Specification  {
 
         then:
         def e = thrown(BeanInstantiationException)
-        e.message.contains('Missing bean argument [int count] for type: io.micronaut.inject.factory.parameterizedfactory.C. Requires arguments: int count')
+        e.message.contains('Missing bean argument [int count] for type: io.micronaut.inject.factory.parameterizedfactory.C. Required arguments: int count')
 
     }
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/factory/parameterizedfactory/ParametrizedFactorySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/factory/parameterizedfactory/ParametrizedFactorySpec.groovy
@@ -47,7 +47,7 @@ class ParametrizedFactorySpec extends Specification  {
 
         then:
         def e = thrown(BeanInstantiationException)
-        e.message.contains('Missing bean argument [int count]')
+        e.message.contains('Missing bean argument [int count] for type: io.micronaut.inject.factory.parameterizedfactory.C. Requires arguments: int count')
 
     }
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/factory/parameterizedfactory/ParametrizedFactorySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/factory/parameterizedfactory/ParametrizedFactorySpec.groovy
@@ -19,6 +19,7 @@ import io.micronaut.context.BeanContext
 import io.micronaut.context.DefaultBeanContext
 import io.micronaut.context.exceptions.BeanInstantiationException
 import spock.lang.Specification
+
 /**
  * @author Graeme Rocher
  * @since 1.0
@@ -46,7 +47,7 @@ class ParametrizedFactorySpec extends Specification  {
 
         then:
         def e = thrown(BeanInstantiationException)
-        e.message.contains('Missing bean arguments for type: io.micronaut.inject.factory.parameterizedfactory.C')
+        e.message.contains('Missing bean argument [int count]')
 
     }
 
@@ -63,6 +64,14 @@ class ParametrizedFactorySpec extends Specification  {
 
     }
 
+    def "verify that parametrized bean with nullable arguments can be initialized"() {
+        given:
+        BeanContext beanContext = new DefaultBeanContext().start()
 
+        when:
+        D parametrizedBean = beanContext.createBean(D)
 
+        then:
+        parametrizedBean != null
+    }
 }

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -43,7 +43,6 @@ import io.micronaut.core.util.clhm.ConcurrentLinkedHashMap;
 import io.micronaut.inject.*;
 import io.micronaut.inject.qualifiers.Qualified;
 import io.micronaut.inject.qualifiers.Qualifiers;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1546,6 +1545,7 @@ public class DefaultBeanContext implements BeanContext {
                        @Nullable Qualifier<T> qualifier,
                        boolean isSingleton,
                        @Nullable Map<String, Object> argumentValues) {
+        argumentValues = Optional.ofNullable(argumentValues).orElse(Collections.emptyMap());
         Qualifier declaredQualifier = resolveDeclaredQualifier(beanDefinition);
         T bean;
         Class<T> beanType = beanDefinition.getBeanType();
@@ -1574,9 +1574,6 @@ public class DefaultBeanContext implements BeanContext {
                 if (beanFactory instanceof ParametrizedBeanFactory) {
                     ParametrizedBeanFactory<T> parametrizedBeanFactory = (ParametrizedBeanFactory<T>) beanFactory;
                     Argument<?>[] requiredArguments = parametrizedBeanFactory.getRequiredArguments();
-                    if (argumentValues == null) {
-                        throw new BeanInstantiationException(resolutionContext, "Missing bean arguments for type: " + beanType.getName() + ". Requires arguments: " + ArrayUtils.toString(requiredArguments));
-                    }
                     Map<String, Object> convertedValues = new LinkedHashMap<>(argumentValues);
                     for (Argument<?> requiredArgument : requiredArguments) {
                         String argumentName = requiredArgument.getName();

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1579,7 +1579,7 @@ public class DefaultBeanContext implements BeanContext {
                         String argumentName = requiredArgument.getName();
                         Object val = argumentValues.get(argumentName);
                         if (val == null && !requiredArgument.isDeclaredNullable()) {
-                            throw new BeanInstantiationException(resolutionContext, "Missing bean argument [" + requiredArgument + "].");
+                            throw new BeanInstantiationException(resolutionContext, "Missing bean argument [" + requiredArgument + "] for type: " + beanType.getName() + ". Requires arguments: " + ArrayUtils.toString(requiredArguments));
                         }
                         BeanResolutionContext finalResolutionContext = resolutionContext;
                         Object convertedValue = null;

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1545,7 +1545,9 @@ public class DefaultBeanContext implements BeanContext {
                        @Nullable Qualifier<T> qualifier,
                        boolean isSingleton,
                        @Nullable Map<String, Object> argumentValues) {
-        argumentValues = Optional.ofNullable(argumentValues).orElse(Collections.emptyMap());
+        if (argumentValues == null) {
+            argumentValues = Collections.emptyMap();
+        }
         Qualifier declaredQualifier = resolveDeclaredQualifier(beanDefinition);
         T bean;
         Class<T> beanType = beanDefinition.getBeanType();

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1579,7 +1579,7 @@ public class DefaultBeanContext implements BeanContext {
                         String argumentName = requiredArgument.getName();
                         Object val = argumentValues.get(argumentName);
                         if (val == null && !requiredArgument.isDeclaredNullable()) {
-                            throw new BeanInstantiationException(resolutionContext, "Missing bean argument [" + requiredArgument + "] for type: " + beanType.getName() + ". Requires arguments: " + ArrayUtils.toString(requiredArguments));
+                            throw new BeanInstantiationException(resolutionContext, "Missing bean argument [" + requiredArgument + "] for type: " + beanType.getName() + ". Required arguments: " + ArrayUtils.toString(requiredArguments));
                         }
                         BeanResolutionContext finalResolutionContext = resolutionContext;
                         Object convertedValue = null;


### PR DESCRIPTION
When all parameters are marked as Nullable and none arguments provided, bean initialization fails

```
io.micronaut.context.exceptions.BeanInstantiationException: Error instantiating bean of type  [io.micronaut.inject.ParametrizedBeanInjectionSpec$ParametrizedBean]

Message: Missing bean arguments for type: io.micronaut.inject.ParametrizedBeanInjectionSpec$ParametrizedBean. Requires arguments: SomeBean someBean
```