### PR TITLE
Add simple integration with JBang

### DIFF
--- a/context/src/main/java/io/micronaut/runtime/Micronaut.java
+++ b/context/src/main/java/io/micronaut/runtime/Micronaut.java
@@ -287,6 +287,16 @@ public class Micronaut extends DefaultApplicationContextBuilder implements Appli
     }
 
     /**
+     * Run the application for the given arguments. Classes for the application will be discovered automatically
+     *
+     * @param args The arguments
+     * @since 2.5.5
+     */
+    public static void main(String... args) {
+        run(new Class[0], args);
+    }
+
+    /**
      * Run the application for the given arguments.
      *
      * @param cls  The application class

--- a/context/src/main/java/io/micronaut/runtime/jbang/JBangIntegration.java
+++ b/context/src/main/java/io/micronaut/runtime/jbang/JBangIntegration.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.runtime.jbang;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.runtime.Micronaut;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Provides integration for running Micronaut application's as JBang scripts.
+ *
+ * @author graemerocher
+ * @since 2.5.5
+ */
+@Internal
+public final class JBangIntegration {
+
+    public static final String CONFIG = "//M:CONFIG ";
+
+    /**
+     * The JBang integration hook.
+     * @param appClasses The application classes
+     * @param pomFile The POM file
+     * @param repositories the repositories
+     * @param originalDeps The original dependencies
+     * @param comments The comments
+     * @param nativeImage Is this a native image
+     * @return The integration data
+     */
+    public static Map<String, Object> postBuild(Path appClasses,
+                                                Path pomFile,
+                                                List<Map.Entry<String, String>> repositories,
+                                                List<Map.Entry<String, Path>> originalDeps,
+                                                List<String> comments,
+                                                boolean nativeImage) {
+        Map<String, Object> integration = new HashMap<>(4);
+        integration.put("main-class", Micronaut.class.getName());
+
+        List<String> javaArgs = new ArrayList<>();
+        for (String comment : comments) {
+            if (comment.startsWith(CONFIG)) {
+                String conf = comment.substring(CONFIG.length()).trim();
+                int equals = conf.indexOf("=");
+                if (equals == -1) {
+                    javaArgs.add("-D" + conf + "=true");
+                } else {
+                    final String n = conf.substring(0, equals);
+                    final String v = conf.substring(equals + 1);
+                    javaArgs.add("-D" + n + "=" + v);
+                }
+            }
+        }
+        if (!javaArgs.isEmpty()) {
+            integration.put("java-args", javaArgs);
+        }
+        return integration;
+    }
+}

--- a/context/src/main/java/io/micronaut/runtime/jbang/JBangIntegration.java
+++ b/context/src/main/java/io/micronaut/runtime/jbang/JBangIntegration.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.runtime.jbang;
 
+import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.runtime.Micronaut;
 
@@ -31,6 +32,7 @@ import java.util.Map;
  * @since 2.5.5
  */
 @Internal
+@Experimental
 public final class JBangIntegration {
 
     public static final String CONFIG = "//M:CONFIG ";

--- a/context/src/main/resources/META-INF/jbang-integration.list
+++ b/context/src/main/resources/META-INF/jbang-integration.list
@@ -1,0 +1,1 @@
+io.micronaut.runtime.jbang.JBangIntegration


### PR DESCRIPTION
This is a fairly non invasive change so I am targeting 2.5.x as it changes no existing code. With this in place you can define scripts like the following and execute them with JBang. See https://www.jbang.dev:

```java
///usr/bin/env jbang "$0" "$@" ; exit $?
//DEPS io.micronaut:micronaut-bom:2.5.5-SNAPSHOT@pom
//DEPS io.micronaut:micronaut-http-server-netty
//DEPS io.micronaut:micronaut-inject-java
//DEPS io.micronaut.data:micronaut-data-jdbc
//DEPS io.micronaut.data:micronaut-data-processor
//DEPS io.micronaut.sql:micronaut-jdbc-hikari
//DEPS com.h2database:h2
//DEPS org.slf4j:slf4j-simple
//M:CONFIG datasources.default.url=jdbc:h2:mem:devDb;MVCC=TRUE;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE
//M:CONFIG datasources.default.schema-generate=CREATE_DROP
//M:CONFIG datasources.default.dialect=H2

package app;

import io.micronaut.http.annotation.*;
import io.micronaut.data.annotation.*;
import io.micronaut.core.annotation.*;
import io.micronaut.data.jdbc.annotation.*;
import io.micronaut.data.repository.CrudRepository;

@Controller("/books")
class BookController {
    private final BookRepository repository;
    BookController(BookRepository repository) {
        this.repository = repository;
    }
    @Get("/")
    Iterable<Book> list() {
        return repository.findAll();
    }
}

@MappedEntity
record Book(
    @Id @GeneratedValue @Nullable Long id,
    String title,
    int pages
) {}

@JdbcRepository(dialectName="H2")
interface BookRepository extends CrudRepository<Book, Long> {}
```