### PR TITLE
Use low timeout when attempting to connect to localhost

### DIFF
--- a/core/src/main/java/io/micronaut/core/io/socket/SocketUtils.java
+++ b/core/src/main/java/io/micronaut/core/io/socket/SocketUtils.java
@@ -17,8 +17,8 @@ package io.micronaut.core.io.socket;
 
 import io.micronaut.core.util.ArgumentUtils;
 
-import javax.net.SocketFactory;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.util.Random;
 
@@ -86,9 +86,8 @@ public class SocketUtils {
      * @return True if it is
      */
     public static boolean isTcpPortAvailable(int currentPort) {
-        try {
-            Socket socket = SocketFactory.getDefault().createSocket(InetAddress.getLocalHost(), currentPort);
-            socket.close();
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress(InetAddress.getLocalHost(), currentPort), 20);
             return false;
         } catch (Throwable e) {
             return true;


### PR DESCRIPTION
Because `SocketUtils.isTcpPortAvailable()` is only attempting to connect to `localhost`, there is no need for a long timeout (0 means unlimited).

Using an unlimited timeout may lead to an increase in test time when `@MicronautTest` is used massively because `NettyHttpServer.stop()` is using this function.