### PR TITLE
Support for transforming annotations values and source retention 

### DIFF
--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationValue.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationValue.java
@@ -30,6 +30,7 @@ import io.micronaut.core.util.StringUtils;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.lang.annotation.Annotation;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.Array;
 import java.util.*;
 import java.util.function.Function;
@@ -61,11 +62,7 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
      */
     @UsedByGeneratedCode
     public AnnotationValue(String annotationName, Map<CharSequence, Object> values) {
-        this.annotationName = annotationName;
-        this.convertibleValues = newConvertibleValues(values);
-        this.values = values;
-        this.defaultValues = Collections.emptyMap();
-        this.valueMapper = null;
+        this(annotationName, values, Collections.emptyMap());
     }
 
     /**
@@ -88,11 +85,7 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
     @SuppressWarnings("unchecked")
     @UsedByGeneratedCode
     public AnnotationValue(String annotationName) {
-        this.annotationName = annotationName;
-        this.convertibleValues = ConvertibleValues.EMPTY;
-        this.values = Collections.emptyMap();
-        this.defaultValues = Collections.emptyMap();
-        this.valueMapper = null;
+        this(annotationName, Collections.emptyMap(), Collections.emptyMap());
     }
 
     /**
@@ -103,8 +96,7 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
         this.annotationName = annotationName;
         this.convertibleValues = convertibleValues;
         Map<String, Object> existing = convertibleValues.asMap();
-        this.values = new HashMap<>(existing.size());
-        this.values.putAll(existing);
+        this.values = new HashMap<>(existing);
         this.defaultValues = Collections.emptyMap();
         this.valueMapper = null;
     }
@@ -118,12 +110,24 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
      */
     @Internal
     @UsedByGeneratedCode
