### PR TITLE
Default to manual thread selection for Micronaut 2.0 & clarify docs. Fixes #2215

### DIFF
--- a/core/src/main/java/io/micronaut/core/convert/DefaultArgumentConversionContext.java
+++ b/core/src/main/java/io/micronaut/core/convert/DefaultArgumentConversionContext.java
@@ -33,7 +33,7 @@ class DefaultArgumentConversionContext<T> implements ArgumentConversionContext<T
     private final Argument<T> argument;
     private final Locale finalLocale;
     private final Charset finalCharset;
-    private final List<ConversionError> conversionErrors = new ArrayList<>();
+    private final List<ConversionError> conversionErrors = new ArrayList<>(3);
 
     /**
      * @param argument     The argument

--- a/http-client/src/test/groovy/io/micronaut/http/client/JsonStreamSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/JsonStreamSpec.groovy
@@ -24,6 +24,8 @@ import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Post
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.annotation.ScheduleOn
 import io.reactivex.Flowable
 import io.reactivex.Single
 import org.reactivestreams.Publisher
@@ -205,6 +207,7 @@ class JsonStreamSpec  extends Specification {
     }
 
     @Controller("/jsonstream/books")
+    @ScheduleOn(TaskExecutors.IO)
     static class BookController {
 
         @Get(produces = MediaType.APPLICATION_JSON_STREAM)

--- a/http-client/src/test/groovy/io/micronaut/http/client/sse/ServerSentEventStreamingSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/sse/ServerSentEventStreamingSpec.groovy
@@ -24,6 +24,8 @@ import io.micronaut.http.annotation.Get
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.http.sse.Event
 import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.annotation.ScheduleOn
 import io.reactivex.Flowable
 import spock.lang.AutoCleanup
 import spock.lang.Shared
@@ -119,6 +121,7 @@ class ServerSentEventStreamingSpec extends Specification {
     }
 
     @Controller("/stream/sse")
+    @ScheduleOn(TaskExecutors.IO)
     static class SseController {
 
 

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
@@ -975,19 +975,28 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
         // Select the most appropriate Executor
         ExecutorService executor;
         final ThreadSelection threadSelection = serverConfiguration.getThreadSelection();
+        final MediaType contentType = request.getContentType().orElse(null);
         switch (threadSelection) {
             case MANUAL:
-                executor = null;
+                if (MediaType.APPLICATION_JSON_STREAM_TYPE.equals(contentType)) {
+                    executor = ioExecutor;
+                } else {
+                    executor = null;
+                }
             break;
             case IO:
                 executor = ioExecutor;
             break;
             case AUTO:
             default:
-                if (route instanceof MethodBasedRouteMatch) {
-                    executor = executorSelector.select((MethodBasedRouteMatch) route, threadSelection).orElse(null);
+                if (MediaType.APPLICATION_JSON_STREAM_TYPE.equals(contentType)) {
+                    executor = ioExecutor;
                 } else {
-                    executor = null;
+                    if (route instanceof MethodBasedRouteMatch) {
+                        executor = executorSelector.select((MethodBasedRouteMatch) route, threadSelection).orElse(null);
+                    } else {
+                        executor = null;
+                    }
                 }
                 break;
         }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
@@ -1491,7 +1491,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
                             ByteBufOutputStream outputStream = new ByteBufOutputStream(byteBuf);
                             writable.writeTo(outputStream, requestReference.get().getCharacterEncoding());
                             return byteBuf;
-                        }).subscribe((byteBuf -> {
+                        }).subscribeOn(Schedulers.from(ioExecutor)).subscribe((byteBuf -> {
                             emitter.onNext(byteBuf);
                             emitter.onComplete();
                         }));

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
@@ -90,6 +90,7 @@ import io.micronaut.http.server.netty.types.files.NettySystemFileCustomizableRes
 import io.micronaut.http.server.types.files.FileCustomizableResponseType;
 import io.micronaut.inject.BeanType;
 import io.micronaut.inject.MethodExecutionHandle;
+import io.micronaut.inject.MethodReference;
 import io.micronaut.inject.qualifiers.Qualifiers;
 import io.micronaut.runtime.http.codec.TextPlainCodec;
 import io.micronaut.scheduling.executor.ExecutorSelector;
@@ -975,11 +976,10 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
         // Select the most appropriate Executor
         ExecutorService executor;
         final ThreadSelection threadSelection = serverConfiguration.getThreadSelection();
-        final MediaType contentType = request.getContentType().orElse(null);
         switch (threadSelection) {
             case MANUAL:
-                if (MediaType.APPLICATION_JSON_STREAM_TYPE.equals(contentType)) {
-                    executor = ioExecutor;
+                if (route instanceof MethodReference) {
+                    executor = executorSelector.select((MethodReference) route, threadSelection).orElse(null);
                 } else {
                     executor = null;
                 }
@@ -989,14 +989,10 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
             break;
             case AUTO:
             default:
-                if (MediaType.APPLICATION_JSON_STREAM_TYPE.equals(contentType)) {
-                    executor = ioExecutor;
+                if (route instanceof MethodReference) {
+                    executor = executorSelector.select((MethodReference) route, threadSelection).orElse(null);
                 } else {
-                    if (route instanceof MethodBasedRouteMatch) {
-                        executor = executorSelector.select((MethodBasedRouteMatch) route, threadSelection).orElse(null);
-                    } else {
-                        executor = null;
-                    }
+                    executor = null;
                 }
                 break;
         }

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/threading/ThreadSelectionSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/threading/ThreadSelectionSpec.groovy
@@ -7,6 +7,8 @@ import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.annotation.ScheduleOn
 import io.micronaut.scheduling.executor.ThreadSelection
 import io.reactivex.Single
 import spock.lang.Specification
@@ -30,10 +32,10 @@ class ThreadSelectionSpec extends Specification {
         embeddedServer.close()
 
         where:
-        strategy               | blocking            | nonBlocking         | reactive            | blockingReactive
-        ThreadSelection.AUTO   | 'pool-'             | 'nioEventLoopGroup' | 'nioEventLoopGroup' | 'pool-'
-        ThreadSelection.IO     | 'pool-'             | 'pool-'             | 'pool-'             | 'pool-'
-        ThreadSelection.MANUAL | 'nioEventLoopGroup' | 'nioEventLoopGroup' | 'nioEventLoopGroup' | 'nioEventLoopGroup'
+        strategy               | blocking            | nonBlocking         | reactive            | blockingReactive    | scheduleBlocking | scheduleReactive
+        ThreadSelection.AUTO   | 'pool-'             | 'nioEventLoopGroup' | 'nioEventLoopGroup' | 'pool-'             | "pool-"          | "pool-"
+        ThreadSelection.IO     | 'pool-'             | 'pool-'             | 'pool-'             | 'pool-'             | "pool-"          | "pool-"
+        ThreadSelection.MANUAL | 'nioEventLoopGroup' | 'nioEventLoopGroup' | 'nioEventLoopGroup' | 'nioEventLoopGroup' | "pool-"          | "pool-"
 
 
     }
@@ -51,6 +53,13 @@ class ThreadSelectionSpec extends Specification {
 
         @Get("/reactiveblocking")
         Single<String> reactiveBlocking()
+
+        @Get("/scheduleblocking")
+        String scheduleBlocking()
+
+        @Get("/schedulereactive")
+        Single<String> scheduleReactive()
+
     }
 
     @Controller("/thread-selection")
@@ -74,6 +83,18 @@ class ThreadSelectionSpec extends Specification {
         @Get("/reactiveblocking")
         @Blocking
         Single<String> reactiveBlocking() {
+            Single.fromCallable({ -> "thread: ${Thread.currentThread().name}" })
+        }
+
+        @Get("/scheduleblocking")
+        @ScheduleOn(TaskExecutors.IO)
+        String scheduleBlocking() {
+            return "thread: ${Thread.currentThread().name}"
+        }
+
+        @Get("/schedulereactive")
+        @ScheduleOn(TaskExecutors.IO)
+        Single<String> scheduleReactive() {
             Single.fromCallable({ -> "thread: ${Thread.currentThread().name}" })
         }
     }

--- a/http-server/src/main/java/io/micronaut/http/server/HttpServerConfiguration.java
+++ b/http-server/src/main/java/io/micronaut/http/server/HttpServerConfiguration.java
@@ -122,7 +122,7 @@ public class HttpServerConfiguration implements ServerContextPathProvider {
 
     private final ApplicationConfiguration applicationConfiguration;
     private Charset defaultCharset;
-    private ThreadSelection threadSelection = ThreadSelection.AUTO;
+    private ThreadSelection threadSelection = ThreadSelection.MANUAL;
 
     /**
      * Default constructor.

--- a/http-server/src/main/java/io/micronaut/http/server/binding/RequestArgumentSatisfier.java
+++ b/http-server/src/main/java/io/micronaut/http/server/binding/RequestArgumentSatisfier.java
@@ -79,7 +79,7 @@ public class RequestArgumentSatisfier {
             // no required arguments so just execute
             argumentValues = Collections.emptyMap();
         } else {
-            argumentValues = new LinkedHashMap<>();
+            argumentValues = new LinkedHashMap<>(requiredArguments.size());
             // Begin try fulfilling the argument requirements
             for (Argument argument : requiredArguments) {
                 getValueForArgument(argument, request, satisfyOptionals).ifPresent((value) ->

--- a/runtime/src/main/java/io/micronaut/scheduling/annotation/ScheduleOn.java
+++ b/runtime/src/main/java/io/micronaut/scheduling/annotation/ScheduleOn.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.scheduling.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Annotation used to indicate which executor service a particular task should run on.
+ *
+ * <p>Micronaut will by default run end user operations in the same thread that executes the request.
+ * This annotation can be used to indicate that a different thread should be used when scheduling
+ * the execution of an operation.</p>
+ *
+ * <p>Used to, for example, offload blocking I/O operations to specifically configured thread pool.</p>
+ *
+ * @author graemerocher
+ * @since 2.0
+ * @see io.micronaut.scheduling.TaskExecutors#IO
+ */
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE, ElementType.TYPE})
+public @interface ScheduleOn {
+    /**
+     * @return The name of a configured executor service.
+     * @see io.micronaut.scheduling.TaskExecutors#IO
+     */
+    String value();
+}

