### PR TITLE
Reuse executable methods

### DIFF
--- a/core/src/main/java/io/micronaut/core/io/service/SoftServiceLoader.java
+++ b/core/src/main/java/io/micronaut/core/io/service/SoftServiceLoader.java
@@ -20,6 +20,7 @@ import io.micronaut.core.reflect.ClassUtils;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
 import java.net.URL;
 import java.util.Enumeration;
 import java.util.Iterator;
@@ -213,7 +214,7 @@ public final class SoftServiceLoader<S> implements Iterable<ServiceDefinition<S>
                         unprocessed = lines.iterator();
 
                     }
-                } catch (IOException e) {
+                } catch (IOException | UncheckedIOException e) {
                     // ignore, can't do anything here and can't log because class used in compiler
                 }
             }

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/InjectTransform.groovy
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/InjectTransform.groovy
@@ -594,22 +594,6 @@ class InjectTransform implements ASTTransformation, CompilationUnitAware {
                             annotationMetadata = addAnnotation(annotationMetadata, ANN_CONFIGURATION_ADVICE)
                         }
 
-                        if (IS_CONSTRAINT.test(annotationMetadata) && !annotationMetadata.hasStereotype(Executable.class)) {
-                            aopProxyWriter.visitExecutableMethod(
-                                    owningType,
-                                    returnType,
-                                    resolvedReturnType,
-                                    resolvedGenericTypes,
-                                    methodNode.name,
-                                    targetMethodParamsToType,
-                                    targetGenericParams,
-                                    targetAnnotationMetadata,
-                                    targetMethodGenericTypeMap,
-                                    annotationMetadata,
-                                    methodNode.declaringClass.isInterface(),
-                                    false
-                            )
-                        }
                     }
 
                     if (AstAnnotationUtils.hasStereotype(source, unit, methodNode, AROUND_TYPE)) {
@@ -617,22 +601,6 @@ class InjectTransform implements ASTTransformation, CompilationUnitAware {
                         aopProxyWriter.visitInterceptorTypes(interceptorTypeReferences)
                     }
 
-                    if (annotationMetadata.hasStereotype(Executable.class)) {
-                        aopProxyWriter.visitExecutableMethod(
-                                owningType,
-                                returnType,
-                                resolvedReturnType,
-                                resolvedGenericTypes,
-                                methodNode.name,
-                                targetMethodParamsToType,
-                                targetGenericParams,
-                                targetAnnotationMetadata,
-                                targetMethodGenericTypeMap,
-                                annotationMetadata,
-                                methodNode.declaringClass.isInterface(),
-                                false
-                        )
-                    }
                     if (methodNode.isAbstract()) {
                         aopProxyWriter.visitIntroductionMethod(
                                 owningType,
@@ -838,21 +806,6 @@ class InjectTransform implements ASTTransformation, CompilationUnitAware {
                                 )
                             }
 
-                            ExecutableMethodWriter writer = beanMethodWriter.visitExecutableMethod(
-                                    AstGenericUtils.resolveTypeReference(targetBeanMethodNode.declaringClass),
-                                    returnTypeReference,
-                                    resolvedReturnType,
-                                    resolvedGenericTypes,
-                                    targetBeanMethodNode.name,
-                                    targetMethodParamsToType,
-                                    targetGenericParams,
-                                    targetAnnotationMetadata,
-                                    targetMethodGenericTypeMap,
-                                    annotationMetadata,
-                                    targetBeanMethodNode.declaringClass.isInterface(),
-                                    false
-                            )
-
                             proxyWriter.visitAroundMethod(
                                     AstGenericUtils.resolveTypeReference(targetBeanMethodNode.declaringClass),
                                     returnTypeReference,
@@ -863,7 +816,7 @@ class InjectTransform implements ASTTransformation, CompilationUnitAware {
                                     targetGenericParams,
                                     targetAnnotationMetadata,
                                     targetMethodGenericTypeMap,
-                                    new AnnotationMetadataReference(writer.getClassName(), annotationMetadata),
+                                    annotationMetadata,
                                     targetBeanMethodNode.declaringClass.isInterface(),
                                     false
                             )
@@ -1134,20 +1087,8 @@ class InjectTransform implements ASTTransformation, CompilationUnitAware {
                         methodAnnotationMetadata = addValidated(methodAnnotationMetadata)
                     }
                 }
-                ExecutableMethodWriter executableMethodWriter = getBeanWriter().visitExecutableMethod(
-                        AstGenericUtils.resolveTypeReference(methodNode.declaringClass),
-                        AstGenericUtils.resolveTypeReference(methodNode.returnType),
-                        AstGenericUtils.resolveTypeReference(methodNode.returnType, declaringTypeGenericInfo),
-                        returnTypeGenerics,
-                        methodName,
-                        paramsToType,
-                        genericParams,
-                        argumentAnnotationMetadata,
-                        genericTypeMap,
-                        methodAnnotationMetadata,
-                        methodNode.declaringClass.isInterface(),
-                        false
-                )
+
+                boolean executorMethodAdded = false
 
                 if (methodAnnotationMetadata.hasStereotype(Adapter.class)) {
                     visitAdaptedMethod(methodNode, methodAnnotationMetadata)
@@ -1190,12 +1131,31 @@ class InjectTransform implements ASTTransformation, CompilationUnitAware {
                                     genericParams,
                                     argumentAnnotationMetadata,
                                     genericTypeMap,
-                                    new AnnotationMetadataReference(executableMethodWriter.getClassName(), methodAnnotationMetadata),
+                                    methodAnnotationMetadata,
                                     methodNode.declaringClass.isInterface(),
                                     false
                             )
+
+                            executorMethodAdded = true
                         }
                     }
+                }
+
+                if (!executorMethodAdded) {
+                    getBeanWriter().visitExecutableMethod(
+                            AstGenericUtils.resolveTypeReference(methodNode.declaringClass),
+                            AstGenericUtils.resolveTypeReference(methodNode.returnType),
+                            AstGenericUtils.resolveTypeReference(methodNode.returnType, declaringTypeGenericInfo),
+                            returnTypeGenerics,
+                            methodName,
+                            paramsToType,
+                            genericParams,
+                            argumentAnnotationMetadata,
+                            genericTypeMap,
+                            methodAnnotationMetadata,
+                            methodNode.declaringClass.isInterface(),
+                            false
+                    )
                 }
             }
         }
