### PR TITLE
Remove consul version

### DIFF
--- a/src/main/docs/guide/cloud/serviceDiscovery/serviceDiscoveryConsul.adoc
+++ b/src/main/docs/guide/cloud/serviceDiscovery/serviceDiscoveryConsul.adoc
@@ -4,10 +4,10 @@ https://www.consul.io[Consul] is a popular Service Discovery and Distributed Con
 
 The quickest way to start using Consul is via Docker:
 
-. Starting Consul with Docker. Currently only v1.2.x is supported.
+. Starting Consul with Docker.
 [source,bash]
 ----
-docker run -p 8500:8500 consul:1.2.4
+docker run -p 8500:8500 consul
 ----
 
 Alternatively you can https://www.consul.io/docs/install/index.html[install and run a local Consul instance].


### PR DESCRIPTION
The documentation suggests that "only" consul 1.2 works with micronaut (actually meaning "1.2 or newer"). As other documentation parts about consul also do not reference any version, it might be just removed from the documentation.