### PR TITLE
Allow to use @Around and @Introduction(interfaces) together

### DIFF
--- a/aop/src/main/java/io/micronaut/aop/chain/InterceptorChain.java
+++ b/aop/src/main/java/io/micronaut/aop/chain/InterceptorChain.java
@@ -285,9 +285,9 @@ public class InterceptorChain<B, R> implements InvocationContext<B, R> {
         Set<Class> applicableClasses = new HashSet<>();
 
         for (Class<? extends Annotation> aClass: annotations) {
-            if (annotationType == Around.class && aClass.getAnnotation(Introduction.class) != null) {
+            if (annotationType == Around.class && aClass.getAnnotation(Around.class) == null && aClass.getAnnotation(Introduction.class) != null) {
                 continue;
-            } else if (annotationType == Introduction.class && aClass.getAnnotation(Around.class) != null) {
+            } else if (annotationType == Introduction.class && aClass.getAnnotation(Introduction.class) == null && aClass.getAnnotation(Around.class) != null) {
                 continue;
             }
             Type typeAnn = aClass.getAnnotation(Type.class);

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -597,7 +597,9 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
 
                 @Override
                 protected boolean isAcceptableMethod(ExecutableElement executableElement) {
-                    return super.isAcceptableMethod(executableElement) || annotationUtils.getAnnotationMetadata(executableElement).hasDeclaredStereotype(AROUND_TYPE);
+                    return super.isAcceptableMethod(executableElement)
+                            || annotationUtils.getAnnotationMetadata(executableElement).hasDeclaredStereotype(AROUND_TYPE)
+                            || annotationUtils.getAnnotationMetadata(classElement).hasDeclaredStereotype(AROUND_TYPE);
                 }
 
                 @Override

--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/CustomProxy.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/CustomProxy.java
@@ -1,0 +1,7 @@
+package io.micronaut.aop.introduction.with_around;
+
+public interface CustomProxy {
+
+    boolean isProxy();
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/IntroductionWithAroundOnConcreteClassSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/IntroductionWithAroundOnConcreteClassSpec.groovy
@@ -1,0 +1,51 @@
+package io.micronaut.aop.introduction.with_around
+
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.beans.BeanIntrospection
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class IntroductionWithAroundOnConcreteClassSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    ApplicationContext applicationContext = ApplicationContext.run()
+
+    @Unroll
+    void "test introduction with around for #clazz"(Class clazz) {
+        when:
+            def beanDefinition = applicationContext.findProxyTargetBeanDefinition(clazz, null).get()
+            def bean = applicationContext.getBean(beanDefinition)
+
+        then:
+            bean instanceof CustomProxy
+            ((CustomProxy) bean).isProxy()
+            bean.getId() == 1
+            bean.getName() == null
+
+        when:
+            bean = applicationContext.getProxyTargetBean(clazz, null)
+
+        then:
+            bean instanceof CustomProxy
+            ((CustomProxy) bean).isProxy()
+            bean.getId() == 1
+            bean.getName() == null
+
+        where:
+            clazz << [MyBean1, MyBean2, MyBean3, MyBean4]
+    }
+
+    void "test introspected preset"(Class clazz) {
+        when:
+            def introspection = BeanIntrospection.getIntrospection(clazz)
+        then:
+            introspection
+
+        where:
+            clazz << [MyBean4, MyBean5]
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/MyBean1.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/MyBean1.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.introduction.with_around;
+
+@ProxyIntroduction
+@ProxyAround
+public class MyBean1 {
+
+    private Long id;
+    private String name;
+
+    public MyBean1() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/MyBean2.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/MyBean2.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.introduction.with_around;
+
+@ProxyIntroductionAndAround
+public class MyBean2 {
+
+    private Long id;
+    private String name;
+
+    public MyBean2() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/MyBean3.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/MyBean3.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.introduction.with_around;
+
+@ProxyIntroductionAndAroundOneAnnotation
+public class MyBean3 {
+
+    private Long id;
+    private String name;
+
+    public MyBean3() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/MyBean4.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/MyBean4.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.introduction.with_around;
+
+import io.micronaut.core.annotation.Introspected;
+
+@ProxyIntroductionAndAroundOneAnnotation
+@Introspected
+public class MyBean4 {
+
+    private Long id;
+    private String name;
+
+    public MyBean4() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/MyBean5.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/MyBean5.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.introduction.with_around;
+
+@ProxyIntroductionAndAroundAndIntrospected
+public class MyBean5 {
+
+    private Long id;
+    private String name;
+
+    public MyBean5() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/ProxyAdviceInterceptor.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/ProxyAdviceInterceptor.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.introduction.with_around;
+
+import io.micronaut.aop.MethodInterceptor;
+import io.micronaut.aop.MethodInvocationContext;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class ProxyAdviceInterceptor implements MethodInterceptor<Object, Object> {
+
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        if (context.getMethodName().equalsIgnoreCase("isProxy")) {
+            return true;
+        }
+        if (context.getMethodName().equalsIgnoreCase("getId")) {
+            return 1L;
+        }
+        return context.proceed();
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/ProxyAround.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/ProxyAround.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.introduction.with_around;
+
+import io.micronaut.aop.Around;
+import io.micronaut.context.annotation.Type;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Around
+@Type(ProxyAdviceInterceptor.class)
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+public @interface ProxyAround {
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/ProxyAroundInterceptor.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/ProxyAroundInterceptor.java
@@ -15,20 +15,20 @@
  */
 package io.micronaut.aop.introduction.with_around;
 
-import io.micronaut.aop.Around;
-import io.micronaut.context.annotation.Type;
+import io.micronaut.aop.MethodInterceptor;
+import io.micronaut.aop.MethodInvocationContext;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
+import javax.inject.Singleton;
 
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
+@Singleton
+public class ProxyAroundInterceptor implements MethodInterceptor<Object, Object> {
 
-@Around
-@Type(ProxyAroundInterceptor.class)
-@Documented
-@Retention(RUNTIME)
-@Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE})
-public @interface ProxyAround {
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        // Intercept everything other when CustomProxy
+        if (context.getMethodName().equalsIgnoreCase("getId")) {
+            return 1L;
+        }
+        return context.proceed();
+    }
 }

--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/ProxyIntroduction.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/ProxyIntroduction.java
@@ -26,7 +26,7 @@ import java.lang.annotation.Target;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 @Introduction(interfaces = CustomProxy.class)
-@Type(ProxyAdviceInterceptor.class)
+@Type(ProxyIntroductionInterceptor.class)
 @Documented
 @Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE})
 public @interface ProxyIntroduction {

--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/ProxyIntroduction.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/ProxyIntroduction.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.introduction.with_around;
+
+import io.micronaut.aop.Introduction;
+import io.micronaut.context.annotation.Type;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Introduction(interfaces = CustomProxy.class)
+@Type(ProxyAdviceInterceptor.class)
+@Documented
+@Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+public @interface ProxyIntroduction {
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/ProxyIntroductionAndAround.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/ProxyIntroductionAndAround.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.introduction.with_around;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Documented
+@Retention(RUNTIME)
+@ProxyIntroduction
+@ProxyAround
+public @interface ProxyIntroductionAndAround {
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/ProxyIntroductionAndAroundAndIntrospected.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/ProxyIntroductionAndAroundAndIntrospected.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.introduction.with_around;
+
+import io.micronaut.aop.Around;
+import io.micronaut.aop.Introduction;
+import io.micronaut.context.annotation.Type;
+import io.micronaut.core.annotation.Introspected;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Around
+@Introduction(interfaces = CustomProxy.class)
+@Type(ProxyAdviceInterceptor.class)
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+@Introspected
+public @interface ProxyIntroductionAndAroundAndIntrospected {
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/ProxyIntroductionAndAroundOneAnnotation.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/ProxyIntroductionAndAroundOneAnnotation.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.introduction.with_around;
+
+import io.micronaut.aop.Around;
+import io.micronaut.aop.Introduction;
+import io.micronaut.context.annotation.Type;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Around
+@Introduction(interfaces = CustomProxy.class)
+@Type(ProxyAdviceInterceptor.class)
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+public @interface ProxyIntroductionAndAroundOneAnnotation {
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/ProxyIntroductionInterceptor.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/ProxyIntroductionInterceptor.java
@@ -15,20 +15,20 @@
  */
 package io.micronaut.aop.introduction.with_around;
 
-import io.micronaut.aop.Around;
-import io.micronaut.context.annotation.Type;
+import io.micronaut.aop.MethodInterceptor;
+import io.micronaut.aop.MethodInvocationContext;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
+import javax.inject.Singleton;
 
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
+@Singleton
+public class ProxyIntroductionInterceptor implements MethodInterceptor<Object, Object> {
 
-@Around
-@Type(ProxyAroundInterceptor.class)
-@Documented
-@Retention(RUNTIME)
-@Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE})
-public @interface ProxyAround {
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        // Only intercept CustomProxy
+        if (context.getMethodName().equalsIgnoreCase("isProxy")) {
+            return true;
+        }
+        return context.proceed();
+    }
 }


### PR DESCRIPTION
I have a use case where I want to implement an interface and also intercept all the methods, at the moment is not possible.

