### PR TITLE
SimpleRetry behaviour differs from the document

### DIFF
--- a/src/main/docs/guide/aop/retry.adoc
+++ b/src/main/docs/guide/aop/retry.adoc
@@ -4,7 +4,7 @@ With this in mind Micronaut comes with a api:retry.annotation.Retryable[] annota
 
 == Simple Retry
 
-The simplest form of retry is just to add the `@Retryable` annotation to any type or method. The default behaviour of `@Retryable` is to retry 3 times with an exponential delay of 1 second between each retry. (first attempt with 1s delay, second attempt with 2s delay, thrid attempt with 3s delay)
+The simplest form of retry is just to add the `@Retryable` annotation to any type or method. The default behaviour of `@Retryable` is to retry 3 times with an exponential delay of 1 second between each retry. (first attempt with 1s delay, second attempt with 2s delay, third attempt with 3s delay)
 
 For example:
 

--- a/src/main/docs/guide/aop/retry.adoc
+++ b/src/main/docs/guide/aop/retry.adoc
@@ -4,7 +4,7 @@ With this in mind Micronaut comes with a api:retry.annotation.Retryable[] annota
 
 == Simple Retry
 
-The simplest form of retry is just to add the `@Retryable` annotation to any type or method. The default behaviour of `@Retryable` is to retry 3 times with a delay of 1 second between each retry.
+The simplest form of retry is just to add the `@Retryable` annotation to any type or method. The default behaviour of `@Retryable` is to retry 3 times with an exponential delay of 1 second between each retry. (first attempt with 1s delay, second attempt with 2s delay, thrid attempt with 3s delay)
 
 For example:
 


### PR DESCRIPTION
Hi there.
I thought this retry behaviour differs from the documentation mentioning `with a delay of 1 second between each retry`. 
Actually the delay is gonna be increased exponentially.

The is the source code multiplying with 'attemptsNumber'
https://github.com/micronaut-projects/micronaut-core/blob/f8e0497b7cdb334c04d99ff8d7443571e9b64b27/runtime/src/main/java/io/micronaut/retry/intercept/SimpleRetry.java#L159

Test code mentions it's exponential
https://github.com/micronaut-projects/micronaut-core/blob/f8e0497b7cdb334c04d99ff8d7443571e9b64b27/runtime/src/test/groovy/io/micronaut/retry/intercept/SimpleRetryInstanceSpec.groovy#L66

Thanks.