### PR TITLE
Support multiple headers with same field name

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/NettyClientHttpRequest.java
+++ b/http-client/src/main/java/io/micronaut/http/client/NettyClientHttpRequest.java
@@ -183,7 +183,7 @@ class NettyClientHttpRequest<B> implements MutableHttpRequest<B> {
         io.netty.handler.codec.http.HttpMethod method = io.netty.handler.codec.http.HttpMethod.valueOf(httpMethod.name());
         DefaultFullHttpRequest req = content != null ? new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, method, uriStr, content) :
             new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, method, uriStr);
-        req.headers().setAll(headers.getNettyHeaders());
+        req.headers().set(headers.getNettyHeaders());
         return req;
     }
 
@@ -196,7 +196,7 @@ class NettyClientHttpRequest<B> implements MutableHttpRequest<B> {
         io.netty.handler.codec.http.HttpMethod method = io.netty.handler.codec.http.HttpMethod.valueOf(httpMethod.name());
         HttpRequest req = publisher != null ? new DefaultStreamedHttpRequest(HttpVersion.HTTP_1_1, method, uriStr, publisher) :
             new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, method, uriStr);
-        req.headers().setAll(headers.getNettyHeaders());
+        req.headers().set(headers.getNettyHeaders());
         return req;
     }
 

--- a/http-client/src/test/groovy/io/micronaut/http/client/MultiHeaderSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/MultiHeaderSpec.groovy
@@ -22,7 +22,6 @@ import io.micronaut.http.MediaType
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Header
-import io.micronaut.http.context.ServerRequestContext
 import io.micronaut.runtime.server.EmbeddedServer
 import spock.lang.Specification
 
@@ -51,19 +50,25 @@ class MultiHeaderSpec extends Specification {
         where:
         path | _
         "/echo-multi-header-as-list/from-request" | _
-        "/echo-multi-header-as-list/from-param" | _
+        "/echo-multi-header-as-list/from-list-param" | _
+        "/echo-multi-header-as-list/from-array-param" | _
     }
 
     @Controller("/echo-multi-header-as-list")
     static class EchoMultiHeaderController {
 
         @Get(uri = "/from-request", produces = MediaType.TEXT_PLAIN)
-        String fromRequest() {
-            ServerRequestContext.currentRequest().get().headers.getAll("multi")
+        String fromRequest(HttpRequest request) {
+            request.headers.getAll("multi")
         }
 
-        @Get(uri = "/from-param", produces = MediaType.TEXT_PLAIN)
-        String fromParam(@Header List<String> multi) {
+        @Get(uri = "/from-list-param", produces = MediaType.TEXT_PLAIN)
+        String fromListParam(@Header List<String> multi) {
+            multi
+        }
+
+        @Get(uri = "/from-array-param", produces = MediaType.TEXT_PLAIN)
+        String fromArrayParam(@Header String[] multi) {
             multi
         }
     }

--- a/http-client/src/test/groovy/io/micronaut/http/client/MultiHeaderSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/MultiHeaderSpec.groovy
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.client
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Header
+import io.micronaut.http.context.ServerRequestContext
+import io.micronaut.runtime.server.EmbeddedServer
+import spock.lang.Specification
+
+class MultiHeaderSpec extends Specification {
+
+    void "test multi-valued header"() {
+        given:
+        EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer)
+        def asyncClient = HttpClient.create(embeddedServer.getURL())
+        BlockingHttpClient client = asyncClient.toBlocking()
+
+        when:
+        HttpRequest request = HttpRequest.GET(path)
+        request.getHeaders().add("multi", "a").add("multi", "b")
+        HttpResponse<String> response = client.exchange(
+                request,
+                String
+        )
+
+        then:
+        response.body() == "[a, b]"
+
+        cleanup:
+        embeddedServer.close()
+
+        where:
+        path | _
+        "/echo-multi-header-as-list/from-request" | _
+        "/echo-multi-header-as-list/from-param" | _
+    }
+
+    @Controller("/echo-multi-header-as-list")
+    static class EchoMultiHeaderController {
+
+        @Get(uri = "/from-request", produces = MediaType.TEXT_PLAIN)
+        String fromRequest() {
+            ServerRequestContext.currentRequest().get().headers.getAll("multi")
+        }
+
+        @Get(uri = "/from-param", produces = MediaType.TEXT_PLAIN)
+        String fromParam(@Header List<String> multi) {
+            multi
+        }
+    }
+}

--- a/http-client/src/test/groovy/io/micronaut/http/client/MultiHeaderSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/MultiHeaderSpec.groovy
@@ -42,16 +42,17 @@ class MultiHeaderSpec extends Specification {
         )
 
         then:
-        response.body() == "[a, b]"
+        response.body() == expected
 
         cleanup:
         embeddedServer.close()
 
         where:
-        path | _
-        "/echo-multi-header-as-list/from-request" | _
-        "/echo-multi-header-as-list/from-list-param" | _
-        "/echo-multi-header-as-list/from-array-param" | _
+        path | expected
+        "/echo-multi-header-as-list/from-request" | "[a, b]"
+        "/echo-multi-header-as-list/from-list-param" | "[a, b]"
+        "/echo-multi-header-as-list/from-array-param" | "[a, b]"
+        "/echo-multi-header-as-list/from-string-param" | "a"
     }
 
     @Controller("/echo-multi-header-as-list")
