### PR TITLE
Use Argument constants where possible instead of class

### DIFF
--- a/core/src/main/java/io/micronaut/core/convert/ConversionContext.java
+++ b/core/src/main/java/io/micronaut/core/convert/ConversionContext.java
@@ -42,6 +42,31 @@ public interface ConversionContext extends AnnotationMetadataProvider, TypeVaria
     };
 
     /**
+     * Constant for Boolean argument.
+     */
+    ArgumentConversionContext<Boolean> BOOLEAN = ConversionContext.of(Argument.BOOLEAN);
+
+    /**
+     * Constant for Integer argument.
+     */
+    ArgumentConversionContext<Integer> INT = ConversionContext.of(Argument.INT);
+
+    /**
+     * Constant for Long argument.
+     */
+    ArgumentConversionContext<Long> LONG = ConversionContext.of(Argument.LONG);
+
+    /**
+     * Constant for String argument.
+     */
+    ArgumentConversionContext<String> STRING = ConversionContext.of(Argument.STRING);
+
+    /**
+     * Constant for List<String> argument.
+     */
+    ArgumentConversionContext<List<String>> LIST_OF_STRING = ConversionContext.of(Argument.LIST_OF_STRING);
+
+    /**
      * In the case where the type to be converted contains generic type arguments this map will return
      * the concrete types of those arguments. For example for the {@link Map} type two keys will be present
      * called 'K' and 'V' with the actual types of the key and value.

--- a/core/src/main/java/io/micronaut/core/convert/DefaultArgumentConversionContext.java
+++ b/core/src/main/java/io/micronaut/core/convert/DefaultArgumentConversionContext.java
@@ -19,13 +19,7 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.type.Argument;
 
 import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 /**
  * Default implementation of the {@link ConversionContext} interface.
@@ -112,6 +106,25 @@ class DefaultArgumentConversionContext<T> implements ArgumentConversionContext<T
     @Override
     public Argument<T> getArgument() {
         return argument;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DefaultArgumentConversionContext<?> that = (DefaultArgumentConversionContext<?>) o;
+        return Objects.equals(getArgument(), that.getArgument()) &&
+            Objects.equals(finalLocale, that.finalLocale) &&
+            Objects.equals(finalCharset, that.finalCharset);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(argument, finalLocale, finalCharset);
     }
 
     @Override

--- a/core/src/main/java/io/micronaut/core/convert/value/ConvertibleMultiValues.java
+++ b/core/src/main/java/io/micronaut/core/convert/value/ConvertibleMultiValues.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.core.convert.value;
 
+import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.ConversionContext;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.reflect.GenericTypeUtils;
@@ -166,6 +167,22 @@ public interface ConvertibleMultiValues<V> extends ConvertibleValues<List<V>> {
         V v = get(name);
         if (v != null) {
             return ConversionService.SHARED.convert(v, ConversionContext.of(requiredType));
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Find a header and convert it to the given type.
+     *
+     * @param name              The name of the header
+     * @param conversionContext The conversion context
+     * @param <T>               The generic type
+     * @return If the header is presented and can be converted an optional of the value otherwise {@link Optional#empty()}
+     */
+    default <T> Optional<T> getFirst(CharSequence name, ArgumentConversionContext<T> conversionContext) {
+        V v = get(name);
+        if (v != null) {
+            return ConversionService.SHARED.convert(v, conversionContext);
         }
         return Optional.empty();
     }

--- a/core/src/main/java/io/micronaut/core/convert/value/ConvertibleValues.java
+++ b/core/src/main/java/io/micronaut/core/convert/value/ConvertibleValues.java
@@ -70,7 +70,7 @@ public interface ConvertibleValues<V> extends ValueResolver<CharSequence>, Itera
      * @return True if it is
      */
     default boolean contains(String name) {
-        return get(name, Object.class).isPresent();
+        return get(name, Argument.OBJECT_ARGUMENT).isPresent();
     }
 
     /**

--- a/core/src/main/java/io/micronaut/core/type/Argument.java
+++ b/core/src/main/java/io/micronaut/core/type/Argument.java
@@ -41,58 +41,63 @@ import java.util.stream.Collectors;
 public interface Argument<T> extends TypeVariableResolver, AnnotatedElement, Type {
 
     /**
+     * Constant for string argument.
+     */
+    Argument<String> STRING = Argument.of(String.class);
+
+    /**
      * Constant for int argument. Used by generated code, do not remove.
      */
     @SuppressWarnings("unused")
