### PR TITLE
Fix for distributed tracing instrumentation on blocking controllers

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
@@ -365,12 +365,12 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
                 ExceptionHandler handler = exceptionHandler.get();
                 MediaType defaultResponseMediaType = MediaType.fromType(handler.getClass()).orElse(MediaType.APPLICATION_JSON_TYPE);
                 try {
-                    Publisher<MutableHttpResponse<?>> routePublisher = Flowable.fromCallable(() -> {
+                    Flowable<MutableHttpResponse<?>> routePublisher = Flowable.fromCallable(() -> {
                         Object result = handler.handle(nettyHttpRequest, cause);
                         return errorResultToResponse(result);
                     });
-
-                    filterPublisher(new AtomicReference<>(nettyHttpRequest), routePublisher, ctx.executor(), nettyException)
+                    Supplier<Flowable<? extends MutableHttpResponse<?>>> publisherSupplier = () -> routePublisher;
+                    filterPublisher(new AtomicReference<HttpRequest<?>>(nettyHttpRequest), publisherSupplier, ctx.executor(), nettyException)
                             .firstOrError()
                             .subscribe((mutableHttpResponse, throwable) -> {
                                 if (throwable != null) {
@@ -618,7 +618,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
         AtomicReference<HttpRequest<?>> requestReference = new AtomicReference<>(request);
         filterPublisher(
                 requestReference,
-                Flowable.just(finalResponse),
+                () -> Flowable.just(finalResponse),
                 ctx.channel().eventLoop(),
                 skipOncePerRequest
         ).singleOrError().subscribe((Consumer<MutableHttpResponse<?>>) mutableHttpResponse ->
@@ -1378,7 +1378,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
             boolean isErrorRoute,
             boolean skipOncePerRequest) {
         // build the result emitter. This result emitter emits the response from a controller action
-        Flowable<MutableHttpResponse<?>> resultEmitter = Flowable.defer(() -> {
+        Supplier<Flowable<? extends MutableHttpResponse<?>>> resultEmitter = () -> {
             final RouteMatch<?> routeMatch;
 
             // ensure the route requirements are completely satisfied
@@ -1515,7 +1515,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
             }
             outgoingResponse.setAttribute(HttpAttributes.ROUTE_MATCH, finalRoute);
             return Flowable.just(outgoingResponse);
-        });
+        };
 
         // process the publisher through the available filters
         return filterPublisher(
@@ -1927,7 +1927,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
 
     private Flowable<? extends MutableHttpResponse<?>> filterPublisher(
             AtomicReference<HttpRequest<?>> requestReference,
-            Publisher<MutableHttpResponse<?>> routePublisher,
+            Supplier<? extends Publisher<? extends MutableHttpResponse<?>>> routePublisherSupplier,
             @Nullable ExecutorService executor,
             boolean skipOncePerRequest) {
         Publisher<? extends io.micronaut.http.MutableHttpResponse<?>> finalPublisher;
@@ -1937,20 +1937,8 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
         }
         if (!filters.isEmpty()) {
             // make the action executor the last filter in the chain
-            filters.add((HttpServerFilter) (req, chain) -> {
-                if (executor != null) {
-                    if (routePublisher instanceof Flowable) {
-                        return ((Flowable<MutableHttpResponse<?>>) routePublisher)
-                                .subscribeOn(Schedulers.from(executor));
-                    } else {
-                        return Flowable.fromPublisher(routePublisher)
-                                .subscribeOn(Schedulers.from(executor));
-                    }
-                } else {
-                    return routePublisher;
-                }
-            });
-
+            filters.add((HttpServerFilter) (req, chain) -> Flowable.defer(() ->
+                    applyExecutorToPublisher(Flowable.defer(routePublisherSupplier::get), executor)));
             AtomicInteger integer = new AtomicInteger();
             int len = filters.size();
             ServerFilterChain filterChain = new ServerFilterChain() {
@@ -1969,13 +1957,27 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
             Publisher<? extends HttpResponse<?>> resultingPublisher = httpFilter.doFilter(requestReference.get(), filterChain);
             finalPublisher = (Publisher<? extends MutableHttpResponse<?>>) resultingPublisher;
         } else {
-            finalPublisher = routePublisher;
+            finalPublisher = applyExecutorToPublisher(routePublisherSupplier.get(), executor);
         }
+        return publisherToFlowable(finalPublisher);
+    }
 
-        if (finalPublisher instanceof Flowable) {
-            return (Flowable<? extends MutableHttpResponse<?>>) finalPublisher;
+    private <T extends MutableHttpResponse<?>> Publisher<T> applyExecutorToPublisher(
+            Publisher<T> publisher,
+            @Nullable ExecutorService executor) {
+        if (executor != null) {
+            return publisherToFlowable(publisher).subscribeOn(Schedulers.from(executor));
         } else {
-            return Flowable.fromPublisher(finalPublisher);
+            return publisher;
+        }
+    }
+
+    private <T extends MutableHttpResponse<?>> Flowable<T> publisherToFlowable(
+            Publisher<T> publisher) {
+        if (publisher instanceof Flowable) {
+            return (Flowable<T>) publisher;
+        } else {
+            return Flowable.fromPublisher(publisher);
         }
     }
 

--- a/test-suite/src/test/groovy/io/micronaut/tracing/jaeger/HttpTracingSpec.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/tracing/jaeger/HttpTracingSpec.groovy
@@ -29,6 +29,8 @@ import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.annotation.ExecuteOn
 import io.micronaut.tracing.annotation.ContinueSpan
 import io.opentracing.Tracer
 import io.reactivex.Flowable
@@ -522,6 +524,7 @@ class HttpTracingSpec extends Specification {
         TracedClient tracedClient
 
         @Get("/hello/{name}")
+        @ExecuteOn(TaskExecutors.IO)
         String hello(String name) {
             spanCustomizer.activeSpan().setTag("foo", "bar")
             return name
@@ -544,6 +547,7 @@ class HttpTracingSpec extends Specification {
         }
 
         @Get("/error/{name}")
+        @ExecuteOn(TaskExecutors.IO)
         String error(String name) {
             throw new RuntimeException("bad")
         }
@@ -554,12 +558,14 @@ class HttpTracingSpec extends Specification {
         }
 
         @Get("/nested/{name}")
+        @ExecuteOn(TaskExecutors.IO)
         String nested(String name) {
             tracedClient.hello(name)
         }
 
         @ContinueSpan
         @Get("/continued/{name}")
+        @ExecuteOn(TaskExecutors.IO)
         String continued(String name) {
             tracedClient.continued(name)
         }
@@ -571,11 +577,13 @@ class HttpTracingSpec extends Specification {
         }
 
         @Get("/nestedError/{name}")
+        @ExecuteOn(TaskExecutors.IO)
         String nestedError(String name) {
             tracedClient.error(name)
         }
 
         @Get("/customised/name")
+        @ExecuteOn(TaskExecutors.IO)
         String customisedName() {
             spanCustomizer.activeSpan().setOperationName("custom name")
             "response"

--- a/test-suite/src/test/groovy/io/micronaut/tracing/jaeger/HttpTracingSpec.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/tracing/jaeger/HttpTracingSpec.groovy
@@ -81,6 +81,33 @@ class HttpTracingSpec extends Specification {
         }
     }
 
+    void "test basic http tracing - blocking controller method"() {
+
+        when:
+        InMemoryReporter reporter = context.getBean(InMemoryReporter)
+        EmbeddedServer embeddedServer = context.getBean(EmbeddedServer).start()
+        HttpClient client = context.createBean(HttpClient, embeddedServer.getURL())
+
+        then:
+        context.containsBean(JaegerTracer)
+
+        when:
+        HttpResponse<String> response = client.toBlocking().exchange('/traced/blocking/hello/John', String)
+        PollingConditions conditions = new PollingConditions()
+
+        then:
+        response
+        conditions.eventually {
+            reporter.spans.size() == 2
+            def span = reporter.spans.find { it.operationName == 'GET /traced/blocking/hello/{name}' }
+            span != null
+            span.tags.get("foo") == 'bar'
+            span.tags.get('http.path') == '/traced/blocking/hello/John'
+            nrOfStartedSpans > 0
+            nrOfFinishedSpans == nrOfStartedSpans
+        }
+    }
+
     void "test basic response rx http tracing"() {
 
         when:
@@ -159,6 +186,39 @@ class HttpTracingSpec extends Specification {
             serverSpan.tags.get('http.method') == 'GET'
             serverSpan.tags.get('error') == 'Internal Server Error'
             serverSpan.operationName == 'GET /traced/error/{name}'
+            nrOfStartedSpans > 0
+            nrOfFinishedSpans == nrOfStartedSpans
+        }
+    }
+
+    void "test basic http trace error - blocking controller method"() {
+        given:
+        InMemoryReporter reporter = context.getBean(InMemoryReporter)
+        EmbeddedServer embeddedServer = context.getBean(EmbeddedServer).start()
+        HttpClient client = context.createBean(HttpClient, embeddedServer.getURL())
+        PollingConditions conditions = new PollingConditions()
+
+        when:
+        client.toBlocking().exchange('/traced/blocking/error/John', String)
+
+        then:
+        def e = thrown(HttpClientResponseException)
+        def response = e.response
+        response
+        conditions.eventually {
+            reporter.spans.size() == 2
+            def span = reporter.spans.find { it.tags.containsKey('http.client') }
+            span.tags.get('http.path') == '/traced/blocking/error/John'
+            span.tags.get('http.status_code') == 500
+            span.tags.get('http.method') == 'GET'
+            span.tags.get('error') == 'Internal Server Error: bad'
+            span.operationName == 'GET /traced/blocking/error/John'
+            def serverSpan = reporter.spans.find { it.tags.containsKey('http.server') }
+            serverSpan.tags.get('http.path') == '/traced/blocking/error/John'
+            serverSpan.tags.get('http.status_code') == 500
+            serverSpan.tags.get('http.method') == 'GET'
+            serverSpan.tags.get('error') == 'Internal Server Error'
+            serverSpan.operationName == 'GET /traced/blocking/error/{name}'
             nrOfStartedSpans > 0
             nrOfFinishedSpans == nrOfStartedSpans
         }
@@ -310,6 +370,52 @@ class HttpTracingSpec extends Specification {
         client.close()
     }
 
+    void "tested continue http tracing - blocking controller method"() {
+        given:
+        InMemoryReporter reporter = context.getBean(InMemoryReporter)
+        EmbeddedServer embeddedServer = context.getBean(EmbeddedServer).start()
+        HttpClient client = context.createBean(HttpClient, embeddedServer.getURL())
+        PollingConditions conditions = new PollingConditions()
+
+        when:
+        HttpResponse<String> response = client.toBlocking().exchange('/traced/blocking/continued/John', String)
+
+        then:
+        response
+        conditions.eventually {
+            reporter.spans.size() == 4
+            reporter.spans.find {
+                it.operationName == 'GET /traced/blocking/hello/{name}' &&
+                        it.tags.get('foo') == 'bar' &&
+                        it.tags.get('http.path') == '/traced/blocking/hello/John' &&
+                        it.tags.get('http.server')
+            } != null
+            reporter.spans.find {
+                it.operationName == 'GET /traced/blocking/hello/{name}' &&
+                        !it.tags.get('foo') &&
+                        it.tags.get('http.path') == '/traced/blocking/hello/John' &&
+                        it.tags.get('http.client')
+            } != null
+            reporter.spans.find {
+                it.operationName == 'GET /traced/blocking/continued/{name}' &&
+                        !it.tags.get('foo') &&
+                        it.tags.get('http.path') == '/traced/blocking/continued/John' &&
+                        it.tags.get('http.server')
+            } != null
+            reporter.spans.find {
+                it.operationName == 'GET /traced/blocking/continued/John' &&
+                        !it.tags.get('foo') &&
+                        it.tags.get('http.path') == '/traced/blocking/continued/John' &&
+                        it.tags.get('http.client')
+            } != null
+            nrOfStartedSpans > 0
+            nrOfFinishedSpans == nrOfStartedSpans
+        }
+
+        cleanup:
+        client.close()
+    }
+
     void "tested continue http tracing - rx"() {
         given:
         InMemoryReporter reporter = context.getBean(InMemoryReporter)
@@ -402,6 +508,52 @@ class HttpTracingSpec extends Specification {
         client.close()
     }
 
+    void "tested nested http tracing - blocking controller method"() {
+        given:
+        InMemoryReporter reporter = context.getBean(InMemoryReporter)
+        EmbeddedServer embeddedServer = context.getBean(EmbeddedServer).start()
+        HttpClient client = context.createBean(HttpClient, embeddedServer.getURL())
+        PollingConditions conditions = new PollingConditions()
+
+        when:
+        HttpResponse<String> response = client.toBlocking().exchange('/traced/blocking/nested/John', String)
+
+        then:
+        response
+        conditions.eventually {
+            reporter.spans.size() == 4
+            reporter.spans.find {
+                it.operationName == 'GET /traced/blocking/hello/{name}' &&
+                        it.tags.get('foo') == 'bar' &&
+                        it.tags.get('http.path') == '/traced/blocking/hello/John' &&
+                        it.tags.get('http.server')
+            } != null
+            reporter.spans.find {
+                it.operationName == 'GET /traced/blocking/hello/{name}' &&
+                        !it.tags.get('foo') &&
+                        it.tags.get('http.path') == '/traced/blocking/hello/John' &&
+                        it.tags.get('http.client')
+            } != null
+            reporter.spans.find {
+                it.operationName == 'GET /traced/blocking/nested/{name}' &&
+                        !it.tags.get('foo') &&
+                        it.tags.get('http.path') == '/traced/blocking/nested/John' &&
+                        it.tags.get('http.server')
+            } != null
+            reporter.spans.find {
+                it.operationName == 'GET /traced/blocking/nested/John' &&
+                        !it.tags.get('foo') &&
+                        it.tags.get('http.path') == '/traced/blocking/nested/John' &&
+                        it.tags.get('http.client')
+            } != null
+            nrOfStartedSpans > 0
+            nrOfFinishedSpans == nrOfStartedSpans
+        }
+
+        cleanup:
+        client.close()
+    }
+
     void "tested nested http error tracing"() {
         given:
         InMemoryReporter reporter = context.getBean(InMemoryReporter)
@@ -442,6 +594,55 @@ class HttpTracingSpec extends Specification {
             reporter.spans.find {
                 it.operationName == 'GET /traced/nestedError/John' &&
                         it.tags.get('http.path') == '/traced/nestedError/John' &&
+                        it.tags.get('http.status_code') == 500 &&
+                        it.tags.get('error') &&
+                        it.tags.get('http.client')
+            } != null
+            nrOfStartedSpans > 0
+            nrOfFinishedSpans == nrOfStartedSpans
+        }
+    }
+
+    void "tested nested http error tracing - blocking controller method"() {
+        given:
+        InMemoryReporter reporter = context.getBean(InMemoryReporter)
+        EmbeddedServer embeddedServer = context.getBean(EmbeddedServer).start()
+        HttpClient client = context.createBean(HttpClient, embeddedServer.getURL())
+        PollingConditions conditions = new PollingConditions()
+
+        when:
+        client.toBlocking().exchange('/traced/blocking/nestedError/John', String)
+
+        then:
+        def ex = thrown(HttpClientResponseException)
+        ex != null
+        conditions.eventually {
+            reporter.spans.size() == 4
+            reporter.spans.find {
+                it.operationName == 'GET /traced/blocking/error/{name}' &&
+                        it.tags.containsKey('error') &&
+                        it.tags.get('http.path') == '/traced/blocking/error/John' &&
+                        it.tags.get('http.status_code') == 500 &&
+                        it.tags.get('http.server')
+
+            } != null
+            reporter.spans.find {
+                it.operationName == 'GET /traced/blocking/error/{name}' &&
+                        it.tags.get('http.path') == '/traced/blocking/error/John' &&
+                        it.tags.get('http.status_code') == 500 &&
+                        it.tags.get('error') == 'Internal Server Error: bad' &&
+                        it.tags.get('http.client')
+            } != null
+            reporter.spans.find {
+                it.operationName == 'GET /traced/blocking/nestedError/{name}' &&
+                        it.tags.containsKey('error') &&
+                        it.tags.get('http.path') == '/traced/blocking/nestedError/John' &&
+                        it.tags.get('http.status_code') == 500 &&
+                        it.tags.get('http.server')
+            } != null
+            reporter.spans.find {
+                it.operationName == 'GET /traced/blocking/nestedError/John' &&
+                        it.tags.get('http.path') == '/traced/blocking/nestedError/John' &&
                         it.tags.get('http.status_code') == 500 &&
                         it.tags.get('error') &&
                         it.tags.get('http.client')
@@ -494,6 +695,27 @@ class HttpTracingSpec extends Specification {
         client.close()
     }
 
+    void "tested customising span name - blocking controller method"() {
+        given:
+        EmbeddedServer embeddedServer = context.getBean(EmbeddedServer).start()
+        InMemoryReporter reporter = context.getBean(InMemoryReporter)
+        HttpClient client = context.createBean(HttpClient, embeddedServer.getURL())
+        PollingConditions conditions = new PollingConditions()
+
+        when:
+        client.toBlocking().exchange('/traced/blocking/customised/name', String)
+
+        then:
+        conditions.eventually {
+            reporter.spans.any { it.operationName == "custom name" }
+            nrOfStartedSpans > 0
+            nrOfFinishedSpans == nrOfStartedSpans
+        }
+
+        cleanup:
+        client.close()
+    }
+
     ApplicationContext buildContext() {
         def reporter = new InMemoryReporter()
         def metricsFactory = new InMemoryMetricsFactory()
@@ -524,8 +746,14 @@ class HttpTracingSpec extends Specification {
         TracedClient tracedClient
 
         @Get("/hello/{name}")
-        @ExecuteOn(TaskExecutors.IO)
         String hello(String name) {
+            spanCustomizer.activeSpan().setTag("foo", "bar")
+            return name
+        }
+
+        @Get("/blocking/hello/{name}")
+        @ExecuteOn(TaskExecutors.IO)
+        String blockingHello(String name) {
             spanCustomizer.activeSpan().setTag("foo", "bar")
             return name
         }
@@ -547,8 +775,13 @@ class HttpTracingSpec extends Specification {
         }
 
         @Get("/error/{name}")
-        @ExecuteOn(TaskExecutors.IO)
         String error(String name) {
+            throw new RuntimeException("bad")
+        }
+
+        @Get("/blocking/error/{name}")
+        @ExecuteOn(TaskExecutors.IO)
+        String blockingError(String name) {
             throw new RuntimeException("bad")
         }
 
@@ -558,16 +791,27 @@ class HttpTracingSpec extends Specification {
         }
 
         @Get("/nested/{name}")
-        @ExecuteOn(TaskExecutors.IO)
         String nested(String name) {
             tracedClient.hello(name)
         }
 
+        @Get("/blocking/nested/{name}")
+        @ExecuteOn(TaskExecutors.IO)
+        String blockingNested(String name) {
+            tracedClient.blockingHello(name)
+        }
+
         @ContinueSpan
         @Get("/continued/{name}")
-        @ExecuteOn(TaskExecutors.IO)
         String continued(String name) {
             tracedClient.continued(name)
+        }
+
+        @ContinueSpan
+        @Get("/blocking/continued/{name}")
+        @ExecuteOn(TaskExecutors.IO)
+        String blockingContinued(String name) {
+            tracedClient.blockingContinued(name)
         }
 
         @ContinueSpan
@@ -577,14 +821,25 @@ class HttpTracingSpec extends Specification {
         }
 
         @Get("/nestedError/{name}")
-        @ExecuteOn(TaskExecutors.IO)
         String nestedError(String name) {
             tracedClient.error(name)
         }
 
-        @Get("/customised/name")
+        @Get("/blocking/nestedError/{name}")
         @ExecuteOn(TaskExecutors.IO)
+        String blockingNestedError(String name) {
+            tracedClient.blockingError(name)
+        }
+
+        @Get("/customised/name")
         String customisedName() {
+            spanCustomizer.activeSpan().setOperationName("custom name")
+            "response"
+        }
+
+        @Get("/blocking/customised/name")
+        @ExecuteOn(TaskExecutors.IO)
+        String blockingCustomisedName() {
             spanCustomizer.activeSpan().setOperationName("custom name")
             "response"
         }
@@ -633,11 +888,20 @@ class HttpTracingSpec extends Specification {
         @Get("/hello/{name}")
         String hello(String name)
 
+        @Get("/blocking/hello/{name}")
+        String blockingHello(String name)
+
         @Get("/error/{name}")
         String error(String name)
 
+        @Get("/blocking/error/{name}")
+        String blockingError(String name)
+
         @Get("/hello/{name}")
         String continued(String name)
+
+        @Get("/blocking/hello/{name}")
+        String blockingContinued(String name)
 
         @Get("/hello/{name}")
         Single<String> continuedRx(String name)


### PR DESCRIPTION
Closes #4383 

The problem seemed to be that the resultEmitter is constructed before the http filter chain was assembled and executed, thus the deffered Flowable could not catch all the changes to the context done by any of the filters or the publishers created by them. I think the only valid option is to delay this defer until the subscribe() of the publisher produced by the innermost http filter is called. This is only done after subscribing to all publishers created by all the other http filters. However, I needed to add an extra `Flowable.defer(...)` operation to achive this. I am not sure if this is the best way, but it does not seem to break any other tests.