### PR TITLE
refactor: deprecated logic to @Deprecated methods

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/converters/DuplicateRouteHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/converters/DuplicateRouteHandler.java
@@ -15,9 +15,9 @@
  */
 package io.micronaut.http.server.netty.converters;
 
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
-import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.http.annotation.Produces;
 import io.micronaut.http.hateoas.JsonError;
 import io.micronaut.http.hateoas.Link;
@@ -53,16 +53,19 @@ public class DuplicateRouteHandler implements ExceptionHandler<DuplicateRouteExc
 
     @Override
     public HttpResponse handle(HttpRequest request, DuplicateRouteException exception) {
-        MutableHttpResponse<?> response = HttpResponse.badRequest();
-        if (responseProcessor != null) {
-            return responseProcessor.processResponse(ErrorContext.builder(request)
-                    .cause(exception)
-                    .errorMessage(exception.getMessage())
-                    .build(), response);
-        } else {
-            return response.body(new JsonError(exception.getMessage())
-                    .link(Link.SELF, Link.of(request.getUri())));
+        if (responseProcessor == null) {
+            return handleWithoutProcessor(request, exception);
         }
+        return responseProcessor.processResponse(ErrorContext.builder(request)
+                .cause(exception)
+                .errorMessage(exception.getMessage())
+                .build(), HttpResponse.badRequest());
+    }
 
+    @Deprecated
+    @NonNull
+    private HttpResponse<?> handleWithoutProcessor(@NonNull HttpRequest<?> request, @NonNull DuplicateRouteException exception) {
+        return HttpResponse.badRequest().body(new JsonError(exception.getMessage())
+                .link(Link.SELF, Link.of(request.getUri())));
     }
 }

--- a/http-server/src/main/java/io/micronaut/http/server/exceptions/URISyntaxHandler.java
+++ b/http-server/src/main/java/io/micronaut/http/server/exceptions/URISyntaxHandler.java
@@ -15,9 +15,9 @@
  */
 package io.micronaut.http.server.exceptions;
 
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
-import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.http.annotation.Produces;
 import io.micronaut.http.hateoas.JsonError;
 import io.micronaut.http.server.exceptions.response.Error;
@@ -53,24 +53,27 @@ public class URISyntaxHandler implements ExceptionHandler<URISyntaxException, Ht
 
     @Override
     public HttpResponse handle(HttpRequest request, URISyntaxException exception) {
-        MutableHttpResponse<?> response = HttpResponse.badRequest();
-        if (responseProcessor != null) {
-            return responseProcessor.processResponse(ErrorContext.builder(request)
-                    .cause(exception)
-                    .error(new Error() {
-                        @Override
-                        public String getMessage() {
-                            return "Malformed URI: " + exception.getMessage();
-                        }
+        if (responseProcessor == null) {
+            return handleWithoutProcessor(exception);
+        }
+        return responseProcessor.processResponse(ErrorContext.builder(request)
+                .cause(exception)
+                .error(new Error() {
+                    @Override
+                    public String getMessage() {
+                        return "Malformed URI: " + exception.getMessage();
+                    }
 
-                        @Override
-                        public Optional<String> getTitle() {
+                    @Override
+                    public Optional<String> getTitle() {
                             return Optional.of("Malformed URI");
                         }
-                    })
-                    .build(), response);
-        } else {
-            return response.body(new JsonError("Malformed URI: " + exception.getMessage()));
-        }
+                }).build(), HttpResponse.badRequest());
+    }
+
+    @Deprecated
+    @NonNull
+    private HttpResponse<?> handleWithoutProcessor(@NonNull URISyntaxException exception) {
+        return HttpResponse.badRequest().body(new JsonError("Malformed URI: " + exception.getMessage()));
     }
 }


### PR DESCRIPTION
Moves the deprecated logic to private method annoatated with `@Deprecated` so that it is easy to remove all that dead code in the future. 

This was part of https://github.com/micronaut-projects/micronaut-core/pull/5068 but it was not merged. Thus, I have extracted it to a separate PR. 