### PR TITLE
Avoid re-encoding messages if already provided as a Frame

### DIFF
--- a/http-netty/src/main/java/io/micronaut/http/netty/websocket/NettyRxWebSocketSession.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/websocket/NettyRxWebSocketSession.java
@@ -137,8 +137,12 @@ public class NettyRxWebSocketSession implements RxWebSocketSession {
         if (isOpen()) {
             if (message != null) {
                 CompletableFuture<T> future = new CompletableFuture<>();
-
-                WebSocketFrame frame = messageEncoder.encodeMessage(message, mediaType);
+                WebSocketFrame frame;
+                if (message instanceof WebSocketFrame) {
+                    frame = (WebSocketFrame) message;
+                } else {
+                    frame = messageEncoder.encodeMessage(message, mediaType);
+                }
                 channel.writeAndFlush(frame).addListener(f -> {
                     if (f.isSuccess()) {
                         future.complete(message);
@@ -160,7 +164,12 @@ public class NettyRxWebSocketSession implements RxWebSocketSession {
         if (isOpen()) {
             if (message != null) {
                 try {
-                    WebSocketFrame frame = messageEncoder.encodeMessage(message, mediaType);
+                    WebSocketFrame frame;
+                    if (message instanceof WebSocketFrame) {
+                        frame = (WebSocketFrame) message;
+                    } else {
+                        frame = messageEncoder.encodeMessage(message, mediaType);
+                    }
                     channel.writeAndFlush(frame).sync().get();
                 } catch (InterruptedException e) {
                     throw new WebSocketSessionException("Send interrupt: " + e.getMessage(), e);
@@ -183,7 +192,12 @@ public class NettyRxWebSocketSession implements RxWebSocketSession {
             if (!isOpen()) {
                 emitter.onError(new WebSocketSessionException("Session closed"));
             } else {
-                WebSocketFrame frame = messageEncoder.encodeMessage(message, mediaType);
+                WebSocketFrame frame;
+                if (message instanceof WebSocketFrame) {
+                    frame = (WebSocketFrame) message;
+                } else {
+                    frame = messageEncoder.encodeMessage(message, mediaType);
+                }
 
                 ChannelFuture channelFuture = channel.writeAndFlush(frame);
                 channelFuture.addListener(future -> {

--- a/http-netty/src/main/java/io/micronaut/http/netty/websocket/NettyRxWebSocketSession.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/websocket/NettyRxWebSocketSession.java
@@ -108,6 +108,11 @@ public class NettyRxWebSocketSession implements RxWebSocketSession {
     }
 
     @Override
+    public boolean isWritable() {
+        return channel.isWritable();
+    }
+
+    @Override
     public boolean isSecure() {
         return isSecure;
     }

--- a/websocket/src/main/java/io/micronaut/websocket/WebSocketSession.java
+++ b/websocket/src/main/java/io/micronaut/websocket/WebSocketSession.java
@@ -56,6 +56,12 @@ public interface WebSocketSession extends MutableConvertibleValues<Object>, Auto
     boolean isOpen();
 
     /**
+     * Whether the session is writable. It may not be writable, if the buffer is currently full
+     * @return True if it is
+     */
+    boolean isWritable();
+
+    /**
      * Whether the connection is secure.
      *
      * @return True if it is secure


### PR DESCRIPTION
Helps in cases when the user wants to send the same message to multiple sessions, like this:
```
public void sendToMultipleChannels(final String json, final Collection<WebSocketSession> sessions) {
        final TextWebSocketFrame frame = new TextWebSocketFrame(json);
        try {
            Iterator<WebSocketSession> iterator = sessions.iterator();
            while(iterator.hasNext()) {
                WebSocketSession s = iterator.next();
                if (s.isOpen()) {
                    s.sendAsync(frame.retainedDuplicate(), MediaType.APPLICATION_JSON_TYPE);
                } else {
                    iterator.remove();
                }
            }
        } finally {
            frame.release();
        }
    }
```

The second commit merely exposes the writable status. This is an important piece of information in case we have a slow consumer whose send-buffer is already full. Instead of letting netty increase the buffer size (and eventually reaching OOM) we could chose to either wait until it becomes writable (backpressue) or disconnect.