### PR TITLE
Add PropertyLoaders for cloudfoundry environment variables. Fixes #1898

### DIFF
--- a/inject/src/main/java/io/micronaut/context/env/AbstractPropertySourceLoader.java
+++ b/inject/src/main/java/io/micronaut/context/env/AbstractPropertySourceLoader.java
@@ -68,18 +68,28 @@ public abstract class AbstractPropertySourceLoader implements PropertySourceLoad
                 Map<String, Object> finalMap = loadProperties(resourceLoader, fileName, fileExt);
 
                 if (!finalMap.isEmpty()) {
-                    MapPropertySource newPropertySource = new MapPropertySource(fileName, finalMap) {
-                        @Override
-                        public int getOrder() {
-                            return order;
-                        }
-                    };
-                    return Optional.of(newPropertySource);
+                    return Optional.of(createPropertySource(fileName, finalMap, order));
                 }
             }
         }
 
         return Optional.empty();
+    }
+
+    /**
+     *
+     * @param name The name of the property source
+     * @param map  The map
+     * @param order The order of the property source
+     * @return property source
+     */
+    protected MapPropertySource createPropertySource(String name, Map<String, Object> map, int order) {
+        return new MapPropertySource(name, map) {
+                            @Override
+                            public int getOrder() {
+                                return order;
+                            }
+                        };
     }
 
     private Map<String, Object> loadProperties(ResourceLoader resourceLoader, String qualifiedName, String fileName) {

--- a/runtime/src/main/java/io/micronaut/jackson/env/CloudFoundryVcapApplicationPropertySourceLoader.java
+++ b/runtime/src/main/java/io/micronaut/jackson/env/CloudFoundryVcapApplicationPropertySourceLoader.java
@@ -16,6 +16,7 @@
 package io.micronaut.jackson.env;
 
 import com.fasterxml.jackson.core.JsonParseException;
+import io.micronaut.context.env.MapPropertySource;
 import io.micronaut.context.exceptions.ConfigurationException;
 
 import java.io.IOException;
@@ -27,14 +28,14 @@ import java.util.Map;
  * which is used by CloudFoundry.</p>
  *
  * @author Fabian Nonnenmacher
- * @since 3.4
+ * @since 2.0
  */
 public class CloudFoundryVcapApplicationPropertySourceLoader extends EnvJsonPropertySourceLoader {
 
     /**
      * Position for the system property source loader in the chain.
      */
-    public static final int POSITION = EnvJsonPropertySourceLoader.POSITION + 30;
+    public static final int POSITION = EnvJsonPropertySourceLoader.POSITION + 10;
 
     private static final String VCAP_APPLICATION = "VCAP_APPLICATION";
 
@@ -56,5 +57,10 @@ public class CloudFoundryVcapApplicationPropertySourceLoader extends EnvJsonProp
         } catch (JsonParseException e) {
             throw new ConfigurationException("Could not parse '" + VCAP_APPLICATION + "'." + e.getMessage(), e);
         }
+    }
+
+    @Override
+    protected MapPropertySource createPropertySource(String name, Map<String, Object> map, int order) {
+        return super.createPropertySource("cloudfoundry-vcap-application", map, order);
     }
 }