-    Argument INT = Argument.of(int.class);
+    Argument<Integer> INT = Argument.of(int.class);
 
     /**
      * Constant for long argument. Used by generated code, do not remove.
      */
     @SuppressWarnings("unused")
-    Argument LONG = Argument.of(long.class);
+    Argument<Long> LONG = Argument.of(long.class);
 
     /**
      * Constant for float argument. Used by generated code, do not remove.
      */
     @SuppressWarnings("unused")
-    Argument FLOAT = Argument.of(float.class);
+    Argument<Float> FLOAT = Argument.of(float.class);
 
     /**
      * Constant for double argument. Used by generated code, do not remove.
      */
     @SuppressWarnings("unused")
-    Argument DOUBLE = Argument.of(double.class);
+    Argument<Double> DOUBLE = Argument.of(double.class);
 
     /**
      * Constant for void argument. Used by generated code, do not remove.
      */
     @SuppressWarnings("unused")
-    Argument VOID = Argument.of(void.class);
+    Argument<Void> VOID = Argument.of(void.class);
 
     /**
      * Constant for byte argument. Used by generated code, do not remove.
      */
     @SuppressWarnings("unused")
-    Argument BYTE = Argument.of(byte.class);
+    Argument<Byte> BYTE = Argument.of(byte.class);
 
     /**
      * Constant for boolean argument. Used by generated code, do not remove.
      */
     @SuppressWarnings("unused")
-    Argument BOOLEAN = Argument.of(boolean.class);
+    Argument<Boolean> BOOLEAN = Argument.of(boolean.class);
 
     /**
      * Constant char argument. Used by generated code, do not remove.
      */
     @SuppressWarnings("unused")
-    Argument CHAR = Argument.of(char.class);
+    Argument<Character> CHAR = Argument.of(char.class);
 
     /**
      * Constant short argument. Used by generated code, do not remove.
      */
     @SuppressWarnings("unused")
-    Argument SHORT = Argument.of(short.class);
+    Argument<Short> SHORT = Argument.of(short.class);
 
     /**
      * Constant representing zero arguments. Used by generated code, do not remove.
@@ -106,6 +111,11 @@ public interface Argument<T> extends TypeVariableResolver, AnnotatedElement, Typ
      */
     @SuppressWarnings("unused")
     Argument<Object> OBJECT_ARGUMENT = of(Object.class);
