### PR TITLE
fix for issue 5255

### DIFF
--- a/tracing/src/main/java/io/micronaut/tracing/brave/sender/HttpClientSenderFactory.java
+++ b/tracing/src/main/java/io/micronaut/tracing/brave/sender/HttpClientSenderFactory.java
@@ -23,6 +23,7 @@ import io.micronaut.tracing.brave.BraveTracerConfiguration;
 import zipkin2.reporter.Sender;
 
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 
@@ -37,7 +38,7 @@ import javax.inject.Singleton;
 public class HttpClientSenderFactory {
 
     private final BraveTracerConfiguration.HttpClientSenderConfiguration configuration;
-    private final List<InvocationInstrumenterFactory> invocationInstrumenterFactories;
+    private final List<Provider<InvocationInstrumenterFactory>> invocationInstrumenterFactories;
 
     /**
      * Initialize the factory for creating Zipkin {@link Sender} with configurations.
@@ -46,8 +47,8 @@ public class HttpClientSenderFactory {
      * @param invocationInstrumenterFactories The invocation instrumeter factories to instrument http client netty handlers execution with
      */
     protected HttpClientSenderFactory(
-            BraveTracerConfiguration.HttpClientSenderConfiguration configuration,
-            List<InvocationInstrumenterFactory> invocationInstrumenterFactories) {
+        BraveTracerConfiguration.HttpClientSenderConfiguration configuration,
+        List<Provider<InvocationInstrumenterFactory>> invocationInstrumenterFactories) {
         this.configuration = configuration;
         this.invocationInstrumenterFactories = invocationInstrumenterFactories;
     }
@@ -60,7 +61,7 @@ public class HttpClientSenderFactory {
     @Requires(missingBeans = Sender.class)
     Sender zipkinSender(Provider<LoadBalancerResolver> loadBalancerResolver) {
         return configuration.getBuilder()
-                .invocationInstrumenterFactories(invocationInstrumenterFactories)
-                .build(loadBalancerResolver);
+            .invocationInstrumenterFactories(invocationInstrumenterFactories.stream().map(Provider::get).collect(Collectors.toList()))
+            .build(loadBalancerResolver);
     }
 }

--- a/tracing/src/test/groovy/io/micronaut/tracing/brave/HttpClientSenderSpec.groovy
+++ b/tracing/src/test/groovy/io/micronaut/tracing/brave/HttpClientSenderSpec.groovy
@@ -41,6 +41,26 @@ import javax.inject.Singleton
  */
 class HttpClientSenderSpec extends Specification {
 
+    void "test http client sender bean initialization with instrumented threads"() {
+        given:
+        ApplicationContext context = ApplicationContext.run(
+          'tracing.zipkin.enabled':true,
+          'tracing.instrument-threads':true,
+          'tracing.zipkin.sampler.probability':1,
+          'tracing.zipkin.http.url':HttpClientSender.Builder.DEFAULT_SERVER_URL
+        )
+
+        when:
+        HttpClientSender httpClientSender = context.getBean(HttpClientSender)
+
+        then:
+        httpClientSender != null
+
+        cleanup:
+        httpClientSender.close()
+        context.close()
+    }
+
     void "test http client sender receives spans"() {
         given:
         ApplicationContext context = ApplicationContext.run(


### PR DESCRIPTION
changed the http client sender factory to use Providers for the instrumentation factories for late bean resolution to resolve circular dependency introduced

This is to resolve: https://github.com/micronaut-projects/micronaut-core/issues/5255