### PR TITLE
Copy headers from original response when returning not modified.

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/types/files/FileTypeHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/types/files/FileTypeHandler.java
@@ -86,7 +86,7 @@ public class FileTypeHandler implements NettyCustomizableResponseTypeHandler<Obj
             long ifModifiedSinceDateSeconds = ifModifiedSince.toEpochSecond();
             long fileLastModifiedSeconds = lastModified / 1000;
             if (ifModifiedSinceDateSeconds == fileLastModifiedSeconds) {
-                FullHttpResponse nettyResponse = notModified();
+                FullHttpResponse nettyResponse = notModified(response);
                 context.writeAndFlush(nettyResponse);
                 return;
             }
@@ -157,8 +157,13 @@ public class FileTypeHandler implements NettyCustomizableResponseTypeHandler<Obj
         headers.date(now);
     }
 
-    private FullHttpResponse notModified() {
+    private static void copyHeaders(NettyMutableHttpResponse<?> from, NettyMutableHttpResponse to) {
+        from.getHeaders().forEachValue((header, value) -> to.getHeaders().add(header, value));
+    }
+
+    private FullHttpResponse notModified(NettyMutableHttpResponse<?> originalResponse) {
         NettyMutableHttpResponse response = (NettyMutableHttpResponse) HttpResponse.notModified();
+        copyHeaders(originalResponse, response);
         setDateHeader(response);
         return response.getNativeResponse();
     }

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
@@ -39,6 +39,7 @@ import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementScanner8;
+
 import java.util.*;
 import java.util.stream.Collectors;
 


### PR DESCRIPTION
Otherwise headers added by filters are lost.