### PR TITLE
Raise constraint exception if @Valid pojo is not introspected

### DIFF
--- a/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java
@@ -22,6 +22,7 @@ import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.AnnotatedElement;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.core.beans.BeanIntrospection;
 import io.micronaut.core.beans.BeanIntrospector;
@@ -908,6 +909,17 @@ public class DefaultValidator implements Validator, ExecutableMethodValidator, R
                 for (Class<? extends Annotation> pojoConstraint : pojoConstraints) {
                     validatePojoInternal(rootClass, object, argumentValues, context, overallViolations, parameterType, parameterValue, pojoConstraint, introspection.getAnnotation(pojoConstraint));
                 }
+            } else {
+                String messageTemplate = "{" + Introspected.class.getName() + ".message}";
+                overallViolations.add(new DefaultConstraintViolation(
+                        object,
+                        rootClass,
+                        null,
+                        parameterValue,
+                        messageSource.interpolate(messageTemplate, MessageSource.MessageContext.of(Collections.singletonMap("type", parameterType.getName()))),
+                        messageTemplate,
+                        new PathImpl(context.currentPath),
+                        argumentValues));
             }
         } finally {
             context.removeLast();

--- a/validation/src/main/java/io/micronaut/validation/validator/messages/DefaultValidationMessages.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/messages/DefaultValidationMessages.java
@@ -17,6 +17,7 @@
 package io.micronaut.validation.validator.messages;
 
 import io.micronaut.context.StaticMessageSource;
+import io.micronaut.core.annotation.Introspected;
 
 import javax.inject.Singleton;
 import javax.validation.constraints.*;
@@ -60,5 +61,7 @@ public class DefaultValidationMessages extends StaticMessageSource {
         addMessage(Positive.class.getName() + MESSAGE_SUFFIX, "must be greater than 0");
         addMessage(PositiveOrZero.class.getName() + MESSAGE_SUFFIX, "must be greater than or equal to 0");
         addMessage(Size.class.getName() + MESSAGE_SUFFIX, "size must be between {min} and {max}");
+
+        addMessage(Introspected.class.getName() + MESSAGE_SUFFIX, "Cannot validate {type}. No bean introspection present");
     }
 }

--- a/validation/src/test/groovy/io/micronaut/validation/PojoNoIntrospection.java
+++ b/validation/src/test/groovy/io/micronaut/validation/PojoNoIntrospection.java
@@ -1,0 +1,29 @@
+package io.micronaut.validation;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+
+public class PojoNoIntrospection {
+
+    @Email(message = "Email should be valid")
+    private String email;
+
+    @NotBlank
+    private String name;
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/validation/src/test/groovy/io/micronaut/validation/ValidatedController.java
+++ b/validation/src/test/groovy/io/micronaut/validation/ValidatedController.java
@@ -29,7 +29,6 @@ import javax.validation.constraints.Digits;
 @Controller("/validated")
 public class ValidatedController {
 
-
     @Post("/args")
     public String args(@Digits(integer = 3, fraction = 2) String amount) {
         return "$" + amount;
@@ -37,6 +36,11 @@ public class ValidatedController {
 
     @Post("/pojo")
     public Pojo pojo(@Body @Valid Pojo pojo) {
+        return pojo;
+    }
+
+    @Post("/no-introspection")
+    public PojoNoIntrospection pojo(@Body @Valid PojoNoIntrospection pojo) {
         return pojo;
     }
 }


### PR DESCRIPTION
Targeting this to 1.2.x because I believe it's a bug. The validation annotations are applied and objects that would normally fail validation are being passed to methods that have the reasonable expectation that they would be valid.