### PR TITLE
Issue #2901 - Improve bean introspection

### DIFF
--- a/aop/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
+++ b/aop/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
@@ -291,6 +291,8 @@ public class AopProxyWriter extends AbstractClassFileWriter implements ProxyingB
         String[] interfaces = getImplementedInterfaceInternalNames();
         classWriter.visit(V1_8, ACC_SYNTHETIC, className, null, !isInterface ? superType.getInternalName() : null, interfaces);
 
+        classWriter.visitAnnotation(TYPE_GENERATED.getDescriptor(), false);
+
         classWriter.visitField(ACC_FINAL | ACC_PRIVATE, FIELD_INTERCEPTORS, FIELD_TYPE_INTERCEPTORS.getDescriptor(), null, null);
         classWriter.visitField(ACC_FINAL | ACC_PRIVATE, FIELD_PROXY_METHODS, FIELD_TYPE_PROXY_METHODS.getDescriptor(), null, null);
     }
@@ -890,6 +892,8 @@ public class AopProxyWriter extends AbstractClassFileWriter implements ProxyingB
                 null,
                 isInterface ? TYPE_OBJECT.getInternalName() : getTypeReference(targetClassFullName).getInternalName(),
                 interfaces);
+
+        proxyClassWriter.visitAnnotation(TYPE_GENERATED.getDescriptor(), false);
 
         // set $proxyMethods field
         proxyConstructorGenerator.loadThis();

--- a/core/src/main/java/io/micronaut/core/annotation/Generated.java
+++ b/core/src/main/java/io/micronaut/core/annotation/Generated.java
@@ -26,7 +26,9 @@ import java.lang.annotation.Target;
  * @author David Bidorff
  * @since 2.0
  */
-@Target({ElementType.ANNOTATION_TYPE, ElementType.TYPE})
+@Target({ElementType.PACKAGE, ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR,
+    ElementType.FIELD, ElementType.LOCAL_VARIABLE, ElementType.PARAMETER})
 @Retention(RetentionPolicy.CLASS)
 public @interface Generated {
+
 }

--- a/core/src/main/java/io/micronaut/core/annotation/Generated.java
+++ b/core/src/main/java/io/micronaut/core/annotation/Generated.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.core.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A marker annotation for methods that are generated though an annotation processor.
+ *
+ * @author David Bidorff
+ * @since 2.0
+ */
+@Target({ElementType.ANNOTATION_TYPE, ElementType.TYPE})
+@Retention(RetentionPolicy.CLASS)
+public @interface Generated {
+}

--- a/graal/src/main/java/io/micronaut/graal/reflect/GraalTypeElementVisitor.java
+++ b/graal/src/main/java/io/micronaut/graal/reflect/GraalTypeElementVisitor.java
@@ -82,6 +82,8 @@ public class GraalTypeElementVisitor implements TypeElementVisitor<Object, Objec
 
     private boolean isSubclass = getClass() != GraalTypeElementVisitor.class;
 
