### PR TITLE
Apply VersionFilter to find the route by HTTP Method and URI logic

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
@@ -476,7 +476,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
 
             // if there is no route present try to locate a route that matches a different content type
             Set<MediaType> existingRouteConsumes = router
-                    .find(httpMethod, requestPath)
+                    .find(httpMethod, requestPath, request)
                     .map(UriRouteMatch::getRoute)
                     .flatMap(r -> r.getConsumes().stream())
                     .collect(Collectors.toSet());
@@ -502,7 +502,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
 
             // if there is no route present try to locate a route that matches a different HTTP method
             Set<io.micronaut.http.HttpMethod> existingRouteMethods = router
-                    .findAny(request.getUri().toString())
+                    .findAny(request.getUri().toString(), request)
                     .map(UriRouteMatch::getHttpMethod)
                     .collect(Collectors.toSet());
 

--- a/http-server-netty/src/test/groovy/io/micronaut/web/router/version/VersionControllerSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/web/router/version/VersionControllerSpec.groovy
@@ -46,7 +46,7 @@ class VersionControllerSpec extends Specification {
         httpClient.toBlocking()
     }
 
-    void "if I supply a wrong version, then response status should be BAD_REQUEST"() {
+    void "if I supply a wrong version, then response status should be NOT_FOUND"() {
         given:
         HttpRequest request = HttpRequest.GET("/versioned/hello").header("X-API-VERSION", "4")
 
@@ -59,7 +59,7 @@ class VersionControllerSpec extends Specification {
 
         then:
         HttpClientResponseException e = thrown()
-        e.response.status() == HttpStatus.BAD_REQUEST
+        e.response.status() == HttpStatus.NOT_FOUND
     }
 
     void "if I do not supply a version, and there are multiple versioned routes a DuplicateRouteException is thrown"() {

--- a/router/src/main/java/io/micronaut/web/router/DefaultRouter.java
+++ b/router/src/main/java/io/micronaut/web/router/DefaultRouter.java
@@ -24,6 +24,8 @@ import io.micronaut.http.MediaType;
 import io.micronaut.http.filter.HttpFilter;
 import io.micronaut.http.uri.UriMatchTemplate;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.net.URI;
@@ -158,6 +160,18 @@ public class DefaultRouter implements Router {
             .stream(routes)
             .map((route -> (UriRouteMatch<T, R>) route.match(uriString).orElse(null)))
             .filter(Objects::nonNull);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Nonnull
+    @Override
+    public <T, R> Stream<UriRouteMatch<T, R>> find(@Nonnull HttpMethod httpMethod, @Nonnull CharSequence uri, @Nullable HttpRequest<?> context) {
+        UriRoute[] routes = routesByMethod[httpMethod.ordinal()];
+        String uriString = uri.toString();
+        return Arrays
+                .stream(routes)
+                .map((route -> (UriRouteMatch<T, R>) route.match(uriString).orElse(null)))
+                .filter(Objects::nonNull);
     }
 
     @Override
@@ -317,6 +331,19 @@ public class DefaultRouter implements Router {
             .map(route -> route.match(uri.toString()))
             .filter(Optional::isPresent)
             .map(Optional::get);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Nonnull
+    @Override
+    public <T, R> Stream<UriRouteMatch<T, R>> findAny(@Nonnull CharSequence uri, @Nullable HttpRequest<?> context) {
+        return Arrays
+                .stream(routesByMethod)
+                .filter(Objects::nonNull)
+                .flatMap(Arrays::stream)
+                .map(route -> route.match(uri.toString()))
+                .filter(Optional::isPresent)
+                .map(Optional::get);
     }
 
     private UriRoute[] finalizeRoutes(List<UriRoute> routes) {

--- a/router/src/main/java/io/micronaut/web/router/Router.java
+++ b/router/src/main/java/io/micronaut/web/router/Router.java
@@ -21,6 +21,7 @@ import io.micronaut.http.HttpStatus;
 import io.micronaut.http.filter.HttpFilter;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.net.URI;
 import java.util.List;
 import java.util.Optional;
@@ -46,6 +47,17 @@ public interface Router {
     @Nonnull <T, R> Stream<UriRouteMatch<T, R>> findAny(@Nonnull CharSequence uri);
 
     /**
+     * Find any {@link RouteMatch} regardless of HTTP method.
+     *
+     * @param uri     The URI
+     * @param context The optional {@link HttpRequest} context information to apply {@link io.micronaut.web.router.filter.RouteMatchFilter}.
+     * @param <T>     The target type
+     * @param <R>     The return type
+     * @return A stream of route matches
+     */
+    @Nonnull <T, R> Stream<UriRouteMatch<T, R>> findAny(@Nonnull CharSequence uri, @Nullable HttpRequest<?> context);
+
+    /**
      * Finds all of the possible routes for the given HTTP method and URI.
      *
      * @param httpMethod The HTTP method
@@ -55,6 +67,18 @@ public interface Router {
      * @return A {@link Stream} of possible {@link Route} instances.
      */
     @Nonnull <T, R> Stream<UriRouteMatch<T, R>> find(@Nonnull HttpMethod httpMethod, @Nonnull CharSequence uri);
+
+    /**
+     * Finds all of the possible routes for the given HTTP method and URI.
+     *
+     * @param httpMethod The HTTP method
+     * @param uri        The URI route match
+     * @param context    The optional {@link HttpRequest} context information to apply {@link io.micronaut.web.router.filter.RouteMatchFilter}.
+     * @param <T>        The target type
+     * @param <R>        The type
+     * @return A {@link Stream} of possible {@link Route} instances.
+     */
+    @Nonnull <T, R> Stream<UriRouteMatch<T, R>> find(@Nonnull HttpMethod httpMethod, @Nonnull CharSequence uri, @Nullable HttpRequest<?> context);
 
     /**
      * Finds the closest match for the given request.

--- a/router/src/main/java/io/micronaut/web/router/filter/FilteredRouter.java
+++ b/router/src/main/java/io/micronaut/web/router/filter/FilteredRouter.java
@@ -25,6 +25,7 @@ import io.micronaut.web.router.UriRoute;
 import io.micronaut.web.router.UriRouteMatch;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.net.URI;
 import java.util.List;
 import java.util.Optional;
@@ -66,9 +67,29 @@ public class FilteredRouter implements Router {
         return router.findAny(uri);
     }
 
+    @Nonnull
+    @Override
+    public <T, R> Stream<UriRouteMatch<T, R>> findAny(@Nonnull CharSequence uri, @Nullable HttpRequest<?> context) {
+        final Stream<UriRouteMatch<T, R>> matchStream = router.findAny(uri);
+        if (context != null) {
+            return matchStream.filter(routeFilter.filter(context));
+        }
+        return matchStream;
+    }
+
     @Override
     public <T, R> Stream<UriRouteMatch<T, R>> find(HttpMethod httpMethod, CharSequence uri) {
         return router.find(httpMethod, uri);
+    }
+
+    @Nonnull
+    @Override
+    public <T, R> Stream<UriRouteMatch<T, R>> find(@Nonnull HttpMethod httpMethod, @Nonnull CharSequence uri, @Nullable HttpRequest<?> context) {
+        final Stream<UriRouteMatch<T, R>> matchStream = router.find(httpMethod, uri);
+        if (context != null) {
+            return matchStream.filter(routeFilter.filter(context));
+        }
+        return matchStream;
     }
 
     @Nonnull


### PR DESCRIPTION
Fixes #2305 and added new methods `findAny(uri, context)` and `find(httpMethod, requestPath, request)` methods to `Router.java` and implemented VersionFilter check in `FilteredRouter.java`.