### PR TITLE
Show example with proxy

### DIFF
--- a/src/main/docs/guide/quickStart/creatingServer.adoc
+++ b/src/main/docs/guide/quickStart/creatingServer.adoc
@@ -11,6 +11,14 @@ $ mn create-app hello-world
 
 TIP: You can supply `--build maven` if you wish to create a Maven based build instead
 
+If you are behind a proxy, you might have to export MN_OPTS before running the mn command
+
+[source,bash]
+----
+$ export MN_OPTS="-Dhttps.proxyHost=your.proxy.host -Dhttps.proxyPort=3128 -Dhttp.proxyUser=test -Dhttp.proxyPassword=test"
+$ mn create-app hello-world
+----
+
 The previous command will create a new Java application in a directory called `hello-world` featuring a Gradle build. The application can be run with `./gradlew run`:
 
 [source,bash]


### PR DESCRIPTION
If the machine on which we are running the Micronaut CLI is behind a proxy, then MN_OPTS needs to be exported. 

Though this is explained in section 17.6 of the guide, for someone who is trying the "quick start" steps, it results in a failure if the machine is behind a proxy. So, does it sound ok to make a mention of this in the Quick Start as well ?