### PR TITLE
Support for customizing the management port. Fixes #948

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
@@ -370,6 +370,7 @@ public class NettyHttpServer implements EmbeddedServer, WebSocketSessionReposito
                                 LOG.error("Error starting Micronaut server: " + e.getMessage(), e);
                             }
                         }
+                        throw new ServerStartupException("Unable to start Micronaut server on port: " + serverPort, e);
                     }
                 }
             }

--- a/management/src/main/java/io/micronaut/management/endpoint/EndpointDefaultConfiguration.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/EndpointDefaultConfiguration.java
@@ -40,12 +40,18 @@ public class EndpointDefaultConfiguration {
     public static final String PATH = "endpoints.all.path";
 
     /**
+     * The path for endpoints settings.
+     */
+    public static final String PORT = "endpoints.all.port";
+
+    /**
      * The default base path.
      */
     public static final String DEFAULT_ENDPOINT_BASE_PATH = "/";
 
     private Boolean enabled;
     private Boolean sensitive;
+    private Integer port;
     private String path = DEFAULT_ENDPOINT_BASE_PATH;
 
     /**
@@ -96,5 +102,20 @@ public class EndpointDefaultConfiguration {
         if (StringUtils.isNotEmpty(path)) {
             this.path = path;
         }
+    }
+
+    /**
+     * @return The port to expose endpoints via.
+     */
+    public Optional<Integer> getPort() {
+        return Optional.ofNullable(port);
+    }
+
+    /**
+     * Sets the port to expose endpoints via.
+     * @param port The port
+     */
+    public void setPort(Integer port) {
+        this.port = port;
     }
 }

--- a/management/src/main/java/io/micronaut/management/endpoint/processors/AbstractEndpointRouteBuilder.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/processors/AbstractEndpointRouteBuilder.java
@@ -21,7 +21,6 @@ import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.async.subscriber.Completable;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.naming.NameUtils;
-import io.micronaut.core.reflect.ClassLoadingReporter;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.uri.UriTemplate;
@@ -32,6 +31,7 @@ import io.micronaut.management.endpoint.annotation.Endpoint;
 import io.micronaut.management.endpoint.annotation.Selector;
 import io.micronaut.web.router.DefaultRouteBuilder;
 
+import javax.annotation.Nullable;
 import java.lang.annotation.Annotation;
 import java.util.Map;
 import java.util.Optional;
