### PR TITLE
Loggers endpoint is not enabled by default

### DIFF
--- a/management/src/main/java/io/micronaut/management/endpoint/loggers/LoggersEndpoint.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/loggers/LoggersEndpoint.java
@@ -31,7 +31,9 @@ import java.util.Map;
  * @author Matthew Moss
  * @since 1.0
  */
-@Endpoint(id = LoggersEndpoint.NAME, defaultSensitive = LoggersEndpoint.DEFAULT_SENSITIVE)
+@Endpoint(id = LoggersEndpoint.NAME,
+        defaultSensitive = LoggersEndpoint.DEFAULT_SENSITIVE,
+        defaultEnabled = LoggersEndpoint.DEFAULT_ENABLED)
 public class LoggersEndpoint {
 
     /**
@@ -47,7 +49,7 @@ public class LoggersEndpoint {
     /**
      * Endpoint default enabled.
      */
-    public static final boolean DEFAULT_ENABLED = true;
+    public static final boolean DEFAULT_ENABLED = false;
 
     /**
      * Endpoint default sensitivity.

--- a/management/src/test/groovy/io/micronaut/management/endpoint/loggers/LoggersEndpointConfigurationSpec.groovy
+++ b/management/src/test/groovy/io/micronaut/management/endpoint/loggers/LoggersEndpointConfigurationSpec.groovy
@@ -24,6 +24,17 @@ import spock.lang.Specification
  */
 class LoggersEndpointConfigurationSpec extends Specification {
 
+    void 'test that the loggers endpoint is not enabled by default'() {
+        given:
+        ApplicationContext context = ApplicationContext.run()
+
+        expect:
+        !context.containsBean(LoggersEndpoint)
+
+        cleanup:
+        context.close()
+    }
+
     void 'test that the loggers endpoint is not available when disabled via config'() {
         given:
         ApplicationContext context = ApplicationContext.run(['endpoints.loggers.enabled': false])


### PR DESCRIPTION
Fixes #3925

The documentation states clearly that the endpoint is disabled by default: https://docs.micronaut.io/latest/guide/index.html#loggersEndpoint

![image](https://user-images.githubusercontent.com/559192/90654961-4533dd80-e241-11ea-8770-9ca0145910f9.png)
