### PR TITLE
Initial support for dependency injection narrowing by generic types

### DIFF
--- a/core/src/main/java/io/micronaut/core/beans/BeanProperty.java
+++ b/core/src/main/java/io/micronaut/core/beans/BeanProperty.java
@@ -22,6 +22,7 @@ import io.micronaut.core.convert.ConversionContext;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.exceptions.ConversionErrorException;
 import io.micronaut.core.type.Argument;
+import io.micronaut.core.type.ArgumentCoercible;
 import io.micronaut.core.util.ArgumentUtils;
 
 import io.micronaut.core.annotation.NonNull;
@@ -45,7 +46,7 @@ import java.util.Optional;
  * @see BeanIntrospection
  */
 @Immutable
-public interface BeanProperty<B, T> extends AnnotatedElement, AnnotationMetadataDelegate {
+public interface BeanProperty<B, T> extends AnnotatedElement, AnnotationMetadataDelegate, ArgumentCoercible<T> {
 
     /**
      * @return The declaring bean introspection.
@@ -254,6 +255,7 @@ public interface BeanProperty<B, T> extends AnnotatedElement, AnnotationMetadata
      *
      * @return The argument
      */
+    @Override
     default Argument<T> asArgument() {
         return Argument.of(getType());
     }

--- a/core/src/main/java/io/micronaut/core/type/Argument.java
+++ b/core/src/main/java/io/micronaut/core/type/Argument.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.Collections;
 
 /**
  * Represents an argument to a method or constructor or type.
@@ -155,18 +156,28 @@ public interface Argument<T> extends TypeInformation<T>, AnnotatedElement, Type 
     }
 
     /**
+     * Delegates to {@link Class#isAssignableFrom(Class)} for this argument.
+     * @param candidateType The candidate type
+     * @return True if it is assignable from.
+     * @since 3.0.0
+     */
+    default boolean isAssignableFrom(@NonNull Class<?> candidateType) {
+        return getType().isAssignableFrom(Objects.requireNonNull(candidateType, "Candidate type cannot be null"));
+    }
+
+    /**
      * Convert an argument array to a class array.
      *
      * @param arguments The arguments
      * @return The class array
      */
-    static @NonNull Class[] toClassArray(Argument... arguments) {
+    static @NonNull Class<?>[] toClassArray(@Nullable Argument<?>... arguments) {
         if (ArrayUtils.isEmpty(arguments)) {
             return ReflectionUtils.EMPTY_CLASS_ARRAY;
         }
-        Class[] types = new Class[arguments.length];
+        Class<?>[] types = new Class[arguments.length];
         for (int i = 0; i < arguments.length; i++) {
-            Argument argument = arguments[i];
+            Argument<?> argument = arguments[i];
             types[i] = argument.getType();
         }
         return types;
@@ -178,18 +189,20 @@ public interface Argument<T> extends TypeInformation<T>, AnnotatedElement, Type 
      * @param arguments The arguments
      * @return The String representation
      */
-    static @NonNull String toString(Argument... arguments) {
-        StringBuilder baseString = new StringBuilder();
+    static @NonNull String toString(@Nullable Argument<?>... arguments) {
         if (ArrayUtils.isNotEmpty(arguments)) {
+            StringBuilder baseString = new StringBuilder();
             for (int i = 0; i < arguments.length; i++) {
-                Argument argument = arguments[i];
+                Argument<?> argument = arguments[i];
                 baseString.append(argument.toString());
                 if (i != arguments.length - 1) {
                     baseString.append(',');
                 }
             }
+            return baseString.toString();
+        } else {
+            return "";
         }
-        return baseString.toString();
     }
 
     /**
@@ -204,9 +217,9 @@ public interface Argument<T> extends TypeInformation<T>, AnnotatedElement, Type 
     @UsedByGeneratedCode
     @NonNull
     static <T> Argument<T> of(
-        Class<T> type,
-        String name,
-        @Nullable Argument... typeParameters) {
+        @NonNull Class<T> type,
+        @Nullable String name,
+        @Nullable Argument<?>... typeParameters) {
         return new DefaultArgument<>(type, name, AnnotationMetadata.EMPTY_METADATA, typeParameters);
     }
 
@@ -225,10 +238,10 @@ public interface Argument<T> extends TypeInformation<T>, AnnotatedElement, Type 
     @UsedByGeneratedCode
     @NonNull
     static <T> Argument<T> of(
-        Class<T> type,
-        String name,
-        AnnotationMetadata annotationMetadata,
-        @Nullable Argument... typeParameters) {
+        @NonNull Class<T> type,
+        @Nullable String name,
+        @Nullable AnnotationMetadata annotationMetadata,
+        @Nullable Argument<?>... typeParameters) {
         return new DefaultArgument<>(type, name, annotationMetadata, typeParameters);
     }
 
@@ -244,8 +257,8 @@ public interface Argument<T> extends TypeInformation<T>, AnnotatedElement, Type 
     @UsedByGeneratedCode
     @NonNull
     static <T> Argument<T> of(
-            Class<T> type,
-            AnnotationMetadata annotationMetadata,
+            @NonNull Class<T> type,
+            @Nullable AnnotationMetadata annotationMetadata,
             @Nullable Argument... typeParameters) {
         return new DefaultArgument<>(type, annotationMetadata, typeParameters);
     }
@@ -261,8 +274,8 @@ public interface Argument<T> extends TypeInformation<T>, AnnotatedElement, Type 
     @UsedByGeneratedCode
     @NonNull
     static <T> Argument<T> of(
-        Class<T> type,
-        String name) {
+        @NonNull Class<T> type,
+        @Nullable String name) {
         return new DefaultArgument<>(type, name, AnnotationMetadata.EMPTY_METADATA, Argument.ZERO_ARGUMENTS);
     }
 
@@ -277,7 +290,8 @@ public interface Argument<T> extends TypeInformation<T>, AnnotatedElement, Type 
     @UsedByGeneratedCode
     @NonNull
     static <T> Argument<T> of(
-        Class<T> type, @Nullable Argument... typeParameters) {
+            @NonNull Class<T> type,
+            @Nullable Argument<?>... typeParameters) {
         if (ArrayUtils.isEmpty(typeParameters)) {
             return of(type);
         }
@@ -334,8 +348,8 @@ public interface Argument<T> extends TypeInformation<T>, AnnotatedElement, Type 
     @UsedByGeneratedCode
     @NonNull
     static <T> Argument<T> of(
-        Class<T> type) {
-        return new DefaultArgument<>(type, AnnotationMetadata.EMPTY_METADATA, Argument.ZERO_ARGUMENTS);
+        @NonNull Class<T> type) {
+        return new DefaultArgument<>(type, null, AnnotationMetadata.EMPTY_METADATA, Collections.emptyMap(), Argument.ZERO_ARGUMENTS);
     }
 
     /**
@@ -348,7 +362,7 @@ public interface Argument<T> extends TypeInformation<T>, AnnotatedElement, Type 
      */
     @UsedByGeneratedCode
     @NonNull
-    static <T> Argument<T> of(Class<T> type, @Nullable Class<?>... typeParameters) {
+    static <T> Argument<T> of(@NonNull Class<T> type, @Nullable Class<?>... typeParameters) {
         if (ArrayUtils.isEmpty(typeParameters)) {
             return of(type);
         }
@@ -374,7 +388,7 @@ public interface Argument<T> extends TypeInformation<T>, AnnotatedElement, Type 
      * @return The argument instance
      */
     @NonNull
-    static <T> Argument<List<T>> listOf(Class<T> type) {
+    static <T> Argument<List<T>> listOf(@NonNull Class<T> type) {
         //noinspection unchecked
         return of((Class<List<T>>) ((Class) List.class), type);
     }
@@ -388,7 +402,7 @@ public interface Argument<T> extends TypeInformation<T>, AnnotatedElement, Type 
      * @return The argument instance
      */
     @NonNull
-    static <T> Argument<List<T>> listOf(Argument<T> type) {
+    static <T> Argument<List<T>> listOf(@NonNull Argument<T> type) {
         //noinspection unchecked
         return of((Class<List<T>>) ((Class) List.class), type);
     }
@@ -401,7 +415,7 @@ public interface Argument<T> extends TypeInformation<T>, AnnotatedElement, Type 
      * @return The argument instance
      */
     @NonNull
-    static <T> Argument<Set<T>> setOf(Class<T> type) {
+    static <T> Argument<Set<T>> setOf(@NonNull Class<T> type) {
         //noinspection unchecked
         return of((Class<Set<T>>) ((Class) Set.class), type);
     }
@@ -415,7 +429,7 @@ public interface Argument<T> extends TypeInformation<T>, AnnotatedElement, Type 
      * @return The argument instance
      */
     @NonNull
-    static <T> Argument<Set<T>> setOf(Argument<T> type) {
+    static <T> Argument<Set<T>> setOf(@NonNull Argument<T> type) {
         //noinspection unchecked
         return of((Class<Set<T>>) ((Class) Set.class), type);
     }
@@ -430,7 +444,7 @@ public interface Argument<T> extends TypeInformation<T>, AnnotatedElement, Type 
      * @return The argument instance
      */
     @NonNull
-    static <K, V> Argument<Map<K, V>> mapOf(Class<K> keyType, Class<V> valueType) {
+    static <K, V> Argument<Map<K, V>> mapOf(@NonNull Class<K> keyType, @NonNull Class<V> valueType) {
         //noinspection unchecked
         return of((Class<Map<K, V>>) ((Class) Map.class), keyType, valueType);
     }
@@ -446,9 +460,8 @@ public interface Argument<T> extends TypeInformation<T>, AnnotatedElement, Type 
      * @return The argument instance
      */
     @NonNull
-    static <K, V> Argument<Map<K, V>> mapOf(Argument<K> keyType, Argument<V> valueType) {
+    static <K, V> Argument<Map<K, V>> mapOf(@NonNull Argument<K> keyType, @NonNull Argument<V> valueType) {
         //noinspection unchecked
         return of((Class<Map<K, V>>) ((Class) Map.class), keyType, valueType);
     }
-
 }

--- a/core/src/main/java/io/micronaut/core/type/ArgumentCoercible.java
+++ b/core/src/main/java/io/micronaut/core/type/ArgumentCoercible.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2021 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.docs.inject.generics;
+package io.micronaut.core.type;
 
-import javax.inject.Singleton;
+import io.micronaut.core.annotation.NonNull;
 
-// tag::class[]
-@Singleton
-public class V6Engine implements Engine<V6> {  // <2>
-    @Override
-    public String start() {
-        return "Starting V6";
-    }
-
-    @Override
-    public V6 getCylinderProvider() {
-        return new V6();
-    }
+/**
+ * An interface for types that can be represented as an {@link Argument}.
+ *
+ * @since 3.0.0
+ * @author graemerocher
+ */
+public interface ArgumentCoercible<T> {
+    /**
+     * @return The argument
+     */
+    @NonNull Argument<T> asArgument();
 }
-// end::class[]

--- a/core/src/main/java/io/micronaut/core/type/DefaultArgument.java
+++ b/core/src/main/java/io/micronaut/core/type/DefaultArgument.java
@@ -17,6 +17,7 @@ package io.micronaut.core.type;
 
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
 
@@ -49,7 +50,7 @@ public class DefaultArgument<T> implements Argument<T> {
     private final Class<T> type;
     private final String name;
     private final Map<String, Argument<?>> typeParameters;
-    private final Argument[] typeParameterArray;
+    private final Argument<?>[] typeParameterArray;
     private final AnnotationMetadata annotationMetadata;
 
     /**
@@ -88,8 +89,8 @@ public class DefaultArgument<T> implements Argument<T> {
      * @param typeParameters     The map of parameters
      * @param typeParameterArray The array of arguments
      */
-    public DefaultArgument(Class<T> type, String name, AnnotationMetadata annotationMetadata, Map<String, Argument<?>> typeParameters, Argument[] typeParameterArray) {
-        this.type = type;
+    public DefaultArgument(Class<T> type, String name, AnnotationMetadata annotationMetadata, Map<String, Argument<?>> typeParameters, Argument<?>[] typeParameterArray) {
+        this.type = Objects.requireNonNull(type, "Type cannot be null");
         this.name = name;
         this.annotationMetadata = annotationMetadata != null ? annotationMetadata : AnnotationMetadata.EMPTY_METADATA;
         this.typeParameters = typeParameters;
@@ -161,11 +162,13 @@ public class DefaultArgument<T> implements Argument<T> {
     }
 
     @Override
+    @NonNull
     public Class<T> getType() {
         return type;
     }
 
     @Override
+    @NonNull
     public String getName() {
         if (name == null) {
             return getType().getSimpleName();

--- a/core/src/main/java/io/micronaut/core/type/ReturnType.java
+++ b/core/src/main/java/io/micronaut/core/type/ReturnType.java
@@ -28,11 +28,12 @@ import java.util.Map;
  * @author Graeme Rocher
  * @since 1.0
  */
-public interface ReturnType<T> extends TypeInformation<T>, AnnotationMetadataProvider {
+public interface ReturnType<T> extends TypeInformation<T>, AnnotationMetadataProvider, ArgumentCoercible<T> {
 
     /**
      * @return The return type as an argument
      */
+    @Override
     default @NonNull Argument<T> asArgument() {
         Collection<Argument<?>> values = getTypeVariables().values();
         return Argument.of(getType(), values.toArray(Argument.ZERO_ARGUMENTS));

--- a/core/src/main/java/io/micronaut/core/type/TypeInformation.java
+++ b/core/src/main/java/io/micronaut/core/type/TypeInformation.java
@@ -212,4 +212,13 @@ public interface TypeInformation<T> extends TypeVariableResolver, AnnotationMeta
     default boolean isArray() {
         return getType().isArray();
     }
+
+    /**
+     * Obtains the type's simple name.
+     * @return The simple name
+     * @since 3.0.0
+     */
+    default @NonNull String getSimpleName() {
+        return getType().getSimpleName();
+    }
 }

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/LoadedVisitor.groovy
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/LoadedVisitor.groovy
@@ -140,7 +140,7 @@ class LoadedVisitor implements Ordered {
                 visitor.visitField(e, visitorContext)
                 return e
             case FieldNode:
-                def e = visitorContext.getElementFactory().newFieldElement((FieldNode) annotatedNode, annotationMetadata)
+                def e = visitorContext.getElementFactory().newFieldElement(currentClassElement, (FieldNode) annotatedNode, annotationMetadata)
                 visitor.visitField(e, visitorContext)
                 return e
             case ConstructorNode:

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -1512,7 +1512,7 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                 }
 
                 ClassElement declaringClassElement = elementFactory.newClassElement(declaringClass, concreteClassMetadata);
-                FieldElement javaFieldElement = elementFactory.newFieldElement(variable, fieldAnnotationMetadata);
+                FieldElement javaFieldElement = elementFactory.newFieldElement(concreteClassElement, variable, fieldAnnotationMetadata);
                 addOriginatingElementIfNecessary(writer, declaringClass);
 
                 boolean isPrivate = javaFieldElement.isPrivate();

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaElementFactory.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaElementFactory.java
@@ -150,7 +150,7 @@ public class JavaElementFactory implements ElementFactory<Element, TypeElement, 
     @Override
     public JavaFieldElement newFieldElement(ClassElement declaringClass, @NonNull VariableElement field, @NonNull AnnotationMetadata annotationMetadata) {
         return new JavaFieldElement(
-                declaringClass,
+                (JavaClassElement) declaringClass,
                 field,
                 annotationMetadata,
                 visitorContext

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaFieldElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaFieldElement.java
@@ -37,8 +37,9 @@ class JavaFieldElement extends AbstractJavaElement implements FieldElement {
 
     private final JavaVisitorContext visitorContext;
     private final VariableElement variableElement;
-    private ClassElement declaringElement;
+    private JavaClassElement declaringElement;
     private ClassElement typeElement;
+    private ClassElement genericType;
 
     /**
      * @param variableElement    The {@link VariableElement}
@@ -57,12 +58,29 @@ class JavaFieldElement extends AbstractJavaElement implements FieldElement {
      * @param annotationMetadata The annotation metadata
      * @param visitorContext     The visitor context
      */
-    JavaFieldElement(ClassElement declaringElement,
+    JavaFieldElement(JavaClassElement declaringElement,
                      VariableElement variableElement,
                      AnnotationMetadata annotationMetadata,
                      JavaVisitorContext visitorContext) {
         this(variableElement, annotationMetadata, visitorContext);
         this.declaringElement = declaringElement;
+    }
+
+    @Override
+    public ClassElement getGenericType() {
+        if (this.genericType == null) {
+            if (declaringElement == null) {
+                this.genericType = getType();
+            } else {
+                this.genericType = mirrorToClassElement(
+                        variableElement.asType(),
+                        visitorContext,
+                        declaringElement.getGenericTypeInfo(),
+                        false
+                );
+            }
+        }
+        return this.genericType;
     }
 
     @Override

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/LoadedVisitor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/LoadedVisitor.java
@@ -125,7 +125,7 @@ public class LoadedVisitor implements Ordered {
     public @Nullable io.micronaut.inject.ast.Element visit(
             Element element, AnnotationMetadata annotationMetadata) {
         if (element instanceof VariableElement) {
-            final JavaFieldElement e = elementFactory.newFieldElement((VariableElement) element, annotationMetadata);
+            final JavaFieldElement e = elementFactory.newFieldElement(rootClassElement, (VariableElement) element, annotationMetadata);
             visitor.visitField(
                     e,
                     visitorContext

--- a/inject-java/src/test/groovy/io/micronaut/inject/generics/CylinderProvider.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/generics/CylinderProvider.java
@@ -1,4 +1,4 @@
-package io.micronaut.docs.inject.generics;
+package io.micronaut.inject.generics;
 
 public interface CylinderProvider {
     int getCylinders();

--- a/inject-java/src/test/groovy/io/micronaut/inject/generics/Engine.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/generics/Engine.java
@@ -13,27 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.docs.inject.generics;
+package io.micronaut.inject.generics;
 
-import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
-import org.junit.jupiter.api.Test;
-
-import javax.inject.Inject;
-
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-
-@MicronautTest
-public class VehicleSpec {
-    @Inject Vehicle vehicle;
-    @Inject List<Engine<V6>> v6Engines;
-
-    @Test
-    public void testStartVehicle() {
-        assertEquals("Starting V8", vehicle.start());
-        assertEquals(1, v6Engines.size());
-        assertEquals(6, v6Engines.iterator().next().getCylinders());
+// tag::class[]
+public interface Engine<T extends CylinderProvider> { // <1>
+    default int getCylinders() {
+        return getCylinderProvider().getCylinders();
     }
+
+    String start();
+
+    T getCylinderProvider();
 }
+// tag::class[]

--- a/inject-java/src/test/groovy/io/micronaut/inject/generics/GenericInjectionSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/generics/GenericInjectionSpec.groovy
@@ -1,0 +1,21 @@
+package io.micronaut.inject.generics
+
+import io.micronaut.context.ApplicationContext
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class GenericInjectionSpec extends Specification {
+    @Shared @AutoCleanup ApplicationContext context = ApplicationContext.run()
+
+    void "test narrow injection by generic type"() {
+        given:
+        def bean = context.getBean(Vehicle)
+        expect:
+        bean.start() == 'Starting V8'
+        bean.v6Engines.size() == 1
+        bean.v6Engines.first().start() == 'Starting V6'
+        bean.anotherV8.start() == 'Starting V8'
+        bean.anotherV8.is(bean.engine)
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/generics/GenericTypeArgumentsSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/generics/GenericTypeArgumentsSpec.groovy
@@ -29,6 +29,38 @@ import java.util.function.Supplier
 
 class GenericTypeArgumentsSpec extends AbstractTypeElementSpec {
 
+    void "test type arguments with inherited fields"() {
+        given:
+        BeanDefinition definition = buildBeanDefinition('inheritedfields.UserDaoClient', '''
+package inheritedfields;
+
+import javax.inject.*;
+
+@Singleton
+class UserDaoClient extends DaoClient<User>{
+}
+
+@Singleton
+class UserDao extends Dao<User> {
+}
+
+class User {
+}
+
+class DaoClient<T> {
+
+    @Inject
+    Dao<T> dao;
+}
+
+class Dao<T> {
+}
+''')
+        expect:
+        definition.injectedFields.first().asArgument().typeParameters.length == 1
+        definition.injectedFields.first().asArgument().typeParameters[0].type.simpleName == "User"
+    }
+
     void "test type arguments for exception handler"() {
         given:
         BeanDefinition definition = buildBeanDefinition('exceptionhandler.Test', '''\

--- a/inject-java/src/test/groovy/io/micronaut/inject/generics/V6.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/generics/V6.java
@@ -1,4 +1,4 @@
-package io.micronaut.docs.inject.generics;
+package io.micronaut.inject.generics;
 
 public class V6 implements CylinderProvider {
     @Override

--- a/inject-java/src/test/groovy/io/micronaut/inject/generics/V6Engine.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/generics/V6Engine.java
@@ -13,22 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.docs.inject.generics;
+package io.micronaut.inject.generics;
 
 import javax.inject.Singleton;
 
 // tag::class[]
 @Singleton
-public class V8Engine implements Engine<V8> {  // <3>
+public class V6Engine implements Engine<V6> {  // <2>
     @Override
     public String start() {
-        return "Starting V8";
+        return "Starting V6";
     }
 
     @Override
-    public V8 getCylinderProvider() {
-        return new V8();
+    public V6 getCylinderProvider() {
+        return new V6();
     }
-
 }
 // end::class[]

--- a/inject-java/src/test/groovy/io/micronaut/inject/generics/V8.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/generics/V8.java
@@ -1,4 +1,4 @@
-package io.micronaut.docs.inject.generics;
+package io.micronaut.inject.generics;
 
 public class V8 implements CylinderProvider {
     @Override

--- a/inject-java/src/test/groovy/io/micronaut/inject/generics/V8Engine.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/generics/V8Engine.java
@@ -13,16 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.docs.inject.generics;
+package io.micronaut.inject.generics;
+
+import javax.inject.Singleton;
 
 // tag::class[]
-public interface Engine<T extends CylinderProvider> { // <1>
-    default int getCylinders() {
-        return getCylinderProvider().getCylinders();
+@Singleton
+public class V8Engine implements Engine<V8> {  // <3>
+    @Override
+    public String start() {
+        return "Starting V8";
     }
 
-    String start();
+    @Override
+    public V8 getCylinderProvider() {
+        return new V8();
+    }
 
-    T getCylinderProvider();
 }
-// tag::class[]
+// end::class[]

--- a/inject-java/src/test/groovy/io/micronaut/inject/generics/Vehicle.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/generics/Vehicle.java
@@ -13,15 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.docs.inject.generics;
+package io.micronaut.inject.generics;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import java.util.List;
 
-// tag::class[]
 @Singleton
 public class Vehicle {
     private final Engine<V8> engine;
+
+    @Inject
+    List<Engine<V6>> v6Engines;
+
+    private Engine<V8> anotherV8;
 
     @Inject
     public Vehicle(Engine<V8> engine) {// <4>
@@ -31,5 +36,17 @@ public class Vehicle {
     public String start() {
         return engine.start();// <5>
     }
+
+    @Inject
+    public void setAnotherV8(Engine<V8> anotherV8) {
+        this.anotherV8 = anotherV8;
+    }
+
+    public Engine<V8> getAnotherV8() {
+        return anotherV8;
+    }
+
+    public Engine<V8> getEngine() {
+        return engine;
+    }
 }
-// end::class[]

--- a/inject-java/src/test/groovy/io/micronaut/inject/generics/inheritance/Dao.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/generics/inheritance/Dao.java
@@ -1,0 +1,4 @@
+package io.micronaut.inject.generics.inheritance;
+
+public class Dao<T> {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/generics/inheritance/DaoClient.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/generics/inheritance/DaoClient.java
@@ -1,0 +1,21 @@
+package io.micronaut.inject.generics.inheritance;
+
+import javax.inject.Inject;
+
+public class DaoClient<T> {
+
+    @Inject
+    Dao<T> dao;
+    Dao<T> anotherDao;
+
+    final Dao<T> constructorDao;
+
+    public DaoClient(Dao<T> constructorDao) {
+        this.constructorDao = constructorDao;
+    }
+
+    @Inject
+    void setAnotherDao(Dao<T> dao) {
+        this.anotherDao = dao;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/generics/inheritance/GenericInjectionInheritanceSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/generics/inheritance/GenericInjectionInheritanceSpec.groovy
@@ -1,0 +1,24 @@
+package io.micronaut.inject.generics.inheritance
+
+import io.micronaut.context.ApplicationContext
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class GenericInjectionInheritanceSpec extends Specification {
+    @Shared @AutoCleanup ApplicationContext context = ApplicationContext.run()
+
+    void "test generic injection with inheritance"() {
+        given:
+        def userClient = context.getBean(UserDaoClient)
+        def jobClient = context.getBean(JobDaoClient)
+
+        expect:
+        userClient.dao instanceof UserDao
+        userClient.anotherDao instanceof UserDao
+        userClient.dao.is(userClient.anotherDao)
+        userClient.constructorDao instanceof UserDao
+        jobClient.dao instanceof JobDao
+        jobClient.constructorDao instanceof JobDao
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/generics/inheritance/Job.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/generics/inheritance/Job.java
@@ -1,0 +1,4 @@
+package io.micronaut.inject.generics.inheritance;
+
+public class Job {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/generics/inheritance/JobDao.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/generics/inheritance/JobDao.java
@@ -1,0 +1,7 @@
+package io.micronaut.inject.generics.inheritance;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class JobDao extends Dao<Job> {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/generics/inheritance/JobDaoClient.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/generics/inheritance/JobDaoClient.java
@@ -1,0 +1,10 @@
+package io.micronaut.inject.generics.inheritance;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class JobDaoClient extends DaoClient<Job> {
+    public JobDaoClient(Dao<Job> constructorDao) {
+        super(constructorDao);
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/generics/inheritance/User.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/generics/inheritance/User.java
@@ -1,0 +1,4 @@
+package io.micronaut.inject.generics.inheritance;
+
+public class User {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/generics/inheritance/UserDao.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/generics/inheritance/UserDao.java
@@ -1,0 +1,7 @@
+package io.micronaut.inject.generics.inheritance;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class UserDao extends Dao<User> {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/generics/inheritance/UserDaoClient.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/generics/inheritance/UserDaoClient.java
@@ -1,0 +1,10 @@
+package io.micronaut.inject.generics.inheritance;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class UserDaoClient extends DaoClient<User>{
+    public UserDaoClient(Dao<User> constructorDao) {
+        super(constructorDao);
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/BeanDefinitionRegistry.java
+++ b/inject/src/main/java/io/micronaut/context/BeanDefinitionRegistry.java
@@ -16,6 +16,7 @@
 package io.micronaut.context;
 
 import io.micronaut.context.exceptions.NoSuchBeanException;
+import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.inject.BeanConfiguration;
 import io.micronaut.inject.BeanDefinition;
@@ -24,6 +25,7 @@ import io.micronaut.inject.BeanDefinitionReference;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -90,6 +92,40 @@ public interface BeanDefinitionRegistry {
      */
     @NonNull <T> Optional<BeanDefinition<T>> findBeanDefinition(@NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier);
 
+    /**
+     * Obtain a {@link BeanDefinition} for the given type.
+     *
+     * @param beanType  The potentially parameterized type
+     * @param qualifier The qualifier
+     * @param <T>       The concrete type
+     * @return An {@link Optional} of the bean definition
+     * @throws io.micronaut.context.exceptions.NonUniqueBeanException When multiple possible bean definitions exist
+     *                                                                for the given type
+     * @since 3.0.0
+     */
+    default @NonNull <T> Optional<BeanDefinition<T>> findBeanDefinition(@NonNull Argument<T> beanType, @Nullable Qualifier<T> qualifier) {
+        return findBeanDefinition(
+                Objects.requireNonNull(beanType, "Bean type cannot be null").getType(),
+                qualifier
+        );
+    }
+
+    /**
+     * Obtain a {@link BeanDefinition} for the given type.
+     *
+     * @param beanType  The potentially parameterized type
+     * @param <T>       The concrete type
+     * @return An {@link Optional} of the bean definition
+     * @throws io.micronaut.context.exceptions.NonUniqueBeanException When multiple possible bean definitions exist
+     *                                                                for the given type
+     * @since 3.0.0
+     */
+    default @NonNull <T> Optional<BeanDefinition<T>> findBeanDefinition(@NonNull Argument<T> beanType) {
+        return findBeanDefinition(
+                Objects.requireNonNull(beanType, "Bean type cannot be null").getType(),
+                null
+        );
+    }
 
     /**
      * Obtain a {@link BeanDefinition} for the given bean.
@@ -118,6 +154,21 @@ public interface BeanDefinitionRegistry {
      * Obtain a {@link BeanDefinition} for the given type.
      *
      * @param beanType The type
+     * @param <T>      The concrete type
+     * @return An {@link Optional} of the bean definition
+     * @throws io.micronaut.context.exceptions.NonUniqueBeanException When multiple possible
+     * bean definitions exist for the given type
+     * @since 3.0.0
+     */
+    default @NonNull <T> Collection<BeanDefinition<T>> getBeanDefinitions(@NonNull Argument<T> beanType) {
+        Objects.requireNonNull(beanType, "Bean type cannot be null");
+        return getBeanDefinitions(beanType.getType(), null);
+    }
+
+    /**
+     * Obtain a {@link BeanDefinition} for the given type.
+     *
+     * @param beanType The type
      * @param qualifier The qualifier
      * @param <T>      The concrete type
      * @return An {@link Optional} of the bean definition
@@ -126,11 +177,27 @@ public interface BeanDefinitionRegistry {
      */
     @NonNull <T> Collection<BeanDefinition<T>> getBeanDefinitions(@NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier);
 
+    /**
+     * Obtain a {@link BeanDefinition} for the given type.
+     *
+     * @param beanType The type
+     * @param qualifier The qualifier
+     * @param <T>      The concrete type
+     * @return An {@link Optional} of the bean definition
+     * @throws io.micronaut.context.exceptions.NonUniqueBeanException When multiple possible
+     * bean definitions exist for the given type
+     * @since 3.0.0
+     */
+    default @NonNull <T> Collection<BeanDefinition<T>> getBeanDefinitions(@NonNull Argument<T> beanType, @Nullable Qualifier<T> qualifier) {
+        Objects.requireNonNull(beanType, "Bean type cannot be null");
+        return getBeanDefinitions(beanType.getType(), qualifier);
+    }
+
 
     /**
      * Get all of the {@link BeanDefinition} for the given qualifier.
      *
-     * @param qualifier The qualifer
+     * @param qualifier The qualifier
      * @return The bean definitions
      */
     @NonNull Collection<BeanDefinition<?>> getBeanDefinitions(@NonNull Qualifier<Object> qualifier);
@@ -191,6 +258,23 @@ public interface BeanDefinitionRegistry {
     @NonNull <T> Collection<BeanRegistration<T>> getBeanRegistrations(@NonNull Class<T> beanType, @NonNull Qualifier<T> qualifier);
 
     /**
+     * Find and if necessary initialize {@link javax.inject.Singleton} beans for the given bean type, returning all the active registrations. Note that
+     * this method can return multiple registrations for a given singleton bean instance since each bean may have multiple qualifiers.
+     *
+     * @param beanType The bean type
+     * @param qualifier The qualifier
+     * @param <T>      The concrete type
+     * @return The beans
+     * @since 3.0.0
+     */
+    default @NonNull <T> Collection<BeanRegistration<T>> getBeanRegistrations(@NonNull Argument<T> beanType, @NonNull Qualifier<T> qualifier) {
+        return getBeanRegistrations(
+                Objects.requireNonNull(beanType, "Bean type cannot be null").getType(),
+                qualifier
+        );
+    }
+
+    /**
      * Find a bean registration for the given bean type and optional qualifier.
      *
      * @param beanType The bean type
@@ -203,6 +287,23 @@ public interface BeanDefinitionRegistry {
     @NonNull <T> BeanRegistration<T> getBeanRegistration(@NonNull Class<T> beanType, @NonNull Qualifier<T> qualifier);
 
     /**
+     * Find a bean registration for the given bean type and optional qualifier.
+     *
+     * @param beanType The potentially parameterized bean type
+     * @param qualifier The qualifier
+     * @param <T>      The concrete type
+     * @return The bean registration
+     * @throws NoSuchBeanException if the bean doesn't exist
+     * @since 3.0.0
+     */
+    default @NonNull <T> BeanRegistration<T> getBeanRegistration(@NonNull Argument<T> beanType, @NonNull Qualifier<T> qualifier) {
+        return getBeanRegistration(
+                Objects.requireNonNull(beanType, "Bean type cannot be null").getType(),
+                qualifier
+        );
+    }
+
+    /**
      * Obtain the original {@link BeanDefinition} for a {@link io.micronaut.inject.ProxyBeanDefinition}.
      *
      * @param beanType  The type
@@ -213,6 +314,24 @@ public interface BeanDefinitionRegistry {
      *                                                                for the given type
      */
     @NonNull <T> Optional<BeanDefinition<T>> findProxyTargetBeanDefinition(@NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier);
+
+    /**
+     * Obtain the original {@link BeanDefinition} for a {@link io.micronaut.inject.ProxyBeanDefinition}.
+     *
+     * @param beanType  The type
+     * @param qualifier The qualifier
+     * @param <T>       The concrete type
+     * @return An {@link Optional} of the bean definition
+     * @throws io.micronaut.context.exceptions.NonUniqueBeanException When multiple possible bean definitions exist
+     *                                                                for the given type
+     */
+    default @NonNull <T> Optional<BeanDefinition<T>> findProxyTargetBeanDefinition(@NonNull Argument<T> beanType, @Nullable Qualifier<T> qualifier) {
+        Objects.requireNonNull(beanType, "Bean type cannot be null");
+        return findProxyTargetBeanDefinition(
+                beanType.getType(),
+                qualifier
+        );
+    }
 
     /**
      * Obtain the original {@link BeanDefinition} for a {@link io.micronaut.inject.ProxyBeanDefinition}.
@@ -286,6 +405,22 @@ public interface BeanDefinitionRegistry {
     }
 
     /**
+     * Obtain a {@link BeanDefinition} for the given type.
+     *
+     * @param beanType  The potentially parameterized type type
+     * @param qualifier The qualifier
+     * @param <T>       The concrete type
+     * @return The {@link BeanDefinition}
+     * @throws io.micronaut.context.exceptions.NonUniqueBeanException When multiple possible bean definitions exist
+     *                                                                for the given type
+     * @throws NoSuchBeanException                                    If the bean cannot be found
+     * @since 3.0.
+     */
+    default @NonNull <T> BeanDefinition<T> getBeanDefinition(@NonNull Argument<T> beanType, @Nullable Qualifier<T> qualifier) {
+        return findBeanDefinition(beanType, qualifier).orElseThrow(() -> new NoSuchBeanException(beanType, qualifier));
+    }
+
+    /**
      * Obtain the original {@link BeanDefinition} for a {@link io.micronaut.inject.ProxyBeanDefinition}.
      *
      * @param beanType  The type
@@ -297,6 +432,22 @@ public interface BeanDefinitionRegistry {
      * @throws NoSuchBeanException                                    If the bean cannot be found
      */
     default @NonNull <T> BeanDefinition<T> getProxyTargetBeanDefinition(@NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier) {
+        return findProxyTargetBeanDefinition(beanType, qualifier).orElseThrow(() -> new NoSuchBeanException(beanType, qualifier));
+    }
+
+    /**
+     * Obtain the original {@link BeanDefinition} for a {@link io.micronaut.inject.ProxyBeanDefinition}.
+     *
+     * @param beanType  The type
+     * @param qualifier The qualifier
+     * @param <T>       The concrete type
+     * @return The {@link BeanDefinition}
+     * @throws io.micronaut.context.exceptions.NonUniqueBeanException When multiple possible bean definitions exist
+     *                                                                for the given type
+     * @throws NoSuchBeanException                                    If the bean cannot be found
+     * @since 3.0.0
+     */
+    default @NonNull <T> BeanDefinition<T> getProxyTargetBeanDefinition(@NonNull Argument<T> beanType, @Nullable Qualifier<T> qualifier) {
         return findProxyTargetBeanDefinition(beanType, qualifier).orElseThrow(() -> new NoSuchBeanException(beanType, qualifier));
     }
 

--- a/inject/src/main/java/io/micronaut/context/BeanLocator.java
+++ b/inject/src/main/java/io/micronaut/context/BeanLocator.java
@@ -19,9 +19,11 @@ import io.micronaut.core.reflect.InstantiationUtils;
 
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.type.Argument;
 import io.micronaut.inject.BeanDefinition;
 
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -59,6 +61,24 @@ public interface BeanLocator {
     @NonNull <T> T getBean(@NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier);
 
     /**
+     * Obtains a Bean for the given type and qualifier.
+     *
+     * @param beanType  The potentially parameterized bean type
+     * @param qualifier The qualifier
+     * @param <T>       The bean type parameter
+     * @return An instanceof said bean
+     * @throws io.micronaut.context.exceptions.NonUniqueBeanException When multiple possible bean definitions exist
+     *                                                                for the given type
+     * @see io.micronaut.inject.qualifiers.Qualifiers
+     */
+    default @NonNull <T> T getBean(@NonNull Argument<T> beanType, @Nullable Qualifier<T> qualifier) {
+        return getBean(
+                Objects.requireNonNull(beanType, "Bean type cannot be null").getType(),
+                qualifier
+        );
+    }
+
+    /**
      * Finds a Bean for the given type and qualifier.
      *
      * @param beanType  The bean type
@@ -91,6 +111,33 @@ public interface BeanLocator {
     @NonNull <T> Collection<T> getBeansOfType(@NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier);
 
     /**
+     * Get all beans of the given type.
+     *
+     * @param beanType The potenitally parameterized bean type
+     * @param <T>      The bean type parameter
+     * @return The found beans
+     * @since 3.0.0
+     */
+    default @NonNull <T> Collection<T> getBeansOfType(@NonNull Argument<T> beanType) {
+        Objects.requireNonNull(beanType, "Bean type cannot be null");
+        return getBeansOfType(beanType.getType());
+    }
+
+    /**
+     * Get all beans of the given type.
+     *
+     * @param beanType  The potenitally parameterized bean type
+     * @param qualifier The qualifier
+     * @param <T>       The bean type parameter
+     * @return The found beans
+     * @since 3.0.0
+     */
+    default @NonNull <T> Collection<T> getBeansOfType(@NonNull Argument<T> beanType, @Nullable Qualifier<T> qualifier) {
+        Objects.requireNonNull(beanType, "Bean type cannot be null");
+        return getBeansOfType(beanType.getType(), qualifier);
+    }
+
+    /**
      * Obtain a stream of beans of the given type.
      *
      * @param beanType  The bean type
@@ -100,6 +147,24 @@ public interface BeanLocator {
      * @see io.micronaut.inject.qualifiers.Qualifiers
      */
     @NonNull <T> Stream<T> streamOfType(@NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier);
+
+    /**
+     * Obtain a stream of beans of the given type.
+     *
+     * @param beanType  The potentially parameterized bean type
+     * @param qualifier The qualifier
+     * @param <T>       The bean concrete type
+     * @return A stream of instances
+     * @see io.micronaut.inject.qualifiers.Qualifiers
+     * @since 3.0.0
+     */
+    default @NonNull <T> Stream<T> streamOfType(@NonNull Argument<T> beanType, @Nullable Qualifier<T> qualifier) {
+        return streamOfType(
+                Objects.requireNonNull(beanType, "Bean type cannot be null").getType(),
+                qualifier
+        );
+    }
+
 
     /**
      * Resolves the proxy target for a given bean type. If the bean has no proxy then the original bean is returned.

--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
@@ -220,7 +220,7 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
     }
 
     @Override
-    protected <T> Collection<BeanDefinition<T>> findBeanCandidates(BeanResolutionContext resolutionContext, Class<T> beanType, BeanDefinition<?> filter, boolean filterProxied) {
+    protected <T> Collection<BeanDefinition<T>> findBeanCandidates(BeanResolutionContext resolutionContext, Argument<T> beanType, BeanDefinition<?> filter, boolean filterProxied) {
         Collection<BeanDefinition<T>> candidates = super.findBeanCandidates(resolutionContext, beanType, filter, filterProxied);
         return transformIterables(resolutionContext, candidates, filterProxied);
     }
@@ -286,7 +286,7 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
                         continue;
                     }
 
-                    Collection<BeanDefinition> dependentCandidates = findBeanCandidates(resolutionContext, dependentType, null, filterProxied);
+                    Collection<BeanDefinition> dependentCandidates = findBeanCandidates(resolutionContext, Argument.of(dependentType), null, filterProxied);
                     if (!dependentCandidates.isEmpty()) {
                         for (BeanDefinition dependentCandidate : dependentCandidates) {
 

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -2161,7 +2161,6 @@ public class DefaultBeanContext implements BeanContext {
      * Execution the creation of a bean. The returned value can be null if a
      * factory method returned null.
      *
-<<<<<<< HEAD
      * @param resolutionContext The {@link BeanResolutionContext}
      * @param beanDefinition    The {@link BeanDefinition}
      * @param qualifier         The {@link Qualifier}
@@ -2185,8 +2184,6 @@ public class DefaultBeanContext implements BeanContext {
      * Execution the creation of a bean. The returned value can be null if a
      * factory method returned null.
      *
-=======
->>>>>>> Support for generic bean injection. Fixes #5079
      * @param resolutionContext The {@link BeanResolutionContext}
      * @param beanDefinition    The {@link BeanDefinition}
      * @param qualifier         The {@link Qualifier}

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -81,7 +81,9 @@ public class DefaultBeanContext implements BeanContext {
     protected static final Logger LOG = LoggerFactory.getLogger(DefaultBeanContext.class);
     protected static final Logger LOG_LIFECYCLE = LoggerFactory.getLogger(DefaultBeanContext.class.getPackage().getName() + ".lifecycle");
     private static final Logger EVENT_LOGGER = LoggerFactory.getLogger(ApplicationEventPublisher.class);
+    @SuppressWarnings("rawtypes")
     private static final Qualifier PROXY_TARGET_QUALIFIER = new Qualifier<Object>() {
+        @SuppressWarnings("rawtypes")
         @Override
         public <BT extends BeanType<Object>> Stream<BT> reduce(Class<Object> beanType, Stream<BT> candidates) {
             return candidates.filter(bt -> {
@@ -124,7 +126,7 @@ public class DefaultBeanContext implements BeanContext {
     private final Map<BeanKey, Collection> initializedObjectsByType = new ConcurrentHashMap<>(50);
     private final Map<BeanKey, Optional<BeanDefinition>> beanConcreteCandidateCache =
             new ConcurrentLinkedHashMap.Builder<BeanKey, Optional<BeanDefinition>>().maximumWeightedCapacity(30).build();
-    private final Map<Class, Collection<BeanDefinition>> beanCandidateCache = new ConcurrentLinkedHashMap.Builder<Class, Collection<BeanDefinition>>().maximumWeightedCapacity(30).build();
+    private final Map<Argument, Collection<BeanDefinition>> beanCandidateCache = new ConcurrentLinkedHashMap.Builder<Argument, Collection<BeanDefinition>>().maximumWeightedCapacity(30).build();
     private final Map<Class, Collection<BeanDefinitionReference>> beanIndex = new ConcurrentHashMap<>(12);
 
     private final ClassLoader classLoader;
@@ -305,7 +307,13 @@ public class DefaultBeanContext implements BeanContext {
         if (type == null) {
             return AnnotationMetadata.EMPTY_METADATA;
         } else {
-            Optional<? extends BeanDefinition<?>> candidate = findConcreteCandidate(null, type, null, false, false);
+            Optional<? extends BeanDefinition<?>> candidate = findConcreteCandidate(
+                    null,
+                    Argument.of(type),
+                    null,
+                    false,
+                    false
+            );
             return candidate.map(AnnotationMetadataProvider::getAnnotationMetadata).orElse(AnnotationMetadata.EMPTY_METADATA);
         }
     }
@@ -362,12 +370,12 @@ public class DefaultBeanContext implements BeanContext {
         if (beanType == null) {
             return Collections.emptyList();
         }
-        return getBeanRegistrations(null, beanType, null);
+        return getBeanRegistrations(null, Argument.of(beanType), null);
     }
 
     @Override
     public <T> BeanRegistration<T> getBeanRegistration(Class<T> beanType, Qualifier<T> qualifier) {
-        return getBeanRegistration(null, beanType, qualifier);
+        return getBeanRegistration(null, Argument.of(beanType), qualifier);
     }
 
     @Override
@@ -375,7 +383,25 @@ public class DefaultBeanContext implements BeanContext {
         if (beanType == null) {
             return Collections.emptyList();
         }
-        return getBeanRegistrations(null, beanType, null);
+        return getBeanRegistrations(null, Argument.of(beanType), null);
+    }
+
+    @Override
+    public <T> Collection<BeanRegistration<T>> getBeanRegistrations(Argument<T> beanType, Qualifier<T> qualifier) {
+        return getBeanRegistrations(
+                null,
+                Objects.requireNonNull(beanType, "Bean type cannot be null"),
+                qualifier
+        );
+    }
+
+    @Override
+    public <T> BeanRegistration<T> getBeanRegistration(Argument<T> beanType, Qualifier<T> qualifier) {
+        return getBeanRegistration(
+                null,
+                Objects.requireNonNull(beanType, "Bean type cannot be null"),
+                qualifier
+        );
     }
 
     @Override
@@ -425,7 +451,7 @@ public class DefaultBeanContext implements BeanContext {
                                 BeanDefinition rawDefinition = beanDefinition;
                                 target = getBeanForDefinition(
                                         context,
-                                        rawDefinition.getBeanType(),
+                                        Argument.of(rawDefinition.getBeanType()),
                                         rawDefinition.getDeclaredQualifier(),
                                         true,
                                         rawDefinition
@@ -555,8 +581,13 @@ public class DefaultBeanContext implements BeanContext {
         synchronized (singletonObjects) {
 
             initializedObjectsByType.clear();
-            beanCandidateCache.remove(type);
-            BeanDefinition<T> beanDefinition = inject ? findConcreteCandidate(null, type, qualifier, false, false).orElse(null) : null;
+            beanCandidateCache.remove(Argument.of(type));
+            BeanDefinition<T> beanDefinition = inject ? findConcreteCandidate(
+                    null,
+                    beanKey.beanType,
+                    qualifier,
+                    false,
+                    false).orElse(null) : null;
             if (beanDefinition != null && beanDefinition.getBeanType().isInstance(singleton)) {
                 try (BeanResolutionContext context = newResolutionContext(beanDefinition, null)) {
                     doInject(context, singleton, beanDefinition);
@@ -653,8 +684,8 @@ public class DefaultBeanContext implements BeanContext {
     }
 
     @Override
-    public <T> Optional<BeanDefinition<T>> findBeanDefinition(Class<T> beanType, Qualifier<T> qualifier) {
-        if (Object.class == beanType) {
+    public <T> Optional<BeanDefinition<T>> findBeanDefinition(Argument<T> beanType, Qualifier<T> qualifier) {
+        if (Objects.requireNonNull(beanType, "Bean type cannot be null").equalsType(Argument.OBJECT_ARGUMENT)) {
             // optimization for object resolve
             return Optional.empty();
         }
@@ -664,9 +695,9 @@ public class DefaultBeanContext implements BeanContext {
         if (reg != null) {
             return Optional.of(reg.getBeanDefinition());
         }
-        Collection<BeanDefinition<T>> beanCandidates = new ArrayList<>(findBeanCandidatesInternal(null, beanType));
+        Collection<BeanDefinition<T>> beanCandidates = new ArrayList<>(findBeanCandidatesInternal(null, beanKey.beanType));
         if (qualifier != null) {
-            beanCandidates = qualifier.reduce(beanType, beanCandidates.stream()).collect(Collectors.toList());
+            beanCandidates = qualifier.reduce(beanType.getType(), beanCandidates.stream()).collect(Collectors.toList());
         }
         filterProxiedTypes(beanCandidates, true, true);
         if (beanCandidates.isEmpty()) {
@@ -675,22 +706,47 @@ public class DefaultBeanContext implements BeanContext {
             if (beanCandidates.size() == 1) {
                 return Optional.of(beanCandidates.iterator().next());
             } else {
-                return findConcreteCandidate(null, beanType, null, false, true);
+                return findConcreteCandidate(null, beanKey.beanType, null, false, true);
             }
         }
     }
 
     @Override
+    public <T> Optional<BeanDefinition<T>> findBeanDefinition(Class<T> beanType, Qualifier<T> qualifier) {
+        return findBeanDefinition(
+                Argument.of(beanType),
+                qualifier
+        );
+    }
+
+    @Override
     public <T> Collection<BeanDefinition<T>> getBeanDefinitions(Class<T> beanType) {
-        Collection<BeanDefinition<T>> candidates = findBeanCandidatesInternal(null, beanType);
+        return getBeanDefinitions(Argument.of(beanType));
+    }
+
+    @Override
+    public <T> Collection<BeanDefinition<T>> getBeanDefinitions(Argument<T> beanType) {
+        Collection<BeanDefinition<T>> candidates = findBeanCandidatesInternal(
+                null,
+                Objects.requireNonNull(beanType, "Bean type cannot be null")
+        );
         return Collections.unmodifiableCollection(candidates);
     }
 
     @Override
     public <T> Collection<BeanDefinition<T>> getBeanDefinitions(Class<T> beanType, Qualifier<T> qualifier) {
+        return getBeanDefinitions(
+                Argument.of(Objects.requireNonNull(beanType, "Bean type cannot be null")),
+                qualifier
+        );
+    }
+
+    @Override
+    public <T> Collection<BeanDefinition<T>> getBeanDefinitions(Argument<T> beanType, Qualifier<T> qualifier) {
+        Objects.requireNonNull(beanType, "Bean type cannot be null");
         Collection<BeanDefinition<T>> candidates = findBeanCandidatesInternal(null, beanType);
         if (qualifier != null) {
-            candidates = qualifier.reduce(beanType, new ArrayList<>(candidates).stream()).collect(Collectors.toList());
+            candidates = qualifier.reduce(beanType.getType(), new ArrayList<>(candidates).stream()).collect(Collectors.toList());
         }
         return Collections.unmodifiableCollection(candidates);
     }
@@ -703,7 +759,7 @@ public class DefaultBeanContext implements BeanContext {
             return containsBeanCache.get(beanKey);
         } else {
             boolean result = singletonObjects.containsKey(beanKey) ||
-                    isCandidatePresent(beanType, qualifier);
+                    isCandidatePresent(beanKey.beanType, qualifier);
 
             containsBeanCache.put(beanKey, result);
             return result;
@@ -711,9 +767,17 @@ public class DefaultBeanContext implements BeanContext {
     }
 
     @Override
-    public <T> T getBean(Class<T> beanType, Qualifier<T> qualifier) {
+    public @NonNull <T> T getBean(@NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier) {
+        Objects.requireNonNull(beanType, "Bean type cannot be null");
         try {
-            return getBeanInternal(null, beanType, qualifier, true, true);
+            //noinspection ConstantConditions
+            return getBeanInternal(
+                    null,
+                    Argument.of(beanType),
+                    qualifier,
+                    true,
+                    true
+            );
         } catch (DisabledBeanException e) {
             if (AbstractBeanContextConditional.LOG.isDebugEnabled()) {
                 AbstractBeanContextConditional.LOG.debug("Bean of type [{}] disabled for reason: {}", beanType.getSimpleName(), e.getMessage());
@@ -723,9 +787,17 @@ public class DefaultBeanContext implements BeanContext {
     }
 
     @Override
-    public <T> T getBean(Class<T> beanType) {
+    public @NonNull <T> T getBean(@NonNull Class<T> beanType) {
+        Objects.requireNonNull(beanType, "Bean type cannot be null");
         try {
-            return getBeanInternal(null, beanType, null, true, true);
+            //noinspection ConstantConditions
+            return getBeanInternal(
+                    null,
+                    Argument.of(beanType),
+                    null,
+                    true,
+                    true
+            );
         } catch (DisabledBeanException e) {
             if (AbstractBeanContextConditional.LOG.isDebugEnabled()) {
                 AbstractBeanContextConditional.LOG.debug("Bean of type [{}] disabled for reason: {}", beanType.getSimpleName(), e.getMessage());
@@ -741,19 +813,34 @@ public class DefaultBeanContext implements BeanContext {
 
     @Override
     public <T> Collection<T> getBeansOfType(Class<T> beanType) {
-        return getBeansOfType(null, beanType);
+        return getBeansOfType(null, Argument.of(beanType));
     }
 
     @Override
     public <T> Collection<T> getBeansOfType(Class<T> beanType, Qualifier<T> qualifier) {
-        return getBeanRegistrations(null, beanType, qualifier)
-                .stream()
-                .map(BeanRegistration::getBean)
-                .collect(Collectors.toList());
+        return getBeanRegistrations(null, Argument.of(beanType), qualifier)
+                    .stream()
+                    .map(BeanRegistration::getBean)
+                    .collect(Collectors.toList());
+    }
+
+    @Override
+    public <T> Collection<T> getBeansOfType(Argument<T> beanType) {
+        return getBeansOfType(null, beanType);
+    }
+
+    @Override
+    public <T> Collection<T> getBeansOfType(Argument<T> beanType, Qualifier<T> qualifier) {
+        return getBeansOfType(null, beanType, qualifier);
     }
 
     @Override
     public <T> Stream<T> streamOfType(Class<T> beanType, Qualifier<T> qualifier) {
+        return streamOfType(null, beanType, qualifier);
+    }
+
+    @Override
+    public <T> Stream<T> streamOfType(Argument<T> beanType, Qualifier<T> qualifier) {
         return streamOfType(null, beanType, qualifier);
     }
 
@@ -767,6 +854,20 @@ public class DefaultBeanContext implements BeanContext {
      * @return A stream
      */
     protected <T> Stream<T> streamOfType(BeanResolutionContext resolutionContext, Class<T> beanType, Qualifier<T> qualifier) {
+        return streamOfType(resolutionContext, Argument.of(beanType), qualifier);
+    }
+
+    /**
+     * Obtains a stream of beans of the given type and qualifier.
+     *
+     * @param resolutionContext The bean resolution context
+     * @param beanType          The bean type
+     * @param qualifier         The qualifier
+     * @param <T>               The bean concrete type
+     * @return A stream
+     */
+    protected <T> Stream<T> streamOfType(BeanResolutionContext resolutionContext, Argument<T> beanType, Qualifier<T> qualifier) {
+        Objects.requireNonNull(beanType, "Bean type cannot be null");
         return getBeanRegistrations(resolutionContext, beanType, qualifier).stream()
                 .map(BeanRegistration::getBean);
     }
@@ -810,10 +911,24 @@ public class DefaultBeanContext implements BeanContext {
     <T> T createBean(@NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier, @Nullable Map<String, Object> argumentValues) {
         ArgumentUtils.requireNonNull("beanType", beanType);
 
-        Optional<BeanDefinition<T>> candidate = findConcreteCandidate(null, beanType, qualifier, true, false);
+        final Argument<T> beanArg = Argument.of(beanType);
+        Optional<BeanDefinition<T>> candidate = findConcreteCandidate(
+                null,
+                beanArg,
+                qualifier,
+                true,
+                false
+        );
         if (candidate.isPresent()) {
             try (BeanResolutionContext resolutionContext = newResolutionContext(candidate.get(), null)) {
-                T createdBean = doCreateBean(resolutionContext, candidate.get(), qualifier, beanType, false, argumentValues);
+                T createdBean = doCreateBean(
+                        resolutionContext,
+                        candidate.get(),
+                        qualifier,
+                        beanType,
+                        false,
+                        argumentValues
+                );
                 if (createdBean == null) {
                     throw new NoSuchBeanException(beanType);
                 }
@@ -827,11 +942,24 @@ public class DefaultBeanContext implements BeanContext {
     public @NonNull
     <T> T createBean(@NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier, @Nullable Object... args) {
         ArgumentUtils.requireNonNull("beanType", beanType);
-        Optional<BeanDefinition<T>> candidate = findConcreteCandidate(null, beanType, qualifier, true, false);
+        final Argument<T> beanArg = Argument.of(beanType);
+        Optional<BeanDefinition<T>> candidate = findConcreteCandidate(
+                null,
+                beanArg,
+                qualifier,
+                true,
+                false
+        );
         if (candidate.isPresent()) {
             BeanDefinition<T> definition = candidate.get();
             try (BeanResolutionContext resolutionContext = newResolutionContext(definition, null)) {
-                return doCreateBean(resolutionContext, definition, beanType, qualifier, args);
+                return doCreateBean(
+                        resolutionContext,
+                        definition,
+                        beanType,
+                        qualifier,
+                        args
+                );
             }
         }
         throw new NoSuchBeanException(beanType);
@@ -935,7 +1063,13 @@ public class DefaultBeanContext implements BeanContext {
         }
 
         if (bean != null) {
-            Optional<BeanDefinition<T>> concreteCandidate = findConcreteCandidate(null, beanType, null, false, true);
+            Optional<BeanDefinition<T>> concreteCandidate = findConcreteCandidate(
+                    null,
+                    beanKey.beanType,
+                    null,
+                    false,
+                    true
+            );
             T finalBean = bean;
             concreteCandidate.ifPresent(definition -> {
                 disposeBean(beanType, finalBean, definition);
@@ -1048,11 +1182,24 @@ public class DefaultBeanContext implements BeanContext {
     <T> T createBean(@Nullable BeanResolutionContext resolutionContext, @NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier) {
         ArgumentUtils.requireNonNull("beanType", beanType);
 
-        Optional<BeanDefinition<T>> concreteCandidate = findConcreteCandidate(resolutionContext, beanType, qualifier, true, false);
+        final Argument<T> beanArgument = Argument.of(beanType);
+        Optional<BeanDefinition<T>> concreteCandidate = findConcreteCandidate(
+                resolutionContext,
+                beanArgument,
+                qualifier,
+                true,
+                false
+        );
         if (concreteCandidate.isPresent()) {
             BeanDefinition<T> candidate = concreteCandidate.get();
             try (BeanResolutionContext context = newResolutionContext(candidate, resolutionContext)) {
-                T createBean = doCreateBean(context, candidate, qualifier, beanType, false, null);
+                T createBean = doCreateBean(
+                        context,
+                        candidate,
+                        qualifier,
+                        beanType,
+                        false, null
+                );
                 if (createBean == null) {
                     throw new NoSuchBeanException(beanType);
                 }
@@ -1074,7 +1221,13 @@ public class DefaultBeanContext implements BeanContext {
     protected @NonNull
     <T> T inject(@NonNull BeanResolutionContext resolutionContext, @Nullable BeanDefinition requestingBeanDefinition, @NonNull T instance) {
         @SuppressWarnings("unchecked") Class<T> beanType = (Class<T>) instance.getClass();
-        Optional<BeanDefinition<T>> concreteCandidate = findConcreteCandidate(resolutionContext, beanType, null, false, true);
+        Optional<BeanDefinition<T>> concreteCandidate = findConcreteCandidate(
+                resolutionContext,
+                Argument.of(beanType),
+                null,
+                false,
+                true
+        );
         if (concreteCandidate.isPresent()) {
             BeanDefinition definition = concreteCandidate.get();
             if (requestingBeanDefinition != null && requestingBeanDefinition.equals(definition)) {
@@ -1095,7 +1248,7 @@ public class DefaultBeanContext implements BeanContext {
      * @return The found beans
      */
     protected @NonNull
-    <T> Collection<T> getBeansOfType(@Nullable BeanResolutionContext resolutionContext, @NonNull Class<T> beanType) {
+    <T> Collection<T> getBeansOfType(@Nullable BeanResolutionContext resolutionContext, @NonNull Argument<T> beanType) {
         return getBeanRegistrations(resolutionContext, beanType, null)
                 .stream().map(BeanRegistration::getBean)
                 .collect(Collectors.toList());
@@ -1113,7 +1266,7 @@ public class DefaultBeanContext implements BeanContext {
     protected @NonNull
     <T> Collection<T> getBeansOfType(
             @Nullable BeanResolutionContext resolutionContext,
-            @NonNull Class<T> beanType,
+            @NonNull Argument<T> beanType,
             @Nullable Qualifier<T> qualifier) {
         return getBeanRegistrations(resolutionContext, beanType, qualifier)
                 .stream().map(BeanRegistration::getBean)
@@ -1144,7 +1297,7 @@ public class DefaultBeanContext implements BeanContext {
 
             return getBeanForDefinition(
                     resolutionContext,
-                    beanType,
+                    Argument.of(beanType),
                     proxyQualifier,
                     true,
                     definition
@@ -1173,9 +1326,17 @@ public class DefaultBeanContext implements BeanContext {
     @SuppressWarnings({"unchecked", "rawtypes"})
     public @NonNull
     <T> Optional<BeanDefinition<T>> findProxyTargetBeanDefinition(@NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier) {
+        return findProxyTargetBeanDefinition(
+                Argument.of(beanType),
+                qualifier
+        );
+    }
+
+    @Override
+    public <T> Optional<BeanDefinition<T>> findProxyTargetBeanDefinition(Argument<T> beanType, Qualifier<T> qualifier) {
         ArgumentUtils.requireNonNull("beanType", beanType);
         Qualifier<T> proxyQualifier = qualifier != null ? Qualifiers.byQualifiers(qualifier, PROXY_TARGET_QUALIFIER) : PROXY_TARGET_QUALIFIER;
-        BeanKey key = new BeanKey(beanType, proxyQualifier);
+        BeanKey<T> key = new BeanKey<>(beanType, proxyQualifier);
 
         Optional beanDefinition = beanConcreteCandidateCache.get(key);
         //noinspection OptionalAssignedToNull
@@ -1189,7 +1350,7 @@ public class DefaultBeanContext implements BeanContext {
             } else {
                 beanDefinition = findConcreteCandidateNoCache(
                         null,
-                        (Class) beanType,
+                        beanType,
                         proxyQualifier,
                         true,
                         false,
@@ -1278,7 +1439,14 @@ public class DefaultBeanContext implements BeanContext {
     public @NonNull
     <T> T getBean(@Nullable BeanResolutionContext resolutionContext, @NonNull Class<T> beanType) {
         ArgumentUtils.requireNonNull("beanType", beanType);
-        return getBeanInternal(resolutionContext, beanType, null, true, true);
+        //noinspection ConstantConditions
+        return getBeanInternal(
+                resolutionContext,
+                Argument.of(beanType),
+                null,
+                true,
+                true
+        );
     }
 
     @NonNull
@@ -1286,18 +1454,17 @@ public class DefaultBeanContext implements BeanContext {
     public <T> T getBean(@NonNull BeanDefinition<T> definition) {
         ArgumentUtils.requireNonNull("definition", definition);
         Qualifier<T> declaredQualifier = definition.getDeclaredQualifier();
+        BeanKey<T> key = new BeanKey<>(definition, declaredQualifier);
         if (definition.isSingleton()) {
-            BeanKey<T> key = new BeanKey<>(definition, declaredQualifier);
             BeanRegistration beanRegistration = singletonObjects.get(key);
             if (beanRegistration != null) {
                 return (T) beanRegistration.bean;
             }
         }
-        Class<T> beanType = definition.getBeanType();
         try (BeanResolutionContext context = newResolutionContext(definition, null)) {
             return getBeanForDefinition(
                     context,
-                    beanType,
+                    key.beanType,
                     declaredQualifier,
                     true,
                     definition
@@ -1316,8 +1483,53 @@ public class DefaultBeanContext implements BeanContext {
      */
     public @NonNull
     <T> T getBean(@Nullable BeanResolutionContext resolutionContext, @NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier) {
+        return getBean(
+                resolutionContext,
+                Argument.of(beanType),
+                qualifier
+        );
+    }
+
+    /**
+     * Get a bean of the given type and qualifier.
+     *
+     * @param resolutionContext The bean context resolution
+     * @param beanType          The bean type
+     * @param qualifier         The qualifier
+     * @param <T>               The bean type parameter
+     * @return The found bean
+     * @since 3.0.0
+     */
+    public @NonNull
+    <T> T getBean(@Nullable BeanResolutionContext resolutionContext, @NonNull Argument<T> beanType, @Nullable Qualifier<T> qualifier) {
         ArgumentUtils.requireNonNull("beanType", beanType);
-        return getBeanInternal(resolutionContext, beanType, qualifier, true, true);
+        final T bean = getBeanInternal(
+                resolutionContext,
+                beanType,
+                qualifier,
+                true,
+                true
+        );
+        if (bean == null) {
+            throw new NoSuchBeanException(beanType, qualifier);
+        }
+        return bean;
+    }
+
+    @Override
+    public <T> T getBean(Argument<T> beanType, Qualifier<T> qualifier) {
+        ArgumentUtils.requireNonNull("beanType", beanType);
+        final T bean = getBeanInternal(
+                null,
+                beanType,
+                qualifier,
+                true,
+                true
+        );
+        if (bean == null) {
+            throw new NoSuchBeanException(beanType, qualifier);
+        }
+        return bean;
     }
 
     /**
@@ -1331,14 +1543,39 @@ public class DefaultBeanContext implements BeanContext {
      */
     public @NonNull
     <T> Optional<T> findBean(@Nullable BeanResolutionContext resolutionContext, @NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier) {
+        return findBean(
+                resolutionContext,
+                Argument.of(beanType),
+                qualifier
+        );
+    }
+
+    /**
+     * Find an optional bean of the given type and qualifier.
+     *
+     * @param resolutionContext The bean context resolution
+     * @param beanType          The bean type
+     * @param qualifier         The qualifier
+     * @param <T>               The bean type parameter
+     * @return The found bean wrapped as an {@link Optional}
+     * @since 3.0.0
+     */
+    public @NonNull
+    <T> Optional<T> findBean(@Nullable BeanResolutionContext resolutionContext, @NonNull Argument<T> beanType, @Nullable Qualifier<T> qualifier) {
         ArgumentUtils.requireNonNull("beanType", beanType);
         // allow injection the bean context
-        if (thisInterfaces.contains(beanType)) {
+        if (thisInterfaces.contains(beanType.getType())) {
             return Optional.of((T) this);
         }
 
         try {
-            T bean = getBeanInternal(resolutionContext, beanType, qualifier, true, false);
+            T bean = getBeanInternal(
+                    resolutionContext,
+                    beanType,
+                    qualifier,
+                    true,
+                    false
+            );
             if (bean == null) {
                 return Optional.empty();
             } else {
@@ -1446,9 +1683,28 @@ public class DefaultBeanContext implements BeanContext {
      */
     protected @NonNull
     <T> Provider<T> getBeanProvider(@Nullable BeanResolutionContext resolutionContext, @NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier) {
+        return getBeanProvider(
+                resolutionContext,
+                Argument.of(beanType),
+                qualifier
+        );
+    }
+
+    /**
+     * Get a bean provider.
+     *
+     * @param resolutionContext The bean resolution context
+     * @param beanType          The bean type
+     * @param qualifier         The qualifier
+     * @param <T>               The bean type parameter
+     * @return The bean provider
+     * @since 3.0.0
+     */
+    protected @NonNull
+    <T> Provider<T> getBeanProvider(@Nullable BeanResolutionContext resolutionContext, @NonNull Argument<T> beanType, @Nullable Qualifier<T> qualifier) {
         ArgumentUtils.requireNonNull("beanType", beanType);
 
-        BeanKey beanKey = new BeanKey(beanType, qualifier);
+        BeanKey<T> beanKey = new BeanKey<>(beanType, qualifier);
 
         T inFlightBean = resolutionContext != null ? resolutionContext.getInFlightBean(beanKey) : null;
         if (inFlightBean != null) {
@@ -1460,7 +1716,13 @@ public class DefaultBeanContext implements BeanContext {
             return new ResolvedProvider<>(beanRegistration.bean);
         }
 
-        Optional<BeanDefinition<T>> concreteCandidate = findConcreteCandidate(resolutionContext, beanType, qualifier, true, false);
+        Optional<BeanDefinition<T>> concreteCandidate = findConcreteCandidate(
+                resolutionContext,
+                beanType,
+                qualifier,
+                true,
+                false
+        );
         if (concreteCandidate.isPresent()) {
             return new UnresolvedProvider<>(concreteCandidate.get(), this);
         } else {
@@ -1526,7 +1788,6 @@ public class DefaultBeanContext implements BeanContext {
                             qualifier
                     );
                 } else {
-
                     listener = doCreateBean(
                             context,
                             beanCreatedDefinition,
@@ -1562,7 +1823,6 @@ public class DefaultBeanContext implements BeanContext {
                             qualifier
                     );
                 } else {
-
                     listener = doCreateBean(
                             context,
                             definition,
@@ -1728,7 +1988,7 @@ public class DefaultBeanContext implements BeanContext {
      */
     protected @NonNull
     <T> Collection<BeanDefinition<T>> findBeanCandidates(@NonNull Class<T> beanType, @Nullable BeanDefinition<?> filter) {
-        return findBeanCandidates(null, beanType, filter, true);
+        return findBeanCandidates(null, Argument.of(beanType), filter, true);
     }
 
     /**
@@ -1745,11 +2005,11 @@ public class DefaultBeanContext implements BeanContext {
     protected @NonNull
     <T> Collection<BeanDefinition<T>> findBeanCandidates(
             @Nullable BeanResolutionContext resolutionContext,
-            @NonNull Class<T> beanType,
+            @NonNull Argument<T> beanType,
             @Nullable BeanDefinition<?> filter,
             boolean filterProxied) {
         ArgumentUtils.requireNonNull("beanType", beanType);
-
+        final Class<T> beanClass = beanType.getType();
         if (LOG.isDebugEnabled()) {
             LOG.debug("Finding candidate beans for type: {}", beanType);
         }
@@ -1757,8 +2017,8 @@ public class DefaultBeanContext implements BeanContext {
 
         Collection<BeanDefinitionReference> beanDefinitionsClasses;
 
-        if (indexedTypes.contains(beanType)) {
-            beanDefinitionsClasses = beanIndex.get(beanType);
+        if (indexedTypes.contains(beanClass)) {
+            beanDefinitionsClasses = beanIndex.get(beanClass);
             if (beanDefinitionsClasses == null) {
                 beanDefinitionsClasses = Collections.emptyList();
             }
@@ -1772,7 +2032,8 @@ public class DefaultBeanContext implements BeanContext {
                     .stream()
                     .filter(reference -> {
                         Class<?> candidateType = reference.getBeanType();
-                        final boolean isCandidate = candidateType != null && (beanType.isAssignableFrom(candidateType) || beanType == candidateType);
+                        final boolean isCandidate = candidateType != null &&
+                                (beanType.isAssignableFrom(candidateType) || beanClass == candidateType);
                         return isCandidate && reference.isEnabled(this, resolutionContext);
                     })
                     .map(ref -> {
@@ -1838,7 +2099,8 @@ public class DefaultBeanContext implements BeanContext {
             LOG.debug("Finding candidate beans for instance: {}", instance);
         }
         Collection<BeanDefinitionReference> beanDefinitionsClasses = this.beanDefinitionsClasses;
-        Class<?> beanType = instance.getClass();
+        final Class<?> beanClass = instance.getClass();
+        Argument<?> beanType = Argument.of(beanClass);
         Collection<BeanDefinition> beanDefinitions = beanCandidateCache.get(beanType);
         if (beanDefinitions == null) {
             // first traverse component definition classes and load candidates
@@ -1865,7 +2127,7 @@ public class DefaultBeanContext implements BeanContext {
                             .stream()
                             .filter(candidate ->
                                     !(candidate instanceof NoInjectionBeanDefinition) &&
-                                            candidate.getBeanType() == beanType
+                                            candidate.getBeanType() == beanClass
                             )
                             .collect(Collectors.toList());
                     beanDefinitions = candidates;
@@ -1899,6 +2161,7 @@ public class DefaultBeanContext implements BeanContext {
      * Execution the creation of a bean. The returned value can be null if a
      * factory method returned null.
      *
+<<<<<<< HEAD
      * @param resolutionContext The {@link BeanResolutionContext}
      * @param beanDefinition    The {@link BeanDefinition}
      * @param qualifier         The {@link Qualifier}
@@ -1922,6 +2185,8 @@ public class DefaultBeanContext implements BeanContext {
      * Execution the creation of a bean. The returned value can be null if a
      * factory method returned null.
      *
+=======
+>>>>>>> Support for generic bean injection. Fixes #5079
      * @param resolutionContext The {@link BeanResolutionContext}
      * @param beanDefinition    The {@link BeanDefinition}
      * @param qualifier         The {@link Qualifier}
@@ -1941,16 +2206,16 @@ public class DefaultBeanContext implements BeanContext {
         if (argumentValues == null) {
             argumentValues = Collections.emptyMap();
         }
-        Qualifier declaredQualifier = beanDefinition.getDeclaredQualifier();
+        Qualifier<T> declaredQualifier = beanDefinition.getDeclaredQualifier();
         Class<T> beanType = beanDefinition.getBeanType();
         if (isSingleton) {
-            BeanRegistration<T> beanRegistration = singletonObjects.get(new BeanKey(beanDefinition, declaredQualifier));
+            BeanRegistration<T> beanRegistration = singletonObjects.get(new BeanKey<>(beanDefinition, declaredQualifier));
             if (beanRegistration != null) {
                 if (qualifier == null || qualifier.reduce(qualifierBeanType, Stream.of(beanRegistration.beanDefinition)).findFirst().isPresent()) {
                     return beanRegistration.bean;
                 }
             } else if (qualifier != null) {
-                beanRegistration = singletonObjects.get(new BeanKey(beanDefinition, null));
+                beanRegistration = singletonObjects.get(new BeanKey<>(beanDefinition, null));
                 if (beanRegistration != null && qualifier.reduce(qualifierBeanType, Stream.of(beanRegistration.beanDefinition)).findFirst().isPresent()) {
                     return beanRegistration.bean;
                 }
@@ -1971,14 +2236,13 @@ public class DefaultBeanContext implements BeanContext {
                         if (val == null && !requiredArgument.isDeclaredNullable()) {
                             throw new BeanInstantiationException(resolutionContext, "Missing bean argument [" + requiredArgument + "] for type: " + beanType.getName() + ". Required arguments: " + ArrayUtils.toString(requiredArguments));
                         }
-                        BeanResolutionContext finalResolutionContext = resolutionContext;
                         Object convertedValue = null;
                         if (val != null) {
                             if (requiredArgument.getType().isInstance(val)) {
                                 convertedValue = val;
                             } else {
                                 convertedValue = ConversionService.SHARED.convert(val, requiredArgument).orElseThrow(() ->
-                                        new BeanInstantiationException(finalResolutionContext, "Invalid bean argument [" + requiredArgument + "]. Cannot convert object [" + val + "] to required type: " + requiredArgument.getType())
+                                        new BeanInstantiationException(resolutionContext, "Invalid bean argument [" + requiredArgument + "]. Cannot convert object [" + val + "] to required type: " + requiredArgument.getType())
                                 );
                             }
                         }
@@ -2033,13 +2297,13 @@ public class DefaultBeanContext implements BeanContext {
             }
         } else {
             ConstructorInjectionPoint<T> constructor = beanDefinition.getConstructor();
-            Argument[] requiredConstructorArguments = constructor.getArguments();
+            Argument<?>[] requiredConstructorArguments = constructor.getArguments();
             if (requiredConstructorArguments.length == 0) {
                 bean = constructor.invoke();
             } else {
                 Object[] constructorArgs = new Object[requiredConstructorArguments.length];
                 for (int i = 0; i < requiredConstructorArguments.length; i++) {
-                    Class argument = requiredConstructorArguments[i].getType();
+                    Class<?> argument = requiredConstructorArguments[i].getType();
                     constructorArgs[i] = getBean(resolutionContext, argument);
                 }
                 bean = constructor.invoke(constructorArgs);
@@ -2049,12 +2313,12 @@ public class DefaultBeanContext implements BeanContext {
         }
 
         if (bean != null) {
-            Qualifier finalQualifier = qualifier != null ? qualifier : declaredQualifier;
+            Qualifier<T> finalQualifier = qualifier != null ? qualifier : declaredQualifier;
             if (!BeanCreatedEventListener.class.isInstance(bean) && CollectionUtils.isNotEmpty(beanCreationEventListeners)) {
                 for (Map.Entry<Class, List<BeanCreatedEventListener>> entry : beanCreationEventListeners) {
                     if (entry.getKey().isAssignableFrom(beanType)) {
-                        BeanKey beanKey = new BeanKey(beanDefinition, finalQualifier);
-                        for (BeanCreatedEventListener listener : entry.getValue()) {
+                        BeanKey<T> beanKey = new BeanKey<>(beanDefinition, finalQualifier);
+                        for (BeanCreatedEventListener<?> listener : entry.getValue()) {
                             bean = (T) listener.onCreated(new BeanCreatedEvent(this, beanDefinition, beanKey, bean));
                             if (bean == null) {
                                 throw new BeanInstantiationException(resolutionContext, "Listener [" + listener + "] returned null from onCreated event");
@@ -2322,16 +2586,17 @@ public class DefaultBeanContext implements BeanContext {
 
     private <T> T getBeanInternal(
             @Nullable BeanResolutionContext resolutionContext,
-            Class<T> beanType,
+            @NonNull Argument<T> beanType,
             Qualifier<T> qualifier,
             boolean throwNonUnique,
             boolean throwNoSuchBean) {
         // allow injection the bean context
-        if (thisInterfaces.contains(beanType)) {
+        final Class<T> beanClass = beanType.getType();
+        if (thisInterfaces.contains(beanClass)) {
             return (T) this;
         }
 
-        if (beanType == InjectionPoint.class) {
+        if (beanClass == InjectionPoint.class) {
             final BeanResolutionContext.Path path = resolutionContext != null ? resolutionContext.getPath() : null;
 
             if (CollectionUtils.isNotEmpty(path)) {
@@ -2391,13 +2656,24 @@ public class DefaultBeanContext implements BeanContext {
 
         synchronized (singletonObjects) {
 
-            Optional<BeanDefinition<T>> concreteCandidate = findConcreteCandidate(resolutionContext, beanType, qualifier, throwNonUnique, false);
+            Optional<BeanDefinition<T>> concreteCandidate = findConcreteCandidate(
+                    resolutionContext,
+                    beanType,
+                    qualifier,
+                    throwNonUnique,
+                    false
+            );
             T bean;
 
             if (concreteCandidate.isPresent()) {
                 BeanDefinition<T> definition = concreteCandidate.get();
 
-                bean = findExistingCompatibleSingleton(definition.getBeanType(), beanType, qualifier, definition);
+                bean = findExistingCompatibleSingleton(
+                        definition.asArgument(),
+                        beanType,
+                        qualifier,
+                        definition
+                );
                 if (bean != null) {
                     if (LOG.isDebugEnabled()) {
                         LOG.debug("Resolved existing bean [{}] for type [{}] and qualifier [{}]", bean, beanType, qualifier);
@@ -2405,7 +2681,7 @@ public class DefaultBeanContext implements BeanContext {
                     return bean;
                 }
 
-                if (definition.isProvided() && beanType == definition.getBeanType()) {
+                if (definition.isProvided() && beanType.getType() == definition.getBeanType()) {
                     if (throwNoSuchBean) {
                         throw new NoSuchBeanException(beanType, qualifier);
                     }
@@ -2432,12 +2708,13 @@ public class DefaultBeanContext implements BeanContext {
 
     private <T> T getBeanForDefinition(
             BeanResolutionContext resolutionContext,
-            Class<T> beanType, Qualifier<T> qualifier,
+            Argument<T> beanType,
+            Qualifier<T> qualifier,
             boolean throwNoSuchBean,
             BeanDefinition<T> definition) {
         try (BeanResolutionContext context = newResolutionContext(definition, resolutionContext)) {
             if (definition.isSingleton() && !definition.hasStereotype(SCOPED_PROXY_ANN)) {
-                return createAndRegisterSingleton(context, definition, beanType, qualifier);
+                return createAndRegisterSingleton(context, definition, beanType.getType(), qualifier);
             } else {
                 return getScopedBeanForDefinition(context, beanType, qualifier, throwNoSuchBean, definition);
             }
@@ -2447,14 +2724,15 @@ public class DefaultBeanContext implements BeanContext {
     @SuppressWarnings("unchecked")
     private <T> T getScopedBeanForDefinition(
             final @NonNull BeanResolutionContext resolutionContext,
-            Class<T> beanType,
+            Argument<T> beanType,
             Qualifier<T> qualifier,
             boolean throwNoSuchBean,
             BeanDefinition<T> definition) {
         final boolean isProxy = definition.isProxy();
         final boolean isScopedProxyDefinition = definition.hasStereotype(SCOPED_PROXY_ANN);
+        final Class<T> beanClass = beanType.getType();
         if (qualifier != PROXY_TARGET_QUALIFIER && isProxy && isScopedProxyDefinition) {
-            Class<?> proxiedType = resolveProxiedType(beanType, definition);
+            Class<?> proxiedType = resolveProxiedType(beanClass, definition);
             BeanKey key = new BeanKey(proxiedType, qualifier);
             BeanDefinition<T> finalDefinition = definition;
             return (T) scopedProxies.computeIfAbsent(key, beanKey -> ProviderUtils.memoized(() -> {
@@ -2464,7 +2742,15 @@ public class DefaultBeanContext implements BeanContext {
                 }
                 BeanDefinition<T> proxyDefinition = (BeanDefinition<T>) findProxyBeanDefinition((Class) proxiedType, q).orElse(finalDefinition);
 
-                T createBean = doCreateBean(resolutionContext, proxyDefinition, qualifier, beanType, false, null);
+
+                T createBean = doCreateBean(
+                        resolutionContext,
+                        proxyDefinition,
+                        qualifier,
+                        beanClass,
+                        false,
+                        null
+                );
                 if (createBean instanceof Qualified) {
                     ((Qualified) createBean).$withBeanQualifier(qualifier);
                 }
@@ -2495,18 +2781,29 @@ public class DefaultBeanContext implements BeanContext {
             if (registeredScope.isPresent()) {
                 CustomScope customScope = registeredScope.get();
                 if (isProxy) {
-                    definition = getProxyTargetBeanDefinition(beanType, qualifier);
+                    definition = getProxyTargetBeanDefinition(
+                            beanType,
+                            qualifier
+                    );
                 }
                 BeanDefinition<T> finalDefinition = definition;
 
+                final BeanKey<T> beanKey = new BeanKey<>(beanType, qualifier);
                 return (T) customScope.get(
                         resolutionContext,
                         finalDefinition,
-                        new BeanKey(beanType, qualifier),
+                        beanKey,
                         new ParametrizedProvider() {
                             @Override
                             public Object get(Map argumentValues) {
-                                Object createBean = doCreateBean(resolutionContext, finalDefinition, qualifier, beanType, false, argumentValues);
+                                Object createBean = doCreateBean(
+                                        resolutionContext,
+                                        finalDefinition,
+                                        qualifier,
+                                        beanType.getType(),
+                                        false,
+                                        argumentValues
+                                );
                                 if (createBean == null && throwNoSuchBean) {
                                     throw new NoSuchBeanException(finalDefinition.getBeanType(), qualifier);
                                 }
@@ -2515,7 +2812,13 @@ public class DefaultBeanContext implements BeanContext {
 
                             @Override
                             public Object get(Object... argumentValues) {
-                                T createdBean = doCreateBean(resolutionContext, finalDefinition, beanType, qualifier, argumentValues);
+                                T createdBean = doCreateBean(
+                                        resolutionContext,
+                                        finalDefinition,
+                                        beanType.getType(),
+                                        qualifier,
+                                        argumentValues
+                                );
                                 if (createdBean == null && throwNoSuchBean) {
                                     throw new NoSuchBeanException(finalDefinition.getBeanType(), qualifier);
                                 }
@@ -2524,7 +2827,14 @@ public class DefaultBeanContext implements BeanContext {
                         }
                 );
             } else {
-                T createBean = doCreateBean(resolutionContext, definition, qualifier, beanType, false, null);
+                T createBean = doCreateBean(
+                        resolutionContext,
+                        definition,
+                        qualifier,
+                        beanType.getType(),
+                        false,
+                        null
+                );
                 if (createBean == null && throwNoSuchBean) {
                     throw new NoSuchBeanException(definition.getBeanType(), qualifier);
                 }
@@ -2551,10 +2861,15 @@ public class DefaultBeanContext implements BeanContext {
         return proxiedType;
     }
 
-    private <T> T findExistingCompatibleSingleton(Class<T> beanType, @Nullable Class<?> requestedType, Qualifier<T> qualifier, @Nullable BeanDefinition<T> definition) {
+    private <T> T findExistingCompatibleSingleton(
+            @NonNull Argument<T> beanType,
+            @Nullable Argument<?> requestedType,
+            @Nullable Qualifier<T> qualifier,
+            @Nullable BeanDefinition<T> definition) {
         T bean = null;
+        final Class<T> beanClass = beanType.getType();
         for (Map.Entry<BeanKey, BeanRegistration> entry : singletonObjects.entrySet()) {
-            BeanKey key = entry.getKey();
+            BeanKey<?> key = entry.getKey();
             if (qualifier == null || qualifier.equals(key.qualifier)) {
                 BeanRegistration reg = entry.getValue();
                 if (beanType.isInstance(reg.bean)) {
@@ -2564,7 +2879,13 @@ public class DefaultBeanContext implements BeanContext {
                     }
                     synchronized (singletonObjects) {
                         bean = (T) reg.bean;
-                        registerSingletonBean(reg.beanDefinition, beanType, bean, qualifier, true);
+                        registerSingletonBean(
+                                reg.beanDefinition,
+                                beanType.getType(),
+                                bean,
+                                qualifier,
+                                true
+                        );
                         break;
                     }
                 }
@@ -2572,14 +2893,20 @@ public class DefaultBeanContext implements BeanContext {
                 BeanRegistration registration = entry.getValue();
                 Object existing = registration.bean;
                 if (beanType.isInstance(existing)) {
-                    Optional<BeanDefinition<T>> candidate = qualifier.qualify(beanType, Stream.of(registration.beanDefinition));
+                    Optional<BeanDefinition<T>> candidate = qualifier.qualify(beanClass, Stream.of(registration.beanDefinition));
                     if (!candidate.isPresent() && requestedType != null && requestedType != beanType) {
-                        candidate = qualifier.qualify((Class<T>) requestedType, Stream.of(registration.beanDefinition));
+                        candidate = qualifier.qualify((Class<T>) requestedType.getType(), Stream.of(registration.beanDefinition));
                     }
                     if (candidate.isPresent()) {
                         synchronized (singletonObjects) {
                             bean = (T) existing;
-                            registerSingletonBean(candidate.get(), beanType, bean, qualifier, true);
+                            registerSingletonBean(
+                                    candidate.get(),
+                                    beanType.getType(),
+                                    bean,
+                                    qualifier,
+                                    true
+                            );
                             break;
                         }
                     }
@@ -2602,7 +2929,7 @@ public class DefaultBeanContext implements BeanContext {
     @SuppressWarnings({"unchecked", "rawtypes"})
     private <T> Optional<BeanDefinition<T>> findConcreteCandidate(
             BeanResolutionContext resolutionContext,
-            Class<T> beanType,
+            Argument<T> beanType,
             Qualifier<T> qualifier,
             boolean throwNonUnique,
             boolean includeProvided) {
@@ -2625,7 +2952,7 @@ public class DefaultBeanContext implements BeanContext {
 
     private <T> Optional<BeanDefinition<T>> findConcreteCandidateNoCache(
             BeanResolutionContext resolutionContext,
-            Class<T> beanType,
+            Argument<T> beanType,
             Qualifier<T> qualifier,
             boolean throwNonUnique,
             boolean includeProvided,
@@ -2658,7 +2985,7 @@ public class DefaultBeanContext implements BeanContext {
                     }
                     return false;
                 });
-                Stream<BeanDefinition<T>> qualified = qualifier.reduce(beanType, candidateStream);
+                Stream<BeanDefinition<T>> qualified = qualifier.reduce(beanType.getType(), candidateStream);
                 List<BeanDefinition<T>> beanDefinitionList = qualified.collect(Collectors.toList());
                 if (beanDefinitionList.isEmpty()) {
                     if (LOG.isDebugEnabled()) {
@@ -2667,7 +2994,7 @@ public class DefaultBeanContext implements BeanContext {
                     return Optional.empty();
                 }
 
-                definition = lastChanceResolve(resolutionContext, beanType, qualifier, throwNonUnique, beanDefinitionList);
+                definition = lastChanceResolve(beanType, qualifier, throwNonUnique, beanDefinitionList);
             } else {
                 candidates.removeIf(BeanDefinition::isAbstract);
                 if (candidates.size() == 1) {
@@ -2681,11 +3008,11 @@ public class DefaultBeanContext implements BeanContext {
                             LOG.debug("Searching for @Primary for type [{}] from candidates: {} ", beanType.getName(), candidates);
                         }
                         definition = lastChanceResolve(
-                                resolutionContext,
                                 beanType,
                                 null,
                                 throwNonUnique,
-                                candidates);
+                                candidates
+                        );
                     }
                 }
             }
@@ -2741,23 +3068,19 @@ public class DefaultBeanContext implements BeanContext {
     }
 
     private <T> BeanDefinition<T> lastChanceResolve(
-            BeanResolutionContext resolutionContext,
-            Class<T> beanType,
+            Argument<T> beanType,
             Qualifier<T> qualifier,
             boolean throwNonUnique,
             Collection<BeanDefinition<T>> candidates) {
-        if (resolutionContext != null && candidates.size() > 1) {
-            BeanResolutionContext.Path path = resolutionContext.getPath();
-            BeanResolutionContext.Segment<?> segment = path.currentSegment().orElse(null);
-            if (segment != null) {
-                Argument[] typeParameters = segment.getArgument().getTypeParameters();
-                if (ArrayUtils.isNotEmpty(typeParameters)) {
-                    Qualifier<T> genericQualifier = getTypeArgumentQualifier(typeParameters);
-                    List<BeanDefinition<T>> byGenerics = genericQualifier.reduce(beanType, candidates.stream())
-                            .collect(Collectors.toList());
-                    if (!byGenerics.isEmpty()) {
-                        candidates = byGenerics;
-                    }
+        final Class<T> beanClass = beanType.getType();
+        if (candidates.size() > 1) {
+            Argument<?>[] typeParameters = beanType.getTypeParameters();
+            if (ArrayUtils.isNotEmpty(typeParameters)) {
+                Qualifier<T> genericQualifier = getTypeArgumentQualifier(typeParameters);
+                List<BeanDefinition<T>> byGenerics = genericQualifier.reduce(beanClass, candidates.stream())
+                        .collect(Collectors.toList());
+                if (!byGenerics.isEmpty()) {
+                    candidates = byGenerics;
                 }
             }
         }
@@ -2777,11 +3100,11 @@ public class DefaultBeanContext implements BeanContext {
             if (candidates.size() == 1) {
                 return candidates.iterator().next();
             } else {
-                Collection<BeanDefinition<T>> exactMatches = filterExactMatch(beanType, candidates);
+                Collection<BeanDefinition<T>> exactMatches = filterExactMatch(beanClass, candidates);
                 if (exactMatches.size() == 1) {
                     definition = exactMatches.iterator().next();
                 } else if (throwNonUnique) {
-                    definition = findConcreteCandidate(beanType, qualifier, candidates);
+                    definition = findConcreteCandidate(beanClass, qualifier, candidates);
                 }
                 return definition;
             }
@@ -2797,7 +3120,11 @@ public class DefaultBeanContext implements BeanContext {
         return genericQualifier;
     }
 
-    private <T> T createAndRegisterSingleton(BeanResolutionContext resolutionContext, BeanDefinition<T> definition, Class<T> beanType, Qualifier<T> qualifier) {
+    private <T> T createAndRegisterSingleton(
+            BeanResolutionContext resolutionContext,
+            BeanDefinition<T> definition,
+            Class<T> beanType,
+            Qualifier<T> qualifier) {
         synchronized (singletonObjects) {
             return createAndRegisterSingletonInternal(resolutionContext, definition, beanType, qualifier);
         }
@@ -2833,7 +3160,12 @@ public class DefaultBeanContext implements BeanContext {
         return filteredResults.collect(Collectors.toList());
     }
 
-    private <T> void registerSingletonBean(BeanDefinition<T> beanDefinition, Class<T> beanType, T createdBean, Qualifier<T> qualifier, boolean singleCandidate) {
+    private <T> void registerSingletonBean(
+            BeanDefinition<T> beanDefinition,
+            Class<T> beanType,
+            T createdBean,
+            Qualifier<T> qualifier,
+            boolean singleCandidate) {
         // for only one candidate create link to bean type as singleton
         if (qualifier == null) {
             qualifier = beanDefinition.getDeclaredQualifier();
@@ -2849,7 +3181,7 @@ public class DefaultBeanContext implements BeanContext {
         }
         BeanRegistration<T> registration = new BeanRegistration<>(key, beanDefinition, createdBean);
 
-        if (singleCandidate || key.typeArguments != null) {
+        if (singleCandidate || key.beanType.getTypeParameters().length > 0) {
             singletonObjects.put(key, registration);
         }
 
@@ -2964,7 +3296,7 @@ public class DefaultBeanContext implements BeanContext {
     }
 
     @SuppressWarnings("unchecked")
-    private <T> Collection<BeanDefinition<T>> findBeanCandidatesInternal(BeanResolutionContext resolutionContext, Class<T> beanType) {
+    private <T> Collection<BeanDefinition<T>> findBeanCandidatesInternal(BeanResolutionContext resolutionContext, Argument<T> beanType) {
         @SuppressWarnings("rawtypes")
         Collection beanDefinitions = beanCandidateCache.get(beanType);
         if (beanDefinitions == null) {
@@ -2983,7 +3315,7 @@ public class DefaultBeanContext implements BeanContext {
      * @param <T>               The generic type
      * @return A {@link BeanRegistration}
      */
-    protected <T> BeanRegistration<T> getBeanRegistration(@Nullable BeanResolutionContext resolutionContext, @NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier) {
+    protected <T> BeanRegistration<T> getBeanRegistration(@Nullable BeanResolutionContext resolutionContext, @NonNull Argument<T> beanType, @Nullable Qualifier<T> qualifier) {
         final BeanDefinition<T> beanDefinition = getBeanDefinition(beanType, qualifier);
         final T bean = getBeanInternal(resolutionContext, beanType, qualifier, true, true);
         return new BeanRegistration<>(new BeanKey<>(beanDefinition, qualifier), beanDefinition, bean);
@@ -3001,30 +3333,27 @@ public class DefaultBeanContext implements BeanContext {
     @SuppressWarnings("unchecked")
     protected <T> Collection<BeanRegistration<T>> getBeanRegistrations(
             @Nullable BeanResolutionContext resolutionContext,
-            @NonNull Class<T> beanType,
+            @NonNull Argument<T> beanType,
             @Nullable Qualifier<T> qualifier) {
         boolean hasQualifier = qualifier != null;
         if (LOG.isDebugEnabled()) {
             if (hasQualifier) {
-                LOG.debug("Resolving beans for type: {} {} ", qualifier, beanType.getName());
+                LOG.debug("Resolving beans for type: {} {} ", qualifier, beanType.getTypeName());
             } else {
-                LOG.debug("Resolving beans for type: {}", beanType.getName());
+                LOG.debug("Resolving beans for type: {}", beanType.getTypeName());
             }
         }
-        if (resolutionContext != null) {
-            BeanResolutionContext.Segment<?> segment = resolutionContext.getPath().currentSegment().orElse(null);
-            if (segment != null) {
-                Argument[] typeParameters = segment.getArgument().getTypeParameters();
-                if (ArrayUtils.isNotEmpty(typeParameters)) {
-                    if (qualifier == null) {
-                        qualifier = getTypeArgumentQualifier(typeParameters);
-                    } else {
-                        qualifier = Qualifiers.byQualifiers(
-                                qualifier,
-                                getTypeArgumentQualifier(typeParameters)
-                        );
-                    }
-                }
+        final Class<T> beanClass = beanType.getType();
+        Argument<?>[] typeParameters = beanType.getTypeParameters();
+        if (ArrayUtils.isNotEmpty(typeParameters)) {
+            if (hasQualifier) {
+                qualifier = Qualifiers.byQualifiers(
+                        qualifier,
+                        getTypeArgumentQualifier(typeParameters)
+                );
+            } else {
+                hasQualifier = true;
+                qualifier = getTypeArgumentQualifier(typeParameters);
             }
         }
         BeanKey<T> key = new BeanKey<>(beanType, qualifier);
@@ -3064,7 +3393,7 @@ public class DefaultBeanContext implements BeanContext {
                 Stream<BeanDefinition<T>> candidateStream = candidates.stream();
                 candidateStream = applyBeanResolutionFilters(resolutionContext, candidateStream);
 
-                List<BeanDefinition<T>> reduced = qualifier.reduce(beanType, candidateStream)
+                List<BeanDefinition<T>> reduced = qualifier.reduce(beanClass, candidateStream)
                         .collect(Collectors.toList());
                 if (!reduced.isEmpty()) {
                     beansOfTypeList = new HashSet<>(reduced.size());
@@ -3118,7 +3447,7 @@ public class DefaultBeanContext implements BeanContext {
             Collection<BeanRegistration<T>> beans = Collections.emptyList();
             if (beanRegistrations != Collections.EMPTY_SET) {
                 Stream<BeanRegistration<T>> stream = beanRegistrations.stream();
-                if (Ordered.class.isAssignableFrom(beanType)) {
+                if (Ordered.class.isAssignableFrom(beanClass)) {
                     beans = stream
                             .sorted(OrderUtil.COMPARATOR)
                             .collect(StreamUtils.toImmutableCollection());
@@ -3146,7 +3475,18 @@ public class DefaultBeanContext implements BeanContext {
         }
     }
 
-    private <T> void logResolvedExisting(Class<T> beanType, Qualifier<T> qualifier, boolean hasQualifier, Collection<BeanRegistration<T>> existing) {
+    @Nullable
+    private Argument<?> unwrapBeanType(Argument<?> argument) {
+        if (argument.isContainerType() || argument.isOptional()) {
+            argument = argument.getFirstTypeVariable().orElse(null);
+            if (argument != null && BeanRegistration.class == argument.getType()) {
+                argument = argument.getFirstTypeVariable().orElse(null);
+            }
+        }
+        return argument;
+    }
+
+    private <T> void logResolvedExisting(Argument<T> beanType, Qualifier<T> qualifier, boolean hasQualifier, Collection<BeanRegistration<T>> existing) {
         if (LOG.isTraceEnabled()) {
             if (hasQualifier) {
                 LOG.trace("Found {} existing beans for type [{} {}]: {} ", existing.size(), qualifier, beanType.getName(), existing);
@@ -3178,7 +3518,7 @@ public class DefaultBeanContext implements BeanContext {
 
     private <T> void addCandidateToList(
             @Nullable BeanResolutionContext resolutionContext,
-            Class<T> beanType,
+            Argument<T> beanType,
             BeanDefinition<T> candidate,
             Collection<BeanRegistration<T>> beansOfTypeList,
             Qualifier<T> qualifier,
@@ -3198,8 +3538,21 @@ public class DefaultBeanContext implements BeanContext {
                                 throw new IllegalStateException("Singleton not present for key: " + key);
                             }
                         } else {
-                            bean = doCreateBean(context, candidate, qualifier, beanType, true, null);
-                            registerSingletonBean(candidate, beanType, bean, qualifier, singleCandidate);
+                            bean = doCreateBean(
+                                    context,
+                                    candidate,
+                                    qualifier,
+                                    beanType.getType(),
+                                    true,
+                                    null
+                            );
+                            registerSingletonBean(
+                                    candidate,
+                                    beanType.getType(),
+                                    bean,
+                                    qualifier,
+                                    singleCandidate
+                            );
                         }
                     }
                 }
@@ -3210,7 +3563,7 @@ public class DefaultBeanContext implements BeanContext {
             }
         } catch (DisabledBeanException e) {
             if (AbstractBeanContextConditional.LOG.isDebugEnabled()) {
-                AbstractBeanContextConditional.LOG.debug("Bean of type [{}] disabled for reason: {}", beanType.getSimpleName(), e.getMessage());
+                AbstractBeanContextConditional.LOG.debug("Bean of type [{}] disabled for reason: {}", beanType.getTypeName(), e.getMessage());
             }
         }
 
@@ -3219,13 +3572,13 @@ public class DefaultBeanContext implements BeanContext {
         }
     }
 
-    private <T> boolean isCandidatePresent(Class<T> beanType, Qualifier<T> qualifier) {
+    private <T> boolean isCandidatePresent(Argument<T> beanType, Qualifier<T> qualifier) {
         final Collection<BeanDefinition<T>> candidates = findBeanCandidates(null, beanType, null, true);
         if (!candidates.isEmpty()) {
             filterReplacedBeans(null, candidates);
             Stream<BeanDefinition<T>> stream = candidates.stream();
             if (qualifier != null) {
-                stream = qualifier.reduce(beanType, stream);
+                stream = qualifier.reduce(beanType.getType(), stream);
             }
             return stream.count() > 0;
         }
@@ -3484,9 +3837,8 @@ public class DefaultBeanContext implements BeanContext {
      * @param <T> The bean type
      */
     static final class BeanKey<T> implements BeanIdentifier {
-        private final Class beanType;
-        private final Qualifier qualifier;
-        private final Class[] typeArguments;
+        private final Argument<T> beanType;
+        private final Qualifier<T> qualifier;
         private final int hashCode;
 
         /**
@@ -3496,7 +3848,19 @@ public class DefaultBeanContext implements BeanContext {
          * @param qualifier  The qualifier
          */
         BeanKey(BeanDefinition<T> definition, Qualifier<T> qualifier) {
-            this(definition.getBeanType(), qualifier, definition.getTypeParameters());
+            this(definition.asArgument(), qualifier);
+        }
+
+        /**
+         * A bean key for the given bean definition.
+         *
+         * @param argument The argument
+         * @param qualifier  The qualifier
+         */
+        BeanKey(Argument<T> argument, Qualifier<T> qualifier) {
+            this.beanType = argument;
+            this.qualifier = qualifier;
+            this.hashCode = argument.typeHashCode();
         }
 
         /**
@@ -3505,12 +3869,7 @@ public class DefaultBeanContext implements BeanContext {
          * @param typeArguments The type arguments
          */
         BeanKey(Class<T> beanType, Qualifier<T> qualifier, @Nullable Class... typeArguments) {
-            this.beanType = beanType;
-            this.qualifier = qualifier;
-            this.typeArguments = ArrayUtils.isEmpty(typeArguments) ? null : typeArguments;
-            int result = Objects.hash(beanType, qualifier);
-            result = 31 * result + Arrays.hashCode(this.typeArguments);
-            this.hashCode = result;
+            this(Argument.of(beanType, typeArguments), qualifier);
         }
 
         @Override
@@ -3542,9 +3901,8 @@ public class DefaultBeanContext implements BeanContext {
                 return false;
             }
             BeanKey<?> beanKey = (BeanKey<?>) o;
-            return beanType.equals(beanKey.beanType) &&
-                    Objects.equals(qualifier, beanKey.qualifier) &&
-                    Arrays.equals(typeArguments, beanKey.typeArguments);
+            return beanType.equalsType(beanKey.beanType) &&
+                    Objects.equals(qualifier, beanKey.qualifier);
         }
 
         @Override

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -684,6 +684,12 @@ public class DefaultBeanContext implements BeanContext {
     }
 
     @Override
+    public <T> BeanDefinition<T> getBeanDefinition(Argument<T> beanType, Qualifier<T> qualifier) {
+        return findConcreteCandidate(null, beanType, qualifier, true, false)
+                    .orElseThrow(() -> new NoSuchBeanException(beanType, qualifier));
+    }
+
+    @Override
     public <T> Optional<BeanDefinition<T>> findBeanDefinition(Argument<T> beanType, Qualifier<T> qualifier) {
         if (Objects.requireNonNull(beanType, "Bean type cannot be null").equalsType(Argument.OBJECT_ARGUMENT)) {
             // optimization for object resolve

--- a/inject/src/main/java/io/micronaut/context/DefaultConditionContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultConditionContext.java
@@ -23,6 +23,7 @@ import io.micronaut.core.annotation.Internal;
 
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.convert.ArgumentConversionContext;
+import io.micronaut.core.type.Argument;
 import io.micronaut.core.value.PropertyResolver;
 import io.micronaut.inject.BeanDefinition;
 
@@ -107,13 +108,13 @@ class DefaultConditionContext<B extends AnnotationMetadataProvider> implements C
     @NonNull
     @Override
     public <T> Collection<T> getBeansOfType(@NonNull Class<T> beanType) {
-        return beanContext.getBeansOfType(resolutionContext, beanType);
+        return beanContext.getBeansOfType(resolutionContext, Argument.of(beanType));
     }
 
     @NonNull
     @Override
     public <T> Collection<T> getBeansOfType(@NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier) {
-        return beanContext.getBeansOfType(resolutionContext, beanType, qualifier);
+        return beanContext.getBeansOfType(resolutionContext, Argument.of(beanType), qualifier);
     }
 
     @NonNull

--- a/inject/src/main/java/io/micronaut/context/RequiresCondition.java
+++ b/inject/src/main/java/io/micronaut/context/RequiresCondition.java
@@ -34,6 +34,7 @@ import io.micronaut.core.io.scan.ClassPathResourceLoader;
 import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.core.reflect.InstantiationUtils;
 import io.micronaut.core.reflect.ReflectionUtils;
+import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.core.value.PropertyResolver;
@@ -580,7 +581,7 @@ public class RequiresCondition implements Condition {
                     // remove self by passing definition as filter
                     final Collection<? extends BeanDefinition<?>> beanDefinitions = beanContext.findBeanCandidates(
                             context.getBeanResolutionContext(),
-                            type,
+                            Argument.of(type),
                             bd,
                             true
                     );

--- a/inject/src/main/java/io/micronaut/context/exceptions/NoSuchBeanException.java
+++ b/inject/src/main/java/io/micronaut/context/exceptions/NoSuchBeanException.java
@@ -16,6 +16,9 @@
 package io.micronaut.context.exceptions;
 
 import io.micronaut.context.Qualifier;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.type.Argument;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -29,8 +32,15 @@ public class NoSuchBeanException extends BeanContextException {
     /**
      * @param beanType The bean type
      */
-    public NoSuchBeanException(Class beanType) {
+    public NoSuchBeanException(@NonNull Class<?> beanType) {
         super("No bean of type [" + beanType.getName() + "] exists." + additionalMessage());
+    }
+
+    /**
+     * @param beanType The bean type
+     */
+    public NoSuchBeanException(@NonNull Argument<?> beanType) {
+        super("No bean of type [" + beanType.getTypeName() + "] exists." + additionalMessage());
     }
 
     /**
@@ -38,8 +48,17 @@ public class NoSuchBeanException extends BeanContextException {
      * @param qualifier The qualifier
      * @param <T>       The type
      */
-    public <T> NoSuchBeanException(Class<T> beanType, Qualifier<T> qualifier) {
+    public <T> NoSuchBeanException(@NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier) {
         super("No bean of type [" + beanType.getName() + "] exists" + (qualifier != null ? " for the given qualifier: " + qualifier : "") + "." + additionalMessage());
+    }
+
+    /**
+     * @param beanType  The bean type
+     * @param qualifier The qualifier
+     * @param <T>       The type
+     */
+    public <T> NoSuchBeanException(@NonNull Argument<T> beanType, @Nullable Qualifier<T> qualifier) {
+        super("No bean of type [" + beanType.getTypeName() + "] exists" + (qualifier != null ? " for the given qualifier: " + qualifier : "") + "." + additionalMessage());
     }
 
     /**

--- a/inject/src/main/java/io/micronaut/inject/BeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/inject/BeanDefinition.java
@@ -24,6 +24,7 @@ import io.micronaut.core.annotation.AnnotationMetadataDelegate;
 import io.micronaut.core.naming.Named;
 import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.type.Argument;
+import io.micronaut.core.type.ArgumentCoercible;
 import io.micronaut.inject.qualifiers.Qualifiers;
 
 import java.lang.annotation.Annotation;
@@ -42,7 +43,7 @@ import java.util.stream.Stream;
  * @author Graeme Rocher
  * @since 1.0
  */
-public interface BeanDefinition<T> extends AnnotationMetadataDelegate, Named, BeanType<T> {
+public interface BeanDefinition<T> extends AnnotationMetadataDelegate, Named, BeanType<T>, ArgumentCoercible<T> {
 
     /**
      * Attribute used to store a dynamic bean name.
@@ -169,6 +170,14 @@ public interface BeanDefinition<T> extends AnnotationMetadataDelegate, Named, Be
      * @return The {@link ExecutableMethod} instances for this definition
      */
     Collection<ExecutableMethod<T, ?>> getExecutableMethods();
+
+    @Override
+    default Argument<T> asArgument() {
+        return Argument.of(
+                getBeanType(),
+                getTypeParameters()
+        );
+    }
 
     /**
      * Whether this bean definition represents a proxy.

--- a/inject/src/main/java/io/micronaut/inject/FieldInjectionPoint.java
+++ b/inject/src/main/java/io/micronaut/inject/FieldInjectionPoint.java
@@ -17,7 +17,8 @@ package io.micronaut.inject;
 
 import io.micronaut.core.annotation.AnnotatedElement;
 import io.micronaut.core.annotation.AnnotationMetadataProvider;
-import io.micronaut.core.type.Argument;
+import io.micronaut.core.type.ArgumentCoercible;
+
 import java.lang.reflect.Field;
 
 /**
@@ -28,7 +29,7 @@ import java.lang.reflect.Field;
  * @author Graeme Rocher
  * @since 1.0
  */
-public interface FieldInjectionPoint<B, T> extends InjectionPoint<B>, AnnotationMetadataProvider, AnnotatedElement {
+public interface FieldInjectionPoint<B, T> extends InjectionPoint<B>, AnnotationMetadataProvider, AnnotatedElement, ArgumentCoercible<T> {
 
     /**
      * @return The name of the field
@@ -57,11 +58,4 @@ public interface FieldInjectionPoint<B, T> extends InjectionPoint<B>, Annotation
      * @param object   The the field on the target object
      */
     void set(T instance, Object object);
-
-    /**
-     * Convert this field to an {@link Argument} reference.
-     *
-     * @return The argument
-     */
-    Argument<T> asArgument();
 }

--- a/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -59,7 +59,6 @@ import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * <p>Responsible for building {@link BeanDefinition} instances at compile time. Uses ASM build the class definition.</p>

--- a/src/main/docs/guide/introduction/whatsNew.adoc
+++ b/src/main/docs/guide/introduction/whatsNew.adoc
@@ -2,148 +2,16 @@ Micronaut {version} includes the following changes:
 
 === Core Features
 
-==== Jakarta Inject
+==== Support for Injecting by Generic Type Arguments
 
-The `jakarta.inject` inject annotations are now supported as an alternative to `javax.inject`. Micronaut 3 will change the default inject annotations to Jakarta, however the javax annotations will continue to be supported if added to your build explicitly.
+Micronaut and now resolve the correct bean to inject based on the generic type arguments specifed on the injection point:
 
-Micronaut 3 will change the bean context API to return our custom provider contract, api:context.BeanProvider[]. We suggest existing applications to change to use that interface instead of `javax.inject.Provider`, however both the `jakarta.inject.Provider` and `javax.inject.Provider` interfaces will continue to be supported.
-
-==== Core Nullability Annotations
-
-With the future of JSR-305 unclear and issues with regards to the module system with existing solutions, Micronaut 2.4 will replace usages of Spotbugs with core nullability annotations: ann:core.annotation.Nullable[] and ann:core.annotation.NotNull[].
-
-Existing applications should switch to using these annotations. If other annotations are preferable, the dependency should be added explicitly to your build because no third party `Nullable` or `NonNull` annotations will be available transitively in the next major version.
-
-==== Improvements to Interceptor Binding
-
-Micronaut's support for AOP interceptors has been improved allowing interceptors to be attached to any annotation through the use of api:inject.annotation.AnnotationMapper[] instances. It is also now possible to bind multiple api:aop.MethodInterceptor[] instances to a single annotation instead of there being a 1-to-1 mapping between annotation and interceptor.
-
-From 2.4.x onwards the recommending way to define AOP advise is to use the ann:aop.InterceptorBinding[] annotation on the annotation you wish to trigger AOP advise:
-
-snippet::io.micronaut.docs.aop.around.NotNull[tags="imports,annotation", indent=0, title="Around Advice Annotation Example"]
-
-Then use ann:aop.InterceptorBean[] on the api:aop.MethodInterceptor[] you wish to bind to the above advise:
-
-snippet::io.micronaut.docs.aop.around.NotNullInterceptor[tags="imports,interceptor", indent=0, title="MethodInterceptor Example"]
-
-Multiple api:aop.MethodInterceptor[] types can bind to a single advise annotation and any given interceptor can bind to multiple annotations.
-
-==== JSON Error Responses
-
-In previous versions of Micronaut, to control the format of error response bodies, it required replacing all of the existing api:http.server.exceptions.ExceptionHanlder[] instances. In Micronaut 2.4, the logic to create error response bodies has been moved to a single bean that implements api:http.server.exceptions.response.ErrorResponseProcessor[]. Now instead of having to replace many beans to have a consistent format, only a single bean needs to be replaced. The default implementation behaves the same as in previous versions to maintain backward compatibility.
-
-=== Micronaut Data
-
-==== Support for Java 14+ Records with JDBC
-
-Micronaut Data JDBC now https://micronaut-projects.github.io/micronaut-data/latest/guide/#javaRecords[supports using Java 14+ records to represent persistent entities], for example:
-
-[source,java]
-----
-package example;
-
-import edu.umd.cs.findbugs.annotations.Nullable;
-import io.micronaut.data.annotation.*;
-import java.util.Date;
-
-@MappedEntity
-record Book(
-        @Id @GeneratedValue @Nullable Long id,
-        @DateCreated @Nullable Date dateCreated,
-        String title,
-        int pages) {
-    Book(String title, int pages) {
-        this(null, null, title, pages)
-    }
-}
-----
-
-==== Persistence Events Support
-
-Micronaut Data JPA, JDBC and R2DBC now support https://micronaut-projects.github.io/micronaut-data/latest/guide/#entityEvents[persistence events] on either entities or Micronaut beans. For example:
-
-[source,java]
-----
-package example;
-
-import io.micronaut.data.annotation.event.PrePersist;
-import javax.inject.Singleton;
-
-@Singleton
-public class AccountUsernameValidator {
-    @PrePersist
-    void validateUsername(Account account) {
-        final String username = account.getUsername();
-        if (username == null || !username.matches("[a-z0-9]+")) {
-            throw new IllegalArgumentException("Invalid username");
-        }
-    }
-}
-----
-
-=== Integration with Oracle Coherence CE
-
-We are pleased to announce a first milestone release of Micronaut integration with Oracle Coherence Community Edition, which makes implementation of Micronaut applications with a Coherence back end a breeze.
-
-Below are some of the features supported by the various modules within `micronaut-coherence` project:
-
-==== Micronaut Data Support
-
-The `micronaut-coherence-data` module alows you to use https://micronaut-projects.github.io/micronaut-coherence/latest/guide/#repository[Micronaut Data with Coherence as a back end data store].
-
-==== Dependency Injection of Coherence-managed Objects
-
-A new `micronaut-coherence` module provides factories for commonly used Coherence objects, such as `Cluster`, `Session`, `NamedMap`, `NamedCache`, `NamedTopic`, and many others, which allows you to https://micronaut-projects.github.io/micronaut-coherence/latest/guide/#injection[easily inject those objects] into your application classes.
-
-==== Listeners for Coherence Events
-
-The `micronaut-coherence` module also provides support for Coherence https://micronaut-projects.github.io/micronaut-coherence/latest/guide/#coherenceEvents[server-] and https://micronaut-projects.github.io/micronaut-coherence/latest/guide/#mapEvents[client-side] events via Micronaut event listeners.
-
-==== Micronaut Messaging Support
-
-Finally, the `micronaut-coherence` module provides support for https://micronaut-projects.github.io/micronaut-coherence/latest/guide/#messagingWithTopics[Micronaut Messaging using Coherence Topics].
-
-==== Micronaut Caching Support
-
-The `micronaut-coherence-cache` module adds support for https://micronaut-projects.github.io/micronaut-coherence/latest/guide/#cache[using Coherence as a back end for Micronaut Cache].
-
-==== Micronaut Distributed Config Support
-
-The `micronaut-coherence-distributed-configuration` module adds support for https://micronaut-projects.github.io/micronaut-coherence/latest/guide/#distributedConfiguration[using Coherence as a store for Micronaut Distributed Configuration].
-
-==== Micronaut HTTP Sessions Support
-
-The `micronaut-coherence-session` module adds support for https://micronaut-projects.github.io/micronaut-coherence/latest/guide/#coherenceHttpSessions[using Coherence as a store for Micronaut HTTP Sessions].
-
-=== Cloud Features
-
-==== Easier Configuration of Oracle Cloud Autonomous Database
-
-A new `micronaut-oraclecloud-atp` has been added that makes it easier to https://micronaut-projects.github.io/micronaut-oracle-cloud/latest/guide/#autonomousDatabase[automatically download the Oracle Wallet definition and connect to Autonomous Database] on Oracle Cloud.
-
-==== Support for Oracle Cloud Monitoring via Micrometer
-
-A new `micronaut-oraclecloud-micrometer` module has been added that adds support for https://micronaut-projects.github.io/micronaut-oracle-cloud/latest/guide/#micrometer[exporting Micrometer metrics to Oracle Cloud].
-
-==== Official Kubernetes Client
-
-With the new `micronaut-kubernetes-client` module you can now inject apis objects from the https://github.com/kubernetes-client/java[official Kubernetes Java SDK] as regular beans.
-
-In Micronaut 3 this new module will be used as primary kubernetes client, making the current one deprecated.
-
-==== Micronaut AWS
-
-Micronaut AWS now includes the new AWS SDK v2 that has support for GraalVM out of the box. Every service included in the module like S3, Parameter Store, SES, SQS,... is now compatible with Micronaut-GraalVM integration.
+snippet::io.micronaut.docs.inject.generics.Vehicle[tags="constructor",indent=0]
 
 === Module Upgrades
 
-* Micronaut Oracle Cloud `1.1.1` -> `1.2.1`
-* Micronaut Data `2.2.4` -> `2.3.0`
-* Micronaut R2DBC `1.0.1` -> `1.1.0`
-* Micronaut Kubernetes `2.2.0` -> `2.3.0`
-* Micronaut AWS `2.3.0` -> `2.4.0`
+TODO
 
 === Dependency Upgrades
 
-* Jaeger Version `1.3.1` -> `1.5.0`
-* Zipkin Version `2.15.0` -> `2.16.3`
+TODO

--- a/src/main/docs/guide/ioc/qualifiers.adoc
+++ b/src/main/docs/guide/ioc/qualifiers.adoc
@@ -30,6 +30,45 @@ The above annotation is itself annotated with the `@Qualifier` annotation to des
 
 snippet::io.micronaut.docs.qualifiers.annotation.Vehicle[tags="constructor",indent=0]
 
+== Qualifying by Generic Type Arguments
+
+Since Micronaut 3.0, it is possible to select which bean to inject based on the generic type arguments of the class or interface. Consider the following example:
+
+snippet::io.micronaut.docs.inject.generics.CylinderProvider[tags="class",indent=0]
+
+The `CylinderProvider` interface provides the number of cylinders.
+
+snippet::io.micronaut.docs.inject.generics.Engine[tags="class",indent=0]
+
+<1> The engine class defines a generic type argument `<T>` that must be an instance of `CylinderProvider`
+
+You can define implementations of the `Engine` interface with different generic type arguments. For example for a V6 engine:
+
+snippet::io.micronaut.docs.inject.generics.V6[tags="class",indent=0]
+
+The above defines a `V6` class that implements the `CylinderProvider` interface.
+
+snippet::io.micronaut.docs.inject.generics.V6Engine[tags="class",indent=0]
+
+<1> The `V6Engine` implements `Engine` providing `V6` as a generic type parameter
+
+And a V8 engine:
+
+snippet::io.micronaut.docs.inject.generics.V8[tags="class",indent=0]
+
+The above defines a `V8` class that implements the `CylinderProvider` interface.
+
+snippet::io.micronaut.docs.inject.generics.V8Engine[tags="class",indent=0]
+
+<1> The `V8Engine` implements `Engine` providing `V8` as a generic type parameter
+
+You can then use the generic arguments when defining the injection point and Micronaut will pick the correct bean
+to inject based on the specific generic type arguments:
+
+snippet::io.micronaut.docs.inject.generics.Vehicle[tags="constructor",indent=0]
+
+In the above example the `V8Engine` bean is injected.
+
 == Primary and Secondary Beans
 
 api:context.annotation.Primary[] is a qualifier that indicates that a bean is the primary bean to be selected in the case of multiple interface implementations.

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/inject/generics/CylinderProvider.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/inject/generics/CylinderProvider.groovy
@@ -1,0 +1,7 @@
+package io.micronaut.docs.inject.generics
+
+// tag::class[]
+interface CylinderProvider {
+    int getCylinders()
+}
+// end::class[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/inject/generics/Engine.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/inject/generics/Engine.groovy
@@ -1,0 +1,11 @@
+package io.micronaut.docs.inject.generics
+
+// tag::class[]
+interface Engine<T extends CylinderProvider> { // <1>
+    default int getCylinders() { cylinderProvider.cylinders }
+
+    default String start() { "Starting ${cylinderProvider.class.simpleName}" }
+
+    T getCylinderProvider()
+}
+// tag::class[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/inject/generics/V6.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/inject/generics/V6.groovy
@@ -1,0 +1,8 @@
+package io.micronaut.docs.inject.generics
+
+// tag::class[]
+class V6 implements CylinderProvider {
+    @Override
+    int getCylinders() { 7 }
+}
+// end::class[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/inject/generics/V6Engine.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/inject/generics/V6Engine.groovy
@@ -1,0 +1,11 @@
+package io.micronaut.docs.inject.generics
+
+import javax.inject.Singleton
+
+// tag::class[]
+@Singleton
+class V6Engine implements Engine<V6> {  // <1>
+    @Override
+    V6 getCylinderProvider() { new V6() }
+}
+// end::class[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/inject/generics/V8.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/inject/generics/V8.groovy
@@ -1,0 +1,8 @@
+package io.micronaut.docs.inject.generics
+
+// tag::class[]
+class V8 implements CylinderProvider {
+    @Override
+    int getCylinders() { 8 }
+}
+// end::class[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/inject/generics/V8Engine.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/inject/generics/V8Engine.groovy
@@ -1,0 +1,11 @@
+package io.micronaut.docs.inject.generics
+
+import javax.inject.Singleton
+
+// tag::class[]
+@Singleton
+class V8Engine implements Engine<V8> {  // <1>
+    @Override
+    V8 getCylinderProvider() { new V8() }
+}
+// end::class[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/inject/generics/Vehicle.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/inject/generics/Vehicle.groovy
@@ -1,0 +1,38 @@
+package io.micronaut.docs.inject.generics
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class Vehicle {
+    private final Engine<V8> engine
+
+    @Inject
+    List<Engine<V6>> v6Engines
+
+    private Engine<V8> anotherV8
+
+    // tag::constructor[]
+    @Inject
+    Vehicle(Engine<V8> engine) {
+        this.engine = engine
+    }
+    // end::constructor[]
+
+    String start() {
+        return engine.start()
+    }
+
+    @Inject
+    void setAnotherV8(Engine<V8> anotherV8) {
+        this.anotherV8 = anotherV8
+    }
+
+    Engine<V8> getAnotherV8() {
+        return anotherV8
+    }
+
+    Engine<V8> getEngine() {
+        return engine
+    }
+}

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/inject/generics/VehicleSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/inject/generics/VehicleSpec.groovy
@@ -1,0 +1,16 @@
+package io.micronaut.docs.inject.generics
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import spock.lang.Specification
+
+import javax.inject.Inject
+
+@MicronautTest
+class VehicleSpec extends Specification {
+    @Inject Vehicle vehicle
+
+    void 'test start engine'()  {
+        expect:
+        vehicle.start() == 'Starting V8'
+    }
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/inject/generics/CylinderProvider.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/inject/generics/CylinderProvider.kt
@@ -1,0 +1,7 @@
+package io.micronaut.docs.inject.generics
+
+// tag::class[]
+interface CylinderProvider {
+    val cylinders: Int
+}
+// end::class[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/inject/generics/Engine.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/inject/generics/Engine.kt
@@ -1,0 +1,14 @@
+package io.micronaut.docs.inject.generics
+
+// tag::class[]
+interface Engine<T : CylinderProvider> { // <1>
+    val cylinders: Int
+        get() = cylinderProvider.cylinders
+
+    fun start(): String {
+        return "Starting ${cylinderProvider.javaClass.simpleName}"
+    }
+
+    val cylinderProvider: T
+}
+// end::class[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/inject/generics/V6.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/inject/generics/V6.kt
@@ -1,0 +1,7 @@
+package io.micronaut.docs.inject.generics
+
+// tag::class[]
+class V6 : CylinderProvider {
+    override val cylinders: Int = 7
+}
+// end::class[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/inject/generics/V6Engine.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/inject/generics/V6Engine.kt
@@ -1,0 +1,11 @@
+package io.micronaut.docs.inject.generics
+
+import javax.inject.Singleton
+
+// tag::class[]
+@Singleton
+class V6Engine : Engine<V6> { // <1>
+    override val cylinderProvider: V6
+        get() = V6()
+}
+// end::class[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/inject/generics/V8.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/inject/generics/V8.kt
@@ -1,0 +1,7 @@
+package io.micronaut.docs.inject.generics
+
+// tag::class[]
+class V8 : CylinderProvider {
+    override val cylinders: Int = 8
+}
+// end::class[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/inject/generics/V8Engine.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/inject/generics/V8Engine.kt
@@ -1,0 +1,11 @@
+package io.micronaut.docs.inject.generics
+
+import javax.inject.Singleton
+
+// tag::class[]
+@Singleton
+class V8Engine : Engine<V8> { // <1>
+    override val cylinderProvider: V8
+        get() = V8()
+}
+// end::class[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/inject/generics/Vehicle.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/inject/generics/Vehicle.kt
@@ -1,0 +1,21 @@
+package io.micronaut.docs.inject.generics
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+// tag::constructor[]
+@Singleton
+class Vehicle(val engine: Engine<V8>) {
+// end::constructor[]
+
+    @Inject
+    lateinit var v6Engines: List<Engine<V6>>
+
+    @set:Inject
+    lateinit var anotherV8: Engine<V8>
+
+
+    fun start(): String {
+        return engine.start()
+    }
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/inject/generics/VehicleSpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/inject/generics/VehicleSpec.kt
@@ -1,0 +1,13 @@
+package io.micronaut.docs.inject.generics
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+@MicronautTest
+class VehicleSpec(private val vehicle: Vehicle) {
+    @Test
+    fun testStartVehicle() {
+        assertEquals("Starting V8", vehicle.start())
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/docs/inject/generics/CylinderProvider.java
+++ b/test-suite/src/test/java/io/micronaut/docs/inject/generics/CylinderProvider.java
@@ -1,0 +1,5 @@
+package io.micronaut.docs.inject.generics;
+
+public interface CylinderProvider {
+    int getCylinders();
+}

--- a/test-suite/src/test/java/io/micronaut/docs/inject/generics/CylinderProvider.java
+++ b/test-suite/src/test/java/io/micronaut/docs/inject/generics/CylinderProvider.java
@@ -1,0 +1,7 @@
+package io.micronaut.docs.inject.generics;
+
+// tag::class[]
+public interface CylinderProvider {
+    int getCylinders();
+}
+// end::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/inject/generics/Engine.java
+++ b/test-suite/src/test/java/io/micronaut/docs/inject/generics/Engine.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.inject.generics;
+
+// tag::class[]
+public interface Engine<T extends CylinderProvider> { // <1>
+    default int getCylinders() {
+        return getCylinderProvider().getCylinders();
+    }
+
+    String start();
+
+    T getCylinderProvider();
+}
+// tag::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/inject/generics/Engine.java
+++ b/test-suite/src/test/java/io/micronaut/docs/inject/generics/Engine.java
@@ -1,0 +1,15 @@
+package io.micronaut.docs.inject.generics;
+
+// tag::class[]
+public interface Engine<T extends CylinderProvider> { // <1>
+    default int getCylinders() {
+        return getCylinderProvider().getCylinders();
+    }
+
+    default String start() {
+        return "Starting " + getCylinderProvider().getClass().getSimpleName();
+    }
+
+    T getCylinderProvider();
+}
+// tag::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/inject/generics/V6.java
+++ b/test-suite/src/test/java/io/micronaut/docs/inject/generics/V6.java
@@ -1,0 +1,10 @@
+package io.micronaut.docs.inject.generics;
+
+// tag::class[]
+public class V6 implements CylinderProvider {
+    @Override
+    public int getCylinders() {
+        return 7;
+    }
+}
+// end::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/inject/generics/V6.java
+++ b/test-suite/src/test/java/io/micronaut/docs/inject/generics/V6.java
@@ -1,0 +1,8 @@
+package io.micronaut.docs.inject.generics;
+
+public class V6 implements CylinderProvider {
+    @Override
+    public int getCylinders() {
+        return 7;
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/docs/inject/generics/V6Engine.java
+++ b/test-suite/src/test/java/io/micronaut/docs/inject/generics/V6Engine.java
@@ -1,0 +1,13 @@
+package io.micronaut.docs.inject.generics;
+
+import javax.inject.Singleton;
+
+// tag::class[]
+@Singleton
+public class V6Engine implements Engine<V6> {  // <1>
+    @Override
+    public V6 getCylinderProvider() {
+        return new V6();
+    }
+}
+// end::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/inject/generics/V6Engine.java
+++ b/test-suite/src/test/java/io/micronaut/docs/inject/generics/V6Engine.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.inject.generics;
+
+import javax.inject.Singleton;
+
+// tag::class[]
+@Singleton
+public class V6Engine implements Engine<V6> {  // <2>
+    @Override
+    public String start() {
+        return "Starting V6";
+    }
+
+    @Override
+    public V6 getCylinderProvider() {
+        return new V6();
+    }
+}
+// end::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/inject/generics/V8.java
+++ b/test-suite/src/test/java/io/micronaut/docs/inject/generics/V8.java
@@ -1,0 +1,10 @@
+package io.micronaut.docs.inject.generics;
+
+// tag::class[]
+public class V8 implements CylinderProvider {
+    @Override
+    public int getCylinders() {
+        return 8;
+    }
+}
+// end::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/inject/generics/V8.java
+++ b/test-suite/src/test/java/io/micronaut/docs/inject/generics/V8.java
@@ -1,0 +1,8 @@
+package io.micronaut.docs.inject.generics;
+
+public class V8 implements CylinderProvider {
+    @Override
+    public int getCylinders() {
+        return 8;
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/docs/inject/generics/V8Engine.java
+++ b/test-suite/src/test/java/io/micronaut/docs/inject/generics/V8Engine.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.inject.generics;
+
+import javax.inject.Singleton;
+
+// tag::class[]
+@Singleton
+public class V8Engine implements Engine<V8> {  // <1>
+    @Override
+    public V8 getCylinderProvider() {
+        return new V8();
+    }
+}
+// end::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/inject/generics/V8Engine.java
+++ b/test-suite/src/test/java/io/micronaut/docs/inject/generics/V8Engine.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.inject.generics;
+
+import javax.inject.Singleton;
+
+// tag::class[]
+@Singleton
+public class V8Engine implements Engine<V8> {  // <3>
+    @Override
+    public String start() {
+        return "Starting V8";
+    }
+
+    @Override
+    public V8 getCylinderProvider() {
+        return new V8();
+    }
+
+}
+// end::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/inject/generics/Vehicle.java
+++ b/test-suite/src/test/java/io/micronaut/docs/inject/generics/Vehicle.java
@@ -1,0 +1,39 @@
+package io.micronaut.docs.inject.generics;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.List;
+
+@Singleton
+public class Vehicle {
+    private final Engine<V8> engine;
+
+    @Inject
+    List<Engine<V6>> v6Engines;
+
+    private Engine<V8> anotherV8;
+
+    // tag::constructor[]
+    @Inject
+    public Vehicle(Engine<V8> engine) {
+        this.engine = engine;
+    }
+    // end::constructor[]
+
+    public String start() {
+        return engine.start();
+    }
+
+    @Inject
+    public void setAnotherV8(Engine<V8> anotherV8) {
+        this.anotherV8 = anotherV8;
+    }
+
+    public Engine<V8> getAnotherV8() {
+        return anotherV8;
+    }
+
+    public Engine<V8> getEngine() {
+        return engine;
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/docs/inject/generics/Vehicle.java
+++ b/test-suite/src/test/java/io/micronaut/docs/inject/generics/Vehicle.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.inject.generics;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+// tag::class[]
+@Singleton
+public class Vehicle {
+    private final Engine<V8> engine;
+
+    @Inject
+    public Vehicle(Engine<V8> engine) {// <4>
+        this.engine = engine;
+    }
+
+    public String start() {
+        return engine.start();// <5>
+    }
+}
+// end::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/inject/generics/VehicleSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/inject/generics/VehicleSpec.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.inject.generics;
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+@MicronautTest
+public class VehicleSpec {
+    @Inject Vehicle vehicle;
+    @Inject List<Engine<V6>> v6Engines;
+
+    @Test
+    public void testStartVehicle() {
+        assertEquals("Starting V8", vehicle.start());
+        assertEquals(1, v6Engines.size());
+        assertEquals(6, v6Engines.iterator().next().getCylinders());
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/docs/inject/generics/VehicleSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/inject/generics/VehicleSpec.java
@@ -1,0 +1,21 @@
+package io.micronaut.docs.inject.generics;
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+@MicronautTest
+public class VehicleSpec {
+    private final Vehicle vehicle;
+
+    public VehicleSpec(Vehicle vehicle) {
+        this.vehicle = vehicle;
+    }
+
+    @Test
+    public void testStartVehicle() {
+        assertEquals("Starting V8", vehicle.start());
+    }
+
+}


### PR DESCRIPTION
Fixes #5079

Probably needs more tests for more complex cases but this handles the basic case.

The fundamental change is bean keys are now `Argument` instances and the type and the generic types are factored into bean identity.
