### PR TITLE
MDCSpec: more detailed tracing

### DIFF
--- a/tracing/src/main/java/io/micronaut/tracing/instrument/util/MdcInstrumenter.java
+++ b/tracing/src/main/java/io/micronaut/tracing/instrument/util/MdcInstrumenter.java
@@ -57,6 +57,9 @@ public final class MdcInstrumenter implements InvocationInstrumenterFactory, Rea
             @Override
             public void beforeInvocation() {
                 oldContextMap = MDC.getCopyOfContextMap();
+                if (oldContextMap == null || oldContextMap.isEmpty()) {
+                    LOG.debug("{} pushes data to MDC: {}", this, contextMap);
+                }
                 if (contextMap != null) {
                     MDC.setContextMap(contextMap);
                 }
@@ -67,6 +70,7 @@ public final class MdcInstrumenter implements InvocationInstrumenterFactory, Rea
                 if (oldContextMap != null && !oldContextMap.isEmpty()) {
                     MDC.setContextMap(oldContextMap);
                 } else {
+                    LOG.debug("{} clears MDC", this);
                     MDC.clear();
                 }
             }

--- a/tracing/src/test/groovy/io/micronaut/tracing/instrument/util/MDCSpec.groovy
+++ b/tracing/src/test/groovy/io/micronaut/tracing/instrument/util/MDCSpec.groovy
@@ -14,6 +14,7 @@ import io.micronaut.http.filter.ServerFilterChain
 import io.micronaut.runtime.server.EmbeddedServer
 import io.reactivex.Flowable
 import org.reactivestreams.Publisher
+import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 import spock.lang.AutoCleanup
@@ -21,6 +22,8 @@ import spock.lang.Shared
 import spock.lang.Specification
 
 class MDCSpec extends Specification {
+
+    static final Logger LOG = LoggerFactory.getLogger(MDCSpec.class)
 
     @Shared @AutoCleanup
     EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
@@ -31,6 +34,9 @@ class MDCSpec extends Specification {
     RxHttpClient client = RxHttpClient.create(embeddedServer.URL)
 
     void "test MDC doesn't leak"() {
+        given:
+        LOG.info ('MDC adapter: {}', MDC.getMDCAdapter())
+
         expect:
         100.times {
             String traceId = UUID.randomUUID().toString()
@@ -47,14 +53,12 @@ class MDCSpec extends Specification {
         @Get("/mdc-test")
         HttpResponse<String> getMdc() {
             Map<String, String> mdc = MDC.getCopyOfContextMap() ?: [:]
-            Thread currentThread = Thread.currentThread()
-            println ("Thread = " + currentThread.getName())
             String traceId = mdc.get(RequestIdFilter.TRACE_ID_MDC_KEY)
+            LOG.info ('traceId: {}', traceId)
             if (traceId == null) {
-                println ('traceId: ' + MDC.get(RequestIdFilter.TRACE_ID_MDC_KEY))
-                throw new IllegalStateException("Missing traceId")
+                throw new IllegalStateException('Missing traceId')
             }
-            return HttpResponse.ok(traceId)
+            HttpResponse.ok(traceId)
         }
     }
 
@@ -62,7 +66,7 @@ class MDCSpec extends Specification {
     @Requires(property = 'mdc.test.enabled')
     static class RequestIdFilter extends OncePerRequestHttpServerFilter {
 
-        private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(RequestIdFilter.class)
+        private static final Logger LOG = LoggerFactory.getLogger(RequestIdFilter.class)
 
         public static final String TRACE_ID_MDC_KEY = "traceId"
 
@@ -74,11 +78,12 @@ class MDCSpec extends Specification {
             }
             LOG.info("Storing traceId in MDC: " + traceIdHeader)
             MDC.put(TRACE_ID_MDC_KEY, traceIdHeader)
+            LOG.info('MDC updated')
 
             return Flowable
                     .fromPublisher(chain.proceed(request))
                     .doFinally{->
-                        LOG.info("Removing traceId id from MDC: {}", MDC.get(TRACE_ID_MDC_KEY))
+                        LOG.info('Removing traceId id from MDC')
                         MDC.clear()
                     }
         }
@@ -88,6 +93,5 @@ class MDCSpec extends Specification {
             return -1
         }
     }
-
 
 }

--- a/tracing/src/test/groovy/io/micronaut/tracing/instrument/util/MdcInstrumenterSpec.groovy
+++ b/tracing/src/test/groovy/io/micronaut/tracing/instrument/util/MdcInstrumenterSpec.groovy
@@ -3,6 +3,8 @@ package io.micronaut.tracing.instrument.util
 import io.micronaut.context.ApplicationContext
 import io.micronaut.inject.qualifiers.Qualifiers
 import io.micronaut.scheduling.instrument.InvocationInstrumenter
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 import spock.lang.AutoCleanup
 import spock.lang.Shared
@@ -13,6 +15,7 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutorService
 
 class MdcInstrumenterSpec extends Specification {
+    static final Logger LOG = LoggerFactory.getLogger(MdcInstrumenterSpec.class)
     static final String key = 'foo'
     static final String value = 'bar'
 
@@ -20,6 +23,7 @@ class MdcInstrumenterSpec extends Specification {
     MdcInstrumenter mdcInstrumenter = new MdcInstrumenter()
 
     def cleanup() {
+        LOG.info('Clearing MDC')
         MDC.clear()
     }
 

--- a/tracing/src/test/resources/logback.xml
+++ b/tracing/src/test/resources/logback.xml
@@ -4,7 +4,7 @@
         <!-- encoders are assigned the type
              ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %5p [%X{X-B3-TraceId:-}] %m%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %5p %logger{0} [%t:%X{traceId:-}] %m%n</pattern>
         </encoder>
     </appender>
 
@@ -12,5 +12,6 @@
         <appender-ref ref="STDOUT" />
     </root>
     <!--<logger name="io.micronaut.http" level="debug"/>-->
+    <logger name="io.micronaut.tracing.instrument.util.MdcInstrumenter" level="debug"/>
     <logger name="brave.internal.recorder.PendingSpans" level="trace" />
 </configuration>


### PR DESCRIPTION
Follow-up to #3322 and #3298 to investigate random failure of MDCSpec: verbose logging added to find out how MDC gets cleared between the filter and the controller.