### PR TITLE
Making the parent HTTP Request available in handlers of the DefaultHttpClient

### DIFF
--- a/tracing/src/main/java/io/micronaut/tracing/brave/sender/HttpClientSender.java
+++ b/tracing/src/main/java/io/micronaut/tracing/brave/sender/HttpClientSender.java
@@ -356,7 +356,7 @@ public final class HttpClientSender extends Sender {
         }
 
         /**
-         * The path to use.
+         * The invocation instrumenter factories to use.
          *
          * @param invocationInstrumenterFactories The invocation instrumeter factories to instrument http client netty handlers execution with
          * @return This builder

--- a/tracing/src/main/java/io/micronaut/tracing/brave/sender/HttpClientSender.java
+++ b/tracing/src/main/java/io/micronaut/tracing/brave/sender/HttpClientSender.java
@@ -24,6 +24,7 @@ import io.micronaut.http.HttpStatus;
 import io.micronaut.http.MutableHttpRequest;
 import io.micronaut.http.client.*;
 import io.micronaut.http.client.netty.DefaultHttpClient;
+import io.micronaut.scheduling.instrument.InvocationInstrumenterFactory;
 import io.micronaut.tracing.brave.ZipkinServiceInstanceList;
 import io.reactivex.BackpressureStrategy;
 import io.reactivex.Flowable;
@@ -57,6 +58,7 @@ public final class HttpClientSender extends Sender {
     private final int messageMaxBytes;
     private final boolean compressionEnabled;
     private final URI endpoint;
+    private final List<InvocationInstrumenterFactory> invocationInstrumenterFactories;
     private final Provider<LoadBalancerResolver> loadBalancerResolver;
     private final HttpClientConfiguration clientConfiguration;
     private HttpClient httpClient;
@@ -67,13 +69,15 @@ public final class HttpClientSender extends Sender {
             boolean compressionEnabled,
             HttpClientConfiguration clientConfiguration,
             Provider<LoadBalancerResolver> loadBalancerResolver,
-            String path) {
+            String path,
+            List<InvocationInstrumenterFactory> invocationInstrumenterFactories) {
         this.loadBalancerResolver = loadBalancerResolver;
         this.clientConfiguration = clientConfiguration;
         this.encoding = encoding;
         this.messageMaxBytes = messageMaxBytes;
         this.compressionEnabled = compressionEnabled;
         this.endpoint = path != null ? URI.create(path) : URI.create(Builder.DEFAULT_PATH);
+        this.invocationInstrumenterFactories = invocationInstrumenterFactories;
     }
 
     @Override
@@ -127,7 +131,8 @@ public final class HttpClientSender extends Sender {
 
             this.httpClient = loadBalancer.map(lb -> new DefaultHttpClient(
                     lb,
-                    clientConfiguration
+                    clientConfiguration,
+                    invocationInstrumenterFactories
             )).orElse(null);
         }
     }
@@ -250,6 +255,7 @@ public final class HttpClientSender extends Sender {
         private boolean compressionEnabled = true;
         private List<URI> servers = Collections.singletonList(URI.create(DEFAULT_SERVER_URL));
         private final HttpClientConfiguration clientConfiguration;
+        private List<InvocationInstrumenterFactory> invocationInstrumenterFactories;
 
         /**
          * Initialize the builder with HTTP client configurations.
@@ -345,7 +351,18 @@ public final class HttpClientSender extends Sender {
          * @return This builder
          */
         public Builder path(String path) {
-                this.path = path;
+            this.path = path;
+            return this;
+        }
+
+        /**
+         * The path to use.
+         *
+         * @param invocationInstrumenterFactories The invocation instrumeter factories to instrument http client netty handlers execution with
+         * @return This builder
+         */
+        public Builder invocationInstrumenterFactories(List<InvocationInstrumenterFactory> invocationInstrumenterFactories) {
+            this.invocationInstrumenterFactories = invocationInstrumenterFactories;
             return this;
         }
 
@@ -362,7 +379,8 @@ public final class HttpClientSender extends Sender {
                     compressionEnabled,
                     clientConfiguration,
                     loadBalancerResolver,
-                    path
+                    path,
+                    invocationInstrumenterFactories
             );
         }
     }

--- a/tracing/src/main/java/io/micronaut/tracing/brave/sender/HttpClientSenderFactory.java
+++ b/tracing/src/main/java/io/micronaut/tracing/brave/sender/HttpClientSenderFactory.java
@@ -18,9 +18,11 @@ package io.micronaut.tracing.brave.sender;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.client.LoadBalancerResolver;
+import io.micronaut.scheduling.instrument.InvocationInstrumenterFactory;
 import io.micronaut.tracing.brave.BraveTracerConfiguration;
 import zipkin2.reporter.Sender;
 
