### PR TITLE
Fixes #2831 document startup and shutdown events

### DIFF
--- a/src/main/docs/guide/ioc/contextEvents.adoc
+++ b/src/main/docs/guide/ioc/contextEvents.adoc
@@ -19,7 +19,7 @@ snippet::io.micronaut.docs.context.events.application.SampleEventListener,io.mic
 
 NOTE: The link:{api}/io/micronaut/context/event/ApplicationEventListener.html#supports-E-[supports] method can be overridden to further clarify events that should be processed.
 
-Alternatively you can use the ann:runtime.event.annotation.EventListener[] annotation if you do not wish to specifically implement an interface:
+Alternatively you can use the ann:runtime.event.annotation.EventListener[] annotation if you do not wish to specifically implement an interface or utilize one of the built in events like api:context.event.StartupEvent[] and api:context.event.ShutdownEvent[]:
 
 snippet::io.micronaut.docs.context.events.listener.SampleEventListener[tags="imports,class",indent=0,title="Listening for Events with `@EventListener`"]
 

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/context/events/listener/SampleEventListener.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/context/events/listener/SampleEventListener.groovy
@@ -17,6 +17,8 @@ package io.micronaut.docs.context.events.listener
 
 // tag::imports[]
 import io.micronaut.docs.context.events.SampleEvent
+import io.micronaut.context.event.StartupEvent
+import io.micronaut.context.event.ShutdownEvent
 import io.micronaut.runtime.event.annotation.EventListener
 // end::imports[]
 import javax.inject.Singleton
@@ -29,6 +31,16 @@ class SampleEventListener {
     @EventListener
     void onSampleEvent(SampleEvent event) {
         invocationCounter++
+    }
+
+    @EventListener
+    void onStartupEvent(StartupEvent event) {
+        // startup logic here
+    }
+
+    @EventListener
+    void onShutdownEvent(ShutdownEvent event) {
+        // shutdown logic here
     }
 }
 // end::class[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/context/events/listener/SampleEventListener.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/context/events/listener/SampleEventListener.kt
@@ -17,6 +17,8 @@ package io.micronaut.docs.context.events.listener
 
 // tag::imports[]
 import io.micronaut.docs.context.events.SampleEvent
+import io.micronaut.context.event.StartupEvent
+import io.micronaut.context.event.ShutdownEvent
 import io.micronaut.runtime.event.annotation.EventListener
 // end::imports[]
 import javax.inject.Singleton
@@ -29,6 +31,16 @@ class SampleEventListener {
     @EventListener
     internal fun onSampleEvent(event: SampleEvent) {
         invocationCounter++
+    }
+
+    @EventListener
+    internal fun onStartupEvent(event: StartupEvent) {
+        // startup logic here
+    }
+
+    @EventListener
+    internal fun onShutdownEvent(event: ShutdownEvent) {
+        // shutdown logic here
     }
 }
 // end::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/context/events/listener/SampleEventListener.java
+++ b/test-suite/src/test/java/io/micronaut/docs/context/events/listener/SampleEventListener.java
@@ -17,6 +17,8 @@ package io.micronaut.docs.context.events.listener;
 
 // tag::imports[]
 import io.micronaut.docs.context.events.SampleEvent;
+import io.micronaut.context.event.StartupEvent;
+import io.micronaut.context.event.ShutdownEvent;
 import io.micronaut.runtime.event.annotation.EventListener;
 // end::imports[]
 import javax.inject.Singleton;
@@ -29,6 +31,16 @@ public class SampleEventListener {
     @EventListener
     public void onSampleEvent(SampleEvent event) {
         invocationCounter++;
+    }
+
+    @EventListener
+    public void onStartupEvent(StartupEvent event) {
+        // startup logic here
+    }
+
+    @EventListener
+    public void onShutdownEvent(ShutdownEvent event) {
+        // shutdown logic here
     }
 
     public int getInvocationCounter() {


### PR DESCRIPTION
Adds some docs about StartupEvent and ShutdownEvent to the context events section of the docs.