### PR TITLE
refactor: del uncessary @Inject ann in constructor

### DIFF
--- a/http-client-core/src/main/java/io/micronaut/http/client/bind/DefaultHttpClientBinderRegistry.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/bind/DefaultHttpClientBinderRegistry.java
@@ -29,8 +29,6 @@ import io.micronaut.http.annotation.*;
 import io.micronaut.http.cookie.Cookie;
 import io.micronaut.http.cookie.Cookies;
 import kotlin.coroutines.Continuation;
-
-import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.lang.annotation.Annotation;
 import java.util.*;
@@ -55,7 +53,6 @@ public class DefaultHttpClientBinderRegistry implements HttpClientBinderRegistry
      * @param conversionService The conversion service
      * @param binders           The request argument binders
      */
-    @Inject
     protected DefaultHttpClientBinderRegistry(ConversionService<?> conversionService,
                                               List<ClientArgumentRequestBinder> binders) {
         byType.put(Argument.of(HttpHeaders.class).typeHashCode(), (ClientArgumentRequestBinder<HttpHeaders>) (context, uriContext, value, request) -> {

--- a/http-client-core/src/main/java/io/micronaut/http/client/interceptor/HttpClientIntroductionAdvice.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/interceptor/HttpClientIntroductionAdvice.java
@@ -58,7 +58,6 @@ import org.reactivestreams.Subscription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.io.Closeable;
 import java.lang.annotation.Annotation;
@@ -106,7 +105,6 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
      * @param transformers         transformation classes
      * @param binderRegistry       The client binder registry
      */
-    @Inject
     public HttpClientIntroductionAdvice(
             BeanContext beanContext,
             RxHttpClientRegistry clientFactory,

--- a/http-client/src/main/java/io/micronaut/http/client/netty/ssl/NettyClientSslBuilder.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/ssl/NettyClientSslBuilder.java
@@ -47,7 +47,6 @@ public class NettyClientSslBuilder extends SslBuilder<SslContext> {
     /**
      * @param resourceResolver The resource resolver
      */
-    @Inject
     public NettyClientSslBuilder(ResourceResolver resourceResolver) {
         super(resourceResolver);
     }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
@@ -86,7 +86,6 @@ import org.slf4j.LoggerFactory;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 
-import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 import java.io.File;
@@ -170,7 +169,6 @@ public class NettyHttpServer implements EmbeddedServer, WebSocketSessionReposito
      * @param channelOptionFactory                    The channel option factory
      */
     @SuppressWarnings("ParameterNumber")
-    @Inject
     public NettyHttpServer(
             NettyHttpServerConfiguration serverConfiguration,
             ApplicationContext applicationContext,

--- a/http/src/main/java/io/micronaut/http/resource/ResourceLoaderFactory.java
+++ b/http/src/main/java/io/micronaut/http/resource/ResourceLoaderFactory.java
@@ -50,7 +50,6 @@ public class ResourceLoaderFactory {
      *
      * @param environment The environment
      */
-    @Inject
     public ResourceLoaderFactory(Environment environment) {
         this.classLoader = environment.getClassLoader();
     }

--- a/management/src/main/java/io/micronaut/management/health/indicator/jdbc/JdbcIndicator.java
+++ b/management/src/main/java/io/micronaut/management/health/indicator/jdbc/JdbcIndicator.java
@@ -71,7 +71,6 @@ public class JdbcIndicator implements HealthIndicator {
      * @param dataSourceResolver The data source resolver
      * @param healthAggregator   The health aggregator
      */
-    @Inject
     public JdbcIndicator(@Named(TaskExecutors.IO) ExecutorService executorService,
                          DataSource[] dataSources,
                          @Nullable DataSourceResolver dataSourceResolver,

--- a/router/src/main/java/io/micronaut/web/router/naming/ConfigurableUriNamingStrategy.java
+++ b/router/src/main/java/io/micronaut/web/router/naming/ConfigurableUriNamingStrategy.java
@@ -23,7 +23,6 @@ import io.micronaut.core.naming.conventions.PropertyConvention;
 import io.micronaut.inject.BeanDefinition;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import javax.inject.Inject;
 import javax.inject.Singleton;
 
 /**
@@ -46,7 +45,6 @@ public class ConfigurableUriNamingStrategy extends HyphenatedUriNamingStrategy {
      *
      * @param contextPath the "micronaut.server.context-path" property value
      */
-    @Inject
     public ConfigurableUriNamingStrategy(@Value("${micronaut.server.context-path}") String contextPath) {
         this.contextPath = normalizeContextPath(contextPath);
     }

--- a/router/src/main/java/io/micronaut/web/router/resource/StaticResourceConfiguration.java
+++ b/router/src/main/java/io/micronaut/web/router/resource/StaticResourceConfiguration.java
@@ -25,7 +25,6 @@ import io.micronaut.core.util.Toggleable;
 import io.micronaut.http.context.ServerContextPathProvider;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
-import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -68,7 +67,6 @@ public class StaticResourceConfiguration implements Toggleable {
      * @param resourceResolver The {@linkplain ResourceResolver}
      * @param contextPathProvider The context path provider
      */
-    @Inject
     public StaticResourceConfiguration(ResourceResolver resourceResolver,
                                        @Nullable ServerContextPathProvider contextPathProvider) {
         this.resourceResolver = resourceResolver;

--- a/router/src/main/java/io/micronaut/web/router/version/RouteVersionFilter.java
+++ b/router/src/main/java/io/micronaut/web/router/version/RouteVersionFilter.java
@@ -26,7 +26,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
-import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.List;
 import java.util.Objects;
@@ -54,7 +53,6 @@ public class RouteVersionFilter implements RouteMatchFilter {
      * @param resolvingStrategies A list of {@link RequestVersionResolver} beans to extract version from HTTP request
      * @param defaultVersionProvider The Default Version Provider
      */
-    @Inject
     public RouteVersionFilter(List<RequestVersionResolver> resolvingStrategies,
                               @Nullable DefaultVersionProvider defaultVersionProvider) {
         this.resolvingStrategies = resolvingStrategies;

--- a/router/src/main/java/io/micronaut/web/router/version/VersionAwareRouterListener.java
+++ b/router/src/main/java/io/micronaut/web/router/version/VersionAwareRouterListener.java
@@ -21,8 +21,6 @@ import io.micronaut.context.event.BeanCreatedEventListener;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.web.router.Router;
 import io.micronaut.web.router.filter.FilteredRouter;
-
-import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import static io.micronaut.web.router.version.RoutesVersioningConfiguration.PREFIX;
@@ -45,7 +43,6 @@ public class VersionAwareRouterListener implements BeanCreatedEventListener<Rout
      *
      * @param filter A {@link io.micronaut.web.router.filter.RouteMatchFilter} to delegate routes filtering
      */
-    @Inject
     public VersionAwareRouterListener(RouteVersionFilter filter) {
         this.routeVersionFilter = filter;
     }

--- a/router/src/main/java/io/micronaut/web/router/version/resolution/HeaderVersionResolver.java
+++ b/router/src/main/java/io/micronaut/web/router/version/resolution/HeaderVersionResolver.java
@@ -19,7 +19,6 @@ import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.web.router.version.RoutesVersioningConfiguration;
 
-import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.List;
 import java.util.Objects;
@@ -42,7 +41,6 @@ public class HeaderVersionResolver implements RequestVersionResolver {
      *
      * @param configuration A configuration to pick correct request header names.
      */
-    @Inject
     public HeaderVersionResolver(HeaderVersionResolverConfiguration configuration) {
         this.headerNames = configuration.getNames();
     }

--- a/router/src/main/java/io/micronaut/web/router/version/resolution/ParameterVersionResolver.java
+++ b/router/src/main/java/io/micronaut/web/router/version/resolution/ParameterVersionResolver.java
@@ -19,7 +19,6 @@ import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.web.router.version.RoutesVersioningConfiguration;
 
-import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.List;
 import java.util.Objects;
@@ -42,7 +41,6 @@ public class ParameterVersionResolver implements RequestVersionResolver {
      *
      * @param configuration A configuration to pick correct request parameter names.
      */
-    @Inject
     public ParameterVersionResolver(ParameterVersionResolverConfiguration configuration) {
         this.parameterNames = configuration.getNames();
     }

--- a/runtime/src/main/java/io/micronaut/reactive/rxjava2/RxJava2Instrumentation.java
+++ b/runtime/src/main/java/io/micronaut/reactive/rxjava2/RxJava2Instrumentation.java
@@ -38,7 +38,6 @@ import org.reactivestreams.Subscriber;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
-import javax.inject.Inject;
 import javax.inject.Singleton;
 
 /**
@@ -82,7 +81,6 @@ class RxJava2Instrumentation implements AutoCloseable {
      *
      * @param instrumenterFactory to instrument rx calls
      */
-    @Inject
     public RxJava2Instrumentation(RxInstrumenterFactory instrumenterFactory) {
         this.instrumenterFactory = instrumenterFactory;
     }

--- a/runtime/src/main/java/io/micronaut/retry/intercept/DefaultRetryInterceptor.java
+++ b/runtime/src/main/java/io/micronaut/retry/intercept/DefaultRetryInterceptor.java
@@ -34,7 +34,6 @@ import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 import java.time.Duration;
@@ -72,7 +71,6 @@ public class DefaultRetryInterceptor implements MethodInterceptor<Object, Object
      * @param eventPublisher  The event publisher to publish retry events
      * @param executorService The executor service to use for completable futures
      */
-    @Inject
     public DefaultRetryInterceptor(ApplicationEventPublisher eventPublisher, @Named(TaskExecutors.SCHEDULED) ExecutorService executorService) {
         this.eventPublisher = eventPublisher;
         this.executorService = (ScheduledExecutorService) executorService;

--- a/tracing/src/main/java/io/micronaut/tracing/instrument/hystrix/TracingHystrixConcurrentStrategy.java
+++ b/tracing/src/main/java/io/micronaut/tracing/instrument/hystrix/TracingHystrixConcurrentStrategy.java
@@ -56,7 +56,6 @@ public class TracingHystrixConcurrentStrategy extends HystrixConcurrencyStrategy
      * @param tracingInvocationInstrumenterFactory For instrumenting callable
      * @param hystrixConcurrencyStrategy           Different behavior or implementations for concurrency related aspects of the system with default implementations
      */
-    @Inject
     public TracingHystrixConcurrentStrategy(TracingInvocationInstrumenterFactory tracingInvocationInstrumenterFactory,
                                             @Nullable HystrixConcurrencyStrategy hystrixConcurrencyStrategy) {
         this.delegate = hystrixConcurrencyStrategy != null ? hystrixConcurrencyStrategy : HystrixConcurrencyStrategyDefault.getInstance();

--- a/validation/src/main/java/io/micronaut/validation/ValidatingInterceptor.java
+++ b/validation/src/main/java/io/micronaut/validation/ValidatingInterceptor.java
@@ -25,7 +25,6 @@ import io.micronaut.validation.validator.ExecutableMethodValidator;
 import io.micronaut.validation.validator.ReactiveValidator;
 import io.micronaut.validation.validator.Validator;
 
-import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
@@ -57,7 +56,6 @@ public class ValidatingInterceptor implements MethodInterceptor<Object, Object> 
      * @param micronautValidator The micronaut validator use if no factory is available
      * @param validatorFactory   Factory returning initialized {@code Validator} instances
      */
-    @Inject
     public ValidatingInterceptor(@Nullable Validator micronautValidator,
                                  @Nullable ValidatorFactory validatorFactory) {
 

--- a/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java
@@ -57,7 +57,6 @@ import io.micronaut.validation.validator.extractors.ValueExtractorRegistry;
 import io.reactivex.Flowable;
 import org.reactivestreams.Publisher;
 
-import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.validation.*;
 import javax.validation.groups.Default;
@@ -96,7 +95,6 @@ public class DefaultValidator implements Validator, ExecutableMethodValidator, R
      *
      * @param configuration The validator configuration
      */
-    @Inject
     protected DefaultValidator(
             @NonNull ValidatorConfiguration configuration) {
         ArgumentUtils.requireNonNull("configuration", configuration);


### PR DESCRIPTION
Removes `@Inject` from classes' constructors. Those classes have only one constructor and thus, I think that `@Inject` annotation is not necessary. 