### PR TITLE
Support for copy-constructors on immutable introspections

### DIFF
--- a/core/src/main/java/io/micronaut/core/beans/AbstractBeanProperty.java
+++ b/core/src/main/java/io/micronaut/core/beans/AbstractBeanProperty.java
@@ -24,6 +24,7 @@ import io.micronaut.core.util.ArgumentUtils;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+
 import java.util.Objects;
 
 /**
@@ -116,6 +117,16 @@ public abstract class AbstractBeanProperty<B, P> implements BeanProperty<B, P> {
     }
 
     @Override
+    public B mutate(@NonNull B bean, @Nullable P value) {
+        ArgumentUtils.requireNonNull("bean", bean);
+
+        if (!beanType.isInstance(bean)) {
+            throw new IllegalArgumentException("Invalid bean [" + bean + "] for type: " + introspection.getBeanType());
+        }
+        return mutateInternal(bean, value);
+    }
+
+    @Override
     public final void set(@NonNull B bean, @Nullable P value) {
         ArgumentUtils.requireNonNull("bean", bean);
 
@@ -132,6 +143,21 @@ public abstract class AbstractBeanProperty<B, P> implements BeanProperty<B, P> {
             throw new IllegalArgumentException("Null values not supported by property: " + getName());
         }
         writeInternal(bean, value);
+    }
+
+
+    /**
+     * Mutates a property value.
+     * @param bean The bean
+     * @param value The value
+     * @see BeanProperty#mutate(Object, Object)
+     * @return Either a copy of the bean with the copy constructor invoked or the mutated instance if it mutable
+     */
+    @SuppressWarnings("WeakerAccess")
+    @UsedByGeneratedCode
+    @Internal
+    protected B mutateInternal(B bean, P value) {
+        return BeanProperty.super.mutate(bean, value);
     }
 
     /**

--- a/core/src/main/java/io/micronaut/core/beans/AbstractBeanProperty.java
+++ b/core/src/main/java/io/micronaut/core/beans/AbstractBeanProperty.java
@@ -128,7 +128,9 @@ public abstract class AbstractBeanProperty<B, P> implements BeanProperty<B, P> {
         if (value != null && !ReflectionUtils.getWrapperType(getType()).isInstance(value)) {
             throw new IllegalArgumentException("Specified value [" + value + "] is not of the correct type: " + getType());
         }
-
+        if (value == null && isNonNull()) {
+            throw new IllegalArgumentException("Null values not supported by property: " + getName());
+        }
         writeInternal(bean, value);
     }
 

--- a/core/src/main/java/io/micronaut/core/beans/AbstractBeanProperty.java
+++ b/core/src/main/java/io/micronaut/core/beans/AbstractBeanProperty.java
@@ -123,7 +123,11 @@ public abstract class AbstractBeanProperty<B, P> implements BeanProperty<B, P> {
         if (!beanType.isInstance(bean)) {
             throw new IllegalArgumentException("Invalid bean [" + bean + "] for type: " + introspection.getBeanType());
         }
-        return withValueInternal(bean, value);
+        if (value == get(bean)) {
+            return bean;
+        } else {
+            return withValueInternal(bean, value);
+        }
     }
 
     @Override

--- a/core/src/main/java/io/micronaut/core/beans/AbstractBeanProperty.java
+++ b/core/src/main/java/io/micronaut/core/beans/AbstractBeanProperty.java
@@ -117,13 +117,13 @@ public abstract class AbstractBeanProperty<B, P> implements BeanProperty<B, P> {
     }
 
     @Override
-    public B mutate(@NonNull B bean, @Nullable P value) {
+    public B withValue(@NonNull B bean, @Nullable P value) {
         ArgumentUtils.requireNonNull("bean", bean);
 
         if (!beanType.isInstance(bean)) {
             throw new IllegalArgumentException("Invalid bean [" + bean + "] for type: " + introspection.getBeanType());
         }
-        return mutateInternal(bean, value);
+        return withValueInternal(bean, value);
     }
 
     @Override
@@ -150,14 +150,14 @@ public abstract class AbstractBeanProperty<B, P> implements BeanProperty<B, P> {
      * Mutates a property value.
      * @param bean The bean
      * @param value The value
-     * @see BeanProperty#mutate(Object, Object)
+     * @see BeanProperty#withValue(Object, Object)
      * @return Either a copy of the bean with the copy constructor invoked or the mutated instance if it mutable
      */
     @SuppressWarnings("WeakerAccess")
     @UsedByGeneratedCode
     @Internal
