### PR TITLE
Fix BOM check

### DIFF
--- a/bom-check/build.gradle
+++ b/bom-check/build.gradle
@@ -6,8 +6,8 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven { url "https://repo.grails.org/grails/core" }
-    maven { url "https://dl.bintray.com/micronaut/core-releases-local" }
+    jcenter()
+    maven { url "https://repo.grails.org/grails/libs-releases" }
 }
 
 boolean micronautSnapshot = rootProject.version.toString().endsWith("-SNAPSHOT")


### PR DESCRIPTION
The issue was that `"https://repo.grails.org/grails/core"` contains `io.micronaut.neo4j:micronaut-neo4j-bolt:4.0.0` and it was hiding the issue.

We only need that repo for the GORM dependencies, so changed it to `lib-releases`.

Note that this will make the build faild with:

```
> Could not resolve all files for configuration ':bom-check:compileClasspath'.
   > Could not find io.micronaut.neo4j:micronaut-neo4j-bolt:4.0.0.
     Searched in the following locations:
       - https://repo.maven.apache.org/maven2/io/micronaut/neo4j/micronaut-neo4j-bolt/4.0.0/micronaut-neo4j-bolt-4.0.0.pom
       - https://jcenter.bintray.com/io/micronaut/neo4j/micronaut-neo4j-bolt/4.0.0/micronaut-neo4j-bolt-4.0.0.pom
       - https://repo.grails.org/grails/libs-releases/io/micronaut/neo4j/micronaut-neo4j-bolt/4.0.0/micronaut-neo4j-bolt-4.0.0.pom
     Required by:
         project :bom-check
         project :bom-check > project :bom
```