### PR TITLE
Improve file watch documentation

### DIFF
--- a/src/main/docs/guide/cli/reloading/automaticRestart.adoc
+++ b/src/main/docs/guide/cli/reloading/automaticRestart.adoc
@@ -33,6 +33,7 @@ This essentially introduces the following configuration to `application.yml`:
 micronaut:
     io:
         watch:
+            enabled: true
             paths: src/main
             restart: true
 ----


### PR DESCRIPTION
I was unable to get auto restart working until I explicitly set `micronaut.io.watch.enabled = true`.

This config looks to be enabled by default in `io.micronaut.scheduling.io.watch.DefaultWatchThread` has a prerequisite that I suspect requires the value to be explicitly set:
```
@Requires(property = FileWatchConfiguration.ENABLED, value = StringUtils.TRUE, defaultValue = StringUtils.FALSE)
```