### PR TITLE
Changed Publisher to Maybe Conversion to use Flowable

### DIFF
--- a/runtime/src/main/java/io/micronaut/reactive/rxjava2/converters/RxJavaConverterRegistrar.java
+++ b/runtime/src/main/java/io/micronaut/reactive/rxjava2/converters/RxJavaConverterRegistrar.java
@@ -99,7 +99,7 @@ public class RxJavaConverterRegistrar implements TypeConverterRegistrar {
         );
         conversionService.addConverter(Publisher.class, Single.class, (Function<Publisher, Single>) Single::fromPublisher);
         conversionService.addConverter(Publisher.class, Observable.class, (Function<Publisher, Observable>) Observable::fromPublisher);
-        conversionService.addConverter(Publisher.class, Maybe.class, (Function<Publisher, Maybe>) publisher -> Maybe.fromSingle(Single.fromPublisher(publisher)));
+        conversionService.addConverter(Publisher.class, Maybe.class, (Function<Publisher, Maybe>) publisher -> Flowable.fromPublisher(publisher).firstElement());
         conversionService.addConverter(Publisher.class, Completable.class, (Function<Publisher, Completable>) Completable::fromPublisher);
     }
 }


### PR DESCRIPTION
Changed the conversion of Publisher to Maybe to use Flowable to allow support of the source emitting 0 items.  

In the current implementation, it uses `Single.fromPublisher(publisher)` which means that in case where the publisher emits 0 items, the Single will throw:

```
java.util.NoSuchElementException: The source Publisher is empty
```

For a Maybe - it's valid that the source can be empty.