### PR TITLE
Changed the LoggersEndpoint to default to be disabled. Previously was enabled by default.

### DIFF
--- a/management/src/main/java/io/micronaut/management/endpoint/loggers/LoggersEndpoint.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/loggers/LoggersEndpoint.java
@@ -57,7 +57,7 @@ public class LoggersEndpoint {
     /**
      * Endpoint default sensitivity.
      */
-    public static final boolean DEFAULT_SENSITIVE = false;
+    public static final boolean DEFAULT_SENSITIVE = true;
 
     private final LoggingSystem loggingSystem;
     private final LoggersManager<Map<String, Object>> loggersManager;

--- a/management/src/main/java/io/micronaut/management/endpoint/loggers/LoggersEndpoint.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/loggers/LoggersEndpoint.java
@@ -52,7 +52,7 @@ public class LoggersEndpoint {
     /**
      * Endpoint default enabled.
      */
-    public static final boolean DEFAULT_ENABLED = true;
+    public static final boolean DEFAULT_ENABLED = false;
 
     /**
      * Endpoint default sensitivity.

--- a/management/src/test/groovy/io/micronaut/management/endpoint/loggers/LoggersEndpointSpec.groovy
+++ b/management/src/test/groovy/io/micronaut/management/endpoint/loggers/LoggersEndpointSpec.groovy
@@ -58,7 +58,7 @@ class LoggersEndpointSpec extends Specification {
     static final expectedBuiltinLoggers = ['io.micronaut', 'io.netty']
 
     void setup() {
-        server = ApplicationContext.run(EmbeddedServer, ['endpoints.loggers.enabled': true], Environment.TEST)
+        server = ApplicationContext.run(EmbeddedServer, ['endpoints.loggers.enabled': true, 'endpoints.loggers.sensitive': false], Environment.TEST)
         client = server.applicationContext.createBean(RxHttpClient, server.URL)
     }
 

--- a/src/main/docs/guide/appendix/breaks.adoc
+++ b/src/main/docs/guide/appendix/breaks.adoc
@@ -238,3 +238,22 @@ my.message=We love Micronaut''s documentation
 ----
 
 NOTE: This change also applies to messages in custom constraint annotations, which interpolate the message via the message source api.
+
+=== LoggersEndpoint is disabled by default
+In Micronaut 1.x, the LoggersEndpoint ( /logger ) management endpoint was enabled by default. This allowed unauthenticated modification of the services logging.
+This was also inconsistent with other management endpoints that allowed modification of the internal state, such as ServerStopEndpoint ( /stop ) which allows users to shutdown the service. Which was disabled by default.
+
+In Microanut 2.x, the LoggersEndpoint ( /logger ) is disabled by default. To enable the logger endpoint  following properties must be set.
+[source,yaml]
+-----
+endpoints.loggers.enabled
+endpoints:
+    loggers:
+        enabled: true
+        sensitive: false
+
+ ----
+
+
+
+

--- a/src/main/docs/guide/management/providedEndpoints/loggersEndpoint.adoc
+++ b/src/main/docs/guide/management/providedEndpoints/loggersEndpoint.adoc
@@ -2,8 +2,11 @@
 The loggers endpoint returns information about the available loggers in the application and
 permits configuring the their log level.
 
+NOTE: By default, the loggers endpoint is disabled and needs to be explicitly enabled to be used.
+
 To get a collection of all loggers by name with their configured and effective log levels,
 send a GET request to /loggers. This will also provide a list of the available log levels.
+
 
 [source,bash]
 ----


### PR DESCRIPTION
Changed the LoggersEndpoint to default to be disabled. Previously was enabled by default.
To enable the LoggersEndpoint the following property needs to be set.
endpoints.loggers.enabled = true
This is due to the LoggersEndpoint allows unauthenticated users to modify the logging configuration of the service by default. This is inconsistent with the other management endpoints that allow modification of the internal state of the application, such as CachesEndpoint or ServerStopEndpoint which default to disabled.

Also updated the tests to validate the new behaviour and updated the documentation to reflect this change.
