### PR TITLE
Docs - Fixed wrong annotation reference and name

### DIFF
--- a/src/main/docs/guide/httpClient/clientFilter.adoc
+++ b/src/main/docs/guide/httpClient/clientFilter.adoc
@@ -53,4 +53,4 @@ The `@BasicAuth` annotation is just an example and can be replaced with your own
 
 snippet::io.micronaut.docs.client.filter.BasicAuth[tags="class"]
 
-<1> The only requirement for custom annotations is that the ann:http.annotation.HttpFilterStereotype[] annotation must be present
+<1> The only requirement for custom annotations is that the ann:http.annotation.FilterMatcher[] annotation must be present


### PR DESCRIPTION
In the docs, in the Http Client Filter section has wrong reference and name to an annotation. There is reference to @HttpFilterStereotype annotation, but the correct is @FilterMatcher annotation.

You can check this at one line above to this link in the docs: https://docs.micronaut.io/snapshot/guide/index.html#clientSample