### PR TITLE
Add missing path segment in quickstart docs

### DIFF
--- a/src/main/docs/guide/quickStart/creatingServer.adoc
+++ b/src/main/docs/guide/quickStart/creatingServer.adoc
@@ -35,9 +35,9 @@ snippet::io.micronaut.docs.server.intro.HelloController[tags="imports,class"]
 <3> A String "Hello World" is returned as the result
 
 [%hardbreaks]
-If you are using Java, place the previous file in `src/main/java/hello/world`.
-If you are using Groovy, place the previous file in `src/main/groovy/hello/world`.
-If you are using Kotlin, place the previous file in `src/main/kotlin/hello/world`.
+If you are using Java, place the previous file in `src/main/java/micronaut/hello/world`.
+If you are using Groovy, place the previous file in `src/main/groovy/micronaut/hello/world`.
+If you are using Kotlin, place the previous file in `src/main/kotlin/micronaut/hello/world`.
 
 If you start the application and send a request to the `/hello` URI then the text "Hello World" is returned:
 


### PR DESCRIPTION
Closes https://github.com/micronaut-projects/micronaut-core/issues/3102

This is also an issue in older version of the docs, so should probably be backported. I tested that 1.3.4 also creates the `Application` with `micronaut` in the path, but I did not test versions prior to that. Another possible way of fixing this would be to have the quickstart app not add `micronaut` to the path to match the docs