### PR TITLE
Support for limiting the injectable type #5098

### DIFF
--- a/aop/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
+++ b/aop/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
@@ -34,6 +34,7 @@ import io.micronaut.inject.ProxyBeanDefinition;
 import io.micronaut.inject.ast.*;
 import io.micronaut.inject.configuration.ConfigurationMetadataBuilder;
 import io.micronaut.inject.processing.JavaModelUtils;
+import io.micronaut.inject.visitor.VisitorContext;
 import io.micronaut.inject.writer.*;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
@@ -150,20 +151,22 @@ public class AopProxyWriter extends AbstractClassFileWriter implements ProxyingB
     private MethodElement newConstructor;
     private ParameterElement interceptorParameter;
     private ParameterElement qualifierParameter;
+    private VisitorContext visitorContext;
 
     /**
      * <p>Constructs a new {@link AopProxyWriter} for the given parent {@link BeanDefinitionWriter} and starting interceptors types.</p>
      * <p>
      * <p>Additional {@link Interceptor} types can be added downstream with {@link #visitInterceptorBinding(AnnotationValue[])} .</p>
-     *
-     * @param parent           The parent {@link BeanDefinitionWriter}
-     * @param settings         optional setting
-     * @param metadataBuilder  The configuration metadata builder
+     *  @param parent             The parent {@link BeanDefinitionWriter}
+     * @param settings           optional setting
+     * @param metadataBuilder    The configuration metadata builder
+     * @param visitorContext     The visitor context
      * @param interceptorBinding The interceptor binding of the {@link Interceptor} instances to be injected
      */
     public AopProxyWriter(BeanDefinitionWriter parent,
                           OptionalValues<Boolean> settings,
                           ConfigurationMetadataBuilder<?> metadataBuilder,
+                          VisitorContext visitorContext,
                           AnnotationValue<?>... interceptorBinding) {
         super(parent.getOriginatingElements());
         this.isIntroduction = false;
@@ -184,13 +187,11 @@ public class AopProxyWriter extends AbstractClassFileWriter implements ProxyingB
         this.proxyType = getTypeReferenceForName(proxyFullName);
         this.interceptorBinding = new LinkedHashMap<>(toInterceptorBindingMap(interceptorBinding));
         this.interfaceTypes = Collections.emptySet();
+        final ClassElement aopElement = ClassElement.of(proxyFullName, isInterface, parent.getAnnotationMetadata());
         this.proxyBeanDefinitionWriter = new BeanDefinitionWriter(
-                NameUtils.getPackageName(proxyFullName),
-                proxyShortName,
-                isInterface,
+                aopElement,
                 parent,
-                parent.getAnnotationMetadata(),
-                metadataBuilder
+                metadataBuilder, visitorContext
         );
         startClass(classWriter, getInternalName(proxyFullName), getTypeReferenceForName(targetClassFullName));
         processAlreadyVisitedMethods(parent);
@@ -199,15 +200,15 @@ public class AopProxyWriter extends AbstractClassFileWriter implements ProxyingB
 
     /**
      * Constructs a new {@link AopProxyWriter} for the purposes of writing {@link io.micronaut.aop.Introduction} advise.
-     *
-     * @param packageName        The package name
+     *  @param packageName        The package name
      * @param className          The class name
      * @param isInterface        Is the target of the advise an interface
      * @param originatingElement The originating element
      * @param annotationMetadata The annotation metadata
      * @param interfaceTypes     The additional interfaces to implement
      * @param metadataBuilder    The configuration metadata builder
-     * @param interceptorBinding   The interceptor types
+     * @param visitorContext     The visitor context
+     * @param interceptorBinding The interceptor types
      */
     public AopProxyWriter(String packageName,
                           String className,
@@ -216,22 +217,23 @@ public class AopProxyWriter extends AbstractClassFileWriter implements ProxyingB
                           AnnotationMetadata annotationMetadata,
                           ClassElement[] interfaceTypes,
                           ConfigurationMetadataBuilder<?> metadataBuilder,
+                          VisitorContext visitorContext,
                           AnnotationValue<?>... interceptorBinding) {
-        this(packageName, className, isInterface, true, originatingElement, annotationMetadata, interfaceTypes, metadataBuilder, interceptorBinding);
+        this(packageName, className, isInterface, true, originatingElement, annotationMetadata, interfaceTypes, visitorContext, metadataBuilder, interceptorBinding);
     }
 
     /**
      * Constructs a new {@link AopProxyWriter} for the purposes of writing {@link io.micronaut.aop.Introduction} advise.
-     *
-     * @param packageName        The package name
+     *  @param packageName        The package name
      * @param className          The class name
      * @param isInterface        Is the target of the advise an interface
      * @param implementInterface Whether the interface should be implemented. If false the {@code interfaceTypes} argument should contain at least one entry
      * @param originatingElement The originating elements
      * @param annotationMetadata The annotation metadata
      * @param interfaceTypes     The additional interfaces to implement
+     * @param visitorContext     The visitor context
      * @param metadataBuilder    The configuration metadata builder
-     * @param interceptorBinding   The interceptor binding
+     * @param interceptorBinding The interceptor binding
      */
     public AopProxyWriter(String packageName,
                           String className,
@@ -240,6 +242,7 @@ public class AopProxyWriter extends AbstractClassFileWriter implements ProxyingB
                           Element originatingElement,
                           AnnotationMetadata annotationMetadata,
                           ClassElement[] interfaceTypes,
+                          VisitorContext visitorContext,
                           ConfigurationMetadataBuilder<?> metadataBuilder,
                           AnnotationValue<?>... interceptorBinding) {
         super(OriginatingElements.of(originatingElement));
@@ -263,14 +266,15 @@ public class AopProxyWriter extends AbstractClassFileWriter implements ProxyingB
         this.interceptorBinding = toInterceptorBindingMap(interceptorBinding);
         this.interfaceTypes = interfaceTypes != null ? new LinkedHashSet<>(Arrays.asList(interfaceTypes)) : Collections.emptySet();
         this.classWriter = new ClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES);
-        String proxyShortName = NameUtils.getSimpleName(proxyFullName);
-        this.proxyBeanDefinitionWriter = new BeanDefinitionWriter(
-                NameUtils.getPackageName(proxyFullName),
-                proxyShortName,
+        ClassElement aopElement = ClassElement.of(
+                proxyFullName,
                 isInterface,
+                annotationMetadata
+        );
+        this.proxyBeanDefinitionWriter = new BeanDefinitionWriter(
+                aopElement,
                 this,
-                annotationMetadata,
-                metadataBuilder
+                metadataBuilder, visitorContext
         );
         if (isInterface) {
             if (implementInterface) {
@@ -367,17 +371,20 @@ public class AopProxyWriter extends AbstractClassFileWriter implements ProxyingB
      *
      * @param constructor        The constructor
      * @param requiresReflection Whether reflection is required
+     * @param visitorContext     The visitor context
      */
     @Override
     public void visitBeanDefinitionConstructor(
             MethodElement constructor,
-            boolean requiresReflection) {
+            boolean requiresReflection,
+            VisitorContext visitorContext) {
         this.constructorRequiresReflection = requiresReflection;
         this.declaredConstructor = constructor;
+        this.visitorContext = visitorContext;
     }
 
     @Override
-    public void visitDefaultConstructor(AnnotationMetadata annotationMetadata) {
+    public void visitDefaultConstructor(AnnotationMetadata annotationMetadata, VisitorContext visitorContext) {
         this.constructorRequiresReflection = false;
         ClassElement classElement = ClassElement.of(proxyType.getClassName());
         this.declaredConstructor = MethodElement.of(
@@ -629,7 +636,8 @@ public class AopProxyWriter extends AbstractClassFileWriter implements ProxyingB
 
         proxyBeanDefinitionWriter.visitBeanDefinitionConstructor(
                 newConstructor,
-                constructorRequiresReflection
+                constructorRequiresReflection,
+                visitorContext
         );
 
         GeneratorAdapter targetDefinitionGenerator = null;
@@ -952,11 +960,13 @@ public class AopProxyWriter extends AbstractClassFileWriter implements ProxyingB
     public void visitPostConstructMethod(
             TypedElement declaringType,
             MethodElement methodElement,
-            boolean requiresReflection) {
+            boolean requiresReflection,
+            VisitorContext visitorContext) {
         deferredInjectionPoints.add(() -> proxyBeanDefinitionWriter.visitPostConstructMethod(
                 declaringType,
                 methodElement,
-                requiresReflection
+                requiresReflection,
+                visitorContext
         ));
     }
 
@@ -964,35 +974,41 @@ public class AopProxyWriter extends AbstractClassFileWriter implements ProxyingB
     public void visitPreDestroyMethod(
             TypedElement declaringType,
             MethodElement methodElement,
-            boolean requiresReflection) {
+            boolean requiresReflection,
+            VisitorContext visitorContext) {
         deferredInjectionPoints.add(() ->
                 proxyBeanDefinitionWriter.visitPreDestroyMethod(
                         declaringType,
                         methodElement,
-                        requiresReflection)
+                        requiresReflection,
+                        visitorContext)
         );
     }
 
     @Override
     public void visitMethodInjectionPoint(TypedElement beanType,
                                           MethodElement methodElement,
-                                          boolean requiresReflection) {
+                                          boolean requiresReflection,
+                                          VisitorContext visitorContext) {
         deferredInjectionPoints.add(() ->
                 proxyBeanDefinitionWriter.visitMethodInjectionPoint(
                         beanType,
                         methodElement,
-                        requiresReflection)
+                        requiresReflection,
+                        visitorContext)
         );
     }
 
     @Override
     public ExecutableMethodWriter visitExecutableMethod(
             TypedElement declaringBean,
-            MethodElement methodElement) {
+            MethodElement methodElement,
+            VisitorContext visitorContext) {
         deferredInjectionPoints.add(() ->
                 proxyBeanDefinitionWriter.visitExecutableMethod(
                         declaringBean,
-                        methodElement
+                        methodElement,
+                        visitorContext
                 )
         );
         return null;
@@ -1102,7 +1118,7 @@ public class AopProxyWriter extends AbstractClassFileWriter implements ProxyingB
         if (interceptorBinding != null) {
             for (AnnotationValue<?> annotationValue : interceptorBinding) {
                 annotationValue.stringValue().ifPresent(annName ->
-                    this.interceptorBinding.put(annName, annotationValue)
+                        this.interceptorBinding.put(annName, annotationValue)
                 );
             }
         }
@@ -1313,14 +1329,17 @@ public class AopProxyWriter extends AbstractClassFileWriter implements ProxyingB
             visitPostConstructMethod(
                     methodVisit.getBeanType(),
                     methodVisit.getMethodElement(),
-                    methodVisit.isRequiresReflection());
+                    methodVisit.isRequiresReflection(),
+                    visitorContext
+            );
         }
         final List<BeanDefinitionWriter.MethodVisitData> preDestroyMethodVisits = parent.getPreDestroyMethodVisits();
         for (BeanDefinitionWriter.MethodVisitData methodVisit : preDestroyMethodVisits) {
             visitPreDestroyMethod(
                     methodVisit.getBeanType(),
                     methodVisit.getMethodElement(),
-                    methodVisit.isRequiresReflection()
+                    methodVisit.isRequiresReflection(),
+                    visitorContext
             );
         }
     }

--- a/context/src/main/java/io/micronaut/scheduling/executor/UserExecutorConfiguration.java
+++ b/context/src/main/java/io/micronaut/scheduling/executor/UserExecutorConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.scheduling.executor;
 
+import io.micronaut.context.annotation.ConfigurationInject;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.context.annotation.EachProperty;
 import io.micronaut.context.annotation.Parameter;
@@ -69,7 +70,7 @@ public class UserExecutorConfiguration implements ExecutorConfiguration {
      * @param corePoolSize the core pool size
      * @param threadFactoryClass the thread factory class
      */
-    @Inject
+    @ConfigurationInject
     protected UserExecutorConfiguration(@Nullable @Parameter String name,
                                         @Nullable Integer nThreads,
                                         @Nullable ExecutorType type,

--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationValue.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationValue.java
@@ -1048,7 +1048,9 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
         // conditional branches ordered from most likely to least likely
         // generally at runtime values are always AnnotationClassValue
         // A class can be present at compilation time
-        if (value instanceof AnnotationClassValue) {
+        if (value == null) {
+            return null;
+        } else if (value instanceof AnnotationClassValue) {
             Class<?> type = ((AnnotationClassValue<?>) value).getType().orElse(null);
             if (type != null) {
                 return new Class[]{type};

--- a/core/src/main/java/io/micronaut/core/type/DefaultArgument.java
+++ b/core/src/main/java/io/micronaut/core/type/DefaultArgument.java
@@ -178,7 +178,11 @@ public class DefaultArgument<T> implements Argument<T> {
 
     @Override
     public String toString() {
-        return type.getSimpleName() + " " + getName();
+        if (this.name == null) {
+            return getTypeName();
+        } else {
+            return getTypeName() + " " + getName();
+        }
     }
 
     @Override

--- a/core/src/main/java/io/micronaut/core/type/DefaultArgument.java
+++ b/core/src/main/java/io/micronaut/core/type/DefaultArgument.java
@@ -179,9 +179,9 @@ public class DefaultArgument<T> implements Argument<T> {
     @Override
     public String toString() {
         if (this.name == null) {
-            return getTypeName();
+            return getType().getSimpleName();
         } else {
-            return getTypeName() + " " + getName();
+            return getType().getSimpleName() + " " + getName();
         }
     }
 

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/InjectVisitor.groovy
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/InjectVisitor.groovy
@@ -67,7 +67,6 @@ import io.micronaut.inject.configuration.ConfigurationMetadataBuilder
 import io.micronaut.inject.configuration.PropertyMetadata
 import io.micronaut.inject.processing.ProcessedTypes
 import io.micronaut.inject.visitor.VisitorConfiguration
-import io.micronaut.inject.visitor.VisitorContext
 import io.micronaut.inject.writer.BeanDefinitionReferenceWriter
 import io.micronaut.inject.writer.BeanDefinitionVisitor
 import io.micronaut.inject.writer.BeanDefinitionWriter
@@ -130,7 +129,7 @@ final class InjectVisitor extends ClassCodeVisitorSupport {
     final AtomicInteger factoryMethodIndex = new AtomicInteger(0)
     private final CompilationUnit compilationUnit
     private final GroovyElementFactory elementFactory
-    VisitorContext groovyVisitorContext
+    GroovyVisitorContext groovyVisitorContext
 
     InjectVisitor(SourceUnit sourceUnit, CompilationUnit compilationUnit, ClassNode targetClassNode, ConfigurationMetadataBuilder<ClassNode> configurationMetadataBuilder) {
         this(sourceUnit, compilationUnit, targetClassNode, null, configurationMetadataBuilder)
@@ -1054,6 +1053,7 @@ final class InjectVisitor extends ClassCodeVisitorSupport {
                         fieldElement.declaringType,
                         methodElement,
                         false,
+                        groovyVisitorContext
                 )
             } else if (isValue) {
                 if (isConfigurationProperties && fieldAnnotationMetadata.hasStereotype(ConfigurationBuilder.class)) {
@@ -1273,11 +1273,12 @@ final class InjectVisitor extends ClassCodeVisitorSupport {
                         false,
                         originatingElement,
                         methodAnnotationMetadata,
-                        [elementFactory.newClassElement(typeToImplement, AnnotationMetadata.EMPTY_METADATA)] as ClassElement[], ,
+                        [elementFactory.newClassElement(typeToImplement, AnnotationMetadata.EMPTY_METADATA)] as ClassElement[],
+                        groovyVisitorContext,
                         configurationMetadataBuilder
                 )
 
-                aopProxyWriter.visitDefaultConstructor(methodAnnotationMetadata,)
+                aopProxyWriter.visitDefaultConstructor(methodAnnotationMetadata, groovyVisitorContext)
 
                 beanDefinitionWriters.put(ClassHelper.make(packageName + '.' + beanClassName), aopProxyWriter)
 

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/InjectVisitor.groovy
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/InjectVisitor.groovy
@@ -67,6 +67,7 @@ import io.micronaut.inject.configuration.ConfigurationMetadataBuilder
 import io.micronaut.inject.configuration.PropertyMetadata
 import io.micronaut.inject.processing.ProcessedTypes
 import io.micronaut.inject.visitor.VisitorConfiguration
+import io.micronaut.inject.visitor.VisitorContext
 import io.micronaut.inject.writer.BeanDefinitionReferenceWriter
 import io.micronaut.inject.writer.BeanDefinitionVisitor
 import io.micronaut.inject.writer.BeanDefinitionWriter
@@ -129,6 +130,7 @@ final class InjectVisitor extends ClassCodeVisitorSupport {
     final AtomicInteger factoryMethodIndex = new AtomicInteger(0)
     private final CompilationUnit compilationUnit
     private final GroovyElementFactory elementFactory
+    VisitorContext groovyVisitorContext
 
     InjectVisitor(SourceUnit sourceUnit, CompilationUnit compilationUnit, ClassNode targetClassNode, ConfigurationMetadataBuilder<ClassNode> configurationMetadataBuilder) {
         this(sourceUnit, compilationUnit, targetClassNode, null, configurationMetadataBuilder)
@@ -137,7 +139,7 @@ final class InjectVisitor extends ClassCodeVisitorSupport {
     InjectVisitor(SourceUnit sourceUnit, CompilationUnit compilationUnit, ClassNode targetClassNode, Boolean configurationProperties, ConfigurationMetadataBuilder<ClassNode> configurationMetadataBuilder) {
         this.compilationUnit = compilationUnit
         this.sourceUnit = sourceUnit
-        def visitorContext = new GroovyVisitorContext(sourceUnit, compilationUnit) {
+        groovyVisitorContext = new GroovyVisitorContext(sourceUnit, compilationUnit) {
             @Override
             VisitorConfiguration getConfiguration() {
                 new VisitorConfiguration() {
@@ -148,7 +150,7 @@ final class InjectVisitor extends ClassCodeVisitorSupport {
                 }
             }
         }
-        this.elementFactory = visitorContext.getElementFactory()
+        this.elementFactory = groovyVisitorContext.getElementFactory()
         this.configurationMetadataBuilder = configurationMetadataBuilder
         this.concreteClass = targetClassNode
         def annotationMetadata = AstAnnotationUtils.getAnnotationMetadata(sourceUnit, compilationUnit, targetClassNode)
@@ -245,6 +247,7 @@ final class InjectVisitor extends ClassCodeVisitorSupport {
                     annotationMetadata,
                     interfaceTypes,
                     configurationMetadataBuilder,
+                    groovyVisitorContext,
                     interceptorTypes
             )
             ClassElement groovyClassElement = elementFactory.newClassElement(
@@ -476,20 +479,12 @@ final class InjectVisitor extends ClassCodeVisitorSupport {
                     methodAnnotationMetadata
             )
             ClassElement producedClassElement = factoryMethodElement.genericReturnType
-            String beanDefinitionPackage = concreteClass.packageName
-            String upperCaseMethodName = NameUtils.capitalize(methodNode.getName())
-            String factoryMethodBeanDefinitionName =
-                    beanDefinitionPackage + '.$' + concreteClass.nameWithoutPackage + '$' + upperCaseMethodName + factoryMethodIndex.getAndIncrement() + "Definition"
-
             BeanDefinitionWriter beanMethodWriter = new BeanDefinitionWriter(
-                    producedClassElement.packageName,
-                    producedClassElement.simpleName,
-                    factoryMethodBeanDefinitionName,
-                    producedClassElement.name,
-                    producedClassElement.isInterface(),
+                    factoryMethodElement,
                     OriginatingElements.of(originatingElement),
-                    methodAnnotationMetadata,
-                    configurationMetadataBuilder
+                    configurationMetadataBuilder,
+                    groovyVisitorContext,
+                    factoryMethodIndex.getAndIncrement()
             )
 
             ClassNode returnType = methodNode.getReturnType()
@@ -522,10 +517,11 @@ final class InjectVisitor extends ClassCodeVisitorSupport {
                         beanMethodWriter,
                         OptionalValues.of(Boolean.class, finalSettings),
                         configurationMetadataBuilder,
+                        groovyVisitorContext,
                         interceptorTypeReferences
                 )
                 if (producedClassElement.isInterface()) {
-                    proxyWriter.visitDefaultConstructor(AnnotationMetadata.EMPTY_METADATA)
+                    proxyWriter.visitDefaultConstructor(AnnotationMetadata.EMPTY_METADATA, groovyVisitorContext)
                 } else {
                     populateProxyWriterConstructor(producedClassElement, proxyWriter)
                 }
@@ -573,7 +569,8 @@ final class InjectVisitor extends ClassCodeVisitorSupport {
                     beanMethodWriter.visitPreDestroyMethod(
                             producedClassElement,
                             destroyMethodElement,
-                            false
+                            false,
+                            groovyVisitorContext
                     )
                 } else {
                     addError("@Bean method defines a preDestroy method that does not exist or is not public: $destroyMethodName", methodNode )
@@ -633,7 +630,8 @@ final class InjectVisitor extends ClassCodeVisitorSupport {
                         beanWriter.visitPostConstructMethod(
                                 declaringElement,
                                 groovyMethodElement,
-                                requiresReflection
+                                requiresReflection,
+                                groovyVisitorContext
                         )
                     } else if (isDeclaredBean && methodAnnotationMetadata.hasStereotype(ProcessedTypes.PRE_DESTROY)) {
                         defineBeanDefinition(concreteClass)
@@ -644,14 +642,16 @@ final class InjectVisitor extends ClassCodeVisitorSupport {
                         beanWriter.visitPreDestroyMethod(
                                 declaringElement,
                                 groovyMethodElement,
-                                requiresReflection
+                                requiresReflection,
+                                groovyVisitorContext
                         )
                     } else if (methodAnnotationMetadata.hasStereotype(Inject.class)) {
                         defineBeanDefinition(concreteClass)
                         getBeanWriter().visitMethodInjectionPoint(
                                 declaringElement,
                                 groovyMethodElement,
-                                requiresReflection
+                                requiresReflection,
+                                groovyVisitorContext
                         )
                     }
                 }
@@ -829,7 +829,8 @@ final class InjectVisitor extends ClassCodeVisitorSupport {
             if (!executorMethodAdded) {
                 getBeanWriter().visitExecutableMethod(
                         declaringElement,
-                        methodElement
+                        methodElement,
+                        groovyVisitorContext
                 )
             }
         }
@@ -868,6 +869,7 @@ final class InjectVisitor extends ClassCodeVisitorSupport {
                     (BeanDefinitionWriter) getBeanWriter(),
                     aopSettings,
                     configurationMetadataBuilder,
+                    groovyVisitorContext,
                     interceptorTypeReferences
             )
 
@@ -892,18 +894,20 @@ final class InjectVisitor extends ClassCodeVisitorSupport {
         if (constructor != null) {
             if (constructor.parameters.length == 0) {
                 proxyWriter.visitDefaultConstructor(
-                        AnnotationMetadata.EMPTY_METADATA
+                        AnnotationMetadata.EMPTY_METADATA,
+                        groovyVisitorContext
                 )
             } else {
                 proxyWriter.visitBeanDefinitionConstructor(
                         constructor,
-                        constructor.isPrivate()
+                        constructor.isPrivate(),
+                        groovyVisitorContext
                 )
             }
         } else {
             ClassNode cn = targetClass.nativeType as ClassNode
             if (cn.declaredConstructors.isEmpty()) {
-                proxyWriter.visitDefaultConstructor(AnnotationMetadata.EMPTY_METADATA)
+                proxyWriter.visitDefaultConstructor(AnnotationMetadata.EMPTY_METADATA, groovyVisitorContext)
             } else {
                 addError("Class must have at least one non private constructor in order to be a candidate for dependency injection", (ASTNode) targetClass.nativeType)
             }
@@ -1049,7 +1053,7 @@ final class InjectVisitor extends ClassCodeVisitorSupport {
                 getBeanWriter().visitMethodInjectionPoint(
                         fieldElement.declaringType,
                         methodElement,
-                        false
+                        false,
                 )
             } else if (isValue) {
                 if (isConfigurationProperties && fieldAnnotationMetadata.hasStereotype(ConfigurationBuilder.class)) {
@@ -1198,7 +1202,7 @@ final class InjectVisitor extends ClassCodeVisitorSupport {
                 addError("Class annotated with groovy.lang.Singleton instead of javax.inject.Singleton. Import javax.inject.Singleton to use Micronaut Dependency Injection.", classNode)
             }
 
-            beanWriter = new BeanDefinitionWriter(groovyClassElement, configurationMetadataBuilder)
+            beanWriter = new BeanDefinitionWriter(groovyClassElement, configurationMetadataBuilder, groovyVisitorContext)
             beanWriter.visitTypeArguments(groovyClassElement.allTypeArguments)
             beanDefinitionWriters.put(classNode, beanWriter)
 
@@ -1207,7 +1211,7 @@ final class InjectVisitor extends ClassCodeVisitorSupport {
             if (constructor != null) {
                 if (constructor.parameters.length == 0) {
 
-                    beanWriter.visitDefaultConstructor(AnnotationMetadata.EMPTY_METADATA)
+                    beanWriter.visitDefaultConstructor(AnnotationMetadata.EMPTY_METADATA, groovyVisitorContext)
                 } else {
                     def constructorMetadata = constructor.annotationMetadata
                     final boolean isConstructBinding = constructorMetadata.hasDeclaredStereotype(ConfigurationInject.class)
@@ -1216,13 +1220,13 @@ final class InjectVisitor extends ClassCodeVisitorSupport {
                                 concreteClass,
                                 null)
                     }
-                    beanWriter.visitBeanDefinitionConstructor(constructor, constructor.isPrivate())
+                    beanWriter.visitBeanDefinitionConstructor(constructor, constructor.isPrivate(), groovyVisitorContext)
                 }
 
             } else {
                 ClassNode cn = groovyClassElement.nativeType as ClassNode
                 if (cn.declaredConstructors.isEmpty()) {
-                    beanWriter.visitDefaultConstructor(AnnotationMetadata.EMPTY_METADATA)
+                    beanWriter.visitDefaultConstructor(AnnotationMetadata.EMPTY_METADATA, groovyVisitorContext)
                 } else {
                     addError("Class must have at least one non private constructor in order to be a candidate for dependency injection", classNode)
                 }
@@ -1269,11 +1273,11 @@ final class InjectVisitor extends ClassCodeVisitorSupport {
                         false,
                         originatingElement,
                         methodAnnotationMetadata,
-                        [elementFactory.newClassElement(typeToImplement, AnnotationMetadata.EMPTY_METADATA)] as ClassElement[],
+                        [elementFactory.newClassElement(typeToImplement, AnnotationMetadata.EMPTY_METADATA)] as ClassElement[], ,
                         configurationMetadataBuilder
                 )
 
-                aopProxyWriter.visitDefaultConstructor(methodAnnotationMetadata)
+                aopProxyWriter.visitDefaultConstructor(methodAnnotationMetadata,)
 
                 beanDefinitionWriters.put(ClassHelper.make(packageName + '.' + beanClassName), aopProxyWriter)
 

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyVisitorContext.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyVisitorContext.java
@@ -170,7 +170,7 @@ public class GroovyVisitorContext implements VisitorContext {
     @Override
     public void fail(String message, @Nullable Element element) {
         Message msg;
-        if (element != null) {
+        if (element instanceof AbstractGroovyElement) {
             msg = buildErrorMessage(message, element);
         } else {
             msg = new SimpleMessage(message, sourceUnit);

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaVisitorContext.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaVisitorContext.java
@@ -198,7 +198,7 @@ public class JavaVisitorContext implements VisitorContext {
 
     private void printMessage(String message, Diagnostic.Kind kind, @Nullable io.micronaut.inject.ast.Element element) {
         if (StringUtils.isNotEmpty(message)) {
-            if (element != null) {
+            if (element instanceof AbstractJavaElement) {
                 Element el = (Element) element.getNativeType();
                 messager.printMessage(kind, message, el);
             } else {

--- a/inject-java/src/test/groovy/io/micronaut/inject/beans/BeanDefinitionSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beans/BeanDefinitionSpec.groovy
@@ -9,7 +9,65 @@ import spock.lang.Issue
 import javax.inject.Named
 import javax.inject.Qualifier
 
-class BeanDefinitionSpec extends AbstractTypeElementSpec{
+class BeanDefinitionSpec extends AbstractTypeElementSpec {
+
+    void "test limit the exposed bean types"() {
+        given:
+        def definition = buildBeanDefinition('limittypes.Test', '''
+package limittypes;
+
+import io.micronaut.context.annotation.*;
+import javax.inject.*;
+
+@Singleton
+@Bean(typed = Runnable.class)
+class Test implements Runnable {
+    public void run() {}
+}
+
+''')
+        expect:
+        definition.exposedTypes == [Runnable] as Class[]
+    }
+
+    void "test limit the exposed bean types - reference"() {
+        given:
+        def reference = buildBeanDefinitionReference('limittypes.Test', '''
+package limittypes;
+
+import io.micronaut.context.annotation.*;
+import javax.inject.*;
+
+@Singleton
+@Bean(typed = Runnable.class)
+class Test implements Runnable {
+    public void run() {}
+}
+
+''')
+        expect:
+        reference.exposedTypes == [Runnable] as Class[]
+    }
+
+    void "test fail compilation on invalid exposed bean type"() {
+        when:
+        buildBeanDefinition('limittypes.Test', '''
+package limittypes;
+
+import io.micronaut.context.annotation.*;
+import javax.inject.*;
+
+@Singleton
+@Bean(typed = Runnable.class)
+class Test {
+
+}
+
+''')
+        then:
+        def e = thrown(RuntimeException)
+        e.message.contains("Bean defines an exposed type [java.lang.Runnable] that is not implemented by the bean type")
+    }
 
     void 'test order annotation'() {
         given:

--- a/inject-java/src/test/groovy/io/micronaut/inject/beans/BeanDefinitionSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beans/BeanDefinitionSpec.groovy
@@ -27,7 +27,7 @@ class Test implements Runnable {
 
 ''')
         expect:
-        definition.exposedTypes == [Runnable] as Class[]
+        definition.exposedTypes == [Runnable] as Set
     }
 
     void "test limit the exposed bean types - reference"() {
@@ -46,7 +46,7 @@ class Test implements Runnable {
 
 ''')
         expect:
-        reference.exposedTypes == [Runnable] as Class[]
+        reference.exposedTypes == [Runnable] as Set
     }
 
     void "test fail compilation on invalid exposed bean type"() {

--- a/inject-java/src/test/groovy/io/micronaut/inject/typed/BeanTypedSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/typed/BeanTypedSpec.groovy
@@ -1,0 +1,45 @@
+package io.micronaut.inject.typed
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.exceptions.NoSuchBeanException
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class BeanTypedSpec extends Specification {
+    @Shared @AutoCleanup ApplicationContext context = ApplicationContext.run()
+
+    void 'test limit exposed type'() {
+        when:"Lookup a type not exposed"
+        context.getBean(Foo2)
+
+        then:"Not there"
+        thrown(NoSuchBeanException)
+
+        when:"Lookup a type exposed"
+        def bean = context.getBean(Foo1)
+
+        then:"Works"
+        bean != null
+
+        when:"Lookup a type not exposed again to trigger looking into existing singletons"
+        context.getBean(Foo2)
+
+        then:
+        thrown(NoSuchBeanException)
+        context.containsBean(Foo1)
+        !context.containsBean(Foo2)
+        !context.containsBean(FooImpl)
+        context.getBeansOfType(Foo1).size() == 1
+        context.getBeansOfType(Foo2).size() == 0
+        context.getBeansOfType(FooImpl).size() == 0
+        context.findBeanDefinition(Foo1).isPresent()
+        !context.findBeanDefinition(Foo2).isPresent()
+        !context.findBeanDefinition(FooImpl).isPresent()
+        context.findBeanDefinition(Foo1).isPresent()
+        !context.findBeanDefinition(Foo2).isPresent()
+        context.findBeanDefinition(Foo1).isPresent()
+        !context.findBeanDefinition(Foo2).isPresent()
+        !context.findBeanDefinition(FooImpl).isPresent()
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/typed/BeanTypedSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/typed/BeanTypedSpec.groovy
@@ -41,5 +41,11 @@ class BeanTypedSpec extends Specification {
         context.findBeanDefinition(Foo1).isPresent()
         !context.findBeanDefinition(Foo2).isPresent()
         !context.findBeanDefinition(FooImpl).isPresent()
+
+        when:
+        context.getBean(FooImpl)
+
+        then:
+        thrown(NoSuchBeanException)
     }
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/typed/Foo1.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/typed/Foo1.java
@@ -1,0 +1,4 @@
+package io.micronaut.inject.typed;
+
+public interface Foo1 {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/typed/Foo2.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/typed/Foo2.java
@@ -1,0 +1,4 @@
+package io.micronaut.inject.typed;
+
+public interface Foo2 {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/typed/FooImpl.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/typed/FooImpl.java
@@ -1,0 +1,10 @@
+package io.micronaut.inject.typed;
+
+import io.micronaut.context.annotation.Bean;
+
+import javax.inject.Singleton;
+
+@Bean(typed = Foo1.class)
+@Singleton
+public class FooImpl implements Foo1, Foo2 {
+}

--- a/inject/src/main/java/io/micronaut/context/AbstractBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractBeanDefinition.java
@@ -89,6 +89,7 @@ public class AbstractBeanDefinition<T> extends AbstractBeanContextConditional im
     private final Collection<Class> requiredComponents = new HashSet<>(3);
     private AnnotationMetadata beanAnnotationMetadata;
     private Environment environment;
+    private Set<Class<?>> exposedTypes;
 
     /**
      * Constructs a bean definition that is produced from a method call on another type (factory bean).
@@ -279,6 +280,15 @@ public class AbstractBeanDefinition<T> extends AbstractBeanContextConditional im
     @Override
     public final Class<T> getBeanType() {
         return type;
+    }
+
+    @Override
+    @NonNull
+    public final Set<Class<?>> getExposedTypes() {
+        if (this.exposedTypes == null) {
+            this.exposedTypes = BeanDefinition.super.getExposedTypes();
+        }
+        return this.exposedTypes;
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/context/AbstractBeanDefinitionReference.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractBeanDefinitionReference.java
@@ -41,7 +41,7 @@ public abstract class AbstractBeanDefinitionReference extends AbstractBeanContex
     private final String beanTypeName;
     private final String beanDefinitionTypeName;
     private Boolean present;
-    private Set exposedTypes;
+    private Set<Class<?>> exposedTypes;
 
     /**
      * @param beanTypeName           The bean type name
@@ -59,7 +59,7 @@ public abstract class AbstractBeanDefinitionReference extends AbstractBeanContex
 
     @Override
     @NonNull
-    public Set<Class<?>> getExposedTypes() {
+    public final Set<Class<?>> getExposedTypes() {
         if (exposedTypes == null) {
             this.exposedTypes = BeanDefinitionReference.super.getExposedTypes();
         }

--- a/inject/src/main/java/io/micronaut/context/AbstractBeanDefinitionReference.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractBeanDefinitionReference.java
@@ -22,7 +22,6 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.BeanDefinitionReference;
-import io.micronaut.inject.BeanType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/inject/src/main/java/io/micronaut/context/AbstractBeanDefinitionReference.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractBeanDefinitionReference.java
@@ -19,10 +19,14 @@ import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.exceptions.BeanContextException;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.BeanDefinitionReference;
+import io.micronaut.inject.BeanType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Set;
 
 /**
  * An uninitialized and unloaded component definition with basic information available regarding its requirements.
@@ -37,6 +41,7 @@ public abstract class AbstractBeanDefinitionReference extends AbstractBeanContex
     private final String beanTypeName;
     private final String beanDefinitionTypeName;
     private Boolean present;
+    private Set exposedTypes;
 
     /**
      * @param beanTypeName           The bean type name
@@ -50,6 +55,15 @@ public abstract class AbstractBeanDefinitionReference extends AbstractBeanContex
     @Override
     public boolean isPrimary() {
         return getAnnotationMetadata().hasAnnotation(Primary.class);
+    }
+
+    @Override
+    @NonNull
+    public Set<Class<?>> getExposedTypes() {
+        if (exposedTypes == null) {
+            this.exposedTypes = BeanDefinitionReference.super.getExposedTypes();
+        }
+        return this.exposedTypes;
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/context/BeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/BeanContext.java
@@ -185,8 +185,9 @@ public interface BeanContext extends
      * Destroys the bean for the given type causing it to be re-created. If a singleton has been loaded it will be
      * destroyed and removed from the context, otherwise null will be returned.
      *
-     * @param beanType The bean type
-     * @param <T>      The concrete class
+     * @param beanType  The bean type
+     * @param qualifier The qualifier
+     * @param <T>       The concrete class
      * @return The destroy instance or null if no such bean exists
      * @since 3.0.0
      */

--- a/inject/src/main/java/io/micronaut/context/annotation/Bean.java
+++ b/inject/src/main/java/io/micronaut/context/annotation/Bean.java
@@ -41,11 +41,17 @@ import java.lang.annotation.Target;
  */
 @Documented
 @Retention(RUNTIME)
-@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE, ElementType.TYPE})
 public @interface Bean {
 
     /**
      * @return The method to invoke to destroy the bean
      */
     String preDestroy() default "";
-}
+
+    /**
+     * @return Limits the types exposed by this been to the given type or types.
+     * @since 3.0.0
+     */
+    Class<?>[] typed() default {};
+ }

--- a/inject/src/main/java/io/micronaut/context/annotation/Type.java
+++ b/inject/src/main/java/io/micronaut/context/annotation/Type.java
@@ -32,5 +32,5 @@ public @interface Type {
     /**
      * @return The types
      */
-    Class[] value();
+    Class<?>[] value();
 }

--- a/inject/src/main/java/io/micronaut/inject/BeanType.java
+++ b/inject/src/main/java/io/micronaut/inject/BeanType.java
@@ -20,7 +20,6 @@ import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationMetadataProvider;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
-import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
 

--- a/inject/src/main/java/io/micronaut/inject/ast/ClassElement.java
+++ b/inject/src/main/java/io/micronaut/inject/ast/ClassElement.java
@@ -17,10 +17,10 @@ package io.micronaut.inject.ast;
 
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.core.annotation.NonNull;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
 import java.util.function.Predicate;
@@ -350,53 +350,18 @@ public interface ClassElement extends TypedElement {
      */
     @Internal
     static @NonNull ClassElement of(@NonNull String typeName) {
-        return new ClassElement() {
-            @Override
-            public boolean isAssignable(String type) {
-                return false;
-            }
+        return new SimpleClassElement(typeName);
+    }
 
-            @Override
-            public boolean isAssignable(ClassElement type) {
-                return false;
-            }
-
-            @Override
-            public ClassElement toArray() {
-                throw new UnsupportedOperationException("Cannot convert class elements produced by name to an array");
-            }
-
-            @Override
-            public ClassElement fromArray() {
-                throw new UnsupportedOperationException("Cannot convert class elements produced by from an array");
-            }
-
-            @NotNull
-            @Override
-            public String getName() {
-                return typeName;
-            }
-
-            @Override
-            public boolean isPackagePrivate() {
-                return false;
-            }
-
-            @Override
-            public boolean isProtected() {
-                return false;
-            }
-
-            @Override
-            public boolean isPublic() {
-                return false;
-            }
-
-            @NotNull
-            @Override
-            public Object getNativeType() {
-                return typeName;
-            }
-        };
+    /**
+     * Create a class element for the given simple type.
+     * @param typeName The type
+     * @param isInterface Is the type an interface
+     * @param annotationMetadata The annotation metadata
+     * @return The class element
+     */
+    @Internal
+    static @NonNull ClassElement of(@NonNull String typeName, boolean isInterface, @Nullable AnnotationMetadata annotationMetadata) {
+        return new SimpleClassElement(typeName, isInterface, annotationMetadata);
     }
 }

--- a/inject/src/main/java/io/micronaut/inject/ast/SimpleClassElement.java
+++ b/inject/src/main/java/io/micronaut/inject/ast/SimpleClassElement.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.inject.ast;
 
 import io.micronaut.core.annotation.AnnotationMetadata;

--- a/inject/src/main/java/io/micronaut/inject/ast/SimpleClassElement.java
+++ b/inject/src/main/java/io/micronaut/inject/ast/SimpleClassElement.java
@@ -1,0 +1,79 @@
+package io.micronaut.inject.ast;
+
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.Internal;
+import org.jetbrains.annotations.NotNull;
+
+@Internal
+final class SimpleClassElement implements ClassElement {
+    private final String typeName;
+    private final boolean isInterface;
+    private final AnnotationMetadata annotationMetadata;
+
+    SimpleClassElement(String typeName) {
+        this(typeName, false, AnnotationMetadata.EMPTY_METADATA);
+    }
+
+    SimpleClassElement(String typeName, boolean isInterface, AnnotationMetadata annotationMetadata) {
+        this.typeName = typeName;
+        this.isInterface = isInterface;
+        this.annotationMetadata = annotationMetadata != null ? annotationMetadata : AnnotationMetadata.EMPTY_METADATA;
+    }
+
+    @Override
+    public AnnotationMetadata getAnnotationMetadata() {
+        return this.annotationMetadata;
+    }
+
+    @Override
+    public boolean isInterface() {
+        return isInterface;
+    }
+
+    @Override
+    public boolean isAssignable(String type) {
+        return false;
+    }
+
+    @Override
+    public boolean isAssignable(ClassElement type) {
+        return false;
+    }
+
+    @Override
+    public ClassElement toArray() {
+        throw new UnsupportedOperationException("Cannot convert class elements produced by name to an array");
+    }
+
+    @Override
+    public ClassElement fromArray() {
+        throw new UnsupportedOperationException("Cannot convert class elements produced by from an array");
+    }
+
+    @NotNull
+    @Override
+    public String getName() {
+        return typeName;
+    }
+
+    @Override
+    public boolean isPackagePrivate() {
+        return false;
+    }
+
+    @Override
+    public boolean isProtected() {
+        return false;
+    }
+
+    @Override
+    public boolean isPublic() {
+        return false;
+    }
+
+    @NotNull
+    @Override
+    public Object getNativeType() {
+        return typeName;
+    }
+}

--- a/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionVisitor.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionVisitor.java
@@ -19,6 +19,7 @@ import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.ast.*;
 import io.micronaut.inject.configuration.ConfigurationMetadataBuilder;
+import io.micronaut.inject.visitor.VisitorContext;
 import org.objectweb.asm.Type;
 
 import io.micronaut.core.annotation.NonNull;
@@ -53,20 +54,25 @@ public interface BeanDefinitionVisitor extends OriginatingElements {
     /**
      * Visits the constructor used to create the bean definition.
      *
-     * @param constructor  The method element that represents the constructor
-     * @param requiresReflection         Whether invoking the constructor requires reflection
+     * @param constructor        The method element that represents the constructor
+     * @param requiresReflection Whether invoking the constructor requires reflection
+     * @param visitorContext     The visitor context
      */
     void visitBeanDefinitionConstructor(MethodElement constructor,
-                                        boolean requiresReflection);
+                                        boolean requiresReflection,
+                                        VisitorContext visitorContext);
 
     /**
      * Visits the constructor used to create the bean definition in the case where no constructor is present.
      * This method should only be called in the class defines no constructor.
      *
      * @param annotationMetadata The annotation metadata for the constructor
-     *
+     * @param visitorContext     The visitor context
      */
-    void visitDefaultConstructor(AnnotationMetadata annotationMetadata);
+    void visitDefaultConstructor(
+            AnnotationMetadata annotationMetadata,
+            VisitorContext visitorContext
+    );
 
     /**
      * @return The name of the bean definition reference class.
@@ -173,10 +179,10 @@ public interface BeanDefinitionVisitor extends OriginatingElements {
     /**
      * Visits an injection point for a setter.
      *
-     * @param declaringType          The declaring type
-     * @param methodElement          The method element
-     * @param requiresReflection     Whether the setter requires reflection
-     * @param isOptional             Whether the setter is optional
+     * @param declaringType      The declaring type
+     * @param methodElement      The method element
+     * @param requiresReflection Whether the setter requires reflection
+     * @param isOptional         Whether the setter is optional
      */
     void visitSetterValue(TypedElement declaringType,
                           MethodElement methodElement,
@@ -185,15 +191,16 @@ public interface BeanDefinitionVisitor extends OriginatingElements {
 
     /**
      * Visits a method injection point.
-     *
-     * @param declaringType              The declaring type of the method. Either a Class or a string representing
-     *                                   the name of the type
-     * @param methodElement              The method element
-     * @param requiresReflection         Whether the method requires reflection
+     *  @param declaringType      The declaring type of the method. Either a Class or a string representing
+     *                           the name of the type
+     * @param methodElement      The method element
+     * @param requiresReflection Whether the method requires reflection
+     * @param visitorContext     The visitor context
      */
     void visitPostConstructMethod(TypedElement declaringType,
                                   MethodElement methodElement,
-                                  boolean requiresReflection);
+                                  boolean requiresReflection,
+                                  VisitorContext visitorContext);
 
     /**
      * Visits a method injection point.
@@ -201,10 +208,12 @@ public interface BeanDefinitionVisitor extends OriginatingElements {
      * @param beanType           The bean type of the method
      * @param methodElement      The method element
      * @param requiresReflection Whether the method requires reflection
+     * @param visitorContext     The visitor context
      */
     void visitPreDestroyMethod(TypedElement beanType,
                                MethodElement methodElement,
-                               boolean requiresReflection);
+                               boolean requiresReflection,
+                               VisitorContext visitorContext);
 
     /**
      * Visits a method injection point.
@@ -212,20 +221,24 @@ public interface BeanDefinitionVisitor extends OriginatingElements {
      * @param beanType           The bean type of the method
      * @param methodElement      The method element
      * @param requiresReflection Whether the method requires reflection
+     * @param visitorContext     The visitor context
      */
     void visitMethodInjectionPoint(TypedElement beanType,
                                    MethodElement methodElement,
-                                   boolean requiresReflection);
+                                   boolean requiresReflection,
+                                   VisitorContext visitorContext);
 
     /**
      * Visit a method that is to be made executable allow invocation of said method without reflection.
      *
-     * @param declaringBean The declaring bean of the method. Note this may differ from {@link MethodElement#getDeclaringType()} in the case of the method coming from a super class or interface.
-     * @param methodElement The method element
+     * @param declaringBean  The declaring bean of the method. Note this may differ from {@link MethodElement#getDeclaringType()} in the case of the method coming from a super class or interface.
+     * @param methodElement  The method element
+     * @param visitorContext The visitor context
      * @return The {@link ExecutableMethodWriter}.
      */
     ExecutableMethodWriter visitExecutableMethod(TypedElement declaringBean,
-                                                 MethodElement methodElement);
+                                                 MethodElement methodElement,
+                                                 VisitorContext visitorContext);
 
     /**
      * Visits a field injection point.

--- a/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -16,15 +16,13 @@
 package io.micronaut.inject.writer;
 
 import io.micronaut.context.*;
-import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.*;
 import io.micronaut.context.annotation.*;
-import io.micronaut.core.annotation.AnnotationMetadata;
-import io.micronaut.core.annotation.AnnotationMetadataProvider;
-import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.bind.annotation.Bindable;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.type.Argument;
+import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.*;
@@ -36,6 +34,7 @@ import io.micronaut.inject.ast.*;
 import io.micronaut.inject.configuration.ConfigurationMetadataBuilder;
 import io.micronaut.inject.configuration.PropertyMetadata;
 import io.micronaut.inject.processing.JavaModelUtils;
+import io.micronaut.inject.visitor.VisitorContext;
 import org.jetbrains.annotations.NotNull;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
@@ -187,6 +186,8 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
     private final boolean isInterface;
     private final boolean isConfigurationProperties;
     private final ConfigurationMetadataBuilder<?> metadataBuilder;
+    private final Element beanProducingElement;
+    private final ClassElement beanTypeElement;
     private GeneratorAdapter constructorVisitor;
     private GeneratorAdapter buildMethodVisitor;
     private GeneratorAdapter injectMethodVisitor;
@@ -232,81 +233,75 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
     /**
      * Creates a bean definition writer.
      *
-     * @param packageName         The package name of the bean
-     * @param className           The class name, without the package, of the bean
-     * @param isInterface         Whether the writer is for an interface.
-     * @param originatingElements The originating elements
-     * @param annotationMetadata  The annotation metadata
-     * @param metadataBuilder     The configuration metadata builder
-     * @since 2.1.1
-     */
-    public BeanDefinitionWriter(String packageName,
-                                String className,
-                                boolean isInterface,
-                                OriginatingElements originatingElements,
-                                AnnotationMetadata annotationMetadata,
-                                ConfigurationMetadataBuilder<?> metadataBuilder) {
-        this(packageName,
-                className,
-                getBeanDefinitionName(packageName, className),
-                packageName + '.' + className,
-                isInterface,
-                originatingElements,
-                annotationMetadata,
-                metadataBuilder
-        );
-    }
-
-    /**
-     * Creates a bean definition writer.
-     *
      * @param classElement    The class element
      * @param metadataBuilder The configuration metadata builder
+     * @param visitorContext  The visitor context
      */
     public BeanDefinitionWriter(ClassElement classElement,
-                                ConfigurationMetadataBuilder<?> metadataBuilder) {
-        this(
-                classElement.getPackageName(),
-                classElement.getSimpleName(),
-                getBeanDefinitionName(classElement.getPackageName(), classElement.getSimpleName()),
-                getProvidedClassName(classElement),
-                classElement.isInterface(),
-                OriginatingElements.of(classElement),
-                classElement.getAnnotationMetadata(),
-                metadataBuilder
-        );
+                                ConfigurationMetadataBuilder<?> metadataBuilder,
+                                VisitorContext visitorContext) {
+        this(classElement, OriginatingElements.of(classElement), metadataBuilder, visitorContext, null);
+    }
+
+    /**
+     * Creates a bean definition writer.
+     *  @param classElement        The class element
+     * @param originatingElements The originating elements
+     * @param metadataBuilder     The configuration metadata builder
+     * @param visitorContext      The visitor context
+     */
+    public BeanDefinitionWriter(ClassElement classElement,
+                                OriginatingElements originatingElements,
+                                ConfigurationMetadataBuilder<?> metadataBuilder, VisitorContext visitorContext) {
+        this(classElement, originatingElements, metadataBuilder, visitorContext, null);
     }
 
     /**
      * Creates a bean definition writer.
      *
-     * @param packageName         The package name of the bean
-     * @param className           The class name, without the package, of the bean
-     * @param beanDefinitionName  The name of the bean definition
-     * @param providedClassName   The type this bean definition provides, which differs from the class name in the case of factory beans
-     * @param isInterface         Whether the provided type is an interface
-     * @param originatingElements The originating elements
-     * @param annotationMetadata  The annotation metadata
-     * @param metadataBuilder     The configuration metadata builder
+     * @param beanProducingElement The bean producing element
+     * @param originatingElements  The originating elements
+     * @param metadataBuilder      The configuration metadata builder
+     * @param visitorContext       The visitor context
+     * @param uniqueIdentifier     An optional unique identifier to include in the bean name
      */
-    public BeanDefinitionWriter(String packageName,
-                                String className,
-                                String beanDefinitionName,
-                                String providedClassName,
-                                boolean isInterface,
+    public BeanDefinitionWriter(Element beanProducingElement,
                                 OriginatingElements originatingElements,
-                                AnnotationMetadata annotationMetadata,
-                                ConfigurationMetadataBuilder<?> metadataBuilder) {
+                                ConfigurationMetadataBuilder<?> metadataBuilder,
+                                VisitorContext visitorContext,
+                                @Nullable Integer uniqueIdentifier) {
         super(originatingElements);
         this.metadataBuilder = metadataBuilder;
         this.classWriter = new ClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES);
-        this.packageName = packageName;
-        this.isInterface = isInterface;
-        this.beanFullClassName = packageName + '.' + className;
-        this.annotationMetadata = annotationMetadata;
-        this.beanSimpleClassName = className;
-        this.providedBeanClassName = providedClassName;
-        this.beanDefinitionName = beanDefinitionName;
+        this.beanProducingElement = beanProducingElement;
+        if (beanProducingElement instanceof ClassElement) {
+            ClassElement classElement = (ClassElement) beanProducingElement;
+            this.beanTypeElement = classElement;
+            this.packageName = classElement.getPackageName();
+            this.isInterface = classElement.isInterface();
+            this.beanFullClassName = classElement.getName();
+            this.beanSimpleClassName = classElement.getSimpleName();
+            this.providedBeanClassName = getProvidedClassName(classElement);
+            this.beanDefinitionName = getBeanDefinitionName(packageName, beanSimpleClassName);
+        } else if (beanProducingElement instanceof MethodElement) {
+            MethodElement factoryMethodElement = (MethodElement) beanProducingElement;
+            final ClassElement producedElement = factoryMethodElement.getGenericReturnType();
+            this.beanTypeElement = producedElement;
+            this.packageName = producedElement.getPackageName();
+            this.isInterface = producedElement.isInterface();
+            this.beanFullClassName = producedElement.getName();
+            this.beanSimpleClassName = producedElement.getSimpleName();
+            this.providedBeanClassName = producedElement.getName();
+            String upperCaseMethodName = NameUtils.capitalize(factoryMethodElement.getName());
+            if (uniqueIdentifier == null) {
+                throw new IllegalArgumentException("Factory methods require passing a unique identifier");
+            }
+            final ClassElement declaringType = factoryMethodElement.getDeclaringType();
+            this.beanDefinitionName = declaringType.getPackageName() + ".$" + declaringType.getSimpleName() + "$" + upperCaseMethodName + uniqueIdentifier + "Definition";
+        } else {
+            throw new IllegalArgumentException("Unsupported element type: " + beanProducingElement.getClass().getName());
+        }
+        this.annotationMetadata = beanProducingElement.getAnnotationMetadata();
         this.beanDefinitionType = getTypeReferenceForName(this.beanDefinitionName);
         this.beanType = getTypeReferenceForName(beanFullClassName);
         this.providedType = getTypeReferenceForName(providedBeanClassName);
@@ -314,6 +309,21 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
         this.interfaceTypes = new TreeSet<>(Comparator.comparing(Class::getName));
         this.interfaceTypes.add(BeanFactory.class);
         this.isConfigurationProperties = annotationMetadata.hasDeclaredStereotype(ConfigurationProperties.class);
+        validateExposedTypes(annotationMetadata, visitorContext);
+    }
+
+    private void validateExposedTypes(AnnotationMetadata annotationMetadata, VisitorContext visitorContext) {
+        final String[] types = annotationMetadata.stringValues(Bean.class, "typed");
+        if (ArrayUtils.isNotEmpty(types)) {
+            for (String name : types) {
+                final ClassElement exposedType = visitorContext.getClassElement(name).orElse(null);
+                if (exposedType == null) {
+                    visitorContext.fail("Bean defines an exposed type [" + name + "] that is not on the classpath", beanProducingElement);
+                } else if (!beanTypeElement.isAssignable(exposedType)) {
+                    visitorContext.fail("Bean defines an exposed type [" + name + "] that is not implemented by the bean type", beanProducingElement);
+                }
+            }
+        }
     }
 
     private static String getProvidedClassName(ClassElement classElement) {
@@ -473,10 +483,12 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
      *
      * @param constructor        The constructor
      * @param requiresReflection Whether invoking the constructor requires reflection
+     * @param visitorContext     The visitor context
      */
     @Override
     public void visitBeanDefinitionConstructor(MethodElement constructor,
-                                               boolean requiresReflection) {
+                                               boolean requiresReflection,
+                                               VisitorContext visitorContext) {
         if (constructorVisitor == null) {
             applyConfigurationInjectionIfNecessary(constructor);
             // first build the constructor
@@ -558,7 +570,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
     }
 
     @Override
-    public void visitDefaultConstructor(AnnotationMetadata annotationMetadata) {
+    public void visitDefaultConstructor(AnnotationMetadata annotationMetadata, VisitorContext visitorContext) {
         if (constructorVisitor == null) {
             ClassElement bean = ClassElement.of(beanType.getClassName());
             MethodElement constructor = MethodElement.of(
@@ -838,7 +850,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
     @Override
     public void visitPostConstructMethod(TypedElement declaringType,
                                          MethodElement methodElement,
-                                         boolean requiresReflection) {
+                                         boolean requiresReflection, VisitorContext visitorContext) {
 
         visitPostConstructMethodDefinition();
 
@@ -858,7 +870,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
     @Override
     public void visitPreDestroyMethod(TypedElement declaringType,
                                       MethodElement methodElement,
-                                      boolean requiresReflection) {
+                                      boolean requiresReflection, VisitorContext visitorContext) {
 
         visitPreDestroyMethodDefinition();
         final MethodVisitData methodVisitData = new MethodVisitData(declaringType,
@@ -877,7 +889,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
     @Override
     public void visitMethodInjectionPoint(TypedElement declaringType,
                                           MethodElement methodElement,
-                                          boolean requiresReflection) {
+                                          boolean requiresReflection, VisitorContext visitorContext) {
         applyConfigurationInjectionIfNecessary(methodElement);
         GeneratorAdapter constructorVisitor = this.constructorVisitor;
         GeneratorAdapter injectMethodVisitor = this.injectMethodVisitor;
@@ -896,7 +908,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
 
     @Override
     public ExecutableMethodWriter visitExecutableMethod(TypedElement declaringBean,
-                                                        MethodElement methodElement) {
+                                                        MethodElement methodElement, VisitorContext visitorContext) {
 
         return visitExecutableMethod(
                 declaringBean,
@@ -2164,8 +2176,8 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
             List<ParameterElement> parameterList = Arrays.asList(parameters);
             Optional<AnnotationMetadata> argumentQualifier = parameterList
                     .stream()
-                    .filter(p -> isAnnotatedWithParameter(p.getAnnotationMetadata()))
-                    .map(AnnotationMetadataProvider::getAnnotationMetadata).findFirst();
+                    .map(AnnotationMetadataProvider::getAnnotationMetadata)
+                    .filter(this::isAnnotatedWithParameter).findFirst();
             boolean isParametrized = argumentQualifier.isPresent();
             if (isParametrized) {
                 superType = TYPE_ABSTRACT_PARAMETRIZED_BEAN_DEFINITION;

--- a/src/main/docs/guide/introduction/whatsNew.adoc
+++ b/src/main/docs/guide/introduction/whatsNew.adoc
@@ -2,11 +2,27 @@ Micronaut {version} includes the following changes:
 
 === Core Features
 
-==== Support for Injecting by Generic Type Arguments
+==== Support Narrowing Injection by Generic Type Arguments
 
-Micronaut and now resolve the correct bean to inject based on the generic type arguments specifed on the injection point:
+Micronaut can now resolve the correct bean to inject based on the generic type arguments specified on the injection point:
 
 snippet::io.micronaut.docs.inject.generics.Vehicle[tags="constructor",indent=0]
+
+For more information see the section on <<qualifiers, Qualifying by Generic Type Arguments>>.
+
+==== Support for using Annotation Members in Qualifiers
+
+You can now use annotation members in qualifiers and specify which members should be excluded with the new ann:context.annotation.NonBinding[] annotation.
+
+For more information see the section on <<qualifiers, Qualifying By Annotation Members>>.
+
+==== Support for Limiting the Injectable Types
+
+You can now limit the exposed types of a bean using the `typed` member of the ann:context.annotation.Bean[] annotation:
+
+snippet::io.micronaut.docs.inject.typed.V8Engine[tags="class",indent=0]
+
+For more information see the section on <<typed, Limiting Injectable Types>>.
 
 === Module Upgrades
 

--- a/src/main/docs/guide/ioc/typed.adoc
+++ b/src/main/docs/guide/ioc/typed.adoc
@@ -1,0 +1,21 @@
+By default when you annotate a bean with a scope such as `@Singleton` the bean class and all interfaces it implements and super classes it extends from become injectable via `@Inject`.
+
+Consider the following example from the previous section on defining beans:
+
+snippet::io.micronaut.docs.inject.qualifiers.named.V8Engine[tags="class",indent=0]
+
+In the above case other classes in your application can choose to either inject the interface `Engine` or the concrete implementation `V8Engine`.
+
+If this is undesirable you can use the `typed` member of the ann:context.annotation.Bean[] annotation to limit the exposed types. For example:
+
+snippet::io.micronaut.docs.inject.typed.V8Engine[tags="class",indent=0]
+
+<1> `@Bean(typed=..)` is used to only allow injection the interface `Engine` and not the concrete type
+<2> The class must implement the class or interface defined by `typed` otherwise a compilation error will occur
+
+The following test demonstrates the behaviour of `typed` using programmatic lookup and the api:context.BeanContext[] API:
+
+snippet::io.micronaut.docs.inject.typed.EngineSpec[tags="class",indent=0]
+
+<1> Trying to lookup `V8Engine` throws a api:context.exceptions.NoSuchBeanException[]
+<2> Whilst looking up the `Engine` interface succeeds

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -20,6 +20,7 @@ ioc:
   beanContext: The BeanContext
   types: Injectable Container Types
   qualifiers: Bean Qualifiers
+  typed: Limiting Injectable Types
   scopes:
     title: Scopes
     builtInScopes:

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/inject/typed/Engine.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/inject/typed/Engine.groovy
@@ -1,0 +1,8 @@
+package io.micronaut.docs.inject.typed
+
+// tag::class[]
+interface Engine {
+    int getCylinders()
+    String start()
+}
+// tag::class[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/inject/typed/EngineSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/inject/typed/EngineSpec.groovy
@@ -1,0 +1,25 @@
+package io.micronaut.docs.inject.typed
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.exceptions.NoSuchBeanException
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+// tag::class[]
+class EngineSpec extends Specification {
+    @Shared @AutoCleanup
+    ApplicationContext beanContext = ApplicationContext.run()
+
+    void 'test engine'() {
+        when:'the class is looked up'
+        beanContext.getBean(V8Engine) // <1>
+
+        then:'a no such bean exception is thrown'
+        thrown(NoSuchBeanException)
+
+        and:'it is possible to lookup by the typed interface'
+        beanContext.getBean(Engine) instanceof V8Engine // <2>
+    }
+}
+// end::class[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/inject/typed/V8Engine.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/inject/typed/V8Engine.groovy
@@ -1,0 +1,16 @@
+package io.micronaut.docs.inject.typed
+
+import io.micronaut.context.annotation.Bean
+import javax.inject.Singleton
+
+// tag::class[]
+@Singleton
+@Bean(typed = Engine) // <1>
+class V8Engine implements Engine {  // <2>
+    @Override
+    String start() { "Starting V8" }
+
+    @Override
+    int getCylinders() { 8 }
+}
+// end::class[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/inject/typed/Engine.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/inject/typed/Engine.kt
@@ -1,0 +1,8 @@
+package io.micronaut.docs.inject.typed
+
+// tag::class[]
+interface Engine {
+    val cylinders: Int
+    fun start(): String
+}
+// tag::class[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/inject/typed/EngineSpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/inject/typed/EngineSpec.kt
@@ -17,11 +17,11 @@ class EngineSpec {
     @Test
     fun testEngine() {
         assertThrows(NoSuchBeanException::class.java) {
-            beanContext.getBean(V6Engine::class.java) // <1>
+            beanContext.getBean(V8Engine::class.java) // <1>
         }
 
         val engine = beanContext.getBean(Engine::class.java) // <2>
-        assertTrue(engine is V6Engine)
+        assertTrue(engine is V8Engine)
     }
 }
 // end::class[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/inject/typed/EngineSpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/inject/typed/EngineSpec.kt
@@ -1,0 +1,27 @@
+package io.micronaut.docs.inject.typed
+
+import io.micronaut.context.BeanContext
+import io.micronaut.context.exceptions.NoSuchBeanException
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import javax.inject.Inject
+
+// tag::class[]
+@MicronautTest
+class EngineSpec {
+    @Inject
+    lateinit var beanContext: BeanContext
+
+    @Test
+    fun testEngine() {
+        assertThrows(NoSuchBeanException::class.java) {
+            beanContext.getBean(V6Engine::class.java) // <1>
+        }
+
+        val engine = beanContext.getBean(Engine::class.java) // <2>
+        assertTrue(engine is V6Engine)
+    }
+}
+// end::class[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/inject/typed/V8Engine.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/inject/typed/V8Engine.kt
@@ -1,0 +1,16 @@
+package io.micronaut.docs.inject.typed
+
+import io.micronaut.context.annotation.Bean
+import javax.inject.Singleton
+
+// tag::class[]
+@Singleton
+@Bean(typed = [Engine::class]) // <1>
+class V8Engine : Engine { // <2>
+    override fun start(): String {
+        return "Starting V8"
+    }
+
+    override val cylinders: Int = 8
+}
+// ebd::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/inject/typed/Engine.java
+++ b/test-suite/src/test/java/io/micronaut/docs/inject/typed/Engine.java
@@ -1,0 +1,8 @@
+package io.micronaut.docs.inject.typed;
+
+// tag::class[]
+public interface Engine {
+    int getCylinders();
+    String start();
+}
+// tag::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/inject/typed/EngineSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/inject/typed/EngineSpec.java
@@ -1,0 +1,28 @@
+package io.micronaut.docs.inject.typed;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.exceptions.NoSuchBeanException;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+// tag::class[]
+@MicronautTest
+public class EngineSpec {
+    @Inject
+    BeanContext beanContext;
+
+    @Test
+    public void testEngine() {
+        assertThrows(NoSuchBeanException.class, () ->
+                beanContext.getBean(V8Engine.class) // <1>
+        );
+        final Engine engine = beanContext.getBean(Engine.class); // <2>
+        assertTrue(engine instanceof V8Engine);
+    }
+}
+// end::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/inject/typed/V8Engine.java
+++ b/test-suite/src/test/java/io/micronaut/docs/inject/typed/V8Engine.java
@@ -1,0 +1,21 @@
+package io.micronaut.docs.inject.typed;
+
+import io.micronaut.context.annotation.Bean;
+
+import javax.inject.Singleton;
+
+// tag::class[]
+@Singleton
+@Bean(typed = Engine.class) // <1>
+public class V8Engine implements Engine {  // <2>
+    @Override
+    public String start() {
+        return "Starting V8";
+    }
+
+    @Override
+    public int getCylinders() {
+        return 8;
+    }
+}
+// end::class[]


### PR DESCRIPTION
This adds support for limiting the injectable type. Fixes #5098

Note this may solve other issues like for example the issue where by the Netty Event Loop can be injected as an `ExecutorService`

