### PR TITLE
Add org.mockito:mockito-core:3.6.28 to BOM

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -649,6 +649,11 @@ ext {
                 version: lombokVersion,
                 group  : 'org.projectlombok',
                 name   : 'lombok'
+            ],
+            mockito: [
+                version: mockitoVersion,
+                group  : 'org.mockito',
+                name   : 'mockito-core'
             ]
     ]
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -89,6 +89,7 @@ grpcVersion=1.33.1
 spotbugsVersion=4.0.3
 swaggerVersion=2.1.5
 junitVersion=5.7.0
+mockitoVersion=3.6.28
 javaxAnnotationApiVersion=1.3.2
 picocliVersion=4.5.2
 reactiveStreamsVersion=1.0.3


### PR DESCRIPTION
This also supports adding mockito as a feature to micoronaut-starter.