### PR TITLE
Generate service descriptors in a separate annotation processor

### DIFF
--- a/aop/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
+++ b/aop/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
@@ -39,7 +39,6 @@ import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.ExecutableMethod;
 import io.micronaut.inject.ProxyBeanDefinition;
 import io.micronaut.inject.annotation.DefaultAnnotationMetadata;
-import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.Element;
 import io.micronaut.inject.configuration.ConfigurationMetadataBuilder;
 import io.micronaut.inject.writer.AbstractClassFileWriter;

--- a/core/src/main/java/io/micronaut/core/annotation/Generated.java
+++ b/core/src/main/java/io/micronaut/core/annotation/Generated.java
@@ -24,11 +24,15 @@ import java.lang.annotation.Target;
  * A marker annotation for methods that are generated though an annotation processor.
  *
  * @author David Bidorff
+ * @author graemerocher
  * @since 2.0
  */
 @Target({ElementType.PACKAGE, ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR,
     ElementType.FIELD, ElementType.LOCAL_VARIABLE, ElementType.PARAMETER})
 @Retention(RetentionPolicy.CLASS)
 public @interface Generated {
-
+    /**
+     * @return The name of the ServiceLoader service this generated type should be registered with (if any).
+     */
+    String service() default "";
 }

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyClassElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyClassElement.java
@@ -22,6 +22,7 @@ import io.micronaut.ast.groovy.utils.AstGenericUtils;
 import io.micronaut.ast.groovy.utils.PublicMethodVisitor;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Creator;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.ast.ClassElement;
@@ -46,6 +47,7 @@ import static org.codehaus.groovy.ast.ClassHelper.makeCached;
  * @author James Kleeh
  * @since 1.0
  */
