### PR TITLE
Annotations on bean properies should be used to process record parameters

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/records/RecordBeansSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/records/RecordBeansSpec.groovy
@@ -49,7 +49,7 @@ record Test(
         def bean = context.getBean(type)
 
         then:
-        definition.constructor.arguments.length == 3
+        definition.constructor.arguments.length == 4
         bean.num() == 25
         bean.conversionService() != null
         bean.beanContext().is(context)

--- a/inject-java/src/test/groovy/io/micronaut/inject/records/RecordBeansSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/records/RecordBeansSpec.groovy
@@ -18,9 +18,17 @@ class RecordBeansSpec extends AbstractTypeElementSpec {
         ApplicationContext context = buildContext('test.Test', '''
 package test;
 import io.micronaut.context.annotation.*;
+import io.micronaut.core.convert.ConversionService;
+import javax.validation.constraints.Min;
+import javax.inject.Inject;
+import io.micronaut.context.BeanContext;
 
 @ConfigurationProperties("foo")
-record Test(@javax.validation.constraints.Min(20) int num, String name, @Primary io.micronaut.core.convert.ConversionService conversionService) {
+record Test(
+    @Min(20) int num, 
+    String name, 
+    @Primary ConversionService conversionService,
+    @Inject BeanContext beanContext) {
 }
 ''')
         def type = context.classLoader.loadClass('test.Test')
@@ -42,7 +50,9 @@ record Test(@javax.validation.constraints.Min(20) int num, String name, @Primary
 
         then:
         definition.constructor.arguments.length == 3
-        bean.num == 25
+        bean.num() == 25
+        bean.conversionService() != null
+        bean.beanContext().is(context)
 
         cleanup:
         context.close()


### PR DESCRIPTION
Basically the bean properties have the merged metadata from the record access method and parameter so we need to use that when processing constructor injection