### PR TITLE
Added Support for specifying range on random number in properties

### DIFF
--- a/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
+++ b/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
@@ -903,7 +903,7 @@ public class PropertySourcePropertyResolver implements PropertyResolver {
             int upperBound = Integer.parseInt(tokens[1]);
             return lowerBound + (int) (Math.random() * (upperBound - lowerBound));
         } catch (NumberFormatException ex) {
-            throw new ValueException("Invalid range: `" + range + "` found for type Integer while parsing property: " + property);
+            throw new ValueException("Invalid range: `" + range + "` found for type Integer while parsing property: " + property, ex);
         }
     }
 

--- a/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
+++ b/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
@@ -30,6 +30,7 @@ import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.core.value.MapPropertyResolver;
 import io.micronaut.core.value.PropertyResolver;
+import io.micronaut.core.value.ValueException;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 
@@ -902,8 +903,7 @@ public class PropertySourcePropertyResolver implements PropertyResolver {
             int upperBound = Integer.parseInt(tokens[1]);
             return lowerBound + (int) (Math.random() * (upperBound - lowerBound));
         } catch (NumberFormatException ex) {
-            LOG.error("Invalid range: \"" + range + "\" found for type Integer while parsing property: ", property);
-            throw ex;
+            throw new ValueException("Invalid range: `" + range + "` found for type Integer while parsing property: " + property);
         }
     }
 
@@ -917,8 +917,7 @@ public class PropertySourcePropertyResolver implements PropertyResolver {
             long upperBound = Long.parseLong(tokens[1]);
             return lowerBound + (long) (Math.random() * (upperBound - lowerBound));
         } catch (NumberFormatException ex) {
-            LOG.error("Invalid range: \"" + range + "\" found for type Long while parsing property: ", property);
-            throw ex;
+            throw new ValueException("Invalid range: `" + range + "` found for type Long while parsing property: " + property, ex);
         }
     }
 
@@ -932,8 +931,7 @@ public class PropertySourcePropertyResolver implements PropertyResolver {
             float upperBound = Float.parseFloat(tokens[1]);
             return lowerBound + (float) (Math.random() * (upperBound - lowerBound));
         } catch (NumberFormatException ex) {
-            LOG.error("Invalid range: \"" + range + "\" found for type Float while parsing property: ", property);
-            throw ex;
+            throw new ValueException("Invalid range: `" + range + "` found for type Float while parsing property: " + property, ex);
         }
     }
 

