### PR TITLE
Fix JakartaProviderBeanDefinition GraalVM warning

### DIFF
--- a/inject/src/main/resources/META-INF/native-image/io.micronaut/micronaut-inject/native-image.properties
+++ b/inject/src/main/resources/META-INF/native-image/io.micronaut/micronaut-inject/native-image.properties
@@ -15,4 +15,5 @@
 #
 
 Args = --allow-incomplete-classpath \
-       -H:EnableURLProtocols=http,https
+       -H:EnableURLProtocols=http,https \
+       --initialize-at-run-time=io.micronaut.inject.provider.JakartaProviderBeanDefinition


### PR DESCRIPTION
This PR fixes the following warning when building a GraalVM native image:

```
Warning: class initialization of class io.micronaut.inject.provider.JakartaProviderBeanDefinition failed with exception java.lang.NoClassDefFoundError: jakarta/inject/Provider. This class will be initialized at run time because option --allow-incomplete-classpath is used for image building. Use the option --initialize-at-run-time=io.micronaut.inject.provider.JakartaProviderBeanDefinition to explicitly request delayed initialization of this class.
```