### PR TITLE
Refactor JacksonProcessor to use TokenBuffer

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/DefaultHttpClient.java
@@ -15,8 +15,9 @@
  */
 package io.micronaut.http.client;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.util.TokenBuffer;
+
 import io.micronaut.buffer.netty.NettyByteBufferFactory;
 import io.micronaut.context.BeanContext;
 import io.micronaut.context.annotation.BootstrapContextCompatible;
@@ -869,7 +870,7 @@ public class DefaultHttpClient implements RxWebSocketClient, RxHttpClient, RxStr
                 boolean streamArray = !Iterable.class.isAssignableFrom(type.getType()) && !isJsonStream;
                 JacksonProcessor jacksonProcessor = new JacksonProcessor(mediaTypeCodec.getObjectMapper().getFactory(), streamArray, mediaTypeCodec.getObjectMapper()) {
                     @Override
-                    public void subscribe(Subscriber<? super JsonNode> downstreamSubscriber) {
+                    public void subscribe(Subscriber<? super TokenBuffer> downstreamSubscriber) {
                         httpContentFlowable.map(content -> {
                             ByteBuf chunk = content.content();
                             if (log.isTraceEnabled()) {
@@ -886,8 +887,8 @@ public class DefaultHttpClient implements RxWebSocketClient, RxHttpClient, RxStr
                         super.subscribe(downstreamSubscriber);
                     }
                 };
-                return Flowable.fromPublisher(jacksonProcessor).map(jsonNode ->
-                        mediaTypeCodec.decode(type, jsonNode)
+                return Flowable.fromPublisher(jacksonProcessor).map(tokenBuffer ->
+                        mediaTypeCodec.decode(type, tokenBuffer)
                 );
             });
         };

--- a/http-client/src/main/java/io/micronaut/http/client/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/DefaultHttpClient.java
@@ -867,7 +867,7 @@ public class DefaultHttpClient implements RxWebSocketClient, RxHttpClient, RxStr
 
                 boolean isJsonStream = response.getContentType().map(mediaType -> mediaType.equals(MediaType.APPLICATION_JSON_STREAM_TYPE)).orElse(false);
                 boolean streamArray = !Iterable.class.isAssignableFrom(type.getType()) && !isJsonStream;
-                JacksonProcessor jacksonProcessor = new JacksonProcessor(mediaTypeCodec.getObjectMapper().getFactory(), streamArray, mediaTypeCodec.getObjectMapper().getDeserializationConfig()) {
+                JacksonProcessor jacksonProcessor = new JacksonProcessor(mediaTypeCodec.getObjectMapper().getFactory(), streamArray, mediaTypeCodec.getObjectMapper()) {
                     @Override
                     public void subscribe(Subscriber<? super JsonNode> downstreamSubscriber) {
                         httpContentFlowable.map(content -> {

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/jackson/JsonContentProcessor.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/jackson/JsonContentProcessor.java
@@ -16,8 +16,9 @@
 package io.micronaut.http.server.netty.jackson;
 
 import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.databind.DeserializationConfig;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.core.async.subscriber.CompletionAwareSubscriber;
@@ -49,23 +50,23 @@ import java.util.Optional;
 public class JsonContentProcessor extends AbstractHttpContentProcessor<JsonNode> {
 
     private final JsonFactory jsonFactory;
-    private final DeserializationConfig deserializationConfig;
+    private final ObjectMapper objectMapper;
     private JacksonProcessor jacksonProcessor;
 
     /**
      * @param nettyHttpRequest The Netty Http request
      * @param configuration    The Http server configuration
      * @param jsonFactory      The json factory
-     * @param deserializationConfig The jackson deserialization configuration
+     * @param objectMapper The jackson object mapper
      */
     public JsonContentProcessor(
             NettyHttpRequest<?> nettyHttpRequest,
             HttpServerConfiguration configuration,
             @Nullable JsonFactory jsonFactory,
-            DeserializationConfig deserializationConfig) {
+            ObjectMapper objectMapper) {
         super(nettyHttpRequest, configuration);
         this.jsonFactory = jsonFactory != null ? jsonFactory : new JsonFactory();
-        this.deserializationConfig = deserializationConfig;
+        this.objectMapper = objectMapper;
     }
 
     @Override
@@ -94,7 +95,7 @@ public class JsonContentProcessor extends AbstractHttpContentProcessor<JsonNode>
             }
         }
 
-        this.jacksonProcessor = new JacksonProcessor(jsonFactory, streamArray, deserializationConfig);
+        this.jacksonProcessor = new JacksonProcessor(jsonFactory, streamArray, objectMapper);
         this.jacksonProcessor.subscribe(new CompletionAwareSubscriber<JsonNode>() {
 
             @Override

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/jackson/JsonContentProcessor.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/jackson/JsonContentProcessor.java
@@ -16,8 +16,8 @@
 package io.micronaut.http.server.netty.jackson;
 
 import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.util.TokenBuffer;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.async.publisher.Publishers;
@@ -47,7 +47,7 @@ import java.util.Optional;
  * @since 1.0
  */
 @Internal
-public class JsonContentProcessor extends AbstractHttpContentProcessor<JsonNode> {
+public class JsonContentProcessor extends AbstractHttpContentProcessor<TokenBuffer> {
 
     private final JsonFactory jsonFactory;
     private final ObjectMapper objectMapper;
@@ -70,7 +70,7 @@ public class JsonContentProcessor extends AbstractHttpContentProcessor<JsonNode>
     }
 
     @Override
-    protected void doOnSubscribe(Subscription subscription, Subscriber<? super JsonNode> subscriber) {
+    protected void doOnSubscribe(Subscription subscription, Subscriber<? super TokenBuffer> subscriber) {
         if (parentSubscription == null) {
             return;
         }
@@ -94,9 +94,8 @@ public class JsonContentProcessor extends AbstractHttpContentProcessor<JsonNode>
                 }
             }
         }
-
         this.jacksonProcessor = new JacksonProcessor(jsonFactory, streamArray, objectMapper);
-        this.jacksonProcessor.subscribe(new CompletionAwareSubscriber<JsonNode>() {
+        this.jacksonProcessor.subscribe(new CompletionAwareSubscriber<TokenBuffer>() {
 
             @Override
             protected void doOnSubscribe(Subscription jsonSubscription) {
@@ -127,7 +126,7 @@ public class JsonContentProcessor extends AbstractHttpContentProcessor<JsonNode>
             }
 
             @Override
-            protected void doOnNext(JsonNode message) {
+            protected void doOnNext(TokenBuffer message) {
                 subscriber.onNext(message);
             }
 

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/jackson/JsonHttpContentSubscriberFactory.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/jackson/JsonHttpContentSubscriberFactory.java
@@ -16,7 +16,6 @@
 package io.micronaut.http.server.netty.jackson;
 
 import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.databind.DeserializationConfig;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.micronaut.core.annotation.Internal;
@@ -44,7 +43,7 @@ public class JsonHttpContentSubscriberFactory implements HttpContentSubscriberFa
 
     private final HttpServerConfiguration httpServerConfiguration;
     private final @Nullable JsonFactory jsonFactory;
-    private final DeserializationConfig deserializationConfig;
+    private final ObjectMapper objectMapper;
 
     /**
      * @param objectMapper The jackson object mapper.
@@ -58,11 +57,11 @@ public class JsonHttpContentSubscriberFactory implements HttpContentSubscriberFa
         ArgumentUtils.requireNonNull("objectMapper", objectMapper);
         this.httpServerConfiguration = httpServerConfiguration;
         this.jsonFactory = jsonFactory;
-        this.deserializationConfig = objectMapper.getDeserializationConfig();
+        this.objectMapper = objectMapper;
     }
 
     @Override
     public HttpContentProcessor build(NettyHttpRequest request) {
-        return new JsonContentProcessor(request, httpServerConfiguration, jsonFactory, deserializationConfig);
+        return new JsonContentProcessor(request, httpServerConfiguration, jsonFactory, objectMapper);
     }
 }

--- a/runtime/src/main/java/io/micronaut/jackson/codec/JacksonMediaTypeCodec.java
+++ b/runtime/src/main/java/io/micronaut/jackson/codec/JacksonMediaTypeCodec.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.fasterxml.jackson.databind.util.TokenBuffer;
+
 import io.micronaut.core.io.buffer.ByteBuffer;
 import io.micronaut.core.io.buffer.ByteBufferFactory;
 import io.micronaut.core.type.Argument;
@@ -118,10 +120,27 @@ public abstract class JacksonMediaTypeCodec implements MediaTypeCodec {
     }
 
     /**
+     * Decodes the given JSON TokenBuffer.
+     *
+     * @param type The type
+     * @param tokenBuffer The Json TokenBuffer
+     * @param <T> The generic type
+     * @return The decoded object
+     * @throws CodecException When object cannot be decoded
+     */
+    public <T> T decode(Argument<T> type, TokenBuffer tokenBuffer) throws CodecException {
+        try {
+            return objectMapper.readValue(tokenBuffer.asParser(), type.getType());
+        } catch (IOException e) {
+            throw new CodecException("Error decoding JSON stream for type [" + type.getName() + "]: " + e.getMessage(), e);
+        }
+    }
+
+    /**
      * Decodes the given JSON node.
      *
      * @param type The type
-     * @param node The Json Node
+     * @param node The JsonNode
      * @param <T> The generic type
      * @return The decoded object
      * @throws CodecException When object cannot be decoded

--- a/runtime/src/main/java/io/micronaut/jackson/convert/TokenBufferConvertibleValues.java
+++ b/runtime/src/main/java/io/micronaut/jackson/convert/TokenBufferConvertibleValues.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.jackson.convert;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.util.TokenBuffer;
+
+import io.micronaut.core.convert.ArgumentConversionContext;
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.convert.value.ConvertibleValues;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Simple facade over a Jackson {@link TokenBuffer} to make it a {@link ConvertibleValues}.
+ *
+ * @param <V> The generic type for values
+ *
+ * @author Christophe Roudet
+ * @since 1.3
+ */
+public class TokenBufferConvertibleValues<V> implements ConvertibleValues<V> {
+
+    private final Map<String, TokenBuffer> tokenBuffers;
+    private final ConversionService<?> conversionService;
+
+    /**
+     * @param tokenBuffer        The node that maps to JSON object structure
+     * @param conversionService To convert the JSON node into given type
+     * @param objectMapper To read/write JSON
+     * @throws IOException If json is not valid
+     */
+    public TokenBufferConvertibleValues(TokenBuffer tokenBuffer, ConversionService<?> conversionService, ObjectMapper objectMapper) throws IOException {
+        this.tokenBuffers = toMap(tokenBuffer, objectMapper.getDeserializationContext());
+        this.conversionService = conversionService;
+    }
+
+    private static Map<String, TokenBuffer> toMap(TokenBuffer tokenBuffer, DeserializationContext context) throws IOException {
+        JsonParser p = tokenBuffer.asParser();
+        JsonToken current = p.nextToken();
+        if (current != JsonToken.START_OBJECT) {
+            throw new IOException("Expecting START_OBJECT, got " + current);
+        }
+        Map<String, TokenBuffer> result = new HashMap<>();
+        int depth = 1;
+        TokenBuffer tb = null;
+        current = p.nextToken();
+        while (current != JsonToken.END_OBJECT && depth >= 1) {
+            if (current == JsonToken.FIELD_NAME && depth == 1) {
+                final String fieldName = p.getCurrentName();
+                current = p.nextToken();
+                tb = new TokenBuffer(p, context);
+                result.put(fieldName, tb);
+                continue;
+            } else if (current.isStructStart()) {
+                ++depth;
+            } else if (current.isStructEnd()) {
+                --depth;
+            }
+            tb.copyCurrentEvent(p);
+            current = p.nextToken();
+        }
+        return result;
+    }
+
+    @Override
+    public Set<String> names() {
+        return tokenBuffers.keySet();
+    }
+
+    @Override
+    public Collection<V> values() {
+        return (Collection<V>) Collections.unmodifiableCollection(tokenBuffers.values());
+    }
+
+    @Override
+    public <T> Optional<T> get(CharSequence name, ArgumentConversionContext<T> conversionContext) {
+        String fieldName = name.toString();
+        TokenBuffer tokenBuffer = tokenBuffers.get(fieldName);
+        if (tokenBuffer == null) {
+            return Optional.empty();
+        } else {
+            return conversionService.convert(tokenBuffer, conversionContext);
+        }
+    }
+}

--- a/runtime/src/main/java/io/micronaut/jackson/convert/TokenBufferToArrayConverter.java
+++ b/runtime/src/main/java/io/micronaut/jackson/convert/TokenBufferToArrayConverter.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.jackson.convert;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.util.TokenBuffer;
+
+import io.micronaut.core.convert.ConversionContext;
+import io.micronaut.core.convert.TypeConverter;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import java.io.IOException;
+import java.util.Optional;
+
+/**
+ * Converts {@link TokenBuffer} instances to arrays.
+ *
+ * @author Christophe Roudet
+ * @since 1.3
+ */
+@Singleton
+public class TokenBufferToArrayConverter implements TypeConverter<TokenBuffer, Object[]> {
+
+    private final Provider<ObjectMapper> objectMapper;
+
+    /**
+     * Create a converter to convert form ArrayNode to Array.
+     *
+     * @param objectMapper To convert from Json to Array
+     * @deprecated Use {@link #TokenBufferToArrayConverter(Provider)} instead
+     */
+    @Deprecated
+    public TokenBufferToArrayConverter(ObjectMapper objectMapper) {
+        this(() -> objectMapper);
+    }
+
+    /**
+     * Create a converter to convert form ArrayNode to Array.
+     *
+     * @param objectMapper To convert from Json to Array
+     */
+    @Inject
+    public TokenBufferToArrayConverter(Provider<ObjectMapper> objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public Optional<Object[]> convert(TokenBuffer tokenBuffer, Class<Object[]> targetType, ConversionContext context) {
+        try {
+            Object[] result = objectMapper.get().readValue(tokenBuffer.asParser(), targetType);
+            return Optional.of(result);
+        } catch (IOException e) {
+            context.reject(e);
+            return Optional.empty();
+        }
+    }
+}

--- a/runtime/src/main/java/io/micronaut/jackson/convert/TokenBufferToConvertibleValuesConverter.java
+++ b/runtime/src/main/java/io/micronaut/jackson/convert/TokenBufferToConvertibleValuesConverter.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.jackson.convert;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.util.TokenBuffer;
+
+import io.micronaut.core.convert.ConversionContext;
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.convert.TypeConverter;
+import io.micronaut.core.convert.value.ConvertibleValues;
+
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import java.io.IOException;
+import java.util.Optional;
+
+/**
+ * Converts a {@link TokenBuffer} to a {@link ConvertibleValues} instance.
+ *
+ * @author Christophe Roudet
+ * @since 1.3
+ */
+@Singleton
+public class TokenBufferToConvertibleValuesConverter implements TypeConverter<TokenBuffer, ConvertibleValues> {
+
+    private final Provider<ObjectMapper> objectMapper;
+    private final ConversionService<?> conversionService;
+
+    /**
+     * @param objectMapper To read/write JSON
+     * @param conversionService To convert from JSON node to a {@link ConvertibleValues} instance
+     */
+    public TokenBufferToConvertibleValuesConverter(Provider<ObjectMapper> objectMapper, ConversionService<?> conversionService) {
+        this.objectMapper = objectMapper;
+        this.conversionService = conversionService;
+    }
+
+    @Override
+    public Optional<ConvertibleValues> convert(TokenBuffer tokenBuffer, Class<ConvertibleValues> targetType, ConversionContext context) {
+        try {
+            return Optional.of(new TokenBufferConvertibleValues(tokenBuffer, conversionService, objectMapper.get()));
+        } catch (IOException e) {
+            context.reject(e);
+            return Optional.empty();
+        }
+    }
+}

--- a/runtime/src/main/java/io/micronaut/jackson/convert/TokenBufferToIterableConverter.java
+++ b/runtime/src/main/java/io/micronaut/jackson/convert/TokenBufferToIterableConverter.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.jackson.convert;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.util.TokenBuffer;
+
+import io.micronaut.core.convert.ConversionContext;
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.convert.TypeConverter;
+import io.micronaut.core.type.Argument;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * @author Christophe Roudet
+ * @since 1.3
+ */
+@Singleton
+public class TokenBufferToIterableConverter implements TypeConverter<TokenBuffer, Iterable> {
+
+    private final Provider<ObjectMapper> objectMapper;
+    private final ConversionService conversionService;
+
+    /**
+     * Create a new converter to convert from json to given type iteratively.
+     *
+     * @param objectMapper  To convert from Json
+     * @param conversionService Convert the given json node to the given target type.
+     * @deprecated Use {@link #TokenBufferToIterableConverter(ConversionService)} instead
+     */
+    @Deprecated
+    public TokenBufferToIterableConverter(ObjectMapper objectMapper, ConversionService conversionService) {
+        this(() -> objectMapper, conversionService);
+    }
+
+    /**
+     * Create a new converter to convert from json to given type iteratively.
+     *
+     * @param objectMapper  To convert from Json
+     * @param conversionService Convert the given json node to the given target type.
+     */
+    @Inject
+    public TokenBufferToIterableConverter(Provider<ObjectMapper> objectMapper, ConversionService conversionService) {
+        this.objectMapper = objectMapper;
+        this.conversionService = conversionService;
+    }
+
+    @Override
+    public Optional<Iterable> convert(TokenBuffer tokenBuffer, Class<Iterable> targetType, ConversionContext context) {
+        Map<String, Argument<?>> typeVariables = context.getTypeVariables();
+        Class elementType = typeVariables.isEmpty() ? Map.class : typeVariables.values().iterator().next().getType();
+        try {
+            return Optional.of(splitArray(tokenBuffer, objectMapper.get().getDeserializationContext())
+                    .stream()
+                    .map(tb -> conversionService.convert(tb, elementType, context))
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .collect(Collectors.toList()));
+        } catch (IOException e) {
+            context.reject(e);
+            return Optional.empty();
+        }
+    }
+
+    private static List<TokenBuffer> splitArray(TokenBuffer tokenBuffer, DeserializationContext context) throws IOException {
+        JsonParser p = tokenBuffer.asParser();
+        JsonToken current = p.nextToken();
+        if (current != JsonToken.START_ARRAY) {
+            throw new IOException("Expecting START_ARRAY, got " + current);
+        }
+        List<TokenBuffer> result = new ArrayList<>();
+        int depth = 1;
+        TokenBuffer tb = new TokenBuffer(p, context);
+        current = p.nextToken();
+        while (current != JsonToken.END_ARRAY && depth >= 1) {
+            if (tb == null) {
+                tb = new TokenBuffer(p, context);
+            }
+            if (current.isScalarValue() && depth == 1) {
+                tb.copyCurrentEvent(p);
+                result.add(tb);
+                tb = null;
+            } else if (current.isStructStart()) {
+                ++depth;
+                tb.copyCurrentEvent(p);
+            } else if (current.isStructEnd()) {
+                --depth;
+                tb.copyCurrentEvent(p);
+                if (depth == 1) {
+                    result.add(tb);
+                    tb = null;
+                }
+            } else {
+                tb.copyCurrentEvent(p);
+            }
+            current = p.nextToken();
+        }
+        return result;
+    }
+}

--- a/runtime/src/main/java/io/micronaut/jackson/convert/TokenBufferToObjectConverter.java
+++ b/runtime/src/main/java/io/micronaut/jackson/convert/TokenBufferToObjectConverter.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.jackson.convert;
+
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.util.TokenBuffer;
+
+import io.micronaut.core.convert.ConversionContext;
+import io.micronaut.core.convert.TypeConverter;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import java.io.IOException;
+import java.util.Optional;
+
+/**
+ * A {@link TypeConverter} that leverages Jackson {@link ObjectMapper} to convert from {@link TokenBuffer} instances to
+ * objects.
+ *
+ * @author Christophe Roudet
+ * @since 1.3
+ */
+@Singleton
+public class TokenBufferToObjectConverter implements TypeConverter<TokenBuffer, Object> {
+    private final Provider<ObjectMapper> objectMapper;
+
+    /**
+     * @param objectMapper To read/write JSON
+     * @deprecated Use {@link #TokenBufferToObjectConverter(Provider)} instead
+     */
+    @Deprecated
+    public TokenBufferToObjectConverter(ObjectMapper objectMapper) {
+        this(() -> objectMapper);
+    }
+
+    /**
+     * @param objectMapper To read/write JSON
+     */
+    @Inject
+    public TokenBufferToObjectConverter(Provider<ObjectMapper> objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public Optional<Object> convert(TokenBuffer tokenBuffer, Class<Object> targetType, ConversionContext context) {
+        try {
+            if (CharSequence.class.isAssignableFrom(targetType) && tokenBuffer.firstToken().equals(JsonToken.START_OBJECT)) {
+                return Optional.of(objectMapper.get().readTree(tokenBuffer.asParser()).toString());
+            } else {
+                Object result = objectMapper.get().readValue(tokenBuffer.asParser(), targetType);
+                return Optional.ofNullable(result);
+            }
+        } catch (IOException e) {
+            context.reject(e);
+            return Optional.empty();
+        }
+    }
+
+}

--- a/runtime/src/main/java/io/micronaut/jackson/parser/JacksonProcessor.java
+++ b/runtime/src/main/java/io/micronaut/jackson/parser/JacksonProcessor.java
@@ -40,6 +40,11 @@ import java.io.IOException;
  * non-blocking manner
  *
  * @author Graeme Rocher
+ *
+ * Token buffer processing based on spring Jackson2Tokenizer:
+ * @author Arjen Poutsma
+ * @author Rossen Stoyanchev
+ * @author Juergen Hoeller
  * @since 1.0
  */
 public class JacksonProcessor extends SingleThreadedBufferingProcessor<byte[], TokenBuffer> {

--- a/runtime/src/main/java/io/micronaut/jackson/parser/JacksonProcessor.java
+++ b/runtime/src/main/java/io/micronaut/jackson/parser/JacksonProcessor.java
@@ -19,24 +19,26 @@ import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.async.ByteArrayFeeder;
 import com.fasterxml.jackson.core.io.JsonEOFException;
 import com.fasterxml.jackson.core.json.async.NonBlockingJsonParser;
-import com.fasterxml.jackson.databind.DeserializationConfig;
+import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.deser.DefaultDeserializationContext;
+import com.fasterxml.jackson.databind.util.TokenBuffer;
+
 import io.micronaut.core.async.processor.SingleThreadedBufferingProcessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
-import java.util.concurrent.ConcurrentLinkedDeque;
 
 /**
- * A Reactive streams publisher that publishes a {@link JsonNode} once the JSON has been fully consumed.
- * Uses {@link com.fasterxml.jackson.core.json.async.NonBlockingJsonParser} internally allowing the parsing of
- * JSON from an incoming stream of bytes in a non-blocking manner
+ * A Reactive streams publisher that publishes a {@link JsonNode} once the JSON
+ * has been fully consumed. Uses
+ * {@link com.fasterxml.jackson.core.json.async.NonBlockingJsonParser}
+ * internally allowing the parsing of JSON from an incoming stream of bytes in a
+ * non-blocking manner
  *
  * @author Graeme Rocher
  * @since 1.0
@@ -46,28 +48,35 @@ public class JacksonProcessor extends SingleThreadedBufferingProcessor<byte[], J
     private static final Logger LOG = LoggerFactory.getLogger(JacksonProcessor.class);
 
     private NonBlockingJsonParser currentNonBlockingJsonParser;
-    private final ConcurrentLinkedDeque<JsonNode> nodeStack = new ConcurrentLinkedDeque<>();
     private final JsonFactory jsonFactory;
-    private final @Nullable DeserializationConfig deserializationConfig;
-    private String currentFieldName;
+    private DeserializationContext deserializationContext;
+    private final ObjectMapper objectMapper;
     private boolean streamArray;
-    private boolean rootIsArray;
-    private boolean jsonStream;
+    private TokenBuffer tokenBuffer;
+    private int objectDepth;
+    private int arrayDepth;
+
+    private boolean rootArray;
 
     /**
      * Creates a new JacksonProcessor.
      *
-     * @param jsonFactory The JSON factory
-     * @param streamArray Whether arrays should be streamed
-     * @param deserializationConfig The jackson deserialization configuration
+     * @param jsonFactory  The JSON factory
+     * @param streamArray  Whether arrays should be streamed
+     * @param objectMapper The jackson object mapper
      */
-    public JacksonProcessor(JsonFactory jsonFactory, boolean streamArray, @Nullable DeserializationConfig deserializationConfig) {
+    public JacksonProcessor(JsonFactory jsonFactory, boolean streamArray, ObjectMapper objectMapper) {
         try {
             this.jsonFactory = jsonFactory;
-            this.deserializationConfig = deserializationConfig;
             this.currentNonBlockingJsonParser = (NonBlockingJsonParser) jsonFactory.createNonBlockingByteArrayParser();
+            this.objectMapper = objectMapper.copy().disable(DeserializationFeature.UNWRAP_ROOT_VALUE).disable(SerializationFeature.WRAP_ROOT_VALUE);
+            this.deserializationContext = objectMapper.getDeserializationContext();
+            if (this.deserializationContext instanceof DefaultDeserializationContext) {
+                this.deserializationContext = ((DefaultDeserializationContext) this.deserializationContext).createInstance(objectMapper.getDeserializationConfig(),
+                        currentNonBlockingJsonParser, objectMapper.getInjectableValues());
+            }
+            this.tokenBuffer = new TokenBuffer(this.currentNonBlockingJsonParser, this.deserializationContext);
             this.streamArray = streamArray;
-            this.jsonStream = true;
         } catch (IOException e) {
             throw new IllegalStateException("Failed to create non-blocking JSON parser: " + e.getMessage(), e);
         }
@@ -86,19 +95,21 @@ public class JacksonProcessor extends SingleThreadedBufferingProcessor<byte[], J
     /**
      * Construct with given JSON factory.
      *
-     * @param jsonFactory To configure and construct reader (aka parser, {@link JsonParser})
-     *                    and writer (aka generator, {@link JsonGenerator}) instances.
-     * @param deserializationConfig The jackson deserialization configuration
+     * @param jsonFactory  To configure and construct reader (aka parser,
+     *                     {@link JsonParser}) and writer (aka generator,
+     *                     {@link JsonGenerator}) instances.
+     * @param objectMapper The jackson object mapper
      */
-    public JacksonProcessor(JsonFactory jsonFactory, DeserializationConfig deserializationConfig) {
-        this(jsonFactory, false, deserializationConfig);
+    public JacksonProcessor(JsonFactory jsonFactory, ObjectMapper objectMapper) {
+        this(jsonFactory, false, objectMapper);
     }
 
     /**
      * Construct with given JSON factory.
      *
-     * @param jsonFactory To configure and construct reader (aka parser, {@link JsonParser})
-     *                    and writer (aka generator, {@link JsonGenerator}) instances.
+     * @param jsonFactory To configure and construct reader (aka parser,
+     *                    {@link JsonParser}) and writer (aka generator,
+     *                    {@link JsonGenerator}) instances.
      */
     public JacksonProcessor(JsonFactory jsonFactory) {
         this(jsonFactory, false, null);
@@ -106,10 +117,11 @@ public class JacksonProcessor extends SingleThreadedBufferingProcessor<byte[], J
 
     /**
      * Construct with default JSON factory.
-     * @param deserializationConfig The jackson deserialization configuration
+     *
+     * @param objectMapper The jackson object mapper
      */
-    public JacksonProcessor(DeserializationConfig deserializationConfig) {
-        this(new JsonFactory(), deserializationConfig);
+    public JacksonProcessor(ObjectMapper objectMapper) {
+        this(new JsonFactory(), objectMapper);
     }
 
     /**
@@ -158,47 +170,22 @@ public class JacksonProcessor extends SingleThreadedBufferingProcessor<byte[], J
             if (!needMoreInput) {
                 currentNonBlockingJsonParser = (NonBlockingJsonParser) jsonFactory.createNonBlockingByteArrayParser();
                 byteFeeder = currentNonBlockingJsonParser.getNonBlockingInputFeeder();
+                this.tokenBuffer = new TokenBuffer(currentNonBlockingJsonParser, deserializationContext);
             }
 
             byteFeeder.feedInput(message, 0, message.length);
 
             JsonToken event = currentNonBlockingJsonParser.nextToken();
-            if (event == JsonToken.START_ARRAY && nodeStack.peekFirst() == null) {
-                rootIsArray = true;
-                jsonStream = false;
+            if (event == JsonToken.START_ARRAY && objectDepth == 0 && arrayDepth == 0) {
+                rootArray = true;
             }
-
-            while (event != JsonToken.NOT_AVAILABLE) {
-                JsonNode root = asJsonNode(event);
-                if (root != null) {
-
-                    boolean isLast = nodeStack.isEmpty() && !jsonStream;
-                    if (isLast) {
-                        byteFeeder.endOfInput();
-                    }
-
-                    if (isLast && streamArray && root instanceof ArrayNode) {
-                        break;
-                    } else {
-                        currentDownstreamSubscriber()
-                                .ifPresent(subscriber -> {
-                                        if (LOG.isTraceEnabled()) {
-                                            LOG.trace("Materialized new JsonNode call onNext...");
-                                        }
-                                        subscriber.onNext(root);
-                                    }
-                                );
-                    }
-                    if (isLast) {
-                        break;
-                    }
-                }
-                event = currentNonBlockingJsonParser.nextToken();
-            }
-            if (jsonStream && nodeStack.isEmpty()) {
+            parseTokenBufferFlux(event);
+            if (objectDepth == 0 && arrayDepth == 0) {
                 byteFeeder.endOfInput();
+                event = currentNonBlockingJsonParser.nextToken();
+                parseTokenBufferFlux(event);
             }
-            if (jsonStream || needMoreInput()) {
+            if (needMoreInput()) {
                 if (LOG.isTraceEnabled()) {
                     LOG.trace("More input required to parse JSON. Demanding more.");
                 }
@@ -210,205 +197,82 @@ public class JacksonProcessor extends SingleThreadedBufferingProcessor<byte[], J
         }
     }
 
-    /**
-     * @return The root node when the whole tree is built.
-     **/
-    private JsonNode asJsonNode(JsonToken event) throws IOException {
-        switch (event) {
-            case START_OBJECT:
-                nodeStack.push(node(nodeStack.peekFirst()));
-                break;
-
-            case START_ARRAY:
-                JsonNode node = nodeStack.peekFirst();
-                if (node == null) {
-                    rootIsArray = true;
-                }
-                nodeStack.push(array(node));
-                break;
-
-            case END_OBJECT:
-            case END_ARRAY:
-                if (nodeStack.isEmpty()) {
-                    throw new JsonParseException(currentNonBlockingJsonParser, "Unexpected array end literal");
-                }
-                JsonNode current = nodeStack.pop();
-                if (nodeStack.isEmpty()) {
-                    return current;
-                } else {
-                    if (streamArray && nodeStack.size() == 1) {
-                        JsonNode jsonNode = nodeStack.peekFirst();
-                        if (jsonNode instanceof ArrayNode) {
-                            return current;
-                        } else {
-                            return null;
-                        }
-                    } else {
-                        return null;
-                    }
-                }
-
-            case FIELD_NAME:
-                if (nodeStack.isEmpty()) {
-                    throw new JsonParseException(currentNonBlockingJsonParser, "Unexpected field literal");
-                }
-                currentFieldName = currentNonBlockingJsonParser.getCurrentName();
-                break;
-
-            case VALUE_NUMBER_INT:
-                if (nodeStack.isEmpty()) {
-                    throw new JsonParseException(currentNonBlockingJsonParser, "Unexpected integer literal");
-                }
-                JsonNode intNode = nodeStack.peekFirst();
-                if (intNode instanceof ObjectNode) {
-                    ((ObjectNode) intNode).put(currentFieldName, currentNonBlockingJsonParser.getLongValue());
-                } else {
-                    ((ArrayNode) intNode).add(currentNonBlockingJsonParser.getLongValue());
-                }
-                break;
-
-            case VALUE_STRING:
-                if (nodeStack.isEmpty()) {
-                    throw new JsonParseException(currentNonBlockingJsonParser, "Unexpected string literal");
-                }
-                JsonNode stringNode = nodeStack.peekFirst();
-                if (stringNode instanceof ObjectNode) {
-                    ((ObjectNode) stringNode).put(currentFieldName, currentNonBlockingJsonParser.getValueAsString());
-                } else {
-                    ((ArrayNode) stringNode).add(currentNonBlockingJsonParser.getValueAsString());
-                }
-                break;
-
-            case VALUE_NUMBER_FLOAT:
-                if (nodeStack.isEmpty()) {
-                    throw new JsonParseException(currentNonBlockingJsonParser, "Unexpected float literal");
-                }
-
-                final JsonParser.NumberType numberType = currentNonBlockingJsonParser.getNumberType();
-                JsonNode decimalNode = nodeStack.peekFirst();
-                switch (numberType) {
-                    case FLOAT:
-                        if (deserializationConfig != null && deserializationConfig.isEnabled(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)) {
-                            if (decimalNode instanceof ObjectNode) {
-                                ((ObjectNode) decimalNode).put(currentFieldName, currentNonBlockingJsonParser.getDecimalValue());
-                            } else {
-                                ((ArrayNode) decimalNode).add(currentNonBlockingJsonParser.getDecimalValue());
-                            }
-                        } else if (decimalNode instanceof ObjectNode) {
-                            ((ObjectNode) decimalNode).put(currentFieldName, currentNonBlockingJsonParser.getFloatValue());
-                        } else {
-                            ((ArrayNode) decimalNode).add(currentNonBlockingJsonParser.getFloatValue());
-                        }
-                        break;
-                    case DOUBLE:
-                        if (deserializationConfig != null && deserializationConfig.isEnabled(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)) {
-                            if (decimalNode instanceof ObjectNode) {
-                                ((ObjectNode) decimalNode).put(currentFieldName, currentNonBlockingJsonParser.getDecimalValue());
-                            } else {
-                                ((ArrayNode) decimalNode).add(currentNonBlockingJsonParser.getDecimalValue());
-                            }
-                        } else if (decimalNode instanceof ObjectNode) {
-                            ((ObjectNode) decimalNode).put(currentFieldName, currentNonBlockingJsonParser.getDoubleValue());
-                        } else {
-                            ((ArrayNode) decimalNode).add(currentNonBlockingJsonParser.getDoubleValue());
-                        }
-                    break;
-                    case BIG_DECIMAL:
-                        if (decimalNode instanceof ObjectNode) {
-                            ((ObjectNode) decimalNode).put(currentFieldName, currentNonBlockingJsonParser.getDecimalValue());
-                        } else {
-                            ((ArrayNode) decimalNode).add(currentNonBlockingJsonParser.getDecimalValue());
-                        }
-                    break;
-                    case BIG_INTEGER:
-                        if (decimalNode instanceof ObjectNode) {
-                            ((ObjectNode) decimalNode).put(currentFieldName, currentNonBlockingJsonParser.getBigIntegerValue());
-                        } else {
-                            ((ArrayNode) decimalNode).add(currentNonBlockingJsonParser.getBigIntegerValue());
-                        }
-                    break;
-                    case LONG:
-                        if (decimalNode instanceof ObjectNode) {
-                            ((ObjectNode) decimalNode).put(currentFieldName, currentNonBlockingJsonParser.getLongValue());
-                        } else {
-                            ((ArrayNode) decimalNode).add(currentNonBlockingJsonParser.getLongValue());
-                        }
-                    break;
-                    case INT:
-                        if (deserializationConfig != null && deserializationConfig.isEnabled(DeserializationFeature.USE_BIG_INTEGER_FOR_INTS)) {
-                            if (decimalNode instanceof ObjectNode) {
-                                ((ObjectNode) decimalNode).put(currentFieldName, currentNonBlockingJsonParser.getBigIntegerValue());
-                            } else {
-                                ((ArrayNode) decimalNode).add(currentNonBlockingJsonParser.getBigIntegerValue());
-                            }
-                        } else if (decimalNode instanceof ObjectNode) {
-                            ((ObjectNode) decimalNode).put(currentFieldName, currentNonBlockingJsonParser.getIntValue());
-                        } else {
-                            ((ArrayNode) decimalNode).add(currentNonBlockingJsonParser.getIntValue());
-                        }
-                    break;
-                    default:
-                        // shouldn't get here
-                        throw new IllegalStateException("Unsupported number type: " + numberType);
-                }
-                break;
-            case VALUE_NULL:
-                if (nodeStack.isEmpty()) {
-                    throw new JsonParseException(currentNonBlockingJsonParser, "Unexpected null literal");
-                }
-                JsonNode nullNode = nodeStack.peekFirst();
-                if (nullNode instanceof ObjectNode) {
-                    ((ObjectNode) nullNode).putNull(currentFieldName);
-                } else {
-                    ((ArrayNode) nullNode).addNull();
-                }
-                break;
-
-            case VALUE_TRUE:
-            case VALUE_FALSE:
-                if (nodeStack.isEmpty()) {
-                    throw new JsonParseException(currentNonBlockingJsonParser, "Unexpected boolean literal");
-                }
-                JsonNode booleanNode = nodeStack.peekFirst();
-                if (booleanNode instanceof ObjectNode) {
-                    ((ObjectNode) booleanNode).put(currentFieldName, currentNonBlockingJsonParser.getBooleanValue());
-                } else {
-                    ((ArrayNode) booleanNode).add(currentNonBlockingJsonParser.getBooleanValue());
-                }
-                break;
-
-            default:
-                throw new IllegalStateException("Unsupported JSON event: " + event);
+    private void updateDepth(JsonToken token) {
+        switch (token) {
+        case START_OBJECT:
+            this.objectDepth++;
+            break;
+        case END_OBJECT:
+            this.objectDepth--;
+            break;
+        case START_ARRAY:
+            this.arrayDepth++;
+            break;
+        case END_ARRAY:
+            this.arrayDepth--;
+            break;
+        default:
+            break;
         }
+    }
 
-        //its an array and the stack size is 1 which means the value is scalar
-        if (rootIsArray && streamArray && nodeStack.size() == 1) {
-            ArrayNode arrayNode = (ArrayNode) nodeStack.peekFirst();
-            if (arrayNode.size() > 0) {
-                return arrayNode.remove(arrayNode.size() - 1);
+    private void parseTokenBufferFlux(JsonToken token) throws IOException {
+        boolean previousNull = false;
+        while (!this.currentNonBlockingJsonParser.isClosed()) {
+            if (token == JsonToken.NOT_AVAILABLE || token == null && previousNull) {
+                break;
+            } else if (token == null) { // !previousNull
+                previousNull = true;
+                token = this.currentNonBlockingJsonParser.nextToken();
+                continue;
             }
-        }
+            updateDepth(token);
+            if (rootArray && this.streamArray) {
+                processTokenArray(token);
+            } else {
+                processTokenNormal(token);
+            }
 
-        return null;
-    }
-
-    private JsonNode array(JsonNode node) {
-        if (node instanceof ObjectNode) {
-            return ((ObjectNode) node).putArray(currentFieldName);
-        } else if (node instanceof ArrayNode) {
-            return ((ArrayNode) node).addArray();
-        } else {
-            return JsonNodeFactory.instance.arrayNode();
+            token = this.currentNonBlockingJsonParser.nextToken();
         }
     }
 
-    private JsonNode node(JsonNode node) {
-        if (node instanceof ObjectNode) {
-            return ((ObjectNode) node).putObject(currentFieldName);
-        } else if (node instanceof ArrayNode && !(streamArray && nodeStack.size() == 1)) {
-            return ((ArrayNode) node).addObject();
-        } else {
-            return JsonNodeFactory.instance.objectNode();
+    private void submitJsonNode() {
+        currentDownstreamSubscriber().ifPresent(subscriber -> {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Materialized new JsonNode call onNext...");
+            }
+            try {
+                JsonNode node = this.objectMapper.readTree(tokenBuffer.asParser());
+                subscriber.onNext(node);
+            } catch (IOException e) {
+                onError(e);
+            }
+        });
+    }
+
+    private void processTokenNormal(JsonToken token) throws IOException {
+        this.tokenBuffer.copyCurrentEvent(this.currentNonBlockingJsonParser);
+        if ((token.isStructEnd() || token.isScalarValue()) && this.objectDepth == 0 && this.arrayDepth == 0) {
+            submitJsonNode();
+            this.tokenBuffer = new TokenBuffer(this.currentNonBlockingJsonParser, this.deserializationContext);
         }
     }
+
+    private void processTokenArray(JsonToken token) throws IOException {
+        if (!isTopLevelArrayToken(token)) {
+            this.tokenBuffer.copyCurrentEvent(this.currentNonBlockingJsonParser);
+        }
+        if (this.objectDepth == 0 && (this.arrayDepth == 0 || this.arrayDepth == 1) && (token.isStructEnd() || token.isScalarValue())) {
+            if (!(token == JsonToken.END_ARRAY && arrayDepth == 0)) {
+                submitJsonNode();
+            }
+            this.tokenBuffer = new TokenBuffer(this.currentNonBlockingJsonParser, this.deserializationContext);
+        }
+    }
+
+    private boolean isTopLevelArrayToken(JsonToken token) {
+        return this.objectDepth == 0 && ((token == JsonToken.START_ARRAY && this.arrayDepth == 1) || (token == JsonToken.END_ARRAY && this.arrayDepth == 0));
+    }
+
 }

--- a/runtime/src/test/groovy/io/micronaut/jackson/parser/JacksonProcessorSpec.groovy
+++ b/runtime/src/test/groovy/io/micronaut/jackson/parser/JacksonProcessorSpec.groovy
@@ -23,11 +23,13 @@ import com.fasterxml.jackson.databind.DeserializationConfig
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.databind.node.ArrayNode
 import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.LongNode
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.DefaultApplicationContext
+import io.micronaut.runtime.server.EmbeddedServer
 
 import java.math.BigDecimal
 
@@ -44,12 +46,12 @@ import spock.lang.Specification
 class JacksonProcessorSpec extends Specification {
     @Shared @AutoCleanup
     ApplicationContext applicationContext = new DefaultApplicationContext("test").start()
-
+            
     void "test big decimal"() {
 
         given:
         ObjectMapper objectMapper = applicationContext.getBean(ObjectMapper)
-        JacksonProcessor processor = new JacksonProcessor(objectMapper.getDeserializationConfig())
+        JacksonProcessor processor = new JacksonProcessor(objectMapper)
         BigDecimal dec = new BigDecimal("888.7794538169553400000")
         BigD bigD = new BigD(bd1: dec, bd2: dec)
 
@@ -115,9 +117,8 @@ class JacksonProcessorSpec extends Specification {
     void "test big decimal - USE_BIG_DECIMAL_FOR_FLOATS"() {
 
         given:
-        ObjectMapper objectMapper = applicationContext.getBean(ObjectMapper)
-        DeserializationConfig cfg = objectMapper.getDeserializationConfig()
-        JacksonProcessor processor = new JacksonProcessor(cfg.with(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS))
+        ObjectMapper objectMapper = applicationContext.getBean(ObjectMapper).enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
+        JacksonProcessor processor = new JacksonProcessor(objectMapper)
         BigDecimal dec = new BigDecimal("888.7794538169553400000")
         BigD bigD = new BigD(bd1: dec, bd2: dec)
 
@@ -184,7 +185,7 @@ class JacksonProcessorSpec extends Specification {
 
         given:
         ObjectMapper objectMapper = applicationContext.getBean(ObjectMapper)
-        JacksonProcessor processor = new JacksonProcessor(objectMapper.getDeserializationConfig())
+        JacksonProcessor processor = new JacksonProcessor(objectMapper)
         Foo instance = new Foo(name: "Fred", age: 10)
 
 
@@ -251,7 +252,7 @@ class JacksonProcessorSpec extends Specification {
 
         given:
         ObjectMapper objectMapper = applicationContext.getBean(ObjectMapper)
-        JacksonProcessor processor = new JacksonProcessor(objectMapper.getDeserializationConfig())
+        JacksonProcessor processor = new JacksonProcessor(objectMapper)
         Foo[] instances = [new Foo(name: "Fred", age: 10), new Foo(name: "Barney", age: 11)] as Foo[]
 
 
@@ -319,7 +320,7 @@ class JacksonProcessorSpec extends Specification {
     void "test incomplete JSON error"() {
         given:
         ObjectMapper objectMapper = applicationContext.getBean(ObjectMapper)
-        JacksonProcessor processor = new JacksonProcessor(objectMapper.getDeserializationConfig())
+        JacksonProcessor processor = new JacksonProcessor(objectMapper)
 
 
         when:
@@ -374,7 +375,7 @@ class JacksonProcessorSpec extends Specification {
     void "test JSON syntax error"() {
         given:
         ObjectMapper objectMapper = applicationContext.getBean(ObjectMapper)
-        JacksonProcessor processor = new JacksonProcessor(objectMapper.getDeserializationConfig())
+        JacksonProcessor processor = new JacksonProcessor(objectMapper)
 
 
         when:
@@ -429,7 +430,7 @@ class JacksonProcessorSpec extends Specification {
     void "test nested arrays"() {
         given:
         ObjectMapper objectMapper = applicationContext.getBean(ObjectMapper)
-        JacksonProcessor processor = new JacksonProcessor(new JsonFactory(), true, objectMapper.getDeserializationConfig())
+        JacksonProcessor processor = new JacksonProcessor(new JsonFactory(), true, objectMapper)
 
         when:
         byte[] bytes = '[1, 2, [3, 4, [5, 6], 7], [8, 9, 10], 11, 12]'.bytes
@@ -475,12 +476,12 @@ class JacksonProcessorSpec extends Specification {
 
         then:
         nodeCount == 6
-        nodes[0].equals(JsonNodeFactory.instance.numberNode(1L))
-        nodes[1].equals(JsonNodeFactory.instance.numberNode(2L))
+        nodes[0].equals(JsonNodeFactory.instance.numberNode(1))
+        nodes[1].equals(JsonNodeFactory.instance.numberNode(2))
         ((ArrayNode) nodes[2]).size() == 4
         ((ArrayNode) nodes[3]).size() == 3
-        nodes[4].equals(JsonNodeFactory.instance.numberNode(11L))
-        nodes[5].equals(JsonNodeFactory.instance.numberNode(12L))
+        nodes[4].equals(JsonNodeFactory.instance.numberNode(11))
+        nodes[5].equals(JsonNodeFactory.instance.numberNode(12))
     }
 
 }


### PR DESCRIPTION
So that the object mapper configuration is used when parsing.
Avoids case like https://github.com/micronaut-projects/micronaut-core/pull/2648
Based on https://github.com/spring-projects/spring-framework/blob/2d86f221ce9e4df99aec801ae226ed228f5b64ac/spring-web/src/main/java/org/springframework/http/codec/json/Jackson2Tokenizer.java