-    protected AnnotationValue(AnnotationValue<A> target, Map<String, Object> defaultValues, ConvertibleValues<Object> convertibleValues, Function<Object, Object> valueMapper) {
+    protected AnnotationValue(
+            AnnotationValue<A> target,
+            Map<String, Object> defaultValues,
+            ConvertibleValues<Object> convertibleValues,
+            Function<Object, Object> valueMapper) {
         this.annotationName = target.annotationName;
         this.defaultValues = defaultValues != null ? defaultValues : target.defaultValues;
         this.values = target.values;
         this.convertibleValues = convertibleValues;
         this.valueMapper = valueMapper;
+    }
+
+    /**
+     * @return The retention policy.
+     */
+    @Nonnull
+    public RetentionPolicy getRetentionPolicy() {
+        return RetentionPolicy.CLASS;
     }
 
     /**
@@ -869,6 +873,19 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
      */
     public static <T extends Annotation> AnnotationValueBuilder<T> builder(Class<T> annotation) {
         return new AnnotationValueBuilder<>(annotation);
+    }
+
+    /**
+     * Start building a new annotation existing value and retention policy.
+     *
+     * @param annotation The annotation name
+     * @param retentionPolicy The retention policy. Defaults to runtime.
+     * @param <T> The annotation type
+     * @return The builder
+     */
+    public static <T extends Annotation> AnnotationValueBuilder<T> builder(@Nonnull AnnotationValue<T> annotation, @Nullable RetentionPolicy retentionPolicy) {
+        ArgumentUtils.requireNonNull("annotation", annotation);
+        return new AnnotationValueBuilder<>(annotation, retentionPolicy);
     }
 
     /**

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/annotation/GroovyAnnotationMetadataBuilder.groovy
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/annotation/GroovyAnnotationMetadataBuilder.groovy
@@ -51,6 +51,8 @@ import org.codehaus.groovy.control.SourceUnit
 import javax.annotation.Nonnull
 import java.lang.annotation.Annotation
 import java.lang.annotation.Repeatable
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
 import java.lang.reflect.Array
 
 /**
@@ -95,6 +97,29 @@ class GroovyAnnotationMetadataBuilder extends AbstractAnnotationMetadataBuilder<
             this.elementValidator = null
         }
 
+    }
+
+    @Override
+    protected RetentionPolicy getRetentionPolicy(@Nonnull AnnotatedNode annotation) {
+        List<AnnotationNode> annotations = annotation.getAnnotations()
+        for(ann in annotations) {
+            if (ann.classNode.name == Retention.name) {
+                def i = ann.members.values().iterator()
+                if (i.hasNext()) {
+                    def expr = i.next()
+                    if (expr instanceof PropertyExpression) {
+                        PropertyExpression pe = (PropertyExpression) expr
+                        try {
+                            return RetentionPolicy.valueOf(pe.propertyAsString)
+                        } catch (e) {
+                            // should never happen
+                            return RetentionPolicy.RUNTIME
+                        }
+                    }
+                }
+            }
+        }
+        return RetentionPolicy.RUNTIME
     }
 
     @Override

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/annotation/SourceRetentionSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/annotation/SourceRetentionSpec.groovy
@@ -1,0 +1,28 @@
+package io.micronaut.inject.annotation
+
+import io.micronaut.AbstractBeanDefinitionSpec
+import io.micronaut.inject.BeanDefinition
+
+import java.lang.annotation.Native
+
+class SourceRetentionSpec extends AbstractBeanDefinitionSpec {
+    void "test source retention annotations are not retained"() {
+        given:
+        BeanDefinition definition = buildBeanDefinition('test.Test','''
+package test;
+
+@javax.inject.Singleton
+class Test {
+    
+    
+    @javax.inject.Inject
+    @java.lang.annotation.Native
+    protected String someField;
+    
+}
+''')
+
+        expect:
+        !definition.injectedFields.first().annotationMetadata.hasAnnotation(Native)
+    }
+}

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/annotation/AnnotationTransformerSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/annotation/AnnotationTransformerSpec.groovy
@@ -1,0 +1,40 @@
+package io.micronaut.inject.annotation
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+
+class AnnotationTransformerSpec extends AbstractTypeElementSpec {
+
+    void "test transform annotation metadata"() {
+        given:
+        def definition = buildBeanDefinition('test.Test', '''
+package test;
+
+@io.micronaut.inject.annotation.ToTransform
+@javax.inject.Singleton
+class Test {
+
+}
+''')
+
+        expect:"The original annotation wasn't retained"
+        !definition.hasAnnotation(ToTransform)
+        definition.hasAnnotation('test.Test')
+    }
+
+
+    void "test transform retention level"() {
+        given:
+        def definition = buildBeanDefinition('test.Test', '''
+package test;
+
+@io.micronaut.inject.annotation.ToTransformRetention
+@javax.inject.Singleton
+class Test {
+
+}
+''')
+
+        expect:"The original annotation wasn't retained"
+        definition.hasAnnotation(ToTransformRetention)
+    }
+}

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/annotation/ToTransform.java
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/annotation/ToTransform.java
@@ -1,0 +1,14 @@
+package io.micronaut.inject.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE, ElementType.METHOD})
+public @interface ToTransform {
+}

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/annotation/ToTransformRetention.java
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/annotation/ToTransformRetention.java
@@ -1,0 +1,15 @@
+package io.micronaut.inject.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
+@Documented
+@Retention(SOURCE)
+@Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE, ElementType.METHOD})
+public @interface ToTransformRetention {
+}
+

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/annotation/ToTransformRetentionTransformer.java
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/annotation/ToTransformRetentionTransformer.java
@@ -1,0 +1,26 @@
+package io.micronaut.inject.annotation;
+
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.inject.visitor.VisitorContext;
+
+import javax.annotation.Nonnull;
+import java.lang.annotation.Annotation;
+import java.lang.annotation.RetentionPolicy;
+import java.util.Collections;
+import java.util.List;
+
+public class ToTransformRetentionTransformer implements NamedAnnotationTransformer {
+
+    @Nonnull
+    @Override
+    public String getName() {
+        return ToTransformRetention.class.getName();
+    }
+
+    @Override
+    public List<AnnotationValue<?>> transform(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
+        return Collections.singletonList(
+                AnnotationValue.builder(annotation, RetentionPolicy.RUNTIME).build()
+        );
+    }
+}

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/annotation/ToTransformTransformer.java
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/annotation/ToTransformTransformer.java
@@ -1,0 +1,21 @@
+package io.micronaut.inject.annotation;
+
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.inject.visitor.VisitorContext;
+
+import java.util.Collections;
+import java.util.List;
+
+public class ToTransformTransformer implements TypedAnnotationTransformer<ToTransform> {
+    @Override
+    public List<AnnotationValue<?>> transform(AnnotationValue<ToTransform> annotation, VisitorContext visitorContext) {
+        return Collections.singletonList(
+                AnnotationValue.builder("test.Test").build()
+        );
+    }
+
+    @Override
+    public Class<ToTransform> annotationType() {
+        return ToTransform.class;
+    }
+}

--- a/inject-java-test/src/test/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationTransformer
+++ b/inject-java-test/src/test/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationTransformer
@@ -1,0 +1,2 @@
+io.micronaut.inject.annotation.ToTransformTransformer
+io.micronaut.inject.annotation.ToTransformRetentionTransformer

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/JavaAnnotationMetadataBuilder.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/JavaAnnotationMetadataBuilder.java
@@ -36,6 +36,8 @@ import javax.lang.model.util.Elements;
 import javax.tools.Diagnostic;
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.Array;
 import java.util.*;
 import java.util.stream.Stream;
@@ -128,6 +130,28 @@ public class JavaAnnotationMetadataBuilder extends AbstractAnnotationMetadataBui
     @Override
     protected VisitorContext createVisitorContext() {
         return annotationUtils.newVisitorContext();
+    }
+
+    @Nonnull
+    @Override
+    protected RetentionPolicy getRetentionPolicy(@Nonnull Element annotation) {
+        final List<? extends AnnotationMirror> annotationMirrors = annotation.getAnnotationMirrors();
+        for (AnnotationMirror annotationMirror : annotationMirrors) {
+            final String annotationTypeName = getAnnotationTypeName(annotationMirror);
+            if (Retention.class.getName().equals(annotationTypeName)) {
+
+                final Iterator<? extends AnnotationValue> i = annotationMirror
+                        .getElementValues().values().iterator();
+                if (i.hasNext()) {
+                    final AnnotationValue av = i.next();
+                    final String v = av.getValue().toString();
+                    return RetentionPolicy.valueOf(v);
+                }
+                break;
+            }
+
+        }
+        return RetentionPolicy.RUNTIME;
     }
 
     @Override

--- a/inject-java/src/test/groovy/io/micronaut/inject/annotation/SourceRetentionSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/annotation/SourceRetentionSpec.groovy
@@ -1,0 +1,30 @@
+package io.micronaut.inject.annotation
+
+
+import io.micronaut.inject.AbstractTypeElementSpec
+import io.micronaut.inject.BeanDefinition
+
+import java.lang.annotation.Native
+
+class SourceRetentionSpec extends AbstractTypeElementSpec {
+
+    void "test source retention annotations are not retained"() {
+        given:
+        BeanDefinition definition = buildBeanDefinition('test.Test','''
+package test;
+
+@javax.inject.Singleton
+class Test {
+    
+    
+    @javax.inject.Inject
+    @java.lang.annotation.Native
+    String someField;
+    
+}
+''')
+
+        expect:"source retention annotations are not retained at runtime"
+        !definition.injectedFields.first().annotationMetadata.hasAnnotation(Native)
+    }
+}

--- a/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataWriter.java
@@ -398,13 +398,13 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
             generatorAdapter.loadThis();
         }
         // 1st argument: the declared annotations
-        pushCreateAnnotationData(owningType, declaringClassWriter, generatorAdapter, annotationMetadata.declaredAnnotations, loadTypeMethods);
+        pushCreateAnnotationData(owningType, declaringClassWriter, generatorAdapter, annotationMetadata.declaredAnnotations, loadTypeMethods, annotationMetadata.getSourceRetentionAnnotations());
         // 2nd argument: the declared stereotypes
-        pushCreateAnnotationData(owningType, declaringClassWriter, generatorAdapter, annotationMetadata.declaredStereotypes, loadTypeMethods);
+        pushCreateAnnotationData(owningType, declaringClassWriter, generatorAdapter, annotationMetadata.declaredStereotypes, loadTypeMethods, annotationMetadata.getSourceRetentionAnnotations());
         // 3rd argument: all stereotypes
-        pushCreateAnnotationData(owningType, declaringClassWriter, generatorAdapter, annotationMetadata.allStereotypes, loadTypeMethods);
+        pushCreateAnnotationData(owningType, declaringClassWriter, generatorAdapter, annotationMetadata.allStereotypes, loadTypeMethods, annotationMetadata.getSourceRetentionAnnotations());
         // 4th argument: all annotations
-        pushCreateAnnotationData(owningType, declaringClassWriter, generatorAdapter, annotationMetadata.allAnnotations, loadTypeMethods);
+        pushCreateAnnotationData(owningType, declaringClassWriter, generatorAdapter, annotationMetadata.allAnnotations, loadTypeMethods, annotationMetadata.getSourceRetentionAnnotations());
         // 5th argument: annotations by stereotype
         pushCreateAnnotationsByStereotypeData(generatorAdapter, annotationMetadata.annotationsByStereotype);
 
@@ -485,7 +485,19 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
         }
     }
 
-    private static void pushCreateAnnotationData(Type declaringType, ClassWriter declaringClassWriter, GeneratorAdapter methodVisitor, Map<String, Map<CharSequence, Object>> annotationData, Map<String, GeneratorAdapter> loadTypeMethods) {
+    private static void pushCreateAnnotationData(
+            Type declaringType,
+            ClassWriter declaringClassWriter,
+            GeneratorAdapter methodVisitor,
+            Map<String, Map<CharSequence, Object>> annotationData,
+            Map<String, GeneratorAdapter> loadTypeMethods,
+            Set<String> sourceRetentionAnnotations) {
+        if (annotationData != null) {
+            annotationData = new LinkedHashMap<>(annotationData);
+            for (String sourceRetentionAnnotation : sourceRetentionAnnotations) {
+                annotationData.remove(sourceRetentionAnnotation);
+            }
+        }
         int totalSize = annotationData == null ? 0 : annotationData.size() * 2;
         if (totalSize > 0) {
 

--- a/inject/src/main/java/io/micronaut/inject/annotation/AnnotationTransformer.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AnnotationTransformer.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.annotation;
+
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.inject.visitor.VisitorContext;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+
+/**
+ * An {@code AnnotationTransformer} transforms an annotation definition into one or many other annotation
+ * definitions discarding the original annotation.
+ *
+ * <p>Unlike {@link AnnotationMapper} which retains the original annotation information this interface can
+ * be used to optimize produced annotation metadata and discard unnecessary annotations.</p>
+ *
+ * @since 2.0
+ * @author graemerocher
+ * @see AnnotationMapper
+ * @param <T> The annotation type
+ */
+public interface AnnotationTransformer<T extends Annotation> {
+
+    /**
+     * The transform method will be called for each instances of the annotation returned via this method.
+     *
+     * @param annotation The annotation values
+     * @param visitorContext The context that is being visited
+     * @return A list of zero or many annotations and values to map to
+     */
+    List<AnnotationValue<?>> transform(AnnotationValue<T> annotation, VisitorContext visitorContext);
+}

--- a/inject/src/main/java/io/micronaut/inject/annotation/DefaultAnnotationMetadata.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/DefaultAnnotationMetadata.java
@@ -26,10 +26,12 @@ import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.core.value.OptionalValues;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Repeatable;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.Array;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -93,6 +95,7 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     // should not be used in any of the read methods
     // The following fields are used only at compile time, and
     private Map<String, String> repeated = null;
+    private Set<String> sourceRetentionAnnotations;
 
     /**
      * Constructs empty annotation metadata.
@@ -124,6 +127,17 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
         this.allStereotypes = allStereotypes;
         this.allAnnotations = allAnnotations;
         this.annotationsByStereotype = annotationsByStereotype;
+    }
+
+    /**
+     * @return The annotations that are source retention.
+     */
+    @Internal
+    Set<String> getSourceRetentionAnnotations() {
+        if (sourceRetentionAnnotations != null) {
+            return Collections.unmodifiableSet(sourceRetentionAnnotations);
+        }
+        return Collections.emptySet();
     }
 
     @Nonnull
@@ -172,11 +186,12 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
 
     /**
      * Retrieve the class value and optionally map its value.
-     * @param annotation The annotation
-     * @param member The member
-     * @param enumType The enum type
+     *
+     * @param annotation  The annotation
+     * @param member      The member
+     * @param enumType    The enum type
      * @param valueMapper The value mapper
-     * @param <E> The enum type
+     * @param <E>         The enum type
      * @return The class value
      */
     @Override
@@ -243,11 +258,12 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
 
     /**
      * Retrieve the class value and optionally map its value.
-     * @param annotation The annotation
-     * @param member The member
-     * @param enumType The enum type
+     *
+     * @param annotation  The annotation
+     * @param member      The member
+     * @param enumType    The enum type
      * @param valueMapper The value mapper
-     * @param <E> The enum type
+     * @param <E>         The enum type
      * @return The class value
      */
     @Override
@@ -312,8 +328,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
 
     /**
      * Retrieve the class value and optionally map its value.
-     * @param annotation The annotation
-     * @param member The member
+     *
+     * @param annotation  The annotation
+     * @param member      The member
      * @param valueMapper The value mapper
      * @return The class value
      */
@@ -345,8 +362,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
 
     /**
      * Retrieve the class value and optionally map its value.
-     * @param annotation The annotation
-     * @param member The member
+     *
+     * @param annotation  The annotation
+     * @param member      The member
      * @param valueMapper The value mapper
      * @return The class value
      */
@@ -383,8 +401,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
 
     /**
      * Retrieve the int value and optionally map its value.
-     * @param annotation The annotation
-     * @param member The member
+     *
+     * @param annotation  The annotation
+     * @param member      The member
      * @param valueMapper The value mapper
      * @return The int value
      */
@@ -418,15 +437,16 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
         return booleanValue(annotation, member, null);
     }
 
