### PR TITLE
Groovy properties should expose read/write methods. Fixes #5129

### DIFF
--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyClassElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyClassElement.java
@@ -15,25 +15,19 @@
  */
 package io.micronaut.ast.groovy.visitor;
 
-import groovy.lang.MetaProperty;
-import io.micronaut.core.annotation.Nullable;
 import io.micronaut.ast.groovy.annotation.GroovyAnnotationMetadataBuilder;
 import io.micronaut.ast.groovy.utils.AstAnnotationUtils;
 import io.micronaut.ast.groovy.utils.AstClassUtils;
 import io.micronaut.ast.groovy.utils.AstGenericUtils;
 import io.micronaut.ast.groovy.utils.PublicMethodVisitor;
-import io.micronaut.core.annotation.AnnotationMetadata;
-import io.micronaut.core.annotation.Creator;
-import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.*;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.ast.*;
 import org.apache.groovy.ast.tools.ClassNodeUtils;
-import org.apache.groovy.util.BeanUtils;
 import org.codehaus.groovy.ast.*;
 import org.codehaus.groovy.ast.stmt.BlockStatement;
-import io.micronaut.core.annotation.NonNull;
 
 import javax.inject.Inject;
 import java.lang.reflect.Modifier;
@@ -538,7 +532,7 @@ public class GroovyClassElement extends AbstractGroovyElement implements Arrayab
                                     annotationMetadata,
                                     PrimitiveElement.VOID,
                                     PrimitiveElement.VOID,
-                                    MetaProperty.getSetterName(propertyName),
+                                    NameUtils.setterNameFor(propertyName),
                                     ParameterElement.of(getType(), propertyName)
 
                             ));
@@ -558,13 +552,10 @@ public class GroovyClassElement extends AbstractGroovyElement implements Arrayab
                     }
 
                     private String getGetterName(String propertyName, ClassElement type) {
-                        final String prefix;
-                        if (type.equals(PrimitiveElement.BOOLEAN) || type.getName().equals(Boolean.class.getName())) {
-                            prefix = "is";
-                        } else {
-                            prefix = "get";
-                        }
-                        return prefix + BeanUtils.capitalize(propertyName);
+                        return NameUtils.getterNameFor(
+                                propertyName,
+                                type.equals(PrimitiveElement.BOOLEAN) || type.getName().equals(Boolean.class.getName())
+                        );
                     }
                 };
                 propertyElements.add(groovyPropertyElement);

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/BeanIntrospectionSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/BeanIntrospectionSpec.groovy
@@ -23,6 +23,86 @@ class BeanIntrospectionSpec extends AbstractBeanDefinitionSpec {
         System.setProperty(TypeElementVisitorStart.ELEMENT_VISITORS_PROPERTY, IntrospectedTypeElementVisitor.name)
     }
 
+    void "test copy constructor via mutate method"() {
+        given:
+        BeanIntrospection introspection = buildBeanIntrospection('test.CopyMe','''\
+package test;
+
+import java.net.URL;
+
+@io.micronaut.core.annotation.Introspected
+class CopyMe {
+
+    URL url
+    boolean enabled = false
+    private final String name
+    private final String another
+    
+    CopyMe(String name, String another) {
+        this.name = name;
+        this.another = another;
+    }
+    
+    String getName() {
+        return name
+    }
+    
+    String getAnother() {
+        return another
+    }
+    
+    public CopyMe withAnother(String a) {
+        return this.another == a ? this : new CopyMe(this.name, a.toUpperCase())
+    }
+}
+''')
+        when:
+        def copyMe = introspection.instantiate("Test", "Another")
+        def expectUrl = new URL("http://test.com")
+        copyMe.url = expectUrl
+
+        then:
+        copyMe.name == 'Test'
+        copyMe.another == "Another"
+        copyMe.url == expectUrl
+
+
+        when:
+        def enabled = introspection.getRequiredProperty("enabled", boolean.class)
+        def urlProperty = introspection.getRequiredProperty("url", URL)
+        def property = introspection.getRequiredProperty("name", String)
+        def another = introspection.getRequiredProperty("another", String)
+        def newInstance = property.withValue(copyMe, "Changed")
+
+        then:
+        !newInstance.is(copyMe)
+        enabled.get(newInstance) == false
+        newInstance.name == 'Changed'
+        newInstance.url == expectUrl
+        newInstance.another == "Another"
+
+        when:"the instance is changed with the same value"
+        def result = property.withValue(newInstance, "Changed")
+
+        then:"The existing instance is returned"
+        newInstance.is(result)
+
+        when:"An explicit with method is used"
+        result = another.withValue(newInstance, "changed")
+
+        then:"It was invoked"
+        !result.is(newInstance)
+        result.another == 'CHANGED'
+
+        when:"a mutable property is used"
+        def anotherUrl = new URL("http://another.com")
+        urlProperty.withValue(result, anotherUrl)
+        enabled.withValue(result, true)
+        then:"it is correct"
+        result.url == anotherUrl
+        result.enabled == true
+    }
+
     void "test generate bean method for introspected class"() {
         given:
         BeanIntrospection introspection = buildBeanIntrospection('test.MethodTest', '''

--- a/inject/src/main/java/io/micronaut/inject/ast/PrimitiveElement.java
+++ b/inject/src/main/java/io/micronaut/inject/ast/PrimitiveElement.java
@@ -21,14 +21,14 @@ import io.micronaut.core.annotation.AnnotationMetadata;
 public final class PrimitiveElement implements ArrayableClassElement {
 
     public static final PrimitiveElement VOID = new PrimitiveElement("void");
-    private static final PrimitiveElement INT = new PrimitiveElement("int");
-    private static final PrimitiveElement CHAR = new PrimitiveElement("char");
-    private static final PrimitiveElement BOOLEAN = new PrimitiveElement("boolean");
-    private static final PrimitiveElement LONG = new PrimitiveElement("long");
-    private static final PrimitiveElement FLOAT = new PrimitiveElement("float");
-    private static final PrimitiveElement DOUBLE = new PrimitiveElement("double");
-    private static final PrimitiveElement SHORT = new PrimitiveElement("short");
-    private static final PrimitiveElement BYTE = new PrimitiveElement("byte");
+    public static final PrimitiveElement BOOLEAN = new PrimitiveElement("boolean");
+    public static final PrimitiveElement INT = new PrimitiveElement("int");
+    public static final PrimitiveElement CHAR = new PrimitiveElement("char");
+    public static final PrimitiveElement LONG = new PrimitiveElement("long");
+    public static final PrimitiveElement FLOAT = new PrimitiveElement("float");
+    public static final PrimitiveElement DOUBLE = new PrimitiveElement("double");
+    public static final PrimitiveElement SHORT = new PrimitiveElement("short");
+    public static final PrimitiveElement BYTE = new PrimitiveElement("byte");
     private static final PrimitiveElement[] PRIMITIVES = new PrimitiveElement[] {INT, CHAR, BOOLEAN, LONG, FLOAT, DOUBLE, SHORT, BYTE, VOID};
 
     private final String typeName;


### PR DESCRIPTION
Currently `GroovyPropertyElement` doesn't expose read/write methods for the property which means they have to be handled differently.

This alters `GroovyPropertyElement` with new synthetic read/write methods so the behaviour is consistent with when getters/setters are defined.

Fixes #5129