### PR TITLE
Only show banner for run but not tests

### DIFF
--- a/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
+++ b/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
@@ -18,8 +18,6 @@ package io.micronaut.context.env;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import io.micronaut.context.ApplicationContextConfiguration;
-import io.micronaut.context.banner.MicronautBanner;
-import io.micronaut.context.banner.ResourceBanner;
 import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.core.convert.ConversionContext;
 import io.micronaut.core.convert.TypeConverter;
@@ -84,8 +82,6 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
     private static final String DO_SYS_VENDOR_FILE = "/sys/devices/virtual/dmi/id/sys_vendor";
     private static final Boolean DEDUCE_ENVIRONMENT_DEFAULT = true;
     private static final List<String> DEFAULT_CONFIG_LOCATIONS = Arrays.asList("classpath:/", "file:config/");
-    private static final String BANNER_NAME = "micronaut-banner.txt";
-
     protected final ClassPathResourceLoader resourceLoader;
     protected final List<PropertySource> refreshablePropertySources = new ArrayList<>(10);
 
@@ -115,8 +111,6 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
         super(configuration.getConversionService());
         this.configuration = configuration;
         this.resourceLoader = configuration.getResourceLoader();
-
-        printBanner();
 
         Set<String> environments = new LinkedHashSet<>(3);
         List<String> specifiedNames = new ArrayList<>(configuration.getEnvironments());
@@ -982,19 +976,6 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
         }
     }
 
-    private void printBanner() {
-        if (!configuration.isBannerEnabled()) {
-            return;
-        }
-        PrintStream out = System.out;
-
-        Optional<URL> resource = resourceLoader.getResource(BANNER_NAME);
-        if (resource.isPresent()) {
-            new ResourceBanner(resource.get(), out).print();
-        } else {
-            new MicronautBanner(out).print();
-        }
-    }
 
     /**
      * Helper class for handling environments and package.

--- a/runtime/src/main/java/io/micronaut/runtime/Micronaut.java
+++ b/runtime/src/main/java/io/micronaut/runtime/Micronaut.java
@@ -20,6 +20,8 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.ApplicationContextBuilder;
 import io.micronaut.context.DefaultApplicationContextBuilder;
+import io.micronaut.context.banner.MicronautBanner;
+import io.micronaut.context.banner.ResourceBanner;
 import io.micronaut.context.env.Environment;
 import io.micronaut.context.env.PropertySource;
 import io.micronaut.core.naming.Described;
@@ -28,6 +30,7 @@ import io.micronaut.runtime.server.EmbeddedServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.PrintStream;
 import java.net.URL;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -42,7 +45,7 @@ import java.util.function.Function;
  * @since 1.0
  */
 public class Micronaut extends DefaultApplicationContextBuilder implements ApplicationContextBuilder  {
-
+    private static final String BANNER_NAME = "micronaut-banner.txt";
     private static final Logger LOG = LoggerFactory.getLogger(Micronaut.class);
     private static final String SHUTDOWN_MONITOR_THREAD = "micronaut-shutdown-monitor-thread";
 
@@ -60,9 +63,11 @@ public class Micronaut extends DefaultApplicationContextBuilder implements Appli
     @Override
     public @NonNull ApplicationContext start() {
         long start = System.currentTimeMillis();
+        printBanner();
         ApplicationContext applicationContext = super.build();
 
         try {
+
             applicationContext.start();
 
             Optional<EmbeddedApplication> embeddedContainerBean = applicationContext.findBean(EmbeddedApplication.class);
@@ -324,4 +329,19 @@ public class Micronaut extends DefaultApplicationContextBuilder implements Appli
         }
         throw new ApplicationStartupException("Error starting Micronaut server: " + exception.getMessage(), exception);
     }
+
+    private void printBanner() {
+        if (!isBannerEnabled()) {
+            return;
+        }
+        PrintStream out = System.out;
+
+        Optional<URL> resource = getResourceLoader().getResource(BANNER_NAME);
+        if (resource.isPresent()) {
+            new ResourceBanner(resource.get(), out).print();
+        } else {
+            new MicronautBanner(out).print();
+        }
+    }
+
 }


### PR DESCRIPTION
The banner currently pollutes test output which I think is worse, this changes it to only show when doing `./gradlew run` or running the Application class