### PR TITLE
Fix runtime issues in native-image+kotlin (#3961)

### DIFF
--- a/runtime/src/main/resources/META-INF/native-image/kotlin/runtime-graal/native-image.properties
+++ b/runtime/src/main/resources/META-INF/native-image/kotlin/runtime-graal/native-image.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2017-2020 original authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Args = -H:ReflectionConfigurationResources=${.}/reflection-config.json

--- a/runtime/src/main/resources/META-INF/native-image/kotlin/runtime-graal/reflection-config.json
+++ b/runtime/src/main/resources/META-INF/native-image/kotlin/runtime-graal/reflection-config.json
@@ -1,0 +1,21 @@
+[ {
+    "name": "kotlin.internal.jdk8.JDK8PlatformImplementations",
+    "methods": [
+      { "name": "<init>", "parameterTypes": [] }
+    ]
+}, {
+  "name": "kotlin.internal.JRE8PlatformImplementations",
+  "methods": [
+    { "name": "<init>", "parameterTypes": [] }
+  ]
+}, {
+  "name": "kotlin.internal.jdk7.JDK7PlatformImplementations",
+  "methods": [
+    { "name": "<init>", "parameterTypes": [] }
+  ]
+}, {
+  "name": "kotlin.internal.JRE7PlatformImplementations",
+  "methods": [
+    { "name": "<init>", "parameterTypes": [] }
+  ]
+} ]


### PR DESCRIPTION
Kotlin's PlatformImplementations are instantiated using reflection (depending on the current JVM) and must have their `<init>` methods explicit in reflection-config.json so `Class.forName` works as expected when running on native image.

Link to relevant code in Kotlin source (highlighted):
https://github.com/JetBrains/kotlin/blob/65244b4bea81f737466618927d4f3afe339cad0d/libraries/stdlib/jvm/src/kotlin/internal/PlatformImplementations.kt#L41-L53

I think this is a good place to put these files. Feel free to move them anywhere.

Fixes #3961