### PR TITLE
Publish new snapshots following semantic versioning

### DIFF
--- a/core/src/test/groovy/io/micronaut/core/version/SemanticVersionSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/version/SemanticVersionSpec.groovy
@@ -16,7 +16,7 @@ class SemanticVersionSpec extends Specification {
         SemanticVersion.isAtLeastMajorMinor(version.version, 1, 0)
 
         where:
-        semver << ["1.0.0", "1.0.0.M1", "1.0.0.RC1", "1.0.0.BUILD-SNAPSHOT", "1.0.0-M1", "1.0.0-RC1", "1.0.0-BUILD-SNAPSHOT"]
+        semver << ["1.0.0", "1.0.0.M1", "1.0.0.RC1", "1.0.0.BUILD-SNAPSHOT", "1.0.0-M1", "1.0.0-RC1", "1.0.0-BUILD-SNAPSHOT", "1.0.0-SNAPSHOT"]
     }
 
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=2.2.1.BUILD-SNAPSHOT
+projectVersion=2.2.1-SNAPSHOT
 projectGroupId=io.micronaut
 title=Micronaut
 projectDesc=Natively Cloud Native

--- a/src/main/docs/guide/appendix/usingsnapshots.adoc
+++ b/src/main/docs/guide/appendix/usingsnapshots.adoc
@@ -1,11 +1,11 @@
 Micronaut milestone and stable releases are distributed to https://bintray.com/micronaut[Bintray].
 
-The following snippet shows how to use Micronaut `BUILD-SNAPSHOT` with Gradle. The latest snapshot will always be the next patch version plus 1 with `.BUILD-SNAPSHOT` appended. For example if the latest release is "1.0.1", the current snapshot would be "1.0.2.BUILD-SNAPSHOT".
+The following snippet shows how to use Micronaut `SNAPSHOT` with Gradle. The latest snapshot will always be the next patch version plus 1 with `-SNAPSHOT` appended. For example if the latest release is "1.0.1", the current snapshot would be "1.0.2-SNAPSHOT".
 
 [source, groovy]
 ----
 ext {
-  micronautVersion = '2.2.0.BUILD-SNAPSHOT'
+  micronautVersion = '2.2.0-SNAPSHOT'
 }
 repositories {
   jcenter() <1>
@@ -26,11 +26,11 @@ In the case of Maven, edit `pom.xml`:
   <parent>
     <groupId>io.micronaut</groupId>
     <artifactId>micronaut-parent</artifactId>
-    <version>2.2.0.BUILD-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
 
   <properties>
-    <micronaut.version>2.2.0.BUILD-SNAPSHOT</micronaut.version> <!--1-->
+    <micronaut.version>2.2.0-SNAPSHOT</micronaut.version> <!--1-->
     ...
   </properties>
 


### PR DESCRIPTION
Same as #4633 but for 2.2.x branch.

See https://github.com/micronaut-projects/github-actions/pull/7