### PR TITLE
Change log level to DEBUG for no request state present error

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
@@ -264,8 +264,8 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         NettyHttpRequest nettyHttpRequest = NettyHttpRequest.remove(ctx);
         if (nettyHttpRequest == null) {
-            if (LOG.isErrorEnabled()) {
-                LOG.error("Micronaut Server Error - No request state present. Cause: " + cause.getMessage(), cause);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Micronaut Server Error - No request state present. Cause: " + cause.getMessage());
             }
             ctx.writeAndFlush(new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.INTERNAL_SERVER_ERROR));
             return;


### PR DESCRIPTION
These ERROR logs are polluting our logging, changing to `DEBUG` level until some other solution is identified.

See https://github.com/micronaut-projects/micronaut-core/issues/3244