### PR TITLE
Only close http connection for 500 errors

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
@@ -1647,7 +1647,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
         if (!isHttp2) {
             if (!nettyHeaders.contains(HttpHeaderNames.CONNECTION)) {
                 boolean expectKeepAlive = nettyResponse.protocolVersion().isKeepAliveDefault() || request.getHeaders().isKeepAlive();
-                if (!expectKeepAlive || httpStatus.getCode() > 299) {
+                if (!expectKeepAlive || httpStatus.getCode() > 499) {
                     nettyHeaders.set(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE);
                 } else {
                     nettyHeaders.set(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE);


### PR DESCRIPTION
Fixes #3777

Previously redirects, and other 3xx and 4xx, responses caused the HTTP
connection to be closed, which uses up too many TCP connections and
generally hurts performance.