### PR TITLE
ability to specify the main class for an application or function

### DIFF
--- a/cli/src/main/groovy/io/micronaut/cli/profile/commands/AbstractCreateCommand.groovy
+++ b/cli/src/main/groovy/io/micronaut/cli/profile/commands/AbstractCreateCommand.groovy
@@ -63,6 +63,9 @@ abstract class AbstractCreateCommand extends ArgumentCompletingCommand implement
     @Option(names = ['-i', '--inplace'], description = 'Create a service using the current directory')
     boolean inplace
 
+    @Option(names = ['-m', '--mainClass'], paramLabel = 'MAINCLASS', description = 'The main class to use. Possible values: The full package and class name (ie. io.micronaut.CustomApplication).')
+    String mainClass
+
     @Option(names = ['-p', '--profile'], paramLabel = 'PROFILE', description = 'The profile to use. Possible values: ${COMPLETION-CANDIDATES}.', completionCandidates = ProfileCompletionCandidates)
     String profile
 
@@ -463,6 +466,16 @@ abstract class AbstractCreateCommand extends ArgumentCompletingCommand implement
         }
 
         tokens.put("micronautVersion", cmd.micronautVersion)
+
+        if (profile.name.contains("function")) {
+            if (cmd.lang == "kotlin") {
+                tokens.put("mainClass", mainClass ? "${mainClass}FunctionKt" : "${this.defaultpackagename}.${variables['project.className']}FunctionKt")
+            } else {
+                tokens.put("mainClass", mainClass ? "${mainClass}Function" : "${this.defaultpackagename}.${variables['project.className']}Function")
+            }
+        } else {
+            tokens.put("mainClass", mainClass ? mainClass : "${this.defaultpackagename}.Application")
+        }
 
         ant.replace(dir: targetDirectory) {
             tokens.each { k, v ->

--- a/cli/src/main/groovy/io/micronaut/cli/profile/commands/AbstractCreateCommand.groovy
+++ b/cli/src/main/groovy/io/micronaut/cli/profile/commands/AbstractCreateCommand.groovy
@@ -474,13 +474,14 @@ abstract class AbstractCreateCommand extends ArgumentCompletingCommand implement
             } else {
                 tokens.put("mainClass", mainClass ? "${mainClass}Function" : "${this.defaultpackagename}.${variables['project.className']}Function")
             }
+
+            // Allows for a separate custom main in native-image.properties
+            if (features.any{ it.name == "graal-native-image" || it.name == "graal-native-image-kotlin"} ) {
+                tokens.put("graalFunctionMainClass", "io.micronaut.function.executor.FunctionApplication")
+            }
         } else {
             tokens.put("mainClass", mainClass ? mainClass : "${this.defaultpackagename}.Application")
-        }
-
-        // Allows for a separate custom main in native-image.properties
-        if (features.any{ it.name == "graal-native-image" || it.name == "graal-native-image-kotlin"} ) {
-            tokens.put("graalFunctionMainClass", "io.micronaut.function.executor.FunctionApplication")
+            tokens.put("graalFunctionMainClass", mainClass ? mainClass : "${this.defaultpackagename}.Application")
         }
 
         ant.replace(dir: targetDirectory) {

--- a/cli/src/main/groovy/io/micronaut/cli/profile/commands/AbstractCreateCommand.groovy
+++ b/cli/src/main/groovy/io/micronaut/cli/profile/commands/AbstractCreateCommand.groovy
@@ -467,6 +467,7 @@ abstract class AbstractCreateCommand extends ArgumentCompletingCommand implement
 
         tokens.put("micronautVersion", cmd.micronautVersion)
 
+        // Allows for a custom mainClassName
         if (profile.name.contains("function")) {
             if (cmd.lang == "kotlin") {
                 tokens.put("mainClass", mainClass ? "${mainClass}FunctionKt" : "${this.defaultpackagename}.${variables['project.className']}FunctionKt")
@@ -475,6 +476,11 @@ abstract class AbstractCreateCommand extends ArgumentCompletingCommand implement
             }
         } else {
             tokens.put("mainClass", mainClass ? mainClass : "${this.defaultpackagename}.Application")
+        }
+
+        // Allows for a separate custom main in native-image.properties
+        if (features.any{ it.name == "graal-native-image"} ) {
+            tokens.put("graalFunctionMainClass", "io.micronaut.function.executor.FunctionApplication")
         }
 
         ant.replace(dir: targetDirectory) {

--- a/cli/src/main/groovy/io/micronaut/cli/profile/commands/AbstractCreateCommand.groovy
+++ b/cli/src/main/groovy/io/micronaut/cli/profile/commands/AbstractCreateCommand.groovy
@@ -479,7 +479,7 @@ abstract class AbstractCreateCommand extends ArgumentCompletingCommand implement
         }
 
         // Allows for a separate custom main in native-image.properties
-        if (features.any{ it.name == "graal-native-image"} ) {
+        if (features.any{ it.name == "graal-native-image" || it.name == "graal-native-image-kotlin"} ) {
             tokens.put("graalFunctionMainClass", "io.micronaut.function.executor.FunctionApplication")
         }
 


### PR DESCRIPTION
This addresses the request to be able to set a custom `mainClassName` from issue https://github.com/micronaut-projects/micronaut-core/issues/1207. When running `create-app` or `create-function` adding `-m com.io.CustomApplication` will set a custom main. It does require you specify with the full package path as it can not be assumed that the custom main is in the default package.

This pr is DEPENDENT on profiles pr https://github.com/micronaut-projects/micronaut-profiles/pull/207. Without this it will break code generation as the token replacement has been updated. These prs must be reviewed and merged together