### PR TITLE
Let @Around advice intercept default Object methods.

### DIFF
--- a/aop/src/main/java/io/micronaut/aop/Around.java
+++ b/aop/src/main/java/io/micronaut/aop/Around.java
@@ -80,4 +80,13 @@ public @interface Around {
      * @return True if the proxy target should be resolved lazily
      */
     boolean lazy() default false;
+
+    /**
+     * Process the {@link Object} non-final method by
+     * the {@code @Around} handlers or not.
+     *
+     * @return true if {@code Object} methods shall be processed
+     * @since 2.2
+     */
+    boolean wrapObjectMethods() default false;
 }

--- a/inject-java/src/test/groovy/io/micronaut/aop/compile/AroundEqualsSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/compile/AroundEqualsSpec.groovy
@@ -37,21 +37,24 @@ import io.micronaut.aop.*;
 import io.micronaut.aop.introduction.*;
 import io.micronaut.context.annotation.*;
 import io.micronaut.core.annotation.*;
-import java.lang.annotation.*;
+import java.lang.annotation.*;\n\
+import java.util.Properties;
 
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD, ElementType.PARAMETER})
 @Around
-@Type(SomeInterceptor.class)
+@Type(EqualsInterceptor.class)
 @interface EverythingEvenEquals{}
 
 
 @javax.inject.Singleton
-class SomeInterceptor implements MethodInterceptor<Object, Object> {
+class EqualsInterceptor implements MethodInterceptor<Object, Object> {\n\
+    public final Properties methods = new Properties();
+
     @Override
     public Object intercept(MethodInvocationContext<Object, Object> context) {\n\
-        System.setProperty("intercepted." + context.getMethodName(), "true");
+        methods.setProperty(context.getMethodName(), "true");
         return context.proceed();
     }
 }
@@ -66,14 +69,14 @@ class MyBean {\n\
 
 ''')
         then:
-        Class clazz = ctx.classLoader.loadClass("test.MyBean")
-        def bean = ctx.getBean(clazz)
-        System.getProperty("intercepted.someMethod") == null
+        def bean = ctx.getBean(ctx.classLoader.loadClass("test.MyBean"))
+        def interceptor = ctx.getBean(ctx.classLoader.loadClass("test.EqualsInterceptor"))
+        interceptor.methods.getProperty("someMethod") == null
         bean.someMethod()
-        System.getProperty("intercepted.someMethod") != null
+        interceptor.methods.getProperty("someMethod") != null
 
-        System.getProperty("intercepted.equals") == null
+        interceptor.methods.getProperty("equals") == null
         bean.equals(bean)
-        System.getProperty("intercepted.equals") != null
+        interceptor.methods.getProperty("equals") != null
     }
 }

--- a/inject-java/src/test/groovy/io/micronaut/aop/compile/AroundEqualsSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/compile/AroundEqualsSpec.groovy
@@ -43,7 +43,7 @@ import java.util.Properties;
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD, ElementType.PARAMETER})
-@Around
+@Around(wrapObjectMethods = true)
 @Type(EqualsInterceptor.class)
 @interface EverythingEvenEquals{}
 

--- a/inject-java/src/test/groovy/io/micronaut/aop/compile/AroundEqualsSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/compile/AroundEqualsSpec.groovy
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.compile
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.annotation.Blocking
+import io.micronaut.inject.AbstractTypeElementSpec
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.BeanFactory
+import io.micronaut.inject.writer.BeanDefinitionVisitor
+
+/**
+ * @author Jaroslav Tulach
+ * @since 2.2
+ */
+class AroundEqualsSpec extends AbstractTypeElementSpec {
+
+    void "test that @Around can intercept also Object.equals"() {
+        when:
+        ApplicationContext ctx = buildContext('test.MyBean', '''
+package test;
+
+import io.micronaut.aop.*;
+import io.micronaut.aop.introduction.*;
+import io.micronaut.context.annotation.*;
+import io.micronaut.core.annotation.*;
+import java.lang.annotation.*;
+
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.PARAMETER})
+@Around
+@Type(SomeInterceptor.class)
+@interface EverythingEvenEquals{}
+
+
+@javax.inject.Singleton
+class SomeInterceptor implements MethodInterceptor<Object, Object> {
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {\n\
+        System.setProperty("intercepted." + context.getMethodName(), "true");
+        return context.proceed();
+    }
+}
+
+
+@EverythingEvenEquals
+class MyBean {\n\
+    public String someMethod() {\n\
+        return "MyBean";\n\
+    }
+}
+
+''')
+        then:
+        Class clazz = ctx.classLoader.loadClass("test.MyBean")
+        def bean = ctx.getBean(clazz)
+        System.getProperty("intercepted.someMethod") == null
+        bean.someMethod()
+        System.getProperty("intercepted.someMethod") != null
+
+        System.getProperty("intercepted.equals") == null
+        bean.equals(bean)
+        System.getProperty("intercepted.equals") != null
+    }
+}


### PR DESCRIPTION
This PR is one possible solution to #4484. There may be other solutions as such I am reporting the issue and the fix separately. If this PR is found acceptable, one can consider it a good fix for to necessary `equals` override as well.

Currently the #4484 problem is being solved by [explicitly overriding equals](https://github.com/jtulach/micronautui/blob/b0bbbbbe522ec9c47f48ee388aab109e293fed5f/micronautui-demo/src/main/java/io/micronaut/ui/demo/Demo.java#L101) in each "UI-ready class" and intercepting such `equals` calls later by the [ObservableInterceptor](https://github.com/jtulach/micronautui/blob/5a336657c4a0be74b3451ea2381b803422a58470/micronautui-api/src/main/java/io/micronaut/ui/impl/ObservableInterceptor.java#L57). It is easy to forget to override `equals` and then everything falls apart. It would be better to avoid the need of overriding `equals`.

This PR introduces new `wrapObjectMethods` attribute to the `@Around` annotation. With its help I shall be able to change my [ObservableUI](https://github.com/jtulach/micronautui/blob/b0bbbbbe522ec9c47f48ee388aab109e293fed5f/micronautui-api/src/main/java/io/micronaut/ui/ObservableUI.java#L40) annotation to use 

```java
@Around(wrapObjectMethods = true)
```
and then my code will be able to [intercept calls to equals](https://github.com/jtulach/micronautui/blob/b0bbbbbe522ec9c47f48ee388aab109e293fed5f/micronautui-api/src/main/java/io/micronaut/ui/impl/QueryProto.java#L49) without forcing client code to override

```java
    @Override
    public boolean equals(Object obj) {
        return super.equals(obj);
    }
```

Thanks for considering this enhancement.