### PR TITLE
Declare SocketUtils for GraalvM run-time execution

### DIFF
--- a/core/src/main/resources/META-INF/native-image/io.micronaut.core/io.socket/native-image.properties
+++ b/core/src/main/resources/META-INF/native-image/io.micronaut.core/io.socket/native-image.properties
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-Args = -H:ReflectionConfigurationResources=${.}/reflection-config.json
+Args = --initialize-at-run-time=io.micronaut.core.io.socket.SocketUtils


### PR DESCRIPTION
This way the port is not set at compile time. This is useful when
`micronaut.server.port` is set to -1 for the app (not the tests)