### PR TITLE
Enabling Visitors to declare annotation processors options.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=1.3.0.BUILD-SNAPSHOT
+projectVersion=1.3.0.RC2
 projectGroupId=io.micronaut
 title=Micronaut
 projectDesc=Natively Cloud Native

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/consumes/ConsumesMatchesRouteSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/consumes/ConsumesMatchesRouteSpec.groovy
@@ -47,7 +47,7 @@ class ConsumesMatchesRouteSpec extends AbstractMicronautSpec {
         URL url = new URL(url1.getProtocol(), url1.getHost(), url1.getPort(), url1.getFile() + "/test-consumes", null)
         URLConnection connection = url.openConnection()
         connection.setRequestMethod("POST")
-        connection.setRequestProperty('Content-Type', null)
+        connection.setRequestProperty('Content-Type', TEXT_PLAIN_TYPE.getName())
         connection.doOutput = true
 
         def writer = new OutputStreamWriter(connection.outputStream)
@@ -83,7 +83,7 @@ class ConsumesMatchesRouteSpec extends AbstractMicronautSpec {
         URL url = new URL(url1.getProtocol(), url1.getHost(), url1.getPort(), url1.getFile() + "/test-consumes-all", null)
         URLConnection connection = url.openConnection()
         connection.setRequestMethod("POST")
-        connection.setRequestProperty('Content-Type', null)
+        connection.setRequestProperty('Content-Type', TEXT_PLAIN_TYPE.getName())
         connection.doOutput = true
 
         def writer = new OutputStreamWriter(connection.outputStream)

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyVisitorContext.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyVisitorContext.java
@@ -248,6 +248,11 @@ public class GroovyVisitorContext implements VisitorContext {
         return sourceUnit;
     }
 
+    @Override
+    public Map<String, String> getOptions() {
+        return Collections.emptyMap();
+    }
+
     private SyntaxErrorMessage buildErrorMessage(String message, Element element) {
         ASTNode expr = (ASTNode) element.getNativeType();
         return new SyntaxErrorMessage(

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
@@ -19,17 +19,18 @@ import io.micronaut.annotation.processing.visitor.LoadedVisitor;
 import io.micronaut.aop.Introduction;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.AnnotationMetadata;
-import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.io.service.ServiceDefinition;
 import io.micronaut.core.io.service.SoftServiceLoader;
 import io.micronaut.core.order.OrderUtil;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.core.version.VersionUtils;
+import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
 import io.micronaut.inject.processing.JavaModelUtils;
 import io.micronaut.inject.visitor.TypeElementVisitor;
 
 import javax.annotation.Nonnull;
+import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.lang.model.element.Element;
@@ -41,6 +42,7 @@ import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementScanner8;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static javax.lang.model.element.ElementKind.FIELD;
 
@@ -55,10 +57,23 @@ import static javax.lang.model.element.ElementKind.FIELD;
 public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcessor {
 
     private boolean executed = false;
+    private Collection<TypeElementVisitor> typeElementVisitors;
+
+    @Override
+    public synchronized void init(ProcessingEnvironment processingEnv) {
+        super.init(processingEnv);
+        this.typeElementVisitors = findTypeElementVisitors();
+    }
 
     @Override
     public Set<String> getSupportedOptions() {
-        return Collections.singleton("org.gradle.annotation.processing.aggregating");
+        Stream<String> baseOption = Stream.of("org.gradle.annotation.processing.aggregating");
+        Stream<String> visitorsOptions = typeElementVisitors
+                .stream()
+                .map(TypeElementVisitor::getSupportedOptions)
+                .flatMap(Collection::stream);
+        return Stream.concat(baseOption, visitorsOptions)
+                .collect(Collectors.toSet());
     }
 
     @Override
@@ -68,8 +83,6 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
             return false;
         }
 
-
-        Collection<TypeElementVisitor> typeElementVisitors = findTypeElementVisitors();
         List<LoadedVisitor> loadedVisitors = new ArrayList<>(typeElementVisitors.size());
         for (TypeElementVisitor visitor : typeElementVisitors) {
             try {
@@ -125,7 +138,8 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
      *
      * @return A collection of type element visitors.
      */
-    protected @Nonnull Collection<TypeElementVisitor> findTypeElementVisitors() {
+    protected @Nonnull
+    Collection<TypeElementVisitor> findTypeElementVisitors() {
         Map<String, TypeElementVisitor> typeElementVisitors = new HashMap<>(10);
         SoftServiceLoader<TypeElementVisitor> serviceLoader = SoftServiceLoader.load(TypeElementVisitor.class, getClass().getClassLoader());
         for (ServiceDefinition<TypeElementVisitor> definition : serviceLoader) {

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaVisitorContext.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaVisitorContext.java
@@ -67,7 +67,7 @@ public class JavaVisitorContext implements VisitorContext {
     private final AnnotationProcessingOutputVisitor outputVisitor;
     private final MutableConvertibleValues<Object> visitorAttributes;
     private final GenericUtils genericUtils;
-    private final ProcessingEnvironment proccessingEnv;
+    private final ProcessingEnvironment processingEnv;
     private @Nullable JavaFileManager standardFileManager;
 
     /**
@@ -100,7 +100,7 @@ public class JavaVisitorContext implements VisitorContext {
         this.genericUtils = genericUtils;
         this.outputVisitor = new AnnotationProcessingOutputVisitor(filer);
         this.visitorAttributes = visitorAttributes;
-        this.proccessingEnv = processingEnv;
+        this.processingEnv = processingEnv;
     }
 
     @Nonnull
@@ -109,7 +109,7 @@ public class JavaVisitorContext implements VisitorContext {
         // reflective hack required because no way to get the JavaFileManager
         // from public processor API
         info("EXPERIMENTAL: Compile time resource scanning is experimental", null);
-        JavaFileManager standardFileManager = getStandardFileManager(proccessingEnv).orElse(null);
+        JavaFileManager standardFileManager = getStandardFileManager(processingEnv).orElse(null);
         if (standardFileManager != null) {
             try {
                 final ClassLoader classLoader = standardFileManager
@@ -257,6 +257,14 @@ public class JavaVisitorContext implements VisitorContext {
      */
     public GenericUtils getGenericUtils() {
         return genericUtils;
+    }
+
+    @Override
+    public Map<String, String> getOptions() {
+        Map<String, String> processorOptions = Optional.ofNullable(processingEnv)
+                .map(ProcessingEnvironment::getOptions)
+                .orElse(Collections.emptyMap());
+        return processorOptions;
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/inject/visitor/TypeElementVisitor.java
+++ b/inject/src/main/java/io/micronaut/inject/visitor/TypeElementVisitor.java
@@ -15,11 +15,15 @@
  */
 package io.micronaut.inject.visitor;
 
+import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.order.Ordered;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.ConstructorElement;
 import io.micronaut.inject.ast.FieldElement;
 import io.micronaut.inject.ast.MethodElement;
+
+import java.util.Collections;
+import java.util.Set;
 
 /**
  * Provides a hook into the compilation process to allow user defined functionality to be created at compile time.
@@ -88,5 +92,17 @@ public interface TypeElementVisitor<C, E> extends Ordered {
      */
     default void finish(VisitorContext visitorContext) {
         // no-op
+    }
+
+    /**
+     * Called once when processor loads.
+     *
+     * Used to expose visitors custom processor options.
+     *
+     * @return Set with custom options
+     */
+    @Experimental
+    default Set<String> getSupportedOptions() {
+        return Collections.emptySet();
     }
 }

--- a/inject/src/main/java/io/micronaut/inject/visitor/VisitorContext.java
+++ b/inject/src/main/java/io/micronaut/inject/visitor/VisitorContext.java
@@ -26,6 +26,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.net.URL;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -129,5 +130,15 @@ public interface VisitorContext extends MutableConvertibleValues<Object>, ClassW
      */
     default @Nonnull ClassElement[] getClassElements(@Nonnull String aPackage, @Nonnull String... stereotypes) {
         return new ClassElement[0];
+    }
+
+    /**
+     * The annotation processor environment custom options.
+     * @return A Map with annotation processor runtime options
+     * @see javax.annotation.processing.ProcessingEnvironment#getOptions()
+     */
+    @Experimental
+    default Map<String, String> getOptions() {
+        return Collections.emptyMap();
     }
 }


### PR DESCRIPTION
  - Needed to fix issue micronaut-projects/micronaut-openapi#108
    By enabling annotation processors arguments, one can remove the need
    for ugly System properties on thirdy party visitors. E.g.:
      micronaut-openapi
  - Fixing http-server-netty integration test, according to HTTP spec regarding to
    Content-Type negotiation:
    See https://tools.ietf.org/html/rfc7231#section-3.1.1.5