### PR TITLE
SocketUtils considers a port available if a ConnectException is thrown during connect attempt

### DIFF
--- a/core/src/main/java/io/micronaut/core/io/socket/SocketUtils.java
+++ b/core/src/main/java/io/micronaut/core/io/socket/SocketUtils.java
@@ -17,6 +17,7 @@ package io.micronaut.core.io.socket;
 
 import io.micronaut.core.util.ArgumentUtils;
 
+import java.net.ConnectException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
@@ -89,8 +90,10 @@ public class SocketUtils {
         try (Socket socket = new Socket()) {
             socket.connect(new InetSocketAddress(InetAddress.getLocalHost(), currentPort), 20);
             return false;
-        } catch (Throwable e) {
+        } catch (ConnectException e) {
             return true;
+        } catch (Throwable e) {
+            return false;
         }
     }
 


### PR DESCRIPTION
This might help out with #3670 

Currently, `SocketUtils` considers a port available if an attempt to connect to it fails.  This isn't always the case.  For example, a timeout might indicate that something is using the port but did not respond to the connection in time.  I'm sure there are other situations where an exception might mean that the port is not available.

I'm not convinced that what I've proposed is actually the best approach here, but I think it is more correct than what we have now.  I believe that a port that isn't in use will always throw a`java.net.ConnectException` with a message of "Connection refused".  

I was thinking that it may be more conclusive to try to listen on the port, or maybe listen and send a short message through to determine if it is actually available, but I suspect that will be a lot slower than what we have and I'm also concerned that the port may not be cleaned up in time for the caller to use it for something else.