### PR TITLE
Fix default ProxySelector

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -1363,6 +1363,13 @@ public class DefaultHttpClient implements
         String username = configuration.getProxyUsername().orElse(null);
         String password = configuration.getProxyPassword().orElse(null);
 
+        if (proxyAddress instanceof InetSocketAddress) {
+            InetSocketAddress isa = (InetSocketAddress) proxyAddress;
+            if (isa.isUnresolved()) {
+                proxyAddress = new InetSocketAddress(isa.getHostString(), isa.getPort());
+            }
+        }
+
         if (StringUtils.isNotEmpty(username) && StringUtils.isNotEmpty(password)) {
             switch (proxyType) {
                 case HTTP:

--- a/http/src/main/java/io/micronaut/http/converters/HttpConverterRegistrar.java
+++ b/http/src/main/java/io/micronaut/http/converters/HttpConverterRegistrar.java
@@ -117,7 +117,7 @@ public class HttpConverterRegistrar implements TypeConverterRegistrar {
                     String[] parts = object.toString().split(":");
                     if (parts.length == 2) {
                         int port = Integer.parseInt(parts[1]);
-                        return Optional.of(new InetSocketAddress(parts[0], port));
+                        return Optional.of(InetSocketAddress.createUnresolved(parts[0], port));
                     } else {
                         return Optional.empty();
                     }

--- a/http/src/main/java/io/micronaut/http/converters/HttpConverterRegistrar.java
+++ b/http/src/main/java/io/micronaut/http/converters/HttpConverterRegistrar.java
@@ -27,6 +27,7 @@ import io.micronaut.http.MediaType;
 
 import javax.inject.Singleton;
 import java.net.InetSocketAddress;
+import java.net.ProxySelector;
 import java.net.SocketAddress;
 import java.net.URL;
 import java.util.Optional;
@@ -117,6 +118,17 @@ public class HttpConverterRegistrar implements TypeConverterRegistrar {
                     if (parts.length == 2) {
                         int port = Integer.parseInt(parts[1]);
                         return Optional.of(new InetSocketAddress(parts[0], port));
+                    } else {
+                        return Optional.empty();
+                    }
+                }
+        );
+        conversionService.addConverter(
+                CharSequence.class,
+                ProxySelector.class,
+                (object, targetType, context) -> {
+                    if (object.toString().equals("default")) {
+                        return Optional.of(ProxySelector.getDefault());
                     } else {
                         return Optional.empty();
                     }

--- a/inject/src/test/groovy/io/micronaut/context/env/yaml/RequiresSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/env/yaml/RequiresSpec.groovy
@@ -2,10 +2,12 @@ package io.micronaut.context.env.yaml
 
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Requires
+import spock.lang.IgnoreIf
 import spock.lang.Specification
 
 import javax.inject.Singleton
 
+@IgnoreIf({ os.windows })
 class RequiresSpec extends Specification {
 
     void "requirements for existing files are checked"() {

--- a/test-suite/src/test/groovy/io/micronaut/docs/http/client/proxy/ClientProxySpec.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/docs/http/client/proxy/ClientProxySpec.groovy
@@ -1,0 +1,88 @@
+package io.micronaut.docs.http.client.proxy
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.env.Environment
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.exceptions.HttpClientException
+import io.micronaut.runtime.server.EmbeddedServer
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy
+import org.testcontainers.utility.MountableFile
+import spock.lang.AutoCleanup
+import spock.lang.Retry
+import spock.lang.Specification
+
+@Retry
+class ClientProxySpec extends Specification {
+
+    static final int PROXY_PORT = 3128
+    static final String URL = "https://micronaut.io/"
+    static final String HTML_FRAGMENT = 'https://micronaut.io/documentation.html'
+
+    @AutoCleanup
+    GenericContainer proxyContainer =
+            new GenericContainer('sameersbn/squid:latest')
+                    .withCopyFileToContainer(MountableFile.forClasspathResource('/squid.conf'), '/etc/squid/squid.conf')
+                    .withExposedPorts(PROXY_PORT)
+                    .waitingFor(new HostPortWaitStrategy())
+
+    @AutoCleanup
+    EmbeddedServer embeddedServer
+
+    def setup() {
+        proxyContainer.start()
+    }
+
+    void "test downloading via http proxy using proxy-address"() {
+        given:
+        startServer([
+                'micronaut.http.client.exception-on-error-status': false,
+                'micronaut.http.client.proxy-type'               : 'http',
+                'micronaut.http.client.proxy-address'            : "${proxyHost}:${proxyPort}"
+        ])
+
+        when: 'download page via proxy'
+        def response = downloadPage()
+
+        then: 'page is downloaded'
+        response.status == HttpStatus.OK
+        response.body().contains(HTML_FRAGMENT)
+
+        when: 'proxy container is stopped'
+        proxyContainer.stop()
+
+        then: 'page download fails'
+        downloadFailsWithException() instanceof HttpClientException
+    }
+
+    private String getProxyHost() {
+        proxyContainer.containerIpAddress
+    }
+
+    private int getProxyPort() {
+        proxyContainer.getMappedPort(PROXY_PORT)
+    }
+
+    private void startServer(Map<String, Object> config) {
+        embeddedServer = ApplicationContext.run(EmbeddedServer, config, Environment.TEST)
+    }
+
+    private HttpClient getClient() {
+        embeddedServer.applicationContext.getBean(HttpClient)
+    }
+
+    private HttpResponse<String> downloadPage() {
+        client.toBlocking().exchange(URL, String)
+    }
+
+    private Throwable downloadFailsWithException() {
+        try {
+            downloadPage()
+            return null
+        } catch (Throwable ex) {
+            return ex
+        }
+    }
+}

--- a/test-suite/src/test/resources/squid.conf
+++ b/test-suite/src/test/resources/squid.conf
@@ -1,0 +1,2 @@
+http_port 3128
+http_access allow all


### PR DESCRIPTION
Fixes #4229 

Besides fixing the proxyAddress resolution I also made `SocketAddress` instances returned by the `ConversionService` to be unresolved to avoid storing the IP indefinitely and `ProxySelector.getDefault()` configurable from yaml:

```yaml
micronaut.http.client.proxy-selector: 'default'
```

This did not seem to cause any issues here in micronaut-core, however it may need to be tested in separate modules to avoid side-effects. Also, it would worth mentioning in the docs, however I did not attempt to make that change.

I am not sure if testing this kind of public page download is the best way to test this behaviour, I could not come up with anything more elegant.

Unfortunately testcontainers does not seem to work for me on Mac, however it seems to build on Linux and Windows.