### PR TITLE
Server Side Content Negotiation. Fixes #2743

### DIFF
--- a/core/src/main/java/io/micronaut/core/type/DefaultArgument.java
+++ b/core/src/main/java/io/micronaut/core/type/DefaultArgument.java
@@ -35,7 +35,7 @@ import java.util.*;
 @Internal
 public class DefaultArgument<T> implements Argument<T> {
 
-    static final Set<Class> CONTAINER_TYPES = CollectionUtils.setOf(
+    static final Set<Class<?>> CONTAINER_TYPES = CollectionUtils.setOf(
         List.class,
         Set.class,
         Map.class,

--- a/function-web/src/main/java/io/micronaut/function/web/AnnotatedFunctionRouteBuilder.java
+++ b/function-web/src/main/java/io/micronaut/function/web/AnnotatedFunctionRouteBuilder.java
@@ -159,7 +159,7 @@ public class AnnotatedFunctionRouteBuilder
                                     }
                                 } else {
                                     route.body(method.getArgumentNames()[0])
-                                            .acceptAll();
+                                            .consumesAll();
                                 }
                             }
                         }

--- a/http-client/src/main/java/io/micronaut/http/client/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/DefaultHttpClient.java
@@ -1914,6 +1914,9 @@ public class DefaultHttpClient implements RxWebSocketClient, RxHttpClient, RxStr
                     } else {
                         channelPool.release(ch);
                     }
+                } else {
+                    // just close it to prevent any future reads without a handler registered
+                    ctx.close();
                 }
             }
 

