### PR TITLE
Add Eclipse Paho v3 and v5 versions to BOM

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -635,6 +635,16 @@ ext {
                 group  : 'io.micronaut.mqtt',
                 modules: ['micronaut-mqtt-core', 'micronaut-mqtt-ssl',  'micronaut-mqttv3',  'micronaut-mqttv5']
             ],
+            'pahov3': [
+                version: pahov3Version,
+                group  : 'org.eclipse.paho',
+                name   : 'org.eclipse.paho.client.mqttv3'
+            ],
+            'pahov5': [
+                version: pahov5Version,
+                group  : 'org.eclipse.paho',
+                name   : 'org.eclipse.paho.mqttv5.client'
+            ],
             'lombok': [
                 version: lombokVersion,
                 group  : 'org.projectlombok',

--- a/gradle.properties
+++ b/gradle.properties
@@ -159,3 +159,5 @@ dekorateVersion=1.0.3
 igniteVersion=2.8.1
 lombokVersion=1.18.16
 testContainersVersion=1.15.0
+pahov3Version=1.2.5
+pahov5Version=1.2.5


### PR DESCRIPTION
It's not a mistake. They have different names `client.mqttv3` and `mqttv5.client` for the different v3 and v5 versions :man_shrugging: 