### PR TITLE
Remove GraalVM warning about OracleCloudVaultConfigurationClient

### DIFF
--- a/discovery-client/src/main/resources/META-INF/native-image/io.micronaut.discovery/oraclecloud/native-image.properties
+++ b/discovery-client/src/main/resources/META-INF/native-image/io.micronaut.discovery/oraclecloud/native-image.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2017-2020 original authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Args = --initialize-at-run-time=io.micronaut.discovery.oraclecloud.vault.config.OracleCloudVaultConfigurationClient


### PR DESCRIPTION
Fixes the Oracle client warning in #3294. The other warning is handled in https://github.com/micronaut-projects/micronaut-core/pull/3311