### PR TITLE
simplify return statement on doc snippet

### DIFF
--- a/test-suite/src/test/java/io/micronaut/docs/events/factory/EngineInitializer.java
+++ b/test-suite/src/test/java/io/micronaut/docs/events/factory/EngineInitializer.java
@@ -12,7 +12,7 @@ public class EngineInitializer implements BeanInitializedEventListener<EngineFac
     public EngineFactory onInitialized(BeanInitializingEvent<EngineFactory> event) {
         EngineFactory engineFactory = event.getBean();
         engineFactory.setRodLength(6.6);// <5>
-        return ((EngineFactory) (event.getBean()));
+        return engineFactory;
     }
 }
 // tag::class[]


### PR DESCRIPTION
while reading the docs, I noticed a code snippet where the return statement could be simplified