### PR TITLE
Clean MDC context, Fixes #3106

### DIFF
--- a/http-server/src/main/java/io/micronaut/http/server/context/ServerRequestContextFilter.java
+++ b/http-server/src/main/java/io/micronaut/http/server/context/ServerRequestContextFilter.java
@@ -19,14 +19,16 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.http.annotation.Filter;
-import io.micronaut.http.context.ServerRequestContext;
-import io.micronaut.http.context.ServerRequestTracingPublisher;
 import io.micronaut.http.filter.HttpServerFilter;
 import io.micronaut.http.filter.ServerFilterChain;
 import io.micronaut.http.filter.ServerFilterPhase;
+import io.micronaut.scheduling.instrument.InvocationInstrumenter;
+import io.micronaut.scheduling.instrument.InvocationInstrumenterFactory;
 import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
 
-import java.util.function.Supplier;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A filter that instruments the request with the {@link io.micronaut.http.context.ServerRequestContext}.
@@ -38,15 +40,54 @@ import java.util.function.Supplier;
 @Internal
 public final class ServerRequestContextFilter implements HttpServerFilter {
 
+    private final List<InvocationInstrumenterFactory> invocationInstrumenterFactories;
+
+    /**
+     * Creates new filter.
+     *
+     * @param invocationInstrumenterFactories the invocationInstrumenterFactories
+     */
+    public ServerRequestContextFilter(List<InvocationInstrumenterFactory> invocationInstrumenterFactories) {
+        this.invocationInstrumenterFactories = invocationInstrumenterFactories;
+    }
+
     @Override
     public Publisher<MutableHttpResponse<?>> doFilter(HttpRequest<?> request, ServerFilterChain chain) {
-        return ServerRequestContext.with(request, (Supplier<Publisher<MutableHttpResponse<?>>>) () ->
-                new ServerRequestTracingPublisher(request, chain.proceed(request))
-        );
+        InvocationInstrumenter invocationInstrumenter = InvocationInstrumenter.combine(getInvocationInstrumenter(request));
+        try {
+            invocationInstrumenter.beforeInvocation();
+            Publisher<MutableHttpResponse<?>> actual = chain.proceed(request);
+            return new Publisher<MutableHttpResponse<?>>() {
+                @Override
+                public void subscribe(Subscriber<? super MutableHttpResponse<?>> s) {
+                    invocationInstrumenter.beforeInvocation();
+                    try {
+                        actual.subscribe(s);
+                    } finally {
+                        invocationInstrumenter.afterInvocation();
+                    }
+                }
+            };
+        } finally {
+            invocationInstrumenter.afterInvocation();
+        }
     }
 
     @Override
     public int getOrder() {
         return ServerFilterPhase.FIRST.order();
     }
+
+    private List<InvocationInstrumenter> getInvocationInstrumenter(HttpRequest<?> request) {
+        List<InvocationInstrumenter> instrumenters = new ArrayList<>(invocationInstrumenterFactories.size() + 1);
+        instrumenters.add(new ServerRequestContextInvocationInstrumenter(request));
+        for (InvocationInstrumenterFactory instrumenterFactory : invocationInstrumenterFactories) {
+            final InvocationInstrumenter instrumenter = instrumenterFactory.newInvocationInstrumenter();
+            if (instrumenter != null) {
+                instrumenters.add(instrumenter);
+            }
+        }
+        return instrumenters;
+    }
+
 }

--- a/http-server/src/main/java/io/micronaut/http/server/context/ServerRequestContextInstrumentation.java
+++ b/http-server/src/main/java/io/micronaut/http/server/context/ServerRequestContextInstrumentation.java
@@ -16,7 +16,6 @@
 package io.micronaut.http.server.context;
 
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.http.HttpRequest;
 import io.micronaut.http.context.ServerRequestContext;
 import io.micronaut.scheduling.instrument.InvocationInstrumenter;
 import io.micronaut.scheduling.instrument.InvocationInstrumenterFactory;
@@ -36,29 +35,7 @@ final class ServerRequestContextInstrumentation implements InvocationInstrumente
 
     @Override
     public InvocationInstrumenter newInvocationInstrumenter() {
-        return ServerRequestContext.currentRequest().map(invocationRequest -> new InvocationInstrumenter() {
-
-            private HttpRequest<Object> currentRequest;
-            private boolean isSet = false;
-
-            @Override
-            public void beforeInvocation() {
-                currentRequest = ServerRequestContext.currentRequest().orElse(null);
-                if (invocationRequest != currentRequest) {
-                    isSet = true;
-                    ServerRequestContext.set(invocationRequest);
-                }
-            }
-
-            @Override
-            public void afterInvocation(boolean cleanup) {
-                if (isSet || cleanup) {
-                    ServerRequestContext.set(cleanup ? null : currentRequest);
-                    isSet = false;
-                }
-            }
-
-        }).orElse(null);
+        return ServerRequestContext.currentRequest().map(ServerRequestContextInvocationInstrumenter::new).orElse(null);
     }
 
     @Override

