### PR TITLE
Correctly set convention and order of KubernetesEnvironmentPropertySource

### DIFF
--- a/inject/src/main/java/io/micronaut/context/env/KubernetesEnvironmentPropertySource.java
+++ b/inject/src/main/java/io/micronaut/context/env/KubernetesEnvironmentPropertySource.java
@@ -71,6 +71,16 @@ public class KubernetesEnvironmentPropertySource extends MapPropertySource {
         super(NAME, getEnv(getEnvNoK8s(), includes, excludes));
     }
 
+    @Override
+    public int getOrder() {
+        return EnvironmentPropertySource.POSITION;
+    }
+
+    @Override
+    public PropertyConvention getConvention() {
+        return PropertyConvention.ENVIRONMENT_VARIABLE;
+    }
+
     static Map<String, String> getEnvNoK8s() {
         Map<String, String> props = new HashMap<>(System.getenv());
         props.entrySet().removeIf(entry -> VAR_SUFFIXES.stream().anyMatch(s -> entry.getKey().endsWith(s)));

--- a/inject/src/test/groovy/io/micronaut/context/env/DefaultEnvironmentSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/env/DefaultEnvironmentSpec.groovy
@@ -20,6 +20,7 @@ import io.micronaut.context.ApplicationContext
 import io.micronaut.context.ApplicationContextConfiguration
 import io.micronaut.context.exceptions.ConfigurationException
 import io.micronaut.core.naming.NameUtils
+import spock.lang.Issue
 import spock.lang.Specification
 import spock.util.environment.RestoreSystemProperties
 
@@ -708,6 +709,23 @@ class DefaultEnvironmentSpec extends Specification {
         env.propertySources.find {it.name == KubernetesEnvironmentPropertySource.NAME }
         !env.propertySources.find {it.name == EnvironmentPropertySource.NAME }
         !env.getProperty("v1-service-xpto-service-host", String).isPresent()
+    }
+
+    @Issue("https://github.com/micronaut-projects/micronaut-core/issues/4861")
+    void "In the Kubernetes environment, environment variables can be read"() {
+        given:
+        Environment env = SystemLambda.withEnvironmentVariable("MICRONAUT_SERVER_PORT", "8081")
+                .execute {
+                    new DefaultEnvironment(new ApplicationContextConfiguration() {
+                        @Override
+                        List<String> getEnvironments() {
+                            return Arrays.asList(Environment.KUBERNETES)
+                        }
+                    }).start()
+                }
+
+        expect:
+        env.getProperty("micronaut.server.port", Integer).get() == 8081
     }
 
     private static Environment startEnv(String files) {

--- a/inject/src/test/groovy/io/micronaut/context/env/KubernetesEnvironmentPropertySourceSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/env/KubernetesEnvironmentPropertySourceSpec.groovy
@@ -20,4 +20,14 @@ class KubernetesEnvironmentPropertySourceSpec extends Specification {
         suffix << KubernetesEnvironmentPropertySource.VAR_SUFFIXES
     }
 
+    void "it has the same position and convention than the EnvironmentPropertySource"() {
+        given:
+        KubernetesEnvironmentPropertySource keps = new KubernetesEnvironmentPropertySource()
+        EnvironmentPropertySource eps = new EnvironmentPropertySource()
+
+        expect:
+        keps.order == eps.order
+        keps.convention == eps.convention
+    }
+
 }


### PR DESCRIPTION
Fixes #4861
