### PR TITLE
Avoiding NPE exception when cookie is undecodable

### DIFF
--- a/http-netty/src/main/java/io/micronaut/http/netty/cookies/NettyCookies.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/cookies/NettyCookies.java
@@ -75,7 +75,9 @@ public class NettyCookies implements Cookies {
                 cookies = new LinkedHashMap<>();
                 for (String value: values) {
                     io.netty.handler.codec.http.cookie.Cookie nettyCookie = ClientCookieDecoder.STRICT.decode(value);
-                    cookies.put(nettyCookie.name(), new NettyCookie(nettyCookie));
+                    if (nettyCookie != null) {
+                        cookies.put(nettyCookie.name(), new NettyCookie(nettyCookie));
+                    }
                 }
             } else {
                 cookies = Collections.emptyMap();


### PR DESCRIPTION
Should fix this issue: https://github.com/micronaut-projects/micronaut-core/issues/5441 by avoiding the NPE when the cookie is not decodable with STRICT. 