--- a/runtime/src/main/java/io/micronaut/jackson/env/CloudFoundryVcapApplicationPropertySourceLoader.java
+++ b/runtime/src/main/java/io/micronaut/jackson/env/CloudFoundryVcapApplicationPropertySourceLoader.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.jackson.env;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import io.micronaut.context.exceptions.ConfigurationException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+
+/**
+ * <p>A {@link io.micronaut.context.env.PropertySourceLoader} that reads from the environment variable VCAP_APPLICATION
+ * which is used by CloudFoundry.</p>
+ *
+ * @author Fabian Nonnenmacher
+ * @since 3.4
+ */
+public class CloudFoundryVcapApplicationPropertySourceLoader extends EnvJsonPropertySourceLoader {
+
+    /**
+     * Position for the system property source loader in the chain.
+     */
+    public static final int POSITION = EnvJsonPropertySourceLoader.POSITION + 30;
+
+    private static final String VCAP_APPLICATION = "VCAP_APPLICATION";
+
+    @Override
+    public int getOrder() {
+        return POSITION;
+    }
+
+    @Override
+    protected String getEnvValue() {
+        return System.getenv(VCAP_APPLICATION);
+    }
+
+    @Override
+    protected void processInput(String name, InputStream input, Map<String, Object> finalMap) throws IOException {
+        try {
+            Map<String, Object> map = readJsonAsMap(input);
+            processMap(finalMap, map, "vcap.application.");
+        } catch (JsonParseException e) {
+            throw new ConfigurationException("Could not parse '" + VCAP_APPLICATION + "'." + e.getMessage(), e);
+        }
+    }
+}

--- a/runtime/src/main/java/io/micronaut/jackson/env/CloudFoundryVcapApplicationPropertySourceLoader.java
+++ b/runtime/src/main/java/io/micronaut/jackson/env/CloudFoundryVcapApplicationPropertySourceLoader.java
@@ -21,7 +21,9 @@ import io.micronaut.context.exceptions.ConfigurationException;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * <p>A {@link io.micronaut.context.env.PropertySourceLoader} that reads from the environment variable VCAP_APPLICATION
@@ -42,6 +44,11 @@ public class CloudFoundryVcapApplicationPropertySourceLoader extends EnvJsonProp
     @Override
     public int getOrder() {
         return POSITION;
+    }
+
+    @Override
+    public Set<String> getExtensions() {
+        return Collections.emptySet();
     }
 
     @Override

--- a/runtime/src/main/java/io/micronaut/jackson/env/CloudFoundryVcapServicesPropertySourceLoader.java
+++ b/runtime/src/main/java/io/micronaut/jackson/env/CloudFoundryVcapServicesPropertySourceLoader.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.jackson.env;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import io.micronaut.context.exceptions.ConfigurationException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * <p>A {@link io.micronaut.context.env.PropertySourceLoader} that reads from the environment variable VCAP_SERVICES
+ * which is used by CloudFoundry.</p>
+ *
+ * @author Fabian Nonnenmacher
+ * @since 3.4
+ */
+public class CloudFoundryVcapServicesPropertySourceLoader extends EnvJsonPropertySourceLoader {
+
+    /**
+     * Position for the system property source loader in the chain.
+     */
+    public static final int POSITION = EnvJsonPropertySourceLoader.POSITION + 31;
+
+    private static final String VCAP_SERVICES = "VCAP_SERVICES";
+
+    @Override
+    public int getOrder() {
+        return POSITION;
+    }
+
+    @Override
+    protected String getEnvValue() {
+        return System.getenv(VCAP_SERVICES);
+    }
+
+    @Override
+    protected void processInput(String name, InputStream input, Map<String, Object> finalMap) throws IOException {
+        try {
+            Map<String, Object> map = readJsonAsMap(input);
+            processVcapServices(finalMap, map);
+        } catch (JsonParseException e) {
+            throw new ConfigurationException("Could not parse '" + VCAP_SERVICES + "': " + e.getMessage(), e);
+        }
+    }
+
+    private void processVcapServices(Map<String, Object> finalMap, Map<String, Object> vcapServices) {
+        if (vcapServices != null) {
+            for (Object services : vcapServices.values()) {
+                @SuppressWarnings("unchecked")
+                List<Object> list = (List<Object>) services;
+                for (Object object : list) {
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> service = (Map<String, Object>) object;
+                    String key = (String) service.get("name");
+                    if (key == null) {
+                        key = (String) service.get("label");
+                    }
+                    processMap(finalMap, service, "vcap.services." + key + ".");
+                }
+            }
+        }
+    }
+}

