### PR TITLE
Allow ClassLoader to be passed as parameter to load annotation type

### DIFF
--- a/aop/src/main/java/io/micronaut/aop/chain/InterceptorChain.java
+++ b/aop/src/main/java/io/micronaut/aop/chain/InterceptorChain.java
@@ -243,7 +243,7 @@ public class InterceptorChain<B, R> implements InvocationContext<B, R> {
     @UsedByGeneratedCode
     public static Interceptor[] resolveAroundInterceptors(BeanContext beanContext, ExecutableMethod<?, ?> method, Interceptor... interceptors) {
         instrumentAnnotationMetadata(beanContext, method);
-        return resolveInterceptorsInternal(method, Around.class, interceptors);
+        return resolveInterceptorsInternal(method, Around.class, interceptors, beanContext.getClassLoader());
     }
 
     /**
@@ -259,7 +259,7 @@ public class InterceptorChain<B, R> implements InvocationContext<B, R> {
     @UsedByGeneratedCode
     public static Interceptor[] resolveIntroductionInterceptors(BeanContext beanContext, ExecutableMethod<?, ?> method, Interceptor... interceptors) {
         instrumentAnnotationMetadata(beanContext, method);
-        Interceptor[] introductionInterceptors = resolveInterceptorsInternal(method, Introduction.class, interceptors);
+        Interceptor[] introductionInterceptors = resolveInterceptorsInternal(method, Introduction.class, interceptors, beanContext.getClassLoader());
         if (introductionInterceptors.length == 0) {
             if (method.hasStereotype(Adapter.class)) {
                 introductionInterceptors = new Interceptor[] { new AdapterIntroduction(beanContext, method) };
@@ -279,8 +279,8 @@ public class InterceptorChain<B, R> implements InvocationContext<B, R> {
         }
     }
 
-    private static Interceptor[] resolveInterceptorsInternal(ExecutableMethod<?, ?> method, Class<? extends Annotation> annotationType, Interceptor[] interceptors) {
-        List<Class<? extends Annotation>> annotations = method.getAnnotationTypesByStereotype(annotationType);
+    private static Interceptor[] resolveInterceptorsInternal(ExecutableMethod<?, ?> method, Class<? extends Annotation> annotationType, Interceptor[] interceptors, ClassLoader classLoader) {
+        List<Class<? extends Annotation>> annotations = method.getAnnotationTypesByStereotype(annotationType, classLoader);
 
         Set<Class> applicableClasses = new HashSet<>();
 

--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationMetadata.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationMetadata.java
@@ -409,6 +409,24 @@ public interface AnnotationMetadata extends AnnotationSource {
     /**
      * Gets the type for a given annotation if it is present on the classpath. Subclasses can potentially override to provide optimized loading.
      * @param name The type name
+     * @param classLoader The ClassLoader to load the type
+     * @return The type if present
+     */
+    default Optional<Class<? extends Annotation>> getAnnotationType(@NonNull String name, @NonNull ClassLoader classLoader) {
+        ArgumentUtils.requireNonNull("name", name);
+        final Optional<Class> aClass = ClassUtils.forName(name, classLoader);
+        return aClass.flatMap((Function<Class, Optional<Class<? extends Annotation>>>) aClass1 -> {
+            if (Annotation.class.isAssignableFrom(aClass1)) {
+                //noinspection unchecked
+                return Optional.of(aClass1);
+            }
+            return Optional.empty();
+        });
+    }
+
+    /**
+     * Gets the type for a given annotation if it is present on the classpath. Subclasses can potentially override to provide optimized loading.
+     * @param name The type name
      * @return The type if present
      */
     default Optional<Class<? extends Annotation>> getAnnotationType(@NonNull String name) {
@@ -484,6 +502,23 @@ public interface AnnotationMetadata extends AnnotationSource {
             .filter(Optional::isPresent)
             .map(opt -> (Class<? extends Annotation>) opt.get())
             .collect(Collectors.toList());
+    }
+
+    /**
+     * Resolve all of the annotation names that feature the given stereotype.
+     *
+     * @param stereotype The annotation names
+     * @param classLoader The classloader to load annotation type
+     * @return A set of annotation names
+     */
+    default @NonNull List<Class<? extends Annotation>> getAnnotationTypesByStereotype(@NonNull Class<? extends Annotation> stereotype, @NonNull ClassLoader classLoader) {
+        ArgumentUtils.requireNonNull("stereotype", stereotype);
+
+        List<String> names = getAnnotationNamesByStereotype(stereotype.getName());
+        return names.stream().map(name -> getAnnotationType(name, classLoader))
+                .filter(Optional::isPresent)
+                .map(opt -> (Class<? extends Annotation>) opt.get())
+                .collect(Collectors.toList());
     }
 
     /**

--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationMetadataDelegate.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationMetadataDelegate.java
@@ -339,6 +339,11 @@ public interface AnnotationMetadataDelegate extends AnnotationMetadataProvider, 
     }
 
     @Override
+    default @NonNull List<Class<? extends Annotation>> getAnnotationTypesByStereotype(@NonNull Class<? extends Annotation> stereotype, @NonNull ClassLoader classLoader) {
+        return getAnnotationMetadata().getAnnotationTypesByStereotype(stereotype, classLoader);
+    }
+
+    @Override
     default @NonNull <T extends Annotation> Optional<AnnotationValue<T>> findAnnotation(@NonNull Class<T> annotationClass) {
         return getAnnotationMetadata().findAnnotation(annotationClass);
     }
@@ -446,6 +451,11 @@ public interface AnnotationMetadataDelegate extends AnnotationMetadataProvider, 
     @Override
     default @NonNull Optional<Class<? extends Annotation>> getAnnotationType(@NonNull String name) {
         return getAnnotationMetadata().getAnnotationType(name);
+    }
+
+    @Override
+    default @NonNull Optional<Class<? extends Annotation>> getAnnotationType(@NonNull String name, @NonNull ClassLoader classLoader) {
+        return getAnnotationMetadata().getAnnotationType(name, classLoader);
     }
 
     @Override


### PR DESCRIPTION
…type

* Added overloaded methods (getAnnotationTypesByStereotype, getAnnotationType) in AnnotationMetadata.java which accepts classloader as a parameter.
* Override the new methods in AnnotationMetadataDelegate.java.
* Update InterceptorChain method resolveInterceptorsInternal, resolveAroundInterceptors to resolve classloader from the beanContext and pass it to downstream methods.

Fixes #4396 