### PR TITLE
Handle LogLevel.OFF in LoggerLevelsConfigurer

### DIFF
--- a/runtime/src/main/java/io/micronaut/logging/PropertiesLoggingLevelsConfigurer.java
+++ b/runtime/src/main/java/io/micronaut/logging/PropertiesLoggingLevelsConfigurer.java
@@ -22,6 +22,7 @@ import io.micronaut.context.env.Environment;
 import io.micronaut.context.event.ApplicationEventListener;
 import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.naming.conventions.StringConvention;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.runtime.context.scope.refresh.RefreshEvent;
@@ -87,7 +88,12 @@ final class PropertiesLoggingLevelsConfigurer implements ApplicationEventListene
     }
 
     private void configureLogLevelForPrefix(String loggerPrefix, Object levelValue) {
-        LogLevel newLevel = toLogLevel(levelValue.toString());
+        final LogLevel newLevel;
+        if (levelValue instanceof Boolean && !((boolean) levelValue)) {
+            newLevel = LogLevel.OFF; // SnakeYAML converts OFF (without quotations) to a boolean false value, hence we need to handle that here...
+        } else {
+            newLevel = toLogLevel(levelValue.toString());
+        }
         if (newLevel == null) {
             throw new ConfigurationException("Invalid log level: '" + levelValue + "' for logger: '" + loggerPrefix + "'");
         }

--- a/runtime/src/main/java/io/micronaut/logging/PropertiesLoggingLevelsConfigurer.java
+++ b/runtime/src/main/java/io/micronaut/logging/PropertiesLoggingLevelsConfigurer.java
@@ -22,7 +22,6 @@ import io.micronaut.context.env.Environment;
 import io.micronaut.context.event.ApplicationEventListener;
 import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.naming.conventions.StringConvention;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.runtime.context.scope.refresh.RefreshEvent;
@@ -87,7 +86,7 @@ final class PropertiesLoggingLevelsConfigurer implements ApplicationEventListene
         properties.forEach(this::configureLogLevelForPrefix);
     }
 
