### PR TITLE
setting JAEGER_SERVICE_NAME system prop if not present in system prop and env var

### DIFF
--- a/tracing/src/main/java/io/micronaut/tracing/jaeger/JaegerConfiguration.java
+++ b/tracing/src/main/java/io/micronaut/tracing/jaeger/JaegerConfiguration.java
@@ -63,7 +63,8 @@ public class JaegerConfiguration implements Toggleable  {
      */
     public JaegerConfiguration(
             ApplicationConfiguration applicationConfiguration) {
-        if (StringUtils.isEmpty(System.getProperty(JAEGER_SERVICE_NAME))) {
+		if (StringUtils.isEmpty(System.getProperty(JAEGER_SERVICE_NAME))
+				&& StringUtils.isEmpty(System.getenv(JAEGER_SERVICE_NAME))) {
             System.setProperty(JAEGER_SERVICE_NAME, applicationConfiguration.getName().orElse(Environment.DEFAULT_NAME));
         }
         configuration = Configuration.fromEnv();


### PR DESCRIPTION
The PR contains the changes to allow user to set JAEGER_SERVICE_NAME via environment variable. More details can be found in the following link of the issue.

**_ISSUE-5527:_** https://github.com/micronaut-projects/micronaut-core/issues/5527