### PR TITLE
Use 'extension' field in exception message because it more informative then 'fileName'

### DIFF
--- a/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
+++ b/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
@@ -453,7 +453,8 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
                             }
                             order++;
                         } else {
-                            throw new ConfigurationException("Unsupported properties file format: " + extension);
+                            throw new ConfigurationException("Unsupported properties file: " + filePath +
+                                    " Extension " + extension + " is not supported for properties file");
                         }
                     }
                 }

--- a/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
+++ b/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
@@ -453,7 +453,7 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
                             }
                             order++;
                         } else {
-                            throw new ConfigurationException("Unsupported properties file: " + filePath +
+                            throw new ConfigurationException("Unsupported properties file: " + fileName + "." + extension +
                                     " Extension " + extension + " is not supported for properties file");
                         }
                     }

--- a/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
+++ b/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
@@ -453,7 +453,7 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
                             }
                             order++;
                         } else {
-                            throw new ConfigurationException("Unsupported properties file format: " + fileName);
+                            throw new ConfigurationException("Unsupported properties file format: " + extension);
                         }
                     }
                 }

--- a/inject/src/test/groovy/io/micronaut/context/env/DefaultEnvironmentSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/env/DefaultEnvironmentSpec.groovy
@@ -130,7 +130,8 @@ class DefaultEnvironmentSpec extends Specification {
 
         then: "should throw exception"
         def e = thrown(ConfigurationException)
-        e.message == "Unsupported properties file format: " + NameUtils.extension(unsupportedFile.absolutePath)
+        e.message == "Unsupported properties file: ${unsupportedFile.absolutePath} " +
+                "Extension ${NameUtils.extension(unsupportedFile.absolutePath)} is not supported for properties file"
 
         when: "file from system property source loader does not override the key"
         System.setProperty("foo.baz", "10")
@@ -197,7 +198,8 @@ class DefaultEnvironmentSpec extends Specification {
 
         then: "should throw exception"
         def e = thrown(ConfigurationException)
-        e.message == "Unsupported properties file format: " + NameUtils.extension(unsupportedFile.absolutePath)
+        e.message == "Unsupported properties file: ${unsupportedFile.absolutePath} " +
+                "Extension ${NameUtils.extension(unsupportedFile.absolutePath)} is not supported for properties file"
 
         when: "file from system property source loader does not override the key"
         System.setProperty("foo.baz", "10")

--- a/inject/src/test/groovy/io/micronaut/context/env/DefaultEnvironmentSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/env/DefaultEnvironmentSpec.groovy
@@ -130,7 +130,7 @@ class DefaultEnvironmentSpec extends Specification {
 
         then: "should throw exception"
         def e = thrown(ConfigurationException)
-        e.message == "Unsupported properties file: ${unsupportedFile.absolutePath} " +
+        e.message == "Unsupported properties file: ${unsupportedFile.name} " +
                 "Extension ${NameUtils.extension(unsupportedFile.absolutePath)} is not supported for properties file"
 
         when: "file from system property source loader does not override the key"
@@ -198,7 +198,7 @@ class DefaultEnvironmentSpec extends Specification {
 
         then: "should throw exception"
         def e = thrown(ConfigurationException)
-        e.message == "Unsupported properties file: ${unsupportedFile.absolutePath} " +
+        e.message == "Unsupported properties file: ${unsupportedFile.name} " +
                 "Extension ${NameUtils.extension(unsupportedFile.absolutePath)} is not supported for properties file"
 
         when: "file from system property source loader does not override the key"

--- a/inject/src/test/groovy/io/micronaut/context/env/DefaultEnvironmentSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/env/DefaultEnvironmentSpec.groovy
@@ -130,7 +130,7 @@ class DefaultEnvironmentSpec extends Specification {
 
         then: "should throw exception"
         def e = thrown(ConfigurationException)
-        e.message == "Unsupported properties file format: " + NameUtils.filename(unsupportedFile.absolutePath)
+        e.message == "Unsupported properties file format: " + NameUtils.extension(unsupportedFile.absolutePath)
 
         when: "file from system property source loader does not override the key"
         System.setProperty("foo.baz", "10")
@@ -197,7 +197,7 @@ class DefaultEnvironmentSpec extends Specification {
 
         then: "should throw exception"
         def e = thrown(ConfigurationException)
-        e.message == "Unsupported properties file format: " + NameUtils.filename(unsupportedFile.absolutePath)
+        e.message == "Unsupported properties file format: " + NameUtils.extension(unsupportedFile.absolutePath)
 
         when: "file from system property source loader does not override the key"
         System.setProperty("foo.baz", "10")


### PR DESCRIPTION
Fix for issue https://github.com/micronaut-projects/micronaut-core/issues/5418