### PR TITLE
Dependabot config file

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,11 @@
+version: 1
+update_configs:
+  - package_manager: "java:gradle"
+    directory: "/"
+    update_schedule: "daily"
+    default_labels:
+      - "type: dependency-upgrade"
+    automerged_updates:
+      - match:
+          dependency_name: "com.amazonaws:*"
+          update_type: "semver:patch"


### PR DESCRIPTION
Allows auto-merging AWS SDK patch releases.