### PR TITLE
Add API to make it easier to write method interceptors and support Kotlin suspend functions

### DIFF
--- a/aop/build.gradle
+++ b/aop/build.gradle
@@ -1,7 +1,16 @@
+plugins {
+    id "org.jetbrains.kotlin.jvm" version "1.3.72"
+}
+
 ext {
     shadowJarEnabled = true
 }
 dependencies {
     api project(':inject')
     api project(':core')
+    compileOnly "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.8"
+}
+
+compileKotlin {
+    kotlinOptions.jvmTarget = "1.8"
 }

--- a/aop/src/main/java/io/micronaut/aop/InterceptedMethod.java
+++ b/aop/src/main/java/io/micronaut/aop/InterceptedMethod.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop;
+
+import io.micronaut.aop.internal.intercepted.InterceptedMethodUtil;
+import io.micronaut.context.exceptions.ConfigurationException;
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.type.Argument;
+import org.reactivestreams.Publisher;
+
+import java.util.concurrent.CompletionStage;
+
+/**
+ * The intercept method supporting intercepting different reactive invocations.
+ *
+ * @author Denis Stepanov
+ * @since 2.1.0
+ */
+@Experimental
+public interface InterceptedMethod {
+
+    /**
+     * Creates a new instance of intercept method supporting intercepting different reactive invocations.
+     *
+     * @param context The {@link MethodInvocationContext}
+     * @return The {@link InterceptedMethod}
+     */
+    static InterceptedMethod of(MethodInvocationContext<?, ?> context) {
+        return InterceptedMethodUtil.of(context);
+    }
+
+    /**
+     * Returns result type of the method.
+     *
+     * @return The {@link ResultType}
+     */
+    ResultType resultType();
+
+    /**
+     * Returns result type value.
+     *
+     * @return The return type value.
+     */
+    Argument<?> returnTypeValue();
+
+    /**
+     * Proceeds with invocation of {@link InvocationContext#proceed()} and converts result to appropriate type.
+     *
+     * @return The intercepted result
+     */
+    Object interceptResult();
+
+
+    /**
+     * Proceeds with invocation of {@link InvocationContext#proceed(Interceptor)} and converts result to appropriate type.
+     *
+     * @param from The interceptor to start from
+     * @return The intercepted result
+     */
+    Object interceptResult(Interceptor<?, ?> from);
+
+    /**
+     * Proceeds with invocation of {@link InvocationContext#proceed()} and converts result to {@link CompletionStage}.
+     *
+     * @return The intercepted result
+     */
+    default CompletionStage<?> interceptResultAsCompletionStage() {
+        if (resultType() != ResultType.COMPLETION_STAGE) {
+            throw new ConfigurationException("Cannot return `CompletionStage` result from '" + resultType() + "' interceptor");
+        }
+        return (CompletionStage<?>) interceptResult();
+    }
+
+    /**
+     * Proceeds with invocation of {@link InvocationContext#proceed()} and converts result to {@link Publisher}.
+     *
+     * @return The intercepted result
+     */
+    default Publisher<?> interceptResultAsPublisher() {
+        if (resultType() != ResultType.PUBLISHER) {
+            throw new ConfigurationException("Cannot return `Publisher` result from '" + resultType() + "' interceptor");
+        }
+        return (Publisher<?>) interceptResult();
+    }
+
+    /**
+     * Proceeds with invocation of {@link InvocationContext#proceed(Interceptor)} and converts result to {@link CompletionStage}.
+     *
+     * @param from The interceptor to start from
+     * @return The intercepted result
+     */
+    default CompletionStage<?> interceptResultAsCompletionStage(Interceptor<?, ?> from) {
+        if (resultType() != ResultType.COMPLETION_STAGE) {
+            throw new ConfigurationException("Cannot return `CompletionStage` result from '" + resultType() + "' interceptor");
+        }
+        return (CompletionStage<?>) interceptResult(from);
+    }
+
+    /**
+     * Proceeds with invocation of {@link InvocationContext#proceed(Interceptor)} and converts result to {@link Publisher}.
+     *
+     * @param from The interceptor to start from
+     * @return The intercepted result
+     */
+    default Publisher<?> interceptResultAsPublisher(Interceptor<?, ?> from) {
+        if (resultType() != ResultType.PUBLISHER) {
+            throw new ConfigurationException("Cannot return `Publisher` result from '" + resultType() + "' interceptor");
+        }
+        return (Publisher<?>) interceptResult(from);
+    }
+
+
+    /**
+     * Handle the value that should be the result of the invocation.
+     *
+     * @param result The result of the invocation
+     * @return The result of the invocation being returned from the interceptor
+     */
+    Object handleResult(Object result);
+
+    /**
+     * Handle the exception that should be thrown out of the invocation.
+     *
+     * @param exception The exception
+     * @param <E> Sneaky throws helper
+     * @return The result of the invocation being returned from the interceptor
+     * @throws E The exception
+     */
+    <E extends Throwable> Object handleException(Exception exception) throws E;
+
+    /**
+     * Indicated unsupported return type.
+     *
+     * @return The result of the invocation being returned from the interceptor
+     */
+    default Object unsupported() {
+        throw new ConfigurationException("Cannot intercept method invocation, missing '" + resultType() + "' interceptor configured");
+    }
+
+    /**
+     * Possible result types.
+     */
+    enum ResultType {
+        COMPLETION_STAGE, PUBLISHER, SYNCHRONOUS
+    }
+
+}

