### PR TITLE
Added another example for maven group id renaming

### DIFF
--- a/src/main/docs/guide/introduction/upgrading.adoc
+++ b/src/main/docs/guide/introduction/upgrading.adoc
@@ -88,6 +88,9 @@ Some dependencies have new Maven Group IDs so you may need to update your depend
 |`io.micronaut.configuration:micronaut-views-*`
 |`io.micronaut.views:micronaut-views-*`
 
+|`io.micronaut.configuration:micronaut-jdbc-*`
+|`io.micronaut.sql:micronaut-jdbc-*`
+
 |===
 
 === AWS Module Changes


### PR DESCRIPTION
In case for maven group id renaming for micronaut jdbc dependencies, the group was renamed from configuration to sql.