### PR TITLE
Fix dependency resolution happening at configuration time

### DIFF
--- a/bom-check/build.gradle
+++ b/bom-check/build.gradle
@@ -83,42 +83,46 @@ publishing {
 
 publish.enabled = false
 
-task validateMicronautBom() {
-    configurations.each { cfg ->
-        if (cfg.isCanBeResolved()) {
-            cfg.resolve()
-        }
+task validateMicronautBom {
+    doLast {
+		configurations.each { cfg ->
+		    if (cfg.isCanBeResolved()) {
+		        cfg.resolve()
+		    }
+		}
     }
 }
 
 task validateThirdPartyBoms(dependsOn:['validateMicronautBom']) {
-    for (dep in bomVersions) {
-        def info = dep.value
-        if (info.group.startsWith("io.micronaut")) continue
+    doLast {
+		for (dep in bomVersions) {
+		    def info = dep.value
+		    if (info.group.startsWith("io.micronaut")) continue
 
-        def componentId = "$info.group:$info.name:$info.version"
+		    def componentId = "$info.group:$info.name:$info.version"
 
-        Configuration cfg = configurations.detachedConfiguration(dependencies.create(componentId))
+		    Configuration cfg = configurations.detachedConfiguration(dependencies.create(componentId))
 
-        cfg.incoming.resolutionResult.allDependencies { DependencyResult dr ->
-            def result = dependencies.createArtifactResolutionQuery()
-                    .forModule(info.group, info.name, info.version)
-                    .withArtifacts(MavenModule, MavenPomArtifact)
-                    .execute()
+		    cfg.incoming.resolutionResult.allDependencies { DependencyResult dr ->
+		        def result = dependencies.createArtifactResolutionQuery()
+		                .forModule(info.group, info.name, info.version)
+		                .withArtifacts(MavenModule, MavenPomArtifact)
+		                .execute()
 
-            for (component in result.resolvedComponents) {
-                component.getArtifacts(MavenPomArtifact).each {
-                    def pom = new XmlSlurper().parse(it.file)
+		        for (component in result.resolvedComponents) {
+		            component.getArtifacts(MavenPomArtifact).each {
+		                def pom = new XmlSlurper().parse(it.file)
 
-                    pom.dependencyManagement.dependencies.dependency.each {
-                        if (!it.groupId.text().startsWith(info.group)) {
-                            throw new GradleException("Error validating BOM [${componentId}]: includes the dependency [${it.groupId}:${it.artifactId}:${it.version}] that doesn't belong to the group id of the BOM: [${info.group}]")
-                        }
-                    }
+		                pom.dependencyManagement.dependencies.dependency.each {
+		                    if (!it.groupId.text().startsWith(info.group)) {
+		                        throw new GradleException("Error validating BOM [${componentId}]: includes the dependency [${it.groupId}:${it.artifactId}:${it.version}] that doesn't belong to the group id of the BOM: [${info.group}]")
+		                    }
+		                }
 
-                }
-            }
-        }
+		            }
+		        }
+		    }
+		}
     }
 }
 


### PR DESCRIPTION
The BOM check tasks were not using `doLast`, which means that
everything was done at configuration time, which is particularly
bad in this case because it resolves _all_ configurations, and
also requires _all_ artifacts to be downloaded, for every build.

This is a major performance issue, which this commit just fixes
by wrapping everything into an appropriate `doLast`.

Ideally this code should be moved in a `buildSrc` plugin, in order
to avoid bloating the build script, and which would have made
this evident (because the code would have lived in a `@TaskAction`).

I noticed the problem because after updating a local branch and starting a build, it spent more than 10 minutes **downloading jars** during configuration time, which should _never_ happen.

Before, just running `tasks`:
   - dependency resolution: https://scans.gradle.com/s/fqguly56fsz6c/performance/suggestions?open=WyJwYXJhbGxlbCIsInJlc29sdXRpb25EdXJpbmdDb25maWd1cmF0aW9uIiwib3V0T2ZEYXRlR3JhZGxlVmVyc2lvbkNoZWNrIiwibm9uQ2FjaGVhYmxlVGFza091dHB1dCJd#resolution-during-configuration
   - downloads: https://scans.gradle.com/s/fqguly56fsz6c/performance/networkActivity

After:

https://scans.gradle.com/s/d663hiitaorqo/performance/resolution

I didn't optimize anything, it's just a quickfix. In particular, it also looks like you're resolving way too many configurations.