--- a/aop/src/main/java/io/micronaut/aop/internal/intercepted/CompletionStageInterceptedMethod.java
+++ b/aop/src/main/java/io/micronaut/aop/internal/intercepted/CompletionStageInterceptedMethod.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.internal.intercepted;
+
+import io.micronaut.aop.InterceptedMethod;
+import io.micronaut.aop.Interceptor;
+import io.micronaut.aop.MethodInvocationContext;
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.type.Argument;
+import io.micronaut.core.type.ReturnType;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Future;
+
+/**
+ * The {@link CompletionStage} method intercept.
+ *
+ * @author Denis Stepanov
+ * @since 2.1.0
+ */
+@Internal
+@Experimental
+class CompletionStageInterceptedMethod implements InterceptedMethod {
+    private final ConversionService<?> conversionService = ConversionService.SHARED;
+
+    private final MethodInvocationContext<?, ?> context;
+    private final Argument<?> returnTypeValue;
+
+    CompletionStageInterceptedMethod(MethodInvocationContext<?, ?> context) {
+        this.context = context;
+        this.returnTypeValue = context.getReturnType().asArgument().getFirstTypeVariable().orElse(Argument.OBJECT_ARGUMENT);
+    }
+
+    @Override
+    public ResultType resultType() {
+        return ResultType.COMPLETION_STAGE;
+    }
+
+    @Override
+    public Argument<?> returnTypeValue() {
+        return returnTypeValue;
+    }
+
+    @Override
+    public Object interceptResult() {
+        return interceptResultAsCompletionStage();
+    }
+
+    @Override
+    public Object interceptResult(Interceptor<?, ?> from) {
+        return interceptResultAsCompletionStage(from);
+    }
+
+    @Override
+    public CompletionStage<Object> interceptResultAsCompletionStage() {
+        return convertToCompletionStage(context.proceed());
+    }
+
+    @Override
+    public CompletionStage<Object> interceptResultAsCompletionStage(Interceptor<?, ?> from) {
+        return convertToCompletionStage(context.proceed(from));
+    }
+
+    @Override
+    public Object handleResult(Object result) {
+        if (result == null) {
+            result = CompletableFuture.completedFuture(null);
+        }
+        return convertCompletionStageResult(context.getReturnType(), result);
+    }
+
+    @Override
+    public <E extends Throwable> Object handleException(Exception exception) throws E {
+        CompletableFuture<Object> newFuture = new CompletableFuture<>();
+        newFuture.completeExceptionally(exception);
+        return convertCompletionStageResult(context.getReturnType(), newFuture);
+    }
+
+    private CompletionStage<Object> convertToCompletionStage(Object result) {
+        if (result instanceof CompletionStage) {
+            return (CompletionStage<Object>) result;
+        }
+        throw new IllegalStateException("Cannot convert " + result + "  to 'java.util.concurrent.CompletionStage'");
+    }
+
+    private Object convertCompletionStageResult(ReturnType<?> returnType, Object result) {
+        Class<?> returnTypeClass = returnType.getType();
+        if (returnTypeClass.isInstance(result)) {
+            return result;
+        }
+        if (result instanceof CompletionStage && (returnTypeClass == CompletableFuture.class || returnTypeClass == Future.class)) {
+            return ((CompletionStage<?>) result).toCompletableFuture();
+        }
+        return conversionService.convert(result, returnType.asArgument())
+                .orElseThrow(() -> new IllegalStateException("Cannot convert completion stage result: " + result + " to '" + returnType.getType().getName() + "'"));
+    }
+}

--- a/aop/src/main/java/io/micronaut/aop/internal/intercepted/InterceptedMethodUtil.java
+++ b/aop/src/main/java/io/micronaut/aop/internal/intercepted/InterceptedMethodUtil.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.internal.intercepted;
+
+import io.micronaut.aop.InterceptedMethod;
+import io.micronaut.aop.MethodInvocationContext;
+import io.micronaut.core.async.publisher.Publishers;
+import io.micronaut.core.type.ReturnType;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Future;
+
+/**
+ * The {@link InterceptedMethod} utils class.
+ *
+ * @author Denis Stepanov
+ * @since 2.1.0
+ */
+public class InterceptedMethodUtil {
+
+    /**
+     * Find possible {@link InterceptedMethod} implementation.
+     *
+     * @param context The {@link MethodInvocationContext}
+     * @return The {@link InterceptedMethod}
+     */
+    public static InterceptedMethod of(MethodInvocationContext<?, ?> context) {
+        ReturnType<?> returnType = context.getReturnType();
+        Class<?> returnTypeClass = returnType.getType();
+        if (returnTypeClass == void.class || returnTypeClass == String.class) {
+            // Micro Optimization
+            return new SynchronousInterceptedMethod(context);
+        } else if (CompletionStage.class.isAssignableFrom(returnTypeClass) || Future.class.isAssignableFrom(returnTypeClass)) {
+            return new CompletionStageInterceptedMethod(context);
+        } else if (Publishers.isConvertibleToPublisher(returnTypeClass)) {
+            return new PublisherInterceptedMethod(context);
+        } else {
+            KotlinInterceptedMethod kotlinInterceptedMethod = KotlinInterceptedMethod.of(context);
+            if (kotlinInterceptedMethod != null) {
+                return kotlinInterceptedMethod;
+            }
+            return new SynchronousInterceptedMethod(context);
+        }
+    }
+
+}

