### PR TITLE
Add Oracle db driver to BOM

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -556,6 +556,11 @@ ext {
                     group  : 'com.microsoft.sqlserver',
                     name   : 'mssql-jdbc'
             ],
+            oracle                  : [
+                version: '19.3.0.0',
+                group  : 'com.oracle.ojdbc',
+                name   : 'ojdbc8'
+            ],
             tomcatJdbc                 : [
                     version: tomcatJdbcVersion,
                     group  : 'org.apache.tomcat',


### PR DESCRIPTION
Adding the missing Oracle DB driver to the BOM as we already include the drivers for other databases: https://github.com/micronaut-projects/micronaut-core/blob/master/build.gradle#L534-L558