### PR TITLE
Optimize compiler performance and runtime data structures for improve memory efficiency

### DIFF
--- a/aop/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
+++ b/aop/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
@@ -53,6 +53,7 @@ import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.GeneratorAdapter;
 import org.objectweb.asm.commons.Method;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
@@ -376,6 +377,12 @@ public class AopProxyWriter extends AbstractClassFileWriter implements ProxyingB
         this.interceptorArgumentIndex = constructorNewArgumentTypes.size();
         constructorNewArgumentTypes.put("interceptors", Interceptor[].class);
 
+    }
+
+    @Nonnull
+    @Override
+    public String getBeanDefinitionReferenceClassName() {
+        return proxyBeanDefinitionWriter.getBeanDefinitionReferenceClassName();
     }
 
     /**

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     compileOnly project(":inject-java")
     compileOnly project(":validation")
     compile project(":inject")
+    compile project(":inject-java-test")
     compile project(":validation")
     compile project(":runtime")
 
@@ -16,8 +17,10 @@ dependencies {
     jmh 'org.openjdk.jmh:jmh-generator-annprocess:1.21'
 }
 jmh {
+    include =['io.micronaut.aop.around.AroundCompileBenchmark']
     duplicateClassesStrategy = 'warn'
     warmupIterations = 2
     iterations = 4
     fork = 1
+//    jvmArgs = ["-agentpath:/Applications/YourKit-Java-Profiler-2018.04.app/Contents/Resources/bin/mac/libyjpagent.jnilib"]
 }

--- a/benchmarks/src/jmh/java/io/micronaut/aop/around/AroundCompileBenchmark.java
+++ b/benchmarks/src/jmh/java/io/micronaut/aop/around/AroundCompileBenchmark.java
@@ -1,0 +1,109 @@
+package io.micronaut.aop.around;
+
+import io.micronaut.annotation.processing.test.JavaParser;
+import io.micronaut.core.naming.NameUtils;
+import io.micronaut.core.reflect.InstantiationUtils;
+import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.inject.BeanDefinition;
+import org.codehaus.groovy.runtime.IOGroovyMethods;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import javax.tools.JavaFileObject;
+import java.io.IOException;
+import java.util.Objects;
+
+@State(Scope.Benchmark)
+public class AroundCompileBenchmark {
+
+    StringBuilder source = new StringBuilder();
+
+
+    @Setup
+    public void prepare() {
+        source.append("package test;\n" +
+                "\n" +
+                "import javax.inject.Singleton;\n" +
+                "import javax.sql.DataSource;\n" +
+                "import io.micronaut.validation.Validated;\n" +
+                "\n" +
+                "@Singleton\n" +
+                "@Validated\n" +
+                "public class Test {\n" );
+
+        for (int i = 0; i < 1000; i++) {
+             source.append("\npublic void insert")
+                     .append(i)
+                     .append("(int i) {\n")
+                     .append("        System.out.println(\"hello\" + i);\n")
+                     .append("    };");
+
+        }
+        source.append("}");
+    }
+
+    @Benchmark
+    public void benchmarkCompileAround() {
+        final BeanDefinition beanDefinition = buildBeanDefinition("test.Test", source.toString());
+        Objects.requireNonNull(beanDefinition);
+    }
+
+    BeanDefinition buildBeanDefinition(String className, String cls) {
+        String beanDefName= '$' + NameUtils.getSimpleName(className) + "Definition";
+        String packageName = NameUtils.getPackageName(className);
+        String beanFullName = packageName + "." + beanDefName;
+
+        ClassLoader classLoader = buildClassLoader(className, cls);
+        return (BeanDefinition) InstantiationUtils.instantiate(beanFullName, classLoader);
+    }
+
+    protected ClassLoader buildClassLoader(String className, String cls) {
+        final Iterable<? extends JavaFileObject> files = newJavaParser().generate(className, cls);
+        ClassLoader classLoader = new ClassLoader() {
+            @Override
+            protected Class<?> findClass(String name) throws ClassNotFoundException {
+                String fileName = name.replace('.', '/') + ".class";
+                JavaFileObject generated = CollectionUtils.iterableToList(files)
+                    .stream().filter((it) -> it.getName().endsWith(fileName))
+                    .findFirst().orElse(null);
+                try {
+                    if (generated != null) {
+                        byte[] bytes = IOGroovyMethods.getBytes(generated.openInputStream());
+                        return defineClass(name, bytes, 0, bytes.length);
+                    }
+                } catch (IOException e) {
+                    throw new RuntimeException("Compile failed: " + e.getMessage());
+                }
+                return super.findClass(name);
+            }
+        };
+        return classLoader;
+    }
+
+    /**
+     * Create and return a new Java parser.
+     * @return The java parser to use
+     */
+    protected JavaParser newJavaParser() {
+        return new JavaParser();
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(".*" + AroundCompileBenchmark.class.getSimpleName() + ".*")
+                .warmupIterations(3)
+                .measurementIterations(5)
+                .forks(1)
+//                .jvmArgs("-agentpath:/Applications/YourKit-Java-Profiler-2018.04.app/Contents/Resources/bin/mac/libyjpagent.jnilib")
+                .build();
+
+        new Runner(opt).run();
+    }
+
+}

--- a/core/src/main/java/io/micronaut/core/util/ArrayUtils.java
+++ b/core/src/main/java/io/micronaut/core/util/ArrayUtils.java
@@ -17,8 +17,7 @@ package io.micronaut.core.util;
 
 import javax.annotation.Nullable;
 import java.lang.reflect.Array;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 
 /**
  * Utility methods for working with arrays.
@@ -129,5 +128,110 @@ public class ArrayUtils {
         }
         List<Object> list = Arrays.asList(array);
         return CollectionUtils.toString(delimiter, list);
+    }
+
+    /**
+     * Produce an iterator for the given array.
+     * @param array The array
+     * @param <T> The array type
+     * @return The iterator
+     */
+    public static <T> Iterator<T> iterator(T...array) {
+        if (isNotEmpty(array)) {
+            return new ArrayIterator<>(array);
+        } else {
+            return Collections.emptyIterator();
+        }
+    }
+
+
+    /**
+     * Produce an iterator for the given array.
+     * @param array The array
+     * @param <T> The array type
+     * @return The iterator
+     */
+    public static <T> Iterator<T> reverseIterator(T...array) {
+        if (isNotEmpty(array)) {
+            return new ReverseArrayIterator<>(array);
+        } else {
+            return Collections.emptyIterator();
+        }
+    }
+
+    /**
+     * Iterator implementation used to efficiently expose contents of an
+     * Array as read-only iterator.
+     *
+     * @param <T> the type
+     */
+    private static final class ArrayIterator<T> implements Iterator<T>, Iterable<T> {
+
+        private final T[] _a;
+        private int _index;
+
+        private ArrayIterator(T[] a) {
+            _a = a;
+            _index = 0;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return _index < _a.length;
+        }
+
+        @Override
+        public T next() {
+            if (_index >= _a.length) {
+                throw new NoSuchElementException();
+            }
+            return _a[_index++];
+        }
+
+        @Override public void remove() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override public Iterator<T> iterator() {
+            return this;
+        }
+    }
+
+    /**
+     * Iterator implementation used to efficiently expose contents of an
+     * Array as read-only iterator.
+     *
+     * @param <T> the type
+     */
+    private static final class ReverseArrayIterator<T> implements Iterator<T>, Iterable<T> {
+
+        private final T[] _a;
+        private int _index;
+
+        private ReverseArrayIterator(T[] a) {
+            _a = a;
+            _index = a.length > 0 ? a.length : -1;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return _index > -1;
+        }
+
+        @Override
+        public T next() {
+            if (_index >= -1) {
+                throw new NoSuchElementException();
+            }
+            return _a[_index--];
+        }
+
+        @Override public void remove() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override public Iterator<T> iterator() {
+            return this;
+        }
     }
 }

--- a/inject-java-test/src/main/groovy/io/micronaut/annotation/processing/test/AbstractTypeElementSpec.groovy
+++ b/inject-java-test/src/main/groovy/io/micronaut/annotation/processing/test/AbstractTypeElementSpec.groovy
@@ -235,7 +235,7 @@ class Test {
         return (TypeElement) element
     }
 
