### PR TITLE
Configprops innerclass

### DIFF
--- a/inject-groovy/src/test/groovy/io/micronaut/inject/configproperties/ConfigPropertiesInnerClassSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/configproperties/ConfigPropertiesInnerClassSpec.groovy
@@ -1,0 +1,29 @@
+package io.micronaut.inject.configproperties
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.DefaultApplicationContext
+import io.micronaut.context.env.PropertySource
+import spock.lang.Specification
+
+class ConfigPropertiesInnerClassSpec extends Specification {
+
+    void "test configuration properties binding with inner class"() {
+        given:
+        ApplicationContext applicationContext = new DefaultApplicationContext("test")
+        applicationContext.environment.addPropertySource(PropertySource.of(
+                'test',
+                ['foo.bar.innerVals': [
+                        ['expire-unsigned-seconds': 123], ['expireUnsignedSeconds': 600]
+                ]]
+        ))
+
+        applicationContext.start()
+
+        MyConfigInner config = applicationContext.getBean(MyConfigInner)
+
+        expect:
+        config.innerVals.size() == 2
+        config.innerVals[0].expireUnsignedSeconds == 123
+        config.innerVals[1].expireUnsignedSeconds == 600
+    }
+}

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/configproperties/MyConfigInner.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/configproperties/MyConfigInner.groovy
@@ -1,0 +1,15 @@
+package io.micronaut.inject.configproperties
+
+import io.micronaut.context.annotation.ConfigurationProperties
+
+@ConfigurationProperties("foo.bar")
+class MyConfigInner {
+
+    List<InnerVal> innerVals
+
+    static class InnerVal {
+        Integer expireUnsignedSeconds
+    }
+
+}
+

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
@@ -198,6 +198,88 @@ public class ValidatedConfig {
         introspection != null
     }
 
+    void "test generate bean introspection for @ConfigurationProperties with validation rules on getters with inner class"() {
+        BeanIntrospection introspection = buildBeanIntrospection('test.ValidatedConfig','''\
+package test;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.NotBlank;
+import java.net.URL;
+
+@ConfigurationProperties("foo.bar")
+public class ValidatedConfig {
+
+    private URL url;
+
+    @NotNull
+    public URL getUrl() {
+        return url;
+    }
+
+    public void setUrl(URL url) {
+        this.url = url;
+    }
+    
+    public static class Inner {
+    
+    }
+    
+}
+''')
+        expect:
+        introspection != null
+    }
+
+    void "test generate bean introspection for inner @ConfigurationProperties"() {
+        BeanIntrospection introspection = buildBeanIntrospection('test.ValidatedConfig$Another','''\
+package test;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.NotBlank;
+import java.net.URL;
+
+@ConfigurationProperties("foo.bar")
+class ValidatedConfig {
+
+    private URL url;
+
+    @NotNull
+    public URL getUrl() {
+        return url;
+    }
+
+    public void setUrl(URL url) {
+        this.url = url;
+    }
+    
+    public static class Inner {
+    
+    }
+    
+    @ConfigurationProperties("another")
+    static class Another {
+    
+        private URL url;
+
+        @NotNull
+        public URL getUrl() {
+            return url;
+        }
+    
+        public void setUrl(URL url) {
+            this.url = url;
+        }
+    }
+}
+''')
+        expect:
+        introspection != null
+    }
+
     void "test generate bean introspection for @ConfigurationProperties with validation rules on fields"() {
         BeanIntrospection introspection = buildBeanIntrospection('test.ValidatedConfig','''\
 package test;

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
@@ -18,7 +18,6 @@ package io.micronaut.annotation.processing;
 import io.micronaut.annotation.processing.visitor.LoadedVisitor;
 import io.micronaut.aop.Introduction;
 import io.micronaut.context.annotation.Requires;
-import io.micronaut.context.annotation.Type;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Generated;
 import io.micronaut.core.annotation.Introspected;

--- a/inject-java/src/test/groovy/io/micronaut/inject/configproperties/ConfigPropertiesInnerClassSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configproperties/ConfigPropertiesInnerClassSpec.groovy
@@ -1,0 +1,29 @@
+package io.micronaut.inject.configproperties
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.DefaultApplicationContext
+import io.micronaut.context.env.PropertySource
+import spock.lang.Specification
+
+class ConfigPropertiesInnerClassSpec extends Specification {
+
+    void "test configuration properties binding with inner class"() {
+        given:
+        ApplicationContext applicationContext = new DefaultApplicationContext("test")
+        applicationContext.environment.addPropertySource(PropertySource.of(
+                'test',
+                ['foo.bar.innerVals': [
+                        ['expire-unsigned-seconds': 123], ['expireUnsignedSeconds': 600]
+                ]]
+        ))
+
+        applicationContext.start()
+
+        MyConfigInner config = applicationContext.getBean(MyConfigInner)
+
+        expect:
+        config.innerVals.size() == 2
+        config.innerVals[0].expireUnsignedSeconds == 123
+        config.innerVals[1].expireUnsignedSeconds == 600
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/configproperties/MyConfigInner.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configproperties/MyConfigInner.java
@@ -1,0 +1,33 @@
+package io.micronaut.inject.configproperties;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+
+import java.util.List;
+
+@ConfigurationProperties("foo.bar")
+public class MyConfigInner {
+
+    private List<InnerVal> innerVals;
+
+    public List<InnerVal> getInnerVals() {
+        return innerVals;
+    }
+
+    public void setInnerVals(List<InnerVal> innerVals) {
+        this.innerVals = innerVals;
+    }
+
+    public static class InnerVal {
+
+        private Integer expireUnsignedSeconds;
+
+        public Integer getExpireUnsignedSeconds() {
+            return expireUnsignedSeconds;
+        }
+
+        public void setExpireUnsignedSeconds(Integer expireUnsignedSeconds) {
+            this.expireUnsignedSeconds = expireUnsignedSeconds;
+        }
+    }
+
+}


### PR DESCRIPTION
Notable changes:

* `isInnerConfiguration` now checks for a bean definition that has the annotation
* Type element visitors now visit the contents of inner classes. Previously only `visitClass` was called.
* The annotation metadata for type element visitors for inner classes now represents the metadata of the inner class instead of its owner

Closes https://github.com/micronaut-projects/micronaut-core/issues/3303