### PR TITLE
Add tracing where MDCSpecs randomly fail

### DIFF
--- a/tracing/src/test/groovy/io/micronaut/tracing/instrument/util/MDCSpec.groovy
+++ b/tracing/src/test/groovy/io/micronaut/tracing/instrument/util/MDCSpec.groovy
@@ -46,9 +46,15 @@ class MDCSpec extends Specification {
 
         @Get("/mdc-test")
         HttpResponse<String> getMdc() {
-            Map<String, String> mdc = MDC.getCopyOfContextMap()
-            println ("Thread = " + Thread.currentThread().getName())
-            return HttpResponse.ok(mdc.get(RequestIdFilter.TRACE_ID_MDC_KEY))
+            Map<String, String> mdc = MDC.getCopyOfContextMap() ?: [:]
+            Thread currentThread = Thread.currentThread()
+            println ("Thread = " + currentThread.getName())
+            String traceId = mdc.get(RequestIdFilter.TRACE_ID_MDC_KEY)
+            if (traceId == null) {
+                println ('traceId: ' + MDC.get(RequestIdFilter.TRACE_ID_MDC_KEY))
+                throw new IllegalStateException("Missing traceId")
+            }
+            return HttpResponse.ok(traceId)
         }
     }
 

--- a/tracing/src/test/groovy/io/micronaut/tracing/instrument/util/MDCSpec2.groovy
+++ b/tracing/src/test/groovy/io/micronaut/tracing/instrument/util/MDCSpec2.groovy
@@ -46,9 +46,15 @@ class MDCSpec2 extends Specification {
 
         @Get("/mdc-test")
         HttpResponse<String> getMdc() {
-            Map<String, String> mdc = MDC.getCopyOfContextMap()
-            println ("Thread = " + Thread.currentThread().getName())
-            return HttpResponse.ok(mdc.get(RequestIdFilter.TRACE_ID_MDC_KEY))
+            Map<String, String> mdc = MDC.getCopyOfContextMap() ?: [:]
+            Thread currentThread = Thread.currentThread()
+            println ("Thread = " + currentThread.getName())
+            String traceId = mdc.get(RequestIdFilter.TRACE_ID_MDC_KEY)
+            if (traceId == null) {
+                println ('traceId: ' + MDC.get(RequestIdFilter.TRACE_ID_MDC_KEY))
+                throw new IllegalStateException("Missing traceId")
+            }
+            return HttpResponse.ok(traceId)
         }
     }
 


### PR DESCRIPTION
@graemerocher I could not reproduce [this failure](https://github.com/micronaut-projects/micronaut-core/runs/699190252?check_suite_focus=true#step:7:1462), but analysing the logs how it failed I added some extra tracing to better see what might have gone wrong when the trace_id is not found. I am only creating this PR as a draft hoping that build will still be triggered. Since it surfaces randomly we might need to trigger the build multiple times, is that possible?