### PR TITLE
Respect client close code in WebSocketHandler. Fixes #2851

### DIFF
--- a/http-netty/src/main/java/io/micronaut/http/netty/websocket/AbstractNettyWebSocketHandler.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/websocket/AbstractNettyWebSocketHandler.java
@@ -459,7 +459,7 @@ public abstract class AbstractNettyWebSocketHandler extends SimpleChannelInbound
                     }
                 }
             } else {
-                ctx.close();
+                writeCloseFrameAndTerminate(ctx, cr);
             }
         }
     }


### PR DESCRIPTION
This PR changes the `AbstractNettyWebSocketHandler` such that it closes the WebSocket session using the close code that is specified by the client. 

Reproducing the steps in #2851 now results in the following:
![image](https://user-images.githubusercontent.com/23633658/76467288-91a10480-63e9-11ea-9c9c-c0c55462fa6f.png)
