### PR TITLE
Backported dstepanov's solution to fix issue #3106

### DIFF
--- a/http-server/src/main/java/io/micronaut/http/server/context/ServerRequestContextFilter.java
+++ b/http-server/src/main/java/io/micronaut/http/server/context/ServerRequestContextFilter.java
@@ -19,13 +19,15 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.http.annotation.Filter;
-import io.micronaut.http.context.ServerRequestContext;
-import io.micronaut.http.context.ServerRequestTracingPublisher;
 import io.micronaut.http.filter.HttpServerFilter;
 import io.micronaut.http.filter.ServerFilterChain;
+import io.micronaut.scheduling.instrument.InvocationInstrumenter;
+import io.micronaut.scheduling.instrument.InvocationInstrumenterFactory;
 import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
 
-import java.util.function.Supplier;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A filter that instruments the request with the {@link io.micronaut.http.context.ServerRequestContext}.
@@ -36,10 +38,57 @@ import java.util.function.Supplier;
 @Filter("/**")
 @Internal
 public final class ServerRequestContextFilter implements HttpServerFilter {
+
+    private final List<InvocationInstrumenterFactory> invocationInstrumenterFactories;
+
+    /**
+     * Creates new filter.
+     *
+     * @param invocationInstrumenterFactories the invocationInstrumenterFactories
+     */
+    public ServerRequestContextFilter(List<InvocationInstrumenterFactory> invocationInstrumenterFactories) {
+        this.invocationInstrumenterFactories = invocationInstrumenterFactories;
+    }
+
     @Override
     public Publisher<MutableHttpResponse<?>> doFilter(HttpRequest<?> request, ServerFilterChain chain) {
-        return ServerRequestContext.with(request, (Supplier<Publisher<MutableHttpResponse<?>>>) () ->
-                new ServerRequestTracingPublisher(request, chain.proceed(request))
-        );
+        InvocationInstrumenter invocationInstrumenter = InvocationInstrumenter.combine(getInvocationInstrumenter(request));
+        try {
+            invocationInstrumenter.beforeInvocation();
+            Publisher<MutableHttpResponse<?>> actual = chain.proceed(request);
+            InvocationInstrumenter invocationInstrumenterAfterProceed
+                    = InvocationInstrumenter.combine(getInvocationInstrumenter(request));
+            return new Publisher<MutableHttpResponse<?>>() {
+                @Override
+                public void subscribe(Subscriber<? super MutableHttpResponse<?>> actualSubscriber) {
+                    invocationInstrumenterAfterProceed.beforeInvocation();
+                    try {
+                        actual.subscribe(actualSubscriber);
+                    } finally {
+                        invocationInstrumenterAfterProceed.afterInvocation();
+                    }
+                }
+            };
+        } finally {
+            invocationInstrumenter.afterInvocation();
+        }
     }
+
+    @Override
+    public int getOrder() {
+        return -1000;
+    }
+
+    private List<InvocationInstrumenter> getInvocationInstrumenter(HttpRequest<?> request) {
+        List<InvocationInstrumenter> instrumenters = new ArrayList<>(invocationInstrumenterFactories.size() + 1);
+        instrumenters.add(new ServerRequestContextInvocationInstrumenter(request));
+        for (InvocationInstrumenterFactory instrumenterFactory : invocationInstrumenterFactories) {
+            final InvocationInstrumenter instrumenter = instrumenterFactory.newInvocationInstrumenter();
+            if (instrumenter != null) {
+                instrumenters.add(instrumenter);
+            }
+        }
+        return instrumenters;
+    }
+
 }

--- a/http-server/src/main/java/io/micronaut/http/server/context/ServerRequestContextInstrumentation.java
+++ b/http-server/src/main/java/io/micronaut/http/server/context/ServerRequestContextInstrumentation.java
@@ -16,7 +16,6 @@
 package io.micronaut.http.server.context;
 
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.http.HttpRequest;
 import io.micronaut.http.context.ServerRequestContext;
 import io.micronaut.scheduling.instrument.InvocationInstrumenter;
 import io.micronaut.scheduling.instrument.InvocationInstrumenterFactory;
