### PR TITLE
Add support for @RequestBean

### DIFF
--- a/http-client/src/test/groovy/io/micronaut/http/client/aop/RequestBeanSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/aop/RequestBeanSpec.groovy
@@ -1,0 +1,257 @@
+package io.micronaut.http.client.aop
+
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Header
+import io.micronaut.http.annotation.PathVariable
+import io.micronaut.http.annotation.QueryValue
+import io.micronaut.http.annotation.RequestBean
+
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.runtime.server.EmbeddedServer
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+import javax.annotation.Nullable
+import javax.validation.Valid
+import javax.validation.constraints.Pattern
+
+class RequestBeanSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer)
+
+    @Shared
+    RequestBeanClient client = embeddedServer.getApplicationContext().getBean(RequestBeanClient)
+
+    void "test @QueryValue is injected to Bean"() {
+        expect:
+            client.getQueryValue("Riverside") == "Riverside"
+    }
+
+    void "test @QueryValue have empty Optional Value"() {
+        expect:
+            !client.getOptionalValue()
+    }
+
+    void "test @QueryValue has value in Optional"() {
+        expect:
+            client.getOptionalValue("hello value")
+    }
+
+    void "test validated value returns bad request when invalid"() {
+        when:
+            client.getValidatedValue("third")
+        then:
+            def ex = thrown(HttpClientResponseException)
+            ex.message.contains("Field must have value first or second.")
+    }
+
+    void "test validated value returns ok when valid"() {
+        expect:
+            client.getValidatedValue("second") == "second"
+    }
+
+    void "test @PathVariable is injected in to Bean"() {
+        expect:
+            client.getPathVariable("v1beta") == "v1beta"
+    }
+
+    void "test @Header is injected in to Bean"() {
+        expect:
+            client.getHeader("127.0.0.1") == "127.0.0.1"
+    }
+
+    void "test HttpRequest is injected in to Bean"() {
+        expect:
+            client.getPath() == "/request/bean/httpRequest"
+    }
+
+    void "test Immutable injections works"() {
+        expect:
+            client.getImmutableBean("I am immutable! Muahahah") == "I am immutable! Muahahah"
+    }
+
+    void "test Immutable get request path"() {
+        expect:
+            client.getImmutableBeanGetRequestPath() == "/request/bean/immutable/request/path"
+    }
+
+    void "test Immutable validated parameter"() {
+        when:
+            client.getImmutableBeanValidatedValue("third")
+        then:
+            def ex = thrown(HttpClientResponseException)
+            ex.message.contains("Field must have value first or second.")
+    }
+
+    void "test Extending Bean has super values"() {
+        expect:
+            client.getExtendingBeanValues("I am not super!", "I am super!") == "Extending: 'I am not super!', Super: 'I am super!'"
+    }
+
+    @Controller('/request/bean')
+    static class RequestBeanController {
+
+        @Get("/queryValue{?queryValue}")
+        String getQueryValue(@RequestBean Bean bean) {
+            return bean.queryValue
+        }
+
+        @Get("/optionalQueryValue{?optionalValue}")
+        Boolean getOptionalValue(@RequestBean Bean bean) {
+            return bean.optionalValue.isPresent()
+        }
+
+        @Get("/{pathVariable}")
+        String getPathVariable(@RequestBean Bean bean) {
+            return bean.pathVariable
+        }
+
+        @Get("/validatedValue{?validatedValue}")
+        String getValidatedValue(@Valid @RequestBean Bean bean) {
+            return bean.validatedValue
+        }
+
+        @Get("/header")
+        String getHeader(@RequestBean Bean bean) {
+            return bean.forwardedFor
+        }
+
+        @Get("/httpRequest")
+        String getPath(@RequestBean Bean bean) {
+            return bean.request.path
+        }
+
+        @Get("/immutable")
+        String immutableBeanRequest(@RequestBean ImmutableBean bean) {
+            return bean.queryValue
+        }
+
+        @Get("/immutable/request/path")
+        String immutableBeanGetRequestPath(@RequestBean ImmutableBean bean) {
+            return bean.request.path
+        }
+
+        @Get("/immutable/validated/field{?validatedValue}")
+        String getImmutableBeanValidatedParameter(@Valid @RequestBean ImmutableBean bean) {
+            return bean.validatedValue
+        }
+
+        @Get("/extended/values")
+        String getExtendingBeanValues(@RequestBean ExtendingBean bean) {
+            return "Extending: '$bean.extendingValue', Super: '$bean.superValue'"
+        }
+
+    }
+
+    @Client('/request/bean')
+    static interface RequestBeanClient {
+
+        @Get("/queryValue{?queryValue}")
+        String getQueryValue(String queryValue)
+
+        @Get("/optionalQueryValue{?optionalValue}")
+        Boolean getOptionalValue(@Nullable String optionalValue)
+
+        @Get("/validatedValue{?validatedValue}")
+        String getValidatedValue(@Nullable String validatedValue)
+
+        @Get("/{pathVariable}")
+        String getPathVariable(@PathVariable String pathVariable)
+
+        @Get("/header")
+        String getHeader(@Header("X-Forwarded-For") String forwardedFor)
+
+        @Get("/httpRequest")
+        String getPath()
+
+        @Get("/immutable{?queryValue}")
+        String getImmutableBean(String queryValue)
+
+        @Get("/immutable/request/path")
+        String getImmutableBeanGetRequestPath()
+
+        @Get("/immutable/validated/field{?validatedValue}")
+        String getImmutableBeanValidatedValue(String validatedValue)
+
+        @Get("/extended/values{?extendingValue,superValue}")
+        String getExtendingBeanValues(String extendingValue, String superValue)
+
+    }
+
+    @Introspected
+    static class Bean {
+
+        HttpRequest<?> request
+
+        @Nullable
+        @QueryValue
+        String queryValue
+
+        @QueryValue
+        Optional<String> optionalValue
+
+        @Nullable
+        @QueryValue
+        @Pattern(regexp = "first|second", message = "Field must have value 'first' or 'second'.")
+        String validatedValue
+
+        @Nullable
+        @PathVariable
+        String pathVariable
+
+        @Nullable
+        @Header("X-Forwarded-For")
+        String forwardedFor
+
+    }
+
+    @Introspected
+    static class ImmutableBean {
+
+        final HttpRequest<?> request
+
+        @Nullable
+        @QueryValue
+        @Pattern(regexp = "first|second", message = "Field must have value 'first' or 'second'.")
+        final String queryValue
+
+        @Nullable
+        @QueryValue
+        @Pattern(regexp = "first|second", message = "Field must have value 'first' or 'second'.")
+        final String validatedValue
+
+        ImmutableBean(HttpRequest request, String queryValue, String validatedValue) {
+            this.request = request
+            this.queryValue = queryValue
+            this.validatedValue = validatedValue
+        }
+
+    }
+
+    @Introspected
+    static class ExtendingBean extends SuperBean {
+
+        @Nullable
+        @QueryValue
+        String extendingValue
+
+    }
+
+    static class SuperBean {
+
+        @Nullable
+        @QueryValue
+        String superValue
+
+    }
+
+}