@@ -1528,21 +1488,6 @@ class InjectTransform implements ASTTransformation, CompilationUnitAware {
                         resolvedAnnotationMetadata = emptyMap
                     }
 
-                    beanWriter.visitExecutableMethod(
-                            propertyNode.getDeclaringClass().name,
-                            void.class,
-                            void.class,
-                            emptyMap,
-                            getSetterName(propertyName),
-                            resolvedArguments,
-                            resolvedArguments,
-                            resolvedAnnotationMetadata,
-                            resolvedGenericTypes,
-                            fieldAnnotationMetadata,
-                            propertyNode.declaringClass.isInterface(),
-                            false
-                    )
-
                     aopWriter.visitAroundMethod(
                             propertyNode.getDeclaringClass().name,
                             void.class,
@@ -1559,21 +1504,6 @@ class InjectTransform implements ASTTransformation, CompilationUnitAware {
                     )
 
                     // also visit getter to ensure proxying
-
-                    beanWriter.visitExecutableMethod(
-                            propertyNode.getDeclaringClass().name,
-                            propertyType,
-                            propertyType,
-                            emptyMap,
-                            getGetterName(propertyNode),
-                            emptyMap,
-                            emptyMap,
-                            emptyMap,
-                            emptyMap,
-                            fieldAnnotationMetadata,
-                            propertyNode.declaringClass.isInterface(),
-                            false
-                    )
 
                     aopWriter.visitAroundMethod(
                             propertyNode.getDeclaringClass().name,

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -719,23 +719,6 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                             annotationMetadata = metadataBuilder.annotate(
                                     annotationMetadata,
                                     builder.build());
-
-                            if (annotationMetadata.hasStereotype(ANN_CONSTRAINT) && !annotationMetadata.hasStereotype(Executable.class)) {
-                                aopProxyWriter.visitExecutableMethod(
-                                        owningType,
-                                        returnType,
-                                        resolvedReturnType,
-                                        returnTypeGenerics,
-                                        methodName,
-                                        methodParameters,
-                                        genericParameters,
-                                        parameterAnnotationMetadata,
-                                        methodGenericTypes,
-                                        annotationMetadata,
-                                        JavaModelUtils.isInterface(method.getEnclosingElement()),
-                                        method.isDefault()
-                                );
-                            }
                         }
                     }
 
@@ -747,23 +730,6 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                         aopProxyWriter.visitInterceptorTypes(interceptorTypes);
                     }
 