+
+    /**
+     * Constant for List<String> argument.
+     */
+    Argument<List<String>> LIST_OF_STRING = Argument.listOf(String.class);
 
     /**
      * @return The name of the argument

--- a/core/src/main/java/io/micronaut/core/type/DefaultArgument.java
+++ b/core/src/main/java/io/micronaut/core/type/DefaultArgument.java
@@ -47,11 +47,7 @@ public class DefaultArgument<T> implements Argument<T> {
      * @param genericTypes       The generic types
      */
     public DefaultArgument(Class<T> type, String name, AnnotationMetadata annotationMetadata, Argument... genericTypes) {
-        this.type = type;
-        this.name = name;
-        this.annotationMetadata = annotationMetadata != null ? annotationMetadata : AnnotationMetadata.EMPTY_METADATA;
-        this.typeParameters = initializeTypeParameters(genericTypes);
-        this.typeParameterArray = genericTypes;
+        this(type, name, annotationMetadata, initializeTypeParameters(genericTypes), genericTypes);
     }
 
     /**
@@ -184,7 +180,7 @@ public class DefaultArgument<T> implements Argument<T> {
         return Objects.hash(type, name, typeParameters);
     }
 
-    private Map<String, Argument<?>> initializeTypeParameters(Argument[] genericTypes) {
+    private static Map<String, Argument<?>> initializeTypeParameters(Argument[] genericTypes) {
         Map<String, Argument<?>> typeParameters;
         if (genericTypes != null && genericTypes.length > 0) {
             typeParameters = new LinkedHashMap<>(genericTypes.length);

--- a/http-client/src/main/java/io/micronaut/http/client/exceptions/HttpClientErrorDecoder.java
+++ b/http-client/src/main/java/io/micronaut/http/client/exceptions/HttpClientErrorDecoder.java
@@ -71,7 +71,7 @@ public interface HttpClientErrorDecoder {
         } else if (mediaType.equals(MediaType.APPLICATION_VND_ERROR_TYPE)) {
             return Argument.of(VndError.class);
         } else {
-            return Argument.of(String.class);
+            return Argument.STRING;
         }
     }
 }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
@@ -141,6 +141,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
     private static final Logger LOG = LoggerFactory.getLogger(RoutingInBoundHandler.class);
     private static final Pattern IGNORABLE_ERROR_MESSAGE = Pattern.compile(
             "^.*(?:connection.*(?:reset|closed|abort|broken)|broken.*pipe).*$", Pattern.CASE_INSENSITIVE);
+    private static final Argument ARGUMENT_PART_DATA = Argument.of(PartData.class);
 
     private final Router router;
     private final ExecutorSelector executorSelector;
@@ -769,7 +770,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
                                 Argument typeVariable;
 
                                 if (StreamingFileUpload.class.isAssignableFrom(argument.getType())) {
-                                    typeVariable = Argument.of(PartData.class);
+                                    typeVariable = ARGUMENT_PART_DATA;
                                 } else {
                                     typeVariable = argument.getFirstTypeVariable().orElse(Argument.OBJECT_ARGUMENT);
                                 }
@@ -784,7 +785,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
                                 if (Publishers.isConvertibleToPublisher(typeVariableType)) {
                                     boolean streamingFileUpload = StreamingFileUpload.class.isAssignableFrom(typeVariableType);
                                     if (streamingFileUpload) {
-                                        typeVariable = Argument.of(PartData.class);
+                                        typeVariable = ARGUMENT_PART_DATA;
                                     } else {
                                         typeVariable = typeVariable.getFirstTypeVariable().orElse(Argument.OBJECT_ARGUMENT);
                                     }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/CompletableFutureBodyBinder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/CompletableFutureBodyBinder.java
@@ -49,6 +49,8 @@ import java.util.concurrent.CompletableFuture;
 public class CompletableFutureBodyBinder extends DefaultBodyAnnotationBinder<CompletableFuture>
     implements NonBlockingBodyArgumentBinder<CompletableFuture> {
 
+    private static final Argument<CompletableFuture> TYPE = Argument.of(CompletableFuture.class);
+
     private final BeanLocator beanLocator;
     private final HttpServerConfiguration httpServerConfiguration;
 
@@ -65,7 +67,7 @@ public class CompletableFutureBodyBinder extends DefaultBodyAnnotationBinder<Com
 
     @Override
     public Argument<CompletableFuture> argumentType() {
-        return Argument.of(CompletableFuture.class);
+        return TYPE;
     }
 
     @Override

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/PublisherBodyBinder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/PublisherBodyBinder.java
@@ -54,6 +54,7 @@ import java.util.Optional;
 public class PublisherBodyBinder extends DefaultBodyAnnotationBinder<Publisher> implements NonBlockingBodyArgumentBinder<Publisher> {
 
     private static final Logger LOG = LoggerFactory.getLogger(NettyHttpServer.class);
+    private static final Argument<Publisher> TYPE = Argument.of(Publisher.class);
 
     private final BeanLocator beanLocator;
     private final HttpServerConfiguration httpServerConfiguration;
@@ -71,7 +72,7 @@ public class PublisherBodyBinder extends DefaultBodyAnnotationBinder<Publisher> 
 
     @Override
     public Argument<Publisher> argumentType() {
-        return Argument.of(Publisher.class);
+        return TYPE;
     }
 
     @Override

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/cors/CorsFilterSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/cors/CorsFilterSpec.groovy
@@ -15,6 +15,7 @@
  */
 package io.micronaut.http.server.netty.cors
 
