### PR TITLE
Native-image.properties that defers the initialization of various classes to run-time

### DIFF
--- a/tracing/src/main/resources/META-INF/native-image/io.micronaut/micronaut-tracing/native-image.properties
+++ b/tracing/src/main/resources/META-INF/native-image/io.micronaut/micronaut-tracing/native-image.properties
@@ -1,0 +1,1 @@
+Args = --initialize-at-run-time=io.micronaut.tracing.brave.BraveTracerFactory,io.micronaut.tracing.brave.instrument.http.HttpTracingFactory,io.micronaut.tracing.brave.log.Slf4jCurrentTraceContextFactory,io.micronaut.tracing.brave.sender.HttpClientSenderFactory,io.micronaut.tracing.instrument.rxjava.RxJava1TracingInstrumentation


### PR DESCRIPTION
it adds following classes:
* `io.micronaut.tracing.brave.BraveTracerFactory`
* `io.micronaut.tracing.brave.instrument.http.HttpTracingFactory`
* `io.micronaut.tracing.brave.log.Slf4jCurrentTraceContextFactory`
* `io.micronaut.tracing.brave.sender.HttpClientSenderFactory`
* `io.micronaut.tracing.instrument.rxjava.RxJava1TracingInstrumentation`

..for the `initialize-at-run-time`