### PR TITLE
Skip non executable methods for processing instead of throwing an error

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/aop/CombinedBean.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/CombinedBean.java
@@ -1,0 +1,21 @@
+package io.micronaut.aop;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.scheduling.annotation.Scheduled;
+
+import javax.inject.Singleton;
+
+@Requires(property = "spec.name", value = "CombinedBeanSpec")
+@Singleton
+public class CombinedBean {
+
+    @Logged
+    void methodOne() {
+
+    }
+
+    @Scheduled(fixedRate = "10s")
+    void methodTwo() {
+
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/CombinedBeanSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/CombinedBeanSpec.groovy
@@ -1,0 +1,15 @@
+package io.micronaut.aop
+
+import io.micronaut.context.ApplicationContext
+import spock.lang.Specification
+
+class CombinedBeanSpec extends Specification {
+
+    void "test a bean with both AOP and executable methods"() {
+        given:
+        ApplicationContext ctx = ApplicationContext.run('spec.name': CombinedBeanSpec.simpleName)
+
+        expect:
+        ctx.getBean(CombinedBean) != null
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1562,6 +1562,7 @@ public class DefaultBeanContext implements BeanContext {
                     .flatMap(beanDefinition ->
                             beanDefinition.getExecutableMethods()
                                     .parallelStream()
+                                    .filter(method -> method.hasStereotype(Executable.class))
                                     .map((Function<ExecutableMethod<?, ?>, BeanDefinitionMethodReference<?, ?>>) executableMethod ->
                                             BeanDefinitionMethodReference.of((BeanDefinition) beanDefinition, executableMethod)
                                     )
@@ -1572,17 +1573,13 @@ public class DefaultBeanContext implements BeanContext {
             Map<Class<? extends Annotation>, List<BeanDefinitionMethodReference<?, ?>>> byAnnotation = new HashMap<>(processedBeans.size());
             methodStream.forEach(reference -> {
                 List<Class<? extends Annotation>> annotations = reference.getAnnotationTypesByStereotype(Executable.class);
-                if (annotations.isEmpty()) {
-                    throw new IllegalStateException("BeanDefinition.requiresMethodProcessing() returned true but method has no @Executable definition. This should never happen. Please report an issue.");
-                } else {
-                    annotations.forEach(annotation -> byAnnotation.compute(annotation, (ann, list) -> {
+                annotations.forEach(annotation -> byAnnotation.compute(annotation, (ann, list) -> {
                         if (list == null) {
                             list = new ArrayList<>(10);
                         }
                         list.add(reference);
                         return list;
                     }));
-                }
             });
 
             // Find ExecutableMethodProcessor for each annotation and process the BeanDefinitionMethodReference


### PR DESCRIPTION
Fixes #3721

I think this is a left over artifact from https://github.com/micronaut-projects/micronaut-core/pull/2728

The bean definition reference `requiresProcessing` will return true if there is at least one method with `@Executable`, however not all methods should be subject to executable method processing (AOP for example). Before when all executable methods had `@Executable`, that condition wasn't possible so this wasn't an issue.