### PR TITLE
Fixing ClientHost test for Windows

### DIFF
--- a/http-client/src/test/groovy/io/micronaut/http/client/ClientHostNameSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/ClientHostNameSpec.groovy
@@ -12,7 +12,7 @@ class ClientHostNameSpec extends Specification {
 
         then:
         def e = thrown(HttpClientException)
-        e.message.contains('Connect Error: foo_bar')
+        e.message.contains('Connect Error: foo_bar') || e.message.contains('Connect Error: No such host is known (foo_bar)')
 
         cleanup:
         client.close()
@@ -25,7 +25,7 @@ class ClientHostNameSpec extends Specification {
 
         then:
         def e = thrown(HttpClientException)
-        e.message.contains('Connect Error: foo_bar')
+        e.message.contains('Connect Error: foo_bar') || e.message.contains('Connect Error: No such host is known (foo_bar)')
 
         cleanup:
         client.close()
@@ -38,7 +38,7 @@ class ClientHostNameSpec extends Specification {
 
         then:
         def e = thrown(HttpClientException)
-        e.message.contains('Connect Error: slave1-6x8-build-agent-2.0.1-5h7sl')
+        e.message.contains('Connect Error: slave1-6x8-build-agent-2.0.1-5h7sl') || e.message.contains('Connect Error: No such host is known (slave1-6x8-build-agent-2.0.1-5h7sl)')
 
         cleanup:
         client.close()


### PR DESCRIPTION
Error message returned for ClientHostNameSpec are different in windows