### PR TITLE
Make AbstractExecutor public to enable bean definitions from subclasses

### DIFF
--- a/function/src/main/java/io/micronaut/function/executor/AbstractExecutor.java
+++ b/function/src/main/java/io/micronaut/function/executor/AbstractExecutor.java
@@ -40,7 +40,7 @@ import java.util.Optional;
  * @author Graeme Rocher
  * @since 1.0
  */
-class AbstractExecutor<C> implements ApplicationContextProvider, Closeable, AutoCloseable  {
+public class AbstractExecutor<C> implements ApplicationContextProvider, Closeable, AutoCloseable  {
 
     /**
      * The current {@link ApplicationContext}.


### PR DESCRIPTION
Fixes #4586

This would also help find elegant solutions to https://github.com/micronaut-projects/micronaut-test/issues/330.