### PR TITLE
Use official maven-compiler-plugin's property `maven.compiler.paramet…

### DIFF
--- a/parent/build.gradle
+++ b/parent/build.gradle
@@ -14,6 +14,7 @@ ext.extraPomInfo = {
         'maven.compiler.source'('${jdk.version}')
         'maven.compiler.target'('${jdk.version}')
         'maven.compiler.release'('${jdk.version}')
+        'maven.compiler.parameters'('true')
         'project.build.sourceEncoding'('UTF-8')
         'project.reporting.outputEncoding'('UTF-8')
 
@@ -108,24 +109,6 @@ ext.extraPomInfo = {
                     groupId "org.apache.maven.plugins"
                     artifactId "maven-compiler-plugin"
                     delegate.version '${maven-compiler-plugin.version}'
-                    delegate.configuration {
-                        compilerArgs {
-                            arg("-parameters")
-                        }
-                    }
-                    delegate.executions {
-                        execution {
-                            delegate.id "test-compile"
-                            goals {
-                                goal "testCompile"
-                            }
-                            delegate.configuration {
-                                compilerArgs {
-                                    arg("-parameters")
-                                }
-                            }
-                        }
-                    }
                 }
                 delegate.plugin {
                     groupId 'org.apache.maven.plugins'


### PR DESCRIPTION
…ers` to retain parameter names

The use of this property instead of explicit configuration is preferred because the user of the pom parent can change the plugin configuration and don't lose this behaviour. Even if she wants to change it, is easier to simply override the property in their own pom.xml