### PR TITLE
collect most specific type

### DIFF
--- a/inject-java-test/src/main/groovy/io/micronaut/annotation/processing/test/AbstractTypeElementSpec.groovy
+++ b/inject-java-test/src/main/groovy/io/micronaut/annotation/processing/test/AbstractTypeElementSpec.groovy
@@ -15,6 +15,7 @@
  */
 package io.micronaut.annotation.processing.test
 
+import com.google.testing.compile.JavaFileObjects
 import com.sun.tools.javac.model.JavacElements
 import com.sun.tools.javac.processing.JavacProcessingEnvironment
 import com.sun.tools.javac.util.Context
@@ -108,12 +109,12 @@ abstract class AbstractTypeElementSpec extends Specification {
     *
     * @return the introspection if it is correct
     **/
-    protected BeanIntrospection buildBeanIntrospection(String className, String cls) {
+    protected BeanIntrospection buildBeanIntrospection(String className, String cls, Tuple2<String, String> ... otherClasses) {
         def beanDefName= '$' + NameUtils.getSimpleName(className) + '$Introspection'
         def packageName = NameUtils.getPackageName(className)
         String beanFullName = "${packageName}.${beanDefName}"
 
-        ClassLoader classLoader = buildClassLoader(className, cls)
+        ClassLoader classLoader = buildClassLoader(className, cls, otherClasses)
         return (BeanIntrospection)classLoader.loadClass(beanFullName).newInstance()
     }
 
@@ -257,8 +258,11 @@ class Test {
         return (BeanConfiguration)classLoader.loadClass(packageName + '.' + BeanConfigurationWriter.CLASS_SUFFIX).newInstance()
     }
 
-    protected ClassLoader buildClassLoader(String className, String cls) {
-        def files = newJavaParser().generate(className, cls)
+    protected ClassLoader buildClassLoader(String className, String cls, Tuple2<String, String> ... otherClasses) {
+        def classes = otherClasses.collect { JavaFileObjects.forSourceString(it.v1, it.v2)}
+        classes.add(JavaFileObjects.forSourceString(className, cls))
+
+        def files = newJavaParser().generate(*classes)
         ClassLoader classLoader = new ClassLoader() {
             @Override
             protected Class<?> findClass(String name) throws ClassNotFoundException {

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
@@ -35,6 +35,34 @@ import java.lang.reflect.Field
 
 class BeanIntrospectionSpec extends AbstractTypeElementSpec {
 
+
+    void "test bean introspection with property of generic interface"() {
+        given:
+        BeanIntrospection introspection = buildBeanIntrospection('test.Foo', '''
+package test;
+
+@io.micronaut.core.annotation.Introspected
+class Foo implements GenBase<String> {
+    public String getName() {
+        return "test";
+    }
+}
+
+''', Tuple.tuple('test.GenBase', '''
+package test;
+    
+interface GenBase<T> {
+    T getName();
+}
+'''))
+        when:
+        def test = introspection.instantiate()
+
+        then:
+        introspection.getRequiredProperty("name", String)
+                .get(test) == 'test'
+    }
+
     void "test bean introspection with property with static creator method on interface"() {
         given:
         BeanIntrospection introspection = buildBeanIntrospection('test.Foo', '''

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
@@ -228,7 +228,9 @@ public class JavaClassElement extends AbstractJavaElement implements ClassElemen
 
                     BeanPropertyData beanPropertyData = props.computeIfAbsent(propertyName, BeanPropertyData::new);
                     configureDeclaringType(declaringTypeElement, beanPropertyData);
-                    beanPropertyData.type = getterReturnType;
+                    if (beanPropertyData.type == null || getterReturnType.isAssignable(beanPropertyData.type.getName())) {
+                        beanPropertyData.type = getterReturnType;
+                    }
                     beanPropertyData.getter = executableElement;
                     if (beanPropertyData.setter != null) {
                         TypeMirror typeMirror = beanPropertyData.setter.getParameters().get(0).asType();


### PR DESCRIPTION
This is a fix for a regression introduced by #3200 . Before this merge, abstract methods where ignored in the introspection.

Introspection now wrongfully deduces `Object` as return type for classes which implements a generic interface with a property with a generic return type.

i.e.
```java
interface BaseEntity<ID> {
  ID getId();
}

@Entity
class Person implements BaseEntity<Long> {
...
}
```