### PR TITLE
Fix for method argument annotation visitors.

### DIFF
--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/ElementAnnotateSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/ElementAnnotateSpec.groovy
@@ -82,7 +82,7 @@ class TestListener {
         definition.getValue(Ann, "foo", String).get() == 'bar'
         receiveMethod.hasAnnotation(Ann)
         vArgument.getAnnotationMetadata().hasAnnotation(Ann)
-        vArgument.getAnnotationMetadata().getValue(Ann, "foo, String").get() == 'bar'
+        vArgument.getAnnotationMetadata().getValue(Ann, "foo", String).get() == 'bar'
     }
 
     void "test annotation bean introspection properties"() {
@@ -172,6 +172,7 @@ class Test {
                         builder.member("foo", "bar")
                 }
             }
+
         }
     }
 

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/AbstractJavaElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/AbstractJavaElement.java
@@ -25,6 +25,7 @@ import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.MemberElement;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import io.micronaut.inject.ast.ParameterElement;
 import io.micronaut.inject.ast.PrimitiveElement;
 
 import javax.lang.model.element.Element;
@@ -76,7 +77,20 @@ public abstract class AbstractJavaElement implements io.micronaut.inject.ast.Ele
                 .newAnnotationBuilder()
                 .annotate(annotationMetadata, av);
 
-        String declaringTypeName = this instanceof MemberElement ? ((MemberElement) this).getOwningType().getName() : getName();
+        String declaringTypeName;
+        if (this instanceof MemberElement) {
+            declaringTypeName = ((MemberElement) this).getOwningType().getName();
+        } else if (this instanceof ParameterElement) {
+            TypeElement typeElement = visitorContext.getModelUtils().classElementFor((Element) this.getNativeType());
+            if (typeElement == null) {
+                declaringTypeName = getName();
+            } else {
+                declaringTypeName = typeElement.getQualifiedName().toString();
+            }
+        } else {
+            declaringTypeName = getName();
+        }
+
         AbstractAnnotationMetadataBuilder.addMutatedMetadata(declaringTypeName, element, annotationMetadata);
         visitorContext.getAnnotationUtils().invalidateMetadata(element);
         return this;


### PR DESCRIPTION
Resolves #4008 

This fix makes sure the updated annotation metadata is stored in the modified cache under the same key it is retrieved later on.

This PR also includes a test verifying the annotation is correctly added.