-     /**
+    /**
      * Retrieve the boolean value and optionally map its value.
-     * @param annotation The annotation
-     * @param member The member
+     *
+     * @param annotation  The annotation
+     * @param member      The member
      * @param valueMapper The value mapper
      * @return The boolean value
      */
-     @Override
-     public Optional<Boolean> booleanValue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member, Function<Object, Object> valueMapper) {
+    @Override
+    public Optional<Boolean> booleanValue(@Nonnull Class<? extends Annotation> annotation, @Nonnull String member, Function<Object, Object> valueMapper) {
         ArgumentUtils.requireNonNull("annotation", annotation);
         ArgumentUtils.requireNonNull("member", member);
         final Repeatable repeatable = annotation.getAnnotation(Repeatable.class);
@@ -443,8 +463,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
 
     /**
      * Retrieve the boolean value and optionally map its value.
-     * @param annotation The annotation
-     * @param member The member
+     *
+     * @param annotation  The annotation
+     * @param member      The member
      * @param valueMapper The value mapper
      * @return The boolean value
      */
@@ -477,8 +498,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
 
     /**
      * Retrieve the long value and optionally map its value.
-     * @param annotation The annotation
-     * @param member The member
+     *
+     * @param annotation  The annotation
+     * @param member      The member
      * @param valueMapper The value mapper
      * @return The long value
      */
@@ -501,8 +523,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
 
     /**
      * Retrieve the long value and optionally map its value.
-     * @param annotation The annotation
-     * @param member The member
+     *
+     * @param annotation  The annotation
+     * @param member      The member
      * @param valueMapper The value mapper
      * @return The long value
      */
@@ -529,8 +552,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
 
     /**
      * Retrieve the int value and optionally map its value.
-     * @param annotation The annotation
-     * @param member The member
+     *
+     * @param annotation  The annotation
+     * @param member      The member
      * @param valueMapper The value mapper
      * @return The int value
      */
@@ -563,8 +587,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
 
     /**
      * Retrieve the string value and optionally map its value.
-     * @param annotation The annotation
-     * @param member The member
+     *
+     * @param annotation  The annotation
+     * @param member      The member
      * @param valueMapper The value mapper
      * @return The int value
      */
@@ -591,8 +616,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
 
     /**
      * Retrieve the string value and optionally map its value.
-     * @param annotation The annotation
-     * @param member The member
+     *
+     * @param annotation  The annotation
+     * @param member      The member
      * @param valueMapper The value mapper
      * @return The int value
      */
@@ -624,8 +650,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
 
     /**
      * Retrieve the string value and optionally map its value.
-     * @param annotation The annotation
-     * @param member The member
+     *
+     * @param annotation  The annotation
+     * @param member      The member
      * @param valueMapper The value mapper
      * @return The string value
      */
@@ -651,8 +678,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
 
     /**
      * Retrieve the boolean value and optionally map its value.
-     * @param annotation The annotation
-     * @param member The member
+     *
+     * @param annotation  The annotation
+     * @param member      The member
      * @param valueMapper The value mapper
      * @return The boolean value
      */
@@ -682,8 +710,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
 
     /**
      * Retrieve the boolean value and optionally map its value.
-     * @param annotation The annotation
-     * @param member The member
+     *
+     * @param annotation  The annotation
+     * @param member      The member
      * @param valueMapper The value mapper
      * @return The boolean value
      */
@@ -721,8 +750,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
 
     /**
      * Retrieve the double value and optionally map its value.
-     * @param annotation The annotation
-     * @param member The member
+     *
+     * @param annotation  The annotation
+     * @param member      The member
      * @param valueMapper The value mapper
      * @return The double value
      */
@@ -745,8 +775,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
 
     /**
      * Retrieve the double value and optionally map its value.
-     * @param annotation The annotation
-     * @param member The member
+     *
+     * @param annotation  The annotation
+     * @param member      The member
      * @param valueMapper The value mapper
      * @return The double value
      */
@@ -801,11 +832,12 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
 
     /**
      * Resolves the given value performing type conversion as necessary.
-     * @param annotation The annotation
-     * @param member The member
+     *
+     * @param annotation   The annotation
+     * @param member       The member
      * @param requiredType The required type
-     * @param valueMapper The value mapper
-     * @param <T> The generic type
+     * @param valueMapper  The value mapper
+     * @param <T>          The generic type
      * @return The resolved value
      */
     @Override
@@ -1010,7 +1042,8 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     }
 
     @Override
-    public @Nonnull List<String> getAnnotationNamesByStereotype(@Nullable String stereotype) {
+    public @Nonnull
+    List<String> getAnnotationNamesByStereotype(@Nullable String stereotype) {
         if (stereotype == null) {
             return Collections.emptyList();
         }
@@ -1136,7 +1169,8 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     }
 
     @Override
-    public @Nonnull <T> Optional<T> getDefaultValue(@Nonnull String annotation, @Nonnull String member, @Nonnull Argument<T> requiredType) {
+    public @Nonnull
+    <T> Optional<T> getDefaultValue(@Nonnull String annotation, @Nonnull String member, @Nonnull Argument<T> requiredType) {
         ArgumentUtils.requireNonNull("annotation", annotation);
         ArgumentUtils.requireNonNull("member", member);
         ArgumentUtils.requireNonNull("requiredType", requiredType);
@@ -1168,6 +1202,20 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
      */
     @SuppressWarnings("WeakerAccess")
     protected final void addAnnotation(String annotation, Map<CharSequence, Object> values) {
+        addAnnotation(annotation, values, RetentionPolicy.RUNTIME);
+    }
+
+
+    /**
+     * Adds an annotation and its member values, if the annotation already exists the data will be merged with existing
+     * values replaced.
+     *
+     * @param annotation      The annotation
+     * @param values          The values
+     * @param retentionPolicy The retention policy
+     */
+    @SuppressWarnings("WeakerAccess")
+    protected final void addAnnotation(String annotation, Map<CharSequence, Object> values, RetentionPolicy retentionPolicy) {
         if (annotation != null) {
             String repeatedName = getRepeatedName(annotation);
             Object v = values.get(AnnotationMetadata.VALUE_MEMBER);
@@ -1185,7 +1233,7 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
                 }
             } else {
                 Map<String, Map<CharSequence, Object>> allAnnotations = getAllAnnotations();
-                addAnnotation(annotation, values, null, allAnnotations, false);
+                addAnnotation(annotation, values, null, allAnnotations, false, retentionPolicy);
             }
         }
     }
@@ -1268,10 +1316,21 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
      * @param annotationValue The annotation value
      */
     protected final void addRepeatable(String annotationName, io.micronaut.core.annotation.AnnotationValue annotationValue) {
+        addRepeatable(annotationName, annotationValue, annotationValue.getRetentionPolicy());
+    }
+
+    /**
+     * Adds a repeatable annotation value. If a value already exists will be added
+     *
+     * @param annotationName  The annotation name
+     * @param annotationValue The annotation value
+     * @param retentionPolicy The retention policy
+     */
+    protected final void addRepeatable(String annotationName, io.micronaut.core.annotation.AnnotationValue annotationValue, RetentionPolicy retentionPolicy) {
         if (StringUtils.isNotEmpty(annotationName) && annotationValue != null) {
             Map<String, Map<CharSequence, Object>> allAnnotations = getAllAnnotations();
 
-            addRepeatableInternal(annotationName, annotationValue, allAnnotations);
+            addRepeatableInternal(annotationName, annotationValue, allAnnotations, retentionPolicy);
         }
     }
 
@@ -1291,7 +1350,7 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
             }
         }
 
