### PR TITLE
Specialized UnsatisfiedRouteException

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/PublisherBodyBinder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/PublisherBodyBinder.java
@@ -120,7 +120,7 @@ public class PublisherBodyBinder extends DefaultBodyAnnotationBinder<Publisher> 
                                     if (LOG.isDebugEnabled()) {
                                         LOG.debug("Cannot convert message for argument [{}] and value: {}", context.getArgument(), message);
                                     }
-                                    subscriber.onError(new UnsatisfiedRouteException(context.getArgument()));
+                                    subscriber.onError(UnsatisfiedRouteException.create(context.getArgument()));
                                 }
                             } finally {
                                 s.cancel();

--- a/router/src/main/java/io/micronaut/web/router/AbstractRouteMatch.java
+++ b/router/src/main/java/io/micronaut/web/router/AbstractRouteMatch.java
@@ -275,7 +275,7 @@ abstract class AbstractRouteMatch<T, R> implements MethodBasedRouteMatch<T, R> {
                                 ConversionError conversionError = conversionErrors.iterator().next();
                                 throw new ConversionErrorException(argument, conversionError);
                             } else {
-                                throw new UnsatisfiedRouteException(argument);
+                                throw UnsatisfiedRouteException.create(argument);
                             }
                         }
 
@@ -283,7 +283,7 @@ abstract class AbstractRouteMatch<T, R> implements MethodBasedRouteMatch<T, R> {
                 } else if (value instanceof ConversionError) {
                     throw new ConversionErrorException(argument, (ConversionError) value);
                 } else if (value == DefaultRouteBuilder.NO_VALUE) {
-                    throw new UnsatisfiedRouteException(argument);
+                    throw UnsatisfiedRouteException.create(argument);
                 } else {
                     ConversionContext conversionContext = ConversionContext.of(argument);
                     Optional<?> result = conversionService.convert(value, argument.getType(), conversionContext);
@@ -355,7 +355,7 @@ abstract class AbstractRouteMatch<T, R> implements MethodBasedRouteMatch<T, R> {
                 return null;
             }
             throw lastError.map(conversionError ->
-                (RuntimeException) new ConversionErrorException(argument, conversionError)).orElseGet(() -> new UnsatisfiedRouteException(argument)
+                (RuntimeException) new ConversionErrorException(argument, conversionError)).orElseGet(() -> UnsatisfiedRouteException.create(argument)
             );
         } else {
             return result.get();

--- a/router/src/main/java/io/micronaut/web/router/exceptions/UnsatisfiedBodyRouteException.java
+++ b/router/src/main/java/io/micronaut/web/router/exceptions/UnsatisfiedBodyRouteException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.web.router.exceptions;
+
+import io.micronaut.core.type.Argument;
+
+/**
+ * An exception thrown when the an {@link io.micronaut.http.annotation.Body} to a {@link io.micronaut.web.router.Route} cannot be satisfied.
+ *
+ * @author Fabien Renaud
+ * @since 1.3.0
+ */
+public final class UnsatisfiedBodyRouteException extends UnsatisfiedRouteException {
+
+    private final String name;
+
+    /**
+     * @param name     The type and variable name of the Body
+     * @param argument The {@link Argument}
+     */
+    public UnsatisfiedBodyRouteException(String name, Argument<?> argument) {
+        super("Required Body [" + name + "] not specified", argument);
+        this.name = name;
+    }
+
+    /**
+     * @return The type and variable name of the Body
+     */
+    public String getBodyVariableName() {
+        return name;
+    }
+}

--- a/router/src/main/java/io/micronaut/web/router/exceptions/UnsatisfiedCookieValueRouteException.java
+++ b/router/src/main/java/io/micronaut/web/router/exceptions/UnsatisfiedCookieValueRouteException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.web.router.exceptions;
+
+import io.micronaut.core.type.Argument;
+
+/**
+ * An exception thrown when the an {@link io.micronaut.http.annotation.CookieValue} to a {@link io.micronaut.web.router.Route} cannot be satisfied.
+ *
+ * @author Fabien Renaud
+ * @since 1.3.0
+ */
+public final class UnsatisfiedCookieValueRouteException extends UnsatisfiedRouteException {
+
+    private final String name;
+
+    /**
+     * @param name     The name of the cookie
+     * @param argument The {@link Argument}
+     */
+    public UnsatisfiedCookieValueRouteException(String name, Argument<?> argument) {
+        super("Required CookieValue [" + name + "] not specified", argument);
+        this.name = name;
+    }
+
+    /**
+     * @return The name of the cookie
+     */
+    public String getCookieName() {
+        return name;
+    }
+}

--- a/router/src/main/java/io/micronaut/web/router/exceptions/UnsatisfiedHeaderRouteException.java
+++ b/router/src/main/java/io/micronaut/web/router/exceptions/UnsatisfiedHeaderRouteException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.web.router.exceptions;
+
+import io.micronaut.core.type.Argument;
+
+/**
+ * An exception thrown when the an {@link io.micronaut.http.annotation.Header} to a {@link io.micronaut.web.router.Route} cannot be satisfied.
+ *
+ * @author Fabien Renaud
+ * @since 1.3.0
+ */
+public final class UnsatisfiedHeaderRouteException extends UnsatisfiedRouteException {
+
+    private final String name;
+
+    /**
+     * @param name     The name of the header
+     * @param argument The {@link Argument}
+     */
+    public UnsatisfiedHeaderRouteException(String name, Argument<?> argument) {
+        super("Required Header [" + name + "] not specified", argument);
+        this.name = name;
+    }
+
+    /**
+     * @return The name of the header
+     */
+    public String getHeaderName() {
+        return name;
+    }
+}

--- a/router/src/main/java/io/micronaut/web/router/exceptions/UnsatisfiedPartRouteException.java
+++ b/router/src/main/java/io/micronaut/web/router/exceptions/UnsatisfiedPartRouteException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.web.router.exceptions;
+
+import io.micronaut.core.type.Argument;
+
+/**
+ * An exception thrown when the an {@link io.micronaut.http.annotation.Part} to a {@link io.micronaut.web.router.Route} cannot be satisfied.
+ *
+ * @author Fabien Renaud
+ * @since 1.3.0
+ */
+public final class UnsatisfiedPartRouteException extends UnsatisfiedRouteException {
+
+    private final String name;
+
+    /**
+     * @param name     The name of the part
+     * @param argument The {@link Argument}
+     */
+    public UnsatisfiedPartRouteException(String name, Argument<?> argument) {
+        super("Required Part [" + name + "] not specified", argument);
+        this.name = name;
+    }
+
+    /**
+     * @return The name of the part
+     */
+    public String getPartName() {
+        return name;
+    }
+}

--- a/router/src/main/java/io/micronaut/web/router/exceptions/UnsatisfiedPathVariableRouteException.java
+++ b/router/src/main/java/io/micronaut/web/router/exceptions/UnsatisfiedPathVariableRouteException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.web.router.exceptions;
+
+import io.micronaut.core.type.Argument;
+
+/**
+ * An exception thrown when the an {@link io.micronaut.http.annotation.PathVariable} to a {@link io.micronaut.web.router.Route} cannot be satisfied.
+ *
+ * @author Fabien Renaud
+ * @since 1.3.0
+ */
+public final class UnsatisfiedPathVariableRouteException extends UnsatisfiedRouteException {
+
+    private final String name;
+
+    /**
+     * @param name     The name of the path variable
+     * @param argument The {@link Argument}
+     */
+    public UnsatisfiedPathVariableRouteException(String name, Argument<?> argument) {
+        super("Required PathVariable [" + name + "] not specified", argument);
+        this.name = name;
+    }
+
+    /**
+     * @return The name of the path variable
+     */
+    public String getPathVariableName() {
+        return name;
+    }
+}

--- a/router/src/main/java/io/micronaut/web/router/exceptions/UnsatisfiedQueryValueRouteException.java
+++ b/router/src/main/java/io/micronaut/web/router/exceptions/UnsatisfiedQueryValueRouteException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.web.router.exceptions;
+
+import io.micronaut.core.type.Argument;
+
+/**
+ * An exception thrown when the an {@link io.micronaut.http.annotation.QueryValue} to a {@link io.micronaut.web.router.Route} cannot be satisfied.
+ *
+ * @author Fabien Renaud
+ * @since 1.3.0
+ */
+public final class UnsatisfiedQueryValueRouteException extends UnsatisfiedRouteException {
+
+    private final String name;
+
+    /**
+     * @param name     The name of the query parameter
+     * @param argument The {@link Argument}
+     */
+    public UnsatisfiedQueryValueRouteException(String name, Argument<?> argument) {
+        super("Required QueryValue [" + name + "] not specified", argument);
+        this.name = name;
+    }
+
+    /**
+     * @return The name of the query parameter
+     */
+    public String getQueryParameterName() {
+        return name;
+    }
+}

--- a/router/src/main/java/io/micronaut/web/router/exceptions/UnsatisfiedRequestAttributeRouteException.java
+++ b/router/src/main/java/io/micronaut/web/router/exceptions/UnsatisfiedRequestAttributeRouteException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.web.router.exceptions;
+
+import io.micronaut.core.type.Argument;
+
+/**
+ * An exception thrown when the an {@link io.micronaut.http.annotation.RequestAttribute} to a {@link io.micronaut.web.router.Route} cannot be satisfied.
+ *
+ * @author Fabien Renaud
+ * @since 1.3.0
+ */
+public final class UnsatisfiedRequestAttributeRouteException extends UnsatisfiedRouteException {
+
+    private final String name;
+
+    /**
+     * @param name     The name of the request attribute
+     * @param argument The {@link Argument}
+     */
+    public UnsatisfiedRequestAttributeRouteException(String name, Argument<?> argument) {
+        super("Required RequestAttribute [" + name + "] not specified", argument);
+        this.name = name;
+    }
+
+    /**
+     * @return The name of the request attribute
+     */
+    public String getRequestAttributeName() {
+        return name;
+    }
+}

--- a/router/src/main/java/io/micronaut/web/router/exceptions/UnsatisfiedRouteException.java
+++ b/router/src/main/java/io/micronaut/web/router/exceptions/UnsatisfiedRouteException.java
@@ -17,6 +17,7 @@ package io.micronaut.web.router.exceptions;
 
 import io.micronaut.core.bind.annotation.Bindable;
 import io.micronaut.core.type.Argument;
+import io.micronaut.http.annotation.*;
 
 import java.lang.annotation.Annotation;
 import java.util.Optional;
@@ -32,11 +33,48 @@ public class UnsatisfiedRouteException extends RoutingException {
     private final Argument<?> argument;
 
     /**
+     * @param message  The error message
      * @param argument The {@link Argument}
      */
-    public UnsatisfiedRouteException(Argument<?> argument) {
-        super(buildMessage(argument));
+    UnsatisfiedRouteException(String message, Argument<?> argument) {
+        super(message);
         this.argument = argument;
+    }
+
+    /**
+     * Creates a specialized UnsatisfiedRouteException given the provided argument.
+     *
+     * @param argument The {@link Argument}
+     * @return A UnsatisfiedRouteException
+     */
+    public static UnsatisfiedRouteException create(Argument<?> argument) {
+        Optional<Class<? extends Annotation>> classOptional = argument.getAnnotationMetadata().getAnnotationTypeByStereotype(Bindable.class);
+
+        if (classOptional.isPresent()) {
+            Class<? extends Annotation> clazz = classOptional.get();
+            Optional<Object> valOptional = argument.getAnnotationMetadata().getValue(clazz);
+            String name = valOptional.orElse(argument).toString();
+
+            if (clazz == Body.class) {
+                throw new UnsatisfiedBodyRouteException(name, argument);
+            } else if (clazz == QueryValue.class) {
+                throw new UnsatisfiedQueryValueRouteException(name, argument);
+            } else if (clazz == PathVariable.class) {
+                throw new UnsatisfiedPathVariableRouteException(name, argument);
+            } else if (clazz == Header.class) {
+                throw new UnsatisfiedHeaderRouteException(name, argument);
+            } else if (clazz == Part.class) {
+                throw new UnsatisfiedPartRouteException(name, argument);
+            } else if (clazz == RequestAttribute.class) {
+                throw new UnsatisfiedRequestAttributeRouteException(name, argument);
+            } else if (clazz == CookieValue.class) {
+                throw new UnsatisfiedCookieValueRouteException(name, argument);
+            } else {
+                throw new UnsatisfiedRouteException("Required " + clazz.getSimpleName() + " [" + name + "] not specified", argument);
+            }
+        }
+
+        throw new UnsatisfiedRouteException("Required argument [" + argument + "] not specified", argument);
     }
 
     /**
@@ -44,22 +82,5 @@ public class UnsatisfiedRouteException extends RoutingException {
      */
     public Argument<?> getArgument() {
         return argument;
-    }
-
-    private static String buildMessage(Argument<?> argument) {
-
-        Optional<Class<? extends Annotation>> classOptional = argument.getAnnotationMetadata().getAnnotationTypeByStereotype(Bindable.class);
-
-        if (classOptional.isPresent()) {
-            Class<? extends Annotation> clazz = classOptional.get();
-            Optional<Object> valOptional = argument.getAnnotationMetadata().getValue(clazz);
-            if (valOptional.isPresent()) {
-                return "Required " + clazz.getSimpleName() + " [" + valOptional.get().toString() + "] not specified";
-            } else {
-                return "Required " + clazz.getSimpleName() + " [" + argument + "] not specified";
-            }
-        }
-
-        return "Required argument [" + argument + "] not specified";
     }
 }


### PR DESCRIPTION
Each Bindable annotation defined under io.micronaut.http.annotation now
has a dedicated UnsatisfiedRouteException.

Resolves issue #2249

For 1.3.x