### PR TITLE
Add Micronaut banner

### DIFF
--- a/inject/src/main/java/io/micronaut/context/ApplicationContextBuilder.java
+++ b/inject/src/main/java/io/micronaut/context/ApplicationContextBuilder.java
@@ -198,6 +198,14 @@ public interface ApplicationContextBuilder {
     @NonNull ApplicationContextBuilder exclude(@Nullable String... configurations);
 
     /**
+     * Whether the banner is enabled or not.
+     *
+     * @param isEnabled Whether the banner is enabled or not
+     * @return This application
+     */
+    @NonNull ApplicationContextBuilder banner(boolean isEnabled);
+
+    /**
      * Set the command line arguments.
      *
      * @param args The arguments

--- a/inject/src/main/java/io/micronaut/context/ApplicationContextConfiguration.java
+++ b/inject/src/main/java/io/micronaut/context/ApplicationContextConfiguration.java
@@ -101,4 +101,13 @@ public interface ApplicationContextConfiguration extends BeanContextConfiguratio
     default @Nullable List<String> getOverrideConfigLocations() {
         return null;
     }
+
+    /**
+     * The banner is enabled by default.
+     *
+     * @return The banner is enabled by default
+     */
+    default boolean isBannerEnabled() {
+        return true;
+    }
 }

--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContextBuilder.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContextBuilder.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.context;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import io.micronaut.context.env.CommandLinePropertySource;
 import io.micronaut.context.env.Environment;
 import io.micronaut.context.env.PropertySource;
@@ -22,9 +24,6 @@ import io.micronaut.context.env.SystemPropertiesPropertySource;
 import io.micronaut.core.cli.CommandLine;
 import io.micronaut.core.io.scan.ClassPathResourceLoader;
 import io.micronaut.core.util.StringUtils;
-
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
 
 import java.lang.annotation.Annotation;
 import java.util.*;
@@ -52,6 +51,7 @@ public class DefaultApplicationContextBuilder implements ApplicationContextBuild
     private String[] args = new String[0];
     private Set<Class<? extends Annotation>> eagerInitAnnotated = new HashSet<>(3);
     private String[] overrideConfigLocations;
+    private boolean banner = true;
 
     /**
      * Default constructor.
@@ -78,6 +78,11 @@ public class DefaultApplicationContextBuilder implements ApplicationContextBuild
     @Override
     public @Nullable  List<String> getOverrideConfigLocations() {
         return overrideConfigLocations == null ? null : Arrays.asList(overrideConfigLocations);
+    }
+
+    @Override
+    public boolean isBannerEnabled() {
+        return banner;
     }
 
     @Override
@@ -312,6 +317,12 @@ public class DefaultApplicationContextBuilder implements ApplicationContextBuild
         if (configurations != null) {
             this.configurationExcludes.addAll(Arrays.asList(configurations));
         }
+        return this;
+    }
+
+    @Override
+    public @NonNull ApplicationContextBuilder banner(boolean isEnabled) {
+        this.banner = isEnabled;
         return this;
     }
 }

--- a/inject/src/main/java/io/micronaut/context/banner/Banner.java
+++ b/inject/src/main/java/io/micronaut/context/banner/Banner.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context.banner;
+
+/**
+ * Print a banner programmatically.
+ */
+public interface Banner {
+
+    /**
+     * Print the banner.
+     */
+    void print();
+
+}