+@Internal
 public class GroovyClassElement extends AbstractGroovyElement implements ClassElement {
 
     private final ClassNode classNode;
@@ -57,7 +59,7 @@ public class GroovyClassElement extends AbstractGroovyElement implements ClassEl
      * @param classNode          The {@link ClassNode}
      * @param annotationMetadata The annotation metadata
      */
-    GroovyClassElement(SourceUnit sourceUnit, CompilationUnit compilationUnit, ClassNode classNode, AnnotationMetadata annotationMetadata) {
+    public GroovyClassElement(SourceUnit sourceUnit, CompilationUnit compilationUnit, ClassNode classNode, AnnotationMetadata annotationMetadata) {
         this(sourceUnit, compilationUnit, classNode, annotationMetadata, null);
     }
 

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyPackageElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyPackageElement.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.ast.groovy.visitor;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.Internal;
+import org.codehaus.groovy.ast.PackageNode;
+import org.codehaus.groovy.control.CompilationUnit;
+import org.codehaus.groovy.control.SourceUnit;
+
+/**
+ * A class element returning data from a {@link PackageNode}.
+ *
+ * @author Graeme Rocher
+ * @since 2.0
+ */
+@Internal
+public class GroovyPackageElement extends AbstractGroovyElement {
+    private final PackageNode packageNode;
+
+    /**
+     * Default constructor.
+     *
+     * @param sourceUnit         The source unit
+     * @param compilationUnit    The compilation unit
+     * @param packageNode      The annotated node
+     * @param annotationMetadata The annotation metadata
+     */
+    public GroovyPackageElement(SourceUnit sourceUnit, CompilationUnit compilationUnit, PackageNode packageNode, AnnotationMetadata annotationMetadata) {
+        super(sourceUnit, compilationUnit, packageNode, annotationMetadata);
+        this.packageNode = packageNode;
+    }
+
+    @NonNull
+    @Override
+    public String getName() {
+        return packageNode.getName();
+    }
+
+    @Override
+    public boolean isProtected() {
+        return false;
+    }
+
+    @Override
+    public boolean isPublic() {
+        return true;
+    }
+
+    @NonNull
+    @Override
+    public Object getNativeType() {
+        return packageNode;
+    }
+}

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyVisitorContext.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyVisitorContext.java
@@ -182,13 +182,13 @@ public class GroovyVisitorContext implements VisitorContext {
     }
 
     @Override
-    public OutputStream visitClass(String classname) throws IOException {
+    public OutputStream visitClass(String classname, @Nullable Element originatingElement) throws IOException {
         File classesDir = compilationUnit.getConfiguration().getTargetDirectory();
         if (classesDir != null) {
             DirectoryClassWriterOutputVisitor outputVisitor = new DirectoryClassWriterOutputVisitor(
                     classesDir
             );
-            return outputVisitor.visitClass(classname);
+            return outputVisitor.visitClass(classname, originatingElement);
         } else {
             // should only arrive here in testing scenarios
             if (compilationUnit.getClassLoader() instanceof InMemoryByteCodeGroovyClassLoader) {
@@ -207,7 +207,6 @@ public class GroovyVisitorContext implements VisitorContext {
                 return new ByteArrayOutputStream(); // in-memory, mock or unit tests situation?
             }
         }
-
     }
 
     @Override

--- a/inject-groovy/src/test/groovy/io/micronaut/AbstractBeanDefinitionSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/AbstractBeanDefinitionSpec.groovy
@@ -94,7 +94,7 @@ abstract class AbstractBeanDefinitionSpec extends Specification {
 
     protected AnnotationMetadata writeAndLoadMetadata(String className, AnnotationMetadata toWrite) {
         def stream = new ByteArrayOutputStream()
-        new AnnotationMetadataWriter(className, toWrite, true)
+        new AnnotationMetadataWriter(className, null, toWrite, true)
                 .writeTo(stream)
         className = className + AnnotationMetadata.CLASS_NAME_SUFFIX
         ClassLoader classLoader = new ClassLoader() {

--- a/inject-java-test/src/main/groovy/io/micronaut/annotation/processing/test/JavaParser.java
+++ b/inject-java-test/src/main/groovy/io/micronaut/annotation/processing/test/JavaParser.java
@@ -19,10 +19,7 @@ import com.google.testing.compile.JavaFileObjects;
 import com.sun.source.util.JavacTask;
 import com.sun.tools.javac.api.JavacTool;
 import com.sun.tools.javac.util.Context;
-import io.micronaut.annotation.processing.BeanDefinitionInjectProcessor;
-import io.micronaut.annotation.processing.PackageConfigurationInjectProcessor;
-import io.micronaut.annotation.processing.ServiceDescriptionProcessor;
-import io.micronaut.annotation.processing.TypeElementVisitorProcessor;
+import io.micronaut.annotation.processing.*;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -187,6 +184,7 @@ public class JavaParser implements Closeable {
     protected @NonNull List<Processor> getAnnotationProcessors() {
         List<Processor> processors = new ArrayList<>();
         processors.add(getTypeElementVisitorProcessor());
+        processors.add(getAggregatingTypeElementVisitorProcessor());
         processors.add(new PackageConfigurationInjectProcessor());
         processors.add(getBeanDefinitionInjectProcessor());
         processors.add(new ServiceDescriptionProcessor());
@@ -208,6 +206,15 @@ public class JavaParser implements Closeable {
      */
     protected @NonNull TypeElementVisitorProcessor getTypeElementVisitorProcessor() {
         return new TypeElementVisitorProcessor();
+    }
+
+    /**
+     * The type element visitor processor to use.
+     *
+     * @return The type element visitor processor
+     */
+    protected @NonNull AggregatingTypeElementVisitorProcessor getAggregatingTypeElementVisitorProcessor() {
+        return new AggregatingTypeElementVisitorProcessor();
     }
 
     @Override

--- a/inject-java-test/src/main/groovy/io/micronaut/annotation/processing/test/JavaParser.java
+++ b/inject-java-test/src/main/groovy/io/micronaut/annotation/processing/test/JavaParser.java
@@ -21,6 +21,7 @@ import com.sun.tools.javac.api.JavacTool;
 import com.sun.tools.javac.util.Context;
 import io.micronaut.annotation.processing.BeanDefinitionInjectProcessor;
 import io.micronaut.annotation.processing.PackageConfigurationInjectProcessor;
+import io.micronaut.annotation.processing.ServiceDescriptionProcessor;
 import io.micronaut.annotation.processing.TypeElementVisitorProcessor;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -188,6 +189,7 @@ public class JavaParser implements Closeable {
         processors.add(getTypeElementVisitorProcessor());
         processors.add(new PackageConfigurationInjectProcessor());
         processors.add(getBeanDefinitionInjectProcessor());
+        processors.add(new ServiceDescriptionProcessor());
         return processors;
     }
 

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/AllClassesVisitor.java
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/AllClassesVisitor.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.inject.visitor;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.FieldElement;
 import io.micronaut.inject.ast.MethodElement;
@@ -29,6 +30,12 @@ public class AllClassesVisitor implements TypeElementVisitor<Object, Object> {
 
     public AllClassesVisitor() {
         reset();
+    }
+
+    @NonNull
+    @Override
+    public VisitorKind getVisitorKind() {
+        return VisitorKind.ISOLATING;
     }
 
     public void reset() {

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/AbstractInjectAnnotationProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/AbstractInjectAnnotationProcessor.java
@@ -115,7 +115,12 @@ abstract class AbstractInjectAnnotationProcessor extends AbstractProcessor {
                     "io.micronaut.*"
             );
             types.addAll(supportedAnnotationTypes);
-            types.addAll(AbstractAnnotationMetadataBuilder.getMappedAnnotationNames());
+            Set<String> mappedAnnotationNames = AbstractAnnotationMetadataBuilder.getMappedAnnotationNames();
+            for (String mappedAnnotationName : mappedAnnotationNames) {
+                if (!mappedAnnotationName.contains("Nullable") && !mappedAnnotationName.contains("NotNull")) {
+                    types.add(mappedAnnotationName);
+                }
+            }
             return types;
         } else {
             return Collections.singleton("*");

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/AbstractInjectAnnotationProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/AbstractInjectAnnotationProcessor.java
@@ -69,7 +69,7 @@ abstract class AbstractInjectAnnotationProcessor extends AbstractProcessor {
     protected AnnotationProcessingOutputVisitor classWriterOutputVisitor;
     protected JavaVisitorContext javaVisitorContext;
     private boolean incremental = false;
-    private Set<String> supportedAnnotationTypes = new HashSet<>(5);
+    private final Set<String> supportedAnnotationTypes = new HashSet<>(5);
 
     @Override
     public SourceVersion getSupportedSourceVersion() {

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/AbstractInjectAnnotationProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/AbstractInjectAnnotationProcessor.java
@@ -51,6 +51,14 @@ abstract class AbstractInjectAnnotationProcessor extends AbstractProcessor {
      * Annotation processor option used to add additional annotation patterns to process.
      */
     protected static final String MICRONAUT_PROCESSING_ANNOTATIONS = "micronaut.processing.annotations";
+    /**
+     * Constant for aggregating processor.
+     */
+    protected static final String GRADLE_PROCESSING_AGGREGATING = "org.gradle.annotation.processing.aggregating";
+    /**
+     * Constant for isolating processor.
+     */
+    protected static final String GRADLE_PROCESSING_ISOLATING = "org.gradle.annotation.processing.isolating";
 
     protected Messager messager;
     protected Filer filer;
@@ -83,12 +91,22 @@ abstract class AbstractInjectAnnotationProcessor extends AbstractProcessor {
     public Set<String> getSupportedOptions() {
         final Set<String> options;
         if (incremental) {
-            options = CollectionUtils.setOf("org.gradle.annotation.processing.aggregating");
+            options = CollectionUtils.setOf(getIncrementalProcessorType());
         } else {
             options = new HashSet<>(5);
         }
         options.addAll(super.getSupportedOptions());
         return options;
+    }
+
+    /**
+     *
+     * @return The incremental processor type.
+     * @see #GRADLE_PROCESSING_AGGREGATING
+     * @see #GRADLE_PROCESSING_ISOLATING
+     */
+    protected String getIncrementalProcessorType() {
+        return GRADLE_PROCESSING_ISOLATING;
     }
 
     @Override

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/AbstractInjectAnnotationProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/AbstractInjectAnnotationProcessor.java
@@ -20,8 +20,6 @@ import io.micronaut.core.convert.value.MutableConvertibleValues;
 import io.micronaut.core.convert.value.MutableConvertibleValuesMap;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.annotation.AbstractAnnotationMetadataBuilder;
-import io.micronaut.inject.writer.ClassWriterOutputVisitor;
-
 import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Filer;
@@ -68,7 +66,7 @@ abstract class AbstractInjectAnnotationProcessor extends AbstractProcessor {
     protected GenericUtils genericUtils;
     protected ModelUtils modelUtils;
     protected MutableConvertibleValues<Object> visitorAttributes = new MutableConvertibleValuesMap<>();
-    protected ClassWriterOutputVisitor classWriterOutputVisitor;
+    protected AnnotationProcessingOutputVisitor classWriterOutputVisitor;
     protected JavaVisitorContext javaVisitorContext;
     private boolean incremental = false;
     private Set<String> supportedAnnotationTypes = new HashSet<>(5);

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/AggregatingTypeElementVisitorProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/AggregatingTypeElementVisitorProcessor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.annotation.processing;
+
+import javax.annotation.processing.SupportedOptions;
+
+/**
+ * <p>The annotation processed used to execute type element visitors.</p>
+ *
+ * @author graemerocher
+ * @since 2.0
+ */
+@SupportedOptions({AbstractInjectAnnotationProcessor.MICRONAUT_PROCESSING_INCREMENTAL, AbstractInjectAnnotationProcessor.MICRONAUT_PROCESSING_ANNOTATIONS})
+public class AggregatingTypeElementVisitorProcessor extends TypeElementVisitorProcessor {
+
+    @Override
+    protected String getIncrementalProcessorType() {
+        return GRADLE_PROCESSING_AGGREGATING;
+    }
+}

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/AggregatingTypeElementVisitorProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/AggregatingTypeElementVisitorProcessor.java
@@ -15,7 +15,13 @@
  */
 package io.micronaut.annotation.processing;
 
+import io.micronaut.annotation.processing.visitor.LoadedVisitor;
+import io.micronaut.inject.visitor.TypeElementVisitor;
+
 import javax.annotation.processing.SupportedOptions;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * <p>The annotation processed used to execute type element visitors.</p>
@@ -29,5 +35,27 @@ public class AggregatingTypeElementVisitorProcessor extends TypeElementVisitorPr
     @Override
     protected String getIncrementalProcessorType() {
         return GRADLE_PROCESSING_AGGREGATING;
+    }
+
+    @Override
+    public Set<String> getSupportedAnnotationTypes() {
+        if (isIncremental(processingEnv)) {
+            List<LoadedVisitor> loadedVisitors = getLoadedVisitors();
+            Set<String> annotationNames = new HashSet<>();
+            // try and narrow the annotations to only the ones interesting to the visitors
+            // if a visitor is interested in Object than fall back to all
+            for (LoadedVisitor loadedVisitor : loadedVisitors) {
+                TypeElementVisitor<?, ?> visitor = loadedVisitor.getVisitor();
+                Set<String> supportedAnnotationNames = visitor.getSupportedAnnotationNames();
+                if (supportedAnnotationNames.contains("*")) {
+                    return super.getSupportedAnnotationTypes();
+                } else {
+                    annotationNames.addAll(supportedAnnotationNames);
+                }
+            }
+            return annotationNames;
+        } else {
+            return super.getSupportedAnnotationTypes();
+        }
     }
 }

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/AnnotationProcessingOutputVisitor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/AnnotationProcessingOutputVisitor.java
@@ -15,11 +15,13 @@
  */
 package io.micronaut.annotation.processing;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
 import io.micronaut.inject.writer.AbstractClassWriterOutputVisitor;
 import io.micronaut.inject.writer.ClassGenerationException;
 import io.micronaut.inject.writer.GeneratedFile;
 
 import javax.annotation.processing.Filer;
+import javax.lang.model.element.Element;
 import javax.tools.FileObject;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardLocation;
@@ -55,9 +57,20 @@ public class AnnotationProcessingOutputVisitor extends AbstractClassWriterOutput
     }
 
     @Override
-    public OutputStream visitClass(String classname) throws IOException {
-        JavaFileObject javaFileObject = filer.createClassFile(classname);
+    public OutputStream visitClass(String classname, @Nullable io.micronaut.inject.ast.Element originatingElement) throws IOException {
+        JavaFileObject javaFileObject;
+        if (originatingElement != null) {
+            Object nativeType = originatingElement.getNativeType();
+            if (nativeType instanceof Element) {
+                javaFileObject = filer.createClassFile(classname, (Element) nativeType);
+            } else {
+                javaFileObject = filer.createClassFile(classname);
+            }
+        } else {
+            javaFileObject = filer.createClassFile(classname);
+        }
         return javaFileObject.openOutputStream();
+
     }
 
     @Override

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -202,7 +202,6 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
         if (processingOver) {
             try {
                 writeConfigurationMetadata();
-                writeBeanDefinitionsToMetaInf();
             } finally {
                 AnnotationUtils.invalidateCache();
                 AbstractAnnotationMetadataBuilder.clearMutated();
@@ -227,18 +226,6 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
             } catch (ServiceConfigurationError e) {
                 warning("Unable to load ConfigurationMetadataWriter due to : %s", e.getMessage());
             }
-        }
-    }
-
-    /**
-     * Writes {@link io.micronaut.inject.BeanDefinitionReference} into /META-INF/services/io.micronaut.inject.BeanDefinitionReference.
-     */
-    private void writeBeanDefinitionsToMetaInf() {
-        try {
-            classWriterOutputVisitor.finish();
-        } catch (Exception e) {
-            String message = e.getMessage();
-            error("Error occurred writing META-INF files: %s", message != null ? message : e);
         }
     }
 

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.annotation.processing;
 
+import io.micronaut.annotation.processing.visitor.JavaClassElement;
+import io.micronaut.annotation.processing.visitor.JavaVisitorContext;
 import io.micronaut.aop.Adapter;
 import io.micronaut.aop.Interceptor;
 import io.micronaut.aop.Introduction;
@@ -269,7 +271,12 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
 
             AnnotationMetadata annotationMetadata = beanDefinitionWriter.getAnnotationMetadata();
             BeanDefinitionReferenceWriter beanDefinitionReferenceWriter =
-                    new BeanDefinitionReferenceWriter(beanTypeName, beanDefinitionName, annotationMetadata);
+                    new BeanDefinitionReferenceWriter(
+                            beanTypeName,
+                            beanDefinitionName,
+                            beanDefinitionWriter.getOriginatingElement(),
+                            annotationMetadata
+                    );
             beanDefinitionReferenceWriter.setRequiresMethodProcessing(beanDefinitionWriter.requiresMethodProcessing());
 
             String className = beanDefinitionReferenceWriter.getBeanDefinitionQualifiedClassName();
@@ -341,6 +348,7 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
         private final boolean isAopProxyType;
         private final OptionalValues<Boolean> aopSettings;
         private final boolean isDeclaredBean;
+        private final JavaClassElement originatingElement;
         private ConfigurationMetadata configurationMetadata;
         private ExecutableElementParamInfo constructorParameterInfo;
         private AtomicInteger adaptedMethodIndex = new AtomicInteger(0);
@@ -353,6 +361,17 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
         AnnBeanElementVisitor(TypeElement concreteClass) {
             this.concreteClass = concreteClass;
             this.concreteClassMetadata = annotationUtils.getAnnotationMetadata(concreteClass);
+            this.originatingElement = new JavaClassElement(concreteClass, concreteClassMetadata, new JavaVisitorContext(
+                processingEnv,
+                messager,
+                elementUtils,
+                annotationUtils,
+                typeUtils,
+                modelUtils,
+                genericUtils,
+                filer,
+                visitorAttributes
+            ));
             beanDefinitionWriters = new LinkedHashMap<>();
             this.isFactoryType = concreteClassMetadata.hasStereotype(Factory.class);
             this.isConfigurationPropertiesType = concreteClassMetadata.hasDeclaredStereotype(ConfigurationReader.class) || concreteClassMetadata.hasDeclaredStereotype(EachProperty.class);
@@ -1426,9 +1445,11 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                                 beanClassName,
                                 true,
                                 false,
+                                originatingElement,
                                 methodAnnotationMetadata,
                                 new Object[]{modelUtils.resolveTypeReference(typeToImplement)},
-                                ArrayUtils.EMPTY_OBJECT_ARRAY);
+                                ArrayUtils.EMPTY_OBJECT_ARRAY
+                        );
 
                         aopProxyWriter.visitBeanDefinitionConstructor(methodAnnotationMetadata, false);
 
@@ -2109,7 +2130,9 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                             ? elementUtils.getBinaryName(typeElement).toString()
                             : providerTypeParam.toString(),
                     isInterface,
-                    annotationMetadata);
+                    originatingElement,
+                    annotationMetadata
+            );
 
             visitTypeArguments(typeElement, beanDefinitionWriter);
 
@@ -2148,9 +2171,11 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                     packageElement.getQualifiedName().toString(),
                     beanClassName,
                     isInterface,
+                    originatingElement,
                     annotationMetadata,
                     interfaceTypes,
-                    interceptorTypes);
+                    interceptorTypes
+            );
 
             if (ArrayUtils.isNotEmpty(interfaceTypes)) {
                 List<? extends AnnotationMirror> annotationMirrors = typeElement.getAnnotationMirrors();
@@ -2222,7 +2247,9 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                     factoryMethodBeanDefinitionName,
                     modelUtils.resolveTypeReference(producedElement).toString(),
                     isInterface,
-                    annotationMetadata);
+                    originatingElement,
+                    annotationMetadata
+            );
         }
 
         private ExecutableElementParamInfo populateParameterData(@Nullable String declaringTypeName, ExecutableElement element, Map<String, Object> boundTypes) {

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/PackageConfigurationInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/PackageConfigurationInjectProcessor.java
@@ -65,11 +65,6 @@ public class PackageConfigurationInjectProcessor extends AbstractInjectAnnotatio
         AnnotationElementScanner scanner = new AnnotationElementScanner();
         Set<? extends Element> elements = roundEnv.getRootElements();
         ElementFilter.packagesIn(elements).forEach(element -> element.accept(scanner, element));
-        try {
-            classWriterOutputVisitor.finish();
-        } catch (Exception e) {
-            error("I/O error occurred writing META-INF services information: %s", e);
-        }
         return false;
     }
 

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/PackageConfigurationInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/PackageConfigurationInjectProcessor.java
@@ -15,7 +15,10 @@
  */
 package io.micronaut.annotation.processing;
 
+import io.micronaut.annotation.processing.visitor.JavaPackageElement;
+import io.micronaut.annotation.processing.visitor.JavaVisitorContext;
 import io.micronaut.context.annotation.Configuration;
+import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.inject.writer.BeanConfigurationWriter;
 
@@ -80,9 +83,21 @@ public class PackageConfigurationInjectProcessor extends AbstractInjectAnnotatio
             Object aPackage = super.visitPackage(packageElement, p);
             if (annotationUtils.hasStereotype(packageElement, Configuration.class)) {
                 String packageName = packageElement.getQualifiedName().toString();
+                AnnotationMetadata annotationMetadata = annotationUtils.getAnnotationMetadata(packageElement);
                 BeanConfigurationWriter writer = new BeanConfigurationWriter(
                     packageName,
-                    annotationUtils.getAnnotationMetadata(packageElement)
+                    new JavaPackageElement(packageElement, annotationMetadata, new JavaVisitorContext(
+                        processingEnv,
+                        messager,
+                        elementUtils,
+                        annotationUtils,
+                        typeUtils,
+                        modelUtils,
+                        genericUtils,
+                        filer,
+                        visitorAttributes
+                    )),
+                    annotationMetadata
                 );
                 try {
                     writer.accept(classWriterOutputVisitor);

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/ServiceDescriptionProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/ServiceDescriptionProcessor.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.annotation.processing;
+
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.Generated;
+
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedOptions;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import java.util.*;
+
+/**
+ * A separate aggregating annotation processor responsible for creating META-INF/services entries.
+ *
+ * @author graemerocher
+ * @since 2.0.0
+ */
+@SupportedOptions({
+        AbstractInjectAnnotationProcessor.MICRONAUT_PROCESSING_INCREMENTAL,
+        AbstractInjectAnnotationProcessor.MICRONAUT_PROCESSING_ANNOTATIONS
+})
+public class ServiceDescriptionProcessor extends AbstractInjectAnnotationProcessor {
+
+    private final Map<String, Set<String>> serviceDescriptors = new HashMap<>();
+
+    @Override
+    protected String getIncrementalProcessorType() {
+        return GRADLE_PROCESSING_AGGREGATING;
+    }
+
+    @Override
+    public Set<String> getSupportedAnnotationTypes() {
+        return Collections.singleton("io.micronaut.core.annotation.Generated");
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        for (TypeElement annotation : annotations) {
+            Set<? extends Element> elements = roundEnv.getElementsAnnotatedWith(annotation);
+            for (Element element : elements) {
+                if (element instanceof TypeElement) {
+                    String name = ((TypeElement) element).getQualifiedName().toString();
+                    AnnotationMetadata annotationMetadata = annotationUtils.getAnnotationMetadata(element);
+                    String serviceName = annotationMetadata.stringValue(
+                            Generated.class,
+                            "service"
+                    ).orElse(null);
+
+                    if (serviceName != null) {
+                        serviceDescriptors.computeIfAbsent(serviceName, s1 -> new HashSet<>())
+                                .add(name);
+                    }
+                }
+
+            }
+        }
+        if (roundEnv.processingOver()) {
+            if (!serviceDescriptors.isEmpty()) {
+                classWriterOutputVisitor.writeServiceEntries(
+                        serviceDescriptors
+                );
+            }
+        }
+        return true;
+    }
+}

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
@@ -127,6 +127,15 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
     }
 
     @Override
+    public Set<String> getSupportedAnnotationTypes() {
+        if (loadedVisitors.isEmpty()) {
+            return Collections.emptySet();
+        } else {
+            return super.getSupportedAnnotationTypes();
+        }
+    }
+
+    @Override
     public Set<String> getSupportedOptions() {
         Stream<String> baseOption = super.getSupportedOptions().stream();
         Stream<String> visitorsOptions = typeElementVisitors

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
@@ -106,6 +106,13 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
     }
 
     /**
+     * @return The loaded visitors.
+     */
+    protected List<LoadedVisitor> getLoadedVisitors() {
+        return loadedVisitors;
+    }
+
+    /**
      *
      * @return The incremental processor type.
      * @see #GRADLE_PROCESSING_AGGREGATING

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
@@ -76,15 +76,19 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
         this.loadedVisitors = new ArrayList<>(typeElementVisitors.size());
 
         for (TypeElementVisitor visitor : typeElementVisitors) {
-            try {
-                loadedVisitors.add(new LoadedVisitor(
-                    visitor,
-                    javaVisitorContext,
-                    genericUtils,
-                    processingEnv
-                ));
-            } catch (TypeNotPresentException | NoClassDefFoundError e) {
-                // ignored, means annotations referenced are not on the classpath
+            TypeElementVisitor.VisitorKind visitorKind = visitor.getVisitorKind();
+            TypeElementVisitor.VisitorKind incrementalProcessorKind = getIncrementalProcessorKind();
+            if (incrementalProcessorKind == visitorKind) {
+                try {
+                    loadedVisitors.add(new LoadedVisitor(
+                            visitor,
+                            javaVisitorContext,
+                            genericUtils,
+                            processingEnv
+                    ));
+                } catch (TypeNotPresentException | NoClassDefFoundError e) {
+                    // ignored, means annotations referenced are not on the classpath
+                }
             }
 
         }
@@ -99,6 +103,20 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
             }
         }
 
+    }
+
+    /**
+     *
+     * @return The incremental processor type.
+     * @see #GRADLE_PROCESSING_AGGREGATING
+     * @see #GRADLE_PROCESSING_ISOLATING
+     */
+    protected TypeElementVisitor.VisitorKind getIncrementalProcessorKind() {
+        String type = getIncrementalProcessorType();
+        if (type.equals(GRADLE_PROCESSING_AGGREGATING)) {
+            return TypeElementVisitor.VisitorKind.AGGREGATING;
+        }
+        return TypeElementVisitor.VisitorKind.ISOLATING;
     }
 
     @Override
@@ -122,26 +140,29 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
     @Override
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
 
-        TypeElement groovyObjectTypeElement = elementUtils.getTypeElement("groovy.lang.GroovyObject");
-        TypeMirror groovyObjectType = groovyObjectTypeElement != null ? groovyObjectTypeElement.asType() : null;
+        if (!loadedVisitors.isEmpty()) {
 
-        roundEnv.getRootElements()
-                .stream()
-                .filter(element -> JavaModelUtils.isClassOrInterface(element) || JavaModelUtils.isEnum(element))
-                .filter(element -> element.getAnnotation(Generated.class) == null)
-                .map(modelUtils::classElementFor)
-                .filter(typeElement -> typeElement == null || (groovyObjectType == null || !typeUtils.isAssignable(typeElement.asType(), groovyObjectType)))
-                .forEach((typeElement) -> {
-                    String className = typeElement.getQualifiedName().toString();
-                    List<LoadedVisitor> matchedVisitors = loadedVisitors.stream().filter((v) -> v.matches(typeElement)).collect(Collectors.toList());
-                    typeElement.accept(new ElementVisitor(typeElement, matchedVisitors), className);
-                });
+            TypeElement groovyObjectTypeElement = elementUtils.getTypeElement("groovy.lang.GroovyObject");
+            TypeMirror groovyObjectType = groovyObjectTypeElement != null ? groovyObjectTypeElement.asType() : null;
 
-        for (LoadedVisitor loadedVisitor : loadedVisitors) {
-            try {
-                loadedVisitor.getVisitor().finish(javaVisitorContext);
-            } catch (Throwable e) {
-                error("Error finalizing type visitor [%s]: %s", loadedVisitor.getVisitor(), e.getMessage());
+            roundEnv.getRootElements()
+                    .stream()
+                    .filter(element -> JavaModelUtils.isClassOrInterface(element) || JavaModelUtils.isEnum(element))
+                    .filter(element -> element.getAnnotation(Generated.class) == null)
+                    .map(modelUtils::classElementFor)
+                    .filter(typeElement -> typeElement == null || (groovyObjectType == null || !typeUtils.isAssignable(typeElement.asType(), groovyObjectType)))
+                    .forEach((typeElement) -> {
+                        String className = typeElement.getQualifiedName().toString();
+                        List<LoadedVisitor> matchedVisitors = loadedVisitors.stream().filter((v) -> v.matches(typeElement)).collect(Collectors.toList());
+                        typeElement.accept(new ElementVisitor(typeElement, matchedVisitors), className);
+                    });
+
+            for (LoadedVisitor loadedVisitor : loadedVisitors) {
+                try {
+                    loadedVisitor.getVisitor().finish(javaVisitorContext);
+                } catch (Throwable e) {
+                    error("Error finalizing type visitor [%s]: %s", loadedVisitor.getVisitor(), e.getMessage());
+                }
             }
         }
 

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
@@ -145,10 +145,6 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
             }
         }
 
-        if (roundEnv.processingOver()) {
-            javaVisitorContext.finish();
-        }
-
         return false;
     }
 

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
@@ -58,7 +58,8 @@ public class JavaClassElement extends AbstractJavaElement implements ClassElemen
      * @param annotationMetadata The annotation metadata
      * @param visitorContext     The visitor context
      */
-    protected JavaClassElement(TypeElement classElement, AnnotationMetadata annotationMetadata, JavaVisitorContext visitorContext) {
+    @Internal
+    public JavaClassElement(TypeElement classElement, AnnotationMetadata annotationMetadata, JavaVisitorContext visitorContext) {
         super(classElement, annotationMetadata, visitorContext);
         this.classElement = classElement;
         this.visitorContext = visitorContext;

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaPackageElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaPackageElement.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.annotation.processing.visitor;
+
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.Internal;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.PackageElement;
+
+/**
+ * A package element for Java.
+ *
+ * @author graemerocher
+ * @since 2.0.0
+ */
+@Internal
+public class JavaPackageElement extends AbstractJavaElement {
+    /**
+     * @param element            The {@link Element}
+     * @param annotationMetadata The Annotation metadata
+     * @param visitorContext     The Java visitor context
+     */
+    public JavaPackageElement(
+            PackageElement element,
+            AnnotationMetadata annotationMetadata,
+            JavaVisitorContext visitorContext) {
+        super(element, annotationMetadata, visitorContext);
+    }
+}

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaPackageElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaPackageElement.java
@@ -18,7 +18,6 @@ package io.micronaut.annotation.processing.visitor;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
 
-import javax.lang.model.element.Element;
 import javax.lang.model.element.PackageElement;
 
 /**
@@ -30,7 +29,7 @@ import javax.lang.model.element.PackageElement;
 @Internal
 public class JavaPackageElement extends AbstractJavaElement {
     /**
-     * @param element            The {@link Element}
+     * @param element            The {@link PackageElement}
      * @param annotationMetadata The Annotation metadata
      * @param visitorContext     The Java visitor context
      */

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaVisitorContext.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaVisitorContext.java
@@ -188,8 +188,8 @@ public class JavaVisitorContext implements VisitorContext {
     }
 
     @Override
-    public OutputStream visitClass(String classname) throws IOException {
-        return outputVisitor.visitClass(classname);
+    public OutputStream visitClass(String classname, @Nullable io.micronaut.inject.ast.Element originatingElement) throws IOException {
+        return outputVisitor.visitClass(classname, originatingElement);
     }
 
     @Override

--- a/inject-java/src/main/resources/META-INF/gradle/incremental.annotation.processors
+++ b/inject-java/src/main/resources/META-INF/gradle/incremental.annotation.processors
@@ -1,4 +1,5 @@
 io.micronaut.annotation.processing.TypeElementVisitorProcessor,dynamic
+io.micronaut.annotation.processing.AggregatingTypeElementVisitorProcessor,dynamic
 io.micronaut.annotation.processing.BeanDefinitionInjectProcessor,dynamic
 io.micronaut.annotation.processing.PackageConfigurationInjectProcessor,dynamic
 io.micronaut.annotation.processing.ServiceDescriptionProcessor,dynamic

--- a/inject-java/src/main/resources/META-INF/gradle/incremental.annotation.processors
+++ b/inject-java/src/main/resources/META-INF/gradle/incremental.annotation.processors
@@ -1,3 +1,4 @@
 io.micronaut.annotation.processing.TypeElementVisitorProcessor,dynamic
 io.micronaut.annotation.processing.BeanDefinitionInjectProcessor,dynamic
 io.micronaut.annotation.processing.PackageConfigurationInjectProcessor,dynamic
+io.micronaut.annotation.processing.ServiceDescriptionProcessor,dynamic

--- a/inject-java/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/inject-java/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,3 +1,4 @@
 io.micronaut.annotation.processing.TypeElementVisitorProcessor
 io.micronaut.annotation.processing.PackageConfigurationInjectProcessor
 io.micronaut.annotation.processing.BeanDefinitionInjectProcessor
+io.micronaut.annotation.processing.ServiceDescriptionProcessor

--- a/inject-java/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/inject-java/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,4 +1,5 @@
 io.micronaut.annotation.processing.TypeElementVisitorProcessor
+io.micronaut.annotation.processing.AggregatingTypeElementVisitorProcessor
 io.micronaut.annotation.processing.PackageConfigurationInjectProcessor
 io.micronaut.annotation.processing.BeanDefinitionInjectProcessor
 io.micronaut.annotation.processing.ServiceDescriptionProcessor

--- a/inject-java/src/test/groovy/io/micronaut/inject/AbstractTypeElementSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/AbstractTypeElementSpec.groovy
@@ -164,7 +164,7 @@ abstract class AbstractTypeElementSpec extends Specification {
 
     protected AnnotationMetadata writeAndLoadMetadata(String className, AnnotationMetadata toWrite) {
         def stream = new ByteArrayOutputStream()
-        new AnnotationMetadataWriter(className, toWrite, true)
+        new AnnotationMetadataWriter(className, null, toWrite, true)
                 .writeTo(stream)
         className = className + AnnotationMetadata.CLASS_NAME_SUFFIX
         ClassLoader classLoader = new ClassLoader() {

--- a/inject-java/src/test/groovy/io/micronaut/support/Parser.java
+++ b/inject-java/src/test/groovy/io/micronaut/support/Parser.java
@@ -37,6 +37,7 @@ import com.sun.tools.javac.api.JavacTool;
 import com.sun.tools.javac.util.Context;
 import io.micronaut.annotation.processing.PackageConfigurationInjectProcessor;
 import io.micronaut.annotation.processing.BeanDefinitionInjectProcessor;
+import io.micronaut.annotation.processing.ServiceDescriptionProcessor;
 import io.micronaut.annotation.processing.TypeElementVisitorProcessor;
 
 import java.io.File;
@@ -127,6 +128,7 @@ public final class Parser {
             processors.add(new TypeElementVisitorProcessor());
             processors.add(new PackageConfigurationInjectProcessor());
             processors.add(new BeanDefinitionInjectProcessor());
+            processors.add(new ServiceDescriptionProcessor());
             task.setProcessors(processors);
             task.generate();
 

--- a/inject-java/src/test/groovy/io/micronaut/support/Parser.java
+++ b/inject-java/src/test/groovy/io/micronaut/support/Parser.java
@@ -35,10 +35,7 @@ import com.sun.source.util.TreeScanner;
 import com.sun.source.util.Trees;
 import com.sun.tools.javac.api.JavacTool;
 import com.sun.tools.javac.util.Context;
-import io.micronaut.annotation.processing.PackageConfigurationInjectProcessor;
-import io.micronaut.annotation.processing.BeanDefinitionInjectProcessor;
-import io.micronaut.annotation.processing.ServiceDescriptionProcessor;
-import io.micronaut.annotation.processing.TypeElementVisitorProcessor;
+import io.micronaut.annotation.processing.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -126,6 +123,7 @@ public final class Parser {
 
             List<Processor> processors = new ArrayList<>();
             processors.add(new TypeElementVisitorProcessor());
+            processors.add(new AggregatingTypeElementVisitorProcessor());
             processors.add(new PackageConfigurationInjectProcessor());
             processors.add(new BeanDefinitionInjectProcessor());
             processors.add(new ServiceDescriptionProcessor());

--- a/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataWriter.java
@@ -18,6 +18,7 @@ package io.micronaut.inject.annotation;
 import io.micronaut.core.annotation.*;
 import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.writer.AbstractAnnotationMetadataWriter;
 import io.micronaut.inject.writer.AbstractClassFileWriter;
 import io.micronaut.inject.writer.ClassGenerationException;
@@ -151,10 +152,16 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
      * Constructs a new writer for the given class name and metadata.
      *
      * @param className               The class name for which the metadata relates
+     * @param originatingElement      The originating element
      * @param annotationMetadata      The annotation metadata
      * @param writeAnnotationDefaults Whether annotations defaults should be written
      */
-    public AnnotationMetadataWriter(String className, AnnotationMetadata annotationMetadata, boolean writeAnnotationDefaults) {
+    public AnnotationMetadataWriter(
+            String className,
+            ClassElement originatingElement,
+            AnnotationMetadata annotationMetadata,
+            boolean writeAnnotationDefaults) {
+        super(originatingElement);
         this.className = className + AnnotationMetadata.CLASS_NAME_SUFFIX;
         if (annotationMetadata instanceof DefaultAnnotationMetadata) {
             this.parent = null;
@@ -174,10 +181,14 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
      * Constructs a new writer for the given class name and metadata.
      *
      * @param className          The class name for which the metadata relates
+     * @param originatingElement The originating element
      * @param annotationMetadata The annotation metadata
      */
-    public AnnotationMetadataWriter(String className, AnnotationMetadata annotationMetadata) {
-        this(className, annotationMetadata, false);
+    public AnnotationMetadataWriter(
+            String className,
+            ClassElement originatingElement,
+            AnnotationMetadata annotationMetadata) {
+        this(className, originatingElement, annotationMetadata, false);
     }
 
     /**
@@ -197,7 +208,7 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
         ClassWriter classWriter = generateClassBytes();
         if (classWriter != null) {
 
-            try (OutputStream outputStream = outputVisitor.visitClass(className)) {
+            try (OutputStream outputStream = outputVisitor.visitClass(className, getOriginatingElement())) {
                 outputStream.write(classWriter.toByteArray());
             }
         }

--- a/inject/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
@@ -410,7 +410,7 @@ class BeanIntrospectionWriter extends AbstractAnnotationMetadataWriter {
         classWriterOutputVisitor.visitServiceDescriptor(BeanIntrospectionReference.class, referenceName);
 
         try (OutputStream referenceStream = classWriterOutputVisitor.visitClass(referenceName, getOriginatingElement())) {
-            startPublicFinalClass(referenceWriter, targetClassType.getInternalName(), superType);
+            startService(referenceWriter, BeanIntrospectionReference.class, targetClassType.getInternalName(), superType);
             final ClassWriter classWriter = generateClassBytes(referenceWriter);
             for (GeneratorAdapter generatorAdapter : loadTypeMethods.values()) {
                 generatorAdapter.visitMaxs(1, 1);

--- a/inject/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
@@ -80,7 +80,7 @@ class BeanIntrospectionWriter extends AbstractAnnotationMetadataWriter {
      * @param beanAnnotationMetadata The bean annotation metadata
      */
     BeanIntrospectionWriter(ClassElement classElement, AnnotationMetadata beanAnnotationMetadata) {
-        super(computeReferenceName(classElement.getName()), beanAnnotationMetadata, true);
+        super(computeReferenceName(classElement.getName()), classElement, beanAnnotationMetadata, true);
         final String name = classElement.getName();
         this.classElement = classElement;
         this.referenceWriter = new ClassWriter(ClassWriter.COMPUTE_MAXS);
@@ -94,11 +94,17 @@ class BeanIntrospectionWriter extends AbstractAnnotationMetadataWriter {
      * Constructor used to generate a reference for already compiled classes.
      * @param generatingType The originating type
      * @param index A unique index
+     * @param originatingElement The originating element
      * @param classElement The class element
      * @param beanAnnotationMetadata The bean annotation metadata
      */
-    BeanIntrospectionWriter(String generatingType, int index, ClassElement classElement, AnnotationMetadata beanAnnotationMetadata) {
-        super(computeReferenceName(generatingType) + index, beanAnnotationMetadata, true);
+    BeanIntrospectionWriter(
+            String generatingType,
+            int index,
+            ClassElement originatingElement,
+            ClassElement classElement,
+            AnnotationMetadata beanAnnotationMetadata) {
+        super(computeReferenceName(generatingType) + index, originatingElement, beanAnnotationMetadata, true);
         final String className = classElement.getName();
         this.classElement = classElement;
         this.referenceWriter = new ClassWriter(ClassWriter.COMPUTE_MAXS);
@@ -201,7 +207,7 @@ class BeanIntrospectionWriter extends AbstractAnnotationMetadataWriter {
     private void writeIntrospectionClass(ClassWriterOutputVisitor classWriterOutputVisitor) throws IOException {
         final Type superType = Type.getType(AbstractBeanIntrospection.class);
 
-        try (OutputStream introspectionStream = classWriterOutputVisitor.visitClass(introspectionName)) {
+        try (OutputStream introspectionStream = classWriterOutputVisitor.visitClass(introspectionName, getOriginatingElement())) {
 
             startFinalClass(introspectionWriter, introspectionType.getInternalName(), superType);
             final GeneratorAdapter constructorWriter = startConstructor(introspectionWriter);
@@ -403,7 +409,7 @@ class BeanIntrospectionWriter extends AbstractAnnotationMetadataWriter {
         final String referenceName = targetClassType.getClassName();
         classWriterOutputVisitor.visitServiceDescriptor(BeanIntrospectionReference.class, referenceName);
 
-        try (OutputStream referenceStream = classWriterOutputVisitor.visitClass(referenceName)) {
+        try (OutputStream referenceStream = classWriterOutputVisitor.visitClass(referenceName, getOriginatingElement())) {
             startPublicFinalClass(referenceWriter, targetClassType.getInternalName(), superType);
             final ClassWriter classWriter = generateClassBytes(referenceWriter);
             for (GeneratorAdapter generatorAdapter : loadTypeMethods.values()) {

--- a/inject/src/main/java/io/micronaut/inject/beans/visitor/BeanPropertyWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/visitor/BeanPropertyWriter.java
@@ -94,7 +94,7 @@ class BeanPropertyWriter extends AbstractClassFileWriter implements Named {
             int index,
             @Nullable AnnotationMetadata annotationMetadata,
             @Nullable Map<String, ClassElement> typeArguments) {
-
+        super(introspectionWriter.getOriginatingElement());
         Type introspectionType = introspectionWriter.getIntrospectionType();
         this.declaringElement = introspectionWriter.getClassElement();
         this.typeElement = typeElement;
@@ -138,7 +138,7 @@ class BeanPropertyWriter extends AbstractClassFileWriter implements Named {
 
     @Override
     public void accept(ClassWriterOutputVisitor classWriterOutputVisitor) throws IOException {
-        try (OutputStream classOutput = classWriterOutputVisitor.visitClass(getName())) {
+        try (OutputStream classOutput = classWriterOutputVisitor.visitClass(getName(), getOriginatingElement())) {
             startFinalClass(classWriter, type.getInternalName(), TYPE_BEAN_PROPERTY);
 
             writeConstructor();

--- a/inject/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
@@ -235,6 +235,12 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
         }
     }
 
+    @NonNull
+    @Override
+    public VisitorKind getVisitorKind() {
+        return VisitorKind.ISOLATING;
+    }
+
     @Override
     public void finish(VisitorContext visitorContext) {
 

--- a/inject/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
@@ -191,6 +191,7 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                         final BeanIntrospectionWriter writer = new BeanIntrospectionWriter(
                                 element.getName(),
                                 index.getAndIncrement(),
+                                element,
                                 ce,
                                 metadata ? element.getAnnotationMetadata() : null
                         );
@@ -214,6 +215,7 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                         final BeanIntrospectionWriter writer = new BeanIntrospectionWriter(
                                 element.getName(),
                                 j++,
+                                element,
                                 classElement,
                                 metadata ? element.getAnnotationMetadata() : null
                         );

--- a/inject/src/main/java/io/micronaut/inject/visitor/TypeElementVisitor.java
+++ b/inject/src/main/java/io/micronaut/inject/visitor/TypeElementVisitor.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.inject.visitor;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.order.Ordered;
 import io.micronaut.inject.ast.ClassElement;
@@ -104,5 +105,32 @@ public interface TypeElementVisitor<C, E> extends Ordered {
     @Experimental
     default Set<String> getSupportedOptions() {
         return Collections.emptySet();
+    }
+
+    /**
+     * @return The visitor kind.
+     */
+    default @NonNull VisitorKind getVisitorKind() {
+        return VisitorKind.AGGREGATING;
+    }
+
+    /**
+     * Implementors of the {@link TypeElementVisitor} interface should specify what kind of visitor it is.
+     *
+     * If the visitor looks at multiple {@link io.micronaut.inject.ast.Element} and builds a file that references
+     * multiple {@link io.micronaut.inject.ast.Element} (meaning it doesn't have an originating element) then
+     * {@link VisitorKind#AGGREGATING} should be used
+     *
+     * If the visitor generates classes from an originating {@link io.micronaut.inject.ast.Element} then {@link VisitorKind#ISOLATING} should be used.
+     */
+    enum VisitorKind {
+        /**
+         * A visitor that generates a file for each visited element and calls
+         */
+        ISOLATING,
+        /**
+         * A visitor that generates a one or more files in the {@link #finish(VisitorContext)} method computed from visiting multiple {@link io.micronaut.inject.ast.Element} instances.
+         */
+        AGGREGATING
     }
 }

--- a/inject/src/main/java/io/micronaut/inject/visitor/TypeElementVisitor.java
+++ b/inject/src/main/java/io/micronaut/inject/visitor/TypeElementVisitor.java
@@ -18,6 +18,8 @@ package io.micronaut.inject.visitor;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.order.Ordered;
+import io.micronaut.core.reflect.GenericTypeUtils;
+import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.ConstructorElement;
 import io.micronaut.inject.ast.FieldElement;
@@ -93,6 +95,29 @@ public interface TypeElementVisitor<C, E> extends Ordered {
      */
     default void finish(VisitorContext visitorContext) {
         // no-op
+    }
+
+    /**
+     * @return The supported default annotation names.
+     */
+    default Set<String> getSupportedAnnotationNames() {
+        Class<?>[] classes = GenericTypeUtils.resolveInterfaceTypeArguments(getClass(), TypeElementVisitor.class);
+
+        if (classes.length == 2) {
+            Class<?> classType = classes[0];
+            if (classType == Object.class) {
+                return Collections.singleton("*");
+            } else {
+                Class<?> methodType = classes[1];
+                if (methodType != Object.class) {
+                    return CollectionUtils.setOf(classType.getName(), methodType.getName());
+                } else {
+                    return CollectionUtils.setOf(classType.getName());
+                }
+
+            }
+        }
+        return Collections.singleton("*");
     }
 
     /**

--- a/inject/src/main/java/io/micronaut/inject/writer/AbstractAnnotationMetadataWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/AbstractAnnotationMetadataWriter.java
@@ -21,6 +21,7 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.inject.annotation.AnnotationMetadataReference;
 import io.micronaut.inject.annotation.AnnotationMetadataWriter;
 import io.micronaut.inject.annotation.DefaultAnnotationMetadata;
+import io.micronaut.inject.ast.Element;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.Type;
@@ -51,13 +52,16 @@ public abstract class AbstractAnnotationMetadataWriter extends AbstractClassFile
 
     /**
      * @param className               The class name
+     * @param originatingElement      The originating element
      * @param annotationMetadata      The annotation metadata
      * @param writeAnnotationDefaults Whether to write annotation defaults
      */
     protected AbstractAnnotationMetadataWriter(
             String className,
+            Element originatingElement,
             AnnotationMetadata annotationMetadata,
             boolean writeAnnotationDefaults) {
+        super(originatingElement);
         this.targetClassType = getTypeReference(className);
         this.annotationMetadata = annotationMetadata;
         this.writeAnnotationDefault = writeAnnotationDefaults;

--- a/inject/src/main/java/io/micronaut/inject/writer/AbstractClassFileWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/AbstractClassFileWriter.java
@@ -30,15 +30,12 @@ import io.micronaut.inject.ast.Element;
 import io.micronaut.inject.ast.ParameterElement;
 import io.micronaut.inject.ast.TypedElement;
 import org.jetbrains.annotations.NotNull;
-import org.objectweb.asm.ClassVisitor;
-import org.objectweb.asm.ClassWriter;
-import org.objectweb.asm.MethodVisitor;
-import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.Type;
+import org.objectweb.asm.*;
 import org.objectweb.asm.commons.GeneratorAdapter;
 import org.objectweb.asm.commons.Method;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
@@ -120,7 +117,7 @@ public abstract class AbstractClassFileWriter implements Opcodes {
      * Pushes type arguments onto the stack.
      *
      * @param generatorAdapter The generator adapter
-     * @param declaringElement     The declaring class element of the generics
+     * @param declaringElement The declaring class element of the generics
      * @param types            The type references
      */
     protected static void pushTypeArgumentElements(
@@ -262,7 +259,8 @@ public abstract class AbstractClassFileWriter implements Opcodes {
 
     /**
      * Builds generic type arguments recursively.
-     *  @param generatorAdapter The generator adapter to use
+     *
+     * @param generatorAdapter The generator adapter to use
      * @param argumentName     The argument name
      * @param typeReference    The type name
      * @param classElement     The class element that declares the generics
@@ -533,8 +531,9 @@ public abstract class AbstractClassFileWriter implements Opcodes {
 
     /**
      * Writes a method that returns a boolean value with the value supplied by the given supplier.
-     * @param classWriter The class writer
-     * @param methodName The method name
+     *
+     * @param classWriter   The class writer
+     * @param methodName    The method name
      * @param valueSupplier The supplier
      */
     protected void writeBooleanMethod(ClassWriter classWriter, String methodName, Supplier<Boolean> valueSupplier) {
@@ -553,7 +552,8 @@ public abstract class AbstractClassFileWriter implements Opcodes {
     /**
      * @return The originating element
      */
-    public @Nullable Element getOriginatingElement() {
+    public @Nullable
+    Element getOriginatingElement() {
         return this.originatingElement;
     }
 
@@ -1079,6 +1079,29 @@ public abstract class AbstractClassFileWriter implements Opcodes {
     protected void startPublicClass(ClassVisitor classWriter, String className, Type superType) {
         classWriter.visit(V1_8, ACC_PUBLIC | ACC_SYNTHETIC, className, null, superType.getInternalName(), null);
         classWriter.visitAnnotation(TYPE_GENERATED.getDescriptor(), false);
+    }
+
+    /**
+     * @param classWriter       The current class writer
+     * @param serviceType       The service type
+     * @param internalClassName The class name
+     * @param superType         The super type
+     */
+    protected void startService(ClassVisitor classWriter, Class<?> serviceType, String internalClassName, Type superType) {
+        startService(classWriter, serviceType.getName(), internalClassName, superType);
+    }
+
+    /**
+     * @param classWriter       The current class writer
+     * @param serviceName       The service name
+     * @param internalClassName The class name
+     * @param superType         The super type
+     */
+    protected void startService(ClassVisitor classWriter, String serviceName, String internalClassName, Type superType) {
+        classWriter.visit(V1_8, ACC_PUBLIC | ACC_FINAL | ACC_SYNTHETIC, internalClassName, null, superType.getInternalName(), null);
+        AnnotationVisitor annotationVisitor = classWriter.visitAnnotation(TYPE_GENERATED.getDescriptor(), false);
+        annotationVisitor.visit("service", serviceName);
+        annotationVisitor.visitEnd();
     }
 
     /**

--- a/inject/src/main/java/io/micronaut/inject/writer/AbstractClassFileWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/AbstractClassFileWriter.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.inject.writer;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Generated;
 import io.micronaut.core.annotation.Internal;
@@ -25,6 +26,7 @@ import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.annotation.AnnotationMetadataWriter;
 import io.micronaut.inject.annotation.DefaultAnnotationMetadata;
 import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.ast.Element;
 import io.micronaut.inject.ast.ParameterElement;
 import io.micronaut.inject.ast.TypedElement;
 import org.jetbrains.annotations.NotNull;
@@ -103,6 +105,15 @@ public abstract class AbstractClassFileWriter implements Opcodes {
         NAME_TO_TYPE_MAP.put("long", "J");
         NAME_TO_TYPE_MAP.put("double", "D");
         NAME_TO_TYPE_MAP.put("float", "F");
+    }
+
+    protected final Element originatingElement;
+
+    /**
+     * @param originatingElement The originating element
+     */
+    protected AbstractClassFileWriter(Element originatingElement) {
+        this.originatingElement = originatingElement;
     }
 
     /**
@@ -537,6 +548,13 @@ public abstract class AbstractClassFileWriter implements Opcodes {
         isSingletonMethod.returnValue();
         isSingletonMethod.visitMaxs(1, 1);
         isSingletonMethod.visitEnd();
+    }
+
+    /**
+     * @return The originating element
+     */
+    public @Nullable Element getOriginatingElement() {
+        return this.originatingElement;
     }
 
     /**

--- a/inject/src/main/java/io/micronaut/inject/writer/AbstractClassWriterOutputVisitor.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/AbstractClassWriterOutputVisitor.java
@@ -55,6 +55,15 @@ public abstract class AbstractClassWriterOutputVisitor implements ClassWriterOut
     public final void finish() {
         Map<String, Set<String>> serviceEntries = getServiceEntries();
 
+        writeServiceEntries(serviceEntries);
+    }
+
+    /**
+     * Writes the service entries.
+     *
+     * @param serviceEntries The service entries
+     */
+    public void writeServiceEntries(Map<String, Set<String>> serviceEntries) {
         for (Map.Entry<String, Set<String>> entry : serviceEntries.entrySet()) {
             String serviceName = entry.getKey();
             Set<String> serviceTypes = entry.getValue();
@@ -94,7 +103,6 @@ public abstract class AbstractClassWriterOutputVisitor implements ClassWriterOut
                 } catch (IOException x) {
                     throw new ClassGenerationException("Failed to open writer for service definition files: " + x);
                 }
-
             }
         }
     }

--- a/inject/src/main/java/io/micronaut/inject/writer/BeanConfigurationWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/BeanConfigurationWriter.java
@@ -77,7 +77,7 @@ public class BeanConfigurationWriter extends AbstractAnnotationMetadataWriter {
             Class<AbstractBeanConfiguration> superType = AbstractBeanConfiguration.class;
             Type beanConfigurationType = Type.getType(superType);
 
-            startPublicClass(classWriter, configurationClassInternalName, beanConfigurationType);
+            startService(classWriter, BeanConfiguration.class, configurationClassInternalName, beanConfigurationType);
             writeAnnotationMetadataStaticInitializer(classWriter);
 
             writeConstructor(classWriter);

--- a/inject/src/main/java/io/micronaut/inject/writer/BeanConfigurationWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/BeanConfigurationWriter.java
@@ -19,6 +19,7 @@ import io.micronaut.context.AbstractBeanConfiguration;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.inject.BeanConfiguration;
+import io.micronaut.inject.ast.Element;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.GeneratorAdapter;
@@ -47,10 +48,14 @@ public class BeanConfigurationWriter extends AbstractAnnotationMetadataWriter {
 
     /**
      * @param packageName        The package name
+     * @param originatingElement The originating element
      * @param annotationMetadata The annotation metadata
      */
-    public BeanConfigurationWriter(String packageName, AnnotationMetadata annotationMetadata) {
-        super(packageName + '.' + CLASS_SUFFIX, annotationMetadata, true);
+    public BeanConfigurationWriter(
+            String packageName,
+            Element originatingElement,
+            AnnotationMetadata annotationMetadata) {
+        super(packageName + '.' + CLASS_SUFFIX, originatingElement, annotationMetadata, true);
         this.packageName = packageName;
         this.configurationClassName = targetClassType.getClassName();
         this.configurationClassInternalName = targetClassType.getInternalName();
@@ -58,7 +63,7 @@ public class BeanConfigurationWriter extends AbstractAnnotationMetadataWriter {
 
     @Override
     public void accept(ClassWriterOutputVisitor classWriterOutputVisitor) throws IOException {
-        try (OutputStream outputStream = classWriterOutputVisitor.visitClass(configurationClassName)) {
+        try (OutputStream outputStream = classWriterOutputVisitor.visitClass(configurationClassName, getOriginatingElement())) {
             ClassWriter classWriter = generateClassBytes();
             outputStream.write(classWriter.toByteArray());
         }

--- a/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionReferenceWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionReferenceWriter.java
@@ -125,7 +125,7 @@ public class BeanDefinitionReferenceWriter extends AbstractAnnotationMetadataWri
         ClassWriter classWriter = new ClassWriter(ClassWriter.COMPUTE_MAXS);
 
         Type superType = Type.getType(AbstractBeanDefinitionReference.class);
-        startPublicClass(classWriter, beanDefinitionClassInternalName, superType);
+        startService(classWriter, BeanDefinitionReference.class, beanDefinitionClassInternalName, superType);
         Type beanDefinitionType = getTypeReference(beanDefinitionName);
         writeAnnotationMetadataStaticInitializer(classWriter);
 

--- a/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionReferenceWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionReferenceWriter.java
@@ -22,6 +22,7 @@ import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.BeanDefinitionReference;
+import io.micronaut.inject.ast.Element;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.GeneratorAdapter;
@@ -55,10 +56,15 @@ public class BeanDefinitionReferenceWriter extends AbstractAnnotationMetadataWri
     /**
      * @param beanTypeName       The bean type name
      * @param beanDefinitionName The bean definition name
+     * @param originatingElement The originating element
      * @param annotationMetadata The annotation metadata
      */
-    public BeanDefinitionReferenceWriter(String beanTypeName, String beanDefinitionName, AnnotationMetadata annotationMetadata) {
-        super(beanDefinitionName + REF_SUFFIX, annotationMetadata, true);
+    public BeanDefinitionReferenceWriter(
+            String beanTypeName,
+            String beanDefinitionName,
+            Element originatingElement,
+            AnnotationMetadata annotationMetadata) {
+        super(beanDefinitionName + REF_SUFFIX, originatingElement, annotationMetadata, true);
         this.beanTypeName = beanTypeName;
         this.beanDefinitionName = beanDefinitionName;
         this.beanDefinitionReferenceClassName = beanDefinitionName + REF_SUFFIX;
@@ -73,7 +79,7 @@ public class BeanDefinitionReferenceWriter extends AbstractAnnotationMetadataWri
      */
     @Override
     public void accept(ClassWriterOutputVisitor outputVisitor) throws IOException {
-        try (OutputStream outputStream = outputVisitor.visitClass(getBeanDefinitionQualifiedClassName())) {
+        try (OutputStream outputStream = outputVisitor.visitClass(getBeanDefinitionQualifiedClassName(), getOriginatingElement())) {
             ClassWriter classWriter = generateClassBytes();
             outputStream.write(classWriter.toByteArray());
         }

--- a/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionVisitor.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionVisitor.java
@@ -17,6 +17,7 @@ package io.micronaut.inject.writer;
 
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.inject.BeanDefinition;
+import io.micronaut.inject.ast.Element;
 import io.micronaut.inject.configuration.ConfigurationMetadataBuilder;
 import org.objectweb.asm.Type;
 
@@ -38,6 +39,11 @@ public interface BeanDefinitionVisitor {
      * The suffix use for generated AOP intercepted types.
      */
     String PROXY_SUFFIX = "$Intercepted";
+
+    /**
+     * @return The element where the bean definition originated from.
+     */
+    @Nullable Element getOriginatingElement();
 
     /**
      * Visits a no arguments constructor. Either this method or

--- a/inject/src/main/java/io/micronaut/inject/writer/ClassWriterOutputVisitor.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/ClassWriterOutputVisitor.java
@@ -15,6 +15,9 @@
  */
 package io.micronaut.inject.writer;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
+import io.micronaut.inject.ast.Element;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Collections;
@@ -33,11 +36,26 @@ public interface ClassWriterOutputVisitor {
      * Visits a new class and returns the output stream with which should be written the bytes of the class to be
      * generated.
      *
-     * @param classname the fully qualified classname
+     * @param classname          the fully qualified classname
+     * @return the output stream to write to
+     * @deprecated Use {@link #visitClass(String, Element)} instead
+     * @throws IOException if an error occurs creating the output stream
+     */
+    @Deprecated
+    default OutputStream visitClass(String classname) throws IOException {
+        return visitClass(classname, null);
+    }
+
+    /**
+     * Visits a new class and returns the output stream with which should be written the bytes of the class to be
+     * generated.
+     *
+     * @param classname          the fully qualified classname
+     * @param originatingElement The originating element
      * @return the output stream to write to
      * @throws IOException if an error occurs creating the output stream
      */
-    OutputStream visitClass(String classname) throws IOException;
+    OutputStream visitClass(String classname, @Nullable Element originatingElement) throws IOException;
 
     /**
      * Allows adding a class that will be written to the {@code META-INF/services} file under the given type and class

--- a/inject/src/main/java/io/micronaut/inject/writer/ClassWriterOutputVisitor.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/ClassWriterOutputVisitor.java
@@ -57,6 +57,7 @@ public interface ClassWriterOutputVisitor {
      */
     OutputStream visitClass(String classname, @Nullable Element originatingElement) throws IOException;
 
+
     /**
      * Allows adding a class that will be written to the {@code META-INF/services} file under the given type and class
      * name.

--- a/inject/src/main/java/io/micronaut/inject/writer/ClassWriterOutputVisitor.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/ClassWriterOutputVisitor.java
@@ -36,12 +36,12 @@ public interface ClassWriterOutputVisitor {
      * Visits a new class and returns the output stream with which should be written the bytes of the class to be
      * generated.
      *
+     * Note that this method should only be called from a {@link io.micronaut.inject.visitor.TypeElementVisitor.VisitorKind#AGGREGATING} visitor from within the {@link io.micronaut.inject.visitor.TypeElementVisitor#finish(io.micronaut.inject.visitor.VisitorContext)} method. If the file
+     *
      * @param classname          the fully qualified classname
      * @return the output stream to write to
-     * @deprecated Use {@link #visitClass(String, Element)} instead
      * @throws IOException if an error occurs creating the output stream
      */
-    @Deprecated
     default OutputStream visitClass(String classname) throws IOException {
         return visitClass(classname, null);
     }

--- a/inject/src/main/java/io/micronaut/inject/writer/DirectoryClassWriterOutputVisitor.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/DirectoryClassWriterOutputVisitor.java
@@ -15,7 +15,9 @@
  */
 package io.micronaut.inject.writer;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.inject.ast.Element;
 
 import java.io.File;
 import java.io.IOException;
@@ -42,8 +44,8 @@ public class DirectoryClassWriterOutputVisitor extends AbstractClassWriterOutput
     }
 
     @Override
-    public OutputStream visitClass(String className) throws IOException {
-        File targetFile = new File(targetDir, getClassFileName(className)).getCanonicalFile();
+    public OutputStream visitClass(String classname, @Nullable Element originatingElement) throws IOException {
+        File targetFile = new File(targetDir, getClassFileName(classname)).getCanonicalFile();
         File parentDir = targetFile.getParentFile();
         if (!parentDir.exists() && !parentDir.mkdirs()) {
             throw new IOException("Cannot create parent directory: " + targetFile.getParentFile());

--- a/router/src/test/groovy/io/micronaut/ast/groovy/annotation/GroovyAnnotationMetadataBuilderSpec.groovy
+++ b/router/src/test/groovy/io/micronaut/ast/groovy/annotation/GroovyAnnotationMetadataBuilderSpec.groovy
@@ -111,7 +111,7 @@ class FormController {
 
     protected AnnotationMetadata writeAndLoadMetadata(String className, AnnotationMetadata toWrite) {
         def stream = new ByteArrayOutputStream()
-        new AnnotationMetadataWriter(className, toWrite)
+        new AnnotationMetadataWriter(className, null, toWrite)
                 .writeTo(stream)
         className = className + AnnotationMetadata.CLASS_NAME_SUFFIX
         ClassLoader classLoader = new ClassLoader() {

--- a/test-suite/src/main/java/example/micronaut/inject/visitor/AnnotatingVisitor.java
+++ b/test-suite/src/main/java/example/micronaut/inject/visitor/AnnotatingVisitor.java
@@ -15,6 +15,7 @@
  */
 package example.micronaut.inject.visitor;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import io.micronaut.core.version.annotation.Version;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.ConstructorElement;
@@ -32,6 +33,12 @@ public class AnnotatingVisitor implements TypeElementVisitor<Version, Version> {
     public void visitClass(ClassElement element, VisitorContext context) {
         context.info("Annotating type", element);
         element.annotate(TestAnn.class, (builder) -> builder.value("class"));
+    }
+
+    @NonNull
+    @Override
+    public VisitorKind getVisitorKind() {
+        return VisitorKind.ISOLATING;
     }
 
     @Override

--- a/validation/src/main/java/io/micronaut/validation/async/AsyncTypeElementVisitor.java
+++ b/validation/src/main/java/io/micronaut/validation/async/AsyncTypeElementVisitor.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.validation.async;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.MethodElement;
@@ -32,6 +33,12 @@ import java.util.concurrent.CompletionStage;
  */
 @Internal
 public final class AsyncTypeElementVisitor implements TypeElementVisitor<Object, Async> {
+
+    @NonNull
+    @Override
+    public VisitorKind getVisitorKind() {
+        return VisitorKind.ISOLATING;
+    }
 
     @Override
     public void visitMethod(MethodElement element, VisitorContext context) {

--- a/validation/src/main/java/io/micronaut/validation/internal/InternalApiTypeElementVisitor.java
+++ b/validation/src/main/java/io/micronaut/validation/internal/InternalApiTypeElementVisitor.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.validation.internal;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.inject.ast.*;
@@ -33,6 +34,12 @@ public class InternalApiTypeElementVisitor implements TypeElementVisitor<Object,
     private static final String IO_MICRONAUT = "io.micronaut";
 
     private boolean warned = false;
+
+    @NonNull
+    @Override
+    public VisitorKind getVisitorKind() {
+        return VisitorKind.ISOLATING;
+    }
 
     @Override
     public void visitClass(ClassElement element, VisitorContext context) {

--- a/validation/src/main/java/io/micronaut/validation/routes/RouteValidationVisitor.java
+++ b/validation/src/main/java/io/micronaut/validation/routes/RouteValidationVisitor.java
@@ -15,12 +15,14 @@
  */
 package io.micronaut.validation.routes;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import io.micronaut.context.env.DefaultPropertyPlaceholderResolver;
 import io.micronaut.context.env.DefaultPropertyPlaceholderResolver.RawSegment;
 import io.micronaut.context.env.DefaultPropertyPlaceholderResolver.Segment;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.convert.DefaultConversionService;
 import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.HttpMethodMapping;
 import io.micronaut.http.uri.UriMatchTemplate;
 import io.micronaut.inject.ast.MethodElement;
@@ -52,6 +54,20 @@ public class RouteValidationVisitor implements TypeElementVisitor<Object, HttpMe
     private List<RouteValidationRule> rules = new ArrayList<>();
     private boolean skipValidation = false;
     private final DefaultPropertyPlaceholderResolver resolver = new DefaultPropertyPlaceholderResolver(null, new DefaultConversionService());
+
+    @NonNull
+    @Override
+    public VisitorKind getVisitorKind() {
+        return VisitorKind.ISOLATING;
+    }
+
+    @Override
+    public Set<String> getSupportedAnnotationNames() {
+        return CollectionUtils.setOf(
+            Controller.class.getName(),
+            "io.micronaut.http.client.annotation.Client"
+        );
+    }
 
     @Override
     public void visitMethod(MethodElement element, VisitorContext context) {

--- a/validation/src/main/java/io/micronaut/validation/websocket/WebSocketVisitor.java
+++ b/validation/src/main/java/io/micronaut/validation/websocket/WebSocketVisitor.java
@@ -15,8 +15,10 @@
  */
 package io.micronaut.validation.websocket;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import io.micronaut.core.bind.annotation.Bindable;
 import io.micronaut.core.util.ArrayUtils;
+import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.http.uri.UriMatchTemplate;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.MethodElement;
@@ -48,6 +50,19 @@ public class WebSocketVisitor implements TypeElementVisitor<WebSocketComponent, 
 
     private Map<String, UriMatchTemplate> uriCache = new HashMap<>(3);
     private boolean skipValidation = false;
+
+    @NonNull
+    @Override
+    public VisitorKind getVisitorKind() {
+        return VisitorKind.ISOLATING;
+    }
+
+    @Override
+    public Set<String> getSupportedAnnotationNames() {
+        return CollectionUtils.setOf(
+                WebSocketComponent.class.getName()
+        );
+    }
 
     @Override
     public void visitMethod(MethodElement element, VisitorContext context) {


### PR DESCRIPTION
This change alters the way in which we generate service descriptors so that each class we generate adds an annotation such as `@Generated(service="io.micronaut.inject.BeanDefinitionReference")` to the generated byte code which are then visited by `ServiceDescriptionProcessor` which actually writes out the `META-INF/services` files.

This allows `BeanDefinitionInjectProcessor` to be an isolating processor and `ServiceDescriptionProcessor` can be a separate aggregating processor fixing incremental compilation with Gradle. 

Fixes #2922