### PR TITLE
Avoid IllegalStateException "Not a Kotlin coroutine" when suspend function returns a value

### DIFF
--- a/aop/src/main/java/io/micronaut/aop/internal/intercepted/KotlinInterceptedMethod.java
+++ b/aop/src/main/java/io/micronaut/aop/internal/intercepted/KotlinInterceptedMethod.java
@@ -106,7 +106,7 @@ final class KotlinInterceptedMethod implements InterceptedMethod {
         Object result = context.proceed();
         replaceContinuation.accept(continuation);
         if (result != KotlinUtils.COROUTINE_SUSPENDED) {
-            throw new IllegalStateException("Not a Kotlin coroutine");
+            completableFutureContinuation.resumeWith(result);
         }
         return completableFutureContinuation.getCompletableFuture();
     }
@@ -123,7 +123,7 @@ final class KotlinInterceptedMethod implements InterceptedMethod {
         Object result = context.proceed(from);
         replaceContinuation.accept(continuation);
         if (result != KotlinUtils.COROUTINE_SUSPENDED) {
-            throw new IllegalStateException("Not a Kotlin coroutine");
+            completableFutureContinuation.resumeWith(result);
         }
         return completableFutureContinuation.getCompletableFuture();
     }

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/SuspendController.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/SuspendController.kt
@@ -110,4 +110,9 @@ class SuspendController(@Named(TaskExecutors.IO) private val executor: ExecutorS
             suspendService.delayedCalculation2()
         }
     }
+
+    @Get("/callSuspendServiceWithRetriesWithoutDelay")
+    suspend fun callSuspendServiceWithRetriesWithoutDelay(): String {
+        return suspendService.calculation3()
+    }
 }

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/SuspendControllerSpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/SuspendControllerSpec.kt
@@ -90,6 +90,14 @@ class SuspendControllerSpec: StringSpec() {
             response.status shouldBe HttpStatus.OK
         }
 
+        "test suspend service with retries without delay"() {
+            val response = client.exchange(HttpRequest.GET<Any>("/suspend/callSuspendServiceWithRetriesWithoutDelay"), String::class.java).blockingFirst()
+            val body = response.body.get()
+
+            body shouldBe "delayedCalculation3"
+            response.status shouldBe HttpStatus.OK
+        }
+
         "test suspend"() {
             val response = client.exchange(HttpRequest.GET<Any>("/suspend/simple"), String::class.java).blockingFirst()
             val body = response.body.get()

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/SuspendService.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/SuspendService.kt
@@ -10,6 +10,7 @@ open class SuspendService {
 
     var counter1: Int = 0
     var counter2: Int = 0
+    var counter3: Int = 0
 
     @Retryable
     open suspend fun delayedCalculation1(): String {
@@ -31,6 +32,15 @@ open class SuspendService {
         }
         delay(1)
         return "delayedCalculation2"
+    }
+
+    @Retryable
+    open suspend fun calculation3(): String {
+        if (counter3 != 2) {
+            counter3++
+            throw RuntimeException("error $counter3")
+        }
+        return "delayedCalculation3"
     }
 
 }


### PR DESCRIPTION
As commented in https://github.com/micronaut-projects/micronaut-core/issues/4438 coroutines intercepted with `@Retryable` annotation fail when they return values. 

This PR changes that and allows to return the values instead of throwing an exception.