--- a/aop/src/main/java/io/micronaut/aop/internal/intercepted/KotlinInterceptedMethod.java
+++ b/aop/src/main/java/io/micronaut/aop/internal/intercepted/KotlinInterceptedMethod.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.internal.intercepted;
+
+import io.micronaut.aop.InterceptedMethod;
+import io.micronaut.aop.Interceptor;
+import io.micronaut.aop.MethodInvocationContext;
+import io.micronaut.aop.util.CompletableFutureContinuation;
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.type.Argument;
+import io.micronaut.core.util.KotlinUtils;
+import kotlin.coroutines.Continuation;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Consumer;
+
+/**
+ * The Kotlin coroutine method intercepted as a value of {@link CompletionStage}.
+ *
+ * @author Denis Stepanov
+ * @since 2.1.0
+ */
+@Internal
+@Experimental
+class KotlinInterceptedMethod implements InterceptedMethod {
+
+    private final MethodInvocationContext<?, ?> context;
+    private final Continuation continuation;
+    private final Consumer<Object> replaceContinuation;
+    private final Argument<?> returnTypeValue;
+    private final boolean isUnitValueType;
+
+    private KotlinInterceptedMethod(MethodInvocationContext<?, ?> context,
+                                    Continuation continuation, Consumer<Object> replaceContinuation,
+                                    Argument<?> returnTypeValue, boolean isUnitValueType) {
+        this.context = context;
+        this.continuation = continuation;
+        this.returnTypeValue = returnTypeValue;
+        this.isUnitValueType = isUnitValueType;
+        this.replaceContinuation = replaceContinuation;
+    }
+
+    /**
+     * Checks if the method invocation is a Kotlin coroutine.
+     *
+     * @param context {@link MethodInvocationContext}
+     * @return true if Kotlin coroutine
+     */
+    public static KotlinInterceptedMethod of(MethodInvocationContext<?, ?> context) {
+        if (!KotlinUtils.KOTLIN_COROUTINES_SUPPORTED || !context.getExecutableMethod().isSuspend()) {
+            return null;
+        }
+        Object[] parameterValues = context.getParameterValues();
+        if (parameterValues.length == 0) {
+            return null;
+        }
+        int lastParameterIndex = parameterValues.length - 1;
+        Object lastArgumentValue = parameterValues[lastParameterIndex];
+        if (lastArgumentValue instanceof Continuation) {
+            Continuation continuation = (Continuation) lastArgumentValue;
+            Consumer<Object> replaceContinuation = value -> parameterValues[lastParameterIndex] = value;
+            Argument<?> returnTypeValue = context.getArguments()[lastParameterIndex].getFirstTypeVariable().orElse(Argument.OBJECT_ARGUMENT);
+            boolean isUnitValueType = returnTypeValue.getType() == kotlin.Unit.class;
+            if (isUnitValueType) {
+                returnTypeValue = Argument.VOID_OBJECT;
+            }
+            return new KotlinInterceptedMethod(context, continuation, replaceContinuation, returnTypeValue, isUnitValueType);
+        }
+        return null;
+    }
+
+    @Override
+    public ResultType resultType() {
+        return ResultType.COMPLETION_STAGE;
+    }
+
+    @Override
+    public Argument<?> returnTypeValue() {
+        return returnTypeValue;
+    }
+
+    @Override
+    public CompletableFuture<Object> interceptResultAsCompletionStage() {
+        CompletableFutureContinuation completableFutureContinuation;
+        if (continuation instanceof CompletableFutureContinuation) {
+            completableFutureContinuation = (CompletableFutureContinuation) continuation;
+        } else {
+            completableFutureContinuation = new CompletableFutureContinuation(continuation);
+            replaceContinuation.accept(completableFutureContinuation);
+        }
+        Object result = context.proceed();
+        replaceContinuation.accept(continuation);
+        if (result != KotlinUtils.COROUTINE_SUSPENDED) {
+            throw new IllegalStateException("Not a Kotlin coroutine");
+        }
+        return completableFutureContinuation.getCompletableFuture();
+    }
+
+    @Override
+    public CompletableFuture<Object> interceptResultAsCompletionStage(Interceptor<?, ?> from) {
+        CompletableFutureContinuation completableFutureContinuation;
+        if (continuation instanceof CompletableFutureContinuation) {
+            completableFutureContinuation = (CompletableFutureContinuation) continuation;
+        } else {
+            completableFutureContinuation = new CompletableFutureContinuation(continuation);
+            replaceContinuation.accept(completableFutureContinuation);
+        }
+        Object result = context.proceed(from);
+        replaceContinuation.accept(continuation);
+        if (result != KotlinUtils.COROUTINE_SUSPENDED) {
+            throw new IllegalStateException("Not a Kotlin coroutine");
+        }
+        return completableFutureContinuation.getCompletableFuture();
+    }
+
+    @Override
+    public Object interceptResult() {
+        return interceptResultAsCompletionStage();
+    }
+
+    @Override
+    public Object interceptResult(Interceptor<?, ?> from) {
+        return interceptResultAsCompletionStage(from);
+    }
+
+    @Override
+    public Object handleResult(Object result) {
+        CompletionStage completionStageResult;
+        if (result instanceof CompletionStage) {
+            completionStageResult = (CompletionStage<?>) result;
+        } else {
+            throw new IllegalStateException("Cannot convert " + result + "  to 'java.util.concurrent.CompletionStage'");
+        }
+        completionStageResult.whenComplete((value, throwable) -> {
+            if (throwable == null) {
+                if (value == null) {
+                    if (isUnitValueType) {
+                        value = kotlin.Unit.INSTANCE;
+                    } else {
+                        throw new IllegalStateException("Cannot complete Kotlin coroutine with null: " + returnTypeValue.getType());
+                    }
+                }
+                CompletableFutureContinuation.Companion.completeSuccess(continuation, value);
+            } else {
+                CompletableFutureContinuation.Companion.completeExceptionally(continuation, (Throwable) throwable);
+            }
+        });
+        return KotlinUtils.COROUTINE_SUSPENDED;
+    }
+
+    @Override
+    public <E extends Throwable> Object handleException(Exception exception) throws E {
+        CompletableFutureContinuation.Companion.completeExceptionally(continuation, exception);
+        return KotlinUtils.COROUTINE_SUSPENDED;
+    }
+
+}

