### PR TITLE
Enhance HTTP server/client request and response log

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -1774,9 +1774,12 @@ public class DefaultHttpClient implements
                 permitsBody,
                 poolMap == null
         );
+
         if (log.isDebugEnabled()) {
             debugRequest(requestURI, nettyRequest);
-        } else if (log.isTraceEnabled()) {
+        }
+
+        if (log.isTraceEnabled()) {
             traceRequest(finalRequest, nettyRequest);
         }
 
@@ -1936,9 +1939,12 @@ public class DefaultHttpClient implements
                 }
             }
         });
+
         if (log.isDebugEnabled()) {
             debugRequest(requestURI, nettyRequest);
-        } else if (log.isTraceEnabled()) {
+        }
+
+        if (log.isTraceEnabled()) {
             traceRequest(requestWrapper.get(), nettyRequest);
         }
 
@@ -2039,11 +2045,12 @@ public class DefaultHttpClient implements
 
                     try {
                         HttpHeaders headers = fullResponse.headers();
+
                         if (log.isDebugEnabled()) {
                             log.debug("Received response {} from {}", status.code(), request.getUri());
-                        } else if (log.isTraceEnabled()) {
-                            log.trace("HTTP Client Response Received for Request: {} {}", request.getMethod(), request.getUri());
-                            log.trace("Status Code: {}", status);
+                        }
+
+                        if (log.isTraceEnabled()) {
                             traceHeaders(headers);
                             traceBody("Response", fullResponse.content());
                         }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
@@ -456,12 +456,12 @@ public class NettyHttpServer implements EmbeddedServer, WebSocketSessionReposito
         boolean isRandomPort = specifiedPort == -1;
         Optional<String> applicationName = serverConfiguration.getApplicationConfiguration().getName();
         if (applicationName.isPresent()) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Binding {} server to {}:{}", applicationName.get(), host != null ? host : "*", port);
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Binding {} server to {}:{}", applicationName.get(), host != null ? host : "*", port);
             }
         } else {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Binding server to {}:{}", host != null ? host : "*", port);
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Binding server to {}:{}", host != null ? host : "*", port);
             }
         }
 

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
@@ -406,7 +406,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
         String requestPath = request.getPath();
 
         if (LOG.isDebugEnabled()) {
-            LOG.debug("Matching route {} - {}", httpMethod, requestPath);
+            LOG.debug("Request {} {}", httpMethod, request.getUri());
         }
 
         NettyHttpRequest nettyHttpRequest = (NettyHttpRequest) request;
@@ -444,7 +444,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
         final String requestMethodName = request.getMethodName();
         if (routeMatch == null) {
             if (LOG.isDebugEnabled()) {
-                LOG.debug("No matching route found for URI {} and method {}", request.getUri(), httpMethod);
+                LOG.debug("No matching route: {} {}", httpMethod, request.getUri());
             }
 
             // if there is no route present try to locate a route that matches a different HTTP method
@@ -534,11 +534,11 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
             route = routeMatch;
         }
 
-        if (LOG.isDebugEnabled()) {
+        if (LOG.isTraceEnabled()) {
             if (route instanceof MethodBasedRouteMatch) {
-                LOG.debug("Matched route {} - {} to controller {}", requestMethodName, requestPath, route.getDeclaringType());
+                LOG.trace("Matched route {} - {} to controller {}", requestMethodName, requestPath, route.getDeclaringType());
             } else {
-                LOG.debug("Matched route {} - {}", requestMethodName, requestPath);
+                LOG.trace("Matched route {} - {}", requestMethodName, requestPath);
             }
         }
         // all ok proceed to try and execute the route
@@ -1237,8 +1237,8 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
                                                 MediaTypeCodec codec = mediaTypeCodecRegistry.findCodec(mediaType, message.getClass()).orElse(
                                                         new TextPlainCodec(serverConfiguration.getDefaultCharset()));
 
-                                                if (LOG.isDebugEnabled()) {
-                                                    LOG.debug("Encoding emitted response object [{}] using codec: {}", message, codec);
+                                                if (LOG.isTraceEnabled()) {
+                                                    LOG.trace("Encoding emitted response object [{}] using codec: {}", message, codec);
                                                 }
                                                 ByteBuffer<ByteBuf> encoded = codec.encode(message, byteBufferFactory);
                                                 httpContent = new DefaultHttpContent(encoded.asNativeBuffer());
@@ -1751,8 +1751,14 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
             } else {
                 context.writeAndFlush(nettyResponse)
                         .addListener(requestCompletor);
-            }
 
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Response {} - {} {}",
+                            nettyResponse.status().code(),
+                            request.getMethodName(),
+                            request.getUri());
+                }
+            }
         }
     }
 
@@ -1872,8 +1878,8 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
             }
 
         } else {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Encoding emitted response object [{}] using codec: {}", body, codec);
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Encoding emitted response object [{}] using codec: {}", body, codec);
             }
             byteBuf = codec.encode(body, new NettyByteBufferFactory(context.alloc())).asNativeBuffer();
         }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/decoders/HttpRequestDecoder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/decoders/HttpRequestDecoder.java
