### PR TITLE
Correctly use generics in bean introspections. Fixes #3187

### DIFF
--- a/http-client/src/test/groovy/io/micronaut/http/client/convert/GenericsJacksonSerdeSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/convert/GenericsJacksonSerdeSpec.groovy
@@ -62,7 +62,6 @@ class GenericsJacksonSerdeSpec extends Specification {
         }
     }
 
-    @Introspected
     static final class Token {
         private final String value
 

--- a/http-client/src/test/groovy/io/micronaut/http/client/convert/GenericsJacksonSerdeSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/convert/GenericsJacksonSerdeSpec.groovy
@@ -1,0 +1,80 @@
+package io.micronaut.http.client.convert
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonValue
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.annotation.Creator
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Post
+import io.micronaut.http.client.RxHttpClient
+import io.micronaut.runtime.server.EmbeddedServer
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class GenericsJacksonSerdeSpec extends Specification {
+    @Shared @AutoCleanup
+    EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer)
+
+    @Shared @AutoCleanup RxHttpClient client = embeddedServer.applicationContext
+                                                        .createBean(RxHttpClient, embeddedServer.getURL())
+
+    void "test ser/deser body with generics"() {
+
+        when:
+        def response = client.exchange(HttpRequest.POST("/generics-test", new WrappedData<Token>("1", new Token("test"))), Token)
+                .blockingFirst()
+
+        then:
+        response.body().value == 'test'
+    }
+
+    @Controller("/generics-test")
+    static final class GenericsController {
+        @Post(consumes = "application/json", produces = "application/json")
+        Token create(@Body WrappedData<Token> value) {
+            return value.getData()
+        }
+    }
+
+    @Introspected
+    static final class WrappedData<T> {
+        private final String id
+        private final T data
+
+        @JsonCreator
+        WrappedData(@JsonProperty("id") String id, @JsonProperty("data") T data) {
+            this.id = id
+            this.data = data
+        }
+
+        String getId() {
+            return id
+        }
+
+        T getData() {
+            return data
+        }
+    }
+
+    static final class Token {
+        private final String value
+
+        Token(String value) {
+            if (value.length() < 3) {
+                throw new IllegalArgumentException("Some invalid condition: " + value)
+            }
+            this.value = value
+        }
+
+        @JsonValue
+        String getValue() {
+            return value
+        }
+    }
+}

--- a/http-client/src/test/groovy/io/micronaut/http/client/convert/GenericsJacksonSerdeSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/convert/GenericsJacksonSerdeSpec.groovy
@@ -62,6 +62,7 @@ class GenericsJacksonSerdeSpec extends Specification {
         }
     }
 
