### PR TITLE
Enable changing logger levels from properties when using Log4j

### DIFF
--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -26,6 +26,7 @@ dependencies {
         transitive = false
     }
 
+    compileOnly "org.apache.logging.log4j:log4j-core:2.12.1"
     compileOnly 'org.glassfish:javax.el:3.0.1-b11'
     compileOnly "com.github.ben-manes.caffeine:caffeine:$caffeineVersion"
     compileOnly 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9-native-mt'

--- a/runtime/src/main/java/io/micronaut/logging/impl/Log4jLoggingSystem.java
+++ b/runtime/src/main/java/io/micronaut/logging/impl/Log4jLoggingSystem.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.logging.impl;
+
+import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.logging.LogLevel;
+import io.micronaut.logging.LoggingSystem;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
+
+import javax.inject.Singleton;
+
+/**
+ * An implementation of {@link LoggingSystem} that works with Log4j.
+ *
+ * @author Matteo Vaccari
+ */
+@Singleton
+@Requires(classes = Configurator.class)
+@Internal
+public class Log4jLoggingSystem implements LoggingSystem {
+
+    @Override
+    public void setLogLevel(String name, LogLevel level) {
+        Configurator.setLevel(name, toLevel(level));
+    }
+
+    /**
+     * @param logLevel The micronaut {@link LogLevel} to convert
+     * @return The converted log4j {@link Level}
+     */
+    private static Level toLevel(LogLevel logLevel) {
+        if (logLevel == LogLevel.NOT_SPECIFIED) {
+            return null;
+        } else {
+            return Level.valueOf(logLevel.name());
+        }
+    }
+}


### PR DESCRIPTION
When using the log4j2 feature, setting log levels via application properties does not work.  It turns out it doesn't because there is no implementation of LoggingSystem for Log4j.  This pull request fixes the problem, I think.