--- a/runtime/src/main/java/io/micronaut/scheduling/exceptions/SchedulerConfigurationException.java
+++ b/runtime/src/main/java/io/micronaut/scheduling/exceptions/SchedulerConfigurationException.java
@@ -17,6 +17,7 @@ package io.micronaut.scheduling.exceptions;
 
 import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.inject.ExecutableMethod;
+import io.micronaut.inject.MethodReference;
 
 /**
  * @author graemerocher
@@ -29,6 +30,14 @@ public class SchedulerConfigurationException extends ConfigurationException {
      * @param message The detailed message
      */
     public SchedulerConfigurationException(ExecutableMethod<?, ?> method, String message) {
+        super("Invalid @Scheduled definition for method: " + method + " - Reason: " + message);
+    }
+
+    /**
+     * @param method  A compile time produced invocation of a method call
+     * @param message The detailed message
+     */
+    public SchedulerConfigurationException(MethodReference<?, ?> method, String message) {
         super("Invalid @Scheduled definition for method: " + method + " - Reason: " + message);
     }
 }

--- a/runtime/src/main/java/io/micronaut/scheduling/executor/DefaultExecutorSelector.java
+++ b/runtime/src/main/java/io/micronaut/scheduling/executor/DefaultExecutorSelector.java
@@ -15,14 +15,16 @@
  */
 package io.micronaut.scheduling.executor;
 
