### PR TITLE
Graalvm support for the shaded version of caffeine

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -10,6 +10,8 @@ dependencies {
     api dependencyVersion("slf4j")
     api dependencyVersion("reactive.streams")
     api dependencyVersion("spotbugs")
+
+    compileOnly "org.graalvm.nativeimage:svm:$graalVersion"
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"    
 
     compileOnly "org.ow2.asm:asm-tree:$asmVersion"

--- a/core/src/main/java/io/micronaut/core/graal/CacheSubstitutions.java
+++ b/core/src/main/java/io/micronaut/core/graal/CacheSubstitutions.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.core.graal;
+
+//CHECKSTYLE:OFF
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.RecomputeFieldValue;
+import com.oracle.svm.core.annotate.TargetClass;
+
+/**
+ * Substitutions for Caffeine UnsafeRefArrayAccess.
+ */
+@TargetClass(className = "io.micronaut.caffeine.cache.UnsafeRefArrayAccess")
+final class Target_io_micronaut_caffeine_cache_UnsafeRefArrayAccess {
+    @Alias
+    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.ArrayIndexShift, declClass = Object[].class)
+    public static int REF_ELEMENT_SHIFT;
+}
+//CHECKSTYLE:ON

--- a/core/src/main/resources/META-INF/native-image/io.micronaut.core/cache-caffeiene-graal/native-image.properties
+++ b/core/src/main/resources/META-INF/native-image/io.micronaut.core/cache-caffeiene-graal/native-image.properties
@@ -1,0 +1,1 @@
+Args = -H:ReflectionConfigurationResources=${.}/reflection-config.json

--- a/core/src/main/resources/META-INF/native-image/io.micronaut.core/cache-caffeiene-graal/reflection-config.json
+++ b/core/src/main/resources/META-INF/native-image/io.micronaut.core/cache-caffeiene-graal/reflection-config.json
@@ -1,0 +1,7 @@
+[ {
+  "name" : "io.micronaut.caffeine.cache.PSW",
+  "allDeclaredConstructors" : true
+}, {
+  "name" : "io.micronaut.caffeine.cache.SSLA",
+  "allDeclaredConstructors" : true
+} ]


### PR DESCRIPTION
I talked with James about this change I did https://github.com/micronaut-projects/micronaut-cache/pull/108/commits/3067eb3077926eca21600353ef059c01cb6eba4f in micronaut-cache and we agreed on moving that to micronaut-core.

The rationale behind this change is that we're using the shaded version of Caffeine in Micronaut Core so we should add support for GraalVM for those shaded classes, meaning:
- The GraalVM substitution for `io.micronaut.caffeine.cache.UnsafeRefArrayAccess`, that only adds the graalvm native image dependency as compileOnly.
- We can't use `@TypeHint` to generate the GraalVM configuration because this goes in `micronaut-core` and can't depend on any other module. That's why I added the config files directly for the two shaded classes that we need: `io.micronaut.caffeine.cache.PSW` and `io.micronaut.caffeine.cache.SSLA`. 
- We decided to put it in micronaut-core instead of in runtime because the latter is not mandatory in all the cases.


After this is merged I'll revert the commit linked before in micronaut-cache.