### PR TITLE
Fix changing log level at runtime in native image. Fixes #5083

### DIFF
--- a/runtime/src/main/java/io/micronaut/logging/LogLevel.java
+++ b/runtime/src/main/java/io/micronaut/logging/LogLevel.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.logging;
 
+import io.micronaut.core.annotation.Introspected;
+
 /**
  * Logging levels supported by a {@link LoggingSystem}
  *
@@ -25,6 +27,7 @@ package io.micronaut.logging;
  * @author Matthew Moss
  * @since 1.0
  */
+@Introspected
 public enum LogLevel {
     ALL,
     TRACE,


### PR DESCRIPTION
The log levels can be adjusted at runtime using the loggers endpoint.
This doesn't work when the application is build as a GraalVM native
image, because the LogLevel class is missing the reflection
configuration.

By marking the LogLevel class as Introspected the correct reflection
configuration is generated and the loggers endpoint can be used in a
native image.