### PR TITLE
Issue 4244 - ensure that the environments list is mutable #4244

### DIFF
--- a/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
+++ b/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
@@ -112,7 +112,7 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
         super(configuration.getConversionService());
         this.configuration = configuration;
         Set<String> environments = new LinkedHashSet<>(3);
-        List<String> specifiedNames = configuration.getEnvironments();
+        List<String> specifiedNames = new ArrayList<>(configuration.getEnvironments());
 
         specifiedNames.addAll(0, Stream.of(System.getProperty(ENVIRONMENTS_PROPERTY),
                 System.getenv(ENVIRONMENTS_ENV))

--- a/inject/src/test/groovy/io/micronaut/context/env/DefaultEnvironmentSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/env/DefaultEnvironmentSpec.groovy
@@ -625,7 +625,7 @@ class DefaultEnvironmentSpec extends Specification {
                     env = new DefaultEnvironment(new ApplicationContextConfiguration() {
                         @Override
                         List<String> getEnvironments() {
-                            return []
+                            return Arrays.asList()
                         }
 
                         @Override

--- a/inject/src/test/groovy/io/micronaut/context/env/DefaultEnvironmentSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/env/DefaultEnvironmentSpec.groovy
@@ -591,7 +591,7 @@ class DefaultEnvironmentSpec extends Specification {
         Environment env = new DefaultEnvironment(new ApplicationContextConfiguration() {
             @Override
             List<String> getEnvironments() {
-                return []
+                return Arrays.asList()
             }
 
             @Override
@@ -643,7 +643,7 @@ class DefaultEnvironmentSpec extends Specification {
         env = new DefaultEnvironment(new ApplicationContextConfiguration() {
             @Override
             List<String> getEnvironments() {
-                return []
+                return Arrays.asList()
             }
 
             @Override


### PR DESCRIPTION
Since the BootstrapEnvironment calls the contructor with an implementation of `getEnvironments`
that is immutable, as could others, the DefaultEnvironment class was updated to convert the list
to a mutable implementation.

The test case for getting Micronauts environments from the environment variables has been updated
to reflect the case of setting the bootstrap environment when the environment variable is used.

Fixes: issue #4244 