--- a/aop/src/main/java/io/micronaut/aop/internal/intercepted/PublisherInterceptedMethod.java
+++ b/aop/src/main/java/io/micronaut/aop/internal/intercepted/PublisherInterceptedMethod.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.internal.intercepted;
+
+import io.micronaut.aop.InterceptedMethod;
+import io.micronaut.aop.Interceptor;
+import io.micronaut.aop.MethodInvocationContext;
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.async.publisher.Publishers;
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.type.Argument;
+import io.micronaut.core.type.ReturnType;
+import org.reactivestreams.Publisher;
+
+/**
+ * The {@link Publisher} method intercept.
+ *
+ * @author Denis Stepanov
+ * @since 2.1.0
+ */
+@Internal
+@Experimental
+class PublisherInterceptedMethod implements InterceptedMethod {
+    private final ConversionService<?> conversionService = ConversionService.SHARED;
+
+    private final MethodInvocationContext<?, ?> context;
+    private final Argument<?> returnTypeValue;
+
+    PublisherInterceptedMethod(MethodInvocationContext<?, ?> context) {
+        this.context = context;
+        this.returnTypeValue = context.getReturnType().asArgument().getFirstTypeVariable().orElse(Argument.OBJECT_ARGUMENT);
+    }
+
+    @Override
+    public ResultType resultType() {
+        return ResultType.PUBLISHER;
+    }
+
+    @Override
+    public Argument<?> returnTypeValue() {
+        return returnTypeValue;
+    }
+
+    @Override
+    public Publisher<?> interceptResultAsPublisher() {
+        return convertToPublisher(context.proceed());
+    }
+
+    @Override
+    public Publisher<?> interceptResultAsPublisher(Interceptor<?, ?> from) {
+        return convertToPublisher(context.proceed(from));
+    }
+
+    @Override
+    public Publisher<?> interceptResult() {
+        return interceptResultAsPublisher();
+    }
+
+    @Override
+    public Publisher<?> interceptResult(Interceptor<?, ?> from) {
+        return interceptResultAsPublisher(from);
+    }
+
+    @Override
+    public Object handleResult(Object result) {
+        if (result == null) {
+            result = Publishers.empty();
+        }
+        return convertPublisherResult(context.getReturnType(), result);
+    }
+
+    @Override
+    public <E extends Throwable> Object handleException(Exception exception) throws E {
+        return convertPublisherResult(context.getReturnType(), Publishers.just(exception));
+    }
+
+    private Object convertPublisherResult(ReturnType<?> returnType, Object result) {
+        if (returnType.getType().isInstance(result)) {
+            return result;
+        }
+        return conversionService.convert(result, returnType.asArgument())
+                .orElseThrow(() -> new IllegalStateException("Cannot convert publisher result: " + result + " to '" + returnType.getType().getName() + "'"));
+    }
+
+    private Publisher<?> convertToPublisher(Object result) {
+        if (result == null) {
+            return Publishers.empty();
+        }
+        if (result instanceof Publisher) {
+            return (Publisher<?>) result;
+        }
+        return conversionService
+                .convert(result, Publisher.class)
+                .orElseThrow(() -> new IllegalStateException("Cannot convert reactive type " + result + " to 'org.reactivestreams.Publisher'"));
+    }
+}

--- a/aop/src/main/java/io/micronaut/aop/internal/intercepted/SynchronousInterceptedMethod.java
+++ b/aop/src/main/java/io/micronaut/aop/internal/intercepted/SynchronousInterceptedMethod.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.internal.intercepted;
+
+import io.micronaut.aop.InterceptedMethod;
+import io.micronaut.aop.Interceptor;
+import io.micronaut.aop.MethodInvocationContext;
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.type.Argument;
+
+/**
+ * The synchronous method intercept.
+ *
+ * @author Denis Stepanov
+ * @since 2.1.0
+ */
+@Internal
+@Experimental
+public class SynchronousInterceptedMethod implements InterceptedMethod {
+
+    private final MethodInvocationContext<?, ?> context;
+    private final Argument<?> returnTypeValue;
+
+    SynchronousInterceptedMethod(MethodInvocationContext<?, ?> context) {
+        this.context = context;
+        this.returnTypeValue = context.getReturnType().asArgument();
+    }
+
+    @Override
+    public ResultType resultType() {
+        return ResultType.SYNCHRONOUS;
+    }
+
+    @Override
+    public Argument<?> returnTypeValue() {
+        return returnTypeValue;
+    }
+
+    @Override
+    public Object interceptResult() {
+        return context.proceed();
+    }
+
+    @Override
+    public Object interceptResult(Interceptor<?, ?> from) {
+        return context.proceed(from);
+    }
+
+    @Override
+    public Object handleResult(Object result) {
+        return result;
+    }
+
+    @Override
+    public <E extends Throwable> Object handleException(Exception exception) throws E {
+        throw (E) exception;
+    }
+
+}

--- a/aop/src/main/kotlin/io/micronaut/aop/util/CompletableFutureContinuation.kt
+++ b/aop/src/main/kotlin/io/micronaut/aop/util/CompletableFutureContinuation.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.util
+
+import io.micronaut.core.annotation.Experimental
+import io.micronaut.core.annotation.Internal
+import java.util.concurrent.CompletableFuture
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Continuation represented as CompletableFuture
+ *
+ * @author Denis Stepanov
+ * @since 2.1.0
+ */
+@Internal
+@Experimental
+class CompletableFutureContinuation(private val continuation: Continuation<Any>) : Continuation<Any> {
+
+    var completableFuture = CompletableFuture<Any>()
+
+    override val context: CoroutineContext
+        get() = continuation.context
+
+    override fun resumeWith(result: Result<Any>) {
+        if (result.isSuccess) {
+            completableFuture.complete(result.getOrNull())
+        } else {
+            completableFuture.completeExceptionally(result.exceptionOrNull())
+        }
+    }
+
+    companion object {
+
+        fun completeSuccess(continuation: Continuation<Any>, result: Any) {
+            continuation.resumeWith(Result.success(result))
+        }
+        fun completeExceptionally(continuation: Continuation<Any>, exception: Throwable) {
+            continuation.resumeWith(Result.failure(exception))
+        }
+    }
+
+}

