### PR TITLE
Allow to change Netty's resource leak detection

### DIFF
--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/DefaultEventLoopGroupFactory.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/DefaultEventLoopGroupFactory.java
@@ -21,9 +21,11 @@ import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.core.util.ArgumentUtils;
+import io.micronaut.http.netty.configuration.NettyGlobalConfiguration;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.ServerSocketChannel;
 import io.netty.channel.socket.SocketChannel;
+import io.netty.util.ResourceLeakDetector;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -55,8 +57,25 @@ public class DefaultEventLoopGroupFactory implements EventLoopGroupFactory {
     public DefaultEventLoopGroupFactory(
             NioEventLoopGroupFactory nioEventLoopGroupFactory,
             @Nullable @Named(EventLoopGroupFactory.NATIVE) EventLoopGroupFactory nativeFactory) {
+        this(nioEventLoopGroupFactory, nativeFactory, null);
+    }
+
+    /**
+     * Default constructor.
+     * @param nioEventLoopGroupFactory The NIO factory
+     * @param nativeFactory The native factory if available
+     * @param nettyGlobalConfiguration The netty global configuration
+     */
+    @Inject
+    public DefaultEventLoopGroupFactory(
+            NioEventLoopGroupFactory nioEventLoopGroupFactory,
+            @Nullable @Named(EventLoopGroupFactory.NATIVE) EventLoopGroupFactory nativeFactory,
+            @Nullable NettyGlobalConfiguration nettyGlobalConfiguration) {
         this.defaultFactory = nioEventLoopGroupFactory;
         this.nativeFactory = nativeFactory != null ? nativeFactory : defaultFactory;
+        if (nettyGlobalConfiguration != null && nettyGlobalConfiguration.getResourceLeakDetectorLevel() != null) {
+            ResourceLeakDetector.setLevel(nettyGlobalConfiguration.getResourceLeakDetectorLevel());
+        }
     }
 
     /**

--- a/http-netty/src/main/java/io/micronaut/http/netty/configuration/NettyGlobalConfiguration.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/configuration/NettyGlobalConfiguration.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.netty.configuration;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.Nullable;
+import io.netty.util.ResourceLeakDetector;
+
+/**
+ * Allows configuring Netty global properties.
+ *
+ * @author Denis Stepannov
+ * @since 2.5.0
+ */
+@ConfigurationProperties("netty")
+public class NettyGlobalConfiguration {
+
+    private ResourceLeakDetector.Level resourceLeakDetectorLevel;
+
+    /**
+     * Sets the resource leak detection level.
+     *
+     * @param resourceLeakDetectorLevel the resource leak detection level
+     */
+    public void setResourceLeakDetectorLevel(ResourceLeakDetector.Level resourceLeakDetectorLevel) {
+        this.resourceLeakDetectorLevel = resourceLeakDetectorLevel;
+    }
+
+    /**
+     * Provides the value set for the resource leak detection.
+     *
+     * @return the resource leak detection level
+     */
+    @Nullable
+    public ResourceLeakDetector.Level getResourceLeakDetectorLevel() {
+        return resourceLeakDetectorLevel;
+    }
+
+}

--- a/src/main/docs/guide/httpServer/serverConfiguration.adoc
+++ b/src/main/docs/guide/httpServer/serverConfiguration.adoc
@@ -52,3 +52,5 @@ micronaut:
       default:
         prefer-native-transport: true
 ----
+
+NOTE: Netty enables simplistic sampling resource leak detection which reports there is a leak or not, at the cost of small overhead. You can disable it or enable more advanced detection by setting property `netty.resource-leak-detector-level` to one of: `SIMPLE` (default), `DISABLED`, `PARANOID` or `ADVANCED`.


### PR DESCRIPTION
I find the best way to put it into `DefaultEventLoopGroupFactory` as it's shared between server/client.