### PR TITLE
Disable downloading javadoc and sources in IntelliJ IDEA.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -897,6 +897,9 @@ allprojects {
         module {
             outputDir file('build/classes/java/main')
             testOutputDir file('build/classes/groovy/test')
+
+            downloadJavadoc = false
+            downloadSources = false
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -422,7 +422,7 @@ ext {
             picocli                    : [
                     version: picocliVersion,
                     group  : 'info.picocli',
-                    modules: ['picocli', 'picocli-codegen']                    
+                    modules: ['picocli', 'picocli-codegen']
             ],
             lettuce                    : [
                     version: lettuceVersion,
@@ -898,8 +898,14 @@ allprojects {
             outputDir file('build/classes/java/main')
             testOutputDir file('build/classes/groovy/test')
 
-            downloadJavadoc = false
-            downloadSources = false
+            boolean downloadJavadocValue = System.getenv('MICRONAUT_DOWNLOAD_JAVADOC') != null ?
+                    (System.getenv('MICRONAUT_DOWNLOAD_JAVADOC') == 'true') : (project.properties['micronautDownloadJavadoc'] == 'true')
+
+            boolean downloadSourcesValue = System.getenv('MICRONAUT_DOWNLOAD_SOURCES') != null ?
+                    (System.getenv('MICRONAUT_DOWNLOAD_SOURCES') == 'true') : (project.properties['micronautDownloadSources'] == 'true')
+
+            downloadJavadoc = downloadJavadocValue
+            downloadSources = downloadSourcesValue
         }
     }
 }


### PR DESCRIPTION
Otherwise, it takes quite a long time to download all sources and javadocs. But for those who need to use javadocs and sources they can download them from IDEA directly per one dependency.