### PR TITLE
Allow configuration of metadata when registering an application in Consul

### DIFF
--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/ConsulConfiguration.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/ConsulConfiguration.java
@@ -327,6 +327,7 @@ public class ConsulConfiguration extends DiscoveryClientConfiguration {
         public static final String PREFIX = ConsulConfiguration.PREFIX + "." + RegistrationConfiguration.PREFIX;
 
         private List<String> tags = Collections.emptyList();
+        private Map<String, String> meta = Collections.emptyMap();
         private CheckConfiguration check = new CheckConfiguration();
 
         /**
@@ -341,6 +342,20 @@ public class ConsulConfiguration extends DiscoveryClientConfiguration {
          */
         public void setTags(List<String> tags) {
             this.tags = tags;
+        }
+
+        /**
+         * @return That metadata to use for registering the service
+         */
+        public Map<String, String> getMeta() {
+            return meta;
+        }
+
+        /**
+         * @param meta The metadata for registering the service
+         */
+        public void setMeta(Map<String, String> meta) {
+            this.meta = meta;
         }
 
         /**
@@ -361,6 +376,7 @@ public class ConsulConfiguration extends DiscoveryClientConfiguration {
         public String toString() {
             return "ConsulRegistrationConfiguration{" +
                 "tags=" + tags +
+                ", meta=" + meta +
                 ", check=" + check +
                 '}';
         }

--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/ConsulServiceInstance.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/ConsulServiceInstance.java
@@ -140,6 +140,10 @@ public class ConsulServiceInstance implements ServiceInstance {
                 map.put(tag.substring(0, i), tag.substring(i + 1));
             }
         }
+
+        Map<String, String> meta = healthEntry.getService().getMeta();
+        map.putAll(meta);
+
         return ConvertibleValues.of(map);
     }
 }

--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/client/v1/AbstractServiceEntry.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/client/v1/AbstractServiceEntry.java
@@ -25,6 +25,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -233,11 +234,11 @@ public abstract class AbstractServiceEntry {
         }
         AbstractServiceEntry that = (AbstractServiceEntry) o;
         return Objects.equals(name, that.name) &&
-                Objects.equals(address, that.address) &&
-                Objects.equals(port, that.port) &&
-                Objects.equals(tags, that.tags) &&
-                Objects.equals(meta, that.meta) &&
-                Objects.equals(ID, that.ID);
+            Objects.equals(address, that.address) &&
+            Objects.equals(port, that.port) &&
+            Objects.equals(tags, that.tags) &&
+            Objects.equals(meta, that.meta) &&
+            Objects.equals(ID, that.ID);
     }
 
     @Override

--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/client/v1/AbstractServiceEntry.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/client/v1/AbstractServiceEntry.java
@@ -44,6 +44,7 @@ public abstract class AbstractServiceEntry {
     private Integer port;
     private List<String> tags;
     private String ID;
+    private Map<String, String> meta;
 
     /**
      * @param name The service name
@@ -134,6 +135,27 @@ public abstract class AbstractServiceEntry {
     }
 
     /**
+     * See https://www.consul.io/api/agent/service.html#meta.
+     *
+     * @return The service metadata
+     */
+    public Map<String, String> getMeta() {
+        if (meta == null) {
+            return Collections.emptyMap();
+        }
+        return meta;
+    }
+
+    /**
+     * See https://www.consul.io/api/agent/service.html#meta.
+     *
+     * @param meta The service metadata
+     */
+    public void setMeta(Map<String, String> meta) {
+        this.meta = meta;
+    }
+
+    /**
      * See https://www.consul.io/api/agent/service.html#name.
      *
      * @return The name of the service
@@ -191,6 +213,16 @@ public abstract class AbstractServiceEntry {
         return this;
     }
 
+    /**
+     *
+     * @param meta The service metadata
+     * @return The {@link AbstractServiceEntry} instance
+     */
+    public AbstractServiceEntry meta(Map<String, String> meta) {
+        this.meta = meta;
+        return this;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -201,14 +233,15 @@ public abstract class AbstractServiceEntry {
         }
         AbstractServiceEntry that = (AbstractServiceEntry) o;
         return Objects.equals(name, that.name) &&
-            Objects.equals(address, that.address) &&
-            Objects.equals(port, that.port) &&
-            Objects.equals(tags, that.tags) &&
-            Objects.equals(ID, that.ID);
+                Objects.equals(address, that.address) &&
+                Objects.equals(port, that.port) &&
+                Objects.equals(tags, that.tags) &&
+                Objects.equals(meta, that.meta) &&
+                Objects.equals(ID, that.ID);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, address, port, tags, ID);
+        return Objects.hash(name, address, port, tags, meta, ID);
     }
 }