--- a/http-server/src/main/java/io/micronaut/http/server/context/ServerRequestContextInvocationInstrumenter.java
+++ b/http-server/src/main/java/io/micronaut/http/server/context/ServerRequestContextInvocationInstrumenter.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.context;
+
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.context.ServerRequestContext;
+import io.micronaut.scheduling.instrument.InvocationInstrumenter;
+
+/**
+ * Server request context invocation instrumenter
+ *
+ * @author dstepanov
+ * @since 2.0
+ */
+class ServerRequestContextInvocationInstrumenter implements InvocationInstrumenter {
+
+    private final HttpRequest<?> invocationRequest;
+    private HttpRequest<?> currentRequest;
+    private boolean isSet;
+
+    /**
+     * @param invocationRequest current request
+     */
+    public ServerRequestContextInvocationInstrumenter(HttpRequest<?> invocationRequest) {
+        this.invocationRequest = invocationRequest;
+        isSet = false;
+    }
+
+    /**
+     * Before call.
+     */
+    @Override
+    public void beforeInvocation() {
+        currentRequest = ServerRequestContext.currentRequest().orElse(null);
+        if (invocationRequest != currentRequest) {
+            isSet = true;
+            ServerRequestContext.set(invocationRequest);
+        }
+    }
+
+    /**
+     * After call.
+     *
+     * @param cleanup Whether to enforce cleanup
+     */
+    @Override
+    public void afterInvocation(boolean cleanup) {
+        if (isSet || cleanup) {
+            ServerRequestContext.set(cleanup ? null : currentRequest);
+            isSet = false;
+        }
+    }
+
+}

--- a/tracing/src/main/java/io/micronaut/tracing/instrument/util/MdcInstrumenter.java
+++ b/tracing/src/main/java/io/micronaut/tracing/instrument/util/MdcInstrumenter.java
@@ -20,6 +20,8 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.scheduling.instrument.InvocationInstrumenter;
 import io.micronaut.scheduling.instrument.InvocationInstrumenterFactory;
 import io.micronaut.scheduling.instrument.ReactiveInvocationInstrumenterFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
 import javax.inject.Singleton;
@@ -37,35 +39,38 @@ import java.util.Map;
 @Internal
 public final class MdcInstrumenter implements InvocationInstrumenterFactory, ReactiveInvocationInstrumenterFactory {
 
+    private static final Logger LOG = LoggerFactory.getLogger(MdcInstrumenter.class);
+
+
     /**
      * Creates optional invocation instrumenter.
+     *
      * @return An optional that contains the invocation instrumenter
      */
     @Override
     public InvocationInstrumenter newInvocationInstrumenter() {
         Map<String, String> contextMap = MDC.getCopyOfContextMap();
-        if (contextMap != null && !contextMap.isEmpty()) {
-            return new InvocationInstrumenter() {
+        return new InvocationInstrumenter() {
 
-                Map<String, String> oldContextMap;
+            Map<String, String> oldContextMap;
 
-                @Override
-                public void beforeInvocation() {
-                    oldContextMap = MDC.getCopyOfContextMap();
+            @Override
+            public void beforeInvocation() {
+                oldContextMap = MDC.getCopyOfContextMap();
+                if (contextMap != null) {
                     MDC.setContextMap(contextMap);
                 }
+            }
 
-                @Override
-                public void afterInvocation(boolean cleanup) {
-                    if (oldContextMap != null && !oldContextMap.isEmpty()) {
-                        MDC.setContextMap(oldContextMap);
-                    } else {
-                        MDC.clear();
-                    }
+            @Override
+            public void afterInvocation(boolean cleanup) {
+                if (oldContextMap != null && !oldContextMap.isEmpty()) {
+                    MDC.setContextMap(oldContextMap);
+                } else {
+                    MDC.clear();
                 }
-            };
-        }
-        return null;
+            }
+        };
     }
 
     @Override

--- a/tracing/src/test/groovy/io/micronaut/tracing/instrument/util/MDCSpec.groovy
+++ b/tracing/src/test/groovy/io/micronaut/tracing/instrument/util/MDCSpec.groovy
@@ -14,15 +14,11 @@ import io.micronaut.http.filter.ServerFilterChain
 import io.micronaut.runtime.server.EmbeddedServer
 import io.reactivex.Flowable
 import org.reactivestreams.Publisher
-import org.reactivestreams.Subscription
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 import spock.lang.AutoCleanup
-import spock.lang.PendingFeature
 import spock.lang.Shared
 import spock.lang.Specification
-
-import java.util.logging.Logger
 
 class MDCSpec extends Specification {
 
@@ -34,8 +30,6 @@ class MDCSpec extends Specification {
     @Shared @AutoCleanup
     RxHttpClient client = RxHttpClient.create(embeddedServer.URL)
 
-
-    @PendingFeature(reason = "Requires reworking the instrumentation APIs - again")
     void "test MDC doesn't leak"() {
         expect:
         100.times {
@@ -73,12 +67,10 @@ class MDCSpec extends Specification {
                 LOG.warn("MDC should have been empty here.")
             }
             LOG.info("Storing traceId in MDC: " + traceIdHeader)
+            MDC.put(TRACE_ID_MDC_KEY, traceIdHeader)
 
             return Flowable
                     .fromPublisher(chain.proceed(request))
-                    .doOnSubscribe({ Subscription s ->
-                        MDC.put(TRACE_ID_MDC_KEY, traceIdHeader)
-                    })
                     .doFinally{->
                         LOG.info("Removing traceId id from MDC: {}", MDC.get(TRACE_ID_MDC_KEY))
                         MDC.clear()
@@ -90,5 +82,6 @@ class MDCSpec extends Specification {
             return -1
         }
     }
+
 
 }


### PR DESCRIPTION
The problem is a bit more complicated, MdcInstrumenter needs to be used all the time and reset context if somebody modified it. 

If somebody is setting MDC outside of MdcInstrumenter begin/after it will stay bound to the thread.