### PR TITLE
Fix GraalVM warning

### DIFF
--- a/validation/src/main/resources/native-image/io.micronaut.validation/micronaut-validation/native-image.properties
+++ b/validation/src/main/resources/native-image/io.micronaut.validation/micronaut-validation/native-image.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2017-2020 original authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Args = --initialize-at-run-time=io.micronaut.validation.exceptions.ValidationExceptionHandler


### PR DESCRIPTION
This PR fixes the following warning during native image creation:

```
Warning: class initialization of class io.micronaut.validation.exceptions.ValidationExceptionHandler failed with exception java.lang.NoClassDefFoundError: org/grails/datastore/mapping/validation/ValidationException. This class will be initialized at run time because option --allow-incomplete-classpath is used for image building. Use the option --initialize-at-run-time=io.micronaut.validation.exceptions.ValidationExceptionHandler to explicitly request delayed initialization of this class.
```