### PR TITLE
 Fix JsonView filtering when snake_case and bean introspection are enabled together (#5160)

### DIFF
--- a/runtime/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
+++ b/runtime/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
@@ -230,6 +230,7 @@ public class BeanIntrospectionModule extends SimpleModule {
                     }
                     newBuilder.setProperties(newProperties);
                 }
+                newBuilder.setFilteredProperties(builder.getFilteredProperties());
                 return newBuilder;
             }
         }


### PR DESCRIPTION
* Added test case for #5160
* Copy over filteredProperties from original BeanSerializerBuilder when creating a new one in BeanInstrospectionModule