### PR TITLE
Apply execute on to route flowable

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
@@ -1470,7 +1470,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
                 }
 
                 // for head request we never emit the body
-                if (incomingRequest.getMethod().equals(HttpMethod.HEAD)) {
+                if (incomingRequest != null && incomingRequest.getMethod().equals(HttpMethod.HEAD)) {
                     final Object o = outgoingResponse.getBody().orElse(null);
                     if (o instanceof ReferenceCounted) {
                         ((ReferenceCounted) o).release();


### PR DESCRIPTION
This changes alters the subscribeOn to apply the route flowable.

This prevents the case where a filter creates another flowable and then the subscribeOn call no longer applies to the flowable emitted by the controller but instead the one from the filter.

Separately to this we should allow ExecuteOn to be applied to filters, but that is a separate enhancement.

Fixes #4300
