### PR TITLE
Enabling Visitors to declare annotation processors options.

### DIFF
--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/consumes/ConsumesMatchesRouteSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/consumes/ConsumesMatchesRouteSpec.groovy
@@ -47,6 +47,7 @@ class ConsumesMatchesRouteSpec extends AbstractMicronautSpec {
         URL url = new URL(url1.getProtocol(), url1.getHost(), url1.getPort(), url1.getFile() + "/test-consumes", null)
         URLConnection connection = url.openConnection()
         connection.setRequestMethod("POST")
+        connection.setRequestProperty('Content-Type', TEXT_PLAIN_TYPE.getName())
         connection.doOutput = true
 
         def writer = new OutputStreamWriter(connection.outputStream)
@@ -82,6 +83,7 @@ class ConsumesMatchesRouteSpec extends AbstractMicronautSpec {
         URL url = new URL(url1.getProtocol(), url1.getHost(), url1.getPort(), url1.getFile() + "/test-consumes-all", null)
         URLConnection connection = url.openConnection()
         connection.setRequestMethod("POST")
+        connection.setRequestProperty('Content-Type', TEXT_PLAIN_TYPE.getName())
         connection.doOutput = true
 
         def writer = new OutputStreamWriter(connection.outputStream)

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyVisitorContext.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyVisitorContext.java
@@ -26,6 +26,7 @@ import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.Element;
+import io.micronaut.inject.util.VisitorContextUtils;
 import io.micronaut.inject.visitor.VisitorContext;
 import io.micronaut.inject.writer.DirectoryClassWriterOutputVisitor;
 import io.micronaut.inject.writer.GeneratedFile;
@@ -246,6 +247,16 @@ public class GroovyVisitorContext implements VisitorContext {
      */
     SourceUnit getSourceUnit() {
         return sourceUnit;
+    }
+
+    /**
+     * Groovy options source are {@link System#getProperties()} based.
+     * <p><b>All properties MUST start with {@link GroovyVisitorContext#MICRONAUT_BASE_OPTION_NAME}</b></p>
+     * @return options {@link Map}
+     */
+    @Override
+    public Map<String, String> getOptions() {
+        return VisitorContextUtils.getSystemOptions();
     }
 
     private SyntaxErrorMessage buildErrorMessage(String message, Element element) {

--- a/inject/src/main/java/io/micronaut/inject/util/VisitorContextUtils.java
+++ b/inject/src/main/java/io/micronaut/inject/util/VisitorContextUtils.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micronaut.inject.util;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.inject.visitor.VisitorContext;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Internal common helper functions to share among {@link VisitorContext} implementations.
+ * @author Miguel A. Baldi Horlle
+ * @since 1.3.0
+ */
+@Internal
+public class VisitorContextUtils {
+
+    /**
+     * Get visitor's context options from {@link System#getProperties()}
+     * <p>
+     * Transforms {@link System#getProperties()} into {@link Map}
+     * allowing only Micronaut's properties, filtering everything else.
+     * </p>
+     * @return options map
+     */
+    public static Map<String, String> getSystemOptions() {
+        return Optional.ofNullable(System.getProperties())
+                .map(properties ->
+                        properties.stringPropertyNames()
+                                .stream()
+                                .filter(name -> name.startsWith(VisitorContext.MICRONAUT_BASE_OPTION_NAME))
+                                .map(k -> new AbstractMap.SimpleEntry<>(k, System.getProperty(k)))
+                                .collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue)))
+                .orElse(Collections.emptyMap());
+    }
+
+    /**
+     * Get visitor's context options from {@link ProcessingEnvironment#getOptions()}
+     * <p>
+     * Get {@link ProcessingEnvironment#getOptions()}
+     * allowing only Micronaut's properties, filtering everything else.
+     * </p>
+     * @param processingEnv {@link ProcessingEnvironment}
+     * @return options map
+     */
+    public static Map<String, String> getProcessorOptions(ProcessingEnvironment processingEnv) {
+        return Optional.ofNullable(processingEnv)
+                .map(ProcessingEnvironment::getOptions)
+                .map(Map::entrySet)
+                .map(Set::stream)
+                // Only collects properties with name starting with MICRONAUT_BASE_OPTION_NAME
+                .map(entryStream -> entryStream.filter(e -> e.getKey().startsWith(VisitorContext.MICRONAUT_BASE_OPTION_NAME))
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)))
+                .orElse(Collections.emptyMap());
+    }
+}