@@ -36,29 +35,7 @@ final class ServerRequestContextInstrumentation implements InvocationInstrumente
 
     @Override
     public InvocationInstrumenter newInvocationInstrumenter() {
-        return ServerRequestContext.currentRequest().map(invocationRequest -> new InvocationInstrumenter() {
-
-            private HttpRequest<Object> currentRequest;
-            private boolean isSet = false;
-
-            @Override
-            public void beforeInvocation() {
-                currentRequest = ServerRequestContext.currentRequest().orElse(null);
-                if (invocationRequest != currentRequest) {
-                    isSet = true;
-                    ServerRequestContext.set(invocationRequest);
-                }
-            }
-
-            @Override
-            public void afterInvocation(boolean cleanup) {
-                if (isSet || cleanup) {
-                    ServerRequestContext.set(cleanup ? null : currentRequest);
-                    isSet = false;
-                }
-            }
-
-        }).orElse(null);
+        return ServerRequestContext.currentRequest().map(ServerRequestContextInvocationInstrumenter::new).orElse(null);
     }
 
     @Override

--- a/http-server/src/main/java/io/micronaut/http/server/context/ServerRequestContextInvocationInstrumenter.java
+++ b/http-server/src/main/java/io/micronaut/http/server/context/ServerRequestContextInvocationInstrumenter.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.context;
+
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.context.ServerRequestContext;
+import io.micronaut.scheduling.instrument.InvocationInstrumenter;
+
+/**
+ * Server request context invocation instrumenter.
+ *
+ * @author dstepanov
+ * @since 2.0
+ */
+class ServerRequestContextInvocationInstrumenter implements InvocationInstrumenter {
+
+    private final HttpRequest<?> invocationRequest;
+    private HttpRequest<?> currentRequest;
+    private boolean isSet;
+
+    /**
+     * @param invocationRequest current request
+     */
+    public ServerRequestContextInvocationInstrumenter(HttpRequest<?> invocationRequest) {
+        this.invocationRequest = invocationRequest;
+        isSet = false;
+    }
+
+    /**
+     * Before call.
+     */
+    @Override
+    public void beforeInvocation() {
+        currentRequest = ServerRequestContext.currentRequest().orElse(null);
+        if (invocationRequest != currentRequest) {
+            isSet = true;
+            ServerRequestContext.set(invocationRequest);
+        }
+    }
+
+    /**
+     * After call.
+     *
+     * @param cleanup Whether to enforce cleanup
+     */
+    @Override
+    public void afterInvocation(boolean cleanup) {
+        if (isSet || cleanup) {
+            ServerRequestContext.set(cleanup ? null : currentRequest);
+            isSet = false;
+        }
+    }
+
+}

