### PR TITLE
Support implicit bean names for factories and injection points

### DIFF
--- a/inject-groovy/src/test/groovy/io/micronaut/inject/constructor/ConstructorFactorySpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/constructor/ConstructorFactorySpec.groovy
@@ -66,7 +66,7 @@ class ConstructorFactorySpec extends Specification {
     static class AImpl implements A {
         final C c
         final C c2
-        @Inject protected D d
+        protected D d
 
         AImpl(C c, C c2) {
             this.c = c

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/factory/named/ImplicitNamedSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/factory/named/ImplicitNamedSpec.groovy
@@ -1,9 +1,8 @@
 package io.micronaut.inject.factory.named
 
-import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.ast.transform.test.AbstractBeanDefinitionSpec
 
-class ImplicitNamedSpec extends AbstractTypeElementSpec {
-
+class ImplicitNamedSpec extends AbstractBeanDefinitionSpec {
     void 'test use of implicit @Named annotation'() {
         given:
         def context = buildContext('''

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/factory/named/ImplicitNamedSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/factory/named/ImplicitNamedSpec.groovy
@@ -15,12 +15,14 @@ import javax.inject.*;
 class TestFactory {
     
     @Singleton
+    @Named
     Foo foo1() {
         return ()-> "one";
     }
     
     @Singleton
     @Primary
+    @Named
     Foo fooPrimary() {
         return ()-> "primary";
     }

--- a/inject-java/src/test/groovy/io/micronaut/inject/constructor/factoryinjection/AImpl.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/constructor/factoryinjection/AImpl.java
@@ -16,12 +16,9 @@
 package io.micronaut.inject.constructor.factoryinjection;
 
 
-import javax.inject.Inject;
-
 public class AImpl implements A {
     final C c;
     final C c2;
-    @Inject
     protected D d;
 
     public AImpl(C c, C c2) {

--- a/inject-java/src/test/groovy/io/micronaut/inject/factory/named/ImplicitNamedSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/factory/named/ImplicitNamedSpec.groovy
@@ -16,12 +16,14 @@ import javax.inject.*;
 class TestFactory {
     
     @Singleton
+    @Named
     Foo foo1() {
         return ()-> "one";
     }
     
     @Singleton
     @Primary
+    @Named
     Foo fooPrimary() {
         return ()-> "primary";
     }

--- a/inject-java/src/test/groovy/io/micronaut/inject/factory/named/ImplicitNamedSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/factory/named/ImplicitNamedSpec.groovy
@@ -1,0 +1,57 @@
+package io.micronaut.inject.factory.named
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+
+class ImplicitNamedSpec extends AbstractTypeElementSpec {
+
+    void 'test use of implicit @Named annotation'() {
+        given:
+        def context = buildContext('''
+package implicitnamed;
+
+import io.micronaut.context.annotation.*;
+import javax.inject.*;
+
+@Factory
+class TestFactory {
+    
+    @Singleton
+    Foo foo1() {
+        return ()-> "one";
+    }
+    
+    @Singleton
+    @Primary
+    Foo fooPrimary() {
+        return ()-> "primary";
+    }
+    
+}
+
+class Test {
+    @Named
+    public Foo foo1;
+    
+    @Named("foo1")
+    public Foo foo1;
+    
+    @Inject
+    public Foo fooDefault;
+    
+    @Named
+    public Foo fooPrimary;
+    
+}
+
+interface Foo {
+    String name();
+}
+        ''')
+
+        expect:
+        context != null
+
+        cleanup:
+        context.close()
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1074,9 +1074,7 @@ public class DefaultBeanContext implements BeanContext {
                         LOG_LIFECYCLE.debug("Destroying bean [{}] with identifier [{}]", bean, beanKey);
                     }
 
-                    singletonObjects.remove(beanKey);
-                    BeanKey<?> concreteKey = new BeanKey<>(bean.getClass(), null);
-                    singletonObjects.remove(concreteKey);
+                    purgeBeanRegistrations(bean);
                 }
             }
         }
@@ -1085,7 +1083,7 @@ public class DefaultBeanContext implements BeanContext {
             Optional<BeanDefinition<T>> concreteCandidate = findConcreteCandidate(
                     null,
                     beanKey.beanType,
-                    null,
+                    qualifier,
                     false,
                     true
             );
@@ -1093,8 +1091,29 @@ public class DefaultBeanContext implements BeanContext {
             concreteCandidate.ifPresent(definition -> {
                 disposeBean(beanType, finalBean, definition);
             });
+        } else {
+            final BeanDefinition<T> candidate = findConcreteCandidate(
+                    null,
+                    beanKey.beanType,
+                    qualifier,
+                    false,
+                    true
+            ).orElse(null);
+            if (candidate != null) {
+                bean = findExistingCompatibleSingleton(beanType, null, qualifier, candidate);
+                if (bean != null) {
+                    purgeBeanRegistrations(bean);
+                    disposeBean(beanType, bean, candidate);
+                }
+            }
         }
         return bean;
+    }
+
+    private <T> void purgeBeanRegistrations(T bean) {
+        synchronized (singletonObjects) {
+            singletonObjects.entrySet().removeIf(entry -> entry.getValue().bean == bean);
+        }
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -371,7 +371,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
     private void autoApplyNamedToBeanProducingElement(Element beanProducingElement) {
         final AnnotationMetadata annotationMetadata = beanProducingElement.getAnnotationMetadata();
         if (!annotationMetadata.hasAnnotation(EachProperty.class) && !annotationMetadata.hasAnnotation(EachBean.class)) {
-            autoApplyNamed(beanProducingElement);
+            autoApplyNamedIfPresent(beanProducingElement, annotationMetadata);
         }
     }
 


### PR DESCRIPTION
Support for `@Named` without a value https://jakarta.ee/specifications/cdi/3.0/jakarta-cdi-spec-3.0.html#named_at_injection_point

And alignment with Spring/CDI to make beans from factories inherit the method / field name as the bean name.

Other changes in this PR were related to bugs that this change uncovered in the bean destruction logic 