--- a/inject/src/main/java/io/micronaut/inject/visitor/TypeElementVisitor.java
+++ b/inject/src/main/java/io/micronaut/inject/visitor/TypeElementVisitor.java
@@ -15,11 +15,15 @@
  */
 package io.micronaut.inject.visitor;
 
+import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.order.Ordered;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.ConstructorElement;
 import io.micronaut.inject.ast.FieldElement;
 import io.micronaut.inject.ast.MethodElement;
+
+import java.util.Collections;
+import java.util.Set;
 
 /**
  * Provides a hook into the compilation process to allow user defined functionality to be created at compile time.
@@ -88,5 +92,17 @@ public interface TypeElementVisitor<C, E> extends Ordered {
      */
     default void finish(VisitorContext visitorContext) {
         // no-op
+    }
+
+    /**
+     * Called once when processor loads.
+     *
+     * Used to expose visitors custom processor options.
+     *
+     * @return Set with custom options
+     */
+    @Experimental
+    default Set<String> getSupportedOptions() {
+        return Collections.emptySet();
     }
 }

--- a/inject/src/main/java/io/micronaut/inject/visitor/VisitorContext.java
+++ b/inject/src/main/java/io/micronaut/inject/visitor/VisitorContext.java
@@ -26,6 +26,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.net.URL;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -36,7 +37,7 @@ import java.util.Optional;
  * @since 1.0
  */
 public interface VisitorContext extends MutableConvertibleValues<Object>, ClassWriterOutputVisitor {
-
+    String MICRONAUT_BASE_OPTION_NAME = "micronaut";
     /**
      * Allows printing informational messages.
      *
@@ -129,5 +130,16 @@ public interface VisitorContext extends MutableConvertibleValues<Object>, ClassW
      */
     default @Nonnull ClassElement[] getClassElements(@Nonnull String aPackage, @Nonnull String... stereotypes) {
         return new ClassElement[0];
+    }
+
+    /**
+     * The annotation processor environment custom options.
+     * <p><b>All options names MUST start with {@link VisitorContext#MICRONAUT_BASE_OPTION_NAME}</b></p>
+     * @return A Map with annotation processor runtime options
+     * @see javax.annotation.processing.ProcessingEnvironment#getOptions()
+     */
+    @Experimental
+    default Map<String, String> getOptions() {
+        return Collections.emptyMap();
     }
 }

--- a/inject/src/test/groovy/io/micronaut/inject/util/VisitorContextUtilsSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/inject/util/VisitorContextUtilsSpec.groovy
@@ -1,0 +1,67 @@
+package io.micronaut.inject.util
+
+import spock.lang.Specification
+import spock.lang.Stepwise
+import spock.util.environment.RestoreSystemProperties
+
+import javax.annotation.processing.ProcessingEnvironment
+
+@Stepwise
+class VisitorContextUtilsSpec extends Specification {
+    public static final String INVALID_CUSTOM_PROP_1 = "invalid.custom.prop"
+    public static final String VALID_CUSTOM_PROP_1 = "micronaut.custom.prop"
+    public static final String VALID_CUSTOM_PROP_2 = "micronaut.another.custom.prop"
+
+    @RestoreSystemProperties
+    def "should build options map from system properties"() {
+        given:
+
+        System.setProperty(VALID_CUSTOM_PROP_1, "test1")
+        System.setProperty(INVALID_CUSTOM_PROP_1, "test1")
+        System.setProperty(VALID_CUSTOM_PROP_2, "test1")
+
+        when:
+
+        def options = VisitorContextUtils.getSystemOptions()
+
+        then:
+
+        options != null
+        !options.isEmpty()
+        options.containsKey(VALID_CUSTOM_PROP_1)
+        options.containsKey(VALID_CUSTOM_PROP_2)
+        !options.containsKey(INVALID_CUSTOM_PROP_1)
+
+    }
+
+    def "should contains base options"() {
+        given:
+
+        Map<String, String> mapOpts = new HashMap<>()
+        def env = Mock(ProcessingEnvironment)
+        mapOpts.put(INVALID_CUSTOM_PROP_1, "test1")
+        mapOpts.put(VALID_CUSTOM_PROP_1, "test2")
+        mapOpts.put(VALID_CUSTOM_PROP_2, "test3")
+        env.getOptions() >> mapOpts
+
+        when:
+
+        def options = VisitorContextUtils.getProcessorOptions(env)
+
+        then:
+
+        with(options) {
+            size() == 2
+            containsKey(VALID_CUSTOM_PROP_1)
+            containsKey(VALID_CUSTOM_PROP_2)
+            !containsKey(INVALID_CUSTOM_PROP_1)
+        }
+    }
+
+    def "system options should not contain custom properties"() {
+        expect:
+
+        !VisitorContextUtils.getSystemOptions().containsKey(VALID_CUSTOM_PROP_1)
+        !VisitorContextUtils.getSystemOptions().containsKey(VALID_CUSTOM_PROP_2)
+    }
+}

