### PR TITLE
Rewrite the RoutingInBoundHandler to simplify trace and allow chunking

### DIFF
--- a/core/src/main/java/io/micronaut/core/type/ReturnType.java
+++ b/core/src/main/java/io/micronaut/core/type/ReturnType.java
@@ -15,11 +15,16 @@
  */
 package io.micronaut.core.type;
 
-import io.micronaut.core.annotation.AnnotationSource;
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.AnnotationMetadataProvider;
+import io.micronaut.core.async.annotation.SingleResult;
+import io.micronaut.core.async.publisher.Publishers;
 
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
 
 /**
  * Models a return type of an {@link Executable} method in Micronaut.
@@ -28,7 +33,7 @@ import java.util.Map;
  * @author Graeme Rocher
  * @since 1.0
  */
-public interface ReturnType<T> extends TypeVariableResolver, AnnotationSource {
+public interface ReturnType<T> extends TypeVariableResolver, AnnotationMetadataProvider {
 
     /**
      * @return The type of the argument
@@ -41,6 +46,84 @@ public interface ReturnType<T> extends TypeVariableResolver, AnnotationSource {
     default Argument<T> asArgument() {
         Collection<Argument<?>> values = getTypeVariables().values();
         return Argument.of(getType(), values.toArray(new Argument[0]));
+    }
+
+    /**
+     * @return Is this route match a suspended function (Kotlin).
+     * @since 2.0.0
+     */
+    default boolean isSuspended() {
+        return false;
+    }
+
+    /**
+     * @return Is the route a reactive route.
+     * @since 2.0.0
+     */
+    default boolean isReactive() {
+        return Publishers.isConvertibleToPublisher(getType());
+    }
+
+    /**
+     * @return Is the route a reactive route.
+     * @since 2.0.0
+     */
+    default boolean isCompletable() {
+        return Publishers.isCompletable(getType());
+    }
+
+    /**
+     * @return Does the route emit a single result or multiple results
+     * @since 2.0
+     */
+    default boolean isSingleResult() {
+        AnnotationMetadata annotationMetadata = getAnnotationMetadata();
+        boolean single = annotationMetadata.booleanValue(SingleResult.class).orElse(false);
+        if (single) {
+            return true;
+        } else {
+            if (isReactive()) {
+                Class<T> returnType = getType();
+                return Publishers.isSingle(returnType);
+            } else {
+                return true;
+            }
+        }
+    }
+
+    /**
+     * @return Is the route an async route.
+     * @since 2.0.0
+     */
+    default boolean isAsync() {
+        Class<T> type = getType();
+        return CompletionStage.class.isAssignableFrom(type);
+    }
+
+    /**
+     * @return Is the route an async or reactive route.
+     * @since 2.0.0
+     */
+    default boolean isAsyncOrReactive() {
+        return isAsync() || isReactive();
+    }
+
+    /**
+     * @return Does the route return void
+     * @since 2.0.0
+     */
+    default boolean isVoid() {
+        Class<T> javaReturnType = getType();
+        if (javaReturnType == void.class) {
+            return true;
+        } else {
+            if (isReactive() || isAsync()) {
+                return Publishers.isCompletable(javaReturnType) ||
+                        getFirstTypeVariable()
+                                .filter(arg -> arg.getType() == Void.class).isPresent();
+            }
+        }
+        return false;
     }
 
     /**

--- a/core/src/main/java/io/micronaut/core/type/ReturnType.java
+++ b/core/src/main/java/io/micronaut/core/type/ReturnType.java
@@ -23,7 +23,6 @@ import io.micronaut.core.async.publisher.Publishers;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
 /**

--- a/http-client-core/src/main/java/io/micronaut/http/client/interceptor/HttpClientIntroductionAdvice.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/interceptor/HttpClientIntroductionAdvice.java
@@ -23,6 +23,7 @@ import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.async.annotation.SingleResult;
 import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.core.async.subscriber.CompletionAwareSubscriber;
 import io.micronaut.core.beans.BeanMap;
@@ -391,7 +392,7 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
             boolean isFuture = CompletionStage.class.isAssignableFrom(javaReturnType);
             final Class<?> methodDeclaringType = declaringType;
             if (Publishers.isConvertibleToPublisher(javaReturnType) || isFuture) {
-                boolean isSingle = Publishers.isSingle(javaReturnType) || isFuture || context.isTrue(Consumes.class, "single");
+                boolean isSingle = Publishers.isCompletable(javaReturnType) || Publishers.isSingle(javaReturnType) || isFuture || context.isTrue(SingleResult.class, AnnotationMetadata.VALUE_MEMBER);
                 Argument<?> publisherArgument = returnType.asArgument().getFirstTypeVariable().orElse(Argument.OBJECT_ARGUMENT);
 
 

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -95,6 +95,7 @@ import io.netty.handler.codec.http.multipart.*;
 import io.netty.handler.codec.http.websocketx.WebSocketClientHandshakerFactory;
 import io.netty.handler.codec.http.websocketx.WebSocketVersion;
 import io.netty.handler.codec.http2.*;
+import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.proxy.HttpProxyHandler;
 import io.netty.handler.proxy.Socks5ProxyHandler;
 import io.netty.handler.ssl.ApplicationProtocolNames;
@@ -2508,6 +2509,18 @@ public class DefaultHttpClient implements RxWebSocketClient, RxHttpClient, RxStr
                     // so that the consumer is in charge of back pressure
                     ch.config().setAutoRead(false);
                 }
+
+                configuration.getLogLevel().ifPresent(logLevel -> {
+                    try {
+                        final io.netty.handler.logging.LogLevel nettyLevel = io.netty.handler.logging.LogLevel.valueOf(
+                                logLevel.name()
+                        );
+                        p.addLast(new LoggingHandler(DefaultHttpClient.class, nettyLevel));
+                    } catch (IllegalArgumentException e) {
+                        throw new HttpClientException("Unsupported log level: " + logLevel);
+                    }
+                });
+
                 if (sslContext != null) {
                     SslHandler sslHandler = sslContext.newHandler(
                             ch.alloc(),

--- a/http-client/src/test/groovy/io/micronaut/http/client/HttpGetSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/HttpGetSpec.groovy
@@ -15,7 +15,7 @@
  */
 package io.micronaut.http.client
 
-
+import io.micronaut.context.annotation.Property
 import io.micronaut.core.convert.format.Format
 import io.micronaut.core.type.Argument
 import io.micronaut.http.*
@@ -45,6 +45,8 @@ import java.time.LocalDate
  * @since 1.0
  */
 @MicronautTest
+@Property(name = "micronaut.server.netty.log-level", value = 'trace')
+@Property(name = "micronaut.http.client.log-level", value = 'trace')
 class HttpGetSpec extends Specification {
 
     @Inject
@@ -421,10 +423,11 @@ class HttpGetSpec extends Specification {
     void "test completable returns 200"() {
         when:
         MyGetClient client = this.myGetClient
+        def returnsNull = client.completable().blockingGet()
         def ex = client.completableError().blockingGet()
 
         then:
-        client.completable().blockingGet() == null
+        returnsNull == null
         ex instanceof HttpClientResponseException
         ex.message.contains("completable error")
     }

--- a/http-client/src/test/groovy/io/micronaut/http/client/ResponseAndStreamSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/ResponseAndStreamSpec.groovy
@@ -1,0 +1,65 @@
+package io.micronaut.http.client
+
+import io.micronaut.http.HttpHeaders
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MediaType
+import io.micronaut.http.MutableHttpResponse
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Filter
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.filter.HttpServerFilter
+import io.micronaut.http.filter.ServerFilterChain
+import io.micronaut.test.annotation.MicronautTest
+import io.reactivex.Flowable
+import org.reactivestreams.Publisher
+import spock.lang.Specification
+
+import javax.inject.Inject
+
+@MicronautTest
+class ResponseAndStreamSpec extends Specification {
+
+    @Inject
+    ResponseStreamClient client
+
+    void "test switch to streaming on flowable body"() {
+        when:
+        def response = client.go()
+
+        then:
+        response.body() == 'chunk1chunk2chunk3'
+    }
+
+    @Client('/test/response-stream')
+    static interface ResponseStreamClient {
+        @Get('/model')
+        HttpResponse<String> go()
+    }
+
+    @Controller('/test/response-stream')
+    static class ResponseStreamController {
+
+        @Get('/model')
+        Map<String, String> go() {
+            return [test:'model']
+        }
+    }
+
+    @Filter('/test/response-stream/*')
+    static class MyFilter implements HttpServerFilter {
+
+        @Override
+        Publisher<MutableHttpResponse<?>> doFilter(
+                HttpRequest<?> request, ServerFilterChain chain) {
+            return Flowable.fromPublisher(chain.proceed()).map { MutableHttpResponse<?> response ->
+                return response.body(Flowable.fromIterable([
+                        "chunk1",
+                        "chunk2",
+                        "chunk3",
+                ])).contentType(MediaType.TEXT_PLAIN)
+            }
+        }
+    }
+}

--- a/http-client/src/test/groovy/io/micronaut/http/client/ServerRedirectSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/ServerRedirectSpec.groovy
@@ -119,7 +119,7 @@ class ServerRedirectSpec extends Specification {
                 .blockingFirst()
 
         then:
-        response == "data: The Stand\n\n"
+        response == "data: The Stand"
     }
 
     void "test redirect headers"() {
@@ -216,12 +216,11 @@ class ServerRedirectSpec extends Specification {
 
         @Get("/text")
         @Produces([MediaType.TEXT_EVENT_STREAM, MediaType.APPLICATION_JSON_STREAM])
-        Flowable<HttpResponse<?>> title(final HttpHeaders headers) {
+        HttpResponse<Flowable<?>> title(final HttpHeaders headers) {
             if (headers.accept().contains(MediaType.TEXT_EVENT_STREAM_TYPE)) {
-                return Flowable.just(HttpResponse.ok("The Stand").contentType(MediaType.TEXT_EVENT_STREAM))
+                return HttpResponse.ok(Flowable.just("The Stand")).contentType(MediaType.TEXT_EVENT_STREAM)
             }
-            return Flowable.just(HttpResponse.ok(new Book(title: "The Stand")).contentType(MediaType.APPLICATION_JSON_STREAM))
-
+            return HttpResponse.ok(Flowable.just(new Book(title: "The Stand"))).contentType(MediaType.APPLICATION_JSON_STREAM)
         }
 
     }

--- a/http-client/src/test/groovy/io/micronaut/http/client/docs/httpstatus/HttpStatusSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/docs/httpstatus/HttpStatusSpec.groovy
@@ -65,7 +65,8 @@ class HttpStatusSpec extends Specification {
     }
 
     @Issue("https://github.com/micronaut-projects/micronaut-core/issues/866")
-    void "Verify a controller can be annotated with @Status and void return"() {
+    @Unroll
+    void "Verify a controller can be annotated with @Status and void return for #uri"() {
         when:
         HttpResponse response = client.toBlocking().exchange(HttpRequest.GET(uri))
 

--- a/http-client/src/test/groovy/io/micronaut/http/client/rxjava2/RxHttpPostSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/rxjava2/RxHttpPostSpec.groovy
@@ -43,7 +43,7 @@ import spock.lang.Specification
  * @author Graeme Rocher
  * @since 1.0
  */
-class   RxHttpPostSpec extends Specification {
+class RxHttpPostSpec extends Specification {
 
     @Shared
     @AutoCleanup

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
@@ -29,6 +29,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
@@ -49,14 +50,12 @@ import io.micronaut.core.io.buffer.ByteBuffer;
 import io.micronaut.core.io.buffer.ReferenceCounted;
 import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.core.type.Argument;
-import io.micronaut.core.type.ReturnType;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.HttpMethod;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.*;
-import io.micronaut.http.annotation.Produces;
 import io.micronaut.http.annotation.Status;
 import io.micronaut.http.bind.binders.ContinuationArgumentBinder;
 import io.micronaut.http.codec.MediaTypeCodec;
@@ -117,12 +116,12 @@ import io.netty.handler.codec.http.multipart.FileUpload;
 import io.netty.handler.codec.http.multipart.HttpData;
 import io.netty.handler.timeout.IdleState;
 import io.netty.handler.timeout.IdleStateEvent;
-import io.reactivex.BackpressureStrategy;
-import io.reactivex.Completable;
-import io.reactivex.Flowable;
+import io.reactivex.*;
+import io.reactivex.functions.Consumer;
 import io.reactivex.functions.LongConsumer;
 import io.reactivex.processors.UnicastProcessor;
 import io.reactivex.schedulers.Schedulers;
+import org.jetbrains.annotations.NotNull;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -146,6 +145,8 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
     private static final Pattern IGNORABLE_ERROR_MESSAGE = Pattern.compile(
             "^.*(?:connection.*(?:reset|closed|abort|broken)|broken.*pipe).*$", Pattern.CASE_INSENSITIVE);
     private static final Argument ARGUMENT_PART_DATA = Argument.of(PartData.class);
+    private static final Object NOT_FOUND = new Object();
+    private static final Single<Object> NOT_FOUND_SINGLE = Single.just(NOT_FOUND);
 
     private final Router router;
     private final ExecutorSelector executorSelector;
@@ -171,16 +172,16 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
      * @param httpContentProcessorResolver            The http content processor resolver
      */
     RoutingInBoundHandler(
-        BeanContext beanContext,
-        Router router,
-        MediaTypeCodecRegistry mediaTypeCodecRegistry,
-        NettyCustomizableResponseTypeHandlerRegistry customizableResponseTypeHandlerRegistry,
-        StaticResourceResolver staticResourceResolver,
-        NettyHttpServerConfiguration serverConfiguration,
-        RequestArgumentSatisfier requestArgumentSatisfier,
-        ExecutorSelector executorSelector,
-        ExecutorService ioExecutor,
-        HttpContentProcessorResolver httpContentProcessorResolver) {
+            BeanContext beanContext,
+            Router router,
+            MediaTypeCodecRegistry mediaTypeCodecRegistry,
+            NettyCustomizableResponseTypeHandlerRegistry customizableResponseTypeHandlerRegistry,
+            StaticResourceResolver staticResourceResolver,
+            NettyHttpServerConfiguration serverConfiguration,
+            RequestArgumentSatisfier requestArgumentSatisfier,
+            ExecutorSelector executorSelector,
+            ExecutorService ioExecutor,
+            HttpContentProcessorResolver httpContentProcessorResolver) {
         this.mediaTypeCodecRegistry = mediaTypeCodecRegistry;
         this.customizableResponseTypeHandlerRegistry = customizableResponseTypeHandlerRegistry;
         this.beanContext = beanContext;
@@ -320,58 +321,17 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
                 LOG.debug("Found matching exception handler for exception [{}]: {}", cause.getMessage(), errorRoute);
             }
             errorRoute = requestArgumentSatisfier.fulfillArgumentRequirements(errorRoute, nettyHttpRequest, false);
-            MediaType defaultResponseMediaType = resolveDefaultResponseContentType(
-                    nettyHttpRequest,
-                    errorRoute
-            );
             try {
-                final MethodBasedRouteMatch<?, ?> methodBasedRoute = (MethodBasedRouteMatch) errorRoute;
-                Class<?> javaReturnType = errorRoute.getReturnType().getType();
-                boolean isFuture = CompletionStage.class.isAssignableFrom(javaReturnType);
-                boolean isReactiveReturnType = Publishers.isConvertibleToPublisher(javaReturnType) || isFuture;
-                boolean isKotlinSuspendingFunction = methodBasedRoute.getExecutableMethod().isSuspend();
-                boolean isKotlinFunctionReturnTypeUnit = isKotlinSuspendingFunction &&
-                        isKotlinFunctionReturnTypeUnit(methodBasedRoute.getExecutableMethod());
-                Flowable resultFlowable = Flowable.defer(() -> {
-                      Object result = methodBasedRoute.execute();
-                      MutableHttpResponse<?> response = errorResultToResponse(result, methodBasedRoute);
-                      response.setAttribute(HttpAttributes.ROUTE_MATCH, methodBasedRoute);
-                      return Flowable.just(response);
-                });
-
-                AtomicReference<HttpRequest<?>> requestReference = new AtomicReference<>(nettyHttpRequest);
-                Flowable<MutableHttpResponse<?>> routePublisher = buildRoutePublisher(
-                        methodBasedRoute.getDeclaringType(),
-                        methodBasedRoute.getReturnType(),
-                        isReactiveReturnType,
-                        isKotlinSuspendingFunction,
-                        isKotlinFunctionReturnTypeUnit,
-                        methodBasedRoute.getAnnotationMetadata(),
-                        requestReference,
-                        resultFlowable);
-
-                Flowable<? extends MutableHttpResponse<?>> filteredPublisher = filterPublisher(
-                        requestReference,
-                        routePublisher,
-                        ctx.channel().eventLoop(),
-                        nettyException);
-
-                subscribeToResponsePublisher(
+                buildExecutableRoute(
+                        errorRoute,
+                        nettyHttpRequest,
                         ctx,
-                        defaultResponseMediaType,
-                        requestReference,
-                        filteredPublisher
-                );
-
-                if (serverConfiguration.isLogHandledExceptions()) {
-                    logException(cause);
-                }
-
+                        ctx.executor(),
+                        true,
+                        nettyException
+                ).execute();
             } catch (Throwable e) {
-                if (LOG.isErrorEnabled()) {
-                    LOG.error("Exception occurred executing error handler. Falling back to default error handling: " + e.getMessage(), e);
-                }
-                writeDefaultErrorResponse(ctx, nettyHttpRequest, e);
+                writeDefaultErrorResponse(ctx, nettyHttpRequest, e, nettyException);
             }
         } else {
 
@@ -382,75 +342,40 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
                 ExceptionHandler handler = exceptionHandler.get();
                 MediaType defaultResponseMediaType = MediaType.fromType(handler.getClass()).orElse(MediaType.APPLICATION_JSON_TYPE);
                 try {
-                    Flowable resultFlowable = Flowable.defer(() -> {
+                    Publisher<MutableHttpResponse<?>> routePublisher = Flowable.fromCallable(() -> {
                         Object result = handler.handle(nettyHttpRequest, cause);
-                        MutableHttpResponse<?> response = errorResultToResponse(result, null);
-                        return Flowable.just(response);
+                        return errorResultToResponse(result);
                     });
 
-                    AtomicReference<HttpRequest<?>> requestReference = new AtomicReference<>(nettyHttpRequest);
-                    Flowable<MutableHttpResponse<?>> routePublisher = buildRoutePublisher(
-                            handler.getClass(),
-                            ReturnType.of(HttpResponse.class),
-                            false,
-                            false,
-                            false,
-                            AnnotationMetadata.EMPTY_METADATA,
-                            requestReference,
-                            resultFlowable);
+                    filterPublisher(new AtomicReference<HttpRequest<?>>(nettyHttpRequest), routePublisher, ctx.executor(), nettyException)
+                            .firstOrError()
+                            .subscribe((mutableHttpResponse, throwable) -> {
+                                if (throwable != null) {
+                                    writeDefaultErrorResponse(ctx, nettyHttpRequest, throwable, nettyException);
+                                } else {
+                                    encodeHttpResponse(
+                                            ctx,
+                                            nettyHttpRequest,
+                                            mutableHttpResponse,
+                                            mutableHttpResponse.body(),
+                                            defaultResponseMediaType
+                                    );
+                                }
+                            });
 
-                    Flowable<? extends MutableHttpResponse<?>> filteredPublisher = filterPublisher(
-                            requestReference,
-                            routePublisher,
-                            ctx.channel().eventLoop(),
-                            nettyException);
-
-                    subscribeToResponsePublisher(
-                            ctx,
-                            defaultResponseMediaType,
-                            requestReference,
-                            filteredPublisher
-                    );
 
                     if (serverConfiguration.isLogHandledExceptions()) {
                         logException(cause);
                     }
                 } catch (Throwable e) {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Exception occurred executing error handler. Falling back to default error handling.");
-                    }
-                    writeDefaultErrorResponse(ctx, nettyHttpRequest, e);
+                    writeDefaultErrorResponse(ctx, nettyHttpRequest, e, nettyException);
                 }
             } else {
-                logException(cause);
-
-                Flowable resultFlowable = Flowable.defer(() ->
-                        Flowable.just(HttpResponse.serverError().body(new JsonError("Internal Server Error: " + cause.getMessage())))
-                );
-
-                AtomicReference<HttpRequest<?>> requestReference = new AtomicReference<>(nettyHttpRequest);
-                Flowable<MutableHttpResponse<?>> routePublisher = buildRoutePublisher(
-                        null,
-                        ReturnType.of(HttpResponse.class),
-                        false,
-                        false,
-                        false,
-                        AnnotationMetadata.EMPTY_METADATA,
-                        requestReference,
-                        resultFlowable);
-
-                Flowable<? extends MutableHttpResponse<?>> filteredPublisher = filterPublisher(
-                        requestReference,
-                        routePublisher,
-                        ctx.channel().eventLoop(),
-                        nettyException);
-
-                subscribeToResponsePublisher(
+                writeDefaultErrorResponse(
                         ctx,
-                        MediaType.APPLICATION_JSON_TYPE,
-                        requestReference,
-                        filteredPublisher
-                );
+                        nettyHttpRequest,
+                        cause,
+                        nettyException);
             }
         }
     }
@@ -502,7 +427,6 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
             if (LOG.isDebugEnabled()) {
                 LOG.debug("No matching route found for URI {} and method {}", request.getUri(), httpMethod);
             }
-
 
             // if there is no route present try to locate a route that matches a different HTTP method
             final List<UriRouteMatch<?, ?>> anyMatchingRoutes = router
@@ -582,7 +506,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
                 if (statusRoute.isPresent()) {
                     route = statusRoute.get();
                 } else {
-                    emitDefaultNotFoundResponse(ctx, request);
+                    emitDefaultNotFoundResponse(ctx, request, false);
                     return;
                 }
             }
@@ -607,7 +531,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
                     HttpResponse.status(HttpStatus.BAD_REQUEST),
                     "Not a WebSocket request");
         } else {
-            handleRouteMatch(route, nettyHttpRequest, ctx);
+            handleRouteMatch(route, nettyHttpRequest, ctx, false);
         }
     }
 
@@ -620,29 +544,45 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
         Optional<RouteMatch<Object>> statusRoute = router.findStatusRoute(defaultResponse.status(), request);
         if (statusRoute.isPresent()) {
             RouteMatch<Object> routeMatch = statusRoute.get();
-            handleRouteMatch(routeMatch, nettyHttpRequest, ctx);
+            handleRouteMatch(routeMatch, nettyHttpRequest, ctx, false);
         } else {
-
             if (request.getMethod() != HttpMethod.HEAD) {
                 JsonError error = newError(request, message);
                 defaultResponse.body(error);
             }
-
-
-            AtomicReference<HttpRequest<?>> requestReference = new AtomicReference<>(request);
-            Flowable<? extends MutableHttpResponse<?>> responsePublisher = filterPublisher(
-                    requestReference,
-                    Flowable.just(defaultResponse),
-                    ctx.channel().eventLoop(),
+            filterAndEncodeResponse(
+                    ctx,
+                    request,
+                    nettyHttpRequest,
+                    defaultResponse,
+                    MediaType.APPLICATION_JSON_TYPE,
                     false
             );
-            subscribeToResponsePublisher(
-                    ctx,
-                    MediaType.APPLICATION_JSON_TYPE,
-                    requestReference,
-                    responsePublisher
-            );
         }
+    }
+
+    private void filterAndEncodeResponse(
+            ChannelHandlerContext ctx,
+            HttpRequest<?> request,
+            NettyHttpRequest nettyHttpRequest,
+            MutableHttpResponse<Object> finalResponse,
+            MediaType defaultResponseMediaType,
+            boolean skipOncePerRequest) {
+        AtomicReference<HttpRequest<?>> requestReference = new AtomicReference<>(request);
+        filterPublisher(
+                requestReference,
+                Flowable.just(finalResponse),
+                ctx.channel().eventLoop(),
+                skipOncePerRequest
+        ).singleOrError().subscribe((Consumer<MutableHttpResponse<?>>) mutableHttpResponse -> {
+            encodeHttpResponse(
+                    ctx,
+                    nettyHttpRequest,
+                    mutableHttpResponse,
+                    mutableHttpResponse.body(),
+                    defaultResponseMediaType
+            );
+        });
     }
 
     private Optional<? extends FileCustomizableResponseType> matchFile(String path) {
@@ -667,21 +607,15 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
         return Optional.empty();
     }
 
-    private void emitDefaultNotFoundResponse(ChannelHandlerContext ctx, io.micronaut.http.HttpRequest<?> request) {
+    private void emitDefaultNotFoundResponse(ChannelHandlerContext ctx, HttpRequest<?> request, boolean skipOncePerRequest) {
         MutableHttpResponse<Object> res = newNotFoundError(request);
-        AtomicReference<HttpRequest<?>> requestReference = new AtomicReference<>(request);
-        Flowable<? extends MutableHttpResponse<?>> responsePublisher = filterPublisher(
-                requestReference,
-                Flowable.just(res),
-                ctx.channel().eventLoop(),
-                false
-        );
-        subscribeToResponsePublisher(
+        filterAndEncodeResponse(
                 ctx,
+                request,
+                (NettyHttpRequest) request,
+                res,
                 MediaType.APPLICATION_JSON_TYPE,
-                requestReference,
-                responsePublisher
-        );
+                skipOncePerRequest);
     }
 
     private MutableHttpResponse<Object> newNotFoundError(HttpRequest<?> request) {
@@ -696,29 +630,25 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
                 .link(Link.SELF, Link.of(uri));
     }
 
-    private MutableHttpResponse errorResultToResponse(Object result, @Nullable RouteMatch routeMatch) {
+    private MutableHttpResponse errorResultToResponse(Object result) {
         MutableHttpResponse<?> response;
         if (result instanceof HttpResponse) {
-            response = ConversionService.SHARED.convert(result, NettyMutableHttpResponse.class)
-                    .orElseThrow(() -> new InternalServerException("Emitted response is not mutable"));
+            return toNettyResponse((HttpResponse<?>) result);
         } else {
             if (result instanceof HttpStatus) {
                 response = HttpResponse.status((HttpStatus) result);
             } else {
-                if (routeMatch != null) {
-                    response = forStatus(routeMatch.getAnnotationMetadata(), HttpStatus.INTERNAL_SERVER_ERROR).body(result);
-                } else {
-                    response = HttpResponse.serverError().body(result);
-                }
+                response = HttpResponse.serverError().body(result);
             }
         }
         return response;
     }
 
     private void handleRouteMatch(
-        RouteMatch<?> route,
-        NettyHttpRequest<?> request,
-        ChannelHandlerContext context) {
+            RouteMatch<?> route,
+            NettyHttpRequest<?> request,
+            ChannelHandlerContext context,
+            boolean skipOncePerRequest) {
         // Set the matched route on the request
         request.setMatchedRoute(route);
 
@@ -736,12 +666,16 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
             httpContentProcessorResolver.resolve(request, route).subscribe(buildSubscriber(request, context, route));
         } else {
             context.read();
-            route = prepareRouteForExecution(route, request);
+            route = prepareRouteForExecution(route, request, skipOncePerRequest);
             route.execute();
         }
     }
 
-    private boolean isJsonFormattable(Class javaType) {
+    private boolean isJsonFormattable(Argument<?> argument) {
+        Class<?> javaType = argument.getType();
+        if (Publishers.isConvertibleToPublisher(javaType)) {
+            javaType = argument.getFirstTypeVariable().orElse(Argument.OBJECT_ARGUMENT).getType();
+        }
         return !(javaType == byte[].class
                 || ByteBuffer.class.isAssignableFrom(javaType)
                 || ByteBuf.class.isAssignableFrom(javaType));
@@ -970,13 +904,13 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
                     exceptionCaught(context, t);
                 } catch (Exception e) {
                     // should never happen
-                    writeDefaultErrorResponse(context, request, e);
+                    writeDefaultErrorResponse(context, request, e, false);
                 }
             }
 
             @Override
             protected void doOnComplete() {
-                for (UnicastProcessor subject: subjects.values()) {
+                for (UnicastProcessor subject : subjects.values()) {
                     if (!subject.hasComplete()) {
                         subject.onComplete();
                     }
@@ -987,7 +921,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
             private void executeRoute() {
                 if (executed.compareAndSet(false, true)) {
                     try {
-                        routeMatch = prepareRouteForExecution(routeMatch, request);
+                        routeMatch = prepareRouteForExecution(routeMatch, request, false);
                         routeMatch.execute();
                     } catch (Exception e) {
                         context.pipeline().fireExceptionCaught(e);
@@ -997,7 +931,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
         };
     }
 
-    private RouteMatch<?> prepareRouteForExecution(RouteMatch<?> route, NettyHttpRequest<?> request) {
+    private RouteMatch<?> prepareRouteForExecution(RouteMatch<?> route, NettyHttpRequest<?> request, boolean skipOncePerRequest) {
         ChannelHandlerContext context = request.getChannelHandlerContext();
         // Select the most appropriate Executor
         ExecutorService executor;
@@ -1009,10 +943,10 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
                 } else {
                     executor = null;
                 }
-            break;
+                break;
             case IO:
                 executor = ioExecutor;
-            break;
+                break;
             case AUTO:
             default:
                 if (route instanceof MethodReference) {
@@ -1024,185 +958,570 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
         }
 
 
+        boolean isErrorRoute = false;
+        route = buildExecutableRoute(
+                route,
+                request,
+                context,
+                executor,
+                isErrorRoute,
+                skipOncePerRequest
+        );
+        return route;
+    }
+
+    private RouteMatch<?> buildExecutableRoute(
+            RouteMatch<?> route,
+            NettyHttpRequest<?> request,
+            ChannelHandlerContext context,
+            ExecutorService executor,
+            boolean isErrorRoute,
+            boolean skipOncePerRequest) {
         route = route.decorate(finalRoute -> {
             MediaType defaultResponseMediaType = resolveDefaultResponseContentType(
                     request,
                     finalRoute
             );
-            ReturnType<?> genericReturnType = finalRoute.getReturnType();
-            Class<?> javaReturnType = genericReturnType.getType();
+            AtomicReference<HttpRequest<?>> requestReference = new AtomicReference<>(request);
+            Flowable<? extends MutableHttpResponse<?>> filteredPublisher = buildResultEmitter(
+                            request,
+                            requestReference,
+                            finalRoute,
+                            executor,
+                            isErrorRoute,
+                            skipOncePerRequest
+                    );
 
-            AtomicReference<io.micronaut.http.HttpRequest<?>> requestReference = new AtomicReference<>(request);
-            boolean isFuture = CompletionStage.class.isAssignableFrom(javaReturnType);
-            boolean isReactiveReturnType = Publishers.isConvertibleToPublisher(javaReturnType) || isFuture;
-            boolean isKotlinSuspendingFunction =
-                    finalRoute instanceof MethodBasedRouteMatch &&
-                    ((MethodBasedRouteMatch) finalRoute).getExecutableMethod().isSuspend();
-            boolean isKotlinFunctionReturnTypeUnit = isKotlinSuspendingFunction &&
-                    isKotlinFunctionReturnTypeUnit(((MethodBasedRouteMatch) finalRoute).getExecutableMethod());
-            boolean isSingle =
-                    isReactiveReturnType && Publishers.isSingle(javaReturnType) ||
-                            isResponsePublisher(genericReturnType, javaReturnType) ||
-                                isFuture ||
-                                    finalRoute.getAnnotationMetadata().booleanValue(Produces.class, "single").orElse(false) ||
-                                        isKotlinSuspendingFunction;
+            filteredPublisher.subscribe(new ContextCompletionAwareSubscriber<MutableHttpResponse<?>>(context) {
+                @Override
+                protected void onComplete(MutableHttpResponse<?> message) {
 
-            // build the result emitter. This result emitter emits the response from a controller action
-            Flowable<?> resultEmitter = buildResultEmitter(
-                    context,
-                    finalRoute,
-                    requestReference,
-                    isReactiveReturnType,
-                    isKotlinSuspendingFunction,
-                    isKotlinFunctionReturnTypeUnit,
-                    isSingle
-            );
+                    HttpRequest<?> incomingRequest = requestReference.get();
+                    applyConfiguredHeaders(message.getHeaders());
+                    MediaType specifiedMediaType = message.getContentType().orElse(null);
+                    MediaType mediaType = specifiedMediaType != null ? specifiedMediaType : defaultResponseMediaType;
 
-            // here we transform the result of the controller action into a MutableHttpResponse
-            Flowable<MutableHttpResponse<?>> routePublisher = resultEmitter.map((message) -> {
-                RouteMatch<?> routeMatch = finalRoute;
-                MutableHttpResponse<?> finalResponse = messageToResponse(routeMatch, message);
-                if (requestReference.get().getMethod().equals(HttpMethod.HEAD)) {
-                    final Object o = finalResponse.getBody().orElse(null);
-                    if (o instanceof ReferenceCounted) {
-                        ((ReferenceCounted) o).release();
-                    }
-                    finalResponse.body(null);
-                }
-                HttpStatus status = finalResponse.getStatus();
+                    Object body = message.body();
+                    HttpStatus status = message.status();
+                    if (status.getCode() >= 400 && !isErrorRoute) {
+                        RouteMatch<Object> statusRoute = findStatusRoute(incomingRequest, status, finalRoute);
 
-                if (status.getCode() >= HttpStatus.BAD_REQUEST.getCode()) {
-                    Class declaringType = ((MethodBasedRouteMatch) routeMatch).getDeclaringType();
-                    // handle re-mapping of errors
-                    Optional<RouteMatch<Object>> statusRoute = Optional.empty();
-                    // if declaringType is not null, this means its a locally marked method handler
-                    if (declaringType != null) {
-                        statusRoute = router.findStatusRoute(declaringType, status, request);
-                    }
-                    io.micronaut.http.HttpRequest<?> httpRequest = requestReference.get();
-                    if (!statusRoute.isPresent()) {
-                        statusRoute = router.findStatusRoute(status, httpRequest);
-                    }
-
-                    if (statusRoute.isPresent()) {
-                        routeMatch = statusRoute.get();
-                        httpRequest.setAttribute(HttpAttributes.ROUTE_MATCH, routeMatch);
-
-                        routeMatch = requestArgumentSatisfier.fulfillArgumentRequirements(routeMatch, httpRequest, true);
-
-                        if (routeMatch.isExecutable()) {
-                            Object result;
-                            try {
-                                result = routeMatch.execute();
-                                finalResponse = messageToResponse(routeMatch, result);
-                            } catch (Throwable e) {
-                                throw new InternalServerException("Error executing status route [" + routeMatch + "]: " + e.getMessage(), e);
-                            }
+                        if (statusRoute != null) {
+                            incomingRequest.setAttribute(HttpAttributes.ROUTE_MATCH, statusRoute);
+                            buildExecutableRoute(
+                                    statusRoute,
+                                    request,
+                                    context,
+                                    executor,
+                                    true,
+                                    true
+                            ).execute();
                         } else {
-                            if (LOG.isWarnEnabled()) {
-                                LOG.warn("Matched status route [" + routeMatch + "] not executed because one or more arguments could not be bound. Returning the original response.");
+                            //noinspection unchecked
+                            filterAndEncodeResponse(
+                                    context,
+                                    request,
+                                    request,
+                                    (MutableHttpResponse<Object>) message,
+                                    mediaType,
+                                    true
+                            );
+                        }
+                    } else if (body != null) {
+                        boolean isReactive = finalRoute.isAsyncOrReactive() || Publishers.isConvertibleToPublisher(body);
+                        if (isReactive && Publishers.isConvertibleToPublisher(body)) {
+                            Class<?> bodyClass = body.getClass();
+                            boolean isSingle = finalRoute.isSingleResult() && (finalRoute.isAsync() || finalRoute.isSuspended() || Publishers.isSingle(bodyClass));
+                            boolean isCompletable = !isSingle && finalRoute.isVoid() && Publishers.isCompletable(bodyClass);
+                            if (isSingle || isCompletable) {
+                                // full response case
+                                Single<Object> single = Publishers.convertPublisher(body, Maybe.class)
+                                        .switchIfEmpty(NOT_FOUND_SINGLE);
+                                single.subscribe((o, throwable) -> {
+                                    if (o == NOT_FOUND) {
+                                        if (isCompletable || finalRoute.isVoid() || finalRoute.isSuspended()) {
+                                            message.body(null);
+                                            message.header(HttpHeaders.CONTENT_LENGTH, HttpHeaderValues.ZERO);
+                                            writeFinalNettyResponse(
+                                                    message,
+                                                    request,
+                                                    context
+                                            );
+                                        } else if (!isErrorRoute) {
+                                            RouteMatch<Object> statusRoute = findStatusRoute(incomingRequest, HttpStatus.NOT_FOUND, finalRoute);
+                                            if (statusRoute != null) {
+                                                buildExecutableRoute(
+                                                        statusRoute,
+                                                        request,
+                                                        context,
+                                                        executor,
+                                                        true,
+                                                        true)
+                                                        .execute();
+                                            } else {
+                                                emitDefaultNotFoundResponse(context, requestReference.get(), skipOncePerRequest);
+                                            }
+                                        } else {
+                                            emitDefaultNotFoundResponse(context, requestReference.get(), skipOncePerRequest);
+                                        }
+                                    } else if (throwable != null) {
+                                        exceptionCaughtInternal(
+                                                context,
+                                                throwable,
+                                                request,
+                                                false
+                                        );
+                                    } else {
+                                        MutableHttpResponse<?> finalResponse;
+                                        if (o instanceof MutableHttpResponse) {
+                                            finalResponse = (MutableHttpResponse<?>) o;
+                                            o = finalResponse.body();
+                                        } else {
+                                            finalResponse = message;
+                                        }
+                                        encodeHttpResponse(
+                                                context,
+                                                request,
+                                                finalResponse,
+                                                o,
+                                                defaultResponseMediaType
+                                        );
+                                    }
+                                });
+
+                            } else {
+                                // streaming case
+                                Argument<?> typeArgument = finalRoute.getReturnType().getFirstTypeVariable().orElse(Argument.OBJECT_ARGUMENT);
+                                boolean isHttp2 = request.getHttpVersion() == io.micronaut.http.HttpVersion.HTTP_2_0;
+                                if (HttpResponse.class.isAssignableFrom(typeArgument.getType())) {
+                                    // a response stream
+                                    Flowable<HttpResponse<?>> bodyFlowable = Publishers.convertPublisher(body, Flowable.class);
+
+                                    // HTTP/2 allows sending multiple responses down a single stream
+                                    if (isHttp2) {
+                                        bodyFlowable.subscribe(httpResponse -> encodeHttpResponse(
+                                                context,
+                                                request,
+                                                toNettyResponse(httpResponse),
+                                                httpResponse.body(),
+                                                defaultResponseMediaType
+                                        ), throwable -> exceptionCaughtInternal(
+                                                context,
+                                                throwable,
+                                                request,
+                                                false
+                                        ));
+                                    } else {
+                                        // HTTP/1 we take the first response or error
+                                        bodyFlowable.firstOrError().subscribe((httpResponse, throwable) -> {
+                                            if (throwable == null) {
+                                                encodeHttpResponse(
+                                                        context,
+                                                        request,
+                                                        toNettyResponse(httpResponse),
+                                                        httpResponse.body(),
+                                                        defaultResponseMediaType
+                                                );
+                                            } else {
+                                                exceptionCaughtInternal(
+                                                        context,
+                                                        throwable,
+                                                        request,
+                                                        false
+                                                );
+                                            }
+                                        });
+                                    }
+                                } else {
+                                    boolean isJson = mediaType.getExtension().equals(MediaType.EXTENSION_JSON) && isJsonFormattable(typeArgument);
+                                    Flowable<Object> bodyFlowable = Publishers.convertPublisher(body, Flowable.class);
+                                    NettyByteBufferFactory byteBufferFactory = new NettyByteBufferFactory(context.alloc());
+
+                                    Publisher<HttpContent> httpContentPublisher = Publishers.map(bodyFlowable, new Function<Object, HttpContent>() {
+                                        boolean first = true;
+
+                                        @Override
+                                        public HttpContent apply(Object message) {
+                                            HttpContent httpContent;
+                                            if (message instanceof ByteBuf) {
+                                                httpContent = new DefaultHttpContent((ByteBuf) message);
+                                            } else if (message instanceof ByteBuffer) {
+                                                ByteBuffer<?> byteBuffer = (ByteBuffer<?>) message;
+                                                Object nativeBuffer = byteBuffer.asNativeBuffer();
+                                                if (nativeBuffer instanceof ByteBuf) {
+                                                    httpContent = new DefaultHttpContent((ByteBuf) nativeBuffer);
+                                                } else {
+                                                    httpContent = new DefaultHttpContent(Unpooled.copiedBuffer(byteBuffer.asNioBuffer()));
+                                                }
+                                            } else if (message instanceof byte[]) {
+                                                httpContent = new DefaultHttpContent(Unpooled.copiedBuffer((byte[]) message));
+                                            } else if (message instanceof HttpContent) {
+                                                httpContent = (HttpContent) message;
+                                            } else {
+
+                                                MediaTypeCodec codec = mediaTypeCodecRegistry.findCodec(mediaType, message.getClass()).orElse(
+                                                        new TextPlainCodec(serverConfiguration.getDefaultCharset()));
+
+                                                if (LOG.isDebugEnabled()) {
+                                                    LOG.debug("Encoding emitted response object [{}] using codec: {}", message, codec);
+                                                }
+                                                ByteBuffer<ByteBuf> encoded = codec.encode(message, byteBufferFactory);
+                                                httpContent = new DefaultHttpContent(encoded.asNativeBuffer());
+                                            }
+                                            if (!isJson || first) {
+                                                first = false;
+                                                return httpContent;
+                                            } else {
+                                                return HttpContentUtil.prefixComma(httpContent);
+                                            }
+                                        }
+                                    });
+
+                                    if (isJson) {
+                                        // if the Publisher is returning JSON then in order for it to be valid JSON for each emitted element
+                                        // we must wrap the JSON in array and delimit the emitted items
+                                        httpContentPublisher = Flowable.concat(
+                                                Flowable.fromCallable(HttpContentUtil::openBracket),
+                                                httpContentPublisher,
+                                                Flowable.fromCallable(HttpContentUtil::closeBracket)
+                                        );
+                                    }
+
+                                    if (mediaType.equals(MediaType.TEXT_EVENT_STREAM_TYPE)) {
+                                        httpContentPublisher = Publishers.onComplete(httpContentPublisher, () -> {
+                                            CompletableFuture<Void> future = new CompletableFuture<>();
+                                            if (!request.getHeaders().isKeepAlive()) {
+                                                if (context.channel().isOpen()) {
+                                                    context.pipeline()
+                                                            .writeAndFlush(new DefaultLastHttpContent())
+                                                            .addListener(f -> {
+                                                                        if (f.isSuccess()) {
+                                                                            future.complete(null);
+                                                                        } else {
+                                                                            future.completeExceptionally(f.cause());
+                                                                        }
+                                                                    }
+                                                            );
+                                                }
+                                            }
+                                            return future;
+                                        });
+                                    }
+
+                                    httpContentPublisher = Publishers.then(httpContentPublisher, httpContent -> {
+                                        // once an http content is written, read the next item if it is available
+                                        context.read();
+                                    });
+
+                                    httpContentPublisher = Flowable.fromPublisher(httpContentPublisher)
+                                            .doAfterTerminate(() -> cleanupRequest(context, request));
+
+                                    DelegateStreamedHttpResponse streamedResponse = new DelegateStreamedHttpResponse(
+                                            toNettyResponse(message).getNativeResponse(),
+                                            httpContentPublisher
+                                    );
+                                    io.netty.handler.codec.http.HttpHeaders headers = streamedResponse.headers();
+                                    headers.set(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
+                                    headers.set(HttpHeaderNames.CONTENT_TYPE, mediaType);
+
+                                    if (isHttp2) {
+                                        addHttp2StreamHeader(request, streamedResponse);
+                                    }
+                                    context.writeAndFlush(streamedResponse);
+                                    context.read();
+                                }
                             }
+
+                        } else {
+                            // non-reactive.. encode and write full response
+                            encodeHttpResponse(
+                                    context,
+                                    request,
+                                    message,
+                                    body,
+                                    defaultResponseMediaType
+                            );
+
                         }
-                    }
-
-                }
-                finalResponse.setAttribute(HttpAttributes.ROUTE_MATCH, routeMatch);
-                return finalResponse;
-            });
-
-            routePublisher = buildRoutePublisher(
-                    finalRoute.getDeclaringType(),
-                    genericReturnType,
-                    isReactiveReturnType,
-                    isKotlinSuspendingFunction,
-                    isKotlinFunctionReturnTypeUnit,
-                    finalRoute.getAnnotationMetadata(),
-                    requestReference,
-                    routePublisher
-            );
-
-            // process the publisher through the available filters
-            Flowable<? extends MutableHttpResponse<?>> filteredPublisher = filterPublisher(
-                    requestReference,
-                    routePublisher,
-                    executor,
-                    false
-            );
-
-            boolean isStreaming = isReactiveReturnType && !isSingle;
-
-            Optional<Class<?>> javaPayloadType = genericReturnType.getFirstTypeVariable().map(Argument::getType);
-
-            if (!isStreaming) {
-                if (HttpResponse.class.isAssignableFrom(javaReturnType)) {
-                    Optional<Argument<?>> generic = genericReturnType.getFirstTypeVariable();
-                    if (generic.isPresent()) {
-                        // Unwrap response type information
-                        Class genericType = generic.get().getType();
-                        isStreaming = Publishers.isConvertibleToPublisher(genericType) && !Publishers.isSingle(genericType);
-
-                        if (isStreaming) {
-                            javaPayloadType = generic.get().getFirstTypeVariable().map(Argument::getType);
-                        }
-                    }
-                }
-            }
-
-            Class finalJavaPayloadType = javaPayloadType.orElse(Object.class);
-            boolean finalIsStreaming = isStreaming;
-            filteredPublisher  = filteredPublisher.switchMap((response) -> {
-                Optional<?> responseBody = response.getBody();
-                if (responseBody.isPresent()) {
-                    Object body = responseBody.get();
-                    if (finalIsStreaming) {
-                        // handled downstream
-                        return Flowable.just(response);
-                    } else if (Publishers.isConvertibleToPublisher(body)) {
-                        Flowable<?> bodyFlowable = Publishers.convertPublisher(body, Flowable.class);
-                        Flowable<MutableHttpResponse<?>> bodyToResponse = bodyFlowable.map((bodyContent) ->
-                                setBodyContent(response, bodyContent)
+                    } else {
+                        // message with an empty body
+                        writeFinalNettyResponse(
+                                message,
+                                requestReference.get(),
+                                context
                         );
-                        return bodyToResponse.switchIfEmpty(Flowable.just(response));
                     }
+
                 }
 
-                return Flowable.just(response);
+                @Override
+                protected void doOnError(Throwable t) {
+                    final NettyHttpRequest nettyHttpRequest = (NettyHttpRequest) requestReference.get();
+                    exceptionCaughtInternal(context, t, nettyHttpRequest, false);
+                }
             });
-
-            if (!isStreaming) {
-                subscribeToResponsePublisher(context, defaultResponseMediaType, requestReference, filteredPublisher);
-            } else {
-                filteredPublisher.subscribe(new ContextCompletionAwareSubscriber<MutableHttpResponse<?>>(context) {
-                    @Override
-                    protected void onComplete(MutableHttpResponse<?> response) {
-                        Optional<?> responseBody = response.getBody();
-                        @SuppressWarnings("unchecked")
-                        Flowable<Object> bodyFlowable = responseBody.map(o -> Publishers.convertPublisher(o, Flowable.class)).orElse(Flowable.empty());
-
-                        NettyMutableHttpResponse nettyHttpResponse = (NettyMutableHttpResponse) response;
-                        FullHttpResponse nettyResponse = nettyHttpResponse.getNativeResponse();
-                        Optional<MediaType> specifiedMediaType = response.getContentType();
-                        MediaType responseMediaType = specifiedMediaType.orElse(defaultResponseMediaType);
-
-                        applyConfiguredHeaders(response.getHeaders());
-
-                        boolean isJson = responseMediaType.getExtension().equals(MediaType.EXTENSION_JSON) &&
-                                isJsonFormattable(finalJavaPayloadType);
-
-                        streamHttpContentChunkByChunk(
-                                context,
-                                request,
-                                nettyResponse,
-                                responseMediaType,
-                                isJson,
-                                bodyFlowable);
-                    }
-                });
-            }
 
             return null;
         });
         return route;
+    }
+
+    private Flowable<? extends MutableHttpResponse<?>> buildResultEmitter(
+            NettyHttpRequest<?> request,
+            AtomicReference<HttpRequest<?>> requestReference,
+            RouteMatch<?> finalRoute,
+            ExecutorService executor,
+            boolean isErrorRoute,
+            boolean skipOncePerRequest) {
+        // build the result emitter. This result emitter emits the response from a controller action
+        Flowable<MutableHttpResponse<?>> resultEmitter = Flowable.defer(() -> {
+            final RouteMatch<?> routeMatch;
+
+            // ensure the route requirements are completely satisfied
+            if (!finalRoute.isExecutable()) {
+                routeMatch = requestArgumentSatisfier
+                        .fulfillArgumentRequirements(finalRoute, requestReference.get(), true);
+            } else {
+                routeMatch = finalRoute;
+            }
+
+            boolean isSuspended = routeMatch.isSuspended();
+
+            Object body = routeMatch.execute();
+            if (body instanceof Optional) {
+                body = ((Optional<?>) body).orElse(null);
+            }
+
+            HttpRequest<?> incomingRequest = requestReference.get();
+            MutableHttpResponse<?> outgoingResponse;
+
+            if (body == null) {
+                if (routeMatch.isVoid()) {
+                    outgoingResponse = forStatus(routeMatch.getAnnotationMetadata());
+                    if (HttpMethod.permitsRequestBody(request.getMethod())) {
+                        outgoingResponse.header(HttpHeaders.CONTENT_LENGTH, HttpHeaderValues.ZERO);
+                    }
+                } else {
+                    outgoingResponse = newNotFoundError(request);
+                }
+            } else {
+                boolean isReactive = finalRoute.isAsyncOrReactive() || Publishers.isConvertibleToPublisher(body);
+                if (isReactive) {
+                    Class<?> bodyClass = body.getClass();
+                    boolean isSingle = finalRoute.isSingleResult() && (finalRoute.isAsync() || Publishers.isSingle(bodyClass));
+                    boolean isCompletable = !isSingle && finalRoute.isVoid() && Publishers.isCompletable(bodyClass);
+                    if (isSingle || isCompletable) {
+                        // full response case
+                        Single<Object> single = Publishers.convertPublisher(body, Maybe.class)
+                                .switchIfEmpty(NOT_FOUND_SINGLE);
+                        return single.map(o -> {
+                            if (o == NOT_FOUND) {
+                                if (isCompletable || finalRoute.isVoid()) {
+                                    return forStatus(routeMatch.getAnnotationMetadata(), HttpStatus.OK)
+                                            .header(HttpHeaders.CONTENT_LENGTH, HttpHeaderValues.ZERO);
+                                } else {
+                                    return newNotFoundError(request);
+                                }
+                            } else {
+                                if (o instanceof MutableHttpResponse) {
+                                    return (MutableHttpResponse<?>) o;
+                                } else {
+                                    return forStatus(routeMatch.getAnnotationMetadata(), isErrorRoute ? HttpStatus.INTERNAL_SERVER_ERROR : HttpStatus.OK)
+                                            .body(o);
+                                }
+                            }
+                        }).toFlowable();
+                    }
+                }
+                // now we have the raw result, transform it as necessary
+                if (body instanceof HttpStatus) {
+                    outgoingResponse = HttpResponse.status((HttpStatus) body);
+                } else {
+                    if (isSuspended) {
+                        boolean isKotlinFunctionReturnTypeUnit =
+                                routeMatch instanceof MethodBasedRouteMatch &&
+                                        isKotlinFunctionReturnTypeUnit(((MethodBasedRouteMatch) routeMatch).getExecutableMethod());
+                        final Supplier<CompletableFuture<?>> supplier = ContinuationArgumentBinder.extractContinuationCompletableFutureSupplier(incomingRequest);
+                        Object result = routeMatch.execute();
+                        Object suspendedBody;
+                        if (isKotlinCoroutineSuspended(result)) {
+                            if (isKotlinFunctionReturnTypeUnit) {
+                                suspendedBody = Completable.create(emitter -> {
+                                    CompletableFuture<?> f = supplier.get();
+                                    f.whenComplete((BiConsumer<Object, Throwable>) (o, throwable) -> {
+                                        if (throwable != null) {
+                                            emitter.onError(throwable);
+                                        } else {
+                                            emitter.onComplete();
+                                        }
+                                    });
+                                });
+                            } else {
+                                suspendedBody = Single.create(emitter -> {
+                                    CompletableFuture<?> f = supplier.get();
+                                    f.whenComplete((BiConsumer<Object, Throwable>) (o, throwable) -> {
+                                        if (throwable != null) {
+                                            emitter.onError(throwable);
+                                        } else {
+                                            emitter.onSuccess(o);
+                                        }
+                                    });
+                                });
+                            }
+                        } else {
+                            if (isKotlinFunctionReturnTypeUnit) {
+                                suspendedBody = Completable.complete();
+                            } else {
+                                suspendedBody = Single.just(result);
+                            }
+                        }
+                        outgoingResponse = forStatus(routeMatch.getAnnotationMetadata(), isErrorRoute ? HttpStatus.INTERNAL_SERVER_ERROR : HttpStatus.OK)
+                                                .body(suspendedBody);
+                    } else {
+                        if (body instanceof MutableHttpResponse) {
+                            outgoingResponse = (MutableHttpResponse<?>) body;
+                        } else {
+                            outgoingResponse = forStatus(routeMatch.getAnnotationMetadata(), isErrorRoute ? HttpStatus.INTERNAL_SERVER_ERROR : HttpStatus.OK)
+                                    .body(body);
+                        }
+                    }
+                }
+
+                // for head request we never emit the body
+                if (incomingRequest.getMethod().equals(HttpMethod.HEAD)) {
+                    final Object o = outgoingResponse.getBody().orElse(null);
+                    if (o instanceof ReferenceCounted) {
+                        ((ReferenceCounted) o).release();
+                    }
+                    outgoingResponse.body(null);
+                }
+            }
+            return Flowable.just(outgoingResponse);
+        });
+
+        // process the publisher through the available filters
+        return filterPublisher(
+                requestReference,
+                resultEmitter,
+                executor,
+                skipOncePerRequest
+        );
+    }
+
+    private void encodeHttpResponse(
+            ChannelHandlerContext context,
+            NettyHttpRequest<?> nettyRequest,
+            MutableHttpResponse<?> response,
+            Object body,
+            MediaType defaultResponseMediaType) {
+        boolean isNotHead = nettyRequest.getMethod() != HttpMethod.HEAD;
+        if (isNotHead && body instanceof Writable) {
+            Writable writable = (Writable) body;
+            ioExecutor.execute(() -> {
+                ByteBuf byteBuf = context.alloc().ioBuffer(128);
+                ByteBufOutputStream outputStream = new ByteBufOutputStream(byteBuf);
+                try {
+                    writable.writeTo(outputStream, nettyRequest.getCharacterEncoding());
+                    ((MutableHttpResponse) response).body(byteBuf);
+                    writeFinalNettyResponse(
+                            response,
+                            nettyRequest,
+                            context
+                    );
+                } catch (IOException e) {
+                    exceptionCaughtInternal(context, e, nettyRequest, false);
+                }
+            });
+        } else {
+
+            try {
+                if (isNotHead) {
+
+                    encodeResponseBody(
+                            context,
+                            nettyRequest,
+                            response,
+                            body,
+                            defaultResponseMediaType
+                    );
+
+                }
+                writeFinalNettyResponse(
+                        response,
+                        nettyRequest,
+                        context
+                );
+            } catch (Exception e) {
+                exceptionCaughtInternal(context, e, nettyRequest, false);
+            }
+        }
+    }
+
+    @Nullable
+    private RouteMatch<Object> findStatusRoute(HttpRequest<?> incomingRequest, HttpStatus status, RouteMatch<?> finalRoute) {
+        Class<?> declaringType = getDeclaringType(finalRoute);
+        // handle re-mapping of errors
+        RouteMatch<Object> statusRoute = null;
+        // if declaringType is not null, this means its a locally marked method handler
+        if (declaringType != null) {
+            statusRoute = router.findStatusRoute(declaringType, status, incomingRequest)
+                .orElseGet(() -> router.findStatusRoute(status, incomingRequest).orElse(null));
+        }
+        return statusRoute;
+    }
+
+    private void encodeResponseBody(
+            ChannelHandlerContext context,
+            HttpRequest<?> request,
+            MutableHttpResponse<?> message,
+            Object body,
+            MediaType defaultResponseMediaType) {
+        if (body == null) {
+            return;
+        }
+
+        MediaType specifiedMediaType = message.getContentType().orElse(null);
+        MediaType responseMediaType = specifiedMediaType != null ? specifiedMediaType : defaultResponseMediaType;
+        Optional<NettyCustomizableResponseTypeHandler> typeHandler = customizableResponseTypeHandlerRegistry
+                .findTypeHandler(body.getClass());
+        if (typeHandler.isPresent()) {
+            NettyCustomizableResponseTypeHandler th = typeHandler.get();
+            setBodyContent(message, new NettyCustomizableResponseTypeHandlerInvoker(th, body));
+        } else if (specifiedMediaType != null) {
+
+            Optional<MediaTypeCodec> registeredCodec = mediaTypeCodecRegistry.findCodec(responseMediaType, body.getClass());
+            if (registeredCodec.isPresent()) {
+                MediaTypeCodec codec = registeredCodec.get();
+                if (!message.getHeaders().contains(HttpHeaders.CONTENT_TYPE)) {
+                    message.header(HttpHeaders.CONTENT_TYPE, responseMediaType);
+                }
+                encodeBodyWithCodec(message, body, codec, responseMediaType, context, request);
+            }
+        } else {
+            Optional<MediaTypeCodec> registeredCodec = mediaTypeCodecRegistry.findCodec(defaultResponseMediaType, body.getClass());
+            if (registeredCodec.isPresent()) {
+                MediaTypeCodec codec = registeredCodec.get();
+                if (!message.getHeaders().contains(HttpHeaders.CONTENT_TYPE)) {
+                    message.header(HttpHeaders.CONTENT_TYPE, responseMediaType);
+                }
+                encodeBodyWithCodec(message, body, codec, responseMediaType, context, request);
+            } else {
+                if (!message.getHeaders().contains(HttpHeaders.CONTENT_TYPE)) {
+                    message.header(HttpHeaders.CONTENT_TYPE, responseMediaType);
+                }
+                MediaTypeCodec defaultCodec = new TextPlainCodec(serverConfiguration.getDefaultCharset());
+                encodeBodyWithCodec(message, body, defaultCodec, responseMediaType, context, request);
+            }
+        }
+
+    }
+
+    @SuppressWarnings("rawtypes")
+    private @Nullable Class<?> getDeclaringType(RouteMatch<?> route) {
+        if (route instanceof MethodBasedRouteMatch) {
+            return ((MethodBasedRouteMatch) route).getDeclaringType();
+        }
+        return null;
     }
 
     private MediaType resolveDefaultResponseContentType(NettyHttpRequest<?> request, RouteMatch<?> finalRoute) {
@@ -1225,151 +1544,19 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
         return defaultResponseMediaType;
     }
 
-    private Flowable<MutableHttpResponse<?>> buildRoutePublisher(
-            Class<?> declaringType,
-            ReturnType<?> genericReturnType,
-            boolean isReactiveReturnType,
-            boolean isKotlinSuspendingFunction,
-            boolean isKotlinFunctionReturnTypeUnit,
-            AnnotationMetadata annotationMetadata,
-            AtomicReference<HttpRequest<?>> requestReference,
-            Flowable<MutableHttpResponse<?>> routePublisher) {
-        // In the case of an empty reactive type we switch handling so that
-        // a 404 NOT_FOUND is returned
-        routePublisher = routePublisher.switchIfEmpty(Flowable.create((emitter) -> {
-            HttpRequest<?> httpRequest = requestReference.get();
-            MutableHttpResponse<?> response;
-            Class<?> javaReturnType = genericReturnType.getType();
-            boolean isVoid = javaReturnType == void.class ||
-                    Completable.class.isAssignableFrom(javaReturnType) ||
-                    (isReactiveReturnType && genericReturnType.getFirstTypeVariable()
-                            .filter(arg -> arg.getType() == Void.class).isPresent()) ||
-                    (isKotlinSuspendingFunction && isKotlinFunctionReturnTypeUnit);
-
-            if (isVoid) {
-                // void return type with no response, nothing else to do
-                response = forStatus(annotationMetadata);
-            } else {
-                // handle re-mapping of errors
-                Optional<RouteMatch<Object>> statusRoute = Optional.empty();
-                // if declaringType is not null, this means its a locally marked method handler
-                if (declaringType != null) {
-                    statusRoute = router.findStatusRoute(declaringType, HttpStatus.NOT_FOUND, httpRequest);
-                }
-                if (!statusRoute.isPresent()) {
-                    statusRoute = router.findStatusRoute(HttpStatus.NOT_FOUND, httpRequest);
-                }
-
-                if (statusRoute.isPresent()) {
-                    RouteMatch<?> newRoute = requestArgumentSatisfier.fulfillArgumentRequirements(statusRoute.get(), httpRequest, true);
-
-                    if (newRoute.isExecutable()) {
-                        try {
-                            Object result = newRoute.execute();
-                            response = messageToResponse(newRoute, result);
-                        } catch (Throwable e) {
-                            emitter.onError(new InternalServerException("Error executing status route [" + newRoute + "]: " + e.getMessage(), e));
-                            return;
-                        }
-
-                    } else {
-                        if (LOG.isWarnEnabled()) {
-                            LOG.warn("Matched status route [" + newRoute + "] not executed because one or more arguments could not be bound. Returning a default response.");
-                        }
-                        response = newNotFoundError(httpRequest);
-                    }
-                    response.setAttribute(HttpAttributes.ROUTE_MATCH, newRoute);
-                } else {
-                    response = newNotFoundError(httpRequest);
-                }
-            }
-
-            try {
-                emitter.onNext(response);
-                emitter.onComplete();
-            } catch (Throwable e) {
-                emitter.onError(new InternalServerException("Error executing Error route [" + response.getStatus() + "]: " + e.getMessage(), e));
-            }
-        }, BackpressureStrategy.ERROR));
-        return routePublisher;
-    }
-
-    private void subscribeToResponsePublisher(
-            ChannelHandlerContext context,
-            MediaType defaultResponseMediaType,
-            AtomicReference<HttpRequest<?>> requestReference,
-            Flowable<? extends MutableHttpResponse<?>> finalPublisher) {
-        finalPublisher =  finalPublisher.map((response) -> {
-            Optional<MediaType> specifiedMediaType = response.getContentType();
-            MediaType responseMediaType = specifiedMediaType.orElse(defaultResponseMediaType);
-
-            applyConfiguredHeaders(response.getHeaders());
-
-            Optional<?> responseBody = response.getBody();
-            if (responseBody.isPresent()) {
-
-                Object body = responseBody.get();
-
-                Optional<NettyCustomizableResponseTypeHandler> typeHandler = customizableResponseTypeHandlerRegistry
-                        .findTypeHandler(body.getClass());
-                if (typeHandler.isPresent()) {
-                    NettyCustomizableResponseTypeHandler th = typeHandler.get();
-                    setBodyContent(response, new NettyCustomizableResponseTypeHandlerInvoker(th, body));
-                    return response;
-                }
-
-                if (specifiedMediaType.isPresent())  {
-
-                    Optional<MediaTypeCodec> registeredCodec = mediaTypeCodecRegistry.findCodec(responseMediaType, body.getClass());
-                    if (registeredCodec.isPresent()) {
-                        MediaTypeCodec codec = registeredCodec.get();
-                        return encodeBodyWithCodec(response, body, codec, responseMediaType, context, requestReference);
-                    }
-                }
-
-                Optional<MediaTypeCodec> registeredCodec = mediaTypeCodecRegistry.findCodec(defaultResponseMediaType, body.getClass());
-                if (registeredCodec.isPresent()) {
-                    MediaTypeCodec codec = registeredCodec.get();
-                    return encodeBodyWithCodec(response, body, codec, responseMediaType, context, requestReference);
-                }
-
-                MediaTypeCodec defaultCodec = new TextPlainCodec(serverConfiguration.getDefaultCharset());
-
-                return encodeBodyWithCodec(response, body, defaultCodec, responseMediaType,  context, requestReference);
-            } else {
-                return response;
-            }
-        });
-
-        finalPublisher.subscribe(new ContextCompletionAwareSubscriber<MutableHttpResponse<?>>(context) {
-            @Override
-            protected void onComplete(MutableHttpResponse<?> message) {
-                writeFinalNettyResponse(message, requestReference, context);
-            }
-
-            @Override
-            protected void doOnError(Throwable t) {
-                final NettyHttpRequest nettyHttpRequest = (NettyHttpRequest) requestReference.get();
-                exceptionCaughtInternal(context, t, nettyHttpRequest, false);
-            }
-        });
-    }
-
-    private void writeFinalNettyResponse(MutableHttpResponse<?> message, AtomicReference<HttpRequest<?>> requestReference, ChannelHandlerContext context) {
-        NettyMutableHttpResponse<?> nettyHttpResponse = (NettyMutableHttpResponse<?>) message;
+    private void writeFinalNettyResponse(MutableHttpResponse<?> message, HttpRequest<?> request, ChannelHandlerContext context) {
+        NettyMutableHttpResponse<?> nettyHttpResponse = toNettyResponse(message);
         FullHttpResponse nettyResponse = nettyHttpResponse.getNativeResponse();
-
-        HttpRequest<?> httpRequest = requestReference.get();
         io.netty.handler.codec.http.HttpHeaders nettyHeaders = nettyResponse.headers();
+        HttpStatus httpStatus = message.status();
 
         // default Connection header if not set explicitly
-        final io.micronaut.http.HttpVersion httpVersion = httpRequest.getHttpVersion();
+        final io.micronaut.http.HttpVersion httpVersion = request.getHttpVersion();
         final boolean isHttp2 = httpVersion == io.micronaut.http.HttpVersion.HTTP_2_0;
         if (!isHttp2) {
             if (!nettyHeaders.contains(HttpHeaderNames.CONNECTION)) {
-                boolean expectKeepAlive = nettyResponse.protocolVersion().isKeepAliveDefault() || httpRequest.getHeaders().isKeepAlive();
-                HttpStatus status = nettyHttpResponse.status();
-                if (!expectKeepAlive || status.getCode() > 299) {
+                boolean expectKeepAlive = nettyResponse.protocolVersion().isKeepAliveDefault() || request.getHeaders().isKeepAlive();
+                if (!expectKeepAlive || httpStatus.getCode() > 299) {
                     nettyHeaders.add(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE);
                 } else {
                     nettyHeaders.add(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE);
@@ -1380,43 +1567,75 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
         final Object body = message.body();
         if (body instanceof NettyCustomizableResponseTypeHandlerInvoker) {
             NettyCustomizableResponseTypeHandlerInvoker handler = (NettyCustomizableResponseTypeHandlerInvoker) body;
-            handler.invoke(httpRequest, nettyHttpResponse, context);
+            handler.invoke(request, nettyHttpResponse, context);
         } else {
             // default to Transfer-Encoding: chunked if Content-Length not set or not already set
             if (!nettyHeaders.contains(HttpHeaderNames.CONTENT_LENGTH) && !nettyHeaders.contains(HttpHeaderNames.TRANSFER_ENCODING)) {
                 nettyHeaders.add(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
             }
             // close handled by HttpServerKeepAliveHandler
-            final NettyHttpRequest<?> nettyHttpRequest = (NettyHttpRequest<?>) requestReference.get();
+            final NettyHttpRequest<?> nettyHttpRequest = (NettyHttpRequest<?>) request;
 
             if (isHttp2) {
-                final io.netty.handler.codec.http.HttpHeaders nativeHeaders = nettyHttpRequest.getNativeRequest().headers();
-                final String streamId = nativeHeaders.get(AbstractNettyHttpRequest.STREAM_ID);
-                if (streamId != null) {
-                    nettyResponse.headers().set(AbstractNettyHttpRequest.STREAM_ID, streamId);
-                }
+                addHttp2StreamHeader(request, nettyResponse);
             }
 
             context.writeAndFlush(nettyResponse)
-                   .addListener(future -> {
-                       try {
-                           if (!future.isSuccess()) {
-                               final Throwable throwable = future.cause();
-                               if (!(throwable instanceof ClosedChannelException)) {
-                                   if (LOG.isErrorEnabled()) {
-                                       LOG.error("Error writing final response: " + throwable.getMessage(), throwable);
-                                   }
-                               }
-                           } else {
-                               context.read();
-                           }
-                       } finally {
-                           cleanupRequest(context, nettyHttpRequest);
-                           context.read();
-                       }
-                   });
+                    .addListener(future -> {
+                        try {
+                            if (!future.isSuccess()) {
+                                final Throwable throwable = future.cause();
+                                if (!(throwable instanceof ClosedChannelException)) {
+                                    if (LOG.isErrorEnabled()) {
+                                        LOG.error("Error writing final response: " + throwable.getMessage(), throwable);
+                                    }
+                                }
+                            } else {
+                                context.read();
+                            }
+                        } finally {
+                            cleanupRequest(context, nettyHttpRequest);
+                            context.read();
+                        }
+                    });
 
         }
+    }
+
+    private void addHttp2StreamHeader(HttpRequest<?> request, io.netty.handler.codec.http.HttpResponse nettyResponse) {
+        final String streamId = request.getHeaders().get(AbstractNettyHttpRequest.STREAM_ID);
+        if (streamId != null) {
+            nettyResponse.headers().set(AbstractNettyHttpRequest.STREAM_ID, streamId);
+        }
+    }
+
+    @NotNull
+    private NettyMutableHttpResponse<?> toNettyResponse(HttpResponse<?> message) {
+        NettyMutableHttpResponse<?> nettyHttpResponse;
+        if (message instanceof NettyMutableHttpResponse) {
+            nettyHttpResponse = (NettyMutableHttpResponse<?>) message;
+
+        } else {
+            HttpStatus httpStatus = message.status();
+            HttpResponseStatus nettyStatus = HttpResponseStatus.valueOf(
+                    httpStatus.getCode(),
+                    httpStatus.getReason()
+            );
+            Object body = message.body();
+            FullHttpResponse nettyResponse;
+            if (body instanceof ByteBuf) {
+                nettyResponse = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, nettyStatus, (ByteBuf) body);
+            } else {
+                nettyResponse = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, nettyStatus);
+            }
+            io.netty.handler.codec.http.HttpHeaders nettyHeaders = nettyResponse.headers();
+            message.getHeaders().forEach((BiConsumer<String, List<String>>) nettyHeaders::set);
+            nettyHttpResponse = new NettyMutableHttpResponse<>(
+                    nettyResponse,
+                    ConversionService.SHARED
+            );
+        }
+        return nettyHttpResponse;
     }
 
     private MutableHttpResponse<?> encodeBodyWithCodec(MutableHttpResponse<?> response,
@@ -1424,10 +1643,10 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
                                                        MediaTypeCodec codec,
                                                        MediaType mediaType,
                                                        ChannelHandlerContext context,
-                                                       AtomicReference<HttpRequest<?>> requestReference) {
+                                                       HttpRequest<?> request) {
         ByteBuf byteBuf;
         try {
-            byteBuf = encodeBodyAsByteBuf(body, codec, context, requestReference);
+            byteBuf = encodeBodyAsByteBuf(body, codec, context, request);
             int len = byteBuf.readableBytes();
             MutableHttpHeaders headers = response.getHeaders();
             if (!headers.contains(HttpHeaders.CONTENT_TYPE)) {
@@ -1440,7 +1659,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
             return response;
         } catch (LinkageError e) {
             // rxjava swallows linkage errors for some reasons so if one occurs, rethrow as a internal error
-            throw new InternalServerException("Fatal error encoding bytebuf: " + e.getMessage() , e);
+            throw new InternalServerException("Fatal error encoding bytebuf: " + e.getMessage(), e);
         }
     }
 
@@ -1450,7 +1669,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
         return res;
     }
 
-    private ByteBuf encodeBodyAsByteBuf(Object body, MediaTypeCodec codec, ChannelHandlerContext context, AtomicReference<HttpRequest<?>> requestReference) {
+    private ByteBuf encodeBodyAsByteBuf(Object body, MediaTypeCodec codec, ChannelHandlerContext context, HttpRequest<?> request) {
         ByteBuf byteBuf;
         if (body instanceof ByteBuf) {
             byteBuf = (ByteBuf) body;
@@ -1470,7 +1689,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
             ByteBufOutputStream outputStream = new ByteBufOutputStream(byteBuf);
             Writable writable = (Writable) body;
             try {
-                writable.writeTo(outputStream, requestReference.get().getCharacterEncoding());
+                writable.writeTo(outputStream, request.getCharacterEncoding());
             } catch (IOException e) {
                 if (LOG.isErrorEnabled()) {
                     LOG.error(e.getMessage());
@@ -1481,119 +1700,9 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Encoding emitted response object [{}] using codec: {}", body, codec);
             }
-            byteBuf = (ByteBuf) codec.encode(body, new NettyByteBufferFactory(context.alloc())).asNativeBuffer();
+            byteBuf = codec.encode(body, new NettyByteBufferFactory(context.alloc())).asNativeBuffer();
         }
         return byteBuf;
-    }
-
-    // builds the result emitter for a given route action
-    private Flowable<?> buildResultEmitter(
-            ChannelHandlerContext context, RouteMatch<?> finalRoute,
-            AtomicReference<HttpRequest<?>> requestReference,
-            boolean isReactiveReturnType,
-            boolean isKotlinSuspendingFunction,
-            boolean isKotlinFunctionReturnTypeUnit,
-            boolean isSingleResult) {
-        Flowable<?> resultEmitter;
-        if (isReactiveReturnType || isKotlinSuspendingFunction) {
-            // if the return type is reactive, execute the action and obtain the Observable
-            try {
-                if (isSingleResult) {
-                    // for a single result we are fine as is
-                    resultEmitter = Flowable.defer(() -> {
-                        final RouteMatch<?> routeMatch = !finalRoute.isExecutable() ? requestArgumentSatisfier.fulfillArgumentRequirements(finalRoute, requestReference.get(), true) : finalRoute;
-                        if (isKotlinSuspendingFunction) {
-                            return executeKotlinSuspendingFunction(isKotlinFunctionReturnTypeUnit, routeMatch, requestReference.get());
-                        } else {
-                            Object result = routeMatch.execute();
-                            return Publishers.convertPublisher(result, Publisher.class);
-                        }
-                    });
-                } else {
-                    // for a streaming response we wrap the result on an HttpResponse so that a single result is received
-                    // then the result can be streamed chunk by chunk
-                    resultEmitter = Flowable.create((emitter) -> {
-                        final RouteMatch<?> routeMatch = !finalRoute.isExecutable() ? requestArgumentSatisfier.fulfillArgumentRequirements(finalRoute, requestReference.get(), true) : finalRoute;
-                        Object result = routeMatch.execute();
-                        MutableHttpResponse<Object> chunkedResponse = HttpResponse.ok(result);
-                        chunkedResponse.getHeaders().set(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
-                        emitter.onNext(chunkedResponse);
-                        emitter.onComplete();
-                        // should be no back pressure
-                    }, BackpressureStrategy.ERROR);
-                }
-            } catch (Throwable e) {
-                resultEmitter = Flowable.error(new InternalServerException("Error executing route [" + finalRoute + "]: " + e.getMessage(), e));
-            }
-        } else {
-            // for non-reactive results we build flowable that executes the
-            // route
-            resultEmitter = Flowable.defer(() -> {
-                HttpRequest<?> httpRequest = requestReference.get();
-                RouteMatch<?> routeMatch = finalRoute;
-                if (!routeMatch.isExecutable()) {
-                    routeMatch = requestArgumentSatisfier.fulfillArgumentRequirements(routeMatch, httpRequest, true);
-                }
-                Object result = routeMatch.execute();
-
-                if (result instanceof Optional) {
-                    result = ((Optional<?>) result).orElse(null);
-                }
-
-                if (result == null) {
-                    // empty flowable
-                    return Flowable.empty();
-                } else {
-                    // emit the result
-                    if (result instanceof Writable) {
-                        Writable writable = (Writable) result;
-                        return Flowable.fromCallable(() -> {
-                            ByteBuf byteBuf = context.alloc().ioBuffer(128);
-                            ByteBufOutputStream outputStream = new ByteBufOutputStream(byteBuf);
-                            writable.writeTo(outputStream, requestReference.get().getCharacterEncoding());
-                            return byteBuf;
-                        }).subscribeOn(Schedulers.from(ioExecutor));
-
-                    } else {
-                        return Publishers.just(result);
-                    }
-                }
-            });
-        }
-        return resultEmitter;
-    }
-
-    private Publisher<?> executeKotlinSuspendingFunction(boolean isKotlinFunctionReturnTypeUnit, RouteMatch<?> routeMatch, HttpRequest<?> source) {
-        final Supplier<CompletableFuture<?>> supplier = ContinuationArgumentBinder.extractContinuationCompletableFutureSupplier(source);
-        Object result = routeMatch.execute();
-        if (isKotlinCoroutineSuspended(result)) {
-            if (isKotlinFunctionReturnTypeUnit) {
-                return Completable.fromPublisher(Publishers.fromCompletableFuture(supplier.get())).toFlowable();
-            } else {
-                return Publishers.fromCompletableFuture(supplier.get());
-            }
-        } else {
-            if (isKotlinFunctionReturnTypeUnit) {
-                return Completable.complete().toFlowable();
-            } else {
-                return Flowable.just(result);
-            }
-        }
-    }
-
-    private MutableHttpResponse<?> messageToResponse(RouteMatch<?> finalRoute, Object message) {
-        MutableHttpResponse<?> response;
-        if (message instanceof HttpResponse) {
-            response = ConversionService.SHARED.convert(message, NettyMutableHttpResponse.class)
-                    .orElseThrow(() -> new InternalServerException("Emitted response is not mutable"));
-        } else {
-            if (message instanceof HttpStatus) {
-                response = HttpResponse.status((HttpStatus) message);
-            } else {
-                response = forStatus(finalRoute.getAnnotationMetadata()).body(message);
-            }
-        }
-        return response;
     }
 
     private MutableHttpResponse<Object> forStatus(AnnotationMetadata annotationMetadata) {
@@ -1604,10 +1713,6 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
         return HttpResponse.status(
                 annotationMetadata.enumValue(Status.class, HttpStatus.class)
                         .orElse(defaultStatus));
-    }
-
-    private boolean isResponsePublisher(ReturnType<?> genericReturnType, Class<?> javaReturnType) {
-        return Publishers.isConvertibleToPublisher(javaReturnType) && genericReturnType.getFirstTypeVariable().map(arg -> HttpResponse.class.isAssignableFrom(arg.getType())).orElse(false);
     }
 
     private Flowable<? extends MutableHttpResponse<?>> filterPublisher(
@@ -1663,115 +1768,19 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
         }
     }
 
-    private void streamHttpContentChunkByChunk(
-        ChannelHandlerContext context,
-        NettyHttpRequest<?> request,
-        FullHttpResponse nativeResponse,
-        MediaType mediaType,
-        boolean isJson,
-        Publisher<Object> publisher) {
-
-        NettyByteBufferFactory byteBufferFactory = new NettyByteBufferFactory(context.alloc());
-
-        Publisher<HttpContent> httpContentPublisher = Publishers.map(publisher, new Function<Object, HttpContent>() {
-            boolean first = true;
-
-            @Override
-            public HttpContent apply(Object message) {
-                HttpContent httpContent;
-                if (message instanceof ByteBuf) {
-                    httpContent = new DefaultHttpContent((ByteBuf) message);
-                } else if (message instanceof ByteBuffer) {
-                    ByteBuffer<?> byteBuffer = (ByteBuffer<?>) message;
-                    Object nativeBuffer = byteBuffer.asNativeBuffer();
-                    if (nativeBuffer instanceof ByteBuf) {
-                        httpContent = new DefaultHttpContent((ByteBuf) nativeBuffer);
-                    } else {
-                        httpContent = new DefaultHttpContent(Unpooled.copiedBuffer(byteBuffer.asNioBuffer()));
-                    }
-                } else if (message instanceof byte[]) {
-                    httpContent = new DefaultHttpContent(Unpooled.copiedBuffer((byte[]) message));
-                } else if (message instanceof HttpContent) {
-                    httpContent = (HttpContent) message;
-                } else {
-
-                    MediaTypeCodec codec = mediaTypeCodecRegistry.findCodec(mediaType, message.getClass()).orElse(
-                        new TextPlainCodec(serverConfiguration.getDefaultCharset()));
-
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Encoding emitted response object [{}] using codec: {}", message, codec);
-                    }
-                    ByteBuffer<ByteBuf> encoded = codec.encode(message, byteBufferFactory);
-                    httpContent = new DefaultHttpContent(encoded.asNativeBuffer());
-                }
-                if (!isJson || first) {
-                    first = false;
-                    return httpContent;
-                } else {
-                    return HttpContentUtil.prefixComma(httpContent);
-                }
-            }
-        });
-
-        if (isJson && !Publishers.isSingle(publisher.getClass())) {
-            // if the Publisher is returning JSON then in order for it to be valid JSON for each emitted element
-            // we must wrap the JSON in array and delimit the emitted items
-            httpContentPublisher = Flowable.concat(
-                Flowable.fromCallable(HttpContentUtil::openBracket),
-                httpContentPublisher,
-                Flowable.fromCallable(HttpContentUtil::closeBracket)
-            );
-        }
-
-        if (mediaType.equals(MediaType.TEXT_EVENT_STREAM_TYPE)) {
-            httpContentPublisher = Publishers.onComplete(httpContentPublisher, () -> {
-                CompletableFuture<Void> future = new CompletableFuture<>();
-                if (request == null || !request.getHeaders().isKeepAlive()) {
-                    if (context.channel().isOpen()) {
-                        context.pipeline()
-                            .writeAndFlush(new DefaultLastHttpContent())
-                            .addListener(f -> {
-                                    if (f.isSuccess()) {
-                                        future.complete(null);
-                                    } else {
-                                        future.completeExceptionally(f.cause());
-                                    }
-                                }
-                            );
-                    }
-                }
-                return future;
-            });
-        }
-
-        httpContentPublisher = Publishers.then(httpContentPublisher, httpContent -> {
-            // once an http content is written, read the next item if it is available
-            context.read();
-        });
-
-        httpContentPublisher = Flowable.fromPublisher(httpContentPublisher)
-                .doAfterTerminate(() -> cleanupRequest(context, request));
-
-        DelegateStreamedHttpResponse streamedResponse = new DelegateStreamedHttpResponse(nativeResponse, httpContentPublisher);
-        io.netty.handler.codec.http.HttpHeaders headers = streamedResponse.headers();
-        headers.set(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
-        headers.set(HttpHeaderNames.CONTENT_TYPE, mediaType);
-        context.writeAndFlush(streamedResponse);
-        context.read();
-    }
-
-    @SuppressWarnings("unchecked")
-    private void writeDefaultErrorResponse(ChannelHandlerContext ctx, NettyHttpRequest nettyHttpRequest, Throwable cause) {
+    private void writeDefaultErrorResponse(ChannelHandlerContext ctx, NettyHttpRequest nettyHttpRequest, Throwable cause, boolean skipOncePerRequest) {
         logException(cause);
 
-        MutableHttpResponse<?> error = io.micronaut.http.HttpResponse.serverError()
-                .body(new JsonError("Internal Server Error: " + cause.getMessage()));
-        subscribeToResponsePublisher(
+        JsonError body = new JsonError("Internal Server Error: " + cause.getMessage());
+        MutableHttpResponse<Object> error = io.micronaut.http.HttpResponse.serverError()
+                .body(body);
+        filterAndEncodeResponse(
                 ctx,
+                nettyHttpRequest,
+                nettyHttpRequest,
+                error,
                 MediaType.APPLICATION_JSON_TYPE,
-                new AtomicReference<>(nettyHttpRequest),
-                Flowable.just(error)
-        );
+                skipOncePerRequest);
     }
 
     private void logException(Throwable cause) {
@@ -1789,12 +1798,12 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
     }
 
     private void applyConfiguredHeaders(MutableHttpHeaders headers) {
-        if (serverConfiguration.isDateHeader() && !headers.contains("Date")) {
+        if (serverConfiguration.isDateHeader() && !headers.contains(HttpHeaders.DATE)) {
             headers.date(LocalDateTime.now());
         }
         serverConfiguration.getServerHeader().ifPresent((server) -> {
-            if (!headers.contains("Server")) {
-                headers.add("Server", server);
+            if (!headers.contains(HttpHeaders.SERVER)) {
+                headers.add(HttpHeaders.SERVER, server);
             }
         });
     }

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/ContentNegotiationSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/ContentNegotiationSpec.groovy
@@ -109,7 +109,7 @@ class ContentNegotiationSpec extends Specification {
 
         where:
         contentType                     | expectedContentType             | expectedBody
-        null                            | MediaType.APPLICATION_XML_TYPE | '<bad>Bad things happened</bad>'
+        null                            | MediaType.APPLICATION_XML_TYPE  | '<bad>Bad things happened</bad>'
         MediaType.APPLICATION_XML_TYPE  | MediaType.APPLICATION_XML_TYPE  | '<bad>Bad things happened</bad>'
         MediaType.APPLICATION_JSON_TYPE | MediaType.APPLICATION_JSON_TYPE | '{"message":"Bad things happened"}'
     }
@@ -133,12 +133,13 @@ class ContentNegotiationSpec extends Specification {
         response != null
         response.getContentType().get() == expectedContentType
         response.body() == expectedBody
+        response.status() == status
 
         where:
-        contentType                     | expectedContentType             | expectedBody
-        null                            | MediaType.APPLICATION_XML_TYPE | '<bad>not a good request</bad>'
-        MediaType.APPLICATION_XML_TYPE  | MediaType.APPLICATION_XML_TYPE  | '<bad>not a good request</bad>'
-        MediaType.APPLICATION_JSON_TYPE | MediaType.APPLICATION_JSON_TYPE | '{"message":"not a good request"}'
+        contentType                     | status                 | expectedContentType             | expectedBody
+        null                            | HttpStatus.BAD_REQUEST | MediaType.APPLICATION_XML_TYPE  | '<bad>not a good request</bad>'
+        MediaType.APPLICATION_XML_TYPE  | HttpStatus.BAD_REQUEST | MediaType.APPLICATION_XML_TYPE  | '<bad>not a good request</bad>'
+        MediaType.APPLICATION_JSON_TYPE | HttpStatus.BAD_REQUEST | MediaType.APPLICATION_JSON_TYPE | '{"message":"not a good request"}'
     }
 
     @Controller("/negotiate")

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/status/StatusControllerSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/status/StatusControllerSpec.groovy
@@ -55,7 +55,8 @@ class StatusControllerSpec extends Specification {
     }
 
     @Issue("https://github.com/micronaut-projects/micronaut-core/issues/866")
-    void "Verify a controller can be annotated with @Status and void return"() {
+    @Unroll
+    void "Verify a controller can be annotated with @Status and void return for #uri"() {
         when:
         HttpResponse response = client.toBlocking().exchange(HttpRequest.GET(uri))
 

--- a/http-server/src/main/java/io/micronaut/http/server/cors/CorsFilter.java
+++ b/http-server/src/main/java/io/micronaut/http/server/cors/CorsFilter.java
@@ -75,9 +75,9 @@ public class CorsFilter implements HttpServerFilter {
     public Publisher<MutableHttpResponse<?>> doFilter(HttpRequest<?> request, ServerFilterChain chain) {
         boolean originHeaderPresent = request.getHeaders().getOrigin().isPresent();
         if (originHeaderPresent) {
-            Optional<MutableHttpResponse<?>> response = handleRequest(request);
-            if (response.isPresent()) {
-                return Publishers.just(response.get());
+            MutableHttpResponse<?> response = handleRequest(request).orElse(null);
+            if (response != null) {
+                return Publishers.just(response);
             } else {
                 return Publishers.map(chain.proceed(request), mutableHttpResponse -> {
                     handleResponse(request, mutableHttpResponse);

--- a/http/src/main/java/io/micronaut/http/HttpRequestFactory.java
+++ b/http/src/main/java/io/micronaut/http/HttpRequestFactory.java
@@ -114,6 +114,6 @@ public interface HttpRequestFactory {
      * @return The request
      */
     default <T> MutableHttpRequest<T> create(HttpMethod httpMethod, String uri, String httpMethodName) {
-        return create(httpMethod, uri, httpMethodName);
+        return create(httpMethod, uri);
     }
 }

--- a/http/src/main/java/io/micronaut/http/annotation/Consumes.java
+++ b/http/src/main/java/io/micronaut/http/annotation/Consumes.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.http.annotation;
 
+import io.micronaut.context.annotation.AliasFor;
+import io.micronaut.core.async.annotation.SingleResult;
 import io.micronaut.http.MediaType;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -52,5 +54,6 @@ public @interface Consumes {
      *
      * @return True if only a single result is emitted
      */
+    @AliasFor(annotation = SingleResult.class, member = "value")
     boolean single() default false;
 }

--- a/http/src/main/java/io/micronaut/http/annotation/Produces.java
+++ b/http/src/main/java/io/micronaut/http/annotation/Produces.java
@@ -17,6 +17,8 @@ package io.micronaut.http.annotation;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import io.micronaut.context.annotation.AliasFor;
+import io.micronaut.core.async.annotation.SingleResult;
 import io.micronaut.http.MediaType;
 
 import java.lang.annotation.Documented;
@@ -55,5 +57,6 @@ public @interface Produces {
      *
      * @return True if only a single result is emitted
      */
+    @AliasFor(annotation = SingleResult.class, member = "value")
     boolean single() default false;
 }

--- a/inject/src/main/java/io/micronaut/context/AbstractExecutableMethod.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractExecutableMethod.java
@@ -15,11 +15,11 @@
  */
 package io.micronaut.context;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import io.micronaut.context.env.Environment;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.UsedByGeneratedCode;
-import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.type.ReturnType;
@@ -199,7 +199,6 @@ public abstract class AbstractExecutableMethod extends AbstractExecutable implem
      */
     class ReturnTypeImpl implements ReturnType {
 
-        @SuppressWarnings("unchecked")
         @Override
         public Class<?> getType() {
             if (genericReturnType != null) {
@@ -207,6 +206,17 @@ public abstract class AbstractExecutableMethod extends AbstractExecutable implem
             } else {
                 return void.class;
             }
+        }
+
+        @Override
+        public boolean isSuspended() {
+            return AbstractExecutableMethod.this.isSuspend();
+        }
+
+        @NonNull
+        @Override
+        public AnnotationMetadata getAnnotationMetadata() {
+            return AbstractExecutableMethod.this.getAnnotationMetadata();
         }
 
         @Override
@@ -229,7 +239,7 @@ public abstract class AbstractExecutableMethod extends AbstractExecutable implem
         public Argument asArgument() {
             Collection<Argument<?>> values = getTypeVariables().values();
             final AnnotationMetadata annotationMetadata = getAnnotationMetadata();
-            return Argument.of(getType(), NameUtils.decapitalize(getType().getSimpleName()), annotationMetadata, values.toArray(new Argument[0]));
+            return Argument.of(getType(), getType().getSimpleName(), annotationMetadata, values.toArray(Argument.ZERO_ARGUMENTS));
         }
     }
 

--- a/management/src/main/java/io/micronaut/management/endpoint/health/filter/HealthResultFilter.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/health/filter/HealthResultFilter.java
@@ -29,8 +29,6 @@ import io.micronaut.management.endpoint.health.HealthEndpoint;
 import io.micronaut.management.health.indicator.HealthResult;
 import org.reactivestreams.Publisher;
 
-import java.util.Optional;
-
 /**
  * A filter that matches the {@link io.micronaut.management.endpoint.health.HealthEndpoint}
  * and returns an appropriate HTTP status code.
@@ -65,9 +63,9 @@ public class HealthResultFilter extends OncePerRequestHttpServerFilter {
     @Override
     protected Publisher<MutableHttpResponse<?>> doFilterOnce(HttpRequest<?> request, ServerFilterChain chain) {
         return Publishers.map(chain.proceed(request), response -> {
-            Optional<HealthResult> body = response.getBody(HealthResult.class);
-            if (body.isPresent()) {
-                HealthResult healthResult = body.get();
+            Object body = response.body();
+            if (body instanceof HealthResult) {
+                HealthResult healthResult = (HealthResult) body;
                 HealthStatus status = healthResult.getStatus();
 
                 HttpStatus httpStatus = healthEndpoint

--- a/router/src/main/java/io/micronaut/web/router/AbstractRouteMatch.java
+++ b/router/src/main/java/io/micronaut/web/router/AbstractRouteMatch.java
@@ -81,6 +81,31 @@ abstract class AbstractRouteMatch<T, R> implements MethodBasedRouteMatch<T, R> {
     }
 
     @Override
+    public final boolean isSuspended() {
+        return this.abstractRoute.isSuspended();
+    }
+
+    @Override
+    public boolean isReactive() {
+        return this.abstractRoute.isReactive();
+    }
+
+    @Override
+    public boolean isSingleResult() {
+        return this.abstractRoute.isSingleResult();
+    }
+
+    @Override
+    public boolean isAsync() {
+        return this.abstractRoute.isAsync();
+    }
+
+    @Override
+    public boolean isVoid() {
+        return this.abstractRoute.isVoid();
+    }
+
+    @Override
     public T getTarget() {
         return executableMethod.getTarget();
     }

--- a/router/src/main/java/io/micronaut/web/router/DefaultRouteBuilder.java
+++ b/router/src/main/java/io/micronaut/web/router/DefaultRouteBuilder.java
@@ -15,12 +15,15 @@
  */
 package io.micronaut.web.router;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.ExecutionHandleLocator;
 import io.micronaut.context.env.Environment;
+import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.naming.NameResolver;
 import io.micronaut.core.type.Argument;
+import io.micronaut.core.type.ReturnType;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.http.HttpMethod;
 import io.micronaut.http.HttpRequest;
@@ -402,7 +405,7 @@ public abstract class DefaultRouteBuilder implements RouteBuilder {
     /**
      * Abstract class for base {@link MethodBasedRoute}.
      */
-    abstract class AbstractRoute implements MethodBasedRoute {
+    abstract class AbstractRoute implements MethodBasedRoute, RouteInfo<Object> {
         protected final List<Predicate<HttpRequest<?>>> conditions = new ArrayList<>();
         protected final MethodExecutionHandle<?, ?> targetMethod;
         protected final ConversionService<?> conversionService;
@@ -410,6 +413,11 @@ public abstract class DefaultRouteBuilder implements RouteBuilder {
         protected List<MediaType> producesMediaTypes;
         protected String bodyArgumentName;
         protected Argument<?> bodyArgument;
+        private final boolean isVoid;
+        private final boolean suspended;
+        private final boolean reactive;
+        private final boolean single;
+        private final boolean async;
 
         /**
          * @param targetMethod The target method execution handle
@@ -429,6 +437,47 @@ public abstract class DefaultRouteBuilder implements RouteBuilder {
             if (ArrayUtils.isNotEmpty(types)) {
                 this.consumesMediaTypes = Arrays.asList(types);
             }
+            suspended = targetMethod.getExecutableMethod().isSuspend();
+            reactive = RouteInfo.super.isReactive();
+            async = RouteInfo.super.isAsync();
+            single = RouteInfo.super.isSingleResult();
+            isVoid = RouteInfo.super.isVoid();
+        }
+
+        @NonNull
+        @Override
+        public AnnotationMetadata getAnnotationMetadata() {
+            return targetMethod.getAnnotationMetadata();
+        }
+
+        @Override
+        public ReturnType<?> getReturnType() {
+            return targetMethod.getReturnType();
+        }
+
+        @Override
+        public boolean isSuspended() {
+            return suspended;
+        }
+
+        @Override
+        public boolean isReactive() {
+            return reactive;
+        }
+
+        @Override
+        public boolean isSingleResult() {
+            return single;
+        }
+
+        @Override
+        public boolean isAsync() {
+            return async;
+        }
+
+        @Override
+        public boolean isVoid() {
+            return isVoid;
         }
 
         @Override

--- a/router/src/main/java/io/micronaut/web/router/Route.java
+++ b/router/src/main/java/io/micronaut/web/router/Route.java
@@ -102,7 +102,6 @@ public interface Route {
         return DEFAULT_PRODUCES;
     }
 
-
     /**
      * The media types able to produced by this route.
      *

--- a/router/src/main/java/io/micronaut/web/router/RouteInfo.java
+++ b/router/src/main/java/io/micronaut/web/router/RouteInfo.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.web.router;
+
+import io.micronaut.core.annotation.AnnotationMetadataProvider;
+import io.micronaut.core.type.ReturnType;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.inject.util.KotlinExecutableMethodUtils;
+
+/**
+ * Common information shared between route and route match.
+ *
+ * @param <R> The route
+ * @author Graeme Rocher
+ * @since 1.0
+ */
+public interface RouteInfo<R> extends AnnotationMetadataProvider {
+    /**
+     * @return The return type
+     */
+    ReturnType<? extends R> getReturnType();
+
+    /**
+     * @return Is this route match a suspended function (Kotlin).
+     * @since 2.0.0
+     */
+    default boolean isSuspended() {
+        return getReturnType().isSuspended();
+    }
+
+    /**
+     * @return Is the route a reactive route.
+     * @since 2.0.0
+     */
+    default boolean isReactive() {
+        return getReturnType().isReactive();
+    }
+
+    /**
+     * @return Does the route emit a single result or multiple results
+     * @since 2.0
+     */
+    default boolean isSingleResult() {
+        ReturnType<? extends R> returnType = getReturnType();
+        return returnType.isSingleResult() ||
+                (isReactive() && returnType.getFirstTypeVariable().filter(t -> HttpResponse.class.isAssignableFrom(t.getType())).isPresent()) ||
+                returnType.isSuspended();
+    }
+
+    /**
+     * @return is the return type completable
+     * @since 2.0
+     */
+    default boolean isCompletable() {
+        return getReturnType().isCompletable();
+    }
+
+    /**
+     * @return Is the route an async route.
+     * @since 2.0.0
+     */
+    default boolean isAsync() {
+        return getReturnType().isAsync();
+    }
+
+    /**
+     * @return Is the route an async or reactive route.
+     * @since 2.0.0
+     */
+    default boolean isAsyncOrReactive() {
+        return getReturnType().isAsyncOrReactive();
+    }
+
+    /**
+     * @return Does the route return void
+     * @since 2.0.0
+     */
+    default boolean isVoid() {
+        if (getReturnType().isVoid()) {
+            return true;
+        } else if (this instanceof MethodBasedRouteMatch && isSuspended()) {
+            return KotlinExecutableMethodUtils.isKotlinFunctionReturnTypeUnit(((MethodBasedRouteMatch) this).getExecutableMethod());
+        }
+        return false;
+    }
+}

--- a/router/src/main/java/io/micronaut/web/router/RouteMatch.java
+++ b/router/src/main/java/io/micronaut/web/router/RouteMatch.java
@@ -15,18 +15,13 @@
  */
 package io.micronaut.web.router;
 
-import io.micronaut.core.annotation.AnnotationMetadataProvider;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.type.ReturnType;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.MediaType;
 
-import edu.umd.cs.findbugs.annotations.Nullable;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -38,7 +33,7 @@ import java.util.function.Predicate;
  * @author Graeme Rocher
  * @since 1.0
  */
-public interface RouteMatch<R> extends Callable<R>, Predicate<HttpRequest>, AnnotationMetadataProvider {
+public interface RouteMatch<R> extends Callable<R>, Predicate<HttpRequest>, RouteInfo<R> {
 
     /**
      * The declaring type of the route.

--- a/runtime/src/main/java/io/micronaut/reactive/reactor/converters/ReactorConverterRegistrar.java
+++ b/runtime/src/main/java/io/micronaut/reactive/reactor/converters/ReactorConverterRegistrar.java
@@ -20,6 +20,8 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.TypeConverter;
 import io.micronaut.core.convert.TypeConverterRegistrar;
+import io.reactivex.Flowable;
+import io.reactivex.Maybe;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -39,6 +41,11 @@ import java.util.Optional;
 class ReactorConverterRegistrar implements TypeConverterRegistrar {
     @Override
     public void register(ConversionService<?> conversionService) {
+        conversionService.addConverter(
+                Mono.class,
+                Maybe.class,
+                (TypeConverter<Mono, Maybe>) (object, targetType, context) -> Optional.of(Flowable.fromPublisher(object).firstElement())
+        );
         conversionService.addConverter(
                 Publisher.class,
                 Flux.class,

--- a/runtime/src/main/java/io/micronaut/reactive/rxjava2/converters/RxJavaConverterRegistrar.java
+++ b/runtime/src/main/java/io/micronaut/reactive/rxjava2/converters/RxJavaConverterRegistrar.java
@@ -99,7 +99,7 @@ public class RxJavaConverterRegistrar implements TypeConverterRegistrar {
         );
         conversionService.addConverter(Publisher.class, Single.class, (Function<Publisher, Single>) Single::fromPublisher);
         conversionService.addConverter(Publisher.class, Observable.class, (Function<Publisher, Observable>) Observable::fromPublisher);
-        conversionService.addConverter(Publisher.class, Maybe.class, (Function<Publisher, Maybe>) publisher -> Maybe.fromSingle(Single.fromPublisher(publisher)));
+        conversionService.addConverter(Publisher.class, Maybe.class, (Function<Publisher, Maybe>) publisher -> Flowable.fromPublisher(publisher).firstElement());
         conversionService.addConverter(Publisher.class, Completable.class, (Function<Publisher, Completable>) Completable::fromPublisher);
     }
 }

--- a/validation/src/test/groovy/io/micronaut/validation/ValidatedSpec.groovy
+++ b/validation/src/test/groovy/io/micronaut/validation/ValidatedSpec.groovy
@@ -98,7 +98,7 @@ class ValidatedSpec extends Specification {
 
         then:
         def e = thrown(ConstraintViolationException)
-        e.message == "string: must not be null"
+        e.message == "String: must not be null"
 
         cleanup:
         beanContext.close()
@@ -114,7 +114,7 @@ class ValidatedSpec extends Specification {
 
         then:
         def e = thrown(ConstraintViolationException)
-        e.message == "bar: must not be null"
+        e.message == "Bar: must not be null"
 
         cleanup:
         beanContext.close()
@@ -130,7 +130,7 @@ class ValidatedSpec extends Specification {
 
         then:
         def e = thrown(ConstraintViolationException)
-        e.message == "bar.prop: must not be null"
+        e.message == "Bar.prop: must not be null"
 
         cleanup:
         beanContext.close()
@@ -146,7 +146,7 @@ class ValidatedSpec extends Specification {
 
         then:
         def e = thrown(ConstraintViolationException)
-        e.message == "list[0].prop: must not be null"
+        e.message == "List[0].prop: must not be null"
 
         cleanup:
         beanContext.close()
@@ -162,7 +162,7 @@ class ValidatedSpec extends Specification {
 
         then:
         def e = thrown(ConstraintViolationException)
-        e.message == "map[barObj].prop: must not be null"
+        e.message == "Map[barObj].prop: must not be null"
 
         cleanup:
         beanContext.close()


### PR DESCRIPTION
This PR is a rewrite of RoutingInBoundHandler to improve performance, reduce the reactive call stack (issue #2566) and allow response chunking (issue #2902) via filter.  