### PR TITLE
Add support for obtaining the interception target

### DIFF
--- a/aop/src/main/java/io/micronaut/aop/TargetAwareMethodInterceptor.java
+++ b/aop/src/main/java/io/micronaut/aop/TargetAwareMethodInterceptor.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import io.micronaut.context.Qualifier;
+
+/**
+ * Extended version of {@link MethodInterceptor} that allows an interceptor to receive the target.
+ *
+ * @param <T> The target type.
+ * @param <R> The return type
+ * @since 2.2.0
+ * @author graemerocher
+ */
+public interface TargetAwareMethodInterceptor<T, R> extends MethodInterceptor<T, R> {
+    /**
+     * Invokes once a target of this interceptor is instantiated. Note that in the case of {@link javax.inject.Singleton}
+     * interceptors this method would be invoked once for each target. Switching to {@link io.micronaut.context.annotation.Prototype}
+     * interceptors will allow for a unique interceptor per target.
+     *
+     * <p>
+     *     It is important to note that logic contained within the newTarget method should exclusively deal with initializing the interceptor and should not
+     *     do any explicit bean lookups with methods such as {@link io.micronaut.context.BeanContext#getBean(Class)} which could lead to dead locks.
+     * </p>
+     *
+     * @param qualifier The qualifier of the bean or null if there is no qualifier as is the case with primary beans
+     * @param target The target bean
+     */
+    void newTarget(@Nullable Qualifier<T> qualifier, @NonNull T target);
+}

--- a/aop/src/main/java/io/micronaut/aop/chain/InterceptorChain.java
+++ b/aop/src/main/java/io/micronaut/aop/chain/InterceptorChain.java
@@ -244,9 +244,6 @@ public class InterceptorChain<B, R> implements InvocationContext<B, R> {
     @Internal
     @UsedByGeneratedCode
     public static void supplyTarget(@Nullable Qualifier<Object> qualifier, Object target, Interceptor<?, ?>... interceptors) {
-        if (target instanceof InterceptedProxy) {
-            target = ((InterceptedProxy<?>) target).interceptedTarget();
-        }
         for (Interceptor<?, ?> interceptor : interceptors) {
             if (interceptor instanceof TargetAwareMethodInterceptor) {
                 @SuppressWarnings("unchecked") TargetAwareMethodInterceptor<Object, Object> tami =
@@ -257,10 +254,18 @@ public class InterceptorChain<B, R> implements InvocationContext<B, R> {
                     if (ArrayUtils.isNotEmpty(args)) {
                         Class<?> arg1 = args[0];
                         if (arg1.isInstance(target)) {
-                            tami.newTarget(qualifier, target);
+                            Object finalTarget = target;
+                            if (target instanceof InterceptedProxy) {
+                                finalTarget = ((InterceptedProxy<?>) target).interceptedTarget();
+                            }
+                            tami.newTarget(qualifier, finalTarget);
                         }
                     } else {
-                        tami.newTarget(qualifier, target);
+                        Object finalTarget = target;
+                        if (target instanceof InterceptedProxy) {
+                            finalTarget = ((InterceptedProxy<?>) target).interceptedTarget();
+                        }
+                        tami.newTarget(qualifier, finalTarget);
                     }
                 } catch (Exception e) {
                     throw new InstantiationException("Error supplying AOP target bean to interceptor [" + interceptor.getClass() + "]: " + e.getMessage(), e);

--- a/inject-java/src/test/groovy/io/micronaut/aop/targetaware/AnotherBean.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/targetaware/AnotherBean.java
@@ -1,0 +1,13 @@
+package io.micronaut.aop.targetaware;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+@Singleton
+@Named("another")
+public class AnotherBean {
+    @TestTargetAwareAnn
+    void foo() {
+
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/targetaware/TargetAwareInterceptorSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/targetaware/TargetAwareInterceptorSpec.groovy
@@ -1,0 +1,26 @@
+package io.micronaut.aop.targetaware
+
+import io.micronaut.context.BeanContext
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Stepwise
+
+@Stepwise
+class TargetAwareInterceptorSpec extends Specification {
+    @Shared @AutoCleanup BeanContext beanContext = BeanContext.run()
+
+    void 'test target aware interceptors'() {
+        given:
+        def bean1 = beanContext.getBean(TestBean)
+        def bean2 = beanContext.getBean(AnotherBean)
+        def interceptor1 = beanContext.getBean(TestTargetAwareInterceptor)
+        def interceptor2 = beanContext.getBean(TypeSpecificTargetAwareInterceptor)
+
+        expect:
+        interceptor1.target
+        interceptor1.count == 2
+        interceptor2.target
+        interceptor2.count == 1
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/targetaware/TestBean.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/targetaware/TestBean.java
@@ -1,0 +1,12 @@
+package io.micronaut.aop.targetaware;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class TestBean {
+
+    @TestTargetAwareAnn
+    void foo() {
+
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/targetaware/TestTargetAwareAnn.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/targetaware/TestTargetAwareAnn.java
@@ -1,0 +1,20 @@
+package io.micronaut.aop.targetaware;
+
+
+import io.micronaut.aop.Around;
+import io.micronaut.context.annotation.Type;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Around
+@Type({TestTargetAwareInterceptor.class, TypeSpecificTargetAwareInterceptor.class})
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface TestTargetAwareAnn {
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/targetaware/TestTargetAwareInterceptor.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/targetaware/TestTargetAwareInterceptor.java
@@ -1,0 +1,40 @@
+package io.micronaut.aop.targetaware;
+
+import io.micronaut.aop.MethodInvocationContext;
+import io.micronaut.aop.TargetAwareMethodInterceptor;
+import io.micronaut.context.Qualifier;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.spockframework.util.Assert;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class TestTargetAwareInterceptor implements TargetAwareMethodInterceptor<Object, Object> {
+    private Object target;
+    private int count;
+
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        Assert.notNull(target);
+        return context.proceed();
+    }
+
+    @Override
+    public void newTarget(@Nullable Qualifier<Object> qualifier, @NotNull Object target) {
+        count++;
+        Assert.notNull(target);
+        if (target instanceof AnotherBean) {
+            Assert.notNull(qualifier);
+        }
+        this.target = target;
+    }
+
+    public Object getTarget() {
+        return target;
+    }
+
+    public int getCount() {
+        return count;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/targetaware/TypeSpecificTargetAwareInterceptor.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/targetaware/TypeSpecificTargetAwareInterceptor.java
@@ -1,0 +1,35 @@
+package io.micronaut.aop.targetaware;
+
+import io.micronaut.aop.MethodInvocationContext;
+import io.micronaut.aop.TargetAwareMethodInterceptor;
+import io.micronaut.context.Qualifier;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.spockframework.util.Assert;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class TypeSpecificTargetAwareInterceptor implements TargetAwareMethodInterceptor<TestBean, Object> {
+    private TestBean target;
+    private int count;
+    @Override
+    public Object intercept(MethodInvocationContext<TestBean, Object> context) {
+        Assert.notNull(target);
+        return context.proceed();
+    }
+
+    @Override
+    public void newTarget(@Nullable Qualifier<TestBean> qualifier, @NotNull TestBean target) {
+        count++;
+        this.target = target;
+    }
+
+    public TestBean getTarget() {
+        return target;
+    }
+
+    public int getCount() {
+        return count;
+    }
+}


### PR DESCRIPTION
This PR adds support for obtaining the target of an interceptor once when the target is created. This always doing any initialization upfront avoiding delaying it until the when the method interceptor executes which can eliminate the need for creating caches in certain circumstances.
