### PR TITLE
HttpClientFilter with 2 Optionals causes CircularDependencyException with HttpClient

### DIFF
--- a/http-client/src/main/java/example/failure/TwoOptionalsFilter.java
+++ b/http-client/src/main/java/example/failure/TwoOptionalsFilter.java
@@ -1,0 +1,30 @@
+package example.failure;
+
+import io.micronaut.context.annotation.Value;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.MutableHttpRequest;
+import io.micronaut.http.annotation.Filter;
+import io.micronaut.http.filter.ClientFilterChain;
+import io.micronaut.http.filter.HttpClientFilter;
+import org.reactivestreams.Publisher;
+
+import java.util.Optional;
+import javax.inject.Inject;
+
+@Filter("/**")
+public class TwoOptionalsFilter implements HttpClientFilter {
+
+    @Inject
+    public TwoOptionalsFilter(
+            @Value("${test.property1}") Optional<String> p1,
+            @Value("${test.property2}") Optional<String> p2
+    ) {
+    }
+
+    @Override
+    public Publisher<? extends HttpResponse<?>> doFilter(MutableHttpRequest<?> targetRequest,
+            ClientFilterChain chain) {
+
+        return chain.proceed(targetRequest);
+    }
+}

--- a/test-suite-kotlin/src/test/java/example/failure/CircularDependencyFailureWithOptionalsAndKaptTest.java
+++ b/test-suite-kotlin/src/test/java/example/failure/CircularDependencyFailureWithOptionalsAndKaptTest.java
@@ -1,0 +1,24 @@
+package example.failure;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.http.client.HttpClient;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+/**
+ * Regardless whether running this is a test or main, it fails with a CircularDependency
+ * because of the {@link TwoOptionalsFilter}.
+ */
+public class CircularDependencyFailureWithOptionalsAndKaptTest {
+
+    public static void main(String[] args) throws MalformedURLException {
+        ApplicationContext applicationContext = ApplicationContext.run();
+
+        try {
+            System.out.println(applicationContext.createBean(HttpClient.class, new URL("http://localhost:80")));
+        } finally {
+            applicationContext.stop();
+        }
+    }
+}


### PR DESCRIPTION
This is a reproducer of a bug.