+    @Introspected
     static final class Token {
         private final String value
 

--- a/http-client/src/test/resources/logback.xml
+++ b/http-client/src/test/resources/logback.xml
@@ -11,7 +11,7 @@
     <root level="info">
         <appender-ref ref="STDOUT" />
     </root>
-    <!--<logger name="io.micronaut.http" level="TRACE"/>-->
+    <logger name="io.micronaut.http" level="TRACE"/>
     <!--<logger name="io.netty.handler.logging" level="TRACE" />-->
     <!--<logger name="io.micronaut.jackson.parser" level="TRACE"/>-->
 </configuration>

--- a/http-client/src/test/resources/logback.xml
+++ b/http-client/src/test/resources/logback.xml
@@ -11,7 +11,7 @@
     <root level="info">
         <appender-ref ref="STDOUT" />
     </root>
-    <logger name="io.micronaut.http" level="TRACE"/>
+<!--    <logger name="io.micronaut.http" level="TRACE"/>-->
     <!--<logger name="io.netty.handler.logging" level="TRACE" />-->
     <!--<logger name="io.micronaut.jackson.parser" level="TRACE"/>-->
 </configuration>

--- a/runtime/src/main/java/io/micronaut/jackson/convert/JsonNodeToObjectConverter.java
+++ b/runtime/src/main/java/io/micronaut/jackson/convert/JsonNodeToObjectConverter.java
@@ -15,16 +15,22 @@
  */
 package io.micronaut.jackson.convert;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.ConversionContext;
 import io.micronaut.core.convert.TypeConverter;
+import io.micronaut.core.type.Argument;
+import io.micronaut.jackson.JacksonConfiguration;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
+import java.io.IOException;
 import java.util.Optional;
 
 /**
@@ -61,10 +67,23 @@ public class JsonNodeToObjectConverter implements TypeConverter<JsonNode, Object
             if (CharSequence.class.isAssignableFrom(targetType) && node instanceof ObjectNode) {
                 return Optional.of(node.toString());
             } else {
-                Object result = objectMapper.get().treeToValue(node, targetType);
+                Argument<Object> argument = null;
+                if (context instanceof ArgumentConversionContext) {
+                    argument = ((ArgumentConversionContext<Object>) context).getArgument();
+                }
+                ObjectMapper om = this.objectMapper.get();
+                JsonParser jsonParser = om.treeAsTokens(node);
+                TypeFactory typeFactory = om.getTypeFactory();
+                Object result;
+                if (argument != null) {
+                    JavaType javaType = JacksonConfiguration.constructType(argument, typeFactory);
+                    result = om.readValue(jsonParser, javaType);
+                } else {
+                    result = om.readValue(jsonParser, targetType);
+                }
                 return Optional.ofNullable(result);
             }
-        } catch (JsonProcessingException e) {
+        } catch (IOException e) {
             context.reject(e);
             return Optional.empty();
         }

--- a/runtime/src/main/java/io/micronaut/jackson/convert/JsonNodeToObjectConverter.java
+++ b/runtime/src/main/java/io/micronaut/jackson/convert/JsonNodeToObjectConverter.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ContainerNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import io.micronaut.core.convert.ArgumentConversionContext;
@@ -68,18 +69,18 @@ public class JsonNodeToObjectConverter implements TypeConverter<JsonNode, Object
                 return Optional.of(node.toString());
             } else {
                 Argument<Object> argument = null;
-                if (context instanceof ArgumentConversionContext) {
+                if (node instanceof ContainerNode && context instanceof ArgumentConversionContext) {
                     argument = ((ArgumentConversionContext<Object>) context).getArgument();
                 }
-                ObjectMapper om = this.objectMapper.get();
-                JsonParser jsonParser = om.treeAsTokens(node);
-                TypeFactory typeFactory = om.getTypeFactory();
                 Object result;
                 if (argument != null) {
+                    ObjectMapper om = this.objectMapper.get();
+                    JsonParser jsonParser = om.treeAsTokens(node);
+                    TypeFactory typeFactory = om.getTypeFactory();
                     JavaType javaType = JacksonConfiguration.constructType(argument, typeFactory);
                     result = om.readValue(jsonParser, javaType);
                 } else {
-                    result = om.readValue(jsonParser, targetType);
+                    result = this.objectMapper.get().treeToValue(node, targetType);
                 }
                 return Optional.ofNullable(result);
             }

--- a/runtime/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
+++ b/runtime/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
@@ -285,7 +285,7 @@ public class BeanIntrospectionModule extends SimpleModule {
                             props = new SettableBeanProperty[constructorArguments.length];
                             for (int i = 0; i < constructorArguments.length; i++) {
                                 Argument<?> argument = constructorArguments[i];
-                                final JavaType javaType = existing.length > i ? existing[i].getType() : newType(argument, typeFactory);
+                                final JavaType javaType = existing != null && existing.length > i ? existing[i].getType() : newType(argument, typeFactory);
                                 final AnnotationMetadata annotationMetadata = argument.getAnnotationMetadata();
                                 PropertyMetadata propertyMetadata = newPropertyMetadata(argument, annotationMetadata);
                                 final String simpleName = annotationMetadata.stringValue(JsonProperty.class).orElse(argument.getName());

--- a/runtime/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
+++ b/runtime/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
@@ -274,89 +274,92 @@ public class BeanIntrospectionModule extends SimpleModule {
 
                 final Argument<?>[] constructorArguments = introspection.getConstructorArguments();
                 final TypeFactory typeFactory = config.getTypeFactory();
+                ValueInstantiator defaultInstantiator = builder.getValueInstantiator();
                 builder.setValueInstantiator(new StdValueInstantiator(config, typeFactory.constructType(beanClass)) {
-
+                    SettableBeanProperty[] props;
                     @Override
                     public SettableBeanProperty[] getFromObjectArguments(DeserializationConfig config) {
 
-
-                        SettableBeanProperty[] props = new SettableBeanProperty[constructorArguments.length];
-                        for (int i = 0; i < constructorArguments.length; i++) {
-                            Argument<?> argument = constructorArguments[i];
-                            final JavaType javaType = newType(argument, typeFactory);
-                            final AnnotationMetadata annotationMetadata = argument.getAnnotationMetadata();
-                            PropertyMetadata propertyMetadata = newPropertyMetadata(argument, annotationMetadata);
-                            final String simpleName = annotationMetadata.stringValue(JsonProperty.class).orElse(argument.getName());
-                            TypeDeserializer typeDeserializer;
-                            try {
-                                typeDeserializer = config.findTypeDeserializer(javaType);
-                            } catch (JsonMappingException e) {
-                                typeDeserializer = null;
-                            }
-                            props[i] = new CreatorProperty(
-                                    PropertyName.construct(simpleName),
-                                    javaType,
-                                    null,
-                                    typeDeserializer,
-                                    null,
-                                    null,
-                                    i,
-                                    null,
-                                    propertyMetadata
-
-                            ) {
-                                private final BeanProperty<Object, Object> property = introspection.getProperty(argument.getName()).orElse(null);
-
-                                @Override
-                                public <A extends Annotation> A getAnnotation(Class<A> acls) {
-                                    return annotationMetadata.synthesize(acls);
+                        SettableBeanProperty[] existing = defaultInstantiator.getFromObjectArguments(config);
+                        if (props == null) {
+                            props = new SettableBeanProperty[constructorArguments.length];
+                            for (int i = 0; i < constructorArguments.length; i++) {
+                                Argument<?> argument = constructorArguments[i];
+                                final JavaType javaType = existing.length > i ? existing[i].getType() : newType(argument, typeFactory);
+                                final AnnotationMetadata annotationMetadata = argument.getAnnotationMetadata();
+                                PropertyMetadata propertyMetadata = newPropertyMetadata(argument, annotationMetadata);
+                                final String simpleName = annotationMetadata.stringValue(JsonProperty.class).orElse(argument.getName());
+                                TypeDeserializer typeDeserializer;
+                                try {
+                                    typeDeserializer = config.findTypeDeserializer(javaType);
+                                } catch (JsonMappingException e) {
+                                    typeDeserializer = null;
                                 }
+                                props[i] = new CreatorProperty(
+                                        PropertyName.construct(simpleName),
+                                        javaType,
+                                        null,
+                                        typeDeserializer,
+                                        null,
+                                        null,
+                                        i,
+                                        null,
+                                        propertyMetadata
 
-                                @Override
-                                public AnnotatedMember getMember() {
-                                    return new VirtualAnnotatedMember(
-                                            beanDesc.getClassInfo(),
-                                            beanClass,
-                                            argument.getName(),
-                                            javaType
-                                    ) {
-                                        @Override
-                                        public boolean hasOneOf(Class<? extends Annotation>[] annoClasses) {
-                                            return Arrays.stream(annoClasses).anyMatch(annotationMetadata::hasAnnotation);
+                                ) {
+                                    private final BeanProperty<Object, Object> property = introspection.getProperty(argument.getName()).orElse(null);
+
+                                    @Override
+                                    public <A extends Annotation> A getAnnotation(Class<A> acls) {
+                                        return annotationMetadata.synthesize(acls);
+                                    }
+
+                                    @Override
+                                    public AnnotatedMember getMember() {
+                                        return new VirtualAnnotatedMember(
+                                                beanDesc.getClassInfo(),
+                                                beanClass,
+                                                argument.getName(),
+                                                javaType
+                                        ) {
+                                            @Override
+                                            public boolean hasOneOf(Class<? extends Annotation>[] annoClasses) {
+                                                return Arrays.stream(annoClasses).anyMatch(annotationMetadata::hasAnnotation);
+                                            }
+                                        };
+                                    }
+
+                                    @Override
+                                    public void deserializeAndSet(JsonParser p, DeserializationContext ctxt, Object instance) throws IOException {
+                                        if (property != null) {
+                                            property.set(instance, deserialize(p, ctxt));
                                         }
-                                    };
-                                }
-
-                                @Override
-                                public void deserializeAndSet(JsonParser p, DeserializationContext ctxt, Object instance) throws IOException {
-                                    if (property != null) {
-                                        property.set(instance, deserialize(p, ctxt));
                                     }
-                                }
 
-                                @Override
-                                public Object deserializeSetAndReturn(JsonParser p, DeserializationContext ctxt, Object instance) throws IOException {
-                                    if (property != null) {
-                                        property.set(instance, deserialize(p, ctxt));
+                                    @Override
+                                    public Object deserializeSetAndReturn(JsonParser p, DeserializationContext ctxt, Object instance) throws IOException {
+                                        if (property != null) {
+                                            property.set(instance, deserialize(p, ctxt));
+                                        }
+                                        return null;
                                     }
-                                    return null;
-                                }
 
-                                @Override
-                                public void set(Object instance, Object value) {
-                                    if (property != null) {
-                                        property.set(instance, value);
+                                    @Override
+                                    public void set(Object instance, Object value) {
+                                        if (property != null) {
+                                            property.set(instance, value);
+                                        }
                                     }
-                                }
 
-                                @Override
-                                public Object setAndReturn(Object instance, Object value) throws IOException {
-                                    if (property != null) {
-                                        property.set(instance, value);
+                                    @Override
+                                    public Object setAndReturn(Object instance, Object value) throws IOException {
+                                        if (property != null) {
+                                            property.set(instance, value);
+                                        }
+                                        return null;
                                     }
-                                    return null;
-                                }
-                            };
+                                };
+                            }
                         }
                         return props;
                     }


### PR DESCRIPTION
Fixes #3187

Had to copy the actual generic types from the value instantiator into the modified one for bean introspection module.

Also `JsonNodeToObjectConverter` was not using generics correctly. 

Note that adding `@Introspected` to https://github.com/micronaut-projects/micronaut-core/pull/3199/files#diff-a278a480adceba1b934e269cb01fa8a2R65

Makes the test fail so we don't seem to support `@JsonValue` types correctly either, but that is a different bug that may be worth a bug report.