### PR TITLE
Removes reflection usages. Fixes #3251

### DIFF
--- a/core/src/main/java/io/micronaut/core/reflect/ReflectionUtils.java
+++ b/core/src/main/java/io/micronaut/core/reflect/ReflectionUtils.java
@@ -217,6 +217,7 @@ public class ReflectionUtils {
      * @param argumentTypes The argument types
      * @return An {@link Optional} contains the method or empty
      */
+    @Internal
     public static Optional<Method> findMethod(Class type, String name, Class... argumentTypes) {
         Class currentType = type;
         while (currentType != null) {
@@ -240,6 +241,7 @@ public class ReflectionUtils {
      * @return An {@link Optional} contains the method or empty
      */
     @UsedByGeneratedCode
+    @Internal
     public static Method getRequiredMethod(Class type, String name, Class... argumentTypes) {
         try {
             return type.getDeclaredMethod(name, argumentTypes);
@@ -293,6 +295,7 @@ public class ReflectionUtils {
      * @param name The name
      * @return An {@link Optional} contains the method or empty
      */
+    @Internal
     public static Field getRequiredField(Class type, String name) {
         try {
             return type.getDeclaredField(name);
@@ -309,6 +312,7 @@ public class ReflectionUtils {
      * @param name The field name
      * @return An {@link Optional} of field
      */
+    @Internal
     public static Optional<Field> findField(Class type, String name) {
         Optional<Field> declaredField = findDeclaredField(type, name);
         if (!declaredField.isPresent()) {
@@ -328,7 +332,9 @@ public class ReflectionUtils {
      * @param type  The type
      * @param name  The field name
      * @param value The value
+     * @deprecated This method uses reflection. Do not use.
      */
+    @Deprecated
     public static void setFieldIfPossible(Class type, String name, Object value) {
         Optional<Field> declaredField = findDeclaredField(type, name);
         if (declaredField.isPresent()) {

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/BasicAuthArgumentBinder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/BasicAuthArgumentBinder.java
@@ -36,6 +36,11 @@ import java.util.Optional;
 public class BasicAuthArgumentBinder implements TypedRequestArgumentBinder<BasicAuth> {
 
     @Override
+    public boolean supportsSuperTypes() {
+        return false;
+    }
+
+    @Override
     public Argument<BasicAuth> argumentType() {
         return Argument.of(BasicAuth.class);
     }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/CompletableFutureBodyBinder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/CompletableFutureBodyBinder.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.http.server.netty.binders;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.http.netty.stream.StreamedHttpRequest;
 import io.micronaut.core.async.subscriber.CompletionAwareSubscriber;
@@ -30,8 +31,12 @@ import io.micronaut.http.server.netty.NettyHttpRequest;
 import io.netty.buffer.ByteBufHolder;
 import org.reactivestreams.Subscription;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Future;
 
 /**
  * A {@link NonBlockingBodyArgumentBinder} that handles {@link CompletableFuture} instances.
@@ -54,6 +59,17 @@ public class CompletableFutureBodyBinder extends DefaultBodyAnnotationBinder<Com
     public CompletableFutureBodyBinder(HttpContentProcessorResolver httpContentProcessorResolver, ConversionService conversionService) {
         super(conversionService);
         this.httpContentProcessorResolver = httpContentProcessorResolver;
+    }
+
+    @Override
+    public boolean supportsSuperTypes() {
+        return false;
+    }
+
+    @NonNull
+    @Override
+    public List<Class<?>> superTypes() {
+        return Arrays.asList(CompletionStage.class, Future.class);
     }
 
     @Override

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/MaybeBodyBinder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/MaybeBodyBinder.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.http.server.netty.binders;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.ConversionContext;
@@ -25,10 +26,13 @@ import io.micronaut.http.bind.binders.DefaultBodyAnnotationBinder;
 import io.micronaut.http.bind.binders.NonBlockingBodyArgumentBinder;
 import io.micronaut.http.server.netty.HttpContentProcessorResolver;
 import io.reactivex.Maybe;
+import io.reactivex.MaybeSource;
 import io.reactivex.Single;
 import org.reactivestreams.Publisher;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -52,6 +56,12 @@ public class MaybeBodyBinder extends DefaultBodyAnnotationBinder<Maybe> implemen
                            HttpContentProcessorResolver httpContentProcessorResolver) {
         super(conversionService);
         this.publisherBodyBinder = new PublisherBodyBinder(conversionService, httpContentProcessorResolver);
+    }
+
+    @NonNull
+    @Override
+    public List<Class<?>> superTypes() {
+        return Collections.singletonList(MaybeSource.class);
     }
 
     @Override

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/ObservableBodyBinder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/ObservableBodyBinder.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.http.server.netty.binders;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.ConversionContext;
@@ -25,9 +26,12 @@ import io.micronaut.http.bind.binders.DefaultBodyAnnotationBinder;
 import io.micronaut.http.bind.binders.NonBlockingBodyArgumentBinder;
 import io.micronaut.http.server.netty.HttpContentProcessorResolver;
 import io.reactivex.Observable;
+import io.reactivex.ObservableSource;
 import org.reactivestreams.Publisher;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -51,6 +55,17 @@ public class ObservableBodyBinder extends DefaultBodyAnnotationBinder<Observable
                                 HttpContentProcessorResolver httpContentProcessorResolver) {
         super(conversionService);
         this.publisherBodyBinder = new PublisherBodyBinder(conversionService, httpContentProcessorResolver);
+    }
+
+    @Override
+    public boolean supportsSuperTypes() {
+        return false;
+    }
+
+    @NonNull
+    @Override
+    public List<Class<?>> superTypes() {
+        return Collections.singletonList(ObservableSource.class);
     }
 
     @Override

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/PublisherBodyBinder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/PublisherBodyBinder.java
@@ -61,6 +61,11 @@ public class PublisherBodyBinder extends DefaultBodyAnnotationBinder<Publisher> 
     }
 
     @Override
+    public boolean supportsSuperTypes() {
+        return false;
+    }
+
+    @Override
     public Argument<Publisher> argumentType() {
         return TYPE;
     }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/SingleBodyBinder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/SingleBodyBinder.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.http.server.netty.binders;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.ConversionContext;
@@ -25,9 +26,12 @@ import io.micronaut.http.bind.binders.DefaultBodyAnnotationBinder;
 import io.micronaut.http.bind.binders.NonBlockingBodyArgumentBinder;
 import io.micronaut.http.server.netty.HttpContentProcessorResolver;
 import io.reactivex.Single;
+import io.reactivex.SingleSource;
 import org.reactivestreams.Publisher;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -51,6 +55,12 @@ public class SingleBodyBinder extends DefaultBodyAnnotationBinder<Single> implem
                             HttpContentProcessorResolver httpContentProcessorResolver) {
         super(conversionService);
         this.publisherBodyBinder = new PublisherBodyBinder(conversionService, httpContentProcessorResolver);
+    }
+
+    @NonNull
+    @Override
+    public List<Class<?>> superTypes() {
+        return Collections.singletonList(SingleSource.class);
     }
 
     @Override

--- a/http/src/main/java/io/micronaut/http/bind/DefaultRequestBinderRegistry.java
+++ b/http/src/main/java/io/micronaut/http/bind/DefaultRequestBinderRegistry.java
@@ -19,6 +19,7 @@ import io.micronaut.core.bind.ArgumentBinder;
 import io.micronaut.core.bind.annotation.Bindable;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.naming.NameUtils;
+import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.CollectionUtils;
@@ -34,6 +35,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.lang.annotation.Annotation;
 import java.util.*;
+import java.util.function.BiConsumer;
 
 import static io.micronaut.core.util.KotlinUtils.KOTLIN_COROUTINES_SUPPORTED;
 
@@ -115,11 +117,24 @@ public class DefaultRequestBinderRegistry implements RequestBinderRegistry {
             AnnotatedRequestArgumentBinder<?, ?> annotatedRequestArgumentBinder = (AnnotatedRequestArgumentBinder) binder;
             Class<? extends Annotation> annotationType = annotatedRequestArgumentBinder.getAnnotationType();
             if (binder instanceof TypedRequestArgumentBinder) {
-                TypedRequestArgumentBinder typedRequestArgumentBinder = (TypedRequestArgumentBinder) binder;
+                TypedRequestArgumentBinder<?> typedRequestArgumentBinder = (TypedRequestArgumentBinder) binder;
                 Argument argumentType = typedRequestArgumentBinder.argumentType();
                 byTypeAndAnnotation.put(new TypeAndAnnotation(argumentType, annotationType), (RequestArgumentBinder) binder);
-                if (((TypedRequestArgumentBinder) binder).supportsSuperTypes()) {
+                List<Class<?>> superTypes = typedRequestArgumentBinder.superTypes();
+                if (CollectionUtils.isNotEmpty(superTypes)) {
+                    for (Class<?> superType : superTypes) {
+                        byTypeAndAnnotation.put(new TypeAndAnnotation(Argument.of(superType), annotationType), (RequestArgumentBinder) binder);
+                    }
+                } else if (typedRequestArgumentBinder.supportsSuperTypes()) {
                     Set<Class> allInterfaces = ReflectionUtils.getAllInterfaces(argumentType.getType());
+                    if (ClassUtils.REFLECTION_LOGGER.isWarnEnabled()) {
+                        ClassUtils.REFLECTION_LOGGER.warn(
+                                "Request argument binder [{}] triggered the use of reflection for types {}",
+                                typedRequestArgumentBinder,
+                                allInterfaces
+                        );
+                    }
+
                     for (Class<?> itfce : allInterfaces) {
                         byTypeAndAnnotation.put(new TypeAndAnnotation(Argument.of(itfce), annotationType), (RequestArgumentBinder) binder);
                     }
@@ -172,11 +187,17 @@ public class DefaultRequestBinderRegistry implements RequestBinderRegistry {
             RequestArgumentBinder requestArgumentBinder = byTypeAndAnnotation.get(key1);
             if (requestArgumentBinder == null) {
                 Class<?> javaType = key1.type.getType();
-                Set<Class> allInterfaces = ReflectionUtils.getAllInterfaces(javaType);
-                for (Class itfce : allInterfaces) {
-                    requestArgumentBinder = byTypeAndAnnotation.get(new TypeAndAnnotation(Argument.of(itfce), annotationType));
-                    if (requestArgumentBinder != null) {
-                        break;
+                for (Map.Entry<TypeAndAnnotation, RequestArgumentBinder> entry : byTypeAndAnnotation.entrySet()) {
+                    TypeAndAnnotation typeAndAnnotation = entry.getKey();
+                    if (typeAndAnnotation.annotation == annotationType) {
+
+                        Argument<?> t = typeAndAnnotation.type;
+                        if (t.getType().isAssignableFrom(javaType)) {
+                            requestArgumentBinder = entry.getValue();
+                            if (requestArgumentBinder != null) {
+                                break;
+                            }
+                        }
                     }
                 }
 

--- a/http/src/main/java/io/micronaut/http/bind/DefaultRequestBinderRegistry.java
+++ b/http/src/main/java/io/micronaut/http/bind/DefaultRequestBinderRegistry.java
@@ -35,7 +35,6 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.lang.annotation.Annotation;
 import java.util.*;
-import java.util.function.BiConsumer;
 
 import static io.micronaut.core.util.KotlinUtils.KOTLIN_COROUTINES_SUPPORTED;
 

--- a/http/src/main/java/io/micronaut/http/bind/binders/TypedRequestArgumentBinder.java
+++ b/http/src/main/java/io/micronaut/http/bind/binders/TypedRequestArgumentBinder.java
@@ -15,8 +15,12 @@
  */
 package io.micronaut.http.bind.binders;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import io.micronaut.core.bind.TypeArgumentBinder;
 import io.micronaut.http.HttpRequest;
+
+import java.util.Collections;
+import java.util.List;
 
 /**
  * A {@link TypeArgumentBinder} that binds from an {@link HttpRequest}.
@@ -35,5 +39,14 @@ public interface TypedRequestArgumentBinder<T> extends RequestArgumentBinder<T>,
      */
     default boolean supportsSuperTypes() {
         return true;
+    }
+
+    /**
+     * Returns additional super types.
+     *
+     * @return Additional supers types
+     */
+    default @NonNull List<Class<?>> superTypes() {
+        return Collections.emptyList();
     }
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/annotation/AnnotationMetadataWriterSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/annotation/AnnotationMetadataWriterSpec.groovy
@@ -27,6 +27,8 @@ import io.micronaut.core.annotation.AnnotationMetadata
 import io.micronaut.core.annotation.AnnotationClassValue
 import io.micronaut.core.annotation.AnnotationValue
 import io.micronaut.inject.AbstractTypeElementSpec
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.ExecutableMethod
 import io.micronaut.retry.annotation.Recoverable
 
 import javax.inject.Qualifier
@@ -40,6 +42,30 @@ import java.lang.annotation.Retention
  * @since 1.0
  */
 class AnnotationMetadataWriterSpec extends AbstractTypeElementSpec {
+
+    void "test write annotation metadata defaults"() {
+        given:
+        BeanDefinition beanDefinition = buildBeanDefinition('test.Test', '''\
+package test;
+
+import io.micrometer.core.annotation.Timed;
+
+@javax.inject.Singleton
+class Test {
+    @Timed
+    @io.micronaut.context.annotation.Executable
+    void testMethod() {}
+}
+''')
+        def method = beanDefinition.getRequiredMethod('testMethod')
+        def metadata = method.getAnnotationMetadata()
+        def timedAnn = metadata.getAnnotation(Timed)
+
+        expect:
+        timedAnn != null
+        metadata.getDefaultValue(Timed, "longTask", Boolean.class).isPresent()
+        !timedAnn.getRequiredValue('longTask', Boolean.class)
+    }
 
     void "test javax nullable on field"() {
         given:

--- a/inject-java/src/test/groovy/io/micronaut/inject/annotation/AnnotationMetadataWriterSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/annotation/AnnotationMetadataWriterSpec.groovy
@@ -27,8 +27,6 @@ import io.micronaut.core.annotation.AnnotationMetadata
 import io.micronaut.core.annotation.AnnotationClassValue
 import io.micronaut.core.annotation.AnnotationValue
 import io.micronaut.inject.AbstractTypeElementSpec
-import io.micronaut.inject.BeanDefinition
-import io.micronaut.inject.ExecutableMethod
 import io.micronaut.retry.annotation.Recoverable
 
 import javax.inject.Qualifier
@@ -42,30 +40,6 @@ import java.lang.annotation.Retention
  * @since 1.0
  */
 class AnnotationMetadataWriterSpec extends AbstractTypeElementSpec {
-
-    void "test write annotation metadata defaults"() {
-        given:
-        BeanDefinition beanDefinition = buildBeanDefinition('test.Test', '''\
-package test;
-
-import io.micrometer.core.annotation.Timed;
-
-@javax.inject.Singleton
-class Test {
-    @Timed
-    @io.micronaut.context.annotation.Executable
-    void testMethod() {}
-}
-''')
-        def method = beanDefinition.getRequiredMethod('testMethod')
-        def metadata = method.getAnnotationMetadata()
-        def timedAnn = metadata.getAnnotation(Timed)
-
-        expect:
-        timedAnn != null
-        metadata.getDefaultValue(Timed, "longTask", Boolean.class).isPresent()
-        !timedAnn.getRequiredValue('longTask', Boolean.class)
-    }
 
     void "test javax nullable on field"() {
         given:

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -37,7 +37,6 @@ import io.micronaut.core.order.OrderUtil;
 import io.micronaut.core.order.Ordered;
 import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.core.reflect.GenericTypeUtils;
-import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.type.ReturnType;
 import io.micronaut.core.util.*;
@@ -120,7 +119,14 @@ public class DefaultBeanContext implements BeanContext {
     private final Map<Class, Collection<BeanDefinitionReference>> beanIndex = new ConcurrentHashMap<>(12);
 
     private final ClassLoader classLoader;
-    private final Set<Class> thisInterfaces = ReflectionUtils.getAllInterfaces(getClass());
+    private final Set<Class> thisInterfaces = CollectionUtils.setOf(
+            BeanDefinitionRegistry.class,
+            BeanContext.class,
+            AnnotationMetadataResolver.class,
+            BeanLocator.class,
+            ApplicationEventPublisher.class,
+            ExecutionHandleLocator.class
+    );
     private final Set<Class> indexedTypes = CollectionUtils.setOf(
             ResourceLoader.class,
             TypeConverter.class,

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -16,6 +16,7 @@
 package io.micronaut.context;
 
 import io.micronaut.context.annotation.*;
+import io.micronaut.context.env.PropertyPlaceholderResolver;
 import io.micronaut.context.event.*;
 import io.micronaut.context.exceptions.*;
 import io.micronaut.context.processor.AnnotationProcessor;
@@ -41,6 +42,8 @@ import io.micronaut.core.type.Argument;
 import io.micronaut.core.type.ReturnType;
 import io.micronaut.core.util.*;
 import io.micronaut.core.util.clhm.ConcurrentLinkedHashMap;
+import io.micronaut.core.value.PropertyResolver;
+import io.micronaut.core.value.ValueResolver;
 import io.micronaut.inject.*;
 import io.micronaut.inject.qualifiers.Qualified;
 import io.micronaut.inject.qualifiers.Qualifiers;
@@ -125,7 +128,11 @@ public class DefaultBeanContext implements BeanContext {
             AnnotationMetadataResolver.class,
             BeanLocator.class,
             ApplicationEventPublisher.class,
-            ExecutionHandleLocator.class
+            ExecutionHandleLocator.class,
+            ApplicationContext.class,
+            PropertyResolver.class,
+            ValueResolver.class,
+            PropertyPlaceholderResolver.class
     );
     private final Set<Class> indexedTypes = CollectionUtils.setOf(
             ResourceLoader.class,

--- a/runtime/src/main/java/io/micronaut/retry/intercept/RecoveryInterceptor.java
+++ b/runtime/src/main/java/io/micronaut/retry/intercept/RecoveryInterceptor.java
@@ -35,7 +35,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Singleton;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 /**

--- a/runtime/src/main/java/io/micronaut/retry/intercept/RecoveryInterceptor.java
+++ b/runtime/src/main/java/io/micronaut/retry/intercept/RecoveryInterceptor.java
@@ -21,8 +21,9 @@ import io.micronaut.aop.MethodInvocationContext;
 import io.micronaut.context.BeanContext;
 import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.core.convert.ConversionService;
-import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.discovery.exceptions.NoAvailableServiceException;
+import io.micronaut.inject.BeanDefinition;
+import io.micronaut.inject.ExecutableMethod;
 import io.micronaut.inject.MethodExecutionHandle;
 import io.micronaut.inject.qualifiers.Qualifiers;
 import io.micronaut.retry.annotation.Fallback;
@@ -127,19 +128,16 @@ public class RecoveryInterceptor implements MethodInterceptor<Object, Object> {
      */
     public Optional<? extends MethodExecutionHandle<?, Object>> findFallbackMethod(MethodInvocationContext<Object, Object> context) {
         Class<?> declaringType = context.getDeclaringType();
-        Optional<? extends MethodExecutionHandle<?, Object>> result = beanContext
-                .findExecutionHandle(declaringType, Qualifiers.byStereotype(Fallback.class), context.getMethodName(), context.getArgumentTypes());
-        if (!result.isPresent()) {
-            Set<Class> allInterfaces = ReflectionUtils.getAllInterfaces(declaringType);
-            for (Class i : allInterfaces) {
-                result = beanContext
-                    .findExecutionHandle(i, Qualifiers.byStereotype(Fallback.class), context.getMethodName(), context.getArgumentTypes());
-                if (result.isPresent()) {
-                    return result;
-                }
+        BeanDefinition<?> beanDefinition = beanContext.findBeanDefinition(declaringType, Qualifiers.byStereotype(Fallback.class)).orElse(null);
+        if (beanDefinition != null) {
+            ExecutableMethod<?, Object> fallBackMethod =
+                    beanDefinition.findMethod(context.getMethodName(), context.getArgumentTypes()).orElse(null);
+            if (fallBackMethod != null) {
+                MethodExecutionHandle<?, Object> executionHandle = beanContext.createExecutionHandle(beanDefinition, (ExecutableMethod<Object, ?>) fallBackMethod);
+                return Optional.of(executionHandle);
             }
         }
-        return result;
+        return Optional.empty();
     }
 
     @SuppressWarnings("unchecked")

--- a/session/src/main/java/io/micronaut/session/binder/OptionalSessionArgumentBinder.java
+++ b/session/src/main/java/io/micronaut/session/binder/OptionalSessionArgumentBinder.java
@@ -46,6 +46,11 @@ public class OptionalSessionArgumentBinder implements TypedRequestArgumentBinder
     }
 
     @Override
+    public boolean supportsSuperTypes() {
+        return false;
+    }
+
+    @Override
     public ArgumentBinder.BindingResult<Optional<Session>> bind(ArgumentConversionContext<Optional<Session>> context, HttpRequest<?> source) {
         MutableConvertibleValues<Object> attrs = source.getAttributes();
         if (!attrs.contains(OncePerRequestHttpServerFilter.getKey(HttpSessionFilter.class))) {

--- a/session/src/main/java/io/micronaut/session/binder/SessionArgumentBinder.java
+++ b/session/src/main/java/io/micronaut/session/binder/SessionArgumentBinder.java
@@ -61,6 +61,11 @@ public class SessionArgumentBinder implements TypedRequestArgumentBinder<Session
     }
 
     @Override
+    public boolean supportsSuperTypes() {
+        return false;
+    }
+
+    @Override
     public ArgumentBinder.BindingResult<Session> bind(ArgumentConversionContext<Session> context, HttpRequest<?> source) {
         if (!source.getAttributes().contains(OncePerRequestHttpServerFilter.getKey(HttpSessionFilter.class))) {
             // the filter hasn't been executed


### PR DESCRIPTION
- Eliminate reflection usages in RequestArgumentBinder/RecoveryInterceptor
- Remove use of getAllInterfaces from BeanContext. Issue #3251
