### PR TITLE
Use the compilation unit for retrieving classes

### DIFF
--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/TypeElementVisitorTransform.groovy
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/TypeElementVisitorTransform.groovy
@@ -15,6 +15,7 @@
  */
 package io.micronaut.ast.groovy
 
+import groovy.transform.CompilationUnitAware
 import groovy.transform.CompileStatic
 import groovy.transform.PackageScope
 import io.micronaut.aop.Introduction
@@ -39,6 +40,7 @@ import org.codehaus.groovy.ast.InnerClassNode
 import org.codehaus.groovy.ast.MethodNode
 import org.codehaus.groovy.ast.ModuleNode
 import org.codehaus.groovy.ast.PropertyNode
+import org.codehaus.groovy.control.CompilationUnit
 import org.codehaus.groovy.control.CompilePhase
 import org.codehaus.groovy.control.SourceUnit
 import org.codehaus.groovy.transform.ASTTransformation
@@ -58,9 +60,10 @@ import static org.codehaus.groovy.ast.ClassHelper.makeCached
 @CompileStatic
 // IMPORTANT NOTE: This transform runs in phase SEMANTIC_ANALYSIS so it runs before InjectTransform
 @GroovyASTTransformation(phase = CompilePhase.SEMANTIC_ANALYSIS)