+import java.util.List;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 
@@ -34,14 +36,19 @@ import javax.inject.Singleton;
 @Requires(beans = BraveTracerConfiguration.HttpClientSenderConfiguration.class)
 public class HttpClientSenderFactory {
     private final BraveTracerConfiguration.HttpClientSenderConfiguration configuration;
+    private final List<InvocationInstrumenterFactory> invocationInstrumenterFactories;
 
     /**
      * Initialize the factory for creating Zipkin {@link Sender} with configurations.
      *
      * @param configuration The HTTP client sender configurations
+     * @param invocationInstrumenterFactories The invocation instrumeter factories to instrument http client netty handlers execution with
      */
-    protected HttpClientSenderFactory(BraveTracerConfiguration.HttpClientSenderConfiguration configuration) {
+    protected HttpClientSenderFactory(
+            BraveTracerConfiguration.HttpClientSenderConfiguration configuration,
+            List<InvocationInstrumenterFactory> invocationInstrumenterFactories) {
         this.configuration = configuration;
+        this.invocationInstrumenterFactories = invocationInstrumenterFactories;
     }
 
     /**
@@ -51,6 +58,8 @@ public class HttpClientSenderFactory {
     @Singleton
     @Requires(missingBeans = Sender.class)
     Sender zipkinSender(Provider<LoadBalancerResolver> loadBalancerResolver) {
-        return configuration.getBuilder().build(loadBalancerResolver);
+        return configuration.getBuilder()
+                .invocationInstrumenterFactories(invocationInstrumenterFactories)
+                .build(loadBalancerResolver);
     }
 }


### PR DESCRIPTION
The aim of this PR is to start a discussion and get confirmation whether this is idea and the implementation is in the right direction. 

This PR has no tests which must be improved.

When executing the business logic in a scope of an incoming parent http request, the `DefaultHttpClient` executes part of its code on the original thread and in such case the `ServerRequestContext.currentRequest()` is available. Most of the logic, however, is executed as handlers on Netty event loop and the original parent request is not available. This PR propagates the original parent request to all the handlers.

As a result, when using the MDC [*] approach to propagate information (such as Correlation ID) between logging messages, all the logging statements logged by the DefaultHttpClient may contain the information from MDC and thanks to that the analysis of the logs becomes much easier.

The resulting log messages can look like:
```
2021-02-02 CET 12:54:07,438 [nioEventLoopGroup-1-5] [correlationId=4400b5bbfaf94515907b84df3e7fc69b] [principal=stepan@appd] INFO  com.appd.myservice - Hello everyone!
2021-02-02 CET 12:54:08,294 [nioEventLoopGroup-1-8] [correlationId=4400b5bbfaf94515907b84df3e7fc69b] [principal=stepan@appd] DEBUG io.micronaut.http.client.netty.DefaultHttpClient - Sending HTTP Request: POST /my-backend/v1.0
2021-02-02 CET 12:55:04,788 [nioEventLoopGroup-1-7] [correlationId=4400b5bbfaf94515907b84df3e7fc69b] [principal=stepan@appd] TRACE io.micronaut.http.client.netty.DefaultHttpClient - HTTP Client Response Received for Request: POST http://localhost:62003/my-backend/v1.0
2021-02-02 CET 12:55:08,448 [nioEventLoopGroup-1-7] [correlationId=4400b5bbfaf94515907b84df3e7fc69b] [principal=stepan@appd] TRACE io.micronaut.http.client.netty.DefaultHttpClient - Status Code: 200 OK
2021-02-02 CET 12:55:08,536 [parallel-1] [correlationId=4400b5bbfaf94515907b84df3e7fc69b] [principal=stepan@appd] INFO  com.appd.logging.info.SLOW_QUERY - Threshold of 30000 (millis) exceeded, execution took = 60617 (millis)
2021-02-02 CET 12:55:12,367 [nioEventLoopGroup-1-5] [correlationId=4400b5bbfaf94515907b84df3e7fc69b] [principal=stepan@appd] INFO  com.appd.logging.info.HTTP_ACCESS - 127.0.0.1 - - "POST /my-service/v1 HTTP/1.1" 200 327 35,741 61,662 ms [X-Forwarded-For: ""]
```

[*] The thread-local approach of using [MDC ](http://www.slf4j.org/api/org/slf4j/MDC.html)(i.e., `MDC.put()`, etc) is not the best in this case. Much better approach is through [Log4j2's](https://logging.apache.org/log4j/2.x/log4j-core/apidocs/org/apache/logging/log4j/core/ContextDataInjector.html) `ContextDataInjector` and provide the resolved values from the `ServerRequestContext.currentRequest()` as a `Map` such as:
```
public class ServerRequestDiagnosticContextDataInjector implements ContextDataInjector {

    @Override
    public ReadOnlyStringMap rawContextData() {
        return ServerRequestContext.currentRequest()
                .map(request -> new SortedArrayStringMap(
                        Map.of(DiagnosticContext.CORRELATION_ID,
                        request.getAttribute(DiagnosticContext.CORRELATION_ID_ATTR, String.class)
                                .orElse("-- no correlation ID --"))))
                .orElse(EMPTY_CONTEXT_DATA);
    }
}

```

