### PR TITLE
Set default formatters for java.time objectsTime converter update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,9 @@ If you are interested in contributing to Micronaut and are looking for issues to
 
 ## JDK Setup
 
-Micronaut currently requires JDK 8
+Micronaut currently requires JDK 8.
+ 
+Additionally, the JDK must have the Java Cryptography Extension (JCE) files installed.
 
 ## IDE Setup
 

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/HeaderBindingSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/HeaderBindingSpec.groovy
@@ -59,7 +59,7 @@ class HeaderBindingSpec extends AbstractMicronautSpec {
         '/header/formatted-date'  | "Header: $formatted"         | ['Date': formatted]
         '/header/optional'        | "Header: application/json"   | ['Content-Type': 'application/json']
         '/header/optional'        | "Header: Not-Present"        | [:]
-        '/header/date'            | "Header: $now"               | ['Date': now]
+        '/header/date'            | "Header: $now"               | ['Date': timeNow.toString()]
         '/header/with-media-type' | "Header: application/json"   | ['Content-Type': 'application/json']
         '/header/all'             | "Header: application/json"   | ['Content-Type': 'application/json']
         '/header/multiple'        | "Header: [application/json]" | ['Content-Type': 'application/json']

--- a/runtime/src/main/java/io/micronaut/runtime/converters/time/TimeConverterRegistrar.java
+++ b/runtime/src/main/java/io/micronaut/runtime/converters/time/TimeConverterRegistrar.java
@@ -92,23 +92,23 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
                         try {
                             switch (type) {
                                 case 's':
-                                    return Optional.of(Duration.ofSeconds(Integer.valueOf(amount)));
+                                    return Optional.of(Duration.ofSeconds(Integer.parseInt(amount)));
                                 case 'm':
                                     String ms = matcher.group(MILLIS);
                                     if (StringUtils.hasText(ms)) {
-                                        return Optional.of(Duration.ofMillis(Integer.valueOf(amount)));
+                                        return Optional.of(Duration.ofMillis(Integer.parseInt(amount)));
                                     } else {
-                                        return Optional.of(Duration.ofMinutes(Integer.valueOf(amount)));
+                                        return Optional.of(Duration.ofMinutes(Integer.parseInt(amount)));
                                     }
                                 case 'h':
-                                    return Optional.of(Duration.ofHours(Integer.valueOf(amount)));
+                                    return Optional.of(Duration.ofHours(Integer.parseInt(amount)));
                                 case 'd':
-                                    return Optional.of(Duration.ofDays(Integer.valueOf(amount)));
+                                    return Optional.of(Duration.ofDays(Integer.parseInt(amount)));
                                 default:
                                     final String seq = g2 + matcher.group(3);
                                     switch (seq) {
                                         case "ns":
-                                            return Optional.of(Duration.ofNanos(Integer.valueOf(amount)));
+                                            return Optional.of(Duration.ofNanos(Integer.parseInt(amount)));
                                         default:
                                             context.reject(
                                                     value,
@@ -131,7 +131,7 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
             LocalDateTime.class,
             (object, targetType, context) -> {
                 try {
-                    DateTimeFormatter formatter = resolveFormatter(context);
+                    DateTimeFormatter formatter = resolveFormatter(context, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
                     LocalDateTime result = LocalDateTime.parse(object, formatter);
                     return Optional.of(result);
                 } catch (DateTimeParseException e) {
@@ -144,7 +144,7 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
         // TemporalAccessor - CharSequence
         final TypeConverter<TemporalAccessor, CharSequence> temporalConverter = (object, targetType, context) -> {
             try {
-                DateTimeFormatter formatter = resolveFormatter(context);
+                DateTimeFormatter formatter = resolveFormatter(context, DateTimeFormatter.RFC_1123_DATE_TIME);
                 return Optional.of(formatter.format(object));
             } catch (DateTimeParseException e) {
                 context.reject(object, e);
@@ -163,7 +163,7 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
             LocalDate.class,
             (object, targetType, context) -> {
                 try {
-                    DateTimeFormatter formatter = resolveFormatter(context);
+                    DateTimeFormatter formatter = resolveFormatter(context, DateTimeFormatter.ISO_LOCAL_DATE);
                     LocalDate result = LocalDate.parse(object, formatter);
                     return Optional.of(result);
                 } catch (DateTimeParseException e) {
@@ -180,7 +180,7 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
             ZonedDateTime.class,
             (object, targetType, context) -> {
                 try {
-                    DateTimeFormatter formatter = resolveFormatter(context);
+                    DateTimeFormatter formatter = resolveFormatter(context, DateTimeFormatter.ISO_ZONED_DATE_TIME);
                     ZonedDateTime result = ZonedDateTime.parse(object, formatter);
                     return Optional.of(result);
                 } catch (DateTimeParseException e) {
@@ -196,7 +196,7 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
                 OffsetDateTime.class,
                 (object, targetType, context) -> {
                     try {
-                        DateTimeFormatter formatter = resolveFormatter(context);
+                        DateTimeFormatter formatter = resolveFormatter(context, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
                         OffsetDateTime result = OffsetDateTime.parse(object, formatter);
                         return Optional.of(result);
                     } catch (DateTimeParseException e) {
@@ -207,10 +207,10 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
         );
     }
 
-    private DateTimeFormatter resolveFormatter(ConversionContext context) {
+    private DateTimeFormatter resolveFormatter(ConversionContext context, DateTimeFormatter defaultFormatter) {
         Optional<String> format = context.getAnnotationMetadata().stringValue(Format.class);
         return format
             .map((pattern) -> DateTimeFormatter.ofPattern(pattern, context.getLocale()))
-            .orElse(DateTimeFormatter.RFC_1123_DATE_TIME);
+            .orElse(defaultFormatter);
     }
 }

--- a/runtime/src/main/java/io/micronaut/runtime/converters/time/TimeConverterRegistrar.java
+++ b/runtime/src/main/java/io/micronaut/runtime/converters/time/TimeConverterRegistrar.java
@@ -144,7 +144,7 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
         // TemporalAccessor - CharSequence
         final TypeConverter<TemporalAccessor, CharSequence> temporalConverter = (object, targetType, context) -> {
             try {
-                DateTimeFormatter formatter = resolveFormatter(context, DateTimeFormatter.RFC_1123_DATE_TIME);
+                DateTimeFormatter formatter = resolveFormatter(context, defaultFormatter(object));
                 return Optional.of(formatter.format(object));
             } catch (DateTimeParseException e) {
                 context.reject(object, e);
@@ -205,6 +205,20 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
                     }
                 }
         );
+    }
+
+    private DateTimeFormatter defaultFormatter(Object current) {
+        if (current instanceof OffsetDateTime) {
+            return DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+        } else if (current instanceof ZonedDateTime) {
+            return DateTimeFormatter.ISO_ZONED_DATE_TIME;
+        } else if (current instanceof LocalDate) {
+           return DateTimeFormatter.ISO_LOCAL_DATE;
+        } else if (current instanceof LocalDateTime) {
+            return DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+        } else {
+            return DateTimeFormatter.RFC_1123_DATE_TIME;
+        }
     }
 
     private DateTimeFormatter resolveFormatter(ConversionContext context, DateTimeFormatter defaultFormatter) {

--- a/runtime/src/test/groovy/io/micronaut/runtime/converters/time/TimeConverterRegistrarSpec.groovy
+++ b/runtime/src/test/groovy/io/micronaut/runtime/converters/time/TimeConverterRegistrarSpec.groovy
@@ -21,6 +21,10 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 import java.time.Duration
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZonedDateTime
 
 class TimeConverterRegistrarSpec extends Specification {
 
@@ -44,4 +48,22 @@ class TimeConverterRegistrarSpec extends Specification {
         '10ns' | Duration.ofNanos(10)
 
     }
+
+    @Unroll
+    void "test convert default formats #val"() {
+        given:
+        ConversionService conversionService = new DefaultConversionService()
+        new TimeConverterRegistrar().register(conversionService)
+
+        expect:
+        conversionService.convert(val1, val2).get() == expected
+
+        where:
+        val1                        | val2              | expected
+        "2020-01-01"                | LocalDate         | LocalDate.of(2020, 1, 1)
+        "2020-02-03T11:15:30"       | LocalDateTime     | LocalDateTime.parse("2020-02-03T11:15:30")
+        "2020-12-03T10:15:30+01:00" | ZonedDateTime     | ZonedDateTime.parse("2020-12-03T10:15:30+01:00")
+        "2011-12-03T10:15:30+01:00" | OffsetDateTime    | OffsetDateTime.parse("2011-12-03T10:15:30+01:00")
+    }
+
 }

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/binding/BindingControllerTest.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/binding/BindingControllerTest.groovy
@@ -74,7 +74,7 @@ class BindingControllerTest extends Specification {
 
     void "test header date binding"() {
         when:
-        String body = client.toBlocking().retrieve(HttpRequest.GET("/binding/date").header("date", "Tue, 3 Jun 2008 11:05:30 GMT"))
+        String body = client.toBlocking().retrieve(HttpRequest.GET("/binding/date").header("date", "2008-06-03T11:05:30Z"))
 
         then:
         body != null

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/binding/BindingControllerTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/binding/BindingControllerTest.kt
@@ -65,7 +65,7 @@ class BindingControllerTest: StringSpec() {
         }
 
         "test header date binding"() {
-            var body = client.toBlocking().retrieve(HttpRequest.GET<Any>("/binding/date").header("date", "Tue, 3 Jun 2008 11:05:30 GMT"))
+            var body = client.toBlocking().retrieve(HttpRequest.GET<Any>("/binding/date").header("date", "2008-06-03T11:05:30Z"))
 
             body shouldNotBe null
             body shouldBe "2008-06-03T11:05:30Z"

--- a/test-suite/src/test/java/io/micronaut/docs/server/binding/BindingControllerTest.java
+++ b/test-suite/src/test/java/io/micronaut/docs/server/binding/BindingControllerTest.java
@@ -89,7 +89,8 @@ public class BindingControllerTest {
 
     @Test
     public void testHeaderDateBinding() {
-        String body = client.toBlocking().retrieve(HttpRequest.GET("/binding/date").header("date", "Tue, 3 Jun 2008 11:05:30 GMT"));
+
+        String body = client.toBlocking().retrieve(HttpRequest.GET("/binding/date").header("date", "2008-06-03T11:05:30Z"));
 
         assertNotNull(body);
         assertEquals("2008-06-03T11:05:30Z", body);


### PR DESCRIPTION
When using java.time objects - the default date format is currently set to RFC_1123_DATE_TIME if no @Format annotation is set. This change adjusts the default format so that it is the same as the defaults defined in the java jdk.