### PR TITLE
Support for @ConfigurationProperties on interfaces

### DIFF
--- a/core/src/main/java/io/micronaut/core/bind/annotation/Bindable.java
+++ b/core/src/main/java/io/micronaut/core/bind/annotation/Bindable.java
@@ -30,7 +30,7 @@ import java.lang.annotation.Target;
  */
 @Documented
 @Retention(RUNTIME)
-@Target({ElementType.ANNOTATION_TYPE, ElementType.PARAMETER})
+@Target({ElementType.ANNOTATION_TYPE, ElementType.PARAMETER, ElementType.METHOD})
 public @interface Bindable {
 
     /**

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/InjectTransform.groovy
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/InjectTransform.groovy
@@ -27,6 +27,7 @@ import io.micronaut.context.annotation.Property
 import io.micronaut.context.annotation.PropertySource
 import io.micronaut.core.annotation.AnnotationClassValue
 import io.micronaut.core.annotation.AnnotationValue
+import io.micronaut.core.bind.annotation.Bindable
 import io.micronaut.core.reflect.ClassUtils
 import io.micronaut.core.util.CollectionUtils
 import io.micronaut.core.util.StringUtils
@@ -128,7 +129,8 @@ class InjectTransform implements ASTTransformation, CompilationUnitAware {
 
     public static final String ANN_VALID = "javax.validation.Valid"
     public static final String ANN_CONSTRAINT = "javax.validation.Constraint"
-
+    public static final String ANN_CONFIGURATION_ADVICE = "io.micronaut.runtime.context.env.ConfigurationAdvice";
+    public static final String ANN_VALIDATED = "io.micronaut.validation.Validated";
     CompilationUnit unit
     ConfigurationMetadataBuilder<ClassNode> configurationMetadataBuilder
 
@@ -165,7 +167,8 @@ class InjectTransform implements ASTTransformation, CompilationUnitAware {
                 continue
             } else {
                 if (classNode.isInterface()) {
-                    if (AstAnnotationUtils.hasStereotype(source, classNode, InjectVisitor.INTRODUCTION_TYPE)) {
+                    if (AstAnnotationUtils.hasStereotype(source, classNode, InjectVisitor.INTRODUCTION_TYPE) ||
+                            AstAnnotationUtils.hasStereotype(source, classNode, ConfigurationReader.class)) {
                         InjectVisitor injectVisitor = new InjectVisitor(source, classNode, configurationMetadataBuilder)
                         injectVisitor.visitClass(classNode)
                         beanDefinitionWriters.putAll(injectVisitor.beanDefinitionWriters)
@@ -359,6 +362,13 @@ class InjectTransform implements ASTTransformation, CompilationUnitAware {
         @Override
         void visitClass(ClassNode node) {
             AnnotationMetadata annotationMetadata = AstAnnotationUtils.getAnnotationMetadata(sourceUnit, node)
+            boolean isInterface = node.isInterface()
+            if (isConfigurationProperties && isInterface) {
+                annotationMetadata = addAnnotation(
+                        annotationMetadata,
+                        InjectTransform.ANN_CONFIGURATION_ADVICE
+                )
+            }
             if (annotationMetadata.hasStereotype(INTRODUCTION_TYPE)) {
                 String packageName = node.packageName
                 String beanClassName = node.nameWithoutPackage
@@ -373,7 +383,7 @@ class InjectTransform implements ASTTransformation, CompilationUnitAware {
                 Object[] interceptorTypes = ArrayUtils.concat(aroundInterceptors, introductionInterceptors)
                 String[] interfaceTypes = annotationMetadata.getValue(Introduction.class, "interfaces", String[].class).orElse(new String[0])
 
-                boolean isInterface = node.isInterface()
+
                 AopProxyWriter aopProxyWriter = new AopProxyWriter(
                         packageName,
                         beanClassName,
@@ -502,6 +512,51 @@ class InjectTransform implements ASTTransformation, CompilationUnitAware {
                         }
                     }
 
+                    if (isConfigurationProperties && methodNode.isAbstract()) {
+                        if (!aopProxyWriter.isValidated()) {
+                            aopProxyWriter.setValidated(annotationMetadata.hasStereotype(InjectTransform.ANN_CONSTRAINT) ||
+                                    annotationMetadata.hasStereotype(InjectTransform.ANN_VALID));
+                        }
+
+                        if (!NameUtils.isGetterName(methodNode.name)) {
+                            error("Only getter methods are allowed on @ConfigurationProperties interfaces: " + methodNode.name, classNode)
+                            return
+                        }
+
+                        if (targetMethodParamsToType) {
+                            error("Only zero argument getter methods are allowed on @ConfigurationProperties interfaces: " + methodNode.name, classNode)
+                            return
+                        }
+                        String propertyName = NameUtils.getPropertyNameForGetter(methodNode.name)
+                        String propertyType = methodNode.returnType.name
+
+                        if ("void".equals(propertyType)) {
+                            error("Getter methods must return a value @ConfigurationProperties interfaces: " + methodNode.name, classNode)
+                            return
+                        }
+
+                        final PropertyMetadata propertyMetadata = configurationMetadataBuilder.visitProperty(
+                                classNode,
+                                classNode,
+                                propertyType,
+                                propertyName,
+                                null,
+                                annotationMetadata.stringValue(Bindable.class, "defaultValue").orElse(null)
+                        );
+
+                        annotationMetadata = addPropertyMetadata(
+                                annotationMetadata,
+                                propertyMetadata
+                        )
+
+                        final ClassNode typeElement = !ClassUtils.isJavaBasicType(propertyType) ? methodNode.returnType : null;
+                        if (typeElement != null && AstAnnotationUtils.hasStereotype(source, typeElement, Scope.class)) {
+                            annotationMetadata = addBeanConfigAdvise(annotationMetadata)
+                        } else {
+                            annotationMetadata = addAnnotation(annotationMetadata, ANN_CONFIGURATION_ADVICE);
+                        }
+                    }
+
                     if (AstAnnotationUtils.hasStereotype(source, methodNode, AROUND_TYPE)) {
                         Object[] interceptorTypeReferences = annotationMetadata.getAnnotationNamesByStereotype(Around).toArray()
                         aopProxyWriter.visitInterceptorTypes(interceptorTypeReferences)
@@ -535,6 +590,19 @@ class InjectTransform implements ASTTransformation, CompilationUnitAware {
                         )
                     }
 
+                }
+
+                @CompileDynamic
+                private void error(String msg, ClassNode classNode) {
+                    addError(msg, (ASTNode) classNode)
+                }
+
+                @CompileDynamic
+                private AnnotationMetadata addBeanConfigAdvise(AnnotationMetadata annotationMetadata) {
+                    new GroovyAnnotationMetadataBuilder(sourceUnit).annotate(
+                            annotationMetadata,
+                            AnnotationValue.builder(ANN_CONFIGURATION_ADVICE).member("bean", true).build()
+                    )
                 }
 
 
@@ -1057,11 +1125,16 @@ class InjectTransform implements ASTTransformation, CompilationUnitAware {
 
         @CompileDynamic
         private AnnotationMetadata addValidated(AnnotationMetadata methodAnnotationMetadata) {
+            return addAnnotation(methodAnnotationMetadata, "io.micronaut.validation.Validated")
+        }
+
+        @CompileDynamic
+        private AnnotationMetadata addAnnotation(AnnotationMetadata methodAnnotationMetadata, String annotationName) {
             methodAnnotationMetadata = new GroovyAnnotationMetadataBuilder(sourceUnit).annotate(
                     methodAnnotationMetadata,
-                    AnnotationValue.<Object> builder("io.micronaut.validation.Validated").build()
+                    AnnotationValue.builder(annotationName).build()
             )
-            methodAnnotationMetadata
+            return methodAnnotationMetadata
         }
 
         private AopProxyWriter resolveProxyWriter(

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/InjectTransform.groovy
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/InjectTransform.groovy
@@ -536,7 +536,7 @@ class InjectTransform implements ASTTransformation, CompilationUnitAware {
                         }
 
                         final PropertyMetadata propertyMetadata = configurationMetadataBuilder.visitProperty(
-                                classNode,
+                                current.isInterface() ? current : classNode,
                                 classNode,
                                 propertyType,
                                 propertyName,

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/configproperties/InterfaceConfigurationPropertiesSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/configproperties/InterfaceConfigurationPropertiesSpec.groovy
@@ -1,15 +1,15 @@
 package io.micronaut.inject.configproperties
 
+import io.micronaut.AbstractBeanDefinitionSpec
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Property
 import io.micronaut.context.exceptions.NoSuchBeanException
-import io.micronaut.inject.AbstractTypeElementSpec
 import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.BeanFactory
 import io.micronaut.inject.ValidatedBeanDefinition
 import io.micronaut.runtime.context.env.ConfigurationAdvice
 
-class InterfaceConfigurationPropertiesSpec extends AbstractTypeElementSpec {
+class InterfaceConfigurationPropertiesSpec extends AbstractBeanDefinitionSpec {
 
 
     void "test simple interface config props"() {
@@ -34,7 +34,7 @@ interface MyConfig {
         then:
         beanDefinition instanceof ValidatedBeanDefinition
         beanDefinition.getRequiredMethod("getHost")
-            .stringValue(Property, "name").get() == 'foo.bar.host'
+                .stringValue(Property, "name").get() == 'foo.bar.host'
         beanDefinition.getRequiredMethod("getServerPort")
                 .stringValue(Property, "name").get() == 'foo.bar.server-port'
 
@@ -160,7 +160,7 @@ interface MyConfig {
 ''')
         then:
         def e = thrown(RuntimeException)
-        e.message.contains('Only getter methods are allowed on @ConfigurationProperties interfaces: junk(java.lang.String)')
+        e.message.contains('Only getter methods are allowed on @ConfigurationProperties interfaces: junk')
     }
 
     void "test getter that returns void method"() {

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/configproperties/InterfaceConfigurationPropertiesSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/configproperties/InterfaceConfigurationPropertiesSpec.groovy
@@ -51,6 +51,49 @@ interface MyConfig {
 
     }
 
+    void "test inheritance interface config props"() {
+
+        when:
+        BeanDefinition beanDefinition = buildBeanDefinition('test.MyConfig$Intercepted', '''
+package test;
+
+import io.micronaut.context.annotation.*;
+import java.time.Duration;
+
+@ConfigurationProperties("bar")
+interface MyConfig extends ParentConfig {
+    
+    @javax.validation.constraints.Min(10L)
+    int getServerPort();
+}
+
+@ConfigurationProperties("foo")
+interface ParentConfig {
+    @javax.validation.constraints.NotBlank
+    String getHost();
+}
+
+''')
+        then:
+        beanDefinition instanceof ValidatedBeanDefinition
+        beanDefinition.getRequiredMethod("getServerPort")
+                .stringValue(Property, "name").get() == 'foo.bar.server-port'
+        beanDefinition.getRequiredMethod("getHost")
+                .stringValue(Property, "name").get() == 'foo.bar.host'
+
+        when:
+        def context = ApplicationContext.run('foo.bar.host': 'test', 'foo.bar.server-port': '9999')
+        def config = ((BeanFactory) beanDefinition).build(context, beanDefinition)
+
+        then:
+        config.host == 'test'
+        config.serverPort == 9999
+
+        cleanup:
+        context.close()
+
+    }
+
     void "test nested interface config props"() {
 
         when:

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
@@ -32,6 +32,30 @@ import java.lang.reflect.Field
 
 class BeanIntrospectionSpec extends AbstractTypeElementSpec {
 
+    void "test generate bean introspection for @ConfigurationProperties interface"() {
+        BeanIntrospection introspection = buildBeanIntrospection('test.ValidatedConfig','''\
+package test;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.NotBlank;
+import java.net.URL;
+
+@ConfigurationProperties("foo.bar")
+public interface ValidatedConfig {
+
+    @NotNull
+    public URL getUrl();
+
+}
+
+
+''')
+        expect:
+        introspection != null
+    }
+
     void "test generate bean introspection for interface"() {
         when:
         BeanIntrospection introspection = buildBeanIntrospection('test.Test','''\

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -563,6 +563,13 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
 
         private void visitIntroductionAdviceInterface(TypeElement classElement, AnnotationMetadata typeAnnotationMetadata, AopProxyWriter aopProxyWriter) {
             String introductionTypeName = classElement.getQualifiedName().toString();
+            final boolean isConfigProps = typeAnnotationMetadata.hasAnnotation("io.micronaut.runtime.context.env.ConfigurationAdvice");
+            if (isConfigProps) {
+                metadataBuilder.visitProperties(
+                        classElement,
+                        null
+                );
+            }
             classElement.asType().accept(new PublicAbstractMethodVisitor<Object, AopProxyWriter>(classElement, modelUtils, elementUtils) {
 
                 @Override

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -68,6 +68,7 @@ import javax.lang.model.type.TypeVariable;
 import javax.lang.model.util.ElementFilter;
 import javax.lang.model.util.ElementScanner8;
 import java.io.IOException;
+import java.lang.annotation.Annotation;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
@@ -674,14 +675,18 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                             );
 
                             final TypeElement typeElement = !ClassUtils.isJavaBasicType(propertyType) ? resolveTypeElement(returnTypeMirror) : null;
+                            final AnnotationValueBuilder<Annotation> builder = io.micronaut.core.annotation.AnnotationValue.builder(ANN_CONFIGURATION_ADVICE);
                             if (typeElement != null && annotationUtils.hasStereotype(typeElement, Scope.class)) {
-                                final JavaAnnotationMetadataBuilder metadataBuilder = javaVisitorContext.getAnnotationUtils().newAnnotationBuilder();
-                                annotationMetadata = metadataBuilder.annotate(
-                                        annotationMetadata,
-                                        io.micronaut.core.annotation.AnnotationValue.builder(ANN_CONFIGURATION_ADVICE).member("bean", true).build());
-                            } else {
-                                annotationMetadata = addAnnotation(annotationMetadata, ANN_CONFIGURATION_ADVICE);
+                                builder.member("bean", true);
                             }
+                            if (typeAnnotationMetadata.hasStereotype(EachProperty.class)) {
+                                builder.member("iterable", true);
+                            }
+
+                            final JavaAnnotationMetadataBuilder metadataBuilder = javaVisitorContext.getAnnotationUtils().newAnnotationBuilder();
+                            annotationMetadata = metadataBuilder.annotate(
+                                    annotationMetadata,
+                                    builder.build());
                         }
                     }
 

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/JavaConfigurationMetadataBuilder.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/JavaConfigurationMetadataBuilder.java
@@ -18,7 +18,6 @@ package io.micronaut.annotation.processing;
 import io.micronaut.context.annotation.ConfigurationReader;
 import io.micronaut.context.annotation.EachProperty;
 import io.micronaut.core.annotation.AnnotationMetadata;
-import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.configuration.ConfigurationMetadataBuilder;
 
@@ -30,10 +29,7 @@ import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Function;
 
 /**

--- a/inject-java/src/test/groovy/io/micronaut/inject/configproperties/InterfaceConfigurationPropertiesSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configproperties/InterfaceConfigurationPropertiesSpec.groovy
@@ -1,0 +1,45 @@
+package io.micronaut.inject.configproperties
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Property
+import io.micronaut.inject.AbstractTypeElementSpec
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.BeanFactory
+import io.micronaut.inject.ValidatedBeanDefinition
+
+class InterfaceConfigurationPropertiesSpec extends AbstractTypeElementSpec {
+
+
+    void "test simple interface config props"() {
+
+        when:
+        BeanDefinition beanDefinition = buildBeanDefinition('test.MyConfig', '''
+package test;
+
+import io.micronaut.context.annotation.*;
+import java.time.Duration;
+
+@ConfigurationProperties("foo.bar")
+interface MyConfig {
+    @javax.validation.constraints.NotBlank
+    String getHost();
+    int getServerPort();
+}
+
+''')
+        then:
+        beanDefinition instanceof ValidatedBeanDefinition
+
+        when:
+        def context = ApplicationContext.run('foo.bar.host': 'test', 'foo.bar.server-port': '9999')
+        def config = ((BeanFactory) beanDefinition).build(context, beanDefinition)
+
+        then:
+        config.host == 'test'
+        config.serverPort == 9999
+
+        cleanup:
+        context.close()
+
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/EachPropertyInterfaceSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/EachPropertyInterfaceSpec.groovy
@@ -1,0 +1,33 @@
+package io.micronaut.inject.foreach
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.inject.qualifiers.Qualifiers
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class EachPropertyInterfaceSpec extends Specification {
+
+    void "test @EachProperty on interface"() {
+        given:
+        def context = ApplicationContext.run(
+                "foo.bar.one.host": 'host1',
+                "foo.bar.one.port": '9999',
+                "foo.bar.two.host": 'host2',
+                "foo.bar.two.port": '8888'
+        )
+
+        when:
+        def one = context.getBean(InterfaceConfig, Qualifiers.byName("one"))
+        def two = context.getBean(InterfaceConfig, Qualifiers.byName("two"))
+
+        then:
+        one.host == 'host1'
+        one.port == 9999
+        two.host == 'host2'
+        two.port == 8888
+
+        cleanup:
+        context.close()
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/InterfaceConfig.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/InterfaceConfig.java
@@ -1,0 +1,11 @@
+package io.micronaut.inject.foreach;
+
+import io.micronaut.context.annotation.EachProperty;
+
+@EachProperty("foo.bar")
+public interface InterfaceConfig {
+
+    String getHost();
+
+    int getPort();
+}

--- a/inject/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
@@ -84,10 +84,6 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                 }
             } else if (element.hasStereotype(ConfigurationReader.class)) {
                 this.lastConfigurationReader = element;
-                if (element.isAbstract()) {
-                    // add configuration advice
-                    element.annotate("io.micronaut.runtime.context.env.ConfigurationAdvice");
-                }
             }
         }
     }
@@ -112,7 +108,9 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                     processIntrospected(declaringType, context, AnnotationValue.builder(Introspected.class).build());
                 }
             }
-        } else if (currentAbstractIntrospection != null) {
+        }
+
+        if (currentAbstractIntrospection != null) {
             if (NameUtils.isGetterName(methodName) && element.getParameters().length == 0) {
                 final String propertyName = NameUtils.getPropertyNameForGetter(methodName);
                 final AbstractPropertyElement propertyElement = currentAbstractIntrospection.properties.computeIfAbsent(propertyName, s -> new AbstractPropertyElement(

--- a/inject/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
@@ -73,7 +73,9 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
 
     @Override
     public void visitClass(ClassElement element, VisitorContext context) {
+        // reset
         currentAbstractIntrospection = null;
+        lastConfigurationReader = null;
         if (!element.isPrivate()) {
             if (element.hasStereotype(Introspected.class)) {
                 final AnnotationValue<Introspected> introspected = element.getAnnotation(Introspected.class);
@@ -82,8 +84,10 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                 }
             } else if (element.hasStereotype(ConfigurationReader.class)) {
                 this.lastConfigurationReader = element;
-            } else {
-                this.lastConfigurationReader = null;
+                if (element.isAbstract()) {
+                    // add configuration advice
+                    element.annotate("io.micronaut.runtime.context.env.ConfigurationAdvice");
+                }
             }
         }
     }

--- a/runtime/src/main/java/io/micronaut/runtime/context/env/ConfigurationAdvice.java
+++ b/runtime/src/main/java/io/micronaut/runtime/context/env/ConfigurationAdvice.java
@@ -33,7 +33,7 @@ import java.lang.annotation.RetentionPolicy;
 @Introduction
 @Type(ConfigurationIntroductionAdvice.class)
 @Internal
-@interface ConfigurationAdvice {
+public @interface ConfigurationAdvice {
     /**
      * @return Is the method call a bean lookup
      */

--- a/runtime/src/main/java/io/micronaut/runtime/context/env/ConfigurationAdvice.java
+++ b/runtime/src/main/java/io/micronaut/runtime/context/env/ConfigurationAdvice.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.runtime.context.env;
+
+import io.micronaut.aop.Introduction;
+import io.micronaut.context.annotation.Type;
+import io.micronaut.core.annotation.Internal;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Internal annotation that allows the definition on {@link io.micronaut.context.annotation.ConfigurationProperties}
+ * on interfaces.
+ *
+ * @author graemerocher
+ * @since 1.3.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Introduction
+@Type(ConfigurationIntroductionAdvice.class)
+@Internal
+@interface ConfigurationAdvice {
+    /**
+     * @return Is the method call a bean lookup
+     */
+    boolean bean() default false;
+
+    /**
+     * @return The property to lookup
+     */
+    String value() default "";
+}

--- a/runtime/src/main/java/io/micronaut/runtime/context/env/ConfigurationAdvice.java
+++ b/runtime/src/main/java/io/micronaut/runtime/context/env/ConfigurationAdvice.java
@@ -40,6 +40,11 @@ public @interface ConfigurationAdvice {
     boolean bean() default false;
 
     /**
+     * @return Is it annotated with {@link io.micronaut.context.annotation.EachProperty}
+     */
+    boolean iterable() default false;
+
+    /**
      * @return The property to lookup
      */
     String value() default "";

--- a/runtime/src/main/java/io/micronaut/runtime/context/env/ConfigurationIntroductionAdvice.java
+++ b/runtime/src/main/java/io/micronaut/runtime/context/env/ConfigurationIntroductionAdvice.java
@@ -1,0 +1,70 @@
+package io.micronaut.runtime.context.env;
+
+import io.micronaut.aop.MethodInterceptor;
+import io.micronaut.aop.MethodInvocationContext;
+import io.micronaut.context.BeanLocator;
+import io.micronaut.context.env.Environment;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.type.ReturnType;
+
+import javax.inject.Singleton;
+
+/**
+ * Internal interceptor that .
+ *
+ * @author graemerocher
+ * @since 1.3.0
+ */
+@Singleton
+@Internal
+class ConfigurationIntroductionAdvice implements MethodInterceptor<Object, Object> {
+    private final Environment environment;
+    private final BeanLocator beanLocator;
+
+    /**
+     * Default constructor.
+     * @param environment The environment
+     * @param beanLocator  The bean locator
+     */
+    ConfigurationIntroductionAdvice(Environment environment, BeanLocator beanLocator) {
+        this.environment = environment;
+        this.beanLocator = beanLocator;
+    }
+
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        final ReturnType<Object> rt = context.getReturnType();
+        final Class<Object> returnType = rt.getType();
+        if (context.isTrue(ConfigurationAdvice.class, "bean")) {
+            if (context.isNullable()) {
+                final Object v = beanLocator.findBean(returnType).orElse(null);
+                if (v != null) {
+                    return environment.convertRequired(v, returnType);
+                } else {
+                    return v;
+                }
+            } else {
+                return environment.convertRequired(
+                        beanLocator.getBean(returnType),
+                        returnType
+                );
+            }
+        } else {
+            final String property = context.stringValue(ConfigurationAdvice.class).orElse(null);
+            if (property == null) {
+                throw new IllegalStateException("No property name available to resolve");
+            }
+            if (context.isNullable()) {
+                return environment.getProperty(
+                        property,
+                        returnType
+                ).orElse(null);
+            } else {
+                return environment.getRequiredProperty(
+                        property,
+                        returnType
+                );
+            }
+        }
+    }
+}

--- a/src/main/docs/guide/config/immutableConfig.adoc
+++ b/src/main/docs/guide/config/immutableConfig.adoc
@@ -1,4 +1,23 @@
-Since 1.3, Micronaut supports the definition of immutable configuration by specifying the ann:context.annotation.ConfigurationInject[] annotation on a constructor of a ann:context.annotation.ConfigurationProperties[] or ann.context.annotation.EachProperty[] bean.
+Since 1.3, Micronaut supports the definition of immutable configuration.
+
+There are two ways to define immutable configuration. The preferred way is to define an interface that is annotated with ann:context.annotation.ConfigurationProperties[]. For example:
+
+snippet::io.micronaut.docs.config.itfce.EngineConfig[tags="imports,class",indent=0,title="@ConfigurationProperties Example"]
+
+<1> The ann:context.annotation.ConfigurationProperties[] annotation takes the configuration prefix and is declared on an interface
+<2> You can use ann:core.bind.annotation.Bindable[] to set a default value if you want
+<3> Validation annotations can be used too
+<4> You can also specify references to other ann:context.annotation.ConfigurationProperties[] beans.
+<5> You can nest immutable configuration
+<6> Optional configuration can be indicated by returning an `Optional` or specifying `@Nullable`
+
+In this case what Micronaut does is provide a compilation time produced implementation that delegates all getters to call the `getProperty(..)` method of the api:context.env.Environment[] interface.
+
+This has the advantage that is the configuration is refreshed then the injected interface will automatically see the new values.
+
+Note that if you try to specify any other method other than a getter a compilation error will occur.
+
+An alternative way to implement immutable configuration is to define a class and use the ann:context.annotation.ConfigurationInject[] annotation on a constructor of a ann:context.annotation.ConfigurationProperties[] or ann:context.annotation.EachProperty[] bean.
 
 An example of an immutable configuration class can be seen below:
 

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/config/itfce/Engine.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/config/itfce/Engine.groovy
@@ -1,0 +1,24 @@
+package io.micronaut.docs.config.itfce
+
+import javax.inject.Singleton
+
+@Singleton
+class Engine {
+    private final EngineConfig config
+
+    Engine(EngineConfig config) {// <1>
+        this.config = config
+    }
+
+    int getCylinders() {
+        return config.cylinders
+    }
+
+    String start() {// <2>
+        return "$config.manufacturer Engine Starting V$config.cylinders [rodLength=${config.crankShaft.rodLength.orElse(6.0d)}]"
+    }
+
+    final EngineConfig getConfig() {
+        return config
+    }
+}

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/config/itfce/EngineConfig.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/config/itfce/EngineConfig.groovy
@@ -1,0 +1,30 @@
+package io.micronaut.docs.config.itfce
+
+// tag::imports[]
+import io.micronaut.context.annotation.ConfigurationProperties
+import io.micronaut.core.bind.annotation.Bindable
+import javax.validation.constraints.*
+
+// end::imports[]
+
+// tag::class[]
+@ConfigurationProperties("my.engine") // <1>
+interface EngineConfig {
+
+    @Bindable(defaultValue = "Ford") // <2>
+    @NotBlank // <3>
+    String getManufacturer()
+
+    @Min(1L)
+    int getCylinders()
+
+    @NotNull
+    CrankShaft getCrankShaft() // <4>
+
+    @ConfigurationProperties("crank-shaft")
+    static interface CrankShaft { // <5>
+        Optional<Double> getRodLength() // <6>
+    }
+}
+// end::class[]
+

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/config/itfce/Vehicle.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/config/itfce/Vehicle.groovy
@@ -1,0 +1,21 @@
+package io.micronaut.docs.config.itfce
+
+import javax.inject.Singleton
+
+@Singleton
+class Vehicle {
+    Vehicle(Engine engine) {// <6>
+        this.engine = engine
+    }
+
+    String start() {
+        return engine.start()
+    }
+
+    final Engine getEngine() {
+        return engine
+    }
+
+    private final Engine engine
+}
+

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/config/itfce/VehicleSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/config/itfce/VehicleSpec.groovy
@@ -1,0 +1,42 @@
+package io.micronaut.docs.config.itfce
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.exceptions.BeanInstantiationException
+import io.micronaut.context.exceptions.DependencyInjectionException
+import spock.lang.Specification
+
+class VehicleSpec extends Specification {
+
+
+    void "test start vehicle"() {
+        given:
+        // tag::start[]
+        ApplicationContext applicationContext = ApplicationContext.run(
+                "my.engine.cylinders": "8",
+                "my.engine.crank-shaft.rod-length": "7.0"
+        )
+
+        Vehicle vehicle = applicationContext.getBean(Vehicle.class)
+        System.out.println(vehicle.start())
+        // end::start[]
+        expect:
+
+        vehicle.start() == "Ford Engine Starting V8 [rodLength=7.0]"
+        cleanup:
+        applicationContext.close()
+    }
+
+    void "test start with invalid valid"() {
+        when:
+        def context = ApplicationContext.run(
+                "my.engine.cylinders": "-10",
+                "my.engine.crank-shaft.rod-length": "7.0"
+        )
+        context.getBean(Vehicle)
+
+        then:
+        def e = thrown(BeanInstantiationException)
+        e.message.contains("EngineConfig.getCylinders - must be greater than or equal to 1")
+    }
+}
+

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/config/immutable/VehicleSpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/config/immutable/VehicleSpec.kt
@@ -3,7 +3,6 @@ package io.micronaut.docs.config.immutable
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.StringSpec
 import io.micronaut.context.ApplicationContext
-import io.micronaut.docs.config.properties.Vehicle
 
 class VehicleSpec: StringSpec({
 

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/config/itfce/Engine.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/config/itfce/Engine.kt
@@ -1,0 +1,14 @@
+package io.micronaut.docs.config.itfce
+
+import javax.inject.Singleton
+
+@Singleton
+class Engine(val config: EngineConfig)// <1>
+{
+    val cylinders: Int
+        get() = config.cylinders
+
+    fun start(): String {// <2>
+        return  "${config.manufacturer} Engine Starting V${config.cylinders} [rodLength=${config.crankShaft.rodLength.orElse(6.0)}]"
+    }
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/config/itfce/Engine.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/config/itfce/Engine.kt
@@ -9,6 +9,6 @@ class Engine(val config: EngineConfig)// <1>
         get() = config.cylinders
 
     fun start(): String {// <2>
-        return  "${config.manufacturer} Engine Starting V${config.cylinders} [rodLength=${config.crankShaft.rodLength.orElse(6.0)}]"
+        return  "${config.manufacturer} Engine Starting V${config.cylinders} [rodLength=${config.crankShaft.rodLength ?: 6.0}]"
     }
 }

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/config/itfce/EngineConfig.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/config/itfce/EngineConfig.kt
@@ -24,7 +24,7 @@ interface EngineConfig {
 
     @ConfigurationProperties("crank-shaft")
     interface CrankShaft { // <5>
-        val rodLength: Optional<Double> // <6>
+        val rodLength: Double? // <6>
     }
 }
 // end::class[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/config/itfce/EngineConfig.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/config/itfce/EngineConfig.kt
@@ -1,0 +1,31 @@
+package io.micronaut.docs.config.itfce
+
+// tag::imports[]
+import io.micronaut.context.annotation.ConfigurationProperties
+import io.micronaut.core.bind.annotation.Bindable
+import javax.validation.constraints.*
+import java.util.Optional
+
+// end::imports[]
+
+// tag::class[]
+@ConfigurationProperties("my.engine") // <1>
+interface EngineConfig {
+
+    @get:Bindable(defaultValue = "Ford") // <2>
+    @get:NotBlank // <3>
+    val manufacturer: String
+
+    @get:Min(1L)
+    val cylinders: Int
+
+    @get:NotNull
+    val crankShaft: CrankShaft // <4>
+
+    @ConfigurationProperties("crank-shaft")
+    interface CrankShaft { // <5>
+        val rodLength: Optional<Double> // <6>
+    }
+}
+// end::class[]
+

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/config/itfce/Vehicle.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/config/itfce/Vehicle.kt
@@ -1,0 +1,11 @@
+package io.micronaut.docs.config.itfce
+
+import javax.inject.Singleton
+
+@Singleton
+class Vehicle(val engine: Engine)// <6>
+{
+    fun start(): String {
+        return engine.start()
+    }
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/config/itfce/VehicleSpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/config/itfce/VehicleSpec.kt
@@ -6,6 +6,7 @@ import io.kotlintest.shouldBe
 import io.kotlintest.shouldThrow
 import io.kotlintest.specs.StringSpec
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.exceptions.BeanInstantiationException
 import io.micronaut.context.exceptions.DependencyInjectionException
 
 class VehicleSpec: StringSpec({
@@ -31,11 +32,10 @@ class VehicleSpec: StringSpec({
                 "my.engine.crank-shaft.rod-length" to "7.0"
         )
         val applicationContext = ApplicationContext.run(map)
-        val exception = shouldThrow<DependencyInjectionException> {
+        val exception = shouldThrow<BeanInstantiationException> {
             applicationContext.getBean(Vehicle::class.java)
         }
-        exception.cause.shouldNotBeNull()
-        exception.cause?.message.shouldContain("EngineConfig.getCylinders - must be greater than or equal to 1")
+        exception.message.shouldContain("EngineConfig.getCylinders - must be greater than or equal to 1")
 
     }
 })

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/config/itfce/VehicleSpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/config/itfce/VehicleSpec.kt
@@ -1,0 +1,41 @@
+package io.micronaut.docs.config.itfce
+
+import io.kotlintest.matchers.string.shouldContain
+import io.kotlintest.matchers.types.shouldNotBeNull
+import io.kotlintest.shouldBe
+import io.kotlintest.shouldThrow
+import io.kotlintest.specs.StringSpec
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.exceptions.DependencyInjectionException
+
+class VehicleSpec: StringSpec({
+
+    "test start vehicle" {
+        // tag::start[]
+        val map = mapOf(
+                "my.engine.cylinders" to "8",
+                "my.engine.crank-shaft.rod-length" to "7.0"
+        )
+        val applicationContext = ApplicationContext.run(map)
+
+        val vehicle = applicationContext.getBean(Vehicle::class.java)
+        // end::start[]
+
+        vehicle.start().shouldBe("Ford Engine Starting V8 [rodLength=7.0]")
+    }
+
+    "test start vehicle - invalid" {
+        // tag::start[]
+        val map = mapOf(
+                "my.engine.cylinders" to "-10",
+                "my.engine.crank-shaft.rod-length" to "7.0"
+        )
+        val applicationContext = ApplicationContext.run(map)
+        val exception = shouldThrow<DependencyInjectionException> {
+            applicationContext.getBean(Vehicle::class.java)
+        }
+        exception.cause.shouldNotBeNull()
+        exception.cause?.message.shouldContain("EngineConfig.getCylinders - must be greater than or equal to 1")
+
+    }
+})

--- a/test-suite/src/test/java/io/micronaut/docs/config/itfce/Engine.java
+++ b/test-suite/src/test/java/io/micronaut/docs/config/itfce/Engine.java
@@ -1,0 +1,25 @@
+package io.micronaut.docs.config.itfce;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class Engine {
+    private final EngineConfig config;
+
+    public Engine(EngineConfig config) {// <1>
+        this.config = config;
+    }
+
+    public int getCylinders() {
+        return config.getCylinders();
+    }
+
+    public String start() {// <2>
+        return getConfig().getManufacturer() + " Engine Starting V" + getConfig().getCylinders() +
+                " [rodLength=" + getConfig().getCrankShaft().getRodLength().orElse(6.0d) + "]";
+    }
+
+    public final EngineConfig getConfig() {
+        return config;
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/docs/config/itfce/EngineConfig.java
+++ b/test-suite/src/test/java/io/micronaut/docs/config/itfce/EngineConfig.java
@@ -1,0 +1,30 @@
+package io.micronaut.docs.config.itfce;
+
+// tag::imports[]
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.bind.annotation.Bindable;
+import javax.validation.constraints.*;
+import java.util.Optional;
+// end::imports[]
+
+// tag::class[]
+@ConfigurationProperties("my.engine") // <1>
+public interface EngineConfig {
+
+    @Bindable(defaultValue = "Ford") // <2>
+    @NotBlank // <3>
+    String getManufacturer();
+
+    @Min(1L)
+    int getCylinders();
+
+    @NotNull
+    CrankShaft getCrankShaft(); // <4>
+
+    @ConfigurationProperties("crank-shaft")
+    interface CrankShaft { // <5>
+        Optional<Double> getRodLength(); // <6>
+    }
+}
+// end::class[]
+

--- a/test-suite/src/test/java/io/micronaut/docs/config/itfce/Vehicle.java
+++ b/test-suite/src/test/java/io/micronaut/docs/config/itfce/Vehicle.java
@@ -1,0 +1,20 @@
+package io.micronaut.docs.config.itfce;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class Vehicle {
+    public Vehicle(Engine engine) {// <6>
+        this.engine = engine;
+    }
+
+    public String start() {
+        return engine.start();
+    }
+
+    public final Engine getEngine() {
+        return engine;
+    }
+
+    private final Engine engine;
+}

--- a/test-suite/src/test/java/io/micronaut/docs/config/itfce/VehicleSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/config/itfce/VehicleSpec.java
@@ -1,0 +1,48 @@
+package io.micronaut.docs.config.itfce;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.exceptions.BeanInstantiationException;
+import io.micronaut.context.exceptions.DependencyInjectionException;
+import io.micronaut.core.util.CollectionUtils;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class VehicleSpec {
+
+    @Test
+    public void testStartVehicle() {
+        // tag::start[]
+        ApplicationContext applicationContext = ApplicationContext.run(CollectionUtils.mapOf(
+                "my.engine.cylinders", "8",
+                "my.engine.crank-shaft.rod-length", "7.0"
+        ));
+
+        Vehicle vehicle = applicationContext.getBean(Vehicle.class);
+        System.out.println(vehicle.start());
+        // end::start[]
+
+        assertEquals("Ford Engine Starting V8 [rodLength=7.0]", vehicle.start());
+        applicationContext.close();
+    }
+
+    @Test
+    public void testStartWithInvalidValue() {
+        ApplicationContext applicationContext = null;
+        try {
+            applicationContext = ApplicationContext.run(CollectionUtils.mapOf(
+                    "my.engine.cylinders", "-10",
+                    "my.engine.crank-shaft.rod-length", "7.0"
+            ));
+
+            Vehicle vehicle = applicationContext.getBean(Vehicle.class);
+            fail("Should have failed with a validation error");
+        } catch (BeanInstantiationException e) {
+            assertTrue(
+                    e.getMessage().contains("EngineConfig.getCylinders - must be greater than or equal to 1")
+            );
+
+        }
+    }
+}
+

--- a/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java
@@ -1381,7 +1381,7 @@ public class DefaultValidator implements Validator, ExecutableMethodValidator, R
             for (AnnotationValue<? extends Annotation> annotationValue : annotationValues) {
                 final Class<?>[] classValues = annotationValue.classValues("groups");
                 if (ArrayUtils.isEmpty(classValues)) {
-                    if (context.groups == DEFAULT_GROUPS) {
+                    if (context.groups == DEFAULT_GROUPS || group == Default.class) {
                         constraints.add(annotationValue);
                     }
                 } else {


### PR DESCRIPTION
Whilst working on the support for immutable configuration properties it seemed to me it would be much nicer to simply allow `@ConfigurationProperties` to be defined for interfaces. It is less verbose for Java, Groovy and Kotlin. This PR adds support for that. I need to think if we can support `@EachProperty` but this is start.