### PR TITLE
Support for Custom Validator Message

### DIFF
--- a/inject-java/src/main/java/io/micronaut/annotation/processing/AnnotationProcessingOutputVisitor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/AnnotationProcessingOutputVisitor.java
@@ -47,23 +47,23 @@ import java.util.*;
  */
 public class AnnotationProcessingOutputVisitor extends AbstractClassWriterOutputVisitor {
 
+    private static final Field FILTER_OUTPUT_STREAM_OUT = ReflectionUtils.findField(FilterOutputStream.class, "out")
+        .map(field -> {
+            try {
+                addOpenJavaModules(FilterOutputStream.class, AnnotationProcessingOutputVisitor.class);
+                field.setAccessible(true);
+                return field;
+            } catch (Exception e) {
+                return null;
+            }
+        })
+        .orElse(null);
+
     private final Filer filer;
     private final Map<String, Optional<GeneratedFile>> metaInfFiles = new LinkedHashMap<>();
     private final Map<String, FileObject> openedFiles = new LinkedHashMap<>();
     private final Map<String, Optional<GeneratedFile>> generatedFiles = new LinkedHashMap<>();
     private final boolean isGradleFiler;
-
-    private static final Field FILTER_OUTPUT_STREAM_OUT = ReflectionUtils.findField(FilterOutputStream.class, "out")
-            .map(field -> {
-                try {
-                    addOpenJavaModules(FilterOutputStream.class, AnnotationProcessingOutputVisitor.class);
-                    field.setAccessible(true);
-                    return field;
-                } catch (Exception e) {
-                    return null;
-                }
-            })
-            .orElse(null);
 
     /**
      * @param filer The {@link Filer} for creating new files

--- a/runtime/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
+++ b/runtime/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
@@ -15,15 +15,33 @@
  */
 package io.micronaut.jackson.modules;
 
-import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.SerializableString;
 import com.fasterxml.jackson.core.io.SerializedString;
-import com.fasterxml.jackson.databind.*;
-import com.fasterxml.jackson.databind.deser.*;
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.DeserializationConfig;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.PropertyMetadata;
+import com.fasterxml.jackson.databind.PropertyName;
+import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.deser.BeanDeserializerBuilder;
+import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;
+import com.fasterxml.jackson.databind.deser.CreatorProperty;
+import com.fasterxml.jackson.databind.deser.NullValueProvider;
+import com.fasterxml.jackson.databind.deser.SettableBeanProperty;
+import com.fasterxml.jackson.databind.deser.ValueInstantiator;
 import com.fasterxml.jackson.databind.deser.impl.MethodProperty;
-import com.fasterxml.jackson.databind.deser.impl.PropertyValueBuffer;
 import com.fasterxml.jackson.databind.deser.std.StdValueInstantiator;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
 import com.fasterxml.jackson.databind.introspect.TypeResolutionContext;
@@ -55,7 +73,14 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Singleton;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * A Jackson module that adds reflection-free bean serialization and deserialization for Micronaut.

--- a/src/main/docs/guide/ioc/beanValidation.adoc
+++ b/src/main/docs/guide/ioc/beanValidation.adoc
@@ -102,6 +102,8 @@ The latter approach is recommended if you plan to define multiple validators:
 .Example Constraint Validator
 snippet::io.micronaut.docs.ioc.validation.custom.MyValidatorFactory[tags="imports,class", indent="0"]
 
+<1> Override the default message template with an inline call for more control over the validation error message.
+
 The above example implements a validator that validates any field, parameter etc. that is annotated with `DurationPattern`, ensuring that the string can be parsed with `java.time.Duration.parse`.
 
 NOTE: Generally `null` is regarded as valid and `@NotNull` is used to constrain a value as not being `null`. The example above regards `null` as a valid value.

--- a/src/main/docs/guide/ioc/beanValidation.adoc
+++ b/src/main/docs/guide/ioc/beanValidation.adoc
@@ -102,7 +102,7 @@ The latter approach is recommended if you plan to define multiple validators:
 .Example Constraint Validator
 snippet::io.micronaut.docs.ioc.validation.custom.MyValidatorFactory[tags="imports,class", indent="0"]
 
-<1> Override the default message template with an inline call for more control over the validation error message.
+<1> Override the default message template with an inline call for more control over the validation error message. (Since `2.5.0`)
 
 The above example implements a validator that validates any field, parameter etc. that is annotated with `DurationPattern`, ensuring that the string can be parsed with `java.time.Duration.parse`.
 

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/ioc/validation/custom/DurationPatternValidatorSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/ioc/validation/custom/DurationPatternValidatorSpec.groovy
@@ -18,7 +18,7 @@ class DurationPatternValidatorSpec extends Specification {
 
         then:"A validation error occurs"
         def e = thrown(ConstraintViolationException)
-        e.message == "startHoliday.duration: invalid duration (junk)" //  <2>
+        e.message == "startHoliday.duration: invalid duration (junk), additional custom message" //  <2>
     }
     // end::test[]
 }

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/ioc/validation/custom/MyValidatorFactory.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/ioc/validation/custom/MyValidatorFactory.groovy
@@ -33,7 +33,7 @@ class MyValidatorFactory {
         return { CharSequence value,
                  AnnotationValue<DurationPattern> annotation,
                  ConstraintValidatorContext context ->
-            context.overrideMessageTemplate("invalid duration ({validatedValue}), additional custom message") // <1>
+            context.messageTemplate("invalid duration ({validatedValue}), additional custom message") // <1>
             return value == null || value.toString() ==~ /^PT?[\d]+[SMHD]{1}$/
         } as ConstraintValidator<DurationPattern, CharSequence>
     }

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/ioc/validation/custom/MyValidatorFactory.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/ioc/validation/custom/MyValidatorFactory.groovy
@@ -33,6 +33,7 @@ class MyValidatorFactory {
         return { CharSequence value,
                  AnnotationValue<DurationPattern> annotation,
                  ConstraintValidatorContext context ->
+            context.overrideMessageTemplate("invalid duration ({validatedValue}), additional custom message") // <1>
             return value == null || value.toString() ==~ /^PT?[\d]+[SMHD]{1}$/
         } as ConstraintValidator<DurationPattern, CharSequence>
     }

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/ioc/validation/custom/DurationPatternValidatorSpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/ioc/validation/custom/DurationPatternValidatorSpec.kt
@@ -20,7 +20,7 @@ internal class DurationPatternValidatorSpec {
             holidayService.startHoliday("Fred", "junk") // <1>
         }
 
