### PR TITLE
Select the bean with the highest precedence as specified by Order annotation

### DIFF
--- a/core/src/main/java/io/micronaut/core/order/OrderUtil.java
+++ b/core/src/main/java/io/micronaut/core/order/OrderUtil.java
@@ -16,6 +16,7 @@
 package io.micronaut.core.order;
 
 import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Order;
 
 import java.util.Arrays;
@@ -127,6 +128,16 @@ public class OrderUtil {
         if (o instanceof Ordered) {
             return getOrder((Ordered) o);
         }
+        return getOrder(annotationMetadata);
+    }
+
+    /**
+     * Get the order for the given annotation metadata.
+     * @param annotationMetadata The metadata
+     * @return The order
+     * @since 3.0.0
+     */
+    public static int getOrder(@NonNull AnnotationMetadata annotationMetadata) {
         return annotationMetadata.intValue(Order.class).orElse(0);
     }
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/ordered/Apple.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/ordered/Apple.java
@@ -1,0 +1,10 @@
+package io.micronaut.inject.ordered;
+
+import io.micronaut.core.annotation.Order;
+
+import javax.inject.Singleton;
+
+@Singleton
+@Order(-3)
+public class Apple implements Fruit {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/ordered/Banana.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/ordered/Banana.java
@@ -1,0 +1,10 @@
+package io.micronaut.inject.ordered;
+
+import io.micronaut.core.annotation.Order;
+
+import javax.inject.Singleton;
+
+@Singleton
+@Order(-3)
+public class Banana implements Fruit {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/ordered/Fruit.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/ordered/Fruit.java
@@ -1,0 +1,4 @@
+package io.micronaut.inject.ordered;
+
+public interface Fruit {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/ordered/HighValueProduct.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/ordered/HighValueProduct.java
@@ -1,0 +1,11 @@
+package io.micronaut.inject.ordered;
+
+import io.micronaut.core.annotation.Order;
+import io.micronaut.core.order.Ordered;
+
+import javax.inject.Singleton;
+
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@Singleton
+public class HighValueProduct implements Product {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/ordered/LowValueProduct.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/ordered/LowValueProduct.java
@@ -1,0 +1,11 @@
+package io.micronaut.inject.ordered;
+
+import io.micronaut.core.annotation.Order;
+import io.micronaut.core.order.Ordered;
+
+import javax.inject.Singleton;
+
+@Order(Ordered.LOWEST_PRECEDENCE)
+@Singleton
+public class LowValueProduct implements Product {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/ordered/MidValueProduct.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/ordered/MidValueProduct.java
@@ -1,0 +1,10 @@
+package io.micronaut.inject.ordered;
+
+import io.micronaut.core.annotation.Order;
+import io.micronaut.core.order.Ordered;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class MidValueProduct implements Product {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/ordered/Orange.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/ordered/Orange.java
@@ -1,0 +1,10 @@
+package io.micronaut.inject.ordered;
+
+import io.micronaut.core.annotation.Order;
+
+import javax.inject.Singleton;
+
+@Singleton
+@Order(5)
+public class Orange implements Fruit {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/ordered/PickHighestPriorityBeanSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/ordered/PickHighestPriorityBeanSpec.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.inject.ordered
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.exceptions.NonUniqueBeanException
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Specification
@@ -15,5 +16,13 @@ class PickHighestPriorityBeanSpec extends Specification {
 
         where:
         repeat << (1..10) // repeat ten times to ensure always the same result
+    }
+
+    void 'test that duplicate order results in non unique bean exception'() {
+        when:
+        context.getBean(Fruit)
+
+        then:
+        thrown(NonUniqueBeanException)
     }
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/ordered/PickHighestPriorityBeanSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/ordered/PickHighestPriorityBeanSpec.groovy
@@ -1,0 +1,19 @@
+package io.micronaut.inject.ordered
+
+import io.micronaut.context.ApplicationContext
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class PickHighestPriorityBeanSpec extends Specification {
+    @Shared @AutoCleanup ApplicationContext context = ApplicationContext.run()
+
+    void "test pick highest priority bean when ordered present"() {
+        expect:
+        context.getBean(Product) instanceof HighValueProduct
+        context.getBean(Product) instanceof HighValueProduct
+
+        where:
+        repeat << (1..10) // repeat ten times to ensure always the same result
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/ordered/Product.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/ordered/Product.java
@@ -1,0 +1,4 @@
+package io.micronaut.inject.ordered;
+
+public interface Product {
+}

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -3159,8 +3159,8 @@ public class DefaultBeanContext implements BeanContext {
                     // pick the bean with the highest priority
                     final Iterator<BeanDefinition<T>> i = candidates.stream()
                             .sorted((bean1, bean2) -> {
-                                int order1 = OrderUtil.getOrder(bean1, bean1);
-                                int order2 = OrderUtil.getOrder(bean2, bean1);
+                                int order1 = OrderUtil.getOrder(bean1.getAnnotationMetadata());
+                                int order2 = OrderUtil.getOrder(bean2.getAnnotationMetadata());
                                 return Integer.compare(order1, order2);
                             })
                             .iterator();
@@ -3169,7 +3169,7 @@ public class DefaultBeanContext implements BeanContext {
                         if (i.hasNext()) {
                             // check there are not 2 beans with the same order
                             final BeanDefinition<T> next = i.next();
-                            if (OrderUtil.getOrder(bean, bean) == OrderUtil.getOrder(next, next)) {
+                            if (OrderUtil.getOrder(bean.getAnnotationMetadata()) == OrderUtil.getOrder(next.getAnnotationMetadata())) {
                                 throw new NonUniqueBeanException(beanType.getType(), candidates.iterator());
                             }
                         }

--- a/src/main/docs/guide/ioc/types.adoc
+++ b/src/main/docs/guide/ioc/types.adoc
@@ -67,3 +67,9 @@ The ann:core.annotation.Order[] annotation is especially useful for ordering bea
 snippet::io.micronaut.docs.config.env.RateLimitsFactory[tags="clazz", indent=0, title="Factory with @Order"]
 
 When a collection of `RateLimit` beans are requested from the context, they are returned in ascending order based on the value in the annotation.
+
+=== Injecting a Bean by Order
+
+When injecting a single instance of a bean the ann:core.annotation.Order[] annotation can also be used to define which bean has the highest precedence and hence should be injected.
+
+NOTE: The api:core.order.Ordered[] interface is not taken into account when selecting a single instance as this would require instantiating the bean to resolve the order.


### PR DESCRIPTION
Alters the logic that would otherwise throw a `NonUniqueBeanException` to make a last effort to pick a bean based on the highest precedence specified.