### PR TITLE
Add micronaut-bom for annotationProcessor in groovy projects

### DIFF
--- a/cli/src/main/groovy/io/micronaut/cli/io/support/GradleBuildTokens.groovy
+++ b/cli/src/main/groovy/io/micronaut/cli/io/support/GradleBuildTokens.groovy
@@ -110,6 +110,7 @@ class GradleBuildTokens extends BuildTokens {
         gradleDependencies.add(new GradleDependency("implementation", enforcedPlatform))
         gradleDependencies.add(new GradleDependency("testImplementation", enforcedPlatform))
         if (sourceLanguage == "groovy") {
+            gradleDependencies.add(new GradleDependency("annotationProcessor", enforcedPlatform))
             gradleDependencies.add(new GradleDependency("compileOnly", enforcedPlatform))
             gradleDependencies.add(new GradleDependency("testCompileOnly", enforcedPlatform))
         } else if (sourceLanguage == "java") {


### PR DESCRIPTION
Creating a project with the following command does not result in a buildable project because the graal-native-image feature is adding multiple annotation processors to the build.gradle file and gradle cannot find the versions for these dependencies. This prevents `./gradlew assemble` from generating a jar file that can then be used for making an image with `docker-build.sh`.

```
mn create-cli-app --lang=groovy --features=graal-native-image groovycli
```

This patch is simply adding the micronaut-bom to annotation processors in the groovy project.

See https://github.com/micronaut-projects/micronaut-picocli/issues/23 for more information.

