### PR TITLE
Jdk 15

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['8', '11', '14']
+        java: ['8', '11', '15']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2

--- a/build.gradle
+++ b/build.gradle
@@ -714,7 +714,7 @@ subprojects { Project subproject ->
         useJUnitPlatform()
         jvmArgs '-Xmx2048m'
         systemProperty "micronaut.cloud.platform", "OTHER"
-        if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_14)) {
+        if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_15)) {
             jvmArgs "--enable-preview"
         }
     }

--- a/inject-java-test/src/main/groovy/io/micronaut/annotation/processing/test/JavaParser.java
+++ b/inject-java-test/src/main/groovy/io/micronaut/annotation/processing/test/JavaParser.java
@@ -183,11 +183,11 @@ public class JavaParser implements Closeable {
 
     private Set<String> getCompilerOptions() {
         Set<String> options;
-        if (Jvm.getCurrent().isJava14Compatible()) {
+        if (Jvm.getCurrent().isJava15Compatible()) {
             options = CollectionUtils.setOf(
                     "--enable-preview",
                     "-source",
-                    "14"
+                    "15"
             );
         } else {
             options = Collections.emptySet();


### PR DESCRIPTION
Updates the support for JDK15 that was released yesterday (Sep 15th 2020)

I've modified directly the workflow file changing JDK14 with 15 to make sure it works on CI. If everything works and we merge this I will update the workflow file in the template so all projects are switched to 15.