-        addRepeatableInternal(stereotype, annotationValue, allStereotypes);
+        addRepeatableInternal(stereotype, annotationValue, allStereotypes, RetentionPolicy.RUNTIME);
     }
 
     /**
@@ -1310,8 +1369,8 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
             }
         }
 
-        addRepeatableInternal(stereotype, annotationValue, declaredStereotypes);
-        addRepeatableInternal(stereotype, annotationValue, getAllStereotypes());
+        addRepeatableInternal(stereotype, annotationValue, declaredStereotypes, RetentionPolicy.RUNTIME);
+        addRepeatableInternal(stereotype, annotationValue, getAllStereotypes(), RetentionPolicy.RUNTIME);
     }
 
     /**
@@ -1321,10 +1380,21 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
      * @param annotationValue The annotation value
      */
     protected final void addDeclaredRepeatable(String annotationName, io.micronaut.core.annotation.AnnotationValue annotationValue) {
+        addDeclaredRepeatable(annotationName, annotationValue, annotationValue.getRetentionPolicy());
+    }
+
+    /**
+     * Adds a repeatable annotation value. If a value already exists will be added
+     *
+     * @param annotationName  The annotation name
+     * @param annotationValue The annotation value
+     * @param retentionPolicy The retention policy
+     */
+    protected final void addDeclaredRepeatable(String annotationName, io.micronaut.core.annotation.AnnotationValue annotationValue, RetentionPolicy retentionPolicy) {
         if (StringUtils.isNotEmpty(annotationName) && annotationValue != null) {
             Map<String, Map<CharSequence, Object>> allAnnotations = getDeclaredAnnotationsInternal();
 
-            addRepeatableInternal(annotationName, annotationValue, allAnnotations);
+            addRepeatableInternal(annotationName, annotationValue, allAnnotations, retentionPolicy);
 
             addRepeatable(annotationName, annotationValue);
         }
@@ -1341,6 +1411,21 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
      */
     @SuppressWarnings("WeakerAccess")
     protected final void addStereotype(List<String> parentAnnotations, String stereotype, Map<CharSequence, Object> values) {
+        addStereotype(parentAnnotations, stereotype, values, RetentionPolicy.RUNTIME);
+    }
+
+
+    /**
+     * Adds a stereotype and its member values, if the annotation already exists the data will be merged with existing
+     * values replaced.
+     *
+     * @param parentAnnotations The parent annotations
+     * @param stereotype        The annotation
+     * @param values            The values
+     * @param retentionPolicy   The retention policy
+     */
+    @SuppressWarnings("WeakerAccess")
+    protected final void addStereotype(List<String> parentAnnotations, String stereotype, Map<CharSequence, Object> values, RetentionPolicy retentionPolicy) {
         if (stereotype != null) {
             String repeatedName = getRepeatedName(stereotype);
             if (repeatedName != null) {
@@ -1373,10 +1458,10 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
                         values,
                         null,
                         allStereotypes,
-                        false
+                        false,
+                        retentionPolicy
                 );
             }
-
         }
     }
 
