### PR TITLE
Preserve MDC original context after instrumented operation completion

### DIFF
--- a/tracing/src/main/java/io/micronaut/tracing/instrument/util/MdcInstrumenter.java
+++ b/tracing/src/main/java/io/micronaut/tracing/instrument/util/MdcInstrumenter.java
@@ -69,11 +69,17 @@ public final class MdcInstrumenter implements Function<Runnable, Runnable>, Runn
 
     private Runnable passMdcTo(Runnable runnable, Map<String, String> contextMap) {
         return () -> {
+            Map<String, String> oldContextMap = MDC.getCopyOfContextMap();
+
             try {
                 MDC.setContextMap(contextMap);
                 runnable.run();
             } finally {
-                MDC.clear();
+                if (oldContextMap != null && !oldContextMap.isEmpty()) {
+                    MDC.setContextMap(oldContextMap);
+                } else {
+                    MDC.clear();
+                }
             }
         };
     }

--- a/tracing/src/test/groovy/io/micronaut/tracing/instrument/util/MdcInstrumenterSpec.groovy
+++ b/tracing/src/test/groovy/io/micronaut/tracing/instrument/util/MdcInstrumenterSpec.groovy
@@ -1,29 +1,101 @@
 package io.micronaut.tracing.instrument.util
 
+import io.micronaut.scheduling.instrument.RunnableInstrumenter
 import org.slf4j.MDC
 import spock.lang.Specification
+import spock.util.concurrent.AsyncConditions
 
 class MdcInstrumenterSpec extends Specification {
+    static final String key = 'foo'
+    static final String value = 'bar'
+
+    AsyncConditions conds = new AsyncConditions()
+    MdcInstrumenter mdcInstrumenter = new MdcInstrumenter()
+
+    def cleanup() {
+        MDC.clear()
+    }
 
     void "test MDC instrumenter"() {
         given:
-        MDC.setContextMap(foo:'bar')
+        MDC.put(key, value)
+
+        and:
+        Runnable runnable = {
+            conds.evaluate {
+                assert MDC.get(key) == value
+            }
+        }
+        runnable = mdcInstrumenter.apply(runnable)
+        def thread = new Thread(runnable)
 
         when:
-        String val =null
-        Runnable runnable = {
-            val =  MDC.get("foo")
-            assert val == "bar"
-        }
-        runnable = new MdcInstrumenter().apply(runnable)
-        def thread = new Thread(runnable)
         thread.start()
-        thread.join()
 
         then:
-        val == 'bar'
+        conds.await()
+        MDC.get(key) == value
 
         cleanup:
-        MDC.clear()
+        thread.join()
+    }
+
+    def "async operation runs as blocking operation within calling thread"() {
+        given:
+        MDC.put(key, value)
+
+        and:
+        RunnableInstrumenter instrumenter = mdcInstrumenter.newInstrumentation().get()
+
+        and:
+        Runnable runnable = {
+            conds.evaluate {
+                assert MDC.get(key) == value
+            }
+        }
+        runnable = instrumenter.instrument(runnable)
+
+        when:
+        runnable.run()
+
+        then:
+        conds.await()
+        MDC.get(key) == value
+    }
+
+    def "old context map is preserved after instrumented execution"() {
+        given:
+        MDC.put(key, value)
+        RunnableInstrumenter instrumenter1 = mdcInstrumenter.newInstrumentation().get()
+        Runnable runnable1 = instrumenter1.instrument({
+            conds.evaluate {
+                assert MDC.get(key) == value
+            }
+        } as Runnable)
+
+
+        and:
+        String value2 = 'baz'
+        MDC.put(key, value2)
+        RunnableInstrumenter instrumenter2 = mdcInstrumenter.newInstrumentation().get()
+        Runnable runnable2 = instrumenter2.instrument({
+            conds.evaluate {
+                assert MDC.get(key) == value2
+            }
+        } as Runnable)
+
+        when:
+        runnable1.run()
+
+        then:
+        conds.await()
+        MDC.get(key) == value2
+
+        when:
+        runnable2.run()
+
+        then:
+        conds.await()
+        MDC.get(key) == value2
     }
 }


### PR DESCRIPTION
Currently, MDC instrumenter always clear the MDC context at the end of
the instrumented execution cycle.  When an Async operation is run as blocking,
the entire execution happens in same thread as the calling thread. At the end of the
execution of the asynchronous operation, the current thread MDC will be cleared, which
can lead to unexpected loss of context.

This change proposes that during an instrumented execution, the MDC
context is only overloaded and at the end of the execution the previous
state is restored.