### PR TITLE
fix staticResources.adoc: disabled -> enabled

### DIFF
--- a/src/main/docs/guide/httpServer/staticResources.adoc
+++ b/src/main/docs/guide/httpServer/staticResources.adoc
@@ -1,4 +1,4 @@
-Static resource resolution is disabled by default. Micronaut supports resolving resources from the classpath or the file system.
+Static resource resolution is enabled by default. Micronaut supports resolving resources from the classpath or the file system.
 
 See the information below for available configuration options:
 


### PR DESCRIPTION
Static resources resolution is enabled by default (as of the code).
The docs mention it differently at the description (wrong) and the property table (correct).