### PR TITLE
Correct inconsistent mapping of camelCase vs kebab-case properties

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/configproperties/ConfigurationPropertiesSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configproperties/ConfigurationPropertiesSpec.groovy
@@ -144,4 +144,19 @@ class ConfigurationPropertiesSpec extends Specification {
         cleanup:
         context.close()
     }
+
+    void "test camelCase vs kebab_case"() {
+        ApplicationContext context1 = ApplicationContext.run("rec1")
+        ApplicationContext context2 = ApplicationContext.run("rec2")
+
+        RecConf config1 = context1.getBean(RecConf.class)
+        RecConf config2 = context2.getBean(RecConf.class)
+
+        expect:
+            config1 == config2
+
+        cleanup:
+            context1.close()
+            context2.close()
+    }
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/configproperties/RecConf.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configproperties/RecConf.java
@@ -1,0 +1,53 @@
+package io.micronaut.inject.configproperties;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+@ConfigurationProperties("rec")
+public class RecConf {
+    private List<String> namesListOf;
+    private Map<String, RecConf> mapChildren;
+    private List<RecConf> listChildren;
+
+    public List<String> getNamesListOf() {
+        return namesListOf;
+    }
+
+    public void setNamesListOf(List<String> namesListOf) {
+        this.namesListOf = namesListOf;
+    }
+
+    public List<RecConf> getListChildren() {
+        return listChildren;
+    }
+
+    public void setListChildren(List<RecConf> listChildren) {
+        this.listChildren = listChildren;
+    }
+
+    public Map<String, RecConf> getMapChildren() {
+        return mapChildren;
+    }
+
+    public void setMapChildren(Map<String, RecConf> mapChildren) {
+        this.mapChildren = mapChildren;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RecConf recConf = (RecConf) o;
+        return Objects.equals(namesListOf, recConf.namesListOf) &&
+                Objects.equals(mapChildren, recConf.mapChildren) &&
+                Objects.equals(listChildren, recConf.listChildren);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(namesListOf, mapChildren, listChildren);
+    }
+}

--- a/inject-java/src/test/resources/application-rec1.yml
+++ b/inject-java/src/test/resources/application-rec1.yml
@@ -1,0 +1,39 @@
+rec:
+  names-list-of:
+    - ABC
+    - 123
+  list-children:
+    - names-list-of:
+        - A
+        - B
+      list-children:
+        - names-list-of:
+            - A2
+            - B2
+      map-children:
+        a:
+          - names-list-of:
+              - A2
+              - B2
+        b:
+          - names-list-of:
+              - A2
+              - B2
+  map-children:
+    xyz:
+      - names-list-of:
+          - A
+          - B
+        list-children:
+          - names-list-of:
+              - A2
+              - B2
+        map-children:
+          a:
+            - names-list-of:
+                - A2
+                - B2
+          b:
+            - names-list-of:
+                - X2
+                - Y2

--- a/inject-java/src/test/resources/application-rec2.yml
+++ b/inject-java/src/test/resources/application-rec2.yml
@@ -1,0 +1,39 @@
+rec:
+  namesListOf:
+    - ABC
+    - 123
+  listChildren:
+    - namesListOf:
+        - A
+        - B
+      listChildren:
+        - namesListOf:
+            - A2
+            - B2
+      mapChildren:
+        a:
+          - namesListOf:
+              - A2
+              - B2
+        b:
+          - namesListOf:
+              - A2
+              - B2
+  mapChildren:
+    xyz:
+      - namesListOf:
+          - A
+          - B
+        listChildren:
+          - namesListOf:
+              - A2
+              - B2
+        mapChildren:
+          a:
+            - namesListOf:
+                - A2
+                - B2
+          b:
+            - namesListOf:
+                - X2
+                - Y2

--- a/runtime/src/main/java/io/micronaut/jackson/convert/JacksonConverterRegistrar.java
+++ b/runtime/src/main/java/io/micronaut/jackson/convert/JacksonConverterRegistrar.java
@@ -151,15 +151,37 @@ public class JacksonConverterRegistrar implements TypeConverterRegistrar {
             } else {
                 conversionContext = ConversionContext.of(targetType);
             }
-            Map mapWithExtraProps = new LinkedHashMap(map.size());
-            for (Map.Entry entry : ((Map<?, ?>) map).entrySet()) {
-                Object key = entry.getKey();
-                mapWithExtraProps.put(NameUtils.decapitalize(NameUtils.dehyphenate(key.toString())), entry.getValue());
-            }
             ArgumentBinder binder = this.beanPropertyBinder.get();
-            ArgumentBinder.BindingResult result = binder.bind(conversionContext, mapWithExtraProps);
+            ArgumentBinder.BindingResult result = binder.bind(conversionContext, correctKeys(map));
             return result.getValue();
         };
+    }
+
+    private Map correctKeys(Map<?, ?> map) {
+        Map mapWithExtraProps = new LinkedHashMap(map.size());
+        for (Map.Entry entry : map.entrySet()) {
+            Object key = entry.getKey();
+            Object value = correctKeys(entry.getValue());
+            mapWithExtraProps.put(NameUtils.decapitalize(NameUtils.dehyphenate(key.toString())), value);
+        }
+        return mapWithExtraProps;
+    }
+
+    private List correctKeys(List list) {
+        List newList = new ArrayList(list.size());
+        for (Object o : list) {
+            newList.add(correctKeys(o));
+        }
+        return newList;
+    }
+
+    private Object correctKeys(Object o) {
+        if (o instanceof List) {
+            return correctKeys((List) o);
+        } else if (o instanceof Map) {
+            return correctKeys((Map) o);
+        }
+        return o;
     }
 
     /**


### PR DESCRIPTION
There should be some refactoring of properties processing so keys processing in Jackson registrar is not needed, this PR just fixed cases when kebab case properties were resolved as nulls.