### PR TITLE
Use Spock MicronautTest for Groovy example

### DIFF
--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/intro/HelloControllerSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/intro/HelloControllerSpec.groovy
@@ -23,7 +23,7 @@ import io.micronaut.http.HttpRequest
 import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.runtime.server.EmbeddedServer
-import io.micronaut.test.annotation.MicronautTest
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import spock.lang.Specification
 import javax.inject.Inject
 // end::imports[]


### PR DESCRIPTION
This is a very minor doc change. I noticed that the Groovy example was using a deprecated annotation while setting up my first app, figured I could submit a quick fix. If it's more complicated than I'm making it out to be, no hard feelings if you need to decline. :)