--- a/tracing/src/main/java/io/micronaut/tracing/instrument/util/MdcInstrumenter.java
+++ b/tracing/src/main/java/io/micronaut/tracing/instrument/util/MdcInstrumenter.java
@@ -39,33 +39,33 @@ public final class MdcInstrumenter implements InvocationInstrumenterFactory, Rea
 
     /**
      * Creates optional invocation instrumenter.
+     *
      * @return An optional that contains the invocation instrumenter
      */
     @Override
     public InvocationInstrumenter newInvocationInstrumenter() {
         Map<String, String> contextMap = MDC.getCopyOfContextMap();
-        if (contextMap != null && !contextMap.isEmpty()) {
-            return new InvocationInstrumenter() {
+        return new InvocationInstrumenter() {
 
-                Map<String, String> oldContextMap;
+            Map<String, String> oldContextMap;
 
-                @Override
-                public void beforeInvocation() {
-                    oldContextMap = MDC.getCopyOfContextMap();
+            @Override
+            public void beforeInvocation() {
+                oldContextMap = MDC.getCopyOfContextMap();
+                if (contextMap != null && !contextMap.isEmpty()) {
                     MDC.setContextMap(contextMap);
                 }
+            }
 
-                @Override
-                public void afterInvocation(boolean cleanup) {
-                    if (oldContextMap != null && !oldContextMap.isEmpty()) {
-                        MDC.setContextMap(oldContextMap);
-                    } else {
-                        MDC.clear();
-                    }
+            @Override
+            public void afterInvocation(boolean cleanup) {
+                if (oldContextMap != null && !oldContextMap.isEmpty()) {
+                    MDC.setContextMap(oldContextMap);
+                } else {
+                    MDC.clear();
                 }
-            };
-        }
-        return null;
+            }
+        };
     }
 
     @Override

--- a/tracing/src/test/groovy/io/micronaut/tracing/instrument/util/MDCSpec.groovy
+++ b/tracing/src/test/groovy/io/micronaut/tracing/instrument/util/MDCSpec.groovy
@@ -1,0 +1,97 @@
+package io.micronaut.tracing.instrument.util
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MutableHttpResponse
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Filter
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.client.RxHttpClient
+import io.micronaut.http.filter.OncePerRequestHttpServerFilter
+import io.micronaut.http.filter.ServerFilterChain
+import io.micronaut.runtime.server.EmbeddedServer
+import io.reactivex.Flowable
+import org.reactivestreams.Publisher
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.slf4j.MDC
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class MDCSpec extends Specification {
+
+    static final Logger LOG = LoggerFactory.getLogger(MDCSpec.class)
+
+    @Shared @AutoCleanup
+    EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
+            'mdc.test.enabled':true
+    ])
+
+    @Shared @AutoCleanup
+    RxHttpClient client = RxHttpClient.create(embeddedServer.URL)
+
+    void "test MDC doesn't leak"() {
+        given:
+        LOG.info ('MDC adapter: {}', MDC.getMDCAdapter())
+
+        expect:
+        100.times {
+            String traceId = UUID.randomUUID().toString()
+            HttpRequest<Object> request = HttpRequest.GET("/mdc-test").header("traceId", traceId)
+            String response = client.toBlocking().retrieve(request)
+            assert response == traceId
+        }
+    }
+
+    @Controller
+    @Requires(property = 'mdc.test.enabled')
+    static class MDCController {
+
+        @Get("/mdc-test")
+        HttpResponse<String> getMdc() {
+            Map<String, String> mdc = MDC.getCopyOfContextMap() ?: [:]
+            String traceId = mdc.get(RequestIdFilter.TRACE_ID_MDC_KEY)
+            LOG.info ('traceId: {}', traceId)
+            if (traceId == null) {
+                throw new IllegalStateException('Missing traceId')
+            }
+            HttpResponse.ok(traceId)
+        }
+    }
+
+    @Filter("/**")
+    @Requires(property = 'mdc.test.enabled')
+    static class RequestIdFilter extends OncePerRequestHttpServerFilter {
+
+        private static final Logger LOG = LoggerFactory.getLogger(RequestIdFilter.class)
+
+        public static final String TRACE_ID_MDC_KEY = "traceId"
+
+        @Override
+        protected Publisher<MutableHttpResponse<?>> doFilterOnce(HttpRequest<?> request, ServerFilterChain chain) {
+            String traceIdHeader = request.getHeaders().get("traceId")
+            if (MDC.get(TRACE_ID_MDC_KEY) != null) {
+                LOG.warn("MDC should have been empty here.")
+            }
+            LOG.info("Storing traceId in MDC: " + traceIdHeader)
+            MDC.put(TRACE_ID_MDC_KEY, traceIdHeader)
+            LOG.info('MDC updated')
+
+            return Flowable
+                    .fromPublisher(chain.proceed(request))
+                    .doFinally{->
+                        LOG.info('Removing traceId id from MDC')
+                        MDC.clear()
+                    }
+        }
+
+        @Override
+        int getOrder() {
+            return -1
+        }
+    }
+
+}

