### PR TITLE
Correct ExecutableMethod cast and allow to change the target in ExecutableMethod generated by `@Around`

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/IntroductionWithAroundOnConcreteClassSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/IntroductionWithAroundOnConcreteClassSpec.groovy
@@ -36,7 +36,7 @@ class IntroductionWithAroundOnConcreteClassSpec extends Specification {
             bean.getName() == null
 
         where:
-            clazz << [MyBean1, MyBean2, MyBean3, MyBean4]
+            clazz << [MyBean1, MyBean2, MyBean3, MyBean4, MyBean5, MyBean6]
     }
 
     void "test introspected preset"(Class clazz) {
@@ -46,6 +46,6 @@ class IntroductionWithAroundOnConcreteClassSpec extends Specification {
             introspection
 
         where:
-            clazz << [MyBean4, MyBean5]
+            clazz << [MyBean4, MyBean5, MyBean6]
     }
 }

--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/MyBean6.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/MyBean6.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.introduction.with_around;
+
+@ProxyIntroductionAndAroundAndIntrospectedAndExecutable
+public class MyBean6 {
+
+    private Long id;
+    private String name;
+
+    public MyBean6() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/ProxyAdviceInterceptor.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/ProxyAdviceInterceptor.java
@@ -35,7 +35,11 @@ public class ProxyAdviceInterceptor implements MethodInterceptor<Object, Object>
     public Object intercept(MethodInvocationContext<Object, Object> context) {
         if (context.getMethodName().equalsIgnoreCase("getId")) {
             // Test invocation delegation
-            if (context.getTarget() instanceof MyBean6) {
+            if (context.getTarget() instanceof MyBean5) {
+                MyBean5 delegate = new MyBean5();
+                delegate.setId(1L);
+                return context.getExecutableMethod().invoke(delegate, context.getParameterValues());
+            } else if (context.getTarget() instanceof MyBean6) {
                 try {
                     ExecutableMethod<MyBean6, Object> proxyTargetMethod = beanContext.getProxyTargetMethod(MyBean6.class, context.getMethodName(), context.getArgumentTypes());
                     MyBean6 delegate = new MyBean6();

--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/ProxyAdviceInterceptor.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/ProxyAdviceInterceptor.java
@@ -17,19 +17,39 @@ package io.micronaut.aop.introduction.with_around;
 
 import io.micronaut.aop.MethodInterceptor;
 import io.micronaut.aop.MethodInvocationContext;
+import io.micronaut.context.BeanContext;
+import io.micronaut.inject.ExecutableMethod;
 
 import javax.inject.Singleton;
 
 @Singleton
 public class ProxyAdviceInterceptor implements MethodInterceptor<Object, Object> {
 
+    private final BeanContext beanContext;
+
+    public ProxyAdviceInterceptor(BeanContext beanContext) {
+        this.beanContext = beanContext;
+    }
+
     @Override
     public Object intercept(MethodInvocationContext<Object, Object> context) {
+        if (context.getMethodName().equalsIgnoreCase("getId")) {
+            // Test invocation delegation
+            if (context.getTarget() instanceof MyBean6) {
+                try {
+                    ExecutableMethod<MyBean6, Object> proxyTargetMethod = beanContext.getProxyTargetMethod(MyBean6.class, context.getMethodName(), context.getArgumentTypes());
+                    MyBean6 delegate = new MyBean6();
+                    delegate.setId(1L);
+                    return proxyTargetMethod.invoke(delegate, context.getParameterValues());
+                } catch (NoSuchMethodException e) {
+                    throw new RuntimeException(e);
+                }
+            } else {
+                return 1L;
+            }
+        }
         if (context.getMethodName().equalsIgnoreCase("isProxy")) {
             return true;
-        }
-        if (context.getMethodName().equalsIgnoreCase("getId")) {
-            return 1L;
         }
         return context.proceed();
     }

--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/ProxyIntroductionAndAroundAndIntrospectedAndExecutable.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/ProxyIntroductionAndAroundAndIntrospectedAndExecutable.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.introduction.with_around;
+
+import io.micronaut.aop.Around;
+import io.micronaut.aop.Introduction;
+import io.micronaut.context.annotation.Executable;
+import io.micronaut.context.annotation.Type;
+import io.micronaut.core.annotation.Introspected;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Around
+@Introduction(interfaces = CustomProxy.class)
+@Type(ProxyAdviceInterceptor.class)
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+@Introspected
+@Executable
+public @interface ProxyIntroductionAndAroundAndIntrospectedAndExecutable {
+}

--- a/inject/src/main/java/io/micronaut/inject/writer/ExecutableMethodWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/ExecutableMethodWriter.java
@@ -420,7 +420,7 @@ public class ExecutableMethodWriter extends AbstractAnnotationMetadataWriter imp
             GeneratorAdapter invokeMethodVisitor) {
         Type returnTypeObject = getTypeReference(returnType);
         invokeMethodVisitor.visitVarInsn(ALOAD, 1);
-        pushCastToType(invokeMethodVisitor, beanFullClassName);
+        pushCastToType(invokeMethodVisitor,  declaringTypeObject.getClassName());
         boolean hasArgs = !argumentTypes.isEmpty();
         String methodDescriptor;
         if (hasArgs) {


### PR DESCRIPTION
Sorry for another PR 🤣 
I have been working on POC to make compile-time Hibernate proxies without any bytecode modifications.

https://github.com/dstepanov/micronaut-sql/commit/89f54fe14e51b084ddb5efca0bacf7cd4f1e5bb1

I think this is the last thing that is needed, it looks like I need all of the AOP features: introduce, around + executable.
It surprised me that it isn't possible to take `ExecutableMethod` from `MethodInvocationContext` and simply invoke it with a different target, looks like the target is hard-wired and the only way is to have an executable method for every bean method 🤔 

Maybe there is a better way @graemerocher @jameskleeh ?
