### PR TITLE
Fix request URI usage for stream requests

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -1002,7 +1002,6 @@ public class DefaultHttpClient implements
                             request.setAttribute(NettyClientHttpRequest.CHANNEL, channel);
                             streamRequestThroughChannel(
                                     parentRequest,
-                                    requestURI,
                                     requestWrapper,
                                     emitter,
                                     channel,
@@ -1021,7 +1020,6 @@ public class DefaultHttpClient implements
                                     request.setAttribute(NettyClientHttpRequest.CHANNEL, channel);
                                     streamRequestThroughChannel(
                                             parentRequest,
-                                            requestURI,
                                             requestWrapper,
                                             emitter,
                                             channel,
@@ -1829,13 +1827,14 @@ public class DefaultHttpClient implements
 
     private void streamRequestThroughChannel(
             io.micronaut.http.HttpRequest<?> parentRequest,
-            URI requestURI,
             AtomicReference<io.micronaut.http.HttpRequest> requestWrapper,
             FlowableEmitter emitter,
             Channel channel,
             boolean failOnError) throws HttpPostRequestEncoder.ErrorDataEncoderException {
+        io.micronaut.http.HttpRequest<?> finalRequest = requestWrapper.get();
+        URI requestURI = finalRequest.getUri();
         NettyRequestWriter requestWriter = prepareRequest(
-                requestWrapper.get(),
+                finalRequest,
                 requestURI,
                 emitter,
                 false
@@ -2634,7 +2633,6 @@ public class DefaultHttpClient implements
                                         request.setAttribute(NettyClientHttpRequest.CHANNEL, channel);
                                         streamRequestThroughChannel(
                                                 request,
-                                                requestURI,
                                                 requestWrapper,
                                                 emitter,
                                                 channel,
@@ -2653,7 +2651,6 @@ public class DefaultHttpClient implements
                                                 request.setAttribute(NettyClientHttpRequest.CHANNEL, channel);
                                                 streamRequestThroughChannel(
                                                         request,
-                                                        requestURI,
                                                         requestWrapper,
                                                         emitter,
                                                         channel,

--- a/http-client/src/test/groovy/io/micronaut/http/client/filter/MutateRequestClientFilterSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/filter/MutateRequestClientFilterSpec.groovy
@@ -27,6 +27,7 @@ import io.micronaut.http.filter.ClientFilterChain
 import io.micronaut.http.filter.HttpClientFilter
 import io.micronaut.http.uri.UriBuilder
 import io.micronaut.runtime.server.EmbeddedServer
+import io.reactivex.Flowable
 import org.reactivestreams.Publisher
 import spock.lang.AutoCleanup
 import spock.lang.Issue
@@ -51,6 +52,11 @@ class MutateRequestClientFilterSpec extends Specification {
         myClient.withQuery("foo") == "fooxxxxxxxxxxx"
     }
 
+    void "test mutate stream request URI"() {
+        expect:
+        myClient.stream().blockingSingle() == "xxxxxxxxxxx"
+    }
+
     @Client("/filters/uri/test")
     static interface MyClient {
         @Get("/")
@@ -58,6 +64,9 @@ class MutateRequestClientFilterSpec extends Specification {
 
         @Get("/foo{?q}")
         String withQuery(@Nullable String q)
+
+        @Get("/stream")
+        Flowable<String> stream()
     }
 
     @Controller('/filters/uri/test')
@@ -69,6 +78,10 @@ class MutateRequestClientFilterSpec extends Specification {
         @Get('/foo')
         String query(@QueryValue String signature, @QueryValue String q) {
             q + signature
+        }
+        @Get('/stream')
+        Flowable<String> stream(@QueryValue String signature) {
+            Flowable.fromArray('"' + signature + '"')
         }
     }
 


### PR DESCRIPTION
Fixes #4908

URI modifications performed in HTTP client filters are not picked up when building streaming requests.