### PR TITLE
Add option to set Response Status for absent value

### DIFF
--- a/http-client/src/test/groovy/io/micronaut/http/client/docs/httpstatus/HttpStatusSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/docs/httpstatus/HttpStatusSpec.groovy
@@ -101,4 +101,39 @@ class HttpStatusSpec extends Specification {
         e.message == "success"
         e.status == HttpStatus.NOT_FOUND
     }
+
+    @Unroll("#description")
+    void "verify default HTTP status when absent value"() {
+        when:
+        client.toBlocking().exchange(HttpRequest.GET(uri), String)
+
+        then:
+        HttpClientResponseException e = thrown()
+        e.message == "Page Not Found"
+        e.status == status
+
+        where:
+        uri                        | status                | description
+        "/status/null"             | HttpStatus.NOT_FOUND  | '404 status is returned by default for null'
+        "/status/emptyOptional"    | HttpStatus.NOT_FOUND  | '404 status is returned by default for empty Optional'
+        "/status/emptyMaybe"       | HttpStatus.NOT_FOUND  | '404 status is returned by default for empty Maybe'
+    }
+
+    @Unroll("#description")
+    void "verify @Status override when absent value"() {
+        when:
+        HttpResponse<String> response = client.toBlocking().exchange(HttpRequest.GET(uri), String)
+        Optional<String> body = response.getBody()
+
+        then:
+        response.status == status
+        !body.isPresent()
+
+        where:
+        uri                        | status                | description
+        "/status/null204"          | HttpStatus.NO_CONTENT | 'It is possible to control the status for null with @Status'
+        "/status/emptyOptional204" | HttpStatus.NO_CONTENT | 'It is possible to control the status for empty Optional with @Status'
+        "/status/emptyMaybe204"    | HttpStatus.NO_CONTENT | 'It is possible to control the status for empty Maybe with @Status'
+    }
+
 }

--- a/http-client/src/test/groovy/io/micronaut/http/client/docs/httpstatus/StatusController.java
+++ b/http-client/src/test/groovy/io/micronaut/http/client/docs/httpstatus/StatusController.java
@@ -23,6 +23,7 @@ import io.micronaut.http.annotation.Get;
 import io.micronaut.http.annotation.Status;
 import io.reactivex.Maybe;
 
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 @Requires(property = "spec.name", value = "httpstatus")
@@ -64,4 +65,38 @@ public class StatusController {
     public String simple404() {
         return "success";
     }
+
+    @Get(value = "/null")
+    public String nullValue() {
+        return null;
+    }
+
+    @Status(absentValue = HttpStatus.NO_CONTENT)
+    @Get(value = "/null204")
+    public String nullValue204() {
+        return null;
+    }
+
+    @Get(value = "/emptyOptional")
+    public Optional<String> optionalEmpty() {
+        return Optional.empty();
+    }
+
+    @Status(absentValue = HttpStatus.NO_CONTENT)
+    @Get(value = "/emptyOptional204")
+    public Optional<String> optionalEmpty204() {
+        return Optional.empty();
+    }
+
+    @Get(value = "/emptyMaybe")
+    public Maybe<String> maybeEmpty() {
+        return Maybe.empty();
+    }
+
+    @Status(absentValue = HttpStatus.NO_CONTENT)
+    @Get(value = "/emptyMaybe204")
+    public Maybe<String> maybeEmpty204() {
+        return Maybe.empty();
+    }
+
 }

--- a/http/src/main/java/io/micronaut/http/annotation/Status.java
+++ b/http/src/main/java/io/micronaut/http/annotation/Status.java
@@ -36,7 +36,13 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 public @interface Status {
 
     /**
-     * @return The HttpStatus specified when declared on the method
+     * @return The HttpStatus specified when returned value is present or method is void
      */
-    HttpStatus value();
+    HttpStatus value() default HttpStatus.OK;
+
+    /**
+     * @return The HttpStatus specified when returned is absent: Optional.empty() or Maybe.empty() or null
+     */
+    HttpStatus absentValue() default HttpStatus.NOT_FOUND;
+
 }


### PR DESCRIPTION
Closes #4098.

`@Status` can now be used also for null, Optional.empty() or Maybe.empty(), e.g.:
`@Status(absentValue =  HttpStatus.NO_CONTENT)` which sets response code to 204 if some absent value is returned.

What do you think?