### PR TITLE
Docs Suggestion - lifecycle.adoc - Add link to bean scopes in section about post construct annotation

### DIFF
--- a/src/main/docs/guide/ioc/lifecycle.adoc
+++ b/src/main/docs/guide/ioc/lifecycle.adoc
@@ -8,6 +8,8 @@ snippet::io.micronaut.docs.lifecycle.V8Engine[tags="imports, class", indent=0]
 <2> A field is defined that requires initialization
 <3> A method is annotated with `@PostConstruct` and will be invoked once the object is constructed and fully injected.
 
+To manage when a bean is constructed, see the section on <<scopes, bean scopes>>.
+
 == When The Context Closes
 
 If you wish for a particular method to be invoked when the context is closed then you can use the `javax.annotation.PreDestroy` annotation:


### PR DESCRIPTION
### Summary
Suggestion to add a link to bean scopes in the post construct section. I found it helpful to link back to the section on when beans would be constructed to understand when post construct would be run.

### Testing
* gradle publishGuide
* Verified appearance and working link in locally built guide