@@ -55,9 +55,9 @@ abstract class AbstractEndpointRouteBuilder extends DefaultRouteBuilder implemen
     private final EndpointDefaultConfiguration endpointDefaultConfiguration;
 
     /**
-     * @param applicationContext The application context
-     * @param uriNamingStrategy  The URI naming strategy
-     * @param conversionService  The conversion service
+     * @param applicationContext           The application context
+     * @param uriNamingStrategy            The URI naming strategy
+     * @param conversionService            The conversion service
      * @param endpointDefaultConfiguration Endpoints default Configuration
      */
     AbstractEndpointRouteBuilder(ApplicationContext applicationContext,
@@ -79,8 +79,9 @@ abstract class AbstractEndpointRouteBuilder extends DefaultRouteBuilder implemen
      *
      * @param method The {@link ExecutableMethod}
      * @param id     The route id
+     * @param port   The port
      */
-    protected abstract void registerRoute(ExecutableMethod<?, ?> method, String id);
+    protected abstract void registerRoute(ExecutableMethod<?, ?> method, String id, @Nullable Integer port);
 
     /**
      * Clears endpoint ids information.
@@ -99,13 +100,8 @@ abstract class AbstractEndpointRouteBuilder extends DefaultRouteBuilder implemen
         Class<?> declaringType = method.getDeclaringType();
         if (method.hasStereotype(getSupportedAnnotation())) {
             Optional<String> endPointId = resolveActiveEndPointId(declaringType);
-            endPointId.ifPresent(id -> {
-                ClassLoadingReporter.reportBeanPresent(method.getReturnType().getType());
-                for (Class argumentType : method.getArgumentTypes()) {
-                    ClassLoadingReporter.reportBeanPresent(argumentType);
-                }
-                registerRoute(method, id);
-            });
+            final Integer port = endpointDefaultConfiguration.getPort().orElse(null);
+            endPointId.ifPresent(id -> registerRoute(method, id, port));
         }
     }
 

--- a/management/src/main/java/io/micronaut/management/endpoint/processors/DeleteEndpointRouteBuilder.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/processors/DeleteEndpointRouteBuilder.java
@@ -55,10 +55,13 @@ public class DeleteEndpointRouteBuilder extends AbstractEndpointRouteBuilder {
     }
 
     @Override
-    protected void registerRoute(ExecutableMethod<?, ?> method, String id) {
+    protected void registerRoute(ExecutableMethod<?, ?> method, String id, Integer port) {
         Class<?> declaringType = method.getDeclaringType();
         UriTemplate template = buildUriTemplate(method, id);
-        final UriRoute uriRoute = DELETE(template.toString(), declaringType, method.getMethodName(), method.getArgumentTypes());
+        UriRoute uriRoute = DELETE(template.toString(), declaringType, method.getMethodName(), method.getArgumentTypes());
+        if (port != null) {
+            uriRoute = uriRoute.port(port);
+        }
         if (LOG.isDebugEnabled()) {
             LOG.debug("Created Route to @Endpoint {}: {}", method.getDeclaringType().getName(), uriRoute);
         }

--- a/management/src/main/java/io/micronaut/management/endpoint/processors/DeleteEndpointRouteBuilder.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/processors/DeleteEndpointRouteBuilder.java
@@ -60,7 +60,7 @@ public class DeleteEndpointRouteBuilder extends AbstractEndpointRouteBuilder {
         UriTemplate template = buildUriTemplate(method, id);
         UriRoute uriRoute = DELETE(template.toString(), declaringType, method.getMethodName(), method.getArgumentTypes());
         if (port != null) {
-            uriRoute = uriRoute.port(port);
+            uriRoute = uriRoute.exposedPort(port);
         }
         if (LOG.isDebugEnabled()) {
             LOG.debug("Created Route to @Endpoint {}: {}", method.getDeclaringType().getName(), uriRoute);

--- a/management/src/main/java/io/micronaut/management/endpoint/processors/ReadEndpointRouteBuilder.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/processors/ReadEndpointRouteBuilder.java
@@ -60,14 +60,14 @@ public class ReadEndpointRouteBuilder extends AbstractEndpointRouteBuilder {
         UriTemplate template = buildUriTemplate(method, id);
         UriRoute uriRoute = GET(template.toString(), declaringType, method.getMethodName(), method.getArgumentTypes());
         if (port != null) {
-            uriRoute = uriRoute.port(port);
+            uriRoute = uriRoute.exposedPort(port);
         }
         if (LOG.isDebugEnabled()) {
             LOG.debug("Created Route to @Endpoint {}: {}", method.getDeclaringType().getName(), uriRoute);
         }
         uriRoute = HEAD(template.toString(), declaringType, method.getMethodName(), method.getArgumentTypes());
         if (port != null) {
-            uriRoute = uriRoute.port(port);
+            uriRoute = uriRoute.exposedPort(port);
         }
         if (LOG.isDebugEnabled()) {
             LOG.debug("Created Route to @Endpoint {}: {}", method.getDeclaringType().getName(), uriRoute);

--- a/management/src/main/java/io/micronaut/management/endpoint/processors/ReadEndpointRouteBuilder.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/processors/ReadEndpointRouteBuilder.java
@@ -55,14 +55,20 @@ public class ReadEndpointRouteBuilder extends AbstractEndpointRouteBuilder {
     }
 
     @Override
-    protected void registerRoute(ExecutableMethod<?, ?> method, String id) {
+    protected void registerRoute(ExecutableMethod<?, ?> method, String id, Integer port) {
         Class<?> declaringType = method.getDeclaringType();
         UriTemplate template = buildUriTemplate(method, id);
         UriRoute uriRoute = GET(template.toString(), declaringType, method.getMethodName(), method.getArgumentTypes());
+        if (port != null) {
+            uriRoute = uriRoute.port(port);
+        }
         if (LOG.isDebugEnabled()) {
             LOG.debug("Created Route to @Endpoint {}: {}", method.getDeclaringType().getName(), uriRoute);
         }
         uriRoute = HEAD(template.toString(), declaringType, method.getMethodName(), method.getArgumentTypes());
+        if (port != null) {
+            uriRoute = uriRoute.port(port);
+        }
         if (LOG.isDebugEnabled()) {
             LOG.debug("Created Route to @Endpoint {}: {}", method.getDeclaringType().getName(), uriRoute);
         }

--- a/management/src/main/java/io/micronaut/management/endpoint/processors/WriteEndpointRouteBuilder.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/processors/WriteEndpointRouteBuilder.java
@@ -65,7 +65,7 @@ public class WriteEndpointRouteBuilder extends AbstractEndpointRouteBuilder {
         UriRoute uriRoute = POST(template.toString(), declaringType, method.getMethodName(), method.getArgumentTypes())
                 .consumes(MediaType.of(consumes));
         if (port != null) {
-            uriRoute = uriRoute.port(port);
+            uriRoute = uriRoute.exposedPort(port);
         }
         if (LOG.isDebugEnabled()) {
             LOG.debug("Created Route to @Endpoint {}: {}", method.getDeclaringType().getName(), uriRoute);

--- a/management/src/main/java/io/micronaut/management/endpoint/processors/WriteEndpointRouteBuilder.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/processors/WriteEndpointRouteBuilder.java
@@ -58,12 +58,15 @@ public class WriteEndpointRouteBuilder extends AbstractEndpointRouteBuilder {
     }
 
     @Override
-    protected void registerRoute(ExecutableMethod<?, ?> method, String id) {
+    protected void registerRoute(ExecutableMethod<?, ?> method, String id, Integer port) {
         Class<?> declaringType = method.getDeclaringType();
         UriTemplate template = buildUriTemplate(method, id);
         String[] consumes = method.stringValues(Write.class, "consumes");
-        final UriRoute uriRoute = POST(template.toString(), declaringType, method.getMethodName(), method.getArgumentTypes())
+        UriRoute uriRoute = POST(template.toString(), declaringType, method.getMethodName(), method.getArgumentTypes())
                 .consumes(MediaType.of(consumes));
+        if (port != null) {
+            uriRoute = uriRoute.port(port);
+        }
         if (LOG.isDebugEnabled()) {
             LOG.debug("Created Route to @Endpoint {}: {}", method.getDeclaringType().getName(), uriRoute);
         }

--- a/management/src/test/groovy/io/micronaut/management/endpoint/EndpointsPortSpec.groovy
+++ b/management/src/test/groovy/io/micronaut/management/endpoint/EndpointsPortSpec.groovy
@@ -1,0 +1,51 @@
+package io.micronaut.management.endpoint
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.io.socket.SocketUtils
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.runtime.server.EmbeddedServer
+import spock.lang.Retry
+import spock.lang.Specification
+
+
+class EndpointsPortSpec extends Specification {
+    // retry as a port binding conflict on CI can occur
+    @Retry
+    def "test that it is possible to change admin port"() {
+
+        given:
+        def port = SocketUtils.findAvailableTcpPort()
+        EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
+                'spec.name': getClass().simpleName,
+                'endpoints.all.port': port,
+                'endpoints.all.enabled': true
+        ])
+        HttpClient rxClient = server.applicationContext.createBean(HttpClient.class, new URL("http://localhost:$port"))
+        HttpClient serverClient = server.applicationContext.createBean(HttpClient.class, server.getURL())
+
+        when:
+        rxClient.toBlocking().retrieve('/health')
+
+        then:
+        noExceptionThrown()
+
+        when:
+        serverClient.toBlocking().retrieve('/health')
+
+        then:
+        def e = thrown(HttpClientResponseException)
+
+        when:
+        def response = e.response
+
+        then:
+        response.status == HttpStatus.NOT_FOUND
+
+        cleanup:
+        serverClient.close()
+        rxClient.close()
+        server.close()
+    }
+}

--- a/router/src/main/java/io/micronaut/web/router/DefaultRouteBuilder.java
+++ b/router/src/main/java/io/micronaut/web/router/DefaultRouteBuilder.java
@@ -101,6 +101,7 @@ public abstract class DefaultRouteBuilder implements RouteBuilder {
     private List<StatusRoute> statusRoutes = new ArrayList<>();
     private List<ErrorRoute> errorRoutes = new ArrayList<>();
     private List<FilterRoute> filterRoutes = new ArrayList<>();
+    private Set<Integer> exposedPorts = new HashSet<>(5);
 
     /**
      * @param executionHandleLocator The execution handler locator
@@ -133,6 +134,11 @@ public abstract class DefaultRouteBuilder implements RouteBuilder {
         } else {
             defaultCharset = StandardCharsets.UTF_8;
         }
+    }
+
+    @Override
+    public Set<Integer> getExposedPorts() {
+        return exposedPorts;
     }
 
     @Override
@@ -878,6 +884,13 @@ public abstract class DefaultRouteBuilder implements RouteBuilder {
         @Override
         public UriRoute body(String argument) {
             return (UriRoute) super.body(argument);
+        }
+
+        @Override
+        public UriRoute port(int port) {
+            where(httpRequest -> httpRequest.getServerAddress().getPort() == port);
+            DefaultRouteBuilder.this.exposedPorts.add(port);
+            return this;
         }
 
         @Override

--- a/router/src/main/java/io/micronaut/web/router/DefaultRouteBuilder.java
+++ b/router/src/main/java/io/micronaut/web/router/DefaultRouteBuilder.java
@@ -887,7 +887,7 @@ public abstract class DefaultRouteBuilder implements RouteBuilder {
         }
 
         @Override
-        public UriRoute port(int port) {
+        public UriRoute exposedPort(int port) {
             where(httpRequest -> httpRequest.getServerAddress().getPort() == port);
             DefaultRouteBuilder.this.exposedPorts.add(port);
             return this;

--- a/router/src/main/java/io/micronaut/web/router/RouteBuilder.java
+++ b/router/src/main/java/io/micronaut/web/router/RouteBuilder.java
@@ -33,6 +33,7 @@ import io.micronaut.inject.ProxyBeanDefinition;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Supplier;
 
 /**
@@ -49,6 +50,11 @@ public interface RouteBuilder {
      * Used to signify to the route that the ID of the resource is used.
      */
     PropertyConvention ID = PropertyConvention.ID;
+
+    /**
+     * @return The exposed ports
+     */
+    Set<Integer> getExposedPorts();
 
     /**
      * @return The filter routes
@@ -1209,8 +1215,7 @@ public interface RouteBuilder {
          * @param id   the route id
          * @return The URI to use
          */
-        default @Nonnull
-        String resolveUri(Class type, PropertyConvention id) {
+        default @Nonnull String resolveUri(Class type, PropertyConvention id) {
             return resolveUri(type) + "/{" + id.lowerCaseName() + "}";
         }
 

--- a/router/src/main/java/io/micronaut/web/router/Router.java
+++ b/router/src/main/java/io/micronaut/web/router/Router.java
@@ -25,6 +25,7 @@ import javax.annotation.Nullable;
 import java.net.URI;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 
 /**
@@ -60,6 +61,11 @@ public interface Router {
     default @Nonnull <T, R> Stream<UriRouteMatch<T, R>> findAny(@Nonnull CharSequence uri, @Nullable HttpRequest<?> context) {
         return findAny(uri);
     }
+
+    /**
+     * @return The exposed ports.
+     */
+    Set<Integer> getExposedPorts();
 
     /**
      * Finds all of the possible routes for the given HTTP method and URI.

--- a/router/src/main/java/io/micronaut/web/router/UriRoute.java
+++ b/router/src/main/java/io/micronaut/web/router/UriRoute.java
@@ -87,6 +87,13 @@ public interface UriRoute extends Route, UriMatcher, Comparable<UriRoute> {
     UriRoute body(String argument);
 
     /**
+     * The port for the route.
+     * @param port The port
+     * @return The route
+     */
+    UriRoute port(int port);
+
+    /**
      *
      * @return The http method. Is equal to {@link #getHttpMethod()} value for standard http methods.
      */

--- a/router/src/main/java/io/micronaut/web/router/UriRoute.java
+++ b/router/src/main/java/io/micronaut/web/router/UriRoute.java
@@ -87,11 +87,12 @@ public interface UriRoute extends Route, UriMatcher, Comparable<UriRoute> {
     UriRoute body(String argument);
 
     /**
-     * The port for the route.
+     * The exposed port that the route applies to.
+     *
      * @param port The port
      * @return The route
      */
-    UriRoute port(int port);
+    UriRoute exposedPort(int port);
 
     /**
      *

--- a/router/src/main/java/io/micronaut/web/router/filter/FilteredRouter.java
+++ b/router/src/main/java/io/micronaut/web/router/filter/FilteredRouter.java
@@ -29,6 +29,7 @@ import javax.annotation.Nullable;
 import java.net.URI;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -77,6 +78,11 @@ public class FilteredRouter implements Router {
             return matchStream.filter(routeFilter.filter(context));
         }
         return matchStream;
+    }
+
+    @Override
+    public Set<Integer> getExposedPorts() {
+        return router.getExposedPorts();
     }
 
     @Nonnull

--- a/src/main/docs/guide/management/providedEndpoints.adoc
+++ b/src/main/docs/guide/management/providedEndpoints.adoc
@@ -63,6 +63,18 @@ In addition, the following built-in endpoint(s) are provided by the `management`
 WARNING: It is possible to open all endpoints for unauthenticated access defining `endpoints.all.sensitive: false` but
 this should be used with care because private and sensitive information will be exposed.
 
+=== Management Port
+
+By default all management endpoints are exposed over the same port as the application. You can alter this behaviour by specifying the `endpoints.all.port` setting:
+
+[source,yaml]
+----
+endpoints:
+    all:
+        port: 8085
+----
+
+In the above example the management endpoints will be exposed only over port 8085.
 
 === JMX
 


### PR DESCRIPTION
This resolves #948 by adding a condition to each `@Endpoint` route and exposing an additional port.