### PR TITLE
Add Support For Oracle Cloud Vault

### DIFF
--- a/discovery-client/build.gradle
+++ b/discovery-client/build.gradle
@@ -18,6 +18,11 @@ dependencies {
     // used by AWSParameterStoreConfigClient
     compileOnly group: 'com.amazonaws', name: 'aws-java-sdk-ssm', version: '1.11.683'
 
+    // used by OracleCloudVaultConfigurationClient
+    compileOnly group: 'com.oracle.oci.sdk', name: 'oci-java-sdk-vault', version: '1.15.4'
+    compileOnly group: 'com.oracle.oci.sdk', name: 'oci-java-sdk-secrets', version: '1.15.4'
+    compileOnly group: 'com.oracle.oci.sdk', name: 'oci-java-sdk-common', version: '1.15.4'
+
     testImplementation "org.testcontainers:spock:1.13.0"
 
     testImplementation dependencyVersion("micronaut.aws"), {
@@ -31,6 +36,9 @@ dependencies {
     testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-servicediscovery', version: '1.11.297'
     testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-ssm', version: '1.11.308'
 
+    testImplementation group: 'com.oracle.oci.sdk', name: 'oci-java-sdk-vault', version: '1.15.4'
+    testImplementation group: 'com.oracle.oci.sdk', name: 'oci-java-sdk-secrets', version: '1.15.4'
+    testImplementation group: 'com.oracle.oci.sdk', name: 'oci-java-sdk-common', version: '1.15.4'
     testImplementation project(":management")
     testImplementation project(":http-server-netty")
     testImplementation project(":inject-java")

--- a/discovery-client/src/main/java/io/micronaut/discovery/oraclecloud/vault/config/OracleCloudVaultClientConfiguration.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/oraclecloud/vault/config/OracleCloudVaultClientConfiguration.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.discovery.oraclecloud.vault.config;
+
+import io.micronaut.context.annotation.BootstrapContextCompatible;
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.context.annotation.EachProperty;
+import io.micronaut.discovery.config.ConfigDiscoveryConfiguration;
+
+import java.util.List;
+
+/**
+ *  OracleCloudVault Client.
+ *
+ *  @author toddsharp
+ *  @since 2.0.0
+ */
+@ConfigurationProperties(OracleCloudVaultClientConfiguration.PREFIX)
+@BootstrapContextCompatible
+public class OracleCloudVaultClientConfiguration {
+
+    public static final String PREFIX = "oraclecloud.vault";
+    private static final Boolean USE_INSTANCE_PRINCIPAL = false;
+    private static final String PATH_TO_OCI_CONFIG = "~/.oci/config";
+    private static final String DEFAULT_PROFILE = "DEFAULT";
+
+    private final OracleCloudVaultClientDiscoveryConfiguration oracleCloudVaultClientDiscoveryConfiguration = new OracleCloudVaultClientDiscoveryConfiguration();
+
+    private List<OracleCloudVault> vaults;
+    private boolean useInstancePrincipal = USE_INSTANCE_PRINCIPAL;
+    private String pathToConfig = PATH_TO_OCI_CONFIG;
+    private String profile = DEFAULT_PROFILE;
+    private String region;
+
+    /**
+     * @return The discovery service configuration
+     */
+    public OracleCloudVaultClientDiscoveryConfiguration getDiscoveryConfiguration() {
+        return oracleCloudVaultClientDiscoveryConfiguration;
+    }
+
+    /**
+     * @return A list of Vaults to retrieve
+     */
+    public List<OracleCloudVault> getVaults() {
+        return vaults;
+    }
+
+    /**
+     * @param vaults A list of Vaults
+     */
+    public void setVaults(List<OracleCloudVault> vaults) {
+        this.vaults = vaults;
+    }
+
+    /**
+     * @return Whether or not we should use instance principal authentication
+     */
+    public boolean isUseInstancePrincipal() {
+        return useInstancePrincipal;
+    }
+
+    /**
+     * @param useInstancePrincipal Should we use instance principal authentication
+     */
+    public void setUseInstancePrincipal(boolean useInstancePrincipal) {
+        this.useInstancePrincipal = useInstancePrincipal;
+    }
+
+    /**
+     * @return The path to the OCI config file (if not using instance principal auth)
+     */
+    public String getPathToConfig() {
+        return pathToConfig;
+    }
+
+    /**
+     * @param pathToConfig The path to the OCI config file
+     */
+    public void setPathToConfig(String pathToConfig) {
+        this.pathToConfig = pathToConfig;
+    }
+
+    /**
+     * @return Which profile in the OCI config file to use (default: DEFAULT)
+     */
+    public String getProfile() {
+        return profile;
+    }
+
+    /**
+     * @param profile Which profile in the OCI config file to use (default: DEFAULT)
+     */
+    public void setProfile(String profile) {
+        this.profile = profile;
+    }
+
+    /**
+     * @return Which region in the Oracle Cloud should the client work in?
+     */
+    public String getRegion() {
+        return region;
+    }
+
+    /**
+     * @param region Which region in the Oracle Cloud should the client work in?
+     */
+    public void setRegion(String region) {
+        this.region = region;
+    }
+
+
+    @EachProperty(value = "vaults", list = true)
+    public static class OracleCloudVault {
+        private String ocid;
+        private String compartmentOcid;
+
+        public OracleCloudVault(String ocid, String compartmentOcid) {
+            this.ocid = ocid;
+            this.compartmentOcid = compartmentOcid;
+        }
+
+        public String getOcid() {
+            return ocid;
+        }
+
+        public void setOcid(String ocid) {
+            this.ocid = ocid;
+        }
+
+        public String getCompartmentOcid() {
+            return compartmentOcid;
+        }
+
+        public void setCompartmentOcid(String compartmentOcid) {
+            this.compartmentOcid = compartmentOcid;
+        }
+    }
+
+    /**
+     * The Discovery Configuration class for Oracle Cloud Vault.
+     */
+    @ConfigurationProperties(ConfigDiscoveryConfiguration.PREFIX)
+    @BootstrapContextCompatible
+    public static class OracleCloudVaultClientDiscoveryConfiguration extends ConfigDiscoveryConfiguration {
+        public static final String PREFIX = OracleCloudVaultClientConfiguration.PREFIX + "." + ConfigDiscoveryConfiguration.PREFIX;
+    }
+}

--- a/discovery-client/src/main/java/io/micronaut/discovery/oraclecloud/vault/config/OracleCloudVaultClientConfiguration.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/oraclecloud/vault/config/OracleCloudVaultClientConfiguration.java
@@ -53,7 +53,7 @@ public class OracleCloudVaultClientConfiguration {
     }
 
     /**
-     * A list of {@link OracleCloudVault} objects that contain secrets that will be retrieved, decoded and set into your application as config variables.
+     * A list of {@link io.micronaut.discovery.oraclecloud.vault.config.OracleCloudVaultClientConfiguration$OracleCloudVault} objects that contain secrets that will be retrieved, decoded and set into your application as config variables.
      *
      * @return A list of Vaults to retrieve
      */
@@ -62,7 +62,7 @@ public class OracleCloudVaultClientConfiguration {
     }
 
     /**
-     * A list of {@link OracleCloudVault} objects that contain secrets that will be retrieved, decoded and set into your application as config variables.
+     * A list of {@link io.micronaut.discovery.oraclecloud.vault.config.OracleCloudVaultClientConfiguration$OracleCloudVault} objects that contain secrets that will be retrieved, decoded and set into your application as config variables.
      *
      * @param vaults A list of Vaults
      */
@@ -71,18 +71,20 @@ public class OracleCloudVaultClientConfiguration {
     }
 
     /**
-     * Whether or not the configuration client should use <a href="https://docs.cloud.oracle.com/en-us/iaas/Content/Identity/Tasks/callingservicesfrominstances.htm">Instance Principal Authentication</a> to interact with the SDK. If this value is false, you must include a path to an OCI Config file to use Config File based auth.
+     * Whether or not the configuration client should use https://docs.cloud.oracle.com/en-us/iaas/Content/Identity/Tasks/callingservicesfrominstances.htm[Instance Principal Authentication] to interact with the SDK. If this value is false, you must include a path to an OCI Config file to use Config File based auth.
      *
      * @return Whether or not we should use instance principal authentication
+     * @see <a href="https://docs.cloud.oracle.com/en-us/iaas/Content/Identity/Tasks/callingservicesfrominstances.htm">Instance Principal Authentication</a>
      */
     public boolean isUseInstancePrincipal() {
         return useInstancePrincipal;
     }
 
     /**
-     * Whether or not the configuration client should use <a href="https://docs.cloud.oracle.com/en-us/iaas/Content/Identity/Tasks/callingservicesfrominstances.htm">Instance Principal Authentication</a> to interact with the SDK. If this value is false, you must include a path to an OCI Config file to use Config File based auth.
+     * Whether or not the configuration client should use https://docs.cloud.oracle.com/en-us/iaas/Content/Identity/Tasks/callingservicesfrominstances.htm[Instance Principal Authentication] to interact with the SDK. If this value is false, you must include a path to an OCI Config file to use Config File based auth.
      *
      * @param useInstancePrincipal Should we use instance principal authentication
+     * @see <a href="https://docs.cloud.oracle.com/en-us/iaas/Content/Identity/Tasks/callingservicesfrominstances.htm">Instance Principal Authentication</a>
      */
     public void setUseInstancePrincipal(boolean useInstancePrincipal) {
         this.useInstancePrincipal = useInstancePrincipal;

--- a/discovery-client/src/main/java/io/micronaut/discovery/oraclecloud/vault/config/OracleCloudVaultClientConfiguration.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/oraclecloud/vault/config/OracleCloudVaultClientConfiguration.java
@@ -142,6 +142,9 @@ public class OracleCloudVaultClientConfiguration {
         this.region = region;
     }
 
+    /**
+     * An Oracle Cloud Vault
+     */
     @EachProperty(value = "vaults", list = true)
     @BootstrapContextCompatible
     public static class OracleCloudVault {
@@ -158,9 +161,9 @@ public class OracleCloudVaultClientConfiguration {
         }
 
         /**
-         * Sets the OCID of the vault that contains secrets that will be retrieved, decoded and set as config vars.
+         * Sets the OCID of the vault that contains secrets that will be retrieved, decoded and set as config vars
          *
-         * @param ocid
+         * @param ocid the ocid of the vault
          */
         public void setOcid(String ocid) {
             this.ocid = ocid;

--- a/discovery-client/src/main/java/io/micronaut/discovery/oraclecloud/vault/config/OracleCloudVaultClientConfiguration.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/oraclecloud/vault/config/OracleCloudVaultClientConfiguration.java
@@ -53,6 +53,8 @@ public class OracleCloudVaultClientConfiguration {
     }
 
     /**
+     * A list of {@link OracleCloudVault} objects that contain secrets that will be retrieved, decoded and set into your application as config variables.
+     *
      * @return A list of Vaults to retrieve
      */
     public List<OracleCloudVault> getVaults() {
@@ -60,6 +62,8 @@ public class OracleCloudVaultClientConfiguration {
     }
 
     /**
+     * A list of {@link OracleCloudVault} objects that contain secrets that will be retrieved, decoded and set into your application as config variables.
+     *
      * @param vaults A list of Vaults
      */
     public void setVaults(List<OracleCloudVault> vaults) {
@@ -67,6 +71,8 @@ public class OracleCloudVaultClientConfiguration {
     }
 
     /**
+     * Whether or not the configuration client should use <a href="https://docs.cloud.oracle.com/en-us/iaas/Content/Identity/Tasks/callingservicesfrominstances.htm">Instance Principal Authentication</a> to interact with the SDK. If this value is false, you must include a path to an OCI Config file to use Config File based auth.
+     *
      * @return Whether or not we should use instance principal authentication
      */
     public boolean isUseInstancePrincipal() {
@@ -74,6 +80,8 @@ public class OracleCloudVaultClientConfiguration {
     }
 
     /**
+     * Whether or not the configuration client should use <a href="https://docs.cloud.oracle.com/en-us/iaas/Content/Identity/Tasks/callingservicesfrominstances.htm">Instance Principal Authentication</a> to interact with the SDK. If this value is false, you must include a path to an OCI Config file to use Config File based auth.
+     *
      * @param useInstancePrincipal Should we use instance principal authentication
      */
     public void setUseInstancePrincipal(boolean useInstancePrincipal) {
@@ -81,6 +89,8 @@ public class OracleCloudVaultClientConfiguration {
     }
 
     /**
+     * If you are not using Instance Principal auth then you must pass the path to a valid OCI config file. Default value {@value #PATH_TO_OCI_CONFIG}.
+     *
      * @return The path to the OCI config file (if not using instance principal auth)
      */
     public String getPathToConfig() {
@@ -88,6 +98,8 @@ public class OracleCloudVaultClientConfiguration {
     }
 
     /**
+     * If you are not using Instance Principal auth then you must pass the path to a valid OCI config file. Default value {@value #PATH_TO_OCI_CONFIG}.
+     *
      * @param pathToConfig The path to the OCI config file
      */
     public void setPathToConfig(String pathToConfig) {
@@ -95,6 +107,8 @@ public class OracleCloudVaultClientConfiguration {
     }
 
     /**
+     * Which profile in the config file should be used? Default value {@value #DEFAULT_PROFILE}.
+     *
      * @return Which profile in the OCI config file to use (default: DEFAULT)
      */
     public String getProfile() {
@@ -102,6 +116,8 @@ public class OracleCloudVaultClientConfiguration {
     }
 
     /**
+     * Which profile in the config file should be used? Default value {@value #DEFAULT_PROFILE}.
+     *
      * @param profile Which profile in the OCI config file to use (default: DEFAULT)
      */
     public void setProfile(String profile) {
@@ -109,6 +125,8 @@ public class OracleCloudVaultClientConfiguration {
     }
 
     /**
+     * The OCI region Ex: 'US-PHOENIX-1'.
+     *
      * @return Which region in the Oracle Cloud should the client work in?
      */
     public String getRegion() {
@@ -116,37 +134,62 @@ public class OracleCloudVaultClientConfiguration {
     }
 
     /**
+     * The OCI region Ex: 'US-PHOENIX-1'.
+     *
      * @param region Which region in the Oracle Cloud should the client work in?
      */
     public void setRegion(String region) {
         this.region = region;
     }
 
-
     @EachProperty(value = "vaults", list = true)
+    @BootstrapContextCompatible
     public static class OracleCloudVault {
         private String ocid;
         private String compartmentOcid;
 
-        public OracleCloudVault(String ocid, String compartmentOcid) {
-            this.ocid = ocid;
-            this.compartmentOcid = compartmentOcid;
-        }
-
+        /**
+         * The OCID of the vault that contains secrets that will be retrieved, decoded and set as config vars.
+         *
+         * @return The OCID of the vault.
+         */
         public String getOcid() {
             return ocid;
         }
 
+        /**
+         * Sets the OCID of the vault that contains secrets that will be retrieved, decoded and set as config vars.
+         *
+         * @param ocid
+         */
         public void setOcid(String ocid) {
             this.ocid = ocid;
         }
 
+        /**
+         * The compartment OCID where the vault resides.
+         *
+         * @return The compartment OCID.
+         */
         public String getCompartmentOcid() {
             return compartmentOcid;
         }
 
+        /**
+         * Sets the compartment OCID where the vault resides.
+         *
+         * @param compartmentOcid The compartment OCID
+         */
         public void setCompartmentOcid(String compartmentOcid) {
             this.compartmentOcid = compartmentOcid;
+        }
+
+        @Override
+        public String toString() {
+            return "OracleCloudVault{" +
+                    "ocid='" + ocid + '\'' +
+                    ", compartmentOcid='" + compartmentOcid + '\'' +
+                    '}';
         }
     }
 

--- a/discovery-client/src/main/java/io/micronaut/discovery/oraclecloud/vault/config/OracleCloudVaultConfigurationClient.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/oraclecloud/vault/config/OracleCloudVaultConfigurationClient.java
@@ -79,6 +79,7 @@ public class OracleCloudVaultConfigurationClient implements ConfigurationClient 
      * @param oracleCloudVaultClientConfiguration   Oracle CloudVault Client Configuration
      * @param applicationConfiguration              The application configuration
      * @param executorService                       Executor Service
+     * @throws Exception                            If no configuration is provided
      */
     public OracleCloudVaultConfigurationClient(OracleCloudVaultClientConfiguration oracleCloudVaultClientConfiguration,
                                     ApplicationConfiguration applicationConfiguration,

--- a/discovery-client/src/main/java/io/micronaut/discovery/oraclecloud/vault/config/OracleCloudVaultConfigurationClient.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/oraclecloud/vault/config/OracleCloudVaultConfigurationClient.java
@@ -95,7 +95,9 @@ public class OracleCloudVaultConfigurationClient implements ConfigurationClient 
             try {
                 provider = new ConfigFileAuthenticationDetailsProvider(oracleCloudVaultClientConfiguration.getPathToConfig(), oracleCloudVaultClientConfiguration.getProfile());
             } catch (IOException e) {
-                e.printStackTrace();
+                if (LOG.isErrorEnabled()) {
+                    LOG.error("An error occurred when attempting to connect with a ConfigFileAuthenticationDetailsProvider: {}", e.getMessage());
+                }
             }
         }
         Region region = Region.fromRegionCodeOrId(oracleCloudVaultClientConfiguration.getRegion());

--- a/discovery-client/src/main/java/io/micronaut/discovery/oraclecloud/vault/config/OracleCloudVaultConfigurationClient.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/oraclecloud/vault/config/OracleCloudVaultConfigurationClient.java
@@ -131,8 +131,10 @@ public class OracleCloudVaultConfigurationClient implements ConfigurationClient 
         Map<String, Object> secrets = new HashMap<>();
 
         for (OracleCloudVaultClientConfiguration.OracleCloudVault vault : oracleCloudVaultClientConfiguration.getVaults()) {
-            if (LOG.isInfoEnabled()) {
-                LOG.info("Retrieving secrets from Oracle Cloud Vault with OCID: {}", vault.getOcid());
+            int retrieved = 0;
+
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Retrieving secrets from Oracle Cloud Vault with OCID: {}", vault.getOcid());
             }
             List<ListSecretsResponse> responses = new ArrayList<>();
             ListSecretsRequest listSecretsRequest = buildRequest(
@@ -154,6 +156,7 @@ public class OracleCloudVaultConfigurationClient implements ConfigurationClient 
             }
 
             for (ListSecretsResponse response : responses) {
+                retrieved += response.getItems().size();
                 response.getItems().forEach((summary) -> {
                     String secretValue = getSecretValue(summary.getId());
                     secrets.put(
@@ -161,6 +164,9 @@ public class OracleCloudVaultConfigurationClient implements ConfigurationClient 
                             secretValue
                     );
                 });
+            }
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("{} secrets where retrieved from Oracle Cloud Vault with OCID: {}", retrieved, vault.getOcid());
             }
         }
 

--- a/discovery-client/src/main/java/io/micronaut/discovery/oraclecloud/vault/config/OracleCloudVaultConfigurationClient.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/oraclecloud/vault/config/OracleCloudVaultConfigurationClient.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.discovery.oraclecloud.vault.config;
+
+import com.oracle.bmc.Region;
+import com.oracle.bmc.auth.BasicAuthenticationDetailsProvider;
+import com.oracle.bmc.auth.ConfigFileAuthenticationDetailsProvider;
+import com.oracle.bmc.auth.InstancePrincipalsAuthenticationDetailsProvider;
+import com.oracle.bmc.secrets.SecretsClient;
+import com.oracle.bmc.vault.VaultsClient;
+import com.oracle.bmc.vault.requests.ListSecretsRequest;
+import com.oracle.bmc.vault.responses.ListSecretsResponse;
+import io.micronaut.context.annotation.BootstrapContextCompatible;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.env.Environment;
+import io.micronaut.context.env.PropertySource;
+import io.micronaut.discovery.config.ConfigurationClient;
+import io.micronaut.runtime.ApplicationConfiguration;
+import io.micronaut.scheduling.TaskExecutors;
+import io.reactivex.Flowable;
+import io.reactivex.Scheduler;
+import io.reactivex.schedulers.Schedulers;
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+
+/**
+ *  A {@link ConfigurationClient} for Oracle Cloud Vault Configuration.
+ *
+ *  @author toddsharp
+ *  @since 2.0.0
+ */
+@Singleton
+@Requires(classes = {
+        SecretsClient.class,
+        VaultsClient.class,
+        InstancePrincipalsAuthenticationDetailsProvider.class,
+        ConfigFileAuthenticationDetailsProvider.class
+})
+@BootstrapContextCompatible
+public class OracleCloudVaultConfigurationClient implements ConfigurationClient {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OracleCloudVaultConfigurationClient.class);
+
+    private final OracleCloudVaultClientConfiguration oracleCloudVaultClientConfiguration;
+    private final ApplicationConfiguration applicationConfiguration;
+    private final ExecutorService executorService;
+    private final SecretsClient secretsClient;
+    private final VaultsClient vaultsClient;
+
+    /**
+     * Default Constructor.
+     *
+     * @param oracleCloudVaultClientConfiguration   Oracle CloudVault Client Configuration
+     * @param applicationConfiguration              The application configuration
+     * @param executorService                       Executor Service
+     */
+    public OracleCloudVaultConfigurationClient(OracleCloudVaultClientConfiguration oracleCloudVaultClientConfiguration,
+                                    ApplicationConfiguration applicationConfiguration,
+                                    @Named(TaskExecutors.IO) @Nullable ExecutorService executorService) throws Exception {
+        this.oracleCloudVaultClientConfiguration = oracleCloudVaultClientConfiguration;
+        this.applicationConfiguration = applicationConfiguration;
+        this.executorService = executorService;
+
+        BasicAuthenticationDetailsProvider provider = null;
+        if( oracleCloudVaultClientConfiguration.isUseInstancePrincipal() ) {
+            provider = InstancePrincipalsAuthenticationDetailsProvider.builder().build();
+        } else {
+            try {
+                provider = new ConfigFileAuthenticationDetailsProvider(oracleCloudVaultClientConfiguration.getPathToConfig(), oracleCloudVaultClientConfiguration.getProfile());
+            }
+            catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        Region region = Region.fromRegionCodeOrId(oracleCloudVaultClientConfiguration.getRegion());
+        if (provider != null) {
+            secretsClient = SecretsClient.builder().region(region).build(provider);
+            vaultsClient = VaultsClient.builder().region(region).build(provider);
+        } else {
+            throw new Exception("You must use instance principal auth or config file auth with the Oracle Cloud Vault Client");
+        }
+    }
+
+    @Override
+    public Publisher<PropertySource> getPropertySources(Environment environment) {
+        if (!oracleCloudVaultClientConfiguration.getDiscoveryConfiguration().isEnabled()) {
+            return Flowable.empty();
+        }
+
+        final String applicationName = applicationConfiguration.getName().orElse(null);
+        final Set<String> activeNames = environment.getActiveNames();
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Oracle Cloud Vault OCIDs: {}, Using Instance Principals: {}, Path To Config: {}, Profile: {}, Region: {}",
+                    oracleCloudVaultClientConfiguration.getVaults(),
+                    oracleCloudVaultClientConfiguration.isUseInstancePrincipal(),
+                    oracleCloudVaultClientConfiguration.getPathToConfig(),
+                    oracleCloudVaultClientConfiguration.getProfile(),
+                    oracleCloudVaultClientConfiguration.getRegion());
+            LOG.debug("Application name: {}, application profiles: {}", applicationName, activeNames);
+        }
+
+        List<Flowable<PropertySource>> propertySources = new ArrayList<>();
+        Scheduler scheduler = executorService != null ? Schedulers.from(executorService) : null;
+
+        for (OracleCloudVaultClientConfiguration.OracleCloudVault vault : oracleCloudVaultClientConfiguration.getVaults()) {
+            LOG.info("Working with OCID: " + vault.getOcid());
+            ListSecretsRequest listSecretsRequest = ListSecretsRequest.builder()
+                    .vaultId(vault.getOcid())
+                    .compartmentId(vault.getCompartmentOcid())
+                    .build();
+            ListSecretsResponse listSecretsResponse = vaultsClient.listSecrets(listSecretsRequest);
+            listSecretsResponse.getItems().forEach( (summary) -> {
+                System.out.println(summary.getSecretName());
+            });
+        }
+
+        /*
+        buildVaultKeys(applicationName, activeNames).entrySet().forEach(entry -> {
+            Flowable<PropertySource> propertySourceFlowable = Flowable.fromPublisher(
+                    configHttpClient.readConfigurationValues(token, engine, entry.getValue()))
+                    .filter(data -> !data.getSecrets().isEmpty())
+                    .map(data -> PropertySource.of(entry.getValue(), data.getSecrets(), entry.getKey()))
+                    .onErrorResumeNext(throwable -> {
+                        //TODO: Discover why the below hack is necessary
+                        Throwable t = (Throwable) throwable;
+                        if (t instanceof HttpClientResponseException) {
+                            if (((HttpClientResponseException) t).getStatus() == HttpStatus.NOT_FOUND) {
+                                if (vaultClientConfiguration.isFailFast()) {
+                                    return Flowable.error(new ConfigurationException(
+                                            "Could not locate PropertySource and the fail fast property is set", t));
+                                }
+                            }
+                            return Flowable.empty();
+                        }
+                        return Flowable.error(new ConfigurationException("Error reading distributed configuration from Vault: " + t.getMessage(), t));
+                    });
+            if (scheduler != null) {
+                propertySourceFlowable = propertySourceFlowable.subscribeOn(scheduler);
+            }
+            propertySources.add(propertySourceFlowable);
+        });
+        */
+        return Flowable.merge(propertySources);
+    }
+
+    @Override
+    public String getDescription() {
+        return "Retrieves secrets from Oracle Cloud vaults";
+    }
+}

--- a/discovery-client/src/main/java/io/micronaut/discovery/oraclecloud/vault/config/package-info.java
+++ b/discovery-client/src/main/java/io/micronaut/discovery/oraclecloud/vault/config/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ *  Classes related to using Oracle Cloud Vault as a distributed configuration client.
+ *
+ *  @author toddsharp
+ *  @since 2.0.0
+ */
+@Requires(property = ConfigurationClient.ENABLED, value = "true", defaultValue = "false")
+@Requires(property = OracleCloudVaultClientConfiguration.PREFIX + "." + ConfigDiscoveryConfiguration.PREFIX + ".enabled", value = "true")
+@Configuration
+package io.micronaut.discovery.oraclecloud.vault.config;
+
+import io.micronaut.context.annotation.Configuration;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.discovery.config.ConfigDiscoveryConfiguration;
+import io.micronaut.discovery.config.ConfigurationClient;

--- a/discovery-client/src/test/groovy/io/micronaut/discovery/oraclecloud/VaultConfigurationTest.groovy
+++ b/discovery-client/src/test/groovy/io/micronaut/discovery/oraclecloud/VaultConfigurationTest.groovy
@@ -1,0 +1,29 @@
+package io.micronaut.discovery.oraclecloud
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.discovery.oraclecloud.vault.config.OracleCloudVaultClientConfiguration
+import spock.lang.Specification
+
+class VaultConfigurationTest extends Specification {
+
+    void testConfig() {
+        ApplicationContext ctx = ApplicationContext.run([
+                'micronaut.config-client.enabled': true,
+                'oraclecloud.vault.config.enabled': true,
+                'oraclecloud.vault.vaults': [
+                        ['ocid': 'ocid1.vault.oc1.phx....',
+                         'compartment-ocid': 'ocid1.compartment.oc1....']
+                ]]);
+        OracleCloudVaultClientConfiguration config = ctx.getBean(OracleCloudVaultClientConfiguration.class)
+
+        expect:
+        1 == config.getVaults().size()
+        "ocid1.vault.oc1.phx...." == config.getVaults().get(0).getOcid()
+        "ocid1.compartment.oc1...." == config.getVaults().get(0).getCompartmentOcid()
+
+        cleanup:
+        ctx.close()
+    }
+}
+
+

--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
@@ -96,7 +96,6 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
         });
     }
 
-
     /**
      * Construct a new ApplicationContext for the given environment name and classloader.
      *
@@ -235,10 +234,9 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
                                     prefix.substring(0, prefix.length() - (isList ? 3 : 2)))
                             .orElseGet(() -> candidate.stringValue(EachProperty.class).orElse(null));
                     String primaryPrefix = candidate.stringValue(EachProperty.class, "primary").orElse(null);
-
                     if (StringUtils.isNotEmpty(property)) {
                         if (isList) {
-                            List entries = environment.getProperty(property, List.class, Collections.emptyList());
+                            List entries = getEnvironment().getProperty(property, List.class, Collections.emptyList());
                             if (!entries.isEmpty()) {
                                 for (int i = 0; i < entries.size(); i++) {
                                     if (entries.get(i) != null) {
@@ -257,7 +255,7 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
                                 }
                             }
                         } else {
-                            Collection<String> propertyEntries = environment.getPropertyEntries(property);
+                            Collection<String> propertyEntries = this.environment.getPropertyEntries(property);
                             if (!propertyEntries.isEmpty()) {
                                 for (String key : propertyEntries) {
                                     BeanDefinitionDelegate delegate = BeanDefinitionDelegate.create(candidate);

--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
@@ -255,7 +255,7 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
                                 }
                             }
                         } else {
-                            Collection<String> propertyEntries = this.environment.getPropertyEntries(property);
+                            Collection<String> propertyEntries = getEnvironment().getPropertyEntries(property);
                             if (!propertyEntries.isEmpty()) {
                                 for (String key : propertyEntries) {
                                     BeanDefinitionDelegate delegate = BeanDefinitionDelegate.create(candidate);

--- a/src/main/docs/guide/cloud/cloudConfiguration/distributedConfigurationOracleCloudVault.adoc
+++ b/src/main/docs/guide/cloud/cloudConfiguration/distributedConfigurationOracleCloudVault.adoc
@@ -1,0 +1,156 @@
+Micronaut supports loading configuration values stored in Oracle Cloud Vaults. To use this feature, add the following dependencies:
+
+.Example `build.gradle` for Oracle Cloud Vault
+[source,groovy]
+----
+compile "io.micronaut:micronaut-discovery-client"
+compile group: 'com.oracle.oci.sdk', name: 'oci-java-sdk-vault', version: '1.15.4'
+compile group: 'com.oracle.oci.sdk', name: 'oci-java-sdk-secrets', version: '1.15.4'
+compile group: 'com.oracle.oci.sdk', name: 'oci-java-sdk-common', version: '1.15.4'
+----
+
+To enable distributed configuration a `src/main/resources/bootstrap.yml` configuration file must be created and configured to use one or more Oracle Cloud Vaults:
+
+.bootstrap.yml
+[source,yaml]
+----
+micronaut:
+  application:
+    name: vault-test
+  config-client:
+    enabled: true
+oraclecloud:
+  vault:
+    config:
+      enabled: true
+    vaults:
+      - ocid: ocid1.vault.oc1.phx...
+        compartment-ocid: ocid1.compartment.oc1...
+    use-instance-principal: false
+    path-to-config: ~/.oci/config
+    profile: DEFAULT
+    region: US-PHOENIX-1
+----
+
+include::{includedir}configurationProperties/io.micronaut.discovery.oraclecloud.vault.config.OracleCloudVaultClientConfiguration.adoc[]
+
+NOTE: You can learn more about Oracle Cloud Vault Secrets by https://blogs.oracle.com/developers/protect-your-sensitive-data-with-secrets-in-the-oracle-cloud[reading this blog post].
+
+Each configured vault will be read and all of the secrets within the vault will be retrieved and set into configuration variables with the exact same name as the secret in the Oracle Cloud Vault.
+
+For example, if you create a secret with the name of `SECRET_ONE` in your Oracle Cloud Vault, then it will be available to use in your application like any standard configuration variable:
+
+[source,java]
+----
+@Value("${SECRET_ONE}") String secretOne
+----
+
+You can also use `@PropertyName`:
+
+[source,java]
+----
+@Property(name = "SECRET_ONE") String secretOne
+----
+
+Another option is to inject your variables in to your configuration files which gives you the ability to store things like database passwords and API keys in your vault:
+
+.application.yaml
+[source, yaml]
+----
+datasources:
+  default:
+    password: ${DB_PASSWORD}
+----
+
+Vault retrieved values are always `String`, but you can use `@ConfigurationProperties` on a bean in conjunction with your `application.yml` file to provide properly typed configuration variables.
+
+So if you where to create secrets in your Oracle Cloud Vault like so:
+
+|===
+|Name |Value
+
+|SECRET_ONE
+|Value One
+|SECRET_TWO
+|value two
+|SECRET_THREE
+|true
+|SECRET_FOUR
+|42
+|SECRET_FIVE
+|3.16
+
+|===
+
+And then added the following to your `application.yml` file:
+
+.application.yml
+[source, yaml]
+----
+secrets:
+  one: ${SECRET_ONE}
+  two: ${SECRET_TWO}
+  three: ${SECRET_THREE}
+  four: ${SECRET_FOUR}
+  five: ${SECRET_FIVE}
+----
+
+You could add a config bean like so:
+
+.Config.java
+[source, java]
+----
+@ConfigurationProperties("secrets")
+public class Config {
+    private String one;
+    private String two;
+    private boolean three;
+    private int four;
+    private Double five;
+
+    /* getters/setters removed for brevity */
+}
+----
+
+You could then inject and use this bean in your application with properly typed values.
+
+.HelloController.java
+[source, java]
+----
+@Controller("/hello")
+public class HelloController {
+
+    private Config config;
+
+    public HelloController(
+            Config config
+    ) {
+        this.config = config;
+    }
+
+    @Get("/")
+    public HttpStatus index() {
+        return HttpStatus.OK;
+    }
+
+    @Get("/secret")
+    public HttpResponse getSecret() {
+        return HttpResponse.ok(config);
+    }
+}
+----
+
+Calling the `/hello/secret` endpoint would return:
+
+[source, json]
+----
+{
+  "one": "Value One",
+  "two": "value two",
+  "three": true,
+  "four": 42,
+  "five": 3.16
+}
+----
+
+TIP: If you need support for different configurations per environment, you can create an environment specific `bootstrap.yml` file and utilize a different vault(s) configuration per environment.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -144,6 +144,7 @@ cloud:
     distributedConfigurationVault: HashiCorp Vault Support
     distributedConfigurationSpringCloud: Spring Cloud Config Support
     distributedConfigurationAwsParameterStore: AWS Parameter Store Support
+    distributedConfigurationOracleCloudVault: Oracle Cloud Vault Support
   serviceDiscovery:
     title: Service Discovery
     serviceDiscoveryConsul: Consul Support


### PR DESCRIPTION
This feature adds support for Oracle Cloud Vault. Users can define a list of vaults in `bootstrap.yml` and each vault will be listed and the secrets within them retrieved and set in to configuration variables in the application. The feature 