### PR TITLE
Standard behavior for ConstraintViolationException

### DIFF
--- a/runtime/src/main/java/io/micronaut/jackson/JacksonConfiguration.java
+++ b/runtime/src/main/java/io/micronaut/jackson/JacksonConfiguration.java
@@ -329,24 +329,6 @@ public class JacksonConfiguration {
         this.hateoas = hateoas;
     }
 
-    @ConfigurationProperties("hateoas")
-    @Requires("jackson.hateoas")
-    public static class Hateoas {
-        /**
-         * If true _embedded.errors will always be an array. When set to false, _embedded.errors will be serialized
-         * as an object for 1 error or serialized as an array for 2 or more errors.
-         */
-        private boolean alwaysSerializeErrorsAsList = false;
-
-        public boolean isAlwaysSerializeErrorsAsList() {
-            return alwaysSerializeErrorsAsList;
-        }
-
-        public void setAlwaysSerializeErrorsAsList(boolean alwaysSerializeErrorsAsList) {
-            this.alwaysSerializeErrorsAsList = alwaysSerializeErrorsAsList;
-        }
-    }
-
     /**
      * Constructors a JavaType for the given argument and type factory.
      * @param type The type
@@ -396,5 +378,23 @@ public class JacksonConfiguration {
             }
         }
         return javaTypes.toArray(new JavaType[0]);
+    }
+
+    @ConfigurationProperties("hateoas")
+    @Requires("jackson.hateoas")
+    public static final class Hateoas {
+        /**
+         * If true _embedded.errors will always be an array. When set to false, _embedded.errors will be serialized
+         * as an object for 1 error or serialized as an array for 2 or more errors.
+         */
+        private boolean alwaysSerializeErrorsAsList = false;
+
+        public boolean isAlwaysSerializeErrorsAsList() {
+            return alwaysSerializeErrorsAsList;
+        }
+
+        public void setAlwaysSerializeErrorsAsList(boolean alwaysSerializeErrorsAsList) {
+            this.alwaysSerializeErrorsAsList = alwaysSerializeErrorsAsList;
+        }
     }
 }

--- a/runtime/src/main/java/io/micronaut/jackson/JacksonConfiguration.java
+++ b/runtime/src/main/java/io/micronaut/jackson/JacksonConfiguration.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import io.micronaut.context.annotation.ConfigurationProperties;
-import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.TypeHint;
 import io.micronaut.core.type.Argument;
@@ -31,8 +30,6 @@ import io.micronaut.core.util.CollectionUtils;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
-import javax.annotation.Nullable;
-import javax.inject.Inject;
 import java.util.*;
 
 /**
@@ -79,7 +76,7 @@ public class JacksonConfiguration {
     private JsonInclude.Include serializationInclusion = JsonInclude.Include.NON_EMPTY;
     private ObjectMapper.DefaultTyping defaultTyping = null;
     private PropertyNamingStrategy propertyNamingStrategy = null;
-    private Hateoas hateoas;
+    private boolean alwaysSerializeErrorsAsList = false;
 
     /**
      * Whether the {@link io.micronaut.core.beans.BeanIntrospection} should be used for reflection free object serialialization/deserialialization.
@@ -202,10 +199,13 @@ public class JacksonConfiguration {
     }
 
     /**
-     * @return Settings for the hateoas configuration
+     * Whether _embedded.errors should always be serialized as list. If set to false, _embedded.errors
+     * with 1 element will be serialized as an object.
+     *
+     * @return True if _embedded.errors should always be serialized as list.
      */