-    private void configureLogLevelForPrefix(String loggerPrefix, Object levelValue) {
+    private void configureLogLevelForPrefix(final String loggerPrefix, final Object levelValue) {
         final LogLevel newLevel;
         if (levelValue instanceof Boolean && !((boolean) levelValue)) {
             newLevel = LogLevel.OFF; // SnakeYAML converts OFF (without quotations) to a boolean false value, hence we need to handle that here...

--- a/runtime/src/test/groovy/io/micronaut/logging/LogbackLogLevelConfigurerSpec.groovy
+++ b/runtime/src/test/groovy/io/micronaut/logging/LogbackLogLevelConfigurerSpec.groovy
@@ -4,6 +4,10 @@ import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.Logger
 import com.github.stefanbirkner.systemlambda.SystemLambda
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.env.PropertySource
+import io.micronaut.context.env.yaml.YamlPropertySourceLoader
+import io.micronaut.context.exceptions.BeanInstantiationException
+import io.micronaut.context.exceptions.ConfigurationException
 import org.slf4j.LoggerFactory
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -17,14 +21,16 @@ class LogbackLogLevelConfigurerSpec extends Specification {
             ((Logger) LoggerFactory.getLogger('foo.bar2')).setLevel(Level.DEBUG)
             ((Logger) LoggerFactory.getLogger('foo.bar3')).setLevel(Level.ERROR)
             ((Logger) LoggerFactory.getLogger('foo.barBaz')).setLevel(Level.WARN)
+            ((Logger) LoggerFactory.getLogger('ignoring.error')).setLevel(Level.INFO)
 
         when:
             ApplicationContext context = ApplicationContext.run(
                     [
-                            'logger.levels.aaa.bbb.ccc': 'ERROR',
-                            'logger.levels.foo.bar2'   : 'INFO',
-                            'logger.levels.foo.bar3'   : '',
-                            'logger.levels.foo.barBaz'   : 'INFO',
+                            'logger.levels.aaa.bbb.ccc'   : 'ERROR',
+                            'logger.levels.foo.bar2'      : 'INFO',
+                            'logger.levels.foo.bar3'      : '',
+                            'logger.levels.foo.barBaz'    : 'INFO',
+                            'logger.levels.ignoring.error': 'OFF',
                     ]
             )
 
@@ -35,13 +41,51 @@ class LogbackLogLevelConfigurerSpec extends Specification {
             context.close()
 
         where:
-            loggerName    | expectedLevel
-            'foo.bar1'    | Level.DEBUG
-            'foo.bar2'    | Level.INFO
-            'foo.bar3'    | null
-            'aaa.bbb.ccc' | Level.ERROR
-            'foo.barBaz'    | Level.INFO
+            loggerName       | expectedLevel
+            'foo.bar1'       | Level.DEBUG
+            'foo.bar2'       | Level.INFO
+            'foo.bar3'       | null
+            'aaa.bbb.ccc'    | Level.ERROR
+            'foo.barBaz'     | Level.INFO
+            'ignoring.error' | Level.OFF
+    }
 
+    void 'test that log level OFF without quotes does not get treated as boolean false'() {
+        given:
+        def map = new YamlPropertySourceLoader().read("myconfig.yml", '''
+logger:
+  levels:
+    io.annoying.class: OFF
+'''.bytes)
+
+        when:
+        ApplicationContext context = ApplicationContext.builder()
+                .propertySources(PropertySource.of(map))
+                .start()
+
+        then:
+        ((Logger) LoggerFactory.getLogger("io.annoying.class")).getLevel() == Level.OFF
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test that log level ON throws BeanInstantiationException with nested cause of ConfigurationException'() {
+        given:
+        def map = new YamlPropertySourceLoader().read("myconfig.yml", '''
+logger:
+  levels:
+    io.annoying.class: ON
+'''.bytes)
+
+        when:
+        ApplicationContext.builder()
+                .propertySources(PropertySource.of(map))
+                .start()
+
+        then:
+        BeanInstantiationException beanInstantiationException = thrown(BeanInstantiationException)
+        beanInstantiationException.cause.cause instanceof ConfigurationException
     }
 
     void 'test that log levels can be configured via environment variables'() {
@@ -66,7 +110,6 @@ class LogbackLogLevelConfigurerSpec extends Specification {
             loggerName    | expectedLevel
             'foo.bar1'    | Level.DEBUG
             'foo.bar2'    | Level.INFO
-
     }
 
 }

--- a/src/main/docs/guide/config/propertySource.adoc
+++ b/src/main/docs/guide/config/propertySource.adoc
@@ -179,4 +179,17 @@ logger:
 
 The same configuration can be achieved by setting the environment variable `LOGGER_LEVELS_FOO_BAR`. Note that there is currently no way to set log levels for unconventional prefixes such as `foo.barBaz`.
 
+==== DIsabling a Logger with Properties
+
+To disable a logger, you need to set the logger level to `OFF`:
+
+[source,yaml]
+----
+logger:
+  levels:
+    com.example.overly.excessive.ErrorLogger: "OFF" <1>
+----
+1. It is required to add quotes to `OFF` to be treated literally as a string.  Otherwise, this will be incorrectly converted to boolean false.
+
+
 Note that the ability to control log levels via config is controlled via the api:logging.LoggingSystem[] interface. Currently, Micronaut includes a single implementation that allows setting log levels for the Logback library. If you use another library, you should provide a bean that implements this interface.

--- a/src/main/docs/guide/config/propertySource.adoc
+++ b/src/main/docs/guide/config/propertySource.adoc
@@ -187,9 +187,9 @@ To disable a logger, you need to set the logger level to `OFF`:
 ----
 logger:
   levels:
-    com.example.overly.excessive.ErrorLogger: OFF <1>
+    io.verbose.logger.who.CriedWolf: OFF <1>
 ----
-1. This will disable ALL logging for the specified logger
+1. This will disable ALL logging for the class `io.verbose.logger.who.CriedWolf`
 
 
 Note that the ability to control log levels via config is controlled via the api:logging.LoggingSystem[] interface. Currently, Micronaut includes a single implementation that allows setting log levels for the Logback library. If you use another library, you should provide a bean that implements this interface.

--- a/src/main/docs/guide/config/propertySource.adoc
+++ b/src/main/docs/guide/config/propertySource.adoc
@@ -179,7 +179,7 @@ logger:
 
 The same configuration can be achieved by setting the environment variable `LOGGER_LEVELS_FOO_BAR`. Note that there is currently no way to set log levels for unconventional prefixes such as `foo.barBaz`.
 
-==== DIsabling a Logger with Properties
+==== Disabling a Logger with Properties
 
 To disable a logger, you need to set the logger level to `OFF`:
 
@@ -187,9 +187,9 @@ To disable a logger, you need to set the logger level to `OFF`:
 ----
 logger:
   levels:
-    com.example.overly.excessive.ErrorLogger: "OFF" <1>
+    com.example.overly.excessive.ErrorLogger: "OFF" # <1>
 ----
-1. It is required to add quotes to `OFF` to be treated literally as a string.  Otherwise, this will be incorrectly converted to boolean false.
+<1> It is required to add quotes to `OFF` to be treated literally as a string.  Otherwise, this will be incorrectly converted to boolean false.
 
 
 Note that the ability to control log levels via config is controlled via the api:logging.LoggingSystem[] interface. Currently, Micronaut includes a single implementation that allows setting log levels for the Logback library. If you use another library, you should provide a bean that implements this interface.

--- a/src/main/docs/guide/config/propertySource.adoc
+++ b/src/main/docs/guide/config/propertySource.adoc
@@ -187,9 +187,9 @@ To disable a logger, you need to set the logger level to `OFF`:
 ----
 logger:
   levels:
-    com.example.overly.excessive.ErrorLogger: "OFF" # <1>
+    com.example.overly.excessive.ErrorLogger: OFF <1>
 ----
-<1> It is required to add quotes to `OFF` to be treated literally as a string.  Otherwise, this will be incorrectly converted to boolean false.
+1. This will disable ALL logging for the specified logger
 
 
 Note that the ability to control log levels via config is controlled via the api:logging.LoggingSystem[] interface. Currently, Micronaut includes a single implementation that allows setting log levels for the Logback library. If you use another library, you should provide a bean that implements this interface.


### PR DESCRIPTION
Properly handle `OFF` as a valid `LogLevel` for disabling a logger.