### PR TITLE
RecoveryInterceptor performance improvement

### DIFF
--- a/runtime/src/main/java/io/micronaut/retry/intercept/RecoveryInterceptor.java
+++ b/runtime/src/main/java/io/micronaut/retry/intercept/RecoveryInterceptor.java
@@ -56,6 +56,8 @@ public class RecoveryInterceptor implements MethodInterceptor<Object, Object> {
     private static final Logger LOG = LoggerFactory.getLogger(RecoveryInterceptor.class);
     private final BeanContext beanContext;
 
+    private final static String FALLBACK_NOT_FOUND = "FALLBACK_NOT_FOUND";
+
     /**
      * @param beanContext The bean context to allow for DI of class annotated with {@link javax.inject.Inject}.
      */
@@ -70,6 +72,9 @@ public class RecoveryInterceptor implements MethodInterceptor<Object, Object> {
 
     @Override
     public Object intercept(MethodInvocationContext<Object, Object> context) {
+        if (context.getAttribute(FALLBACK_NOT_FOUND, Boolean.class).orElse(Boolean.FALSE)) {
+            return context.proceed();
+        }
         try {
             Object result = context.proceed();
             if (result != null) {
@@ -127,10 +132,7 @@ public class RecoveryInterceptor implements MethodInterceptor<Object, Object> {
      * @return The fallback method if it is present
      */
     public Optional<? extends MethodExecutionHandle<?, Object>> findFallbackMethod(MethodInvocationContext<Object, Object> context) {
-        Class<?> declaringType = context.classValue(Recoverable.class, "api").orElse(null);
-        if (declaringType == null) {
-            declaringType = context.getDeclaringType();
-        }
+        Class<?> declaringType = context.classValue(Recoverable.class, "api").orElseGet(context::getDeclaringType);
         BeanDefinition<?> beanDefinition = beanContext.findBeanDefinition(declaringType, Qualifiers.byStereotype(Fallback.class)).orElse(null);
         if (beanDefinition != null) {
             ExecutableMethod<?, Object> fallBackMethod =
@@ -140,6 +142,7 @@ public class RecoveryInterceptor implements MethodInterceptor<Object, Object> {
                 return Optional.of(executionHandle);
             }
         }
+        context.setAttribute(FALLBACK_NOT_FOUND, Boolean.TRUE);
         return Optional.empty();
     }
 

--- a/runtime/src/main/java/io/micronaut/retry/intercept/RecoveryInterceptor.java
+++ b/runtime/src/main/java/io/micronaut/retry/intercept/RecoveryInterceptor.java
@@ -54,9 +54,10 @@ public class RecoveryInterceptor implements MethodInterceptor<Object, Object> {
     public static final int POSITION = InterceptPhase.RETRY.getPosition() - 10;
 
     private static final Logger LOG = LoggerFactory.getLogger(RecoveryInterceptor.class);
+    private static final String FALLBACK_NOT_FOUND = "FALLBACK_NOT_FOUND";
+
     private final BeanContext beanContext;
 
-    private final static String FALLBACK_NOT_FOUND = "FALLBACK_NOT_FOUND";
 
     /**
      * @param beanContext The bean context to allow for DI of class annotated with {@link javax.inject.Inject}.


### PR DESCRIPTION
I have noticed RecoveryInterceptor is called for all methods, PR caches some of the extractions and is able to skip it on the next call, not sure if MethodExecutionHandle is cacheable.

The other solution would be to set some boolean into context.setAttribute indicating that there is no fallback.

Should the execution of the fallback happen in a separate thread?