### PR TITLE
Improve HTTP Client debug log

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -1775,10 +1775,8 @@ public class DefaultHttpClient implements
                 poolMap == null
         );
         if (log.isDebugEnabled()) {
-            log.debug("Sending HTTP Request: {} {}", nettyRequest.method(), nettyRequest.uri());
-            log.debug("Chosen Server: {}({})", requestURI.getHost(), requestURI.getPort());
-        }
-        if (log.isTraceEnabled()) {
+            debugRequest(requestURI, nettyRequest);
+        } else if (log.isTraceEnabled()) {
             traceRequest(finalRequest, nettyRequest);
         }
 
@@ -1939,10 +1937,8 @@ public class DefaultHttpClient implements
             }
         });
         if (log.isDebugEnabled()) {
-            log.debug("Sending HTTP Request: {} {}", nettyRequest.method(), nettyRequest.uri());
-            log.debug("Chosen Server: {}({})", requestURI.getHost(), requestURI.getPort());
-        }
-        if (log.isTraceEnabled()) {
+            debugRequest(requestURI, nettyRequest);
+        } else if (log.isTraceEnabled()) {
             traceRequest(requestWrapper.get(), nettyRequest);
         }
 
@@ -2043,7 +2039,9 @@ public class DefaultHttpClient implements
 
                     try {
                         HttpHeaders headers = fullResponse.headers();
-                        if (log.isTraceEnabled()) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Received response {} from {}", status.code(), request.getUri());
+                        } else if (log.isTraceEnabled()) {
                             log.trace("HTTP Client Response Received for Request: {} {}", request.getMethod(), request.getUri());
                             log.trace("Status Code: {}", status);
                             traceHeaders(headers);
@@ -2397,6 +2395,12 @@ public class DefaultHttpClient implements
         }
 
         return postRequestEncoder;
+    }
+
+    private void debugRequest(URI requestURI, io.netty.handler.codec.http.HttpRequest nettyRequest) {
+        log.debug("Sending HTTP {} to {}",
+                nettyRequest.method(),
+                requestURI.toString());
     }
 
     private void traceRequest(io.micronaut.http.HttpRequest<?> request, io.netty.handler.codec.http.HttpRequest nettyRequest) {


### PR DESCRIPTION
This PR improves how HTTP Client print debug log when using `logger.levels.io.micronaut.http.client=DEBUG`, like this:

```
DEBUG i.m.h.client.netty.DefaultHttpClient - Sending HTTP GET to https://example.com
DEBUG i.m.h.client.netty.DefaultHttpClient - Received response 200 from https://example.com
```

Without these changes the following log is printed:

```
DEBUG i.m.h.client.netty.DefaultHttpClient - Sending HTTP Request: GET /
DEBUG i.m.h.client.netty.DefaultHttpClient - Chosen Server: https://example.com(-1)
```

- Fixes #4581