@@ -69,6 +70,11 @@ class MultiHeaderSpec extends Specification {
 
         @Get(uri = "/from-array-param", produces = MediaType.TEXT_PLAIN)
         String fromArrayParam(@Header String[] multi) {
+            multi
+        }
+
+        @Get(uri = "/from-string-param", produces = MediaType.TEXT_PLAIN)
+        String fromStringParam(@Header String multi) {
             multi
         }
     }

--- a/http-netty/src/main/java/io/micronaut/http/netty/NettyHttpHeaders.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/NettyHttpHeaders.java
@@ -77,13 +77,17 @@ public class NettyHttpHeaders implements MutableHttpHeaders {
     public <T> Optional<T> get(CharSequence name, ArgumentConversionContext<T> conversionContext) {
         List<String> values = nettyHeaders.getAll(name);
         if (values.size() > 0) {
-            if (values.size() == 1 || !Collection.class.isAssignableFrom(conversionContext.getArgument().getType())) {
+            if (values.size() == 1 || !isCollectionOrArray(conversionContext.getArgument().getType())) {
                 return conversionService.convert(values.get(0), conversionContext);
             } else {
                 return conversionService.convert(values, conversionContext);
             }
         }
         return Optional.empty();
+    }
+
+    private boolean isCollectionOrArray(Class<?> clazz) {
+        return clazz.isArray() || Collection.class.isAssignableFrom(clazz);
     }
 
     @Override

--- a/http-netty/src/main/java/io/micronaut/http/netty/NettyHttpHeaders.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/NettyHttpHeaders.java
@@ -75,9 +75,13 @@ public class NettyHttpHeaders implements MutableHttpHeaders {
 
     @Override
     public <T> Optional<T> get(CharSequence name, ArgumentConversionContext<T> conversionContext) {
-        String value = nettyHeaders.get(name);
-        if (value != null) {
-            return conversionService.convert(value, conversionContext);
+        List<String> values = nettyHeaders.getAll(name);
+        if (values.size() > 0) {
+            if (values.size() == 1 || !Collection.class.isAssignableFrom(conversionContext.getArgument().getType())) {
+                return conversionService.convert(values.get(0), conversionContext);
+            } else {
+                return conversionService.convert(values, conversionContext);
+            }
         }
         return Optional.empty();
     }


### PR DESCRIPTION
From https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html: `Multiple message-header fields with the same field-name MAY be present in a message if and only if the entire field-value for that header field is defined as a comma-separated list ...`

The PR contains changes that copies request headers in way that preserves multiple header entries with the same name, and also an improvement to the `@Header` annotation so it supports injecting a list of values from a header that is defined multiple times.