### PR TITLE
Issue #3114 - Allow beans annotated with JsonCreator.Mode.DELEGATING to be deserialized

### DIFF
--- a/runtime/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
+++ b/runtime/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
@@ -232,6 +232,9 @@ public class BeanIntrospectionModule extends SimpleModule {
                 BeanDescription beanDesc,
                 BeanDeserializerBuilder builder) {
 
+            if (builder.getValueInstantiator().getDelegateType(config) != null) {
+                return builder;
+            }
 
             final Class<?> beanClass = beanDesc.getBeanClass();
             final BeanIntrospection<Object> introspection = (BeanIntrospection<Object>) BeanIntrospector.SHARED.findIntrospection(beanClass).orElse(null);


### PR DESCRIPTION
#3114

This fix bypasses the `BeanIntrospectionModule` when a delegatedType is detected (the delegatedType still being processed by the `BeanIntrospectionModule` in a second pass.