--- a/validation/src/main/java/io/micronaut/validation/properties/MixedCasePropertyTypeElementVisitor.java
+++ b/validation/src/main/java/io/micronaut/validation/properties/MixedCasePropertyTypeElementVisitor.java
@@ -31,6 +31,7 @@ import io.micronaut.inject.ast.ParameterElement;
 import io.micronaut.inject.visitor.TypeElementVisitor;
 import io.micronaut.inject.visitor.VisitorContext;
 
+import javax.annotation.processing.SupportedOptions;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -42,9 +43,11 @@ import java.util.Set;
  * @since 1.1.0
  * @deprecated No replacement because mixed case keys can now be resolved
  */
+@SupportedOptions(MixedCasePropertyTypeElementVisitor.VALIDATION_OPTION)
 @Deprecated
 public class MixedCasePropertyTypeElementVisitor implements TypeElementVisitor<Object, Object> {
 
+    static final String VALIDATION_OPTION = "micronaut.configuration.validation";
     private boolean skipValidation = false;
     private final DefaultPropertyPlaceholderResolver resolver = new DefaultPropertyPlaceholderResolver(new PropertySourcePropertyResolver(), new DefaultConversionService());
 
@@ -72,7 +75,7 @@ public class MixedCasePropertyTypeElementVisitor implements TypeElementVisitor<O
 
     @Override
     public void start(VisitorContext visitorContext) {
-        String prop = System.getProperty("micronaut.configuration.validation");
+        String prop = visitorContext.getOptions().getOrDefault(VALIDATION_OPTION, "true");
         skipValidation = prop != null && prop.equals("false");
     }
 

--- a/validation/src/main/java/io/micronaut/validation/websocket/WebSocketVisitor.java
+++ b/validation/src/main/java/io/micronaut/validation/websocket/WebSocketVisitor.java
@@ -24,6 +24,7 @@ import io.micronaut.inject.ast.ParameterElement;
 import io.micronaut.inject.visitor.*;
 import io.micronaut.websocket.annotation.*;
 
+import javax.annotation.processing.SupportedOptions;
 import java.util.*;
 
 /**
@@ -32,8 +33,10 @@ import java.util.*;
  * @author graemerocher
  * @since 1.0
  */
+@SupportedOptions(WebSocketVisitor.VALIDATION_OPTION)
 public class WebSocketVisitor implements TypeElementVisitor<WebSocketComponent, WebSocketMapping> {
 
+    static final String VALIDATION_OPTION = "micronaut.websocket.validation";
     private static final String WEB_SOCKET_COMPONENT = "io.micronaut.websocket.annotation.WebSocketComponent";
     private static final String WEB_SOCKET_SESSION = "io.micronaut.websocket.WebSocketSession";
     private static final String HTTP_REQUEST = "io.micronaut.http.HttpRequest";
@@ -97,7 +100,7 @@ public class WebSocketVisitor implements TypeElementVisitor<WebSocketComponent, 
 
     @Override
     public void start(VisitorContext visitorContext) {
-        String prop = System.getProperty("micronaut.websocket.validation");
+        String prop = visitorContext.getOptions().getOrDefault(VALIDATION_OPTION, "true");
         skipValidation = prop != null && prop.equals("false");
     }
 


### PR DESCRIPTION
  - Needed to fix issue micronaut-projects/micronaut-openapi#108
    By enabling annotation processors arguments, one can remove the need
    for ugly System properties on thirdy party visitors. E.g.:
      micronaut-openapi
  - Fixing http-server-netty integration test, according to HTTP spec regarding to
    Content-Type negotiation:
    See https://tools.ietf.org/html/rfc7231#section-3.1.1.5