### PR TITLE
Support the WRITE_BUFFER_WATER_MARK ChannelOption of netty.

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/converters/WriteBufferWaterMarkConverter.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/converters/WriteBufferWaterMarkConverter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.netty.converters;
+
+import java.util.Map;
+import java.util.Optional;
+import javax.inject.Singleton;
+
+import io.micronaut.core.convert.ConversionContext;
+import io.micronaut.core.convert.TypeConverter;
+import io.netty.channel.WriteBufferWaterMark;
+
+/**
+ * Type converter for the newly introduced https://netty.io/4.1/api/io/netty/channel/ChannelOption.html#WRITE_BUFFER_WATER_MARK
+ * object.
+ *
+ * @author ratcashdev
+ */
+@Singleton
+class WriteBufferWaterMarkConverter implements TypeConverter<Map<String, Integer>, WriteBufferWaterMark> {
+
+    @Override
+    public Optional<WriteBufferWaterMark> convert(Map<String, Integer> range,
+            Class<WriteBufferWaterMark> type, ConversionContext ctx) {
+        return Optional.of(new WriteBufferWaterMark(range.get("low"), range.get("high")));
+    }
+
+}

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/configuration/NettyHttpServerConfigurationSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/configuration/NettyHttpServerConfigurationSpec.groovy
@@ -90,7 +90,10 @@ class NettyHttpServerConfigurationSpec extends Specification {
                  'micronaut.server.netty.worker.threads'       : 8,
                  'micronaut.server.netty.parent.threads'       : 8,
                  'micronaut.server.multipart.maxFileSize'      : 2048,
-                 'micronaut.server.maxRequestSize'             : '2MB']
+                 'micronaut.server.maxRequestSize'             : '2MB',
+                 'micronaut.server.netty.childOptions.write_buffer_water_mark.high': 262143,
+                 'micronaut.server.netty.childOptions.write_buffer_water_mark.low' : 65535
+                ]
 
         ))
         beanContext.start()
