### PR TITLE
Change release workflow to run on push for any file

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -5,19 +5,10 @@
 # and edit them there. Note that it will be sync'ed to all the Micronaut repos
 name: Changelog
 on:
-  pull_request:
-    types: closed
-    branches:
-      - master
-      - '[1-9]+.[0-9]+.x'
-  issues:
-    types: [closed,reopened]
   push:
     branches:
       - master
       - '[1-9]+.[0-9]+.x'
-    paths:
-      - ".github/workflows/release-notes.yml"
 jobs:
   release_notes:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -5,6 +5,8 @@
 # and edit them there. Note that it will be sync'ed to all the Micronaut repos
 name: Changelog
 on:
+  issues:
+    types: [closed,reopened]
   push:
     branches:
       - master


### PR DESCRIPTION
@jameskleeh @graemerocher please watch release notes generation the next time a PR is merged and let me know here if release drafter works, so that I move this change to the template repo.