### PR TITLE
Add `Link` header to `HttpHeaders`

### DIFF
--- a/http/src/main/java/io/micronaut/http/HttpHeaders.java
+++ b/http/src/main/java/io/micronaut/http/HttpHeaders.java
@@ -260,6 +260,11 @@ public interface HttpHeaders extends Headers {
     String LAST_MODIFIED = "Last-Modified";
 
     /**
+     * {@code "Link"}.
+     */
+    String LINK = "Link";
+
+    /**
      * {@code "Location"}.
      */
     String LOCATION = "Location";


### PR DESCRIPTION
Adds the [`Link`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Link) header to the `HttpHeaders` class in Micronaut's HTTP core. The _`Link`_ header is used as an alternate expression of the `<link ... />` tag in HTML pages, for instance with [DNS prefetching](https://developer.mozilla.org/en-US/docs/Web/Performance/dns-prefetch) or [asset pre-loading](https://developer.mozilla.org/en-US/docs/Web/HTML/Preloading_content).