### PR TITLE
Create .rsync-filter

### DIFF
--- a/.github/workflows/.rsync-filter
+++ b/.github/workflows/.rsync-filter
@@ -1,0 +1,2 @@
+- corretto.yml
+- .rsync-filter


### PR DESCRIPTION
Allows whitelisting files so that they don't get removed when the workflows are synced from the template.

See https://github.com/micronaut-projects/micronaut-project-template/issues/15