### PR TITLE
@Error is not global by default, needs global=true

### DIFF
--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/json/PersonController.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/json/PersonController.groovy
@@ -90,7 +90,7 @@ class PersonController {
     }
 
     // tag::globalError[]
-    @Error(global = "true") // <1>
+    @Error(global = true) // <1>
     HttpResponse<JsonError> error(HttpRequest request, Throwable e) {
         JsonError error = new JsonError("Bad Things Happened: " + e.getMessage()) // <2>
                 .link(Link.SELF, Link.of(request.getUri()))

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/json/PersonController.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/json/PersonController.groovy
@@ -90,7 +90,7 @@ class PersonController {
     }
 
     // tag::globalError[]
-    @Error // <1>
+    @Error(global = "true") // <1>
     HttpResponse<JsonError> error(HttpRequest request, Throwable e) {
         JsonError error = new JsonError("Bad Things Happened: " + e.getMessage()) // <2>
                 .link(Link.SELF, Link.of(request.getUri()))

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/json/PersonController.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/json/PersonController.kt
@@ -89,7 +89,7 @@ class PersonController {
     }
 
     // tag::globalError[]
-    @Error // <1>
+    @Error(global = "true") // <1>
     fun error(request: HttpRequest<*>, e: Throwable): HttpResponse<JsonError> {
         val error = JsonError("Bad Things Happened: " + e.message) // <2>
                 .link(Link.SELF, Link.of(request.uri))

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/json/PersonController.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/json/PersonController.kt
@@ -89,7 +89,7 @@ class PersonController {
     }
 
     // tag::globalError[]
-    @Error(global = "true") // <1>
+    @Error(global = true) // <1>
     fun error(request: HttpRequest<*>, e: Throwable): HttpResponse<JsonError> {
         val error = JsonError("Bad Things Happened: " + e.message) // <2>
                 .link(Link.SELF, Link.of(request.uri))

--- a/test-suite/src/test/java/io/micronaut/docs/server/json/PersonController.java
+++ b/test-suite/src/test/java/io/micronaut/docs/server/json/PersonController.java
@@ -94,7 +94,7 @@ public class PersonController {
     }
 
     // tag::globalError[]
-    @Error(global = "true") // <1>
+    @Error(global = true) // <1>
     public HttpResponse<JsonError> error(HttpRequest request, Throwable e) {
         JsonError error = new JsonError("Bad Things Happened: " + e.getMessage()) // <2>
                 .link(Link.SELF, Link.of(request.getUri()));

--- a/test-suite/src/test/java/io/micronaut/docs/server/json/PersonController.java
+++ b/test-suite/src/test/java/io/micronaut/docs/server/json/PersonController.java
@@ -94,7 +94,7 @@ public class PersonController {
     }
 
     // tag::globalError[]
-    @Error // <1>
+    @Error(global = "true") // <1>
     public HttpResponse<JsonError> error(HttpRequest request, Throwable e) {
         JsonError error = new JsonError("Bad Things Happened: " + e.getMessage()) // <2>
                 .link(Link.SELF, Link.of(request.getUri()));


### PR DESCRIPTION
Unless there is something I don't understand, Error annotation has global to false by default, then the snippet to show global error handler registration should explicitly set global as true.