-
-                    if (annotationMetadata.hasStereotype(Executable.class)) {
-                        aopProxyWriter.visitExecutableMethod(
-                                owningType,
-                                returnType,
-                                resolvedReturnType,
-                                returnTypeGenerics,
-                                methodName,
-                                methodParameters,
-                                genericParameters,
-                                parameterAnnotationMetadata,
-                                methodGenericTypes,
-                                annotationMetadata,
-                                JavaModelUtils.isInterface(method.getEnclosingElement()),
-                                method.isDefault()
-                        );
-                    }
                     if (isAbstract) {
                         aopProxyWriter.visitIntroductionMethod(
                                 owningType,
@@ -1120,33 +1086,16 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                         Map<String, Object> genericParameters = params.getGenericParameters();
 
                         AnnotationMetadata annotationMetadata;
-                        boolean isAnnotationReference = false;
                         // if the method is annotated we build metadata for the method
                         if (annotationUtils.isAnnotated(producedTypeName, method)) {
                             annotationMetadata = annotationUtils.getAnnotationMetadata(beanMethod, method);
                         } else {
                             // otherwise we setup a reference to the parent metadata (essentially the annotations declared on the bean factory method)
-                            isAnnotationReference = true;
                             annotationMetadata = new AnnotationMetadataReference(
                                     beanMethodWriter.getBeanDefinitionName() + BeanDefinitionReferenceWriter.REF_SUFFIX,
                                     methodAnnotationMetadata
                             );
                         }
-
-                        ExecutableMethodWriter executableMethodWriter = beanMethodWriter.visitExecutableMethod(
-                                owningType,
-                                modelUtils.resolveTypeReference(returnTypeMirror),
-                                resolvedReturnType,
-                                returnTypeGenerics,
-                                methodName,
-                                methodParameters,
-                                genericParameters,
-                                methodQualifier,
-                                methodGenericTypes,
-                                annotationMetadata,
-                                JavaModelUtils.isInterface(method.getEnclosingElement()),
-                                method.isDefault()
-                        );
 
                         aopProxyWriter.visitAroundMethod(
                                 owningType,
@@ -1158,7 +1107,7 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                                 genericParameters,
                                 methodQualifier,
                                 methodGenericTypes,
-                                !isAnnotationReference ? new AnnotationMetadataReference(executableMethodWriter.getClassName(), annotationMetadata) : annotationMetadata,
+                                annotationMetadata,
                                 JavaModelUtils.isInterface(method.getEnclosingElement()),
                                 method.isDefault()
                         );
@@ -1299,30 +1248,11 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                 typeRef = modelUtils.resolveTypeReference(concreteClass);
             }
 
-            final AopProxyWriter proxyWriter = resolveAopWriter(beanWriter);
-            ExecutableMethodWriter executableMethodWriter = null;
-            if (proxyWriter == null || proxyWriter.isProxyTarget()) {
-                addOriginatingElementIfNecessary(beanWriter, declaringClass);
-                executableMethodWriter = beanWriter.visitExecutableMethod(
-                        typeRef,
-                        resolvedReturnType,
-                        resolvedReturnType,
-                        returnTypeGenerics,
-                        method.getSimpleName().toString(),
-                        params.getParameters(),
-                        params.getGenericParameters(),
-                        params.getParameterMetadata(),
-                        params.getGenericTypes(),
-                        methodAnnotationMetadata,
-                        JavaModelUtils.isInterface(enclosingElement),
-                        method.isDefault());
-            }
-
-
             if (methodAnnotationMetadata.hasStereotype(Adapter.class)) {
                 visitAdaptedMethod(method, methodAnnotationMetadata);
             }
 
+            boolean executableMethodVisited = false;
 
             // shouldn't visit around advice on an introduction advice instance
             if (!(beanWriter instanceof AopProxyWriter)) {
@@ -1346,18 +1276,11 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
 
                     aopProxyWriter.visitInterceptorTypes(interceptorTypes);
 
-                    boolean isAnnotationReference = methodAnnotationMetadata instanceof AnnotationMetadataReference;
-
                     AnnotationMetadata aroundMethodMetadata;
-
-                    if (!isAnnotationReference && executableMethodWriter != null) {
-                        aroundMethodMetadata = new AnnotationMetadataReference(executableMethodWriter.getClassName(), methodAnnotationMetadata);
+                    if (methodAnnotationMetadata instanceof AnnotationMetadataHierarchy) {
+                        aroundMethodMetadata = methodAnnotationMetadata;
                     } else {
-                        if (methodAnnotationMetadata instanceof AnnotationMetadataHierarchy) {
-                            aroundMethodMetadata = methodAnnotationMetadata;
-                        } else {
-                            aroundMethodMetadata = new AnnotationMetadataHierarchy(concreteClassMetadata, methodAnnotationMetadata);
-                        }
+                        aroundMethodMetadata = new AnnotationMetadataHierarchy(concreteClassMetadata, methodAnnotationMetadata);
                     }
 
                     if (modelUtils.isFinal(method)) {
@@ -1365,42 +1288,27 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                             error(method, "Method defines AOP advice but is declared final. Change the method to be non-final in order for AOP advice to be applied.");
                         } else {
                             if (isAopProxyType && isPublic && !declaringClass.equals(concreteClass)) {
-                                if (executableMethodWriter == null) {
-                                    beanWriter.visitExecutableMethod(
-                                            typeRef,
-                                            resolvedReturnType,
-                                            resolvedReturnType,
-                                            returnTypeGenerics,
-                                            method.getSimpleName().toString(),
-                                            params.getParameters(),
-                                            params.getGenericParameters(),
-                                            params.getParameterMetadata(),
-                                            params.getGenericTypes(),
-                                            methodAnnotationMetadata,
-                                            JavaModelUtils.isInterface(enclosingElement),
-                                            method.isDefault());
-                                }
+                                addOriginatingElementIfNecessary(beanWriter, declaringClass);
+                                beanWriter.visitExecutableMethod(
+                                        typeRef,
+                                        resolvedReturnType,
+                                        resolvedReturnType,
+                                        returnTypeGenerics,
+                                        method.getSimpleName().toString(),
+                                        params.getParameters(),
+                                        params.getGenericParameters(),
+                                        params.getParameterMetadata(),
+                                        params.getGenericTypes(),
+                                        aroundMethodMetadata,
+                                        JavaModelUtils.isInterface(enclosingElement),
+                                        method.isDefault());
+                                executableMethodVisited = true;
                             } else {
                                 error(method, "Public method inherits AOP advice but is declared final. Either make the method non-public or apply AOP advice only to public methods declared on the class.");
                             }
                         }
                     } else {
-                        if (aroundMethodMetadata.hasStereotype(Executable.class)) {
-                            aopProxyWriter.visitExecutableMethod(
-                                    typeRef,
-                                    resolvedReturnType,
-                                    resolvedReturnType,
-                                    returnTypeGenerics,
-                                    method.getSimpleName().toString(),
-                                    params.getParameters(),
-                                    params.getGenericParameters(),
-                                    params.getParameterMetadata(),
-                                    params.getGenericTypes(),
-                                    aroundMethodMetadata,
-                                    JavaModelUtils.isInterface(enclosingElement),
-                                    method.isDefault()
-                            );
-                        }
+                        addOriginatingElementIfNecessary(beanWriter, declaringClass);
                         aopProxyWriter.visitAroundMethod(
                                 typeRef,
                                 resolvedReturnType,
@@ -1414,24 +1322,29 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                                 aroundMethodMetadata,
                                 JavaModelUtils.isInterface(enclosingElement),
                                 method.isDefault());
+                        executableMethodVisited = true;
                     }
 
-                } else if (executableMethodWriter == null) {
-                    beanWriter.visitExecutableMethod(
-                            typeRef,
-                            resolvedReturnType,
-                            resolvedReturnType,
-                            returnTypeGenerics,
-                            method.getSimpleName().toString(),
-                            params.getParameters(),
-                            params.getGenericParameters(),
-                            params.getParameterMetadata(),
-                            params.getGenericTypes(),
-                            methodAnnotationMetadata,
-                            JavaModelUtils.isInterface(enclosingElement),
-                            method.isDefault());
                 }
             }