-    protected BeanDefinition buildBeanDefinition(String className, String cls) {
+    BeanDefinition buildBeanDefinition(String className, String cls) {
         def beanDefName= '$' + NameUtils.getSimpleName(className) + 'Definition'
         def packageName = NameUtils.getPackageName(className)
         String beanFullName = "${packageName}.${beanDefName}"

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/AnnotationUtils.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/AnnotationUtils.java
@@ -191,7 +191,7 @@ public class AnnotationUtils {
     public AnnotationMetadata getAnnotationMetadata(Element element) {
         AnnotationMetadata metadata = annotationMetadataCache.get(element);
         if (metadata == null) {
-            metadata = newAnnotationBuilder().build(element);
+            metadata = newAnnotationBuilder().buildOverridden(element);
             annotationMetadataCache.put(element, metadata);
         }
         return metadata;
@@ -208,7 +208,10 @@ public class AnnotationUtils {
     }
 
     /**
-     * Get the annotation metadata for the given element.
+     * Get the annotation metadata for the given element and the given parent.
+     * This method is used for cases when you need to combine annotation metadata for
+     * two elements, for example a JavaBean property where the field and the method metadata
+     * need to be combined.
      *
      * @param parent  The parent
      * @param element The element

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -1197,16 +1197,21 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                 );
             }
 
-            ExecutableMethodWriter executableMethodWriter = beanWriter.visitExecutableMethod(
-                    typeRef,
-                    resolvedReturnType,
-                    resolvedReturnType,
-                    returnTypeGenerics,
-                    method.getSimpleName().toString(),
-                    params.getParameters(),
-                    params.getGenericParameters(),
-                    params.getParameterMetadata(),
-                    params.getGenericTypes(), methodAnnotationMetadata);
+            final AopProxyWriter proxyWriter = resolveAopWriter(beanWriter);
+            ExecutableMethodWriter executableMethodWriter = null;
+            if (proxyWriter == null || proxyWriter.isProxyTarget()) {
+                executableMethodWriter = beanWriter.visitExecutableMethod(
+                        typeRef,
+                        resolvedReturnType,
+                        resolvedReturnType,
+                        returnTypeGenerics,
+                        method.getSimpleName().toString(),
+                        params.getParameters(),
+                        params.getGenericParameters(),
+                        params.getParameterMetadata(),
+                        params.getGenericTypes(), methodAnnotationMetadata);
+            }
+
 
             if (methodAnnotationMetadata.hasStereotype(Adapter.class)) {
                 visitAdaptedMethod(method, methodAnnotationMetadata);

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -559,9 +559,13 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
 
 
                 BeanDefinitionVisitor proxyWriter = beanDefinitionWriters.get(proxyKey);
+                final AnnotationMetadata annotationMetadata = new AnnotationMetadataHierarchy(
+                        concreteClassMetadata,
+                        constructorParameterInfo.getAnnotationMetadata()
+                );
                 if (proxyWriter != null) {
                     proxyWriter.visitBeanDefinitionConstructor(
-                            constructorParameterInfo.getAnnotationMetadata(),
+                            annotationMetadata,
                             constructorParameterInfo.isRequiresReflection(),
                             constructorParameterInfo.getParameters(),
                             constructorParameterInfo.getParameterMetadata(),
@@ -569,7 +573,7 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                 }
 
                 beanDefinitionWriter.visitBeanDefinitionConstructor(
-                        constructorParameterInfo.getAnnotationMetadata(),
+                        annotationMetadata,
                         constructorParameterInfo.isRequiresReflection(),
                         constructorParameterInfo.getParameters(),
                         constructorParameterInfo.getParameterMetadata(),

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -1267,6 +1267,17 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                                 aroundMethodMetadata);
                     }
 
+                } else if (executableMethodWriter == null) {
+                    beanWriter.visitExecutableMethod(
+                            typeRef,
+                            resolvedReturnType,
+                            resolvedReturnType,
+                            returnTypeGenerics,
+                            method.getSimpleName().toString(),
+                            params.getParameters(),
+                            params.getGenericParameters(),
+                            params.getParameterMetadata(),
+                            params.getGenericTypes(), methodAnnotationMetadata);
                 }
             }
         }

--- a/inject-java/src/test/groovy/io/micronaut/inject/AbstractTypeElementSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/AbstractTypeElementSpec.groovy
@@ -63,6 +63,14 @@ abstract class AbstractTypeElementSpec extends Specification {
         return metadata
     }
 
+    AnnotationMetadata buildDeclaredMethodAnnotationMetadata(String cls, String methodName) {
+        TypeElement element = buildTypeElement(cls)
+        Element method = element.getEnclosedElements().find() { it.simpleName.toString() == methodName }
+        JavaAnnotationMetadataBuilder builder = newJavaAnnotationBuilder()
+        AnnotationMetadata metadata = method != null ? builder.buildDeclared(method) : null
+        return metadata
+    }
+
     AnnotationMetadata buildMethodArgumentAnnotationMetadata(String cls, String methodName, String argumentName) {
         TypeElement element = buildTypeElement(cls)
         ExecutableElement method = (ExecutableElement)element.getEnclosedElements().find() { it.simpleName.toString() == methodName }

--- a/inject-java/src/test/groovy/io/micronaut/inject/annotation/AnnotationMetadataHierarchySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/annotation/AnnotationMetadataHierarchySpec.groovy
@@ -1,0 +1,94 @@
+package io.micronaut.inject.annotation
+
+import io.micronaut.context.annotation.Executable
+import io.micronaut.context.annotation.Property
+import io.micronaut.core.annotation.AnnotationMetadata
+import io.micronaut.core.annotation.AnnotationValue
+import io.micronaut.inject.AbstractTypeElementSpec
+
+import javax.inject.Singleton
+
+class AnnotationMetadataHierarchySpec extends AbstractTypeElementSpec{
+
+    void "test basic method annotation metadata"() {
+
+        given:
+        def source = '''\
+package test;
+
+import io.micronaut.context.annotation.*;
+
+@javax.inject.Singleton
+class Test {
+
+    @Executable
+    void someMethod() {}
+}
+'''
+        AnnotationMetadata methodMetadata = buildDeclaredMethodAnnotationMetadata(source, 'someMethod')
+        AnnotationMetadata typeMetadata = buildTypeAnnotationMetadata(source)
+        AnnotationMetadata annotationMetadata = new AnnotationMetadataHierarchy(typeMetadata, methodMetadata)
+
+        expect:
+        annotationMetadata.getAnnotationNamesByStereotype(javax.inject.Scope).contains(Singleton.name)
+        annotationMetadata.declaredAnnotationNames.contains(Executable.name)
+        annotationMetadata.annotationNames.contains(Executable.name)
+        annotationMetadata.annotationNames.contains(Singleton.name)
+        !annotationMetadata.declaredAnnotationNames.contains(Singleton.name)
+        !annotationMetadata.getDeclaredAnnotationNamesByStereotype(javax.inject.Scope.name).contains(Singleton.name)
+        !annotationMetadata.isDeclaredAnnotationPresent(Singleton)
+        annotationMetadata.isAnnotationPresent(Singleton)
+        annotationMetadata.hasAnnotation(Singleton)
+        annotationMetadata.hasDeclaredAnnotation(Executable)
+        !annotationMetadata.hasDeclaredAnnotation(Singleton)
+        annotationMetadata.findAnnotation(Singleton).isPresent()
+        annotationMetadata.synthesize(Singleton)
+    }
+
+    void "test repeatable annotations are combined"() {
+        AnnotationMetadata parent = buildTypeAnnotationMetadata('''\
+package test;
+
+import io.micronaut.inject.annotation.repeatable.*;
+import io.micronaut.context.annotation.*;
+
+@Property(name="prop1", value="value1")
+@Property(name="prop2", value="value2")
+@Property(name="prop3", value="value3")
+class Test {
+
+}
+''')
+        AnnotationMetadata child = buildTypeAnnotationMetadata('''\
+package test;
+
+import io.micronaut.inject.annotation.repeatable.*;
+import io.micronaut.context.annotation.*;
+
+@Property(name="prop2", value="value2")    
+@Property(name="prop3", value="value33")    
+@Property(name="prop4", value="value4")    
+class Test {
+}
+''')
+
+        when:
+        def className = "test"
+        AnnotationMetadata metadata1 = writeAndLoadMetadata(className, parent)
+        AnnotationMetadata metadata2 = writeAndLoadMetadata(className, child)
+
+        then:
+        AnnotationMetadataHierarchy hierarchy = new AnnotationMetadataHierarchy(metadata1, metadata2)
+        List<AnnotationValue<Property>> properties = hierarchy.getAnnotationValuesByType(Property)
+
+        then:
+        properties.size() == 5
+        properties[0].get("name", String).get() == "prop2"
+        properties[1].get("name", String).get() == "prop3"
+        properties[1].getValue(String).get() == "value33"
+        properties[2].get("name", String).get() == "prop4"
+        properties[3].get("name", String).get() == "prop1"
+        properties[4].get("name", String).get() == "prop3"
+        properties[4].getValue(String).get() == "value3"
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/annotation/BeanDefinitionAnnotationMetadataSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/annotation/BeanDefinitionAnnotationMetadataSpec.groovy
@@ -25,6 +25,7 @@ import io.micronaut.context.annotation.Requires
 import io.micronaut.inject.AbstractTypeElementSpec
 import io.micronaut.inject.BeanConfiguration
 import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.ExecutableMethod
 import spock.lang.Issue
 
 import javax.inject.Scope
@@ -136,11 +137,13 @@ class Test {
     void sometMethod() {}
 }
 ''')
+        def method = definition.findMethod('sometMethod').get()
+
         expect:
         definition != null
         definition.hasDeclaredAnnotation(Singleton)
-        definition.findMethod('sometMethod').isPresent()
-        definition.findMethod('sometMethod').get().annotationMetadata.hasDeclaredAnnotation(Executable)
+        method.annotationMetadata.hasAnnotation(Singleton)
+        method.annotationMetadata.hasDeclaredAnnotation(Executable)
     }
 
     void "test build configuration"() {

--- a/inject-java/src/test/groovy/io/micronaut/inject/factory/nullreturn/NullReturnFactorySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/factory/nullreturn/NullReturnFactorySpec.groovy
@@ -8,9 +8,52 @@ import io.micronaut.context.exceptions.BeanInstantiationException
 import io.micronaut.context.exceptions.DependencyInjectionException
 import io.micronaut.context.exceptions.NoSuchBeanException
 import io.micronaut.inject.AbstractTypeElementSpec
+import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.qualifiers.Qualifiers
 
 class NullReturnFactorySpec extends AbstractTypeElementSpec {
+
+    void "test parse factory"() {
+        given:
+        def definition = buildBeanDefinition('test.Test2Processor', '''
+package test;
+
+import io.micronaut.context.annotation.*;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+@EachBean(Test2.class)
+class Test2Processor {
+
+    static AtomicInteger constructed = new AtomicInteger();
+
+    private final Test2 d;
+
+    Test2Processor(Test2 d) {
+        this.d = d;
+        constructed.incrementAndGet();
+    }
+}
+
+@Factory
+class TestFactory {
+    @EachBean(Test1.class)
+    Test2 getD(Test1 c) {
+        if (c.name.equals("two")) {
+            return null;
+        } else {
+            return new Test2();
+        }
+    }
+}
+class Test1 {
+    String name;
+}
+class Test2 {}
+''')
+        expect:
+        definition != null
+    }
 
     void "test factory that returns null"() {
         given:

--- a/inject-java/src/test/groovy/io/micronaut/inject/factory/nullreturn/Test1.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/factory/nullreturn/Test1.java
@@ -1,0 +1,18 @@
+package io.micronaut.inject.factory.nullreturn;
+
+import io.micronaut.core.annotation.AnnotationClassValue;
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.AnnotationUtil;
+import io.micronaut.inject.annotation.DefaultAnnotationMetadata;
+
+public class Test1 {
+
+        public static final AnnotationMetadata $ANNOTATION_METADATA = new DefaultAnnotationMetadata(null, null, null, null, null);
+
+    static {
+        if (!DefaultAnnotationMetadata.areAnnotationDefaultsRegistered("io.micronaut.context.annotation.Requires")) {
+            DefaultAnnotationMetadata.registerAnnotationDefaults(new AnnotationClassValue<Object>("Requires"), AnnotationUtil.internMapOf(new Object[]{"condition", new AnnotationClassValue<Object>("Requires"), "beans", new Object[0], "notEnv", new Object[0], "resources", new Object[0], "env", new Object[0], "entities", new Object[0], "missingConfigurations", new Object[0], "missing", new Object[0], "missingBeans", new Object[0], "classes", new Object[0], "missingClasses", new Object[0], "sdk", "MICRONAUT"}));
+        }
+
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/AbstractBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractBeanDefinition.java
@@ -53,7 +53,6 @@ import io.micronaut.core.util.StringUtils;
 import io.micronaut.core.value.PropertyResolver;
 import io.micronaut.inject.*;
 import io.micronaut.inject.annotation.AbstractEnvironmentAnnotationMetadata;
-import io.micronaut.inject.annotation.DefaultAnnotationMetadata;
 import io.micronaut.inject.qualifiers.Qualifiers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -172,7 +171,6 @@ public class AbstractBeanDefinition<T> extends AbstractBeanContextConditional im
      * @param arguments                     The constructor arguments used to build the bean
      */
     @Internal
-    @SuppressWarnings({"unchecked", "WeakerAccess"})
     @UsedByGeneratedCode
     protected AbstractBeanDefinition(Class<T> type,
                                      AnnotationMetadata constructorAnnotationMetadata,
@@ -299,7 +297,6 @@ public class AbstractBeanDefinition<T> extends AbstractBeanContextConditional im
         return singleton;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public Optional<Class<? extends Annotation>> getScope() {
         return getAnnotationMetadata().getDeclaredAnnotationTypeByStereotype(Scope.class);
@@ -600,7 +597,7 @@ public class AbstractBeanDefinition<T> extends AbstractBeanContextConditional im
      * @return The bean
      */
     @Internal
-    @SuppressWarnings({"WeakerAccess", "unused"})
+    @SuppressWarnings({"unused"})
     @UsedByGeneratedCode
     protected Object injectAnother(BeanResolutionContext resolutionContext, BeanContext context, Object bean) {
         DefaultBeanContext defaultContext = (DefaultBeanContext) context;
@@ -619,7 +616,7 @@ public class AbstractBeanDefinition<T> extends AbstractBeanContextConditional im
      * @param bean              The bean
      * @return The bean
      */
-    @SuppressWarnings({"WeakerAccess", "unused", "unchecked"})
+    @SuppressWarnings({"unused", "unchecked"})
     @Internal
     @UsedByGeneratedCode
     protected Object postConstruct(BeanResolutionContext resolutionContext, BeanContext context, Object bean) {
@@ -1521,10 +1518,10 @@ public class AbstractBeanDefinition<T> extends AbstractBeanContextConditional im
 
     private AnnotationMetadata initializeAnnotationMetadata() {
         AnnotationMetadata annotationMetadata = resolveAnnotationMetadata();
-        if (annotationMetadata instanceof DefaultAnnotationMetadata) {
+        if (annotationMetadata != AnnotationMetadata.EMPTY_METADATA) {
             // we make a copy of the result of annotation metadata which is normally a reference
             // to the class metadata
-            return new BeanAnnotationMetadata((DefaultAnnotationMetadata) annotationMetadata);
+            return new BeanAnnotationMetadata(annotationMetadata);
         } else {
             return AnnotationMetadata.EMPTY_METADATA;
         }
@@ -1877,7 +1874,7 @@ public class AbstractBeanDefinition<T> extends AbstractBeanContextConditional im
      * Internal environment aware annotation metadata delegate.
      */
     private final class BeanAnnotationMetadata extends AbstractEnvironmentAnnotationMetadata {
-        BeanAnnotationMetadata(DefaultAnnotationMetadata targetMetadata) {
+        BeanAnnotationMetadata(AnnotationMetadata targetMetadata) {
             super(targetMetadata);
         }
 

--- a/inject/src/main/java/io/micronaut/context/AbstractExecutableMethod.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractExecutableMethod.java
@@ -24,7 +24,6 @@ import io.micronaut.core.type.Argument;
 import io.micronaut.core.type.ReturnType;
 import io.micronaut.inject.ExecutableMethod;
 import io.micronaut.inject.annotation.AbstractEnvironmentAnnotationMetadata;
-import io.micronaut.inject.annotation.DefaultAnnotationMetadata;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;

--- a/inject/src/main/java/io/micronaut/context/AbstractExecutableMethod.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractExecutableMethod.java
@@ -165,10 +165,10 @@ public abstract class AbstractExecutableMethod extends AbstractExecutable implem
 
     private AnnotationMetadata initializeAnnotationMetadata() {
         AnnotationMetadata annotationMetadata = resolveAnnotationMetadata();
-        if (annotationMetadata instanceof DefaultAnnotationMetadata) {
+        if (annotationMetadata != AnnotationMetadata.EMPTY_METADATA) {
             // we make a copy of the result of annotation metadata which is normally a reference
             // to the class metadata
-            return new MethodAnnotationMetadata((DefaultAnnotationMetadata) annotationMetadata);
+            return new MethodAnnotationMetadata(annotationMetadata);
         } else {
             return AnnotationMetadata.EMPTY_METADATA;
         }
@@ -231,7 +231,7 @@ public abstract class AbstractExecutableMethod extends AbstractExecutable implem
      * Internal environment aware annotation metadata delegate.
      */
     private final class MethodAnnotationMetadata extends AbstractEnvironmentAnnotationMetadata {
-        MethodAnnotationMetadata(DefaultAnnotationMetadata targetMetadata) {
+        MethodAnnotationMetadata(AnnotationMetadata targetMetadata) {
             super(targetMetadata);
         }
 

--- a/inject/src/main/java/io/micronaut/context/DefaultMethodInjectionPoint.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultMethodInjectionPoint.java
@@ -23,8 +23,6 @@ import io.micronaut.core.type.Argument;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.MethodInjectionPoint;
 import io.micronaut.inject.annotation.AbstractEnvironmentAnnotationMetadata;
-import io.micronaut.inject.annotation.DefaultAnnotationMetadata;
-
 import javax.annotation.Nullable;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
@@ -172,10 +170,8 @@ class DefaultMethodInjectionPoint implements MethodInjectionPoint, EnvironmentCo
     }
 
     private AnnotationMetadata initAnnotationMetadata(@Nullable AnnotationMetadata annotationMetadata) {
-        if (annotationMetadata instanceof DefaultAnnotationMetadata) {
-            return new MethodAnnotationMetadata((DefaultAnnotationMetadata) annotationMetadata);
-        } else if (annotationMetadata != null) {
-            return annotationMetadata;
+        if (annotationMetadata != AnnotationMetadata.EMPTY_METADATA) {
+            return new MethodAnnotationMetadata(annotationMetadata);
         }
         return AnnotationMetadata.EMPTY_METADATA;
     }
@@ -184,7 +180,7 @@ class DefaultMethodInjectionPoint implements MethodInjectionPoint, EnvironmentCo
      * Internal environment aware annotation metadata delegate.
      */
     private final class MethodAnnotationMetadata extends AbstractEnvironmentAnnotationMetadata {
-        MethodAnnotationMetadata(DefaultAnnotationMetadata targetMetadata) {
+        MethodAnnotationMetadata(AnnotationMetadata targetMetadata) {
             super(targetMetadata);
         }
 

--- a/inject/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadata.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadata.java
@@ -19,7 +19,6 @@ import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationUtil;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.core.convert.value.ConvertibleValues;
 import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.core.util.CollectionUtils;
@@ -74,8 +73,8 @@ abstract class AbstractAnnotationMetadata implements AnnotationMetadata {
         if (hasAnnotation(annotationClass) || hasStereotype(annotationClass)) {
             String annotationName = annotationClass.getName();
             return (T) annotationMap.computeIfAbsent(annotationName, s -> {
-                ConvertibleValues<Object> annotationValues = findAnnotation(annotationClass).map(AnnotationValue::getConvertibleValues).orElse(ConvertibleValues.empty());
-                return AnnotationMetadataSupport.buildAnnotation(annotationClass, annotationValues);
+                final AnnotationValue<T> annotationValue = findAnnotation(annotationClass).orElse(null);
+                return AnnotationMetadataSupport.buildAnnotation(annotationClass, annotationValue);
 
             });
         }
@@ -92,8 +91,8 @@ abstract class AbstractAnnotationMetadata implements AnnotationMetadata {
         String annotationName = annotationClass.getName();
         if (hasAnnotation(annotationName) || hasStereotype(annotationName)) {
             return (T) declaredAnnotationMap.computeIfAbsent(annotationName, s -> {
-                ConvertibleValues<Object> annotationValues = findAnnotation(annotationClass).map(AnnotationValue::getConvertibleValues).orElse(ConvertibleValues.empty());
-                return AnnotationMetadataSupport.buildAnnotation(annotationClass, annotationValues);
+                final AnnotationValue<T> annotationValue = findAnnotation(annotationClass).orElse(null);
+                return AnnotationMetadataSupport.buildAnnotation(annotationClass, annotationValue);
 
             });
         }

--- a/inject/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -1041,7 +1041,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                     declared,
                     null,
                     null,
-                    null,
+                    declared,
                     null
             );
             annotationMirror.ifPresent(annotationType ->

--- a/inject/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -1035,8 +1035,8 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         } else if (annotationMetadata == AnnotationMetadata.EMPTY_METADATA) {
             final Optional<T> annotationMirror = getAnnotationMirror(annotationValue.getAnnotationName());
             final Map<CharSequence, Object> values = annotationValue.getValues();
-            final Map<String, Map<CharSequence, Object>> declared =
-                    Collections.singletonMap(annotationValue.getAnnotationName(), values);
+            final Map<String, Map<CharSequence, Object>> declared = new HashMap<>(1);
+            declared.put(annotationValue.getAnnotationName(), values);
             final DefaultAnnotationMetadata newMetadata = new DefaultAnnotationMetadata(
                     declared,
                     null,

--- a/inject/src/main/java/io/micronaut/inject/annotation/AbstractEnvironmentAnnotationMetadata.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AbstractEnvironmentAnnotationMetadata.java
@@ -341,7 +341,7 @@ public abstract class AbstractEnvironmentAnnotationMetadata implements Annotatio
             List<AnnotationValue<T>> values = environmentAnnotationMetadata.getAnnotationValuesByType(annotationClass);
 
             return values.stream()
-                    .map(entries -> AnnotationMetadataSupport.buildAnnotation(annotationClass, EnvironmentConvertibleValuesMap.of(environment, entries.getValues())))
+                    .map(entries -> AnnotationMetadataSupport.buildAnnotation(annotationClass, new EnvironmentAnnotationValue<>(environment, entries)))
                     .toArray(value -> (T[]) Array.newInstance(annotationClass, value));
         } else {
             return environmentAnnotationMetadata.synthesizeAnnotationsByType(annotationClass);
@@ -358,7 +358,7 @@ public abstract class AbstractEnvironmentAnnotationMetadata implements Annotatio
             List<AnnotationValue<T>> values = environmentAnnotationMetadata.getDeclaredAnnotationValuesByType(annotationClass);
 
             return values.stream()
-                    .map(entries -> AnnotationMetadataSupport.buildAnnotation(annotationClass, EnvironmentConvertibleValuesMap.of(environment, entries.getValues())))
+                    .map(entries -> AnnotationMetadataSupport.buildAnnotation(annotationClass, new EnvironmentAnnotationValue<>(environment, entries)))
                     .toArray(value -> (T[]) Array.newInstance(annotationClass, value));
         } else {
             return environmentAnnotationMetadata.synthesizeDeclaredAnnotationsByType(annotationClass);

--- a/inject/src/main/java/io/micronaut/inject/annotation/AbstractEnvironmentAnnotationMetadata.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AbstractEnvironmentAnnotationMetadata.java
@@ -18,14 +18,11 @@ package io.micronaut.inject.annotation;
 import io.micronaut.context.env.Environment;
 import io.micronaut.context.env.PropertyPlaceholderResolver;
 import io.micronaut.context.exceptions.ConfigurationException;
-import io.micronaut.core.annotation.AnnotationMetadata;
-import io.micronaut.core.annotation.AnnotationValue;
-import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.*;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.core.value.OptionalValues;
-
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.lang.annotation.Annotation;
@@ -42,25 +39,47 @@ import java.util.stream.Stream;
  * @since 1.0
  */
 @Internal
-public abstract class AbstractEnvironmentAnnotationMetadata extends AbstractAnnotationMetadata implements AnnotationMetadata {
+public abstract class AbstractEnvironmentAnnotationMetadata implements AnnotationMetadata {
 
-    private final DefaultAnnotationMetadata annotationMetadata;
+    private final EnvironmentAnnotationMetadata environmentAnnotationMetadata;
 
     /**
      * Construct a new environment aware annotation metadata.
      *
      * @param targetMetadata The target annotation metadata
      */
-    protected AbstractEnvironmentAnnotationMetadata(DefaultAnnotationMetadata targetMetadata) {
-        super(targetMetadata.declaredAnnotations, targetMetadata.allAnnotations);
-        this.annotationMetadata = targetMetadata;
+    protected AbstractEnvironmentAnnotationMetadata(AnnotationMetadata targetMetadata) {
+        if (targetMetadata instanceof EnvironmentAnnotationMetadata) {
+            this.environmentAnnotationMetadata = (EnvironmentAnnotationMetadata) targetMetadata;
+        } else {
+            this.environmentAnnotationMetadata = new AnnotationMetadataHierarchy(targetMetadata);
+        }
+    }
+
+    /**
+     * @return The backing annotation metadata
+     */
+    public AnnotationMetadata getAnnotationMetadata() {
+        return environmentAnnotationMetadata;
+    }
+
+    @Nullable
+    @Override
+    public <T extends Annotation> T synthesize(@Nonnull Class<T> annotationClass) {
+        return environmentAnnotationMetadata.synthesize(annotationClass);
+    }
+
+    @Nullable
+    @Override
+    public <T extends Annotation> T synthesizeDeclared(@Nonnull Class<T> annotationClass) {
+        return environmentAnnotationMetadata.synthesizeDeclared(annotationClass);
     }
 
     @Override
     public <T> Optional<T> getValue(@Nonnull String annotation, @Nonnull String member, @Nonnull Argument<T> requiredType) {
         Environment environment = getEnvironment();
         if (environment != null) {
-            return annotationMetadata.getValue(annotation, member, requiredType, o -> {
+            return environmentAnnotationMetadata.getValue(annotation, member, requiredType, o -> {
                 PropertyPlaceholderResolver placeholderResolver = environment.getPlaceholderResolver();
                 if (o instanceof String) {
                     String v = (String) o;
@@ -79,25 +98,25 @@ public abstract class AbstractEnvironmentAnnotationMetadata extends AbstractAnno
                 return o;
             });
         } else {
-            return annotationMetadata.getValue(annotation, member, requiredType);
+            return environmentAnnotationMetadata.getValue(annotation, member, requiredType);
         }
     }
 
     @Override
     public <T> Class<T>[] classValues(@Nonnull String annotation, @Nonnull String member) {
-        return annotationMetadata.classValues(annotation, member);
+        return environmentAnnotationMetadata.classValues(annotation, member);
     }
 
     @Override
     public <T> Class<T>[] classValues(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member) {
-        return annotationMetadata.classValues(annotation, member);
+        return environmentAnnotationMetadata.classValues(annotation, member);
     }
 
     @Override
     public boolean isTrue(@Nonnull String annotation, @Nonnull String member) {
         Environment environment = getEnvironment();
         if (environment != null) {
-            return annotationMetadata.isTrue(annotation, member, o -> {
+            return environmentAnnotationMetadata.isTrue(annotation, member, o -> {
                 if (o instanceof String) {
                     String v = (String) o;
                     if (v.contains("${")) {
@@ -107,7 +126,7 @@ public abstract class AbstractEnvironmentAnnotationMetadata extends AbstractAnno
                 return o;
             });
         } else {
-            return annotationMetadata.isTrue(annotation, member);
+            return environmentAnnotationMetadata.isTrue(annotation, member);
         }
     }
 
@@ -115,7 +134,7 @@ public abstract class AbstractEnvironmentAnnotationMetadata extends AbstractAnno
     public boolean isFalse(@Nonnull String annotation, @Nonnull String member) {
         Environment environment = getEnvironment();
         if (environment != null) {
-            return !annotationMetadata.isTrue(annotation, member, o -> {
+            return !environmentAnnotationMetadata.isTrue(annotation, member, o -> {
                 if (o instanceof String) {
                     String v = (String) o;
                     if (v.contains("${")) {
@@ -125,66 +144,66 @@ public abstract class AbstractEnvironmentAnnotationMetadata extends AbstractAnno
                 return o;
             });
         } else {
-            return !annotationMetadata.isTrue(annotation, member);
+            return !environmentAnnotationMetadata.isTrue(annotation, member);
         }
     }
 
     @Nonnull
     @Override
     public Optional<Class<? extends Annotation>> getAnnotationTypeByStereotype(@Nonnull Class<? extends Annotation> stereotype) {
-        return annotationMetadata.getAnnotationTypeByStereotype(stereotype);
+        return environmentAnnotationMetadata.getAnnotationTypeByStereotype(stereotype);
     }
 
     @Nonnull
     @Override
     public Optional<Class<? extends Annotation>> getAnnotationTypeByStereotype(@Nullable String stereotype) {
-        return annotationMetadata.getAnnotationTypeByStereotype(stereotype);
+        return environmentAnnotationMetadata.getAnnotationTypeByStereotype(stereotype);
     }
 
     @Nonnull
     @Override
     public Optional<Class> classValue(@Nonnull String annotation, @Nonnull String member) {
         Function<Object, Object> valueMapper = getEnvironmentValueMapper();
-        return annotationMetadata.classValue(annotation, member, valueMapper);
+        return environmentAnnotationMetadata.classValue(annotation, member, valueMapper);
     }
 
     @Nonnull
     @Override
     public Optional<Class> classValue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member) {
         Function<Object, Object> valueMapper = getEnvironmentValueMapper();
-        return annotationMetadata.classValue(annotation, member, valueMapper);
+        return environmentAnnotationMetadata.classValue(annotation, member, valueMapper);
     }
 
     @Override
     public <E extends Enum> Optional<E> enumValue(@Nonnull String annotation, @Nonnull String member, Class<E> enumType) {
         Function<Object, Object> valueMapper = getEnvironmentValueMapper();
-        return annotationMetadata.enumValue(annotation, member,  enumType, valueMapper);
+        return environmentAnnotationMetadata.enumValue(annotation, member,  enumType, valueMapper);
     }
 
     @Override
     public <E extends Enum> Optional<E> enumValue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member, Class<E> enumType) {
         Function<Object, Object> valueMapper = getEnvironmentValueMapper();
-        return annotationMetadata.enumValue(annotation, member,  enumType, valueMapper);
+        return environmentAnnotationMetadata.enumValue(annotation, member,  enumType, valueMapper);
     }
 
     @Override
     public Optional<Boolean> booleanValue(@Nonnull String annotation, @Nonnull String member) {
         Function<Object, Object> valueMapper = getEnvironmentValueMapper();
-        return annotationMetadata.booleanValue(annotation, member,  valueMapper);
+        return environmentAnnotationMetadata.booleanValue(annotation, member, valueMapper);
 
     }
 
     @Override
     public Optional<Boolean> booleanValue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member) {
         Function<Object, Object> valueMapper = getEnvironmentValueMapper();
-        return annotationMetadata.booleanValue(annotation, member,  valueMapper);
+        return environmentAnnotationMetadata.booleanValue(annotation, member,  valueMapper);
     }
 
     @Nonnull
     @Override
     public Optional<String> stringValue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member) {
         Function<Object, Object> valueMapper = getEnvironmentValueMapper();
-        return annotationMetadata.stringValue(annotation, member, valueMapper);
+        return environmentAnnotationMetadata.stringValue(annotation, member, valueMapper);
     }
 
     @Nonnull
@@ -216,9 +235,9 @@ public abstract class AbstractEnvironmentAnnotationMetadata extends AbstractAnno
                         })
                         .toArray(String[]::new);
             };
-            return annotationMetadata.stringValues(annotation, member, valueMapper);
+            return environmentAnnotationMetadata.stringValues(annotation, member, valueMapper);
         } else {
-            return annotationMetadata.stringValues(annotation, member, null);
+            return environmentAnnotationMetadata.stringValues(annotation, member, null);
         }
     }
 
@@ -226,72 +245,72 @@ public abstract class AbstractEnvironmentAnnotationMetadata extends AbstractAnno
     @Override
     public Optional<String> stringValue(@Nonnull String annotation, @Nonnull String member) {
         Function<Object, Object> valueMapper = getEnvironmentValueMapper();
-        return annotationMetadata.stringValue(annotation, member, valueMapper);
+        return environmentAnnotationMetadata.stringValue(annotation, member, valueMapper);
     }
 
     @Override
     public OptionalLong longValue(@Nonnull String annotation, @Nonnull String member) {
         Function<Object, Object> valueMapper = getEnvironmentValueMapper();
-        return annotationMetadata.longValue(annotation, member, valueMapper);
+        return environmentAnnotationMetadata.longValue(annotation, member, valueMapper);
     }
 
     @Override
     public OptionalLong longValue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member) {
         Function<Object, Object> valueMapper = getEnvironmentValueMapper();
-        return annotationMetadata.longValue(annotation, member, valueMapper);
+        return environmentAnnotationMetadata.longValue(annotation, member, valueMapper);
     }
 
     @Nonnull
     @Override
     public OptionalInt intValue(@Nonnull String annotation, @Nonnull String member) {
         Function<Object, Object> valueMapper = getEnvironmentValueMapper();
-        return annotationMetadata.intValue(annotation, member, valueMapper);
+        return environmentAnnotationMetadata.intValue(annotation, member, valueMapper);
     }
 
     @Nonnull
     @Override
     public OptionalInt intValue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member) {
         Function<Object, Object> valueMapper = getEnvironmentValueMapper();
-        return annotationMetadata.intValue(annotation, member, valueMapper);
+        return environmentAnnotationMetadata.intValue(annotation, member, valueMapper);
     }
 
     @Nonnull
     @Override
     public OptionalDouble doubleValue(@Nonnull String annotation, @Nonnull String member) {
         Function<Object, Object> valueMapper = getEnvironmentValueMapper();
-        return annotationMetadata.doubleValue(annotation, member, valueMapper);
+        return environmentAnnotationMetadata.doubleValue(annotation, member, valueMapper);
     }
 
     @Nonnull
     @Override
     public OptionalDouble doubleValue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member) {
         Function<Object, Object> valueMapper = getEnvironmentValueMapper();
-        return annotationMetadata.doubleValue(annotation, member, valueMapper);
+        return environmentAnnotationMetadata.doubleValue(annotation, member, valueMapper);
     }
 
     @Override
     public boolean isTrue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member) {
         Function<Object, Object> valueMapper = getEnvironmentValueMapper();
-        return annotationMetadata.isTrue(annotation, member, valueMapper);
+        return environmentAnnotationMetadata.isTrue(annotation, member, valueMapper);
     }
 
     @Override
     public boolean isFalse(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member) {
         Function<Object, Object> valueMapper = getEnvironmentValueMapper();
-        return !annotationMetadata.isTrue(annotation, member, valueMapper);
+        return !environmentAnnotationMetadata.isTrue(annotation, member, valueMapper);
     }
 
     @Override
     public @Nonnull Optional<Class<? extends Annotation>> getAnnotationType(@Nonnull String name) {
         ArgumentUtils.requireNonNull("name", name);
-        return annotationMetadata.getAnnotationType(name);
+        return environmentAnnotationMetadata.getAnnotationType(name);
     }
 
     @Override
     public @Nonnull <T extends Annotation> List<AnnotationValue<T>> getAnnotationValuesByType(@Nonnull Class<T> annotationType) {
         ArgumentUtils.requireNonNull("annotationType", annotationType);
         Environment environment = getEnvironment();
-        List<AnnotationValue<T>> values = annotationMetadata.getAnnotationValuesByType(annotationType);
+        List<AnnotationValue<T>> values = environmentAnnotationMetadata.getAnnotationValuesByType(annotationType);
         if (environment != null) {
             return values.stream().map(entries ->
                     new EnvironmentAnnotationValue<>(environment, entries)
@@ -304,7 +323,7 @@ public abstract class AbstractEnvironmentAnnotationMetadata extends AbstractAnno
     public @Nonnull <T extends Annotation> List<AnnotationValue<T>> getDeclaredAnnotationValuesByType(@Nonnull Class<T> annotationType) {
         ArgumentUtils.requireNonNull("annotationType", annotationType);
         Environment environment = getEnvironment();
-        List<AnnotationValue<T>> values = annotationMetadata.getDeclaredAnnotationValuesByType(annotationType);
+        List<AnnotationValue<T>> values = environmentAnnotationMetadata.getDeclaredAnnotationValuesByType(annotationType);
         if (environment != null) {
             return values.stream().map(entries -> new EnvironmentAnnotationValue<>(environment, entries))
                     .collect(Collectors.toList());
@@ -319,13 +338,13 @@ public abstract class AbstractEnvironmentAnnotationMetadata extends AbstractAnno
         Environment environment = getEnvironment();
         if (environment != null) {
 
-            List<AnnotationValue<T>> values = annotationMetadata.getAnnotationValuesByType(annotationClass);
+            List<AnnotationValue<T>> values = environmentAnnotationMetadata.getAnnotationValuesByType(annotationClass);
 
             return values.stream()
                     .map(entries -> AnnotationMetadataSupport.buildAnnotation(annotationClass, EnvironmentConvertibleValuesMap.of(environment, entries.getValues())))
                     .toArray(value -> (T[]) Array.newInstance(annotationClass, value));
         } else {
-            return annotationMetadata.synthesizeAnnotationsByType(annotationClass);
+            return environmentAnnotationMetadata.synthesizeAnnotationsByType(annotationClass);
         }
     }
 
@@ -336,54 +355,54 @@ public abstract class AbstractEnvironmentAnnotationMetadata extends AbstractAnno
         Environment environment = getEnvironment();
         if (environment != null) {
 
-            List<AnnotationValue<T>> values = annotationMetadata.getDeclaredAnnotationValuesByType(annotationClass);
+            List<AnnotationValue<T>> values = environmentAnnotationMetadata.getDeclaredAnnotationValuesByType(annotationClass);
 
             return values.stream()
                     .map(entries -> AnnotationMetadataSupport.buildAnnotation(annotationClass, EnvironmentConvertibleValuesMap.of(environment, entries.getValues())))
                     .toArray(value -> (T[]) Array.newInstance(annotationClass, value));
         } else {
-            return annotationMetadata.synthesizeDeclaredAnnotationsByType(annotationClass);
+            return environmentAnnotationMetadata.synthesizeDeclaredAnnotationsByType(annotationClass);
         }
     }
 
     @Override
     public boolean hasDeclaredAnnotation(@Nullable String annotation) {
-        return annotationMetadata.hasDeclaredAnnotation(annotation);
+        return environmentAnnotationMetadata.hasDeclaredAnnotation(annotation);
     }
 
     @Override
     public boolean hasAnnotation(@Nullable String annotation) {
-        return annotationMetadata.hasAnnotation(annotation);
+        return environmentAnnotationMetadata.hasAnnotation(annotation);
     }
 
     @Override
     public boolean hasStereotype(@Nullable String annotation) {
-        return annotationMetadata.hasStereotype(annotation);
+        return environmentAnnotationMetadata.hasStereotype(annotation);
     }
 
     @Override
     public boolean hasDeclaredStereotype(@Nullable String annotation) {
-        return annotationMetadata.hasDeclaredStereotype(annotation);
+        return environmentAnnotationMetadata.hasDeclaredStereotype(annotation);
     }
 
     @Override
     public @Nonnull List<String> getAnnotationNamesByStereotype(String stereotype) {
-        return annotationMetadata.getAnnotationNamesByStereotype(stereotype);
+        return environmentAnnotationMetadata.getAnnotationNamesByStereotype(stereotype);
     }
 
     @Override
     public @Nonnull Set<String> getAnnotationNames() {
-        return annotationMetadata.getAnnotationNames();
+        return environmentAnnotationMetadata.getAnnotationNames();
     }
 
     @Override
     public @Nonnull Set<String> getDeclaredAnnotationNames() {
-        return annotationMetadata.getDeclaredAnnotationNames();
+        return environmentAnnotationMetadata.getDeclaredAnnotationNames();
     }
 
     @Override
     public @Nonnull List<String> getDeclaredAnnotationNamesByStereotype(String stereotype) {
-        return annotationMetadata.getDeclaredAnnotationNamesByStereotype(stereotype);
+        return environmentAnnotationMetadata.getDeclaredAnnotationNamesByStereotype(stereotype);
     }
 
     @Override
@@ -391,7 +410,7 @@ public abstract class AbstractEnvironmentAnnotationMetadata extends AbstractAnno
         ArgumentUtils.requireNonNull("annotation", annotation);
         Environment env = getEnvironment();
 
-        Optional<AnnotationValue<T>> values = annotationMetadata.findAnnotation(annotation);
+        Optional<AnnotationValue<T>> values = environmentAnnotationMetadata.findAnnotation(annotation);
 
         if (env != null) {
             return values.map(av -> new EnvironmentAnnotationValue<>(env, av));
@@ -404,7 +423,7 @@ public abstract class AbstractEnvironmentAnnotationMetadata extends AbstractAnno
         ArgumentUtils.requireNonNull("annotation", annotation);
         Environment env = getEnvironment();
 
-        Optional<AnnotationValue<T>> values = annotationMetadata.findDeclaredAnnotation(annotation);
+        Optional<AnnotationValue<T>> values = environmentAnnotationMetadata.findDeclaredAnnotation(annotation);
 
         if (env != null) {
             return values.map(av -> new EnvironmentAnnotationValue<>(env, av));
@@ -416,24 +435,37 @@ public abstract class AbstractEnvironmentAnnotationMetadata extends AbstractAnno
     public @Nonnull <T> OptionalValues<T> getValues(@Nonnull String annotation, @Nonnull Class<T> valueType) {
         ArgumentUtils.requireNonNull("annotation", annotation);
         ArgumentUtils.requireNonNull("valueType", valueType);
-        Map<String, Map<CharSequence, Object>> allAnnotations = annotationMetadata.allAnnotations;
-        Map<String, Map<CharSequence, Object>> allStereotypes = annotationMetadata.allStereotypes;
-        Environment environment = getEnvironment();
-        OptionalValues<T> values = resolveOptionalValuesForEnvironment(annotation, valueType, allAnnotations, allStereotypes, environment);
-        if (values != null) {
-            return values;
+
+        if (environmentAnnotationMetadata instanceof DefaultAnnotationMetadata) {
+            Environment environment = getEnvironment();
+            return resolveOptionalValuesForEnvironment(
+                    annotation,
+                    valueType,
+                    Collections.singleton(environmentAnnotationMetadata),
+                    environment
+            );
+        } else if (environmentAnnotationMetadata instanceof AnnotationMetadataHierarchy) {
+            AnnotationMetadataHierarchy hierarchy = (AnnotationMetadataHierarchy) environmentAnnotationMetadata;
+            Environment environment = getEnvironment();
+            return resolveOptionalValuesForEnvironment(
+                    annotation,
+                    valueType,
+                    hierarchy,
+                    environment
+            );
+
         }
         return OptionalValues.empty();
     }
 
     @Override
     public @Nonnull <T> Optional<T> getDefaultValue(@Nonnull String annotation, @Nonnull String member, @Nonnull Class<T> requiredType) {
-        return annotationMetadata.getDefaultValue(annotation, member, requiredType);
+        return environmentAnnotationMetadata.getDefaultValue(annotation, member, requiredType);
     }
 
     @Override
     public @Nonnull <T> Optional<T> getDefaultValue(@Nonnull String annotation, @Nonnull String member, @Nonnull Argument<T> requiredType) {
-        return annotationMetadata.getDefaultValue(annotation, member, requiredType);
+        return environmentAnnotationMetadata.getDefaultValue(annotation, member, requiredType);
     }
 
     /**
@@ -442,16 +474,6 @@ public abstract class AbstractEnvironmentAnnotationMetadata extends AbstractAnno
      * @return The metadata
      */
     protected abstract @Nullable Environment getEnvironment();
-
-    @Override
-    protected void addValuesToResults(List<AnnotationValue> results, AnnotationValue values) {
-        Environment environment = getEnvironment();
-        if (environment != null) {
-            results.add(new EnvironmentAnnotationValue<>(environment, values));
-        } else {
-            results.add(values);
-        }
-    }
 
     /**
      * @return The value mapper for the environment
@@ -472,26 +494,40 @@ public abstract class AbstractEnvironmentAnnotationMetadata extends AbstractAnno
         return null;
     }
 
-    private <T> OptionalValues<T> resolveOptionalValuesForEnvironment(String annotation, Class<T> valueType, Map<String, Map<CharSequence, Object>> allAnnotations, Map<String, Map<CharSequence, Object>> allStereotypes, Environment environment) {
-        if (allAnnotations != null && StringUtils.isNotEmpty(annotation)) {
-            Map<CharSequence, Object> values = allAnnotations.get(annotation);
-            if (values != null) {
-                if (environment != null) {
-                    return new EnvironmentOptionalValuesMap<>(valueType, values, environment);
-                } else {
-                    return OptionalValues.of(valueType, values);
-                }
-            } else {
-                values = allStereotypes.get(annotation);
-                if (values != null) {
-                    if (environment != null) {
-                        return new EnvironmentOptionalValuesMap<>(valueType, values, environment);
-                    } else {
-                        return OptionalValues.of(valueType, values);
-                    }
+    private <T> OptionalValues<T> resolveOptionalValuesForEnvironment(
+            String annotation,
+            Class<T> valueType,
+            Iterable<AnnotationMetadata> metadata,
+            Environment environment) {
+
+        Map<CharSequence, Object> finalValues = new LinkedHashMap<>();
+        for (AnnotationMetadata annotationMetadata : metadata) {
+            if (annotationMetadata instanceof DefaultAnnotationMetadata) {
+
+                Map<String, Map<CharSequence, Object>> allAnnotations = ((DefaultAnnotationMetadata) annotationMetadata).allAnnotations;
+                Map<String, Map<CharSequence, Object>> allStereotypes = ((DefaultAnnotationMetadata) annotationMetadata).allStereotypes;
+                if (allAnnotations != null && StringUtils.isNotEmpty(annotation)) {
+                    processMap(annotation, finalValues, allStereotypes);
+                    processMap(annotation, finalValues, allAnnotations);
                 }
             }
         }
-        return null;
+
+        if (environment != null) {
+            return new EnvironmentOptionalValuesMap<>(valueType, finalValues, environment);
+        } else {
+            return OptionalValues.of(valueType, finalValues);
+        }
+    }
+
+    private void processMap(String annotation, Map<CharSequence, Object> finalValues, Map<String, Map<CharSequence, Object>> allStereotypes) {
+        if (allStereotypes != null) {
+            Map<CharSequence, Object> values = allStereotypes.get(annotation);
+            if (values != null) {
+                for (Map.Entry<CharSequence, Object> entry : values.entrySet()) {
+                    finalValues.putIfAbsent(entry.getKey(), entry.getValue());
+                }
+            }
+        }
     }
 }

--- a/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataHierarchy.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataHierarchy.java
@@ -1,0 +1,653 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.annotation;
+
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.type.Argument;
+import io.micronaut.core.util.ArrayUtils;
+import io.micronaut.core.value.OptionalValues;
+import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.lang.annotation.Annotation;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Used to represent an annotation metadata hierarchy. The first {@link AnnotationMetadata} instance passed
+ * to the constructor represents the annotation metadata that is declared, hence methods like {@link #hasDeclaredAnnotation(String)} will return true for the last annotation metadata passed in the hierarchy.
+ *
+ * <p>This class is used to internally optimize memory usage and compilation time for classes that declare
+ * AOP advice at the type level and where the classes methods typically don't include any annotations and therefore
+ * would be wasteful to generate additional annotation metadata classes.</p>
+ *
+ * @author graemerocher
+ * @since 1.3.0
+ */
+public final class AnnotationMetadataHierarchy implements AnnotationMetadata, EnvironmentAnnotationMetadata, Iterable<AnnotationMetadata> {
+    /**
+     * Constant to represent an empty hierarchy.
+     */
+    public static final AnnotationMetadata[] EMPTY_HIERARCHY = {AnnotationMetadata.EMPTY_METADATA, AnnotationMetadata.EMPTY_METADATA};
+
+    private final AnnotationMetadata[] hierarchy;
+
+    /**
+     * Default constructor.
+     *
+     * @param hierarchy The annotation hierarchy
+     */
+    public AnnotationMetadataHierarchy(AnnotationMetadata... hierarchy) {
+        if (ArrayUtils.isNotEmpty(hierarchy)) {
+            // place the first in the hierarchy first
+            final int len = hierarchy.length;
+            if (len > 1) {
+                for (int i = 0; i < len / 2; i++) {
+                    AnnotationMetadata temp = hierarchy[i];
+                    final int pos = len - i - 1;
+                    hierarchy[i] = hierarchy[pos];
+                    hierarchy[pos] = temp;
+                }
+            }
+            this.hierarchy = hierarchy;
+        } else {
+            this.hierarchy = EMPTY_HIERARCHY;
+        }
+    }
+
+    /**
+     * Copy constructor.
+     * @param existing Existing
+     * @param newChild new child
+     */
+    private AnnotationMetadataHierarchy(AnnotationMetadata[] existing, AnnotationMetadata newChild) {
+        hierarchy = new AnnotationMetadata[existing.length];
+        System.arraycopy(existing, 0, hierarchy, 0, existing.length);
+        hierarchy[0] = newChild;
+    }
+
+    /**
+     * @return The metadata that is actually declared in the element
+     */
+    @Nonnull
+    public AnnotationMetadata getDeclaredMetadata() {
+        return hierarchy[0];
+    }
+
+    /**
+     * @return The metadata that is actually declared in the element
+     */
+    @Nonnull
+    public AnnotationMetadata getRootMetadata() {
+        return hierarchy[hierarchy.length - 1];
+    }
+
+    /**
+     * Create a new hierarchy instance from this metadata using this metadata's parents.
+     * @param child The child annotation metadata
+     * @return A new sibling
+     */
+    @Nonnull
+    public AnnotationMetadata createSibling(@Nonnull AnnotationMetadata child) {
+        if (hierarchy.length > 1) {
+            return new AnnotationMetadataHierarchy(hierarchy, child);
+        } else {
+            return child;
+        }
+    }
+
+    @Nullable
+    @Override
+    public <T extends Annotation> T synthesize(@Nonnull Class<T> annotationClass) {
+        for (AnnotationMetadata annotationMetadata : hierarchy) {
+            final T a = annotationMetadata.synthesize(annotationClass);
+            if (a != null) {
+                return a;
+            }
+        }
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public <T extends Annotation> T synthesizeDeclared(@Nonnull Class<T> annotationClass) {
+        return hierarchy[0].synthesize(annotationClass);
+    }
+
+    @Nonnull
+    @Override
+    public <T extends Annotation> Optional<AnnotationValue<T>> findAnnotation(@Nonnull String annotation) {
+        AnnotationValue<T> ann = null;
+        for (AnnotationMetadata annotationMetadata : hierarchy) {
+            final AnnotationValue<T> av = annotationMetadata.getAnnotation(annotation);
+            if (av != null) {
+                if (ann == null) {
+                    ann = av;
+                } else {
+                    final Map<CharSequence, Object> values = av.getValues();
+                    final Map<CharSequence, Object> existing = ann.getValues();
+                    Map<CharSequence, Object> newValues = new LinkedHashMap<>(values.size() + existing.size());
+                    newValues.putAll(existing);
+                    for (Map.Entry<CharSequence, Object> entry : values.entrySet()) {
+                        newValues.putIfAbsent(entry.getKey(), entry.getValue());
+                    }
+                    ann = new AnnotationValue<>(annotation, newValues);
+                }
+            }
+        }
+        return Optional.ofNullable(ann);
+    }
+
+    @Nonnull
+    @Override
+    public <T extends Annotation> Optional<AnnotationValue<T>> findDeclaredAnnotation(@Nonnull String annotation) {
+        return hierarchy[0].findDeclaredAnnotation(annotation);
+    }
+
+    @Nonnull
+    @Override
+    public OptionalDouble doubleValue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member) {
+        for (AnnotationMetadata annotationMetadata : hierarchy) {
+            final OptionalDouble o = annotationMetadata.doubleValue(annotation, member);
+            if (o.isPresent()) {
+                return o;
+            }
+        }
+        return OptionalDouble.empty();
+    }
+
+    @Nonnull
+    @Override
+    public String[] stringValues(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member) {
+        return Arrays.stream(hierarchy)
+                .flatMap(am -> Stream.of(am.stringValues(annotation, member)))
+                .toArray(String[]::new);
+    }
+
+    @Override
+    public Optional<Boolean> booleanValue(@Nonnull String annotation, @Nonnull String member) {
+        for (AnnotationMetadata annotationMetadata : hierarchy) {
+            final Optional<Boolean> o = annotationMetadata.booleanValue(annotation, member);
+            if (o.isPresent()) {
+                return o;
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean isTrue(@Nonnull String annotation, @Nonnull String member) {
+        return Arrays.stream(hierarchy).anyMatch(am -> am.isTrue(annotation, member));
+    }
+
+    @Override
+    public OptionalLong longValue(@Nonnull String annotation, @Nonnull String member) {
+        for (AnnotationMetadata annotationMetadata : hierarchy) {
+            final OptionalLong o = annotationMetadata.longValue(annotation, member);
+            if (o.isPresent()) {
+                return o;
+            }
+        }
+        return OptionalLong.empty();
+    }
+
+    @Override
+    public Optional<String> stringValue(@Nonnull String annotation, @Nonnull String member) {
+        for (AnnotationMetadata annotationMetadata : hierarchy) {
+            final Optional<String> o = annotationMetadata.stringValue(annotation, member);
+            if (o.isPresent()) {
+                return o;
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public OptionalInt intValue(@Nonnull String annotation, @Nonnull String member) {
+        for (AnnotationMetadata annotationMetadata : hierarchy) {
+            final OptionalInt o = annotationMetadata.intValue(annotation, member);
+            if (o.isPresent()) {
+                return o;
+            }
+        }
+        return OptionalInt.empty();
+    }
+
+    @Nonnull
+    @Override
+    public OptionalDouble doubleValue(@Nonnull String annotation, @Nonnull String member) {
+        for (AnnotationMetadata annotationMetadata : hierarchy) {
+            final OptionalDouble o = annotationMetadata.doubleValue(annotation, member);
+            if (o.isPresent()) {
+                return o;
+            }
+        }
+        return OptionalDouble.empty();
+    }
+
+    @Override
+    public <E extends Enum> Optional<E> enumValue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member, Class<E> enumType) {
+        for (AnnotationMetadata annotationMetadata : hierarchy) {
+            final Optional<E> o = annotationMetadata.enumValue(annotation, member, enumType);
+            if (o.isPresent()) {
+                return o;
+            }
+        }
+        return Optional.empty();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Nonnull
+    @Override
+    public <T> Class<T>[] classValues(@Nonnull String annotation, @Nonnull String member) {
+        final Class[] classes = Arrays.stream(hierarchy)
+                .flatMap(am -> Stream.of(am.classValues(annotation, member)))
+                .toArray(Class[]::new);
+        return (Class<T>[]) classes;
+    }
+
+    @Override
+    public Optional<Class> classValue(@Nonnull String annotation, @Nonnull String member) {
+        for (AnnotationMetadata annotationMetadata : hierarchy) {
+            final Optional<Class> o = annotationMetadata.classValue(annotation, member);
+            if (o.isPresent()) {
+                return o;
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Nonnull
+    @Override
+    public List<String> getAnnotationNamesByStereotype(@Nullable String stereotype) {
+        return Arrays.stream(hierarchy)
+                .flatMap(am -> am.getAnnotationNamesByStereotype(stereotype).stream())
+                .collect(Collectors.toList());
+    }
+
+    @Nonnull
+    @Override
+    public Set<String> getDeclaredAnnotationNames() {
+        return hierarchy[0].getDeclaredAnnotationNames();
+    }
+
+    @Nonnull
+    @Override
+    public Set<String> getAnnotationNames() {
+        return Arrays.stream(hierarchy)
+                .flatMap(am -> am.getAnnotationNames().stream())
+                .collect(Collectors.toSet());
+    }
+
+    @Nonnull
+    @Override
+    public <T> OptionalValues<T> getValues(@Nonnull String annotation, @Nonnull Class<T> valueType) {
+        for (AnnotationMetadata annotationMetadata : hierarchy) {
+            final OptionalValues<T> values = annotationMetadata.getValues(annotation, valueType);
+            if (!values.isEmpty()) {
+                return values;
+            }
+        }
+        return OptionalValues.empty();
+    }
+
+    @Override
+    public <T> Optional<T> getDefaultValue(@Nonnull String annotation, @Nonnull String member, @Nonnull Argument<T> requiredType) {
+        for (AnnotationMetadata annotationMetadata : hierarchy) {
+            final Optional<T> defaultValue = annotationMetadata.getDefaultValue(annotation, member, requiredType);
+            if (defaultValue.isPresent()) {
+                return defaultValue;
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Nonnull
+    @Override
+    public <T extends Annotation> List<AnnotationValue<T>> getAnnotationValuesByType(@Nonnull Class<T> annotationType) {
+        return Arrays.stream(hierarchy)
+                .flatMap(am -> am.getDeclaredAnnotationValuesByType(annotationType).stream())
+                .distinct()
+                .collect(Collectors.toList());
+    }
+
+    @Nonnull
+    @Override
+    public <T extends Annotation> List<AnnotationValue<T>> getDeclaredAnnotationValuesByType(@Nonnull Class<T> annotationType) {
+        return hierarchy[0].getDeclaredAnnotationValuesByType(annotationType);
+    }
+
+    @Override
+    public boolean hasDeclaredAnnotation(@Nullable String annotation) {
+        return hierarchy[0].hasDeclaredAnnotation(annotation);
+    }
+
+    @Override
+    public boolean hasAnnotation(@Nullable String annotation) {
+        for (AnnotationMetadata annotationMetadata : hierarchy) {
+            if (annotationMetadata.hasStereotype(annotation)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean hasStereotype(@Nullable String annotation) {
+        for (AnnotationMetadata annotationMetadata : hierarchy) {
+            if (annotationMetadata.hasStereotype(annotation)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean hasDeclaredStereotype(@Nullable String annotation) {
+        return hierarchy[0].hasDeclaredStereotype(annotation);
+    }
+
+    @Nonnull
+    @Override
+    public Map<String, Object> getDefaultValues(@Nonnull String annotation) {
+        for (AnnotationMetadata annotationMetadata : hierarchy) {
+            final Map<String, Object> defaultValues = annotationMetadata.getDefaultValues(annotation);
+            if (!defaultValues.isEmpty()) {
+                return defaultValues;
+            }
+        }
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public <E extends Enum> Optional<E> enumValue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member, Class<E> enumType, @Nullable Function<Object, Object> valueMapper) {
+        for (AnnotationMetadata annotationMetadata : hierarchy) {
+            final Optional<E> o;
+            if (annotationMetadata instanceof EnvironmentAnnotationMetadata) {
+                o = ((EnvironmentAnnotationMetadata) annotationMetadata).enumValue(annotation, member, enumType, valueMapper);
+            } else {
+                o = annotationMetadata.enumValue(annotation, member, enumType);
+            }
+            if (o.isPresent()) {
+                return o;
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public <E extends Enum> Optional<E> enumValue(@Nonnull String annotation, @Nonnull String member, Class<E> enumType, @Nullable Function<Object, Object> valueMapper) {
+        for (AnnotationMetadata annotationMetadata : hierarchy) {
+            final Optional<E> o;
+            if (annotationMetadata instanceof EnvironmentAnnotationMetadata) {
+                o = ((EnvironmentAnnotationMetadata) annotationMetadata).enumValue(annotation, member, enumType, valueMapper);
+            } else {
+                o = annotationMetadata.enumValue(annotation, member, enumType);
+            }
+            if (o.isPresent()) {
+                return o;
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Class> classValue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member, Function<Object, Object> valueMapper) {
+        for (AnnotationMetadata annotationMetadata : hierarchy) {
+            final Optional<Class> o;
+            if (annotationMetadata instanceof EnvironmentAnnotationMetadata) {
+                o = ((EnvironmentAnnotationMetadata) annotationMetadata).classValue(annotation, member, valueMapper);
+            } else {
+                o = annotationMetadata.classValue(annotation, member);
+            }
+            if (o.isPresent()) {
+                return o;
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Class> classValue(@Nonnull String annotation, @Nonnull String member, @Nullable Function<Object, Object> valueMapper) {
+        for (AnnotationMetadata annotationMetadata : hierarchy) {
+            final Optional<Class> o;
+            if (annotationMetadata instanceof EnvironmentAnnotationMetadata) {
+                o = ((EnvironmentAnnotationMetadata) annotationMetadata).classValue(annotation, member, valueMapper);
+            } else {
+                o = annotationMetadata.classValue(annotation, member);
+            }
+            if (o.isPresent()) {
+                return o;
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public OptionalInt intValue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member, @Nullable Function<Object, Object> valueMapper) {
+        for (AnnotationMetadata annotationMetadata : hierarchy) {
+            final OptionalInt o;
+            if (annotationMetadata instanceof EnvironmentAnnotationMetadata) {
+                o = ((EnvironmentAnnotationMetadata) annotationMetadata).intValue(annotation, member, valueMapper);
+            } else {
+                o = annotationMetadata.intValue(annotation, member);
+            }
+            if (o.isPresent()) {
+                return o;
+            }
+        }
+        return OptionalInt.empty();
+    }
+
+    @Override
+    public Optional<Boolean> booleanValue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member, Function<Object, Object> valueMapper) {
+        for (AnnotationMetadata annotationMetadata : hierarchy) {
+            final Optional<Boolean> o;
+            if (annotationMetadata instanceof EnvironmentAnnotationMetadata) {
+                o = ((EnvironmentAnnotationMetadata) annotationMetadata).booleanValue(annotation, member, valueMapper);
+            } else {
+                o = annotationMetadata.booleanValue(annotation, member);
+            }
+            if (o.isPresent()) {
+                return o;
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Nonnull
+    @Override
+    public Optional<Boolean> booleanValue(@Nonnull String annotation, @Nonnull String member, @Nullable Function<Object, Object> valueMapper) {
+        for (AnnotationMetadata annotationMetadata : hierarchy) {
+            final Optional<Boolean> o;
+            if (annotationMetadata instanceof EnvironmentAnnotationMetadata) {
+                o = ((EnvironmentAnnotationMetadata) annotationMetadata).booleanValue(annotation, member, valueMapper);
+            } else {
+                o = annotationMetadata.booleanValue(annotation, member);
+            }
+            if (o.isPresent()) {
+                return o;
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public OptionalLong longValue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member, @Nullable Function<Object, Object> valueMapper) {
+        for (AnnotationMetadata annotationMetadata : hierarchy) {
+            final OptionalLong o;
+            if (annotationMetadata instanceof EnvironmentAnnotationMetadata) {
+                o = ((EnvironmentAnnotationMetadata) annotationMetadata).longValue(annotation, member, valueMapper);
+            } else {
+                o = annotationMetadata.longValue(annotation, member);
+            }
+            if (o.isPresent()) {
+                return o;
+            }
+        }
+        return OptionalLong.empty();
+    }
+
+    @Nonnull
+    @Override
+    public OptionalLong longValue(@Nonnull String annotation, @Nonnull String member, @Nullable Function<Object, Object> valueMapper) {
+        for (AnnotationMetadata annotationMetadata : hierarchy) {
+            final OptionalLong o;
+            if (annotationMetadata instanceof EnvironmentAnnotationMetadata) {
+                o = ((EnvironmentAnnotationMetadata) annotationMetadata).longValue(annotation, member, valueMapper);
+            } else {
+                o = annotationMetadata.longValue(annotation, member);
+            }
+            if (o.isPresent()) {
+                return o;
+            }
+        }
+        return OptionalLong.empty();
+    }
+
+    @Nonnull
+    @Override
+    public OptionalInt intValue(@Nonnull String annotation, @Nonnull String member, @Nullable Function<Object, Object> valueMapper) {
+        for (AnnotationMetadata annotationMetadata : hierarchy) {
+            final OptionalInt o;
+            if (annotationMetadata instanceof EnvironmentAnnotationMetadata) {
+                o = ((EnvironmentAnnotationMetadata) annotationMetadata).intValue(annotation, member, valueMapper);
+            } else {
+                o = annotationMetadata.intValue(annotation, member);
+            }
+            if (o.isPresent()) {
+                return o;
+            }
+        }
+        return OptionalInt.empty();
+    }
+
+    @Override
+    public Optional<String> stringValue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member, Function<Object, Object> valueMapper) {
+        for (AnnotationMetadata annotationMetadata : hierarchy) {
+            final Optional<String> o;
+            if (annotationMetadata instanceof EnvironmentAnnotationMetadata) {
+                o = ((EnvironmentAnnotationMetadata) annotationMetadata).stringValue(annotation, member, valueMapper);
+            } else {
+                o = annotationMetadata.stringValue(annotation, member);
+            }
+            if (o.isPresent()) {
+                return o;
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Nonnull
+    @Override
+    public String[] stringValues(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member, Function<Object, Object> valueMapper) {
+        return Arrays.stream(hierarchy)
+                .flatMap(am -> {
+                    if (am instanceof EnvironmentAnnotationMetadata) {
+                        return Stream.of(((EnvironmentAnnotationMetadata) am).stringValues(annotation, member, valueMapper));
+                    }
+                    return Stream.of(am.stringValues(annotation, member));
+                })
+                .toArray(String[]::new);
+    }
+
+    @Nonnull
+    @Override
+    public Optional<String> stringValue(@Nonnull String annotation, @Nonnull String member, @Nullable Function<Object, Object> valueMapper) {
+        for (AnnotationMetadata annotationMetadata : hierarchy) {
+            final Optional<String> o;
+            if (annotationMetadata instanceof EnvironmentAnnotationMetadata) {
+                o = ((EnvironmentAnnotationMetadata) annotationMetadata).stringValue(annotation, member, valueMapper);
+            } else {
+                o = annotationMetadata.stringValue(annotation, member);
+            }
+            if (o.isPresent()) {
+                return o;
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean isTrue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member, Function<Object, Object> valueMapper) {
+        return booleanValue(annotation, member, valueMapper).orElse(false);
+    }
+
+    @Override
+    public boolean isTrue(@Nonnull String annotation, @Nonnull String member, @Nullable Function<Object, Object> valueMapper) {
+        return booleanValue(annotation, member, valueMapper).orElse(false);
+    }
+
+    @Override
+    public OptionalDouble doubleValue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member, @Nullable Function<Object, Object> valueMapper) {
+        for (AnnotationMetadata annotationMetadata : hierarchy) {
+            final OptionalDouble o;
+            if (annotationMetadata instanceof EnvironmentAnnotationMetadata) {
+                o = ((EnvironmentAnnotationMetadata) annotationMetadata).doubleValue(annotation, member, valueMapper);
+            } else {
+                o = annotationMetadata.doubleValue(annotation, member);
+            }
+            if (o.isPresent()) {
+                return o;
+            }
+        }
+        return OptionalDouble.empty();
+    }
+
+    @Nonnull
+    @Override
+    public OptionalDouble doubleValue(@Nonnull String annotation, @Nonnull String member, Function<Object, Object> valueMapper) {
+        for (AnnotationMetadata annotationMetadata : hierarchy) {
+            final OptionalDouble o;
+            if (annotationMetadata instanceof EnvironmentAnnotationMetadata) {
+                o = ((EnvironmentAnnotationMetadata) annotationMetadata).doubleValue(annotation, member, valueMapper);
+            } else {
+                o = annotationMetadata.doubleValue(annotation, member);
+            }
+            if (o.isPresent()) {
+                return o;
+            }
+        }
+        return OptionalDouble.empty();
+    }
+
+    @Nonnull
+    @Override
+    public <T> Optional<T> getValue(@Nonnull String annotation, @Nonnull String member, @Nonnull Argument<T> requiredType, @Nullable Function<Object, Object> valueMapper) {
+        for (AnnotationMetadata annotationMetadata : hierarchy) {
+            final Optional<T> o;
+            if (annotationMetadata instanceof EnvironmentAnnotationMetadata) {
+                o = ((EnvironmentAnnotationMetadata) annotationMetadata).getValue(annotation, member, requiredType, valueMapper);
+            } else {
+                o = annotationMetadata.getValue(annotation, member, requiredType);
+            }
+            if (o.isPresent()) {
+                return o;
+            }
+        }
+        return Optional.empty();
+    }
+
+    @NotNull
+    @Override
+    public Iterator<AnnotationMetadata> iterator() {
+        return ArrayUtils.reverseIterator(hierarchy);
+    }
+}

--- a/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataSupport.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataSupport.java
@@ -165,7 +165,7 @@ class AnnotationMetadataSupport {
      */
     static void registerDefaultValues(String annotation, Map<String, Object> defaultValues) {
         if (StringUtils.isNotEmpty(annotation)) {
-            ANNOTATION_DEFAULTS.put(annotation, defaultValues);
+            ANNOTATION_DEFAULTS.putIfAbsent(annotation, defaultValues);
         }
     }
 

--- a/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataSupport.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataSupport.java
@@ -16,11 +16,7 @@
 package io.micronaut.inject.annotation;
 
 import io.micronaut.context.annotation.*;
-import io.micronaut.core.annotation.AnnotationClassValue;
-import io.micronaut.core.annotation.AnnotationUtil;
-import io.micronaut.core.annotation.Internal;
-import io.micronaut.core.annotation.Introspected;
-import io.micronaut.core.convert.value.ConvertibleValues;
+import io.micronaut.core.annotation.*;
 import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.core.reflect.InstantiationUtils;
 import io.micronaut.core.reflect.ReflectionUtils;
@@ -214,27 +210,21 @@ class AnnotationMetadataSupport {
 
     /**
      * @param annotationClass  The annotation class
-     * @param annotationValues The annotation values
+     * @param annotationValue The annotation value
      * @param <T>              The type
      * @return The annotation
      */
-    static <T extends Annotation> T buildAnnotation(Class<T> annotationClass, ConvertibleValues<Object> annotationValues) {
+    static <T extends Annotation> T buildAnnotation(Class<T> annotationClass, @Nullable AnnotationValue<T> annotationValue) {
         Optional<Constructor<InvocationHandler>> proxyClass = getProxyClass(annotationClass);
         if (proxyClass.isPresent()) {
-            Method[] declaredMethods = annotationClass.getDeclaredMethods();
-            Map<CharSequence, Object> resolvedValues = new LinkedHashMap<>(declaredMethods.length);
-            for (Method declaredMethod : declaredMethods) {
-                String name = declaredMethod.getName();
-                if (annotationValues.contains(name)) {
-                    Optional<?> converted = annotationValues.get(name, declaredMethod.getReturnType());
-                    converted.ifPresent(o -> resolvedValues.put(name, o));
-                }
-            }
             Map<String, Object> values = new HashMap<>(getDefaultValues(annotationClass));
-            values.putAll(annotationValues.asMap());
+            if (annotationValue != null) {
+                final Map<CharSequence, Object> annotationValues = annotationValue.getValues();
+                annotationValues.forEach((key, o) -> values.put(key.toString(), o));
+            }
             int hashCode = AnnotationUtil.calculateHashCode(values);
 
-            Optional instantiated = InstantiationUtils.tryInstantiate(proxyClass.get(), (InvocationHandler) new AnnotationProxyHandler(hashCode, annotationClass, resolvedValues));
+            Optional instantiated = InstantiationUtils.tryInstantiate(proxyClass.get(), (InvocationHandler) new AnnotationProxyHandler(hashCode, annotationClass, annotationValue));
             if (instantiated.isPresent()) {
                 return (T) instantiated.get();
             }
@@ -248,17 +238,12 @@ class AnnotationMetadataSupport {
     private static class AnnotationProxyHandler implements InvocationHandler {
         private final int hashCode;
         private final Class<?> annotationClass;
+        private final AnnotationValue<?> annotationValue;
 
-        private final Map<CharSequence, Object> resolvedValues;
-
-        AnnotationProxyHandler(int hashCode, Class<?> annotationClass, Map<CharSequence, Object> resolvedValues) {
+        AnnotationProxyHandler(int hashCode, Class<?> annotationClass, @Nullable AnnotationValue<?> annotationValue) {
             this.hashCode = hashCode;
             this.annotationClass = annotationClass;
-            this.resolvedValues = resolvedValues;
-        }
-
-        public Map<CharSequence, Object> getValues() {
-            return resolvedValues;
+            this.annotationValue = annotationValue;
         }
 
         @Override
@@ -280,30 +265,22 @@ class AnnotationMetadataSupport {
 
             Annotation other = (Annotation) annotationClass.cast(obj);
 
-            Map<CharSequence, Object> otherValues = getAnnotationValues(other);
+            final AnnotationValue<?> otherValues = getAnnotationValues(other);
 
-            if (resolvedValues.size() != otherValues.size()) {
+            if (this.annotationValue == null && otherValues == null) {
+                return true;
+            } else if (this.annotationValue == null || otherValues == null) {
                 return false;
+            } else {
+                return annotationValue.equals(otherValues);
             }
-
-            // compare annotation member values
-            for (Map.Entry<CharSequence, Object> member : resolvedValues.entrySet()) {
-                Object value = member.getValue();
-                Object otherValue = otherValues.get(member.getKey());
-
-                if (!AnnotationUtil.areEqual(value, otherValue)) {
-                    return false;
-                }
-            }
-
-            return true;
         }
 
-        private Map<CharSequence, Object> getAnnotationValues(Annotation other) {
+        private AnnotationValue<?> getAnnotationValues(Annotation other) {
             if (other instanceof AnnotationProxyHandler) {
-                return ((AnnotationProxyHandler) other).resolvedValues;
+                return ((AnnotationProxyHandler) other).annotationValue;
             }
-            return Collections.emptyMap();
+            return null;
         }
 
         @Override
@@ -315,8 +292,8 @@ class AnnotationMetadataSupport {
                 return equals(args[0]);
             } else if ("annotationType".equals(name)) {
                 return annotationClass;
-            } else if (resolvedValues.containsKey(name)) {
-                return resolvedValues.get(name);
+            } else if (annotationValue != null && annotationValue.contains(name)) {
+                return annotationValue.getRequiredValue(name, method.getReturnType());
             }
             return method.getDefaultValue();
         }

--- a/inject/src/main/java/io/micronaut/inject/annotation/DefaultAnnotationMetadata.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/DefaultAnnotationMetadata.java
@@ -47,7 +47,7 @@ import java.util.function.Function;
  * @since 1.0
  */
 @Internal
-public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implements AnnotationMetadata, Cloneable {
+public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implements AnnotationMetadata, Cloneable, EnvironmentAnnotationMetadata {
 
     static {
         ConversionService.SHARED.addConverter(io.micronaut.core.annotation.AnnotationValue.class, Annotation.class, (TypeConverter<io.micronaut.core.annotation.AnnotationValue, Annotation>) (object, targetType, context) -> {
@@ -187,8 +187,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
      * @param <E> The enum type
      * @return The class value
      */
+    @Override
     @Internal
-    <E extends Enum> Optional<E> enumValue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member, Class<E> enumType, @Nullable Function<Object, Object> valueMapper) {
+    public <E extends Enum> Optional<E> enumValue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member, Class<E> enumType, @Nullable Function<Object, Object> valueMapper) {
         ArgumentUtils.requireNonNull("annotation", annotation);
         ArgumentUtils.requireNonNull("member", member);
         final Repeatable repeatable = annotation.getAnnotation(Repeatable.class);
@@ -212,8 +213,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
      * @param <E> The enum type
      * @return The class value
      */
+    @Override
     @Internal
-    <E extends Enum> Optional<E> enumValue(@Nonnull String annotation, @Nonnull String member, Class<E> enumType, @Nullable Function<Object, Object> valueMapper) {
+    public <E extends Enum> Optional<E> enumValue(@Nonnull String annotation, @Nonnull String member, Class<E> enumType, @Nullable Function<Object, Object> valueMapper) {
         Object rawValue = getRawSingleValue(annotation, member, valueMapper);
         return enumValueOf(enumType, rawValue);
     }
@@ -278,7 +280,8 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
      * @param valueMapper The value mapper
      * @return The class value
      */
-    Optional<Class> classValue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member, Function<Object, Object> valueMapper) {
+    @Override
+    public Optional<Class> classValue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member, Function<Object, Object> valueMapper) {
         ArgumentUtils.requireNonNull("annotation", annotation);
         ArgumentUtils.requireNonNull("member", member);
         final Repeatable repeatable = annotation.getAnnotation(Repeatable.class);
@@ -310,8 +313,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
      * @param valueMapper The value mapper
      * @return The class value
      */
+    @Override
     @Internal
-    Optional<Class> classValue(@Nonnull String annotation, @Nonnull String member, @Nullable Function<Object, Object> valueMapper) {
+    public Optional<Class> classValue(@Nonnull String annotation, @Nonnull String member, @Nullable Function<Object, Object> valueMapper) {
         Object rawValue = getRawSingleValue(annotation, member, valueMapper);
 
         if (rawValue instanceof AnnotationClassValue) {
@@ -347,8 +351,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
      * @param valueMapper The value mapper
      * @return The int value
      */
+    @Override
     @Internal
-    OptionalInt intValue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member, @Nullable Function<Object, Object> valueMapper) {
+    public OptionalInt intValue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member, @Nullable Function<Object, Object> valueMapper) {
         ArgumentUtils.requireNonNull("annotation", annotation);
         ArgumentUtils.requireNonNull("member", member);
         final Repeatable repeatable = annotation.getAnnotation(Repeatable.class);
@@ -383,7 +388,8 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
      * @param valueMapper The value mapper
      * @return The boolean value
      */
-    Optional<Boolean> booleanValue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member, Function<Object, Object> valueMapper) {
+     @Override
+     public Optional<Boolean> booleanValue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member, Function<Object, Object> valueMapper) {
         ArgumentUtils.requireNonNull("annotation", annotation);
         ArgumentUtils.requireNonNull("member", member);
         final Repeatable repeatable = annotation.getAnnotation(Repeatable.class);
@@ -405,8 +411,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
      * @param valueMapper The value mapper
      * @return The boolean value
      */
+    @Override
     @Nonnull
-    Optional<Boolean> booleanValue(@Nonnull String annotation, @Nonnull String member, @Nullable Function<Object, Object> valueMapper) {
+    public Optional<Boolean> booleanValue(@Nonnull String annotation, @Nonnull String member, @Nullable Function<Object, Object> valueMapper) {
         Object rawValue = getRawSingleValue(annotation, member, valueMapper);
         if (rawValue instanceof Boolean) {
             return Optional.of((Boolean) rawValue);
@@ -438,8 +445,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
      * @param valueMapper The value mapper
      * @return The long value
      */
+    @Override
     @Internal
-    OptionalLong longValue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member, @Nullable Function<Object, Object> valueMapper) {
+    public OptionalLong longValue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member, @Nullable Function<Object, Object> valueMapper) {
         ArgumentUtils.requireNonNull("annotation", annotation);
         ArgumentUtils.requireNonNull("member", member);
         final Repeatable repeatable = annotation.getAnnotation(Repeatable.class);
@@ -461,8 +469,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
      * @param valueMapper The value mapper
      * @return The long value
      */
+    @Override
     @Nonnull
-    OptionalLong longValue(@Nonnull String annotation, @Nonnull String member, @Nullable Function<Object, Object> valueMapper) {
+    public OptionalLong longValue(@Nonnull String annotation, @Nonnull String member, @Nullable Function<Object, Object> valueMapper) {
         Object rawValue = getRawSingleValue(annotation, member, valueMapper);
         if (rawValue instanceof Number) {
             return OptionalLong.of(((Number) rawValue).longValue());
@@ -477,8 +486,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
      * @param valueMapper The value mapper
      * @return The int value
      */
+    @Override
     @Nonnull
-    OptionalInt intValue(@Nonnull String annotation, @Nonnull String member, @Nullable Function<Object, Object> valueMapper) {
+    public OptionalInt intValue(@Nonnull String annotation, @Nonnull String member, @Nullable Function<Object, Object> valueMapper) {
         Object rawValue = getRawSingleValue(annotation, member, valueMapper);
         if (rawValue instanceof Number) {
             return OptionalInt.of(((Number) rawValue).intValue());
@@ -499,7 +509,8 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
      * @param valueMapper The value mapper
      * @return The int value
      */
-    Optional<String> stringValue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member, Function<Object, Object> valueMapper) {
+    @Override
+    public Optional<String> stringValue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member, Function<Object, Object> valueMapper) {
         ArgumentUtils.requireNonNull("annotation", annotation);
         final Repeatable repeatable = annotation.getAnnotation(Repeatable.class);
         if (repeatable != null) {
@@ -526,7 +537,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
      * @param valueMapper The value mapper
      * @return The int value
      */
-    @Nonnull String[] stringValues(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member, Function<Object, Object> valueMapper) {
+    @Override
+    @Nonnull
+    public String[] stringValues(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member, Function<Object, Object> valueMapper) {
         ArgumentUtils.requireNonNull("annotation", annotation);
         final Repeatable repeatable = annotation.getAnnotation(Repeatable.class);
         if (repeatable != null) {
@@ -557,8 +570,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
      * @param valueMapper The value mapper
      * @return The string value
      */
+    @Override
     @Nonnull
-    Optional<String> stringValue(@Nonnull String annotation, @Nonnull String member, @Nullable Function<Object, Object> valueMapper) {
+    public Optional<String> stringValue(@Nonnull String annotation, @Nonnull String member, @Nullable Function<Object, Object> valueMapper) {
         Object rawValue = getRawSingleValue(annotation, member, valueMapper);
         if (rawValue instanceof CharSequence) {
             return Optional.of(rawValue.toString());
@@ -583,7 +597,8 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
      * @param valueMapper The value mapper
      * @return The boolean value
      */
-    boolean isTrue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member, Function<Object, Object> valueMapper) {
+    @Override
+    public boolean isTrue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member, Function<Object, Object> valueMapper) {
         ArgumentUtils.requireNonNull("annotation", annotation);
         ArgumentUtils.requireNonNull("member", member);
         final Repeatable repeatable = annotation.getAnnotation(Repeatable.class);
@@ -613,7 +628,8 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
      * @param valueMapper The value mapper
      * @return The boolean value
      */
-    boolean isTrue(@Nonnull String annotation, @Nonnull String member, @Nullable Function<Object, Object> valueMapper) {
+    @Override
+    public boolean isTrue(@Nonnull String annotation, @Nonnull String member, @Nullable Function<Object, Object> valueMapper) {
         Object rawValue = getRawSingleValue(annotation, member, valueMapper);
 
         if (rawValue instanceof Boolean) {
@@ -651,8 +667,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
      * @param valueMapper The value mapper
      * @return The double value
      */
+    @Override
     @Internal
-    OptionalDouble doubleValue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member, @Nullable Function<Object, Object> valueMapper) {
+    public OptionalDouble doubleValue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member, @Nullable Function<Object, Object> valueMapper) {
         ArgumentUtils.requireNonNull("annotation", annotation);
         ArgumentUtils.requireNonNull("member", member);
         final Repeatable repeatable = annotation.getAnnotation(Repeatable.class);
@@ -674,9 +691,10 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
      * @param valueMapper The value mapper
      * @return The double value
      */
+    @Override
     @Nonnull
     @Internal
-    OptionalDouble doubleValue(@Nonnull String annotation, @Nonnull String member, Function<Object, Object> valueMapper) {
+    public OptionalDouble doubleValue(@Nonnull String annotation, @Nonnull String member, Function<Object, Object> valueMapper) {
         Object rawValue = getRawSingleValue(annotation, member, valueMapper);
         if (rawValue instanceof Number) {
             return OptionalDouble.of(((Number) rawValue).doubleValue());
@@ -720,8 +738,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
      * @param <T> The generic type
      * @return The resolved value
      */
+    @Override
     @Nonnull
-    <T> Optional<T> getValue(@Nonnull String annotation, @Nonnull String member, @Nonnull Argument<T> requiredType, @Nullable Function<Object, Object> valueMapper) {
+    public <T> Optional<T> getValue(@Nonnull String annotation, @Nonnull String member, @Nonnull Argument<T> requiredType, @Nullable Function<Object, Object> valueMapper) {
         ArgumentUtils.requireNonNull("annotation", annotation);
         ArgumentUtils.requireNonNull("member", member);
         ArgumentUtils.requireNonNull("requiredType", requiredType);
@@ -1055,7 +1074,7 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     }
 
     @Override
-    public AnnotationMetadata clone() {
+    public DefaultAnnotationMetadata clone() {
         return new DefaultAnnotationMetadata(
                 declaredAnnotations != null ? new HashMap<>(declaredAnnotations) : null,
                 declaredStereotypes != null ? new HashMap<>(declaredStereotypes) : null,
@@ -1600,6 +1619,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
      */
     @Internal
     public static void contributeDefaults(AnnotationMetadata target, AnnotationMetadata source) {
+        if (source instanceof AnnotationMetadataHierarchy) {
+            source = ((AnnotationMetadataHierarchy) source).getDeclaredMetadata();
+        }
         if (target instanceof DefaultAnnotationMetadata && source instanceof DefaultAnnotationMetadata) {
             final Map<String, Map<CharSequence, Object>> existingDefaults = ((DefaultAnnotationMetadata) target).annotationDefaultValues;
             if (existingDefaults != null) {

--- a/inject/src/main/java/io/micronaut/inject/annotation/DefaultAnnotationMetadata.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/DefaultAnnotationMetadata.java
@@ -791,7 +791,12 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
 
         Map<String, Object> defaultValues = AnnotationMetadataSupport.getDefaultValues(annotation);
         if (defaultValues.containsKey(member)) {
-            return ConversionService.SHARED.convert(defaultValues.get(member), requiredType);
+            final Object v = defaultValues.get(member);
+            if (requiredType.isInstance(v)) {
+                return (Optional<T>) Optional.of(v);
+            } else {
+                return ConversionService.SHARED.convert(v, requiredType);
+            }
         }
         return Optional.empty();
     }

--- a/inject/src/main/java/io/micronaut/inject/annotation/DefaultAnnotationMetadata.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/DefaultAnnotationMetadata.java
@@ -1676,7 +1676,7 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
         } else {
             DefaultAnnotationMetadata defaultMetadata = (DefaultAnnotationMetadata) annotationMetadata;
 
-            defaultMetadata = (DefaultAnnotationMetadata) defaultMetadata.clone();
+            defaultMetadata = defaultMetadata.clone();
 
             defaultMetadata
                     .addDeclaredAnnotation(annotationName, members);

--- a/inject/src/main/java/io/micronaut/inject/annotation/DefaultAnnotationMetadata.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/DefaultAnnotationMetadata.java
@@ -18,8 +18,6 @@ package io.micronaut.inject.annotation;
 import io.micronaut.core.annotation.*;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.TypeConverter;
-import io.micronaut.core.convert.value.ConvertibleValues;
-import io.micronaut.core.reflect.ClassLoadingReporter;
 import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.type.Argument;
@@ -52,7 +50,7 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     static {
         ConversionService.SHARED.addConverter(io.micronaut.core.annotation.AnnotationValue.class, Annotation.class, (TypeConverter<io.micronaut.core.annotation.AnnotationValue, Annotation>) (object, targetType, context) -> {
             Optional<Class> annotationClass = ClassUtils.forName(object.getAnnotationName(), targetType.getClassLoader());
-            return annotationClass.map(aClass -> AnnotationMetadataSupport.buildAnnotation(aClass, ConvertibleValues.of(object.getValues())));
+            return annotationClass.map(aClass -> AnnotationMetadataSupport.buildAnnotation(aClass, object));
         });
 
         ConversionService.SHARED.addConverter(io.micronaut.core.annotation.AnnotationValue[].class, Object[].class, (TypeConverter<io.micronaut.core.annotation.AnnotationValue[], Object[]>) (object, targetType, context) -> {
@@ -67,7 +65,7 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
                     }
                     annotationClass = aClass.get();
                 }
-                Annotation annotation = AnnotationMetadataSupport.buildAnnotation(annotationClass, ConvertibleValues.of(annotationValue.getValues()));
+                Annotation annotation = AnnotationMetadataSupport.buildAnnotation(annotationClass, annotationValue);
                 result.add(annotation);
             }
             if (!result.isEmpty()) {
@@ -125,13 +123,6 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
         this.allStereotypes = allStereotypes;
         this.allAnnotations = allAnnotations;
         this.annotationsByStereotype = annotationsByStereotype;
-        if (ClassLoadingReporter.isReportingEnabled()) {
-            if (allAnnotations != null) {
-                for (String annotationName : allAnnotations.keySet()) {
-                    ClassUtils.forName(annotationName, DefaultAnnotationMetadata.class.getClassLoader()).ifPresent(ClassLoadingReporter::reportPresent);
-                }
-            }
-        }
     }
 
     @Nonnull
@@ -852,7 +843,7 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
             List<AnnotationValue<T>> values = getAnnotationValuesByType(annotationClass);
 
             return values.stream()
-                    .map(entries -> AnnotationMetadataSupport.buildAnnotation(annotationClass, entries.getConvertibleValues()))
+                    .map(entries -> AnnotationMetadataSupport.buildAnnotation(annotationClass, entries))
                     .toArray(value -> (T[]) Array.newInstance(annotationClass, value));
         }
 
@@ -866,7 +857,7 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
             List<AnnotationValue<T>> values = getAnnotationValuesByType(annotationClass);
 
             return values.stream()
-                    .map(entries -> AnnotationMetadataSupport.buildAnnotation(annotationClass, entries.getConvertibleValues()))
+                    .map(entries -> AnnotationMetadataSupport.buildAnnotation(annotationClass, entries))
                     .toArray(value -> (T[]) Array.newInstance(annotationClass, value));
         }
 

--- a/inject/src/main/java/io/micronaut/inject/annotation/EnvironmentAnnotationMetadata.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/EnvironmentAnnotationMetadata.java
@@ -1,0 +1,202 @@
+package io.micronaut.inject.annotation;
+
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.type.Argument;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.lang.annotation.Annotation;
+import java.util.*;
+import java.util.function.Function;
+
+/**
+ * Internal interface representing environment aware annotation metadata.
+ *
+ * @author graemerocher
+ * @since 1.3.0
+ */
+@Internal
+interface EnvironmentAnnotationMetadata extends AnnotationMetadata {
+    /**
+     * Retrieve the class value and optionally map its value.
+     * @param annotation The annotation
+     * @param member The member
+     * @param enumType The enum type
+     * @param valueMapper The value mapper
+     * @param <E> The enum type
+     * @return The class value
+     */
+    @Internal
+    <E extends Enum> Optional<E> enumValue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member, Class<E> enumType, @Nullable Function<Object, Object> valueMapper);
+
+    /**
+     * Retrieve the class value and optionally map its value.
+     * @param annotation The annotation
+     * @param member The member
+     * @param enumType The enum type
+     * @param valueMapper The value mapper
+     * @param <E> The enum type
+     * @return The class value
+     */
+    @Internal
+    <E extends Enum> Optional<E> enumValue(@Nonnull String annotation, @Nonnull String member, Class<E> enumType, @Nullable Function<Object, Object> valueMapper);
+
+    /**
+     * Retrieve the class value and optionally map its value.
+     * @param annotation The annotation
+     * @param member The member
+     * @param valueMapper The value mapper
+     * @return The class value
+     */
+    Optional<Class> classValue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member, Function<Object, Object> valueMapper);
+
+    /**
+     * Retrieve the class value and optionally map its value.
+     * @param annotation The annotation
+     * @param member The member
+     * @param valueMapper The value mapper
+     * @return The class value
+     */
+    @Internal
+    Optional<Class> classValue(@Nonnull String annotation, @Nonnull String member, @Nullable Function<Object, Object> valueMapper);
+
+    /**
+     * Retrieve the int value and optionally map its value.
+     * @param annotation The annotation
+     * @param member The member
+     * @param valueMapper The value mapper
+     * @return The int value
+     */
+    @Internal
+    OptionalInt intValue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member, @Nullable Function<Object, Object> valueMapper);
+
+    /**
+    * Retrieve the boolean value and optionally map its value.
+    * @param annotation The annotation
+    * @param member The member
+    * @param valueMapper The value mapper
+    * @return The boolean value
+    */
+    Optional<Boolean> booleanValue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member, Function<Object, Object> valueMapper);
+
+    /**
+     * Retrieve the boolean value and optionally map its value.
+     * @param annotation The annotation
+     * @param member The member
+     * @param valueMapper The value mapper
+     * @return The boolean value
+     */
+    @Nonnull
+    Optional<Boolean> booleanValue(@Nonnull String annotation, @Nonnull String member, @Nullable Function<Object, Object> valueMapper);
+
+    /**
+     * Retrieve the long value and optionally map its value.
+     * @param annotation The annotation
+     * @param member The member
+     * @param valueMapper The value mapper
+     * @return The long value
+     */
+    @Internal
+    OptionalLong longValue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member, @Nullable Function<Object, Object> valueMapper);
+
+    /**
+     * Retrieve the long value and optionally map its value.
+     * @param annotation The annotation
+     * @param member The member
+     * @param valueMapper The value mapper
+     * @return The long value
+     */
+    @Nonnull
+    OptionalLong longValue(@Nonnull String annotation, @Nonnull String member, @Nullable Function<Object, Object> valueMapper);
+
+    /**
+     * Retrieve the int value and optionally map its value.
+     * @param annotation The annotation
+     * @param member The member
+     * @param valueMapper The value mapper
+     * @return The int value
+     */
+    @Nonnull
+    OptionalInt intValue(@Nonnull String annotation, @Nonnull String member, @Nullable Function<Object, Object> valueMapper);
+
+    /**
+     * Retrieve the string value and optionally map its value.
+     * @param annotation The annotation
+     * @param member The member
+     * @param valueMapper The value mapper
+     * @return The int value
+     */
+    Optional<String> stringValue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member, Function<Object, Object> valueMapper);
+
+    /**
+     * Retrieve the string value and optionally map its value.
+     * @param annotation The annotation
+     * @param member The member
+     * @param valueMapper The value mapper
+     * @return The int value
+     */
+    @Nonnull
+    String[] stringValues(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member, Function<Object, Object> valueMapper);
+
+    /**
+     * Retrieve the string value and optionally map its value.
+     * @param annotation The annotation
+     * @param member The member
+     * @param valueMapper The value mapper
+     * @return The string value
+     */
+    @Nonnull
+    Optional<String> stringValue(@Nonnull String annotation, @Nonnull String member, @Nullable Function<Object, Object> valueMapper);
+
+    /**
+     * Retrieve the boolean value and optionally map its value.
+     * @param annotation The annotation
+     * @param member The member
+     * @param valueMapper The value mapper
+     * @return The boolean value
+     */
+    boolean isTrue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member, Function<Object, Object> valueMapper);
+
+    /**
+     * Retrieve the boolean value and optionally map its value.
+     * @param annotation The annotation
+     * @param member The member
+     * @param valueMapper The value mapper
+     * @return The boolean value
+     */
+    boolean isTrue(@Nonnull String annotation, @Nonnull String member, @Nullable Function<Object, Object> valueMapper);
+
+    /**
+     * Retrieve the double value and optionally map its value.
+     * @param annotation The annotation
+     * @param member The member
+     * @param valueMapper The value mapper
+     * @return The double value
+     */
+    @Internal
+    OptionalDouble doubleValue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member, @Nullable Function<Object, Object> valueMapper);
+
+    /**
+     * Retrieve the double value and optionally map its value.
+     * @param annotation The annotation
+     * @param member The member
+     * @param valueMapper The value mapper
+     * @return The double value
+     */
+    @Nonnull
+    @Internal
+    OptionalDouble doubleValue(@Nonnull String annotation, @Nonnull String member, Function<Object, Object> valueMapper);
+
+    /**
+     * Resolves the given value performing type conversion as necessary.
+     * @param annotation The annotation
+     * @param member The member
+     * @param requiredType The required type
+     * @param valueMapper The value mapper
+     * @param <T> The generic type
+     * @return The resolved value
+     */
+    @Nonnull
+    <T> Optional<T> getValue(@Nonnull String annotation, @Nonnull String member, @Nonnull Argument<T> requiredType, @Nullable Function<Object, Object> valueMapper);
+}

--- a/inject/src/main/java/io/micronaut/inject/annotation/EnvironmentAnnotationMetadata.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/EnvironmentAnnotationMetadata.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.inject.annotation;
 
 import io.micronaut.core.annotation.AnnotationMetadata;

--- a/inject/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
@@ -27,6 +27,7 @@ import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.reflect.exception.InstantiationException;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArrayUtils;
+import io.micronaut.inject.annotation.DefaultAnnotationMetadata;
 import io.micronaut.inject.ast.*;
 import io.micronaut.core.beans.AbstractBeanIntrospection;
 import io.micronaut.core.beans.AbstractBeanIntrospectionReference;
@@ -66,10 +67,10 @@ class BeanIntrospectionWriter extends AbstractAnnotationMetadataWriter {
     private final ClassWriter introspectionWriter;
     private final List<BeanPropertyWriter> propertyDefinitions = new ArrayList<>();
     private final Map<String, Collection<AnnotationValueIndex>> indexes = new HashMap<>(2);
+    private final Map<String, GeneratorAdapter> localLoadTypeMethods = new HashMap<>();
     private int propertyIndex = 0;
     private MethodElement constructor;
     private MethodElement defaultConstructor;
-    private final HashMap<String, GeneratorAdapter> loadTypeMethods = new HashMap<>();
 
     /**
      * Default constructor.
@@ -139,6 +140,10 @@ class BeanIntrospectionWriter extends AbstractAnnotationMetadataWriter {
 
         final Type propertyType = getTypeForElement(type);
 
+        DefaultAnnotationMetadata.contributeDefaults(
+                this.annotationMetadata,
+                annotationMetadata
+        );
         propertyDefinitions.add(
                 new BeanPropertyWriter(
                         this,
@@ -167,10 +172,6 @@ class BeanIntrospectionWriter extends AbstractAnnotationMetadataWriter {
 
     @Override
     public void accept(ClassWriterOutputVisitor classWriterOutputVisitor) throws IOException {
-        // write the annotation metadata
-        if (annotationMetadataWriter != null) {
-            annotationMetadataWriter.accept(classWriterOutputVisitor);
-        }
         // write the reference
         writeIntrospectionReference(classWriterOutputVisitor);
         // write the introspection
@@ -258,10 +259,11 @@ class BeanIntrospectionWriter extends AbstractAnnotationMetadataWriter {
             if (constructor != null && ArrayUtils.isNotEmpty(constructor.getParameters())) {
                 writeConstructorArguments();
             }
-            for (GeneratorAdapter generatorAdapter : loadTypeMethods.values()) {
-                generatorAdapter.visitMaxs(3, 1);
-            }
 
+            for (GeneratorAdapter generatorAdapter : localLoadTypeMethods.values()) {
+                generatorAdapter.visitMaxs(1, 1);
+                generatorAdapter.visitEnd();
+            }
             introspectionStream.write(introspectionWriter.toByteArray());
         }
     }
@@ -281,7 +283,7 @@ class BeanIntrospectionWriter extends AbstractAnnotationMetadataWriter {
                 args,
                 annotationMetadataMap,
                 toTypeArguments(constructorArguments),
-                loadTypeMethods);
+                localLoadTypeMethods);
 
         getConstructorArguments.returnValue();
         getConstructorArguments.visitMaxs(1, 1);
@@ -370,6 +372,7 @@ class BeanIntrospectionWriter extends AbstractAnnotationMetadataWriter {
     }
 
     private void writeIntrospectionReference(ClassWriterOutputVisitor classWriterOutputVisitor) throws IOException {
+
         Type superType = Type.getType(AbstractBeanIntrospectionReference.class);
         final String referenceName = targetClassType.getClassName();
         classWriterOutputVisitor.visitServiceDescriptor(BeanIntrospectionReference.class, referenceName);
@@ -377,6 +380,10 @@ class BeanIntrospectionWriter extends AbstractAnnotationMetadataWriter {
         try (OutputStream referenceStream = classWriterOutputVisitor.visitClass(referenceName)) {
             startPublicFinalClass(referenceWriter, targetClassType.getInternalName(), superType);
             final ClassWriter classWriter = generateClassBytes(referenceWriter);
+            for (GeneratorAdapter generatorAdapter : loadTypeMethods.values()) {
+                generatorAdapter.visitMaxs(1, 1);
+                generatorAdapter.visitEnd();
+            }
             referenceStream.write(classWriter.toByteArray());
         }
     }
@@ -424,7 +431,6 @@ class BeanIntrospectionWriter extends AbstractAnnotationMetadataWriter {
         getBeanType.endMethod();
 
         writeGetAnnotationMetadataMethod(classWriter);
-
         return classWriter;
     }
 

--- a/inject/src/main/java/io/micronaut/inject/beans/visitor/BeanPropertyWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/visitor/BeanPropertyWriter.java
@@ -148,13 +148,6 @@ class BeanPropertyWriter extends AbstractClassFileWriter implements Named {
             // the write method
             writeWriteMethod();
 
-            if (annotationMetadata != null && annotationMetadata instanceof DefaultAnnotationMetadata) {
-                final DefaultAnnotationMetadata annotationMetadata = (DefaultAnnotationMetadata) this.annotationMetadata;
-                if (!annotationMetadata.isEmpty()) {
-                    AnnotationMetadataWriter.writeAnnotationDefaults(annotationMetadata, classWriter, type, loadTypeMethods);
-                }
-            }
-
             if (readOnly) {
                 // override isReadOnly method
                 final GeneratorAdapter isReadOnly = startPublicMethodZeroArgs(classWriter, boolean.class, "isReadOnly");

--- a/inject/src/main/java/io/micronaut/inject/writer/AbstractAnnotationMetadataWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/AbstractAnnotationMetadataWriter.java
@@ -23,7 +23,6 @@ import io.micronaut.inject.annotation.AnnotationMetadataWriter;
 import io.micronaut.inject.annotation.DefaultAnnotationMetadata;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Label;
-import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.GeneratorAdapter;
 

--- a/inject/src/main/java/io/micronaut/inject/writer/BeanConfigurationWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/BeanConfigurationWriter.java
@@ -59,10 +59,6 @@ public class BeanConfigurationWriter extends AbstractAnnotationMetadataWriter {
 
     @Override
     public void accept(ClassWriterOutputVisitor classWriterOutputVisitor) throws IOException {
-        AnnotationMetadataWriter annotationMetadataWriter = getAnnotationMetadataWriter();
-        if (annotationMetadataWriter != null) {
-            annotationMetadataWriter.accept(classWriterOutputVisitor);
-        }
         try (OutputStream outputStream = classWriterOutputVisitor.visitClass(configurationClassName)) {
             ClassWriter classWriter = generateClassBytes();
             outputStream.write(classWriter.toByteArray());
@@ -85,6 +81,10 @@ public class BeanConfigurationWriter extends AbstractAnnotationMetadataWriter {
 
         } catch (NoSuchMethodException e) {
             throw new ClassGenerationException("Error generating configuration class. Incompatible JVM or Micronaut version?: " + e.getMessage(), e);
+        }
+        for (GeneratorAdapter method : loadTypeMethods.values()) {
+            method.visitMaxs(3, 1);
+            method.visitEnd();
         }
 
         return classWriter;

--- a/inject/src/main/java/io/micronaut/inject/writer/BeanConfigurationWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/BeanConfigurationWriter.java
@@ -19,7 +19,6 @@ import io.micronaut.context.AbstractBeanConfiguration;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.inject.BeanConfiguration;
-import io.micronaut.inject.annotation.AnnotationMetadataWriter;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.GeneratorAdapter;

--- a/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionReferenceWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionReferenceWriter.java
@@ -70,9 +70,6 @@ public class BeanDefinitionReferenceWriter extends AbstractAnnotationMetadataWri
      */
     @Override
     public void accept(ClassWriterOutputVisitor outputVisitor) throws IOException {
-        if (annotationMetadataWriter != null) {
-            annotationMetadataWriter.accept(outputVisitor);
-        }
         try (OutputStream outputStream = outputVisitor.visitClass(getBeanDefinitionQualifiedClassName())) {
             ClassWriter classWriter = generateClassBytes();
             outputStream.write(classWriter.toByteArray());
@@ -180,6 +177,10 @@ public class BeanDefinitionReferenceWriter extends AbstractAnnotationMetadataWri
         }
 
         writeGetAnnotationMetadataMethod(classWriter);
+
+        for (GeneratorAdapter generatorAdapter : loadTypeMethods.values()) {
+            generatorAdapter.visitMaxs(3, 1);
+        }
 
         return classWriter;
     }

--- a/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionVisitor.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionVisitor.java
@@ -20,6 +20,7 @@ import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.configuration.ConfigurationMetadataBuilder;
 import org.objectweb.asm.Type;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
@@ -66,6 +67,12 @@ public interface BeanDefinitionVisitor {
                                         Map<String, Object> argumentTypes,
                                         Map<String, AnnotationMetadata> argumentAnnotationMetadata,
                                         Map<String, Map<String, Object>> genericTypes);
+
+    /**
+     * @return The name of the bean definition reference class.
+     */
+    @Nonnull
+    String getBeanDefinitionReferenceClassName();
 
     /**
      * @return Whether the provided type an interface

--- a/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -823,6 +823,14 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
                 this.annotationMetadata,
                 annotationMetadata
         );
+        if (argumentAnnotationMetadata != null) {
+            for (AnnotationMetadata metadata : argumentAnnotationMetadata.values()) {
+                DefaultAnnotationMetadata.contributeDefaults(
+                        this.annotationMetadata,
+                        metadata
+                );
+            }
+        }
         String methodProxyShortName = "$exec" + ++methodExecutorIndex;
         String methodExecutorClassName = beanDefinitionName + "$" + methodProxyShortName;
         if (annotationMetadata instanceof AnnotationMetadataHierarchy) {

--- a/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -23,6 +23,7 @@ import io.micronaut.context.DefaultBeanContext;
 import io.micronaut.context.annotation.*;
 import io.micronaut.context.exceptions.BeanContextException;
 import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
 import io.micronaut.core.annotation.AnnotationUtil;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.naming.NameUtils;
@@ -36,6 +37,7 @@ import io.micronaut.inject.DisposableBeanDefinition;
 import io.micronaut.inject.ExecutableMethod;
 import io.micronaut.inject.InitializingBeanDefinition;
 import io.micronaut.inject.ValidatedBeanDefinition;
+import io.micronaut.inject.annotation.AnnotationMetadataReference;
 import io.micronaut.inject.annotation.AnnotationMetadataWriter;
 import io.micronaut.inject.annotation.DefaultAnnotationMetadata;
 import io.micronaut.inject.configuration.ConfigurationMetadataBuilder;
@@ -48,6 +50,7 @@ import org.objectweb.asm.commons.GeneratorAdapter;
 import org.objectweb.asm.signature.SignatureVisitor;
 import org.objectweb.asm.signature.SignatureWriter;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.inject.Singleton;
 import java.io.IOException;
@@ -275,6 +278,16 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
         this.interfaceTypes = new HashSet<>();
         this.interfaceTypes.add(BeanFactory.class);
         this.isConfigurationProperties = annotationMetadata.hasDeclaredStereotype(ConfigurationProperties.class);
+    }
+
+
+    /**
+     * @return The name of the bean definition reference class.
+     */
+    @Override
+    @Nonnull
+    public String getBeanDefinitionReferenceClassName() {
+        return beanDefinitionName + BeanDefinitionReferenceWriter.REF_SUFFIX;
     }
 
     /**
@@ -549,7 +562,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
                     AnnotationMetadata.class.getName()
             );
             annotationMetadataMethod.loadThis();
-            annotationMetadataMethod.getStatic(getTypeReference(beanDefinitionName + BeanDefinitionReferenceWriter.REF_SUFFIX), AbstractAnnotationMetadataWriter.FIELD_ANNOTATION_METADATA, Type.getType(AnnotationMetadata.class));
+            annotationMetadataMethod.getStatic(getTypeReference(getBeanDefinitionReferenceClassName()), AbstractAnnotationMetadataWriter.FIELD_ANNOTATION_METADATA, Type.getType(AnnotationMetadata.class));
             annotationMetadataMethod.returnValue();
             annotationMetadataMethod.visitMaxs(1, 1);
             annotationMetadataMethod.visitEnd();
@@ -806,8 +819,18 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
                                                         Map<String, Map<String, Object>> genericTypes,
                                                         AnnotationMetadata annotationMetadata) {
 
+        DefaultAnnotationMetadata.contributeDefaults(
+                this.annotationMetadata,
+                annotationMetadata
+        );
         String methodProxyShortName = "$exec" + ++methodExecutorIndex;
         String methodExecutorClassName = beanDefinitionName + "$" + methodProxyShortName;
+        if (annotationMetadata instanceof AnnotationMetadataHierarchy) {
+            annotationMetadata = new AnnotationMetadataHierarchy(
+                    new AnnotationMetadataReference(getBeanDefinitionReferenceClassName(), this.annotationMetadata),
+                    ((AnnotationMetadataHierarchy) annotationMetadata).getDeclaredMetadata()
+            );
+        }
         ExecutableMethodWriter executableMethodWriter = new ExecutableMethodWriter(
                 beanFullClassName,
                 methodExecutorClassName,
@@ -2081,19 +2104,29 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
             if (constructorMetadata == null || constructorMetadata == AnnotationMetadata.EMPTY_METADATA) {
                 defaultConstructor.visitInsn(ACONST_NULL);
             } else {
-                AnnotationMetadataWriter.instantiateNewMetadata(
-                        beanDefinitionType,
-                        classWriter,
-                        defaultConstructor,
-                        (DefaultAnnotationMetadata) constructorMetadata,
-                        loadTypeMethods);
+                if (constructorMetadata instanceof AnnotationMetadataHierarchy) {
+                    AnnotationMetadataWriter.instantiateNewMetadataHierarchy(
+                            beanDefinitionType,
+                            classWriter,
+                            defaultConstructor,
+                            (AnnotationMetadataHierarchy) constructorMetadata,
+                            loadTypeMethods);
+                } else {
+
+                    AnnotationMetadataWriter.instantiateNewMetadata(
+                            beanDefinitionType,
+                            classWriter,
+                            defaultConstructor,
+                            (DefaultAnnotationMetadata) constructorMetadata,
+                            loadTypeMethods);
+                }
             }
 
             // 3rd argument: Is reflection required
             defaultConstructor.visitInsn(requiresReflection ? ICONST_1 : ICONST_0);
 
             // 4th argument: The arguments
-            if (argumentTypes == null || argumentTypes.isEmpty()) {
+            if (argumentAnnotationMetadata == null || argumentAnnotationMetadata.isEmpty()) {
                 defaultConstructor.visitInsn(ACONST_NULL);
             } else {
                 pushBuildArgumentsForMethod(

--- a/inject/src/main/java/io/micronaut/inject/writer/ExecutableMethodWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/ExecutableMethodWriter.java
@@ -22,7 +22,6 @@ import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.type.Argument;
 import io.micronaut.inject.ExecutableMethod;
 import io.micronaut.inject.annotation.AnnotationMetadataReference;
-import io.micronaut.inject.annotation.AnnotationMetadataWriter;
 import io.micronaut.inject.annotation.DefaultAnnotationMetadata;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.MethodVisitor;

--- a/inject/src/main/java/io/micronaut/inject/writer/ExecutableMethodWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/ExecutableMethodWriter.java
@@ -70,7 +70,6 @@ public class ExecutableMethodWriter extends AbstractAnnotationMetadataWriter imp
     private final boolean isAbstract;
     private String outerClassName = null;
     private boolean isStatic = false;
-    private final Map<String, GeneratorAdapter> loadTypeMethods = new HashMap<>();
 
     /**
      * @param beanFullClassName    The bean full class name
@@ -334,10 +333,6 @@ public class ExecutableMethodWriter extends AbstractAnnotationMetadataWriter imp
 
     @Override
     public void accept(ClassWriterOutputVisitor classWriterOutputVisitor) throws IOException {
-        AnnotationMetadataWriter annotationMetadataWriter = getAnnotationMetadataWriter();
-        if (annotationMetadataWriter != null) {
-            annotationMetadataWriter.accept(classWriterOutputVisitor);
-        }
         try (OutputStream outputStream = classWriterOutputVisitor.visitClass(className)) {
             outputStream.write(classWriter.toByteArray());
         }

--- a/runtime/src/main/java/io/micronaut/cache/annotation/Cacheable.java
+++ b/runtime/src/main/java/io/micronaut/cache/annotation/Cacheable.java
@@ -51,6 +51,7 @@ public @interface Cacheable {
      * @return The cache names
      */
     @AliasFor(member = "cacheNames")
+    @AliasFor(annotation = CacheConfig.class, member = "cacheNames")
     String[] value() default {};
 
     /**

--- a/runtime/src/main/java/io/micronaut/cache/interceptor/CacheInterceptor.java
+++ b/runtime/src/main/java/io/micronaut/cache/interceptor/CacheInterceptor.java
@@ -65,7 +65,6 @@ import java.util.function.BiConsumer;
  * @since 1.0
  */
 @Singleton
-
 public class CacheInterceptor implements MethodInterceptor<Object, Object> {
     /**
      * The position on the interceptor in the chain.
@@ -142,14 +141,13 @@ public class CacheInterceptor implements MethodInterceptor<Object, Object> {
         final ValueWrapper wrapper = new ValueWrapper();
         CacheOperation cacheOperation = new CacheOperation(context, returnType);
 
-        AnnotationValue<Cacheable> cacheConfig = cacheOperation.cacheable;
-        if (cacheConfig != null) {
+        if (cacheOperation.cacheable) {
             CacheKeyGenerator defaultKeyGenerator = cacheOperation.defaultKeyGenerator;
-            CacheKeyGenerator keyGenerator = resolveKeyGenerator(defaultKeyGenerator, cacheConfig);
-            Object[] parameterValues = resolveParams(context, cacheConfig.get(MEMBER_PARAMETERS, String[].class, StringUtils.EMPTY_STRING_ARRAY));
+            CacheKeyGenerator keyGenerator = resolveKeyGenerator(defaultKeyGenerator, context.classValue(Cacheable.class, MEMBER_KEY_GENERATOR).orElse(null));
+            Object[] parameterValues = resolveParams(context, context.stringValues(Cacheable.class, MEMBER_PARAMETERS));
             Object key = keyGenerator.generateKey(context, parameterValues);
             Argument returnArgument = returnTypeObject.asArgument();
-            if (cacheConfig.getRequiredValue(MEMBER_ATOMIC, Boolean.class)) {
+            if (context.isTrue(Cacheable.class, MEMBER_ATOMIC)) {
                 SyncCache syncCache = cacheManager.getCache(cacheOperation.cacheableCacheName);
 
                 try {
@@ -168,7 +166,7 @@ public class CacheInterceptor implements MethodInterceptor<Object, Object> {
                     throw e;
                 }
             } else {
-                String[] cacheNames = resolveCacheNames(cacheOperation.defaultConfig, cacheConfig);
+                String[] cacheNames = resolveCacheNames(cacheOperation.defaultCacheNames, context.stringValues(Cacheable.class, MEMBER_CACHE_NAMES));
                 boolean cacheHit = false;
                 for (String cacheName : cacheNames) {
                     SyncCache syncCache = cacheManager.getCache(cacheName);
@@ -208,7 +206,7 @@ public class CacheInterceptor implements MethodInterceptor<Object, Object> {
         if (cachePuts != null) {
 
             for (AnnotationValue<CachePut> cachePut : cachePuts) {
-                boolean async = cachePut.get(MEMBER_ASYNC, Boolean.class, false);
+                boolean async = cachePut.isTrue(MEMBER_ASYNC);
                 if (async) {
                     ioExecutor.submit(() ->
                             processCachePut(context, wrapper, cachePut, cacheOperation)
@@ -222,7 +220,7 @@ public class CacheInterceptor implements MethodInterceptor<Object, Object> {
         List<AnnotationValue<CacheInvalidate>> cacheInvalidates = cacheOperation.invalidateOperations;
         if (cacheInvalidates != null) {
             for (AnnotationValue<CacheInvalidate> cacheInvalidate : cacheInvalidates) {
-                boolean async = cacheInvalidate.get(MEMBER_ASYNC, Boolean.class, false);
+                boolean async = cacheInvalidate.isTrue(MEMBER_ASYNC);
                 if (async) {
                     ioExecutor.submit(() -> {
                                 try {
@@ -251,12 +249,11 @@ public class CacheInterceptor implements MethodInterceptor<Object, Object> {
      */
     protected Object interceptCompletableFuture(MethodInvocationContext<Object, Object> context, ReturnType<?> returnTypeObject, Class returnType) {
         CacheOperation cacheOperation = new CacheOperation(context, returnType);
-        AnnotationValue<Cacheable> cacheable = cacheOperation.cacheable;
         CompletableFuture<Object> returnFuture;
-        if (cacheable != null) {
+        if (cacheOperation.cacheable) {
             AsyncCache<?> asyncCache = cacheManager.getCache(cacheOperation.cacheableCacheName).async();
-            CacheKeyGenerator keyGenerator = resolveKeyGenerator(cacheOperation.defaultKeyGenerator, cacheable);
-            Object[] params = resolveParams(context, cacheable.get(MEMBER_PARAMETERS, String[].class, StringUtils.EMPTY_STRING_ARRAY));
+            CacheKeyGenerator keyGenerator = resolveKeyGenerator(cacheOperation.defaultKeyGenerator, context.classValue(Cacheable.class, MEMBER_KEY_GENERATOR).orElse(null));
+            Object[] params = resolveParams(context, context.stringValues(Cacheable.class, MEMBER_PARAMETERS));
             Object key = keyGenerator.generateKey(context, params);
             CompletableFuture<Object> thisFuture = new CompletableFuture<>();
             Argument<?> firstTypeVariable = returnTypeObject.getFirstTypeVariable().orElse(Argument.OBJECT_ARGUMENT);
@@ -341,10 +338,8 @@ public class CacheInterceptor implements MethodInterceptor<Object, Object> {
             throw new CacheSystemException("Only Reactive types that emit a single result can currently be cached. Use either Single, Maybe or Mono for operations that cache.");
         }
         CacheOperation cacheOperation = new CacheOperation(context, returnType);
-        AnnotationValue<Cacheable> cacheable = cacheOperation.cacheable;
-        if (cacheable != null) {
-
-            Publisher<Object> publisher = buildCacheablePublisher(context, returnTypeObject, cacheOperation, cacheable);
+        if (cacheOperation.cacheable) {
+            Publisher<Object> publisher = buildCacheablePublisher(context, returnTypeObject, cacheOperation);
             return Publishers.convertPublisher(publisher, returnType);
         } else {
             final List<AnnotationValue<CachePut>> putOperations = cacheOperation.putOperations;
@@ -502,11 +497,10 @@ public class CacheInterceptor implements MethodInterceptor<Object, Object> {
     private Publisher<Object> buildCacheablePublisher(
             MethodInvocationContext<Object, Object> context,
             ReturnType returnTypeObject,
-            CacheOperation cacheOperation,
-            AnnotationValue<Cacheable> cacheable) {
+            CacheOperation cacheOperation) {
         AsyncCache<?> asyncCache = cacheManager.getCache(cacheOperation.cacheableCacheName).async();
-        CacheKeyGenerator keyGenerator = resolveKeyGenerator(cacheOperation.defaultKeyGenerator, cacheable);
-        Object[] params = resolveParams(context, cacheable.get(MEMBER_PARAMETERS, String[].class, StringUtils.EMPTY_STRING_ARRAY));
+        CacheKeyGenerator keyGenerator = resolveKeyGenerator(cacheOperation.defaultKeyGenerator, context.classValue(Cacheable.class, MEMBER_KEY_GENERATOR).orElse(null));
+        Object[] params = resolveParams(context, context.stringValues(Cacheable.class, MEMBER_PARAMETERS));
         Object key = keyGenerator.generateKey(context, params);
         Argument<?> firstTypeVariable = returnTypeObject.getFirstTypeVariable().orElse(Argument.OBJECT_ARGUMENT);
 
@@ -540,12 +534,7 @@ public class CacheInterceptor implements MethodInterceptor<Object, Object> {
                                    if (throwable1 == null) {
                                        emitter.onSuccess(o);
                                    } else {
-                                       if (errorHandler.handleLoadError(asyncCache, key, asRuntimeException(throwable1))) {
-
-                                           emitter.onError(throwable1);
-                                       } else {
-                                           emitter.onSuccess(o);
-                                       }
+                                       emitter.onSuccess(o);
                                    }
                                };
                                if (o != null) {
@@ -685,28 +674,23 @@ public class CacheInterceptor implements MethodInterceptor<Object, Object> {
         return CompletableFuture.allOf(futureArray);
     }
 
-    private CacheKeyGenerator resolveKeyGenerator(CacheKeyGenerator defaultKeyGenerator, AnnotationValue<Cacheable> cacheConfig) {
+    private CacheKeyGenerator resolveKeyGenerator(CacheKeyGenerator defaultKeyGenerator, Class type) {
         CacheKeyGenerator keyGenerator = defaultKeyGenerator;
-        final CacheKeyGenerator altKeyGenInstance = cacheConfig.get(MEMBER_KEY_GENERATOR, CacheKeyGenerator.class).orElse(null);
-        if (altKeyGenInstance != null) {
-            return altKeyGenInstance;
-        } else {
-            Class<? extends CacheKeyGenerator> alternateKeyGen = cacheConfig.get(MEMBER_KEY_GENERATOR, Class.class).orElse(null);
-            if (alternateKeyGen != null && keyGenerator.getClass() != alternateKeyGen) {
-                keyGenerator = resolveKeyGenerator(alternateKeyGen);
-            }
-            if (keyGenerator == null) {
-                return new DefaultCacheKeyGenerator();
-            }
-            return keyGenerator;
+        @SuppressWarnings("unchecked")
+        Class<? extends CacheKeyGenerator> alternateKeyGen = type != null && CacheKeyGenerator.class.isAssignableFrom(type) ? type : null;
+        if (alternateKeyGen != null && keyGenerator.getClass() != alternateKeyGen) {
+            keyGenerator = resolveKeyGenerator(alternateKeyGen);
         }
+        if (keyGenerator == null) {
+            return new DefaultCacheKeyGenerator();
+        }
+        return keyGenerator;
 
     }
 
-    private String[] resolveCacheNames(AnnotationValue<CacheConfig> defaultConfig, AnnotationValue<Cacheable> cacheConfig) {
-        String[] cacheNames = cacheConfig.get(MEMBER_CACHE_NAMES, String[].class).orElse(null);
+    private String[] resolveCacheNames(String[] defaultCacheNames,  String[] cacheNames) {
         if (ArrayUtils.isEmpty(cacheNames)) {
-            cacheNames = defaultConfig.get(MEMBER_CACHE_NAMES, String[].class).orElse(StringUtils.EMPTY_STRING_ARRAY);
+            cacheNames = defaultCacheNames;
         }
         return cacheNames;
     }
@@ -871,9 +855,9 @@ public class CacheInterceptor implements MethodInterceptor<Object, Object> {
         final Class returnType;
         final MethodInvocationContext<?, ?> context;
         final CacheKeyGenerator defaultKeyGenerator;
-        final AnnotationValue<CacheConfig> defaultConfig;
+        final String[] defaultCacheNames;
+        final boolean cacheable;
         String cacheableCacheName;
-        AnnotationValue<Cacheable> cacheable;
         List<AnnotationValue<CachePut>> putOperations;
         List<AnnotationValue<CacheInvalidate>> invalidateOperations;
 
@@ -881,17 +865,15 @@ public class CacheInterceptor implements MethodInterceptor<Object, Object> {
             this.context = context;
             this.returnType = returnType;
 
-            this.defaultConfig = context.getAnnotation(CacheConfig.class);
-            this.defaultKeyGenerator = resolveKeyGenerator(defaultConfig.get(MEMBER_KEY_GENERATOR, Class.class).orElse(null));
+            this.defaultKeyGenerator = resolveKeyGenerator(context.classValue(CacheConfig.class, MEMBER_KEY_GENERATOR).orElse(null));
             boolean isVoid = isVoid();
             this.putOperations = isVoid ? null : putOperations(context);
             this.invalidateOperations = invalidateOperations(context);
-            if (!isVoid && context.hasStereotype(Cacheable.class)) {
-                AnnotationValue<Cacheable> cacheable = context.getAnnotation(Cacheable.class);
-                String[] names = resolveCacheNames(defaultConfig, cacheable);
-                if (ArrayUtils.isNotEmpty(names)) {
-                    this.cacheableCacheName = names[0];
-                    this.cacheable = cacheable;
+            this.defaultCacheNames = context.stringValues(CacheConfig.class, MEMBER_CACHE_NAMES);
+            this.cacheable = context.hasStereotype(Cacheable.class);
+            if (!isVoid && cacheable) {
+                if (ArrayUtils.isNotEmpty(defaultCacheNames)) {
+                    this.cacheableCacheName = defaultCacheNames[0];
                 } else {
                     if (LOG.isWarnEnabled()) {
                         LOG.warn("No cache names defined for invocation [{}]. Skipping cache read operations.", context);
@@ -930,7 +912,7 @@ public class CacheInterceptor implements MethodInterceptor<Object, Object> {
 
         private String[] getCacheNames(String[] cacheNames) {
             if (ArrayUtils.isEmpty(cacheNames)) {
-                return defaultConfig.get(MEMBER_CACHE_NAMES, String[].class).orElse(StringUtils.EMPTY_STRING_ARRAY);
+                return defaultCacheNames;
             } else {
                 return cacheNames;
             }

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/body/MessageController.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/body/MessageController.kt
@@ -26,8 +26,8 @@ open class MessageController {
 
     // tag::echoReactive[]
     @Post(value = "/echo-flow", consumes = [MediaType.TEXT_PLAIN]) // <1>
-    fun echoFlow(@Body text: Flowable<String>): Single<MutableHttpResponse<String>> { //<2>
-        return text.collect<StringBuffer>({ StringBuffer() }, { obj, str -> obj.append(str) }) // <3>
+    open fun echoFlow(@Body text: Flowable<String>): Single<MutableHttpResponse<String>> { //<2>
+        return text.collect({ StringBuffer() }, { obj, str -> obj.append(str) }) // <3>
                 .map { buffer -> HttpResponse.ok(buffer.toString()) }
     }
     // end::echoReactive[]

--- a/test-suite-kotlin/src/test/resources/logback.xml
+++ b/test-suite-kotlin/src/test/resources/logback.xml
@@ -1,0 +1,16 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+    <logger name="io.micronaut.web.router" level="trace"/>
+    <logger name="io.micronaut.http" level="trace"/>
+</configuration>

--- a/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java
@@ -361,22 +361,6 @@ public class DefaultValidator implements Validator, ExecutableMethodValidator, R
         return Collections.unmodifiableSet(overallViolations);
     }
 
-    private Collection<MutableArgumentValue<?>> toArgumentValues(@Nonnull Object[] parameterValues, Argument[] arguments) {
-        final int argLen = arguments.length;
-        if (argLen != parameterValues.length) {
-            throw new IllegalArgumentException("The method parameter array must have exactly " + argLen + " elements.");
-        }
-
-        Collection<MutableArgumentValue<?>> argumentValues = new ArrayList<>(parameterValues.length);
-        for (int i = 0; i < arguments.length; i++) {
-            Argument argument = arguments[i];
-            final Object v = parameterValues[i];
-            final MutableArgumentValue<?> av = MutableArgumentValue.create(argument, v);
-            argumentValues.add(av);
-        }
-        return argumentValues;
-    }
-
     @Nonnull
     @Override
     public <T> Set<ConstraintViolation<T>> validateParameters(
@@ -1441,7 +1425,7 @@ public class DefaultValidator implements Validator, ExecutableMethodValidator, R
     }
 
     private String buildMessageTemplate(AnnotationValue<?> annotationValue, AnnotationMetadata annotationMetadata) {
-        return annotationValue.get("message", String.class)
+        return annotationValue.stringValue("message")
                 .orElseGet(() ->
                         annotationMetadata.getDefaultValue(annotationValue.getAnnotationName(), "message", String.class)
                             .orElse("{" + annotationValue.getAnnotationName() + ".message}")


### PR DESCRIPTION
This PR optimizes the compiler to improve runtime memory consumption and compiler speed (related issue https://github.com/micronaut-projects/micronaut-data/issues/268)

Instead of generating additional classes for each annotation metadata we store the metadata in a static field for the bean definition and executable methods.

Also instead of duplicating annotation metadata for methods this PR introduces the `AnnotationMetadataHierarchy` type which allows a method to declare it inherits another annotation metadata instance. This reduces the number of data structures we create at runtime and improves memory performance.

Since the changes are significant I have tested this PR also with the following subprojects:

* `micronaut-kafka`
* `micronaut-data`
* `micronaut-openapi`

The change is backwards compatible from a binary perspective, but code compiled with Micronaut 1.3 will not be able to be used in Micronaut 1.2 applications following this change so modules will have to increase the minimum supported Micronaut core version

