### PR TITLE
Fix PropertySourcePropertyResolver.java when property key starts with [.

### DIFF
--- a/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
+++ b/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
@@ -536,7 +536,9 @@ public class PropertySourcePropertyResolver implements PropertyResolver {
                         }
                         if (first) {
                             Map<String, Object> normalized = resolveEntriesForKey(resolvedProperty, true, PropertyCatalog.NORMALIZED);
-                            normalized.put(propertyName, value);
+                            if (normalized != null) {
+                                normalized.put(propertyName, value);
+                            }
                             first = false;
                         }
                     } else {

--- a/inject/src/test/groovy/io/micronaut/context/env/DefaultEnvironmentSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/env/DefaultEnvironmentSpec.groovy
@@ -94,7 +94,7 @@ class DefaultEnvironmentSpec extends Specification {
     void "test system property source loader"() {
         given: "a configuration property file is passed from system properties"
         File configPropertiesFile = File.createTempFile("default", ".properties")
-        configPropertiesFile.write("foo=bar")
+        configPropertiesFile.write("foo=bar\n[baz]=bar2")
         System.setProperty("micronaut.config.files", "${configPropertiesFile.absolutePath}")
 
         when: "load the property sources"


### PR DESCRIPTION
This is a proposed fix for the following problem (the problem started in 2.0.0 when PropertyCatalog.NORMALIZED was added, but the null check on normalized wasn't there like for the entries, so it caused this problem):

Keycloak or jboss wildfly had a system property who's name is something like [foo]=... and in PropertySourcePropertyResolver, any key that contains [ is assumed to have a property name before, which in this case is null... so it crashes with:

```
java.lang.NullPointerException
    at io.micronaut.context.env.PropertySourcePropertyResolver.processPropertySource(PropertySourcePropertyResolver.java:539)
    at io.micronaut.context.env.DefaultEnvironment.readPropertySources(DefaultEnvironment.java:399)
    at io.micronaut.context.env.DefaultEnvironment.start(DefaultEnvironment.java:243)
    at io.micronaut.context.env.DefaultEnvironment.start(DefaultEnvironment.java:62)
    at io.micronaut.context.env.DefaultEnvironmentSpec.test system property source loader(DefaultEnvironmentSpec.groovy:101)
```

I just stuck the case in the test as a little side-check, if you want it to be more explicit, I could try. And I'm not sure whether I should have included the `first = false` in the `if` or not...