--- a/http/src/main/java/io/micronaut/http/annotation/CookieValue.java
+++ b/http/src/main/java/io/micronaut/http/annotation/CookieValue.java
@@ -34,7 +34,7 @@ import java.lang.annotation.Target;
  */
 @Documented
 @Retention(RUNTIME)
-@Target({ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
 @Bindable
 public @interface CookieValue {
 

--- a/http/src/main/java/io/micronaut/http/annotation/Header.java
+++ b/http/src/main/java/io/micronaut/http/annotation/Header.java
@@ -53,7 +53,7 @@ import java.lang.annotation.*;
  */
 @Documented
 @Retention(RUNTIME)
-@Target({ElementType.PARAMETER, ElementType.TYPE, ElementType.METHOD, ElementType.ANNOTATION_TYPE}) // this can be either type or param
+@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.TYPE, ElementType.METHOD, ElementType.ANNOTATION_TYPE}) // this can be either type or param
 @Repeatable(value = Headers.class)
 @Bindable
 public @interface Header {

--- a/http/src/main/java/io/micronaut/http/annotation/PathVariable.java
+++ b/http/src/main/java/io/micronaut/http/annotation/PathVariable.java
@@ -33,7 +33,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Documented
 @Retention(RUNTIME)
-@Target({ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
 @Bindable
 public @interface PathVariable {
     /**

--- a/http/src/main/java/io/micronaut/http/annotation/RequestBean.java
+++ b/http/src/main/java/io/micronaut/http/annotation/RequestBean.java
@@ -17,33 +17,39 @@ package io.micronaut.http.annotation;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-import io.micronaut.context.annotation.AliasFor;
-import io.micronaut.core.bind.annotation.Bindable;
-
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import io.micronaut.context.annotation.AliasFor;
+import io.micronaut.core.bind.annotation.Bindable;
+
 /**
- * Indicates that the parameter to a method should be bound from a value in the query string or path of the URI.
+ * Used to bind Bindable parameters to a Bean object.
  *
- * @author Graeme Rocher
- * @see java.net.URI#getQuery()
- * @see java.net.URI#getPath()
- * @since 1.0
+ * @author Anze Sodja
+ * @since 2.0
  */
 @Documented
 @Retention(RUNTIME)
-@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Target({ ElementType.PARAMETER, ElementType.ANNOTATION_TYPE })
 @Bindable
-public @interface QueryValue {
+public @interface RequestBean {
 
     /**
      * @return The name of the parameter
      */
     @AliasFor(annotation = Bindable.class, member = "value")
+    @AliasFor(member = "name")
     String value() default "";
+
+    /**
+     * @return The name of the parameter
+     */
+    @AliasFor(annotation = Bindable.class, member = "value")
+    @AliasFor(member = "value")
+    String name() default "";
 
     /**
      * @see Bindable#defaultValue()
@@ -51,4 +57,5 @@ public @interface QueryValue {
      */
     @AliasFor(annotation = Bindable.class, member = "defaultValue")
     String defaultValue() default "";
+
 }

--- a/http/src/main/java/io/micronaut/http/bind/DefaultRequestBinderRegistry.java
+++ b/http/src/main/java/io/micronaut/http/bind/DefaultRequestBinderRegistry.java
@@ -234,6 +234,9 @@ public class DefaultRequestBinderRegistry implements RequestBinderRegistry {
         PathVariableAnnotationBinder<Object> pathVariableAnnotationBinder = new PathVariableAnnotationBinder<>(conversionService);
         byAnnotation.put(pathVariableAnnotationBinder.getAnnotationType(), pathVariableAnnotationBinder);
 
+        RequestBeanAnnotationBinder<Object> requestBeanAnnotationBinder = new RequestBeanAnnotationBinder<>(this, conversionService);
+        byAnnotation.put(requestBeanAnnotationBinder.getAnnotationType(), requestBeanAnnotationBinder);
+
         if (KOTLIN_COROUTINES_SUPPORTED) {
             ContinuationArgumentBinder continuationArgumentBinder = new ContinuationArgumentBinder();
             byType.put(continuationArgumentBinder.argumentType().typeHashCode(), continuationArgumentBinder);

--- a/http/src/main/java/io/micronaut/http/bind/binders/RequestBeanAnnotationBinder.java
+++ b/http/src/main/java/io/micronaut/http/bind/binders/RequestBeanAnnotationBinder.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.bind.binders;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.beans.BeanIntrospection;
+import io.micronaut.core.beans.BeanProperty;
+import io.micronaut.core.bind.ArgumentBinder;
+import io.micronaut.core.bind.annotation.AbstractAnnotatedArgumentBinder;
+import io.micronaut.core.bind.annotation.Bindable;
+import io.micronaut.core.bind.exceptions.UnsatisfiedArgumentException;
+import io.micronaut.core.convert.ArgumentConversionContext;
+import io.micronaut.core.convert.ConversionContext;
+import io.micronaut.core.convert.ConversionError;
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.convert.exceptions.ConversionErrorException;
+import io.micronaut.core.type.Argument;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.annotation.RequestBean;
+import io.micronaut.http.bind.RequestBinderRegistry;
+
+/**
+ * Used to bind Bindable parameters to a Bean object.
+ *
+ * @author Anze Sodja
+ * @since 2.0
+ * @see RequestBean
+ * @param <T>
+ */
+public class RequestBeanAnnotationBinder<T> extends AbstractAnnotatedArgumentBinder<RequestBean, T, HttpRequest<?>>
+        implements AnnotatedRequestArgumentBinder<RequestBean, T> {
+
+    private final RequestBinderRegistry requestBinderRegistry;
+
+    /**
+     * @param requestBinderRegistry Original request binder registry
+     * @param conversionService The conversion service
+     */
+    public RequestBeanAnnotationBinder(RequestBinderRegistry requestBinderRegistry, ConversionService<?> conversionService) {
+        super(conversionService);
+        this.requestBinderRegistry = requestBinderRegistry;
+    }
+
+    @Override
+    public Class<RequestBean> getAnnotationType() {
+        return RequestBean.class;
+    }
+
+    @Override
+    public BindingResult<T> bind(ArgumentConversionContext<T> context, HttpRequest<?> source) {
+        Argument<T> argument = context.getArgument();
+        AnnotationMetadata annotationMetadata = argument.getAnnotationMetadata();
+        boolean hasAnnotation = annotationMetadata.hasAnnotation(RequestBean.class);
+
+        if (hasAnnotation) {
+            BeanIntrospection<T> introspection = BeanIntrospection.getIntrospection(context.getArgument().getType());
+            List<BeanProperty<T, Object>> bindableProperties = introspection.getBeanProperties().stream()
+                    .filter(p -> p.getType().isAssignableFrom(HttpRequest.class) || p.hasStereotype(Bindable.class))
+                    .collect(Collectors.toList());
+
+            if (introspection.getConstructorArguments().length > 0) {
+                // Handle injection with Constructor or @Creator
+                Object[] argumentValues = Arrays.stream(introspection.getConstructorArguments())
+                        .map(a -> bindArgument((Argument<Object>) a, bindableProperties, context, source))
+                        .toArray();
+                return () -> Optional.of(introspection.instantiate(false, argumentValues));
+            } else {
+                // Handle injection with setters, we checked that all values are writable at compile time
+                T bean = introspection.instantiate();
+                for (BeanProperty<T, Object> property : bindableProperties) {
+                    ArgumentConversionContext<Object> conversionContext = propertyConversionContext(property, property.getType(), context);
+                    Optional<Object> bindableResult = getBindableResult(conversionContext, source);
+                    property.set(bean, property.getType().isAssignableFrom(Optional.class)
+                            ? bindableResult
+                            : bindableResult.orElse(null));
+                }
+                return () -> Optional.of(bean);
+            }
+        } else {
+            //noinspection unchecked
+            return BindingResult.EMPTY;
+        }
+    }
+
+    private Object bindArgument(Argument<Object> argument, List<BeanProperty<T, Object>> bindableProperties,
+            ArgumentConversionContext<T> parentContext, HttpRequest<?> source) {
+        if (argument.getType().isAssignableFrom(HttpRequest.class)) {
+            return source;
+        }
+        Optional<BeanProperty<T, Object>> bindablePropertyForArgument = bindableProperties.stream()
+                .filter(p -> p.getName().equals(argument.getName()))
+                .findFirst();
+        if (bindablePropertyForArgument.isPresent()) {
+            ArgumentConversionContext<Object> conversionContext = propertyConversionContext(bindablePropertyForArgument.get(), argument.getType(), parentContext);
+            Optional<Object> result = getBindableResult(conversionContext, source);
+            return argument.getType().isAssignableFrom(Optional.class) ? result : result.orElse(null);
+        } else {
+            return argument.getType().isAssignableFrom(Optional.class) ? Optional.empty() : null;
+        }
+    }
+
+    private Optional<Object> getBindableResult(ArgumentConversionContext<Object> conversionContext, HttpRequest<?> source) {
+        if (conversionContext.getArgument().getType().isAssignableFrom(HttpRequest.class)) {
+            return Optional.of(source);
+        }
+        Argument<Object> argument = conversionContext.getArgument();
+        Optional<ArgumentBinder<Object, HttpRequest<?>>> binder = requestBinderRegistry.findArgumentBinder(conversionContext.getArgument(), source);
+        if (!binder.isPresent()) {
+            throw new UnsatisfiedArgumentException(argument);
+        }
+        BindingResult<Object> result = binder.get().bind(conversionContext, source);
+        if (!result.isSatisfied() || !result.getConversionErrors().isEmpty()) {
+            List<ConversionError> errors = result.getConversionErrors();
+            throw new ConversionErrorException(argument, errors.get(errors.size() - 1));
+        }
+        if (!result.isPresentAndSatisfied() && !argument.isNullable() && !argument.getType().isAssignableFrom(Optional.class)) {
+            throw new UnsatisfiedArgumentException(conversionContext.getArgument());
+        }
+        return result.getValue();
+    }
+
+    private ArgumentConversionContext<Object> propertyConversionContext(BeanProperty<T, Object> property,
+            Class<Object> type, ArgumentConversionContext<T> parentContext) {
+        Argument<Object> argument = Argument.of(type, property.getName(), property.getAnnotationMetadata());
+        return ConversionContext.of(argument, parentContext.getLocale(), parentContext.getCharset());
+    }
+
+}

--- a/validation/src/main/java/io/micronaut/validation/routes/RouteValidationVisitor.java
+++ b/validation/src/main/java/io/micronaut/validation/routes/RouteValidationVisitor.java
@@ -28,6 +28,7 @@ import io.micronaut.inject.visitor.TypeElementVisitor;
 import io.micronaut.inject.visitor.VisitorContext;
 import io.micronaut.validation.routes.rules.MissingParameterRule;
 import io.micronaut.validation.routes.rules.NullableParameterRule;
+import io.micronaut.validation.routes.rules.RequestBeanParameterRule;
 import io.micronaut.validation.routes.rules.RouteValidationRule;
 
 import javax.annotation.processing.SupportedOptions;
@@ -98,5 +99,6 @@ public class RouteValidationVisitor implements TypeElementVisitor<Object, HttpMe
         skipValidation = prop != null && prop.equals("false");
         rules.add(new MissingParameterRule());
         rules.add(new NullableParameterRule());
+        rules.add(new RequestBeanParameterRule());
     }
 }

--- a/validation/src/main/java/io/micronaut/validation/routes/rules/RequestBeanParameterRule.java
+++ b/validation/src/main/java/io/micronaut/validation/routes/rules/RequestBeanParameterRule.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.validation.routes.rules;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import io.micronaut.core.bind.annotation.Bindable;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.annotation.RequestBean;
+import io.micronaut.http.uri.UriMatchTemplate;
+import io.micronaut.inject.ast.MethodElement;
+import io.micronaut.inject.ast.ParameterElement;
+import io.micronaut.inject.ast.PropertyElement;
+import io.micronaut.validation.routes.RouteValidationResult;
+
+/**
+ * Validates RequestBean parameters
+ *
+ * @author Anze Sodja
+ * @since 2.0
+ */
+public class RequestBeanParameterRule implements RouteValidationRule {
+
+    @Override
+    public RouteValidationResult validate(List<UriMatchTemplate> templates, ParameterElement[] parameters, MethodElement method) {
+        return new RouteValidationResult(Arrays.stream(parameters)
+                .filter(p -> p.hasAnnotation(RequestBean.class))
+                .flatMap(p -> validate(p).stream())
+                .toArray(String[]::new));
+    }
+
+    private List<String> validate(ParameterElement parameterElement) {
+        List<String> errors = new ArrayList<>();
+        List<PropertyElement> bindableProperties = parameterElement.getType().getBeanProperties().stream()
+                .filter(p -> p.hasStereotype(Bindable.class) || p.getType().isAssignable(HttpRequest.class))
+                .collect(Collectors.toList());
+        Optional<MethodElement> primaryConstructor = parameterElement.getType().getPrimaryConstructor();
+
+        if (primaryConstructor.isPresent() && primaryConstructor.get().getParameters().length > 0) {
+            // @Creator constructor
+            List<ParameterElement> constructorParameters = Arrays.asList(primaryConstructor.get().getParameters());
+
+            // Check no constructor parameter has any @Bindable annotation
+            // We could allow this, but this would add some complexity, some annotations that can be used in combination
+            // with @Bindable works only on fields (e.g. bean validation annotations) and this might confuse Micronaut users
+            constructorParameters.stream()
+                    .filter(p -> p.hasStereotype(Bindable.class))
+                    .forEach(p -> errors.add("Parameter of Primary Constructor (or @Creator Method) [" + p.getName() + "] for type ["
+                            + parameterElement.getType().getName() + "] has one of @Bindable annotations. This is not supported."
+                            + "\nNote1: Primary constructor is a constructor that have parameters or is annotated with @Creator."
+                            + "\nNote2: In case you have multiple @Creator constructors, first is used as primary constructor."));
+
+            // Check readonly bindable properties can be set via constructor
+            bindableProperties.stream()
+                    .filter(PropertyElement::isReadOnly)
+                    .filter(p -> constructorParameters.stream().noneMatch(constructorProperty -> constructorProperty.getName().equals(p.getName())))
+                    .forEach(p -> errors.add(
+                            "Primary Constructor or @Creator Method for Bindable property [" + p.getName() + "] for type ["
+                                    + parameterElement.getType().getName() + "] found, but there is no constructor/method parameter with name equal to [" + p.getName() + "]."
+                                    + "\nAdd parameter with name [" + p.getName() + "] to your @Creator."
+                                    + "\nNote1: Primary constructor is a constructor that have parameters or is annotated with @Creator."
+                                    + "\nNote2: In case you have multiple @Creator constructors, first is used as primary constructor."));
+        } else {
+            // Check readonly bindable properties
+            bindableProperties.stream()
+                    .filter(PropertyElement::isReadOnly)
+                    .forEach(p -> errors.add("Bindable property [" + p.getName()  + "] for type [" + parameterElement.getType().getName() + "]"
+                            + " is Read only and cannot be set during initialization.\n"
+                            + "Add property setter or add @Creator constructor/method."));
+        }
+        return errors;
+    }
+
+}

--- a/validation/src/test/groovy/io/micronaut/validation/routes/NullableParameterRuleSpec.groovy
+++ b/validation/src/test/groovy/io/micronaut/validation/routes/NullableParameterRuleSpec.groovy
@@ -21,7 +21,7 @@ class NullableParameterRuleSpec extends AbstractTypeElementSpec {
 
     void "test nullable parameter"() {
         when:
-        buildTypeElement("""
+            buildTypeElement("""
 
 package test;
 
@@ -40,10 +40,10 @@ class Foo {
 """)
 
         then:
-        noExceptionThrown()
+            noExceptionThrown()
 
         when:
-        buildTypeElement("""
+            buildTypeElement("""
 
 package test;
 
@@ -62,10 +62,10 @@ class Foo {
 """)
 
         then:
-        noExceptionThrown()
+            noExceptionThrown()
 
         when:
-        buildTypeElement("""
+            buildTypeElement("""
 
 package test;
 
@@ -83,11 +83,11 @@ class Foo {
 """)
 
         then:
-        def ex = thrown(RuntimeException)
-        ex.message.contains("The uri variable [abc] is optional, but the corresponding method argument [java.lang.String abc] is not defined as an Optional or annotated with the javax.annotation.Nullable annotation.")
+            def ex = thrown(RuntimeException)
+            ex.message.contains("The uri variable [abc] is optional, but the corresponding method argument [java.lang.String abc] is not defined as an Optional or annotated with the javax.annotation.Nullable annotation.")
 
         when:
-        buildTypeElement("""
+            buildTypeElement("""
 
 package test;
 
@@ -105,12 +105,12 @@ class Foo {
 """)
 
         then:
-        noExceptionThrown()
+            noExceptionThrown()
     }
 
     void "test query optional parameter"() {
         when:
-        buildTypeElement("""
+            buildTypeElement("""
 
 package test;
 
@@ -128,13 +128,13 @@ class Foo {
 """)
 
         then:
-        def ex = thrown(RuntimeException)
-        ex.message.contains("The uri variable [abc] is optional, but the corresponding method argument [java.lang.String abc] is not defined as an Optional or annotated with the javax.annotation.Nullable annotation.")
+            def ex = thrown(RuntimeException)
+            ex.message.contains("The uri variable [abc] is optional, but the corresponding method argument [java.lang.String abc] is not defined as an Optional or annotated with the javax.annotation.Nullable annotation.")
     }
 
     void "test ampersand optional parameter"() {
         when:
-        buildTypeElement("""
+            buildTypeElement("""
 
 package test;
 
@@ -152,13 +152,13 @@ class Foo {
 """)
 
         then:
-        def ex = thrown(RuntimeException)
-        ex.message.contains("The uri variable [abc] is optional, but the corresponding method argument [java.lang.String abc] is not defined as an Optional or annotated with the javax.annotation.Nullable annotation.")
+            def ex = thrown(RuntimeException)
+            ex.message.contains("The uri variable [abc] is optional, but the corresponding method argument [java.lang.String abc] is not defined as an Optional or annotated with the javax.annotation.Nullable annotation.")
     }
 
     void "test required argument doesn't fail compilation"() {
         when:
-        buildTypeElement("""
+            buildTypeElement("""
 
 package test;
 
@@ -177,12 +177,12 @@ class Foo {
 """)
 
         then:
-        noExceptionThrown()
+            noExceptionThrown()
     }
 
     void "test nullable with multiple uris"() {
         when:
-        buildTypeElement("""
+            buildTypeElement("""
 
 package test;
 
@@ -201,10 +201,10 @@ class Foo {
 """)
 
         then:
-        noExceptionThrown()
+            noExceptionThrown()
 
         when:
-        buildTypeElement("""
+            buildTypeElement("""
 
 package test;
 
@@ -223,11 +223,11 @@ class Foo {
 """)
 
         then: "abc is optional because /{?def} may be matched and it does not have {abc}"
-        def ex = thrown(RuntimeException)
-        ex.message.contains("The uri variable [abc] is optional, but the corresponding method argument [java.lang.String abc] is not defined as an Optional or annotated with the javax.annotation.Nullable annotation.")
+            def ex = thrown(RuntimeException)
+            ex.message.contains("The uri variable [abc] is optional, but the corresponding method argument [java.lang.String abc] is not defined as an Optional or annotated with the javax.annotation.Nullable annotation.")
 
         when:
-        buildTypeElement("""
+            buildTypeElement("""
 
 package test;
 
@@ -244,11 +244,11 @@ class Foo {
 
 """)
         then: "abc is optional because it is optional in at least one template"
-        ex = thrown(RuntimeException)
-        ex.message.contains("The uri variable [abc] is optional, but the corresponding method argument [java.lang.String abc] is not defined as an Optional or annotated with the javax.annotation.Nullable annotation.")
+            ex = thrown(RuntimeException)
+            ex.message.contains("The uri variable [abc] is optional, but the corresponding method argument [java.lang.String abc] is not defined as an Optional or annotated with the javax.annotation.Nullable annotation.")
 
         when:
-        buildTypeElement("""
+            buildTypeElement("""
 
 package test;
 
@@ -265,10 +265,10 @@ class Foo {
 
 """)
         then:
-        noExceptionThrown()
+            noExceptionThrown()
 
         when:
-        buildTypeElement("""
+            buildTypeElement("""
 
 package test;
 
@@ -286,10 +286,10 @@ class Foo {
 
 """)
         then:
-        noExceptionThrown()
+            noExceptionThrown()
 
         when:
-        buildTypeElement("""
+            buildTypeElement("""
 
 package test;
 
@@ -306,11 +306,11 @@ class Foo {
 
 """)
         then: "abc is optional because it is optional in at least one template"
-        ex = thrown(RuntimeException)
-        ex.message.contains("The uri variable [abc] is optional, but the corresponding method argument [java.lang.String abc] is not defined as an Optional or annotated with the javax.annotation.Nullable annotation.")
+            ex = thrown(RuntimeException)
+            ex.message.contains("The uri variable [abc] is optional, but the corresponding method argument [java.lang.String abc] is not defined as an Optional or annotated with the javax.annotation.Nullable annotation.")
 
         when:
-        buildTypeElement("""
+            buildTypeElement("""
 
 package test;
 
@@ -328,7 +328,406 @@ class Foo {
 
 """)
         then:
-        ex = thrown(RuntimeException)
+            ex = thrown(RuntimeException)
+            ex.message.contains("The uri variable [abc] is optional, but the corresponding method argument [java.lang.String abc] is not defined as an Optional or annotated with the javax.annotation.Nullable annotation.")
+    }
+
+    void "test nullable parameter with RequestBean"() {
+        when:
+            buildTypeElement("""
+
+package test;
+
+import io.micronaut.http.annotation.*;
+import io.micronaut.core.annotation.*;
+import javax.annotation.Nullable;
+
+@Controller("/foo")
+class Foo {
+
+    @Get("{/abc}")
+    String abc(@RequestBean Bean bean) {
+        return "";
+    }
+    
+    @Introspected
+    private static class Bean {
+        
+        @Nullable
+        @PathVariable
+        private String abc;
+        
+        public String getAbc() { return abc; }
+        public void setAbc(String abc) { this.abc = abc; }
+        
+    }
+    
+}
+
+""")
+        then:
+            noExceptionThrown()
+
+        when:
+            buildTypeElement("""
+
+package test;
+
+import io.micronaut.http.annotation.*;
+import io.micronaut.core.annotation.*;
+import javax.annotation.Nullable;
+import java.util.Optional;
+
+@Controller("/foo")
+class Foo {
+
+    @Get("{/abc}")
+    String abc(@RequestBean Bean bean) {
+        return "";
+    }
+    
+    @Introspected
+    private static class Bean {
+        
+        @PathVariable
+        private Optional<String> abc;
+        
+        public Optional<String> getAbc() { return abc; }
+        public void setAbc(Optional<String> abc) { this.abc = abc; }
+
+    }
+    
+}
+
+""")
+
+        then:
+            noExceptionThrown()
+
+        when:
+            buildTypeElement("""
+
+package test;
+
+import io.micronaut.http.annotation.*;
+import io.micronaut.core.annotation.*;
+
+@Controller("/foo")
+class Foo {
+
+    @Get("{/abc}")
+    String abc(@RequestBean Bean bean) {
+        return "";
+    }
+    
+    @Introspected
+    private static class Bean {
+        
+        @PathVariable
+        private String abc;
+        
+        public String getAbc() { return abc; }
+        public void setAbc(String abc) { this.abc = abc; }
+    }
+    
+}
+
+""")
+        then:
+            def ex = thrown(RuntimeException)
+            ex.message.contains("The uri variable [abc] is optional, but the corresponding method argument [java.lang.String abc] is not defined as an Optional or annotated with the javax.annotation.Nullable annotation.")
+
+        when:
+            buildTypeElement("""
+
+package test;
+
+import io.micronaut.http.annotation.*;
+import io.micronaut.core.annotation.*;
+
+@Controller("/foo")
+class Foo {
+
+    @Get("{/abc}")
+    String abc(@RequestBean Bean bean) {
+        return "";
+    }
+    
+    @Introspected
+    private static class Bean {
+        
+        @PathVariable(defaultValue = "x")
+        private String abc;
+        
+        public String getAbc() { return abc; }
+        public void setAbc(String abc) { this.abc = abc; }
+        
+    }
+    
+}
+
+""")
+
+        then:
+            noExceptionThrown()
+
+    }
+
+    void "test query optional parameter with RequestBean"() {
+        when:
+            buildTypeElement("""
+
+package test;
+
+import io.micronaut.http.annotation.*;
+import io.micronaut.core.annotation.*;
+import java.util.Optional;
+
+@Controller("/foo")
+class Foo {
+
+    @Get("/{?abc}")
+    String abc(@RequestBean Bean bean) {
+        return "";
+    }
+    
+    @Introspected
+    private static class Bean {
+        
+        @QueryValue
+        private Optional<String> abc;
+        
+        public Optional<String> getAbc() { return abc; }
+        public void setAbc(Optional<String> abc) { this.abc = abc; }
+    }
+    
+}
+
+""")
+
+        then:
+            noExceptionThrown()
+
+        when:
+            buildTypeElement("""
+
+package test;
+
+import io.micronaut.http.annotation.*;
+import io.micronaut.core.annotation.*;
+
+@Controller("/foo")
+class Foo {
+
+    @Get("/{?abc}")
+    String abc(@RequestBean Bean bean) {
+        return "";
+    }
+    
+    @Introspected
+    private static class Bean {
+        
+        @QueryValue
+        private String abc;
+        
+        public String getAbc() { return abc; }
+        public void setAbc(String abc) { this.abc = abc; }
+        
+    }
+    
+}
+
+""")
+
+        then:
+            def ex = thrown(RuntimeException)
+            ex.message.contains("The uri variable [abc] is optional, but the corresponding method argument [java.lang.String abc] is not defined as an Optional or annotated with the javax.annotation.Nullable annotation.")
+    }
+
+    void "test ampersand optional RequestBean parameter"() {
+        when:
+            buildTypeElement("""
+
+package test;
+
+import io.micronaut.http.annotation.*;
+import io.micronaut.core.annotation.*;
+
+@Controller("/foo")
+class Foo {
+
+    @Get("/{&abc}")
+    String abc(@RequestBean Bean bean) {
+        return "";
+    }
+    
+    @Introspected
+    private static class Bean {
+        
+        @PathVariable
+        private String abc;
+        
+        public String getAbc() { return abc; }
+        public void setAbc(String abc) { this.abc = abc; }
+
+        
+    }
+    
+}
+
+""")
+
+        then:
+            def ex = thrown(RuntimeException)
+            ex.message.contains("The uri variable [abc] is optional, but the corresponding method argument [java.lang.String abc] is not defined as an Optional or annotated with the javax.annotation.Nullable annotation.")
+    }
+
+    void "test nullable with multiple uris with RequestBean"() {
+        when:
+            buildTypeElement("""
+
+package test;
+
+import io.micronaut.http.annotation.*;
+import io.micronaut.core.annotation.*;
+import javax.annotation.Nullable;
+
+@Controller("/foo")
+class Foo {
+
+    @Get(uris = {"/{abc}", "/{?def}"})
+    String abc(@RequestBean Bean bean) {
+        return "";
+    }
+   
+    @Introspected
+    private static class Bean {
+        
+        @PathVariable
+        private String abc;
+        
+        @Nullable
+        @PathVariable
+        private String def;
+        
+        public String getAbc() { return abc; }
+        public void setAbc(String abc) { this.abc = abc; }
+        
+        public String getDef() { return def; }
+        public void setDef(String def) { this.def = def; }
+        
+    }
+    
+}
+
+""")
+
+        then: "abc is optional because /{?def} may be matched and it does not have {abc}"
+        def ex = thrown(RuntimeException)
         ex.message.contains("The uri variable [abc] is optional, but the corresponding method argument [java.lang.String abc] is not defined as an Optional or annotated with the javax.annotation.Nullable annotation.")
+
+        when:
+            buildTypeElement("""
+
+package test;
+
+import io.micronaut.http.annotation.*;
+import io.micronaut.core.annotation.*;
+
+@Controller("/foo")
+class Foo {
+
+    @Get(uris = {"/{?abc}", "/{abc}"})
+    String abc(@RequestBean Bean bean) {
+        return "";
+    }
+    
+    @Introspected
+    private static class Bean {
+        
+        @PathVariable
+        private String abc;
+        
+        public String getAbc() { return abc; }
+        public void setAbc(String abc) { this.abc = abc; }
+        
+    }
+    
+}
+
+""")
+        then: "abc is optional because it is optional in at least one template"
+            ex = thrown(RuntimeException)
+            ex.message.contains("The uri variable [abc] is optional, but the corresponding method argument [java.lang.String abc] is not defined as an Optional or annotated with the javax.annotation.Nullable annotation.")
+
+        when:
+            buildTypeElement("""
+
+package test;
+
+import io.micronaut.http.annotation.*;
+import io.micronaut.core.annotation.*;
+import javax.annotation.Nullable;
+
+@Controller("/foo")
+class Foo {
+
+    @Get(uris = {"/{?abc}", "/{?abc}"})
+    String abc(@RequestBean Bean bean) {
+        return "";
+    }
+    
+    @Introspected
+    private static class Bean {
+        
+        @Nullable
+        @PathVariable
+        private String abc;
+        
+        public String getAbc() { return abc; }
+        public void setAbc(String abc) { this.abc = abc; }
+        
+    }
+    
+}
+
+""")
+        then:
+        noExceptionThrown()
+
+        when:
+            buildTypeElement("""
+
+package test;
+
+import io.micronaut.http.annotation.*;
+import io.micronaut.core.annotation.*;
+
+@Controller("/foo")
+class Foo {
+
+    @Get(uris = {"/{abc}", "/{abc}"})
+    String abc(@RequestBean Bean bean) {
+        return "";
+    }
+    
+    @Introspected
+    private static class Bean {
+        
+        @PathVariable
+        private String abc;
+        
+        public String getAbc() { return abc; }
+        public void setAbc(String abc) { this.abc = abc; }
+        
+    }
+    
+}
+
+""")
+        then:
+            noExceptionThrown()
+
+
     }
 }

--- a/validation/src/test/groovy/io/micronaut/validation/routes/RequestBeanParameterRuleSpec.groovy
+++ b/validation/src/test/groovy/io/micronaut/validation/routes/RequestBeanParameterRuleSpec.groovy
@@ -1,0 +1,358 @@
+package io.micronaut.validation.routes
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+
+class RequestBeanParameterRuleSpec extends AbstractTypeElementSpec {
+
+    void "test RequestBean compiles with primary constructor"() {
+        when:
+            buildTypeElement("""
+
+package test;
+
+import io.micronaut.http.annotation.*;
+import io.micronaut.core.annotation.*;
+import javax.annotation.Nullable;
+
+@Controller("/foo")
+class Foo {
+
+    @Get("/abc")
+    String abc(@RequestBean Bean bean) {
+        return "";
+    }
+    
+    @Introspected
+    private static class Bean {
+        
+        @Nullable
+        @QueryValue
+        private final String abc;
+        
+        public Bean(String abc) {
+            this.abc = abc;
+        }
+        
+        public String getAbc() { return abc; }
+        
+    }
+    
+}
+
+""")
+        then:
+            noExceptionThrown()
+    }
+
+    void "test RequestBean compiles with @Creator constructor"() {
+        when:
+            buildTypeElement("""
+
+package test;
+
+import io.micronaut.http.annotation.*;
+import io.micronaut.core.annotation.*;
+import javax.annotation.Nullable;
+
+@Controller("/foo")
+class Foo {
+
+    @Get("/abc")
+    String abc(@RequestBean Bean bean) {
+        return "";
+    }
+    
+    @Introspected
+    private static class Bean {
+        
+        @Nullable
+        @QueryValue
+        private final String abc;
+        
+        @Nullable
+        @QueryValue
+        private final String def;
+        
+        public Bean(String abc) {
+            this.abc = abc;
+            this.def = null;
+        }
+        
+        @Creator    
+        public Bean(String abc, String def) {
+            this.abc = abc;
+            this.def = def;
+        }
+        
+        public String getAbc() { return abc; }
+        
+        public String getDef() { return def; }
+        
+    }
+    
+}
+
+""")
+        then:
+            noExceptionThrown()
+    }
+
+    void "test RequestBean compiles with @Creator method"() {
+        when:
+            buildTypeElement("""
+
+package test;
+
+import io.micronaut.http.annotation.*;
+import io.micronaut.core.annotation.*;
+import javax.annotation.Nullable;
+
+@Controller("/foo")
+class Foo {
+
+    @Get("/abc")
+    String abc(@RequestBean Bean bean) {
+        return "";
+    }
+    
+    @Introspected
+    private static class Bean {
+        
+        @Nullable
+        @QueryValue
+        private String abc;
+        
+        @Creator
+        public static Bean of(String abc) {
+            Bean bean = new Bean();
+            bean.abc = abc;
+            return bean;
+        }
+        
+        public String getAbc() { return abc; }
+        
+    }
+    
+}
+
+""")
+        then:
+            noExceptionThrown()
+    }
+
+    void "test RequestBean compiles with setter"() {
+        when:
+            buildTypeElement("""
+
+package test;
+
+import io.micronaut.http.annotation.*;
+import io.micronaut.core.annotation.*;
+import javax.annotation.Nullable;
+
+@Controller("/foo")
+class Foo {
+
+    @Get("/abc")
+    String abc(@RequestBean Bean bean) {
+        return "";
+    }
+    
+    @Introspected
+    private static class Bean {
+        
+        @Nullable
+        @QueryValue
+        private String abc;
+        
+        public String getAbc() { return abc; }
+        
+        public void setAbc(String abc) { this.abc = abc; }
+        
+    }
+    
+}
+
+""")
+        then:
+            noExceptionThrown()
+    }
+
+    void "test RequestBean fails when read only property not settable"() {
+        when:
+            buildTypeElement("""
+
+package test;
+
+import io.micronaut.http.annotation.*;
+import io.micronaut.core.annotation.*;
+import javax.annotation.Nullable;
+
+@Controller("/foo")
+class Foo {
+
+    @Get("/abc")
+    String abc(@RequestBean Bean bean) {
+        return "";
+    }
+    
+    @Introspected
+    public static class Bean {
+        
+        @Nullable
+        @QueryValue
+        private String abc;
+        
+        public String getAbc() { return abc; }
+        
+    }
+    
+}
+
+""")
+        then:
+            def ex = thrown(RuntimeException)
+            ex.message.contains("Bindable property [abc] for type [test.Foo\$Bean] is Read only and cannot be set during initialization.")
+    }
+
+    void "test RequestBean fails when property not settable when primary constructor is present"() {
+        when:
+            buildTypeElement("""
+
+package test;
+
+import io.micronaut.http.annotation.*;
+import io.micronaut.core.annotation.*;
+import javax.annotation.Nullable;
+
+@Controller("/foo")
+class Foo {
+
+    @Get("/abc")
+    String abc(@RequestBean Bean bean) {
+        return "";
+    }
+    
+    @Introspected
+    public static class Bean {
+        
+        @Nullable
+        @QueryValue
+        private String abc;
+        
+        @Nullable
+        @QueryValue
+        private String def;
+        
+        public Bean(String def) {
+            this.def = def;
+        }
+        
+        public String getAbc() { return abc; }
+        
+        public String getDef() { return def; }
+        
+    }
+    
+}
+
+""")
+        then:
+            def ex = thrown(RuntimeException)
+            ex.message.contains("Primary Constructor or @Creator Method for Bindable property [abc] for type [test.Foo\$Bean] found, but there is no constructor/method parameter with name equal to [abc].")
+    }
+
+    void "test RequestBean fails when constructor parameter has Bindable annotation"() {
+        when:
+            buildTypeElement("""
+
+package test;
+
+import io.micronaut.http.annotation.*;
+import io.micronaut.core.annotation.*;
+import javax.annotation.Nullable;
+
+@Controller("/foo")
+class Foo {
+
+    @Get("/abc")
+    String abc(@RequestBean Bean bean) {
+        return "";
+    }
+    
+    @Introspected
+    public static class Bean {
+    
+        @Nullable
+        @QueryValue
+        private String abc;
+        
+        @Creator
+        public Bean(@Nullable @QueryValue String abc) {
+            this.abc = abc;
+        }
+        
+        public String getAbc() { return abc; }
+                
+    }
+    
+}
+
+""")
+        then:
+            def ex = thrown(RuntimeException)
+            ex.message.contains("Parameter of Primary Constructor (or @Creator Method) [abc] for type [test.Foo\$Bean] has one of @Bindable annotations. This is not supported.")
+    }
+
+    void "test RequestBean fails when having setter but not value in constructor"() {
+        when:
+            buildTypeElement("""
+
+package test;
+
+import io.micronaut.http.annotation.*;
+import io.micronaut.core.annotation.*;
+import javax.annotation.Nullable;
+
+@Controller("/foo")
+class Foo {
+
+    @Get("/abc")
+    String abc(@RequestBean Bean bean) {
+        return "";
+    }
+    
+    @Introspected
+    public static class Bean {
+    
+        @Nullable
+        @QueryValue
+        private String abc;
+        
+        @Nullable
+        @QueryValue
+        private String def;
+        
+        @Creator
+        public Bean(String def) {
+            this.def = def;
+        }
+        
+        public String getAbc() { return abc; }
+        
+        public void setAbc() { this.abc = abc; }
+        
+        public String getDef() { return def; }
+                
+    }
+    
+}
+
+""")
+        then:
+            def ex = thrown(RuntimeException)
+            ex.message.contains("Primary Constructor or @Creator Method for Bindable property [abc] for type [test.Foo\$Bean] found, but there is no constructor/method parameter with name equal to [abc].")
+    }
+
+
+}


### PR DESCRIPTION
This PR adds new Bindable annotation @RequestBean. With this annotation you can bind all request bindable values to one object. Example:

```
    @Controller('/rest')
    static class MyController {

        @Get("/{pathVariable}{?queryValue}")
        String getQueryValue(@RequestBean Bean bean) {
            return "Some result"
        }

        @Getter
        @AllArgsConstructor
        @Introspected
        static class Bean {
            @Nullable
            @QueryValue
            String queryValue

           @PathVariable
           String pathVariable

           @Nullable
           @Header("some-header")
           String header

        }
    } 
```

Motivation:
I was testing some Jax-rs application with Micronaut and noticed that there is no construct that is equal to `@BeanParams`. You can use exploded query params, but that is not the same. And in case you move some Jax-rs application to Micronaut and you are heavy user of `@BeanParams` this might not be easy since you have to change a lot of signatures and also micronaut-rs does not support `@BeanParams` (so with this micronaut-rs could support also `@BeanParams`).

Implementation details:
- Added new annotation @RequestBean and RequestBeanAnnotationBinder
- Every Bean marked with @RequestBean have to have `@Introspected` since object is constructed with Instrospection
- Added RequestBeanParameterRule that checks that object can be constructed via @Instropcted with all values. I added it as RouteValidationRule, although this should not be RouteValidationRule since user can disable that, but did not find where this is normally done.
- Added support in NullableParameterRule and MissingParameterRule
- Currently it supports Bindable arguments and HttpRequest. 

In case this feature is doable I already see some improvements:
- Add support for Typed Request Arguments (mapped with TypedRequestArgumentBinder), this should be easy to do but I was not able to test it. This would be cool since you could also have properties of type `Authentication` and friends in your bean
- Add annotation @RequestBeanConfiguration (or something shorter) that would be added to RequestBean class. Currently I would like to have all fields automatic marked as nullable. This will then affect validation (all fields are treated as optional) and bean initialization. This would be again really cool when moving some old app to Micronaut so you don't have to mark all fields with Nullable. Example:
```
 @RequestBeanConfiguration(autoNullable = true)
 class MyBean {
       // This is treated as nullable 
       @QueryValue
       String myValue
  }
```

### Things to consider
I am not familiar with Micronaut code base so I don't know what issues can this feature bring or if this will even work for all cases (from my tests it looks that it works). And I also don't know what should also be done to fully support this (probably at least support for OpenApi has to be added). But from this implementation it seems that it is not that complex.

So is this a feature that could get into the Micronaut or are there some issues that can arise?