--- a/http-client/src/main/java/io/micronaut/http/client/interceptor/HttpClientIntroductionAdvice.java
+++ b/http-client/src/main/java/io/micronaut/http/client/interceptor/HttpClientIntroductionAdvice.java
@@ -563,7 +563,7 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
             } else {
                 BlockingHttpClient blockingHttpClient = httpClient.toBlocking();
 
-                if (void.class != javaReturnType) {
+                if (void.class != javaReturnType && httpMethod != HttpMethod.HEAD) {
                     request.accept(acceptTypes);
                 }
 

--- a/http-client/src/test/groovy/io/micronaut/http/client/ClientScopeSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/ClientScopeSpec.groovy
@@ -306,7 +306,7 @@ class ClientScopeSpec extends Specification {
     @JacksonFeatures(disabledDeserializationFeatures = DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
     static interface MyServiceJacksonFeatures {
 
-        @Get
+        @Get(consumes = MediaType.TEXT_PLAIN)
         String name()
     }
 }

--- a/http-client/src/test/groovy/io/micronaut/http/client/HttpGetSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/HttpGetSpec.groovy
@@ -885,7 +885,7 @@ class HttpGetSpec extends Specification {
     @Client("http://not.used")
     static interface OverrideUrlClient {
 
-        @Get("{+url}/get/simple")
+        @Get(value = "{+url}/get/simple", consumes = MediaType.TEXT_PLAIN)
         String overrideUrl(String url);
 
     }

--- a/http-client/src/test/groovy/io/micronaut/http/client/HttpHeadSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/HttpHeadSpec.groovy
@@ -583,7 +583,7 @@ class HttpHeadSpec extends Specification {
         @Head("/dateTimeQuery")
         String formatDateTimeQuery(@QueryValue @Format('yyyy-MM-dd') LocalDate myDate)
 
-        @Head("/no-head")
+        @Head(value = "/no-head")
         String noHead()
 
         @Head("/multiple")

--- a/http-client/src/test/groovy/io/micronaut/http/client/HttpPutSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/HttpPutSpec.groovy
@@ -166,7 +166,7 @@ class HttpPutSpec extends Specification {
         BlockingHttpClient blockingHttpClient = client.toBlocking()
         String result = blockingHttpClient.retrieve(
                 HttpRequest.PUT("/put/optionalJson", [enable: true])
-                        .accept(MediaType.APPLICATION_JSON_TYPE),
+                        .accept(MediaType.TEXT_PLAIN),
 
                 String
         )

--- a/http-client/src/test/groovy/io/micronaut/http/client/ReadTimeoutSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/ReadTimeoutSpec.groovy
@@ -20,6 +20,7 @@ import io.micronaut.http.HttpHeaders
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Consumes
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.client.annotation.Client
@@ -366,6 +367,7 @@ class ReadTimeoutSpec extends Specification {
     }
 
     @Client("/timeout")
+    @Consumes(MediaType.TEXT_PLAIN)
     static interface TestClient {
         @Get
         String get()

--- a/http-client/src/test/groovy/io/micronaut/http/client/aop/ClientFilterSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/aop/ClientFilterSpec.groovy
@@ -117,7 +117,7 @@ class ClientFilterSpec extends Specification{
     @Requires(property = 'spec.name', value = "ClientFilterSpec")
     @Client('/filters')
     static interface MyApi {
-        @Get('/name')
+        @Get(value = '/name', consumes = MediaType.TEXT_PLAIN)
         String name()
     }
 

--- a/http-client/src/test/groovy/io/micronaut/http/client/aop/NotFoundSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/aop/NotFoundSpec.groovy
@@ -17,6 +17,7 @@ package io.micronaut.http.client.aop
 
 import io.micronaut.context.ApplicationContext
 import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Consumes
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.client.annotation.Client
@@ -54,6 +55,7 @@ class NotFoundSpec extends Specification {
     @Client('/not-found')
     static interface InventoryClient {
         @Get('/maybe/{isbn}')
+        @Consumes(MediaType.TEXT_PLAIN)
         Maybe<Boolean> maybe(String isbn)
 
         @Get(value = '/flowable/{isbn}', processes = MediaType.TEXT_EVENT_STREAM)

--- a/http-client/src/test/groovy/io/micronaut/http/client/convert/DateTimeConversionSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/convert/DateTimeConversionSpec.groovy
@@ -47,7 +47,7 @@ class DateTimeConversionSpec extends Specification {
     }
 
     static interface TimeApi {
-        @Get(uri = "/offset", produces = MediaType.TEXT_PLAIN)
+        @Get(uri = "/offset", processes = MediaType.TEXT_PLAIN)
         String time(@NotNull @QueryValue OffsetDateTime time)
     }
 

--- a/http-client/src/test/resources/logback.xml
+++ b/http-client/src/test/resources/logback.xml
@@ -11,7 +11,7 @@
     <root level="info">
         <appender-ref ref="STDOUT" />
     </root>
-    <logger name="io.micronaut.http" level="TRACE"/>
+    <!--<logger name="io.micronaut.http" level="TRACE"/>-->
     <!--<logger name="io.netty.handler.logging" level="TRACE" />-->
     <!--<logger name="io.micronaut.jackson.parser" level="TRACE"/>-->
 </configuration>

--- a/http-client/src/test/resources/logback.xml
+++ b/http-client/src/test/resources/logback.xml
@@ -11,7 +11,7 @@
     <root level="info">
         <appender-ref ref="STDOUT" />
     </root>
-    <!--<logger name="io.micronaut.http" level="TRACE"/>-->
+    <logger name="io.micronaut.http" level="TRACE"/>
     <!--<logger name="io.netty.handler.logging" level="TRACE" />-->
     <!--<logger name="io.micronaut.jackson.parser" level="TRACE"/>-->
 </configuration>

--- a/http-netty/src/main/java/io/micronaut/http/netty/AbstractNettyHttpRequest.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/AbstractNettyHttpRequest.java
@@ -26,6 +26,7 @@ import io.netty.util.DefaultAttributeMap;
 
 import java.net.URI;
 import java.nio.charset.Charset;
+import java.util.Collection;
 import java.util.Locale;
 import java.util.Optional;
 
@@ -50,6 +51,7 @@ public abstract class AbstractNettyHttpRequest<B> extends DefaultAttributeMap im
     private Charset charset;
     private Locale locale;
     private String path;
+    private Collection<MediaType> accept;
 
     /**
      * @param nettyRequest      The Http netty request
@@ -84,6 +86,21 @@ public abstract class AbstractNettyHttpRequest<B> extends DefaultAttributeMap im
             }
         }
         return httpParameters;
+    }
+
+    @Override
+    public Collection<MediaType> accept() {
+        Collection<MediaType> accept = this.accept;
+        if (accept == null) {
+            synchronized (this) { // double check
+                accept = this.accept;
+                if (accept == null) {
+                    accept = HttpRequest.super.accept();
+                    this.accept = accept;
+                }
+            }
+        }
+        return accept;
     }
 
     @Override

--- a/http-server-netty/build.gradle
+++ b/http-server-netty/build.gradle
@@ -21,6 +21,7 @@ dependencies {
         exclude module:'micronaut-runtime'
         exclude module:'micronaut-inject'
     }
+    testImplementation 'io.micronaut.xml:micronaut-jackson-xml:1.0.0'
     testImplementation dependencyModuleVersion("groovy", "groovy-json")
     testImplementation dependencyModuleVersion("groovy", "groovy-templates")
     testImplementation dependencyVersion("rxjava2")

--- a/http-server-netty/build.gradle
+++ b/http-server-netty/build.gradle
@@ -17,7 +17,10 @@ dependencies {
     testImplementation project(":http-client")
     testImplementation group: 'org.powermock', name: 'powermock-module-junit4', version: '2.0.5'
     testImplementation group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.5'
-
+    testImplementation dependencyModuleVersion("micronaut.test", "micronaut-test-spock"), {
+        exclude module:'micronaut-runtime'
+        exclude module:'micronaut-inject'
+    }
     testImplementation dependencyModuleVersion("groovy", "groovy-json")
     testImplementation dependencyModuleVersion("groovy", "groovy-templates")
     testImplementation dependencyVersion("rxjava2")

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
@@ -275,21 +275,21 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
         if (cause instanceof UnsatisfiedRouteException) {
             if (declaringType != null) {
                 // handle error with a method that is non global with bad request
-                errorRoute = router.route(declaringType, HttpStatus.BAD_REQUEST).orElse(null);
+                errorRoute = router.findStatusRoute(declaringType, HttpStatus.BAD_REQUEST, nettyHttpRequest).orElse(null);
             }
             if (errorRoute == null) {
                 // handle error with a method that is global with bad request
-                errorRoute = router.route(HttpStatus.BAD_REQUEST).orElse(null);
+                errorRoute = router.findStatusRoute(HttpStatus.BAD_REQUEST, nettyHttpRequest).orElse(null);
             }
         } else if (cause instanceof HttpStatusException) {
             HttpStatusException statusException = (HttpStatusException) cause;
             if (declaringType != null) {
                 // handle error with a method that is non global with bad request
-                errorRoute = router.route(declaringType, statusException.getStatus()).orElse(null);
+                errorRoute = router.findStatusRoute(declaringType, statusException.getStatus(), nettyHttpRequest).orElse(null);
             }
             if (errorRoute == null) {
                 // handle error with a method that is global with bad request
-                errorRoute = router.route(statusException.getStatus()).orElse(null);
+                errorRoute = router.findStatusRoute(statusException.getStatus(), nettyHttpRequest).orElse(null);
             }
         } else if (cause instanceof BeanInstantiationException && declaringType != null) {
             // If the controller could not be instantiated, don't look for a local error route
@@ -305,10 +305,10 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
         // any another other exception may arise. handle these with non global exception marked method or a global exception marked method.
         if (errorRoute == null) {
             if (declaringType != null) {
-                errorRoute = router.route(declaringType, cause).orElse(null);
+                errorRoute = router.findErrorRoute(declaringType, cause, nettyHttpRequest).orElse(null);
             }
             if (errorRoute == null) {
-                errorRoute = router.route(cause).orElse(null);
+                errorRoute = router.findErrorRoute(cause, nettyHttpRequest).orElse(null);
             }
         }
 
@@ -576,7 +576,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
             if (optionalFile.isPresent()) {
                 route = new BasicObjectRouteMatch(optionalFile.get());
             } else {
-                Optional<RouteMatch<Object>> statusRoute = router.route(HttpStatus.NOT_FOUND);
+                Optional<RouteMatch<Object>> statusRoute = router.findStatusRoute(HttpStatus.NOT_FOUND, request);
                 if (statusRoute.isPresent()) {
                     route = statusRoute.get();
                 } else {
@@ -615,7 +615,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
             NettyHttpRequest nettyHttpRequest,
             MutableHttpResponse<Object> defaultResponse,
             String message) {
-        Optional<RouteMatch<Object>> statusRoute = router.route(defaultResponse.status());
+        Optional<RouteMatch<Object>> statusRoute = router.findStatusRoute(defaultResponse.status(), request);
         if (statusRoute.isPresent()) {
             RouteMatch<Object> routeMatch = statusRoute.get();
             handleRouteMatch(routeMatch, nettyHttpRequest, ctx);
@@ -1071,12 +1071,12 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
                     Optional<RouteMatch<Object>> statusRoute = Optional.empty();
                     // if declaringType is not null, this means its a locally marked method handler
                     if (declaringType != null) {
-                        statusRoute = router.route(declaringType, status);
-                    }
-                    if (!statusRoute.isPresent()) {
-                        statusRoute = router.route(status);
+                        statusRoute = router.findStatusRoute(declaringType, status, request);
                     }
                     io.micronaut.http.HttpRequest<?> httpRequest = requestReference.get();
+                    if (!statusRoute.isPresent()) {
+                        statusRoute = router.findStatusRoute(status, httpRequest);
+                    }
 
                     if (statusRoute.isPresent()) {
                         routeMatch = statusRoute.get();
@@ -1200,17 +1200,21 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
     }
 
     private MediaType resolveDefaultResponseContentType(NettyHttpRequest<?> request, RouteMatch<?> finalRoute) {
-        MediaType defaultResponseMediaType;
+        final List<MediaType> producesList = finalRoute.getProduces();
         final Iterator<MediaType> i = request.accept().iterator();
         if (i.hasNext()) {
-            defaultResponseMediaType = i.next();
-        } else {
-            final Iterator<MediaType> produces = finalRoute.getProduces().iterator();
-            if (produces.hasNext()) {
-                defaultResponseMediaType = produces.next();
-            } else {
-                defaultResponseMediaType = MediaType.APPLICATION_JSON_TYPE;
+            final MediaType mt = i.next();
+            if (producesList.contains(mt)) {
+                return mt;
             }
+        }
+
+        MediaType defaultResponseMediaType;
+        final Iterator<MediaType> produces = producesList.iterator();
+        if (produces.hasNext()) {
+            defaultResponseMediaType = produces.next();
+        } else {
+            defaultResponseMediaType = MediaType.APPLICATION_JSON_TYPE;
         }
         return defaultResponseMediaType;
     }
@@ -1244,10 +1248,10 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
                 Optional<RouteMatch<Object>> statusRoute = Optional.empty();
                 // if declaringType is not null, this means its a locally marked method handler
                 if (declaringType != null) {
-                    statusRoute = router.route(declaringType, HttpStatus.NOT_FOUND);
+                    statusRoute = router.findStatusRoute(declaringType, HttpStatus.NOT_FOUND, httpRequest);
                 }
                 if (!statusRoute.isPresent()) {
-                    statusRoute = router.route(HttpStatus.NOT_FOUND);
+                    statusRoute = router.findStatusRoute(HttpStatus.NOT_FOUND, httpRequest);
                 }
 
                 if (statusRoute.isPresent()) {

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/ContentNegotiationSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/ContentNegotiationSpec.groovy
@@ -1,0 +1,93 @@
+package io.micronaut.http.server.netty
+
+import io.micronaut.core.type.Argument
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Produces
+import io.micronaut.http.client.RxHttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.http.hateoas.JsonError
+import io.micronaut.test.annotation.MicronautTest
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import javax.inject.Inject
+import static io.micronaut.http.server.netty.ContentNegotiationSpec.NegotiatingController.*
+
+@MicronautTest
+class ContentNegotiationSpec extends Specification {
+
+    @Inject
+    @Client("/")
+    RxHttpClient client
+
+
+    @Unroll
+    void "test ACCEPT header content negotiation #header"() {
+        expect:
+        client.retrieve(HttpRequest.GET("/negotiate").accept(header as MediaType[]), String)
+                .blockingFirst() == response
+
+        where:
+        header                                                                            | response
+        [MediaType.APPLICATION_GRAPHQL_TYPE]                                              | JSON // should default to the all handler
+        [new MediaType("application/json;q=0.5"), new MediaType("application/xml;q=0.9")] | XML
+        [MediaType.APPLICATION_JSON_TYPE]                                                 | JSON
+        [MediaType.APPLICATION_JSON_TYPE, MediaType.APPLICATION_XML_TYPE]                 | JSON
+        [MediaType.APPLICATION_XML_TYPE, MediaType.APPLICATION_JSON_TYPE]                 | XML
+        [MediaType.APPLICATION_XML_TYPE]                                                  | XML
+        [MediaType.TEXT_PLAIN_TYPE]                                                       | TEXT
+        [MediaType.ALL_TYPE]                                                              | JSON
+
+    }
+
+    void "test send unacceptable type"() {
+        when: "An unacceptable type is sent"
+        client.retrieve(HttpRequest.GET("/negotiate/other")
+                .accept(MediaType.APPLICATION_GRAPHQL), Argument.STRING, JsonError.TYPE)
+                .blockingFirst()
+
+        then: "An exception is thrown that states the acceptable types"
+        def e = thrown(HttpClientResponseException)
+        def response = e.response
+        response.status() == HttpStatus.NOT_ACCEPTABLE
+        response.body().toString().contains("Specified Accept Types [application/graphql] not supported. Supported types: [text/plain]")
+    }
+
+    @Controller("/negotiate")
+    static class NegotiatingController {
+
+        public static final String XML = "<hello>world</hello>"
+        public static final String JSON = '{"hello":"world"}'
+        public static final String TEXT = 'Hello World'
+
+        @Get("/")
+        @Produces(MediaType.APPLICATION_XML)
+        String xml() {
+            return XML
+        }
+
+        @Get("/")
+        @Produces([MediaType.APPLICATION_JSON, MediaType.ALL])
+        String json() {
+            return JSON
+        }
+
+        @Get("/")
+        @Produces(MediaType.TEXT_PLAIN)
+        String text() {
+            return TEXT
+        }
+
+        @Get("/other")
+        @Produces(MediaType.TEXT_PLAIN)
+        String other() {
+            return TEXT
+        }
+    }
+}

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/FormDataBindingSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/FormDataBindingSpec.groovy
@@ -15,6 +15,7 @@
  */
 package io.micronaut.http.server.netty.binding
 
+import groovy.transform.EqualsAndHashCode
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpStatus
 import io.micronaut.http.MediaType
@@ -177,6 +178,7 @@ class FormDataBindingSpec extends AbstractMicronautSpec {
             "name: $person.name, age: $person.age"
         }
 
+        @EqualsAndHashCode
         static class Person {
             String name
             Integer age

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/context/ServerRequestContextSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/context/ServerRequestContextSpec.groovy
@@ -19,6 +19,7 @@ import io.micronaut.context.ApplicationContext
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Consumes
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Produces
@@ -72,6 +73,7 @@ class ServerRequestContextSpec extends Specification {
     }
 
     @Client('/test-context')
+    @Consumes(MediaType.TEXT_PLAIN)
     static interface TestClient {
 
         @Get("/method")

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/sse/ServerSentEventSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/sse/ServerSentEventSpec.groovy
@@ -21,6 +21,7 @@ import io.micronaut.context.annotation.Requires
 import io.micronaut.http.MediaType
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Produces
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.http.server.netty.AbstractMicronautSpec
 import io.micronaut.http.sse.Event
@@ -104,6 +105,7 @@ class ServerSentEventSpec extends AbstractMicronautSpec {
     static class SseController {
 
         @Get('/object')
+        @Produces(MediaType.TEXT_EVENT_STREAM)
         Publisher<Event> object() {
             int i = 0
             Flowable.generate( { io.reactivex.Emitter<Event> emitter ->
@@ -118,6 +120,7 @@ class ServerSentEventSpec extends AbstractMicronautSpec {
         }
 
         @Get('/rich')
+        @Produces(MediaType.TEXT_EVENT_STREAM)
         Publisher<Event> rich() {
             Integer i = 0
             Flowable.generate( { io.reactivex.Emitter<Event> emitter ->
@@ -137,6 +140,7 @@ class ServerSentEventSpec extends AbstractMicronautSpec {
         }
 
         @Get('/string')
+        @Produces(MediaType.TEXT_EVENT_STREAM)
         Publisher<Event> string() {
             int i = 0
             Flowable.generate( { io.reactivex.Emitter<Event> emitter ->
@@ -151,6 +155,7 @@ class ServerSentEventSpec extends AbstractMicronautSpec {
         }
 
         @Get('/exception')
+        @Produces(MediaType.TEXT_EVENT_STREAM)
         Publisher<Event> exception() {
             Flowable.generate( { io.reactivex.Emitter<Event> emitter ->
                 throw new RuntimeException("bad things happened")
@@ -158,6 +163,7 @@ class ServerSentEventSpec extends AbstractMicronautSpec {
         }
 
         @Get('on-error')
+        @Produces(MediaType.TEXT_EVENT_STREAM)
         Publisher<Event> onError() {
             Flowable.generate( { io.reactivex.Emitter<Event> emitter ->
                 emitter.onError(new RuntimeException("bad things happened"))

--- a/http-server-netty/src/test/resources/logback.xml
+++ b/http-server-netty/src/test/resources/logback.xml
@@ -11,7 +11,7 @@
     <root level="info">
         <appender-ref ref="STDOUT" />
     </root>
-    <!--<logger name="io.micronaut.http" level="TRACE"/>-->
+    <logger name="io.micronaut.http" level="TRACE"/>
     <!--<logger name="io.micronaut.websocket" level="TRACE"/>-->
 <!--    <logger name="io.netty" level="TRACE"/>-->
 

--- a/http-server-netty/src/test/resources/logback.xml
+++ b/http-server-netty/src/test/resources/logback.xml
@@ -11,7 +11,7 @@
     <root level="info">
         <appender-ref ref="STDOUT" />
     </root>
-    <logger name="io.micronaut.http" level="TRACE"/>
+<!--    <logger name="io.micronaut.http" level="TRACE"/>-->
     <!--<logger name="io.micronaut.websocket" level="TRACE"/>-->
 <!--    <logger name="io.netty" level="TRACE"/>-->
 

--- a/http/src/main/java/io/micronaut/http/HttpHeaderValues.java
+++ b/http/src/main/java/io/micronaut/http/HttpHeaderValues.java
@@ -24,6 +24,11 @@ package io.micronaut.http;
 public interface HttpHeaderValues {
 
     /**
+     * {@code "keep-alive"}.
+     */
+    String CONNECTION_KEEP_ALIVE = "keep-alive";
+
+    /**
      * {@code "Bearer"}.
      */
     String AUTHORIZATION_PREFIX_BEARER = "Bearer";

--- a/http/src/main/java/io/micronaut/http/HttpHeaders.java
+++ b/http/src/main/java/io/micronaut/http/HttpHeaders.java
@@ -16,7 +16,6 @@
 package io.micronaut.http;
 
 import io.micronaut.core.convert.ConversionContext;
-import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.type.Headers;
 
 import java.time.LocalDateTime;
@@ -25,8 +24,6 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * Constants for common HTTP headers. See https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html.
@@ -534,7 +531,7 @@ public interface HttpHeaders extends Headers {
      */
     default boolean isKeepAlive() {
         return getFirst(CONNECTION, ConversionContext.STRING)
-                 .map(val -> val.equalsIgnoreCase("keep-alive")).orElse(false);
+                 .map(val -> val.equalsIgnoreCase(HttpHeaderValues.CONNECTION_KEEP_ALIVE)).orElse(false);
     }
 
     /**

--- a/http/src/main/java/io/micronaut/http/HttpRequest.java
+++ b/http/src/main/java/io/micronaut/http/HttpRequest.java
@@ -24,7 +24,6 @@ import java.net.URI;
 import java.security.Principal;
 import java.security.cert.Certificate;
 import java.util.*;
-import java.util.stream.Collectors;
 
 /**
  * <p>Common interface for HTTP request implementations.</p>
@@ -62,23 +61,25 @@ public interface HttpRequest<B> extends HttpMessage<B> {
      * @return A list of zero or many {@link MediaType} instances
      */
     default Collection<MediaType> accept() {
-        final List<String> values = getHeaders().getAll(HttpHeaders.ACCEPT);
-        if (!values.isEmpty()) {
-            Set<MediaType> mediaTypes = new TreeSet<>();
-            for (String value : values) {
-                final String[] tokens = value.split(",");
-                for (String token : tokens) {
-                    try {
-                        mediaTypes.add(new MediaType(token));
-                    } catch (IllegalArgumentException e) {
-                        // ignore
+        final HttpHeaders headers = getHeaders();
+        if (headers.contains(HttpHeaders.ACCEPT)) {
+            final List<String> values = headers.getAll(HttpHeaders.ACCEPT);
+            if (!values.isEmpty()) {
+                Set<MediaType> mediaTypes = new TreeSet<>();
+                for (String value : values) {
+                    final String[] tokens = value.split(",");
+                    for (String token : tokens) {
+                        try {
+                            mediaTypes.add(new MediaType(token));
+                        } catch (IllegalArgumentException e) {
+                            // ignore
+                        }
                     }
                 }
+                return Collections.unmodifiableSet(mediaTypes);
             }
-            return Collections.unmodifiableSet(mediaTypes);
-        } else {
-            return Collections.emptySet();
         }
+        return Collections.emptySet();
     }
 
     /**

--- a/http/src/main/java/io/micronaut/http/HttpRequest.java
+++ b/http/src/main/java/io/micronaut/http/HttpRequest.java
@@ -23,9 +23,8 @@ import java.net.InetSocketAddress;
 import java.net.URI;
 import java.security.Principal;
 import java.security.cert.Certificate;
-import java.util.Locale;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * <p>Common interface for HTTP request implementations.</p>
@@ -56,6 +55,31 @@ public interface HttpRequest<B> extends HttpMessage<B> {
      * @return The full request URI
      */
     @Nonnull URI getUri();
+
+    /**
+     * A list of accepted {@link MediaType} instances sorted by their quality rating.
+     *
+     * @return A list of zero or many {@link MediaType} instances
+     */
+    default Collection<MediaType> accept() {
+        final List<String> values = getHeaders().getAll(HttpHeaders.ACCEPT);
+        if (!values.isEmpty()) {
+            Set<MediaType> mediaTypes = new TreeSet<>();
+            for (String value : values) {
+                final String[] tokens = value.split(",");
+                for (String token : tokens) {
+                    try {
+                        mediaTypes.add(new MediaType(token));
+                    } catch (IllegalArgumentException e) {
+                        // ignore
+                    }
+                }
+            }
+            return Collections.unmodifiableSet(mediaTypes);
+        } else {
+            return Collections.emptySet();
+        }
+    }
 
     /**
      *

--- a/http/src/main/java/io/micronaut/http/HttpRequest.java
+++ b/http/src/main/java/io/micronaut/http/HttpRequest.java
@@ -63,21 +63,9 @@ public interface HttpRequest<B> extends HttpMessage<B> {
     default Collection<MediaType> accept() {
         final HttpHeaders headers = getHeaders();
         if (headers.contains(HttpHeaders.ACCEPT)) {
-            final List<String> values = headers.getAll(HttpHeaders.ACCEPT);
-            if (!values.isEmpty()) {
-                Set<MediaType> mediaTypes = new TreeSet<>();
-                for (String value : values) {
-                    final String[] tokens = value.split(",");
-                    for (String token : tokens) {
-                        try {
-                            mediaTypes.add(new MediaType(token));
-                        } catch (IllegalArgumentException e) {
-                            // ignore
-                        }
-                    }
-                }
-                return Collections.unmodifiableSet(mediaTypes);
-            }
+            return MediaType.orderedOf(
+                    headers.getAll(HttpHeaders.ACCEPT)
+            );
         }
         return Collections.emptySet();
     }

--- a/http/src/main/java/io/micronaut/http/MutableHttpRequest.java
+++ b/http/src/main/java/io/micronaut/http/MutableHttpRequest.java
@@ -85,6 +85,20 @@ public interface MutableHttpRequest<B> extends HttpRequest<B>, MutableHttpMessag
         return this;
     }
 
+    /**
+     * Sets the acceptable {@link MediaType} instances via the {@link HttpHeaders#ACCEPT} header.
+     *
+     * @param mediaTypes The media types
+     * @return This request
+     */
+    default MutableHttpRequest<B> accept(CharSequence... mediaTypes) {
+        if (ArrayUtils.isNotEmpty(mediaTypes)) {
+            String acceptString = String.join(",", mediaTypes);
+            header(HttpHeaders.ACCEPT, acceptString);
+        }
+        return this;
+    }
+
     @Override
     default MutableHttpRequest<B> headers(Consumer<MutableHttpHeaders> headers) {
         return (MutableHttpRequest<B>) MutableHttpMessage.super.headers(headers);

--- a/http/src/main/java/io/micronaut/http/hateoas/JsonError.java
+++ b/http/src/main/java/io/micronaut/http/hateoas/JsonError.java
@@ -16,6 +16,7 @@
 package io.micronaut.http.hateoas;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.type.Argument;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.Produces;
 
@@ -30,6 +31,13 @@ import java.util.Optional;
  */
 @Produces(MediaType.APPLICATION_JSON)
 public class JsonError extends AbstractResource<JsonError> {
+
+    /**
+     * The argument type.
+     *
+     * @since 1.3.3
+     */
+    public static final Argument<JsonError> TYPE = Argument.of(JsonError.class);
 
     private String message;
     private String logref;

--- a/http/src/test/groovy/io/micronaut/http/MediaTypeSpec.groovy
+++ b/http/src/test/groovy/io/micronaut/http/MediaTypeSpec.groovy
@@ -106,12 +106,12 @@ class MediaTypeSpec extends Specification {
     @Unroll
     void "test order types: #commaSeparatedList"() {
         given:
-        List<MediaType> orderedList = MediaType.of(commaSeparatedList.split(',')).toList().sort()
+        List<MediaType> orderedList = MediaType.orderedOf(commaSeparatedList.split(','))
 
         expect:
-        orderedList.size == expectedList.size
+        orderedList.size() == expectedList.size()
         for (int i = 0; i < orderedList.size(); i++) {
-            assert (orderedList.get(i).equals(expectedList.get(i)) == true)
+            assert orderedList.get(i) == expectedList.get(i)
         }
 
         where:

--- a/http/src/test/groovy/io/micronaut/http/MediaTypeSpec.groovy
+++ b/http/src/test/groovy/io/micronaut/http/MediaTypeSpec.groovy
@@ -36,7 +36,7 @@ class MediaTypeSpec extends Specification {
         mediaType.toString() == fullName
         mediaType.name == expectedName
         mediaType.extension == expectedExt
-        mediaType.parameters == OptionalValues.of(String,expectedParams)
+        mediaType.parameters == OptionalValues.of(String, expectedParams)
         mediaType.qualityAsNumber == quality
         mediaType.subtype == subtype
         mediaType.type == type
@@ -75,22 +75,22 @@ class MediaTypeSpec extends Specification {
         MediaType.isTextBased(contentType) == expected
 
         where:
-        contentType                  | expected
-        "application/hal+xml;q=1.1"  | true
-        "application/hal+xml;q=1.1"  | true
-        "application/hal+json"       | true
-        "application/hal+xml"        | true
-        "application/json"           | true
-        "application/xml"            | true
-        "text/html;charset=utf-8"    | true
-        "text/foo"                   | true
-        "application/hal+text"       | true
-        "application/javascript"     | true
-        "image/png"                  | false
-        "image/jpg"                  | false
-        "multipart/form-data"        | false
-        "application/x-json-stream"  | false
-        "invalid"                    | false
+        contentType                 | expected
+        "application/hal+xml;q=1.1" | true
+        "application/hal+xml;q=1.1" | true
+        "application/hal+json"      | true
+        "application/hal+xml"       | true
+        "application/json"          | true
+        "application/xml"           | true
+        "text/html;charset=utf-8"   | true
+        "text/foo"                  | true
+        "application/hal+text"      | true
+        "application/javascript"    | true
+        "image/png"                 | false
+        "image/jpg"                 | false
+        "multipart/form-data"       | false
+        "application/x-json-stream" | false
+        "invalid"                   | false
     }
 
     @Issue("https://github.com/micronaut-projects/micronaut-core/issues/2746")
@@ -101,5 +101,43 @@ class MediaTypeSpec extends Specification {
         then:
         noExceptionThrown()
         mt.getParameters().get("charset").get() == "UTF-8"
+    }
+
+    @Unroll
+    void "test order types: #commaSeparatedList"() {
+        given:
+        List<MediaType> orderedList = MediaType.of(commaSeparatedList.split(',')).toList().sort()
+
+        expect:
+        orderedList.size == expectedList.size
+        for (int i = 0; i < orderedList.size(); i++) {
+            assert (orderedList.get(i).equals(expectedList.get(i)) == true)
+        }
+
+        where:
+        commaSeparatedList                                | expectedList
+        "audio/basic;q=.5, application/json"              | [new MediaType("application/json"), new MediaType("audio/basic;q=.5")]
+        "text/html"                                       | [new MediaType("text/html")]
+        "*/*, text/*, text/html"                          | [new MediaType("text/html"), new MediaType("text/*"), new MediaType("*/*")]
+        "text/html;level=1, text/html;level=2;q=.3"       | [new MediaType("text/html;level=1"), new MediaType("text/html;level=2;q=.3")]
+        "text/*;blah=1, text/html;q=.3, audio/basic;q=.4" | [new MediaType("audio/basic;q=.4"), new MediaType("text/html;q=.3"), new MediaType("text/*;blah=1")]
+        "text/plain, text/html, application/json;q=1"     | [new MediaType("text/plain"), new MediaType("text/html"), new MediaType("application/json;q=1")]
+    }
+
+    @Unroll
+    void "test type match #desiredType"() {
+        given:
+        boolean match = new MediaType(desiredType).matches(new MediaType(expectedType))
+
+        expect:
+        match == expectedMatch
+
+        where:
+        desiredType             | expectedType          | expectedMatch
+        "text/html"             | "text/html"           | true
+        "text/*"                | "text/html"           | true
+        "*/*"                   | "application/xml"     | true
+        "text/plain"            | "text/hml"            | false
+        "text/*"                | "application/json"    | false
     }
 }

--- a/router/src/main/java/io/micronaut/web/router/AbstractRouteMatch.java
+++ b/router/src/main/java/io/micronaut/web/router/AbstractRouteMatch.java
@@ -66,7 +66,8 @@ abstract class AbstractRouteMatch<T, R> implements MethodBasedRouteMatch<T, R> {
      */
     protected AbstractRouteMatch(DefaultRouteBuilder.AbstractRoute abstractRoute, ConversionService<?> conversionService) {
         this.abstractRoute = abstractRoute;
-        this.executableMethod = abstractRoute.targetMethod;
+        //noinspection unchecked
+        this.executableMethod = (MethodExecutionHandle<T, R>) abstractRoute.targetMethod;
         this.conversionService = conversionService;
         Argument[] requiredArguments = executableMethod.getArguments();
         this.requiredInputs = new LinkedHashMap<>(requiredArguments.length);

--- a/router/src/main/java/io/micronaut/web/router/AbstractRouteMatch.java
+++ b/router/src/main/java/io/micronaut/web/router/AbstractRouteMatch.java
@@ -36,6 +36,7 @@ import io.micronaut.inject.MethodExecutionHandle;
 import io.micronaut.web.router.exceptions.UnsatisfiedRouteException;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.lang.reflect.Method;
 import java.util.*;
 import java.util.function.Predicate;
@@ -54,7 +55,8 @@ abstract class AbstractRouteMatch<T, R> implements MethodBasedRouteMatch<T, R> {
     protected final ConversionService<?> conversionService;
     protected final Map<String, Argument> requiredInputs;
     protected final DefaultRouteBuilder.AbstractRoute abstractRoute;
-    protected final List<MediaType> acceptedMediaTypes;
+    protected final List<MediaType> consumedMediaTypes;
+    protected final List<MediaType> producedMediaTypes;
 
     /**
      * Constructor.
@@ -73,7 +75,8 @@ abstract class AbstractRouteMatch<T, R> implements MethodBasedRouteMatch<T, R> {
             requiredInputs.put(inputName, requiredArgument);
         }
 
-        this.acceptedMediaTypes = abstractRoute.getConsumes();
+        this.consumedMediaTypes = abstractRoute.getConsumes();
+        this.producedMediaTypes = abstractRoute.getProduces();
     }
 
     @Override
@@ -190,17 +193,17 @@ abstract class AbstractRouteMatch<T, R> implements MethodBasedRouteMatch<T, R> {
 
     @Override
     public R invoke(Object... arguments) {
-        ConversionService conversionService = this.conversionService;
+        ConversionService<?> conversionService = this.conversionService;
 
         Argument[] targetArguments = getArguments();
         if (targetArguments.length == 0) {
             return executableMethod.invoke();
         } else {
-            List argumentList = new ArrayList();
+            List<Object> argumentList = new ArrayList<>(arguments.length);
             Map<String, Object> variables = getVariableValues();
             Iterator<Object> valueIterator = variables.values().iterator();
             int i = 0;
-            for (Argument targetArgument : targetArguments) {
+            for (Argument<?> targetArgument : targetArguments) {
                 String name = targetArgument.getName();
                 Object value = variables.get(name);
                 if (value != null) {
@@ -227,9 +230,9 @@ abstract class AbstractRouteMatch<T, R> implements MethodBasedRouteMatch<T, R> {
         if (targetArguments.length == 0) {
             return executableMethod.invoke();
         } else {
-            ConversionService conversionService = this.conversionService;
+            ConversionService<?> conversionService = this.conversionService;
             Map<String, Object> uriVariables = getVariableValues();
-            List argumentList = new ArrayList();
+            List<Object> argumentList = new ArrayList<>(argumentValues.size());
 
             for (Map.Entry<String, Argument> entry : requiredInputs.entrySet()) {
                 Argument argument = entry.getValue();
@@ -308,13 +311,39 @@ abstract class AbstractRouteMatch<T, R> implements MethodBasedRouteMatch<T, R> {
     }
 
     @Override
-    public boolean accept(MediaType contentType) {
-        return acceptedMediaTypes.isEmpty() || contentType == null || acceptedMediaTypes.contains(MediaType.ALL_TYPE) || explicitAccept(contentType);
+    public boolean doesConsume(MediaType contentType) {
+        return consumedMediaTypes.isEmpty() || contentType == null || consumedMediaTypes.contains(MediaType.ALL_TYPE) || explicitlyConsumes(contentType);
     }
 
     @Override
-    public boolean explicitAccept(MediaType contentType) {
-        return acceptedMediaTypes.contains(contentType);
+    public boolean doesProduce(@Nullable Collection<MediaType> acceptableTypes) {
+        return producedMediaTypes == null || producedMediaTypes.isEmpty() || anyMediaTypesMatch(producedMediaTypes, acceptableTypes);
+    }
+
+    @Override
+    public boolean doesProduce(@Nullable MediaType acceptableType) {
+        return producedMediaTypes == null || producedMediaTypes.isEmpty() || producedMediaTypes.contains(acceptableType);
+    }
+
+    private boolean anyMediaTypesMatch(List<MediaType> producedMediaTypes, Collection<MediaType> acceptableTypes) {
+        if (CollectionUtils.isEmpty(acceptableTypes)) {
+            return true;
+        } else {
+            if (producedMediaTypes.contains(MediaType.ALL_TYPE)) {
+                return true;
+            }
+            for (MediaType acceptableType : acceptableTypes) {
+                if (acceptableType.equals(MediaType.ALL_TYPE) || producedMediaTypes.contains(acceptableType)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean explicitlyConsumes(MediaType contentType) {
+        return consumedMediaTypes.contains(contentType);
     }
 
     @Override

--- a/router/src/main/java/io/micronaut/web/router/BasicObjectRouteMatch.java
+++ b/router/src/main/java/io/micronaut/web/router/BasicObjectRouteMatch.java
@@ -21,10 +21,7 @@ import io.micronaut.http.HttpRequest;
 import io.micronaut.http.MediaType;
 
 import javax.annotation.Nullable;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Function;
 
 /**
@@ -90,7 +87,17 @@ public class BasicObjectRouteMatch implements RouteMatch<Object> {
     }
 
     @Override
-    public boolean accept(@Nullable MediaType contentType) {
+    public boolean doesConsume(@Nullable MediaType contentType) {
+        return true;
+    }
+
+    @Override
+    public boolean doesProduce(@Nullable Collection<MediaType> acceptableTypes) {
+        return true;
+    }
+
+    @Override
+    public boolean doesProduce(@Nullable MediaType acceptableType) {
         return true;
     }
 

--- a/router/src/main/java/io/micronaut/web/router/DefaultRouteBuilder.java
+++ b/router/src/main/java/io/micronaut/web/router/DefaultRouteBuilder.java
@@ -483,7 +483,7 @@ public abstract class DefaultRouteBuilder implements RouteBuilder {
         }
 
         @Override
-        public Route acceptAll() {
+        public Route consumesAll() {
             this.acceptedMediaTypes = Collections.emptyList();
             return this;
         }
@@ -603,7 +603,7 @@ public abstract class DefaultRouteBuilder implements RouteBuilder {
         }
 
         @Override
-        public Route acceptAll() {
+        public Route consumesAll() {
             return this;
         }
 
@@ -718,7 +718,7 @@ public abstract class DefaultRouteBuilder implements RouteBuilder {
         }
 
         @Override
-        public Route acceptAll() {
+        public Route consumesAll() {
             return this;
         }
 
@@ -911,8 +911,8 @@ public abstract class DefaultRouteBuilder implements RouteBuilder {
         }
 
         @Override
-        public UriRoute acceptAll() {
-            return (UriRoute) super.acceptAll();
+        public UriRoute consumesAll() {
+            return (UriRoute) super.consumesAll();
         }
 
         @Override
@@ -1049,7 +1049,7 @@ public abstract class DefaultRouteBuilder implements RouteBuilder {
         }
 
         @Override
-        public Route acceptAll() {
+        public Route consumesAll() {
             return consumes(MediaType.EMPTY_ARRAY);
         }
 

--- a/router/src/main/java/io/micronaut/web/router/DefaultRouteBuilder.java
+++ b/router/src/main/java/io/micronaut/web/router/DefaultRouteBuilder.java
@@ -29,6 +29,7 @@ import io.micronaut.http.HttpMethod;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Consumes;
 import io.micronaut.http.annotation.Produces;
 import io.micronaut.http.filter.HttpFilter;
 import io.micronaut.http.uri.UriMatchInfo;
@@ -185,11 +186,6 @@ public abstract class DefaultRouteBuilder implements RouteBuilder {
 
     @Override
     public StatusRoute status(Class originatingClass, HttpStatus status, Class type, String method, Class[] parameterTypes) {
-        // do not allow multiple local status routes in the same controller
-        // locally declared @Error routes will be allowed and will take precedence over globally defined ones
-        if (this.statusRoutes.stream().anyMatch((route) -> route.status() == status && route.originatingType() == originatingClass)) {
-            throw new RoutingException("Attempted to register multiple local routes for http status " + String.valueOf(status.getCode()));
-        }
         Optional<MethodExecutionHandle<?, Object>> executionHandle = executionHandleLocator.findExecutionHandle(type, method, parameterTypes);
 
         MethodExecutionHandle<?, Object> executableHandle = executionHandle.orElseThrow(() ->
@@ -203,10 +199,6 @@ public abstract class DefaultRouteBuilder implements RouteBuilder {
 
     @Override
     public StatusRoute status(HttpStatus status, Class type, String method, Class[] parameterTypes) {
-        // do not allow multiple @Error global routes defined for one status
-        if (this.statusRoutes.stream().anyMatch((route) -> route.status() == status && route.originatingType() == null)) {
-            throw new RoutingException("Attempted to register multiple global routes for http status " + String.valueOf(status.getCode()));
-        }
         Optional<MethodExecutionHandle<?, Object>> executionHandle = executionHandleLocator.findExecutionHandle(type, method, parameterTypes);
 
         MethodExecutionHandle<?, Object> executableHandle = executionHandle.orElseThrow(() ->
@@ -220,9 +212,6 @@ public abstract class DefaultRouteBuilder implements RouteBuilder {
 
     @Override
     public ErrorRoute error(Class originatingClass, Class<? extends Throwable> error, Class type, String method, Class[] parameterTypes) {
-        if (this.errorRoutes.stream().anyMatch((route) -> route.exceptionType() == error && route.originatingType() == originatingClass)) {
-            throw new RoutingException("Attempted to register multiple local error routes for exception " + error.getName());
-        }
         Optional<MethodExecutionHandle<?, Object>> executionHandle = executionHandleLocator.findExecutionHandle(type, method, parameterTypes);
 
         MethodExecutionHandle<?, Object> executableHandle = executionHandle.orElseThrow(() ->
@@ -236,9 +225,6 @@ public abstract class DefaultRouteBuilder implements RouteBuilder {
 
     @Override
     public ErrorRoute error(Class<? extends Throwable> error, Class type, String method, Class[] parameterTypes) {
-        if (this.errorRoutes.stream().anyMatch((route) -> route.exceptionType() == error && route.originatingType() == null)) {
-            throw new RoutingException("Attempted to register multiple global error routes for exception " + error.getName());
-        }
         Optional<MethodExecutionHandle<?, Object>> executionHandle = executionHandleLocator.findExecutionHandle(type, method, parameterTypes);
 
         MethodExecutionHandle<?, Object> executableHandle = executionHandle.orElseThrow(() ->
@@ -446,9 +432,9 @@ public abstract class DefaultRouteBuilder implements RouteBuilder {
      */
     abstract class AbstractRoute implements MethodBasedRoute {
         protected final List<Predicate<HttpRequest<?>>> conditions = new ArrayList<>();
-        protected final MethodExecutionHandle targetMethod;
+        protected final MethodExecutionHandle<?, ?> targetMethod;
         protected final ConversionService<?> conversionService;
-        protected List<MediaType> acceptedMediaTypes;
+        protected List<MediaType> consumesMediaTypes;
         protected List<MediaType> producesMediaTypes;
         protected String bodyArgumentName;
         protected Argument<?> bodyArgument;
@@ -461,30 +447,38 @@ public abstract class DefaultRouteBuilder implements RouteBuilder {
         AbstractRoute(MethodExecutionHandle targetMethod, ConversionService<?> conversionService, List<MediaType> mediaTypes) {
             this.targetMethod = targetMethod;
             this.conversionService = conversionService;
-            this.acceptedMediaTypes = mediaTypes;
+            this.consumesMediaTypes = mediaTypes;
 
             MediaType[] types = MediaType.of(targetMethod.stringValues(Produces.class));
             if (ArrayUtils.isNotEmpty(types)) {
                 this.producesMediaTypes = Arrays.asList(types);
+            }
+            types = MediaType.of(targetMethod.stringValues(Consumes.class));
+            if (ArrayUtils.isNotEmpty(types)) {
+                this.consumesMediaTypes = Arrays.asList(types);
             }
         }
 
         @Override
         public Route consumes(MediaType... mediaTypes) {
             if (mediaTypes != null) {
-                this.acceptedMediaTypes = Collections.unmodifiableList(Arrays.asList(mediaTypes));
+                this.consumesMediaTypes = Collections.unmodifiableList(Arrays.asList(mediaTypes));
             }
             return this;
         }
 
         @Override
         public List<MediaType> getConsumes() {
-            return acceptedMediaTypes;
+            if (consumesMediaTypes != null) {
+                return consumesMediaTypes;
+            } else {
+                return Collections.emptyList();
+            }
         }
 
         @Override
         public Route consumesAll() {
-            this.acceptedMediaTypes = Collections.emptyList();
+            this.consumesMediaTypes = Collections.emptyList();
             return this;
         }
 
@@ -537,6 +531,24 @@ public abstract class DefaultRouteBuilder implements RouteBuilder {
         protected boolean permitsRequestBody() {
             return true;
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof AbstractRoute)) {
+                return false;
+            }
+            AbstractRoute that = (AbstractRoute) o;
+            return Objects.equals(consumesMediaTypes, that.consumesMediaTypes) &&
+                    Objects.equals(producesMediaTypes, that.producesMediaTypes);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(consumesMediaTypes, producesMediaTypes);
+        }
     }
 
     /**
@@ -562,7 +574,10 @@ public abstract class DefaultRouteBuilder implements RouteBuilder {
          * @param targetMethod The target method execution handle
          * @param conversionService The conversion service
          */
-        public  DefaultErrorRoute(Class originatingClass, Class<? extends Throwable> error, MethodExecutionHandle targetMethod, ConversionService<?> conversionService) {
+        public DefaultErrorRoute(
+                Class originatingClass, Class<? extends Throwable> error,
+                MethodExecutionHandle targetMethod,
+                ConversionService<?> conversionService) {
             super(targetMethod, conversionService, Collections.emptyList());
             this.originatingClass = originatingClass;
             this.error = error;
@@ -599,11 +614,17 @@ public abstract class DefaultRouteBuilder implements RouteBuilder {
 
         @Override
         public ErrorRoute consumes(MediaType... mediaType) {
-            return this;
+            return (ErrorRoute) super.consumes(mediaType);
+        }
+
+        @Override
+        public ErrorRoute produces(MediaType... mediaType) {
+            return (ErrorRoute) super.produces(mediaType);
         }
 
         @Override
         public Route consumesAll() {
+            super.consumesAll();
             return this;
         }
 
@@ -625,27 +646,24 @@ public abstract class DefaultRouteBuilder implements RouteBuilder {
             if (o == null || getClass() != o.getClass()) {
                 return false;
             }
-
-            DefaultErrorRoute that = (DefaultErrorRoute) o;
-
-            if (error != null ? !error.equals(that.error) : that.error != null) {
+            if (!super.equals(o)) {
                 return false;
             }
-            return originatingClass != null ? originatingClass.equals(that.originatingClass) : that.originatingClass == null;
+            DefaultErrorRoute that = (DefaultErrorRoute) o;
+            return error.equals(that.error) &&
+                    Objects.equals(originatingClass, that.originatingClass);
         }
 
         @Override
         public int hashCode() {
-            int result = error != null ? error.hashCode() : 0;
-            result = 31 * result + (originatingClass != null ? originatingClass.hashCode() : 0);
-            return result;
+            return Objects.hash(super.hashCode(), error, originatingClass);
         }
 
         @Override
         public String toString() {
             StringBuilder builder = new StringBuilder();
             return builder.append(' ')
-                .append(error.getName())
+                .append(error.getSimpleName())
                 .append(" -> ")
                 .append(targetMethod.getDeclaringType().getSimpleName())
                 .append('#')
@@ -744,23 +762,20 @@ public abstract class DefaultRouteBuilder implements RouteBuilder {
             if (this == o) {
                 return true;
             }
-            if (o == null || getClass() != o.getClass()) {
+            if (!(o instanceof DefaultStatusRoute)) {
                 return false;
             }
-
+            if (!super.equals(o)) {
+                return false;
+            }
             DefaultStatusRoute that = (DefaultStatusRoute) o;
-
-            if (status != null ? !status.equals(that.status) : that.status != null) {
-                return false;
-            }
-            return originatingClass != null ? originatingClass.equals(that.originatingClass) : that.originatingClass == null;
+            return status == that.status &&
+                    Objects.equals(originatingClass, that.originatingClass);
         }
 
         @Override
         public int hashCode() {
-            int result = status != null ? status.hashCode() : 0;
-            result = 31 * result + (originatingClass != null ? originatingClass.hashCode() : 0);
-            return result;
+            return Objects.hash(super.hashCode(), status, originatingClass);
         }
     }
 
@@ -872,7 +887,7 @@ public abstract class DefaultRouteBuilder implements RouteBuilder {
                 .append('#')
                 .append(targetMethod)
                 .append(" (")
-                .append(String.join(",", acceptedMediaTypes))
+                .append(String.join(",", consumesMediaTypes))
                 .append(" )")
                 .toString();
         }

--- a/router/src/main/java/io/micronaut/web/router/DefaultRouter.java
+++ b/router/src/main/java/io/micronaut/web/router/DefaultRouter.java
@@ -24,6 +24,7 @@ import io.micronaut.http.HttpStatus;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.filter.HttpFilter;
 import io.micronaut.http.uri.UriMatchTemplate;
+import io.micronaut.web.router.exceptions.RoutingException;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -45,10 +46,11 @@ import java.util.stream.Stream;
 @Singleton
 public class DefaultRouter implements Router {
 
+    private static final List<MediaType> ACCEPT_ALL = Collections.singletonList(MediaType.ALL_TYPE);
     private final Map<String, List<UriRoute>> routesByMethod = new HashMap<>();
-    private final Set<StatusRoute> statusRoutes = new HashSet<>();
+    private final List<StatusRoute> statusRoutes = new ArrayList<>();
     private final Collection<FilterRoute> filterRoutes = new ArrayList<>();
-    private final Set<ErrorRoute> errorRoutes = new HashSet<>();
+    private final List<ErrorRoute> errorRoutes = new ArrayList<>();
     private final Set<Integer> exposedPorts;
     private List<Integer> defaultPorts;
 
@@ -67,8 +69,20 @@ public class DefaultRouter implements Router {
                 routesByMethod.computeIfAbsent(key, x -> new ArrayList<>()).add(route);
             }
 
-            this.statusRoutes.addAll(builder.getStatusRoutes());
-            this.errorRoutes.addAll(builder.getErrorRoutes());
+            for (StatusRoute statusRoute : builder.getStatusRoutes()) {
+                if (statusRoutes.contains(statusRoute)) {
+                    final StatusRoute existing = statusRoutes.stream().filter(r -> r.equals(statusRoute)).findFirst().orElse(null);
+                    throw new RoutingException("Attempted to register multiple local routes for http status [" + statusRoute.status() + "]. New route: " + statusRoute + ". Existing: " + existing);
+                }
+                this.statusRoutes.add(statusRoute);
+            }
+            for (ErrorRoute errorRoute : builder.getErrorRoutes()) {
+                if (errorRoutes.contains(errorRoute)) {
+                    final ErrorRoute existing = errorRoutes.stream().filter(r -> r.equals(errorRoute)).findFirst().orElse(null);
+                    throw new RoutingException("Attempted to register multiple local routes for error [" + errorRoute.exceptionType().getSimpleName() + "]. New route: " + errorRoute + ". Existing: " + existing);
+                }
+                this.errorRoutes.add(errorRoute);
+            }
             this.filterRoutes.addAll(builder.getFilterRoutes());
             exposedPorts.addAll(builder.getExposedPorts());
         }
@@ -270,6 +284,109 @@ public class DefaultRouter implements Router {
     }
 
     @Override
+    public <R> Optional<RouteMatch<R>> findErrorRoute(
+            @Nonnull Class<?> originatingClass,
+            @Nonnull Throwable error,
+            HttpRequest<?> request) {
+        return findErrorRouteInternal(originatingClass, error, request);
+    }
+
+    private <R> Optional<RouteMatch<R>> findErrorRouteInternal(
+            @Nullable Class<?> originatingClass,
+            @Nonnull Throwable error, HttpRequest<?> request) {
+        Collection<MediaType> accept =
+                request.accept();
+        final boolean hasAcceptHeader = CollectionUtils.isNotEmpty(accept);
+        if (hasAcceptHeader) {
+
+            for (ErrorRoute errorRoute : errorRoutes) {
+                @SuppressWarnings("unchecked")
+                final RouteMatch<R> match = (RouteMatch<R>) errorRoute
+                        .match(originatingClass, error).orElse(null);
+                if (match != null) {
+                    if (match.doesProduce(accept)) {
+                        return Optional.of(match);
+                    }
+                }
+            }
+        } else {
+            RouteMatch<R> firstMatch = null;
+            for (ErrorRoute errorRoute : errorRoutes) {
+                @SuppressWarnings("unchecked")
+                final RouteMatch<R> match = (RouteMatch<R>) errorRoute
+                        .match(originatingClass, error).orElse(null);
+                if (match != null) {
+                    final List<MediaType> produces = match.getProduces();
+                    if (CollectionUtils.isEmpty(produces) || produces.contains(MediaType.ALL_TYPE)) {
+                        return Optional.of(match);
+                    } else if (firstMatch == null) {
+                        firstMatch = match;
+                    }
+                }
+            }
+
+            return Optional.ofNullable(firstMatch);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public <R> Optional<RouteMatch<R>> findErrorRoute(@Nonnull Throwable error, HttpRequest<?> request) {
+        return findErrorRouteInternal(null, error, request);
+    }
+
+    @Override
+    public <R> Optional<RouteMatch<R>> findStatusRoute(
+            @Nonnull Class<?> originatingClass,
+            @Nonnull HttpStatus status,
+            HttpRequest<?> request) {
+        return findStatusInternal(originatingClass, status, request);
+    }
+
+    @Override
+    public <R> Optional<RouteMatch<R>> findStatusRoute(@Nonnull HttpStatus status, HttpRequest<?> request) {
+        return findStatusInternal(null, status, request);
+    }
+
+    private <R> Optional<RouteMatch<R>> findStatusInternal(@Nullable Class<?> originatingClass, @Nonnull HttpStatus status, HttpRequest<?> request) {
+        Collection<MediaType> accept =
+                request.accept();
+        final boolean hasAcceptHeader = CollectionUtils.isNotEmpty(accept);
+        if (hasAcceptHeader) {
+
+            for (StatusRoute statusRoute : statusRoutes) {
+                @SuppressWarnings("unchecked")
+                final RouteMatch<R> match = (RouteMatch<R>) statusRoute
+                        .match(originatingClass, status).orElse(null);
+                if (match != null) {
+                    if (match.doesProduce(accept)) {
+                        return Optional.of(match);
+                    }
+                }
+            }
+        } else {
+            RouteMatch<R> firstMatch = null;
+            for (StatusRoute errorRoute : statusRoutes) {
+                @SuppressWarnings("unchecked")
+                final RouteMatch<R> match = (RouteMatch<R>) errorRoute
+                        .match(originatingClass, status).orElse(null);
+                if (match != null) {
+                    final List<MediaType> produces = match.getProduces();
+                    if (CollectionUtils.isEmpty(produces) || produces.contains(MediaType.ALL_TYPE)) {
+                        return Optional.of(match);
+                    } else if (firstMatch == null) {
+                        firstMatch = match;
+                    }
+                }
+            }
+
+            return Optional.ofNullable(firstMatch);
+
+        }
+        return Optional.empty();
+    }
+
+    @Override
     public <R> Optional<RouteMatch<R>> route(@Nonnull Throwable error) {
         Map<ErrorRoute, RouteMatch<R>> matchedRoutes = new LinkedHashMap<>();
         for (ErrorRoute errorRoute : errorRoutes) {
@@ -300,7 +417,6 @@ public class DefaultRouter implements Router {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Deprecated
     @Nonnull
     @Override

--- a/router/src/main/java/io/micronaut/web/router/ErrorRoute.java
+++ b/router/src/main/java/io/micronaut/web/router/ErrorRoute.java
@@ -66,4 +66,7 @@ public interface ErrorRoute extends MethodBasedRoute {
 
     @Override
     ErrorRoute where(Predicate<HttpRequest<?>> condition);
+
+    @Override
+    ErrorRoute produces(MediaType... mediaType);
 }

--- a/router/src/main/java/io/micronaut/web/router/Route.java
+++ b/router/src/main/java/io/micronaut/web/router/Route.java
@@ -59,7 +59,7 @@ public interface Route {
      *
      * @return A new route with the media type applied
      */
-    Route acceptAll();
+    Route consumesAll();
 
     /**
      * Defines routes nested within this route.
@@ -110,5 +110,16 @@ public interface Route {
      */
     default List<MediaType> getConsumes() {
         return Collections.emptyList();
+    }
+
+    /**
+     * Accept all {@link MediaType} references.
+     *
+     * @return A new route with the media type applied
+     * @deprecated Use {@link #consumesAll()} instead.
+     */
+    @Deprecated
+    default Route acceptAll() {
+        return consumesAll();
     }
 }

--- a/router/src/main/java/io/micronaut/web/router/RouteMatch.java
+++ b/router/src/main/java/io/micronaut/web/router/RouteMatch.java
@@ -157,7 +157,23 @@ public interface RouteMatch<R> extends Callable<R>, Predicate<HttpRequest>, Anno
      * @param contentType The content type
      * @return True if it is
      */
-    boolean accept(@Nullable MediaType contentType);
+    boolean doesConsume(@Nullable MediaType contentType);
+
+    /**
+     * Whether the route does produce any of the given types.
+     *
+     * @param acceptableTypes The acceptable types
+     * @return True if it is
+     */
+    boolean doesProduce(@Nullable Collection<MediaType> acceptableTypes);
+
+    /**
+     * Whether the route does produce any of the given types.
+     *
+     * @param acceptableType The acceptable type
+     * @return True if it is
+     */
+    boolean doesProduce(@Nullable MediaType acceptableType);
 
     /**
      * Whether the specified content type is explicitly an accepted type.
@@ -165,6 +181,18 @@ public interface RouteMatch<R> extends Callable<R>, Predicate<HttpRequest>, Anno
      * @param contentType The content type
      * @return True if it is
      */
+    default boolean explicitlyConsumes(@Nullable MediaType contentType) {
+        return false;
+    }
+
+    /**
+     * Whether the specified content type is explicitly an accepted type.
+     *
+     * @param contentType The content type
+     * @return True if it is
+     * @deprecated Use {@link #explicitlyConsumes(MediaType)} instead
+     */
+    @Deprecated
     default boolean explicitAccept(@Nullable MediaType contentType) {
         return false;
     }
@@ -178,5 +206,17 @@ public interface RouteMatch<R> extends Callable<R>, Predicate<HttpRequest>, Anno
     default boolean isSatisfied(String name) {
         Object val = getVariableValues().get(name);
         return val != null && !(val instanceof UnresolvedArgument);
+    }
+
+    /**
+     * Whether the specified content type is an accepted type.
+     *
+     * @param contentType The content type
+     * @return True if it is
+     * @deprecated Use {@link #doesConsume(MediaType)} instead.
+     */
+    @Deprecated
+    default boolean accept(@Nullable MediaType contentType) {
+        return doesConsume(contentType);
     }
 }

--- a/router/src/main/java/io/micronaut/web/router/Router.java
+++ b/router/src/main/java/io/micronaut/web/router/Router.java
@@ -47,7 +47,8 @@ public interface Router {
      * @deprecated Use {@link #findAny(CharSequence, HttpRequest)} instead
      */
     @Deprecated
-    @Nonnull <T, R> Stream<UriRouteMatch<T, R>> findAny(@Nonnull CharSequence uri);
+    @Nonnull
+    <T, R> Stream<UriRouteMatch<T, R>> findAny(@Nonnull CharSequence uri);
 
     /**
      * Find any {@link RouteMatch} regardless of HTTP method.
@@ -58,7 +59,8 @@ public interface Router {
      * @param <R>     The return type
      * @return A stream of route matches
      */
-    default @Nonnull <T, R> Stream<UriRouteMatch<T, R>> findAny(@Nonnull CharSequence uri, @Nullable HttpRequest<?> context) {
+    default @Nonnull
+    <T, R> Stream<UriRouteMatch<T, R>> findAny(@Nonnull CharSequence uri, @Nullable HttpRequest<?> context) {
         return findAny(uri);
     }
 
@@ -79,13 +81,14 @@ public interface Router {
      *
      * @param httpMethod The HTTP method
      * @param uri        The URI route match
-     * @param <T> The target type
+     * @param <T>        The target type
      * @param <R>        The type
      * @return A {@link Stream} of possible {@link Route} instances.
      * @deprecated Use {@link #find(HttpMethod, CharSequence, HttpRequest)} instead
      */
     @Deprecated
-    @Nonnull <T, R> Stream<UriRouteMatch<T, R>> find(@Nonnull HttpMethod httpMethod, @Nonnull CharSequence uri);
+    @Nonnull
+    <T, R> Stream<UriRouteMatch<T, R>> find(@Nonnull HttpMethod httpMethod, @Nonnull CharSequence uri);
 
     /**
      * Finds all of the possible routes for the given HTTP method and URI.
@@ -97,7 +100,8 @@ public interface Router {
      * @param <R>        The type
      * @return A {@link Stream} of possible {@link Route} instances.
      */
-    default @Nonnull <T, R> Stream<UriRouteMatch<T, R>> find(@Nonnull HttpMethod httpMethod, @Nonnull CharSequence uri, @Nullable HttpRequest<?> context) {
+    default @Nonnull
+    <T, R> Stream<UriRouteMatch<T, R>> find(@Nonnull HttpMethod httpMethod, @Nonnull CharSequence uri, @Nullable HttpRequest<?> context) {
         return find(httpMethod, uri);
     }
 
@@ -106,13 +110,14 @@ public interface Router {
      *
      * @param httpMethod The HTTP method
      * @param uri        The URI
-     * @param <T> The target type
+     * @param <T>        The target type
      * @param <R>        The URI route match
      * @return A {@link Stream} of possible {@link Route} instances.
      * @deprecated Use {@link #find(HttpMethod, URI, HttpRequest)} instead
      */
     @Deprecated
-    default @Nonnull <T, R> Stream<UriRouteMatch<T, R>> find(@Nonnull HttpMethod httpMethod, @Nonnull URI uri) {
+    default @Nonnull
+    <T, R> Stream<UriRouteMatch<T, R>> find(@Nonnull HttpMethod httpMethod, @Nonnull URI uri) {
         return find(httpMethod, uri, null);
     }
 
@@ -122,11 +127,12 @@ public interface Router {
      * @param httpMethod The HTTP method
      * @param uri        The URI
      * @param context    The optional {@link HttpRequest} context
-     * @param <T> The target type
+     * @param <T>        The target type
      * @param <R>        The URI route match
      * @return A {@link Stream} of possible {@link Route} instances.
      */
-    default @Nonnull <T, R> Stream<UriRouteMatch<T, R>> find(@Nonnull HttpMethod httpMethod, @Nonnull URI uri, @Nullable HttpRequest<?> context) {
+    default @Nonnull
+    <T, R> Stream<UriRouteMatch<T, R>> find(@Nonnull HttpMethod httpMethod, @Nonnull URI uri, @Nullable HttpRequest<?> context) {
         return find(httpMethod, uri.toString());
     }
 
@@ -138,20 +144,23 @@ public interface Router {
      * @param <R>     The URI route match
      * @return A {@link Stream} of possible {@link Route} instances.
      */
-    default @Nonnull <T, R> Stream<UriRouteMatch<T, R>> find(@Nonnull HttpRequest<?> request) {
+    default @Nonnull
+    <T, R> Stream<UriRouteMatch<T, R>> find(@Nonnull HttpRequest<?> request) {
         return find(request, request.getPath());
     }
 
     /**
      * Find method, that should be used for non-standard http methods. For standards it should act
      * the same as {@link #find(HttpMethod, URI)}
+     *
      * @param request The request, that can have overridden {@link HttpRequest#getMethodName()}
-     * @param uri The URI route match.
-     * @param <T> The target type.
-     * @param <R> The type of what
+     * @param uri     The URI route match.
+     * @param <T>     The target type.
+     * @param <R>     The type of what
      * @return A {@link Stream} of possible {@link Route} instances.
      */
-    default @Nonnull  <T, R> Stream<UriRouteMatch<T, R>> find(@Nonnull HttpRequest request, @Nonnull CharSequence uri) {
+    default @Nonnull
+    <T, R> Stream<UriRouteMatch<T, R>> find(@Nonnull HttpRequest request, @Nonnull CharSequence uri) {
         return find(HttpMethod.valueOf(request.getMethodName()), uri);
     }
 
@@ -159,26 +168,28 @@ public interface Router {
      * Finds the closest match for the given request.
      *
      * @param request The request
-     * @param <T> The target type
-     * @param <R>        The type
+     * @param <T>     The target type
+     * @param <R>     The type
      * @return A {@link List} of possible {@link Route} instances.
      * @since 1.2.1
      */
-    @Nonnull <T, R> List<UriRouteMatch<T, R>> findAllClosest(@Nonnull HttpRequest<?> request);
+    @Nonnull
+    <T, R> List<UriRouteMatch<T, R>> findAllClosest(@Nonnull HttpRequest<?> request);
 
     /**
      * Returns all UriRoutes.
      *
      * @return A {@link Stream} of all registered {@link UriRoute} instances.
      */
-    @Nonnull Stream<UriRoute> uriRoutes();
+    @Nonnull
+    Stream<UriRoute> uriRoutes();
 
     /**
      * Finds the first possible route for the given HTTP method and URI.
      *
      * @param httpMethod The HTTP method
      * @param uri        The URI
-     * @param <T> The target type
+     * @param <T>        The target type
      * @param <R>        The URI route match
      * @return The route match
      */
@@ -197,8 +208,8 @@ public interface Router {
      * Found a {@link RouteMatch} for the given {@link io.micronaut.http.HttpStatus} code.
      *
      * @param originatingClass The class the error originates from
-     * @param status The HTTP status
-     * @param <R>    The matched route
+     * @param status           The HTTP status
+     * @param <R>              The matched route
      * @return The {@link RouteMatch}
      */
     <R> Optional<RouteMatch<R>> route(@Nonnull Class originatingClass, @Nonnull HttpStatus status);
@@ -223,12 +234,65 @@ public interface Router {
     <R> Optional<RouteMatch<R>> route(@Nonnull Class originatingClass, @Nonnull Throwable error);
 
     /**
+     * Match a route to an error.
+     *
+     * @param originatingClass The class the error originates from
+     * @param error            The error
+     * @param request          The request
+     * @param <R>              The matched route
+     * @return The {@link RouteMatch}
+     */
+    <R> Optional<RouteMatch<R>> findErrorRoute(
+            @Nonnull Class<?> originatingClass,
+            @Nonnull Throwable error,
+            HttpRequest<?> request);
+
+    /**
+     * Match a route to an error.
+     *
+     * @param error            The error
+     * @param request          The request
+     * @param <R>              The matched route
+     * @return The {@link RouteMatch}
+     */
+    <R> Optional<RouteMatch<R>> findErrorRoute(
+            @Nonnull Throwable error,
+            HttpRequest<?> request);
+
+    /**
+     * Found a {@link RouteMatch} for the given {@link io.micronaut.http.HttpStatus} code.
+     *
+     * @param originatingClass The class the error originates from
+     * @param status           The HTTP status
+     * @param request          The request
+     * @param <R>              The matched route
+     * @return The {@link RouteMatch}
+     */
+    <R> Optional<RouteMatch<R>> findStatusRoute(
+            @Nonnull Class<?> originatingClass,
+            @Nonnull HttpStatus status,
+            HttpRequest<?> request);
+
+    /**
+     * Found a {@link RouteMatch} for the given {@link io.micronaut.http.HttpStatus} code.
+     *
+     * @param status           The HTTP status
+     * @param request          The request
+     * @param <R>              The matched route
+     * @return The {@link RouteMatch}
+     */
+    <R> Optional<RouteMatch<R>> findStatusRoute(
+            @Nonnull HttpStatus status,
+            HttpRequest<?> request);
+
+    /**
      * Build a filtered {@link org.reactivestreams.Publisher} for an action.
      *
      * @param request The request
      * @return A new filtered publisher
      */
-    @Nonnull List<HttpFilter> findFilters(
+    @Nonnull
+    List<HttpFilter> findFilters(
             @Nonnull HttpRequest<?> request
     );
 

--- a/router/src/main/java/io/micronaut/web/router/UriRoute.java
+++ b/router/src/main/java/io/micronaut/web/router/UriRoute.java
@@ -79,7 +79,7 @@ public interface UriRoute extends Route, UriMatcher, Comparable<UriRoute> {
     UriRoute produces(MediaType... mediaType);
 
     @Override
-    UriRoute acceptAll();
+    UriRoute consumesAll();
 
     @Override
     UriRoute where(Predicate<HttpRequest<?>> condition);

--- a/router/src/main/java/io/micronaut/web/router/filter/FilteredRouter.java
+++ b/router/src/main/java/io/micronaut/web/router/filter/FilteredRouter.java
@@ -151,6 +151,26 @@ public class FilteredRouter implements Router {
         return router.route(originatingClass, error);
     }
 
+    @Override
+    public <R> Optional<RouteMatch<R>> findErrorRoute(@Nonnull Class<?> originatingClass, @Nonnull Throwable error, HttpRequest<?> request) {
+        return router.findErrorRoute(originatingClass, error, request);
+    }
+
+    @Override
+    public <R> Optional<RouteMatch<R>> findErrorRoute(@Nonnull Throwable error, HttpRequest<?> request) {
+        return router.findErrorRoute(error, request);
+    }
+
+    @Override
+    public <R> Optional<RouteMatch<R>> findStatusRoute(@Nonnull Class<?> originatingClass, @Nonnull HttpStatus status, HttpRequest<?> request) {
+        return router.findStatusRoute(originatingClass, status, request);
+    }
+
+    @Override
+    public <R> Optional<RouteMatch<R>> findStatusRoute(@Nonnull HttpStatus status, HttpRequest<?> request) {
+        return router.findStatusRoute(status, request);
+    }
+
     @Nonnull
     @Override
     public List<HttpFilter> findFilters(@Nonnull HttpRequest<?> request) {

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/client/upload/MultipartFileUploadSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/client/upload/MultipartFileUploadSpec.groovy
@@ -6,6 +6,7 @@ import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.MediaType
 import io.micronaut.http.annotation.Post
+import io.micronaut.http.annotation.Produces
 import io.micronaut.http.client.HttpClient
 
 import io.micronaut.runtime.server.EmbeddedServer
@@ -228,6 +229,7 @@ class MultipartFileUploadSpec extends Specification {
     }
 
     @Controller('/multipart')
+    @Produces(MediaType.TEXT_PLAIN)
     static class MultipartController {
 
 

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/intro/HelloClient.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/intro/HelloClient.groovy
@@ -15,6 +15,8 @@
  */
 package io.micronaut.docs.server.intro
 
+import io.micronaut.http.MediaType
+
 // tag::imports[]
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.client.annotation.Client
@@ -29,7 +31,7 @@ import io.reactivex.Single
 @Client("/hello") // <1>
 interface HelloClient {
 
-    @Get // <2>
+    @Get(consumes = MediaType.TEXT_PLAIN) // <2>
     Single<String> hello() // <3>
 }
 // end::class[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/sse/HeadlineController.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/sse/HeadlineController.groovy
@@ -15,6 +15,8 @@
  */
 package io.micronaut.docs.server.sse
 
+import io.micronaut.http.MediaType
+
 // tag::imports[]
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
@@ -34,7 +36,7 @@ import org.reactivestreams.Publisher
 @Controller("/headlines")
 class HeadlineController {
 
-    @Get
+    @Get(produces = MediaType.TEXT_EVENT_STREAM)
     Publisher<Event<Headline>> index() { // <1>
         String[] versions = ["1.0", "2.0"] // <2>
 

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/upload/BytesUploadController.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/upload/BytesUploadController.groovy
@@ -28,7 +28,9 @@ import java.nio.file.Paths
 @Controller("/upload")
 class BytesUploadController {
 
-    @Post(value = "/bytes", consumes = MediaType.MULTIPART_FORM_DATA) // <1>
+    @Post(value = "/bytes",
+            consumes = MediaType.MULTIPART_FORM_DATA,
+            produces = MediaType.TEXT_PLAIN) // <1>
     HttpResponse<String> uploadBytes(byte[] file, String fileName) { // <2>
         try {
             File tempFile = File.createTempFile(fileName, "temp")

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/upload/CompletedUploadController.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/upload/CompletedUploadController.groovy
@@ -29,7 +29,9 @@ import java.nio.file.Paths
 @Controller("/upload")
 class CompletedUploadController {
 
-    @Post(value = "/completed", consumes = MediaType.MULTIPART_FORM_DATA) // <1>
+    @Post(value = "/completed",
+            consumes = MediaType.MULTIPART_FORM_DATA,
+            produces = MediaType.TEXT_PLAIN) // <1>
     HttpResponse<String> uploadCompleted(CompletedFileUpload file) { // <2>
         try {
             File tempFile = File.createTempFile(file.filename, "temp") //<3>

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/upload/UploadController.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/upload/UploadController.groovy
@@ -28,7 +28,7 @@ import org.reactivestreams.Publisher
 @Controller("/upload")
 class UploadController {
 
-    @Post(value = "/", consumes = MediaType.MULTIPART_FORM_DATA) // <1>
+    @Post(value = "/", consumes = MediaType.MULTIPART_FORM_DATA, produces = MediaType.TEXT_PLAIN) // <1>
     Single<HttpResponse<String>> upload(StreamingFileUpload file) { // <2>
         File tempFile = File.createTempFile(file.filename, "temp")
         Publisher<Boolean> uploadPublisher = file.transferTo(tempFile) // <3>

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/upload/WholeBodyUploadController.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/upload/WholeBodyUploadController.groovy
@@ -30,7 +30,9 @@ import org.reactivestreams.Subscription
 @Controller("/upload")
 class WholeBodyUploadController {
 
-    @Post(value = "/whole-body", consumes = MediaType.MULTIPART_FORM_DATA) // <1>
+    @Post(value = "/whole-body",
+            consumes = MediaType.MULTIPART_FORM_DATA,
+            produces = MediaType.TEXT_PLAIN) // <1>
     Single<String> uploadBytes(@Body MultipartBody body) { // <2>
         Single.<String>create({ emitter ->
             body.subscribe(new Subscriber<CompletedPart>() {

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/client/upload/MultipartFileUploadSpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/client/upload/MultipartFileUploadSpec.kt
@@ -114,7 +114,7 @@ class MultipartFileUploadSpec: StringSpec() {
     @Controller("/multipart")
     internal class MultipartController {
 
-        @Post(value = "/upload", consumes = [MediaType.MULTIPART_FORM_DATA])
+        @Post(value = "/upload", consumes = [MediaType.MULTIPART_FORM_DATA], produces = [MediaType.TEXT_PLAIN])
         fun upload(data: ByteArray): HttpResponse<String> {
             return HttpResponse.ok("Uploaded " + data.size + " bytes")
         }

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/intro/HelloClient.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/intro/HelloClient.kt
@@ -16,6 +16,7 @@
 package io.micronaut.docs.server.intro
 
 // tag::imports[]
+import io.micronaut.http.MediaType
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.client.annotation.Client
 import io.reactivex.Single
@@ -29,7 +30,7 @@ import io.reactivex.Single
 @Client("/hello") // <1>
 interface HelloClient {
 
-    @Get // <2>
+    @Get(consumes = [MediaType.TEXT_PLAIN]) // <2>
     fun hello(): Single<String>  // <3>
 }
 // end::class[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/sse/HeadlineController.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/sse/HeadlineController.kt
@@ -17,6 +17,7 @@ package io.micronaut.docs.server.sse
 
 // tag::imports[]
 
+import io.micronaut.http.MediaType
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.sse.Event
@@ -32,7 +33,7 @@ import java.util.concurrent.Callable
 @Controller("/headlines")
 class HeadlineController {
 
-    @Get
+    @Get(produces = [MediaType.TEXT_EVENT_STREAM])
     fun index(): Publisher<Event<Headline>> { // <1>
         val versions = arrayOf("1.0", "2.0") // <2>
 

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/upload/BytesUploadController.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/upload/BytesUploadController.kt
@@ -30,7 +30,9 @@ import java.nio.file.Paths
 @Controller("/upload")
 class BytesUploadController {
 
-    @Post(value = "/bytes", consumes = [MediaType.MULTIPART_FORM_DATA]) // <1>
+    @Post(value = "/bytes",
+            consumes = [MediaType.MULTIPART_FORM_DATA],
+            produces = [MediaType.TEXT_PLAIN]) // <1>
     fun uploadBytes(file: ByteArray, fileName: String): HttpResponse<String> { // <2>
         return try {
             val tempFile = File.createTempFile(fileName, "temp")

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/upload/CompletedUploadController.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/upload/CompletedUploadController.kt
@@ -31,7 +31,9 @@ import java.nio.file.Paths
 @Controller("/upload")
 class CompletedUploadController {
 
-    @Post(value = "/completed", consumes = [MediaType.MULTIPART_FORM_DATA]) // <1>
+    @Post(value = "/completed",
+            consumes = [MediaType.MULTIPART_FORM_DATA],
+            produces = [MediaType.TEXT_PLAIN]) // <1>
     fun uploadCompleted(file: CompletedFileUpload): HttpResponse<String> { // <2>
         return try {
             val tempFile = File.createTempFile(file.filename, "temp") //<3>

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/upload/UploadController.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/upload/UploadController.kt
@@ -28,7 +28,7 @@ import java.io.File
 @Controller("/upload")
 class UploadController {
 
-    @Post(value = "/", consumes = [MediaType.MULTIPART_FORM_DATA]) // <1>
+    @Post(value = "/", consumes = [MediaType.MULTIPART_FORM_DATA], produces = [MediaType.TEXT_PLAIN]) // <1>
     fun upload(file: StreamingFileUpload): Single<HttpResponse<String>> { // <2>
         val tempFile = File.createTempFile(file.filename, "temp")
         val uploadPublisher = file.transferTo(tempFile) // <3>

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/upload/WholeBodyUploadController.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/upload/WholeBodyUploadController.kt
@@ -30,7 +30,9 @@ import org.reactivestreams.Subscription
 @Controller("/upload")
 class WholeBodyUploadController {
 
-    @Post(value = "/whole-body", consumes = [MediaType.MULTIPART_FORM_DATA]) // <1>
+    @Post(value = "/whole-body",
+            consumes = [MediaType.MULTIPART_FORM_DATA],
+            produces = [MediaType.TEXT_PLAIN]) // <1>
     fun uploadBytes(@Body body: MultipartBody): Single<String> { // <2>
         return Single.create { emitter ->
             body.subscribe(object : Subscriber<CompletedPart> {

--- a/test-suite/src/test/groovy/io/micronaut/upload/DiskUploadSpec.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/upload/DiskUploadSpec.groovy
@@ -181,7 +181,7 @@ class DiskUploadSpec extends AbstractMicronautSpec {
         Flowable<HttpResponse<String>> flowable = Flowable.fromPublisher(client.exchange(
                 HttpRequest.POST("/upload/receive-flow-data", requestBody)
                         .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .accept(MediaType.APPLICATION_JSON_TYPE),
+                        .accept(MediaType.TEXT_PLAIN),
                 String
         ))
         HttpResponse<String> response = flowable.blockingFirst()
@@ -224,7 +224,7 @@ class DiskUploadSpec extends AbstractMicronautSpec {
         Flowable<HttpResponse<String>> flowable = Flowable.fromPublisher(client.exchange(
                 HttpRequest.POST("/upload/receive-multiple-flow-data", requestBody)
                         .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .accept(MediaType.APPLICATION_JSON_TYPE),
+                        .accept(MediaType.TEXT_PLAIN),
                 String
         ))
         HttpResponse<String> response = flowable.blockingFirst()

--- a/test-suite/src/test/groovy/io/micronaut/upload/MixedUploadSpec.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/upload/MixedUploadSpec.groovy
@@ -181,7 +181,7 @@ class MixedUploadSpec extends AbstractMicronautSpec {
         Flowable<HttpResponse<String>> flowable = Flowable.fromPublisher(client.exchange(
                 HttpRequest.POST("/upload/receive-flow-data", requestBody)
                         .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .accept(MediaType.APPLICATION_JSON_TYPE),
+                        .accept(MediaType.TEXT_PLAIN),
                 String
         ))
         HttpResponse<String> response = flowable.blockingFirst()
@@ -224,7 +224,7 @@ class MixedUploadSpec extends AbstractMicronautSpec {
         Flowable<HttpResponse<String>> flowable = Flowable.fromPublisher(client.exchange(
                 HttpRequest.POST("/upload/receive-multiple-flow-data", requestBody)
                         .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .accept(MediaType.APPLICATION_JSON_TYPE),
+                        .accept(MediaType.TEXT_PLAIN),
                 String
         ))
         HttpResponse<String> response = flowable.blockingFirst()

--- a/test-suite/src/test/groovy/io/micronaut/upload/StreamUploadSpec.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/upload/StreamUploadSpec.groovy
@@ -66,8 +66,7 @@ class StreamUploadSpec extends AbstractMicronautSpec {
         when:
         Flowable<HttpResponse<String>> flowable = Flowable.fromPublisher(client.exchange(
                 HttpRequest.POST("/upload/validated/receive-file-upload", requestBody)
-                        .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .accept(MediaType.TEXT_PLAIN_TYPE), String
+                        .contentType(MediaType.MULTIPART_FORM_DATA), String
         ))
         HttpResponse<String> response = flowable.blockingFirst()
 
@@ -84,8 +83,7 @@ class StreamUploadSpec extends AbstractMicronautSpec {
         when:
         HttpResponse response = client.toBlocking().exchange(
                 HttpRequest.POST("/upload/receive-flow-parts", requestBody)
-                        .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .accept(MediaType.TEXT_PLAIN_TYPE), Boolean)
+                        .contentType(MediaType.MULTIPART_FORM_DATA), Boolean)
 
         then:
         response.code() == HttpStatus.OK.code
@@ -216,7 +214,7 @@ class StreamUploadSpec extends AbstractMicronautSpec {
         Flowable<HttpResponse<String>> flowable = Flowable.fromPublisher(client.exchange(
                 HttpRequest.POST("/upload/receive-flow-data", requestBody)
                         .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .accept(MediaType.APPLICATION_JSON_TYPE),
+                        .accept(MediaType.TEXT_PLAIN),
                 String
         ))
         HttpResponse<String> response = flowable.blockingFirst()
@@ -259,7 +257,7 @@ class StreamUploadSpec extends AbstractMicronautSpec {
         Flowable<HttpResponse<String>> flowable = Flowable.fromPublisher(client.exchange(
                 HttpRequest.POST("/upload/receive-multiple-flow-data", requestBody)
                         .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .accept(MediaType.APPLICATION_JSON_TYPE),
+                        .accept(MediaType.TEXT_PLAIN),
                 String
         ))
         HttpResponse<String> response = flowable.blockingFirst()
@@ -412,7 +410,7 @@ class StreamUploadSpec extends AbstractMicronautSpec {
         Flowable<HttpResponse<String>> flowable = Flowable.fromPublisher(client.exchange(
                 HttpRequest.POST("/upload/receive-multipart-body", requestBody)
                         .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .accept(MediaType.APPLICATION_JSON_TYPE),
+                        .accept(MediaType.TEXT_PLAIN),
                 String
         ))
         HttpResponse<String> response = flowable.blockingFirst()

--- a/test-suite/src/test/groovy/io/micronaut/upload/UploadController.java
+++ b/test-suite/src/test/groovy/io/micronaut/upload/UploadController.java
@@ -56,29 +56,29 @@ import java.util.concurrent.atomic.LongAdder;
 @Controller("/upload")
 public class UploadController {
 
-    @Post(value = "/receive-json", consumes = MediaType.MULTIPART_FORM_DATA)
+    @Post(value = "/receive-json", consumes = MediaType.MULTIPART_FORM_DATA, produces = MediaType.TEXT_PLAIN)
     public String receiveJson(Data data, String title) {
         return title + ": " + data.toString();
     }
 
-    @Post(value = "/receive-plain", consumes = MediaType.MULTIPART_FORM_DATA)
+    @Post(value = "/receive-plain", consumes = MediaType.MULTIPART_FORM_DATA, produces = MediaType.TEXT_PLAIN)
     public String receivePlain(String data, String title) {
         return title + ": " + data;
     }
 
-    @Post(value = "/receive-bytes", consumes = MediaType.MULTIPART_FORM_DATA)
+    @Post(value = "/receive-bytes", consumes = MediaType.MULTIPART_FORM_DATA, produces = MediaType.TEXT_PLAIN)
     public String receiveBytes(byte[] data, String title) {
         return title + ": " + data.length;
     }
 
-    @Post(value = "/receive-file-upload", consumes = MediaType.MULTIPART_FORM_DATA)
+    @Post(value = "/receive-file-upload", consumes = MediaType.MULTIPART_FORM_DATA, produces = MediaType.TEXT_PLAIN)
     public Publisher<MutableHttpResponse<?>> receiveFileUpload(StreamingFileUpload data, String title) {
         long size = data.getDefinedSize();
         return Flowable.fromPublisher(data.transferTo(title + ".json"))
                        .map(success -> success ? HttpResponse.ok( "Uploaded " + size  ) : HttpResponse.status(HttpStatus.INTERNAL_SERVER_ERROR, "Something bad happened")).onErrorReturnItem(HttpResponse.status(HttpStatus.INTERNAL_SERVER_ERROR, "Something bad happened"));
     }
 
-    @Post(value = "/receive-completed-file-upload", consumes = MediaType.MULTIPART_FORM_DATA)
+    @Post(value = "/receive-completed-file-upload", consumes = MediaType.MULTIPART_FORM_DATA, produces = MediaType.TEXT_PLAIN)
     public String receiveCompletedFileUpload(CompletedFileUpload data) {
         try {
             return data.getFilename() + ": " + data.getBytes().length;
@@ -87,7 +87,7 @@ public class UploadController {
         }
     }
 
-    @Post(value = "/receive-publisher", consumes = MediaType.MULTIPART_FORM_DATA)
+    @Post(value = "/receive-publisher", consumes = MediaType.MULTIPART_FORM_DATA, produces = MediaType.TEXT_PLAIN)
     public Single<HttpResponse> receivePublisher(Flowable<byte[]> data) {
         return data.reduce(new StringBuilder(), (stringBuilder, bytes) ->
 
@@ -201,7 +201,7 @@ public class UploadController {
         return subject.toFlowable(BackpressureStrategy.ERROR);
     }
 
-    @Post(value = "/receive-multiple-streaming", consumes = MediaType.MULTIPART_FORM_DATA)
+    @Post(value = "/receive-multiple-streaming", consumes = MediaType.MULTIPART_FORM_DATA, produces = MediaType.TEXT_PLAIN)
     public Single<HttpResponse> receiveMultipleStreaming(
             Flowable<StreamingFileUpload> data) {
         return data.subscribeOn(Schedulers.io()).flatMap((StreamingFileUpload upload) -> {
@@ -219,7 +219,7 @@ public class UploadController {
                 });
     }
 
-    @Post(value = "/receive-partdata", consumes = MediaType.MULTIPART_FORM_DATA)
+    @Post(value = "/receive-partdata", consumes = MediaType.MULTIPART_FORM_DATA, produces = MediaType.TEXT_PLAIN)
     public Single<HttpResponse> receivePartdata(
             Flowable<PartData> data) {
         return data.subscribeOn(Schedulers.io())
@@ -236,7 +236,7 @@ public class UploadController {
                 });
     }
 
-    @Post(value = "/receive-multiple-publishers", consumes = MediaType.MULTIPART_FORM_DATA)
+    @Post(value = "/receive-multiple-publishers", consumes = MediaType.MULTIPART_FORM_DATA, produces = MediaType.TEXT_PLAIN)
     public Single<HttpResponse> receiveMultiplePublishers(Flowable<Flowable<byte[]>> data) {
         return data.subscribeOn(Schedulers.io()).flatMap((Flowable<byte[]> upload) -> {
             return upload.map((bytes) -> bytes);

--- a/test-suite/src/test/groovy/io/micronaut/upload/UploadSpec.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/upload/UploadSpec.groovy
@@ -91,7 +91,7 @@ class UploadSpec extends AbstractMicronautSpec {
         Flowable<HttpResponse<String>> flowable = Flowable.fromPublisher(client.exchange(
                 HttpRequest.POST("/upload/receive-json", requestBody)
                         .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
-                        .accept(MediaType.APPLICATION_JSON_TYPE),
+                        .accept(MediaType.TEXT_PLAIN),
                 String
         ))
 

--- a/test-suite/src/test/java/io/micronaut/docs/client/upload/MultipartFileUploadSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/client/upload/MultipartFileUploadSpec.java
@@ -148,7 +148,7 @@ public class MultipartFileUploadSpec {
     @Controller("/multipart")
     static class MultipartController {
 
-        @Post(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA)
+        @Post(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA, produces = MediaType.TEXT_PLAIN)
         HttpResponse<String> upload(byte[] data) {
             return HttpResponse.ok("Uploaded " + data.length + " bytes");
         }

--- a/test-suite/src/test/java/io/micronaut/docs/server/intro/HelloClient.java
+++ b/test-suite/src/test/java/io/micronaut/docs/server/intro/HelloClient.java
@@ -16,6 +16,7 @@
 package io.micronaut.docs.server.intro;
 
 // tag::imports[]
+import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.Get;
 import io.micronaut.http.client.annotation.Client;
 import io.reactivex.Single;
@@ -29,7 +30,7 @@ import io.reactivex.Single;
 @Client("/hello") // <1>
 public interface HelloClient {
 
-    @Get // <2>
+    @Get(consumes = MediaType.TEXT_PLAIN) // <2>
     Single<String> hello(); // <3>
 }
 // end::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/server/sse/HeadlineController.java
+++ b/test-suite/src/test/java/io/micronaut/docs/server/sse/HeadlineController.java
@@ -16,6 +16,7 @@
 package io.micronaut.docs.server.sse;
 
 // tag::imports[]
+import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.*;
 import io.micronaut.http.sse.Event;
 import io.reactivex.Flowable;
@@ -26,7 +27,7 @@ import org.reactivestreams.Publisher;
 @Controller("/headlines")
 public class HeadlineController {
 
-    @Get
+    @Get(produces = MediaType.TEXT_EVENT_STREAM)
     public Publisher<Event<Headline>> index() { // <1>
         String[] versions = new String[]{"1.0", "2.0"}; // <2>
 

--- a/test-suite/src/test/java/io/micronaut/docs/server/sse/HeadlineControllerSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/server/sse/HeadlineControllerSpec.java
@@ -38,7 +38,8 @@ public class HeadlineControllerSpec {
 
         List<Event<Headline>> events = new ArrayList<>();
 
-        client.eventStream(HttpRequest.GET("/headlines"), Headline.class).subscribe(events::add);
+        client.eventStream(HttpRequest.GET("/headlines"), Headline.class)
+                .subscribe(events::add);
 
         await().until(() -> events.size() == 2);
         assertEquals("Micronaut 1.0 Released", events.get(0).getData().getTitle());

--- a/test-suite/src/test/java/io/micronaut/docs/server/upload/BytesUploadController.java
+++ b/test-suite/src/test/java/io/micronaut/docs/server/upload/BytesUploadController.java
@@ -30,7 +30,9 @@ import java.nio.file.Paths;
 @Controller("/upload")
 public class BytesUploadController {
 
-    @Post(value = "/bytes", consumes = MediaType.MULTIPART_FORM_DATA) // <1>
+    @Post(value = "/bytes",
+            consumes = MediaType.MULTIPART_FORM_DATA,
+            produces = MediaType.TEXT_PLAIN) // <1>
     public HttpResponse<String> uploadBytes(byte[] file, String fileName) { // <2>
         try {
             File tempFile = File.createTempFile(fileName, "temp");

--- a/test-suite/src/test/java/io/micronaut/docs/server/upload/CompletedUploadController.java
+++ b/test-suite/src/test/java/io/micronaut/docs/server/upload/CompletedUploadController.java
@@ -31,7 +31,9 @@ import java.nio.file.Paths;
 @Controller("/upload")
 public class CompletedUploadController {
 
-    @Post(value = "/completed", consumes = MediaType.MULTIPART_FORM_DATA) // <1>
+    @Post(value = "/completed",
+            consumes = MediaType.MULTIPART_FORM_DATA,
+            produces = MediaType.TEXT_PLAIN) // <1>
     public HttpResponse<String> uploadCompleted(CompletedFileUpload file) { // <2>
         try {
             File tempFile = File.createTempFile(file.getFilename(), "temp"); //<3>

--- a/test-suite/src/test/java/io/micronaut/docs/server/upload/UploadController.java
+++ b/test-suite/src/test/java/io/micronaut/docs/server/upload/UploadController.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 @Controller("/upload")
 public class UploadController {
 
-    @Post(value = "/", consumes = MediaType.MULTIPART_FORM_DATA) // <1>
+    @Post(value = "/", consumes = MediaType.MULTIPART_FORM_DATA, produces = MediaType.TEXT_PLAIN) // <1>
     public Single<HttpResponse<String>> upload(StreamingFileUpload file) { // <2>
         File tempFile;
         try {

--- a/test-suite/src/test/java/io/micronaut/docs/server/upload/WholeBodyUploadController.java
+++ b/test-suite/src/test/java/io/micronaut/docs/server/upload/WholeBodyUploadController.java
@@ -30,7 +30,9 @@ import org.reactivestreams.Subscription;
 @Controller("/upload")
 public class WholeBodyUploadController {
 
-    @Post(value = "/whole-body", consumes = MediaType.MULTIPART_FORM_DATA) // <1>
+    @Post(value = "/whole-body",
+            consumes = MediaType.MULTIPART_FORM_DATA,
+            produces = MediaType.TEXT_PLAIN) // <1>
     public Single<String> uploadBytes(@Body MultipartBody body) { // <2>
         return Single.create(emitter -> {
             body.subscribe(new Subscriber<CompletedPart>() {

--- a/validation/src/test/groovy/io/micronaut/validation/ValidatedSpec.groovy
+++ b/validation/src/test/groovy/io/micronaut/validation/ValidatedSpec.groovy
@@ -30,6 +30,7 @@ import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus
 import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Consumes
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Header
@@ -83,6 +84,8 @@ class ValidatedSpec extends Specification {
         then:
         result == "\$100.00"
 
+        cleanup:
+        beanContext.close()
     }
 
     def "test validated return value"() {
@@ -96,6 +99,9 @@ class ValidatedSpec extends Specification {
         then:
         def e = thrown(ConstraintViolationException)
         e.message == "string: must not be null"
+
+        cleanup:
+        beanContext.close()
     }
 
     def "test validated return value without cascade"() {
@@ -109,6 +115,9 @@ class ValidatedSpec extends Specification {
         then:
         def e = thrown(ConstraintViolationException)
         e.message == "bar: must not be null"
+
+        cleanup:
+        beanContext.close()
     }
 
     def "test validate return value with cascading"() {
@@ -122,6 +131,9 @@ class ValidatedSpec extends Specification {
         then:
         def e = thrown(ConstraintViolationException)
         e.message == "bar.prop: must not be null"
+
+        cleanup:
+        beanContext.close()
     }
 
     def "test validate list return value with cascading"() {
@@ -135,6 +147,9 @@ class ValidatedSpec extends Specification {
         then:
         def e = thrown(ConstraintViolationException)
         e.message == "list[0].prop: must not be null"
+
+        cleanup:
+        beanContext.close()
     }
 
     def "test validate map return value with cascading"() {
@@ -148,6 +163,9 @@ class ValidatedSpec extends Specification {
         then:
         def e = thrown(ConstraintViolationException)
         e.message == "map[barObj].prop: must not be null"
+
+        cleanup:
+        beanContext.close()
     }
 
     def "test validated controller validates @Valid classes"() {
@@ -366,6 +384,7 @@ class ValidatedSpec extends Specification {
     }
 
     @Client("/validated/tests")
+    @Consumes(MediaType.TEXT_PLAIN)
     static interface TestClient {
 
         @Get(value = "/test1/{value}", produces = MediaType.TEXT_PLAIN)


### PR DESCRIPTION
This change implements server side content negotiation correctly and fixes #2743.

It currently targets `1.3.x` however I have doubts about introducing this in a patch release given it is likely to break existing tests that include incorrect definitions of the accept header (as was the case in our tests where several broke).

