### PR TITLE
Add possibility to set subprotocols on the server web socket

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/websocket/NettyServerWebSocketUpgradeHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/websocket/NettyServerWebSocketUpgradeHandler.java
@@ -18,6 +18,7 @@ package io.micronaut.http.server.netty.websocket;
 
 import io.micronaut.context.event.ApplicationEventPublisher;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.*;
 import io.micronaut.http.codec.MediaTypeCodecRegistry;
 import io.micronaut.http.exceptions.HttpStatusException;
@@ -34,6 +35,7 @@ import io.micronaut.web.router.UriRouteMatch;
 import io.micronaut.websocket.CloseReason;
 import io.micronaut.websocket.annotation.OnMessage;
 import io.micronaut.websocket.annotation.OnOpen;
+import io.micronaut.websocket.annotation.ServerWebSocket;
 import io.micronaut.websocket.context.WebSocketBean;
 import io.micronaut.websocket.context.WebSocketBeanRegistry;
 import io.netty.channel.Channel;
@@ -227,10 +229,13 @@ public class NettyServerWebSocketUpgradeHandler extends SimpleChannelInboundHand
         int maxFramePayloadLength = webSocketBean.messageMethod()
                 .map(m -> m.intValue(OnMessage.class, "maxPayloadLength")
                 .orElse(65536)).orElse(65536);
+        String subprotocols = webSocketBean.getBeanDefinition().stringValue(ServerWebSocket.class, "subprotocols")
+                                           .filter(s -> !StringUtils.isEmpty(s))
+                                           .orElse(null);
         WebSocketServerHandshakerFactory wsFactory =
                 new WebSocketServerHandshakerFactory(
                         getWebSocketURL(ctx, req),
-                        null,
+                        subprotocols,
                         true,
                         maxFramePayloadLength
                 );

--- a/websocket/src/main/java/io/micronaut/websocket/annotation/ServerWebSocket.java
+++ b/websocket/src/main/java/io/micronaut/websocket/annotation/ServerWebSocket.java
@@ -17,6 +17,7 @@ package io.micronaut.websocket.annotation;
 
 import io.micronaut.context.annotation.AliasFor;
 import io.micronaut.context.annotation.DefaultScope;
+import io.micronaut.core.util.StringUtils;
 import io.micronaut.websocket.WebSocketVersion;
 
 import javax.inject.Singleton;
@@ -62,4 +63,9 @@ public @interface ServerWebSocket {
      */
     @AliasFor(annotation = WebSocketComponent.class, member = "version")
     WebSocketVersion version() default WebSocketVersion.V13;
+
+    /**
+     * @return A csv of the supported subprotocols
+     */
+    String subprotocols() default StringUtils.EMPTY_STRING;
 }


### PR DESCRIPTION
This is the server variant of https://github.com/micronaut-projects/micronaut-core/pull/2513

By this commit I would like to give possibility to set subprotocols in ServerWebSocket annotation and I have also added code to pass it properly to netty.

Default value: empty string, which will be turned to null in the UpgradeHandler to keep the same correct behaviour when no subprotocol is set.

Example of use:
```java
@ServerWebSocket(value = "${" + GraphQLConfiguration.PREFIX + "." + GraphQLConfiguration.GraphQLWsConfiguration.PATH + ":"
        + GraphQLConfiguration.GraphQLWsConfiguration.DEFAULT_PATH + "}", subprotocols = "graphql-ws")
```

I encountered the need for the fix working on support for subscriptions in micronaut-graphql, and running into problems with chrome specifically because the server was not sending the `Sec-WebSocket-Protocol` header response. Causing an error. With this change the client (clojurescript) is able to connect to the server.