### PR TITLE
Issue 4306 - Bean validation should fail if @Valid field is not introspected

### DIFF
--- a/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java
@@ -1321,8 +1321,7 @@ public class DefaultValidator implements Validator, ExecutableMethodValidator, R
 
         final BeanIntrospection<Object> beanIntrospection = getBeanIntrospection(propertyValue);
         AnnotationMetadata annotationMetadata = cascadeProperty.getAnnotationMetadata();
-        if (beanIntrospection == null && annotationMetadata.getDeclaredAnnotationNames().equals(
-            Collections.singleton(javax.validation.Valid.class.getName()))) {
+        if (beanIntrospection == null && annotationMetadata.getDeclaredAnnotation(Constraint.class) == null) {
             // error: only has @Valid but the propertyValue class is not @Introspected
             overallViolations.add(createIntrospectionConstraintViolation(
                 rootClass, rootBean, context, propertyValue.getClass(), propertyValue));

--- a/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java
@@ -1321,7 +1321,7 @@ public class DefaultValidator implements Validator, ExecutableMethodValidator, R
 
         final BeanIntrospection<Object> beanIntrospection = getBeanIntrospection(propertyValue);
         AnnotationMetadata annotationMetadata = cascadeProperty.getAnnotationMetadata();
-        if (beanIntrospection == null && annotationMetadata.getDeclaredAnnotation(Constraint.class) == null) {
+        if (beanIntrospection == null && !annotationMetadata.hasStereotype(Constraint.class)) {
             // error: only has @Valid but the propertyValue class is not @Introspected
             overallViolations.add(createIntrospectionConstraintViolation(
                 rootClass, rootBean, context, propertyValue.getClass(), propertyValue));

--- a/validation/src/test/groovy/io/micronaut/validation/validator/ValidatorSpec.groovy
+++ b/validation/src/test/groovy/io/micronaut/validation/validator/ValidatorSpec.groovy
@@ -6,6 +6,7 @@ import io.micronaut.context.annotation.Prototype
 import io.micronaut.core.annotation.Introspected
 import io.micronaut.validation.validator.resolver.CompositeTraversableResolver
 import spock.lang.AutoCleanup
+import spock.lang.Ignore
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -377,6 +378,80 @@ class ValidatorSpec extends Specification {
         !beanDescriptor.isBeanConstrained()
         beanDescriptor.getConstrainedProperties().size() == 0
     }
+
+    void "test cascade to container of non-introspected class" () {
+        when:
+        Bee notIntrospected = new Bee(name: "")
+        HiveOfBeeList beeHive = new HiveOfBeeList(bees: [notIntrospected])
+        def violations = validator.validate(beeHive)
+
+        then:
+        violations.size() == 1
+        !violations[0].constraintDescriptor
+        violations[0].message == "Cannot validate io.micronaut.validation.validator.Bee. No bean introspection present. " +
+                "Please add @Introspected to the class and ensure Micronaut annotation processing is enabled"
+    }
+
+    void "test cascade to map of non-introspected value class" () {
+        when:
+        Bee notIntrospected = new Bee(name: "")
+        HiveOfBeeMap beeHive = new HiveOfBeeMap(bees: ["blank" : notIntrospected])
+        def violations = validator.validate(beeHive)
+
+        then:
+        violations.size() == 1
+        !violations[0].constraintDescriptor
+        violations[0].message == "Cannot validate io.micronaut.validation.validator.Bee. No bean introspection present. " +
+                "Please add @Introspected to the class and ensure Micronaut annotation processing is enabled"
+    }
+
+    @Ignore("FIXME: https://github.com/micronaut-projects/micronaut-core/issues/4410")
+    void "test element validation in String collection" () {
+        when:
+        ListOfStrings strings = new ListOfStrings(strings: ["", null, "a string that's too long"])
+        def violations = validator.validate(strings)
+
+        then:
+        // should be: two for violating element size, and one null string violation
+        violations.size() == 3
+        violations[0].constraintDescriptor
+        violations[0].constraintDescriptor.annotation instanceof Size
+        violations[1].constraintDescriptor
+        violations[1].constraintDescriptor.annotation instanceof NotNull
+        violations[2].constraintDescriptor
+        violations[2].constraintDescriptor.annotation instanceof Size
+    }
+}
+
+@Introspected
+class HiveOfBeeMap {
+    @Valid
+    Map<String, Bee> bees
+}
+
+@Introspected
+class HiveOfBeeList {
+    @Valid
+    List<Bee> bees
+}
+
+// not introspected, expect validation failure
+class Bee {
+    @NotBlank
+    String name
+}
+
+// FIXME see https://github.com/micronaut-projects/micronaut-core/issues/4410
+// demonstrated by "test fail elements in String list"
+// List, Set and array all work same
+// 1) With Valid and constraints, validation is broken because it also applies @Size constraint to the container itself
+// 2) Without @Valid only the container itself is validated for given constraints (makes sense)
+@Introspected
+class ListOfStrings {
+    @Valid
+    @Size(min=1, max=2)
+    @NotNull
+    List<String> strings
 }
 
 @Introspected


### PR DESCRIPTION
Issue 4306 - Bean validation should fail if @Valid field is not introspected
- emit validation failure when `@Valid` alone is applied to a container of elements where the element type is not `@Introspected`.
- this does not address cases with additional constraint(s), since that might still be legal if the element type is supported by those constraints directly (e.g. `@Valid @Size(min=1, max=2) List<String> strs`), even though something like `@Valid @Size(min=1, max=2) List<NotIntrospected> oops` might be bogus.