### PR TITLE
Fix @RequestBean field values that depend on filter result

### DIFF
--- a/http-client/src/test/groovy/io/micronaut/http/client/aop/RequestBeanSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/aop/RequestBeanSpec.groovy
@@ -6,7 +6,9 @@ import io.micronaut.core.annotation.Introspected
 import io.micronaut.core.convert.ArgumentConversionContext
 import io.micronaut.core.type.Argument
 import io.micronaut.http.HttpRequest
+import io.micronaut.http.MutableHttpResponse
 import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Filter
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Header
 import io.micronaut.http.annotation.PathVariable
@@ -15,7 +17,11 @@ import io.micronaut.http.annotation.RequestBean
 import io.micronaut.http.bind.binders.TypedRequestArgumentBinder
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.http.filter.HttpServerFilter
+import io.micronaut.http.filter.OncePerRequestHttpServerFilter
+import io.micronaut.http.filter.ServerFilterChain
 import io.micronaut.runtime.server.EmbeddedServer
+import org.reactivestreams.Publisher
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Specification
@@ -79,7 +85,7 @@ class RequestBeanSpec extends Specification {
 
     void "test Typed Value is injected in to Bean"() {
         expect:
-            client.getInjectedTypedValue() == "Test Typed Value"
+            client.getInjectedTypedValue() == "Type Test Value"
     }
 
     void "test Immutable injections works"() {
@@ -102,12 +108,28 @@ class RequestBeanSpec extends Specification {
 
     void "test Immutable Bean gets injected Typed Value"() {
         expect:
-            client.getImmutableInjectedTypedValue() == "Test Typed Value"
+            client.getImmutableInjectedTypedValue() == "Type Test Value"
     }
 
     void "test Extending Bean has super values"() {
         expect:
             client.getExtendingBeanValues("I am not super!", "I am super!") == "Extending: 'I am not super!', Super: 'I am super!'"
+    }
+
+    /**
+     * Example of such case: Authentication type, where value must be resolved after filters
+     */
+    void "test Filter values are respected"() {
+        expect:
+            client.getFilterValue() == "Filter Test Value"
+    }
+
+    void "test unsatisfied non-nullable value returns bad request"() {
+        when:
+            client.getUnsatisfiedValue()
+        then:
+            def ex = thrown(HttpClientResponseException)
+            ex.message.contains("Required argument [String value] not specified")
     }
 
     @Controller('/request/bean')
@@ -145,7 +167,7 @@ class RequestBeanSpec extends Specification {
 
         @Get("/typed/value")
         String getInjectedTypedValue(@RequestBean Bean bean) {
-            return bean.principal.name
+            return bean.typeValue.value
         }
 
         @Get("/immutable")
@@ -165,12 +187,22 @@ class RequestBeanSpec extends Specification {
 
         @Get("/immutable/typed/value")
         String getImmutableInjectedTypedValue(@RequestBean ImmutableBean bean) {
-            return bean.principal.name
+            return bean.typeValue.value
         }
 
         @Get("/extended/values")
         String getExtendingBeanValues(@RequestBean ExtendingBean bean) {
             return "Extending: '$bean.extendingValue', Super: '$bean.superValue'"
+        }
+
+        @Get("/filter/value")
+        String getFilterValue(@RequestBean ImmutableBean bean) {
+            return bean.filterValue.value
+        }
+
+        @Get("/unsatisfied/value")
+        String getUnsatisfiedValue(@RequestBean UnsatisfiedBean bean) {
+            return bean.value
         }
 
     }
@@ -214,6 +246,12 @@ class RequestBeanSpec extends Specification {
         @Get("/extended/values{?extendingValue,superValue}")
         String getExtendingBeanValues(String extendingValue, String superValue)
 
+        @Get("/filter/value")
+        String getFilterValue()
+
+        @Get("/unsatisfied/value")
+        String getUnsatisfiedValue()
+
     }
 
     @Introspected
@@ -242,7 +280,7 @@ class RequestBeanSpec extends Specification {
         String forwardedFor
 
         @Nullable
-        TestPrincipal principal
+        TestTypeValue typeValue
 
     }
 
@@ -252,7 +290,10 @@ class RequestBeanSpec extends Specification {
         final HttpRequest<?> request
 
         @Nullable
-        final TestPrincipal principal
+        final TestTypeValue typeValue
+
+        @Nullable
+        final TestFilterValue filterValue
 
         @Nullable
         @QueryValue
@@ -264,9 +305,10 @@ class RequestBeanSpec extends Specification {
         @Pattern(regexp = "first|second", message = "Field must have value 'first' or 'second'.")
         final String validatedValue
 
-        ImmutableBean(HttpRequest request, TestPrincipal principal, String queryValue, String validatedValue) {
+        ImmutableBean(HttpRequest request, TestTypeValue typeValue, TestFilterValue filterValue, String queryValue, String validatedValue) {
             this.request = request
-            this.principal = principal
+            this.typeValue = typeValue
+            this.filterValue = filterValue
             this.queryValue = queryValue
             this.validatedValue = validatedValue
         }
@@ -290,32 +332,66 @@ class RequestBeanSpec extends Specification {
 
     }
 
-    static class TestPrincipal {
-        String name
+    @Introspected
+    static class UnsatisfiedBean {
+
+        @QueryValue
+        String value
+
+    }
+
+    static class TestTypeValue {
+        String value
     }
 
     @Singleton
-    static class TestPrincipalBinder implements TypedRequestArgumentBinder<TestPrincipal> {
+    static class TestTypeValueBinder implements TypedRequestArgumentBinder<TestTypeValue> {
 
         @Override
-        Argument<TestPrincipal> argumentType() {
-            return Argument.of(TestPrincipal)
+        Argument<TestTypeValue> argumentType() {
+            return Argument.of(TestTypeValue)
         }
 
         @Override
-        BindingResult<TestPrincipal> bind(ArgumentConversionContext<TestPrincipal> context, HttpRequest<?> source) {
-            return new BindingResult<TestPrincipal>() {
+        BindingResult<TestTypeValue> bind(ArgumentConversionContext<TestTypeValue> context, HttpRequest<?> source) {
+            return new BindingResult<TestTypeValue>() {
                 @Override
-                Optional<TestPrincipal> getValue() {
-                    Optional.of(new TestPrincipal(name: "Test Typed Value"))
+                Optional<TestTypeValue> getValue() {
+                    Optional.of(new TestTypeValue(value: "Type Test Value"))
                 }
             }
         }
+    }
+
+    static class TestFilterValue {
+        String value
+    }
+
+    @Singleton
+    static class TestFilterValueBinder implements TypedRequestArgumentBinder<TestFilterValue> {
 
         @Override
-        @Deprecated
-        boolean supportsSuperTypes() {
-            return false
+        Argument<TestFilterValue> argumentType() {
+            return Argument.of(TestFilterValue)
+        }
+
+        @Override
+        BindingResult<TestFilterValue> bind(ArgumentConversionContext<TestFilterValue> context, HttpRequest<?> source) {
+            return new BindingResult<TestFilterValue>() {
+                @Override
+                Optional<TestFilterValue> getValue() {
+                    Optional.of(new TestFilterValue(value: source.getAttribute("filter.value").orElse(null)))
+                }
+            }
+        }
+    }
+
+    @Filter("/request/bean/**")
+    static class TestFilter extends OncePerRequestHttpServerFilter {
+        @Override
+        protected Publisher<MutableHttpResponse<?>> doFilterOnce(HttpRequest<?> request, ServerFilterChain chain) {
+            request.getAttributes().put("filter.value", "Filter Test Value")
+            return chain.proceed(request)
         }
     }
 

--- a/http-server/src/main/java/io/micronaut/http/server/binding/RequestArgumentSatisfier.java
+++ b/http-server/src/main/java/io/micronaut/http/server/binding/RequestArgumentSatisfier.java
@@ -26,6 +26,7 @@ import io.micronaut.http.HttpRequest;
 import io.micronaut.http.bind.RequestBinderRegistry;
 import io.micronaut.http.bind.binders.BodyArgumentBinder;
 import io.micronaut.http.bind.binders.NonBlockingBodyArgumentBinder;
+import io.micronaut.http.bind.binders.RequestBeanAnnotationBinder;
 import io.micronaut.web.router.NullArgument;
 import io.micronaut.web.router.RouteMatch;
 import io.micronaut.web.router.UnresolvedArgument;
@@ -121,9 +122,11 @@ public class RequestArgumentSatisfier {
                 } else {
                     value = getValueForBlockingBodyArgumentBinder(request, argumentBinder, conversionContext);
                 }
+            } else if (argumentBinder instanceof RequestBeanAnnotationBinder) {
+                // Resolve RequestBean after filters since some field types may depend on filters, i.e. Authentication
+                value = (UnresolvedArgument<?>) () -> argumentBinder.bind(conversionContext, request);
             } else {
-                ArgumentBinder.BindingResult bindingResult = argumentBinder
-                    .bind(conversionContext, request);
+                ArgumentBinder.BindingResult bindingResult = argumentBinder.bind(conversionContext, request);
 
                 if (argument.getType() == Optional.class) {
                     if (bindingResult.isSatisfied() || satisfyOptionals) {


### PR DESCRIPTION
This is proposal to fix https://github.com/micronaut-projects/micronaut-core/issues/3869.

Note that I am not sure if this is correct way, since Micronaut currently binds some arguments before filters and unsatisfied arguments after filters. This PR changes behavior that `@RequestBean` is always resolved after filters. 

And since `@RequestBean` can contain other Bindable values (e.g. @Header), means that these values can be resolved differently when they are part of RequestBean vs when they are method parameters. This can be fixed, but adds some lines of code.

What is the reason that arguments are bound before filters?