### PR TITLE
Fix static method lookup with generic types

### DIFF
--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
@@ -147,6 +147,34 @@ interface Foo {
         def test = introspection.instantiate("test")
 
         then:
+        introspection.constructorArguments.length == 1
+        introspection.getRequiredProperty("name", String)
+                .get(test) == 'test'
+    }
+
+    void "test bean introspection with property with static creator method on interface with generic type arguments"() {
+        given:
+        BeanIntrospection introspection = buildBeanIntrospection('test.Foo', '''
+package test;
+
+import io.micronaut.core.annotation.Creator;
+
+@io.micronaut.core.annotation.Introspected
+interface Foo<T> {
+    String getName();
+    
+    @Creator
+    static <T1> Foo<T1> create(String name) {
+        return () -> name;
+    }
+}
+
+''')
+        when:
+        def test = introspection.instantiate("test")
+
+        then:
+        introspection.constructorArguments.length == 1
         introspection.getRequiredProperty("name", String)
                 .get(test) == 'test'
     }

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/ModelUtils.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/ModelUtils.java
@@ -316,7 +316,7 @@ public class ModelUtils {
                 .stream()
                 .filter(method -> method.getModifiers().contains(STATIC))
                 .filter(method -> !method.getModifiers().contains(PRIVATE))
-                .filter(method -> method.getReturnType().equals(classElement.asType()))
+                .filter(method -> typeUtils.isAssignable(typeUtils.erasure(method.getReturnType()), classElement.asType()))
                 .filter(method -> {
                     final AnnotationMetadata annotationMetadata = annotationUtils.getAnnotationMetadata(method);
                     return annotationMetadata.hasStereotype(Creator.class);


### PR DESCRIPTION
Currently it is not possible to define a static factory method for introspections that use generic type arguments. The type comparison is not erasing the generic types.
