### PR TITLE
test: Spock @Requires port 80

### DIFF
--- a/http-client/src/test/groovy/io/micronaut/http/client/HostHeaderSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/HostHeaderSpec.groovy
@@ -26,6 +26,7 @@ import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Header
 import io.micronaut.runtime.server.EmbeddedServer
 import spock.lang.IgnoreIf
+import spock.lang.Requires
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -36,6 +37,7 @@ class HostHeaderSpec extends Specification {
 
     // Unix-like environments (e.g. Travis) may not allow to bind on reserved ports without proper privileges.
     @IgnoreIf({ os.linux })
+    @Requires({ SocketUtils.isTcpPortAvailable(80) })
     void "test host header with server on 80"() {
         given:
         EmbeddedServer embeddedServer = ApplicationContext.builder(['micronaut.server.port': 80]).run(EmbeddedServer)
@@ -78,6 +80,7 @@ class HostHeaderSpec extends Specification {
 
     // Unix-like environments (e.g. Travis) may not allow to bind on reserved ports without proper privileges.
     @IgnoreIf({ os.linux })
+    @Requires({ SocketUtils.isTcpPortAvailable(80) })
     void "test host header with client authority"() {
         given:
         EmbeddedServer embeddedServer = ApplicationContext.builder(['micronaut.server.port': 80]).run(EmbeddedServer)


### PR DESCRIPTION
Ignore tests which require port 80 to be free if port 80 is not available. 

E.g. I run my computer always with apache running in port 80. 