### PR TITLE
Fix #2066 - Add support for native transport channel options

### DIFF
--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/DefaultEventLoopGroupFactory.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/DefaultEventLoopGroupFactory.java
@@ -28,6 +28,7 @@ import io.netty.channel.socket.SocketChannel;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
+
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadFactory;
 
@@ -106,7 +107,6 @@ public class DefaultEventLoopGroupFactory implements EventLoopGroupFactory {
         } else {
             return this.defaultFactory.serverSocketChannelClass(configuration);
         }
-
     }
 
     @NonNull
@@ -118,4 +118,5 @@ public class DefaultEventLoopGroupFactory implements EventLoopGroupFactory {
             return this.defaultFactory.clientSocketChannelClass(configuration);
         }
     }
+
 }

--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/EpollAvailabilityCondition.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/EpollAvailabilityCondition.java
@@ -23,18 +23,19 @@ import io.netty.channel.epoll.Epoll;
 
 /**
  * Checks if epoll is available.
- * 
+ *
  * @author croudet
  */
 @Internal
-class EpollAvailabilityCondition implements Condition {
+public class EpollAvailabilityCondition implements Condition {
 
     /**
      * Checks if netty's epoll native transport is available.
-     * 
+     *
      * @param context The ConditionContext.
      * @return true if the epoll native transport is available.
      */
+    @Override
     public boolean matches(ConditionContext context) {
         return Epoll.isAvailable();
     }

--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/EpollEventLoopGroupFactory.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/EpollEventLoopGroupFactory.java
@@ -37,7 +37,7 @@ import io.netty.channel.socket.SocketChannel;
 
 /**
  * Factory for EpollEventLoopGroup.
- * 
+ *
  * @author croudet
  */
 @Singleton
@@ -45,11 +45,11 @@ import io.netty.channel.socket.SocketChannel;
 @Internal
 @Named(EventLoopGroupFactory.NATIVE)
 @BootstrapContextCompatible
-class EpollEventLoopGroupFactory implements EventLoopGroupFactory {
+public class EpollEventLoopGroupFactory implements EventLoopGroupFactory {
 
     /**
      * Creates an EpollEventLoopGroup.
-     * 
+     *
      * @param threads The number of threads to use.
      * @param ioRatio The io ratio.
      * @return An EpollEventLoopGroup.
@@ -61,7 +61,7 @@ class EpollEventLoopGroupFactory implements EventLoopGroupFactory {
 
     /**
      * Creates an EpollEventLoopGroup.
-     * 
+     *
      * @param threads       The number of threads to use.
      * @param threadFactory The thread factory.
      * @param ioRatio       The io ratio.
@@ -74,7 +74,7 @@ class EpollEventLoopGroupFactory implements EventLoopGroupFactory {
 
     /**
      * Creates an EpollEventLoopGroup.
-     * 
+     *
      * @param threads  The number of threads to use.
      * @param executor An Executor.
      * @param ioRatio  The io ratio.
@@ -87,7 +87,7 @@ class EpollEventLoopGroupFactory implements EventLoopGroupFactory {
 
     /**
      * Creates a default EpollEventLoopGroup.
-     * 
+     *
      * @param ioRatio The io ratio.
      * @return An EpollEventLoopGroup.
      */
@@ -98,9 +98,10 @@ class EpollEventLoopGroupFactory implements EventLoopGroupFactory {
 
     /**
      * Returns the server channel class.
-     * 
+     *
      * @return EpollServerSocketChannel.
      */
+    @Override
     public Class<? extends ServerSocketChannel> serverSocketChannelClass() {
         return EpollServerSocketChannel.class;
     }
@@ -115,4 +116,5 @@ class EpollEventLoopGroupFactory implements EventLoopGroupFactory {
     public boolean isNative() {
         return true;
     }
+
 }

--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/EventLoopGroupFactory.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/EventLoopGroupFactory.java
@@ -28,7 +28,7 @@ import io.netty.channel.socket.SocketChannel;
 
 /**
  * Factory for EventLoopGroup.
- * 
+ *
  * @author croudet
  * @author graemerocher
  * @since 1.2.0
@@ -106,7 +106,7 @@ public interface EventLoopGroupFactory {
 
     /**
      * Creates a default EventLoopGroup.
-     * 
+     *
      * @param ioRatio The io ratio.
      * @return An EventLoopGroup.
      * @deprecated Use {@link #createEventLoopGroup(EventLoopGroupConfiguration, ThreadFactory)} instead
@@ -118,7 +118,7 @@ public interface EventLoopGroupFactory {
 
     /**
      * Returns the server channel class.
-     * 
+     *
      * @return A ServerChannelClass.
      */
     @NonNull Class<? extends ServerSocketChannel> serverSocketChannelClass();
@@ -140,4 +140,5 @@ public interface EventLoopGroupFactory {
      * @return A SocketChannel.
      */
     @NonNull Class<? extends SocketChannel> clientSocketChannelClass(@Nullable EventLoopGroupConfiguration configuration);
+
 }

--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/KQueueAvailabilityCondition.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/KQueueAvailabilityCondition.java
@@ -23,18 +23,19 @@ import io.netty.channel.kqueue.KQueue;
 
 /**
  * Checks if kqueue is available.
- * 
+ *
  * @author croudet
  */
 @Internal
-class KQueueAvailabilityCondition implements Condition {
+public class KQueueAvailabilityCondition implements Condition {
 
     /**
      * Checks if netty's kqueue native transport is available.
-     * 
+     *
      * @param context The ConditionContext.
      * @return true if the kqueue native transport is available.
      */
+    @Override
     public boolean matches(ConditionContext context) {
         return KQueue.isAvailable();
     }

--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/KQueueEventLoopGroupFactory.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/KQueueEventLoopGroupFactory.java
@@ -30,12 +30,13 @@ import io.netty.channel.socket.SocketChannel;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
+
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadFactory;
 
 /**
  * Factory for KQueueEventLoopGroup.
- * 
+ *
  * @author croudet
  */
 @Singleton
@@ -104,6 +105,7 @@ class KQueueEventLoopGroupFactory implements EventLoopGroupFactory {
      *
      * @return KQueueServerSocketChannel.
      */
+    @Override
     public Class<? extends ServerSocketChannel> serverSocketChannelClass() {
         return KQueueServerSocketChannel.class;
     }
@@ -120,4 +122,5 @@ class KQueueEventLoopGroupFactory implements EventLoopGroupFactory {
         }
         return group;
     }
+
 }

--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/NioEventLoopGroupFactory.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/NioEventLoopGroupFactory.java
@@ -32,7 +32,7 @@ import java.util.concurrent.ThreadFactory;
 
 /**
  * Factory for NioEventLoopGroup.
- * 
+ *
  * @author croudet
  */
 @Internal
@@ -94,6 +94,7 @@ public class NioEventLoopGroupFactory implements EventLoopGroupFactory {
      *
      * @return NioServerSocketChannel.
      */
+    @Override
     public Class<? extends ServerSocketChannel> serverSocketChannelClass() {
         return NioServerSocketChannel.class;
     }

--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/converters/ChannelOptionFactory.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/converters/ChannelOptionFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.netty.channel.converters;
+
+import io.micronaut.context.env.Environment;
+import io.micronaut.core.annotation.Internal;
+import io.netty.channel.ChannelOption;
+
+/**
+ * Creates channel options.
+ * @author croudet
+ */
+@Internal
+public interface ChannelOptionFactory {
+
+    /**
+     * Creates a channel options.
+     * @param name The name of the option.
+     * @return A channel option.
+     */
+    default ChannelOption<?> channelOption(String name) {
+        return ChannelOption.valueOf(name);
+    }
+
+    /**
+     * Converts the specified value given the channel option type.
+     * @param option The channel option.
+     * @param value The value to convert.
+     * @param env The environment use for the conversion.
+     * @return The converted value.
+     */
+    default Object convertValue(ChannelOption<?> option, Object value, Environment env) {
+        return DefaultChannelOptionFactory.convertValue(option, ChannelOption.class, value, env);
+    }
+}

--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/converters/DefaultChannelOptionFactory.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/converters/DefaultChannelOptionFactory.java
@@ -23,6 +23,7 @@ import javax.inject.Singleton;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.env.Environment;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.TypeHint;
 import io.micronaut.core.reflect.GenericTypeUtils;
 import io.micronaut.core.reflect.ReflectionUtils;
 import io.netty.channel.ChannelOption;
@@ -34,6 +35,7 @@ import io.netty.channel.ChannelOption;
 @Internal
 @Requires(missingBeans = { EpollChannelOptionFactory.class, KQueueChannelOptionFactory.class })
 @Singleton
+@TypeHint(value = ChannelOption.class, accessType = TypeHint.AccessType.ALL_DECLARED_FIELDS)
 public class DefaultChannelOptionFactory implements ChannelOptionFactory {
 
     private static Object processChannelOptionValue(Class<? extends ChannelOption> cls, String name, Object value, Environment env) {

--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/converters/DefaultChannelOptionFactory.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/converters/DefaultChannelOptionFactory.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.netty.channel.converters;
+
+import java.lang.reflect.Field;
+import java.util.Optional;
+
+import javax.inject.Singleton;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.env.Environment;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.reflect.GenericTypeUtils;
+import io.micronaut.core.reflect.ReflectionUtils;
+import io.netty.channel.ChannelOption;
+
+/**
+ * Creates channel options.
+ * @author croudet
+ */
+@Internal
+@Requires(missingBeans = { EpollChannelOptionFactory.class, KQueueChannelOptionFactory.class })
+@Singleton
+public class DefaultChannelOptionFactory implements ChannelOptionFactory {
+
+    private static Object processChannelOptionValue(Class<? extends ChannelOption> cls, String name, Object value, Environment env) {
+        Optional<Field> declaredField = ReflectionUtils.findField(cls, name);
+        if (declaredField.isPresent()) {
+            Optional<Class> typeArg = GenericTypeUtils.resolveGenericTypeArgument(declaredField.get());
+            if (typeArg.isPresent()) {
+                Optional<Object> converted = env.convert(value, typeArg.get());
+                value = converted.orElse(value);
+            }
+        }
+        return value;
+    }
+
+    /**
+     * Process a channel option value.
+     * @param option The channel option.
+     * @param cls The channel option type.
+     * @param value The value to convert.
+     * @param env The environment use to convert the value.
+     * @return The converted value.
+     */
+    static Object convertValue(ChannelOption<?> option, Class<? extends ChannelOption> cls, Object value, Environment env) {
+        final String name = option.name();
+        if (ChannelOption.exists(name)) {
+            int idx = name.lastIndexOf('#');
+            final String optionName;
+            if (idx > 0 && idx < name.length() - 1) {
+                // a composed name
+                optionName = name.substring(idx);
+            } else {
+                // A simple name
+                optionName = name;
+            }
+            return processChannelOptionValue(cls, optionName, value, env);
+        } else {
+            // Unknown option
+            return value;
+        }
+    }
+
+    /**
+     * Creates a channel options.
+     * @param name The name of the option.
+     * @param classes The classes to check.
+     * @return A channel option.
+     */
+    static ChannelOption<?> channelOption(String name, Class<?>... classes) {
+        for (Class<?> cls: classes) {
+            final String composedName = cls.getName() + '#' + name;
+            if (ChannelOption.exists(composedName)) {
+                return ChannelOption.valueOf(composedName);
+            }
+        }
+        return ChannelOption.valueOf(name);
+    }
+}

--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/converters/EpollChannelOptionFactory.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/converters/EpollChannelOptionFactory.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.netty.channel.converters;
+
+import javax.inject.Singleton;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.env.Environment;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.http.netty.channel.EpollAvailabilityCondition;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.epoll.Epoll;
+import io.netty.channel.epoll.EpollChannelOption;
+import io.netty.channel.unix.UnixChannelOption;
+
+/**
+ * Creates channel options.
+ * @author croudet
+ */
+@Internal
+@Singleton
+@Requires(classes = Epoll.class, condition = EpollAvailabilityCondition.class)
+public class EpollChannelOptionFactory implements ChannelOptionFactory {
+
+    static {
+        // force loading the class for the channelOption to work
+        EpollChannelOption.EPOLL_MODE.name();
+    }
+
+    @Override
+    public ChannelOption<?> channelOption(String name) {
+        return DefaultChannelOptionFactory.channelOption(name, EpollChannelOption.class, UnixChannelOption.class);
+    }
+
+    @Override
+    public Object convertValue(ChannelOption<?> option, Object value, Environment env) {
+        return DefaultChannelOptionFactory.convertValue(option, EpollChannelOption.class, value, env);
+    }
+
+}

--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/converters/EpollChannelOptionFactory.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/converters/EpollChannelOptionFactory.java
@@ -20,6 +20,7 @@ import javax.inject.Singleton;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.env.Environment;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.TypeHint;
 import io.micronaut.http.netty.channel.EpollAvailabilityCondition;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.epoll.Epoll;
@@ -33,6 +34,7 @@ import io.netty.channel.unix.UnixChannelOption;
 @Internal
 @Singleton
 @Requires(classes = Epoll.class, condition = EpollAvailabilityCondition.class)
+@TypeHint(value = EpollChannelOption.class, accessType = TypeHint.AccessType.ALL_DECLARED_FIELDS)
 public class EpollChannelOptionFactory implements ChannelOptionFactory {
 
     static {

--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/converters/KQueueChannelOptionFactory.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/converters/KQueueChannelOptionFactory.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.netty.channel.converters;
+
+import java.util.Map;
+import java.util.Optional;
+
+import javax.inject.Singleton;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.env.Environment;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.convert.TypeConverterRegistrar;
+import io.micronaut.http.netty.channel.KQueueAvailabilityCondition;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.kqueue.AcceptFilter;
+import io.netty.channel.kqueue.KQueue;
+import io.netty.channel.kqueue.KQueueChannelOption;
+import io.netty.channel.unix.UnixChannelOption;
+
+/**
+ * Creates channel options.
+ * @author croudet
+ */
+@Internal
+@Singleton
+@Requires(classes = KQueue.class, condition = KQueueAvailabilityCondition.class)
+public class KQueueChannelOptionFactory implements ChannelOptionFactory, TypeConverterRegistrar {
+
+    static {
+        // force loading the class for the channelOption to work
+        KQueueChannelOption.SO_ACCEPTFILTER.name();
+    }
+
+    @Override
+    public ChannelOption<?> channelOption(String name) {
+        return DefaultChannelOptionFactory.channelOption(name, KQueueChannelOption.class, UnixChannelOption.class);
+    }
+
+    @Override
+    public Object convertValue(ChannelOption<?> option, Object value, Environment env) {
+        return DefaultChannelOptionFactory.convertValue(option, KQueueChannelOption.class, value, env);
+    }
+
+    @Override
+    public void register(ConversionService<?> conversionService) {
+        conversionService.addConverter(
+                Map.class,
+                AcceptFilter.class,
+                (map, targetType, context) -> {
+                    Object filterName = map.get("filterName");
+                    Object filterArgs = map.get("filterArgs");
+                    if (filterName != null && filterArgs != null) {
+                        return Optional.of(new AcceptFilter(filterName.toString(), filterArgs.toString()));
+                    }
+                    return Optional.empty();
+                }
+        );
+    }
+}

--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/converters/KQueueChannelOptionFactory.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/converters/KQueueChannelOptionFactory.java
@@ -23,6 +23,7 @@ import javax.inject.Singleton;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.env.Environment;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.TypeHint;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.TypeConverterRegistrar;
 import io.micronaut.http.netty.channel.KQueueAvailabilityCondition;
@@ -39,6 +40,7 @@ import io.netty.channel.unix.UnixChannelOption;
 @Internal
 @Singleton
 @Requires(classes = KQueue.class, condition = KQueueAvailabilityCondition.class)
+@TypeHint(value = KQueueChannelOption.class, accessType = TypeHint.AccessType.ALL_DECLARED_FIELDS)
 public class KQueueChannelOptionFactory implements ChannelOptionFactory, TypeConverterRegistrar {
 
     static {

--- a/http-server-netty/build.gradle
+++ b/http-server-netty/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     testImplementation dependencyVersion("rxjava2")
     testImplementation(dependencyModuleVersion("netty", "netty-transport-native-epoll") + ":linux-x86_64")
     testImplementation(dependencyModuleVersion("netty", "netty-transport-native-kqueue") + ":osx-x86_64")
+    testImplementation "ch.qos.logback:logback-classic:1.2.3"
 }
 
 //tasks.withType(Test) {

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/configuration/NettyHttpServerConfiguration.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/configuration/NettyHttpServerConfiguration.java
@@ -483,6 +483,7 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
         /**
          * @return The I/O ratio to use
          */
+        @Override
         public Optional<Integer> getIoRatio() {
             if (ioRatio != null) {
                 return Optional.of(ioRatio);
@@ -493,6 +494,7 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
         /**
          * @return The name of the configured executor to use
          */
+        @Override
         public Optional<String> getExecutorName() {
             if (executor != null) {
                 return Optional.of(executor);

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/configuration/NettyHttpServerConfigurationSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/configuration/NettyHttpServerConfigurationSpec.groovy
@@ -15,18 +15,44 @@
  */
 package io.micronaut.http.server.netty.configuration
 
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.AppenderBase
+import java.util.ArrayList
+import java.util.List
+
+import org.slf4j.LoggerFactory
+
 import io.micronaut.http.server.HttpServerConfiguration
+import io.netty.bootstrap.ServerBootstrap
 import io.netty.channel.ChannelOption
+import io.netty.channel.epoll.Epoll
+import io.netty.channel.epoll.EpollChannelOption
+import io.netty.channel.epoll.EpollServerSocketChannel
+import io.netty.channel.kqueue.KQueueChannelOption
+import io.netty.channel.unix.UnixChannelOption
+import io.netty.util.internal.logging.InternalLogger
+import io.netty.util.internal.logging.InternalLoggerFactory
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.DefaultApplicationContext
 import io.micronaut.context.env.PropertySource
 import io.micronaut.http.HttpMethod
+import io.micronaut.http.netty.channel.EpollEventLoopGroupFactory
+import io.micronaut.http.netty.channel.EventLoopGroupFactory
+import io.micronaut.http.netty.channel.converters.ChannelOptionFactory
+import io.micronaut.http.netty.channel.converters.DefaultChannelOptionFactory
+import io.micronaut.http.netty.channel.converters.EpollChannelOptionFactory
+import io.micronaut.http.netty.channel.converters.KQueueChannelOptionFactory
 import io.micronaut.http.server.cors.CorsOriginConfiguration
 import io.micronaut.http.server.netty.NettyHttpServer
+import io.micronaut.http.server.types.files.SystemFile
+import spock.lang.IgnoreIf
 import spock.lang.Specification
 import spock.lang.Unroll
 
 import java.time.Duration
+import java.util.AbstractMap.SimpleEntry
 
 /**
  * @author Graeme Rocher
@@ -57,11 +83,118 @@ class NettyHttpServerConfigurationSpec extends Specification {
         'idle-timeout'       | 'idleTimeout'      | '-1s' | Duration.ofSeconds(-1)
     }
 
-    void "test netty server use native transport"() {
+    void "test netty server epoll native channel option conversion"() {
+        given:
+        ChannelOptionFactory epollChannelOptionFactory = new EpollChannelOptionFactory()
+
+        when:
+        ChannelOption option = epollChannelOptionFactory.channelOption("TCP_QUICKACK")
+
+        then:
+        option == EpollChannelOption.TCP_QUICKACK
+
+        when:
+        option = epollChannelOptionFactory.channelOption("SO_BACKLOG")
+
+        then:
+        option == ChannelOption.SO_BACKLOG
+
+        when:
+        option = epollChannelOptionFactory.channelOption("DOMAIN_SOCKET_READ_MODE")
+
+        then:
+        option == UnixChannelOption.DOMAIN_SOCKET_READ_MODE
+
+        when:
+        option = epollChannelOptionFactory.channelOption("SO_SNDLOWAT")
+
+        then:
+        option != KQueueChannelOption.SO_SNDLOWAT
+
+        when:
+        option = epollChannelOptionFactory.channelOption("WRITE_BUFFER_WATER_MARK")
+
+        then:
+        option == ChannelOption.WRITE_BUFFER_WATER_MARK
+    }
+
+    void "test netty server kqueue native channel option conversion"() {
+        given:
+        ChannelOptionFactory kqueueChannelOptionFactory = new KQueueChannelOptionFactory()
+
+        when:
+        ChannelOption option = kqueueChannelOptionFactory.channelOption("TCP_QUICKACK")
+
+        then:
+        option != EpollChannelOption.TCP_QUICKACK
+
+        when:
+        option = kqueueChannelOptionFactory.channelOption("SO_BACKLOG")
+
+        then:
+        option == ChannelOption.SO_BACKLOG
+
+        when:
+        option = kqueueChannelOptionFactory.channelOption("DOMAIN_SOCKET_READ_MODE")
+
+        then:
+        option == UnixChannelOption.DOMAIN_SOCKET_READ_MODE
+
+        when:
+        option = kqueueChannelOptionFactory.channelOption("SO_SNDLOWAT")
+
+        then:
+        option == KQueueChannelOption.SO_SNDLOWAT
+
+        when:
+        option = kqueueChannelOptionFactory.channelOption("WRITE_BUFFER_WATER_MARK")
+
+        then:
+        option == ChannelOption.WRITE_BUFFER_WATER_MARK
+    }
+
+    void "test netty server default channel option conversion"() {
+        given:
+        ChannelOptionFactory channelOptionFactory = new DefaultChannelOptionFactory()
+
+        when:
+        ChannelOption option = channelOptionFactory.channelOption("TCP_QUICKACK")
+
+        then:
+        option != EpollChannelOption.TCP_QUICKACK
+
+        when:
+        option = channelOptionFactory.channelOption("SO_BACKLOG")
+
+        then:
+        option == ChannelOption.SO_BACKLOG
+
+        when:
+        option = channelOptionFactory.channelOption("DOMAIN_SOCKET_READ_MODE")
+
+        then:
+        option != UnixChannelOption.DOMAIN_SOCKET_READ_MODE
+
+        when:
+        option = channelOptionFactory.channelOption("SO_SNDLOWAT")
+
+        then:
+        option != KQueueChannelOption.SO_SNDLOWAT
+
+        when:
+        option = channelOptionFactory.channelOption("WRITE_BUFFER_WATER_MARK")
+
+        then:
+        option == ChannelOption.WRITE_BUFFER_WATER_MARK
+    }
+
+    @IgnoreIf({ ! Epoll.isAvailable() })
+    void "test netty server use native transport configuration"() {
         given:
         ApplicationContext beanContext = new DefaultApplicationContext("test")
         beanContext.environment.addPropertySource(PropertySource.of("test",
-              ['micronaut.server.netty.use-native-transport': true]
+              ['micronaut.server.netty.use-native-transport': true,
+               'micronaut.server.netty.childOptions.tcpQuickack': true]
 
         ))
         beanContext.start()
@@ -71,8 +204,72 @@ class NettyHttpServerConfigurationSpec extends Specification {
 
         then:
         config.useNativeTransport
+        config.childOptions.size() == 1
+
+        when:
+        def option = config.childOptions.keySet().first()
+
+        then:
+        option == EpollChannelOption.TCP_QUICKACK
 
         cleanup:
+        beanContext.close()
+    }
+
+    @IgnoreIf({ ! Epoll.isAvailable() })
+    void "test netty server use native transport"() {
+        given:
+        InternalLogger logger = InternalLoggerFactory.getInstance(ServerBootstrap.class)
+        MemoryAppender appender = new MemoryAppender()
+        Logger l = (Logger) LoggerFactory.getLogger(ServerBootstrap.class);
+        l.addAppender(appender);
+        appender.start()
+        ApplicationContext beanContext = new DefaultApplicationContext("test")
+        beanContext.environment.addPropertySource(PropertySource.of("test",
+              ['micronaut.server.netty.use-native-transport': true,
+               'micronaut.server.netty.childOptions.tcpQuickack': true]
+
+        ))
+        beanContext.start()
+
+        when:
+        NettyHttpServerConfiguration config = beanContext.getBean(NettyHttpServerConfiguration)
+        EventLoopGroupFactory eventLoopGroupFactory = beanContext.getBean(EventLoopGroupFactory)
+
+        then:
+        config.useNativeTransport
+        config.childOptions.size() == 1
+
+        when:
+        def option = config.childOptions.keySet().first()
+
+        then:
+        option == EpollChannelOption.TCP_QUICKACK
+        eventLoopGroupFactory.serverSocketChannelClass() == EpollServerSocketChannel.class
+
+        when:
+        NettyHttpServer server = beanContext.getBean(NettyHttpServer)
+        server.start()
+
+        then:
+        server != null
+
+        when:
+        server.stop()
+        Thread.sleep(1000L)
+        def error = null
+        for (String message: appender.getEvents()) {
+            if (message.contains('Unknown channel option \'TCP_QUICKACK\'')) {
+                error = message
+                break
+            }
+        }
+
+        then:
+        error == null
+
+        cleanup:
+        server.stop()
         beanContext.close()
     }
 
@@ -107,7 +304,7 @@ class NettyHttpServerConfigurationSpec extends Specification {
         !config.host.isPresent()
         config.parent.numOfThreads == 8
         config.worker.numOfThreads == 8
-        
+
         then:
         NettyHttpServer server = beanContext.getBean(NettyHttpServer)
         server.start()
@@ -163,6 +360,22 @@ class NettyHttpServerConfigurationSpec extends Specification {
 
         cleanup:
         beanContext.close()
+    }
+
+}
+
+class MemoryAppender extends AppenderBase<ILoggingEvent> {
+    private final List<String> events = new ArrayList<>();
+
+    @Override
+    protected void append(ILoggingEvent e) {
+        synchronized (events) {
+            events.add(e.toString());
+        }
+    }
+
+    public List<String> getEvents() {
+        return events;
     }
 
 }

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/converters/WriteBufferWaterMarkConverterSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/converters/WriteBufferWaterMarkConverterSpec.groovy
@@ -28,10 +28,10 @@ class WriteBufferWaterMarkConverterSpec extends Specification {
         ServerBootstrap bootstrap = new ServerBootstrap()
         embeddedServer.processOptions(options, { option, val -> bootstrap.option(option, val)})
         def writeBufferWaterMark = bootstrap.config().options().get(ChannelOption.WRITE_BUFFER_WATER_MARK)
+
         expect:
         writeBufferWaterMark instanceof WriteBufferWaterMark
         writeBufferWaterMark.high == 262143
         writeBufferWaterMark.low == 65535
-
     }
 }


### PR DESCRIPTION
Options can be specified as regular options and childOptions.

Issue:  https://github.com/micronaut-projects/micronaut-core/issues/2066
alternative PR: https://github.com/micronaut-projects/micronaut-core/pull/2106