@@ -1390,6 +1475,20 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
      */
     @SuppressWarnings("WeakerAccess")
     protected final void addDeclaredStereotype(List<String> parentAnnotations, String stereotype, Map<CharSequence, Object> values) {
+        addDeclaredStereotype(parentAnnotations, stereotype, values, RetentionPolicy.RUNTIME);
+    }
+
+    /**
+     * Adds a stereotype and its member values, if the annotation already exists the data will be merged with existing
+     * values replaced.
+     *
+     * @param parentAnnotations The parent annotations
+     * @param stereotype        The annotation
+     * @param values            The values
+     * @param retentionPolicy   The retention policy
+     */
+    @SuppressWarnings("WeakerAccess")
+    protected final void addDeclaredStereotype(List<String> parentAnnotations, String stereotype, Map<CharSequence, Object> values, RetentionPolicy retentionPolicy) {
         if (stereotype != null) {
             String repeatedName = getRepeatedName(stereotype);
             if (repeatedName != null) {
@@ -1422,7 +1521,8 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
                         values,
                         declaredStereotypes,
                         allStereotypes,
-                        true
+                        true,
+                        retentionPolicy
                 );
             }
 
@@ -1437,6 +1537,18 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
      * @param values     The values
      */
     protected void addDeclaredAnnotation(String annotation, Map<CharSequence, Object> values) {
+        addDeclaredAnnotation(annotation, values, RetentionPolicy.RUNTIME);
+    }
+
+    /**
+     * Adds an annotation directly declared on the element and its member values, if the annotation already exists the
+     * data will be merged with existing values replaced.
+     *
+     * @param annotation      The annotation
+     * @param values          The values
+     * @param retentionPolicy The retention policy
+     */
+    protected void addDeclaredAnnotation(String annotation, Map<CharSequence, Object> values, RetentionPolicy retentionPolicy) {
         if (annotation != null) {
             String repeatedName = getRepeatedName(annotation);
             if (repeatedName != null) {
@@ -1457,7 +1569,7 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
             } else {
                 Map<String, Map<CharSequence, Object>> declaredAnnotations = getDeclaredAnnotationsInternal();
                 Map<String, Map<CharSequence, Object>> allAnnotations = getAllAnnotations();
-                addAnnotation(annotation, values, declaredAnnotations, allAnnotations, true);
+                addAnnotation(annotation, values, declaredAnnotations, allAnnotations, true, retentionPolicy);
             }
         }
     }
@@ -1499,13 +1611,25 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
 
     private void addAnnotation(String annotation,
                                Map<CharSequence, Object> values,
-                               Map<String, Map<CharSequence, Object>> declaredAnnotations, Map<String,
-            Map<CharSequence, Object>> allAnnotations,
-                               boolean isDeclared) {
+                               Map<String, Map<CharSequence, Object>> declaredAnnotations,
+                               Map<String, Map<CharSequence, Object>> allAnnotations,
+                               boolean isDeclared,
+                               RetentionPolicy retentionPolicy) {
         if (isDeclared && declaredAnnotations != null) {
             putValues(annotation, values, declaredAnnotations);
         }
         putValues(annotation, values, allAnnotations);
+
+        if (retentionPolicy == RetentionPolicy.SOURCE) {
+            addSourceRetentionAnnotation(annotation);
+        }
+    }
+
+    private void addSourceRetentionAnnotation(String annotation) {
+        if (sourceRetentionAnnotations == null) {
+            sourceRetentionAnnotations = new HashSet<>(5);
+        }
+        sourceRetentionAnnotations.add(annotation);
     }
 
     private void putValues(String annotation, Map<CharSequence, Object> values, Map<String, Map<CharSequence, Object>> currentAnnotationValues) {
@@ -1593,7 +1717,8 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
         return annotations;
     }
 
-    private @Nullable Object getRawSingleValue(@Nonnull String annotation, @Nonnull String member, @Nullable Function<Object, Object> valueMapper) {
+    private @Nullable
+    Object getRawSingleValue(@Nonnull String annotation, @Nonnull String member, @Nullable Function<Object, Object> valueMapper) {
         Object rawValue = getRawValue(annotation, member);
         if (rawValue != null) {
             if (rawValue.getClass().isArray()) {
@@ -1632,16 +1757,28 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
         return rawValue;
     }
 
-    private void addRepeatableInternal(String annotationName, io.micronaut.core.annotation.AnnotationValue annotationValue, Map<String, Map<CharSequence, Object>> allAnnotations) {
-        addRepeatableInternal(annotationName, AnnotationMetadata.VALUE_MEMBER, annotationValue, allAnnotations);
+    private void addRepeatableInternal(
+            String annotationName,
+            io.micronaut.core.annotation.AnnotationValue annotationValue,
+            Map<String, Map<CharSequence, Object>> allAnnotations,
+            RetentionPolicy retentionPolicy) {
+        addRepeatableInternal(annotationName, AnnotationMetadata.VALUE_MEMBER, annotationValue, allAnnotations, retentionPolicy);
     }
 
-    private void addRepeatableInternal(String annotationName, String member, io.micronaut.core.annotation.AnnotationValue annotationValue, Map<String, Map<CharSequence, Object>> allAnnotations) {
+    private void addRepeatableInternal(
+            String annotationName,
+            String member,
+            io.micronaut.core.annotation.AnnotationValue annotationValue,
+            Map<String, Map<CharSequence, Object>> allAnnotations,
+            RetentionPolicy retentionPolicy) {
         if (repeated == null) {
             repeated = new HashMap<>(2);
         }
 
         repeated.put(annotationName, annotationValue.getAnnotationName());
+        if (retentionPolicy == RetentionPolicy.SOURCE) {
+            addSourceRetentionAnnotation(annotationName);
+        }
 
         Map<CharSequence, Object> values = allAnnotations.computeIfAbsent(annotationName, s -> new HashMap<>());
         Object v = values.get(member);

--- a/inject/src/main/java/io/micronaut/inject/annotation/EnvironmentAnnotationValue.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/EnvironmentAnnotationValue.java
@@ -20,7 +20,6 @@ import io.micronaut.context.env.PropertyPlaceholderResolver;
 import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Internal;
-
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
 import java.util.stream.Stream;
@@ -49,7 +48,7 @@ class EnvironmentAnnotationValue<A extends Annotation> extends AnnotationValue<A
             PropertyPlaceholderResolver resolver = environment.getPlaceholderResolver();
             if (o instanceof String) {
                 String v = (String) o;
-                if (v.contains("${")) {
+                if (v.contains(resolver.getPrefix())) {
                     return resolver.resolveRequiredPlaceholders(v);
                 }
             } else if (o instanceof String[]) {

--- a/inject/src/main/java/io/micronaut/inject/annotation/NamedAnnotationTransformer.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/NamedAnnotationTransformer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.annotation;
+
+import io.micronaut.core.naming.Named;
+
+import java.lang.annotation.Annotation;
+
+/**
+ * A named {@link AnnotationTransformer} operates against any named annotation, and does not require the
+ * annotation to be on the annotation processor classpath.
+ *
+ * @author graemerocher
+ * @since 2.0
+ */
+public interface NamedAnnotationTransformer extends AnnotationTransformer<Annotation>, Named {
+}

--- a/inject/src/main/java/io/micronaut/inject/annotation/TypedAnnotationTransformer.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/TypedAnnotationTransformer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.annotation;
+
+import java.lang.annotation.Annotation;
+
+/**
+ * A typed {@link AnnotationTransformer} operates against a concrete annotation type. Mapper implementations
+ * that implement this class require the annotations to exist on the annotation processor classpath. If this
+ * is problematic consider {@link NamedAnnotationMapper}.
+ *
+ * @param <T> The annotation type.
+ * @since 2.0
+ * @author graemerocher
+ */
+public interface TypedAnnotationTransformer<T extends Annotation> extends AnnotationTransformer<T> {
+
+    /**
+     * The annotation type to be mapped.
+     *
+     * @return The annotation type
+     */
+    Class<T> annotationType();
+}


### PR DESCRIPTION
This change introduces a new interface, `AnnotationTransformer`, that discards the original annotation thus adding the ability for extensions to optimize memory consumption by not retaining metadata that is not used at runtime.

In addition this change provides a solution to transform existing runtime annotations to source level annotations which provides a potential solution for #2703.

This change is also breaking as it alters Micronaut to properly respect source level retention defined in annotations. Source level annotations will no longer be retained metadata from Micronaut 2.0 onwards.