### PR TITLE
Add possibility to set Sec-Websocket-Protocol in ClientWebSocket anno…

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/DefaultHttpClient.java
@@ -767,6 +767,7 @@ public class DefaultHttpClient implements RxWebSocketClient, RxHttpClient, RxStr
             int maxFramePayloadLength = finalWebSocketBean.messageMethod()
                     .map(m -> m.intValue(OnMessage.class, "maxPayloadLength")
                     .orElse(65536)).orElse(65536);
+            String subprotocol = finalWebSocketBean.getBeanDefinition().stringValue(ClientWebSocket.class, "subprotocol").orElse(StringUtils.EMPTY_STRING);
 
             RequestKey requestKey;
             try {
@@ -809,12 +810,15 @@ public class DefaultHttpClient implements RxWebSocketClient, RxHttpClient, RxStr
                         if (headers instanceof NettyHttpHeaders) {
                             customHeaders = ((NettyHttpHeaders) headers).getNettyHeaders();
                         }
+                        if (StringUtils.isNotEmpty(subprotocol)) {
+                            customHeaders.add("Sec-WebSocket-Protocol", subprotocol);
+                        }
 
                         webSocketHandler = new NettyWebSocketClientHandler<>(
                                 request,
                                 finalWebSocketBean,
                                 WebSocketClientHandshakerFactory.newHandshaker(
-                                        webSocketURL, protocolVersion, null, false, customHeaders, maxFramePayloadLength),
+                                        webSocketURL, protocolVersion, subprotocol, false, customHeaders, maxFramePayloadLength),
                                 requestBinderRegistry,
                                 mediaTypeCodecRegistry,
                                 emitter);

--- a/websocket/src/main/java/io/micronaut/websocket/annotation/ClientWebSocket.java
+++ b/websocket/src/main/java/io/micronaut/websocket/annotation/ClientWebSocket.java
@@ -64,4 +64,9 @@ public @interface ClientWebSocket {
      */
     @AliasFor(annotation = WebSocketComponent.class, member = "version")
     WebSocketVersion version() default WebSocketVersion.V13;
+
+    /**
+     * @return The Sec-WebSocket-Protocol header field is used in the WebSocket opening handshake.
+     */
+    String subprotocol() default "";
 }


### PR DESCRIPTION
By this commit I would like to give possibility to set Sec-Websocket-Protocol in ClientWebSocket annotation and I have also added code to get those data and pass to io.netty.handler.codec.http.websocketx.WebSocketClientHandshakerFactory.

Default value: empty string

Example of use:
@ClientWebSocket(value = "ocpp16/{stationName}", subprotocol = "ocpp1.6,ocpp2.0")