### PR TITLE
Support for recieving the injection point in factories/constructors. 

### DIFF
--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationMetadataProvider.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationMetadataProvider.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.core.annotation;
 
+import javax.annotation.Nonnull;
 import java.lang.annotation.Annotation;
 import java.util.Optional;
 
@@ -31,6 +32,7 @@ public interface AnnotationMetadataProvider extends AnnotationSource {
      *
      * @return The {@link AnnotationMetadata}
      */
+    @Nonnull
     default AnnotationMetadata getAnnotationMetadata() {
         return AnnotationMetadata.EMPTY_METADATA;
     }

--- a/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/InjectionPointSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/InjectionPointSpec.groovy
@@ -1,0 +1,33 @@
+package io.micronaut.inject.injectionpoint
+
+import io.micronaut.context.ApplicationContext
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class InjectionPointSpec extends Specification {
+
+    @Shared @AutoCleanup ApplicationContext applicationContext =
+            ApplicationContext.run()
+
+    def "void test that the injection point can be used to construct the object"() {
+        given:
+        def consumer = applicationContext.getBean(SomeBeanConsumer)
+
+        expect:
+        consumer.fromConstructor.name == 'one'
+        consumer.fromField.name == 'two'
+        consumer.fromMethod.name == 'three'
+        consumer.someType.name == 'four'
+    }
+
+    def "void test that the injection point can be used in injected introduction AOP advice"() {
+        given:
+        def consumer = applicationContext.getBean(SomeClientConsumer)
+
+        expect:
+        consumer.fromConstructor.test() == 'one'
+        consumer.fromField.test() == 'two'
+        consumer.fromMethod.test() == 'three'
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/SomeAdvice.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/SomeAdvice.java
@@ -1,0 +1,16 @@
+package io.micronaut.inject.injectionpoint;
+
+import io.micronaut.aop.Introduction;
+import io.micronaut.context.annotation.Type;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Introduction
+@Type(SomeInterceptor.class)
+@Documented
+@Retention(RUNTIME)
+public @interface SomeAdvice {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/SomeAnn.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/SomeAnn.java
@@ -1,0 +1,15 @@
+package io.micronaut.inject.injectionpoint;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.PARAMETER})
+public @interface SomeAnn {
+    String value();
+}
+

--- a/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/SomeBean.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/SomeBean.java
@@ -1,0 +1,13 @@
+package io.micronaut.inject.injectionpoint;
+
+public class SomeBean {
+    private String name;
+
+    public SomeBean(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/SomeBeanConsumer.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/SomeBeanConsumer.java
@@ -1,0 +1,45 @@
+package io.micronaut.inject.injectionpoint;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@Singleton
+public class SomeBeanConsumer {
+
+    private final SomeBean fromConstructor;
+
+    @Inject
+    @SomeAnn("two")
+    SomeBean fromField;
+
+    @Inject
+    @SomeAnn("four")
+    SomeType someType;
+
+    private SomeBean fromMethod;
+
+    public SomeBeanConsumer(@SomeAnn("one") SomeBean fromConstructor) {
+        this.fromConstructor = fromConstructor;
+    }
+
+    public SomeBean getFromConstructor() {
+        return fromConstructor;
+    }
+
+    public SomeBean getFromField() {
+        return fromField;
+    }
+
+    @Inject
+    public void setFromMethod(@SomeAnn("three") SomeBean fromMethod) {
+        this.fromMethod = fromMethod;
+    }
+
+    public SomeBean getFromMethod() {
+        return fromMethod;
+    }
+
+    public SomeType getSomeType() {
+        return someType;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/SomeClient.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/SomeClient.java
@@ -1,0 +1,7 @@
+package io.micronaut.inject.injectionpoint;
+
+@SomeAdvice
+public interface SomeClient {
+
+    String test();
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/SomeClientConsumer.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/SomeClientConsumer.java
@@ -1,0 +1,37 @@
+package io.micronaut.inject.injectionpoint;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@Singleton
+public class SomeClientConsumer {
+
+    private SomeClient fromConstructor;
+
+    @Inject
+    @SomeAnn("two")
+    SomeClient fromField;
+
+    private SomeClient  fromMethod;
+
+    public SomeClientConsumer(@SomeAnn("one") SomeClient fromConstructor) {
+        this.fromConstructor = fromConstructor;
+    }
+
+    @Inject
+    public void setFromMethod(@SomeAnn("three") SomeClient fromMethod) {
+        this.fromMethod = fromMethod;
+    }
+
+    public SomeClient getFromConstructor() {
+        return fromConstructor;
+    }
+
+    public SomeClient getFromField() {
+        return fromField;
+    }
+
+    public SomeClient getFromMethod() {
+        return fromMethod;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/SomeFactory.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/SomeFactory.java
@@ -1,0 +1,19 @@
+package io.micronaut.inject.injectionpoint;
+
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Prototype;
+import io.micronaut.inject.InjectionPoint;
+
+@Factory
+public class SomeFactory {
+
+    @Prototype
+    SomeBean someBean(InjectionPoint<SomeBean> someBean) {
+        final String str = someBean
+                .getAnnotationMetadata()
+                .stringValue(SomeAnn.class)
+                .orElse("no value");
+
+        return new SomeBean(str);
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/SomeInterceptor.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/SomeInterceptor.java
@@ -1,0 +1,24 @@
+package io.micronaut.inject.injectionpoint;
+
+import io.micronaut.aop.MethodInterceptor;
+import io.micronaut.aop.MethodInvocationContext;
+import io.micronaut.context.annotation.Prototype;
+import io.micronaut.inject.InjectionPoint;
+
+@Prototype
+public class SomeInterceptor implements MethodInterceptor<Object, Object> {
+
+    private final String name;
+
+    public SomeInterceptor(InjectionPoint<SomeInterceptor> injectionPoint) {
+        this.name = injectionPoint
+                .getAnnotationMetadata()
+                .stringValue(SomeAnn.class)
+                .orElse("no value");
+    }
+
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        return name;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/SomeType.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/injectionpoint/SomeType.java
@@ -1,0 +1,22 @@
+package io.micronaut.inject.injectionpoint;
+
+import io.micronaut.context.annotation.Prototype;
+import io.micronaut.inject.InjectionPoint;
+
+@Prototype
+public class SomeType {
+
+    private final String name;
+
+
+    public SomeType(InjectionPoint<SomeType> injectionPoint) {
+        this.name = injectionPoint
+                .getAnnotationMetadata()
+                .stringValue(SomeAnn.class)
+                .orElse("no value");
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/AbstractBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractBeanDefinition.java
@@ -1684,7 +1684,7 @@ public class AbstractBeanDefinition<T> extends AbstractBeanContextConditional im
 
     private String substituteWildCards(BeanResolutionContext resolutionContext, String valString) {
         if (valString.indexOf('*') > -1) {
-            Optional<String> namedBean = resolutionContext.get(Named.class.getName(), String.class);
+            Optional<String> namedBean = resolutionContext.get(Named.class.getName(), ArgumentConversionContext.STRING);
             if (namedBean.isPresent()) {
                 valString = valString.replace("*", namedBean.get());
             }
@@ -1825,7 +1825,7 @@ public class AbstractBeanDefinition<T> extends AbstractBeanContextConditional im
                     if ((hasMetadata && argument.isAnnotationPresent(Parameter.class)) ||
                             (innerConfiguration && isIterable) ||
                             Qualifier.class == argument.getType()) {
-                        final Optional<String> n = resolutionContext.get(NAMED_ATTRIBUTE, String.class);
+                        final Optional<String> n = resolutionContext.get(NAMED_ATTRIBUTE, ArgumentConversionContext.STRING);
                         qualifier = n.map(Qualifiers::byName).orElse(null);
                     }
                 }

--- a/inject/src/main/java/io/micronaut/context/BeanResolutionContext.java
+++ b/inject/src/main/java/io/micronaut/context/BeanResolutionContext.java
@@ -18,10 +18,7 @@ package io.micronaut.context;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.value.ValueResolver;
-import io.micronaut.inject.BeanDefinition;
-import io.micronaut.inject.BeanIdentifier;
-import io.micronaut.inject.FieldInjectionPoint;
-import io.micronaut.inject.MethodInjectionPoint;
+import io.micronaut.inject.*;
 
 import javax.annotation.Nullable;
 import java.util.Deque;
@@ -116,7 +113,7 @@ public interface BeanResolutionContext extends ValueResolver<CharSequence>, Auto
     /**
      * Represents a path taken to resolve a bean definitions dependencies.
      */
-    interface Path extends Deque<Segment> {
+    interface Path extends Deque<Segment<?>> {
         /**
          * Push an unresolved constructor call onto the queue.
          *
@@ -155,18 +152,25 @@ public interface BeanResolutionContext extends ValueResolver<CharSequence>, Auto
         /**
          * @return The current path segment
          */
-        Optional<Segment> currentSegment();
+        Optional<Segment<?>> currentSegment();
     }
 
     /**
      * A segment in a path.
+     *
+     * @param <T> the bean type
      */
-    interface Segment {
+    interface Segment<T> {
 
         /**
          * @return The type requested
          */
-        BeanDefinition getDeclaringType();
+        BeanDefinition<T> getDeclaringType();
+
+        /**
+         * @return The inject point
+         */
+        InjectionPoint<T> getInjectionPoint();
 
         /**
          * @return The name of the segment. For a field this is the field name, for a method the method name and for a constructor the type name

--- a/inject/src/main/java/io/micronaut/context/DefaultFieldInjectionPoint.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultFieldInjectionPoint.java
@@ -34,12 +34,13 @@ import java.util.Objects;
 /**
  * Represents an injection point for a field.
  *
+ * @param <B> The declaring bean type
  * @param <T> The field type
  * @author Graeme Rocher
  * @since 1.0
  */
 @Internal
-class DefaultFieldInjectionPoint<T> implements FieldInjectionPoint<T>, EnvironmentConfigurable {
+class DefaultFieldInjectionPoint<B, T> implements FieldInjectionPoint<B, T>, EnvironmentConfigurable {
 
     private final BeanDefinition declaringBean;
     private final Class declaringType;
@@ -91,7 +92,7 @@ class DefaultFieldInjectionPoint<T> implements FieldInjectionPoint<T>, Environme
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        DefaultFieldInjectionPoint<?> that = (DefaultFieldInjectionPoint<?>) o;
+        DefaultFieldInjectionPoint<?, ?> that = (DefaultFieldInjectionPoint<?, ?>) o;
         return Objects.equals(declaringType, that.declaringType) &&
             Objects.equals(fieldType, that.fieldType) &&
             Objects.equals(field, that.field);

--- a/inject/src/main/java/io/micronaut/context/DefaultMethodConstructorInjectionPoint.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultMethodConstructorInjectionPoint.java
@@ -28,9 +28,10 @@ import javax.annotation.Nullable;
  *
  * @author graemerocher
  * @since 1.0
+ * @param <T> The constructed type
  */
 @Internal
-class DefaultMethodConstructorInjectionPoint extends DefaultMethodInjectionPoint implements ConstructorInjectionPoint {
+class DefaultMethodConstructorInjectionPoint<T> extends DefaultMethodInjectionPoint<T, T> implements ConstructorInjectionPoint<T> {
 
     /**
      * @param declaringBean      The declaring bean
@@ -49,7 +50,7 @@ class DefaultMethodConstructorInjectionPoint extends DefaultMethodInjectionPoint
     }
 
     @Override
-    public Object invoke(Object... args) {
+    public T invoke(Object... args) {
         throw new UnsupportedOperationException("Use MethodInjectionPoint#invoke(..) instead");
     }
 }

--- a/inject/src/main/java/io/micronaut/context/DefaultMethodInjectionPoint.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultMethodInjectionPoint.java
@@ -35,9 +35,11 @@ import java.util.Objects;
  *
  * @author graemerocher
  * @since 1.0
+ * @param <B> The bean type
+ * @param <T> The injectable type
  */
 @Internal
-class DefaultMethodInjectionPoint implements MethodInjectionPoint, EnvironmentConfigurable {
+class DefaultMethodInjectionPoint<B, T> implements MethodInjectionPoint<B, T>, EnvironmentConfigurable {
 
     private final BeanDefinition declaringBean;
     private final AnnotationMetadata annotationMetadata;

--- a/inject/src/main/java/io/micronaut/context/ReflectionConstructorInjectionPoint.java
+++ b/inject/src/main/java/io/micronaut/context/ReflectionConstructorInjectionPoint.java
@@ -18,6 +18,7 @@ package io.micronaut.context;
 import io.micronaut.context.exceptions.BeanInstantiationException;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.type.Argument;
 import io.micronaut.inject.BeanDefinition;
@@ -57,6 +58,9 @@ class ReflectionConstructorInjectionPoint<T> implements ConstructorInjectionPoin
         this.declaringComponent = beanDefinition;
         this.declaringType = declaringType;
         this.arguments = arguments == null ? Argument.ZERO_ARGUMENTS : arguments;
+        if (ClassUtils.REFLECTION_LOGGER.isDebugEnabled()) {
+            ClassUtils.REFLECTION_LOGGER.debug("Bean of type [" + beanDefinition.getBeanType() + "] defines constructor that requires the use of reflection to inject");
+        }
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/context/ReflectionFieldInjectionPoint.java
+++ b/inject/src/main/java/io/micronaut/context/ReflectionFieldInjectionPoint.java
@@ -17,6 +17,7 @@ package io.micronaut.context;
 
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.core.type.Argument;
 import io.micronaut.inject.BeanDefinition;
 
@@ -25,12 +26,13 @@ import javax.annotation.Nullable;
 /**
  * A field injection point invoked via reflection.
  *
+ * @param <B> The bean type that declares the injection point
  * @param <T> The field type
  * @author graemerocher
  * @since 1.0
  */
 @Internal
-class ReflectionFieldInjectionPoint<T> extends DefaultFieldInjectionPoint<T> {
+class ReflectionFieldInjectionPoint<B, T> extends DefaultFieldInjectionPoint<B, T> {
 
     /**
      * @param declaringBean      The declaring bean
@@ -47,8 +49,10 @@ class ReflectionFieldInjectionPoint<T> extends DefaultFieldInjectionPoint<T> {
         String field,
         @Nullable AnnotationMetadata annotationMetadata,
         @Nullable Argument[] typeArguments) {
-
         super(declaringBean, declaringType, fieldType, field, annotationMetadata, typeArguments);
+        if (ClassUtils.REFLECTION_LOGGER.isDebugEnabled()) {
+            ClassUtils.REFLECTION_LOGGER.debug("Bean of type [" + declaringBean.getBeanType() + "] defines field [" + field + "] that requires the use of reflection to inject");
+        }
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/context/ReflectionMethodConstructorInjectionPoint.java
+++ b/inject/src/main/java/io/micronaut/context/ReflectionMethodConstructorInjectionPoint.java
@@ -17,6 +17,7 @@ package io.micronaut.context;
 
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.core.type.Argument;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.ConstructorInjectionPoint;
@@ -47,6 +48,9 @@ class ReflectionMethodConstructorInjectionPoint extends ReflectionMethodInjectio
         @Nullable AnnotationMetadata annotationMetadata) {
 
         super(declaringBean, declaringType, methodName, arguments, annotationMetadata);
+        if (ClassUtils.REFLECTION_LOGGER.isDebugEnabled()) {
+            ClassUtils.REFLECTION_LOGGER.debug("Bean of type [" + declaringBean.getBeanType() + "] defines constructor [" + methodName + "] that requires the use of reflection to inject");
+        }
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/context/ReflectionMethodInjectionPoint.java
+++ b/inject/src/main/java/io/micronaut/context/ReflectionMethodInjectionPoint.java
@@ -17,6 +17,7 @@ package io.micronaut.context;
 
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.core.type.Argument;
 import io.micronaut.inject.BeanDefinition;
 
@@ -45,6 +46,9 @@ class ReflectionMethodInjectionPoint extends DefaultMethodInjectionPoint {
         @Nullable Argument[] arguments,
         @Nullable AnnotationMetadata annotationMetadata) {
         super(declaringBean, declaringType, methodName, arguments, annotationMetadata);
+        if (ClassUtils.REFLECTION_LOGGER.isDebugEnabled()) {
+            ClassUtils.REFLECTION_LOGGER.debug("Bean of type [" + declaringBean.getBeanType() + "] defines method [" + methodName + "] that requires the use of reflection to inject");
+        }
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/inject/ArgumentInjectionPoint.java
+++ b/inject/src/main/java/io/micronaut/inject/ArgumentInjectionPoint.java
@@ -15,26 +15,27 @@
  */
 package io.micronaut.inject;
 
-import io.micronaut.core.annotation.AnnotationMetadataProvider;
+import io.micronaut.core.type.Argument;
 
 import javax.annotation.Nonnull;
 
 /**
- * An injection point as a point in a class definition where dependency injection is required.
+ * An injection point for a method or constructor argument.
  *
- * @author Graeme Rocher
+ * @param <B> The declaring bean type
+ * @param <T> The argument type
+ * @author graemerocher
  * @since 1.0
- * @param <T> the bean type
  */
-public interface InjectionPoint<T> extends AnnotationMetadataProvider {
+public interface ArgumentInjectionPoint<B, T> extends InjectionPoint<B> {
 
     /**
-     * @return The bean that declares this injection point
+     * @return The outer injection point (method or constructor)
      */
-    @Nonnull BeanDefinition<T> getDeclaringBean();
+    @Nonnull CallableInjectionPoint<B> getOuterInjectionPoint();
 
     /**
-     * @return Whether reflection is required to satisfy the injection point
+     * @return The argument that is being injected
      */
-    boolean requiresReflection();
+    @Nonnull Argument<T> getArgument();
 }

--- a/inject/src/main/java/io/micronaut/inject/CallableInjectionPoint.java
+++ b/inject/src/main/java/io/micronaut/inject/CallableInjectionPoint.java
@@ -22,8 +22,9 @@ import io.micronaut.core.type.Argument;
  *
  * @author Graeme Rocher
  * @since 1.0
+ * @param <T> The injectable type
  */
-public interface CallableInjectionPoint extends InjectionPoint {
+public interface CallableInjectionPoint<T> extends InjectionPoint<T> {
 
     /**
      *

--- a/inject/src/main/java/io/micronaut/inject/FieldInjectionPoint.java
+++ b/inject/src/main/java/io/micronaut/inject/FieldInjectionPoint.java
@@ -23,11 +23,12 @@ import java.lang.reflect.Field;
 /**
  * Defines an injection point for a field.
  *
+ * @param <B> The bean type that declares the injection point
  * @param <T> The field component type
  * @author Graeme Rocher
  * @since 1.0
  */
-public interface FieldInjectionPoint<T> extends InjectionPoint, AnnotationMetadataProvider, AnnotatedElement {
+public interface FieldInjectionPoint<B, T> extends InjectionPoint<B>, AnnotationMetadataProvider, AnnotatedElement {
 
     /**
      * @return The name of the field
@@ -35,6 +36,9 @@ public interface FieldInjectionPoint<T> extends InjectionPoint, AnnotationMetada
     String getName();
 
     /**
+     * Resolves the underlying field. Note that this method will cause reflection
+     * metadata to be initialized and should be avoided.
+     *
      * @return The target field
      */
     Field getField();
@@ -45,6 +49,9 @@ public interface FieldInjectionPoint<T> extends InjectionPoint, AnnotationMetada
     Class<T> getType();
 
     /**
+     * Sets the value of the field. Note that this method will cause reflection
+     * metadata to be initialized and should be avoided.
+     *
      * @param instance the instance
      * @param object   The the field on the target object
      */

--- a/inject/src/main/java/io/micronaut/inject/MethodInjectionPoint.java
+++ b/inject/src/main/java/io/micronaut/inject/MethodInjectionPoint.java
@@ -22,12 +22,17 @@ import java.lang.reflect.Method;
 /**
  * Defines an injection point for a method.
  *
+ * @param <B> The bean type
+ * @param <T> The injectable type
  * @author Graeme Rocher
  * @since 1.0
  */
-public interface MethodInjectionPoint extends CallableInjectionPoint, Executable {
+public interface MethodInjectionPoint<B, T> extends CallableInjectionPoint<B>, Executable<B, T> {
 
     /**
+     * Resolves the {@link Method} instance. Note that this method will cause reflection
+     * metadata to be initialized and should be avoided.
+     *
      * @return The setter to invoke to set said property
      */
     Method getMethod();
@@ -54,5 +59,5 @@ public interface MethodInjectionPoint extends CallableInjectionPoint, Executable
      * @param args     The arguments. Should match the types of getArguments()
      * @return The new value
      */
-    Object invoke(Object instance, Object... args);
+    T invoke(B instance, Object... args);
 }

--- a/src/main/docs/guide/ioc/factories.adoc
+++ b/src/main/docs/guide/ioc/factories.adoc
@@ -23,5 +23,28 @@ For example:
 snippet::io.micronaut.docs.factories.nullable.Engine,io.micronaut.docs.factories.nullable.EngineConfiguration,io.micronaut.docs.factories.nullable.EngineFactory[tags="class",indent=0]
 
 
+=== Injection Point
+
+A common use case with factories is to take advantage of annotation metadata from the point at which an object is injected such that behaviour can be modified based on said metadata.
+
+Consider an annotation such as the following:
+
+snippet::io.micronaut.docs.injectionpoint.Cylinders[tags="class",indent=0]
+
+The above annotation could be used to customize the type of engine we want to inject into a vehicle at the point at which the injection point is defined:
+
+snippet::io.micronaut.docs.injectionpoint.Vehicle[tags="class",indent=0]
+
+The above `Vehicle` class specifies an annotation value of `@Cylinders(6)` indicating an `Engine` of six cylinders is needed.
+
+To implement this use case you can define a factory that accepts the api:inject.InjectionPoint[] instance which can be used to analyze the annotation values defined:
+
+snippet::io.micronaut.docs.injectionpoint.EngineFactory[tags="class",indent=0]
+
+<1> The factory method defines a parameter of type api:inject.InjectionPoint[].
+<2> The annotation metadata is used to obtain the value of the `@Cylinder` annotation
+<3> The value is used to construct an engine, throwing an exception if an engine cannot be constructed.
+
+NOTE: It is important to note that the factory is declared as ann:context.annotation.Prototype[] scope so that the method is invoked for each injection point. If the `V8Engine` and `V6Engine` types are required to be singletons then the factory should use a map to ensure the objects are only constructed once.
 
 

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/factories/VehicleSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/factories/VehicleSpec.groovy
@@ -15,7 +15,7 @@
  */
 package io.micronaut.docs.factories
 
-import io.micronaut.context.DefaultBeanContext
+import io.micronaut.context.BeanContext
 import spock.lang.Specification
 
 /**
@@ -27,10 +27,11 @@ class VehicleSpec extends Specification {
     void "test start vehicle"() {
         when:
         // tag::start[]
-        Vehicle vehicle = new DefaultBeanContext()
-                .start()
-                .getBean(Vehicle)
-        println( vehicle.start() )
+        Vehicle vehicle = BeanContext.run().withCloseable {
+            Vehicle vehicle = it.getBean(Vehicle)
+            println( vehicle.start() )
+            return vehicle
+        }
         // end::start[]
 
         then:

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/injectionpoint/CrankShaft.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/injectionpoint/CrankShaft.groovy
@@ -13,22 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.inject;
+package io.micronaut.docs.injectionpoint
 
-/**
- * A constructor injection point.
- *
- * @param <T> The constructed type
- * @author Graeme Rocher
- * @since 1.0
- */
-public interface ConstructorInjectionPoint<T> extends CallableInjectionPoint<T> {
+import javax.inject.Singleton
 
-    /**
-     * Invoke the constructor.
-     *
-     * @param args The arguments
-     * @return The new value
-     */
-    T invoke(Object... args);
+// tag::class[]
+@Singleton
+class CrankShaft {
 }
+// end::class[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/injectionpoint/Cylinders.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/injectionpoint/Cylinders.groovy
@@ -1,0 +1,13 @@
+package io.micronaut.docs.injectionpoint
+
+import java.lang.annotation.*
+import static java.lang.annotation.RetentionPolicy.RUNTIME
+
+// tag::class[]
+@Documented
+@Retention(RUNTIME)
+@Target(ElementType.PARAMETER)
+@interface Cylinders {
+    int value() default 8
+}
+// end::class[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/injectionpoint/Engine.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/injectionpoint/Engine.groovy
@@ -13,22 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.inject;
+package io.micronaut.docs.injectionpoint;
 
-/**
- * A constructor injection point.
- *
- * @param <T> The constructed type
- * @author Graeme Rocher
- * @since 1.0
- */
-public interface ConstructorInjectionPoint<T> extends CallableInjectionPoint<T> {
-
-    /**
-     * Invoke the constructor.
-     *
-     * @param args The arguments
-     * @return The new value
-     */
-    T invoke(Object... args);
+// tag::class[]
+interface Engine {
+    String start()
 }
+// end::class[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/injectionpoint/EngineFactory.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/injectionpoint/EngineFactory.groovy
@@ -28,7 +28,7 @@ import io.micronaut.inject.InjectionPoint
 class EngineFactory {
 
     @Prototype
-    Engine v8Engine(InjectionPoint<Engine> injectionPoint, CrankShaft crankShaft) { // <1>
+    Engine v8Engine(InjectionPoint<?> injectionPoint, CrankShaft crankShaft) { // <1>
         final int cylinders = injectionPoint
                 .getAnnotationMetadata()
                 .intValue(Cylinders.class).orElse(8) // <2>

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/injectionpoint/EngineFactory.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/injectionpoint/EngineFactory.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.injectionpoint
+
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Prototype
+import io.micronaut.inject.InjectionPoint
+
+/**
+ * @author Graeme Rocher
+ * @since 1.0
+ */
+// tag::class[]
+@Factory
+class EngineFactory {
+
+    @Prototype
+    Engine v8Engine(InjectionPoint<Engine> injectionPoint, CrankShaft crankShaft) { // <1>
+        final int cylinders = injectionPoint
+                .getAnnotationMetadata()
+                .intValue(Cylinders.class).orElse(8) // <2>
+        switch (cylinders) { // <3>
+            case 6:
+                return new V6Engine(crankShaft)
+            case 8:
+                return new V8Engine(crankShaft)
+            default:
+                throw new IllegalArgumentException("Unsupported number of cylinders specified: $cylinders")
+        }
+    }
+}
+// tag::class[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/injectionpoint/V6Engine.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/injectionpoint/V6Engine.groovy
@@ -1,0 +1,16 @@
+package io.micronaut.docs.injectionpoint
+
+// tag::class[]
+class V6Engine implements Engine {
+    private final int cylinders = 6
+    private final CrankShaft crankShaft
+
+    V6Engine(CrankShaft crankShaft) {
+        this.crankShaft = crankShaft
+    }
+
+    String start() {
+        return "Starting V6"
+    }
+}
+// end::class[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/injectionpoint/V8Engine.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/injectionpoint/V8Engine.groovy
@@ -13,22 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.inject;
+package io.micronaut.docs.injectionpoint
+// tag::class[]
+class V8Engine implements Engine {
+    private final int cylinders = 8
+    private final CrankShaft crankShaft
 
-/**
- * A constructor injection point.
- *
- * @param <T> The constructed type
- * @author Graeme Rocher
- * @since 1.0
- */
-public interface ConstructorInjectionPoint<T> extends CallableInjectionPoint<T> {
+    V8Engine(CrankShaft crankShaft) {
+        this.crankShaft = crankShaft
+    }
 
-    /**
-     * Invoke the constructor.
-     *
-     * @param args The arguments
-     * @return The new value
-     */
-    T invoke(Object... args);
+    String start() {
+        return "Starting V8"
+    }
 }
+// end::class[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/injectionpoint/Vehicle.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/injectionpoint/Vehicle.groovy
@@ -13,22 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.inject;
+package io.micronaut.docs.injectionpoint
 
-/**
- * A constructor injection point.
- *
- * @param <T> The constructed type
- * @author Graeme Rocher
- * @since 1.0
- */
-public interface ConstructorInjectionPoint<T> extends CallableInjectionPoint<T> {
+import javax.inject.Singleton
 
-    /**
-     * Invoke the constructor.
-     *
-     * @param args The arguments
-     * @return The new value
-     */
-    T invoke(Object... args);
+// tag::class[]
+@Singleton
+class Vehicle {
+    private final Engine engine
+    Vehicle(@Cylinders(6) Engine engine) {
+        this.engine = engine
+    }
+
+    String start() {
+        return engine.start()
+    }
 }
+// end::class[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/injectionpoint/VehicleSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/injectionpoint/VehicleSpec.groovy
@@ -1,5 +1,6 @@
 package io.micronaut.docs.injectionpoint
 
+import io.micronaut.context.BeanContext
 import io.micronaut.context.DefaultBeanContext
 import spock.lang.Specification
 
@@ -13,14 +14,16 @@ class VehicleSpec extends Specification {
     void "test start vehicle"() {
         when:
         // tag::start[]
-        io.micronaut.docs.factories.Vehicle vehicle = new DefaultBeanContext()
-                .start()
-                .getBean(io.micronaut.docs.factories.Vehicle)
+        BeanContext beanContext = BeanContext.run()
+        def vehicle = beanContext.getBean(Vehicle)
         println( vehicle.start() )
         // end::start[]
 
         then:
         vehicle.start() == "Starting V6"
+
+        cleanup:
+        beanContext.close()
     }
 }
 

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/injectionpoint/VehicleSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/injectionpoint/VehicleSpec.groovy
@@ -1,0 +1,26 @@
+package io.micronaut.docs.injectionpoint
+
+import io.micronaut.context.DefaultBeanContext
+import spock.lang.Specification
+
+
+/**
+ * @author Graeme Rocher
+ * @since 1.0
+ */
+class VehicleSpec extends Specification {
+
+    void "test start vehicle"() {
+        when:
+        // tag::start[]
+        io.micronaut.docs.factories.Vehicle vehicle = new DefaultBeanContext()
+                .start()
+                .getBean(io.micronaut.docs.factories.Vehicle)
+        println( vehicle.start() )
+        // end::start[]
+
+        then:
+        vehicle.start() == "Starting V6"
+    }
+}
+

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/injectionpoint/CrankShaft.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/injectionpoint/CrankShaft.kt
@@ -13,22 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.inject;
+package io.micronaut.docs.injectionpoint
 
-/**
- * A constructor injection point.
- *
- * @param <T> The constructed type
- * @author Graeme Rocher
- * @since 1.0
- */
-public interface ConstructorInjectionPoint<T> extends CallableInjectionPoint<T> {
+import javax.inject.Singleton
 
-    /**
-     * Invoke the constructor.
-     *
-     * @param args The arguments
-     * @return The new value
-     */
-    T invoke(Object... args);
-}
+// tag::class[]
+@Singleton
+class CrankShaft
+// end::class[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/injectionpoint/Cylinders.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/injectionpoint/Cylinders.kt
@@ -1,0 +1,8 @@
+package io.micronaut.docs.injectionpoint
+
+// tag::class[]
+@MustBeDocumented
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.VALUE_PARAMETER)
+annotation class Cylinders(val value: Int = 8)
+// end::class[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/injectionpoint/Engine.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/injectionpoint/Engine.kt
@@ -13,22 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.inject;
+package io.micronaut.docs.injectionpoint
 
-/**
- * A constructor injection point.
- *
- * @param <T> The constructed type
- * @author Graeme Rocher
- * @since 1.0
- */
-public interface ConstructorInjectionPoint<T> extends CallableInjectionPoint<T> {
-
-    /**
-     * Invoke the constructor.
-     *
-     * @param args The arguments
-     * @return The new value
-     */
-    T invoke(Object... args);
+// tag::class[]
+interface Engine {
+    fun start(): String
 }
+// end::class[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/injectionpoint/EngineFactory.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/injectionpoint/EngineFactory.kt
@@ -28,7 +28,7 @@ import io.micronaut.inject.InjectionPoint
 internal class EngineFactory {
 
     @Prototype
-    fun v8Engine(injectionPoint: InjectionPoint<Engine>, crankShaft: CrankShaft): Engine { // <1>
+    fun v8Engine(injectionPoint: InjectionPoint<*>, crankShaft: CrankShaft): Engine { // <1>
         val cylinders = injectionPoint
                 .annotationMetadata
                 .intValue(Cylinders::class.java).orElse(8) // <2>

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/injectionpoint/EngineFactory.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/injectionpoint/EngineFactory.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.injectionpoint
+
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Prototype
+import io.micronaut.inject.InjectionPoint
+
+/**
+ * @author Graeme Rocher
+ * @since 1.0
+ */
+// tag::class[]
+@Factory
+internal class EngineFactory {
+
+    @Prototype
+    fun v8Engine(injectionPoint: InjectionPoint<Engine>, crankShaft: CrankShaft): Engine { // <1>
+        val cylinders = injectionPoint
+                .annotationMetadata
+                .intValue(Cylinders::class.java).orElse(8) // <2>
+        return when (cylinders) { // <3>
+            6 -> V6Engine(crankShaft)
+            8 -> V8Engine(crankShaft)
+            else -> throw IllegalArgumentException("Unsupported number of cylinders specified: $cylinders")
+        }
+    }
+}
+// tag::class[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/injectionpoint/V6Engine.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/injectionpoint/V6Engine.kt
@@ -1,0 +1,11 @@
+package io.micronaut.docs.injectionpoint
+
+// tag::class[]
+internal class V6Engine(private val crankShaft: CrankShaft) : Engine {
+    private val cylinders = 6
+
+    override fun start(): String {
+        return "Starting V6"
+    }
+}
+// end::class[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/injectionpoint/V8Engine.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/injectionpoint/V8Engine.kt
@@ -13,22 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.inject;
+package io.micronaut.docs.injectionpoint
 
-/**
- * A constructor injection point.
- *
- * @param <T> The constructed type
- * @author Graeme Rocher
- * @since 1.0
- */
-public interface ConstructorInjectionPoint<T> extends CallableInjectionPoint<T> {
+// tag::class[]
+internal class V8Engine(private val crankShaft: CrankShaft) : Engine {
+    private val cylinders = 8
 
-    /**
-     * Invoke the constructor.
-     *
-     * @param args The arguments
-     * @return The new value
-     */
-    T invoke(Object... args);
+    override fun start(): String {
+        return "Starting V8"
+    }
 }
+// end::class[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/injectionpoint/Vehicle.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/injectionpoint/Vehicle.kt
@@ -13,22 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.inject;
+package io.micronaut.docs.injectionpoint
 
-/**
- * A constructor injection point.
- *
- * @param <T> The constructed type
- * @author Graeme Rocher
- * @since 1.0
- */
-public interface ConstructorInjectionPoint<T> extends CallableInjectionPoint<T> {
+import javax.inject.Singleton
 
-    /**
-     * Invoke the constructor.
-     *
-     * @param args The arguments
-     * @return The new value
-     */
-    T invoke(Object... args);
+// tag::class[]
+@Singleton
+internal class Vehicle(@param:Cylinders(6) private val engine: Engine) {
+    fun start(): String {
+        return engine.start()
+    }
 }
+// end::class[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/injectionpoint/VehicleSpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/injectionpoint/VehicleSpec.kt
@@ -1,0 +1,22 @@
+package io.micronaut.docs.injectionpoint
+
+import io.micronaut.context.BeanContext
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+
+internal class VehicleSpec {
+
+    @Test
+    fun testStartVehicle() {
+        // tag::start[]
+        BeanContext.run().use {
+            val vehicle = it.getBean(Vehicle::class.java)
+            println(vehicle.start())
+
+
+            Assertions.assertEquals("Starting V6", vehicle.start())
+        }
+        // end::start[]
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/docs/factories/VehicleSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/factories/VehicleSpec.java
@@ -25,7 +25,7 @@ public class VehicleSpec {
 
     @Test
     public void testStartVehicle() {
-        BeanContext beanContext = new DefaultBeanContext().start();
+        BeanContext beanContext = BeanContext.run();
         Vehicle vehicle = beanContext.getBean(Vehicle.class);
         System.out.println( vehicle.start() );
 

--- a/test-suite/src/test/java/io/micronaut/docs/injectionpoint/CrankShaft.java
+++ b/test-suite/src/test/java/io/micronaut/docs/injectionpoint/CrankShaft.java
@@ -13,22 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.inject;
+package io.micronaut.docs.injectionpoint;
 
-/**
- * A constructor injection point.
- *
- * @param <T> The constructed type
- * @author Graeme Rocher
- * @since 1.0
- */
-public interface ConstructorInjectionPoint<T> extends CallableInjectionPoint<T> {
+import javax.inject.Singleton;
 
-    /**
-     * Invoke the constructor.
-     *
-     * @param args The arguments
-     * @return The new value
-     */
-    T invoke(Object... args);
+// tag::class[]
+@Singleton
+class CrankShaft {
 }
+// end::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/injectionpoint/Cylinders.java
+++ b/test-suite/src/test/java/io/micronaut/docs/injectionpoint/Cylinders.java
@@ -1,0 +1,13 @@
+package io.micronaut.docs.injectionpoint;
+
+import java.lang.annotation.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+// tag::class[]
+@Documented
+@Retention(RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface Cylinders {
+    int value() default 8;
+}
+// end::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/injectionpoint/Engine.java
+++ b/test-suite/src/test/java/io/micronaut/docs/injectionpoint/Engine.java
@@ -13,22 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.inject;
+package io.micronaut.docs.injectionpoint;
 
-/**
- * A constructor injection point.
- *
- * @param <T> The constructed type
- * @author Graeme Rocher
- * @since 1.0
- */
-public interface ConstructorInjectionPoint<T> extends CallableInjectionPoint<T> {
-
-    /**
-     * Invoke the constructor.
-     *
-     * @param args The arguments
-     * @return The new value
-     */
-    T invoke(Object... args);
+// tag::class[]
+interface Engine {
+    String start();
 }
+// end::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/injectionpoint/EngineFactory.java
+++ b/test-suite/src/test/java/io/micronaut/docs/injectionpoint/EngineFactory.java
@@ -28,7 +28,7 @@ import io.micronaut.inject.InjectionPoint;
 class EngineFactory {
 
     @Prototype
-    Engine v8Engine(InjectionPoint<Engine> injectionPoint, CrankShaft crankShaft) { // <1>
+    Engine v8Engine(InjectionPoint<?> injectionPoint, CrankShaft crankShaft) { // <1>
         final int cylinders = injectionPoint
                 .getAnnotationMetadata()
                 .intValue(Cylinders.class).orElse(8); // <2>

--- a/test-suite/src/test/java/io/micronaut/docs/injectionpoint/EngineFactory.java
+++ b/test-suite/src/test/java/io/micronaut/docs/injectionpoint/EngineFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.injectionpoint;
+
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Prototype;
+import io.micronaut.inject.InjectionPoint;
+
+/**
+ * @author Graeme Rocher
+ * @since 1.0
+ */
+// tag::class[]
+@Factory
+class EngineFactory {
+
+    @Prototype
+    Engine v8Engine(InjectionPoint<Engine> injectionPoint, CrankShaft crankShaft) { // <1>
+        final int cylinders = injectionPoint
+                .getAnnotationMetadata()
+                .intValue(Cylinders.class).orElse(8); // <2>
+        switch (cylinders) { // <3>
+            case 6:
+                return new V6Engine(crankShaft);
+            case 8:
+                return new V8Engine(crankShaft);
+            default:
+                throw new IllegalArgumentException("Unsupported number of cylinders specified: " + cylinders);
+        }
+    }
+}
+// tag::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/injectionpoint/V6Engine.java
+++ b/test-suite/src/test/java/io/micronaut/docs/injectionpoint/V6Engine.java
@@ -1,0 +1,16 @@
+package io.micronaut.docs.injectionpoint;
+
+// tag::class[]
+class V6Engine implements Engine {
+    private final int cylinders = 6;
+    private final CrankShaft crankShaft;
+
+    public V6Engine(CrankShaft crankShaft) {
+        this.crankShaft = crankShaft;
+    }
+
+    public String start() {
+        return "Starting V6";
+    }
+}
+// end::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/injectionpoint/V8Engine.java
+++ b/test-suite/src/test/java/io/micronaut/docs/injectionpoint/V8Engine.java
@@ -13,22 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.inject;
+package io.micronaut.docs.injectionpoint;
+// tag::class[]
+class V8Engine implements Engine {
+    private final int cylinders = 8;
+    private final CrankShaft crankShaft;
 
-/**
- * A constructor injection point.
- *
- * @param <T> The constructed type
- * @author Graeme Rocher
- * @since 1.0
- */
-public interface ConstructorInjectionPoint<T> extends CallableInjectionPoint<T> {
+    public V8Engine(CrankShaft crankShaft) {
+        this.crankShaft = crankShaft;
+    }
 
-    /**
-     * Invoke the constructor.
-     *
-     * @param args The arguments
-     * @return The new value
-     */
-    T invoke(Object... args);
+    public String start() {
+        return "Starting V8";
+    }
 }
+// end::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/injectionpoint/Vehicle.java
+++ b/test-suite/src/test/java/io/micronaut/docs/injectionpoint/Vehicle.java
@@ -13,22 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.inject;
+package io.micronaut.docs.injectionpoint;
 
-/**
- * A constructor injection point.
- *
- * @param <T> The constructed type
- * @author Graeme Rocher
- * @since 1.0
- */
-public interface ConstructorInjectionPoint<T> extends CallableInjectionPoint<T> {
+import javax.inject.Singleton;
 
-    /**
-     * Invoke the constructor.
-     *
-     * @param args The arguments
-     * @return The new value
-     */
-    T invoke(Object... args);
+// tag::class[]
+@Singleton
+class Vehicle {
+    private final Engine engine;
+    Vehicle(@Cylinders(6) Engine engine) {
+        this.engine = engine;
+    }
+
+    String start() {
+        return engine.start();
+    }
 }
+// end::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/injectionpoint/VehicleSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/injectionpoint/VehicleSpec.java
@@ -13,22 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.inject;
+package io.micronaut.docs.injectionpoint;
 
-/**
- * A constructor injection point.
- *
- * @param <T> The constructed type
- * @author Graeme Rocher
- * @since 1.0
- */
-public interface ConstructorInjectionPoint<T> extends CallableInjectionPoint<T> {
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.DefaultBeanContext;
+import org.junit.Test;
 
-    /**
-     * Invoke the constructor.
-     *
-     * @param args The arguments
-     * @return The new value
-     */
-    T invoke(Object... args);
+import static org.junit.Assert.assertEquals;
+
+public class VehicleSpec {
+
+    @Test
+    public void testStartVehicle() {
+        BeanContext beanContext = BeanContext.run();
+        Vehicle vehicle = beanContext.getBean(Vehicle.class);
+        System.out.println( vehicle.start() );
+
+        assertEquals("Starting V6", vehicle.start());
+
+        beanContext.close();
+    }
 }


### PR DESCRIPTION
Fixes #2716

This targets Micronaut 2.0 as it includes breaking API changes (the addition of generics to some signatures)