### PR TITLE
Route priority

### DIFF
--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/consumes/RouteComplexitySpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/consumes/RouteComplexitySpec.groovy
@@ -34,6 +34,13 @@ class RouteComplexitySpec extends AbstractMicronautSpec {
         body == "ab/c"
 
         when:
+        body = rxClient.retrieve(HttpRequest.GET("/test-complexity/other2/a/b/c")).blockingFirst()
+
+        then:
+        noExceptionThrown()
+        body == "ab/c"
+
+        when:
         body = rxClient.retrieve(HttpRequest.GET("/test-complexity/list")).blockingFirst()
 
         then:
@@ -63,6 +70,16 @@ class RouteComplexitySpec extends AbstractMicronautSpec {
         @Get("/other{/a}/{b}{/c}/d")
         HttpResponse threeVariablesTwoRaw() {
             HttpResponse.ok("three variables")
+        }
+
+        @Get("/other2{/a}/{+b}")
+        HttpResponse twoVariables2(String a, String b) {
+            HttpResponse.ok(a + b)
+        }
+
+        @Get("/other2{/a}/{b}{/c}")
+        HttpResponse threeVariablesOneRaw() {
+            HttpResponse.ok("three variables one raw")
         }
 
         @Get("/list{?full}")

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/consumes/RouteComplexitySpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/consumes/RouteComplexitySpec.groovy
@@ -13,14 +13,14 @@ class RouteComplexitySpec extends AbstractMicronautSpec {
 
     void "test route complexity"() {
         when:
-        String body = rxClient.retrieve(HttpRequest.GET("/test-complexity/somefile.xls")).blockingFirst()
+        String body = rxClient.retrieve(HttpRequest.GET("/test-complexity/id/somefile.xls")).blockingFirst()
 
         then:
         noExceptionThrown()
         body == "fallback"
 
         when:
-        body = rxClient.retrieve(HttpRequest.GET("/test-complexity/somefile.csv")).blockingFirst()
+        body = rxClient.retrieve(HttpRequest.GET("/test-complexity/id/somefile.csv")).blockingFirst()
 
         then:
         noExceptionThrown()
@@ -31,7 +31,7 @@ class RouteComplexitySpec extends AbstractMicronautSpec {
 
         then:
         noExceptionThrown()
-        body == "ab/c/d"
+        body == "ab/c"
 
         when:
         body = rxClient.retrieve(HttpRequest.GET("/test-complexity/list")).blockingFirst()
@@ -45,29 +45,35 @@ class RouteComplexitySpec extends AbstractMicronautSpec {
     @Controller("/test-complexity")
     static class MyController  {
 
-        @Get("/{id}")
+        @Get("/id/{id}")
         HttpResponse oneVariable() {
             HttpResponse.ok("fallback")
         }
 
-        @Get("/{id}.csv")
+        @Get("/id/{id}.csv")
         HttpResponse twoRaw() {
             HttpResponse.ok("csv")
         }
 
-        @Get("/other{/a}/{+b}")
+        @Get("/other{/a}/{+b}/d")
         HttpResponse twoVariables(String a, String b) {
             HttpResponse.ok(a + b)
         }
 
         @Get("/other{/a}/{b}{/c}/d")
         HttpResponse threeVariablesTwoRaw() {
-            HttpResponse.ok("two variables")
+            HttpResponse.ok("three variables")
         }
 
         @Get("/list{?full}")
         String getFull(@Nullable Boolean full) {
-            return "list"
+            "list"
         }
+
+        @Get("/{+path}")
+        String pathPlus(String path) {
+            path
+        }
+
     }
 }

--- a/http/src/main/java/io/micronaut/http/uri/UriTemplate.java
+++ b/http/src/main/java/io/micronaut/http/uri/UriTemplate.java
@@ -283,11 +283,12 @@ public class UriTemplate implements Comparable<UriTemplate> {
             }
         }
 
-        int variableCompare = thisVariableCount.compareTo(thatVariableCount);
-        if (variableCompare == 0) {
-            return thatRawCount.compareTo(thisRawCount);
+        //using that.compareTo because more raw segments should have higher precedence
+        int rawCompare = thatRawCount.compareTo(thisRawCount);
+        if (rawCompare == 0) {
+            return thisVariableCount.compareTo(thatVariableCount);
         } else {
-            return variableCompare;
+            return rawCompare;
         }
     }
 

--- a/http/src/main/java/io/micronaut/http/uri/UriTemplate.java
+++ b/http/src/main/java/io/micronaut/http/uri/UriTemplate.java
@@ -171,6 +171,17 @@ public class UriTemplate implements Comparable<UriTemplate> {
     }
 
     /**
+     * @return The number of segments that are raw
+     */
+    public int getRawSegmentLength() {
+        return segments.stream()
+                .filter(segment -> !segment.isVariable())
+                .map(CharSequence::length)
+                .reduce(Integer::sum)
+                .orElse(0);
+    }
+
+    /**
      * Nests another URI template with this template.
      *
      * @param uriTemplate The URI template. If it does not begin with forward slash it will automatically be appended with forward slash

--- a/router/src/main/java/io/micronaut/web/router/DefaultRouter.java
+++ b/router/src/main/java/io/micronaut/web/router/DefaultRouter.java
@@ -184,13 +184,6 @@ public class DefaultRouter implements Router {
             uriRoutes = explicitAcceptRoutes.isEmpty() ? acceptRoutes : explicitAcceptRoutes;
         }
 
-        if (uriRoutes.size() > 1) {
-            uriRoutes = uriRoutes.stream().collect(
-                    StreamUtils.maxAll(Comparator.comparingInt((match) ->
-                                    match.getRoute().getUriMatchTemplate().getRawSegmentLength()),
-                            Collectors.toList()));
-        }
-
         /**
          * Any changes to the logic below may also need changes to {@link io.micronaut.http.uri.UriTemplate#compareTo(UriTemplate)}
          */
@@ -215,6 +208,13 @@ public class DefaultRouter implements Router {
                 closestMatches.add(match);
             }
             uriRoutes = closestMatches;
+        }
+
+        if (uriRoutes.size() > 1) {
+            uriRoutes = uriRoutes.stream().collect(
+                    StreamUtils.maxAll(Comparator.comparingInt((match) ->
+                                    match.getRoute().getUriMatchTemplate().getRawSegmentLength()),
+                            Collectors.toList()));
         }
 
         return uriRoutes;

--- a/router/src/main/java/io/micronaut/web/router/DefaultRouter.java
+++ b/router/src/main/java/io/micronaut/web/router/DefaultRouter.java
@@ -17,6 +17,7 @@ package io.micronaut.web.router;
 
 import io.micronaut.core.order.OrderUtil;
 import io.micronaut.core.reflect.ClassUtils;
+import io.micronaut.core.util.StreamUtils;
 import io.micronaut.http.HttpMethod;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpStatus;
@@ -163,8 +164,8 @@ public class DefaultRouter implements Router {
     @Override
     public <T, R> List<UriRouteMatch<T, R>> findAllClosest(HttpRequest<?> request) {
         List<UriRouteMatch<T, R>> uriRoutes = this.<T, R>find(request).collect(Collectors.toList());
-        boolean hasMultipleMatches = uriRoutes.size() > 1;
-        if (hasMultipleMatches && HttpMethod.permitsRequestBody(request.getMethod())) {
+
+        if (uriRoutes.size() > 1 && HttpMethod.permitsRequestBody(request.getMethod())) {
 
             List<UriRouteMatch<T, R>> explicitAcceptRoutes = new ArrayList<>(uriRoutes.size());
             List<UriRouteMatch<T, R>> acceptRoutes = new ArrayList<>(uriRoutes.size());
@@ -181,13 +182,19 @@ public class DefaultRouter implements Router {
             }
 
             uriRoutes = explicitAcceptRoutes.isEmpty() ? acceptRoutes : explicitAcceptRoutes;
-            hasMultipleMatches = uriRoutes.size() > 1;
+        }
+
+        if (uriRoutes.size() > 1) {
+            uriRoutes = uriRoutes.stream().collect(
+                    StreamUtils.maxAll(Comparator.comparingInt((match) ->
+                                    match.getRoute().getUriMatchTemplate().getRawSegmentLength()),
+                            Collectors.toList()));
         }
 
         /**
-         * Any changes to the logic below may also need changes to {@link io.micronaut.http.uri.UriTemplate#compareTo(UriTemplate)} 
+         * Any changes to the logic below may also need changes to {@link io.micronaut.http.uri.UriTemplate#compareTo(UriTemplate)}
          */
-        if (hasMultipleMatches) {
+        if (uriRoutes.size() > 1) {
             long variableCount = 0;
             long rawCount = 0;
 
@@ -209,6 +216,7 @@ public class DefaultRouter implements Router {
             }
             uriRoutes = closestMatches;
         }
+
         return uriRoutes;
     }
 


### PR DESCRIPTION
Creating a PR because this contains a slight change in behavior

A request to `/other/a/b/c/d` would previously match `/other/{a}{/b+}` over `/other/{a}{/b}{/c}/d` because the former has less variables. The change makes more raw segments have priority over the variable segments. Previously routes were ordered by variable segment count then raw count. This change makes it raw segment count then variable segment count.