+import io.micronaut.core.convert.ConversionContext
 import io.micronaut.core.type.Argument
 import io.micronaut.http.HttpHeaders
 import io.micronaut.http.HttpMethod
@@ -146,7 +147,7 @@ class CorsFilterSpec extends Specification {
         2 * headers.getOrigin() >> Optional.of('http://www.foo.com')
         1 * request.getMethod() >> HttpMethod.GET
         !result.isPresent()
-        0 * headers.get(ACCESS_CONTROL_REQUEST_HEADERS, Argument.of(List,String))
+        0 * headers.get(ACCESS_CONTROL_REQUEST_HEADERS, ConversionContext.of(Argument.of(List,String)))
     }
 
     void "test preflight handleRequest with disallowed header"() {
@@ -170,8 +171,8 @@ class CorsFilterSpec extends Specification {
 
         then: "the request is rejected because bar is not allowed"
         2 * headers.getOrigin() >> Optional.of('http://www.foo.com')
-        1 * headers.getFirst(ACCESS_CONTROL_REQUEST_METHOD, HttpMethod.class) >> Optional.of(HttpMethod.GET)
-        1 * headers.get(ACCESS_CONTROL_REQUEST_HEADERS, Argument.of(List,String)) >> ['foo', 'bar']
+        1 * headers.getFirst(ACCESS_CONTROL_REQUEST_METHOD, ConversionContext.of(HttpMethod.class)) >> Optional.of(HttpMethod.GET)
+        1 * headers.get(ACCESS_CONTROL_REQUEST_HEADERS, ConversionContext.of(Argument.of(List,String))) >> ['foo', 'bar']
         result.get().status == HttpStatus.FORBIDDEN
     }
 
@@ -196,8 +197,8 @@ class CorsFilterSpec extends Specification {
 
         then: "the request is successful"
         4 * headers.getOrigin() >> Optional.of('http://www.foo.com')
-        2 * headers.getFirst(ACCESS_CONTROL_REQUEST_METHOD, HttpMethod.class) >> Optional.of(HttpMethod.GET)
-        2 * headers.get(ACCESS_CONTROL_REQUEST_HEADERS, Argument.of(List,String)) >> Optional.of(['foo'])
+        2 * headers.getFirst(ACCESS_CONTROL_REQUEST_METHOD, ConversionContext.of(HttpMethod.class)) >> Optional.of(HttpMethod.GET)
+        2 * headers.get(ACCESS_CONTROL_REQUEST_HEADERS, ConversionContext.of(Argument.of(List,String))) >> Optional.of(['foo'])
         result.get().status == HttpStatus.OK
     }
 
@@ -274,8 +275,8 @@ class CorsFilterSpec extends Specification {
         HttpResponse response = corsHandler.handleRequest(request).get()
 
         then: "the response is not modified"
-        2 * headers.get(ACCESS_CONTROL_REQUEST_HEADERS, Argument.of(List,String)) >> Optional.of(['X-Header', 'Y-Header'])
-        1 * headers.getFirst(ACCESS_CONTROL_REQUEST_METHOD, HttpMethod.class) >> Optional.of(HttpMethod.GET)
+        2 * headers.get(ACCESS_CONTROL_REQUEST_HEADERS, ConversionContext.of(Argument.of(List,String))) >> Optional.of(['X-Header', 'Y-Header'])
+        1 * headers.getFirst(ACCESS_CONTROL_REQUEST_METHOD, ConversionContext.of(HttpMethod.class)) >> Optional.of(HttpMethod.GET)
         response.getHeaders().get(ACCESS_CONTROL_ALLOW_METHODS) == 'GET'
         response.getHeaders().get(ACCESS_CONTROL_ALLOW_ORIGIN) == 'http://www.foo.com' // The origin is echo'd
         response.getHeaders().get(VARY) == 'Origin' // The vary header is set
@@ -305,8 +306,8 @@ class CorsFilterSpec extends Specification {
         HttpResponse response = corsHandler.handleRequest(request).get()
 
         then: "the response is not modified"
-        2 * headers.get(ACCESS_CONTROL_REQUEST_HEADERS, Argument.of(List,String)) >> Optional.of(['X-Header', 'Y-Header'])
-        1 * headers.getFirst(ACCESS_CONTROL_REQUEST_METHOD, HttpMethod.class) >> Optional.of(HttpMethod.GET)
+        2 * headers.get(ACCESS_CONTROL_REQUEST_HEADERS, ConversionContext.of(Argument.of(List,String))) >> Optional.of(['X-Header', 'Y-Header'])
+        1 * headers.getFirst(ACCESS_CONTROL_REQUEST_METHOD, ConversionContext.of(HttpMethod.class)) >> Optional.of(HttpMethod.GET)
         response.getHeaders().get(ACCESS_CONTROL_ALLOW_METHODS) == 'GET'
         response.getHeaders().get(ACCESS_CONTROL_ALLOW_ORIGIN) == 'http://www.foo.com' // The origin is echo'd
         response.getHeaders().get(VARY) == 'Origin' // The vary header is set

--- a/http-server/src/main/java/io/micronaut/http/server/cors/CorsOriginConverter.java
+++ b/http-server/src/main/java/io/micronaut/http/server/cors/CorsOriginConverter.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.http.server.cors;
 
+import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.ConversionContext;
 import io.micronaut.core.convert.TypeConverter;
 import io.micronaut.core.convert.value.ConvertibleValues;
@@ -23,6 +24,7 @@ import io.micronaut.core.type.Argument;
 import io.micronaut.http.HttpMethod;
 
 import javax.inject.Singleton;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -43,6 +45,8 @@ public class CorsOriginConverter implements TypeConverter<Object, CorsOriginConf
     private static final String ALLOW_CREDENTIALS = "allowCredentials";
     private static final String MAX_AGE = "maxAge";
 
+    private static final ArgumentConversionContext<List<HttpMethod>> CONVERSION_CONTEXT_LIST_OF_HTTP_METHOD = ConversionContext.of(Argument.listOf(HttpMethod.class));
+
     @Override
     public Optional<CorsOriginConfiguration> convert(Object object, Class<CorsOriginConfiguration> targetType, ConversionContext context) {
         CorsOriginConfiguration configuration = new CorsOriginConfiguration();
@@ -51,27 +55,27 @@ public class CorsOriginConverter implements TypeConverter<Object, CorsOriginConf
             ConvertibleValues<Object> convertibleValues = new ConvertibleValuesMap<>(mapConfig);
 
             convertibleValues
-                .get(ALLOWED_ORIGINS, Argument.listOf(String.class))
+                .get(ALLOWED_ORIGINS, ConversionContext.LIST_OF_STRING)
                 .ifPresent(configuration::setAllowedOrigins);
 
             convertibleValues
-                .get(ALLOWED_METHODS, Argument.listOf(HttpMethod.class))
+                .get(ALLOWED_METHODS, CONVERSION_CONTEXT_LIST_OF_HTTP_METHOD)
                 .ifPresent(configuration::setAllowedMethods);
 
             convertibleValues
-                .get(ALLOWED_HEADERS, Argument.listOf(String.class))
+                .get(ALLOWED_HEADERS, ConversionContext.LIST_OF_STRING)
                 .ifPresent(configuration::setAllowedHeaders);
 
             convertibleValues
-                .get(EXPOSED_HEADERS, Argument.listOf(String.class))
+                .get(EXPOSED_HEADERS, ConversionContext.LIST_OF_STRING)
                 .ifPresent(configuration::setExposedHeaders);
 
             convertibleValues
-                .get(ALLOW_CREDENTIALS, Boolean.class)
+                .get(ALLOW_CREDENTIALS, ConversionContext.BOOLEAN)
                 .ifPresent(configuration::setAllowCredentials);
 
             convertibleValues
-                .get(MAX_AGE, Long.class)
+                .get(MAX_AGE, ConversionContext.LONG)
                 .ifPresent(configuration::setMaxAge);
         }
         return Optional.of(configuration);

--- a/http/src/main/java/io/micronaut/http/HttpHeaders.java
+++ b/http/src/main/java/io/micronaut/http/HttpHeaders.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.http;
 
+import io.micronaut.core.convert.ConversionContext;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.type.Headers;
 
@@ -470,7 +471,7 @@ public interface HttpHeaders extends Headers {
      * @return An {@link Optional} of {@link Integer}
      */
     default Optional<Integer> findInt(CharSequence name) {
-        return get(name, Integer.class);
+        return get(name, ConversionContext.INT);
     }
 
     /**
@@ -480,7 +481,7 @@ public interface HttpHeaders extends Headers {
      * @return The first value or null if it is present
      */
     default Optional<String> findFirst(CharSequence name) {
-        return getFirst(name, String.class);
+        return getFirst(name, ConversionContext.STRING);
     }
 
     /**
@@ -489,7 +490,7 @@ public interface HttpHeaders extends Headers {
      * @return The content type
      */
     default Optional<MediaType> contentType() {
-        return getFirst(HttpHeaders.CONTENT_TYPE, MediaType.class);
+        return getFirst(HttpHeaders.CONTENT_TYPE, MediaType.CONVERSION_CONTEXT);
     }
 
     /**
@@ -498,7 +499,7 @@ public interface HttpHeaders extends Headers {
      * @return The content type
      */
     default OptionalLong contentLength() {
-        Optional<Long> optional = getFirst(HttpHeaders.CONTENT_LENGTH, Long.class);
+        Optional<Long> optional = getFirst(HttpHeaders.CONTENT_LENGTH, ConversionContext.LONG);
         return optional.map(OptionalLong::of).orElseGet(OptionalLong::empty);
     }
 
@@ -511,7 +512,7 @@ public interface HttpHeaders extends Headers {
         return getAll(HttpHeaders.ACCEPT)
             .stream()
             .flatMap(x -> Arrays.stream(x.split(",")))
-            .flatMap(s -> ConversionService.SHARED.convert(s, MediaType.class).map(Stream::of).orElse(Stream.empty()))
+            .flatMap(s -> ConversionService.SHARED.convert(s, MediaType.CONVERSION_CONTEXT).map(Stream::of).orElse(Stream.empty()))
             .distinct()
             .collect(Collectors.toList());
     }
@@ -520,7 +521,7 @@ public interface HttpHeaders extends Headers {
      * @return Whether the {@link HttpHeaders#CONNECTION} header is set to Keep-Alive
      */
     default boolean isKeepAlive() {
-        return getFirst(CONNECTION, String.class).map(val -> val.equalsIgnoreCase("keep-alive")).orElse(false);
+        return getFirst(CONNECTION, ConversionContext.STRING).map(val -> val.equalsIgnoreCase("keep-alive")).orElse(false);
     }
 
     /**

--- a/http/src/main/java/io/micronaut/http/MediaType.java
+++ b/http/src/main/java/io/micronaut/http/MediaType.java
@@ -15,9 +15,13 @@
  */
 package io.micronaut.http;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.TypeHint;
+import io.micronaut.core.convert.ArgumentConversionContext;
+import io.micronaut.core.convert.ConversionContext;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.naming.NameUtils;
+import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.core.value.OptionalValues;
 import io.micronaut.http.annotation.Produces;
@@ -317,6 +321,12 @@ public class MediaType implements CharSequence {
      * Parameter {@code "v"}.
      */
     public static final String V_PARAMETER = "v";
+
+    @Internal
+    static final Argument<MediaType> ARGUMENT = Argument.of(MediaType.class);
+
+    @Internal
+    static final ArgumentConversionContext<MediaType> CONVERSION_CONTEXT = ConversionContext.of(ARGUMENT);
 
     private static final BigDecimal QUALITY_RATING_NUMBER = new BigDecimal("1.0");
     private static final String QUALITY_RATING = "1.0";

--- a/runtime/src/main/java/io/micronaut/cache/interceptor/CacheInterceptor.java
+++ b/runtime/src/main/java/io/micronaut/cache/interceptor/CacheInterceptor.java
@@ -259,7 +259,7 @@ public class CacheInterceptor implements MethodInterceptor<Object, Object> {
             Object[] params = resolveParams(context, cacheable.get(MEMBER_PARAMETERS, String[].class, StringUtils.EMPTY_STRING_ARRAY));
             Object key = keyGenerator.generateKey(context, params);
             CompletableFuture<Object> thisFuture = new CompletableFuture<>();
-            Argument<?> firstTypeVariable = returnTypeObject.getFirstTypeVariable().orElse(Argument.of(Object.class));
+            Argument<?> firstTypeVariable = returnTypeObject.getFirstTypeVariable().orElse(Argument.OBJECT_ARGUMENT);
             asyncCache.get(key, firstTypeVariable).whenComplete((BiConsumer<Optional<?>, Throwable>) (o, throwable) -> {
                 if (throwable == null && o.isPresent()) {
                     // cache hit, return result
@@ -503,7 +503,7 @@ public class CacheInterceptor implements MethodInterceptor<Object, Object> {
         CacheKeyGenerator keyGenerator = resolveKeyGenerator(cacheOperation.defaultKeyGenerator, cacheable);
         Object[] params = resolveParams(context, cacheable.get(MEMBER_PARAMETERS, String[].class, StringUtils.EMPTY_STRING_ARRAY));
         Object key = keyGenerator.generateKey(context, params);
-        Argument<?> firstTypeVariable = returnTypeObject.getFirstTypeVariable().orElse(Argument.of(Object.class));
+        Argument<?> firstTypeVariable = returnTypeObject.getFirstTypeVariable().orElse(Argument.OBJECT_ARGUMENT);
 
         Maybe<Object> maybe = Maybe.create(emitter -> {
             asyncCache.get(key, firstTypeVariable).whenComplete((opt, throwable) -> {

--- a/runtime/src/main/java/io/micronaut/scheduling/io/watch/FileWatchCondition.java
+++ b/runtime/src/main/java/io/micronaut/scheduling/io/watch/FileWatchCondition.java
@@ -20,7 +20,7 @@ import io.micronaut.context.BeanContext;
 import io.micronaut.context.condition.Condition;
 import io.micronaut.context.condition.ConditionContext;
 import io.micronaut.core.annotation.Introspected;
-import io.micronaut.core.type.Argument;
+import io.micronaut.core.convert.ConversionContext;
 import io.micronaut.core.util.CollectionUtils;
 
 import java.io.File;
@@ -40,7 +40,7 @@ public class FileWatchCondition implements Condition {
         if (beanContext instanceof ApplicationContext) {
             List<String> paths = ((ApplicationContext) beanContext)
                     .getEnvironment()
-                    .getProperty(FileWatchConfiguration.PATHS, Argument.listOf(String.class))
+                    .getProperty(FileWatchConfiguration.PATHS, ConversionContext.LIST_OF_STRING)
                     .orElse(null);
 
             if (CollectionUtils.isNotEmpty(paths)) {

--- a/session/src/main/java/io/micronaut/session/binder/SessionArgumentBinder.java
+++ b/session/src/main/java/io/micronaut/session/binder/SessionArgumentBinder.java
@@ -42,6 +42,8 @@ import java.util.Optional;
 @Requires(classes = HttpServerConfiguration.class)
 public class SessionArgumentBinder implements TypedRequestArgumentBinder<Session> {
 
+    private static final Argument<Session> TYPE = Argument.of(Session.class);
+
     private final SessionStore<Session> sessionStore;
 
     /**
@@ -55,7 +57,7 @@ public class SessionArgumentBinder implements TypedRequestArgumentBinder<Session
 
     @Override
     public Argument<Session> argumentType() {
-        return Argument.of(Session.class);
+        return TYPE;
     }
 
     @Override


### PR DESCRIPTION
Changes
-------
 * Added ArgumentConversionContext constants in ConversionContext
 * Replaced Argument.of and use of argument classes with
ConversionContext constants where possible
 * Added getFirst method in ConvertibleMultiValues that accepts
ArgumentConversionContent parameter

Partially addresses issue #2355