-        assertEquals("startHoliday.duration: invalid duration (junk)", exception.message) // <2>
+        assertEquals("startHoliday.duration: invalid duration (junk), additional custom message", exception.message) // <2>
     }
     // end::test[]
 }

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/ioc/validation/custom/MyValidatorFactory.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/ioc/validation/custom/MyValidatorFactory.kt
@@ -29,7 +29,7 @@ class MyValidatorFactory {
     fun durationPatternValidator() : ConstraintValidator<DurationPattern, CharSequence> {
         return ConstraintValidator { value, annotation, context ->
             context.overrideMessageTemplate("invalid duration ({validatedValue}), additional custom message") // <1>
-            return value == null || value.toString().matches("^PT?[\\d]+[SMHD]{1}$".toRegex())
+            value == null || value.toString().matches("^PT?[\\d]+[SMHD]{1}$".toRegex())
         }
     }
 }

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/ioc/validation/custom/MyValidatorFactory.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/ioc/validation/custom/MyValidatorFactory.kt
@@ -28,7 +28,8 @@ class MyValidatorFactory {
     @Singleton
     fun durationPatternValidator() : ConstraintValidator<DurationPattern, CharSequence> {
         return ConstraintValidator { value, annotation, context ->
-            value == null || value.toString().matches("^PT?[\\d]+[SMHD]{1}$".toRegex())
+            context.overrideMessageTemplate("invalid duration ({validatedValue}), additional custom message") // <1>
+            return value == null || value.toString().matches("^PT?[\\d]+[SMHD]{1}$".toRegex())
         }
     }
 }

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/ioc/validation/custom/MyValidatorFactory.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/ioc/validation/custom/MyValidatorFactory.kt
@@ -28,7 +28,7 @@ class MyValidatorFactory {
     @Singleton
     fun durationPatternValidator() : ConstraintValidator<DurationPattern, CharSequence> {
         return ConstraintValidator { value, annotation, context ->
-            context.overrideMessageTemplate("invalid duration ({validatedValue}), additional custom message") // <1>
+            context.messageTemplate("invalid duration ({validatedValue}), additional custom message") // <1>
             value == null || value.toString().matches("^PT?[\\d]+[SMHD]{1}$".toRegex())
         }
     }

--- a/test-suite/src/test/java/io/micronaut/docs/ioc/validation/custom/DurationPatternValidatorSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/ioc/validation/custom/DurationPatternValidatorSpec.java
@@ -37,7 +37,7 @@ class DurationPatternValidatorSpec {
                 holidayService.startHoliday("Fred", "junk") // <1>
             );
 
-        assertEquals("startHoliday.duration: invalid duration (junk)", exception.getMessage()); // <2>
+        assertEquals("startHoliday.duration: invalid duration (junk), additional custom message", exception.getMessage()); // <2>
     }
     // end::test[]
 }

