### PR TITLE
Prevent parallel invocation instrumentation 2

### DIFF
--- a/test-suite-kotlin/build.gradle
+++ b/test-suite-kotlin/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     testImplementation project(":function-client")
     testImplementation project(":function-web")
     testImplementation 'io.kotlintest:kotlintest-runner-junit5:3.4.2'
+    testImplementation project(':tracing')
 
     kaptTest project(':inject-java')
     kaptTest project(':validation')

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/scheduling/instrument/MultipleInvocationInstrumenterSpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/scheduling/instrument/MultipleInvocationInstrumenterSpec.kt
@@ -1,5 +1,6 @@
 package io.micronaut.scheduling.instrument
 
+import io.micronaut.context.annotation.Property
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.client.RxHttpClient
 import io.micronaut.http.client.annotation.Client
@@ -9,6 +10,7 @@ import javax.inject.Inject
 import kotlin.test.assertTrue
 
 @MicronautTest
+@Property(name = "tracing.zipkin.enabled", value = "true")
 class MultipleInvocationInstrumenterSpec {
 
     @Inject


### PR DESCRIPTION
@graemerocher @lgathy I have removed the mutable state from `MultipleInvocationInstrumenter` it was only there to prevent `after` to be called in a case when an exception is thrown during `begin` which we can just ignore.

It would be better to refactor again to something like:
- capture context = InvocationInstrumenter
- try catch = set/restore context