### PR TITLE
Improve bean destruction API

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/beanwithpredestroy/BeanWithPreDestroySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/beanwithpredestroy/BeanWithPreDestroySpec.groovy
@@ -40,6 +40,9 @@ class BeanWithPreDestroySpec extends Specification{
         then:
         b.noArgsDestroyCalled
         b.injectedDestroyCalled
+
+        cleanup:
+        context.close()
     }
 
     void "test that a bean with a pre-destroy hook works closed on close"() {
@@ -61,5 +64,28 @@ class BeanWithPreDestroySpec extends Specification{
         then:
         b.noArgsDestroyCalled
         b.injectedDestroyCalled
+    }
+
+    void "test that destroy events run in the right phase"() {
+        given:
+        BeanContext context = new DefaultBeanContext()
+        context.start()
+
+
+        when:
+        def pre = context.getBean(CPreDestroyEventListener)
+        def post = context.getBean(CDestroyedListener)
+        def c = context.getBean(C)
+
+        then:
+        !c.isClosed()
+
+        when:
+        context.close()
+
+        then:
+        pre.called
+        post.called
+        c.isClosed()
     }
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/beanwithpredestroy/C.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/beanwithpredestroy/C.java
@@ -15,9 +15,21 @@
  */
 package io.micronaut.inject.lifecycle.beanwithpredestroy;
 
+import javax.annotation.PreDestroy;
 import javax.inject.Singleton;
 
 @Singleton
-public class C {
+public class C implements AutoCloseable {
 
+    private boolean closed;
+
+    @Override
+    @PreDestroy
+    public void close() throws Exception {
+        this.closed = true;
+    }
+
+    public boolean isClosed() {
+        return closed;
+    }
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/beanwithpredestroy/CDestroyedListener.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/beanwithpredestroy/CDestroyedListener.java
@@ -1,0 +1,21 @@
+package io.micronaut.inject.lifecycle.beanwithpredestroy;
+
+import io.micronaut.context.event.BeanDestroyedEvent;
+import io.micronaut.context.event.BeanDestroyedEventListener;
+import org.junit.jupiter.api.Assertions;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class CDestroyedListener implements BeanDestroyedEventListener<C> {
+    private boolean called = true;
+    @Override
+    public void onDestroyed(BeanDestroyedEvent<C> event) {
+        this.called = called;
+        Assertions.assertTrue(event.getBean().isClosed());
+    }
+
+    public boolean isCalled() {
+        return called;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/beanwithpredestroy/CPreDestroyEventListener.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/beanwithpredestroy/CPreDestroyEventListener.java
@@ -1,0 +1,23 @@
+package io.micronaut.inject.lifecycle.beanwithpredestroy;
+
+import io.micronaut.context.event.BeanPreDestroyEvent;
+import io.micronaut.context.event.BeanPreDestroyEventListener;
+import org.junit.jupiter.api.Assertions;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class CPreDestroyEventListener implements BeanPreDestroyEventListener<C> {
+    private boolean called = false;
+    @Override
+    public C onPreDestroy(BeanPreDestroyEvent<C> event) {
+        this.called = true;
+        Assertions.assertFalse(event.getBean().isClosed());
+        return event.getBean();
+    }
+
+    public boolean isCalled() {
+        return called;
+    }
+
+}

--- a/inject/src/main/java/io/micronaut/context/event/ApplicationEventListener.java
+++ b/inject/src/main/java/io/micronaut/context/event/ApplicationEventListener.java
@@ -27,6 +27,7 @@ import java.util.EventListener;
  * @since 1.0
  */
 @Indexed(ApplicationEventListener.class)
+@FunctionalInterface
 public interface ApplicationEventListener<E> extends EventListener {
 
     /**

--- a/inject/src/main/java/io/micronaut/context/event/BeanDestroyedEvent.java
+++ b/inject/src/main/java/io/micronaut/context/event/BeanDestroyedEvent.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context.event;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.inject.BeanDefinition;
+
+/**
+ * <p>An event fired when a bean has been destroyed and all {@link javax.annotation.PreDestroy} methods have been invoked.</p>
+ * <p>
+ *
+ * @param <T> The event type
+ * @author Graeme Rocher
+ * @see BeanPreDestroyEvent
+ * @since 3.0.0
+ */
+public class BeanDestroyedEvent<T> extends BeanEvent<T> {
+    /**
+     * @param beanContext    The bean context
+     * @param beanDefinition The bean definition
+     * @param bean           The bean
+     */
+    public BeanDestroyedEvent(BeanContext beanContext, BeanDefinition<T> beanDefinition, T bean) {
+        super(beanContext, beanDefinition, bean);
+    }
+}
+

--- a/inject/src/main/java/io/micronaut/context/event/BeanDestroyedEventListener.java
+++ b/inject/src/main/java/io/micronaut/context/event/BeanDestroyedEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2021 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,25 +21,22 @@ import io.micronaut.core.annotation.NonNull;
 import java.util.EventListener;
 
 /**
- * <p>An event listener that is triggered each time a bean is created.</p>
+ * <p>An event listener that is triggered after a bean is destroyed.</p>
  * <p>
- * <p>Allows customization of the created beans.</p>
+ * <p>Allows customization of the bean destruction.</p>
  *
  * @param <T> The event type
  * @author Graeme Rocher
- * @see BeanCreatedEvent
- * @since 1.0
+ * @see BeanDestroyedEvent
+ * @since 3.0.0
  */
-@Indexed(BeanCreatedEventListener.class)
+@Indexed(BeanDestroyedEventListener.class)
 @FunctionalInterface
-public interface BeanCreatedEventListener<T> extends EventListener {
-
+public interface BeanDestroyedEventListener<T> extends EventListener {
     /**
-     * Fired when a bean is created and all {@link javax.annotation.PostConstruct} initialization hooks have been
-     * called.
+     * Fired when a bean has been destroyed and all {@link javax.annotation.PreDestroy} methods invoked.
      *
      * @param event The bean created event
-     * @return The bean or a replacement bean of the same type
      */
-    T onCreated(@NonNull BeanCreatedEvent<T> event);
+    void onDestroyed(@NonNull BeanDestroyedEvent<T> event);
 }

--- a/inject/src/main/java/io/micronaut/context/event/BeanInitializedEventListener.java
+++ b/inject/src/main/java/io/micronaut/context/event/BeanInitializedEventListener.java
@@ -31,6 +31,7 @@ import java.util.EventListener;
  * @since 1.0
  */
 @Indexed(BeanInitializedEventListener.class)
+@FunctionalInterface
 public interface BeanInitializedEventListener<T> extends EventListener {
 
     /**

--- a/inject/src/main/java/io/micronaut/context/event/BeanPreDestroyEvent.java
+++ b/inject/src/main/java/io/micronaut/context/event/BeanPreDestroyEvent.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context.event;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.inject.BeanDefinition;
+
+/**
+ * <p>An event fired when a bean is about to be destroyed but before any {@link javax.annotation.PreDestroy} methods are invoked..</p>
+ * <p>
+ *
+ * @param <T> The event type
+ * @author Graeme Rocher
+ * @see BeanDestroyedEvent
+ * @since 3.0.0
+ */
+public class BeanPreDestroyEvent<T> extends BeanEvent<T> {
+    /**
+     * @param beanContext    The bean context
+     * @param beanDefinition The bean definition
+     * @param bean           The bean
+     */
+    public BeanPreDestroyEvent(BeanContext beanContext, BeanDefinition<T> beanDefinition, T bean) {
+        super(beanContext, beanDefinition, bean);
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/event/BeanPreDestroyEventListener.java
+++ b/inject/src/main/java/io/micronaut/context/event/BeanPreDestroyEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2021 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,25 +21,23 @@ import io.micronaut.core.annotation.NonNull;
 import java.util.EventListener;
 
 /**
- * <p>An event listener that is triggered each time a bean is created.</p>
+ * <p>An event listener that is triggered before a bean is destroyed.</p>
  * <p>
- * <p>Allows customization of the created beans.</p>
+ * <p>Allows customization of the bean destruction.</p>
  *
  * @param <T> The event type
  * @author Graeme Rocher
- * @see BeanCreatedEvent
- * @since 1.0
+ * @see BeanPreDestroyEvent
+ * @since 3.0.0
  */
-@Indexed(BeanCreatedEventListener.class)
+@Indexed(BeanPreDestroyEventListener.class)
 @FunctionalInterface
-public interface BeanCreatedEventListener<T> extends EventListener {
-
+public interface BeanPreDestroyEventListener<T> extends EventListener {
     /**
-     * Fired when a bean is created and all {@link javax.annotation.PostConstruct} initialization hooks have been
-     * called.
+     * Fired when a bean is is about to be destroyed but before any {@link javax.annotation.PreDestroy} methods have been invoked.
      *
      * @param event The bean created event
      * @return The bean or a replacement bean of the same type
      */
-    T onCreated(@NonNull BeanCreatedEvent<T> event);
+    @NonNull T onPreDestroy(@NonNull BeanPreDestroyEvent<T> event);
 }

--- a/inject/src/main/java/io/micronaut/context/exceptions/BeanDestructionException.java
+++ b/inject/src/main/java/io/micronaut/context/exceptions/BeanDestructionException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context.exceptions;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.inject.BeanType;
+
+/**
+ * Exception type for exceptions that happen during bean destruction.
+ *
+ * @author graemerocher
+ * @since 3.0.0
+ */
+public class BeanDestructionException extends BeanContextException {
+
+    /**
+     * @param beanType The bean type
+     * @param cause   The throwable
+     */
+    public BeanDestructionException(@NonNull BeanType<?> beanType, @NonNull Throwable cause) {
+        super("Error destroying bean of type [" + beanType.getBeanType() + "]: " + cause.getMessage(), cause);
+    }
+
+}


### PR DESCRIPTION
There is no real bean destruction API like for bean creation in Micronaut.

This PR adds `BeanPreDestroyEventListener` and `BeanDestroyedEventListener` APIs to listen for bean destruction events and also fixes inconsistencies in the behaviour of `destoryBean` and `stop`.

This is a requirement to support #4658 since we need to expose the ability to listen for bean destruction through an event listener API