### PR TITLE
implemented char converter

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/configproperties/ConfigurationPropertiesSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configproperties/ConfigurationPropertiesSpec.groovy
@@ -73,6 +73,7 @@ class ConfigurationPropertiesSpec extends Specification {
             'foo.bar.stringList':"1,2",
             'foo.bar.flags.one':'1',
             'foo.bar.flags.two':'2',
+            'foo.bar.charArray': 'test',
             'foo.bar.urlList':"http://test.com, http://test2.com",
             'foo.bar.urlList2':["http://test.com", "http://test2.com"],
             'foo.bar.url':'http://test.com']
@@ -83,6 +84,7 @@ class ConfigurationPropertiesSpec extends Specification {
         MyConfig config = applicationContext.getBean(MyConfig)
 
         expect:
+        config.charArray == "test".toCharArray()
         config.port == 8080
         config.maxSize == 1048576
         config.anotherSize == 1048576

--- a/inject-java/src/test/groovy/io/micronaut/inject/configproperties/MyConfig.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configproperties/MyConfig.java
@@ -40,11 +40,20 @@ public class MyConfig {
     Inner inner;
     protected int defaultPort = 9999;
     protected Integer anotherPort;
+    char[] charArray;
 
     private int maxSize;
     @ReadableBytes
     int anotherSize;
 
+
+    public char[] getCharArray() {
+        return charArray;
+    }
+
+    public void setCharArray(char[] charArray) {
+        this.charArray = charArray;
+    }
 
     private Map<String, Map<String, Value>> map = new HashMap<>();
 

--- a/inject/src/main/java/io/micronaut/context/converters/StringToCharArray.java
+++ b/inject/src/main/java/io/micronaut/context/converters/StringToCharArray.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.context.converters;
 
 import io.micronaut.core.convert.ConversionContext;

--- a/inject/src/main/java/io/micronaut/context/converters/StringToCharArray.java
+++ b/inject/src/main/java/io/micronaut/context/converters/StringToCharArray.java
@@ -1,0 +1,13 @@
+package io.micronaut.context.converters;
+
+import io.micronaut.core.convert.ConversionContext;
+import io.micronaut.core.convert.TypeConverter;
+
+import java.util.Optional;
+
+public class StringToCharArray implements TypeConverter<CharSequence, char[]> {
+    @Override
+    public Optional<char[]> convert(CharSequence object, Class<char[]> targetType, ConversionContext context) {
+        return Optional.of(object.toString().toCharArray());
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/converters/StringToCharArray.java
+++ b/inject/src/main/java/io/micronaut/context/converters/StringToCharArray.java
@@ -20,6 +20,9 @@ import io.micronaut.core.convert.TypeConverter;
 
 import java.util.Optional;
 
+/**
+ *  Converts a String to a char[]
+ */
 public class StringToCharArray implements TypeConverter<CharSequence, char[]> {
     @Override
     public Optional<char[]> convert(CharSequence object, Class<char[]> targetType, ConversionContext context) {

--- a/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
+++ b/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
@@ -17,6 +17,7 @@ package io.micronaut.context.env;
 
 import io.micronaut.context.ApplicationContextConfiguration;
 import io.micronaut.context.converters.StringArrayToClassArrayConverter;
+import io.micronaut.context.converters.StringToCharArray;
 import io.micronaut.context.converters.StringToClassConverter;
 import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.core.convert.ConversionContext;
@@ -214,6 +215,9 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
         );
         conversionService.addConverter(
                 Object[].class, Class[].class, new StringArrayToClassArrayConverter(conversionService)
+        );
+        conversionService.addConverter(
+                CharSequence.class, char[].class, new StringToCharArray()
         );
         this.resourceLoader = configuration.getResourceLoader();
         this.annotationScanner = createAnnotationScanner(classLoader);


### PR DESCRIPTION
This implemented a string to char[] converter into the default environment for #2614 and allows strings to be converted to a char array when assigned to a configuration. is this the intended behavior because the issue discusses some other problems with this i.e a method that accepts a string and another method for a char[]. would it have to be implemented through another means to avoid this case?  