--- a/core/src/main/java/io/micronaut/core/async/publisher/Publishers.java
+++ b/core/src/main/java/io/micronaut/core/async/publisher/Publishers.java
@@ -350,6 +350,9 @@ public class Publishers {
     public static <T> T convertPublisher(Object object, Class<T> publisherType) {
         Objects.requireNonNull(object, "Argument [object] cannot be null");
         Objects.requireNonNull(publisherType, "Argument [publisherType] cannot be null");
+        if (publisherType.isInstance(object)) {
+            return (T) object;
+        }
         if (object instanceof CompletableFuture) {
             @SuppressWarnings("unchecked") Publisher<T> futurePublisher = Publishers.fromCompletableFuture(() -> ((CompletableFuture) object));
             return ConversionService.SHARED.convert(futurePublisher, publisherType)

--- a/core/src/main/java/io/micronaut/core/type/Argument.java
+++ b/core/src/main/java/io/micronaut/core/type/Argument.java
@@ -120,6 +120,11 @@ public interface Argument<T> extends TypeVariableResolver, AnnotatedElement, Typ
     Argument<List<String>> LIST_OF_STRING = Argument.listOf(String.class);
 
     /**
+     * Constant for Void object argument
+     */
+    Argument<Void> VOID_OBJECT = Argument.of(Void.class);
+
+    /**
      * @return The name of the argument
      */
     @Override

--- a/core/src/main/java/io/micronaut/core/type/ReturnType.java
+++ b/core/src/main/java/io/micronaut/core/type/ReturnType.java
@@ -129,10 +129,11 @@ public interface ReturnType<T> extends TypeVariableResolver, AnnotationMetadataP
         if (javaReturnType == void.class) {
             return true;
         } else {
+            if (isCompletable()) {
+                return true;
+            }
             if (isReactive() || isAsync()) {
-                return isCompletable() ||
-                        getFirstTypeVariable()
-                                .filter(arg -> arg.getType() == Void.class).isPresent();
+                return getFirstTypeVariable().filter(arg -> arg.getType() == Void.class).isPresent();
             }
         }
         return false;

--- a/core/src/main/java/io/micronaut/core/util/KotlinUtils.java
+++ b/core/src/main/java/io/micronaut/core/util/KotlinUtils.java
@@ -35,7 +35,7 @@ public class KotlinUtils {
      */
     public static final boolean KOTLIN_COROUTINES_SUPPORTED;
 
-    private static final Object COROUTINE_SUSPENDED;
+    public static final Object COROUTINE_SUSPENDED;
 
     static {
         boolean areKotlinCoroutinesSupportedCandidate;

--- a/function-client/src/main/java/io/micronaut/function/client/aop/FunctionClientAdvice.java
+++ b/function-client/src/main/java/io/micronaut/function/client/aop/FunctionClientAdvice.java
@@ -15,18 +15,15 @@
  */
 package io.micronaut.function.client.aop;
 
+import io.micronaut.aop.InterceptedMethod;
 import io.micronaut.aop.MethodInterceptor;
 import io.micronaut.aop.MethodInvocationContext;
-import io.micronaut.core.async.publisher.Publishers;
-import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.type.Argument;
-import io.micronaut.core.type.ReturnType;
 import io.micronaut.function.client.FunctionDefinition;
 import io.micronaut.function.client.FunctionDiscoveryClient;
 import io.micronaut.function.client.FunctionInvoker;
 import io.micronaut.function.client.FunctionInvokerChooser;
-import io.micronaut.function.client.exceptions.FunctionExecutionException;
 import io.micronaut.function.client.exceptions.FunctionNotFoundException;
 import io.reactivex.Flowable;
 import io.reactivex.Maybe;
@@ -34,6 +31,7 @@ import io.reactivex.Maybe;
 import javax.inject.Named;
 import javax.inject.Singleton;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Implements advice for the {@link io.micronaut.function.client.FunctionClient} annotation.
@@ -77,24 +75,42 @@ public class FunctionClientAdvice implements MethodInterceptor<Object, Object> {
                 .orElse(NameUtils.hyphenate(context.getMethodName(), true));
 
         Flowable<FunctionDefinition> functionDefinition = Flowable.fromPublisher(discoveryClient.getFunction(functionName));
-        ReturnType<Object> returnType = context.getReturnType();
-        Class<Object> javaReturnType = returnType.getType();
-        if (Publishers.isConvertibleToPublisher(javaReturnType)) {
-            Maybe flowable = functionDefinition.firstElement().flatMap(def -> {
-                FunctionInvoker functionInvoker = functionInvokerChooser.choose(def).orElseThrow(() -> new FunctionNotFoundException(def.getName()));
-                return (Maybe) functionInvoker.invoke(
-                        def,
-                        body,
-                        Argument.of(Maybe.class, returnType.getFirstTypeVariable().orElse(Argument.OBJECT_ARGUMENT))
-                );
-            });
-            flowable = flowable.switchIfEmpty(Maybe.error(new FunctionNotFoundException(functionName)));
-            return ConversionService.SHARED.convert(flowable, returnType.asArgument()).orElseThrow(() -> new FunctionExecutionException("Unsupported reactive type: " + returnType.getType()));
-        } else {
-            // blocking operation
-            FunctionDefinition def = functionDefinition.blockingFirst();
-            FunctionInvoker functionInvoker = functionInvokerChooser.choose(def).orElseThrow(() -> new FunctionNotFoundException(def.getName()));
-            return functionInvoker.invoke(def, body, returnType.asArgument());
+        InterceptedMethod interceptedMethod = InterceptedMethod.of(context);
+        try {
+            switch (interceptedMethod.resultType()) {
+                case PUBLISHER:
+                    return interceptedMethod.handleResult(invokeFn(body, functionName, functionDefinition, interceptedMethod.returnTypeValue()));
+                case COMPLETION_STAGE:
+                    return interceptedMethod.handleResult(toCompletableFuture(
+                            invokeFn(body, functionName, functionDefinition, interceptedMethod.returnTypeValue())
+                    ));
+                case SYNCHRONOUS:
+                    FunctionDefinition def = functionDefinition.blockingFirst();
+                    FunctionInvoker functionInvoker = functionInvokerChooser.choose(def).orElseThrow(() -> new FunctionNotFoundException(def.getName()));
+                    return functionInvoker.invoke(def, body, context.getReturnType().asArgument());
+                default:
+                    return interceptedMethod.unsupported();
+            }
+        } catch (Exception e) {
+            return interceptedMethod.handleException(e);
         }
     }
+
+    private Flowable<Object> invokeFn(Object body, String functionName, Flowable<FunctionDefinition> functionDefinition, Argument<?> valueType) {
+        return functionDefinition.firstElement().flatMap(def -> {
+            FunctionInvoker functionInvoker = functionInvokerChooser.choose(def).orElseThrow(() -> new FunctionNotFoundException(def.getName()));
+            return (Maybe<Object>) functionInvoker.invoke(
+                    def,
+                    body,
+                    Argument.of(Maybe.class, valueType)
+            );
+        }).switchIfEmpty(Maybe.error(() -> new FunctionNotFoundException(functionName))).toFlowable();
+    }
+
+    private CompletableFuture<Object> toCompletableFuture(Flowable<Object> flowable) {
+        CompletableFuture<Object> completableFuture = new CompletableFuture<>();
+        flowable.firstElement().subscribe(completableFuture::complete, completableFuture::completeExceptionally, () -> completableFuture.complete(null));
+        return completableFuture;
+    }
+
 }

--- a/http-client/src/test/groovy/io/micronaut/http/client/aop/StreamSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/aop/StreamSpec.groovy
@@ -103,7 +103,7 @@ class StreamSpec extends Specification {
         given:
         StreamEchoClient myClient = context.getBean(StreamEchoClient)
         when:
-        Flowable<Elephant> _ = myClient.echoAsElephant(42, "Hello, big grey animal!")
+        Flowable<Elephant> _ = myClient.echoAsElephant(42, "Hello, big grey animal!").blockingFirst()
         then:
         def ex = thrown(ConfigurationException)
         ex.message == 'Cannot create the generated HTTP client\'s required return type, since no TypeConverter from ' +

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/SuspendClient.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/SuspendClient.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.server.suspend
+
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.client.annotation.Client
+
+@Client("/suspend")
+interface SuspendClient {
+
+    @Get("/simple", consumes = [MediaType.TEXT_PLAIN])
+    suspend fun simple(): String
+
+    @Get("/simple", consumes = [MediaType.TEXT_PLAIN])
+    suspend fun simpleIgnoreResult()
+
+    @Get("/simple", consumes = [MediaType.TEXT_PLAIN])
+    suspend fun simpleResponse(): HttpResponse<String>
+
+    @Get("/simple", consumes = [MediaType.TEXT_PLAIN])
+    suspend fun simpleResponseIgnoreResult(): HttpResponse<Any>
+
+    @Get("/delayed", consumes = [MediaType.TEXT_PLAIN])
+    suspend fun delayed(): String
+
+    @Get("/illegal", consumes = [MediaType.ALL])
+    suspend fun errorCall(): String
+
+    @Get("/illegal", consumes = [MediaType.ALL])
+    suspend fun errorCallResponse(): HttpResponse<String>
+
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/SuspendService.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/SuspendService.kt
@@ -1,0 +1,36 @@
+package io.micronaut.docs.server.suspend
+
+import io.micronaut.retry.annotation.Retryable
+import kotlinx.coroutines.delay
+import java.lang.RuntimeException
+import javax.inject.Singleton
+
+@Singleton
+open class SuspendService {
+
+    var counter1: Int = 0
+    var counter2: Int = 0
+
+    @Retryable
+    open suspend fun delayedCalculation1(): String {
+        if (counter1 != 2) {
+            delay(1)
+            counter1++
+            throw RuntimeException("error $counter1")
+        }
+        delay(1)
+        return "delayedCalculation1"
+    }
+
+    @Retryable
+    open suspend fun delayedCalculation2(): String {
+        if (counter2 != 2) {
+            delay(1)
+            counter2++
+            throw RuntimeException("error $counter2")
+        }
+        delay(1)
+        return "delayedCalculation2"
+    }
+
+}

--- a/validation/src/main/java/io/micronaut/validation/ValidatingInterceptor.java
+++ b/validation/src/main/java/io/micronaut/validation/ValidatingInterceptor.java
@@ -15,18 +15,16 @@
  */
 package io.micronaut.validation;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
 import io.micronaut.aop.InterceptPhase;
+import io.micronaut.aop.InterceptedMethod;
 import io.micronaut.aop.MethodInterceptor;
 import io.micronaut.aop.MethodInvocationContext;
-import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.inject.ExecutableMethod;
 import io.micronaut.validation.validator.ExecutableMethodValidator;
 import io.micronaut.validation.validator.ReactiveValidator;
 import io.micronaut.validation.validator.Validator;
-import org.reactivestreams.Publisher;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.validation.ConstraintViolation;
@@ -35,7 +33,6 @@ import javax.validation.ValidatorFactory;
 import javax.validation.executable.ExecutableValidator;
 import java.lang.reflect.Method;
 import java.util.Set;
-import java.util.concurrent.CompletionStage;
 
 /**
  * A {@link MethodInterceptor} that validates method invocations.
@@ -44,7 +41,7 @@ import java.util.concurrent.CompletionStage;
  * @since 1.0
  */
 @Singleton
-public class ValidatingInterceptor implements MethodInterceptor {
+public class ValidatingInterceptor implements MethodInterceptor<Object, Object> {
 
     /**
      * The position of the interceptor. See {@link io.micronaut.core.order.Ordered}
@@ -88,79 +85,87 @@ public class ValidatingInterceptor implements MethodInterceptor {
     }
 
     @Override
-    public Object intercept(MethodInvocationContext context) {
-        final boolean isValidatorBeanNull = executableValidator == null;
-        if (isValidatorBeanNull && micronautValidator == null) {
-            return context.proceed();
-        }
-        final Object target = context.getTarget();
-        if (isValidatorBeanNull) {
-            final ExecutableMethod executableMethod = context.getExecutableMethod();
-            @SuppressWarnings("unchecked")
-            Set<ConstraintViolation<Object>> constraintViolations = this.micronautValidator.validateParameters(
-                    target,
-                    executableMethod,
-                    context.getParameterValues());
-            final boolean supportsReactive = micronautValidator instanceof ReactiveValidator;
-            if (constraintViolations.isEmpty()) {
-                final Object result = context.proceed();
-                if (context.hasStereotype(Validator.ANN_VALID) || context.hasStereotype(Validator.ANN_CONSTRAINT)) {
-                    final boolean hasResult = result != null;
-                    if (supportsReactive && hasResult && Publishers.isConvertibleToPublisher(result)) {
-                        ReactiveValidator reactiveValidator = (ReactiveValidator) micronautValidator;
-                        final Publisher newPublisher = reactiveValidator.validatePublisher(
-                                Publishers.convertPublisher(result, Publisher.class)
-                        );
-                        return Publishers.convertPublisher(newPublisher, executableMethod.getReturnType().getType());
-                    } else if (supportsReactive && result instanceof CompletionStage) {
-                        return ((ReactiveValidator) micronautValidator).validateCompletionStage(((CompletionStage) result));
-                    } else {
-                        constraintViolations = this.micronautValidator.validateReturnValue(target, executableMethod, result);
-                        if (!constraintViolations.isEmpty()) {
-                            throw new ConstraintViolationException(constraintViolations);
-                        }
-                    }
-                }
-                return result;
-            } else {
-                throw new ConstraintViolationException(constraintViolations);
-            }
-        } else {
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        if (executableValidator != null) {
             Method targetMethod = context.getTargetMethod();
-            if (targetMethod.getParameterTypes().length == 0) {
-                final Object result = context.proceed();
-                return validateReturnValue(executableValidator, context, target, targetMethod, result);
-            } else {
+            if (targetMethod.getParameterTypes().length != 0) {
                 Set<ConstraintViolation<Object>> constraintViolations = executableValidator
                         .validateParameters(
-                                target,
+                                context.getTarget(),
                                 targetMethod,
                                 context.getParameterValues()
                         );
-                if (constraintViolations.isEmpty()) {
-                    final Object result = context.proceed();
-                    return validateReturnValue(executableValidator, context, target, targetMethod, result);
-                } else {
+                if (!constraintViolations.isEmpty()) {
                     throw new ConstraintViolationException(constraintViolations);
                 }
             }
-
+            return validateReturnExecutableValidator(context, targetMethod);
+        } else if (micronautValidator != null) {
+            ExecutableMethod<Object, Object> executableMethod = context.getExecutableMethod();
+            if (executableMethod.getArguments().length != 0) {
+                Set<ConstraintViolation<Object>> constraintViolations = micronautValidator.validateParameters(
+                        context.getTarget(),
+                        executableMethod,
+                        context.getParameterValues());
+                if (!constraintViolations.isEmpty()) {
+                    throw new ConstraintViolationException(constraintViolations);
+                }
+            }
+            if (hasValidationAnnotation(context)) {
+                if (micronautValidator instanceof ReactiveValidator) {
+                    InterceptedMethod interceptedMethod = InterceptedMethod.of(context);
+                    try {
+                        switch (interceptedMethod.resultType()) {
+                            case PUBLISHER:
+                                return interceptedMethod.handleResult(
+                                        ((ReactiveValidator) micronautValidator).validatePublisher(interceptedMethod.interceptResultAsPublisher())
+                                );
+                            case COMPLETION_STAGE:
+                                return interceptedMethod.handleResult(
+                                        ((ReactiveValidator) micronautValidator).validateCompletionStage(interceptedMethod.interceptResultAsCompletionStage())
+                                );
+                            case SYNCHRONOUS:
+                                return validateReturnMicronautValidator(context, executableMethod);
+                            default:
+                                return interceptedMethod.unsupported();
+                        }
+                    } catch (Exception e) {
+                        return interceptedMethod.handleException(e);
+                    }
+                } else {
+                    return validateReturnMicronautValidator(context, executableMethod);
+                }
+            }
+            return context.proceed();
         }
+        return context.proceed();
     }
 
-    private Object validateReturnValue(@NonNull ExecutableValidator validator, MethodInvocationContext context, Object target, Method targetMethod, Object result) {
-        Set<ConstraintViolation<Object>> constraintViolations;
-        if (context.hasStereotype(Validator.ANN_VALID)) {
-            constraintViolations = validator.validateReturnValue(
-                    target,
+    private Object validateReturnMicronautValidator(MethodInvocationContext<Object, Object> context, ExecutableMethod<Object, Object> executableMethod) {
+        Object result = context.proceed();
+        Set<ConstraintViolation<Object>> constraintViolations = micronautValidator.validateReturnValue(context.getTarget(), executableMethod, result);
+        if (!constraintViolations.isEmpty()) {
+            throw new ConstraintViolationException(constraintViolations);
+        }
+        return result;
+    }
+
+    private Object validateReturnExecutableValidator(MethodInvocationContext<Object, Object> context, Method targetMethod) {
+        final Object result = context.proceed();
+        if (hasValidationAnnotation(context)) {
+            Set<ConstraintViolation<Object>> constraintViolations = executableValidator.validateReturnValue(
+                    context.getTarget(),
                     targetMethod,
                     result
             );
-
             if (!constraintViolations.isEmpty()) {
                 throw new ConstraintViolationException(constraintViolations);
             }
         }
         return result;
+    }
+
+    private boolean hasValidationAnnotation(MethodInvocationContext<Object, Object> context) {
+        return context.hasStereotype(Validator.ANN_VALID) || context.hasStereotype(Validator.ANN_CONSTRAINT);
     }
 }

--- a/websocket/src/main/java/io/micronaut/websocket/interceptor/ClientWebSocketInterceptor.java
+++ b/websocket/src/main/java/io/micronaut/websocket/interceptor/ClientWebSocketInterceptor.java
@@ -15,10 +15,10 @@
  */
 package io.micronaut.websocket.interceptor;
 
+import io.micronaut.aop.InterceptedMethod;
 import io.micronaut.aop.MethodInterceptor;
 import io.micronaut.aop.MethodInvocationContext;
 import io.micronaut.context.annotation.Prototype;
-import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.Produces;
@@ -26,8 +26,6 @@ import io.micronaut.websocket.WebSocketSession;
 import io.micronaut.websocket.exceptions.WebSocketClientException;
 
 import java.io.Closeable;
-import java.util.Map;
-import java.util.concurrent.Future;
 
 /**
  * Intercepts unimplemented {@link io.micronaut.websocket.annotation.ClientWebSocket} methods.
@@ -64,58 +62,46 @@ public class ClientWebSocketInterceptor implements MethodInterceptor<Object, Obj
             if (methodName.startsWith("send") || methodName.startsWith("broadcast")) {
                 MediaType mediaType = context.stringValue(Produces.class).map(MediaType::new).orElse(MediaType.APPLICATION_JSON_TYPE);
                 validateSession();
+
+                InterceptedMethod interceptedMethod = InterceptedMethod.of(context);
                 Class<?> javaReturnType = context.getReturnType().getType();
-                if (void.class == javaReturnType) {
+                if (interceptedMethod.resultType() == InterceptedMethod.ResultType.SYNCHRONOUS && javaReturnType != void.class) {
+                    return context.proceed();
+                }
+                try {
                     Object[] parameterValues = context.getParameterValues();
                     switch (parameterValues.length) {
                         case 0:
                             throw new IllegalArgumentException("At least 1 parameter is required to a send method");
                         case 1:
-                            Object v = parameterValues[0];
-                            if (v == null) {
+                            Object value = parameterValues[0];
+                            if (value == null) {
                                 throw new IllegalArgumentException("Parameter cannot be null");
                             }
-                            webSocketSession.sendSync(v, mediaType);
-                            return null;
+                            return send(interceptedMethod, value, mediaType);
                         default:
-                            Map<String, Object> map = context.getParameterValueMap();
-                            webSocketSession.sendSync(map, mediaType);
-                            break;
+                            return send(interceptedMethod, context.getParameterValueMap(), mediaType);
                     }
-                } else if (Future.class.isAssignableFrom(javaReturnType)) {
-                    Object[] parameterValues = context.getParameterValues();
-                    switch (parameterValues.length) {
-                        case 0:
-                            throw new IllegalArgumentException("At least 1 parameter is required to a send method");
-                        case 1:
-                            Object v = parameterValues[0];
-                            if (v == null) {
-                                throw new IllegalArgumentException("Parameter cannot be null");
-                            }
-                            return webSocketSession.sendAsync(v, mediaType);
-                        default:
-                            Map<String, Object> map = context.getParameterValueMap();
-                            return webSocketSession.sendAsync(map, mediaType);
-                    }
-                } else if (Publishers.isConvertibleToPublisher(javaReturnType)) {
-                    Object[] parameterValues = context.getParameterValues();
-                    switch (parameterValues.length) {
-                        case 0:
-                            throw new IllegalArgumentException("At least 1 parameter is required to a send method");
-                        case 1:
-                            Object v = parameterValues[0];
-                            if (v == null) {
-                                throw new IllegalArgumentException("Parameter cannot be null");
-                            }
-                            return Publishers.convertPublisher(webSocketSession.send(v, mediaType), javaReturnType);
-                        default:
-                            Map<String, Object> map = context.getParameterValueMap();
-                            return Publishers.convertPublisher(webSocketSession.send(map, mediaType), javaReturnType);
-                    }
+                } catch (Exception e) {
+                    return interceptedMethod.handleException(e);
                 }
             }
         }
         return context.proceed();
+    }
+
+    private Object send(InterceptedMethod interceptedMethod, Object message, MediaType mediaType) {
+        switch (interceptedMethod.resultType()) {
+            case COMPLETION_STAGE:
+                return interceptedMethod.handleResult(webSocketSession.sendAsync(message, mediaType));
+            case PUBLISHER:
+                return interceptedMethod.handleResult(webSocketSession.send(message, mediaType));
+            case SYNCHRONOUS:
+                webSocketSession.sendSync(message, mediaType);
+                return null;
+            default:
+                return interceptedMethod.unsupported();
+        }
     }
 
     private void validateSession() {


### PR DESCRIPTION
Added util classes to work with Kotlin's suspend functions in `MethodInterceptor`s and implemented to use it with `@Retryable`.

It should be possible to implement other interceptors like https://github.com/micronaut-projects/micronaut-cache/issues/183.

Personally I'm not a Kotlin user just found it interesting.