### PR TITLE
Use DataSourceResolver in JDBC health indicator

### DIFF
--- a/management/build.gradle
+++ b/management/build.gradle
@@ -4,6 +4,7 @@ dependencies {
         
     api project(":router")
     api project(":runtime")
+    compileOnly project(":jdbc")
 
     testImplementation project(":http-client")
     testImplementation project(":inject-groovy")
@@ -14,6 +15,12 @@ dependencies {
     testImplementation "mysql:mysql-connector-java:8.0.19"
 
     compileOnly "ch.qos.logback:logback-classic:1.2.3"
+}
+
+configurations.all {
+    resolutionStrategy.dependencySubstitution {
+        substitute module("io.micronaut:micronaut-jdbc") with project(":jdbc")
+    }
 }
 
 //compileTestGroovy.groovyOptions.forkOptions.jvmArgs = ['-Xdebug', '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005']

--- a/management/src/main/java/io/micronaut/management/health/indicator/jdbc/JdbcIndicator.java
+++ b/management/src/main/java/io/micronaut/management/health/indicator/jdbc/JdbcIndicator.java
@@ -19,6 +19,7 @@ import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.async.publisher.AsyncSingleResultPublisher;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.health.HealthStatus;
+import io.micronaut.jdbc.DataSourceResolver;
 import io.micronaut.management.endpoint.health.HealthEndpoint;
 import io.micronaut.management.health.aggregator.HealthAggregator;
 import io.micronaut.management.health.indicator.HealthIndicator;
@@ -27,6 +28,7 @@ import io.micronaut.scheduling.TaskExecutors;
 import io.reactivex.Flowable;
 import org.reactivestreams.Publisher;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -51,6 +53,7 @@ import java.util.stream.Collectors;
 @Singleton
 @Requires(beans = HealthEndpoint.class)
 @Requires(property = HealthEndpoint.PREFIX + ".jdbc.enabled", notEquals = StringUtils.FALSE)
+@Requires(classes = DataSourceResolver.class)
 public class JdbcIndicator implements HealthIndicator {
 
     private static final String NAME = "jdbc";
@@ -58,19 +61,23 @@ public class JdbcIndicator implements HealthIndicator {
 
     private final ExecutorService executorService;
     private final DataSource[] dataSources;
-    private final HealthAggregator healthAggregator;
+    private final DataSourceResolver dataSourceResolver;
+    private final HealthAggregator<?> healthAggregator;
 
     /**
-     * @param executorService  The executor service
-     * @param dataSources      The data sources
-     * @param healthAggregator The health aggregator
+     * @param executorService    The executor service
+     * @param dataSources        The data sources
+     * @param dataSourceResolver The data source resolver
+     * @param healthAggregator   The health aggregator
      */
     @Inject
     public JdbcIndicator(@Named(TaskExecutors.IO) ExecutorService executorService,
                          DataSource[] dataSources,
-                         HealthAggregator healthAggregator) {
+                         @Nullable DataSourceResolver dataSourceResolver,
+                         HealthAggregator<?> healthAggregator) {
         this.executorService = executorService;
         this.dataSources = dataSources;
+        this.dataSourceResolver = dataSourceResolver != null ? dataSourceResolver : DataSourceResolver.DEFAULT;
         this.healthAggregator = healthAggregator;
     }
 
@@ -119,7 +126,9 @@ public class JdbcIndicator implements HealthIndicator {
             return Flowable.empty();
         }
         return healthAggregator.aggregate(NAME, Flowable.merge(
-            Arrays.stream(dataSources).map((ds) -> getResult(ds)).collect(Collectors.toList())
+            Arrays.stream(dataSources)
+                    .map(dataSourceResolver::resolve)
+                    .map(this::getResult).collect(Collectors.toList())
         ));
     }
 }


### PR DESCRIPTION
This is related to https://github.com/micronaut-projects/micronaut-data/pull/436 - transactional data source proxy should not be used by this health indicator.

This patch also contains a dependency substitution for jdbc module, otherwise tests are broken because it uses version 1.1.4 which lacks 6b146e4c4067257669438b0e8d20c775b2cb7915. Perhaps it might be a good idea to do something like this for all micronaut-core modules in all tests.