-    protected B mutateInternal(B bean, P value) {
-        return BeanProperty.super.mutate(bean, value);
+    protected B withValueInternal(B bean, P value) {
+        return BeanProperty.super.withValue(bean, value);
     }
 
     /**

--- a/core/src/main/java/io/micronaut/core/beans/BeanProperty.java
+++ b/core/src/main/java/io/micronaut/core/beans/BeanProperty.java
@@ -27,6 +27,8 @@ import io.micronaut.core.util.ArgumentUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import javax.annotation.concurrent.Immutable;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Optional;
 
 /**
@@ -118,6 +120,66 @@ public interface BeanProperty<B, T> extends AnnotatedElement, AnnotationMetadata
         } else {
             final T v = get(bean);
             return ConversionService.SHARED.convert(v, type).orElse(defaultValue);
+        }
+    }
+
+    /**
+     * This method returns true if the property can be mutated either via copy constructor or bean setter.
+     *
+     * @return True if it is mutable
+     * @see #mutate(Object, Object)
+     * @since 2.3.0
+     */
+    default boolean isMutable() {
+        BeanIntrospection<B> declaringBean = getDeclaringBean();
+        return !isReadOnly() || Arrays.stream(declaringBean.getConstructorArguments())
+                                    .anyMatch(arg -> declaringBean.getProperty(arg.getName(), arg.getType()).isPresent());
+    }
+
+    /**
+     * This method will attempt to mutate a property either via setting the property if it is mutable or using a copy constructor.
+     *
+     * <ul>
+     *     <li>If the property is read-only but can be provided via constructor argument a new instance representing a copy of the bean is returned.</li>
+     *     <li>If the property is mutable then the passed instance is returned and {@link #set(Object, Object)} invoked  to mutate the property</li>
+     *     <li>If there is no way for the property to be mutated then an {@link UnsupportedOperationException} is thrown</li>
+     * </ul>
+     *
+     * @param bean The bean
+     * @param value The new value
+     * @return A potentially new instance of the bean with the value mutated
+     * @throws UnsupportedOperationException if the property cannot be mutated
+     * @since 2.3.0
+     */
+    default B mutate(B bean, @Nullable T value) {
+        if (isReadOnly())  {
+            BeanIntrospection<B> declaringBean = getDeclaringBean();
+            Argument<?>[] constructorArguments = declaringBean.getConstructorArguments();
+            Object[] values = new Object[constructorArguments.length];
+            boolean found = false;
+            for (int i = 0; i < constructorArguments.length; i++) {
+                Argument<?> constructorArgument = constructorArguments[i];
+                String argumentName = constructorArgument.getName();
+                Class<?> argumentType = constructorArgument.getType();
+                BeanProperty<B, ?> prop = declaringBean
+                        .getProperty(argumentName, argumentType).orElse(null);
+                if (prop == null) {
+                    throw new UnsupportedOperationException("Cannot create copy of type [" + declaringBean.getBeanType() + "]. Constructor contains argument [" + argumentName + "] that is not a readable property");
+                } else if (prop == this) {
+                    found = true;
+                    values[i] = value;
+                } else {
+                    values[i] = prop.get(bean);
+                }
+            }
+            if (found) {
+                return declaringBean.instantiate(values);
+            } else {
+                throw new UnsupportedOperationException("Cannot mutate property [" + getName() + "] that is not mutable via a setter method or constructor argument for type: " + declaringBean.getBeanType());
+            }
+        } else {
+            set(bean, value);
+            return bean;
         }
     }
 

--- a/core/src/main/java/io/micronaut/core/beans/BeanProperty.java
+++ b/core/src/main/java/io/micronaut/core/beans/BeanProperty.java
@@ -139,6 +139,8 @@ public interface BeanProperty<B, T> extends AnnotatedElement, AnnotationMetadata
     /**
      * This method will attempt to mutate a property either via setting the property if it is mutable or using a copy constructor.
      *
+     * <p>This differs from {@link #set(Object, Object)} which will throw an exception if the property does not have a setter.</p>
+     *
      * <ul>
      *     <li>If the property is read-only but can be provided via constructor argument a new instance representing a copy of the bean is returned.</li>
      *     <li>If the property is mutable then the passed instance is returned and {@link #set(Object, Object)} invoked  to mutate the property</li>
@@ -151,7 +153,7 @@ public interface BeanProperty<B, T> extends AnnotatedElement, AnnotationMetadata
      * @throws UnsupportedOperationException if the property cannot be mutated
      * @since 2.3.0
      */
-    default B mutate(B bean, @Nullable T value) {
+    default B mutate(@NonNull B bean, @Nullable T value) {
         if (isReadOnly())  {
             BeanIntrospection<B> declaringBean = getDeclaringBean();
             Argument<?>[] constructorArguments = declaringBean.getConstructorArguments();

--- a/core/src/main/java/io/micronaut/core/beans/BeanProperty.java
+++ b/core/src/main/java/io/micronaut/core/beans/BeanProperty.java
@@ -127,17 +127,17 @@ public interface BeanProperty<B, T> extends AnnotatedElement, AnnotationMetadata
      * This method returns true if the property can be mutated either via copy constructor or bean setter.
      *
      * @return True if it is mutable
-     * @see #mutate(Object, Object)
+     * @see #withValue(Object, Object)
      * @since 2.3.0
      */
-    default boolean isMutable() {
+    default boolean hasSetterOrConstructorArgument() {
         BeanIntrospection<B> declaringBean = getDeclaringBean();
         return !isReadOnly() || Arrays.stream(declaringBean.getConstructorArguments())
                                     .anyMatch(arg -> declaringBean.getProperty(arg.getName(), arg.getType()).isPresent());
     }
 
     /**
-     * This method will attempt to mutate a property either via setting the property if it is mutable or using a copy constructor.
+     * This method will attempt to modify the property or if this is a immutable type using a copy constructor to return a new instance with the new value.
      *
      * <p>This differs from {@link #set(Object, Object)} which will throw an exception if the property does not have a setter.</p>
      *
@@ -153,7 +153,7 @@ public interface BeanProperty<B, T> extends AnnotatedElement, AnnotationMetadata
      * @throws UnsupportedOperationException if the property cannot be mutated
      * @since 2.3.0
      */
-    default B mutate(@NonNull B bean, @Nullable T value) {
+    default B withValue(@NonNull B bean, @Nullable T value) {
         if (isReadOnly())  {
             BeanIntrospection<B> declaringBean = getDeclaringBean();
             Argument<?>[] constructorArguments = declaringBean.getConstructorArguments();

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
@@ -80,7 +80,7 @@ public class CopyMe {
 
         when:
         def property = introspection.getRequiredProperty("name", String)
-        def newInstance = property.mutate(copyMe, "Changed")
+        def newInstance = property.withValue(copyMe, "Changed")
 
         then:
         !newInstance.is(copyMe)
@@ -181,12 +181,12 @@ public record Foo(@javax.validation.constraints.NotBlank String name, int age){
         introspection.propertyNames == ['name', 'age'] as String[]
         property.hasAnnotation(NotBlank)
         property.isReadOnly()
-        property.isMutable()
+        property.hasSetterOrConstructorArgument()
         property.name == 'name'
         property.get(test) == 'test'
 
         when:"a mutation is applied"
-        def newTest = property.mutate(test, "Changed")
+        def newTest = property.withValue(test, "Changed")
 
         then:"a new instance is returned"
         !newTest.is(test)
@@ -305,10 +305,10 @@ interface GenBase<T> {
         then:
         introspection.beanProperties.first().type == String
         property.get(test) == 'test'
-        !property.isMutable()
+        !property.hasSetterOrConstructorArgument()
 
         when:
-        property.mutate(test, 'try change')
+        property.withValue(test, 'try change')
 
         then:
         def e = thrown(UnsupportedOperationException)
@@ -382,7 +382,7 @@ interface GenBase<T> {
         bp.get(test) == 5L
 
         when:
-        def returnedBean = bp.mutate(test, 10L)
+        def returnedBean = bp.withValue(test, 10L)
 
         then:
         returnedBean.is(test)

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
@@ -262,7 +262,7 @@ interface GenBase<T> {
 
         then:
         def e = thrown(UnsupportedOperationException)
-        e.message =='Cannot mutate property [name] that is not mutable via a setter method or constructor argument for type: class test.Foo'
+        e.message =='Cannot mutate property [name] that is not mutable via a setter method or constructor argument for type: test.Foo'
     }
 
     void "test bean introspection with property of generic superclass"() {
@@ -330,6 +330,13 @@ interface GenBase<T> {
 
         then:
         bp.get(test) == 5L
+
+        when:
+        def returnedBean = bp.mutate(test, 10L)
+
+        then:
+        returnedBean.is(test)
+        bp.get(test) == 10L
     }
 
     void "test bean introspection with property with static creator method on interface"() {

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
@@ -12,7 +12,6 @@ import io.micronaut.core.beans.BeanIntrospector
 import io.micronaut.core.beans.BeanProperty
 import io.micronaut.core.convert.ConversionContext
 import io.micronaut.core.convert.TypeConverter
-import io.micronaut.core.naming.Named
 import io.micronaut.core.reflect.InstantiationUtils
 import io.micronaut.core.reflect.exception.InstantiationException
 import io.micronaut.core.type.Argument
@@ -25,7 +24,6 @@ import spock.lang.IgnoreIf
 //import org.objectweb.asm.util.TraceClassVisitor
 import spock.lang.Issue
 import spock.lang.Requires
-import spock.util.environment.Jvm
 
 import javax.annotation.processing.SupportedAnnotationTypes
 import javax.persistence.Column
@@ -116,11 +114,11 @@ package test;
 import io.micronaut.core.annotation.Creator;
 
 @io.micronaut.core.annotation.Introspected
-public record Foo(@javax.validation.constraints.NotBlank String name){
+public record Foo(@javax.validation.constraints.NotBlank String name, int age){
 }
 ''')
         when:
-        def test = introspection.instantiate("test")
+        def test = introspection.instantiate("test", 20)
         def property = introspection.getRequiredProperty("name", String)
         def argument = introspection.getConstructorArguments()[0]
 
@@ -129,12 +127,21 @@ public record Foo(@javax.validation.constraints.NotBlank String name){
         argument.getAnnotationMetadata().hasAnnotation(NotBlank)
         test.name == 'test'
         test.name() == 'test'
-        introspection.propertyNames.length == 1
-        introspection.propertyNames == ['name'] as String[]
+        introspection.propertyNames.length == 2
+        introspection.propertyNames == ['name', 'age'] as String[]
         property.hasAnnotation(NotBlank)
         property.isReadOnly()
+        property.isMutable()
         property.name == 'name'
         property.get(test) == 'test'
+
+        when:"a mutation is applied"
+        def newTest = property.mutate(test, "Changed")
+
+        then:"a new instance is returned"
+        !newTest.is(test)
+        newTest.name() == 'Changed'
+        newTest.age() == 20
     }
 
     void "test create bean introspection for external inner class"() {
@@ -243,11 +250,19 @@ interface GenBase<T> {
 ''')
         when:
         def test = introspection.instantiate()
+        def property = introspection.getRequiredProperty("name", String)
 
         then:
         introspection.beanProperties.first().type == String
-        introspection.getRequiredProperty("name", String)
-                .get(test) == 'test'
+        property.get(test) == 'test'
+        !property.isMutable()
+
+        when:
+        property.mutate(test, 'try change')
+
+        then:
+        def e = thrown(UnsupportedOperationException)
+        e.message =='Cannot mutate property [name] that is not mutable via a setter method or constructor argument for type: class test.Foo'
     }
 
     void "test bean introspection with property of generic superclass"() {

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
@@ -86,6 +86,12 @@ public class CopyMe {
         !newInstance.is(copyMe)
         newInstance.name == 'Changed'
         newInstance.url == expectUrl
+
+        when:"the instance is changed with the same value"
+        def result = property.withValue(newInstance, "Changed")
+
+        then:"The existing instance is returned"
+        newInstance.is(result)
     }
 
     @Requires({ jvm.isJava14Compatible() })

--- a/inject/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
@@ -66,7 +66,7 @@ class BeanIntrospectionWriter extends AbstractAnnotationMetadataWriter {
     private final Type introspectionType;
     private final Type beanType;
     private final ClassWriter introspectionWriter;
-    private final List<BeanPropertyWriter> propertyDefinitions = new ArrayList<>();
+    private final Map<String, BeanPropertyWriter> propertyDefinitions = new LinkedHashMap<>();
     private final Map<String, Collection<AnnotationValueIndex>> indexes = new HashMap<>(2);
     private final Map<String, GeneratorAdapter> localLoadTypeMethods = new HashMap<>();
     private final ClassElement classElement;
@@ -115,6 +115,13 @@ class BeanIntrospectionWriter extends AbstractAnnotationMetadataWriter {
         this.introspectionName = computeIntrospectionName(generatingType, className);
         this.introspectionType = getTypeReferenceForName(introspectionName);
         this.beanType = getTypeReferenceForName(className);
+    }
+
+    /**
+     * @return The property definitions.
+     */
+    Map<String, BeanPropertyWriter> getPropertyDefinitions() {
+        return propertyDefinitions;
     }
 
     /**
@@ -178,7 +185,8 @@ class BeanIntrospectionWriter extends AbstractAnnotationMetadataWriter {
                 this.annotationMetadata,
                 annotationMetadata
         );
-        propertyDefinitions.add(
+        propertyDefinitions.put(
+                name,
                 new BeanPropertyWriter(
                         this,
                         type,
@@ -254,7 +262,7 @@ class BeanIntrospectionWriter extends AbstractAnnotationMetadataWriter {
                     int.class);
 
             // process the properties, creating them etc.
-            for (BeanPropertyWriter propertyWriter : propertyDefinitions) {
+            for (BeanPropertyWriter propertyWriter : propertyDefinitions.values()) {
                 propertyWriter.accept(classWriterOutputVisitor);
                 final Type writerType = propertyWriter.getType();
                 constructorWriter.loadThis();

--- a/inject/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
@@ -127,6 +127,7 @@ class BeanIntrospectionWriter extends AbstractAnnotationMetadataWriter {
     /**
      * @return The constructor.
      */
+    @Nullable
     public MethodElement getConstructor() {
         return constructor;
     }

--- a/inject/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
@@ -330,7 +330,6 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
             writer.visitDefaultConstructor(defaultConstructor);
         }
 
-        ClassElement classElement = writer.getClassElement();
         processBeanProperties(writer, beanProperties, includes, excludes, ignored, indexedAnnotations, metadata);
 
         writers.put(writer.getBeanType().getClassName(), writer);

--- a/inject/src/main/java/io/micronaut/inject/writer/AbstractClassFileWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/AbstractClassFileWriter.java
@@ -1365,6 +1365,25 @@ public abstract class AbstractClassFileWriter implements Opcodes, OriginatingEle
 
     /**
      * @param writer        The class writer
+     * @param asmMethod     The asm method
+     * @return The {@link GeneratorAdapter}
+     * @since 2.3.0
+     */
+    protected GeneratorAdapter startPublicMethod(ClassWriter writer, Method asmMethod) {
+        String methodName = asmMethod.getName();
+        return new GeneratorAdapter(writer.visitMethod(
+                ACC_PUBLIC,
+                methodName,
+                asmMethod.getDescriptor(),
+                null,
+                null
+        ), ACC_PUBLIC,
+                methodName,
+                asmMethod.getDescriptor());
+    }
+
+    /**
+     * @param writer        The class writer
      * @param methodName    The method name
      * @param returnType    The return type
      * @param argumentTypes The argument types


### PR DESCRIPTION
This PR adds a new `withValue(..)` method on `BeanProperty` that allows using a copy-constructor approach on immutable introspections.

This will help support java records, Kotlin data classes, immutable types etc. better in Micronaut Data 