+    private boolean executed = false;
+
     @Override
     public int getOrder() {
         return POSITION; // allow mutation of metadata
@@ -208,8 +210,12 @@ public class GraalTypeElementVisitor implements TypeElementVisitor<Object, Objec
 
     @Override
     public final void finish(VisitorContext visitorContext) {
-        // don't do this for subclasses
-        if (!isSubclass) {
+
+        // Execute only once and never for subclasses
+        if (!executed && !isSubclass) {
+
+            executed = true;
+
             List<Map> json;
             ObjectMapper mapper = new ObjectMapper();
             ObjectWriter writer = mapper.writer(new DefaultPrettyPrinter());

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/TypeElementVisitorTransform.groovy
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/TypeElementVisitorTransform.groovy
@@ -25,6 +25,7 @@ import io.micronaut.ast.groovy.utils.PublicAbstractMethodVisitor
 import io.micronaut.ast.groovy.visitor.GroovyVisitorContext
 import io.micronaut.ast.groovy.visitor.LoadedVisitor
 import io.micronaut.core.annotation.AnnotationMetadata
+import io.micronaut.core.annotation.Generated
 import io.micronaut.core.annotation.Introspected
 import io.micronaut.core.io.service.ServiceDefinition
 import io.micronaut.core.io.service.SoftServiceLoader
@@ -63,6 +64,7 @@ import static org.codehaus.groovy.ast.ClassHelper.makeCached
 @GroovyASTTransformation(phase = CompilePhase.SEMANTIC_ANALYSIS)
 class TypeElementVisitorTransform implements ASTTransformation, CompilationUnitAware {
 
+    private static ClassNode generatedNode = new ClassNode(Generated)
     protected static Map<String, LoadedVisitor> loadedVisitors = null
     private CompilationUnit compilationUnit
 
@@ -75,7 +77,7 @@ class TypeElementVisitorTransform implements ASTTransformation, CompilationUnitA
 
         GroovyVisitorContext visitorContext = new GroovyVisitorContext(source, compilationUnit)
         for (ClassNode classNode in classes) {
-            if (!(classNode instanceof InnerClassNode && !Modifier.isStatic(classNode.getModifiers()))) {
+            if (!(classNode instanceof InnerClassNode && !Modifier.isStatic(classNode.getModifiers())) && classNode.getAnnotations(generatedNode).empty) {
                 Collection<LoadedVisitor> matchedVisitors = loadedVisitors.values().findAll { v -> v.matches(classNode) }
 
                 List<LoadedVisitor> values = new ArrayList<>(matchedVisitors)

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/CustomVisitorSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/CustomVisitorSpec.groovy
@@ -108,4 +108,34 @@ public class TestController {
         AllClassesVisitor.getVisited() == ["test.TestController", "getMethod"]
         InjectVisitor.getVisited() == ["test.TestController", "privateField"]
     }
+
+    void "test @Generated class is not visited by any visitor"() {
+        buildBeanDefinition('test.TestGenerated', '''
+package test;
+
+import io.micronaut.core.annotation.Generated
+import javax.inject.Inject
+
+@Generated
+public class TestGenerated {
+
+    @Inject private String privateField
+    protected String protectedField  
+    public String publicField
+    @groovy.transform.PackageScope String packagePrivateField
+    String property
+    
+    
+    TestGenerated(String constructorArg) {}
+    
+    void setterMethod(String method) {}
+
+}
+''')
+        expect:
+        ControllerGetVisitor.getVisited().empty
+        AllElementsVisitor.getVisited().empty
+        AllClassesVisitor.getVisited().empty
+        InjectVisitor.getVisited().empty
+    }
 }

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
@@ -19,6 +19,8 @@ import io.micronaut.annotation.processing.visitor.LoadedVisitor;
 import io.micronaut.aop.Introduction;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.Generated;
+import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.io.service.ServiceDefinition;
 import io.micronaut.core.io.service.SoftServiceLoader;
@@ -130,6 +132,7 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
         roundEnv.getRootElements()
                 .stream()
                 .filter(element -> JavaModelUtils.isClassOrInterface(element) || JavaModelUtils.isEnum(element))
+                .filter(element -> element.getAnnotation(Generated.class) == null)
                 .map(modelUtils::classElementFor)
                 .filter(typeElement -> typeElement == null || (groovyObjectType == null || !typeUtils.isAssignable(typeElement.asType(), groovyObjectType)))
                 .forEach((typeElement) -> {

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
@@ -20,7 +20,6 @@ import io.micronaut.aop.Introduction;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Generated;
-import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.io.service.ServiceDefinition;
 import io.micronaut.core.io.service.SoftServiceLoader;
@@ -32,9 +31,6 @@ import io.micronaut.inject.processing.JavaModelUtils;
 import io.micronaut.inject.visitor.TypeElementVisitor;
 import io.micronaut.inject.visitor.VisitorContext;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import javax.annotation.processing.ProcessingEnvironment;
-
-import javax.annotation.Nonnull;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedOptions;

--- a/inject-java/src/test/groovy/io/micronaut/visitors/CustomVisitorSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/CustomVisitorSpec.groovy
@@ -100,4 +100,32 @@ public class TestController {
         AllClassesVisitor.VISITED_ELEMENTS == ["test.TestController", "getMethod"]
         InjectVisitor.VISITED_ELEMENTS == ["test.TestController", "privateField"]
     }
+
+    void "test @Generated class is not visited by any visitor"() {
+        buildBeanDefinition('test.TestGenerated', '''
+package test;
+
+import io.micronaut.core.annotation.Generated;
+import javax.inject.Inject;
+
+@Generated
+public class TestGenerated {
+
+    @Inject private String privateField;  
+    protected String protectedField;   
+    public String publicField;
+    String packagePrivateField;
+    
+    TestGenerated(String constructorArg) {}
+    
+    void setterMethod(String method) {}
+
+}
+''')
+        expect:
+        ControllerGetVisitor.VISITED_ELEMENTS == []
+        AllElementsVisitor.VISITED_ELEMENTS == []
+        AllClassesVisitor.VISITED_ELEMENTS == []
+        InjectVisitor.VISITED_ELEMENTS == []
+    }
 }

--- a/inject/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
@@ -68,6 +68,7 @@ class BeanIntrospectionWriter extends AbstractAnnotationMetadataWriter {
     private final Map<String, Collection<AnnotationValueIndex>> indexes = new HashMap<>(2);
     private final Map<String, GeneratorAdapter> localLoadTypeMethods = new HashMap<>();
     private final ClassElement classElement;
+    private boolean executed = false;
     private int propertyIndex = 0;
     private MethodElement constructor;
     private MethodElement defaultConstructor;
@@ -183,10 +184,17 @@ class BeanIntrospectionWriter extends AbstractAnnotationMetadataWriter {
 
     @Override
     public void accept(ClassWriterOutputVisitor classWriterOutputVisitor) throws IOException {
-        // write the reference
-        writeIntrospectionReference(classWriterOutputVisitor);
-        // write the introspection
-        writeIntrospectionClass(classWriterOutputVisitor);
+        if (!executed) {
+
+            // Run only once
+            executed = true;
+
+            // write the reference
+            writeIntrospectionReference(classWriterOutputVisitor);
+            // write the introspection
+            writeIntrospectionClass(classWriterOutputVisitor);
+
+        }
     }
 
     private void writeIntrospectionClass(ClassWriterOutputVisitor classWriterOutputVisitor) throws IOException {

--- a/inject/src/main/java/io/micronaut/inject/writer/AbstractClassFileWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/AbstractClassFileWriter.java
@@ -16,6 +16,7 @@
 package io.micronaut.inject.writer;
 
 import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.Generated;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.core.reflect.ReflectionUtils;
@@ -62,6 +63,7 @@ public abstract class AbstractClassFileWriter implements Opcodes {
     protected static final Type TYPE_OBJECT = Type.getType(Object.class);
     protected static final Type TYPE_CLASS = Type.getType(Class.class);
     protected static final int DEFAULT_MAX_STACK = 13;
+    protected static final Type TYPE_GENERATED = Type.getType(Generated.class);
 
     protected static final Map<String, String> NAME_TO_TYPE_MAP = new HashMap<>();
     private static final Method METHOD_CREATE_ARGUMENT_SIMPLE = Method.getMethod(
@@ -1048,6 +1050,7 @@ public abstract class AbstractClassFileWriter implements Opcodes {
      */
     protected void startClass(ClassVisitor classWriter, String className, Type superType) {
         classWriter.visit(V1_8, ACC_SYNTHETIC, className, null, superType.getInternalName(), null);
+        classWriter.visitAnnotation(TYPE_GENERATED.getDescriptor(), false);
     }
 
     /**
@@ -1057,6 +1060,7 @@ public abstract class AbstractClassFileWriter implements Opcodes {
      */
     protected void startPublicClass(ClassVisitor classWriter, String className, Type superType) {
         classWriter.visit(V1_8, ACC_PUBLIC | ACC_SYNTHETIC, className, null, superType.getInternalName(), null);
+        classWriter.visitAnnotation(TYPE_GENERATED.getDescriptor(), false);
     }
 
     /**
@@ -1066,6 +1070,7 @@ public abstract class AbstractClassFileWriter implements Opcodes {
      */
     protected void startFinalClass(ClassVisitor classWriter, String className, Type superType) {
         classWriter.visit(V1_8, ACC_FINAL | ACC_SYNTHETIC, className, null, superType.getInternalName(), null);
+        classWriter.visitAnnotation(TYPE_GENERATED.getDescriptor(), false);
     }
 
     /**
@@ -1077,6 +1082,7 @@ public abstract class AbstractClassFileWriter implements Opcodes {
      */
     protected void startPublicFinalClass(ClassVisitor classWriter, String className, Type superType) {
         classWriter.visit(V1_8, ACC_PUBLIC | ACC_FINAL | ACC_SYNTHETIC, className, null, superType.getInternalName(), null);
+        classWriter.visitAnnotation(TYPE_GENERATED.getDescriptor(), false);
     }
 
     /**
@@ -1087,6 +1093,7 @@ public abstract class AbstractClassFileWriter implements Opcodes {
      */
     protected void startClass(ClassWriter classWriter, String className, Type superType, String genericSignature) {
         classWriter.visit(V1_8, ACC_SYNTHETIC, className, genericSignature, superType.getInternalName(), null);
+        classWriter.visitAnnotation(TYPE_GENERATED.getDescriptor(), false);
     }
 
     /**

--- a/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -494,6 +494,8 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
                 isSuperFactory ? TYPE_ABSTRACT_BEAN_DEFINITION.getInternalName() : superType.getInternalName(),
                 interfaceInternalNames);
 
+        classWriter.visitAnnotation(TYPE_GENERATED.getDescriptor(), false);
+
         if (buildMethodVisitor == null) {
             throw new IllegalStateException("At least one call to visitBeanDefinitionConstructor() is required");
         }

--- a/inject/src/main/java/io/micronaut/inject/writer/ExecutableMethodWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/ExecutableMethodWriter.java
@@ -204,6 +204,8 @@ public class ExecutableMethodWriter extends AbstractAnnotationMetadataWriter imp
             Type.getInternalName(AbstractExecutableMethod.class),
             null);
 
+        classWriter.visitAnnotation(TYPE_GENERATED.getDescriptor(), false);
+
         // initialize and write the annotation metadata
         if (!(annotationMetadata instanceof AnnotationMetadataReference)) {
             writeAnnotationMetadataStaticInitializer(classWriter);

--- a/test-suite-helper/src/main/java/io/micronaut/testsuitehelper/TestGeneratingAnnotationProcessor.java
+++ b/test-suite-helper/src/main/java/io/micronaut/testsuitehelper/TestGeneratingAnnotationProcessor.java
@@ -53,12 +53,19 @@ public class TestGeneratingAnnotationProcessor extends AbstractProcessor {
                     break;
                 case "test":
                 case "test-classes":
-                    final JavaFileObject issue = processingEnv
-                        .getFiler()
-                        .createSourceFile("io.micronaut.test.generated.Example");
-                    try (final Writer w = issue.openWriter()) {
+
+                    try (final Writer w = processingEnv.getFiler()
+                        .createSourceFile("io.micronaut.test.generated.Example")
+                        .openWriter()) {
                         w.write("package io.micronaut.test.generated;\n\npublic interface Example {}");
                     }
+
+                    try (final Writer w = processingEnv.getFiler()
+                        .createSourceFile("io.micronaut.test.generated.IntrospectedExample")
+                        .openWriter()) {
+                        w.write("package io.micronaut.test.generated;\n\nimport io.micronaut.core.annotation.Introspected;\n\n@Introspected\npublic class IntrospectedExample {}");
+                    }
+
                     break;
                 default:
                     throw new IllegalStateException("Unknown builder for output " + outputDir);

--- a/test-suite/src/test/java/io/micronaut/docs/inject/generated/VerifyIntrospectionSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/inject/generated/VerifyIntrospectionSpec.java
@@ -1,0 +1,21 @@
+package io.micronaut.docs.inject.generated;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.micronaut.core.beans.BeanIntrospector;
+import io.micronaut.test.generated.IntrospectedExample;
+import io.micronaut.context.BeanContext;
+import org.junit.jupiter.api.Test;
+
+public class VerifyIntrospectionSpec {
+
+    @Test
+    public void test() {
+        BeanContext beanContext = BeanContext.run();
+
+        assertTrue(BeanIntrospector.SHARED.findIntrospection(IntrospectedExample.class).isPresent());
+
+        beanContext.stop();
+    }
+
+}


### PR DESCRIPTION
#2901 

This fix allows the `TypeElementVisitorProcessor` to be executed for each round. This implies several changes :

- the `LoadedVisitor` are initialized once and for all in the `init` method
- `javaVisitorContext.finish` is only called once every class has been generated and processed (this call is responsible for writing the services)
- some visitors needed to be modified to ensure that the files they generated were written only once
- a `@Generated` annotation was added to every generated classes, preventing them to be handled by the `TypeElementVisitorProcessor`

The PR may need some improvements (and an additional control that I didn't miss any Visitor), however the result seems to be OK on my end.