### PR TITLE
Define Jackson Java 8 libs as API dependencies

### DIFF
--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -10,8 +10,8 @@ dependencies {
     api dependencyVersion("validation")
     api "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     api dependencyVersion("rxjava2")
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jacksonVersion"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
+    api "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jacksonVersion"
+    api "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
 
     compileOnly "org.graalvm.nativeimage:svm:$graalVersion"
     compileOnly dependencyVersion("jcache")


### PR DESCRIPTION
Before v2 those dependencies were accessible in the user code. 