--- a/runtime/src/main/java/io/micronaut/jackson/env/CloudFoundryVcapServicesPropertySourceLoader.java
+++ b/runtime/src/main/java/io/micronaut/jackson/env/CloudFoundryVcapServicesPropertySourceLoader.java
@@ -21,8 +21,10 @@ import io.micronaut.context.exceptions.ConfigurationException;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * <p>A {@link io.micronaut.context.env.PropertySourceLoader} that reads from the environment variable VCAP_SERVICES
@@ -48,6 +50,11 @@ public class CloudFoundryVcapServicesPropertySourceLoader extends EnvJsonPropert
     @Override
     protected String getEnvValue() {
         return System.getenv(VCAP_SERVICES);
+    }
+
+    @Override
+    public Set<String> getExtensions() {
+        return Collections.emptySet();
     }
 
     @Override

--- a/runtime/src/main/java/io/micronaut/jackson/env/CloudFoundryVcapServicesPropertySourceLoader.java
+++ b/runtime/src/main/java/io/micronaut/jackson/env/CloudFoundryVcapServicesPropertySourceLoader.java
@@ -16,6 +16,7 @@
 package io.micronaut.jackson.env;
 
 import com.fasterxml.jackson.core.JsonParseException;
+import io.micronaut.context.env.MapPropertySource;
 import io.micronaut.context.exceptions.ConfigurationException;
 
 import java.io.IOException;
@@ -28,14 +29,14 @@ import java.util.Map;
  * which is used by CloudFoundry.</p>
  *
  * @author Fabian Nonnenmacher
- * @since 3.4
+ * @since 2.0
  */
 public class CloudFoundryVcapServicesPropertySourceLoader extends EnvJsonPropertySourceLoader {
 
     /**
      * Position for the system property source loader in the chain.
      */
-    public static final int POSITION = EnvJsonPropertySourceLoader.POSITION + 31;
+    public static final int POSITION = EnvJsonPropertySourceLoader.POSITION + 11;
 
     private static final String VCAP_SERVICES = "VCAP_SERVICES";
 
@@ -75,5 +76,10 @@ public class CloudFoundryVcapServicesPropertySourceLoader extends EnvJsonPropert
                 }
             }
         }
+    }
+
+    @Override
+    protected MapPropertySource createPropertySource(String name, Map<String, Object> map, int order) {
+        return super.createPropertySource("cloudfoundry-vcap-services", map, order);
     }
 }

--- a/runtime/src/main/java/io/micronaut/jackson/env/JsonPropertySourceLoader.java
+++ b/runtime/src/main/java/io/micronaut/jackson/env/JsonPropertySourceLoader.java
@@ -48,11 +48,21 @@ public class JsonPropertySourceLoader extends AbstractPropertySourceLoader {
 
     @Override
     protected void processInput(String name, InputStream input, Map<String, Object> finalMap) throws IOException {
+        Map<String, Object> map = readJsonAsMap(input);
+        processMap(finalMap, map, "");
+    }
+
+    /**
+     * @param input    The input stream
+     * @throws IOException If the input stream doesn't exist
+     *
+     * @return map representation of the json
+     */
+    protected Map<String, Object> readJsonAsMap(InputStream input) throws IOException {
         ObjectMapper objectMapper = new ObjectMapper(new JsonFactory());
         TypeFactory factory = TypeFactory.defaultInstance();
         MapType mapType = factory.constructMapType(LinkedHashMap.class, String.class, Object.class);
 
-        Map<String, Object> map = objectMapper.readValue(input, mapType);
-        processMap(finalMap, map, "");
+        return objectMapper.readValue(input, mapType);
     }
 }

--- a/runtime/src/main/resources/META-INF/services/io.micronaut.context.env.PropertySourceLoader
+++ b/runtime/src/main/resources/META-INF/services/io.micronaut.context.env.PropertySourceLoader
@@ -1,2 +1,4 @@
 io.micronaut.jackson.env.JsonPropertySourceLoader
 io.micronaut.jackson.env.EnvJsonPropertySourceLoader
