### PR TITLE
RequestBean supports binding also Typed Values now

### DIFF
--- a/http/src/main/java/io/micronaut/http/annotation/RequestBean.java
+++ b/http/src/main/java/io/micronaut/http/annotation/RequestBean.java
@@ -22,7 +22,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import io.micronaut.context.annotation.AliasFor;
 import io.micronaut.core.bind.annotation.Bindable;
 
 /**
@@ -33,29 +32,7 @@ import io.micronaut.core.bind.annotation.Bindable;
  */
 @Documented
 @Retention(RUNTIME)
-@Target({ ElementType.PARAMETER, ElementType.ANNOTATION_TYPE })
+@Target({ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
 @Bindable
 public @interface RequestBean {
-
-    /**
-     * @return The name of the parameter
-     */
-    @AliasFor(annotation = Bindable.class, member = "value")
-    @AliasFor(member = "name")
-    String value() default "";
-
-    /**
-     * @return The name of the parameter
-     */
-    @AliasFor(annotation = Bindable.class, member = "value")
-    @AliasFor(member = "value")
-    String name() default "";
-
-    /**
-     * @see Bindable#defaultValue()
-     * @return The default value
-     */
-    @AliasFor(annotation = Bindable.class, member = "defaultValue")
-    String defaultValue() default "";
-
 }

--- a/src/main/docs/guide/httpServer/binding.adoc
+++ b/src/main/docs/guide/httpServer/binding.adoc
@@ -39,7 +39,7 @@ The following table summarizes the annotations, their purpose and provides an ex
 |`@PathVariable String id`
 
 |link:{api}/io/micronaut/http/annotation/RequestBean.html[@RequestBean]
-|Binds any Bindable value or HttpRequest to single Bean object
+|Binds any Bindable value to single Bean object
 |`@RequestBean MyBean bean`
 |===
 
@@ -59,8 +59,8 @@ snippet::io.micronaut.docs.server.binding.BookmarkController[tags="imports,class
 
 == Binding from Multiple Bindable values
 
-Instead of binding just Query values, it is also possible to bind any Bindable value or HttpRequest to POJO  (e.g. when you want to bind `HttpRequest`, `@PathVariable`, `@QueryValue` and `@Header` to single POJO).
-This can be achieved with `@RequestBean` annotation and custom Bean class that has fields with Bindable annotations or field that is of HttpRequest type.
+Instead of binding just Query values, it is also possible to bind any Bindable value to POJO  (e.g. when you want to bind `HttpRequest`, `@PathVariable`, `@QueryValue` and `@Header` to single POJO).
+This can be achieved with `@RequestBean` annotation and custom Bean class that has fields with Bindable annotations or fields that can be bound by type (e.g. HttpRequest, BasicAuth, Authentication etc.).
 For example:
 
 snippet::io.micronaut.docs.server.binding.MovieTicketController[tags="class", indent=0, title="Binding Bindable values to POJO"]
@@ -74,7 +74,7 @@ Bean class has to be introspected with `@Introspected`. It can be one of:
 Arguments of constructor have to match field names so object can be constructed without reflection.
 
 WARNING: Since Java does not retain argument names in the byte code, you have to compile code with `-parameters` in case you want to use Immutable Bean class from another Jar.
-Another option is to override Bean class in your source.
+Another option is to extend Bean class in your source.
 
 == Bindable Types
 


### PR DESCRIPTION
I extended functionality of RequestBean so it supports binding also typed values. 

Now you can bind any typed value like BasicAuth, Authorization or any custom type to single POJO (previously there was just support for HttpRequest and values with `@Bindable` annotation).