+
+            if (!executableMethodVisited) {
+                addOriginatingElementIfNecessary(beanWriter, declaringClass);
+                beanWriter.visitExecutableMethod(
+                        typeRef,
+                        resolvedReturnType,
+                        resolvedReturnType,
+                        returnTypeGenerics,
+                        method.getSimpleName().toString(),
+                        params.getParameters(),
+                        params.getGenericParameters(),
+                        params.getParameterMetadata(),
+                        params.getGenericTypes(),
+                        methodAnnotationMetadata,
+                        JavaModelUtils.isInterface(enclosingElement),
+                        method.isDefault());
+            }
+
         }
 
         private void visitAdaptedMethod(ExecutableElement method, AnnotationMetadata methodAnnotationMetadata) {
@@ -1624,8 +1537,8 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                                             methodQualifier,
                                             methodGenericTypes,
                                             annotationMetadata,
-                                            JavaModelUtils.isInterface(method.getEnclosingElement()),
-                                            method.isDefault()
+                                            JavaModelUtils.isInterface(targetMethod.getEnclosingElement()),
+                                            targetMethod.isDefault()
                                     );
 
 

--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/IntroductionWithAroundOnConcreteClassSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/IntroductionWithAroundOnConcreteClassSpec.groovy
@@ -17,8 +17,9 @@ class IntroductionWithAroundOnConcreteClassSpec extends Specification {
     @Unroll
     void "test introduction with around for #clazz"(Class clazz) {
         when:
-            def beanDefinition = applicationContext.findProxyTargetBeanDefinition(clazz, null).get()
-            def bean = applicationContext.getBean(beanDefinition)
+            def proxyTargetBeanDefinition = applicationContext.getProxyTargetBeanDefinition(clazz, null)
+            def beanDefinition = applicationContext.getBeanDefinition(clazz, null)
+            def bean = applicationContext.getBean(proxyTargetBeanDefinition)
 
         then:
             bean instanceof CustomProxy
@@ -35,6 +36,10 @@ class IntroductionWithAroundOnConcreteClassSpec extends Specification {
             bean.getId() == 1
             bean.getName() == null
 
+        and:
+            beanDefinition.getExecutableMethods().size() == 5
+            proxyTargetBeanDefinition.getExecutableMethods().size() == 5
+
         where:
             clazz << [MyBean1, MyBean2, MyBean3, MyBean4, MyBean5, MyBean6]
     }
@@ -47,5 +52,25 @@ class IntroductionWithAroundOnConcreteClassSpec extends Specification {
 
         where:
             clazz << [MyBean4, MyBean5, MyBean6]
+    }
+
+    void "test executable methods count for introduction with executable"() {
+        when:
+            def clazz = MyBean7.class
+            def proxyTargetBeanDefinition = applicationContext.getProxyTargetBeanDefinition(clazz, null)
+            def beanDefinition = applicationContext.getBeanDefinition(clazz, null)
+        then:
+            proxyTargetBeanDefinition.getExecutableMethods().size() == 5
+            beanDefinition.getExecutableMethods().size() == 5
+    }
+
+    void "test executable methods count for around with executable"() {
+        when:
+            def clazz = MyBean8.class
+            def proxyTargetBeanDefinition = applicationContext.getProxyTargetBeanDefinition(clazz, null)
+            def beanDefinition = applicationContext.getBeanDefinition(clazz, null)
+        then:
+            proxyTargetBeanDefinition.getExecutableMethods().size() == 4
+            beanDefinition.getExecutableMethods().size() == 4
     }
 }

--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/MyBean7.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/MyBean7.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.introduction.with_around;
+
+import io.micronaut.context.annotation.Executable;
+
+@Executable
+@ProxyIntroduction
+public class MyBean7 {
+
+    private Long id;
+    private String name;
+
+    public MyBean7() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/MyBean8.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/MyBean8.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.introduction.with_around;
+
+import io.micronaut.context.annotation.Executable;
+
+@Executable
+@ProxyAround
+public class MyBean8 {
+
+    private Long id;
+    private String name;
+
+    public MyBean8() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/ProxyIntroductionInterceptor.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/with_around/ProxyIntroductionInterceptor.java
@@ -27,7 +27,14 @@ public class ProxyIntroductionInterceptor implements MethodInterceptor<Object, O
     public Object intercept(MethodInvocationContext<Object, Object> context) {
         // Only intercept CustomProxy
         if (context.getMethodName().equalsIgnoreCase("isProxy")) {
-            return true;
+            // test introduced interface delegation
+            CustomProxy customProxy = new CustomProxy() {
+                @Override
+                public boolean isProxy() {
+                    return true;
+                }
+            };
+            return context.getExecutableMethod().invoke(customProxy, context.getParameterValues());
         }
         return context.proceed();
     }

--- a/inject/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
@@ -31,7 +31,6 @@ import io.micronaut.inject.writer.ClassGenerationException;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
-import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.util.*;


### PR DESCRIPTION
This PR changes how Around/Introduce generates executable methods, instead of generating inner classes it generates executable methods with extended ability.

The executable method class now knows about possible interception proxy and allows it to delegate to a target or bypass it by a new boolean field.

I have tested it on private projects:
P1: *.class count 2986 -> 2825
P2: *.class count 4106 -> 3831