--- a/tracing/src/test/groovy/io/micronaut/tracing/instrument/util/MDCSpec2.groovy
+++ b/tracing/src/test/groovy/io/micronaut/tracing/instrument/util/MDCSpec2.groovy
@@ -1,0 +1,91 @@
+package io.micronaut.tracing.instrument.util
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MutableHttpResponse
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Filter
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.client.RxHttpClient
+import io.micronaut.http.filter.OncePerRequestHttpServerFilter
+import io.micronaut.http.filter.ServerFilterChain
+import io.micronaut.runtime.server.EmbeddedServer
+import org.reactivestreams.Publisher
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.slf4j.MDC
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class MDCSpec2 extends Specification {
+
+    static final Logger LOG = LoggerFactory.getLogger(MDCSpec2.class)
+
+    @Shared @AutoCleanup
+    EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
+            'mdc.test2.enabled':true
+    ])
+
+    @Shared @AutoCleanup
+    RxHttpClient client = RxHttpClient.create(embeddedServer.URL)
+
+    void "test MDC doesn't leak"() {
+        given:
+        LOG.info ('MDC adapter: {}', MDC.getMDCAdapter())
+
+        expect:
+        100.times {
+            String traceId = UUID.randomUUID().toString()
+            HttpRequest<Object> request = HttpRequest.GET("/mdc-test").header("traceId", traceId)
+            String response = client.retrieve(request).blockingFirst()
+            assert response == traceId
+        }
+    }
+
+    @Controller
+    @Requires(property = 'mdc.test2.enabled')
+    static class MDCController {
+
+        @Get("/mdc-test")
+        HttpResponse<String> getMdc() {
+            Map<String, String> mdc = MDC.getCopyOfContextMap() ?: [:]
+            String traceId = mdc.get(RequestIdFilter.TRACE_ID_MDC_KEY)
+            LOG.info ('traceId: {}', traceId)
+            if (traceId == null) {
+                throw new IllegalStateException('Missing traceId')
+            }
+            HttpResponse.ok(traceId)
+        }
+    }
+
+    @Filter("/**")
+    @Requires(property = 'mdc.test2.enabled')
+    static class RequestIdFilter extends OncePerRequestHttpServerFilter {
+
+        private static final Logger LOG = LoggerFactory.getLogger(RequestIdFilter.class)
+
+        public static final String TRACE_ID_MDC_KEY = "traceId"
+
+        @Override
+        protected Publisher<MutableHttpResponse<?>> doFilterOnce(HttpRequest<?> request, ServerFilterChain chain) {
+            String traceIdHeader = request.getHeaders().get("traceId")
+            if (MDC.get(TRACE_ID_MDC_KEY) != null) {
+                LOG.warn("MDC should have been empty here.")
+            }
+            LOG.info("Storing traceId in MDC: " + traceIdHeader)
+            MDC.put(TRACE_ID_MDC_KEY, traceIdHeader)
+            LOG.info('MDC updated')
+
+            return chain.proceed(request)
+        }
+
+        @Override
+        int getOrder() {
+            return -1
+        }
+    }
+
+}

--- a/tracing/src/test/groovy/io/micronaut/tracing/instrument/util/MdcInstrumenterSpec.groovy
+++ b/tracing/src/test/groovy/io/micronaut/tracing/instrument/util/MdcInstrumenterSpec.groovy
@@ -107,6 +107,36 @@ class MdcInstrumenterSpec extends Specification {
         MDC.get(key) == value2
     }
 
+    def "empty context should't clean MDC"() {
+        when:
+        MDC.put(key, value)
+        MDC.remove(key) // Make empty context
+        def mdcBeforeNew = MDC.copyOfContextMap
+        def instrumenterWithEmptyContext = mdcInstrumenter.newInvocationInstrumenter()
+        MDC.put("contextValue", "contextValue")
+        def instrumenterWithContext = mdcInstrumenter.newInvocationInstrumenter()
+        MDC.clear()
+        Runnable runnable = InvocationInstrumenter.instrument({
+            MDC.put("inside1", "inside1")
+            InvocationInstrumenter.instrument({
+                assert MDC.get("contextValue") == "contextValue"
+                assert MDC.get("inside1") == "inside1"
+
+                MDC.put("inside2", "inside2")
+            } as Runnable, instrumenterWithEmptyContext).run()
+            assert MDC.get("contextValue") == "contextValue"
+            assert MDC.get("inside1") == "inside1"
+            assert MDC.get("inside2") == null
+        } as Runnable, instrumenterWithContext)
+        runnable.run()
+
+        then:
+        mdcBeforeNew.isEmpty()
+        MDC.get(key) == null
+        MDC.get("XXX") == null
+        MDC.get("aaa") == null
+    }
+
     void "test MDC instrumenter with Executor"() {
 
         given:


### PR DESCRIPTION
Related PRs: #3313 #3314 and #3328

@graemerocher As discussed earlier, backporting this to 1.3.x seems straightforward.

@dstepanov In relation to the fix in #3328 I was wondering if we would need an `MDC.clear()` on the `else` branch in `MdcInstrumenter.beforeInvocation()` symmetric to `afterInvocation()`? I could see this to be a problem when the executing thread already has data in MDC but our instrumented invocation requires MDC to be empty.