--- a/inject/src/main/java/io/micronaut/context/banner/MicronautBanner.java
+++ b/inject/src/main/java/io/micronaut/context/banner/MicronautBanner.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context.banner;
+
+import io.micronaut.context.annotation.DefaultImplementation;
+import io.micronaut.core.version.VersionUtils;
+
+import java.io.PrintStream;
+
+/**
+ * Default implementation of {@link Banner} that prints a the default Micronaut banner.
+ */
+@DefaultImplementation(Banner.class)
+public class MicronautBanner implements Banner {
+
+    private static final String[] MICRONAUT_BANNER = {
+            " __  __ _                                  _   ",
+            "|  \\/  (_) ___ _ __ ___  _ __   __ _ _   _| |_ ",
+            "| |\\/| | |/ __| '__/ _ \\| '_ \\ / _` | | | | __|",
+            "| |  | | | (__| | | (_) | | | | (_| | |_| | |_ ",
+            "|_|  |_|_|\\___|_|  \\___/|_| |_|\\__,_|\\__,_|\\__|"
+    };
+    private static final String MICRONAUT = "  Micronaut";
+
+    private final PrintStream out;
+
+    /**
+     * Constructor.
+     *
+     * @param out The print stream
+     */
+    public MicronautBanner(PrintStream out) {
+        this.out = out;
+    }
+
+    @Override
+    public void print() {
+        for (String line : MICRONAUT_BANNER) {
+            out.println(line);
+        }
+        String version = VersionUtils.getMicronautVersion();
+        version = (version != null) ? " (v" + version + ")" : "";
+        out.println(MICRONAUT + version + "\n");
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/banner/ResourceBanner.java
+++ b/inject/src/main/java/io/micronaut/context/banner/ResourceBanner.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context.banner;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Collectors;
+
+/**
+ * Prints a banner from a resource.
+ */
+public class ResourceBanner implements Banner {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ResourceBanner.class);
+
+    private final URL resource;
+    private final PrintStream out;
+
+    /**
+     * Constructor.
+     * @param resource The resource with the banner
+     * @param out The print stream
+     */
+    public ResourceBanner(URL resource, PrintStream out) {
+        this.resource = resource;
+        this.out = out;
+    }
+
+    @Override
+    public void print() {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(resource.openStream(), StandardCharsets.UTF_8))) {
+            String banner = reader.lines().collect(Collectors.joining("\n"));
+            out.println(banner + "\n");
+        } catch (IOException e) {
+            if (LOG.isErrorEnabled()) {
+                LOG.error("There was an error printing the banner.");
+            }
+        }
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
+++ b/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
@@ -18,6 +18,8 @@ package io.micronaut.context.env;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import io.micronaut.context.ApplicationContextConfiguration;
+import io.micronaut.context.banner.MicronautBanner;
+import io.micronaut.context.banner.ResourceBanner;
 import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.core.convert.ConversionContext;
 import io.micronaut.core.convert.TypeConverter;
@@ -82,6 +84,7 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
     private static final String DO_SYS_VENDOR_FILE = "/sys/devices/virtual/dmi/id/sys_vendor";
     private static final Boolean DEDUCE_ENVIRONMENT_DEFAULT = true;
     private static final List<String> DEFAULT_CONFIG_LOCATIONS = Arrays.asList("classpath:/", "file:config/");
+    private static final String BANNER_NAME = "micronaut-banner.txt";
 
     protected final ClassPathResourceLoader resourceLoader;
     protected final List<PropertySource> refreshablePropertySources = new ArrayList<>(10);
@@ -111,6 +114,10 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
     public DefaultEnvironment(@NonNull ApplicationContextConfiguration configuration) {
         super(configuration.getConversionService());
         this.configuration = configuration;
+        this.resourceLoader = configuration.getResourceLoader();
+
+        printBanner();
+
         Set<String> environments = new LinkedHashSet<>(3);
         List<String> specifiedNames = new ArrayList<>(configuration.getEnvironments());
 
@@ -140,7 +147,6 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
         if (LOG.isInfoEnabled() && !environments.isEmpty()) {
             LOG.info("Established active environments: {}", environments);
         }
-        this.resourceLoader = configuration.getResourceLoader();
         this.annotationScanner = createAnnotationScanner(classLoader);
         List<String> configLocations = configuration.getOverrideConfigLocations() == null ?
                 new ArrayList<>(DEFAULT_CONFIG_LOCATIONS) : configuration.getOverrideConfigLocations();
@@ -969,6 +975,20 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
             return "digitalocean".equalsIgnoreCase(sysVendor);
         } catch (IOException e) {
             return false;
+        }
+    }
+
+    private void printBanner() {
+        if (!configuration.isBannerEnabled()) {
+            return;
+        }
+        PrintStream out = System.out;
+
+        Optional<URL> resource = resourceLoader.getResource(BANNER_NAME);
+        if (resource.isPresent()) {
+            new ResourceBanner(resource.get(), out).print();
+        } else {
+            new MicronautBanner(out).print();
         }
     }
 

