### PR TITLE
Support introspections for interfaces. Issue #1968

### DIFF
--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/TypeElementVisitorTransform.groovy
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/TypeElementVisitorTransform.groovy
@@ -24,6 +24,7 @@ import io.micronaut.ast.groovy.utils.PublicAbstractMethodVisitor
 import io.micronaut.ast.groovy.visitor.GroovyVisitorContext
 import io.micronaut.ast.groovy.visitor.LoadedVisitor
 import io.micronaut.core.annotation.AnnotationMetadata
+import io.micronaut.core.annotation.Introspected
 import io.micronaut.core.io.service.ServiceDefinition
 import io.micronaut.core.io.service.SoftServiceLoader
 import io.micronaut.core.order.OrderUtil
@@ -79,7 +80,7 @@ class TypeElementVisitorTransform implements ASTTransformation {
                 def annotationMetadata = AstAnnotationUtils.getAnnotationMetadata(source, classNode)
                 def isIntroduction = annotationMetadata.hasStereotype(Introduction.class)
                 def visitor = new ElementVisitor(source, classNode, values, visitorContext, !isIntroduction)
-                if (isIntroduction) {
+                if (isIntroduction || (annotationMetadata.hasStereotype(Introspected.class) && classNode.isAbstract())) {
                     visitor.visitClass(classNode)
                     new PublicAbstractMethodVisitor(source) {
                         @Override

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyClassElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyClassElement.java
@@ -72,6 +72,11 @@ public class GroovyClassElement extends AbstractGroovyElement implements ClassEl
     }
 
     @Override
+    public boolean isInterface() {
+        return classNode.isInterface();
+    }
+
+    @Override
     public boolean isPrimitive() {
         return ClassHelper.isPrimitiveType(classNode) || (classNode.isArray() && ClassHelper.isPrimitiveType(classNode.getComponentType()));
     }

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectorSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectorSpec.groovy
@@ -53,7 +53,7 @@ class BeanIntrospectorSpec extends Specification {
     void "test find introspections"() {
         expect:
         BeanIntrospector.SHARED.findIntrospections(Introspected).size() > 0
-        BeanIntrospector.SHARED.findIntrospections(Introspected, "io.micronaut.inject.visitor.beans").size() == 2
+        BeanIntrospector.SHARED.findIntrospections(Introspected, "io.micronaut.inject.visitor.beans").size() == 3
         BeanIntrospector.SHARED.findIntrospections(Introspected, "blah").size() == 0
     }
 }

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/TestNamed.java
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/TestNamed.java
@@ -1,0 +1,9 @@
+package io.micronaut.inject.visitor.beans;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.naming.Named;
+
+@Introspected
+public interface TestNamed extends Named {
+    void setName(String name);
+}

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
@@ -19,6 +19,7 @@ import io.micronaut.annotation.processing.visitor.LoadedVisitor;
 import io.micronaut.aop.Introduction;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.io.service.ServiceDefinition;
 import io.micronaut.core.io.service.SoftServiceLoader;
 import io.micronaut.core.order.OrderUtil;
@@ -194,7 +195,7 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
                     concreteClass.getQualifiedName().equals(classElement.getQualifiedName());
 
             if (shouldVisit) {
-                if (typeAnnotationMetadata.hasStereotype(Introduction.class)) {
+                if (typeAnnotationMetadata.hasStereotype(Introduction.class) || (typeAnnotationMetadata.hasStereotype(Introspected.class) && modelUtils.isAbstract(classElement))) {
                     classElement.asType().accept(new PublicAbstractMethodVisitor<Object, Object>(classElement, modelUtils, elementUtils) {
                         @Override
                         protected void accept(DeclaredType type, Element element, Object o) {

--- a/inject/src/main/java/io/micronaut/inject/beans/visitor/BeanPropertyWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/visitor/BeanPropertyWriter.java
@@ -166,11 +166,11 @@ class BeanPropertyWriter extends AbstractClassFileWriter implements Named {
 
             if (writeMethod != null && readMethod == null) {
                 // override isReadOnly method
-                final GeneratorAdapter isReadOnly = startPublicMethodZeroArgs(classWriter, boolean.class, "isWriteOnly");
-                isReadOnly.push(true);
-                isReadOnly.returnValue();
-                isReadOnly.visitMaxs(1, 1);
-                isReadOnly.endMethod();
+                final GeneratorAdapter isWriteOnly = startPublicMethodZeroArgs(classWriter, boolean.class, "isWriteOnly");
+                isWriteOnly.push(true);
+                isWriteOnly.returnValue();
+                isWriteOnly.visitMaxs(1, 1);
+                isWriteOnly.endMethod();
             }
 
             for (GeneratorAdapter generator : loadTypeMethods.values()) {

--- a/inject/src/main/java/io/micronaut/inject/beans/visitor/BeanPropertyWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/visitor/BeanPropertyWriter.java
@@ -90,7 +90,8 @@ class BeanPropertyWriter extends AbstractClassFileWriter implements Named {
             @Nonnull String propertyName,
             @Nullable MethodElement readMethod,
             @Nullable MethodElement writeMethod,
-            boolean isReadOnly, int index,
+            boolean isReadOnly,
+            int index,
             @Nullable AnnotationMetadata annotationMetadata,
             @Nullable Map<String, ClassElement> typeArguments) {
 
@@ -163,6 +164,15 @@ class BeanPropertyWriter extends AbstractClassFileWriter implements Named {
                 isReadOnly.endMethod();
             }
 
+            if (writeMethod != null && readMethod == null) {
+                // override isReadOnly method
+                final GeneratorAdapter isReadOnly = startPublicMethodZeroArgs(classWriter, boolean.class, "isWriteOnly");
+                isReadOnly.push(true);
+                isReadOnly.returnValue();
+                isReadOnly.visitMaxs(1, 1);
+                isReadOnly.endMethod();
+            }
+
             for (GeneratorAdapter generator : loadTypeMethods.values()) {
                 generator.visitMaxs(3, 1);
                 generator.visitEnd();
@@ -186,11 +196,19 @@ class BeanPropertyWriter extends AbstractClassFileWriter implements Named {
         final boolean hasWriteMethod = this.writeMethod != null;
         final String methodName = hasWriteMethod ? this.writeMethod.getName() : NameUtils.setterNameFor(propertyName);
         final Object returnType = hasWriteMethod ? getTypeForElement(this.writeMethod.getReturnType()) : void.class;
-        writeMethod.invokeVirtual(
-                beanType,
-                new Method(methodName,
-                        getMethodDescriptor(returnType, Collections.singleton(propertyType)))
-        );
+        if (hasWriteMethod && this.writeMethod.getDeclaringType().isInterface()) {
+            writeMethod.invokeInterface(
+                    beanType,
+                    new Method(methodName,
+                            getMethodDescriptor(returnType, Collections.singleton(propertyType)))
+            );
+        } else {
+            writeMethod.invokeVirtual(
+                    beanType,
+                    new Method(methodName,
+                            getMethodDescriptor(returnType, Collections.singleton(propertyType)))
+            );
+        }
         writeMethod.visitInsn(RETURN);
         writeMethod.visitMaxs(1, 1);
         writeMethod.visitEnd();
@@ -208,7 +226,11 @@ class BeanPropertyWriter extends AbstractClassFileWriter implements Named {
         pushCastToType(readMethod, beanType.getClassName());
         final boolean isBoolean = propertyType.getClassName().equals("boolean");
         final String methodName = this.readMethod != null ? this.readMethod.getName() : NameUtils.getterNameFor(propertyName, isBoolean);
-        readMethod.invokeVirtual(beanType, new Method(methodName, getMethodDescriptor(propertyType, Collections.emptyList())));
+        if (this.readMethod != null && this.readMethod.getDeclaringType().isInterface()) {
+            readMethod.invokeInterface(beanType, new Method(methodName, getMethodDescriptor(propertyType, Collections.emptyList())));
+        } else {
+            readMethod.invokeVirtual(beanType, new Method(methodName, getMethodDescriptor(propertyType, Collections.emptyList())));
+        }
         pushBoxPrimitiveIfNecessary(propertyType, readMethod);
         readMethod.returnValue();
         readMethod.visitMaxs(1, 1);

--- a/inject/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
@@ -21,6 +21,7 @@ import io.micronaut.core.annotation.AnnotationClassValue;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
@@ -28,7 +29,10 @@ import io.micronaut.inject.ast.*;
 import io.micronaut.inject.visitor.TypeElementVisitor;
 import io.micronaut.inject.visitor.VisitorContext;
 import io.micronaut.inject.writer.ClassGenerationException;
+import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -58,7 +62,9 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
             .build();
 
     private Map<String, BeanIntrospectionWriter> writers = new LinkedHashMap<>(10);
+    private List<AbstractIntrospection> abstractIntrospections = new ArrayList<>();
     private ClassElement lastConfigurationReader;
+    private AbstractIntrospection currentAbstractIntrospection;
 
     @Override
     public int getOrder() {
@@ -68,10 +74,11 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
 
     @Override
     public void visitClass(ClassElement element, VisitorContext context) {
+        currentAbstractIntrospection = null;
         if (!element.isPrivate()) {
             if (element.hasStereotype(Introspected.class)) {
                 final AnnotationValue<Introspected> introspected = element.getAnnotation(Introspected.class);
-                if (introspected != null && !writers.containsKey(element.getName()) && !element.isAbstract()) {
+                if (introspected != null && !writers.containsKey(element.getName())) {
                     processIntrospected(element, context, introspected);
                 }
             } else if (element.hasStereotype(ConfigurationReader.class)) {
@@ -94,12 +101,31 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
     @Override
     public void visitMethod(MethodElement element, VisitorContext context) {
         final ClassElement declaringType = element.getDeclaringType();
+        final String methodName = element.getName();
         if (lastConfigurationReader != null && lastConfigurationReader.getName().equals(declaringType.getName())) {
-            if (element.getName().startsWith("get")) {
+            if (methodName.startsWith("get")) {
                 final boolean hasConstraints = element.hasStereotype(JAVAX_VALIDATION_CONSTRAINT) || element.hasStereotype(JAVAX_VALIDATION_VALID);
                 if (hasConstraints) {
                     processIntrospected(declaringType, context, AnnotationValue.builder(Introspected.class).build());
                 }
+            }
+        } else if (currentAbstractIntrospection != null) {
+            if (NameUtils.isGetterName(methodName) && element.getParameters().length == 0) {
+                final String propertyName = NameUtils.getPropertyNameForGetter(methodName);
+                final AbstractPropertyElement propertyElement = currentAbstractIntrospection.properties.computeIfAbsent(propertyName, s -> new AbstractPropertyElement(
+                        element.getDeclaringType(),
+                        element.getReturnType(),
+                        propertyName
+                ));
+                propertyElement.readMethod = element;
+            } else if (NameUtils.isSetterName(methodName) && element.getParameters().length == 1) {
+                final String propertyName = NameUtils.getPropertyNameForSetter(methodName);
+                final AbstractPropertyElement propertyElement = currentAbstractIntrospection.properties.computeIfAbsent(propertyName, s -> new AbstractPropertyElement(
+                        element.getDeclaringType(),
+                        element.getParameters()[0].getType(),
+                        propertyName
+                ));
+                propertyElement.writeMethod = element;
             }
         }
     }
@@ -169,7 +195,7 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                                 metadata ? element.getAnnotationMetadata() : null
                         );
 
-                        processElement(context, metadata, includes, excludes, excludedAnnotations, indexedAnnotations, ce, writer);
+                        processElement(metadata, includes, excludes, excludedAnnotations, indexedAnnotations, ce, writer);
 
                     }
                 });
@@ -193,7 +219,7 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                                 metadata ? element.getAnnotationMetadata() : null
                         );
 
-                        processElement(context, metadata, includes, excludes, excludedAnnotations, indexedAnnotations, classElement, writer);
+                        processElement(metadata, includes, excludes, excludedAnnotations, indexedAnnotations, classElement, writer);
                     }
                 }
             }
@@ -204,12 +230,29 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                     metadata ? element.getAnnotationMetadata() : null
             );
 
-            processElement(context, metadata, includes, excludes, excludedAnnotations, indexedAnnotations, element, writer);
+            processElement(metadata, includes, excludes, excludedAnnotations, indexedAnnotations, element, writer);
         }
     }
 
     @Override
     public void finish(VisitorContext visitorContext) {
+
+        for (AbstractIntrospection abstractIntrospection : abstractIntrospections) {
+            final Collection<? extends PropertyElement> properties = abstractIntrospection.properties.values();
+            if (CollectionUtils.isNotEmpty(properties)) {
+                processBeanProperties(
+                        abstractIntrospection.writer,
+                        properties,
+                        abstractIntrospection.includes,
+                        abstractIntrospection.excludes,
+                        abstractIntrospection.ignored,
+                        abstractIntrospection.indexedAnnotations,
+                        abstractIntrospection.metadata
+                );
+                writers.put(abstractIntrospection.writer.getBeanType().getClassName(), abstractIntrospection.writer);
+            }
+
+        }
 
         for (BeanIntrospectionWriter writer : writers.values()) {
             try {
@@ -218,16 +261,32 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                 throw new ClassGenerationException("I/O error occurred during class generation: " + e.getMessage(), e);
             }
         }
+
     }
 
-    private void processElement(VisitorContext context, boolean metadata, Set<String> includes, Set<String> excludes, Set<String> excludedAnnotations, Set<AnnotationValue> indexedAnnotations, ClassElement ce, BeanIntrospectionWriter writer) {
-        final List<PropertyElement> beanProperties = ce.getBeanProperties();
-        Optional<MethodElement> constructorElement = ce.getPrimaryConstructor();
-
-        if (!constructorElement.isPresent()) {
-            context.fail("Introspected types must have a single public constructor or static @Creator method", ce);
+    private void processElement(
+            boolean metadata,
+            Set<String> includes,
+            Set<String> excludes,
+            Set<String> excludedAnnotations,
+            Set<AnnotationValue> indexedAnnotations,
+            ClassElement ce,
+            BeanIntrospectionWriter writer) {
+        if (ce.isAbstract()) {
+            currentAbstractIntrospection = new AbstractIntrospection(
+                    writer,
+                    includes,
+                    excludes,
+                    excludedAnnotations,
+                    indexedAnnotations,
+                    metadata
+            );
+            abstractIntrospections.add(currentAbstractIntrospection);
         } else {
-            final MethodElement constructor = constructorElement.get();
+            final List<PropertyElement> beanProperties = ce.getBeanProperties();
+            Optional<MethodElement> constructorElement = ce.getPrimaryConstructor();
+
+            final MethodElement constructor = constructorElement.orElse(null);
             process(
                     constructor,
                     ce.getDefaultConstructor().orElse(null),
@@ -243,8 +302,8 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
     }
 
     private void process(
-            MethodElement constructorElement,
-            MethodElement defaultConstructor,
+            @Nullable MethodElement constructorElement,
+            @Nullable MethodElement defaultConstructor,
             BeanIntrospectionWriter writer,
             List<PropertyElement> beanProperties,
             Set<String> includes,
@@ -253,14 +312,21 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
             Set<AnnotationValue> indexedAnnotations,
             boolean metadata) {
 
-        final ParameterElement[] parameters = constructorElement.getParameters();
-        if (ArrayUtils.isNotEmpty(parameters)) {
-            writer.visitConstructor(constructorElement);
+        if (constructorElement != null) {
+            final ParameterElement[] parameters = constructorElement.getParameters();
+            if (ArrayUtils.isNotEmpty(parameters)) {
+                writer.visitConstructor(constructorElement);
+            }
         }
         if (defaultConstructor != null) {
             writer.visitDefaultConstructor(defaultConstructor);
         }
 
+        processBeanProperties(writer, beanProperties, includes, excludes, ignored, indexedAnnotations, metadata);
+        writers.put(writer.getBeanType().getClassName(), writer);
+    }
+
+    private void processBeanProperties(BeanIntrospectionWriter writer, Collection<? extends PropertyElement> beanProperties, Set<String> includes, Set<String> excludes, Set<String> ignored, Set<AnnotationValue> indexedAnnotations, boolean metadata) {
         for (PropertyElement beanProperty : beanProperties) {
             final ClassElement type = beanProperty.getType();
 
@@ -300,7 +366,98 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
 
             }
         }
-        writers.put(writer.getBeanType().getClassName(), writer);
+    }
+
+    /**
+     * Holder for an abstract introspection.
+     */
+    private class AbstractIntrospection {
+        final BeanIntrospectionWriter writer;
+        final Set<String> includes;
+        final Set<String> excludes;
+        final Set<String> ignored;
+        final Set<AnnotationValue> indexedAnnotations;
+        final boolean metadata;
+        final Map<String, AbstractPropertyElement> properties = new LinkedHashMap<>();
+
+        public AbstractIntrospection(
+                BeanIntrospectionWriter writer,
+                Set<String> includes,
+                Set<String> excludes,
+                Set<String> ignored,
+                Set<AnnotationValue> indexedAnnotations,
+                boolean metadata) {
+            this.writer = writer;
+            this.includes = includes;
+            this.excludes = excludes;
+            this.ignored = ignored;
+            this.indexedAnnotations = indexedAnnotations;
+            this.metadata = metadata;
+        }
+    }
+
+    /**
+     * Used to accumulate property elements for abstract types.
+     */
+    private class AbstractPropertyElement implements PropertyElement {
+
+        private final ClassElement declaringType;
+        private final ClassElement type;
+        private final String name;
+
+        private MethodElement writeMethod;
+        private MethodElement readMethod;
+
+        AbstractPropertyElement(ClassElement declaringType, ClassElement type, String name) {
+            this.declaringType = declaringType;
+            this.type = type;
+            this.name = name;
+        }
+
+        @Override
+        public Optional<MethodElement> getWriteMethod() {
+            return Optional.ofNullable(writeMethod);
+        }
+
+        @Override
+        public Optional<MethodElement> getReadMethod() {
+            return Optional.ofNullable(readMethod);
+        }
+
+        @Nonnull
+        @NotNull
+        @Override
+        public ClassElement getType() {
+            return type;
+        }
+
+        @Override
+        public ClassElement getDeclaringType() {
+            return declaringType;
+        }
+
+        @Nonnull
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public boolean isProtected() {
+            return false;
+        }
+
+        @Override
+        public boolean isPublic() {
+            return true;
+        }
+
+        @SuppressWarnings("ConstantConditions")
+        @Nonnull
+        @Override
+        public Object getNativeType() {
+            throw null;
+        }
     }
 
 }

--- a/inject/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
@@ -29,7 +29,6 @@ import io.micronaut.inject.ast.*;
 import io.micronaut.inject.visitor.TypeElementVisitor;
 import io.micronaut.inject.visitor.VisitorContext;
 import io.micronaut.inject.writer.ClassGenerationException;
-import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -425,7 +424,6 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
         }
 
         @Nonnull
-        @NotNull
         @Override
         public ClassElement getType() {
             return type;


### PR DESCRIPTION
This adds support for introspections for interfaces. Also removes the restriction that an introspection must have a constructor.