### PR TITLE
Return BadRequest for malformed URI requests.

### DIFF
--- a/http-server/src/main/java/io/micronaut/http/server/exceptions/URISyntaxHandler.java
+++ b/http-server/src/main/java/io/micronaut/http/server/exceptions/URISyntaxHandler.java
@@ -16,12 +16,10 @@
 package io.micronaut.http.server.exceptions;
 
 import io.micronaut.context.annotation.Primary;
-import io.micronaut.core.convert.exceptions.ConversionErrorException;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.annotation.Produces;
 import io.micronaut.http.hateoas.JsonError;
-import io.micronaut.http.hateoas.Link;
 
 import javax.inject.Singleton;
 import java.net.URISyntaxException;

--- a/http-server/src/main/java/io/micronaut/http/server/exceptions/URISyntaxHandler.java
+++ b/http-server/src/main/java/io/micronaut/http/server/exceptions/URISyntaxHandler.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.exceptions;
+
+import io.micronaut.context.annotation.Primary;
+import io.micronaut.core.convert.exceptions.ConversionErrorException;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.annotation.Produces;
+import io.micronaut.http.hateoas.JsonError;
+import io.micronaut.http.hateoas.Link;
+
+import javax.inject.Singleton;
+import java.net.URISyntaxException;
+
+/**
+ * Handles exception of type {@link URISyntaxException}.
+ *
+ * @author Graeme Rocher
+ * @since 2.0
+ */
+@Singleton
+@Primary
+@Produces
+public class URISyntaxHandler implements ExceptionHandler<URISyntaxException, HttpResponse> {
+
+    @Override
+    public HttpResponse handle(HttpRequest request, URISyntaxException exception) {
+        JsonError error = new JsonError("Malformed URI: " + exception.getMessage());
+        return HttpResponse.badRequest(error);
+    }
+}

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/urisyntax/MalformedUriSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/urisyntax/MalformedUriSpec.groovy
@@ -12,7 +12,7 @@ class MalformedUriSpec extends Specification {
 
     @Shared
     @AutoCleanup
-    EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, ['spec.name': MalformedUriSpec.simpleName], Environment.TEST);
+    EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer);
 
     void testMalformedUriReturns400() {
         when:

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/urisyntax/MalformedUriSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/urisyntax/MalformedUriSpec.groovy
@@ -1,0 +1,27 @@
+package io.micronaut.docs.server.urisyntax
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.env.Environment
+import io.micronaut.http.HttpStatus
+import io.micronaut.runtime.server.EmbeddedServer
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class MalformedUriSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, ['spec.name': MalformedUriSpec.simpleName], Environment.TEST);
+
+    void testMalformedUriReturns400() {
+        when:
+        HttpURLConnection connection = (HttpURLConnection) new URL("$embeddedServer.URL/malformed/[]").openConnection()
+        connection.connect()
+
+        then:
+        connection.getResponseCode() == 400
+        connection.getResponseMessage() == HttpStatus.BAD_REQUEST.reason
+        connection.getErrorStream().getText().contains('"message":"Malformed URI:')
+    }
+}


### PR DESCRIPTION
Fixes #2606 
This PR adds a default ExceptionHandler for URISyntax exception and a test to verify the behaviour.

Reproducing the steps in #2606 now results in the following:

```
$ curl -v 'http://localhost:8080/<>'
*   Trying ::1:8080...
* Connected to localhost (::1) port 8080 (#0)
> GET /<> HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.69.1
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 400 Bad Request
< Content-Type: application/json
< content-length: 70
< connection: close
< 
* Closing connection 0
{"message":"Malformed URI: Illegal character in path at index 1: /<>"}
```