+import io.micronaut.context.BeanLocator;
 import io.micronaut.core.annotation.NonBlocking;
 import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.core.type.Argument;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.inject.MethodReference;
+import io.micronaut.inject.qualifiers.Qualifiers;
 import io.micronaut.scheduling.TaskExecutors;
+import io.micronaut.scheduling.annotation.ScheduleOn;
 
-import javax.inject.Named;
 import javax.inject.Singleton;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
@@ -37,38 +39,42 @@ import java.util.concurrent.ExecutorService;
 @Singleton
 public class DefaultExecutorSelector implements ExecutorSelector {
 
-    private final ExecutorService ioExecutor;
+    private final BeanLocator beanLocator;
 
     /**
-     * Construct a default implementation for the given executor service for asynchronous IO tasks.
-     *
-     * @param ioExecutor A service that provide method to manager termination and produce future for tracking
-     *                   progress of one or more asynchronous IO tasks.
+     * Default constructor.
+     * @param beanLocator The bean locator
      */
-    protected DefaultExecutorSelector(@Named(TaskExecutors.IO) ExecutorService ioExecutor) {
-        this.ioExecutor = ioExecutor;
+    protected DefaultExecutorSelector(BeanLocator beanLocator) {
+        this.beanLocator = beanLocator;
     }
 
     @Override
-    public Optional<ExecutorService> select(MethodReference method) {
-        if (method.hasStereotype(NonBlocking.class)) {
-            return Optional.empty();
-        } else {
-            Class returnType = method.getReturnType().getType();
-            if (isNonBlocking(returnType)) {
+    public Optional<ExecutorService> select(MethodReference method, ThreadSelection threadSelection) {
+        final String name = method.stringValue(ScheduleOn.class).orElse(null);
+        if (name != null) {
+            return beanLocator.findBean(ExecutorService.class, Qualifiers.byName(name));
+        } else if (threadSelection == ThreadSelection.AUTO) {
+            if (method.hasStereotype(NonBlocking.class)) {
                 return Optional.empty();
-            }
-            if (HttpResponse.class.isAssignableFrom(returnType)) {
-                Optional<Argument<?>> generic = method.getReturnType().getFirstTypeVariable();
-                if (generic.isPresent()) {
-                    Class argumentType = generic.get().getType();
-                    if (isNonBlocking(argumentType)) {
-                        return Optional.empty();
+            } else {
+                Class returnType = method.getReturnType().getType();
+                if (isNonBlocking(returnType)) {
+                    return Optional.empty();
+                }
+                if (HttpResponse.class.isAssignableFrom(returnType)) {
+                    Optional<Argument<?>> generic = method.getReturnType().getFirstTypeVariable();
+                    if (generic.isPresent()) {
+                        Class argumentType = generic.get().getType();
+                        if (isNonBlocking(argumentType)) {
+                            return Optional.empty();
+                        }
                     }
                 }
+                return beanLocator.findBean(ExecutorService.class, Qualifiers.byName(TaskExecutors.IO));
             }
         }
-        return Optional.of(ioExecutor);
+        return Optional.empty();
     }
 
     private boolean isNonBlocking(Class type) {

--- a/runtime/src/main/java/io/micronaut/scheduling/executor/ExecutorSelector.java
+++ b/runtime/src/main/java/io/micronaut/scheduling/executor/ExecutorSelector.java
@@ -32,8 +32,9 @@ public interface ExecutorSelector {
      * Select an {@link ExecutorService} for the given {@link MethodReference}.
      *
      * @param method The {@link MethodReference}
+     * @param threadSelection The thread selection mode
      * @return An optional {@link ExecutorService}. If an {@link ExecutorService} cannot be established
      * {@link Optional#empty()} is returned
      */
-    Optional<ExecutorService> select(MethodReference method);
+    Optional<ExecutorService> select(MethodReference method, ThreadSelection threadSelection);
 }

--- a/runtime/src/test/groovy/io/micronaut/runtime/executor/ExecutorSelectorSpec.groovy
+++ b/runtime/src/test/groovy/io/micronaut/runtime/executor/ExecutorSelectorSpec.groovy
@@ -16,6 +16,7 @@
 package io.micronaut.runtime.executor
 
 import grails.gorm.transactions.Transactional
+import io.micronaut.scheduling.executor.ThreadSelection
 import io.reactivex.Single
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Executable
@@ -43,7 +44,7 @@ class ExecutorSelectorSpec extends Specification {
         ExecutorSelector selector = applicationContext.getBean(ExecutorSelector)
         Optional<ExecutableMethod> method = applicationContext.findExecutableMethod(MyService, methodName)
 
-        Optional<ExecutorService> executorService = selector.select(method.get(), threadSelection)
+        Optional<ExecutorService> executorService = selector.select(method.get(), ThreadSelection.AUTO)
 
         expect:
         executorService.isPresent() == present

--- a/runtime/src/test/groovy/io/micronaut/runtime/executor/ExecutorSelectorSpec.groovy
+++ b/runtime/src/test/groovy/io/micronaut/runtime/executor/ExecutorSelectorSpec.groovy
@@ -43,7 +43,7 @@ class ExecutorSelectorSpec extends Specification {
         ExecutorSelector selector = applicationContext.getBean(ExecutorSelector)
         Optional<ExecutableMethod> method = applicationContext.findExecutableMethod(MyService, methodName)
 
-        Optional<ExecutorService> executorService = selector.select(method.get())
+        Optional<ExecutorService> executorService = selector.select(method.get(), threadSelection)
 
         expect:
         executorService.isPresent() == present

--- a/src/main/docs/guide/appendix/breaks.adoc
+++ b/src/main/docs/guide/appendix/breaks.adoc
@@ -1,5 +1,21 @@
 This section will document breaking changes between Micronaut 1.0 and Micronaut 2.0
 
+=== Thread Pool Selection Now Manual
+
+In Micronaut 1.x, Micronaut would attempt to automatically deduce the thread pool to use based on the return type of the controller method.
+
+This approach caused some confusion and created a false association between reactive types and blocking operations.
+
+Micronaut 2.x now leaves it up to the user to specify the thread pool to schedule operations on, including blocking operations.
+
+If you are upgrading from Micronaut 1.x and have a controller that executes blocking I/O operations (such as JDBC or JPA) it is recommended that you add the ann:scheduling.annotation.ScheduleOn[] annotation to schedule the blocking operations on a different thread.
+
+snippet::io.micronaut.docs.http.server.scheduleon.PersonController[tags="imports,class", indent=0,title="Using @ScheduleOn"]
+
+<1> The ann:scheduling.annotation.ScheduleOn[] annotation is used to schedule the operation on the I/O thread pool
+
+NOTE: If you wish to return to the previous behaviour as defined in Micronaut 1.x you can set `micronaut.server.thread-selection` to `AUTO` in configuration.
+
 === Heartbeat Events No Longer Published if no Discovery Clients present
 
 A api:health.HeartbeatEvent[] is no longer published automatically if there are no api:discovery.DiscoveryClient[] instances present.

--- a/src/main/docs/guide/httpServer/jsonBinding.adoc
+++ b/src/main/docs/guide/httpServer/jsonBinding.adoc
@@ -35,14 +35,11 @@ The above example uses the `thenApply` method to achieve the same as the previou
 
 == Binding using POJOs
 
-Note however, that if your method does not do any blocking I/O then you can just as easily write:
+Note however you can just as easily write:
 
 snippet::io.micronaut.docs.server.json.PersonController[tags="class,regular,endclass", indent=0, title="Binding JSON POJOs"]
 
-Micronaut will still using non-blocking I/O to read the JSON and only execute your method once the data has been read.
-
-In other words, as a rule reactive types should be used when you plan to do further downstream I/O operations in which case they can greatly simplify composing operations.
-
+Micronaut will only execute your method once the data has been read in a non-blocking manner.
 
 TIP: The output produced by Jackson can be customized in a variety of manners, from defining Jackson modules to using https://github.com/FasterXML/jackson-annotations/wiki/Jackson-Annotations[Jackson's annotations]
 

--- a/src/main/docs/guide/httpServer/reactiveServer.adoc
+++ b/src/main/docs/guide/httpServer/reactiveServer.adoc
@@ -1,17 +1,10 @@
-As mentioned previously, Micronaut is built on Netty which is designed around an Event loop model and non-blocking I/O.
+As mentioned previously, Micronaut is built on Netty which is designed around an Event loop model and non-blocking I/O. Micronaut will execute code defined in ann:http.annotation.Controller[] beans in the same thread as the request thread (an Event Loop thread).
 
-Although it is recommended to follow a non-blocking approach, in particular when making remote calls to other microservices, Micronaut acknowledges the fact that in real world scenarios developers encounter situations where the need arises to interface with blocking APIs and, in order to facilitate this, features automatic thread selection based on the return type of the method.
-
-If your controller method returns a non-blocking type such as an RxJava `Observable` or a `CompletableFuture` then Micronaut will use the Event loop thread to subscribe to the result.
-
-If however you return any other type then Micronaut will execute your `@Controller` method in a preconfigured I/O thread pool.
-
-WARNING: This means effectively that if you write a method that uses `Single.fromCallable(..)` and block within the body of the callable you may unknowingly block the Netty event loop thread and when writing such logic *you must* also invoke `Single.subscribeOn(..)` to ensure the event loop thread is not blocked.
-
-The I/O thread pool by default is a caching, unbound thread pool. However, you may wish to configure the nature of the thread pool to avoid exhausting resources in applications that perform a lot of blocking I/O under high load.
+This makes it critical that if you do any blocking I/O operations (for example interactions with Hibernate/JPA or JDBC) that you offload those tasks to a separate thread pool that does not block the Event loop.
 
 For example the following configuration will configure the I/O thread pool as a fixed thread pool with 75 threads (similar to what a traditional blocking server such as Tomcat uses in the thread per connection model):
 
+.Configuring the IO thread pool
 [source,yaml]
 ----
 micronaut:
@@ -21,13 +14,21 @@ micronaut:
             nThreads: 75
 ----
 
-If automatic thread selection is undesirable for your application you can either annotate the controller or method with ann:core.annotation.NonBlocking[] in which case all operations of the controller will run on the event loop or alternatively you can completely disable automatic thread selection by setting the `micronaut.server.thread-selection` to one of the values in the api:scheduling.executor.ThreadSelection[] enum. For example the following configuration:
+To use this thread pool in a ann:http.annotation.Controller[] bean you have a number of options. The simplest option is to use the ann:scheduling.annotation.ScheduleOn[] annotation which can be declared at the type or method level to indicate which configured thread pool you wish to run the method or methods of the controller on:
 
-[source,yaml]
-----
-micronaut:
-    server:
-        thread-selection: MANUAL
-----
+snippet::io.micronaut.docs.http.server.scheduleon.PersonController[tags="imports,class", indent=0,title="Using @ScheduleOn"]
 
-Will perform no thread selection and run all operations on the Netty event loop thread. It is then up to the developer to ensure logic that includes blocking I/O is scheduled on another thread by, for example, using RxJava's `subscribeOn(..)` facility or the ann:scheduling.annotation.Async[] annotation (amongst other options).
+<1> The ann:scheduling.annotation.ScheduleOn[] annotation is used to schedule the operation on the I/O thread pool
+
+The value of the ann:scheduling.annotation.ScheduleOn[] annotation can be any named executor defined under `micronaut.executors`.
+
+TIP: Generally speaking for database operations you will want a thread pool configured that matches maximum number of connections you have specified in the database connection pool.
+
+An alternative to the ann:scheduling.annotation.ScheduleOn[] annotation is to use the facility provided by the reactive library you have chosen. RxJava for example features a `subscribeOn` method which allows you to alter which thread executes user code. For example:
+
+snippet::io.micronaut.docs.http.server.reactive.PersonController[tags="imports,class", indent=0,title="RxJava subscribeOn Example"]
+
+<1> The configured I/O executor service is injected
+<2> RxJava's `fromCallable` method is used to wrap the blocking operation
+<3> RxJava's `subscribeOn` method is used to schedule the operation on the I/O thread pool
+

--- a/src/main/docs/guide/httpServer/reactiveServer/reactiveResponses.adoc
+++ b/src/main/docs/guide/httpServer/reactiveServer/reactiveResponses.adoc
@@ -4,9 +4,7 @@ Micronaut supports returning common reactive types such as rx:Single[] or rx:Obs
 
 The argument that is designated the body of the request using the api:http.annotation.Body[] annotation can also be a reactive type or a jdk:java.util.concurrent.CompletableFuture[].
 
-Micronaut also uses these types to influence which thread pool to execute the method on. If the request is considered non-blocking (because it returns a non-blocking type) then the Netty event loop thread will be used to execute the method.
-
-If the method is considered blocking then the method is executed on the I/O thread pool, which Micronaut creates at startup.
+When returning a reactive type Micronaut will subscribe to the returned reactive type on the same thread as the request (A Netty Event Loop thread). It is therefore important that if you perform any blocking operations you offload those operations to an appropriately configured thread pool for example, using RxJava's `subscribeOn(..)` facility or ann:scheduling.annotation.ScheduleOn[].
 
 TIP: See the section on <<threadPools, Configuring Thread Pools>> for information on the thread pools that Micronaut sets up and how to configure them.
 

--- a/src/main/docs/guide/httpServer/serverIO.adoc
+++ b/src/main/docs/guide/httpServer/serverIO.adoc
@@ -1,6 +1,6 @@
-=== Writing Data without Blocking
+=== Reactively Writing Response Data
 
-Micronaut's HTTP server supports writing data without blocking simply by returning a rs:Publisher[] the emits objects that can be encoded to the HTTP response.
+Micronaut's HTTP server supports writing chunks of response data by returning a rs:Publisher[] the emits objects that can be encoded to the HTTP response.
 
 The following table summarizes example return type signatures and the behaviour the server exhibits to handle each of them:
 
@@ -25,13 +25,15 @@ The following table summarizes example return type signatures and the behaviour 
 
 When returning reactive type the server will use a `Transfer-Encoding` of `chunked` and keep writing data until the rs:Publisher[]'s `onComplete` method is called.
 
-The server will request a single item from the rs:Publisher[], write the item, without blocking, and then request the next item, thus controlling back pressure.
+The server will request a single item from the rs:Publisher[], write the item and then request the next item, controlling back pressure.
+
+NOTE: It is up to the implementation of the rs:Publisher[] to schedule any blocking I/O work that may be done as a result of subscribing to the publisher.
 
 === Performing Blocking I/O
 
 In some cases you may wish to integrate with a library that does not support non-blocking I/O.
 
-In this you can return a api:core.io.Writable[] object from any controller method. The api:core.io.Writable[] has various signatures that allowing writing to traditional blocking streams like jdk:java.io.Writer[] or jdk:java.io.OutputStream[].
+In this case you can return a api:core.io.Writable[] object from any controller method. The api:core.io.Writable[] has various signatures that allowing writing to traditional blocking streams like jdk:java.io.Writer[] or jdk:java.io.OutputStream[].
 
 When returning a api:core.io.Writable[] object the blocking I/O operation will be shifted to the I/O thread pool so that the Netty event loop is not blocked.
 

--- a/src/main/docs/guide/httpServer/sse.adoc
+++ b/src/main/docs/guide/httpServer/sse.adoc
@@ -18,6 +18,8 @@ snippet::io.micronaut.docs.server.sse.HeadlineController[tags="imports,class", i
 <4> The rx:Emitter[] interface's `onNext` method is used to emit objects of type api:http.sse.Event[]. The api:http.sse.Event.of(ET)[] factory method is used to construct the event.
 <5> The rx:Emitter[] interface's `onComplete` method is used to indicate when to finish sending server sent events.
 
+NOTE: You typically want to schedule SSE event streams on a separate executor. The previous example uses ann:scheduling.annotation.ScheduleOn[] to schedule the stream on the I/O executor.
+
 The above example will send back a response of type `text/event-stream` and for each  api:http.sse.Event[] emitted the `Headline` type previously will be converted to JSON resulting in responses such as:
 
 .Server Sent Event Response Output

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/http/server/reactive/PersonController.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/http/server/reactive/PersonController.groovy
@@ -1,0 +1,35 @@
+package io.micronaut.docs.http.server.reactive
+
+import io.micronaut.docs.ioc.beans.Person
+
+// tag::imports[]
+import io.micronaut.http.annotation.*
+import io.micronaut.scheduling.TaskExecutors
+import io.reactivex.*
+import io.reactivex.schedulers.Schedulers
+import javax.inject.Named
+import java.util.concurrent.ExecutorService
+// end::imports[]
+
+// tag::class[]
+@Controller("/people")
+class PersonController {
+
+    private final Scheduler scheduler
+    private final PersonService personService
+
+    PersonController(
+            @Named(TaskExecutors.IO) ExecutorService executorService, // <1>
+            PersonService personService) {
+        this.scheduler = Schedulers.from(executorService)
+        this.personService = personService
+    }
+
+    @Get("/{name}")
+    Single<Person> byName(String name) {
+        return Single.fromCallable({ -> // <2>
+            personService.findByName(name)
+        }).subscribeOn(scheduler) // <3>
+    }
+}
+// end::class[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/http/server/reactive/PersonController.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/http/server/reactive/PersonController.groovy
@@ -12,7 +12,7 @@ import java.util.concurrent.ExecutorService
 // end::imports[]
 
 // tag::class[]
-@Controller("/people")
+@Controller("/subscribeOn/people")
 class PersonController {
 
     private final Scheduler scheduler

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/http/server/reactive/PersonService.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/http/server/reactive/PersonService.groovy
@@ -1,0 +1,13 @@
+package io.micronaut.docs.http.server.reactive
+
+import io.micronaut.docs.ioc.beans.Person
+
+import javax.inject.Singleton
+
+@Singleton
+class PersonService {
+
+    Person findByName(String name) {
+        return new Person(name)
+    }
+}

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/http/server/scheduleon/PersonController.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/http/server/scheduleon/PersonController.groovy
@@ -10,7 +10,7 @@ import io.micronaut.scheduling.annotation.ScheduleOn
 // end::imports[]
 
 // tag::class[]
-@Controller("/people")
+@Controller("/scheduleOn/people")
 class PersonController {
 
     private final PersonService personService

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/http/server/scheduleon/PersonController.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/http/server/scheduleon/PersonController.groovy
@@ -1,0 +1,30 @@
+package io.micronaut.docs.http.server.scheduleon
+
+import io.micronaut.docs.http.server.reactive.PersonService
+import io.micronaut.docs.ioc.beans.Person
+
+// tag::imports[]
+import io.micronaut.http.annotation.*
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.annotation.ScheduleOn
+// end::imports[]
+
+// tag::class[]
+@Controller("/people")
+class PersonController {
+
+    private final PersonService personService
+
+    PersonController(
+            PersonService personService) {
+        this.personService = personService
+    }
+
+    @Get("/{name}")
+    @ScheduleOn(TaskExecutors.IO) // <1>
+    Person byName(String name) {
+        return personService.findByName(name)
+    }
+}
+// end::class[]
+

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/sse/HeadlineController.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/sse/HeadlineController.groovy
@@ -4,6 +4,8 @@ package io.micronaut.docs.server.sse
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.sse.Event
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.annotation.ScheduleOn
 import io.reactivex.Emitter
 import io.reactivex.Flowable
 import io.reactivex.functions.BiFunction
@@ -20,6 +22,7 @@ import org.reactivestreams.Publisher
 class HeadlineController {
 
     @Get
+    @ScheduleOn(TaskExecutors.IO)
     Publisher<Event<Headline>> index() { // <1>
         String[] versions = ["1.0", "2.0"] // <2>
 

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/http/server/reactive/PersonController.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/http/server/reactive/PersonController.kt
@@ -1,0 +1,31 @@
+package io.micronaut.docs.http.server.reactive
+
+import io.micronaut.docs.ioc.beans.Person
+
+// tag::imports[]
+import io.micronaut.http.annotation.*
+import io.micronaut.scheduling.TaskExecutors
+import io.reactivex.*
+import io.reactivex.schedulers.Schedulers
+import java.util.concurrent.ExecutorService
+import javax.inject.Named
+// end::imports[]
+
+// tag::class[]
+@Controller("/people")
+class PersonController internal constructor(
+        @Named(TaskExecutors.IO) executorService: ExecutorService, // <1>
+        val personService: PersonService) {
+    private val scheduler: Scheduler
+
+    init {
+        scheduler = Schedulers.from(executorService)
+    }
+
+    @Get("/{name}")
+    fun byName(name: String): Single<Person> {
+        return Single.fromCallable { personService.findByName(name) } // <2>
+                .subscribeOn(scheduler) // <3>
+    }
+}
+// end::class[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/http/server/reactive/PersonController.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/http/server/reactive/PersonController.kt
@@ -12,7 +12,7 @@ import javax.inject.Named
 // end::imports[]
 
 // tag::class[]
-@Controller("/people")
+@Controller("/subscribeOn/people")
 class PersonController internal constructor(
         @Named(TaskExecutors.IO) executorService: ExecutorService, // <1>
         val personService: PersonService) {

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/http/server/reactive/PersonService.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/http/server/reactive/PersonService.kt
@@ -1,0 +1,11 @@
+package io.micronaut.docs.http.server.reactive
+
+import io.micronaut.docs.ioc.beans.Person
+import javax.inject.Singleton
+
+@Singleton
+class PersonService {
+    fun findByName(name: String): Person {
+        return Person(name)
+    }
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/http/server/scheduleon/PersonController.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/http/server/scheduleon/PersonController.kt
@@ -1,0 +1,19 @@
+package io.micronaut.docs.http.server.scheduleon
+
+import io.micronaut.docs.http.server.reactive.PersonService
+import io.micronaut.docs.ioc.beans.Person
+// tag::imports[]
+import io.micronaut.http.annotation.*
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.annotation.ScheduleOn
+// end::imports[]
+// tag::class[]
+@Controller("/people")
+class PersonController (private val personService: PersonService) {
+    @Get("/{name}")
+    @ScheduleOn(TaskExecutors.IO) // <1>
+    fun byName(name: String): Person {
+        return personService.findByName(name)
+    }
+}
+// end::class[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/http/server/scheduleon/PersonController.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/http/server/scheduleon/PersonController.kt
@@ -8,7 +8,7 @@ import io.micronaut.scheduling.TaskExecutors
 import io.micronaut.scheduling.annotation.ScheduleOn
 // end::imports[]
 // tag::class[]
-@Controller("/people")
+@Controller("/scheduleOn/people")
 class PersonController (private val personService: PersonService) {
     @Get("/{name}")
     @ScheduleOn(TaskExecutors.IO) // <1>

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/sse/HeadlineController.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/sse/HeadlineController.kt
@@ -5,6 +5,8 @@ package io.micronaut.docs.server.sse
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.sse.Event
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.annotation.ScheduleOn
 import io.reactivex.Emitter
 import io.reactivex.Flowable
 import io.reactivex.functions.BiFunction
@@ -18,6 +20,7 @@ import java.util.concurrent.Callable
 class HeadlineController {
 
     @Get
+    @ScheduleOn(TaskExecutors.IO)
     fun index(): Publisher<Event<Headline>> { // <1>
         val versions = arrayOf("1.0", "2.0") // <2>
 

--- a/test-suite/src/test/java/io/micronaut/docs/http/server/reactive/PersonController.java
+++ b/test-suite/src/test/java/io/micronaut/docs/http/server/reactive/PersonController.java
@@ -12,7 +12,7 @@ import java.util.concurrent.ExecutorService;
 // end::imports[]
 
 // tag::class[]
-@Controller("/people")
+@Controller("/subscribeOn/people")
 public class PersonController {
 
     private final Scheduler scheduler;

--- a/test-suite/src/test/java/io/micronaut/docs/http/server/reactive/PersonController.java
+++ b/test-suite/src/test/java/io/micronaut/docs/http/server/reactive/PersonController.java
@@ -1,0 +1,35 @@
+package io.micronaut.docs.http.server.reactive;
+
+import io.micronaut.docs.ioc.beans.Person;
+
+// tag::imports[]
+import io.micronaut.http.annotation.*;
+import io.micronaut.scheduling.TaskExecutors;
+import io.reactivex.*;
+import io.reactivex.schedulers.Schedulers;
+import javax.inject.Named;
+import java.util.concurrent.ExecutorService;
+// end::imports[]
+
+// tag::class[]
+@Controller("/people")
+public class PersonController {
+
+    private final Scheduler scheduler;
+    private final PersonService personService;
+
+    PersonController(
+            @Named(TaskExecutors.IO) ExecutorService executorService, // <1>
+            PersonService personService) {
+        this.scheduler = Schedulers.from(executorService);
+        this.personService = personService;
+    }
+
+    @Get("/{name}")
+    Single<Person> byName(String name) {
+        return Single.fromCallable(() ->
+                personService.findByName(name) // <2>
+        ).subscribeOn(scheduler); // <3>
+    }
+}
+// end::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/http/server/reactive/PersonService.java
+++ b/test-suite/src/test/java/io/micronaut/docs/http/server/reactive/PersonService.java
@@ -1,0 +1,13 @@
+package io.micronaut.docs.http.server.reactive;
+
+import io.micronaut.docs.ioc.beans.Person;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class PersonService {
+
+    public Person findByName(String name) {
+        return new Person(name);
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/docs/http/server/scheduleon/PersonController.java
+++ b/test-suite/src/test/java/io/micronaut/docs/http/server/scheduleon/PersonController.java
@@ -1,0 +1,30 @@
+package io.micronaut.docs.http.server.scheduleon;
+
+import io.micronaut.docs.http.server.reactive.PersonService;
+import io.micronaut.docs.ioc.beans.Person;
+
+// tag::imports[]
+import io.micronaut.http.annotation.*;
+import io.micronaut.scheduling.TaskExecutors;
+import io.micronaut.scheduling.annotation.ScheduleOn;
+// end::imports[]
+
+// tag::class[]
+@Controller("/people")
+public class PersonController {
+
+    private final PersonService personService;
+
+    PersonController(
+            PersonService personService) {
+        this.personService = personService;
+    }
+
+    @Get("/{name}")
+    @ScheduleOn(TaskExecutors.IO) // <1>
+    Person byName(String name) {
+        return personService.findByName(name);
+    }
+}
+// end::class[]
+

--- a/test-suite/src/test/java/io/micronaut/docs/http/server/scheduleon/PersonController.java
+++ b/test-suite/src/test/java/io/micronaut/docs/http/server/scheduleon/PersonController.java
@@ -10,7 +10,7 @@ import io.micronaut.scheduling.annotation.ScheduleOn;
 // end::imports[]
 
 // tag::class[]
-@Controller("/people")
+@Controller("/scheduleOn/people")
 public class PersonController {
 
     private final PersonService personService;

--- a/test-suite/src/test/java/io/micronaut/docs/server/sse/HeadlineController.java
+++ b/test-suite/src/test/java/io/micronaut/docs/server/sse/HeadlineController.java
@@ -3,6 +3,8 @@ package io.micronaut.docs.server.sse;
 // tag::imports[]
 import io.micronaut.http.annotation.*;
 import io.micronaut.http.sse.Event;
+import io.micronaut.scheduling.TaskExecutors;
+import io.micronaut.scheduling.annotation.ScheduleOn;
 import io.reactivex.Flowable;
 import org.reactivestreams.Publisher;
 // end::imports[]
@@ -12,6 +14,7 @@ import org.reactivestreams.Publisher;
 public class HeadlineController {
 
     @Get
+    @ScheduleOn(TaskExecutors.IO)
     public Publisher<Event<Headline>> index() { // <1>
         String[] versions = new String[]{"1.0", "2.0"}; // <2>
 


### PR DESCRIPTION
* Run all operations on the Netty event loop by default to avoid context switching
* Introduce a new `@ScheduleOn` annotation to allow easily scheduling methods on a different pool
* Clarify documentation