### PR TITLE
javadoc: @deprecated ExceptionHandlers constructor

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/converters/DuplicateRouteHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/converters/DuplicateRouteHandler.java
@@ -41,11 +41,19 @@ public class DuplicateRouteHandler implements ExceptionHandler<DuplicateRouteExc
 
     private final ErrorResponseProcessor<?> responseProcessor;
 
+    /**
+     * Constructor.
+     * Use {@link DuplicateRouteHandler(ErrorResponseProcessor)} instead.
+     */
     @Deprecated
     public DuplicateRouteHandler() {
         this.responseProcessor = null;
     }
 
+    /**
+     * Constructor.
+     * @param responseProcessor Error Response Processor
+     */
     @Inject
     public DuplicateRouteHandler(ErrorResponseProcessor<?> responseProcessor) {
         this.responseProcessor = responseProcessor;

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/converters/UnsatisfiedRouteHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/converters/UnsatisfiedRouteHandler.java
@@ -47,11 +47,19 @@ public class UnsatisfiedRouteHandler implements ExceptionHandler<UnsatisfiedRout
 
     private final ErrorResponseProcessor<?> responseProcessor;
 
+    /**
+     * Constructor.
+     * @deprecated Use {@link UnsatisfiedRouteHandler(ErrorResponseProcessor)} instead.
+     */
     @Deprecated
     public UnsatisfiedRouteHandler() {
         this.responseProcessor = null;
     }
 
+    /**
+     * Constructor.
+     * @param responseProcessor Error Response Processor
+     */
     @Inject
     public UnsatisfiedRouteHandler(ErrorResponseProcessor<?> responseProcessor) {
         this.responseProcessor = responseProcessor;

--- a/http-server/src/main/java/io/micronaut/http/server/exceptions/ContentLengthExceededHandler.java
+++ b/http-server/src/main/java/io/micronaut/http/server/exceptions/ContentLengthExceededHandler.java
@@ -41,11 +41,19 @@ public class ContentLengthExceededHandler implements ExceptionHandler<ContentLen
 
     private final ErrorResponseProcessor<?> responseProcessor;
 
+    /**
+     * Constructor.
+     * @deprecated Use {@link ContentLengthExceededHandler(ErrorResponseProcessor)} instead.
+     */
     @Deprecated
     public ContentLengthExceededHandler() {
         this.responseProcessor = null;
     }
 
+    /**
+     * Constructor.
+     * @param responseProcessor Error Response Processor
+     */
     @Inject
     public ContentLengthExceededHandler(ErrorResponseProcessor<?> responseProcessor) {
         this.responseProcessor = responseProcessor;

--- a/http-server/src/main/java/io/micronaut/http/server/exceptions/ConversionErrorHandler.java
+++ b/http-server/src/main/java/io/micronaut/http/server/exceptions/ConversionErrorHandler.java
@@ -42,11 +42,19 @@ public class ConversionErrorHandler implements ExceptionHandler<ConversionErrorE
 
     private final ErrorResponseProcessor<?> responseProcessor;
 
+    /**
+     * Constructor.
+     * @deprecated Use {@link ConversionErrorHandler(ErrorResponseProcessor)} instead.
+     */
     @Deprecated
     public ConversionErrorHandler() {
         this.responseProcessor = null;
     }
 
+    /**
+     * Constructor.
+     * @param responseProcessor Error Response Processor
+     */
     @Inject
     public ConversionErrorHandler(ErrorResponseProcessor<?> responseProcessor) {
         this.responseProcessor = responseProcessor;

--- a/http-server/src/main/java/io/micronaut/http/server/exceptions/HttpStatusHandler.java
+++ b/http-server/src/main/java/io/micronaut/http/server/exceptions/HttpStatusHandler.java
@@ -41,11 +41,19 @@ public class HttpStatusHandler implements ExceptionHandler<HttpStatusException, 
 
     private final ErrorResponseProcessor<?> responseProcessor;
 
+    /**
+     * Constructor.
+     * @deprecated Use {@link HttpStatusHandler(ErrorResponseProcessor)} instead.
+     */
     @Deprecated
     public HttpStatusHandler() {
         this.responseProcessor = null;
     }
 
+    /**
+     * Constructor.
+     * @param responseProcessor Error Response Processor
+     */
     @Inject
     public HttpStatusHandler(ErrorResponseProcessor<?> responseProcessor) {
         this.responseProcessor = responseProcessor;

--- a/http-server/src/main/java/io/micronaut/http/server/exceptions/JsonExceptionHandler.java
+++ b/http-server/src/main/java/io/micronaut/http/server/exceptions/JsonExceptionHandler.java
@@ -43,11 +43,19 @@ public class JsonExceptionHandler implements ExceptionHandler<JsonProcessingExce
 
     private final ErrorResponseProcessor<?> responseProcessor;
 
+    /**
+     * Constructor.
+     * @deprecated Use {@link JsonExceptionHandler(ErrorResponseProcessor)} instead.
+     */
     @Deprecated
     public JsonExceptionHandler() {
         this.responseProcessor = null;
     }
 
+    /**
+     * Constructor.
+     * @param responseProcessor Error Response Processor
+     */
     @Inject
     public JsonExceptionHandler(ErrorResponseProcessor<?> responseProcessor) {
         this.responseProcessor = responseProcessor;

--- a/http-server/src/main/java/io/micronaut/http/server/exceptions/URISyntaxHandler.java
+++ b/http-server/src/main/java/io/micronaut/http/server/exceptions/URISyntaxHandler.java
@@ -41,11 +41,19 @@ public class URISyntaxHandler implements ExceptionHandler<URISyntaxException, Ht
 
     private final ErrorResponseProcessor<?> responseProcessor;
 
+    /**
+     * Constructor.
+     * @deprecated Use {@link URISyntaxHandler(ErrorResponseProcessor)} instead.
+     */
     @Deprecated
     public URISyntaxHandler() {
         this.responseProcessor = null;
     }
 
+    /**
+     * Constructor.
+     * @param responseProcessor Error Response Processor
+     */
     @Inject
     public URISyntaxHandler(ErrorResponseProcessor<?> responseProcessor) {
         this.responseProcessor = responseProcessor;

--- a/http-server/src/main/java/io/micronaut/http/server/exceptions/UnsatisfiedArgumentHandler.java
+++ b/http-server/src/main/java/io/micronaut/http/server/exceptions/UnsatisfiedArgumentHandler.java
@@ -43,11 +43,19 @@ public class UnsatisfiedArgumentHandler implements ExceptionHandler<UnsatisfiedA
 
     private final ErrorResponseProcessor<?> responseProcessor;
 
+    /**
+     * Constructor.
+     * @deprecated Use {@link UnsatisfiedArgumentHandler(ErrorResponseProcessor)} instead.
+     */
     @Deprecated
     public UnsatisfiedArgumentHandler() {
         this.responseProcessor = null;
     }
 
+    /**
+     * Constructor.
+     * @param responseProcessor Error Response Processor
+     */
     @Inject
     public UnsatisfiedArgumentHandler(ErrorResponseProcessor<?> responseProcessor) {
         this.responseProcessor = responseProcessor;

--- a/validation/src/main/java/io/micronaut/validation/exceptions/ConstraintExceptionHandler.java
+++ b/validation/src/main/java/io/micronaut/validation/exceptions/ConstraintExceptionHandler.java
@@ -55,18 +55,30 @@ public class ConstraintExceptionHandler implements ExceptionHandler<ConstraintVi
     private final boolean alwaysSerializeErrorsAsList;
     private final ErrorResponseProcessor<?> responseProcessor;
 
+    /**
+     * Constructor.
+     * @deprecated Use {@link ConstraintExceptionHandler(ErrorResponseProcessor)} instead.
+     */
     @Deprecated
     public ConstraintExceptionHandler() {
         this.alwaysSerializeErrorsAsList = false;
         this.responseProcessor = null;
     }
 
+    /**
+     * Constructor.
+     * @deprecated Use {@link ConstraintExceptionHandler(ErrorResponseProcessor)} instead.
+     */
     @Deprecated
     public ConstraintExceptionHandler(JacksonConfiguration jacksonConfiguration) {
         this.alwaysSerializeErrorsAsList = jacksonConfiguration.isAlwaysSerializeErrorsAsList();
         this.responseProcessor = null;
     }
 
+    /**
+     * Constructor.
+     * @param responseProcessor Error Response Processor
+     */
     @Inject
     public ConstraintExceptionHandler(ErrorResponseProcessor<?> responseProcessor) {
         this.alwaysSerializeErrorsAsList = false;

--- a/validation/src/main/java/io/micronaut/validation/exceptions/ValidationExceptionHandler.java
+++ b/validation/src/main/java/io/micronaut/validation/exceptions/ValidationExceptionHandler.java
@@ -44,11 +44,19 @@ public class ValidationExceptionHandler implements ExceptionHandler<ValidationEx
 
     private final ErrorResponseProcessor<?> responseProcessor;
 
+    /**
+     * Constructor.
+     * @deprecated Use {@link ValidationExceptionHandler(ErrorResponseProcessor)} instead.
+     */
     @Deprecated
     public ValidationExceptionHandler() {
         this.responseProcessor = null;
     }
 
+    /**
+     * Constructor.
+     * @param responseProcessor Error Response Processor
+     */
     public ValidationExceptionHandler(ErrorResponseProcessor<?> responseProcessor) {
         this.responseProcessor = responseProcessor;
     }


### PR DESCRIPTION
Adds javadoc to Exception handlers constructors. It specifically adds `@deprecated` javadoc to the deprecated constructors pointing to the constructor which should be used instead.

This was part of #5068 but it was not merged. Thus, I have extracted it to a separate PR.