### PR TITLE
Add `Feature-Policy` header to `HttpHeaders`

### DIFF
--- a/http/src/main/java/io/micronaut/http/HttpHeaders.java
+++ b/http/src/main/java/io/micronaut/http/HttpHeaders.java
@@ -215,6 +215,11 @@ public interface HttpHeaders extends Headers {
     String EXPIRES = "Expires";
 
     /**
+     * {@code "Feature-Policy"}.
+     */
+    String FEATURE_POLICY = "Feature-Policy";
+
+    /**
      * {@code "Forwarded"}.
      */
     String FORWARDED = "Forwarded";


### PR DESCRIPTION
This small change adds the [`Feature-Policy`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Feature_Policy) header to the `HttpHeaders` class in Micronaut's HTTP core. *Feature Policy* allows the server to restrict various browser features when serving an HTML document.