### PR TITLE
Add possibility to override the Zipkin path.

### DIFF
--- a/tracing/src/main/java/io/micronaut/tracing/brave/sender/HttpClientSender.java
+++ b/tracing/src/main/java/io/micronaut/tracing/brave/sender/HttpClientSender.java
@@ -339,6 +339,17 @@ public final class HttpClientSender extends Sender {
         }
 
         /**
+         * The path to use.
+         *
+         * @param path The path of the Zipkin endpoint
+         * @return This builder
+         */
+        public Builder path(String path) {
+                this.path = path;
+            return this;
+        }
+
+        /**
          * Constructs a {@link HttpClientSender}.
          *
          * @param loadBalancerResolver Resolver instance capable of resolving references to services into a concrete load-balance


### PR DESCRIPTION
This is my first contribution to Micronaut and my first PR to an open source project.

I am trying to use the Micronaut tracing module with New Relic Trace Api, but to it doesn't follow the standard Zipkin path.

How the full URL+Path needs to look like and the [documentation](https://docs.newrelic.com/docs/understand-dependencies/distributed-tracing/trace-api/report-zipkin-format-traces-trace-api).

```
https://trace-api.eu.newrelic.com/trace/v1?Api-Key={INSERT_API_KEY}&Data-Format=zipkin&Data-Format-Version=2
```

I added a public `path` method to the HttpClientSender Builder.

For the test I copied another test, so a lot of duplicate code. Not very familiar with Spock and what the best way would be to run the test with 2 different configurations.