--- a/test-suite/src/test/java/io/micronaut/docs/ioc/validation/custom/MyValidatorFactory.java
+++ b/test-suite/src/test/java/io/micronaut/docs/ioc/validation/custom/MyValidatorFactory.java
@@ -29,7 +29,7 @@ public class MyValidatorFactory {
     @Singleton
     ConstraintValidator<DurationPattern, CharSequence> durationPatternValidator() {
         return (value, annotationMetadata, context) -> {
-            context.overrideMessageTemplate("invalid duration ({validatedValue}), additional custom message"); // <1>
+            context.messageTemplate("invalid duration ({validatedValue}), additional custom message"); // <1>
             return value == null || value.toString().matches("^PT?[\\d]+[SMHD]{1}$");
         };
     }

--- a/test-suite/src/test/java/io/micronaut/docs/ioc/validation/custom/MyValidatorFactory.java
+++ b/test-suite/src/test/java/io/micronaut/docs/ioc/validation/custom/MyValidatorFactory.java
@@ -28,8 +28,10 @@ public class MyValidatorFactory {
 
     @Singleton
     ConstraintValidator<DurationPattern, CharSequence> durationPatternValidator() {
-        return (value, annotationMetadata, context) ->
-                value == null || value.toString().matches("^PT?[\\d]+[SMHD]{1}$");
+        return (value, annotationMetadata, context) -> {
+            context.overrideMessageTemplate("invalid duration ({validatedValue}), additional custom message"); // <1>
+            return value == null || value.toString().matches("^PT?[\\d]+[SMHD]{1}$");
+        };
     }
 }
 // end::class[]

--- a/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java
@@ -2220,7 +2220,7 @@ public class DefaultValidator implements Validator, ExecutableMethodValidator, R
             this.rootBeanClass = rootBeanClass;
             this.invalidValue = invalidValue;
             this.message = message;
-            this.ildmessageTemplate;
+            this.messageTemplate = messageTemplate;
             this.path = path;
             this.leafBean = leafBean;
             this.constraintDescriptor = constraintDescriptor;

--- a/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java
@@ -1565,7 +1565,7 @@ public class DefaultValidator implements Validator, ExecutableMethodValidator, R
 
     private String buildMessageTemplate(final DefaultConstraintValidatorContext context, final AnnotationValue<?> annotationValue,
                                         final AnnotationMetadata annotationMetadata) {
-        return Optional.ofNullable(context.getMessageTemplateOverride())
+        return context.getMessageTemplate()
             .orElseGet(() -> annotationValue.stringValue("message")
                 .orElseGet(() -> annotationMetadata.getDefaultValue(annotationValue.getAnnotationName(), "message", String.class)
                             .orElse("{" + annotationValue.getAnnotationName() + ".message}")));
@@ -1784,7 +1784,7 @@ public class DefaultValidator implements Validator, ExecutableMethodValidator, R
         Object parameterValue,
         Object... parameters
     ) {
-        final String messageTemplate = Optional.ofNullable(context.getMessageTemplateOverride())
+        final String messageTemplate = context.getMessageTemplate()
             .orElseGet(() -> "{" + Introspected.class.getName() + ".message}");
         return new DefaultConstraintViolation<>(object, rootClass, object, parameterValue,
             messageSource.interpolate(messageTemplate, MessageSource.MessageContext.of(Collections.singletonMap("type", parameterType.getName()))),
@@ -1798,7 +1798,7 @@ public class DefaultValidator implements Validator, ExecutableMethodValidator, R
         final Set<Object> validatedObjects = new HashSet<>(20);
         final PathImpl currentPath;
         final List<Class> groups;
-        String messageTemplateOverride = null;
+        String messageTemplate = null;
 
         private <T> DefaultConstraintValidatorContext(T object, Class<?>... groups) {
             this(object, new PathImpl(), groups);
@@ -1834,14 +1834,12 @@ public class DefaultValidator implements Validator, ExecutableMethodValidator, R
         }
 
         @Override
-        public void overrideMessageTemplate(@Nullable final String messageTemplateOverride) {
-            this.messageTemplateOverride = messageTemplateOverride;
+        public void messageTemplate(@Nullable final String messageTemplate) {
+            this.messageTemplate = messageTemplate;
         }
 
-        @Nullable
-        @Override
-        public String getMessageTemplateOverride() {
-            return messageTemplateOverride;
+        Optional<String> getMessageTemplate() {
+            return Optional.ofNullable(messageTemplate);
         }
 
         Path.Node addPropertyNode(String name, @Nullable DefaultPropertyNode container) {

--- a/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java
@@ -1798,6 +1798,7 @@ public class DefaultValidator implements Validator, ExecutableMethodValidator, R
         final Set<Object> validatedObjects = new HashSet<>(20);
         final PathImpl currentPath;
         final List<Class> groups;
+        String messageTemplateOverride = null;
 
         private <T> DefaultConstraintValidatorContext(T object, Class<?>... groups) {
             this(object, new PathImpl(), groups);
@@ -1830,6 +1831,17 @@ public class DefaultValidator implements Validator, ExecutableMethodValidator, R
         @Override
         public Object getRootBean() {
             return validatedObjects.isEmpty() ? null : validatedObjects.iterator().next();
+        }
+
+        @Override
+        public void overrideMessageTemplate(@Nullable final String messageTemplateOverride) {
+            this.messageTemplateOverride = messageTemplateOverride;
+        }
+
+        @Nullable
+        @Override
+        public String getMessageTemplateOverride() {
+            return messageTemplateOverride;
         }
 
         Path.Node addPropertyNode(String name, @Nullable DefaultPropertyNode container) {

--- a/validation/src/main/java/io/micronaut/validation/validator/constraints/ConstraintValidator.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/constraints/ConstraintValidator.java
@@ -23,6 +23,7 @@ import io.micronaut.core.annotation.Nullable;
 import javax.validation.ClockProvider;
 import javax.validation.Constraint;
 import java.lang.annotation.Annotation;
+import java.util.Optional;
 
 /**
  * Constraint validator that can be used at either runtime or compilation time and
@@ -61,9 +62,9 @@ public interface ConstraintValidator<A extends Annotation, T> extends javax.vali
     @Override
     default boolean isValid(T value, javax.validation.ConstraintValidatorContext context) {
         // simply adapt the interfaces for now.
-        return isValid(value, new AnnotationValue(Constraint.class.getName()), new ConstraintValidatorContext() {
+        return isValid(value, new AnnotationValue<>(Constraint.class.getName()), new ConstraintValidatorContext() {
 
-            private String messageTemplateOverride = null;
+            private String messageTemplate = context.getDefaultConstraintMessageTemplate();
 
             @NonNull
             @Override
@@ -78,14 +79,12 @@ public interface ConstraintValidator<A extends Annotation, T> extends javax.vali
             }
 
             @Override
-            public void overrideMessageTemplate(@Nullable final String messageTemplateOverride) {
-                this.messageTemplateOverride = messageTemplateOverride;
+            public void messageTemplate(@Nullable final String messageTemplate) {
+                this.messageTemplate = messageTemplate;
             }
 
-            @Nullable
-            @Override
-            public String getMessageTemplateOverride() {
-                return messageTemplateOverride;
+            public Optional<String> getMessageTemplate() {
+                return Optional.ofNullable(messageTemplate);
             }
 
         });

--- a/validation/src/main/java/io/micronaut/validation/validator/constraints/ConstraintValidator.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/constraints/ConstraintValidator.java
@@ -23,6 +23,7 @@ import io.micronaut.core.annotation.Nullable;
 import javax.validation.ClockProvider;
 import javax.validation.Constraint;
 import java.lang.annotation.Annotation;
+import java.util.Optional;
 
 /**
  * Constraint validator that can be used at either runtime or compilation time and
@@ -62,6 +63,9 @@ public interface ConstraintValidator<A extends Annotation, T> extends javax.vali
     default boolean isValid(T value, javax.validation.ConstraintValidatorContext context) {
         // simply adapt the interfaces for now.
         return isValid(value, new AnnotationValue(Constraint.class.getName()), new ConstraintValidatorContext() {
+
+            private String messageOverride;
+
             @NonNull
             @Override
             public ClockProvider getClockProvider() {
@@ -73,6 +77,17 @@ public interface ConstraintValidator<A extends Annotation, T> extends javax.vali
             public Object getRootBean() {
                 return null;
             }
+
+            @Override
+            public void overrideMessageTemplate(final String messageTemplateOverride) {
+                this.messageOverride = messageTemplateOverride;
+            }
+
+            @Override
+            public String getMessageTemplateOverride() {
+                return messageOverride;
+            }
+
         });
     }
 }

--- a/validation/src/main/java/io/micronaut/validation/validator/constraints/ConstraintValidator.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/constraints/ConstraintValidator.java
@@ -63,7 +63,7 @@ public interface ConstraintValidator<A extends Annotation, T> extends javax.vali
         // simply adapt the interfaces for now.
         return isValid(value, new AnnotationValue(Constraint.class.getName()), new ConstraintValidatorContext() {
 
-            private String messageOverride = null;
+            private String messageTemplateOverride = null;
 
             @NonNull
             @Override
@@ -79,13 +79,13 @@ public interface ConstraintValidator<A extends Annotation, T> extends javax.vali
 
             @Override
             public void overrideMessageTemplate(@Nullable final String messageTemplateOverride) {
-                this.messageOverride = messageTemplateOverride;
+                this.messageTemplateOverride = messageTemplateOverride;
             }
 
             @Nullable
             @Override
             public String getMessageTemplateOverride() {
-                return messageOverride;
+                return messageTemplateOverride;
             }
 
         });

--- a/validation/src/main/java/io/micronaut/validation/validator/constraints/ConstraintValidator.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/constraints/ConstraintValidator.java
@@ -17,13 +17,12 @@ package io.micronaut.validation.validator.constraints;
 
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Indexed;
-
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
+
 import javax.validation.ClockProvider;
 import javax.validation.Constraint;
 import java.lang.annotation.Annotation;
-import java.util.Optional;
 
 /**
  * Constraint validator that can be used at either runtime or compilation time and
@@ -64,7 +63,7 @@ public interface ConstraintValidator<A extends Annotation, T> extends javax.vali
         // simply adapt the interfaces for now.
         return isValid(value, new AnnotationValue(Constraint.class.getName()), new ConstraintValidatorContext() {
 
-            private String messageOverride;
+            private String messageOverride = null;
 
             @NonNull
             @Override
@@ -79,10 +78,11 @@ public interface ConstraintValidator<A extends Annotation, T> extends javax.vali
             }
 
             @Override
-            public void overrideMessageTemplate(final String messageTemplateOverride) {
+            public void overrideMessageTemplate(@Nullable final String messageTemplateOverride) {
                 this.messageOverride = messageTemplateOverride;
             }
 
+            @Nullable
             @Override
             public String getMessageTemplateOverride() {
                 return messageOverride;

--- a/validation/src/main/java/io/micronaut/validation/validator/constraints/ConstraintValidatorContext.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/constraints/ConstraintValidatorContext.java
@@ -50,18 +50,18 @@ public interface ConstraintValidatorContext {
     @Nullable Object getRootBean();
 
     /**
-     * Sets a message to be used for the validation error to override default
+     * Sets a message template to be used for the validation error to override default.
      *
      * @param messageTemplateOverride the message to override default
      */
-    default void overrideMessageTemplate(final String messageTemplateOverride) { }
+    default void overrideMessageTemplate(@Nullable final String messageTemplateOverride) { }
 
     /**
-     * Get the message override
+     * Get the message template override.
      *
      * @return the message override
      */
-    default String getMessageTemplateOverride() {
+    @Nullable default String getMessageTemplateOverride() {
         return null;
     }
     

--- a/validation/src/main/java/io/micronaut/validation/validator/constraints/ConstraintValidatorContext.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/constraints/ConstraintValidatorContext.java
@@ -48,5 +48,21 @@ public interface ConstraintValidatorContext {
      * @return The root bean under validation.
      */
     @Nullable Object getRootBean();
+
+    /**
+     * Sets a message to be used for the validation error to override default
+     *
+     * @param messageTemplateOverride the message to override default
+     */
+    default void overrideMessageTemplate(final String messageTemplateOverride) { }
+
+    /**
+     * Get the message override
+     *
+     * @return the message override
+     */
+    default String getMessageTemplateOverride() {
+        return null;
+    }
     
 }

--- a/validation/src/main/java/io/micronaut/validation/validator/constraints/ConstraintValidatorContext.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/constraints/ConstraintValidatorContext.java
@@ -54,7 +54,9 @@ public interface ConstraintValidatorContext {
      *
      * @param messageTemplateOverride the message to override default
      */
-    default void overrideMessageTemplate(@Nullable final String messageTemplateOverride) { }
+    default void overrideMessageTemplate(@Nullable final String messageTemplateOverride) {
+        throw new UnsupportedOperationException("not implemented");
+    }
 
     /**
      * Get the message template override.

--- a/validation/src/main/java/io/micronaut/validation/validator/constraints/ConstraintValidatorContext.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/constraints/ConstraintValidatorContext.java
@@ -50,21 +50,13 @@ public interface ConstraintValidatorContext {
     @Nullable Object getRootBean();
 
     /**
-     * Sets a message template to be used for the validation error to override default.
+     * Sets a message template to be used for the validation error message.
      *
-     * @param messageTemplateOverride the message to override default
+     * @param messageTemplate the message template
+     * @since 2.5.0
      */
-    default void overrideMessageTemplate(@Nullable final String messageTemplateOverride) {
+    default void messageTemplate(@Nullable final String messageTemplate) {
         throw new UnsupportedOperationException("not implemented");
-    }
-
-    /**
-     * Get the message template override.
-     *
-     * @return the message override
-     */
-    @Nullable default String getMessageTemplateOverride() {
-        return null;
     }
     
 }

--- a/validation/src/test/groovy/io/micronaut/validation/validator/constraints/custom/CustomConstraintsSpec.groovy
+++ b/validation/src/test/groovy/io/micronaut/validation/validator/constraints/custom/CustomConstraintsSpec.groovy
@@ -170,10 +170,10 @@ class CustomTestInvalid {
     CustomInvalidOuter invalidOuter
 
     @Introspected
-    @AlwaysInvalidConstraint
+    @CustomMessageConstraint
     static class CustomInvalidInner {}
 }
 
 @Introspected
-@AlwaysInvalidConstraint
+@CustomMessageConstraint
 class CustomInvalidOuter {}

--- a/validation/src/test/groovy/io/micronaut/validation/validator/constraints/custom/CustomConstraintsSpec.groovy
+++ b/validation/src/test/groovy/io/micronaut/validation/validator/constraints/custom/CustomConstraintsSpec.groovy
@@ -79,6 +79,69 @@ class CustomConstraintsSpec extends Specification {
         violations.size() == 1
         violations[0].message == "invalid"
     }
+
+    void "test validation where pojo with inner custom message constraint fails"() {
+        given:
+        CustomTestInvalid testInvalid = new CustomTestInvalid(invalidInner: new CustomTestInvalid.CustomInvalidInner())
+
+        when:
+        def violations = validator.validate(testInvalid)
+
+        then:
+        violations.size() == 1
+        violations[0].message == "custom invalid"
+    }
+
+    void "test validation where pojo with outer custom message constraint fails"() {
+        given:
+        CustomTestInvalid testInvalid = new CustomTestInvalid(invalidOuter: new CustomInvalidOuter())
+
+        when:
+        def violations = validator.validate(testInvalid)
+
+        then:
+        violations.size() == 1
+        violations[0].message == "custom invalid"
+    }
+
+    void "test validation where pojo with inner and outer custom message constraint both fail"() {
+        given:
+        CustomTestInvalid testInvalid = new CustomTestInvalid(
+                invalidInner: new CustomTestInvalid.CustomInvalidInner(),
+                invalidOuter: new CustomInvalidOuter())
+
+        when:
+        def violations = validator.validate(testInvalid)
+
+        then:
+        violations.size() == 2
+        violations[0].message == "custom invalid"
+        violations[1].message == "custom invalid"
+    }
+
+    void "test validation where inner custom message constraint fails"() {
+        given:
+        CustomTestInvalid.CustomInvalidInner invalidInner = new CustomTestInvalid.CustomInvalidInner()
+
+        when:
+        def violations = validator.validate(invalidInner)
+
+        then:
+        violations.size() == 1
+        violations[0].message == "custom invalid"
+    }
+
+    void "test validation where outer custom message constraint fails"() {
+        given:
+        CustomInvalidOuter invalidOuter = new CustomInvalidOuter()
+
+        when:
+        def violations = validator.validate(invalidOuter)
+
+        then:
+        violations.size() == 1
+        violations[0].message == "custom invalid"
+    }
 }
 
 @Introspected
@@ -97,3 +160,20 @@ class TestInvalid {
 @Introspected
 @AlwaysInvalidConstraint
 class InvalidOuter {}
+
+@Introspected
+class CustomTestInvalid {
+    @Valid
+    CustomInvalidInner invalidInner
+
+    @Valid
+    CustomInvalidOuter invalidOuter
+
+    @Introspected
+    @AlwaysInvalidConstraint
+    static class CustomInvalidInner {}
+}
+
+@Introspected
+@AlwaysInvalidConstraint
+class CustomInvalidOuter {}

--- a/validation/src/test/groovy/io/micronaut/validation/validator/constraints/custom/CustomConstraintsValidatorFactory.java
+++ b/validation/src/test/groovy/io/micronaut/validation/validator/constraints/custom/CustomConstraintsValidatorFactory.java
@@ -11,4 +11,12 @@ class CustomConstraintsValidatorFactory {
     ConstraintValidator<AlwaysInvalidConstraint, Object> alwaysInvalidConstraintValidator() {
         return (value, annotationMetadata, context) -> false;
     }
+
+    @Singleton
+    ConstraintValidator<CustomMessageConstraint, Object> customMessageConstraintValidator() {
+        return (value, annotationMetadata, context) -> {
+            context.overrideMessageTemplate("custom invalid");
+            return false;
+        };
+    }
 }

--- a/validation/src/test/groovy/io/micronaut/validation/validator/constraints/custom/CustomConstraintsValidatorFactory.java
+++ b/validation/src/test/groovy/io/micronaut/validation/validator/constraints/custom/CustomConstraintsValidatorFactory.java
@@ -15,7 +15,7 @@ class CustomConstraintsValidatorFactory {
     @Singleton
     ConstraintValidator<CustomMessageConstraint, Object> customMessageConstraintValidator() {
         return (value, annotationMetadata, context) -> {
-            context.overrideMessageTemplate("custom invalid");
+            context.messageTemplate("custom invalid");
             return false;
         };
     }

--- a/validation/src/test/groovy/io/micronaut/validation/validator/constraints/custom/CustomMessageConstraint.java
+++ b/validation/src/test/groovy/io/micronaut/validation/validator/constraints/custom/CustomMessageConstraint.java
@@ -1,0 +1,15 @@
+package io.micronaut.validation.validator.constraints.custom;
+
+import javax.validation.Constraint;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Constraint(validatedBy = { })
+@interface CustomMessageConstraint {
+    String message() default "invalid";
+}


### PR DESCRIPTION
This allows for custom validator implementations to override the message template of a given annotation and to supply its own to the context.

This can be useful if validation is at class-level and is validating multiple fields, where the validation message needs to be different.