### PR TITLE
EndpointDefaultConfiguration port should be nullable

### DIFF
--- a/management/src/main/java/io/micronaut/management/endpoint/EndpointDefaultConfiguration.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/EndpointDefaultConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.management.endpoint;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
 import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.core.util.StringUtils;
 
@@ -115,7 +116,7 @@ public class EndpointDefaultConfiguration {
      * Sets the port to expose endpoints via.
      * @param port The port
      */
-    public void setPort(Integer port) {
+    public void setPort(@Nullable Integer port) {
         this.port = port;
     }
 }


### PR DESCRIPTION
This makes it possible to have "endpoints.all.port: null" in property source.