### PR TITLE
Use LinkedHashSet in GenericTypeUtils.getAllGenericInterfaces()

### DIFF
--- a/core/src/main/java/io/micronaut/core/reflect/GenericTypeUtils.java
+++ b/core/src/main/java/io/micronaut/core/reflect/GenericTypeUtils.java
@@ -21,7 +21,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Arrays;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.Set;
 
@@ -203,7 +203,7 @@ public class GenericTypeUtils {
      * @return All generic interfaces
      */
     private static Set<Type> getAllGenericInterfaces(Class<?> aClass) {
-        Set<Type> interfaces = new HashSet<>();
+        Set<Type> interfaces = new LinkedHashSet<>();
         return populateInterfaces(aClass, interfaces);
     }
 

--- a/core/src/test/groovy/io/micronaut/core/reflect/GenericTypeUtilsSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/reflect/GenericTypeUtilsSpec.groovy
@@ -29,5 +29,23 @@ class GenericTypeUtilsSpec extends Specification {
     static class Bar<T> extends Foo<T> {}
 
     static class Baz extends Bar<String> {}
+
+    // =======================
+
+    // https://github.com/micronaut-projects/micronaut-openapi/issues/238
+    void "test resolveInterfaceTypeArguments"() {
+        when:
+        Class[] classes = GenericTypeUtils.resolveInterfaceTypeArguments(B, Iface)
+
+        then:
+        classes.length == 1
+        classes[0] == [String] as Class[]
+    }
+
+    static interface Iface<T> {}
+
+    static abstract class A<T> implements Iface<T> {}
+
+    static class B extends A<String> implements Iface<String> {}
 }
 


### PR DESCRIPTION
So that the most specific interface will be first.

See Issue#238 in micronaut-openapi
https://github.com/micronaut-projects/micronaut-openapi/issues/238