### PR TITLE
Add `Referrer-Policy` header to `HttpHeaders`

### DIFF
--- a/http/src/main/java/io/micronaut/http/HttpHeaders.java
+++ b/http/src/main/java/io/micronaut/http/HttpHeaders.java
@@ -300,6 +300,11 @@ public interface HttpHeaders extends Headers {
     String REFERER = "Referer";
 
     /**
+     * {@code "Referrer-Policy"}.
+     */
+    String REFERRER_POLICY = "Referrer-Policy";
+
+    /**
      * {@code "Retry-After"}.
      */
     String RETRY_AFTER = "Retry-After";


### PR DESCRIPTION
Adds the [`Referrer-Policy`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy) header to the `HttpHeaders` class in Micronaut's HTTP core. This header is used to limit/secure the use of the `Referer` header with potentially unsafe/malicious cross origin actors.