### PR TITLE
Write service descriptors for Eclipse compiler. Fixes #4125

### DIFF
--- a/inject-java/src/main/java/io/micronaut/annotation/processing/AnnotationProcessingOutputVisitor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/AnnotationProcessingOutputVisitor.java
@@ -53,7 +53,12 @@ public class AnnotationProcessingOutputVisitor extends AbstractClassWriterOutput
      * @param filer The {@link Filer} for creating new files
      */
     public AnnotationProcessingOutputVisitor(Filer filer) {
+        super(isEclipseFiler(filer));
         this.filer = filer;
+    }
+
+    private static boolean isEclipseFiler(Filer filer) {
+        return filer.getClass().getTypeName().startsWith("org.eclipse.jdt");
     }
 
     @Override

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -39,10 +39,7 @@ import io.micronaut.inject.configuration.ConfigurationMetadataWriter;
 import io.micronaut.inject.configuration.PropertyMetadata;
 import io.micronaut.inject.processing.JavaModelUtils;
 import io.micronaut.inject.processing.ProcessedTypes;
-import io.micronaut.inject.writer.BeanDefinitionReferenceWriter;
-import io.micronaut.inject.writer.BeanDefinitionVisitor;
-import io.micronaut.inject.writer.BeanDefinitionWriter;
-import io.micronaut.inject.writer.ExecutableMethodWriter;
+import io.micronaut.inject.writer.*;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 import javax.annotation.processing.ProcessingEnvironment;
@@ -201,6 +198,7 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
         if (processingOver) {
             try {
                 writeConfigurationMetadata();
+                writeBeanDefinitionsToMetaInf();
             } finally {
                 AnnotationUtils.invalidateCache();
                 AbstractAnnotationMetadataBuilder.clearMutated();
@@ -208,6 +206,18 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
         }
 
         return false;
+    }
+
+    /**
+     * Writes {@link io.micronaut.inject.BeanDefinitionReference} into /META-INF/services/io.micronaut.inject.BeanDefinitionReference.
+     */
+    private void writeBeanDefinitionsToMetaInf() {
+        try {
+            classWriterOutputVisitor.finish();
+        } catch (Exception e) {
+            String message = e.getMessage();
+            error("Error occurred writing META-INF files: %s", message != null ? message : e);
+        }
     }
 
     private void writeConfigurationMetadata() {

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/PackageConfigurationInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/PackageConfigurationInjectProcessor.java
@@ -65,6 +65,11 @@ public class PackageConfigurationInjectProcessor extends AbstractInjectAnnotatio
         AnnotationElementScanner scanner = new AnnotationElementScanner();
         Set<? extends Element> elements = roundEnv.getRootElements();
         ElementFilter.packagesIn(elements).forEach(element -> element.accept(scanner, element));
+        try {
+            classWriterOutputVisitor.finish();
+        } catch (Exception e) {
+            error("I/O error occurred writing META-INF services information: %s", e);
+        }
         return false;
     }
 

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
@@ -206,6 +206,9 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
             }
         }
 
+        if (roundEnv.processingOver()) {
+            javaVisitorContext.finish();
+        }
         return false;
     }
 

--- a/inject/src/main/java/io/micronaut/inject/writer/AbstractClassWriterOutputVisitor.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/AbstractClassWriterOutputVisitor.java
@@ -38,21 +38,21 @@ import java.util.Set;
 @Internal
 public abstract class AbstractClassWriterOutputVisitor implements ClassWriterOutputVisitor {
     private final Map<String, Set<String>> serviceDescriptors = new HashMap<>();
-    private final boolean isEclipseCompiler;
+    private final boolean isWriteOnFinish;
 
     /**
      * Default constructor.
-     * @param isEclipseCompiler Is this the eclipse compiler
+     * @param isWriteOnFinish Is this the eclipse compiler
      */
-    protected AbstractClassWriterOutputVisitor(boolean isEclipseCompiler) {
-        this.isEclipseCompiler = isEclipseCompiler;
+    protected AbstractClassWriterOutputVisitor(boolean isWriteOnFinish) {
+        this.isWriteOnFinish = isWriteOnFinish;
     }
 
     /**
      * Compatibility constructor.
      */
     public AbstractClassWriterOutputVisitor() {
-        this.isEclipseCompiler = false;
+        this.isWriteOnFinish = false;
     }
 
     @Override
@@ -69,12 +69,15 @@ public abstract class AbstractClassWriterOutputVisitor implements ClassWriterOut
 
     @Override
     public final void finish() {
-        // we only write out service entries for the Eclipse compiler because
+        // for Java we only write out service entries for the Eclipse compiler because
         // for javac we support incremental compilation via ServiceDescriptionProcessor
         // this approach doesn't work in Eclipse.
         // see https://bugs.eclipse.org/bugs/show_bug.cgi?id=567116
         // If the above issue is fixed then this workaround can be removed
-        if (isEclipseCompiler) {
+
+        // for Groovy writing service entries is also required as ServiceDescriptionProcessor
+        // is not triggered. See DirectoryClassWriterOutputVisitor
+        if (isWriteOnFinish) {
             Map<String, Set<String>> serviceEntries = getServiceEntries();
 
             writeServiceEntries(serviceEntries);
@@ -131,7 +134,7 @@ public abstract class AbstractClassWriterOutputVisitor implements ClassWriterOut
     }
 
     private boolean isNotEclipseNotFound(Throwable e) {
-        if (isEclipseCompiler) {
+        if (isWriteOnFinish) {
             return false;
         }
         String message = e.getMessage();

--- a/inject/src/main/java/io/micronaut/inject/writer/DirectoryClassWriterOutputVisitor.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/DirectoryClassWriterOutputVisitor.java
@@ -40,7 +40,7 @@ public class DirectoryClassWriterOutputVisitor extends AbstractClassWriterOutput
      * @param targetDir The target directory
      */
     public DirectoryClassWriterOutputVisitor(File targetDir) {
-        super(false);
+        super(true);
         this.targetDir = targetDir;
     }
 

--- a/inject/src/main/java/io/micronaut/inject/writer/DirectoryClassWriterOutputVisitor.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/DirectoryClassWriterOutputVisitor.java
@@ -40,6 +40,7 @@ public class DirectoryClassWriterOutputVisitor extends AbstractClassWriterOutput
      * @param targetDir The target directory
      */
     public DirectoryClassWriterOutputVisitor(File targetDir) {
+        super(false);
         this.targetDir = targetDir;
     }
 


### PR DESCRIPTION
This issue provides a workaround and fixes #4125 which is an issue for VS Code and Eclipse users as service descriptors are not being generated with the Eclipse compiler.

The fix is a bit hacky and ideally the original issue in Eclipse should be resolved, but this provides a short term solution.