-class TypeElementVisitorTransform implements ASTTransformation {
+class TypeElementVisitorTransform implements ASTTransformation, CompilationUnitAware {
 
     protected static Map<String, LoadedVisitor> loadedVisitors = null
+    private CompilationUnit compilationUnit
 
     @Override
     void visit(ASTNode[] nodes, SourceUnit source) {
@@ -69,19 +72,19 @@ class TypeElementVisitorTransform implements ASTTransformation {
 
         if (loadedVisitors == null) return
 
-        GroovyVisitorContext visitorContext = new GroovyVisitorContext(source)
+        GroovyVisitorContext visitorContext = new GroovyVisitorContext(source, compilationUnit)
         for (ClassNode classNode in classes) {
             if (!(classNode instanceof InnerClassNode && !Modifier.isStatic(classNode.getModifiers()))) {
                 Collection<LoadedVisitor> matchedVisitors = loadedVisitors.values().findAll { v -> v.matches(classNode) }
 
                 List<LoadedVisitor> values = new ArrayList<>(matchedVisitors)
                 OrderUtil.reverseSort(values)
-                def annotationMetadata = AstAnnotationUtils.getAnnotationMetadata(source, classNode)
+                def annotationMetadata = AstAnnotationUtils.getAnnotationMetadata(source, compilationUnit, classNode)
                 def isIntroduction = annotationMetadata.hasStereotype(Introduction.class)
-                def visitor = new ElementVisitor(source, classNode, values, visitorContext, !isIntroduction)
+                def visitor = new ElementVisitor(source, compilationUnit, classNode, values, visitorContext, !isIntroduction)
                 if (isIntroduction) {
                     visitor.visitClass(classNode)
-                    new PublicAbstractMethodVisitor(source) {
+                    new PublicAbstractMethodVisitor(source, compilationUnit) {
                         @Override
                         void accept(ClassNode cn, MethodNode methodNode) {
                             visitor.doVisitMethod(methodNode)
@@ -94,9 +97,15 @@ class TypeElementVisitorTransform implements ASTTransformation {
         }
     }
 
+    @Override
+    void setCompilationUnit(CompilationUnit unit) {
+        this.compilationUnit = unit
+    }
+
     private static class ElementVisitor extends ClassCodeVisitorSupport {
 
         final SourceUnit sourceUnit
+        final CompilationUnit compilationUnit
         final AnnotationMetadata annotationMetadata
         final GroovyVisitorContext visitorContext
         final boolean visitMethods
@@ -105,14 +114,16 @@ class TypeElementVisitorTransform implements ASTTransformation {
 
         ElementVisitor(
                 SourceUnit sourceUnit,
+                CompilationUnit compilationUnit,
                 ClassNode targetClassNode,
                 Collection<LoadedVisitor> typeElementVisitors,
                 GroovyVisitorContext visitorContext,
                 boolean visitMethods = true) {
+            this.compilationUnit = compilationUnit
             this.typeElementVisitors = typeElementVisitors
             this.concreteClass = targetClassNode
             this.sourceUnit = sourceUnit
-            this.annotationMetadata = AstAnnotationUtils.getAnnotationMetadata(sourceUnit, targetClassNode)
+            this.annotationMetadata = AstAnnotationUtils.getAnnotationMetadata(sourceUnit, compilationUnit, targetClassNode)
             this.visitorContext = visitorContext
             this.visitMethods = visitMethods
         }
@@ -123,7 +134,7 @@ class TypeElementVisitorTransform implements ASTTransformation {
 
         @Override
         void visitClass(ClassNode node) {
-            AnnotationMetadata annotationMetadata = AstAnnotationUtils.getAnnotationMetadata(sourceUnit, node)
+            AnnotationMetadata annotationMetadata = AstAnnotationUtils.getAnnotationMetadata(sourceUnit, compilationUnit, node)
             typeElementVisitors.each {
                 def element = it.visit(node, annotationMetadata, visitorContext)
                 if (element != null) {
@@ -154,7 +165,7 @@ class TypeElementVisitorTransform implements ASTTransformation {
         }
 
         void doVisitMethod(MethodNode methodNode) {
-            AnnotationMetadata methodAnnotationMetadata = AstAnnotationUtils.getAnnotationMetadata(sourceUnit, methodNode)
+            AnnotationMetadata methodAnnotationMetadata = AstAnnotationUtils.getAnnotationMetadata(sourceUnit, compilationUnit, methodNode)
             typeElementVisitors.findAll { it.matches(methodAnnotationMetadata) }.each {
                 def element = it.visit(methodNode, methodAnnotationMetadata, visitorContext)
                 if (element != null) {
@@ -173,7 +184,7 @@ class TypeElementVisitorTransform implements ASTTransformation {
             if (fieldNode.isSynthetic() && !isPackagePrivate(fieldNode, fieldNode.modifiers)) {
                 return
             }
-            AnnotationMetadata fieldAnnotationMetadata = AstAnnotationUtils.getAnnotationMetadata(sourceUnit, fieldNode)
+            AnnotationMetadata fieldAnnotationMetadata = AstAnnotationUtils.getAnnotationMetadata(sourceUnit, compilationUnit, fieldNode)
             typeElementVisitors.findAll { it.matches(fieldAnnotationMetadata) }.each {
                 def element = it.visit(fieldNode, fieldAnnotationMetadata, visitorContext)
                 if (element != null) {
@@ -190,7 +201,7 @@ class TypeElementVisitorTransform implements ASTTransformation {
             if (Modifier.isFinal(modifiers) || Modifier.isStatic(modifiers)) {
                 return
             }
-            AnnotationMetadata fieldAnnotationMetadata = AstAnnotationUtils.getAnnotationMetadata(sourceUnit, fieldNode)
+            AnnotationMetadata fieldAnnotationMetadata = AstAnnotationUtils.getAnnotationMetadata(sourceUnit, compilationUnit, fieldNode)
             typeElementVisitors.findAll { it.matches(fieldAnnotationMetadata) }.each {
                 def element = it.visit(fieldNode, fieldAnnotationMetadata, visitorContext)
                 if (element != null) {

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/annotation/GroovyAnnotationMetadataBuilder.groovy
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/annotation/GroovyAnnotationMetadataBuilder.groovy
@@ -44,6 +44,7 @@ import org.codehaus.groovy.ast.expr.PropertyExpression
 import org.codehaus.groovy.ast.stmt.ExpressionStatement
 import org.codehaus.groovy.ast.stmt.ReturnStatement
 import org.codehaus.groovy.ast.stmt.Statement
+import org.codehaus.groovy.control.CompilationUnit
 import org.codehaus.groovy.control.SourceUnit
 
 import javax.annotation.Nonnull
@@ -65,8 +66,10 @@ class GroovyAnnotationMetadataBuilder extends AbstractAnnotationMetadataBuilder<
 
     final SourceUnit sourceUnit
     final AnnotatedElementValidator elementValidator
+    final CompilationUnit compilationUnit
 
-    GroovyAnnotationMetadataBuilder(SourceUnit sourceUnit) {
+    GroovyAnnotationMetadataBuilder(SourceUnit sourceUnit, CompilationUnit compilationUnit) {
+        this.compilationUnit = compilationUnit
         this.sourceUnit = sourceUnit
         def ast = sourceUnit?.getAST()
         if (ast != null) {
@@ -123,7 +126,7 @@ class GroovyAnnotationMetadataBuilder extends AbstractAnnotationMetadataBuilder<
 
     @Override
     protected VisitorContext createVisitorContext() {
-        return new GroovyVisitorContext(sourceUnit)
+        return new GroovyVisitorContext(sourceUnit, compilationUnit)
     }
 
     @Override

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/utils/AstAnnotationUtils.groovy
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/utils/AstAnnotationUtils.groovy
@@ -27,6 +27,7 @@ import org.codehaus.groovy.ast.AnnotationNode
 import org.codehaus.groovy.ast.ClassNode
 import org.codehaus.groovy.ast.MethodNode
 import org.codehaus.groovy.ast.expr.Expression
+import org.codehaus.groovy.control.CompilationUnit
 import org.codehaus.groovy.control.SourceUnit
 
 import java.lang.annotation.Annotation
@@ -48,9 +49,9 @@ class AstAnnotationUtils {
      * @param annotatedNode The node
      * @return The metadata
      */
-    static AnnotationMetadata getAnnotationMetadata(SourceUnit sourceUnit, AnnotatedNode annotatedNode) {
+    static AnnotationMetadata getAnnotationMetadata(SourceUnit sourceUnit, CompilationUnit compilationUnit, AnnotatedNode annotatedNode) {
         return annotationMetadataCache.computeIfAbsent(annotatedNode, { AnnotatedNode annotatedNode1 ->
-            new GroovyAnnotationMetadataBuilder(sourceUnit).build(annotatedNode1)
+            new GroovyAnnotationMetadataBuilder(sourceUnit, compilationUnit).build(annotatedNode1)
         })
     }
 
@@ -62,8 +63,8 @@ class AstAnnotationUtils {
      * @param annotatedNode The node
      * @return The metadata
      */
-    static AnnotationMetadata getAnnotationMetadata(SourceUnit sourceUnit, AnnotatedNode parent, AnnotatedNode annotatedNode) {
-        new GroovyAnnotationMetadataBuilder(sourceUnit).buildForParent(parent, annotatedNode)
+    static AnnotationMetadata getAnnotationMetadata(SourceUnit sourceUnit, CompilationUnit compilationUnit, AnnotatedNode parent, AnnotatedNode annotatedNode) {
+        new GroovyAnnotationMetadataBuilder(sourceUnit, compilationUnit).buildForParent(parent, annotatedNode)
     }
 
 
@@ -75,8 +76,8 @@ class AstAnnotationUtils {
      * @param annotatedNode The node
      * @return The metadata
      */
-    static AnnotationMetadata getAnnotationMetadata(SourceUnit sourceUnit, AnnotatedNode parent, AnnotatedNode annotatedNode, boolean inheritTypeAnnotations) {
-        newBuilder(sourceUnit).buildForParent(parent, annotatedNode, inheritTypeAnnotations)
+    static AnnotationMetadata getAnnotationMetadata(SourceUnit sourceUnit, CompilationUnit compilationUnit, AnnotatedNode parent, AnnotatedNode annotatedNode, boolean inheritTypeAnnotations) {
+        newBuilder(sourceUnit, compilationUnit).buildForParent(parent, annotatedNode, inheritTypeAnnotations)
     }
 
     /**
@@ -84,8 +85,8 @@ class AstAnnotationUtils {
      * @param sourceUnit The unit
      * @return the builder
      */
-    static GroovyAnnotationMetadataBuilder newBuilder(SourceUnit sourceUnit) {
-        new GroovyAnnotationMetadataBuilder(sourceUnit)
+    static GroovyAnnotationMetadataBuilder newBuilder(SourceUnit sourceUnit, CompilationUnit compilationUnit) {
+        new GroovyAnnotationMetadataBuilder(sourceUnit, compilationUnit)
     }
 
     /**
@@ -112,8 +113,8 @@ class AstAnnotationUtils {
      * @param stereotype The stereotype
      * @return True if it does
      */
-    static boolean hasStereotype(SourceUnit sourceUnit, AnnotatedNode annotatedNode, String stereotype) {
-        return getAnnotationMetadata(sourceUnit, annotatedNode).hasStereotype(stereotype)
+    static boolean hasStereotype(SourceUnit sourceUnit, CompilationUnit compilationUnit, AnnotatedNode annotatedNode, String stereotype) {
+        return getAnnotationMetadata(sourceUnit, compilationUnit, annotatedNode).hasStereotype(stereotype)
     }
     /**
      * Return whether the given annotated node has the given stereotype
@@ -122,8 +123,8 @@ class AstAnnotationUtils {
      * @param stereotype The stereotype
      * @return True if it does
      */
-    static boolean hasStereotype(SourceUnit sourceUnit, AnnotatedNode annotatedNode, Class<? extends Annotation> stereotype) {
-        return hasStereotype(sourceUnit, annotatedNode, stereotype.getName())
+    static boolean hasStereotype(SourceUnit sourceUnit, CompilationUnit compilationUnit, AnnotatedNode annotatedNode, Class<? extends Annotation> stereotype) {
+        return hasStereotype(sourceUnit, compilationUnit, annotatedNode, stereotype.getName())
     }
 
     /**
@@ -133,11 +134,11 @@ class AstAnnotationUtils {
      * @param stereotypes The stereotypes
      * @return True if it is
      */
-    static boolean hasStereotype(SourceUnit sourceUnit, AnnotatedNode annotatedNode, List<String> stereotypes) {
+    static boolean hasStereotype(SourceUnit sourceUnit, CompilationUnit compilationUnit, AnnotatedNode annotatedNode, List<String> stereotypes) {
         if (annotatedNode == null) {
             return false
         }
-        AnnotationMetadata annotationMetadata = getAnnotationMetadata(sourceUnit, annotatedNode)
+        AnnotationMetadata annotationMetadata = getAnnotationMetadata(sourceUnit, compilationUnit, annotatedNode)
         for (String stereotype : stereotypes) {
             if (annotationMetadata.hasStereotype(stereotype)) {
                 return true

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/utils/PublicAbstractMethodVisitor.groovy
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/utils/PublicAbstractMethodVisitor.groovy
@@ -15,9 +15,11 @@
  */
 package io.micronaut.ast.groovy.utils
 
+import groovy.transform.CompilationUnitAware
 import groovy.transform.CompileStatic
 import org.codehaus.groovy.ast.ClassNode
 import org.codehaus.groovy.ast.MethodNode
+import org.codehaus.groovy.control.CompilationUnit
 import org.codehaus.groovy.control.SourceUnit
 
 /**
@@ -30,9 +32,15 @@ import org.codehaus.groovy.control.SourceUnit
 abstract class PublicAbstractMethodVisitor extends PublicMethodVisitor {
 
     ClassNode current
+    private final CompilationUnit compilationUnit
 
-    PublicAbstractMethodVisitor(SourceUnit sourceUnit) {
+    PublicAbstractMethodVisitor(SourceUnit sourceUnit, CompilationUnit compilationUnit) {
         super(sourceUnit)
+        this.compilationUnit = compilationUnit
+    }
+
+    CompilationUnit getCompilationUnit() {
+        compilationUnit
     }
 
     @Override

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/AbstractGroovyElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/AbstractGroovyElement.java
@@ -32,6 +32,7 @@ import io.micronaut.inject.ast.MemberElement;
 import org.codehaus.groovy.ast.AnnotatedNode;
 import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.GenericsType;
+import org.codehaus.groovy.control.CompilationUnit;
 import org.codehaus.groovy.control.SourceUnit;
 
 import javax.annotation.Nonnull;
@@ -51,16 +52,19 @@ import java.util.function.Consumer;
 public abstract class AbstractGroovyElement implements AnnotationMetadataDelegate, Element {
 
     protected final SourceUnit sourceUnit;
+    protected final CompilationUnit compilationUnit;
     private final AnnotatedNode annotatedNode;
     private AnnotationMetadata annotationMetadata;
 
     /**
      * Default constructor.
-     * @param sourceUnit The source unit
-     * @param annotatedNode The annotated node
+     * @param sourceUnit         The source unit
+     * @param compilationUnit    The compilation unit
+     * @param annotatedNode      The annotated node
      * @param annotationMetadata The annotation metadata
      */
-    public AbstractGroovyElement(SourceUnit sourceUnit, AnnotatedNode annotatedNode, AnnotationMetadata annotationMetadata) {
+    public AbstractGroovyElement(SourceUnit sourceUnit, CompilationUnit compilationUnit, AnnotatedNode annotatedNode, AnnotationMetadata annotationMetadata) {
+        this.compilationUnit = compilationUnit;
         this.annotatedNode = annotatedNode;
         this.annotationMetadata = annotationMetadata;
         this.sourceUnit = sourceUnit;
@@ -173,9 +177,10 @@ public abstract class AbstractGroovyElement implements AnnotationMetadataDelegat
                     genericsSpec = alignNewGenericsInfo(genericsTypes, redirectTypes, genericsSpec);
                     AnnotationMetadata annotationMetadata = AstAnnotationUtils.getAnnotationMetadata(
                             sourceUnit,
+                            compilationUnit,
                             type
                     );
-                    return new GroovyClassElement(sourceUnit, type, annotationMetadata, Collections.singletonMap(
+                    return new GroovyClassElement(sourceUnit, compilationUnit, type, annotationMetadata, Collections.singletonMap(
                             type.getName(),
                             genericsSpec
                     ));
@@ -193,8 +198,9 @@ public abstract class AbstractGroovyElement implements AnnotationMetadataDelegat
                 if (classNode.isGenericsPlaceHolder()) {
                     return resolveGenericType(sourceUnit, typeGenericInfo, classNode);
                 } else {
-                    return new GroovyClassElement(sourceUnit, classNode, AstAnnotationUtils.getAnnotationMetadata(
+                    return new GroovyClassElement(sourceUnit, compilationUnit, classNode, AstAnnotationUtils.getAnnotationMetadata(
                             sourceUnit,
+                            compilationUnit,
                             classNode
                     ));
                 }

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyClassElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyClassElement.java
@@ -30,6 +30,7 @@ import io.micronaut.inject.ast.MethodElement;
 import io.micronaut.inject.ast.PropertyElement;
 import org.codehaus.groovy.ast.*;
 import org.codehaus.groovy.ast.stmt.BlockStatement;
+import org.codehaus.groovy.control.CompilationUnit;
 import org.codehaus.groovy.control.SourceUnit;
 
 import javax.annotation.Nonnull;
@@ -52,21 +53,23 @@ public class GroovyClassElement extends AbstractGroovyElement implements ClassEl
 
     /**
      * @param sourceUnit         The source unit
+     * @param compilationUnit    The compilation unit
      * @param classNode          The {@link ClassNode}
      * @param annotationMetadata The annotation metadata
      */
-    GroovyClassElement(SourceUnit sourceUnit, ClassNode classNode, AnnotationMetadata annotationMetadata) {
-        this(sourceUnit, classNode, annotationMetadata, null);
+    GroovyClassElement(SourceUnit sourceUnit, CompilationUnit compilationUnit, ClassNode classNode, AnnotationMetadata annotationMetadata) {
+        this(sourceUnit, compilationUnit, classNode, annotationMetadata, null);
     }
 
     /**
      * @param sourceUnit         The source unit
+     * @param compilationUnit    The compilation unit
      * @param classNode          The {@link ClassNode}
      * @param annotationMetadata The annotation metadata
      * @param genericInfo        The generic info
      */
-    GroovyClassElement(SourceUnit sourceUnit, ClassNode classNode, AnnotationMetadata annotationMetadata, Map<String, Map<String, ClassNode>> genericInfo) {
-        super(sourceUnit, classNode, annotationMetadata);
+    GroovyClassElement(SourceUnit sourceUnit, CompilationUnit compilationUnit, ClassNode classNode, AnnotationMetadata annotationMetadata, Map<String, Map<String, ClassNode>> genericInfo) {
+        super(sourceUnit, compilationUnit, classNode, annotationMetadata);
         this.classNode = classNode;
         this.genericInfo = genericInfo;
     }
@@ -83,8 +86,9 @@ public class GroovyClassElement extends AbstractGroovyElement implements ClassEl
             return Optional.of(
                     new GroovyClassElement(
                             sourceUnit,
+                            compilationUnit,
                             superClass,
-                            AstAnnotationUtils.getAnnotationMetadata(sourceUnit, superClass)
+                            AstAnnotationUtils.getAnnotationMetadata(sourceUnit, compilationUnit, superClass)
                     )
             );
         }
@@ -95,8 +99,8 @@ public class GroovyClassElement extends AbstractGroovyElement implements ClassEl
     @Override
     public Optional<ConstructorElement> getPrimaryConstructor() {
         return Optional.ofNullable(findConcreteConstructor(classNode.getDeclaredConstructors())).map(constructorNode -> {
-            final AnnotationMetadata annotationMetadata = AstAnnotationUtils.getAnnotationMetadata(sourceUnit, constructorNode);
-            return new GroovyConstructorElement(this, sourceUnit, constructorNode, annotationMetadata);
+            final AnnotationMetadata annotationMetadata = AstAnnotationUtils.getAnnotationMetadata(sourceUnit, compilationUnit, constructorNode);
+            return new GroovyConstructorElement(this, sourceUnit, compilationUnit, constructorNode, annotationMetadata);
         });
     }
 
@@ -117,7 +121,7 @@ public class GroovyClassElement extends AbstractGroovyElement implements ClassEl
      */
     public Map<String, Map<String, ClassNode>> getGenericTypeInfo() {
         if (genericInfo == null) {
-            genericInfo = AstGenericUtils.buildAllGenericElementInfo(classNode, new GroovyVisitorContext(sourceUnit));
+            genericInfo = AstGenericUtils.buildAllGenericElementInfo(classNode, new GroovyVisitorContext(sourceUnit, compilationUnit));
         }
         return genericInfo;
     }
@@ -134,8 +138,9 @@ public class GroovyClassElement extends AbstractGroovyElement implements ClassEl
             for (Map.Entry<String, ClassNode> entry : forType.entrySet()) {
                 ClassNode classNode = entry.getValue();
 
-                ClassElement rawElement = new GroovyClassElement(sourceUnit, classNode, AstAnnotationUtils.getAnnotationMetadata(
+                ClassElement rawElement = new GroovyClassElement(sourceUnit, compilationUnit, classNode, AstAnnotationUtils.getAnnotationMetadata(
                         sourceUnit,
+                        compilationUnit,
                         classNode
                 ));
                 if (thisSpec != null) {
@@ -169,8 +174,9 @@ public class GroovyClassElement extends AbstractGroovyElement implements ClassEl
                     if (cn != null) {
                         typeArgumentMap.put(name, new GroovyClassElement(
                                 sourceUnit,
+                                compilationUnit,
                                 cn,
-                                AstAnnotationUtils.getAnnotationMetadata(sourceUnit, cn)
+                                AstAnnotationUtils.getAnnotationMetadata(sourceUnit, compilationUnit, cn)
                         ));
                     }
                 }
@@ -186,9 +192,9 @@ public class GroovyClassElement extends AbstractGroovyElement implements ClassEl
                 ClassNode cn = entry.getValue();
                 GroovyClassElement classElement;
                 if (cn.isEnum()) {
-                    classElement = new GroovyEnumElement(sourceUnit, cn, AstAnnotationUtils.getAnnotationMetadata(sourceUnit, cn));
+                    classElement = new GroovyEnumElement(sourceUnit, compilationUnit, cn, AstAnnotationUtils.getAnnotationMetadata(sourceUnit, compilationUnit, cn));
                 } else {
-                    classElement = new GroovyClassElement(sourceUnit, cn, AstAnnotationUtils.getAnnotationMetadata(sourceUnit, cn));
+                    classElement = new GroovyClassElement(sourceUnit, compilationUnit, cn, AstAnnotationUtils.getAnnotationMetadata(sourceUnit, compilationUnit, cn));
                 }
                 map.put(entry.getKey(), classElement);
             }
@@ -208,9 +214,10 @@ public class GroovyClassElement extends AbstractGroovyElement implements ClassEl
                 boolean readOnly = propertyNode.getField().isFinal();
                 GroovyPropertyElement groovyPropertyElement = new GroovyPropertyElement(
                         sourceUnit,
+                        compilationUnit,
                         this,
                         propertyNode.getField(),
-                        AstAnnotationUtils.getAnnotationMetadata(sourceUnit, propertyNode.getField()),
+                        AstAnnotationUtils.getAnnotationMetadata(sourceUnit, compilationUnit, propertyNode.getField()),
                         propertyNode.getName(),
                         readOnly,
                         propertyNode
@@ -219,8 +226,8 @@ public class GroovyClassElement extends AbstractGroovyElement implements ClassEl
                     @Override
                     public ClassElement getType() {
                         ClassNode type = propertyNode.getType();
-                        return new GroovyClassElement(sourceUnit, type,
-                                AstAnnotationUtils.getAnnotationMetadata(sourceUnit, type));
+                        return new GroovyClassElement(sourceUnit, compilationUnit, type,
+                                AstAnnotationUtils.getAnnotationMetadata(sourceUnit, compilationUnit, type));
                     }
                 };
                 propertyElements.add(groovyPropertyElement);
@@ -268,10 +275,10 @@ public class GroovyClassElement extends AbstractGroovyElement implements ClassEl
                                     if (classElement != null) {
                                         getterReturnType = classElement;
                                     } else {
-                                        getterReturnType = new GroovyClassElement(sourceUnit, returnTypeNode, AnnotationMetadata.EMPTY_METADATA);
+                                        getterReturnType = new GroovyClassElement(sourceUnit, compilationUnit, returnTypeNode, AnnotationMetadata.EMPTY_METADATA);
                                     }
                                 } else {
-                                    getterReturnType = new GroovyClassElement(sourceUnit, returnTypeNode, AnnotationMetadata.EMPTY_METADATA);
+                                    getterReturnType = new GroovyClassElement(sourceUnit, compilationUnit, returnTypeNode, AnnotationMetadata.EMPTY_METADATA);
                                 }
 
                                 GetterAndSetter getterAndSetter = props.computeIfAbsent(propertyName, GetterAndSetter::new);
@@ -280,7 +287,7 @@ public class GroovyClassElement extends AbstractGroovyElement implements ClassEl
                                 getterAndSetter.getter = node;
                                 if (getterAndSetter.setter != null) {
                                     ClassNode typeMirror = getterAndSetter.setter.getParameters()[0].getType();
-                                    ClassElement setterParameterType = new GroovyClassElement(sourceUnit, typeMirror, AnnotationMetadata.EMPTY_METADATA);
+                                    ClassElement setterParameterType = new GroovyClassElement(sourceUnit, compilationUnit, typeMirror, AnnotationMetadata.EMPTY_METADATA);
                                     if (!setterParameterType.getName().equals(getterReturnType.getName())) {
                                         getterAndSetter.setter = null; // not a compatible setter
                                     }
@@ -291,7 +298,7 @@ public class GroovyClassElement extends AbstractGroovyElement implements ClassEl
                                     return;
                                 }
                                 ClassNode typeMirror = node.getParameters()[0].getType();
-                                ClassElement setterParameterType = new GroovyClassElement(sourceUnit, typeMirror, AnnotationMetadata.EMPTY_METADATA);
+                                ClassElement setterParameterType = new GroovyClassElement(sourceUnit, compilationUnit, typeMirror, AnnotationMetadata.EMPTY_METADATA);
 
                                 GetterAndSetter getterAndSetter = props.computeIfAbsent(propertyName, GetterAndSetter::new);
                                 configureDeclaringType(declaringTypeElement, getterAndSetter);
@@ -310,8 +317,9 @@ public class GroovyClassElement extends AbstractGroovyElement implements ClassEl
                             if (beanPropertyData.declaringType == null && !GroovyClassElement.this.classNode.equals(declaringTypeElement)) {
                                 beanPropertyData.declaringType = new GroovyClassElement(
                                         sourceUnit,
+                                        compilationUnit,
                                         declaringTypeElement,
-                                        AstAnnotationUtils.getAnnotationMetadata(sourceUnit, declaringTypeElement)
+                                        AstAnnotationUtils.getAnnotationMetadata(sourceUnit, compilationUnit, declaringTypeElement)
                                 );
                             }
                         }
@@ -326,15 +334,16 @@ public class GroovyClassElement extends AbstractGroovyElement implements ClassEl
                 if (value.getter != null) {
 
                     final AnnotationMetadata annotationMetadata;
-                    final GroovyAnnotationMetadataBuilder groovyAnnotationMetadataBuilder = new GroovyAnnotationMetadataBuilder(sourceUnit);
+                    final GroovyAnnotationMetadataBuilder groovyAnnotationMetadataBuilder = new GroovyAnnotationMetadataBuilder(sourceUnit, compilationUnit);
                     final FieldNode field = this.classNode.getField(propertyName);
                     if (field != null) {
-                        annotationMetadata = AstAnnotationUtils.getAnnotationMetadata(sourceUnit, field, value.getter);
+                        annotationMetadata = AstAnnotationUtils.getAnnotationMetadata(sourceUnit, compilationUnit, field, value.getter);
                     } else {
                         annotationMetadata = groovyAnnotationMetadataBuilder.buildForMethod(value.getter);
                     }
                     GroovyPropertyElement propertyElement = new GroovyPropertyElement(
                             sourceUnit,
+                            compilationUnit,
                             value.declaringType == null ? this : value.declaringType,
                             value.getter,
                             annotationMetadata,
@@ -347,6 +356,7 @@ public class GroovyClassElement extends AbstractGroovyElement implements ClassEl
                                 return Optional.of(new GroovyMethodElement(
                                         thisElement,
                                         sourceUnit,
+                                        compilationUnit,
                                         value.setter,
                                         groovyAnnotationMetadataBuilder.buildForMethod(value.setter)
                                 ));
@@ -362,7 +372,7 @@ public class GroovyClassElement extends AbstractGroovyElement implements ClassEl
 
                         @Override
                         public Optional<MethodElement> getReadMethod() {
-                            return Optional.of(new GroovyMethodElement(thisElement, sourceUnit, value.getter, annotationMetadata));
+                            return Optional.of(new GroovyMethodElement(thisElement, sourceUnit, compilationUnit, value.getter, annotationMetadata));
                         }
                     };
                     propertyElements.add(propertyElement);

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyConstructorElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyConstructorElement.java
@@ -18,6 +18,7 @@ package io.micronaut.ast.groovy.visitor;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.inject.ast.ConstructorElement;
 import org.codehaus.groovy.ast.ConstructorNode;
+import org.codehaus.groovy.control.CompilationUnit;
 import org.codehaus.groovy.control.SourceUnit;
 
 /**
@@ -30,10 +31,11 @@ public class GroovyConstructorElement extends GroovyMethodElement implements Con
     /**
      * @param declaringClass     The declaring class
      * @param sourceUnit         The source unit
+     * @param compilationUnit    The compilation unit
      * @param methodNode         The {@link ConstructorNode}
      * @param annotationMetadata The annotation metadata
      */
-    GroovyConstructorElement(GroovyClassElement declaringClass, SourceUnit sourceUnit, ConstructorNode methodNode, AnnotationMetadata annotationMetadata) {
-        super(declaringClass, sourceUnit, methodNode, annotationMetadata);
+    GroovyConstructorElement(GroovyClassElement declaringClass, SourceUnit sourceUnit, CompilationUnit compilationUnit, ConstructorNode methodNode, AnnotationMetadata annotationMetadata) {
+        super(declaringClass, sourceUnit, compilationUnit, methodNode, annotationMetadata);
     }
 }

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyEnumElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyEnumElement.java
@@ -19,6 +19,7 @@ import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.inject.ast.EnumElement;
 import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.FieldNode;
+import org.codehaus.groovy.control.CompilationUnit;
 import org.codehaus.groovy.control.SourceUnit;
 
 import java.util.Collections;
@@ -34,11 +35,12 @@ import java.util.stream.Collectors;
 class GroovyEnumElement extends GroovyClassElement implements EnumElement {
     /**
      * @param sourceUnit The source unit
+     * @param compilationUnit    The compilation unit
      * @param classNode          The {@link ClassNode}
      * @param annotationMetadata The annotation metadata
      */
-    GroovyEnumElement(SourceUnit sourceUnit, ClassNode classNode, AnnotationMetadata annotationMetadata) {
-        super(sourceUnit, classNode, annotationMetadata);
+    GroovyEnumElement(SourceUnit sourceUnit, CompilationUnit compilationUnit, ClassNode classNode, AnnotationMetadata annotationMetadata) {
+        super(sourceUnit, compilationUnit, classNode, annotationMetadata);
     }
 
     @Override

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyFieldElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyFieldElement.java
@@ -20,6 +20,7 @@ import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.FieldElement;
 import org.codehaus.groovy.ast.*;
+import org.codehaus.groovy.control.CompilationUnit;
 import org.codehaus.groovy.control.SourceUnit;
 
 import javax.annotation.Nonnull;
@@ -39,14 +40,16 @@ public class GroovyFieldElement extends AbstractGroovyElement implements FieldEl
 
     /**
      * @param sourceUnit         the source unit
+     * @param compilationUnit    The compilation unit
      * @param variable           The {@link Variable}
      * @param annotatedNode       The annotated ndoe
      * @param annotationMetadata The annotation medatada
      */
     GroovyFieldElement(
             SourceUnit sourceUnit,
+            CompilationUnit compilationUnit,
             Variable variable, AnnotatedNode annotatedNode, AnnotationMetadata annotationMetadata) {
-        super(sourceUnit, annotatedNode, annotationMetadata);
+        super(sourceUnit, compilationUnit, annotatedNode, annotationMetadata);
         this.variable = variable;
         this.sourceUnit = sourceUnit;
     }
@@ -94,7 +97,7 @@ public class GroovyFieldElement extends AbstractGroovyElement implements FieldEl
     @Nonnull
     @Override
     public ClassElement getType() {
-        return new GroovyClassElement(sourceUnit, variable.getType(), AstAnnotationUtils.getAnnotationMetadata(sourceUnit, variable.getType()));
+        return new GroovyClassElement(sourceUnit, compilationUnit, variable.getType(), AstAnnotationUtils.getAnnotationMetadata(sourceUnit, compilationUnit, variable.getType()));
     }
 
     @Override
@@ -114,9 +117,11 @@ public class GroovyFieldElement extends AbstractGroovyElement implements FieldEl
 
         return new GroovyClassElement(
                 sourceUnit,
+                compilationUnit,
                 declaringClass,
                 AstAnnotationUtils.getAnnotationMetadata(
                         sourceUnit,
+                        compilationUnit,
                         declaringClass
                 )
         );

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyMethodElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyMethodElement.java
@@ -26,6 +26,7 @@ import io.micronaut.inject.ast.ParameterElement;
 import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.MethodNode;
 import org.codehaus.groovy.ast.Parameter;
+import org.codehaus.groovy.control.CompilationUnit;
 import org.codehaus.groovy.control.SourceUnit;
 
 import javax.annotation.Nonnull;
@@ -51,11 +52,12 @@ public class GroovyMethodElement extends AbstractGroovyElement implements Method
     /**
      * @param declaringClass     The declaring class
      * @param sourceUnit         The source unit
+     * @param compilationUnit    The compilation unit
      * @param methodNode         The {@link MethodNode}
      * @param annotationMetadata The annotation metadata
      */
-    GroovyMethodElement(GroovyClassElement declaringClass, SourceUnit sourceUnit, MethodNode methodNode, AnnotationMetadata annotationMetadata) {
-        super(sourceUnit, methodNode, annotationMetadata);
+    GroovyMethodElement(GroovyClassElement declaringClass, SourceUnit sourceUnit, CompilationUnit compilationUnit, MethodNode methodNode, AnnotationMetadata annotationMetadata) {
+        super(sourceUnit, compilationUnit, methodNode, annotationMetadata);
         this.methodNode = methodNode;
         this.sourceUnit = sourceUnit;
         this.declaringClass = declaringClass;
@@ -152,9 +154,9 @@ public class GroovyMethodElement extends AbstractGroovyElement implements Method
     public ClassElement getReturnType() {
         ClassNode returnType = methodNode.getReturnType();
         if (returnType.isEnum()) {
-            return new GroovyEnumElement(sourceUnit, returnType, AstAnnotationUtils.getAnnotationMetadata(sourceUnit, returnType));
+            return new GroovyEnumElement(sourceUnit, compilationUnit, returnType, AstAnnotationUtils.getAnnotationMetadata(sourceUnit, compilationUnit, returnType));
         } else {
-            return new GroovyClassElement(sourceUnit, returnType, AstAnnotationUtils.getAnnotationMetadata(sourceUnit, returnType));
+            return new GroovyClassElement(sourceUnit, compilationUnit, returnType, AstAnnotationUtils.getAnnotationMetadata(sourceUnit, compilationUnit, returnType));
         }
     }
 
@@ -165,8 +167,9 @@ public class GroovyMethodElement extends AbstractGroovyElement implements Method
                 new GroovyParameterElement(
                         this,
                         sourceUnit,
+                        compilationUnit,
                         parameter,
-                        AstAnnotationUtils.getAnnotationMetadata(sourceUnit, new ExtendedParameter(methodNode, parameter))
+                        AstAnnotationUtils.getAnnotationMetadata(sourceUnit, compilationUnit, new ExtendedParameter(methodNode, parameter))
                 )
         ).toArray(ParameterElement[]::new);
     }
@@ -175,9 +178,11 @@ public class GroovyMethodElement extends AbstractGroovyElement implements Method
     public ClassElement getDeclaringType() {
         return new GroovyClassElement(
                 sourceUnit,
+                compilationUnit,
                 methodNode.getDeclaringClass(),
                 AstAnnotationUtils.getAnnotationMetadata(
                         sourceUnit,
+                        compilationUnit,
                         methodNode.getDeclaringClass()
                 )
         );

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyParameterElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyParameterElement.java
@@ -22,6 +22,7 @@ import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.ParameterElement;
 import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.Parameter;
+import org.codehaus.groovy.control.CompilationUnit;
 import org.codehaus.groovy.control.SourceUnit;
 
 import javax.annotation.Nonnull;
@@ -43,13 +44,14 @@ public class GroovyParameterElement extends AbstractGroovyElement implements Par
     /**
      * Default constructor.
      *
-     * @param methodElement the parent method element
-     * @param sourceUnit The source unit
-     * @param parameter The parameter
+     * @param methodElement      The parent method element
+     * @param sourceUnit         The source unit
+     * @param compilationUnit    The compilation unit
+     * @param parameter          The parameter
      * @param annotationMetadata The annotation metadata
      */
-    GroovyParameterElement(GroovyMethodElement methodElement, SourceUnit sourceUnit, Parameter parameter, AnnotationMetadata annotationMetadata) {
-        super(sourceUnit, parameter, annotationMetadata);
+    GroovyParameterElement(GroovyMethodElement methodElement, SourceUnit sourceUnit, CompilationUnit compilationUnit, Parameter parameter, AnnotationMetadata annotationMetadata) {
+        super(sourceUnit, compilationUnit, parameter, annotationMetadata);
         this.parameter = parameter;
         this.sourceUnit = sourceUnit;
         this.methodElement = methodElement;
@@ -87,9 +89,9 @@ public class GroovyParameterElement extends AbstractGroovyElement implements Par
     public ClassElement getType() {
         ClassNode t = parameter.getType();
         if (t.isEnum()) {
-            return new GroovyEnumElement(sourceUnit, t, AstAnnotationUtils.getAnnotationMetadata(sourceUnit, t));
+            return new GroovyEnumElement(sourceUnit, compilationUnit, t, AstAnnotationUtils.getAnnotationMetadata(sourceUnit, compilationUnit, t));
         } else {
-            return new GroovyClassElement(sourceUnit, t, AstAnnotationUtils.getAnnotationMetadata(sourceUnit, t));
+            return new GroovyClassElement(sourceUnit, compilationUnit, t, AstAnnotationUtils.getAnnotationMetadata(sourceUnit, compilationUnit, t));
         }
     }
 }

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyPropertyElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyPropertyElement.java
@@ -20,6 +20,7 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.PropertyElement;
 import org.codehaus.groovy.ast.AnnotatedNode;
+import org.codehaus.groovy.control.CompilationUnit;
 import org.codehaus.groovy.control.SourceUnit;
 
 /**
@@ -39,6 +40,7 @@ abstract class GroovyPropertyElement extends AbstractGroovyElement implements Pr
      * Default constructor.
      *
      * @param sourceUnit The source unit
+     * @param compilationUnit    The compilation unit
      * @param declaringElement The declaring element
      * @param annotatedNode    The annotated node
      * @param annotationMetadata the annotation metadata
@@ -48,13 +50,14 @@ abstract class GroovyPropertyElement extends AbstractGroovyElement implements Pr
      */
     GroovyPropertyElement(
             SourceUnit sourceUnit,
+            CompilationUnit compilationUnit,
             GroovyClassElement declaringElement,
             AnnotatedNode annotatedNode,
             AnnotationMetadata annotationMetadata,
             String name,
             boolean readOnly,
             Object nativeType) {
-        super(sourceUnit, annotatedNode, annotationMetadata);
+        super(sourceUnit, compilationUnit, annotatedNode, annotationMetadata);
         this.name = name;
         this.readOnly = readOnly;
         this.nativeType = nativeType;

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyVisitorContext.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyVisitorContext.java
@@ -15,14 +15,12 @@
  */
 package io.micronaut.ast.groovy.visitor;
 
-import groovy.lang.GroovyClassLoader;
 import io.micronaut.ast.groovy.utils.AstAnnotationUtils;
 import io.micronaut.ast.groovy.utils.InMemoryByteCodeGroovyClassLoader;
 import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.value.MutableConvertibleValues;
 import io.micronaut.core.convert.value.MutableConvertibleValuesMap;
 import io.micronaut.core.io.scan.ClassPathAnnotationScanner;
-import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.ast.ClassElement;
@@ -33,7 +31,6 @@ import io.micronaut.inject.writer.GeneratedFile;
 import org.codehaus.groovy.ast.ASTNode;
 import org.codehaus.groovy.ast.ClassHelper;
 import org.codehaus.groovy.ast.ClassNode;
-import org.codehaus.groovy.ast.ModuleNode;
 import org.codehaus.groovy.control.CompilationUnit;
 import org.codehaus.groovy.control.ErrorCollector;
 import org.codehaus.groovy.control.Janitor;

--- a/inject-groovy/src/test/groovy/io/micronaut/AbstractBeanDefinitionSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/AbstractBeanDefinitionSpec.groovy
@@ -62,7 +62,7 @@ abstract class AbstractBeanDefinitionSpec extends Specification {
         ASTNode[] nodes = new AstBuilder().buildFromString(source)
 
         ClassNode element = nodes ? nodes.find { it instanceof ClassNode && it.name == cls } : null
-        GroovyAnnotationMetadataBuilder builder = new GroovyAnnotationMetadataBuilder()
+        GroovyAnnotationMetadataBuilder builder = new GroovyAnnotationMetadataBuilder(null, null)
         AnnotationMetadata metadata = element != null ? builder.build(element) : null
         return metadata
     }
@@ -70,7 +70,7 @@ abstract class AbstractBeanDefinitionSpec extends Specification {
     AnnotationMetadata buildMethodAnnotationMetadata(String cls, String source, String methodName) {
         ClassNode element = buildClassNode(source, cls)
         MethodNode method = element.getMethods(methodName)[0]
-        GroovyAnnotationMetadataBuilder builder = new GroovyAnnotationMetadataBuilder()
+        GroovyAnnotationMetadataBuilder builder = new GroovyAnnotationMetadataBuilder(null, null)
         AnnotationMetadata metadata = method != null ? builder.build(method) : null
         return metadata
     }
@@ -79,7 +79,7 @@ abstract class AbstractBeanDefinitionSpec extends Specification {
         ClassNode element = buildClassNode(source, cls)
         MethodNode method = element.getMethods(methodName)[0]
         Parameter parameter = Arrays.asList(method.getParameters()).find { it.name == fieldName }
-        GroovyAnnotationMetadataBuilder builder = new GroovyAnnotationMetadataBuilder()
+        GroovyAnnotationMetadataBuilder builder = new GroovyAnnotationMetadataBuilder(null, null)
         AnnotationMetadata metadata = method != null ? builder.build(new ExtendedParameter(method, parameter)) : null
         return metadata
     }

--- a/inject-groovy/src/test/groovy/io/micronaut/ast/groovy/annotation/GroovyAnnotationMetadataBuilderSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/ast/groovy/annotation/GroovyAnnotationMetadataBuilderSpec.groovy
@@ -489,7 +489,7 @@ interface ITest {
         ASTNode[] nodes = new AstBuilder().buildFromString(source)
 
         ClassNode element = nodes ? nodes.find { it instanceof ClassNode && it.name == cls } : null
-        GroovyAnnotationMetadataBuilder builder = new GroovyAnnotationMetadataBuilder()
+        GroovyAnnotationMetadataBuilder builder = new GroovyAnnotationMetadataBuilder(null, null)
         AnnotationMetadata metadata = element != null ? builder.build(element) : null
         return metadata
     }
@@ -499,7 +499,7 @@ interface ITest {
 
         ClassNode element = nodes ? nodes.find { it instanceof ClassNode &&  it.name == cls } : null
         MethodNode method = element.getMethods(methodName)[0]
-        GroovyAnnotationMetadataBuilder builder = new GroovyAnnotationMetadataBuilder()
+        GroovyAnnotationMetadataBuilder builder = new GroovyAnnotationMetadataBuilder(null, null)
         AnnotationMetadata metadata = method != null ? builder.build(method) : null
         return metadata
     }

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/configuration/GroovyConfigurationMetadataBuilderSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/configuration/GroovyConfigurationMetadataBuilderSpec.groovy
@@ -47,7 +47,7 @@ class MyProperties {
 ''', "test.MyProperties")
 
         when:
-        GroovyConfigurationMetadataBuilder builder = new GroovyConfigurationMetadataBuilder()
+        GroovyConfigurationMetadataBuilder builder = new GroovyConfigurationMetadataBuilder(null, null)
         def configurationMetadata = builder.visitProperties(element, "some description")
         def propertyMetadata = builder.visitProperty(element, element, "java.lang.String", "setterTest", "some description", null)
 

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/BeanIntrospectionSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/BeanIntrospectionSpec.groovy
@@ -9,6 +9,8 @@ import io.micronaut.core.beans.BeanIntrospectionReference
 import io.micronaut.core.beans.BeanProperty
 import io.micronaut.core.reflect.exception.InstantiationException
 import io.micronaut.inject.beans.visitor.IntrospectedTypeElementVisitor
+import io.micronaut.inject.visitor.introspections.Person
+import io.micronaut.inject.visitor.introspections.packages.Author
 
 import javax.persistence.Id
 import javax.validation.constraints.Size
@@ -468,5 +470,15 @@ class Test {
 
         then:
         thrown(UnsupportedOperationException)
+    }
+
+    void "test introspection class member configuration works"() {
+        when:
+        BeanIntrospection introspection = BeanIntrospection.getIntrospection(Person)
+
+        then:
+        noExceptionThrown()
+        introspection != null
+        introspection.getProperty("name", String).get().get(new Person(name: "Sally")) == "Sally"
     }
 }

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/BeanIntrospectionSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/BeanIntrospectionSpec.groovy
@@ -2,7 +2,6 @@ package io.micronaut.inject.visitor
 
 import io.micronaut.AbstractBeanDefinitionSpec
 import io.micronaut.ast.groovy.TypeElementVisitorStart
-import io.micronaut.context.ApplicationContext
 import io.micronaut.core.annotation.Introspected
 import io.micronaut.core.beans.BeanIntrospection
 import io.micronaut.core.beans.BeanIntrospectionReference
@@ -10,9 +9,7 @@ import io.micronaut.core.beans.BeanProperty
 import io.micronaut.core.reflect.exception.InstantiationException
 import io.micronaut.inject.beans.visitor.IntrospectedTypeElementVisitor
 import io.micronaut.inject.visitor.introspections.Person
-import io.micronaut.inject.visitor.introspections.packages.Author
 
-import javax.persistence.Id
 import javax.validation.constraints.Size
 
 class BeanIntrospectionSpec extends AbstractBeanDefinitionSpec {

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/introspections/Person.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/introspections/Person.groovy
@@ -1,0 +1,5 @@
+package io.micronaut.inject.visitor.introspections
+
+class Person {
+    String name
+}

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/introspections/PersonConfiguration.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/introspections/PersonConfiguration.groovy
@@ -1,0 +1,7 @@
+package io.micronaut.inject.visitor.introspections
+
+import io.micronaut.core.annotation.Introspected
+
+@Introspected(classes = Person)
+class PersonConfiguration {
+}

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
@@ -678,7 +678,6 @@ class Test {}
         reference != null
         reference.getBeanType() == TestBean
 
-
         cleanup:
         context?.close()
     }

--- a/router/src/test/groovy/io/micronaut/ast/groovy/annotation/GroovyAnnotationMetadataBuilderSpec.groovy
+++ b/router/src/test/groovy/io/micronaut/ast/groovy/annotation/GroovyAnnotationMetadataBuilderSpec.groovy
@@ -93,7 +93,7 @@ class FormController {
         ASTNode[] nodes = new AstBuilder().buildFromString(source)
 
         ClassNode element = nodes ? nodes.find { it instanceof ClassNode && it.name == cls } : null
-        GroovyAnnotationMetadataBuilder builder = new GroovyAnnotationMetadataBuilder()
+        GroovyAnnotationMetadataBuilder builder = new GroovyAnnotationMetadataBuilder(null, null)
         AnnotationMetadata metadata = element != null ? builder.build(element) : null
         return metadata
     }
@@ -104,7 +104,7 @@ class FormController {
 
         ClassNode element = nodes ? nodes.find { it instanceof ClassNode &&  it.name == cls } : null
         MethodNode method = element.getMethods(methodName)[0]
-        GroovyAnnotationMetadataBuilder builder = new GroovyAnnotationMetadataBuilder()
+        GroovyAnnotationMetadataBuilder builder = new GroovyAnnotationMetadataBuilder(null, null)
         AnnotationMetadata metadata = method != null ? builder.build(method) : null
         return metadata
     }


### PR DESCRIPTION
Fixes visitorContext.getClass methods not being able to find classes currently being compiled