### PR TITLE
Make HttpRequest.getPath() return the non-decoded path

### DIFF
--- a/http/src/main/java/io/micronaut/http/HttpRequest.java
+++ b/http/src/main/java/io/micronaut/http/HttpRequest.java
@@ -127,10 +127,10 @@ public interface HttpRequest<B> extends HttpMessage<B> {
     }
 
     /**
-     * @return Get the path without any parameters
+     * @return Get the raw, percent-encoded path without any parameters
      */
     default @NonNull String getPath() {
-        return getUri().getPath();
+        return getUri().getRawPath();
     }
 
     /**

--- a/http/src/test/groovy/io/micronaut/http/HttpRequestSpec.groovy
+++ b/http/src/test/groovy/io/micronaut/http/HttpRequestSpec.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http
+
+import spock.lang.Specification
+
+import java.nio.charset.Charset
+
+class HttpRequestSpec extends Specification {
+
+    def "HttpRequest.getPath() returns the non-decoded URI path component"() {
+        when:
+        String pathSegment = "?bar"
+        String encodedPathSegment = URLEncoder.encode(pathSegment, Charset.defaultCharset().name())
+        String path = "http://www.example.org/foo/$encodedPathSegment?queryParam=true"
+        HttpRequest request = HttpRequest.GET(path)
+
+        then:
+        request.getPath() == "/foo/%3Fbar"
+    }
+
+}


### PR DESCRIPTION
Fixes https://github.com/micronaut-projects/micronaut-aws/issues/656

The default implementation of `getPath()` returns the URI-decoded path, while `NettyHttpRequest` returns the raw path:

```java
    // In AbstractNettyHttpRequest
    private String decodePath(String uri) {
        QueryStringDecoder queryStringDecoder = createDecoder(uri);
        return queryStringDecoder.rawPath();
    }
```

It's probably best to align the default impl with the most widely-used implementation. In any case, the Javadoc should also state the expected format.