### PR TITLE
Fix overwritting of span operation name in OpenTracingServerFilter

### DIFF
--- a/tracing/src/main/java/io/micronaut/tracing/instrument/http/OpenTracingServerFilter.java
+++ b/tracing/src/main/java/io/micronaut/tracing/instrument/http/OpenTracingServerFilter.java
@@ -92,8 +92,6 @@ public class OpenTracingServerFilter extends AbstractOpenTracingFilter implement
                                 new HttpHeadersTextMap(response.getHeaders())
                         );
 
-                        String spanName = resolveSpanName(request);
-                        span.setOperationName(spanName);
                         setResponseTags(request, response, span);
                     }
                 }


### PR DESCRIPTION
Simple PR, just removed 2 lines that set span operation name second time which is not needed and make it impossible for user to change it. Added test to show it.

Fixes #3084 .