### PR TITLE
Update Tomcat thread model

### DIFF
--- a/src/main/docs/guide/httpServer/reactiveServer.adoc
+++ b/src/main/docs/guide/httpServer/reactiveServer.adoc
@@ -2,7 +2,7 @@ As mentioned previously, Micronaut is built on Netty which is designed around an
 
 This makes it critical that if you do any blocking I/O operations (for example interactions with Hibernate/JPA or JDBC) that you offload those tasks to a separate thread pool that does not block the Event loop.
 
-For example the following configuration will configure the I/O thread pool as a fixed thread pool with 75 threads (similar to what a traditional blocking server such as Tomcat uses in the thread per connection model):
+For example the following configuration will configure the I/O thread pool as a fixed thread pool with 75 threads (similar to what a traditional blocking server such as Tomcat uses in the thread per request model):
 
 .Configuring the IO thread pool
 [source,yaml]


### PR DESCRIPTION
New Tomcat versions can handle multiple connections with the same thread (NIO threads), the correct is thread per request model.