### PR TITLE
Allow synthesizing metadata from different source annotation

### DIFF
--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationMetadataDelegate.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationMetadataDelegate.java
@@ -583,6 +583,18 @@ public interface AnnotationMetadataDelegate extends AnnotationMetadataProvider, 
         return getAnnotationMetadata().synthesize(annotationClass);
     }
 
+    @Nullable
+    @Override
+    default <T extends Annotation> T synthesize(@NonNull Class<T> annotationClass, @NonNull String sourceAnnotation) {
+        return getAnnotationMetadata().synthesize(annotationClass, sourceAnnotation);
+    }
+
+    @Nullable
+    @Override
+    default <T extends Annotation> T synthesizeDeclared(@NonNull Class<T> annotationClass, @NonNull String sourceAnnotation) {
+        return getAnnotationMetadata().synthesizeDeclared(annotationClass, sourceAnnotation);
+    }
+
     @Override
     default @NonNull Annotation[] synthesizeAll() {
         return getAnnotationMetadata().synthesizeAll();

--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationSource.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationSource.java
@@ -54,6 +54,44 @@ public interface AnnotationSource {
     }
 
     /**
+     * Synthesizes a new annotation for the given annotation type using the member values of the given source annotation.
+     *
+     * <p>This method allows supporting synthesizing annotations that have been renamed, for example a {@code jakarta.inject.Named} annotation an be synthesized from the metadata of the a {@code javax.inject.Named} annotation.</p>
+     *
+     * @param annotationClass The annotation class
+     * @param sourceAnnotation The source annotation that provides the member values
+     * @param <T>             The annotation generic type
+     * @return The annotation or null if it doesn't exist
+     * @since 3.0.0
+     */
+    default @Nullable <T extends Annotation> T synthesize(
+            @NonNull Class<T> annotationClass,
+            @NonNull String sourceAnnotation) {
+        ArgumentUtils.requireNonNull("annotationClass", annotationClass);
+        ArgumentUtils.requireNonNull("sourceAnnotation", sourceAnnotation);
+        return null;
+    }
+
+    /**
+     * Synthesizes a new annotation declared for the given annotation type using the member values of the given source annotation.
+     *
+     * <p>This method allows supporting synthesizing annotations that have been renamed, for example a {@code jakarta.inject.Named} annotation an be synthesized from the metadata of the a {@code javax.inject.Named} annotation.</p>
+     *
+     * @param annotationClass The annotation class
+     * @param sourceAnnotation The source annotation that provides the member values
+     * @param <T>             The annotation generic type
+     * @return The annotation or null if it doesn't exist
+     * @since 3.0.0
+     */
+    default @Nullable <T extends Annotation> T synthesizeDeclared(
+            @NonNull Class<T> annotationClass,
+            @NonNull String sourceAnnotation) {
+        ArgumentUtils.requireNonNull("annotationClass", annotationClass);
+        ArgumentUtils.requireNonNull("sourceAnnotation", sourceAnnotation);
+        return null;
+    }
+
+    /**
      * Synthesizes a new annotation from the metadata for the given annotation type. This method works
      * by creating a runtime proxy of the annotation interface and should be avoided in favour of
      * direct use of the annotation metadata and only used for unique cases that require integrating third party libraries.

--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationValueProvider.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationValueProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.core.annotation;
+
+import java.lang.annotation.Annotation;
+
+/**
+ * An interface that allows obtaining an underlying annotation value.
+ *
+ * @param <A> The annotation type
+ * @since 3.0.0
+ * @author graemerocher
+ */
+public interface AnnotationValueProvider<A extends Annotation> {
+
+    /**
+     * @return The annotation value. Never null.
+     */
+    @NonNull AnnotationValue<A> annotationValue();
+}

--- a/core/src/main/java/io/micronaut/core/type/DefaultArgumentValue.java
+++ b/core/src/main/java/io/micronaut/core/type/DefaultArgumentValue.java
@@ -17,6 +17,8 @@ package io.micronaut.core.type;
 
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 
 import java.lang.annotation.Annotation;
 import java.util.Map;
@@ -76,6 +78,18 @@ class DefaultArgumentValue<V> implements ArgumentValue<V> {
     @Override
     public <T extends Annotation> T synthesize(Class<T> annotationClass) {
         return argument.synthesize(annotationClass);
+    }
+
+    @Nullable
+    @Override
+    public <T extends Annotation> T synthesize(@NonNull Class<T> annotationClass, @NonNull String sourceAnnotation) {
+        return argument.synthesize(annotationClass, sourceAnnotation);
+    }
+
+    @Nullable
+    @Override
+    public <T extends Annotation> T synthesizeDeclared(@NonNull Class<T> annotationClass, @NonNull String sourceAnnotation) {
+        return argument.synthesizeDeclared(annotationClass, sourceAnnotation);
     }
 
     @Override

--- a/inject-java/src/test/groovy/io/micronaut/inject/annotation/BeanDefinitionAnnotationMetadataSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/annotation/BeanDefinitionAnnotationMetadataSpec.groovy
@@ -24,9 +24,11 @@ import io.micronaut.context.annotation.Requirements
 import io.micronaut.context.annotation.Requires
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.micronaut.core.annotation.AnnotationUtil
+import io.micronaut.core.annotation.AnnotationValueProvider
 import io.micronaut.inject.BeanConfiguration
 import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.ExecutableMethod
+import jakarta.inject.Named
 import spock.lang.Issue
 
 import jakarta.inject.Scope
@@ -37,6 +39,29 @@ import jakarta.inject.Singleton
  * @since 1.0
  */
 class BeanDefinitionAnnotationMetadataSpec extends AbstractTypeElementSpec {
+
+    void "test synthesize annotation from different source annotation"() {
+        given:
+        BeanDefinition definition = buildBeanDefinition('test.Test','''\
+package test;
+
+import jakarta.inject.*;
+
+@Singleton
+@Named("test")
+class Test {
+
+}
+''')
+
+
+        expect:
+        def ann = definition.synthesize(Named, "javax.inject.Named")
+        ann.value() == 'test'
+        definition.synthesizeDeclared(Named, "javax.inject.Named").value() == 'test'
+        ann instanceof AnnotationValueProvider
+        ann.annotationValue()
+    }
 
     void "test bean definition computed state"() {
         given:

--- a/inject/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadata.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadata.java
@@ -82,6 +82,46 @@ abstract class AbstractAnnotationMetadata implements AnnotationMetadata {
     }
 
     @SuppressWarnings("unchecked")
+    @Nullable
+    @Override
+    public <T extends Annotation> T synthesize(@NonNull Class<T> annotationClass, @NonNull String sourceAnnotation) {
+        ArgumentUtils.requireNonNull("annotationClass", annotationClass);
+        ArgumentUtils.requireNonNull("sourceAnnotation", sourceAnnotation);
+        if (annotationMap == null) {
+            return null;
+        }
+        if (hasAnnotation(sourceAnnotation) || hasStereotype(sourceAnnotation)) {
+            String annotationName = annotationClass.getName();
+            return (T) annotationMap.computeIfAbsent(annotationName, s -> {
+                final AnnotationValue<T> annotationValue = (AnnotationValue<T>) findAnnotation(sourceAnnotation).orElse(null);
+                return AnnotationMetadataSupport.buildAnnotation(annotationClass, annotationValue);
+
+            });
+        }
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Nullable
+    @Override
+    public <T extends Annotation> T synthesizeDeclared(@NonNull Class<T> annotationClass, @NonNull String sourceAnnotation) {
+        ArgumentUtils.requireNonNull("annotationClass", annotationClass);
+        ArgumentUtils.requireNonNull("sourceAnnotation", sourceAnnotation);
+        if (declaredAnnotationMap == null) {
+            return null;
+        }
+        String annotationName = annotationClass.getName();
+        if (hasDeclaredAnnotation(sourceAnnotation) || hasDeclaredStereotype(sourceAnnotation)) {
+            return (T) declaredAnnotationMap.computeIfAbsent(annotationName, s -> {
+                final AnnotationValue<T> annotationValue = (AnnotationValue<T>) findDeclaredAnnotation(sourceAnnotation).orElse(null);
+                return AnnotationMetadataSupport.buildAnnotation(annotationClass, annotationValue);
+
+            });
+        }
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
     @Override
     public @Nullable <T extends Annotation> T synthesizeDeclared(@NonNull Class<T> annotationClass) {
         ArgumentUtils.requireNonNull("annotationClass", annotationClass);
@@ -89,9 +129,9 @@ abstract class AbstractAnnotationMetadata implements AnnotationMetadata {
             return null;
         }
         String annotationName = annotationClass.getName();
-        if (hasAnnotation(annotationName) || hasStereotype(annotationName)) {
+        if (hasDeclaredAnnotation(annotationName) || hasDeclaredStereotype(annotationName)) {
             return (T) declaredAnnotationMap.computeIfAbsent(annotationName, s -> {
-                final AnnotationValue<T> annotationValue = findAnnotation(annotationClass).orElse(null);
+                final AnnotationValue<T> annotationValue = findDeclaredAnnotation(annotationClass).orElse(null);
                 return AnnotationMetadataSupport.buildAnnotation(annotationClass, annotationValue);
 
             });

--- a/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataHierarchy.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataHierarchy.java
@@ -131,6 +131,24 @@ public final class AnnotationMetadataHierarchy implements AnnotationMetadata, En
 
     @Nullable
     @Override
+    public <T extends Annotation> T synthesize(@NonNull Class<T> annotationClass, @NonNull String sourceAnnotation) {
+        for (AnnotationMetadata annotationMetadata : hierarchy) {
+            final T a = annotationMetadata.synthesize(annotationClass, sourceAnnotation);
+            if (a != null) {
+                return a;
+            }
+        }
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public <T extends Annotation> T synthesizeDeclared(@NonNull Class<T> annotationClass, @NonNull String sourceAnnotation) {
+        return hierarchy[0].synthesize(annotationClass, sourceAnnotation);
+    }
+
+    @Nullable
+    @Override
     public <T extends Annotation> T synthesize(@NonNull Class<T> annotationClass) {
         for (AnnotationMetadata annotationMetadata : hierarchy) {
             final T a = annotationMetadata.synthesize(annotationClass);


### PR DESCRIPTION
The Jakarta changes broke the CDI integration work because there was no way to obtain the scopes as actual annotations since the metadata contains `javax.inject` annotations. This change allows the synthesis of annotations instances from different source metadata so we can create instances of `jakarta.inject.Named` from the `javax.inject` metadata. It also adds an interface to retrieve the underlying metadata from the created proxy.