@@ -68,8 +68,8 @@ public class HttpRequestDecoder extends MessageToMessageDecoder<HttpRequest> imp
 
     @Override
     protected void decode(ChannelHandlerContext ctx, HttpRequest msg, List<Object> out) {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Server {}:{} Received Request: {} {}", embeddedServer.getHost(), embeddedServer.getPort(), msg.method(), msg.uri());
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Server {}:{} Received Request: {} {}", embeddedServer.getHost(), embeddedServer.getPort(), msg.method(), msg.uri());
         }
         try {
             NettyHttpRequest<Object> request = new NettyHttpRequest<>(msg, ctx, conversionService, configuration);


### PR DESCRIPTION
Hello!

This PR enhances HTTP server request and response log, using the same strategy from the HTTP client log, that is, 1 line to debug request and 1 line to debug response. In order to achieve that some logs were promoted to trace.

This PR also fixes a shadowing problem from the previous PR regarding HTTP client log. The debug conditions were hiding the trace conditions when using TRACE log level.

Example 1 - Route found:

```
logger.levels.io.micronaut.http.server=DEBUG
logger.levels.io.micronaut.http.client=DEBUG

DEBUG i.m.h.s.netty.RoutingInBoundHandler - Request GET /something?value=123
DEBUG i.m.h.client.netty.DefaultHttpClient - Sending HTTP GET to https://example.com?query=abc
DEBUG i.m.h.client.netty.DefaultHttpClient - Received response 200 from https://example.com?query=abc
DEBUG i.m.h.s.netty.RoutingInBoundHandler - Response 200 - GET /something?value=123
```

Example 2 - Route not found:

```
logger.levels.io.micronaut.http.server=DEBUG

DEBUG i.m.h.s.netty.RoutingInBoundHandler - Request GET /something?value=123
DEBUG i.m.h.s.netty.RoutingInBoundHandler - No matching route: GET /something?value=123
DEBUG i.m.h.s.netty.RoutingInBoundHandler - Response 404 - GET /something?value=123
```

Example 3 - Mega full trace

```
logger.levels.io.micronaut.http.server=TRACE
logger.levels.io.micronaut.http.client=TRACE

TRACE i.m.h.server.netty.NettyHttpServer - Server localhost:9000 Received Request: GET /something?value=123
DEBUG i.m.h.s.netty.RoutingInBoundHandler - Request GET /something?value=123
TRACE i.m.h.s.netty.RoutingInBoundHandler - Matched route GET - /something to controller class com.micronaut.SomethingController
DEBUG i.m.h.client.netty.DefaultHttpClient - Sending HTTP GET to https://example.com?query=abc
TRACE i.m.h.client.netty.DefaultHttpClient - Accept: application/json
TRACE i.m.h.client.netty.DefaultHttpClient - host: example.com
TRACE i.m.h.client.netty.DefaultHttpClient - connection: close
DEBUG i.m.h.client.netty.DefaultHttpClient - Received response 200 from https://example.com?query=abc
TRACE i.m.h.client.netty.DefaultHttpClient - Server: nginx/1.18.0
TRACE i.m.h.client.netty.DefaultHttpClient - Date: Thu, 26 Nov 2020 02:47:52 GMT
TRACE i.m.h.client.netty.DefaultHttpClient - Content-Type: application/json; charset=utf-8
TRACE i.m.h.client.netty.DefaultHttpClient - Connection: close
TRACE i.m.h.client.netty.DefaultHttpClient - Access-Control-Allow-Origin: *
TRACE i.m.h.client.netty.DefaultHttpClient - Access-Control-Allow-Methods: GET, OPTIONS
TRACE i.m.h.client.netty.DefaultHttpClient - Access-Control-Allow-Headers: Content-Type, X-Request-With, X-Requested-By
TRACE i.m.h.client.netty.DefaultHttpClient - Access-Control-Allow-Credentials: true
TRACE i.m.h.client.netty.DefaultHttpClient - Access-Control-Max-Age: 86400
TRACE i.m.h.client.netty.DefaultHttpClient - Expires: Thu, 26 Nov 2020 03:47:52 GMT
TRACE i.m.h.client.netty.DefaultHttpClient - Cache-Control: max-age=3600
TRACE i.m.h.client.netty.DefaultHttpClient - Cache-Control: public
TRACE i.m.h.client.netty.DefaultHttpClient - Pragma: public
TRACE i.m.h.client.netty.DefaultHttpClient - content-length: 206
TRACE i.m.h.client.netty.DefaultHttpClient - Response Body
TRACE i.m.h.client.netty.DefaultHttpClient - ----
TRACE i.m.h.client.netty.DefaultHttpClient - {
  "some": "thing"
}
TRACE i.m.h.client.netty.DefaultHttpClient - ----
TRACE i.m.h.s.netty.RoutingInBoundHandler - Encoding emitted response object [com.micronaut.SomethingResponse@53b74361] using codec: io.micronaut.jackson.codec.JsonMediaTypeCodec@25456d13
DEBUG i.m.h.s.netty.RoutingInBoundHandler - Response 200 - GET /something?value=123
```