### PR TITLE
Ensure visited annotations for visitors can be visited downstream

### DIFF
--- a/inject-java/src/main/java/io/micronaut/annotation/processing/AbstractInjectAnnotationProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/AbstractInjectAnnotationProcessor.java
@@ -126,6 +126,12 @@ abstract class AbstractInjectAnnotationProcessor extends AbstractProcessor {
             for (String annotationPackage : annotationPackages) {
                 types.add(annotationPackage + ".*");
             }
+            Set<String> visitedAnnotationNames = TypeElementVisitorProcessor.getVisitedAnnotationNames();
+            for (String visitedAnnotationName : visitedAnnotationNames) {
+                if (!"*".equals(visitedAnnotationName)) {
+                    visitedAnnotationName.equals(visitedAnnotationName);
+                }
+            }
             return types;
         } else {
             return Collections.singleton("*");

--- a/inject-java/src/test/groovy/io/micronaut/annotation/processing/TypeElementVisitorProcessorSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/annotation/processing/TypeElementVisitorProcessorSpec.groovy
@@ -1,0 +1,22 @@
+package io.micronaut.annotation.processing
+
+import io.micronaut.annotation.processing.TypeElementVisitorProcessor
+import io.micronaut.aop.introduction.Stub
+import io.micronaut.http.annotation.Controller
+import spock.lang.Specification
+
+class TypeElementVisitorProcessorSpec extends Specification {
+
+    void "test get annotation names"() {
+        given:
+        def visitedAnnotationNames = TypeElementVisitorProcessor.getVisitedAnnotationNames()
+
+        visitedAnnotationNames.forEach(this::println)
+
+        expect:
+        visitedAnnotationNames
+        visitedAnnotationNames.contains(Stub.name)
+        visitedAnnotationNames.contains(Controller.name)
+        !visitedAnnotationNames.contains("*")
+    }
+}

--- a/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataSupport.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataSupport.java
@@ -251,6 +251,8 @@ public final class AnnotationMetadataSupport {
 
     /**
      * Annotation proxy handler.
+     *
+     * @param <A> The annotation type
      */
     private static class AnnotationProxyHandler<A extends Annotation> implements InvocationHandler, AnnotationValueProvider<A> {
         private final int hashCode;


### PR DESCRIPTION
if incremental compilation is enabled and a visitor adds a bean defining annotation to a ClassElement via a visitor with annotate(..) then that type is not subsequently processed downstream when incremental compilation is enabled. The annotations handled by visitors should be included in this list of supported annotations for the bean definition processor. This change fixes that.