--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/client/v1/ServiceEntry.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/client/v1/ServiceEntry.java
@@ -50,6 +50,7 @@ public class ServiceEntry extends AbstractServiceEntry {
         entry.getAddress().ifPresent(this::address);
         entry.getPort().ifPresent(this::port);
         tags(entry.getTags());
+        meta(entry.getMeta());
     }
 
     /**

--- a/discovery-client/src/main/java/io/micronaut/discovery/consul/registration/ConsulAutoRegistration.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/consul/registration/ConsulAutoRegistration.java
@@ -48,6 +48,7 @@ import java.net.URL;
 import java.net.UnknownHostException;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -169,6 +170,7 @@ public class ConsulAutoRegistration extends DiscoveryServiceAutoRegistration {
             if (StringUtils.isNotEmpty(applicationName)) {
                 NewServiceEntry serviceEntry = new NewServiceEntry(applicationName);
                 List<String> tags = new ArrayList<>(registration.getTags());
+                Map<String, String> meta = new HashMap<>(registration.getMeta());
 
                 String address;
                 if (registration.isPreferIpAddress()) {
@@ -187,7 +189,8 @@ public class ConsulAutoRegistration extends DiscoveryServiceAutoRegistration {
 
                 serviceEntry.address(address)
                     .port(instance.getPort())
-                    .tags(tags);
+                    .tags(tags)
+                    .meta(meta);
 
                 String serviceId = idGenerator.generateId(environment, instance);
                 serviceEntry.id(serviceId);

--- a/discovery-client/src/test/groovy/io/micronaut/discovery/consul/ConsulAutoRegistrationSpec.groovy
+++ b/discovery-client/src/test/groovy/io/micronaut/discovery/consul/ConsulAutoRegistrationSpec.groovy
@@ -223,7 +223,7 @@ class ConsulAutoRegistrationSpec extends Specification {
         discoveryClient.close()
     }
 
-        void "test that when Consul is explicitly configured, no AWS service discovery stuff is registered"() {
+    void "test that when Consul is explicitly configured, no AWS service discovery stuff is registered"() {
         when: "A new server is bootstrapped"
         EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer,
             ['micronaut.application.name': 'test-consul-aws',

--- a/discovery-client/src/test/groovy/io/micronaut/discovery/consul/ConsulAutoRegistrationSpec.groovy
+++ b/discovery-client/src/test/groovy/io/micronaut/discovery/consul/ConsulAutoRegistrationSpec.groovy
@@ -189,7 +189,41 @@ class ConsulAutoRegistrationSpec extends Specification {
         discoveryClient.close()
     }
 
-    void "test that when Consul is explicitly configured, no AWS service discovery stuff is registered"() {
+    void 'test that a service can be registered with metadata'() {
+        when: "A new server is bootstrapped"
+        String serviceId = 'myService'
+        EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer,
+                ['micronaut.application.name'     : serviceId,
+                 'consul.client.registration.meta': [foo: 'bar', key: 'value'],
+                 'consul.client.host'             : consulHost,
+                 'consul.client.port'             : consulPort]
+        )
+        Map discoveryClientMap = ['consul.client.host'                       : consulHost,
+                                  'consul.client.port'                       : consulPort,
+                                  "micronaut.caches.discovery-client.enabled": false]
+        DiscoveryClient discoveryClient = ApplicationContext.builder(discoveryClientMap)
+                .build()
+                .start()
+                .getBean(DiscoveryClient)
+
+        PollingConditions conditions = new PollingConditions(timeout: 3)
+
+        then: "the server is registered with Consul and includes the meta data"
+        conditions.eventually {
+            List<ServiceInstance> instances = Flowable.fromPublisher(discoveryClient.getInstances(serviceId)).blockingFirst()
+            instances.size() == 1
+            instances[0].port == embeddedServer.getPort()
+            instances[0].metadata.contains('foo')
+            instances[0].metadata.get('foo', String).get() == 'bar'
+            instances[0].metadata.contains('key')
+            instances[0].metadata.get('key', String).get() == 'value'
+        }
+        cleanup:
+        embeddedServer.stop()
+        discoveryClient.close()
+    }
+
+        void "test that when Consul is explicitly configured, no AWS service discovery stuff is registered"() {
         when: "A new server is bootstrapped"
         EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer,
             ['micronaut.application.name': 'test-consul-aws',

--- a/src/main/docs/guide/cloud/serviceDiscovery/serviceDiscoveryConsul.adoc
+++ b/src/main/docs/guide/cloud/serviceDiscovery/serviceDiscoveryConsul.adoc
@@ -73,6 +73,10 @@ consul:
       tags:
         - hello
         - world
+      # Alters the metadata
+      meta:
+        some: value
+        instance_type: t2.medium
       # Alters the retry count
       retry-count: 5
       # Alters fail fast behaviour


### PR DESCRIPTION
As #2615 describes, until now it was not possible to specify the attribute [meta](https://www.consul.io/api/agent/service.html#meta) in the  Consul registration customization.

This PR adds a new configuration property `consul.client.registration.meta` which allows the user to define custom metadata when registering a service in Consul.

 I checked the test which covers the tag property and I have tried to add corresponding tests for the metadata.

Different from the tag property, Consul [does not support](https://www.consul.io/api/health.html#parameters-2) simple querying based on the meta attribute. Therefore, I have not changed the `ConsulDiscoveryConfiguration`.

I have updated the configuration example in the documentation so that it includes now the new property. Running this example configuration results in the following Consul entry:
```
$ curl http://127.0.0.1:8500/v1/health/service/hello-world
[
    {
        "Node": {...},
        "Service": {
            "ID": "hello-world:8080",
            "Service": "hello-world",
            "Tags": [
                "hello",
                "world"
            ],
            "Address": "localhost",
            "Meta": {
                "instance-type": "t2.medium",
                "some": "value"
            },
            ...
        },
        "Checks": [...]
    }
]
```

