### PR TITLE
Add `SourceMap` header to `HttpHeaders`

### DIFF
--- a/http/src/main/java/io/micronaut/http/HttpHeaders.java
+++ b/http/src/main/java/io/micronaut/http/HttpHeaders.java
@@ -360,6 +360,11 @@ public interface HttpHeaders extends Headers {
     String SET_COOKIE2 = "Set-Cookie2";
 
     /**
+     * {@code "Source-Map"}.
+     */
+    String SOURCE_MAP = "SourceMap";
+
+    /**
      * {@code "TE"}.
      */
     String TE = "TE";


### PR DESCRIPTION
This small change adds the [`SourceMap`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/SourceMap) header to the `HttpHeaders` in Micronaut's HTTP core. This header allows a server which is serving a JavaScript or stylesheet resource to indicate a URL for a source-map relating to the resource.