+io.micronaut.jackson.env.CloudFoundryVcapApplicationPropertySourceLoader
+io.micronaut.jackson.env.CloudFoundryVcapServicesPropertySourceLoader

--- a/runtime/src/test/groovy/io/micronaut/jackson/env/CloudFoundryVcapPropertySourceLoaderSpec.groovy
+++ b/runtime/src/test/groovy/io/micronaut/jackson/env/CloudFoundryVcapPropertySourceLoaderSpec.groovy
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.jackson.env
+
+import io.micronaut.context.env.Environment
+import io.micronaut.context.env.PropertySource
+import io.micronaut.context.exceptions.ConfigurationException
+import spock.lang.Specification
+
+class CloudFoundryVcapPropertySourceLoaderSpec extends Specification {
+
+    void "test properties are read from VCAP_APPLICATION"() {
+
+        given:
+        def loader = new CloudFoundryVcapApplicationPropertySourceLoader() {
+            @Override
+            protected String getEnvValue() {
+                return '''\
+{
+    "application_users":null,
+    "instance_id":"2ce0ac627a6c8e47e936d829a3a47b5b",
+    "instance_index":0,
+    "version":"0138c4a6-2a73-416b-aca0-572c09f7ca53",
+    "name":"foo",
+    "uris":["foo.cfapps.io"]
+}   
+'''
+            }
+        }
+
+        when:
+        Environment env = Mock(Environment)
+        env.isPresent(_) >> true
+        env.getActiveNames() >> ([] as Set)
+
+        def result = loader.load(env)
+
+        then:
+        result.isPresent()
+
+        when:
+        PropertySource propertySource = result.get()
+
+        then:
+        propertySource.get("vcap.application.instance_id") == '2ce0ac627a6c8e47e936d829a3a47b5b'
+        propertySource.get("vcap.application.instance_index") == 0
+        propertySource.get("vcap.application.version") == '0138c4a6-2a73-416b-aca0-572c09f7ca53'
+        propertySource.get("vcap.application.name") == 'foo'
+        propertySource.get("vcap.application.uris")[0] == 'foo.cfapps.io'
+    }
+
+    void "test exception is thrown when VCAP_APPLICATION cannot be parsed"() {
+        given:
+        def loader = new CloudFoundryVcapApplicationPropertySourceLoader() {
+            @Override
+            protected String getEnvValue() {
+                return 'UNPARSABLE:'
+            }
+        }
+
+        when:
+        Environment env = Mock(Environment)
+        env.isPresent(_) >> true
+        env.getActiveNames() >> ([] as Set)
+
+        def result = loader.load(env)
+
+        then:
+        def e = thrown(ConfigurationException)
+        e.getMessage().contains("Could not parse 'VCAP_APPLICATION'")
+    }
+
+    void "test properties are read from VCAP_SERVICES"() {
+
+        given:
+        def loader = new CloudFoundryVcapServicesPropertySourceLoader() {
+            @Override
+            protected String getEnvValue() {
+                return '''\
+{
+    "rds-mysql-n/a": [{
+        "name":"mysql",
+        "label":"rds-mysql-n/a",
+        "plan":"10mb",
+        "credentials": {
+            "name":"d04fb13d27d964c62b267bbba1cffb9da",
+            "hostname":"mysql-service-public.clqg2e2w3ecf.us-east-1.rds.amazonaws.com",
+            "ssl":true,
+            "location":null,
+            "host":"mysql-service-public.clqg2e2w3ecf.us-east-1.rds.amazonaws.com",
+            "port":3306,
+            "user":"urpRuqTf8Cpe6",
+            "username":"urpRuqTf8Cpe6",
+            "password":"pxLsGVpsC9A5S"
+        }
+    }],
+    "service-without-name": [{
+        "label":"service-without-name", 
+        "credentials": {
+            "foo": "bar"
+        }
+    }]
+}'''
+            }
+        }
+
+        when:
+        Environment env = Mock(Environment)
+        env.isPresent(_) >> true
+        env.getActiveNames() >> ([] as Set)
+
+        def result = loader.load(env)
+
+        then:
+        result.isPresent()
+
+        when:
+        PropertySource propertySource = result.get()
+
+        then:
+        propertySource.get("vcap.services.mysql.name") == "mysql"
+        propertySource.get("vcap.services.mysql.credentials.port") == 3306
+        propertySource.get("vcap.services.mysql.credentials.ssl") == true
+        propertySource.get("vcap.services.mysql.credentials.location") == null
+
+        propertySource.get("vcap.services.service-without-name.label") == 'service-without-name'
+        propertySource.get("vcap.services.service-without-name.credentials.foo") == 'bar'
+    }
+
+    void "test exception is thrown when VCAP_SERVICES cannot be parsed"() {
+        given:
+        def loader = new CloudFoundryVcapServicesPropertySourceLoader() {
+            @Override
+            protected String getEnvValue() {
+                return 'UNPARSABLE:'
+            }
+        }
+
+        when:
+        Environment env = Mock(Environment)
+        env.isPresent(_) >> true
+        env.getActiveNames() >> ([] as Set)
+
+        def result = loader.load(env)
+
+        then:
+        def e = thrown(ConfigurationException)
+        e.getMessage().contains("Could not parse 'VCAP_SERVICES'")
+    }
+}

