### PR TITLE
Revert "Enable GraalMV `--install-exit-handlers`. Fixes #3880 (#3881)"

### DIFF
--- a/runtime/src/main/resources/META-INF/native-image/io.micronaut/runtime-graal/native-image.properties
+++ b/runtime/src/main/resources/META-INF/native-image/io.micronaut/runtime-graal/native-image.properties
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 
-Args = --install-exit-handlers \
-       --initialize-at-run-time=io.micronaut.reactive.reactor.ReactorInstrumentation \
+Args = --initialize-at-run-time=io.micronaut.reactive.reactor.ReactorInstrumentation \
        --initialize-at-build-time=ch.qos.logback,com.fasterxml.jackson,io.micronaut,io.reactivex,org.reactivestreams,org.slf4j,org.yaml.snakeyaml,javax \
        --initialize-at-build-time=com.sun.org.apache.xerces.internal.util,com.sun.org.apache.xerces.internal.impl,jdk.xml.internal,com.sun.xml.internal.stream.util,com.sun.org.apache.xerces.internal.xni,com.sun.org.apache.xerces.internal.utils


### PR DESCRIPTION
Enabling flag GraalvM `--install-exit-handlers` flag breaks AWS Lambda native-image support. Reverting the change.

See https://github.com/oracle/graal/issues/2742