### PR TITLE
Fix discovery-client group

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -157,7 +157,7 @@ ext {
             ],
             'micronaut.discovery': [
                     version:micronautDiscoveryClientVersion,
-                    group:'io.micronaut',
+                    group:'io.micronaut.discovery',
                     name:'micronaut-discovery-client'
             ],            
             'micronaut.hibernate.validator': [


### PR DESCRIPTION
The new groupId is now `io.micronaut.discovery`: https://github.com/micronaut-projects/micronaut-discovery-client/blob/159641d2f25907583e36342964f8b25c810e00ab/build.gradle#L14