### PR TITLE
http-client: exceptionless handling of error responses

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/BlockingHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/BlockingHttpClient.java
@@ -51,6 +51,7 @@ public interface BlockingHttpClient extends Closeable {
      * @param <O>      The response body type
      * @param <E>      The error type
      * @return The full {@link HttpResponse} object
+     * @throws HttpClientResponseException when an error status is returned
      */
     <I, O, E> HttpResponse<O> exchange(HttpRequest<I> request, Argument<O> bodyType, Argument<E> errorType);
 
@@ -70,6 +71,7 @@ public interface BlockingHttpClient extends Closeable {
      * @param <I>      The request body type
      * @param <O>      The response body type
      * @return The full {@link HttpResponse} object
+     * @throws HttpClientResponseException when an error status is returned
      */
     default <I, O> HttpResponse<O> exchange(HttpRequest<I> request, Argument<O> bodyType) {
         return exchange(request, bodyType, HttpClient.DEFAULT_ERROR_TYPE);
@@ -83,6 +85,7 @@ public interface BlockingHttpClient extends Closeable {
      * @param <I>     The request body type
      * @param <O>     The response body type
      * @return The full {@link HttpResponse} object
+     * @throws HttpClientResponseException when an error status is returned
      */
     default <I, O> HttpResponse<O> exchange(HttpRequest<I> request) {
         return exchange(request, (Argument<O>) null);
@@ -97,6 +100,7 @@ public interface BlockingHttpClient extends Closeable {
      * @param <I>      The request body type
      * @param <O>      The response body type
      * @return The full {@link HttpResponse} object
+     * @throws HttpClientResponseException when an error status is returned
      */
     default <I, O> HttpResponse<O> exchange(HttpRequest<I> request, Class<O> bodyType) {
         return exchange(request, Argument.of(bodyType));
@@ -111,7 +115,7 @@ public interface BlockingHttpClient extends Closeable {
      * @param <I>      The request body type
      * @param <O>      The response body type
      * @return A result of the given type or null the URI returns a 404
-     * @throws HttpClientResponseException if an error status is returned
+     * @throws HttpClientResponseException when an error status is returned
      */
     @SuppressWarnings("unchecked")
     default <I, O> O retrieve(HttpRequest<I> request, Argument<O> bodyType) {
@@ -129,7 +133,7 @@ public interface BlockingHttpClient extends Closeable {
      * @param <O>      The response body type
      * @param <E>      The error type
      * @return A result of the given type or null the URI returns a 404
-     * @throws HttpClientResponseException if an error status is returned
+     * @throws HttpClientResponseException when an error status is returned
      */
     @SuppressWarnings("unchecked")
     default <I, O, E> O retrieve(HttpRequest<I> request, Argument<O> bodyType, Argument<E> errorType) {
@@ -155,7 +159,7 @@ public interface BlockingHttpClient extends Closeable {
      * @param <I>      The request body type
      * @param <O>      The response body type
      * @return A result of the given type or null the URI returns a 404
-     * @throws HttpClientResponseException if an error status is returned
+     * @throws HttpClientResponseException when an error status is returned
      */
     default <I, O> O retrieve(HttpRequest<I> request, Class<O> bodyType) {
         return retrieve(request, Argument.of(bodyType));
@@ -168,7 +172,7 @@ public interface BlockingHttpClient extends Closeable {
      * @param request The {@link HttpRequest} to execute
      * @param <I>     The request body type
      * @return A string result or null if a 404 is returned
-     * @throws HttpClientResponseException if an error status is returned
+     * @throws HttpClientResponseException when an error status is returned
      */
     default <I> String retrieve(HttpRequest<I> request) {
         return retrieve(request, String.class);
@@ -180,7 +184,7 @@ public interface BlockingHttpClient extends Closeable {
      *
      * @param uri The URI
      * @return A string result or null if a 404 is returned
-     * @throws HttpClientResponseException if an error status is returned
+     * @throws HttpClientResponseException when an error status is returned
      */
     default String retrieve(String uri) {
         return retrieve(HttpRequest.GET(uri), String.class);
@@ -194,7 +198,7 @@ public interface BlockingHttpClient extends Closeable {
      * @param bodyType The body type
      * @param <O> The body generic type
      * @return A result or null if a 404 is returned
-     * @throws HttpClientResponseException if an error status is returned
+     * @throws HttpClientResponseException when an error status is returned
      */
     default <O> O retrieve(String uri, Class<O> bodyType) {
         return retrieve(HttpRequest.GET(uri), bodyType);
@@ -210,6 +214,7 @@ public interface BlockingHttpClient extends Closeable {
      * @param bodyType The body type
      * @param errorType The error type
      * @return The full {@link HttpResponse} object
+     * @throws HttpClientResponseException when an error status is returned
      */
     default <O, E> O retrieve(String uri, Class<O> bodyType, Class<E> errorType) {
         return retrieve(HttpRequest.GET(uri), Argument.of(bodyType), Argument.of(errorType));
@@ -222,6 +227,7 @@ public interface BlockingHttpClient extends Closeable {
      * @param uri The URI of the GET request
      * @param <O> The response body type
      * @return The full {@link HttpResponse} object
+     * @throws HttpClientResponseException when an error status is returned
      */
     default <O> HttpResponse<O> exchange(String uri) {
         return exchange(HttpRequest.GET(uri), (Argument<O>) null);
@@ -235,6 +241,7 @@ public interface BlockingHttpClient extends Closeable {
      * @param <O>      The response body type
      * @param bodyType The body type
      * @return The full {@link HttpResponse} object
+     * @throws HttpClientResponseException when an error status is returned
      */
     default <O> HttpResponse<O> exchange(String uri, Class<O> bodyType) {
         return exchange(HttpRequest.GET(uri), Argument.of(bodyType));
@@ -250,6 +257,7 @@ public interface BlockingHttpClient extends Closeable {
      * @param bodyType The body type
      * @param errorType The error type
      * @return The full {@link HttpResponse} object
+     * @throws HttpClientResponseException when an error status is returned
      */
     default <O, E> HttpResponse<O> exchange(String uri, Class<O> bodyType, Class<E> errorType) {
         return exchange(HttpRequest.GET(uri), Argument.of(bodyType), Argument.of(errorType));

--- a/http-client/src/main/java/io/micronaut/http/client/FullNettyClientHttpResponse.java
+++ b/http-client/src/main/java/io/micronaut/http/client/FullNettyClientHttpResponse.java
@@ -71,7 +71,7 @@ public class FullNettyClientHttpResponse<B> implements HttpResponse<B>, Completa
      * @param mediaTypeCodecRegistry The media type codec registry
      * @param byteBufferFactory      The byte buffer factory
      * @param bodyType               The body type
-     * @param errorStatus            The error status
+     * @param convertBody            Whether to auto convert the body to bodyType
      */
     FullNettyClientHttpResponse(
             FullHttpResponse fullHttpResponse,
@@ -79,7 +79,8 @@ public class FullNettyClientHttpResponse<B> implements HttpResponse<B>, Completa
             MediaTypeCodecRegistry mediaTypeCodecRegistry,
             ByteBufferFactory<ByteBufAllocator,
             ByteBuf> byteBufferFactory,
-            Argument<B> bodyType, boolean errorStatus) {
+            Argument<B> bodyType,
+            boolean convertBody) {
 
         this.status = httpStatus;
         this.headers = new NettyHttpHeaders(fullHttpResponse.headers(), ConversionService.SHARED);
@@ -93,12 +94,12 @@ public class FullNettyClientHttpResponse<B> implements HttpResponse<B>, Completa
                 Optional<Argument<?>> responseBodyType = bodyType.getFirstTypeVariable();
                 if (responseBodyType.isPresent()) {
                     Argument<B> finalResponseBodyType = (Argument<B>) responseBodyType.get();
-                    this.body = !errorStatus || isParseableBodyType(finalResponseBodyType.getType()) ? getBody(finalResponseBodyType).orElse(null) : null;
+                    this.body = convertBody || isParseableBodyType(finalResponseBodyType.getType()) ? getBody(finalResponseBodyType).orElse(null) : null;
                 } else {
                     this.body = null;
                 }
             } else {
-                this.body = !errorStatus || isParseableBodyType(rawBodyType) ? getBody(bodyType).orElse(null) : null;
+                this.body = convertBody || isParseableBodyType(rawBodyType) ? getBody(bodyType).orElse(null) : null;
             }
         } else {
             this.body = null;

--- a/http-client/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
+++ b/http-client/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
@@ -61,16 +61,22 @@ public abstract class HttpClientConfiguration {
     public static final long DEFAULT_SHUTDOWN_TIMEOUT_MILLISECONDS = 100;
 
     /**
-     * The default shutdown timeout in millis.
+     * The default max content length in bytes.
      */
     @SuppressWarnings("WeakerAccess")
-    public static final int DEFAULT_MAX_CONTENT_LENGTH = 1024 * 1024 * 10; // 10MB;
+    public static final int DEFAULT_MAX_CONTENT_LENGTH = 1024 * 1024 * 10; // 10MiB;
 
     /**
      * The default follow redirects value.
      */
     @SuppressWarnings("WeakerAccess")
     public static final boolean DEFAULT_FOLLOW_REDIRECTS = true;
+
+    /**
+     * The default value.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static final boolean DEFAULT_EXCEPTION_ON_ERROR_STATUS = true;
 
     private Map<ChannelOption, Object> channelOptions = Collections.emptyMap();
 
@@ -106,6 +112,8 @@ public abstract class HttpClientConfiguration {
     private Charset defaultCharset = StandardCharsets.UTF_8;
 
     private boolean followRedirects = DEFAULT_FOLLOW_REDIRECTS;
+
+    private boolean exceptionOnErrorStatus = DEFAULT_EXCEPTION_ON_ERROR_STATUS;
 
     private SslConfiguration sslConfiguration = new ClientSslConfiguration();
 
@@ -154,6 +162,23 @@ public abstract class HttpClientConfiguration {
      */
     public boolean isFollowRedirects() {
         return followRedirects;
+    }
+
+    /**
+     *
+     * @return Whether throwing an exception upon HTTP error status (>= 400) is preferred.
+     */
+    public boolean isExceptionOnErrorStatus() {
+        return exceptionOnErrorStatus;
+    }
+
+    /**
+     * Sets whether throwing an exception upon HTTP error status (>= 400) is preferred. Default value ({@link io.micronaut.http.client.HttpClientConfiguration#DEFAULT_EXCEPTION_ON_ERROR_STATUS})
+     *
+     * @param exceptionOnErrorStatus Whether
+     */
+    public void setExceptionOnErrorStatus(boolean exceptionOnErrorStatus) {
+        this.exceptionOnErrorStatus = exceptionOnErrorStatus;
     }
 
     /**

--- a/http-client/src/test/groovy/io/micronaut/http/client/ExceptionOnErrorStatusSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/ExceptionOnErrorStatusSpec.groovy
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.client
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.type.Argument
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.hateoas.JsonError
+import io.micronaut.runtime.server.EmbeddedServer
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+/**
+ * @author Fabien Renaud
+ * @since 1.3.0
+ */
+class ExceptionOnErrorStatusSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    ApplicationContext context = ApplicationContext.run(
+            "micronaut.http.client.exceptionOnErrorStatus":'false'
+    )
+
+    @Shared
+    EmbeddedServer embeddedServer = context.getBean(EmbeddedServer).start()
+
+    @Shared
+    @AutoCleanup
+    HttpClient client = context.createBean(HttpClient, embeddedServer.getURL())
+
+    void "test not found"() {
+        when:
+        def res = client.toBlocking().exchange(HttpRequest.GET('/return-response/doesnotexist'), Argument.STRING, Argument.STRING)
+
+        then:
+        res.status == HttpStatus.NOT_FOUND
+        res.getBody(String).isPresent()
+    }
+
+    void "test internal server error"() {
+        when:
+        def res = client.toBlocking().exchange(HttpRequest.GET('/return-response/error'), Argument.STRING, Argument.STRING)
+
+        then:
+        res.status == HttpStatus.INTERNAL_SERVER_ERROR
+        res.getBody(String).get() == "Server error"
+    }
+
+    @Controller("/return-response")
+    static class GetController {
+
+        @Get(value = "/error", produces = MediaType.TEXT_PLAIN)
+        HttpResponse error() {
+            return HttpResponse.serverError().body("Server error")
+        }
+    }
+}

--- a/http-client/src/test/groovy/io/micronaut/http/client/config/DefaultHttpClientConfigurationSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/config/DefaultHttpClientConfigurationSpec.groovy
@@ -41,13 +41,14 @@ class DefaultHttpClientConfigurationSpec extends Specification {
         ctx.close()
 
         where:
-        key                 | property          | value  | expected
-        'read-timeout'      | 'readTimeout'     | '15s'  | Optional.of(Duration.ofSeconds(15))
-        'proxy-type'        | 'proxyType'       | 'http' | Proxy.Type.HTTP
-        'read-idle-timeout' | 'readIdleTimeout' | '-1s'  | Optional.of(Duration.ofSeconds(-1))
-        'read-idle-timeout' | 'readIdleTimeout' | '1s'   | Optional.of(Duration.ofSeconds(1))
-        'read-idle-timeout' | 'readIdleTimeout' | '-1'   | Optional.empty()
-        'connect-ttl'       | 'connectTtl'      | '1s'   | Optional.of(Duration.ofSeconds(1))
+        key                         | property                 | value   | expected
+        'read-timeout'              | 'readTimeout'            | '15s'   | Optional.of(Duration.ofSeconds(15))
+        'proxy-type'                | 'proxyType'              | 'http'  | Proxy.Type.HTTP
+        'read-idle-timeout'         | 'readIdleTimeout'        | '-1s'   | Optional.of(Duration.ofSeconds(-1))
+        'read-idle-timeout'         | 'readIdleTimeout'        | '1s'    | Optional.of(Duration.ofSeconds(1))
+        'read-idle-timeout'         | 'readIdleTimeout'        | '-1'    | Optional.empty()
+        'connect-ttl'               | 'connectTtl'             | '1s'    | Optional.of(Duration.ofSeconds(1))
+        'exception-on-error-status' | 'exceptionOnErrorStatus' | 'false' | false
     }
 
 


### PR DESCRIPTION
DefaultHttpClient no longer throws HttpClientResponseException when an
error is returned and the response's errorType matches bodyType.

Resolves issue #2193

Targeting 1.3.x release