### PR TITLE
Provide API and solution sending events async 

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/event/DeadlockProducer.java
+++ b/inject-java/src/test/groovy/io/micronaut/event/DeadlockProducer.java
@@ -1,0 +1,31 @@
+package io.micronaut.event;
+import io.micronaut.context.event.ApplicationEvent;
+import io.micronaut.context.event.ApplicationEventPublisher;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.concurrent.ExecutionException;
+
+@Singleton
+public class DeadlockProducer {
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Inject
+    public DeadlockProducer(ApplicationEventPublisher eventPublisher) {
+        this.eventPublisher = eventPublisher;
+    }
+
+    @PostConstruct
+    public void init() {
+        try {
+            eventPublisher.publishEventAsync(new ApplicationEvent("Event")).get();
+        } catch (InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public String method() {
+        return "value";
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/event/PublishPostConstructThreadSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/event/PublishPostConstructThreadSpec.groovy
@@ -1,0 +1,21 @@
+package io.micronaut.event
+
+import io.micronaut.context.ApplicationContext
+import spock.lang.AutoCleanup
+import spock.lang.Issue
+import spock.lang.Shared
+import spock.lang.Specification
+
+
+class PublishPostConstructThreadSpec extends Specification {
+    @Shared @AutoCleanup ApplicationContext context = ApplicationContext.run()
+
+    @Issue('https://github.com/micronaut-projects/micronaut-core/issues/3124')
+    void 'test publishing an event on a different does not deadlock'() {
+        given:
+        DeadlockProducer producer = context.getBean(DeadlockProducer)
+
+        expect:
+        producer != null
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -59,9 +59,7 @@ import java.io.Closeable;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -1132,32 +1130,55 @@ public class DefaultBeanContext implements BeanContext {
 
             eventListeners = eventListeners.stream().sorted(OrderUtil.COMPARATOR).collect(Collectors.toList());
 
-            if (!eventListeners.isEmpty()) {
-                if (EVENT_LOGGER.isTraceEnabled()) {
-                    EVENT_LOGGER.trace("Established event listeners {} for event: {}", eventListeners, event);
-                }
-                for (ApplicationEventListener listener : eventListeners) {
-                    if (listener.supports(event)) {
-                        try {
-                            if (EVENT_LOGGER.isTraceEnabled()) {
-                                EVENT_LOGGER.trace("Invoking event listener [{}] for event: {}", listener, event);
+            notifyEventListeners(event, eventListeners);
+        }
+    }
+
+    private void notifyEventListeners(@Nonnull Object event, Collection<ApplicationEventListener> eventListeners) {
+        if (!eventListeners.isEmpty()) {
+            if (EVENT_LOGGER.isTraceEnabled()) {
+                EVENT_LOGGER.trace("Established event listeners {} for event: {}", eventListeners, event);
+            }
+            for (ApplicationEventListener listener : eventListeners) {
+                if (listener.supports(event)) {
+                    try {
+                        if (EVENT_LOGGER.isTraceEnabled()) {
+                            EVENT_LOGGER.trace("Invoking event listener [{}] for event: {}", listener, event);
+                        }
+                        listener.onApplicationEvent(event);
+                    } catch (ClassCastException ex) {
+                        String msg = ex.getMessage();
+                        if (msg == null || msg.startsWith(event.getClass().getName())) {
+                            if (EVENT_LOGGER.isDebugEnabled()) {
+                                EVENT_LOGGER.debug("Incompatible listener for event: " + listener, ex);
                             }
-                            listener.onApplicationEvent(event);
-                        } catch (ClassCastException ex) {
-                            String msg = ex.getMessage();
-                            if (msg == null || msg.startsWith(event.getClass().getName())) {
-                                if (EVENT_LOGGER.isDebugEnabled()) {
-                                    EVENT_LOGGER.debug("Incompatible listener for event: " + listener, ex);
-                                }
-                            } else {
-                                throw ex;
-                            }
+                        } else {
+                            throw ex;
                         }
                     }
-
                 }
+
             }
         }
+    }
+
+    @Override
+    public Future<Void> publishEventAsync(@Nonnull Object event) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        Collection<ApplicationEventListener> eventListeners = streamOfType(ApplicationEventListener.class, Qualifiers.byTypeArguments(event.getClass()))
+                                                                        .sorted(OrderUtil.COMPARATOR).collect(Collectors.toList());
+
+        Executor executor = findBean(Executor.class, Qualifiers.byName("scheduled"))
+                                .orElseGet(ForkJoinPool::commonPool);
+        executor.execute(() -> {
+            try {
+                notifyEventListeners(event, eventListeners);
+                future.complete(null);
+            } catch (Exception e) {
+                future.completeExceptionally(e);
+            }
+        });
+        return future;
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/context/event/ApplicationEventPublisher.java
+++ b/inject/src/main/java/io/micronaut/context/event/ApplicationEventPublisher.java
@@ -16,7 +16,6 @@
 package io.micronaut.context.event;
 
 import javax.annotation.Nonnull;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 
 /**
@@ -45,13 +44,6 @@ public interface ApplicationEventPublisher {
      * @since 1.3.5
      */
     default Future<Void> publishEventAsync(@Nonnull Object event) {
-        CompletableFuture<Void> future = new CompletableFuture<>();
-        try {
-            publishEvent(event);
-            future.complete(null);
-        } catch (Throwable e) {
-            future.completeExceptionally(e);
-        }
-        return future;
+        throw new UnsupportedOperationException("Asynchronous event publishing is not supported by this implementation");
     }
 }

--- a/inject/src/main/java/io/micronaut/context/event/ApplicationEventPublisher.java
+++ b/inject/src/main/java/io/micronaut/context/event/ApplicationEventPublisher.java
@@ -42,6 +42,7 @@ public interface ApplicationEventPublisher {
      *
      * @param event The event to publish
      * @return A future that completes when the event is published
+     * @since 1.3.5
      */
     default Future<Void> publishEventAsync(@Nonnull Object event) {
         CompletableFuture<Void> future = new CompletableFuture<>();

--- a/inject/src/main/java/io/micronaut/context/event/ApplicationEventPublisher.java
+++ b/inject/src/main/java/io/micronaut/context/event/ApplicationEventPublisher.java
@@ -16,6 +16,8 @@
 package io.micronaut.context.event;
 
 import javax.annotation.Nonnull;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 
 /**
  * <p>Interface for classes that publish events received by {@link ApplicationEventListener} instances.</p>
@@ -34,4 +36,20 @@ public interface ApplicationEventPublisher {
      * @param event The event to publish
      */
     void publishEvent(@Nonnull Object event);
+
+    /**
+     * Publish the given event. The event will be published synchronously and only return once all listeners have consumed the event.
+     *
+     * @param event The event to publish
+     */
+    default Future<Void> publishEventAsync(@Nonnull Object event) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        try {
+            publishEvent(event);
+            future.complete(null);
+        } catch (Throwable e) {
+            future.completeExceptionally(e);
+        }
+        return future;
+    }
 }

--- a/inject/src/main/java/io/micronaut/context/event/ApplicationEventPublisher.java
+++ b/inject/src/main/java/io/micronaut/context/event/ApplicationEventPublisher.java
@@ -41,6 +41,7 @@ public interface ApplicationEventPublisher {
      * Publish the given event. The event will be published synchronously and only return once all listeners have consumed the event.
      *
      * @param event The event to publish
+     * @return A future that completes when the event is published
      */
     default Future<Void> publishEventAsync(@Nonnull Object event) {
         CompletableFuture<Void> future = new CompletableFuture<>();

--- a/inject/src/main/java/io/micronaut/context/event/ApplicationEventPublisher.java
+++ b/inject/src/main/java/io/micronaut/context/event/ApplicationEventPublisher.java
@@ -37,7 +37,7 @@ public interface ApplicationEventPublisher {
     void publishEvent(@Nonnull Object event);
 
     /**
-     * Publish the given event. The event will be published synchronously and only return once all listeners have consumed the event.
+     * Publish the given event. The event will be published asynchronously. A future is returned that can be used to check whether the event completed successfully or not.
      *
      * @param event The event to publish
      * @return A future that completes when the event is published


### PR DESCRIPTION
Provides solution for #3124 

The actual problem is not solvable because a lock is placed on the bean registry to avoid duplicate singletons being created so removing this lock would break correctness. 

However the issue can be resolved by looking up the event listeners before firing events. This change adds an API to do that and provides a solution for this use case.

Debatable whether it should go into 1.3.x or not.