### PR TITLE
Prioritize HTTP/2 over HTTP/1.1 when certificate is provided. Fixes #3299

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/ssl/CertificateProvidedSslBuilder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/ssl/CertificateProvidedSslBuilder.java
@@ -110,8 +110,8 @@ public class CertificateProvidedSslBuilder extends SslBuilder<SslContext> implem
                     ApplicationProtocolConfig.Protocol.ALPN,
                     ApplicationProtocolConfig.SelectorFailureBehavior.NO_ADVERTISE,
                     ApplicationProtocolConfig.SelectedListenerFailureBehavior.ACCEPT,
-                    ApplicationProtocolNames.HTTP_1_1,
-                    ApplicationProtocolNames.HTTP_2
+                    ApplicationProtocolNames.HTTP_2,
+                    ApplicationProtocolNames.HTTP_1_1
             ));
         }
         try {


### PR DESCRIPTION
Fixes #3299 