### PR TITLE
simplified return statement on a doc snippet

### DIFF
--- a/test-suite/src/test/java/io/micronaut/docs/events/factory/EngineInitializer.java
+++ b/test-suite/src/test/java/io/micronaut/docs/events/factory/EngineInitializer.java
@@ -12,7 +12,7 @@ public class EngineInitializer implements BeanInitializedEventListener<EngineFac
     public EngineFactory onInitialized(BeanInitializingEvent<EngineFactory> event) {
         EngineFactory engineFactory = event.getBean();
         engineFactory.setRodLength(6.6);// <5>
-        return ((EngineFactory) (event.getBean()));
+        return engineFactory;
     }
 }
 // tag::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/events/factory/EngineInitializer.java
+++ b/test-suite/src/test/java/io/micronaut/docs/events/factory/EngineInitializer.java
@@ -16,4 +16,3 @@ public class EngineInitializer implements BeanInitializedEventListener<EngineFac
     }
 }
 // tag::class[]
-// bleah

--- a/test-suite/src/test/java/io/micronaut/docs/events/factory/EngineInitializer.java
+++ b/test-suite/src/test/java/io/micronaut/docs/events/factory/EngineInitializer.java
@@ -16,3 +16,4 @@ public class EngineInitializer implements BeanInitializedEventListener<EngineFac
     }
 }
 // tag::class[]
+// bleah


### PR DESCRIPTION
while reading the docs, I noticed the return statement could be simplified to just returning the declared variable.