### PR TITLE
feat: text/vnd.turbo-stream.html media type

### DIFF
--- a/http/src/main/java/io/micronaut/http/MediaType.java
+++ b/http/src/main/java/io/micronaut/http/MediaType.java
@@ -127,6 +127,16 @@ public class MediaType implements CharSequence {
     public static final MediaType APPLICATION_XHTML_TYPE = new MediaType(APPLICATION_XHTML, "html");
 
     /**
+     * HTML: text/vnd.turbo-stream.html.
+     */
+    public static final String TEXT_TURBO_STREAM = "text/vnd.turbo-stream.html";
+
+    /**
+     * HTML: text/vnd.turbo-stream.html.
+     */
+    public static final MediaType TEXT_TURBO_STREAM_TYPE = new MediaType(TEXT_TURBO_STREAM);
+
+    /**
      * XML: application/xml.
      */
     public static final String APPLICATION_XML = "application/xml";


### PR DESCRIPTION
See: https://turbo.hotwire.dev/handbook/streams#streaming-from-http-responses

> Turbo knows to automatically attach <turbo-stream> elements when they arrive in response to <form> submissions that declare a MIME type of text/vnd.turbo-stream.html.