### PR TITLE
add documentation for Netty transport Linux ARM64

### DIFF
--- a/src/main/docs/guide/httpServer/serverConfiguration.adoc
+++ b/src/main/docs/guide/httpServer/serverConfiguration.adoc
@@ -34,7 +34,11 @@ For macOS:
 
 dependency:netty-transport-native-kqueue[groupId="io.netty",scope="runtime",classifier="osx-x86_64"]
 
-For Linux:
+For Linux on ARM64:
+
+dependency:netty-transport-native-epoll[groupId="io.netty",scope="runtime",classifier="linux-aarch_64"]
+
+For Linux on x86:
 
 dependency:netty-transport-native-epoll[groupId="io.netty",scope="runtime",classifier="linux-x86_64"]
 


### PR DESCRIPTION
classifier linux-aarch_64

This classifier indicates ARM architecture 64 bit

Netty 4.1.55 supports the linux-aarch_64 classifier:
https://github.com/netty/netty/pull/10845/files