--- a/runtime/src/main/java/io/micronaut/runtime/Micronaut.java
+++ b/runtime/src/main/java/io/micronaut/runtime/Micronaut.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.runtime;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.ApplicationContextBuilder;
 import io.micronaut.context.DefaultApplicationContextBuilder;
@@ -26,10 +28,10 @@ import io.micronaut.runtime.server.EmbeddedServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import java.net.URL;
-import java.util.*;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.Function;
 
@@ -164,6 +166,11 @@ public class Micronaut extends DefaultApplicationContextBuilder implements Appli
     @Override
     public @NonNull Micronaut exclude(@Nullable String... configurations) {
         return (Micronaut) super.exclude(configurations);
+    }
+
+    @Override
+    public @NonNull Micronaut banner(boolean isEnabled) {
+        return (Micronaut) super.banner(isEnabled);
     }
 
     /**

--- a/src/main/docs/guide/config/environments.adoc
+++ b/src/main/docs/guide/config/environments.adoc
@@ -65,7 +65,7 @@ public static void main(String[] args) {
 
 == Micronaut Banner
 
-Since Micronaut 2.3 a banner it is shown when the application starts up. It is enabled by default and it will also show the Micronaut version.
+Since Micronaut 2.3 a banner is shown when the application starts up. It is enabled by default and it will also show the Micronaut version.
 
 [source,shell,subs="attributes"]
 ----

--- a/src/main/docs/guide/config/environments.adoc
+++ b/src/main/docs/guide/config/environments.adoc
@@ -62,3 +62,38 @@ public static void main(String[] args) {
             .start();
 }
 ----
+
+== Micronaut Banner
+
+Since Micronaut 2.3 a banner it is shown when the application starts up. It is enabled by default and it will also show the Micronaut version.
+
+[source,shell,subs="attributes"]
+----
+$ ./gradlew run
+ __  __ _                                  _
+|  \/  (_) ___ _ __ ___  _ __   __ _ _   _| |_
+| |\/| | |/ __| '__/ _ \| '_ \ / _` | | | | __|
+| |  | | | (__| | | (_) | | | | (_| | |_| | |_
+|_|  |_|_|\___|_|  \___/|_| |_|\__,_|\__,_|\__|
+  Micronaut ({version})
+
+17:07:22.997 [main] INFO  io.micronaut.runtime.Micronaut - Startup completed in 611ms. Server Running: http://localhost:8080
+----
+
+If you want to customize the banner with your own Ascii Art (just plain ascii at this moment) just create the file `src/main/resources/micronaut-banner.txt`
+and it will be used instead.
+
+In case you want to disable it modify your `Application` class:
+
+[source,java]
+----
+public class Application {
+
+    public static void main(String[] args) {
+        Micronaut.build(args)
+                .banner(false) // <1>
+                .start();
+    }
+}
+----
+<1> Disable the banner

--- a/src/main/docs/guide/introduction/whatsNew.adoc
+++ b/src/main/docs/guide/introduction/whatsNew.adoc
@@ -29,6 +29,11 @@ It is now possible to validate a resolved host against a list regular expression
 
 Thanks to a contribution by https://github.com/viniciusccarvalho[Vinicius Carvalho], Micronaut GCP supports distributed configuration via Google Cloud Secret Manager.
 
+==== Banner
+
+A new customizable banner is now displayed when the application starts up. See <<_micronaut_banner, Micronaut Banner>> for more information.
+
+
 === Module Upgrades
 
 TODO


### PR DESCRIPTION
This is the killer feature we've been waiting for... :stuck_out_tongue_closed_eyes:

Adds a Micronaut banner when the application starts up. It can be replaced by putting a `micronaut-banner.txt` on the classpath or completely disabled (who would want that?). 
This only adds support for plain ascii art, not images, gifs, colors, animations or crazy things like that.

As discussed on the engineering meeting, I haven't made everything a bean or listened for an `StatupEvent` because that's too late and all the logs we see when to setting `io.micronaut.context` to `TRACE` to debug beans will be displayed before the banner and not after it. As James said, maybe we should do that because that way the banner is displayed just above the `Startup completed in...` message. With this approach we would be able to provide more configuration options because application context and Micronaut has already been initialized.

Regarding the additional time it takes during startup, I've measured it. Using the default banner adds around 3-6 ms and using a banner on the classpath adds less than 10 ms in all my tests. If that's too much for users banner can be disabled.