--- a/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
+++ b/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
@@ -55,7 +55,7 @@ public class PropertySourcePropertyResolver implements PropertyResolver {
     private static final Pattern DOT_PATTERN = Pattern.compile("\\.");
     private static final String RANDOM_PREFIX = "\\s?random\\.(\\S+?)";
     private static final String RANDOM_UPPER_LIMIT = "(\\(-?\\d+(\\.\\d+)?\\))";
-    private static final String RANDOM_RANGE = "(\\[-?\\d+(\\.\\d+)?,-?\\d+(\\.\\d+)?])";
+    private static final String RANDOM_RANGE = "(\\[-?\\d+(\\.\\d+)?,\\s?-?\\d+(\\.\\d+)?])";
     private static final Pattern RANDOM_PATTERN = Pattern.compile("\\$\\{" + RANDOM_PREFIX + "(" + RANDOM_UPPER_LIMIT + "|" + RANDOM_RANGE + ")?}");
     private static final char[] DOT_DASH = new char[] {'.', '-'};
     private static final Object NO_VALUE = new Object();
@@ -672,13 +672,13 @@ public class PropertySourcePropertyResolver implements PropertyResolver {
                         break;
                     case "int":
                     case "integer":
-                        randomValue = String.valueOf(range == null ? random.nextInt() : getNextIntegerInRange(range));
+                        randomValue = String.valueOf(range == null ? random.nextInt() : getNextIntegerInRange(range, property));
                         break;
                     case "long":
-                        randomValue = String.valueOf(range == null ? random.nextLong() : getNextLongInRange(range));
+                        randomValue = String.valueOf(range == null ? random.nextLong() : getNextLongInRange(range, property));
                         break;
                     case "float":
-                        randomValue = String.valueOf(range == null ? random.nextFloat() : getNextFloatInRange(range));
+                        randomValue = String.valueOf(range == null ? random.nextFloat() : getNextFloatInRange(range, property));
                         break;
                     case "shortuuid":
                         randomValue = UUID.randomUUID().toString().substring(25, 35);
@@ -892,34 +892,49 @@ public class PropertySourcePropertyResolver implements PropertyResolver {
         }
     }
 
-    private int getNextIntegerInRange(String range) {
-        String[] tokens = range.split(",");
-        int lowerBound = Integer.parseInt(tokens[0]);
-        if (tokens.length == 1) {
-            return lowerBound >= 0 ? 1 : -1  * (random.nextInt(Math.abs(lowerBound)));
+    private int getNextIntegerInRange(String range, String property) {
+        try {
+            String[] tokens = range.split(",");
+            int lowerBound = Integer.parseInt(tokens[0]);
+            if (tokens.length == 1) {
+                return lowerBound >= 0 ? 1 : -1  * (random.nextInt(Math.abs(lowerBound)));
+            }
+            int upperBound = Integer.parseInt(tokens[1]);
+            return lowerBound + (int) (Math.random() * (upperBound - lowerBound));
+        } catch (NumberFormatException ex) {
+            LOG.error("Invalid range: \"" + range + "\" found for type Integer while parsing property: ", property);
+            throw ex;
         }
-        int upperBound = Integer.parseInt(tokens[1]);
-        return lowerBound + (int) (Math.random() * (upperBound - lowerBound));
     }
 
-    private long getNextLongInRange(String range) {
-        String[] tokens = range.split(",");
-        long lowerBound = Long.parseLong(tokens[0]);
-        if (tokens.length == 1) {
-            return (long) (Math.random() * (lowerBound));
+    private long getNextLongInRange(String range, String property) {
+        try {
+            String[] tokens = range.split(",");
+            long lowerBound = Long.parseLong(tokens[0]);
+            if (tokens.length == 1) {
+                return (long) (Math.random() * (lowerBound));
+            }
+            long upperBound = Long.parseLong(tokens[1]);
+            return lowerBound + (long) (Math.random() * (upperBound - lowerBound));
+        } catch (NumberFormatException ex) {
+            LOG.error("Invalid range: \"" + range + "\" found for type Long while parsing property: ", property);
+            throw ex;
         }
-        long upperBound = Long.parseLong(tokens[1]);
-        return lowerBound + (long) (Math.random() * (upperBound - lowerBound));
     }
 
-    private float getNextFloatInRange(String range) {
-        String[] tokens = range.split(",");
-        float lowerBound = Float.parseFloat(tokens[0]);
-        if (tokens.length == 1) {
-            return (float) (Math.random() * (lowerBound));
+    private float getNextFloatInRange(String range, String property) {
+        try {
+            String[] tokens = range.split(",");
+            float lowerBound = Float.parseFloat(tokens[0]);
+            if (tokens.length == 1) {
+                return (float) (Math.random() * (lowerBound));
+            }
+            float upperBound = Float.parseFloat(tokens[1]);
+            return lowerBound + (float) (Math.random() * (upperBound - lowerBound));
+        } catch (NumberFormatException ex) {
+            LOG.error("Invalid range: \"" + range + "\" found for type Float while parsing property: ", property);
+            throw ex;
         }
-        float upperBound = Float.parseFloat(tokens[1]);
-        return lowerBound + (float) (Math.random() * (upperBound - lowerBound));
     }
 
     /**

--- a/inject/src/test/groovy/io/micronaut/context/env/PropertySourcePropertyResolverSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/env/PropertySourcePropertyResolverSpec.groovy
@@ -23,6 +23,7 @@ import io.micronaut.core.convert.format.MapFormat
 import io.micronaut.core.naming.conventions.StringConvention
 import io.micronaut.core.value.MapPropertyResolver
 import io.micronaut.core.value.PropertyResolver
+import io.micronaut.core.value.ValueException
 import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -420,20 +421,25 @@ class PropertySourcePropertyResolverSpec extends Specification {
         )
 
         then:
-        thrown(NumberFormatException)
+        def ex= thrown(ValueException)
+        ex.message == 'Invalid range: `9999999999` found for type Integer while parsing property: random.integer'
+        ex.cause == null
     }
 
     void "test invalid random Long range"() {
         when:
         def values = [
-                'random.integer' : '${random.integer(9999999999999999999)}'
+                'random.long' : '${random.long(9999999999999999999)}'
         ]
         new PropertySourcePropertyResolver(
                 PropertySource.of("test", values)
         )
 
         then:
-        thrown(NumberFormatException)
+        def ex= thrown(ValueException)
+        ex.message == 'Invalid range: `9999999999999999999` found for type Long while parsing property: random.long'
+        ex.cause != null
+        ex.cause instanceof NumberFormatException
     }
 
     void "test invalid random placeholders for properties"() {

--- a/inject/src/test/groovy/io/micronaut/context/env/PropertySourcePropertyResolverSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/env/PropertySourcePropertyResolverSpec.groovy
@@ -410,6 +410,32 @@ class PropertySourcePropertyResolverSpec extends Specification {
         resolver.getProperty('random.float_lower-negative_upper-negative', Float).get() >= -10.5
     }
 
+    void "test invalid random Integer range"() {
+        when:
+        def values = [
+            'random.integer' : '${random.integer(9999999999)}'
+        ]
+        new PropertySourcePropertyResolver(
+                PropertySource.of("test", values)
+        )
+
+        then:
+        thrown(NumberFormatException)
+    }
+
+    void "test invalid random Long range"() {
+        when:
+        def values = [
+                'random.integer' : '${random.integer(9999999999999999999)}'
+        ]
+        new PropertySourcePropertyResolver(
+                PropertySource.of("test", values)
+        )
+
+        then:
+        thrown(NumberFormatException)
+    }
+
     void "test invalid random placeholders for properties"() {
         when:
         def values = [

--- a/inject/src/test/groovy/io/micronaut/context/env/PropertySourcePropertyResolverSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/env/PropertySourcePropertyResolverSpec.groovy
@@ -423,7 +423,8 @@ class PropertySourcePropertyResolverSpec extends Specification {
         then:
         def ex= thrown(ValueException)
         ex.message == 'Invalid range: `9999999999` found for type Integer while parsing property: random.integer'
-        ex.cause == null
+        ex.cause != null
+        ex.cause instanceof NumberFormatException
     }
 
     void "test invalid random Long range"() {

--- a/inject/src/test/groovy/io/micronaut/context/env/PropertySourcePropertyResolverSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/env/PropertySourcePropertyResolverSpec.groovy
@@ -293,6 +293,123 @@ class PropertySourcePropertyResolverSpec extends Specification {
         resolver.getProperty('random.shortuuid', String).get().length() == 10
     }
 
+    void "test random integer placeholders in range for properties"() {
+        given:
+        def values = [
+                'random.integer_lower'  : '${random.integer(10)}',
+                'random.integer_lower-negative'  : '${random.integer(-10)}',
+                'random.integer_lower_upper'  : '${random.integer[5,10]}',
+                'random.integer_lower-negative_upper'  : '${random.integer[-5,10]}',
+                'random.integer_lower-negative_upper-negative'  : '${random.integer[-10,-5]}',
+        ]
+        PropertySourcePropertyResolver resolver = new PropertySourcePropertyResolver(
+                PropertySource.of("test", values)
+        )
+
+        expect:
+        resolver.getProperty('random.integer_lower', String).isPresent()
+        resolver.getProperty('random.integer_lower', Integer).get() >= 0
+        resolver.getProperty('random.integer_lower', Integer).get() < 10
+
+        and:
+        resolver.getProperty('random.integer_lower-negative', String).isPresent()
+        resolver.getProperty('random.integer_lower-negative', Integer).get() <= 0
+        resolver.getProperty('random.integer_lower-negative', Integer).get() > -10
+
+        and:
+        resolver.getProperty('random.integer_lower_upper', String).isPresent()
+        resolver.getProperty('random.integer_lower_upper', Integer).get() < 10
+        resolver.getProperty('random.integer_lower_upper', Integer).get() >= 5
+
+        and:
+        resolver.getProperty('random.integer_lower-negative_upper', String).isPresent()
+        resolver.getProperty('random.integer_lower-negative_upper', Integer).get() < 10
+        resolver.getProperty('random.integer_lower-negative_upper', Integer).get() >= -5
+
+        and:
+        resolver.getProperty('random.integer_lower-negative_upper-negative', String).isPresent()
+        resolver.getProperty('random.integer_lower-negative_upper-negative', Integer).get() < -5
+        resolver.getProperty('random.integer_lower-negative_upper-negative', Integer).get() >= -10
+    }
+
+    void "test random long placeholders in range for properties"() {
+        given:
+        def values = [
+                'random.long_lower'  : '${random.long(10)}',
+                'random.long_lower-negative'  : '${random.long(-10)}',
+                'random.long_lower_upper'  : '${random.long[5,10]}',
+                'random.long_lower-negative_upper'  : '${random.long[-5,10]}',
+                'random.long_lower-negative_upper-negative'  : '${random.long[-10,-5]}',
+        ]
+        PropertySourcePropertyResolver resolver = new PropertySourcePropertyResolver(
+                PropertySource.of("test", values)
+        )
+
+        expect:
+        resolver.getProperty('random.long_lower', String).isPresent()
+        resolver.getProperty('random.long_lower', Long).get() >= 0
+        resolver.getProperty('random.long_lower', Long).get() < 10
+
+        and:
+        resolver.getProperty('random.long_lower-negative', String).isPresent()
+        resolver.getProperty('random.long_lower-negative', Long).get() <= 0
+        resolver.getProperty('random.long_lower-negative', Long).get() > -10
+
+        and:
+        resolver.getProperty('random.long_lower_upper', String).isPresent()
+        resolver.getProperty('random.long_lower_upper', Long).get() < 10
+        resolver.getProperty('random.long_lower_upper', Long).get() >= 5
+
+        and:
+        resolver.getProperty('random.long_lower-negative_upper', String).isPresent()
+        resolver.getProperty('random.long_lower-negative_upper', Long).get() < 10
+        resolver.getProperty('random.long_lower-negative_upper', Long).get() >= -5
+
+        and:
+        resolver.getProperty('random.long_lower-negative_upper-negative', String).isPresent()
+        resolver.getProperty('random.long_lower-negative_upper-negative', Long).get() < -5
+        resolver.getProperty('random.long_lower-negative_upper-negative', Long).get() >= -10
+    }
+
+    void "test random float placeholders in range for properties"() {
+        given:
+        def values = [
+                'random.float_lower'  : '${random.float(10.5)}',
+                'random.float_lower-negative'  : '${random.float(-10.5)}',
+                'random.float_lower_upper'  : '${random.float[5.5,10.5]}',
+                'random.float_lower-negative_upper'  : '${random.float[-5.5,10.5]}',
+                'random.float_lower-negative_upper-negative'  : '${random.float[-10.5,-5.5]}',
+        ]
+        PropertySourcePropertyResolver resolver = new PropertySourcePropertyResolver(
+                PropertySource.of("test", values)
+        )
+
+        expect:
+        resolver.getProperty('random.float_lower', String).isPresent()
+        resolver.getProperty('random.float_lower', Float).get() >= 0.5
+        resolver.getProperty('random.float_lower', Float).get() < 10.5
+
+        and:
+        resolver.getProperty('random.float_lower-negative', String).isPresent()
+        resolver.getProperty('random.float_lower-negative', Float).get() <= 0.5
+        resolver.getProperty('random.float_lower-negative', Float).get() > -10.5
+
+        and:
+        resolver.getProperty('random.float_lower_upper', String).isPresent()
+        resolver.getProperty('random.float_lower_upper', Float).get() < 10.5
+        resolver.getProperty('random.float_lower_upper', Float).get() >= 5.5
+
+        and:
+        resolver.getProperty('random.float_lower-negative_upper', String).isPresent()
+        resolver.getProperty('random.float_lower-negative_upper', Float).get() < 10.5
+        resolver.getProperty('random.float_lower-negative_upper', Float).get() >= -5.5
+
+        and:
+        resolver.getProperty('random.float_lower-negative_upper-negative', String).isPresent()
+        resolver.getProperty('random.float_lower-negative_upper-negative', Float).get() < -5.5
+        resolver.getProperty('random.float_lower-negative_upper-negative', Float).get() >= -10.5
+    }
+
     void "test invalid random placeholders for properties"() {
         when:
         def values = [

--- a/src/main/docs/guide/config/propertySource.adoc
+++ b/src/main/docs/guide/config/propertySource.adoc
@@ -160,6 +160,20 @@ micronaut:
 |Random UUID without dashes
 |===
 
+The `random.int`, `random.integer`, `random.long` and `random.float` properties supports a range suffix whose syntax is one of as follows:
+
+- `(max)` where max is an exclusive value
+- `[min,max]` where min being inclusive and max being exclusive values.
+
+[source,yaml]
+----
+instance:
+  id: ${random.int[5,10]}
+  count: ${random.int(5)}
+----
+
+NOTE: The range could very from negative to positive as well.
+
 === Fail Fast Property Injection
 
 For beans that inject required properties, the injection and potential failure will not occur until the bean is requested. To verify at startup that the properties exist and can be injected, the bean can be annotated with ann:io.micronaut.context.annotation.Context[]. Context-scoped beans are injected at startup, and startup fails if any required properties are missing or cannot be converted to the required type.

--- a/src/main/docs/guide/config/propertySource.adoc
+++ b/src/main/docs/guide/config/propertySource.adoc
@@ -172,7 +172,7 @@ instance:
   count: ${random.int(5)}
 ----
 
-NOTE: The range could very from negative to positive as well.
+NOTE: The range could vary from negative to positive as well.
 
 === Fail Fast Property Injection
 


### PR DESCRIPTION
Solves issue #5291 

The range can be defined on  `int`, `integer`, `long` and `float`

There are two ways to specify range now as follows: 
1. `random.integer(number)`
2. `random.integer[lower_bound, upper_bound]`