-    public Hateoas getHateoas() {
-        return hateoas;
+    public boolean isAlwaysSerializeErrorsAsList() {
+        return alwaysSerializeErrorsAsList;
     }
 
     /**
@@ -320,13 +320,13 @@ public class JacksonConfiguration {
     }
 
     /**
-     * Sets the property for hateoas configuration.
+     * Sets whether _embedded.errors should always be serialized as list (defaults to false).
+     * If set to false, _embedded.errors with 1 element will be serialized as an object.
      *
-     * @param hateoas The hateoas configuration
+     * @param alwaysSerializeErrorsAsList True if _embedded.errors should always be serialized as list.
      */
-    @Inject
-    void setHateoas(@Nullable Hateoas hateoas) {
-        this.hateoas = hateoas;
+    public void setAlwaysSerializeErrorsAsList(boolean alwaysSerializeErrorsAsList) {
+        this.alwaysSerializeErrorsAsList = alwaysSerializeErrorsAsList;
     }
 
     /**
@@ -378,23 +378,5 @@ public class JacksonConfiguration {
             }
         }
         return javaTypes.toArray(new JavaType[0]);
-    }
-
-    @ConfigurationProperties("hateoas")
-    @Requires("jackson.hateoas")
-    public static final class Hateoas {
-        /**
-         * If true _embedded.errors will always be an array. When set to false, _embedded.errors will be serialized
-         * as an object for 1 error or serialized as an array for 2 or more errors.
-         */
-        private boolean alwaysSerializeErrorsAsList = false;
-
-        public boolean isAlwaysSerializeErrorsAsList() {
-            return alwaysSerializeErrorsAsList;
-        }
-
-        public void setAlwaysSerializeErrorsAsList(boolean alwaysSerializeErrorsAsList) {
-            this.alwaysSerializeErrorsAsList = alwaysSerializeErrorsAsList;
-        }
     }
 }

--- a/runtime/src/main/java/io/micronaut/jackson/JacksonConfiguration.java
+++ b/runtime/src/main/java/io/micronaut/jackson/JacksonConfiguration.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.TypeHint;
 import io.micronaut.core.type.Argument;
@@ -29,6 +30,9 @@ import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+
+import javax.annotation.Nullable;
+import javax.inject.Inject;
 import java.util.*;
 
 /**
@@ -75,6 +79,7 @@ public class JacksonConfiguration {
     private JsonInclude.Include serializationInclusion = JsonInclude.Include.NON_EMPTY;
     private ObjectMapper.DefaultTyping defaultTyping = null;
     private PropertyNamingStrategy propertyNamingStrategy = null;
+    private Hateoas hateoas;
 
     /**
      * Whether the {@link io.micronaut.core.beans.BeanIntrospection} should be used for reflection free object serialialization/deserialialization.
@@ -197,6 +202,13 @@ public class JacksonConfiguration {
     }
 
     /**
+     * @return Settings for the hateoas configuration
+     */
+    public Hateoas getHateoas() {
+        return hateoas;
+    }
+
+    /**
      * Sets the default date format to use.
      * @param dateFormat The date format
      */
