### PR TITLE
Fix Jackson bean introspection constructor initialization

### DIFF
--- a/runtime/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
+++ b/runtime/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
@@ -297,8 +297,16 @@ public class BeanIntrospectionModule extends SimpleModule {
                                 } catch (JsonMappingException e) {
                                     typeDeserializer = null;
                                 }
+                                PropertyName propertyName = PropertyName.construct(simpleName);
+                                if (typeDeserializer == null) {
+                                    SettableBeanProperty settableBeanProperty = builder.findProperty(propertyName);
+                                    if (settableBeanProperty != null) {
+                                        typeDeserializer = settableBeanProperty.getValueTypeDeserializer();
+                                    }
+                                }
+
                                 props[i] = new CreatorProperty(
-                                        PropertyName.construct(simpleName),
+                                        propertyName,
                                         javaType,
                                         null,
                                         typeDeserializer,

--- a/runtime/src/test/groovy/io/micronaut/jackson/modules/BeanIntrospectionModuleSpec.groovy
+++ b/runtime/src/test/groovy/io/micronaut/jackson/modules/BeanIntrospectionModuleSpec.groovy
@@ -11,12 +11,9 @@ import io.micronaut.context.ApplicationContext
 import io.micronaut.core.annotation.Introspected
 import io.micronaut.http.hateoas.JsonError
 import io.micronaut.jackson.JacksonConfiguration
-import org.checkerframework.checker.nullness.qual.NonNull
-import spock.lang.Issue
+import io.micronaut.jackson.modules.testcase.EmailTemplate
+import io.micronaut.jackson.modules.testcase.Notification
 import spock.lang.Specification
-
-import javax.annotation.Nullable
-import javax.validation.constraints.NotBlank
 
 class BeanIntrospectionModuleSpec extends Specification {
 
@@ -219,6 +216,25 @@ class BeanIntrospectionModuleSpec extends Specification {
 
         cleanup:
         ctx.close()
+    }
+
+    def "should deserialize field with hierarchy"() {
+        given:
+            ApplicationContext ctx = ApplicationContext.run(
+                    (JacksonConfiguration.PROPERTY_USE_BEAN_INTROSPECTION):true
+            )
+            ObjectMapper objectMapper = ctx.getBean(ObjectMapper)
+
+        when:
+            def notif = """
+{"id":586387198220282880, "template":{"templateType":"email","textTemplate":"Ahoj"}}
+"""
+            def value = objectMapper.readValue(notif, Notification.class)
+        then:
+            value.getTemplate() instanceof EmailTemplate
+
+        cleanup:
+            ctx.close()
     }
 
     @Introspected

--- a/runtime/src/test/groovy/io/micronaut/jackson/modules/testcase/EmailTemplate.java
+++ b/runtime/src/test/groovy/io/micronaut/jackson/modules/testcase/EmailTemplate.java
@@ -1,0 +1,14 @@
+package io.micronaut.jackson.modules.testcase;
+
+public class EmailTemplate extends MessageTemplate {
+    private String subject;
+
+    public String getSubject() {
+        return subject;
+    }
+
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
+
+}

--- a/runtime/src/test/groovy/io/micronaut/jackson/modules/testcase/MessageTemplate.java
+++ b/runtime/src/test/groovy/io/micronaut/jackson/modules/testcase/MessageTemplate.java
@@ -1,0 +1,13 @@
+package io.micronaut.jackson.modules.testcase;
+
+public abstract class MessageTemplate {
+    private String templateType;
+
+    public String getTemplateType() {
+        return templateType;
+    }
+
+    public void setTemplateType(String templateType) {
+        this.templateType = templateType;
+    }
+}

--- a/runtime/src/test/groovy/io/micronaut/jackson/modules/testcase/Notification.java
+++ b/runtime/src/test/groovy/io/micronaut/jackson/modules/testcase/Notification.java
@@ -1,0 +1,42 @@
+package io.micronaut.jackson.modules.testcase;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+public class Notification {
+
+    private Long id;
+
+    @JsonTypeInfo(
+            use = JsonTypeInfo.Id.NAME,
+            include = JsonTypeInfo.As.PROPERTY,
+            property = "templateType")
+    @JsonSubTypes({
+            @JsonSubTypes.Type(value = EmailTemplate.class, name = "email"),
+            @JsonSubTypes.Type(value = SmsTemplate.class, name = "sms")
+    })
+    private MessageTemplate template;
+
+    public Notification(Long id, MessageTemplate template) {
+        this.id = id;
+        this.template = template;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public MessageTemplate getTemplate() {
+        return template;
+    }
+
+    public void setTemplate(MessageTemplate template) {
+        this.template = template;
+    }
+}

--- a/runtime/src/test/groovy/io/micronaut/jackson/modules/testcase/SmsTemplate.java
+++ b/runtime/src/test/groovy/io/micronaut/jackson/modules/testcase/SmsTemplate.java
@@ -1,0 +1,14 @@
+package io.micronaut.jackson.modules.testcase;
+
+public class SmsTemplate extends MessageTemplate {
+    private String text;
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+
+}


### PR DESCRIPTION
This fix make it work in the same way as ordinary Jackson.

BTW: I have observed unexpected behavior: it looks like bean introspection will choose the first constructor without any logic around.

I this case no args constructor is choosen: 
```java
    public Notification() {
    }

    public Notification(Long id, MessageTemplate template) {
        this.id = id;
        this.template = template;
    }
```

I this case all args constructor is choosen: 
```java
    public Notification(Long id, MessageTemplate template) {
        this.id = id;
        this.template = template;
    }

    public Notification() {
    }
```