### PR TITLE
Make binding of form data consistent with JSON. Fixes #2919

### DIFF
--- a/core/src/main/java/io/micronaut/core/convert/ErrorsContext.java
+++ b/core/src/main/java/io/micronaut/core/convert/ErrorsContext.java
@@ -60,4 +60,11 @@ public interface ErrorsContext extends Iterable<ConversionError> {
         return Optional.empty();
     }
 
+    /**
+     * @return Check whether errors exist
+     */
+    default boolean hasErrors() {
+        return getLastError().isPresent();
+    }
+
 }

--- a/http-client/src/test/groovy/io/micronaut/http/client/docs/binding/BookControllerTest.java
+++ b/http-client/src/test/groovy/io/micronaut/http/client/docs/binding/BookControllerTest.java
@@ -59,7 +59,7 @@ public class BookControllerTest {
         // end::postform[]
 
         thrown.expect(HttpClientResponseException.class);
-        thrown.expectMessage(CoreMatchers.startsWith("Failed to convert argument [book] for value [{title=The Stand, pages=notnumber, url=noturl}]"));
+        thrown.expectMessage(CoreMatchers.startsWith("Failed to convert argument [book] for value [null] due to: Cannot deserialize value of type `int` from String \"notnumber\""));
 
         HttpResponse<Book> response = call.blockingFirst();
 

--- a/http-client/src/test/groovy/io/micronaut/http/client/docs/binding/BookControllerTest.java
+++ b/http-client/src/test/groovy/io/micronaut/http/client/docs/binding/BookControllerTest.java
@@ -59,7 +59,7 @@ public class BookControllerTest {
         // end::postform[]
 
         thrown.expect(HttpClientResponseException.class);
-        thrown.expectMessage(CoreMatchers.startsWith("Failed to convert argument [pages] for value [notnumber]"));
+        thrown.expectMessage(CoreMatchers.startsWith("Failed to convert argument [book] for value [{title=The Stand, pages=notnumber, url=noturl}]"));
 
         HttpResponse<Book> response = call.blockingFirst();
 

--- a/http-client/src/test/groovy/io/micronaut/http/client/rxjava2/RxHttpPostSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/rxjava2/RxHttpPostSpec.groovy
@@ -41,6 +41,9 @@ import spock.lang.IgnoreIf
 import spock.lang.Shared
 import spock.lang.Specification
 
+import javax.validation.Valid
+import javax.validation.constraints.NotNull
+
 /**
  * @author Graeme Rocher
  * @since 1.0
@@ -238,21 +241,10 @@ class RxHttpPostSpec extends Specification {
     @Introspected
     static class Person {
 
-        private final String firstName
-        private final String lastName
-
-        Person(String firstName, String lastName) {
-            this.lastName = lastName
-            this.firstName = firstName
-        }
-
-        String getFirstName() {
-            return firstName
-        }
-
-        String getLastName() {
-            return lastName
-        }
+        @NotNull
+        String firstName
+        @NotNull
+        String lastName
     }
 
     @Controller('/reactive/post')
@@ -288,7 +280,7 @@ class RxHttpPostSpec extends Specification {
         }
 
         @Post(uri = "/person", consumes = MediaType.APPLICATION_FORM_URLENCODED)
-        Single<HttpResponse<Person>> createPerson(@Body Person person)  {
+        Single<HttpResponse<Person>> createPerson(@Valid @Body Person person)  {
             return Single.just(HttpResponse.created(person))
         }
 

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/ParameterBindingSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/ParameterBindingSpec.groovy
@@ -92,7 +92,7 @@ class ParameterBindingSpec extends AbstractMicronautSpec {
 
         expect:
         response.status() == HttpStatus.BAD_REQUEST
-        response.body().contains('Failed to convert argument [age]')
+        response.body().contains('Unexpected token (VALUE_STRING), expected END_ARRAY')
     }
 
     @Controller(value = "/parameter", produces = MediaType.TEXT_PLAIN)

--- a/http-server/src/main/java/io/micronaut/http/server/binding/RequestArgumentSatisfier.java
+++ b/http-server/src/main/java/io/micronaut/http/server/binding/RequestArgumentSatisfier.java
@@ -138,7 +138,7 @@ public class RequestArgumentSatisfier {
                     value = bindingResult.get();
                 } else if (bindingResult.isSatisfied() && argument.isNullable()) {
                     value = NullArgument.INSTANCE;
-                } else if (HttpMethod.requiresRequestBody(request.getMethod()) || argument.isNullable()) {
+                } else if (HttpMethod.requiresRequestBody(request.getMethod()) || argument.isNullable() || conversionContext.hasErrors()) {
                     value = (UnresolvedArgument) () -> {
                         ArgumentBinder.BindingResult result = argumentBinder.bind(conversionContext, request);
                         Optional<ConversionError> lastError = conversionContext.getLastError();

--- a/runtime/src/main/java/io/micronaut/jackson/bind/MapToObjectConverter.java
+++ b/runtime/src/main/java/io/micronaut/jackson/bind/MapToObjectConverter.java
@@ -19,14 +19,11 @@ import io.micronaut.core.bind.ArgumentBinder;
 import io.micronaut.core.bind.BeanPropertyBinder;
 import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.ConversionContext;
-import io.micronaut.core.convert.ConversionError;
 import io.micronaut.core.convert.TypeConverter;
-import io.micronaut.core.convert.exceptions.ConversionErrorException;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -68,12 +65,7 @@ public class MapToObjectConverter implements TypeConverter<Map, Object> {
         }
         ArgumentBinder binder = this.beanPropertyBinder.get();
         ArgumentBinder.BindingResult result = binder.bind(conversionContext, map);
-        List<ConversionError> conversionErrors = result.getConversionErrors();
-        if (!conversionErrors.isEmpty()) {
-            context.reject(map, new ConversionErrorException(conversionContext.getArgument(), conversionErrors.iterator().next()));
-            return Optional.empty();
-        } else {
-            return result.getValue();
-        }
+        Optional opt = result.getValue();
+        return opt;
     }
 }

--- a/runtime/src/main/java/io/micronaut/jackson/bind/MapToObjectConverter.java
+++ b/runtime/src/main/java/io/micronaut/jackson/bind/MapToObjectConverter.java
@@ -15,19 +15,20 @@
  */
 package io.micronaut.jackson.bind;
 
+import io.micronaut.core.bind.ArgumentBinder;
 import io.micronaut.core.bind.BeanPropertyBinder;
+import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.ConversionContext;
+import io.micronaut.core.convert.ConversionError;
 import io.micronaut.core.convert.TypeConverter;
-import io.micronaut.core.naming.NameUtils;
-import io.micronaut.core.reflect.InstantiationUtils;
+import io.micronaut.core.convert.exceptions.ConversionErrorException;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
-import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.BiFunction;
 
 /**
  * A class that uses the {@link BeanPropertyBinder} to bind maps to {@link Object} instances.
@@ -59,26 +60,20 @@ public class MapToObjectConverter implements TypeConverter<Map, Object> {
 
     @Override
     public Optional<Object> convert(Map map, Class<Object> targetType, ConversionContext context) {
-        final BiFunction<Object, Map<?, ?>, Object> propertiesBinderFunction = (object, properties) -> {
-            Map bindMap = new LinkedHashMap(properties.size());
-            for (Map.Entry entry : properties.entrySet()) {
-                Object key = entry.getKey();
-                bindMap.put(NameUtils.decapitalize(NameUtils.dehyphenate(key.toString())), entry.getValue());
-            }
-            return beanPropertyBinder.get().bind(object, bindMap);
-        };
-
-        Optional<Object> instance = InstantiationUtils.tryInstantiate(targetType, map, context)
-                    .map(object -> propertiesBinderFunction.apply(object, map));
-
-        if (instance.isPresent()) {
-            return instance;
-        } else if (targetType.isInstance(map)) {
-            return Optional.of(map);
+        ArgumentConversionContext<Object> conversionContext;
+        if (context instanceof ArgumentConversionContext) {
+            conversionContext = (ArgumentConversionContext<Object>) context;
         } else {
-            return InstantiationUtils
-                    .tryInstantiate(targetType)
-                    .map(object -> propertiesBinderFunction.apply(object, map));
+            conversionContext = ConversionContext.of(targetType);
+        }
+        ArgumentBinder binder = this.beanPropertyBinder.get();
+        ArgumentBinder.BindingResult result = binder.bind(conversionContext, map);
+        List<ConversionError> conversionErrors = result.getConversionErrors();
+        if (!conversionErrors.isEmpty()) {
+            context.reject(map, new ConversionErrorException(conversionContext.getArgument(), conversionErrors.iterator().next()));
+            return Optional.empty();
+        } else {
+            return result.getValue();
         }
     }
 }


### PR DESCRIPTION
This provides a fix for #2919 

Note however it could be regarded as a breaking change since the previous implementation validated `null` values, however this was consistent with the way JSON was bound (which doesn't do this) and really is the job of the `validation` module. I had to alter the tests to take into account this new behaviour.