### PR TITLE
- Changed order of responsePublisher declaration, allows downstream f…

### DIFF
--- a/tracing/src/main/java/io/micronaut/tracing/instrument/http/OpenTracingServerFilter.java
+++ b/tracing/src/main/java/io/micronaut/tracing/instrument/http/OpenTracingServerFilter.java
@@ -60,9 +60,9 @@ public class OpenTracingServerFilter extends AbstractOpenTracingFilter implement
     @SuppressWarnings("unchecked")
     @Override
     public Publisher<MutableHttpResponse<?>> doFilter(HttpRequest<?> request, ServerFilterChain chain) {
-        Publisher<MutableHttpResponse<?>> responsePublisher = chain.proceed(request);
+
         if (request.getAttribute(APPLIED, Boolean.class).isPresent()) {
-            return responsePublisher;
+            return chain.proceed(request);
         } else {
             request.setAttribute(APPLIED, true);
             SpanContext spanContext = tracer.extract(
@@ -75,6 +75,7 @@ public class OpenTracingServerFilter extends AbstractOpenTracingFilter implement
             );
 
             Tracer.SpanBuilder spanBuilder = newSpan(request, spanContext);
+            Publisher<MutableHttpResponse<?>> responsePublisher = chain.proceed(request);
             return new TracingPublisher(responsePublisher, tracer, spanBuilder) {
                 @Override
                 protected void doOnSubscribe(@NonNull Span span) {


### PR DESCRIPTION
Bumped into this issue when trying to create a downstream filter that would rely on the SpanContext from the HttpRequest.

Turns out that because the responsePublisher is being invoked prior the request configuration, downstream filters would never be able to see the request attributes.

Changing the declaration order fixes the issue.