### PR TITLE
Issue #3065 - TypeElementVisitor visits classes that have not the required annotation

### DIFF
--- a/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
@@ -179,7 +179,6 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
         @Override
         public Object visitType(TypeElement classElement, Object o) {
 
-
             for (LoadedVisitor visitor : visitors) {
                 final io.micronaut.inject.ast.Element resultingElement = visitor.visit(classElement, typeAnnotationMetadata);
                 if (resultingElement != null) {

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaMethodElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaMethodElement.java
@@ -93,28 +93,25 @@ class JavaMethodElement extends AbstractJavaElement implements MethodElement {
         ).toArray(ParameterElement[]::new);
     }
 
-	@Override
-	public ClassElement getDeclaringType() {
-		Element enclosingElement = executableElement.getEnclosingElement();
-		ClassElement result = declaringClass;
-		while (enclosingElement instanceof TypeElement) {
-			TypeElement te = (TypeElement) enclosingElement;
-			for (Element elt : te.getEnclosedElements()) {
-				if (!(elt instanceof ExecutableElement)) {
-					continue;
-				}
-				ExecutableElement ex = (ExecutableElement) elt;
-				if (visitorContext.getElements().overrides(executableElement, ex,
-						(TypeElement) executableElement.getEnclosingElement())) {
-					result = new JavaClassElement(te, visitorContext.getAnnotationUtils().getAnnotationMetadata(te),
-							visitorContext, declaringClass.getGenericTypeInfo());
-					break;
-				}
-			}
-			enclosingElement = visitorContext.getTypes().asElement(te.getSuperclass());
-		}
-		return result;
-	}
+    @Override
+    public ClassElement getDeclaringType() {
+        Element enclosingElement = executableElement.getEnclosingElement();
+        if (enclosingElement instanceof TypeElement) {
+            TypeElement te = (TypeElement) enclosingElement;
+            if (declaringClass.getName().equals(te.getQualifiedName().toString())) {
+                return declaringClass;
+            } else {
+                return new JavaClassElement(
+                        te,
+                        visitorContext.getAnnotationUtils().getAnnotationMetadata(te),
+                        visitorContext,
+                        declaringClass.getGenericTypeInfo()
+                );
+            }
+        } else {
+            return declaringClass;
+        }
+    }
 
     @Override
     public ClassElement getOwningType() {

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaMethodElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaMethodElement.java
@@ -93,25 +93,28 @@ class JavaMethodElement extends AbstractJavaElement implements MethodElement {
         ).toArray(ParameterElement[]::new);
     }
 
-    @Override
-    public ClassElement getDeclaringType() {
-        Element enclosingElement = executableElement.getEnclosingElement();
-        if (enclosingElement instanceof TypeElement) {
-            TypeElement te = (TypeElement) enclosingElement;
-            if (declaringClass.getName().equals(te.getQualifiedName().toString())) {
-                return declaringClass;
-            } else {
-                return new JavaClassElement(
-                        te,
-                        visitorContext.getAnnotationUtils().getAnnotationMetadata(te),
-                        visitorContext,
-                        declaringClass.getGenericTypeInfo()
-                );
-            }
-        } else {
-            return declaringClass;
-        }
-    }
+	@Override
+	public ClassElement getDeclaringType() {
+		Element enclosingElement = executableElement.getEnclosingElement();
+		ClassElement result = declaringClass;
+		while (enclosingElement instanceof TypeElement) {
+			TypeElement te = (TypeElement) enclosingElement;
+			for (Element elt : te.getEnclosedElements()) {
+				if (!(elt instanceof ExecutableElement)) {
+					continue;
+				}
+				ExecutableElement ex = (ExecutableElement) elt;
+				if (visitorContext.getElements().overrides(executableElement, ex,
+						(TypeElement) executableElement.getEnclosingElement())) {
+					result = new JavaClassElement(te, visitorContext.getAnnotationUtils().getAnnotationMetadata(te),
+							visitorContext, declaringClass.getGenericTypeInfo());
+					break;
+				}
+			}
+			enclosingElement = visitorContext.getTypes().asElement(te.getSuperclass());
+		}
+		return result;
+	}
 
     @Override
     public ClassElement getOwningType() {

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/LoadedVisitor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/LoadedVisitor.java
@@ -98,6 +98,7 @@ public class LoadedVisitor implements Ordered {
             return true;
         }
         AnnotationMetadata annotationMetadata = visitorContext.getAnnotationUtils().getAnnotationMetadata(typeElement);
+
         return annotationMetadata.hasStereotype(classAnnotation);
     }
 

--- a/inject-java/src/test/groovy/io/micronaut/visitors/AllElementsVisitor.java
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/AllElementsVisitor.java
@@ -31,7 +31,6 @@ public class AllElementsVisitor implements TypeElementVisitor<Controller, Object
     public static List<ClassElement> VISITED_CLASS_ELEMENTS = new ArrayList<>();
     public static List<MethodElement> VISITED_METHOD_ELEMENTS = new ArrayList<>();
 
-
     @Override
     public void start(VisitorContext visitorContext) {
         VISITED_ELEMENTS.clear();

--- a/inject-java/src/test/groovy/io/micronaut/visitors/ClassElementSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/ClassElementSpec.groovy
@@ -15,6 +15,7 @@
  */
 package io.micronaut.visitors
 
+import io.micronaut.http.annotation.Controller
 import io.micronaut.inject.AbstractTypeElementSpec
 import io.micronaut.inject.ast.EnumElement
 import spock.lang.IgnoreIf
@@ -23,6 +24,36 @@ import spock.util.environment.Jvm
 import java.util.function.Supplier
 
 class ClassElementSpec extends AbstractTypeElementSpec {
+
+    void "test visit inherited controller classes"() {
+        buildBeanDefinition('test.TestController', '''
+package test;
+
+import io.micronaut.http.annotation.*;
+import javax.inject.Inject;
+
+@Controller("/test")
+public class TestController extends BaseTestController {
+
+    @Get("/getMethod")
+    public String getMethod(int[] argument) {
+        return null;
+    }
+
+}
+
+class BaseTestController {
+
+    public String hello(String name) {
+        return name;
+    }
+
+}
+''')
+        expect:
+        AllElementsVisitor.VISITED_CLASS_ELEMENTS.size() == 1
+        AllElementsVisitor.VISITED_CLASS_ELEMENTS[0].hasAnnotation(Controller)
+    }
 
     void "test visit methods that take and return arrays"() {
         buildBeanDefinition('test.TestController', '''
@@ -33,12 +64,12 @@ import javax.inject.Inject;
 
 @Controller("/test")
 public class TestController {
-    
+
     @Get("/getMethod")
     public String[] getMethod(int[] argument) {
         return null;
     }
-    
+
 
 }
 ''')
@@ -60,12 +91,12 @@ import javax.inject.Inject;
 
 @Controller("/test")
 public class TestController {
-    
+
     @Get("/getMethod")
     public HttpMethod getMethod(HttpMethod argument) {
         return null;
     }
-    
+
 
 }
 ''')
@@ -88,12 +119,12 @@ import javax.inject.Inject;
 
 @Controller("/test")
 public class TestController {
-    
+
     @Get("/getMethod")
     public int getMethod(long argument) {
         return 0;
     }
-    
+
 
 }
 ''')
@@ -114,12 +145,12 @@ import javax.inject.Inject;
 
 @Controller("/test")
 public class TestController<T extends Foo> {
-    
+
     @Get("/getMethod")
     public T getMethod(T argument) {
         return null;
     }
-    
+
 
 }
 
@@ -145,12 +176,12 @@ import javax.inject.Inject;
 
 @Controller("/test")
 public class TestController implements java.util.function.Supplier<String> {
-    
+
     @Get("/getMethod")
     public String get() {
         return null;
     }
-    
+
 
 }
 
@@ -170,12 +201,12 @@ import javax.inject.Inject;
 
 @Controller("/test")
 public class TestController<T extends Foo> {
-    
+
     @Get("/getMethod")
     public T[] getMethod(T[] argument) {
         return null;
     }
-    
+
 
 }
 
@@ -200,12 +231,12 @@ import javax.inject.Inject;
 
 @Controller("/test")
 public class TestController {
-    
+
     @Get("/getMethod")
     public <T extends Foo> T getMethod(T argument) {
         return null;
     }
-    
+
 
 }
 
@@ -228,12 +259,12 @@ import javax.inject.Inject;
 
 @Controller("/test")
 public class TestController<MT extends Foo> {
-    
+
     @Get("/getMethod")
     public java.util.List<MT> getMethod(java.util.Set<MT> argument) {
         return null;
     }
-    
+
 
 }
 

--- a/inject-java/src/test/groovy/io/micronaut/visitors/ClassElementSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/ClassElementSpec.groovy
@@ -40,11 +40,59 @@ public class TestController extends BaseTestController {
         return null;
     }
 
+    @Get("/hello/annotinbase")
+    @Override
+    public String baseOverrideAnnotInBase(String name) {
+        return name;
+    }
+
+    @Get("/noannotinbase")
+    @Override
+    public String baseOverrideNoAnnotInBase(String name) {
+        return name;
+    }
+
+    @Get("/hellohello")
+    @Override
+    public String hellohello(String name) {
+        return name;
+    }
+
 }
 
-class BaseTestController {
+class BaseTestController extends Base {
 
     public String hello(String name) {
+        return name;
+    }
+
+    @Get("/base")
+    public String base(String name) {
+        return name;
+    }
+
+    public String baseOverrideAnnotInBase(String name) {
+        return name;
+    }
+
+    @Get("/noannotinbase")
+    public String baseOverrideNoAnnotInBase(String name) {
+        return name;
+    }
+
+}
+
+class Base {
+
+    public String hellohello(String name) {
+        return name;
+    }
+}
+
+class B {
+
+    @Get("/b")
+    public String b(String name) {
         return name;
     }
 
@@ -52,7 +100,8 @@ class BaseTestController {
 ''')
         expect:
         AllElementsVisitor.VISITED_CLASS_ELEMENTS.size() == 1
-        AllElementsVisitor.VISITED_CLASS_ELEMENTS[0].hasAnnotation(Controller)
+        AllElementsVisitor.VISITED_METHOD_ELEMENTS.size() == 6
+        ControllerGetVisitor.VISITED_METHOD_ELEMENTS.size() == 5
     }
 
     void "test visit methods that take and return arrays"() {

--- a/inject-java/src/test/groovy/io/micronaut/visitors/ControllerGetVisitor.java
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/ControllerGetVisitor.java
@@ -29,6 +29,13 @@ import java.util.List;
 public class ControllerGetVisitor implements TypeElementVisitor<Controller, Get> {
 
     public static List<String> VISITED_ELEMENTS = new ArrayList<>();
+    public static List<MethodElement> VISITED_METHOD_ELEMENTS = new ArrayList<>();
+
+    @Override
+    public void start(VisitorContext visitorContext) {
+        VISITED_ELEMENTS.clear();
+        VISITED_METHOD_ELEMENTS.clear();
+    }
 
     @Override
     public void visitClass(ClassElement element, VisitorContext context) {
@@ -38,6 +45,7 @@ public class ControllerGetVisitor implements TypeElementVisitor<Controller, Get>
     @Override
     public void visitMethod(MethodElement element, VisitorContext context) {
         visit(element);
+        VISITED_METHOD_ELEMENTS.add(element);
     }
 
     @Override


### PR DESCRIPTION
https://github.com/micronaut-projects/micronaut-core/issues/3065

Potential fix.
Scan enclosed elements in type hierarchy and discards method overrides.