### PR TITLE
Fix annotate not working when invoked multiple times by different visitors

### DIFF
--- a/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
@@ -380,10 +380,18 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
 
         @Override
         public Object visitExecutable(ExecutableElement executableElement, Object o) {
-            AnnotationMetadata methodAnnotationMetadata = new AnnotationMetadataHierarchy(
-                    annotationUtils.getAnnotationMetadata(executableElement.getEnclosingElement()),
-                    annotationUtils.getAnnotationMetadata(executableElement)
-            );
+            final AnnotationMetadata resolvedMethodMetadata = annotationUtils.getAnnotationMetadata(executableElement);
+
+            AnnotationMetadata methodAnnotationMetadata;
+
+            if (resolvedMethodMetadata instanceof AnnotationMetadataHierarchy) {
+                methodAnnotationMetadata = resolvedMethodMetadata;
+            } else {
+                methodAnnotationMetadata = new AnnotationMetadataHierarchy(
+                        annotationUtils.getAnnotationMetadata(executableElement.getEnclosingElement()),
+                        resolvedMethodMetadata
+                );
+            }
             if (executableElement.getSimpleName().toString().equals("<init>")) {
                 for (LoadedVisitor visitor : visitors) {
                     final io.micronaut.inject.ast.Element resultingElement = visitor.visit(executableElement, methodAnnotationMetadata);

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
@@ -104,6 +104,11 @@ public class JavaClassElement extends AbstractJavaElement implements ArrayableCl
     }
 
     @Override
+    public String toString() {
+        return getName();
+    }
+
+    @Override
     public boolean isInner() {
         return classElement.getNestingKind().isNested();
     }

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/AnnotateReplacesSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/AnnotateReplacesSpec.groovy
@@ -1,0 +1,147 @@
+package io.micronaut.inject.qualifiers.replaces
+
+import io.micronaut.annotation.processing.TypeElementVisitorProcessor
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.annotation.processing.test.JavaParser
+import io.micronaut.context.annotation.Bean
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Replaces
+import io.micronaut.core.annotation.AnnotationClassValue
+import io.micronaut.core.annotation.AnnotationMetadata
+import io.micronaut.inject.ast.ClassElement
+import io.micronaut.inject.ast.MethodElement
+import io.micronaut.inject.visitor.TypeElementVisitor
+import io.micronaut.inject.visitor.VisitorContext
+
+import javax.annotation.processing.SupportedAnnotationTypes
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+
+class AnnotateReplacesSpec extends AbstractTypeElementSpec {
+    void 'test that replaces can be applied at compile time to a factory method'() {
+        given:
+        def context = buildContext('''
+package annreplaces;
+
+import io.micronaut.inject.qualifiers.replaces.TestProduces;
+import io.micronaut.inject.qualifiers.replaces.TestSpecializes;
+import jakarta.inject.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+@Singleton
+class Catalog {
+    @Inject
+    public PaymentProcessor paymentProcessor;   
+}
+@Singleton
+class Shop {
+    @TestProduces
+    PaymentProcessor getPaymentProcessor() {
+        return new CreditCardProcessor();
+    }
+    @TestProduces
+    List<Product> getProducts() {
+        return Arrays.asList(
+                new Product("Apple"),
+                new Product("Orange")
+        );
+    }
+}
+
+@TestSpecializes
+class MockShop extends Shop {
+    @Override @TestSpecializes
+    @TestProduces
+    PaymentProcessor getPaymentProcessor() {
+        return new MockPaymentProcessor();
+    }
+
+    @Override @TestSpecializes
+    @TestProduces
+    List<Product> getProducts() {
+        return Collections.singletonList(new Product("Mocked"));
+    }
+}
+
+class MockPaymentProcessor implements PaymentProcessor {}
+
+interface PaymentProcessor {
+}
+class CreditCardProcessor implements PaymentProcessor {}
+class Product {
+    final String name;
+
+    Product(String name) {
+        this.name = name;
+    }
+}
+
+''')
+        def bean = getBean(context, 'annreplaces.Catalog')
+
+        expect:
+        bean
+
+    }
+
+    @Override
+    protected JavaParser newJavaParser() {
+        return new JavaParser() {
+            @Override
+            protected TypeElementVisitorProcessor getTypeElementVisitorProcessor() {
+                return new MyTypeElementVisitorProcessor()
+            }
+        }
+    }
+
+    @SupportedAnnotationTypes("*")
+    static class MyTypeElementVisitorProcessor extends TypeElementVisitorProcessor {
+        @Override
+        protected Collection<TypeElementVisitor> findTypeElementVisitors() {
+            return [new MyProducesVisitor(), new MySpecializesVisitor()]
+        }
+    }
+    static class MySpecializesVisitor implements TypeElementVisitor<Object, TestSpecializes> {
+        @Override
+        void visitMethod(MethodElement element, VisitorContext context) {
+            element.annotate(Replaces.class, (builder) -> {
+                builder.member(AnnotationMetadata.VALUE_MEMBER, new AnnotationClassValue<>(element.getGenericReturnType().getName()));
+                builder.member("factory", new AnnotationClassValue<>(element.getDeclaringType().getSuperType().get().getName()));
+            });
+        }
+
+        @Override
+        VisitorKind getVisitorKind() {
+            return VisitorKind.ISOLATING
+        }
+    }
+    static class MyProducesVisitor implements TypeElementVisitor<Object, TestProduces> {
+        ClassElement currentClass
+
+        @Override
+        void visitClass(ClassElement element, VisitorContext context) {
+            this.currentClass = element;
+        }
+
+        @Override
+        void visitMethod(MethodElement element, VisitorContext context) {
+            if (!this.currentClass.hasAnnotation(Factory.class)) {
+                this.currentClass.annotate(Factory.class);
+                element.annotate(Bean)
+            }
+        }
+
+        @Override
+        VisitorKind getVisitorKind() {
+            return VisitorKind.ISOLATING
+        }
+    }
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface TestSpecializes {}
+@Retention(RetentionPolicy.RUNTIME)
+@interface TestProduces {}

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/AnnotateReplacesSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/AnnotateReplacesSpec.groovy
@@ -26,7 +26,7 @@ package annreplaces;
 import io.micronaut.inject.qualifiers.replaces.TestProduces;
 import io.micronaut.inject.qualifiers.replaces.TestSpecializes;
 import jakarta.inject.*;
-
+import io.micronaut.context.annotation.Factory;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -37,6 +37,7 @@ class Catalog {
     public PaymentProcessor paymentProcessor;   
 }
 @Singleton
+@Factory
 class Shop {
     @TestProduces
     PaymentProcessor getPaymentProcessor() {
@@ -52,6 +53,7 @@ class Shop {
 }
 
 @TestSpecializes
+@Factory
 class MockShop extends Shop {
     @Override @TestSpecializes
     @TestProduces
@@ -84,6 +86,8 @@ class Product {
 
         expect:
         bean
+        getBean(context, 'annreplaces.MockShop')
+        bean.paymentProcessor.getClass().name.contains("Mock")
 
     }
 
@@ -101,7 +105,7 @@ class Product {
     static class MyTypeElementVisitorProcessor extends TypeElementVisitorProcessor {
         @Override
         protected Collection<TypeElementVisitor> findTypeElementVisitors() {
-            return [new MyProducesVisitor(), new MySpecializesVisitor()]
+            return [new MySpecializesVisitor(), new MyProducesVisitor()]
         }
     }
     static class MySpecializesVisitor implements TypeElementVisitor<Object, TestSpecializes> {
@@ -130,8 +134,8 @@ class Product {
         void visitMethod(MethodElement element, VisitorContext context) {
             if (!this.currentClass.hasAnnotation(Factory.class)) {
                 this.currentClass.annotate(Factory.class);
-                element.annotate(Bean)
             }
+            element.annotate(Bean)
         }
 
         @Override

--- a/inject/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -349,6 +349,13 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         if (existing instanceof DefaultAnnotationMetadata) {
             // ugly, but will have to do
             annotationMetadata = ((DefaultAnnotationMetadata) existing).clone();
+        } else if (existing instanceof AnnotationMetadataHierarchy) {
+            final AnnotationMetadata declaredMetadata = ((AnnotationMetadataHierarchy) existing).getDeclaredMetadata();
+            if (declaredMetadata instanceof DefaultAnnotationMetadata) {
+                annotationMetadata = ((DefaultAnnotationMetadata) declaredMetadata).clone();
+            } else {
+                annotationMetadata = new MutableAnnotationMetadata();
+            }
         } else {
             annotationMetadata = new MutableAnnotationMetadata();
         }


### PR DESCRIPTION
If `annotate` is called multiple times by multiple visitors type element visitor doesn't take into account annotation hierarchy and they. fail. This is fixes it