### PR TITLE
Modify some typos and make a line readable

### DIFF
--- a/inject/src/main/java/io/micronaut/context/StaticMessageSource.java
+++ b/inject/src/main/java/io/micronaut/context/StaticMessageSource.java
@@ -37,7 +37,7 @@ public class StaticMessageSource extends AbstractMessageSource {
     /**
      * Adds a message to the default locale.
      * @param code The code
-     * @param message The the message
+     * @param message The message
      * @return This message source
      */
     public @Nonnull StaticMessageSource addMessage(@Nonnull String code, @Nonnull String message) {
@@ -51,7 +51,7 @@ public class StaticMessageSource extends AbstractMessageSource {
      * Adds a message to the default locale.
      * @param locale The locale
      * @param code The code
-     * @param message The the message
+     * @param message The message
      * @return This message source
      */
     public @Nonnull StaticMessageSource addMessage(@Nonnull Locale locale, @Nonnull String code, @Nonnull String message) {
@@ -69,9 +69,7 @@ public class StaticMessageSource extends AbstractMessageSource {
         ArgumentUtils.requireNonNull("context", context);
         final String msg = messageMap.get(new MessageKey(context.getLocale(), code));
         if (msg != null) {
-            return Optional.of(
-                    msg
-            );
+            return Optional.of(msg);
         } else {
             return Optional.ofNullable(messageMap.get(new MessageKey(Locale.getDefault(), code)));
         }


### PR DESCRIPTION
During reading codes for working on [this issue](https://github.com/micronaut-projects/micronaut-core/issues/2617), I found two typos in `StaticMessageSource`.
I think the phrase `The the message` is `The message`, so I modified.
And I think [here](https://github.com/micronaut-projects/micronaut-core/blob/88a809f176ddf85c0c8456f45f4fd527cfbf8257/inject/src/main/java/io/micronaut/context/StaticMessageSource.java#L72-L74) is more readable by coding with one line.
`return Optional.of(msg);`