### PR TITLE
Refactor JacksonProcessor to use TokenBuffer

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/DefaultHttpClient.java
@@ -867,7 +867,7 @@ public class DefaultHttpClient implements RxWebSocketClient, RxHttpClient, RxStr
 
                 boolean isJsonStream = response.getContentType().map(mediaType -> mediaType.equals(MediaType.APPLICATION_JSON_STREAM_TYPE)).orElse(false);
                 boolean streamArray = !Iterable.class.isAssignableFrom(type.getType()) && !isJsonStream;
-                JacksonProcessor jacksonProcessor = new JacksonProcessor(mediaTypeCodec.getObjectMapper().getFactory(), streamArray, mediaTypeCodec.getObjectMapper().getDeserializationConfig()) {
+                JacksonProcessor jacksonProcessor = new JacksonProcessor(mediaTypeCodec.getObjectMapper().getFactory(), streamArray, mediaTypeCodec.getObjectMapper()) {
                     @Override
                     public void subscribe(Subscriber<? super JsonNode> downstreamSubscriber) {
                         httpContentFlowable.map(content -> {

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/jackson/JsonContentProcessor.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/jackson/JsonContentProcessor.java
@@ -16,8 +16,9 @@
 package io.micronaut.http.server.netty.jackson;
 
 import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.databind.DeserializationConfig;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.core.async.subscriber.CompletionAwareSubscriber;
@@ -49,23 +50,23 @@ import java.util.Optional;
 public class JsonContentProcessor extends AbstractHttpContentProcessor<JsonNode> {
 
     private final JsonFactory jsonFactory;
-    private final DeserializationConfig deserializationConfig;
+    private final ObjectMapper objectMapper;
     private JacksonProcessor jacksonProcessor;
 
     /**
      * @param nettyHttpRequest The Netty Http request
      * @param configuration    The Http server configuration
      * @param jsonFactory      The json factory
-     * @param deserializationConfig The jackson deserialization configuration
+     * @param objectMapper The jackson object mapper
      */
     public JsonContentProcessor(
             NettyHttpRequest<?> nettyHttpRequest,
             HttpServerConfiguration configuration,
             @Nullable JsonFactory jsonFactory,
-            DeserializationConfig deserializationConfig) {
+            ObjectMapper objectMapper) {
         super(nettyHttpRequest, configuration);
         this.jsonFactory = jsonFactory != null ? jsonFactory : new JsonFactory();
-        this.deserializationConfig = deserializationConfig;
+        this.objectMapper = objectMapper;
     }
 
     @Override
@@ -94,7 +95,7 @@ public class JsonContentProcessor extends AbstractHttpContentProcessor<JsonNode>
             }
         }
 
-        this.jacksonProcessor = new JacksonProcessor(jsonFactory, streamArray, deserializationConfig);
+        this.jacksonProcessor = new JacksonProcessor(jsonFactory, streamArray, objectMapper);
         this.jacksonProcessor.subscribe(new CompletionAwareSubscriber<JsonNode>() {
 
             @Override

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/jackson/JsonHttpContentSubscriberFactory.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/jackson/JsonHttpContentSubscriberFactory.java
@@ -16,7 +16,6 @@
 package io.micronaut.http.server.netty.jackson;
 
 import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.databind.DeserializationConfig;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.micronaut.core.annotation.Internal;
@@ -44,7 +43,7 @@ public class JsonHttpContentSubscriberFactory implements HttpContentSubscriberFa
 
     private final HttpServerConfiguration httpServerConfiguration;
     private final @Nullable JsonFactory jsonFactory;
-    private final DeserializationConfig deserializationConfig;
+    private final ObjectMapper objectMapper;
 
     /**
      * @param objectMapper The jackson object mapper.
@@ -58,11 +57,11 @@ public class JsonHttpContentSubscriberFactory implements HttpContentSubscriberFa
         ArgumentUtils.requireNonNull("objectMapper", objectMapper);
         this.httpServerConfiguration = httpServerConfiguration;
         this.jsonFactory = jsonFactory;
-        this.deserializationConfig = objectMapper.getDeserializationConfig();
+        this.objectMapper = objectMapper;
     }
 
     @Override
     public HttpContentProcessor build(NettyHttpRequest request) {
-        return new JsonContentProcessor(request, httpServerConfiguration, jsonFactory, deserializationConfig);
+        return new JsonContentProcessor(request, httpServerConfiguration, jsonFactory, objectMapper);
     }
 }

--- a/runtime/src/test/groovy/io/micronaut/jackson/parser/JacksonProcessorSpec.groovy
+++ b/runtime/src/test/groovy/io/micronaut/jackson/parser/JacksonProcessorSpec.groovy
@@ -49,7 +49,7 @@ class JacksonProcessorSpec extends Specification {
 
         given:
         ObjectMapper objectMapper = applicationContext.getBean(ObjectMapper)
-        JacksonProcessor processor = new JacksonProcessor(objectMapper.getDeserializationConfig())
+        JacksonProcessor processor = new JacksonProcessor(objectMapper)
         BigDecimal dec = new BigDecimal("888.7794538169553400000")
         BigD bigD = new BigD(bd1: dec, bd2: dec)
 
@@ -115,9 +115,8 @@ class JacksonProcessorSpec extends Specification {
     void "test big decimal - USE_BIG_DECIMAL_FOR_FLOATS"() {
 
         given:
-        ObjectMapper objectMapper = applicationContext.getBean(ObjectMapper)
-        DeserializationConfig cfg = objectMapper.getDeserializationConfig()
-        JacksonProcessor processor = new JacksonProcessor(cfg.with(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS))
+        ObjectMapper objectMapper = applicationContext.getBean(ObjectMapper).enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
+        JacksonProcessor processor = new JacksonProcessor(objectMapper)
         BigDecimal dec = new BigDecimal("888.7794538169553400000")
         BigD bigD = new BigD(bd1: dec, bd2: dec)
 
@@ -184,7 +183,7 @@ class JacksonProcessorSpec extends Specification {
 
         given:
         ObjectMapper objectMapper = applicationContext.getBean(ObjectMapper)
-        JacksonProcessor processor = new JacksonProcessor(objectMapper.getDeserializationConfig())
+        JacksonProcessor processor = new JacksonProcessor(objectMapper)
         Foo instance = new Foo(name: "Fred", age: 10)
 
 
@@ -251,7 +250,7 @@ class JacksonProcessorSpec extends Specification {
 
         given:
         ObjectMapper objectMapper = applicationContext.getBean(ObjectMapper)
-        JacksonProcessor processor = new JacksonProcessor(objectMapper.getDeserializationConfig())
+        JacksonProcessor processor = new JacksonProcessor(objectMapper)
         Foo[] instances = [new Foo(name: "Fred", age: 10), new Foo(name: "Barney", age: 11)] as Foo[]
 
 
@@ -319,7 +318,7 @@ class JacksonProcessorSpec extends Specification {
     void "test incomplete JSON error"() {
         given:
         ObjectMapper objectMapper = applicationContext.getBean(ObjectMapper)
-        JacksonProcessor processor = new JacksonProcessor(objectMapper.getDeserializationConfig())
+        JacksonProcessor processor = new JacksonProcessor(objectMapper)
 
 
         when:
@@ -374,7 +373,7 @@ class JacksonProcessorSpec extends Specification {
     void "test JSON syntax error"() {
         given:
         ObjectMapper objectMapper = applicationContext.getBean(ObjectMapper)
-        JacksonProcessor processor = new JacksonProcessor(objectMapper.getDeserializationConfig())
+        JacksonProcessor processor = new JacksonProcessor(objectMapper)
 
 
         when:
@@ -429,7 +428,7 @@ class JacksonProcessorSpec extends Specification {
     void "test nested arrays"() {
         given:
         ObjectMapper objectMapper = applicationContext.getBean(ObjectMapper)
-        JacksonProcessor processor = new JacksonProcessor(new JsonFactory(), true, objectMapper.getDeserializationConfig())
+        JacksonProcessor processor = new JacksonProcessor(new JsonFactory(), true, objectMapper)
 
         when:
         byte[] bytes = '[1, 2, [3, 4, [5, 6], 7], [8, 9, 10], 11, 12]'.bytes
@@ -475,12 +474,12 @@ class JacksonProcessorSpec extends Specification {
 
         then:
         nodeCount == 6
-        nodes[0].equals(JsonNodeFactory.instance.numberNode(1L))
-        nodes[1].equals(JsonNodeFactory.instance.numberNode(2L))
+        nodes[0].equals(JsonNodeFactory.instance.numberNode(1))
+        nodes[1].equals(JsonNodeFactory.instance.numberNode(2))
         ((ArrayNode) nodes[2]).size() == 4
         ((ArrayNode) nodes[3]).size() == 3
-        nodes[4].equals(JsonNodeFactory.instance.numberNode(11L))
-        nodes[5].equals(JsonNodeFactory.instance.numberNode(12L))
+        nodes[4].equals(JsonNodeFactory.instance.numberNode(11))
+        nodes[5].equals(JsonNodeFactory.instance.numberNode(12))
     }
 
 }


### PR DESCRIPTION
So that the object mapper configuration is used when parsing.
Avoids case like https://github.com/micronaut-projects/micronaut-core/pull/2648

Based on https://github.com/spring-projects/spring-framework/blob/2d86f221ce9e4df99aec801ae226ed228f5b64ac/spring-web/src/main/java/org/springframework/http/codec/json/Jackson2Tokenizer.java