### PR TITLE
Allow for annotation mappers to supply stereotypes

### DIFF
--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationValueBuilder.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationValueBuilder.java
@@ -20,7 +20,10 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 
 import java.lang.annotation.Annotation;
 import java.lang.annotation.RetentionPolicy;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -35,6 +38,7 @@ public class AnnotationValueBuilder<T extends Annotation> {
     private final String annotationName;
     private final Map<CharSequence, Object> values = new HashMap<>(5);
     private final RetentionPolicy retentionPolicy;
+    private final List<AnnotationValue<? extends Annotation>> stereotypes = new ArrayList<>(2);
 
     /**
      * Default constructor.
@@ -86,8 +90,56 @@ public class AnnotationValueBuilder<T extends Annotation> {
      *
      * @return The {@link AnnotationValue}
      */
-    public @NonNull AnnotationValue<T> build() {
-        return new AnnotationValue<>(annotationName, values, retentionPolicy);
+    public @NonNull
+    AnnotationValue<T> build() {
+        if (stereotypes.size() == 0) {
+            return new AnnotationValue<>(annotationName, values, retentionPolicy);
+        } else {
+            return new SourceAnnotationValue<>(annotationName, values, stereotypes, retentionPolicy);
+        }
+    }
+
+    /**
+     * stereotype associated with the annotation.
+     *
+     * @param annotations target annotations
+     * @return this builder
+     */
+    public AnnotationValueBuilder<T> stereotype(String... annotations) {
+        if (annotations != null) {
+            for (String ann : annotations) {
+                this.stereotypes.add(new AnnotationValue<>(ann));
+            }
+        }
+        return this;
+    }
+
+    /**
+     * stereotype associated with the annotation.
+     *
+     * @param annotations target annotations
+     * @return this builder
+     */
+    public AnnotationValueBuilder<T> stereotype(Class<? extends Annotation>... annotations) {
+        if (annotations != null) {
+            for (Class<?> aClass : annotations) {
+                this.stereotypes.add(new AnnotationValue<>(aClass.getName()));
+            }
+        }
+        return this;
+    }
+
+    /**
+     * stereotype associated with the annotation.
+     *
+     * @param annotations target annotations
+     * @return this builder
+     */
+    public AnnotationValueBuilder<T> stereotype(AnnotationValue<? extends Annotation>... annotations) {
+        if (annotations != null) {
+            Collections.addAll(this.stereotypes, annotations);
+        }
+        return this;
     }
 
     /**

--- a/core/src/main/java/io/micronaut/core/annotation/SourceAnnotationValue.java
+++ b/core/src/main/java/io/micronaut/core/annotation/SourceAnnotationValue.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 /**
- * A runtime representation of the an stereotype annotation and its values.
+ * A compile time representation of an annotation.
  *
  * <p>This class implements the {@link AnnotationValueResolver} interface and methods such as {@link AnnotationValueResolver#get(CharSequence, Class)} can be used to retrieve the values of annotation members.</p>
  *

--- a/core/src/main/java/io/micronaut/core/annotation/SourceAnnotationValue.java
+++ b/core/src/main/java/io/micronaut/core/annotation/SourceAnnotationValue.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.core.annotation;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.micronaut.core.convert.value.ConvertibleValues;
+import io.micronaut.core.util.ArgumentUtils;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.RetentionPolicy;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * A runtime representation of the an stereotype annotation and its values.
+ *
+ * <p>This class implements the {@link AnnotationValueResolver} interface and methods such as {@link AnnotationValueResolver#get(CharSequence, Class)} can be used to retrieve the values of annotation members.</p>
+ *
+ * <p>This this class implements a list of {@link AnnotationValue} for parent stereotypes</p>
+ *
+ * <p>If a member is not present then the methods of the class will attempt to resolve the default value for a given annotation member. In this sense the behaviour of this class is similar to how
+ * a implementation of {@link Annotation} behaves.</p>
+ *
+ * @param <A> The annotation type
+ * @author Michael Pollind
+ * @since 1.0
+ */
+public class SourceAnnotationValue<A extends Annotation> extends AnnotationValue<A> {
+    private final List<AnnotationValue<? extends Annotation>> stereotypes;
+
+    /**
+     * @param annotationName the annotation name
+     * @param values         the values
+     */
+    public SourceAnnotationValue(String annotationName, Map<CharSequence, Object> values) {
+        this(annotationName, values, Collections.emptyList());
+    }
+
+    /**
+     * @param annotationName the annotation name
+     * @param values         the values
+     * @param stereotypes    annotation stereotypes
+     */
+    public SourceAnnotationValue(String annotationName, Map<CharSequence, Object> values, List<AnnotationValue<? extends Annotation>> stereotypes) {
+        super(annotationName, values);
+        ArgumentUtils.requireNonNull("stereotypes", stereotypes);
+        this.stereotypes = stereotypes;
+    }
+
+    /**
+     * @param annotationName  The annotation name
+     * @param values          The values
+     * @param retentionPolicy The retention policy
+     */
+    public SourceAnnotationValue(String annotationName, Map<CharSequence, Object> values, RetentionPolicy retentionPolicy) {
+        this(annotationName, values, Collections.emptyList(), retentionPolicy);
+    }
+
+    /**
+     * @param annotationName  The annotation name
+     * @param values          The values
+     * @param stereotypes     Annotation stereotypes
+     * @param retentionPolicy The retention policy
+     */
+    public SourceAnnotationValue(String annotationName, Map<CharSequence, Object> values, List<AnnotationValue<? extends Annotation>> stereotypes, RetentionPolicy retentionPolicy) {
+        super(annotationName, values, retentionPolicy);
+        ArgumentUtils.requireNonNull("stereotypes", stereotypes);
+        this.stereotypes = stereotypes;
+    }
+
+    /**
+     * @param annotationName The annotation name
+     * @param values         The values
+     * @param defaultValues  The default values
+     */
+    public SourceAnnotationValue(String annotationName, Map<CharSequence, Object> values, Map<String, Object> defaultValues) {
+        this(annotationName, values, defaultValues, Collections.emptyList());
+    }
+
+    /**
+     * @param annotationName The annotation name
+     * @param values         The values
+     * @param defaultValues  The default values
+     * @param stereotypes    The stereotypes
+     */
+    public SourceAnnotationValue(String annotationName, Map<CharSequence, Object> values, Map<String, Object> defaultValues, List<AnnotationValue<? extends Annotation>> stereotypes) {
+        super(annotationName, values, defaultValues);
+        ArgumentUtils.requireNonNull("stereotypes", stereotypes);
+        this.stereotypes = stereotypes;
+    }
+
+    /**
+     * @param annotationName  The annotation name
+     * @param values          The values
+     * @param defaultValues   The default values
+     * @param retentionPolicy The retention policy
+     */
+    public SourceAnnotationValue(String annotationName, Map<CharSequence, Object> values, Map<String, Object> defaultValues, RetentionPolicy retentionPolicy) {
+        this(annotationName, values, defaultValues, Collections.emptyList(), retentionPolicy);
+    }
+
+    /**
+     * @param annotationName  The annotation name
+     * @param values          The values
+     * @param defaultValues   The default values
+     * @param stereotypes     The stereotypes
+     * @param retentionPolicy The retention policy
+     */
+    public SourceAnnotationValue(String annotationName, Map<CharSequence, Object> values, Map<String, Object> defaultValues, List<AnnotationValue<? extends Annotation>> stereotypes, RetentionPolicy retentionPolicy) {
+        super(annotationName, values, defaultValues, retentionPolicy);
+        ArgumentUtils.requireNonNull("stereotypes", stereotypes);
+        this.stereotypes = stereotypes;
+    }
+
+    /**
+     * @param annotationName The annotation name
+     */
+    public SourceAnnotationValue(String annotationName) {
+        super(annotationName);
+        this.stereotypes = Collections.emptyList();
+    }
+
+    /**
+     * @param annotationName    The annotation name
+     * @param convertibleValues The convertible values
+     */
+    public SourceAnnotationValue(String annotationName, ConvertibleValues<Object> convertibleValues) {
+        super(annotationName, convertibleValues);
+        this.stereotypes = Collections.emptyList();
+    }
+
+    /**
+     * @param target            The target
+     * @param defaultValues     The default values
+     * @param convertibleValues The convertible values
+     * @param valueMapper       The value mapper
+     */
+    protected SourceAnnotationValue(AnnotationValue<A> target, Map<String, Object> defaultValues, ConvertibleValues<Object> convertibleValues, Function<Object, Object> valueMapper) {
+        super(target, defaultValues, convertibleValues, valueMapper);
+        this.stereotypes = Collections.emptyList();
+    }
+
+    /**
+     * The annotation stereotypes associated with annotation.
+     *
+     * @return annotation stereotypes
+     */
+    public @NonNull
+    final List<AnnotationValue<? extends Annotation>> getStereotypes() {
+        return this.stereotypes;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/annotation/AnnotationMapperSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/annotation/AnnotationMapperSpec.groovy
@@ -4,6 +4,7 @@ import edu.umd.cs.findbugs.annotations.NonNull
 import io.micronaut.aop.Around
 import io.micronaut.context.annotation.ConfigurationInject
 import io.micronaut.context.annotation.Type
+import io.micronaut.core.annotation.AnnotationClassValue
 import io.micronaut.core.annotation.AnnotationValue
 import io.micronaut.core.annotation.AnnotationValueBuilder
 import io.micronaut.core.annotation.Creator
@@ -40,10 +41,11 @@ class Test {
 
         metadata != null
         List<Class<? extends Annotation>> annotations = metadata.getAnnotationTypesByStereotype(Around.class)
-        annotations.size() == 3
-        annotations.contains(Type.class)
-        annotations.contains(CustomAround.class)
-        annotations.contains(Around.class)
+        annotations.size() == 1
+        Class<? extends Annotation> aroundAnn = annotations[0]
+        aroundAnn == CustomAround.class
+//        Class<? extends Annotation> tp = aroundAnn.getAnnotation(Type.class);
+//        tp != null
 
     }
 
@@ -145,25 +147,23 @@ class Test {
         }
     }
 
-    static class  CustomAroundMapper implements AnnotationMapper<CustomAround> {
+    static class CustomAroundMapper implements AnnotationMapper<CustomAround> {
         @Override
         List<AnnotationValue<?>> map(AnnotationValue<CustomAround> annotation, VisitorContext visitorContext) {
 
-            AnnotationValueBuilder<CustomAround> customAroundValueBuilder =
-                AnnotationValue.builder(CustomAround.class);
-
             AnnotationValueBuilder<Type> typeAnnotationValueBuilder =
-                AnnotationValue.builder(Type.class);
+                AnnotationValue.builder(Type.class).member("value",
+                    new AnnotationClassValue("io.micronaut.aop.TraceInterceptor"));
 
             AnnotationValueBuilder<Around> aroundAnnotationValueBuilder =
-                AnnotationValue.builder(Around.class)
-                    .stereotype(typeAnnotationValueBuilder.build(), customAroundValueBuilder.build());
+                AnnotationValue.builder(Around.class);
 
-            return Arrays.asList(aroundAnnotationValueBuilder.build())
+            AnnotationValueBuilder<CustomAround> customAroundValueBuilder =
+                AnnotationValue.builder(CustomAround.class).stereotype(typeAnnotationValueBuilder.build(), aroundAnnotationValueBuilder.build());
+
+            return Arrays.asList(customAroundValueBuilder.build())
         }
     }
-
-
 }
 
 @Target(ElementType.METHOD)

--- a/inject/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -715,40 +715,34 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                             if (o instanceof SourceAnnotationValue) {
                                 SourceAnnotationValue sav = (SourceAnnotationValue) o;
                                 List<AnnotationValue> stereotypes = sav.getStereotypes();
-                                final List<String> parents = new ArrayList<String>(stereotypes.size() + 1);
-                                parents.add(mappedAnnotationName);
-                                for (AnnotationValue stereotype : stereotypes) {
-                                    String name = stereotype.getAnnotationName();
-                                    if (!parents.contains(name)) {
-                                        parents.add(name);
-                                    }
-                                }
+                                List<String> parentAnnoation = Collections.singletonList(mappedAnnotationName);
                                 for (AnnotationValue stereotype : stereotypes) {
                                     retentionPolicy = stereotype.getRetentionPolicy();
+                                    String stereotypeName = stereotype.getAnnotationName();
                                     if (repeatableName != null) {
                                         if (isDeclared) {
                                             metadata.addDeclaredRepeatableStereotype(
-                                                parents,
-                                                mappedAnnotationName,
+                                                parentAnnoation,
+                                                stereotypeName,
                                                 stereotype);
                                         } else {
                                             metadata.addRepeatableStereotype(
-                                                parents,
-                                                mappedAnnotationName,
+                                                parentAnnoation,
+                                                stereotypeName,
                                                 stereotype);
                                         }
                                     } else {
                                         Map<CharSequence, Object> values = stereotype.getValues();
                                         if (isDeclared) {
                                             metadata.addDeclaredStereotype(
-                                                parents,
-                                                mappedAnnotationName,
+                                                parentAnnoation,
+                                                stereotypeName,
                                                 values,
                                                 retentionPolicy);
                                         } else {
                                             metadata.addStereotype(
-                                                parents,
-                                                mappedAnnotationName,
+                                                parentAnnoation,
+                                                stereotypeName,
                                                 values,
                                                 retentionPolicy);
                                         }

--- a/inject/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -711,6 +711,51 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                                         isDeclared);
 
                             });
+
+                            if (o instanceof SourceAnnotationValue) {
+                                SourceAnnotationValue sav = (SourceAnnotationValue) o;
+                                List<AnnotationValue> stereotypes = sav.getStereotypes();
+                                final List<String> parents = new ArrayList<String>(stereotypes.size() + 1);
+                                parents.add(mappedAnnotationName);
+                                for (AnnotationValue stereotype : stereotypes) {
+                                    String name = stereotype.getAnnotationName();
+                                    if (!parents.contains(name)) {
+                                        parents.add(name);
+                                    }
+                                }
+                                for (AnnotationValue stereotype : stereotypes) {
+                                    retentionPolicy = stereotype.getRetentionPolicy();
+                                    if (repeatableName != null) {
+                                        if (isDeclared) {
+                                            metadata.addDeclaredRepeatableStereotype(
+                                                parents,
+                                                mappedAnnotationName,
+                                                stereotype);
+                                        } else {
+                                            metadata.addRepeatableStereotype(
+                                                parents,
+                                                mappedAnnotationName,
+                                                stereotype);
+                                        }
+                                    } else {
+                                        Map<CharSequence, Object> values = stereotype.getValues();
+                                        if (isDeclared) {
+                                            metadata.addDeclaredStereotype(
+                                                parents,
+                                                mappedAnnotationName,
+                                                values,
+                                                retentionPolicy);
+                                        } else {
+                                            metadata.addStereotype(
+                                                parents,
+                                                mappedAnnotationName,
+                                                values,
+                                                retentionPolicy);
+                                        }
+                                    }
+                                }
+                            }
+
                         }
                     }
                 }


### PR DESCRIPTION
This adds a way to define a mapped stereotype for an annotation builder. I mainly want to be able to define an @Arround annotation with a Type so a targeted annotation could be used with AOP.  I explain the problem in the issue and PR's listed below for additional context. 

https://github.com/micronaut-projects/micronaut-core/issues/3767
https://github.com/resilience4j/resilience4j/pull/967
https://github.com/micronaut-projects/micronaut-ignite/pull/23

```
AnnotationValue.builder(Test.class)
.parent(Test1.class,Test2.class)
```