### PR TITLE
Support `Optional` in interface config

### DIFF
--- a/core/src/main/java/io/micronaut/core/type/ReturnType.java
+++ b/core/src/main/java/io/micronaut/core/type/ReturnType.java
@@ -23,6 +23,7 @@ import io.micronaut.core.async.publisher.Publishers;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -136,6 +137,15 @@ public interface ReturnType<T> extends TypeVariableResolver, AnnotationMetadataP
             }
         }
         return false;
+    }
+
+    /**
+     * @return Is the return type {@link java.util.Optional}.
+     * @since 2.0.1
+     */
+    default boolean isOptional() {
+        Class<T> type = getType();
+        return type == Optional.class;
     }
 
     /**

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/configproperties/InterfaceConfigurationPropertiesSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/configproperties/InterfaceConfigurationPropertiesSpec.groovy
@@ -51,6 +51,64 @@ interface MyConfig {
 
     }
 
+    void "test optional interface config props"() {
+
+        when:
+        BeanDefinition beanDefinition = buildBeanDefinition('test.MyConfig$Intercepted', '''
+package test;
+
+import io.micronaut.context.annotation.*;
+import java.net.URL;
+import java.util.Optional;
+
+@ConfigurationProperties("foo.bar")
+@Executable
+interface MyConfig {
+    @javax.annotation.Nullable
+    String getHost();
+
+    @javax.validation.constraints.Min(10L)
+    Optional<Integer> getServerPort();
+
+    @io.micronaut.core.bind.annotation.Bindable(defaultValue = "http://default")
+    Optional<URL> getURL();
+}
+
+''')
+        then:
+        beanDefinition.getAnnotationMetadata().getAnnotationType(ConfigurationAdvice.class.getName()).isPresent()
+        beanDefinition instanceof ValidatedBeanDefinition
+        beanDefinition.getRequiredMethod("getHost")
+                .stringValue(Property, "name").get() == 'foo.bar.host'
+        beanDefinition.getRequiredMethod("getServerPort")
+                .stringValue(Property, "name").get() == 'foo.bar.server-port'
+        beanDefinition.getRequiredMethod("getURL")
+                .stringValue(Property, "name").get() == 'foo.bar.url'
+
+        when:
+        def context = ApplicationContext.run()
+        def config = ((BeanFactory) beanDefinition).build(context, beanDefinition)
+
+        then:
+        config.host == null
+        config.serverPort == Optional.empty()
+        config.URL == Optional.of(new URL("http://default"))
+
+        when:
+        def context2 = ApplicationContext.run('foo.bar.host': 'test', 'foo.bar.server-port': '9999', 'foo.bar.url': 'http://test')
+        def config2 = ((BeanFactory) beanDefinition).build(context2, beanDefinition)
+
+        then:
+        config2.host == 'test'
+        config2.serverPort == Optional.of(9999)
+        config2.URL == Optional.of(new URL("http://test"))
+
+        cleanup:
+        context.close()
+        context2.close()
+
+    }
+
     void "test inheritance interface config props"() {
 
         when:

--- a/inject-java/src/test/groovy/io/micronaut/inject/configproperties/InterfaceConfigurationPropertiesSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configproperties/InterfaceConfigurationPropertiesSpec.groovy
@@ -35,7 +35,7 @@ interface MyConfig {
         beanDefinition.getAnnotationMetadata().getAnnotationType(ConfigurationAdvice.class.getName()).isPresent()
         beanDefinition instanceof ValidatedBeanDefinition
         beanDefinition.getRequiredMethod("getHost")
-            .stringValue(Property, "name").get() == 'foo.bar.host'
+                .stringValue(Property, "name").get() == 'foo.bar.host'
         beanDefinition.getRequiredMethod("getServerPort")
                 .stringValue(Property, "name").get() == 'foo.bar.server-port'
 
@@ -49,6 +49,64 @@ interface MyConfig {
 
         cleanup:
         context.close()
+
+    }
+
+    void "test optional interface config props"() {
+
+        when:
+        BeanDefinition beanDefinition = buildBeanDefinition('test.MyConfig$Intercepted', '''
+package test;
+
+import io.micronaut.context.annotation.*;
+import java.net.URL;
+import java.util.Optional;
+
+@ConfigurationProperties("foo.bar")
+@Executable
+interface MyConfig {
+    @javax.annotation.Nullable
+    String getHost();
+
+    @javax.validation.constraints.Min(10L)
+    Optional<Integer> getServerPort();
+
+    @io.micronaut.core.bind.annotation.Bindable(defaultValue = "http://default")
+    Optional<URL> getURL();
+}
+
+''')
+        then:
+        beanDefinition.getAnnotationMetadata().getAnnotationType(ConfigurationAdvice.class.getName()).isPresent()
+        beanDefinition instanceof ValidatedBeanDefinition
+        beanDefinition.getRequiredMethod("getHost")
+                .stringValue(Property, "name").get() == 'foo.bar.host'
+        beanDefinition.getRequiredMethod("getServerPort")
+                .stringValue(Property, "name").get() == 'foo.bar.server-port'
+        beanDefinition.getRequiredMethod("getURL")
+                .stringValue(Property, "name").get() == 'foo.bar.url'
+
+        when:
+        def context = ApplicationContext.run()
+        def config = ((BeanFactory) beanDefinition).build(context, beanDefinition)
+
+        then:
+        config.host == null
+        config.serverPort == Optional.empty()
+        config.URL == Optional.of(new URL("http://default"))
+
+        when:
+        def context2 = ApplicationContext.run('foo.bar.host': 'test', 'foo.bar.server-port': '9999', 'foo.bar.url': 'http://test')
+        def config2 = ((BeanFactory) beanDefinition).build(context2, beanDefinition)
+
+        then:
+        config2.host == 'test'
+        config2.serverPort == Optional.of(9999)
+        config2.URL == Optional.of(new URL("http://test"))
+
+        cleanup:
+        context.close()
+        context2.close()
 
     }
 

--- a/runtime/src/main/java/io/micronaut/runtime/context/env/ConfigurationIntroductionAdvice.java
+++ b/runtime/src/main/java/io/micronaut/runtime/context/env/ConfigurationIntroductionAdvice.java
@@ -28,6 +28,7 @@ import io.micronaut.core.type.ReturnType;
 import io.micronaut.core.value.PropertyNotFoundException;
 
 import javax.inject.Singleton;
+import java.util.Optional;
 
 /**
  * Internal introduction advice used to allow {@link io.micronaut.context.annotation.ConfigurationProperties} on interfaces. Considered internal and not for direct use.
@@ -88,27 +89,24 @@ public class ConfigurationIntroductionAdvice implements MethodInterceptor<Object
             }
             final String defaultValue = context.stringValue(Bindable.class, "defaultValue").orElse(null);
             final Argument<Object> argument = rt.asArgument();
+
+            final Optional<Object> value = environment.getProperty(
+                    property,
+                    argument
+            );
+
             if (defaultValue != null) {
-                return environment.getProperty(
-                        property,
-                        argument
-                ).orElseGet(() -> environment.convertRequired(
+                return value.orElseGet(() -> environment.convertRequired(
                         defaultValue,
                         argument
                 ));
+            } else if (rt.isOptional()) {
+                return value.orElse(Optional.empty());
+            } else if (context.isNullable()) {
+                return value.orElse(null);
             } else {
-                if (context.isNullable()) {
-                    return environment.getProperty(
-                            property,
-                            argument
-                    ).orElse(null);
-                } else {
-                    String finalProperty = property;
-                    return environment.getProperty(
-                            property,
-                            argument
-                    ).orElseThrow(() -> new PropertyNotFoundException(finalProperty, argument.getType()));
-                }
+                String finalProperty = property;
+                return value.orElseThrow(() -> new PropertyNotFoundException(finalProperty, argument.getType()));
             }
         }
     }


### PR DESCRIPTION
Previously, returning an `Optional` type in immutable / interface config would cause failures if the property did not exist

This PR amends the behavior to return `Optional.empty()` in the event the property does not exist similar to how `@Nullable` will cause it to return `null`