### PR TITLE
fix building with eclipse ecj for micronaut 2.5.1

### DIFF
--- a/inject/src/main/java/io/micronaut/inject/processing/JavaModelUtils.java
+++ b/inject/src/main/java/io/micronaut/inject/processing/JavaModelUtils.java
@@ -225,6 +225,8 @@ public class JavaModelUtils {
         }
         if (enclosingElement == null) {
             return StringUtils.EMPTY_STRING;
+        } else if(enclosingElement instanceof PackageElement) {
+            return ((PackageElement)enclosingElement).getQualifiedName().toString();
         } else {
             return enclosingElement.toString();
         }

--- a/inject/src/main/java/io/micronaut/inject/processing/JavaModelUtils.java
+++ b/inject/src/main/java/io/micronaut/inject/processing/JavaModelUtils.java
@@ -225,8 +225,8 @@ public class JavaModelUtils {
         }
         if (enclosingElement == null) {
             return StringUtils.EMPTY_STRING;
-        } else if(enclosingElement instanceof PackageElement) {
-            return ((PackageElement)enclosingElement).getQualifiedName().toString();
+        } else if (enclosingElement instanceof PackageElement) {
+            return ((PackageElement) enclosingElement).getQualifiedName().toString();
         } else {
             return enclosingElement.toString();
         }


### PR DESCRIPTION
A bug was introduced in micronaut-core commit 356945845 which breaks eclipse ecj based builds.

The existing code assumes that the toString() of the TypeElement
of the package will return the package name. This is not true
for the eclipse ecj compiler, where the toString() will return
"package " + the package name. For example, a TypeElement
representing io.micronaut would return "package io.micronaut"
on ecj.

This change will get the qualified name from the type element if
it is a PackageElement instance, then use toString() on the
Name that is returned. If the element is not a PackageElement,
fallback to the toString() directly on the type element.