### PR TITLE
Preserve byte[] of the body in FullNettyClientHttpResponse to allow more body conversions

### DIFF
--- a/http-client/src/test/groovy/io/micronaut/http/client/CustomErrorTypeSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/CustomErrorTypeSpec.groovy
@@ -46,6 +46,8 @@ class CustomErrorTypeSpec extends Specification {
         then:
         def e = thrown(HttpClientResponseException)
         e.response.getBody(MyError).get().reason == 'bad things'
+        e.response.getBody(String).get() == '{"reason":"bad things"}'
+        e.response.getBody(MyError2).get().reason == 'bad things'
     }
 
     void "test custom error type with generic"() {
@@ -80,6 +82,10 @@ class CustomErrorTypeSpec extends Specification {
     }
 
     static class MyError {
+        String reason
+    }
+
+    static class MyError2 {
         String reason
     }
 

--- a/http-client/src/test/groovy/io/micronaut/http/client/HttpGetSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/HttpGetSpec.groovy
@@ -190,13 +190,32 @@ class HttpGetSpec extends Specification {
 
         HttpResponse<Book> response = flowable.blockingFirst()
         Optional<Book> body = response.getBody()
-
         then:
         response.contentType.isPresent()
         response.contentType.get() == MediaType.APPLICATION_JSON_TYPE
         response.status == HttpStatus.OK
         body.isPresent()
         body.get().title == 'The Stand'
+        response.getBody(String.class).get() == '{"title":"The Stand"}'
+        response.getBody(byte[].class).get().length > 0
+    }
+
+    void "test simple exchange request with POJO with String response"() {
+        when:
+        Flowable<HttpResponse<Book>> flowable = Flowable.fromPublisher(client.exchange(
+                HttpRequest.GET("/get/pojo"), String
+        ))
+
+        HttpResponse<String> response = flowable.blockingFirst()
+        Optional<String> body = response.getBody()
+        then:
+        response.contentType.isPresent()
+        response.contentType.get() == MediaType.APPLICATION_JSON_TYPE
+        response.status == HttpStatus.OK
+        body.isPresent()
+        response.getBody(String.class).get() == '{"title":"The Stand"}'
+        response.getBody(Book.class).get().title == 'The Stand'
+        response.getBody(byte[].class).get().length > 0
     }
 
     void "test simple retrieve request with POJO"() {

--- a/runtime/src/main/java/io/micronaut/jackson/codec/JacksonMediaTypeCodec.java
+++ b/runtime/src/main/java/io/micronaut/jackson/codec/JacksonMediaTypeCodec.java
@@ -179,6 +179,22 @@ public abstract class JacksonMediaTypeCodec implements MediaTypeCodec {
         }
     }
 
+    @Override
+    public <T> T decode(Argument<T> type, byte[] bytes) throws CodecException {
+        try {
+            if (CharSequence.class.isAssignableFrom(type.getType())) {
+                return (T) new String(bytes, applicationConfiguration.getDefaultCharset());
+            } else if (type.hasTypeVariables()) {
+                JavaType javaType = constructJavaType(type);
+                return getObjectMapper().readValue(bytes, javaType);
+            } else {
+                return getObjectMapper().readValue(bytes, type.getType());
+            }
+        } catch (IOException e) {
+            throw new CodecException("Error decoding stream for type [" + type.getType() + "]: " + e.getMessage(), e);
+        }
+    }
+
     @SuppressWarnings("Duplicates")
     @Override
     public <T> T decode(Argument<T> type, String data) throws CodecException {

--- a/runtime/src/main/java/io/micronaut/runtime/http/codec/TextPlainCodec.java
+++ b/runtime/src/main/java/io/micronaut/runtime/http/codec/TextPlainCodec.java
@@ -90,9 +90,23 @@ public class TextPlainCodec implements MediaTypeCodec {
     @Override
     public <T> T decode(Argument<T> type, ByteBuffer<?> buffer) throws CodecException {
         String text = buffer.toString(defaultCharset);
+        if (CharSequence.class.isAssignableFrom(type.getType())) {
+            return (T) text;
+        }
         return ConversionService.SHARED
             .convert(text, type)
             .orElseThrow(() -> new CodecException("Cannot decode byte buffer with value [" + text + "] to type: " + type));
+    }
+
+    @Override
+    public <T> T decode(Argument<T> type, byte[] bytes) throws CodecException {
+        String text = new String(bytes, defaultCharset);
+        if (CharSequence.class.isAssignableFrom(type.getType())) {
+            return (T) text;
+        }
+        return ConversionService.SHARED
+            .convert(text, type)
+            .orElseThrow(() -> new CodecException("Cannot decode bytes with value [" + text + "] to type: " + type));
     }
 
     @Override


### PR DESCRIPTION
Solving the problem when the response body didn't support returning different body representations after the response has been completed.

All media type codecs are extracting bytes for `ByteBuffer` already, I have moved it a level up and keeping it in `FullNettyClientHttpResponse`.