### PR TITLE
Introduce IntrospectionBeanPropertyBinder as alternative to JacksonBeanPropertyBinder

### DIFF
--- a/inject-groovy/src/test/groovy/io/micronaut/inject/configproperties/ConfigurationPropertiesListBindingSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/configproperties/ConfigurationPropertiesListBindingSpec.groovy
@@ -4,15 +4,15 @@ import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.ConfigurationProperties
 import io.micronaut.context.env.PropertySource
 import io.micronaut.context.env.yaml.YamlPropertySourceLoader
+import io.micronaut.core.annotation.Introspected
 import io.netty.handler.codec.http.HttpMethod
-import org.yaml.snakeyaml.Yaml
 import spock.lang.Specification
 
 class ConfigurationPropertiesListBindingSpec extends Specification {
 
     void "test bind to list of POJO"() {
         given:
-        def map = new YamlPropertySourceLoader().read("myconfig.yml", '''
+        def map = new YamlPropertySourceLoader().read("myconfig.ymlmyconfig.yml", '''
 my:
   security:
     intercept-url-map:
@@ -46,6 +46,7 @@ my:
         Map<String, List<BindableInterceptUrlMapPattern>> interceptUrlMap
     }
 
+    @Introspected
     static class BindableInterceptUrlMapPattern {
         String pattern;
         List<String> access = new ArrayList<>();

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/configproperties/MyConfigInner.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/configproperties/MyConfigInner.groovy
@@ -1,12 +1,14 @@
 package io.micronaut.inject.configproperties
 
 import io.micronaut.context.annotation.ConfigurationProperties
+import io.micronaut.core.annotation.Introspected
 
 @ConfigurationProperties("foo.bar")
 class MyConfigInner {
 
     List<InnerVal> innerVals
 
+    @Introspected
     static class InnerVal {
         Integer expireUnsignedSeconds
     }

--- a/inject-java/src/test/groovy/io/micronaut/inject/configproperties/MyConfig.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configproperties/MyConfig.java
@@ -16,6 +16,7 @@
 package io.micronaut.inject.configproperties;
 
 import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.convert.format.ReadableBytes;
 
 import java.net.URL;
@@ -57,6 +58,7 @@ public class MyConfig {
         return map;
     }
 
+    @Introspected
     public static class Value {
         private int property;
         private Value2 property2;
@@ -86,6 +88,7 @@ public class MyConfig {
         }
     }
 
+    @Introspected
     public static class Value2 {
         private int property;
 
@@ -246,6 +249,7 @@ public class MyConfig {
     }
 }
 
+@Introspected
 class InnerVal {
     private Integer expireUnsignedSeconds;
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/configproperties/MyConfigInner.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configproperties/MyConfigInner.java
@@ -16,6 +16,7 @@
 package io.micronaut.inject.configproperties;
 
 import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.Introspected;
 
 import java.util.List;
 
@@ -32,6 +33,7 @@ public class MyConfigInner {
         this.innerVals = innerVals;
     }
 
+    @Introspected
     public static class InnerVal {
 
         private Integer expireUnsignedSeconds;

--- a/runtime/src/main/java/io/micronaut/jackson/bind/JacksonBeanPropertyBinder.java
+++ b/runtime/src/main/java/io/micronaut/jackson/bind/JacksonBeanPropertyBinder.java
@@ -44,7 +44,7 @@ import java.util.Set;
  * @author Graeme Rocher
  * @since 1.0
  */
-@Requires(property = "jackson.bean-property-binder.enabled", value = "true")
+@Requires(property = "jackson.bean-property-binder.enabled", value = "true", defaultValue = "true")
 @Singleton
 public class JacksonBeanPropertyBinder extends AbstractBeanPropertyBinder implements BeanPropertyBinder {
 

--- a/runtime/src/main/java/io/micronaut/jackson/bind/JacksonBeanPropertyBinder.java
+++ b/runtime/src/main/java/io/micronaut/jackson/bind/JacksonBeanPropertyBinder.java
@@ -29,12 +29,10 @@ import io.micronaut.core.convert.exceptions.ConversionErrorException;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.CollectionUtils;
-import io.micronaut.core.util.StringUtils;
 import io.micronaut.jackson.JacksonConfiguration;
+import io.micronaut.runtime.bind.AbstractBeanPropertyBinder;
 
 import javax.inject.Singleton;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -48,7 +46,7 @@ import java.util.Set;
  */
 @Requires(property = "jackson.bean-property-binder.enabled", value = "true")
 @Singleton
-public class JacksonBeanPropertyBinder implements BeanPropertyBinder {
+public class JacksonBeanPropertyBinder extends AbstractBeanPropertyBinder implements BeanPropertyBinder {
 
     private final ObjectMapper objectMapper;
     private final int arraySizeThreshhold;
@@ -65,7 +63,7 @@ public class JacksonBeanPropertyBinder implements BeanPropertyBinder {
     @Override
     public BindingResult<Object> bind(ArgumentConversionContext<Object> context, Map<CharSequence, ? super Object> source) {
         try {
-            Map objectNode = buildSourceMapNode(source.entrySet());
+            Map objectNode = buildMapObject(source.entrySet());
             TypeFactory typeFactory = objectMapper.getTypeFactory();
             JavaType javaType = JacksonConfiguration.constructType(context.getArgument(), typeFactory);
             Object result = objectMapper.convertValue(objectNode, javaType);
@@ -94,7 +92,7 @@ public class JacksonBeanPropertyBinder implements BeanPropertyBinder {
     @Override
     public <T2> T2 bind(Class<T2> type, Set<? extends Map.Entry<? extends CharSequence, Object>> source) throws ConversionErrorException {
         try {
-            Map objectNode = buildSourceMapNode(source);
+            Map objectNode = buildMapObject(source);
             return objectMapper.convertValue(objectNode, type);
         } catch (Exception e) {
             throw newConversionError(null, e);
@@ -104,7 +102,7 @@ public class JacksonBeanPropertyBinder implements BeanPropertyBinder {
     @Override
     public <T2> T2 bind(T2 object, ArgumentConversionContext<T2> context, Set<? extends Map.Entry<? extends CharSequence, Object>> source) {
         try {
-            Map objectNode = buildSourceMapNode(source);
+            Map objectNode = buildMapObject(source);
             JsonNode jacksonTree = objectMapper.valueToTree(objectNode);
             objectMapper.readerForUpdating(object).readValue(jacksonTree);
         } catch (Exception e) {
@@ -116,7 +114,7 @@ public class JacksonBeanPropertyBinder implements BeanPropertyBinder {
     @Override
     public <T2> T2 bind(T2 object, Set<? extends Map.Entry<? extends CharSequence, Object>> source) throws ConversionErrorException {
         try {
-            Map objectNode = buildSourceMapNode(source);
+            Map objectNode = buildMapObject(source);
             JsonNode jacksonTree = objectMapper.valueToTree(objectNode);
             return objectMapper.readerForUpdating(object).readValue(jacksonTree);
         } catch (Exception e) {
@@ -171,152 +169,13 @@ public class JacksonBeanPropertyBinder implements BeanPropertyBinder {
         }
     }
 
-    private Map<String, Object> buildSourceMapNode(Set<? extends Map.Entry<? extends CharSequence, Object>> source) {
-        Map<String, Object> rootNode = new LinkedHashMap<>();
-        for (Map.Entry<? extends CharSequence, ? super Object> entry : source) {
-            Object value = entry.getValue();
-            String property = correctKey(entry.getKey().toString());
-            String[] tokens = property.split("\\.");
-            Object current = rootNode;
-            String index = null;
-            for (int i = 0; i < tokens.length; i++) {
-                String token = tokens[i];
-                int j = token.indexOf('[');
-                if (j > -1 && token.endsWith("]")) {
-                    index = token.substring(j + 1, token.length() - 1);
-                    token = token.substring(0, j);
-                }
-                if (i == tokens.length - 1) {
-                    if (current instanceof Map) {
-                        Map mapNode = (Map) current;
-                        if (index != null) {
-                            if (StringUtils.isDigits(index)) {
-                                int arrayIndex = Integer.parseInt(index);
-                                List arrayNode = getOrCreateListNodeAtKey(mapNode, token);
-                                arrayNode.add(arrayIndex, processValue(value));
-                            } else {
-                                Map map = getOrCreateMapNodeAtKey(mapNode, token);
-                                map.put(index, processValue(value));
-                            }
-                            index = null;
-                        } else {
-                            mapNode.put(token, processValue(value));
-                        }
-                    } else if (current instanceof List && index != null) {
-                        List arrayNode = (List) current;
-                        int arrayIndex = Integer.parseInt(index);
-                        Map mapNode = getOrCreateMapNodeAtIndex(arrayNode, arrayIndex);
-                        mapNode.put(token, processValue(value));
-                        index = null;
-                    }
-                } else {
-                    if (current instanceof Map) {
-                        Map objectNode = (Map) current;
-                        if (index != null) {
-                            if (StringUtils.isDigits(index)) {
-                                int arrayIndex = Integer.parseInt(index);
-                                List arrayNode = getOrCreateListNodeAtKey(objectNode, token);
-                                current = getOrCreateMapNodeAtIndex(arrayNode, arrayIndex);
-                            } else {
-                                Map mapNode = getOrCreateMapNodeAtKey(objectNode, token);
-                                current = getOrCreateMapNodeAtKey(mapNode, index);
-                            }
-                            index = null;
-                        } else {
-                            current = getOrCreateMapNodeAtKey(objectNode, token);
-                        }
-                    } else if (current instanceof List && StringUtils.isDigits(index)) {
-                        int arrayIndex = Integer.parseInt(index);
-                        Map jsonNode = getOrCreateMapNodeAtIndex((List) current, arrayIndex);
-
-                        current = new LinkedHashMap<>();
-                        jsonNode.put(token, current);
-                        index = null;
-                    }
-                }
-            }
-        }
-        return rootNode;
+    @Override
+    protected Object convertUnknownValue(Object o) {
+        return objectMapper.valueToTree(o);
     }
 
-    private Map getOrCreateMapNodeAtIndex(List arrayNode, int arrayIndex) {
-        if (arrayIndex >= arrayNode.size()) {
-            arrayNode = expandArrayToThreshold(arrayIndex, arrayNode);
-        }
-        Object jsonNode = arrayNode.get(arrayIndex);
-        if (!(jsonNode instanceof Map)) {
-            jsonNode = new LinkedHashMap<>();
-            arrayNode.set(arrayIndex, jsonNode);
-        }
-        return (Map) jsonNode;
+    @Override
+    protected int getArraySizeThreshold() {
+        return arraySizeThreshhold;
     }
-
-    private Map getOrCreateMapNodeAtKey(Map objectNode, Object key) {
-        Object jsonNode = objectNode.get(key);
-        if (!(jsonNode instanceof Map)) {
-            jsonNode = new LinkedHashMap<>();
-            objectNode.put(key, jsonNode);
-        }
-        return (Map) jsonNode;
-    }
-
-    private List getOrCreateListNodeAtKey(Map objectNode, Object key) {
-        Object jsonNode = objectNode.get(key);
-        if (!(jsonNode instanceof List)) {
-            jsonNode = new ArrayList<>();
-            objectNode.put(key, jsonNode);
-        }
-        return (List) jsonNode;
-    }
-
-    private List expandArrayToThreshold(int arrayIndex, List arrayNode) {
-        if (arrayIndex < arraySizeThreshhold) {
-            ArrayList arrayListNode;
-            if (arrayNode instanceof ArrayList) {
-                arrayListNode = (ArrayList) arrayNode;
-            } else {
-                arrayListNode = new ArrayList(arrayNode);
-            }
-            while (arrayNode.size() != arrayIndex + 1) {
-                arrayNode.add(arrayIndex, null);
-            }
-            return arrayListNode;
-        }
-        return arrayNode;
-    }
-
-    private Object processValue(Object o) {
-        if (o instanceof List) {
-            return processList((List) o);
-        } else if (o instanceof Map) {
-            return processMap((Map) o);
-        } else if (o instanceof Number || o instanceof String || o instanceof Boolean) {
-            return o;
-        }
-        // Not a JSON object (Map, List, Number, String, Boolean) -> needs to be converted to and processed
-        return processValue(objectMapper.valueToTree(o));
-    }
-
-    private Map processMap(Map<?, ?> map) {
-        Map newMap = new LinkedHashMap(map.size());
-        for (Map.Entry entry : map.entrySet()) {
-            Object key = correctKey(entry.getKey().toString());
-            Object value = processValue(entry.getValue());
-            newMap.put(key, value);
-        }
-        return newMap;
-    }
-
-    private List processList(List list) {
-        List newList = new ArrayList(list.size());
-        for (Object o : list) {
-            newList.add(processValue(o));
-        }
-        return newList;
-    }
-
-    private String correctKey(String key) {
-        return NameUtils.decapitalize(NameUtils.dehyphenate(key));
-    }
-
 }

--- a/runtime/src/main/java/io/micronaut/jackson/convert/JacksonConverterRegistrar.java
+++ b/runtime/src/main/java/io/micronaut/jackson/convert/JacksonConverterRegistrar.java
@@ -25,8 +25,6 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ContainerNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.type.TypeFactory;
-import io.micronaut.core.bind.ArgumentBinder;
-import io.micronaut.core.bind.BeanPropertyBinder;
 import io.micronaut.core.convert.*;
 import io.micronaut.core.convert.value.ConvertibleValues;
 import io.micronaut.core.naming.NameUtils;
@@ -50,21 +48,17 @@ public class JacksonConverterRegistrar implements TypeConverterRegistrar {
 
     private final Provider<ObjectMapper> objectMapper;
     private final ConversionService<?> conversionService;
-    private final Provider<BeanPropertyBinder> beanPropertyBinder;
 
     /**
      * Default constructor.
      * @param objectMapper The object mapper provider
-     * @param beanPropertyBinder The bean property binder provider
      * @param conversionService The conversion service
      */
     protected JacksonConverterRegistrar(
             Provider<ObjectMapper> objectMapper,
-            Provider<BeanPropertyBinder> beanPropertyBinder,
             ConversionService<?> conversionService) {
         this.objectMapper = objectMapper;
         this.conversionService = conversionService;
-        this.beanPropertyBinder = beanPropertyBinder;
     }
 
     @Override
@@ -93,11 +87,6 @@ public class JacksonConverterRegistrar implements TypeConverterRegistrar {
                 Object.class,
                 JsonNode.class,
                 objectToJsonNodeConverter()
-        );
-        conversionService.addConverter(
-                Map.class,
-                Object.class,
-                mapToObjectConverter()
         );
         conversionService.addConverter(
                 CharSequence.class,
@@ -138,23 +127,6 @@ public class JacksonConverterRegistrar implements TypeConverterRegistrar {
                     return Optional.ofNullable(propertyNamingStrategy);
                 }
         );
-    }
-
-    /**
-     * @return The map to object converter
-     */
-    protected TypeConverter<Map, Object> mapToObjectConverter() {
-        return (map, targetType, context) -> {
-            ArgumentConversionContext<Object> conversionContext;
-            if (context instanceof ArgumentConversionContext) {
-                conversionContext = (ArgumentConversionContext<Object>) context;
-            } else {
-                conversionContext = ConversionContext.of(targetType);
-            }
-            ArgumentBinder binder = this.beanPropertyBinder.get();
-            ArgumentBinder.BindingResult result = binder.bind(conversionContext, map);
-            return result.getValue();
-        };
     }
 
     /**

--- a/runtime/src/main/java/io/micronaut/jackson/convert/JacksonConverterRegistrar.java
+++ b/runtime/src/main/java/io/micronaut/jackson/convert/JacksonConverterRegistrar.java
@@ -152,36 +152,9 @@ public class JacksonConverterRegistrar implements TypeConverterRegistrar {
                 conversionContext = ConversionContext.of(targetType);
             }
             ArgumentBinder binder = this.beanPropertyBinder.get();
-            ArgumentBinder.BindingResult result = binder.bind(conversionContext, correctKeys(map));
+            ArgumentBinder.BindingResult result = binder.bind(conversionContext, map);
             return result.getValue();
         };
-    }
-
-    private Map correctKeys(Map<?, ?> map) {
-        Map mapWithExtraProps = new LinkedHashMap(map.size());
-        for (Map.Entry entry : map.entrySet()) {
-            Object key = entry.getKey();
-            Object value = correctKeys(entry.getValue());
-            mapWithExtraProps.put(NameUtils.decapitalize(NameUtils.dehyphenate(key.toString())), value);
-        }
-        return mapWithExtraProps;
-    }
-
-    private List correctKeys(List list) {
-        List newList = new ArrayList(list.size());
-        for (Object o : list) {
-            newList.add(correctKeys(o));
-        }
-        return newList;
-    }
-
-    private Object correctKeys(Object o) {
-        if (o instanceof List) {
-            return correctKeys((List) o);
-        } else if (o instanceof Map) {
-            return correctKeys((Map) o);
-        }
-        return o;
     }
 
     /**

--- a/runtime/src/main/java/io/micronaut/runtime/bind/AbstractBeanPropertyBinder.java
+++ b/runtime/src/main/java/io/micronaut/runtime/bind/AbstractBeanPropertyBinder.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.runtime.bind;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.bind.BeanPropertyBinder;
+import io.micronaut.core.naming.NameUtils;
+import io.micronaut.core.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Internal implementation of {@link BeanPropertyBinder} for mapping properties to Map object.
+ *
+ * @author Denis Stepanov
+ * @since 2.1.0
+ */
+@Internal
+public abstract class AbstractBeanPropertyBinder implements BeanPropertyBinder {
+
+    /**
+     * The array size threshold.
+     *
+     * @return the value
+     */
+    protected abstract int getArraySizeThreshold();
+
+    /**
+     * Convert unknown value to something that we recognize.
+     *
+     * @param o unknown value
+     * @return converted value
+     */
+    protected abstract Object convertUnknownValue(Object o);
+
+    /**
+     * Group properties in Map/List.
+     *
+     * @param source the properties
+     * @return new map object
+     */
+    protected Map<String, Object> buildMapObject(Set<? extends Map.Entry<? extends CharSequence, Object>> source) {
+        Map<String, Object> rootNode = new LinkedHashMap<>();
+        for (Map.Entry<? extends CharSequence, ? super Object> entry : source) {
+            Object value = entry.getValue();
+            String property = correctKey(entry.getKey().toString());
+            String[] tokens = property.split("\\.");
+            Object current = rootNode;
+            String index = null;
+            for (int i = 0; i < tokens.length; i++) {
+                String token = tokens[i];
+                int j = token.indexOf('[');
+                if (j > -1 && token.endsWith("]")) {
+                    index = token.substring(j + 1, token.length() - 1);
+                    token = token.substring(0, j);
+                }
+                if (i == tokens.length - 1) {
+                    if (current instanceof Map) {
+                        Map mapNode = (Map) current;
+                        if (index != null) {
+                            if (StringUtils.isDigits(index)) {
+                                int arrayIndex = Integer.parseInt(index);
+                                List arrayNode = getOrCreateListNodeAtKey(mapNode, token);
+                                arrayNode.add(arrayIndex, processValue(value));
+                            } else {
+                                Map map = getOrCreateMapNodeAtKey(mapNode, token);
+                                map.put(index, processValue(value));
+                            }
+                            index = null;
+                        } else {
+                            mapNode.put(token, processValue(value));
+                        }
+                    } else if (current instanceof List && index != null) {
+                        List arrayNode = (List) current;
+                        int arrayIndex = Integer.parseInt(index);
+                        Map mapNode = getOrCreateMapNodeAtIndex(arrayNode, arrayIndex);
+                        mapNode.put(token, processValue(value));
+                        index = null;
+                    }
+                } else {
+                    if (current instanceof Map) {
+                        Map objectNode = (Map) current;
+                        if (index != null) {
+                            if (StringUtils.isDigits(index)) {
+                                int arrayIndex = Integer.parseInt(index);
+                                List arrayNode = getOrCreateListNodeAtKey(objectNode, token);
+                                current = getOrCreateMapNodeAtIndex(arrayNode, arrayIndex);
+                            } else {
+                                Map mapNode = getOrCreateMapNodeAtKey(objectNode, token);
+                                current = getOrCreateMapNodeAtKey(mapNode, index);
+                            }
+                            index = null;
+                        } else {
+                            current = getOrCreateMapNodeAtKey(objectNode, token);
+                        }
+                    } else if (current instanceof List && StringUtils.isDigits(index)) {
+                        int arrayIndex = Integer.parseInt(index);
+                        Map jsonNode = getOrCreateMapNodeAtIndex((List) current, arrayIndex);
+
+                        current = new LinkedHashMap<>();
+                        jsonNode.put(token, current);
+                        index = null;
+                    }
+                }
+            }
+        }
+        return rootNode;
+    }
+
+    private Map getOrCreateMapNodeAtIndex(List arrayNode, int arrayIndex) {
+        if (arrayIndex >= arrayNode.size()) {
+            arrayNode = expandArrayToThreshold(arrayIndex, arrayNode);
+        }
+        Object jsonNode = arrayNode.get(arrayIndex);
+        if (!(jsonNode instanceof Map)) {
+            jsonNode = new LinkedHashMap<>();
+            arrayNode.set(arrayIndex, jsonNode);
+        }
+        return (Map) jsonNode;
+    }
+
+    private Map getOrCreateMapNodeAtKey(Map objectNode, Object key) {
+        Object jsonNode = objectNode.get(key);
+        if (!(jsonNode instanceof Map)) {
+            jsonNode = new LinkedHashMap<>();
+            objectNode.put(key, jsonNode);
+        }
+        return (Map) jsonNode;
+    }
+
+    private List getOrCreateListNodeAtKey(Map objectNode, Object key) {
+        Object jsonNode = objectNode.get(key);
+        if (!(jsonNode instanceof List)) {
+            jsonNode = new ArrayList<>();
+            objectNode.put(key, jsonNode);
+        }
+        return (List) jsonNode;
+    }
+
+    private List expandArrayToThreshold(int arrayIndex, List arrayNode) {
+        if (arrayIndex < getArraySizeThreshold()) {
+            ArrayList arrayListNode;
+            if (arrayNode instanceof ArrayList) {
+                arrayListNode = (ArrayList) arrayNode;
+            } else {
+                arrayListNode = new ArrayList(arrayNode);
+            }
+            while (arrayNode.size() != arrayIndex + 1) {
+                arrayNode.add(arrayIndex, null);
+            }
+            return arrayListNode;
+        }
+        return arrayNode;
+    }
+
+    private Object processValue(Object o) {
+        if (o instanceof List) {
+            return processList((List) o);
+        } else if (o instanceof Map) {
+            return processMap((Map) o);
+        } else if (o instanceof Number || o instanceof String || o instanceof Boolean) {
+            return o;
+        }
+        // Not one of (Map, List, Number, String, Boolean) -> needs to be converted to and processed
+        return processValue(convertUnknownValue(o));
+    }
+
+    private Map processMap(Map<?, ?> map) {
+        Map newMap = new LinkedHashMap(map.size());
+        for (Map.Entry entry : map.entrySet()) {
+            Object key = correctKey(entry.getKey().toString());
+            Object value = processValue(entry.getValue());
+            newMap.put(key, value);
+        }
+        return newMap;
+    }
+
+    private List processList(List list) {
+        List newList = new ArrayList(list.size());
+        for (Object o : list) {
+            newList.add(processValue(o));
+        }
+        return newList;
+    }
+
+    private String correctKey(String key) {
+        return NameUtils.decapitalize(NameUtils.dehyphenate(key));
+    }
+
+}

--- a/runtime/src/main/java/io/micronaut/runtime/bind/BeanPropertyBinderRegistrar.java
+++ b/runtime/src/main/java/io/micronaut/runtime/bind/BeanPropertyBinderRegistrar.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.runtime.bind;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.bind.ArgumentBinder;
+import io.micronaut.core.bind.BeanPropertyBinder;
+import io.micronaut.core.convert.ArgumentConversionContext;
+import io.micronaut.core.convert.ConversionContext;
+import io.micronaut.core.convert.ConversionError;
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.convert.TypeConverterRegistrar;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Singleton;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * {@link BeanPropertyBinder} type convert registrar.
+ *
+ * @author Denis Stepanov
+ * @since 2.1.0
+ */
+@Singleton
+@Requires(beans = BeanPropertyBinder.class)
+public class BeanPropertyBinderRegistrar implements TypeConverterRegistrar {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BeanPropertyBinderRegistrar.class);
+
+    private final BeanPropertyBinder beanPropertyBinder;
+
+    public BeanPropertyBinderRegistrar(BeanPropertyBinder beanPropertyBinder) {
+        this.beanPropertyBinder = beanPropertyBinder;
+    }
+
+    @Override
+    public void register(ConversionService<?> conversionService) {
+        conversionService.addConverter(Map.class, Object.class, (map, targetType, context) -> {
+            ArgumentConversionContext<Object> conversionContext;
+            if (context instanceof ArgumentConversionContext) {
+                conversionContext = (ArgumentConversionContext<Object>) context;
+            } else {
+                conversionContext = ConversionContext.of(targetType);
+            }
+            ArgumentBinder binder = beanPropertyBinder;
+            ArgumentBinder.BindingResult<Object> result = binder.bind(conversionContext, map);
+            for (ConversionError conversionError : result.getConversionErrors()) {
+                Exception cause = conversionError.getCause();
+                LOG.error("Bean property bind to '{}' error '{}'", targetType, cause.getMessage());
+            }
+            return result.getValue();
+        });
+        conversionService.addConverter(Map.class, List.class, (map, targetType, context) -> Optional.of(Collections.singletonList(map)));
+    }
+}

--- a/runtime/src/main/java/io/micronaut/runtime/bind/IntrospectionBeanPropertyBinder.java
+++ b/runtime/src/main/java/io/micronaut/runtime/bind/IntrospectionBeanPropertyBinder.java
@@ -1,0 +1,365 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.runtime.bind;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.annotation.Value;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.beans.BeanIntrospection;
+import io.micronaut.core.beans.BeanProperty;
+import io.micronaut.core.bind.BeanPropertyBinder;
+import io.micronaut.core.convert.ArgumentConversionContext;
+import io.micronaut.core.convert.ConversionContext;
+import io.micronaut.core.convert.ConversionError;
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.convert.exceptions.ConversionErrorException;
+import io.micronaut.core.naming.NameUtils;
+import io.micronaut.core.type.Argument;
+import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.core.util.StringUtils;
+
+import javax.inject.Singleton;
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Implementation of {@link BeanPropertyBinder} using Micronaut's {@link BeanIntrospection}.
+ *
+ * @author Denis Stepanov
+ * @since 2.1.0
+ */
+@Singleton
+@Requires(missingBeans = BeanPropertyBinder.class)
+public class IntrospectionBeanPropertyBinder implements BeanPropertyBinder {
+
+    @Value("${micronaut.bean-property-binder.array-size-threshold:100}")
+    private int arraySizeThreshold;
+
+    @Override
+    public <T2> T2 bind(Class<T2> type, Set<? extends Map.Entry<? extends CharSequence, Object>> source) throws ConversionErrorException {
+        Argument<T2> argument = Argument.of(type);
+        try {
+            ConversionContext conversionContext = ConversionContext.of(argument);
+            Map<String, Object> properties = buildSourceMapNode(source);
+            BeanIntrospection<T2> introspection = BeanIntrospection.getIntrospection(type);
+            T2 instance = instantiate(introspection, properties, conversionContext);
+            if (instance != null) {
+                setProperties(introspection, properties, instance, conversionContext);
+            }
+            Optional<ConversionError> lastError = conversionContext.getLastError();
+            if (lastError.isPresent()) {
+                throw new ConversionErrorException(argument, lastError.get());
+            }
+            return instance;
+        } catch (Exception e) {
+            throw newConversionError(null, e);
+        }
+    }
+
+    @Override
+    public <T2> T2 bind(T2 instance, ArgumentConversionContext<T2> context, Set<? extends Map.Entry<? extends CharSequence, Object>> source) {
+        try {
+            Map<String, Object> properties = buildSourceMapNode(source);
+            BeanIntrospection<T2> introspection = (BeanIntrospection<T2>) BeanIntrospection.getIntrospection(instance.getClass());
+            setProperties(introspection, properties, instance, context);
+            return instance;
+        } catch (Exception e) {
+            context.reject(e);
+        }
+        return instance;
+    }
+
+    @Override
+    public <T2> T2 bind(T2 instance, Set<? extends Map.Entry<? extends CharSequence, Object>> source) throws ConversionErrorException {
+        try {
+            ConversionContext conversionContext = ConversionContext.DEFAULT;
+            Map<String, Object> properties = buildSourceMapNode(source);
+            BeanIntrospection<T2> introspection = (BeanIntrospection<T2>) BeanIntrospection.getIntrospection(instance.getClass());
+            setProperties(introspection, properties, instance, conversionContext);
+            Optional<ConversionError> lastError = conversionContext.getLastError();
+            if (lastError.isPresent()) {
+                throw new ConversionErrorException(Argument.of(instance.getClass()), lastError.get());
+            }
+            return instance;
+        } catch (Exception e) {
+            throw newConversionError(instance, e);
+        }
+    }
+
+    @Override
+    public BindingResult<Object> bind(ArgumentConversionContext<Object> context, Map<CharSequence, ? super Object> source) {
+        try {
+            Map<String, Object> properties = buildSourceMapNode(source.entrySet());
+            BeanIntrospection<Object> introspection = BeanIntrospection.getIntrospection(context.getArgument().getType());
+            Object instance = instantiate(introspection, properties, context);
+            if (instance != null) {
+                setProperties(introspection, properties, instance, context);
+            }
+            if (context.hasErrors()) {
+                return bindingResultWithErrors(context);
+            }
+            return () -> Optional.of(instance);
+        } catch (Exception e) {
+            context.reject(e);
+            return bindingResultWithErrors(context);
+        }
+    }
+
+    private BindingResult<Object> bindingResultWithErrors(ArgumentConversionContext<Object> context) {
+        return new BindingResult<Object>() {
+            @Override
+            public List<ConversionError> getConversionErrors() {
+                return CollectionUtils.iterableToList(context);
+            }
+
+            @Override
+            public boolean isSatisfied() {
+                return false;
+            }
+
+            @Override
+            public Optional<Object> getValue() {
+                return Optional.empty();
+            }
+        };
+    }
+
+    private <T2> void setProperties(BeanIntrospection<T2> introspection, Map<String, Object> properties, T2 instance, ConversionContext context) {
+        for (BeanProperty<T2, Object> beanProperty : introspection.getBeanProperties()) {
+            Object value = properties.get(beanProperty.getName());
+            if (value != null) {
+                convertAndSet(instance, beanProperty, value, context);
+            }
+        }
+    }
+
+    private <I> I instantiate(BeanIntrospection<I> introspection, Map<String, Object> propertiesMap, ConversionContext context) {
+        Argument<?>[] constructorArguments = introspection.getConstructorArguments();
+        if (constructorArguments.length > 0) {
+            List<Object> arguments = new ArrayList<>(constructorArguments.length);
+            boolean rejected = false;
+            for (Argument<?> argument : constructorArguments) {
+                Object propertyValue = getPropertyValue(propertiesMap, argument);
+                if (propertyValue != null) {
+                    Object converted = ConversionService.SHARED.convert(propertyValue, argument.getType(), ConversionContext.of(argument)).orElseThrow(() ->
+                            new ConversionErrorException(argument, context.getLastError()
+                                    .orElse(() -> new IllegalArgumentException("Value [" + propertyValue + "] cannot be converted to type : " + argument.getType())))
+                    );
+                    arguments.add(converted);
+                } else if (argument.isDeclaredNullable()) {
+                    arguments.add(null);
+                } else {
+                    context.reject(new ConversionErrorException(argument, () -> new IllegalArgumentException("No Value found for argument " + argument.getName())));
+                    rejected = true;
+                }
+            }
+            if (rejected) {
+                return null;
+            }
+            return introspection.instantiate(false, arguments.toArray());
+        }
+        return introspection.instantiate();
+    }
+
+    private Object getPropertyValue(Map<String, Object> propertiesMap, Argument<?> argument) {
+        AnnotationValue<Annotation> jsonProperty = argument.getAnnotation("com.fasterxml.jackson.annotation.JsonProperty");
+        if (jsonProperty != null) {
+            String name = jsonProperty.stringValue().orElseGet(argument::getName);
+            return propertiesMap.get(name);
+        }
+        return propertiesMap.get(argument.getName());
+    }
+
+    private <T> void convertAndSet(T instance, BeanProperty<T, Object> beanProperty, Object value, ConversionContext conversionContext) {
+        Argument<Object> argument = beanProperty.asArgument();
+        ArgumentConversionContext<Object> context = conversionContext.with(argument);
+        Object converted = ConversionService.SHARED.convert(value, context).orElseThrow(() ->
+                new ConversionErrorException(argument, context.getLastError()
+                        .orElse(() -> new IllegalArgumentException("Value [" + value + "] cannot be converted to type : " + argument.getType())))
+        );
+        beanProperty.set(instance, converted);
+    }
+
+    private ConversionErrorException newConversionError(Object object, Exception e) {
+        ConversionError conversionError = new ConversionError() {
+            @Override
+            public Exception getCause() {
+                return e;
+            }
+
+            @Override
+            public Optional<Object> getOriginalValue() {
+                return Optional.ofNullable(object);
+            }
+        };
+        Class type = object != null ? object.getClass() : Object.class;
+        return new ConversionErrorException(Argument.of(type), conversionError);
+    }
+
+    private Map<String, Object> buildSourceMapNode(Set<? extends Map.Entry<? extends CharSequence, Object>> source) {
+        Map<String, Object> rootNode = new LinkedHashMap<>();
+        for (Map.Entry<? extends CharSequence, ? super Object> entry : source) {
+            Object value = entry.getValue();
+            String property = correctKey(entry.getKey().toString());
+            String[] tokens = property.split("\\.");
+            Object current = rootNode;
+            String index = null;
+            for (int i = 0; i < tokens.length; i++) {
+                String token = tokens[i];
+                int j = token.indexOf('[');
+                if (j > -1 && token.endsWith("]")) {
+                    index = token.substring(j + 1, token.length() - 1);
+                    token = token.substring(0, j);
+                }
+                if (i == tokens.length - 1) {
+                    if (current instanceof Map) {
+                        Map mapNode = (Map) current;
+                        if (index != null) {
+                            if (StringUtils.isDigits(index)) {
+                                int arrayIndex = Integer.parseInt(index);
+                                List arrayNode = getOrCreateListNodeAtKey(mapNode, token);
+                                arrayNode.add(arrayIndex, processValue(value));
+                            } else {
+                                Map map = getOrCreateMapNodeAtKey(mapNode, token);
+                                map.put(index, processValue(value));
+                            }
+                            index = null;
+                        } else {
+                            mapNode.put(token, processValue(value));
+                        }
+                    } else if (current instanceof List && index != null) {
+                        List arrayNode = (List) current;
+                        int arrayIndex = Integer.parseInt(index);
+                        Map mapNode = getOrCreateMapNodeAtIndex(arrayNode, arrayIndex);
+                        mapNode.put(token, processValue(value));
+                        index = null;
+                    }
+                } else {
+                    if (current instanceof Map) {
+                        Map objectNode = (Map) current;
+                        if (index != null) {
+                            if (StringUtils.isDigits(index)) {
+                                int arrayIndex = Integer.parseInt(index);
+                                List arrayNode = getOrCreateListNodeAtKey(objectNode, token);
+                                current = getOrCreateMapNodeAtIndex(arrayNode, arrayIndex);
+                            } else {
+                                Map mapNode = getOrCreateMapNodeAtKey(objectNode, token);
+                                current = getOrCreateMapNodeAtKey(mapNode, index);
+                            }
+                            index = null;
+                        } else {
+                            current = getOrCreateMapNodeAtKey(objectNode, token);
+                        }
+                    } else if (current instanceof List && StringUtils.isDigits(index)) {
+                        int arrayIndex = Integer.parseInt(index);
+                        Map jsonNode = getOrCreateMapNodeAtIndex((List) current, arrayIndex);
+
+                        current = new LinkedHashMap<>();
+                        jsonNode.put(token, current);
+                        index = null;
+                    }
+                }
+            }
+        }
+        return rootNode;
+    }
+
+    private Map getOrCreateMapNodeAtIndex(List arrayNode, int arrayIndex) {
+        if (arrayIndex >= arrayNode.size()) {
+            arrayNode = expandArrayToThreshold(arrayIndex, arrayNode);
+        }
+        Object jsonNode = arrayNode.get(arrayIndex);
+        if (!(jsonNode instanceof Map)) {
+            jsonNode = new LinkedHashMap<>();
+            arrayNode.set(arrayIndex, jsonNode);
+        }
+        return (Map) jsonNode;
+    }
+
+    private Map getOrCreateMapNodeAtKey(Map objectNode, Object key) {
+        Object jsonNode = objectNode.get(key);
+        if (!(jsonNode instanceof Map)) {
+            jsonNode = new LinkedHashMap<>();
+            objectNode.put(key, jsonNode);
+        }
+        return (Map) jsonNode;
+    }
+
+    private List getOrCreateListNodeAtKey(Map objectNode, Object key) {
+        Object jsonNode = objectNode.get(key);
+        if (!(jsonNode instanceof List)) {
+            jsonNode = new ArrayList<>();
+            objectNode.put(key, jsonNode);
+        }
+        return (List) jsonNode;
+    }
+
+    private List expandArrayToThreshold(int arrayIndex, List arrayNode) {
+        if (arrayIndex < arraySizeThreshold) {
+            ArrayList arrayListNode;
+            if (arrayNode instanceof ArrayList) {
+                arrayListNode = (ArrayList) arrayNode;
+            } else {
+                arrayListNode = new ArrayList(arrayNode);
+            }
+            while (arrayNode.size() != arrayIndex + 1) {
+                arrayNode.add(arrayIndex, null);
+            }
+            return arrayListNode;
+        }
+        return arrayNode;
+    }
+
+    private Object processValue(Object o) {
+        if (o instanceof List) {
+            return processList((List) o);
+        } else if (o instanceof Map) {
+            return processMap((Map) o);
+        } else if (o instanceof Number || o instanceof String || o instanceof Boolean) {
+            return o;
+        }
+        // Not one of (Map, List, Number, String, Boolean) -> needs to be converted to and processed
+        return ConversionService.SHARED.convert(o, Map.class);
+    }
+
+    private Map processMap(Map<?, ?> map) {
+        Map newMap = new LinkedHashMap(map.size());
+        for (Map.Entry entry : map.entrySet()) {
+            Object key = correctKey(entry.getKey().toString());
+            Object value = processValue(entry.getValue());
+            newMap.put(key, value);
+        }
+        return newMap;
+    }
+
+    private List processList(List list) {
+        List newList = new ArrayList(list.size());
+        for (Object o : list) {
+            newList.add(processValue(o));
+        }
+        return newList;
+    }
+
+    private String correctKey(String key) {
+        return NameUtils.decapitalize(NameUtils.dehyphenate(key));
+    }
+
+}

--- a/runtime/src/test/groovy/io/micronaut/bind/InstrospectionBeanPropertyBinderSpec.groovy
+++ b/runtime/src/test/groovy/io/micronaut/bind/InstrospectionBeanPropertyBinderSpec.groovy
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.jackson.bind
+package io.micronaut.bind
 
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
@@ -22,6 +22,7 @@ import groovy.transform.ToString
 import io.micronaut.context.ApplicationContext
 import io.micronaut.core.annotation.Introspected
 import io.micronaut.core.convert.ConversionService
+import io.micronaut.runtime.bind.IntrospectionBeanPropertyBinder
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Specification
@@ -31,17 +32,14 @@ import spock.lang.Unroll
  * @author Graeme Rocher
  * @since 1.0
  */
-class JacksonBeanPropertyBinderSpec extends Specification {
+class InstrospectionBeanPropertyBinderSpec extends Specification {
 
-    @Shared @AutoCleanup ApplicationContext context = ApplicationContext.builder()
-            .properties(['jackson.bean-property-binder.enabled': true])
-            .build()
-            .start()
+    @Shared @AutoCleanup ApplicationContext context = ApplicationContext.run()
 
     @Unroll
     void "test bind map properties to object"() {
         given:
-        JacksonBeanPropertyBinder binder = context.getBean(JacksonBeanPropertyBinder)
+            IntrospectionBeanPropertyBinder binder = context.getBean(IntrospectionBeanPropertyBinder.class)
         def result = binder.bind(type.newInstance(), map)
 
         expect:
@@ -73,6 +71,7 @@ class JacksonBeanPropertyBinderSpec extends Specification {
         optional.get().firstName == 'Todd'
     }
 
+    @Introspected
     @EqualsAndHashCode
     @ToString
     static class Book {
@@ -83,6 +82,7 @@ class JacksonBeanPropertyBinderSpec extends Specification {
         Map<String, Author> authorsByInitials = [:]
     }
 
+    @Introspected
     @EqualsAndHashCode
     @ToString
     static class Author {
@@ -92,12 +92,12 @@ class JacksonBeanPropertyBinderSpec extends Specification {
         Publisher publisher
     }
 
+    @Introspected
     @EqualsAndHashCode
     @ToString
     static class Publisher {
         String name
     }
-
 
     @Introspected
     static class ImmutablePerson {

--- a/runtime/src/test/groovy/io/micronaut/bind/InstrospectionBeanPropertyBinderSpec.groovy
+++ b/runtime/src/test/groovy/io/micronaut/bind/InstrospectionBeanPropertyBinderSpec.groovy
@@ -34,7 +34,10 @@ import spock.lang.Unroll
  */
 class InstrospectionBeanPropertyBinderSpec extends Specification {
 
-    @Shared @AutoCleanup ApplicationContext context = ApplicationContext.run()
+    @Shared @AutoCleanup ApplicationContext context = ApplicationContext.builder()
+            .properties(['jackson.bean-property-binder.enabled': false])
+            .build()
+            .start()
 
     @Unroll
     void "test bind map properties to object"() {


### PR DESCRIPTION
I had another look at properties binding, PR based on https://github.com/micronaut-projects/micronaut-core/pull/3859
Moved all the keys processing to `JacksonBeanPropertyBinder` with some refactoring.

Probably not for a minor release.