@@ -305,6 +317,34 @@ public class JacksonConfiguration {
      */
     public void setPropertyNamingStrategy(PropertyNamingStrategy propertyNamingStrategy) {
         this.propertyNamingStrategy = propertyNamingStrategy;
+    }
+
+    /**
+     * Sets the property for hateoas configuration.
+     *
+     * @param hateoas The hateoas configuration
+     */
+    @Inject
+    void setHateoas(@Nullable Hateoas hateoas) {
+        this.hateoas = hateoas;
+    }
+
+    @ConfigurationProperties("hateoas")
+    @Requires("jackson.hateoas")
+    public static class Hateoas {
+        /**
+         * If true _embedded.errors will always be an array. When set to false, _embedded.errors will be serialized
+         * as an object for 1 error or serialized as an array for 2 or more errors.
+         */
+        private boolean alwaysSerializeErrorsAsList = false;
+
+        public boolean isAlwaysSerializeErrorsAsList() {
+            return alwaysSerializeErrorsAsList;
+        }
+
+        public void setAlwaysSerializeErrorsAsList(boolean alwaysSerializeErrorsAsList) {
+            this.alwaysSerializeErrorsAsList = alwaysSerializeErrorsAsList;
+        }
     }
 
     /**

--- a/runtime/src/main/java/io/micronaut/jackson/JacksonConfiguration.java
+++ b/runtime/src/main/java/io/micronaut/jackson/JacksonConfiguration.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.type.TypeFactory;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.TypeHint;
@@ -27,8 +28,6 @@ import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
-
-import edu.umd.cs.findbugs.annotations.NonNull;
 
 import java.util.*;
 

--- a/runtime/src/main/java/io/micronaut/jackson/serialize/OptionalValuesSerializer.java
+++ b/runtime/src/main/java/io/micronaut/jackson/serialize/OptionalValuesSerializer.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import io.micronaut.core.value.OptionalMultiValues;
 import io.micronaut.core.value.OptionalValues;
 import io.micronaut.http.hateoas.JsonError;
+import io.micronaut.jackson.JacksonConfiguration;
 
 import javax.inject.Singleton;
 import java.io.IOException;
@@ -35,6 +36,12 @@ import java.util.Optional;
  */
 @Singleton
 public class OptionalValuesSerializer extends JsonSerializer<OptionalValues<?>> {
+
+    private final JacksonConfiguration jacksonConfiguration;
+
+    public OptionalValuesSerializer(JacksonConfiguration jacksonConfiguration) {
+        this.jacksonConfiguration = jacksonConfiguration;
+    }
 
     @Override
     public boolean isEmpty(SerializerProvider provider, OptionalValues<?> value) {
@@ -54,7 +61,7 @@ public class OptionalValuesSerializer extends JsonSerializer<OptionalValues<?>> 
                 if (value instanceof OptionalMultiValues) {
                     List<?> list = (List<?>) v;
 
-                    if (list.size() == 1 && list.get(0).getClass() != JsonError.class) {
+                    if (list.size() == 1 && canSerializeElementAsObject(list.get(0).getClass())) {
                         gen.writeObject(list.get(0));
                     } else {
                         gen.writeObject(list);
@@ -65,5 +72,9 @@ public class OptionalValuesSerializer extends JsonSerializer<OptionalValues<?>> 
             }
         }
         gen.writeEndObject();
+    }
+
+    private boolean canSerializeElementAsObject(Class<?> type) {
+        return type != JsonError.class || !jacksonConfiguration.getHateoas().isAlwaysSerializeErrorsAsList();
     }
 }

--- a/runtime/src/main/java/io/micronaut/jackson/serialize/OptionalValuesSerializer.java
+++ b/runtime/src/main/java/io/micronaut/jackson/serialize/OptionalValuesSerializer.java
@@ -38,8 +38,16 @@ import java.util.Optional;
 @Singleton
 public class OptionalValuesSerializer extends JsonSerializer<OptionalValues<?>> {
 
+    private final boolean alwaysSerializeErrorsAsList;
+
+    public OptionalValuesSerializer() {
+        this.alwaysSerializeErrorsAsList = false;
+    }
+
     @Inject
-    private JacksonConfiguration jacksonConfiguration;
+    public OptionalValuesSerializer(JacksonConfiguration jacksonConfiguration) {
+        this.alwaysSerializeErrorsAsList = jacksonConfiguration.isAlwaysSerializeErrorsAsList();
+    }
 
     @Override
     public boolean isEmpty(SerializerProvider provider, OptionalValues<?> value) {
@@ -48,8 +56,6 @@ public class OptionalValuesSerializer extends JsonSerializer<OptionalValues<?>> 
 
     @Override
     public void serialize(OptionalValues<?> value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
-        final boolean alwaysSerializeErrorsAsList = jacksonConfiguration.isAlwaysSerializeErrorsAsList();
-
         gen.writeStartObject();
 
         for (CharSequence key : value) {

--- a/runtime/src/main/java/io/micronaut/jackson/serialize/OptionalValuesSerializer.java
+++ b/runtime/src/main/java/io/micronaut/jackson/serialize/OptionalValuesSerializer.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import io.micronaut.core.value.OptionalMultiValues;
 import io.micronaut.core.value.OptionalValues;
+import io.micronaut.http.hateoas.JsonError;
 
 import javax.inject.Singleton;
 import java.io.IOException;
@@ -51,8 +52,9 @@ public class OptionalValuesSerializer extends JsonSerializer<OptionalValues<?>> 
                 gen.writeFieldName(fieldName);
                 Object v = opt.get();
                 if (value instanceof OptionalMultiValues) {
-                    List list = (List) v;
-                    if (list.size() == 1) {
+                    List<?> list = (List<?>) v;
+
+                    if (list.size() == 1 && list.get(0).getClass() != JsonError.class) {
                         gen.writeObject(list.get(0));
                     } else {
                         gen.writeObject(list);

--- a/validation/src/main/java/io/micronaut/validation/exceptions/ConstraintExceptionHandler.java
+++ b/validation/src/main/java/io/micronaut/validation/exceptions/ConstraintExceptionHandler.java
@@ -54,35 +54,6 @@ public class ConstraintExceptionHandler implements ExceptionHandler<ConstraintVi
         this.jacksonConfiguration = jacksonConfiguration;
     }
 
-    // @Override
-    // public HttpResponse<JsonError> handle(HttpRequest request, ConstraintViolationException exception) {
-    //     Set<ConstraintViolation<?>> constraintViolations = exception.getConstraintViolations();
-    //
-    //     JsonError error;
-    //
-    //     if (constraintViolations == null || constraintViolations.isEmpty()) {
-    //         if (exception.getMessage() == null) {
-    //             error = new JsonError(HttpStatus.BAD_REQUEST.getReason());
-    //         } else {
-    //             error = new JsonError(exception.getMessage());
-    //         }
-    //     } else {
-    //         error = new JsonError(HttpStatus.BAD_REQUEST.getReason());
-    //
-    //         List<Resource> errors = new ArrayList<>();
-    //
-    //         for (ConstraintViolation<?> violation : constraintViolations) {
-    //             errors.add(new JsonError(buildMessage(violation)));
-    //         }
-    //
-    //         error.embedded("errors", errors);
-    //     }
-    //
-    //     error.link(Link.SELF, Link.of(request.getUri()));
-    //
-    //     return HttpResponse.badRequest(error);
-    // }
-
     @Override
     public HttpResponse<JsonError> handle(HttpRequest request, ConstraintViolationException exception) {
         Set<ConstraintViolation<?>> constraintViolations = exception.getConstraintViolations();

--- a/validation/src/main/java/io/micronaut/validation/exceptions/ConstraintExceptionHandler.java
+++ b/validation/src/main/java/io/micronaut/validation/exceptions/ConstraintExceptionHandler.java
@@ -25,7 +25,6 @@ import io.micronaut.http.hateoas.Link;
 import io.micronaut.http.hateoas.Resource;
 import io.micronaut.http.server.exceptions.ExceptionHandler;
 import io.micronaut.jackson.JacksonConfiguration;
-import io.micronaut.validation.validator.DefaultValidatorConfiguration;
 
 import javax.inject.Singleton;
 import javax.validation.ConstraintViolation;

--- a/validation/src/main/java/io/micronaut/validation/exceptions/ConstraintExceptionHandler.java
+++ b/validation/src/main/java/io/micronaut/validation/exceptions/ConstraintExceptionHandler.java
@@ -48,13 +48,19 @@ import java.util.Set;
 @Requires(classes = {ConstraintViolationException.class, ExceptionHandler.class})
 public class ConstraintExceptionHandler implements ExceptionHandler<ConstraintViolationException, HttpResponse<JsonError>> {
 
+    private final boolean alwaysSerializeErrorsAsList;
+
+    public ConstraintExceptionHandler() {
+        this.alwaysSerializeErrorsAsList = false;
+    }
+
     @Inject
-    private JacksonConfiguration jacksonConfiguration;
+    public ConstraintExceptionHandler(JacksonConfiguration jacksonConfiguration) {
+        this.alwaysSerializeErrorsAsList = jacksonConfiguration.isAlwaysSerializeErrorsAsList();
+    }
 
     @Override
     public HttpResponse<JsonError> handle(HttpRequest request, ConstraintViolationException exception) {
-        final boolean alwaysSerializeErrorsAsList = jacksonConfiguration.isAlwaysSerializeErrorsAsList();
-
         Set<ConstraintViolation<?>> constraintViolations = exception.getConstraintViolations();
         if (constraintViolations == null || constraintViolations.isEmpty()) {
             JsonError error = new JsonError(exception.getMessage() == null ? HttpStatus.BAD_REQUEST.getReason() : exception.getMessage());

--- a/validation/src/test/groovy/io/micronaut/validation/ValidatedSpec.groovy
+++ b/validation/src/test/groovy/io/micronaut/validation/ValidatedSpec.groovy
@@ -194,7 +194,7 @@ class ValidatedSpec extends Specification {
         when:
         HttpResponse<String> response = client.toBlocking().exchange(
                 HttpRequest.POST("/validated/pojo", '{"email":"abc","name":"Micronaut"}')
-                        .contentType(io.micronaut.http.MediaType.APPLICATION_JSON_TYPE),
+                        .contentType(MediaType.APPLICATION_JSON_TYPE),
                 String
         )
 
@@ -206,7 +206,9 @@ class ValidatedSpec extends Specification {
         def result = new JsonSlurper().parseText((String) e.response.getBody().get())
 
         then:
-        result.message == 'pojo.email: Email should be valid'
+        result.message == 'Bad Request'
+        result._embedded.errors.size == 1
+        result._embedded.errors.find { it.message == 'pojo.email: Email should be valid' }
 
         cleanup:
         server.close()
@@ -224,7 +226,7 @@ class ValidatedSpec extends Specification {
         when:
         HttpResponse<String> response = client.toBlocking().exchange(
                 HttpRequest.POST("/validated/pojo", '{"email":"abc"}')
-                        .contentType(io.micronaut.http.MediaType.APPLICATION_JSON_TYPE),
+                        .contentType(MediaType.APPLICATION_JSON_TYPE),
                 String
         )
 
@@ -257,7 +259,7 @@ class ValidatedSpec extends Specification {
         when:
         Flowable<HttpResponse<String>> flowable = Flowable.fromPublisher(client.exchange(
                 HttpRequest.POST("/validated/args", '{"amount":"xxx"}')
-                        .contentType(io.micronaut.http.MediaType.APPLICATION_JSON_TYPE),
+                        .contentType(MediaType.APPLICATION_JSON_TYPE),
                 String
         ))
         flowable.blockingFirst()
@@ -270,7 +272,9 @@ class ValidatedSpec extends Specification {
         def result = new JsonSlurper().parseText((String) e.response.getBody().get())
 
         then:
-        result.message == 'amount: numeric value out of bounds (<3 digits>.<2 digits> expected)'
+        result.message == 'Bad Request'
+        result._embedded.errors.size == 1
+        result._embedded.errors.find { it.message == 'amount: numeric value out of bounds (<3 digits>.<2 digits> expected)' }
 
         cleanup:
         server.close()
@@ -301,7 +305,9 @@ class ValidatedSpec extends Specification {
         Map result = e.response.getBody(Argument.of(Map, String, Object)).get()
 
         then:
-        result.message == 'limit: must be greater than or equal to 1'
+        result.message == 'Bad Request'
+        result._embedded.errors.size == 1
+        result._embedded.errors.find { it.message == 'limit: must be greater than or equal to 1' }
 
         cleanup:
         server.close()
@@ -354,7 +360,9 @@ class ValidatedSpec extends Specification {
         Map result = e.response.getBody(Argument.of(Map, String, Object)).get()
 
         then:
-        result.message == 'limit: must not be null'
+        result.message == 'Bad Request'
+        result._embedded.errors.size == 1
+        result._embedded.errors.find { it.message == 'limit: must not be null' }
 
         cleanup:
         server.close()
@@ -370,8 +378,14 @@ class ValidatedSpec extends Specification {
 
         then:
         def e = thrown(HttpClientResponseException)
-        e.message == 'value: size must be between 2 and 2147483647'
 
+        when:
+        def result = new JsonSlurper().parseText((String) e.response.getBody().get())
+
+        then:
+        result.message == 'Bad Request'
+        result._embedded.errors.size == 1
+        result._embedded.errors.find { it.message == 'value: size must be between 2 and 2147483647' }
 
         cleanup:
         server.close()
@@ -450,7 +464,7 @@ class ValidatedSpec extends Specification {
         when:
         HttpResponse<String> response = client.toBlocking().exchange(
                 HttpRequest.POST("/validated/no-introspection", '{"email":"a@a.com","name":"Micronaut"}')
-                        .contentType(io.micronaut.http.MediaType.APPLICATION_JSON_TYPE),
+                        .contentType(MediaType.APPLICATION_JSON_TYPE),
                 String
         )
 
@@ -462,7 +476,9 @@ class ValidatedSpec extends Specification {
         def result = new JsonSlurper().parseText((String) e.response.getBody().get())
 
         then:
-        result.message == 'pojo: Cannot validate io.micronaut.validation.PojoNoIntrospection. No bean introspection present. Please add @Introspected to the class and ensure Micronaut annotation processing is enabled'
+        result.message == 'Bad Request'
+        result._embedded.errors.size == 1
+        result._embedded.errors.find { it.message == 'pojo: Cannot validate io.micronaut.validation.PojoNoIntrospection. No bean introspection present. Please add @Introspected to the class and ensure Micronaut annotation processing is enabled' }
 
         cleanup:
         server.close()

--- a/validation/src/test/groovy/io/micronaut/validation/ValidatedSpec.groovy
+++ b/validation/src/test/groovy/io/micronaut/validation/ValidatedSpec.groovy
@@ -216,7 +216,7 @@ class ValidatedSpec extends Specification {
         given:
         ApplicationContext context = ApplicationContext.run([
                 'spec.name': getClass().simpleName,
-                'jackson.hateoas.always-serialize-errors-as-list': true
+                'jackson.always-serialize-errors-as-list': true
         ])
         EmbeddedServer embeddedServer = context.getBean(EmbeddedServer).start()
         HttpClient client = context.createBean(HttpClient, embeddedServer.getURL())
@@ -313,7 +313,7 @@ class ValidatedSpec extends Specification {
         given:
         ApplicationContext context = ApplicationContext.run([
                 'spec.name': getClass().simpleName,
-                'jackson.hateoas.always-serialize-errors-as-list': true
+                'jackson.always-serialize-errors-as-list': true
         ])
         EmbeddedServer embeddedServer = context.getBean(EmbeddedServer).start()
         HttpClient client = context.createBean(HttpClient, embeddedServer.getURL())
@@ -378,7 +378,7 @@ class ValidatedSpec extends Specification {
         given:
         ApplicationContext context = ApplicationContext.run([
                 'spec.name': getClass().simpleName,
-                'jackson.hateoas.always-serialize-errors-as-list': true
+                'jackson.always-serialize-errors-as-list': true
         ])
         EmbeddedServer embeddedServer = context.getBean(EmbeddedServer).start()
         HttpClient client = context.createBean(HttpClient, embeddedServer.getURL())
@@ -465,7 +465,7 @@ class ValidatedSpec extends Specification {
         given:
         EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
                 'spec.name': getClass().simpleName,
-                'jackson.hateoas.always-serialize-errors-as-list': true
+                'jackson.always-serialize-errors-as-list': true
         ])
         HttpClient client = server.applicationContext.createBean(HttpClient, server.getURL())
 
@@ -513,7 +513,7 @@ class ValidatedSpec extends Specification {
     void "test validated response with annotation with standard embedded errors"() {
         given:
         EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
-                'jackson.hateoas.always-serialize-errors-as-list': true
+                'jackson.always-serialize-errors-as-list': true
         ])
         TestClient client = server.applicationContext.getBean(TestClient)
 
@@ -630,7 +630,7 @@ class ValidatedSpec extends Specification {
         given:
         ApplicationContext context = ApplicationContext.run([
                 'spec.name': getClass().simpleName,
-                'jackson.hateoas.always-serialize-errors-as-list': true
+                'jackson.always-serialize-errors-as-list': true
         ])
         EmbeddedServer embeddedServer = context.getBean(EmbeddedServer).start()
         HttpClient client = context.createBean(HttpClient, embeddedServer.getURL())


### PR DESCRIPTION
To avoid breaking changes, this PR creates a new property:
- `jackson.always-serialize-errors-as-list`

By default it will be `false`, resulting in no changes on how `ConstraintExceptionHandler` and `OptionalValuesSerializer` serializes `_embedded.errors`.

On the other hand, if set to `true`, there will be a standard behavior for the `_embedded.errors` serialization.
So, when `ConstraintExceptionHandler` is thrown, all violation messages will be serialized in the `_embedded.errors` array, like this:

```json
{
  "message": "Bad Request",
  "_links": {
    "self": {
      "href": "/users",
      "templated": false
    }
  },
  "_embedded": {
    "errors": [
      {
        "message": "userCreateRequest.name: must not be blank"
      }
    ]
  }
}
```

```json
{
  "message": "Bad Request",
  "_links": {
    "self": {
      "href": "/users",
      "templated": false
    }
  },
  "_embedded": {
    "errors": [
      {
        "message": "userCreateRequest.name: must not be blank"
      },
      {
        "message": "userCreateRequest.email: must not be blank"
      }
    ]
  }
}
```

For more details take a loot at #4616.

- Fixes #4616