--- a/runtime/src/test/groovy/io/micronaut/jackson/env/CloudFoundryVcapPropertySourceLoaderSpec.groovy
+++ b/runtime/src/test/groovy/io/micronaut/jackson/env/CloudFoundryVcapPropertySourceLoaderSpec.groovy
@@ -55,6 +55,7 @@ class CloudFoundryVcapPropertySourceLoaderSpec extends Specification {
         PropertySource propertySource = result.get()
 
         then:
+        propertySource.name == "cloudfoundry-vcap-application"
         propertySource.get("vcap.application.instance_id") == '2ce0ac627a6c8e47e936d829a3a47b5b'
         propertySource.get("vcap.application.instance_index") == 0
         propertySource.get("vcap.application.version") == '0138c4a6-2a73-416b-aca0-572c09f7ca53'
@@ -131,6 +132,7 @@ class CloudFoundryVcapPropertySourceLoaderSpec extends Specification {
         PropertySource propertySource = result.get()
 
         then:
+        propertySource.name == "cloudfoundry-vcap-services"
         propertySource.get("vcap.services.mysql.name") == "mysql"
         propertySource.get("vcap.services.mysql.credentials.port") == 3306
         propertySource.get("vcap.services.mysql.credentials.ssl") == true


### PR DESCRIPTION
Add 2 property loaders for the environment variables VCAP_APPLICATION and VCAP_SERVICES injected by Cloudfoundry. (See #1898 )

With this change, two new property sources will be added when the variables are available:
![image](https://user-images.githubusercontent.com/16265743/76691629-09bb3480-664d-11ea-832a-11fa05a7970f.png)

The tests and the method `processVcapServices` are inspired by the [CloudFoundryVcapEnvironmentPostProcessor](https://github.com/spring-projects/spring-boot/blob/master/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/cloud/CloudFoundryVcapEnvironmentPostProcessor.java) of Spring Boot

Some Implementation Decisions:
* I decided to implement it with two classed instead of one so that I was able to reuse the existing `EnvJsonPropertySourceLoader` class.
* I extracted the method `readJsonAsMap(input)` in `EnvJsonPropertySourceLoader` so that I could modify the returned map before writing it to the PropertySource. For VCAP_APPLICATION an additional prefix is required, for VCAP_SERVICES the structure has to be changed a bit.
* I renamed the PropertySource to "cloudfoundry-vcaps-application" and "cloudfoundry-vcaps-services" so that they don't overwrite each other and the other application properties. Please let me know if there is a better way to do it and I will change it.

Also, I am not sure about the file location