### PR TITLE
Fix for #2581: allow empty values for command line parameter

### DIFF
--- a/core/src/main/java/io/micronaut/core/cli/CommandLineParser.java
+++ b/core/src/main/java/io/micronaut/core/cli/CommandLineParser.java
@@ -166,7 +166,7 @@ class CommandLineParser implements CommandLine.Builder<CommandLineParser> {
             String[] split = arg.split("=");
             String name = split[0].trim();
             validateOptionName(name);
-            String value = split[1].trim();
+            String value = split.length > 1 ? split[1].trim() : "";
             if (declaredOptions.containsKey(name)) {
                 cl.addDeclaredOption(declaredOptions.get(name), value);
             } else {


### PR DESCRIPTION
Fixes #2581 