### PR TITLE
Only initialize javax.xml instead of javax for GraalVM

### DIFF
--- a/runtime/src/main/resources/META-INF/native-image/io.micronaut/runtime-graal/native-image.properties
+++ b/runtime/src/main/resources/META-INF/native-image/io.micronaut/runtime-graal/native-image.properties
@@ -15,5 +15,5 @@
 #
 
 Args = --initialize-at-run-time=io.micronaut.reactive.reactor.ReactorInstrumentation \
-       --initialize-at-build-time=ch.qos.logback,com.fasterxml.jackson,io.micronaut,io.reactivex,org.reactivestreams,org.slf4j,org.yaml.snakeyaml,javax \
+       --initialize-at-build-time=ch.qos.logback,com.fasterxml.jackson,io.micronaut,io.reactivex,org.reactivestreams,org.slf4j,org.yaml.snakeyaml,javax.xml \
        --initialize-at-build-time=com.sun.org.apache.xerces.internal.util,com.sun.org.apache.xerces.internal.impl,jdk.xml.internal,com.sun.xml.internal.stream.util,com.sun.org.apache.xerces.internal.xni,com.sun.org.apache.xerces.internal.utils


### PR DESCRIPTION
See https://github.com/oracle/graal/issues/2958

This changes is compatible with GraalVM 20.3 that will be released in a couple of weeks so better to have it in both 2.1.x and 2.2.x