### PR TITLE
Add `Cross-Origin-Resource-Policy` header to `HttpHeaders`

### DIFF
--- a/http/src/main/java/io/micronaut/http/HttpHeaders.java
+++ b/http/src/main/java/io/micronaut/http/HttpHeaders.java
@@ -195,6 +195,11 @@ public interface HttpHeaders extends Headers {
     String COOKIE = "Cookie";
 
     /**
+     * {@code "Cross-Origin-Resource-Policy"}.
+     */
+    String CROSS_ORIGIN_RESOURCE_POLICY = "Cross-Origin-Resource-Policy";
+
+    /**
      * {@code "Date"}.
      */
     String DATE = "Date";


### PR DESCRIPTION
This small change adds the [`Cross-Origin-Resource-Policy`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cross-Origin_Resource_Policy_(CORP)) header to the `HttpHeaders` class in Micronaut's HTTP core. *Cross-Origin Resource Policy* allows web apps and sites to opt-in to additional protections against cross-origin vulnerabilities (speculative side-channel attacks, as well as Cross-Site Script Inclusion attacks, according to MDN).