### PR TITLE
Set plugin versions using Maven properties

### DIFF
--- a/parent/build.gradle
+++ b/parent/build.gradle
@@ -11,6 +11,16 @@ ext.startPomInfo = {
 ext.extraPomInfo = {
     delegate.properties {
         "micronaut.version"(projectVersion)
+        'micronaut-maven-plugin.version'(micronautMavenPluginVersion)
+
+        'azure-functions-maven-plugin.version'('1.5.0')
+        'exec-maven-plugin.version'('1.6.0')
+        'function-maven-plugin.version'('0.9.3')
+        'jib-maven-plugin.version'('2.4.0')
+        'maven-compiler-plugin.version'('3.8.1')
+        'maven-resources-plugin.version'('3.1.0')
+        'maven-shade-plugin.version'('3.1.0')
+        'protoc-jar-maven-plugin.version'('3.11.4')
     }
     delegate.build {
         delegate.pluginManagement {
@@ -18,12 +28,12 @@ ext.extraPomInfo = {
                 delegate.plugin {
                     groupId "io.micronaut.build"
                     artifactId "micronaut-maven-plugin"
-                    delegate.version micronautMavenPluginVersion
+                    delegate.version '${micronaut-maven-plugin.version}'
                 }
                 delegate.plugin {
                     groupId "com.github.os72"
                     artifactId "protoc-jar-maven-plugin"
-                    delegate.version "3.11.4"
+                    delegate.version '${protoc-jar-maven-plugin.version}'
                     delegate.executions {
                         execution {
                             phase('generate-sources')
@@ -52,7 +62,7 @@ ext.extraPomInfo = {
                 delegate.plugin {
                     groupId "org.codehaus.mojo"
                     artifactId "exec-maven-plugin"
-                    delegate.version "1.6.0"
+                    delegate.version '${exec-maven-plugin.version}'
                     delegate.configuration {
                         executable("java")
                         arguments {
@@ -67,27 +77,27 @@ ext.extraPomInfo = {
                 delegate.plugin {
                     groupId "com.google.cloud.functions"
                     artifactId "function-maven-plugin"
-                    delegate.version "0.9.3"
+                    delegate.version '${function-maven-plugin.version}'
                 }
                 delegate.plugin {
                     groupId "com.google.cloud.tools"
                     artifactId "jib-maven-plugin"
-                    delegate.version "2.4.0"
+                    delegate.version '${jib-maven-plugin.version}'
                 }
                 delegate.plugin {
                     groupId "com.microsoft.azure"
                     artifactId "azure-functions-maven-plugin"
-                    delegate.version "1.5.0"
+                    delegate.version '${azure-functions-maven-plugin.version}'
                 }
                 delegate.plugin {
                     groupId "org.apache.maven.plugins"
                     artifactId "maven-resources-plugin"
-                    delegate.version "3.1.0"
+                    delegate.version '${maven-resources-plugin.version}'
                 }
                 delegate.plugin {
                     groupId "org.apache.maven.plugins"
                     artifactId "maven-compiler-plugin"
-                    delegate.version "3.8.1"
+                    delegate.version '${maven-compiler-plugin.version}'
                     delegate.configuration {
                         compilerArgs {
                             arg("-parameters")
@@ -110,7 +120,7 @@ ext.extraPomInfo = {
                 delegate.plugin {
                     groupId "org.apache.maven.plugins"
                     artifactId "maven-shade-plugin"
-                    delegate.version "3.1.0"
+                    delegate.version '${maven-shade-plugin.version}'
                     delegate.executions {
                         execution {
                             delegate.phase "package"


### PR DESCRIPTION
In Maven this is the preferred way because it allows any user of the pom parent to change the version simply overwriting the property in their own pom.xml