@@ -102,12 +105,15 @@ class NettyHttpServerConfigurationSpec extends Specification {
         !config.useNativeTransport
         config.maxRequestSize == 2097152
         config.multipart.maxFileSize == 2048
-        config.childOptions.size() == 1
+        config.childOptions.size() == 2
         config.childOptions.keySet().first() instanceof ChannelOption
+        config.childOptions.keySet()[1] instanceof ChannelOption
+        config.childOptions.get(ChannelOption.WRITE_BUFFER_WATER_MARK).high == 262143
+        config.childOptions.get(ChannelOption.WRITE_BUFFER_WATER_MARK).low == 65535
         !config.host.isPresent()
         config.parent.numOfThreads == 8
         config.worker.numOfThreads == 8
-
+        
         then:
         NettyHttpServer server = beanContext.getBean(NettyHttpServer)
         server.start()

--- a/http-server-netty/src/test/java/io/micronaut/http/server/netty/converters/WriteBufferWaterMarkConverterTest.java
+++ b/http-server-netty/src/test/java/io/micronaut/http/server/netty/converters/WriteBufferWaterMarkConverterTest.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import java.util.function.BiConsumer;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertNotNull;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -43,6 +44,7 @@ public class WriteBufferWaterMarkConverterTest {
     NettyHttpServerConfiguration micronautConfig;
     Environment environment;
     long callCount = 0;
+    ApplicationContext ctx;
 
     @Before
     public void init() {
@@ -50,9 +52,16 @@ public class WriteBufferWaterMarkConverterTest {
         params.put("micronaut.server.netty.childOptions.write_buffer_water_mark.high", 262143);
         params.put("micronaut.server.netty.childOptions.write_buffer_water_mark.low", 65535);
 
-        ApplicationContext ctx = ApplicationContext.run(params, (String) null);
+        ctx = ApplicationContext.run(params, (String) null);
         micronautConfig = ctx.createBean(NettyHttpServerConfiguration.class);
         environment = ctx.getEnvironment();
+    }
+
+    @After
+    public void tearDown() {
+        micronautConfig = null;
+        environment.close();
+        ctx.close();
     }
 
     @Test

--- a/http-server-netty/src/test/java/io/micronaut/http/server/netty/converters/WriteBufferWaterMarkConverterTest.java
+++ b/http-server-netty/src/test/java/io/micronaut/http/server/netty/converters/WriteBufferWaterMarkConverterTest.java
@@ -25,6 +25,7 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.WriteBufferWaterMark;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiConsumer;
@@ -45,10 +46,9 @@ public class WriteBufferWaterMarkConverterTest {
 
     @Before
     public void init() {
-        Map<String, Object> params = Map.of(
-                "micronaut.server.netty.childOptions.write_buffer_water_mark.high", 262143,
-                "micronaut.server.netty.childOptions.write_buffer_water_mark.low", 65535
-        );
+        Map<String, Object> params = new HashMap<>();
+        params.put("micronaut.server.netty.childOptions.write_buffer_water_mark.high", 262143);
+        params.put("micronaut.server.netty.childOptions.write_buffer_water_mark.low", 65535);
 
         ApplicationContext ctx = ApplicationContext.run(params, (String) null);
         micronautConfig = ctx.createBean(NettyHttpServerConfiguration.class);

--- a/http-server-netty/src/test/java/io/micronaut/http/server/netty/converters/WriteBufferWaterMarkConverterTest.java
+++ b/http-server-netty/src/test/java/io/micronaut/http/server/netty/converters/WriteBufferWaterMarkConverterTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.netty.converters;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.env.Environment;
+import io.micronaut.core.reflect.GenericTypeUtils;
+import io.micronaut.core.reflect.ReflectionUtils;
+import io.micronaut.http.server.netty.configuration.NettyHttpServerConfiguration;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.WriteBufferWaterMark;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNotNull;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ *
+ * @author ratcashdev
+ */
+public class WriteBufferWaterMarkConverterTest {
+
+    NettyHttpServerConfiguration micronautConfig;
+    Environment environment;
+    long callCount = 0;
+
+    @Before
+    public void init() {
+        Map<String, Object> params = Map.of(
+                "micronaut.server.netty.childOptions.write_buffer_water_mark.high", 262143,
+                "micronaut.server.netty.childOptions.write_buffer_water_mark.low", 65535
+        );
+
+        ApplicationContext ctx = ApplicationContext.run(params, (String) null);
+        micronautConfig = ctx.createBean(NettyHttpServerConfiguration.class);
+        environment = ctx.getEnvironment();
+    }
+
+    @Test
+    public void testNettyConfig() throws IOException {
+        ServerBootstrap serverBootstrap = new ServerBootstrap();
+
+        Map<String, Object> configValue
+                = (Map<String, Object>) micronautConfig.getChildOptions().get(ChannelOption.WRITE_BUFFER_WATER_MARK);
+        assertEquals(configValue.get("high"), 262143);
+        assertEquals(configValue.get("low"), 65535);
+
+        processOptions(micronautConfig.getChildOptions(), serverBootstrap::childOption);
+
+        WriteBufferWaterMark val = (WriteBufferWaterMark)
+                serverBootstrap.config().childOptions().get(ChannelOption.WRITE_BUFFER_WATER_MARK);
+        assertNotNull(val);
+        assertEquals(val.high(), 262143);
+        assertEquals(val.low(), 65535);
+    }
+
+    // method copied from NettyHttpServer
+    private void processOptions(Map<ChannelOption, Object> options, BiConsumer<ChannelOption, Object> biConsumer) {
+        for (ChannelOption channelOption : options.keySet()) {
+            String name = channelOption.name();
+            Object value = options.get(channelOption);
+            Optional<Field> declaredField = ReflectionUtils.findDeclaredField(ChannelOption.class, name);
+            declaredField.ifPresent((field) -> {
+                Optional<Class> typeArg = GenericTypeUtils.resolveGenericTypeArgument(field);
+                typeArg.ifPresent((arg) -> {
+                    Optional converted = environment.convert(value, arg);
+                    converted.ifPresent((convertedValue) ->
+                        biConsumer.accept(channelOption, convertedValue)
+                    );
+                });
+
+            });
+            if (!declaredField.isPresent()) {
+                biConsumer.accept(channelOption, value);
+            }
+        }
+    }
+}


### PR DESCRIPTION
https://netty.io/4.1/api/io/netty/channel/ChannelOption.html#WRITE_BUFFER_WATER_MARK introduced a new way of configuring watermarks that requires a new TypeConverter in netty to be able to configure it through `NettyHttpServerConfiguration`.
The `WriteBufferWaterMarkConverterTest` is rather heavy (and java) but could not find a better way of ensuring that the TypeConverter actually kicks in and hands over the config values to `ServerBootstrap`. Feel free to amend.
Solves https://github.com/micronaut-projects/micronaut-core/issues/2970