### PR TITLE
Fix proxy generation of inherited default method

### DIFF
--- a/aop/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
+++ b/aop/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
@@ -638,7 +638,7 @@ public class AopProxyWriter extends AbstractClassFileWriter implements ProxyingB
                 bridgeGenerator.loadArg(i);
             }
 
-            bridgeWriter.visitMethodInsn(INVOKESPECIAL, declaringTypeReference.getInternalName(), methodName, overrideDescriptor, isDefault);
+            bridgeWriter.visitMethodInsn(INVOKESPECIAL, declaringTypeReference.getInternalName(), methodName, overrideDescriptor, this.isInterface && isDefault);
             pushReturnValue(bridgeWriter, returnType);
             bridgeWriter.visitMaxs(DEFAULT_MAX_STACK, 1);
             bridgeWriter.visitEnd();

--- a/http-client/src/test/groovy/io/micronaut/http/client/ClientIntroductionAdviceSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/ClientIntroductionAdviceSpec.groovy
@@ -138,6 +138,34 @@ class ClientIntroductionAdviceSpec extends Specification {
         context.close()
     }
 
+    void "test execution of a default method 2"() {
+        given:
+        ApplicationContext context = ApplicationContext.run()
+        context.getBean(EmbeddedServer).start()
+        DefaultMethodClient2 myService = context.getBean(DefaultMethodClient2)
+        expect:
+        myService.index("ZZZ") == 'success ZZZ XYZ from default method'
+        myService.defaultMethod() == 'success from default method mutated'
+        myService.defaultMethod2("ABC") == 'success ABC XYZ from default method 2 mutated'
+
+        cleanup:
+        context.close()
+    }
+
+    void "test execution of a default method 3"() {
+        given:
+        ApplicationContext context = ApplicationContext.run()
+        context.getBean(EmbeddedServer).start()
+        DefaultMethodClient3 myService = context.getBean(DefaultMethodClient3)
+        expect:
+        myService.index("ZZZ") == 'success ZZZ XYZ from default method'
+        myService.defaultMethod() == 'success from default method mutated'
+        myService.defaultMethod2("ABC") == 'success ABC XYZ from default method 2 mutated'
+
+        cleanup:
+        context.close()
+    }
+
     @Controller('/aop')
     static class AopController implements MyApi {
         @Override

--- a/http-client/src/test/groovy/io/micronaut/http/client/DefaultMethodClient2.java
+++ b/http-client/src/test/groovy/io/micronaut/http/client/DefaultMethodClient2.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.client;
+
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.http.client.aop.Mutating;
+
+@Client("/aop")
+public interface DefaultMethodClient2 extends IDefaultMethodClient {
+
+    @Get(produces = MediaType.TEXT_PLAIN, consumes = MediaType.TEXT_PLAIN)
+    String index2();
+
+    @Mutating
+    default String defaultMethod2(String zzz) {
+        return index(zzz) + " 2";
+    }
+
+}

--- a/http-client/src/test/groovy/io/micronaut/http/client/DefaultMethodClient3.java
+++ b/http-client/src/test/groovy/io/micronaut/http/client/DefaultMethodClient3.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.client;
+
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.http.client.aop.Mutating;
+
+@Client("/aop")
+public abstract class DefaultMethodClient3 implements IDefaultMethodClient {
+
+    @Get(produces = MediaType.TEXT_PLAIN, consumes = MediaType.TEXT_PLAIN)
+    public abstract String index2();
+
+    @Mutating
+    public String defaultMethod2(String zzz) {
+        return index(zzz) + " 2";
+    }
+
+}

--- a/http-client/src/test/groovy/io/micronaut/http/client/IDefaultMethodClient.java
+++ b/http-client/src/test/groovy/io/micronaut/http/client/IDefaultMethodClient.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.client;
+
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.client.aop.Mutating;
+
+public interface IDefaultMethodClient {
+
+    @Get(produces = MediaType.TEXT_PLAIN, consumes = MediaType.TEXT_PLAIN)
+    String index();
+
+    @Mutating
+    default String defaultMethod() {
+        return index() + " from default method";
+    }
+
+    default String index(String param) {
+        return index() + " " + param + " XYZ from default method";
+    }
+}

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -778,6 +778,13 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                                 annotationMetadata
                         );
                     } else {
+                        boolean isInterface = JavaModelUtils.isInterface(method.getEnclosingElement());
+                        boolean isDefault = method.isDefault();
+                        if (isInterface && isDefault) {
+                            // Default methods cannot be "super" accessed on the defined type
+                            owningType = introductionTypeName;
+                        }
+
                         // only apply around advise to non-abstract methods of introduction advise
                         aopProxyWriter.visitAroundMethod(
                                 owningType,
@@ -790,8 +797,8 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                                 parameterAnnotationMetadata,
                                 methodGenericTypes,
                                 annotationMetadata,
-                                JavaModelUtils.isInterface(method.getEnclosingElement()),
-                                method.isDefault()
+                                isInterface,
+                                isDefault
                         );
                     }
 


### PR DESCRIPTION
The problem introduced in 2.1.
Bridge proxy should't use the default method's declared class to make "super" call, which doesn't work when the method is inherited from another interface, solution is to use actual type.