### PR TITLE
explicitly setting random port in application-test.yml

### DIFF
--- a/src/main/docs/guide/httpServer/runningSpecificPort.adoc
+++ b/src/main/docs/guide/httpServer/runningSpecificPort.adoc
@@ -18,4 +18,4 @@ micronaut:
     port: -1
 ----
 
-TIP: If an explicit port is set, that may cause tests to fail because multiple servers are starting simultaneously. To prevent that, set the port to be random in the test environment configuration.
+TIP: If an explicit port is set, that may cause tests to fail because multiple servers are starting simultaneously on the same port. To prevent that, set the port to be random in the test environment configuration.

--- a/src/main/docs/guide/httpServer/runningSpecificPort.adoc
+++ b/src/main/docs/guide/httpServer/runningSpecificPort.adoc
@@ -18,6 +18,4 @@ micronaut:
     port: -1
 ----
 
-Your build tool (e.g. gradle) might pick up the micronaut.server.port from application.yml also _for your tests_ (via classpath scanning).
-
-In that case you'd need to specify that tests should explicitly use a random port (like above) in your src/**test**/resources/application-test.yml
+TIP: If an explicit port is set, that may cause tests to fail because multiple servers are starting simultaneously. To prevent that, set the port to be random in the test environment configuration.

--- a/src/main/docs/guide/httpServer/runningSpecificPort.adoc
+++ b/src/main/docs/guide/httpServer/runningSpecificPort.adoc
@@ -17,3 +17,7 @@ micronaut:
   server:
     port: -1
 ----
+
+Your build tool (e.g. gradle) might pick up the micronaut.server.port from application.yml also _for your tests_ (via classpath scanning).
+
+In that case you'd need to specify that tests should explicitly use a random port (like above) in your src/**test**/resources/application-test.yml


### PR DESCRIPTION
if you have a micronaut.server.port in src/**main**/resources/application.yml and use a classpath scanning build tool like gradle, only the first test (starting up the embedded server) will succeed, all consecutive tests will fail with `Unable to start Micronaut server on port: xxxx` and `Address already in use`