### PR TITLE
Fix introspecting external @Entity classes

### DIFF
--- a/inject-groovy/build.gradle
+++ b/inject-groovy/build.gradle
@@ -14,6 +14,8 @@ dependencies {
     testImplementation project(":validation")
     testImplementation 'org.neo4j.driver:neo4j-java-driver:1.4.5'
     testImplementation dependencyModuleVersion("groovy", "groovy-json")
+    testImplementation "com.blazebit:blaze-persistence-core-impl:1.5.0-Alpha1"
+
 }
 
 test {

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/BeanIntrospectionSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/BeanIntrospectionSpec.groovy
@@ -1,5 +1,6 @@
 package io.micronaut.inject.visitor
 
+import com.blazebit.persistence.impl.function.entity.ValuesEntity
 import io.micronaut.AbstractBeanDefinitionSpec
 import io.micronaut.ast.groovy.TypeElementVisitorStart
 import io.micronaut.core.annotation.Introspected
@@ -763,6 +764,15 @@ enum Test {
         noExceptionThrown()
         introspection != null
         introspection.getProperty("name", String).get().get(new Person(name: "Sally")) == "Sally"
+    }
+
+    void "test introspection class member configuration works 2"() {
+        when:
+        BeanIntrospection introspection = BeanIntrospection.getIntrospection(ValuesEntity)
+
+        then:
+        noExceptionThrown()
+        introspection != null
     }
 
     void "test generate bean introspection for @ConfigurationProperties with validation rules on getters"() {

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/introspections/ValueConfiguration.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/introspections/ValueConfiguration.groovy
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.visitor.introspections
+
+import com.blazebit.persistence.impl.function.entity.ValuesEntity
+import io.micronaut.core.annotation.Introspected
+
+@Introspected(classes = ValuesEntity.class)
+class ValueConfiguration {
+}

--- a/inject-java-test/build.gradle
+++ b/inject-java-test/build.gradle
@@ -15,4 +15,5 @@ dependencies {
     testImplementation dependencyVersion("validation")
     testImplementation "javax.persistence:javax.persistence-api:2.2"
     testImplementation project(":runtime")
+    api "com.blazebit:blaze-persistence-core-impl:1.5.0-Alpha1"
 }

--- a/inject-java-test/src/main/groovy/io/micronaut/annotation/processing/test/ValueConfiguration.java
+++ b/inject-java-test/src/main/groovy/io/micronaut/annotation/processing/test/ValueConfiguration.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.annotation.processing.test;
+
+import com.blazebit.persistence.impl.function.entity.ValuesEntity;
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected(classes = ValuesEntity.class)
+public class ValueConfiguration {
+}

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
@@ -1,5 +1,6 @@
 package io.micronaut.inject.visitor.beans
 
+import com.blazebit.persistence.impl.function.entity.ValuesEntity
 import io.micronaut.annotation.processing.TypeElementVisitorProcessor
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.micronaut.annotation.processing.test.JavaParser
@@ -144,6 +145,14 @@ class Test {}
 
         cleanup:
         applicationContext.close()
+    }
+    void "test introspection class member configuration works 2"() {
+        when:
+            BeanIntrospection introspection = BeanIntrospection.getIntrospection(ValuesEntity)
+
+        then:
+            noExceptionThrown()
+            introspection != null
     }
 
     void "test bean introspection with property of generic interface"() {

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/ValueConfiguration.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/ValueConfiguration.groovy
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.visitor.beans
+
+import com.blazebit.persistence.impl.function.entity.ValuesEntity
+import io.micronaut.core.annotation.Introspected
+
+@Introspected(classes = ValuesEntity.class)
+class ValueConfiguration {
+}

--- a/inject/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
@@ -93,6 +93,10 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
         }
     }
 
+    private boolean isIntrospected(VisitorContext context, ClassElement c) {
+        return writers.containsKey(c.getName()) || context.getClassElement(c.getPackageName() + ".$" + c.getSimpleName() + "$Introspection").isPresent();
+    }
+
     @Override
     public void visitMethod(MethodElement element, VisitorContext context) {
         final ClassElement declaringType = element.getDeclaringType();
@@ -194,7 +198,7 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
             for (AnnotationClassValue aClass : classes) {
                 final Optional<ClassElement> classElement = context.getClassElement(aClass.getName());
                 classElement.ifPresent(ce -> {
-                    if (ce.isPublic() && !ce.hasStereotype(Introspected.class)) {
+                    if (ce.isPublic() && !isIntrospected(context, ce)) {
                         final BeanIntrospectionWriter writer = new BeanIntrospectionWriter(
                                 element.getName(),
                                 index.getAndIncrement(),
@@ -216,7 +220,7 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                     ClassElement[] elements = context.getClassElements(aPackage, includedAnnotations.toArray(new String[0]));
                     int j = 0;
                     for (ClassElement classElement : elements) {
-                        if (classElement.isAbstract() || !classElement.isPublic() || classElement.hasStereotype(Introspected.class)) {
+                        if (classElement.isAbstract() || !classElement.isPublic() || isIntrospected(context, classElement)) {
                             continue;
                         }
                         final BeanIntrospectionWriter writer = new BeanIntrospectionWriter(


### PR DESCRIPTION
It's not enough to check if the class has `@Introspected`, external classes present the annotation because if the mapper.

Not sure if the fix is correct.