### PR TITLE
Support for removing annotations in a visitor

### DIFF
--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -6,7 +6,7 @@
 
 <suppressions>
     <suppress checks="FileLength"
-              files="DefaultBeanContext.java|BeanDefinitionWriter.java|DefaultHttpClient.java|BeanDefinitionInjectProcessor.java|AbstractBeanDefinition.java|DefaultValidator.java|RoutingInBoundHandler.java"/>
+              files="DefaultBeanContext.java|BeanDefinitionWriter.java|DefaultHttpClient.java|BeanDefinitionInjectProcessor.java|AbstractBeanDefinition.java|DefaultValidator.java|RoutingInBoundHandler.java|DefaultAnnotationMetadata.java|AbstractAnnotationMetadataBuilder.java"/>
     <suppress checks="DeclarationOrder"
               files="UriTemplate.java"/>
     <suppress checks="Header"

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/AbstractGroovyElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/AbstractGroovyElement.java
@@ -41,6 +41,7 @@ import io.micronaut.core.annotation.NonNull;
 import java.lang.annotation.Annotation;
 import java.util.*;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 /**
  * Abstract Groovy element.
@@ -95,15 +96,50 @@ public abstract class AbstractGroovyElement implements AnnotationMetadataDelegat
                     this.annotationMetadata,
                     av
             );
-            String declaringTypeName = this instanceof MemberElement ? ((MemberElement) this).getOwningType().getName() : getName();
-            AbstractAnnotationMetadataBuilder.addMutatedMetadata(
-                    declaringTypeName,
-                    annotatedNode,
-                    this.annotationMetadata
-            );
-            AstAnnotationUtils.invalidateCache(annotatedNode);
+            updateAnnotationCaches();
         }
         return this;
+    }
+
+    @Override
+    public Element removeAnnotation(@NonNull String annotationType) {
+        ArgumentUtils.requireNonNull("annotationType", annotationType);
+        this.annotationMetadata = new GroovyAnnotationMetadataBuilder(sourceUnit, compilationUnit).removeAnnotation(
+                this.annotationMetadata, annotationType
+        );
+        updateAnnotationCaches();
+        return this;
+    }
+
+    @Override
+    public <T extends Annotation> Element removeAnnotationIf(@NonNull Predicate<AnnotationValue<T>> predicate) {
+        ArgumentUtils.requireNonNull("predicate", predicate);
+        this.annotationMetadata = new GroovyAnnotationMetadataBuilder(sourceUnit, compilationUnit).removeAnnotationIf(
+                this.annotationMetadata, predicate
+        );
+        updateAnnotationCaches();
+        return this;
+
+    }
+
+    @Override
+    public Element removeStereotype(@NonNull String annotationType) {
+        ArgumentUtils.requireNonNull("annotationType", annotationType);
+        this.annotationMetadata = new GroovyAnnotationMetadataBuilder(sourceUnit, compilationUnit).removeStereotype(
+                this.annotationMetadata, annotationType
+        );
+        updateAnnotationCaches();
+        return this;
+    }
+
+    private void updateAnnotationCaches() {
+        String declaringTypeName = this instanceof MemberElement ? ((MemberElement) this).getOwningType().getName() : getName();
+        AbstractAnnotationMetadataBuilder.addMutatedMetadata(
+                declaringTypeName,
+                annotatedNode,
+                this.annotationMetadata
+        );
+        AstAnnotationUtils.invalidateCache(annotatedNode);
     }
 
     /**

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/annotation/RemoveAnnotationSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/annotation/RemoveAnnotationSpec.groovy
@@ -1,0 +1,53 @@
+package io.micronaut.inject.annotation
+
+import io.micronaut.ast.groovy.TypeElementVisitorStart
+import io.micronaut.ast.transform.test.AbstractBeanDefinitionSpec
+import io.micronaut.context.annotation.Prototype
+import io.micronaut.core.annotation.AnnotationUtil
+import io.micronaut.inject.ast.ClassElement
+import io.micronaut.inject.visitor.AllElementsVisitor
+import io.micronaut.inject.visitor.TypeElementVisitor
+import io.micronaut.inject.visitor.VisitorContext
+
+class RemoveAnnotationSpec extends AbstractBeanDefinitionSpec {
+    def setup() {
+        System.setProperty(TypeElementVisitorStart.ELEMENT_VISITORS_PROPERTY, ReplacingTypeElementVisitor.name)
+    }
+
+    def cleanup() {
+        AllElementsVisitor.clearVisited()
+    }
+
+    void 'test replace simple annotation'() {
+        given:
+        def definition = buildBeanDefinition('removeann.Test', '''
+package removeann;
+
+import io.micronaut.inject.annotation.ScopeOne;
+import io.micronaut.context.annotation.Bean;
+
+@ScopeOne
+@Bean
+class Test {
+
+}    
+''')
+        expect:
+        definition
+        definition.hasStereotype(AnnotationUtil.SCOPE)
+        definition.hasDeclaredAnnotation(Prototype)
+        !definition.hasDeclaredAnnotation(ScopeOne)
+        def stereotypes = definition.getAnnotationNamesByStereotype(AnnotationUtil.SCOPE)
+        stereotypes.contains(Prototype.name)
+        stereotypes.size() == 1
+    }
+
+    static class ReplacingTypeElementVisitor implements TypeElementVisitor<Object, Object> {
+        @Override
+        void visitClass(ClassElement element, VisitorContext context) {
+            element.removeAnnotation(ScopeOne)
+            element.annotate(Prototype)
+        }
+    }
+
+}

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/annotation/ScopeOne.java
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/annotation/ScopeOne.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.annotation;
+
+
+import jakarta.inject.Scope;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Scope
+@Retention(RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface ScopeOne {
+    String value() default "";
+}

--- a/inject-java-test/src/main/groovy/io/micronaut/annotation/processing/test/AbstractTypeElementSpec.groovy
+++ b/inject-java-test/src/main/groovy/io/micronaut/annotation/processing/test/AbstractTypeElementSpec.groovy
@@ -17,10 +17,12 @@ package io.micronaut.annotation.processing.test
 
 import com.sun.source.util.JavacTask
 import groovy.transform.CompileStatic
+import io.micronaut.annotation.processing.AggregatingTypeElementVisitorProcessor
 import io.micronaut.annotation.processing.AnnotationUtils
 import io.micronaut.annotation.processing.GenericUtils
 import io.micronaut.annotation.processing.JavaAnnotationMetadataBuilder
 import io.micronaut.annotation.processing.ModelUtils
+import io.micronaut.annotation.processing.TypeElementVisitorProcessor
 import io.micronaut.annotation.processing.visitor.JavaClassElement
 import io.micronaut.annotation.processing.visitor.JavaVisitorContext
 import io.micronaut.aop.internal.InterceptorRegistryBean
@@ -42,6 +44,7 @@ import io.micronaut.inject.annotation.AnnotationMetadataWriter
 import io.micronaut.inject.annotation.AnnotationTransformer
 import io.micronaut.inject.ast.ClassElement
 import io.micronaut.inject.provider.BeanProviderDefinition
+import io.micronaut.inject.visitor.TypeElementVisitor
 import io.micronaut.inject.writer.BeanConfigurationWriter
 import io.micronaut.inject.writer.BeanDefinitionVisitor
 import spock.lang.Specification
@@ -249,9 +252,33 @@ class Test {
      * Create and return a new Java parser.
      * @return The java parser to use
      */
-    @CompileStatic
     protected JavaParser newJavaParser() {
-        return new JavaParser()
+        def visitors = getLocalTypeElementVisitors()
+        if (visitors) {
+            return new JavaParser() {
+                @Override
+                protected TypeElementVisitorProcessor getTypeElementVisitorProcessor() {
+                    return new TypeElementVisitorProcessor() {
+                        @Override
+                        protected Collection<TypeElementVisitor> findTypeElementVisitors() {
+                            return visitors
+                        }
+                    }
+                }
+
+                @Override
+                protected AggregatingTypeElementVisitorProcessor getAggregatingTypeElementVisitorProcessor() {
+                    return new AggregatingTypeElementVisitorProcessor() {
+                        @Override
+                        protected Collection<TypeElementVisitor> findTypeElementVisitors() {
+                            return visitors
+                        }
+                    }
+                }
+            }
+        } else {
+            return new JavaParser()
+        }
     }
 
     /**
@@ -366,6 +393,14 @@ class Test {
      * @return The transformers for the annotation
      */
     protected List<AnnotationTransformer<? extends Annotation>> getLocalAnnotationTransformers(@NonNull String annotationName) {
+        return Collections.emptyList()
+    }
+
+    /**
+     * Retrieve additional type element visitors for this test.
+     * @return the visitors
+     */
+    protected Collection<TypeElementVisitor> getLocalTypeElementVisitors() {
         return Collections.emptyList()
     }
 

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/AbstractJavaElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/AbstractJavaElement.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 import static javax.lang.model.element.Modifier.*;
 
@@ -79,6 +80,61 @@ public abstract class AbstractJavaElement implements io.micronaut.inject.ast.Ele
                 .newAnnotationBuilder()
                 .annotate(annotationMetadata, av);
 
+        updateMetadataCaches();
+        return this;
+    }
+
+    @Override
+    public io.micronaut.inject.ast.Element removeAnnotation(@NonNull String annotationType) {
+        ArgumentUtils.requireNonNull("annotationType", annotationType);
+        try {
+            AnnotationUtils annotationUtils = visitorContext
+                    .getAnnotationUtils();
+            this.annotationMetadata = annotationUtils
+                    .newAnnotationBuilder()
+                    .removeAnnotation(annotationMetadata, annotationType);
+            return this;
+        } finally {
+            updateMetadataCaches();
+        }
+    }
+
+    @Override
+    public <T extends Annotation> io.micronaut.inject.ast.Element removeAnnotationIf(@NonNull Predicate<AnnotationValue<T>> predicate) {
+        //noinspection ConstantConditions
+        if (predicate != null) {
+            AnnotationUtils annotationUtils = visitorContext
+                    .getAnnotationUtils();
+            this.annotationMetadata = annotationUtils
+                    .newAnnotationBuilder()
+                    .removeAnnotationIf(annotationMetadata, predicate);
+            return this;
+        }
+        return this;
+    }
+
+    @Override
+    public io.micronaut.inject.ast.Element removeStereotype(@NonNull String annotationType) {
+        ArgumentUtils.requireNonNull("annotationType", annotationType);
+        try {
+            AnnotationUtils annotationUtils = visitorContext
+                    .getAnnotationUtils();
+            this.annotationMetadata = annotationUtils
+                    .newAnnotationBuilder()
+                    .removeStereotype(annotationMetadata, annotationType);
+            return this;
+        } finally {
+            updateMetadataCaches();
+        }
+    }
+
+    private void updateMetadataCaches() {
+        String declaringTypeName = resolveDeclaringTypeName();
+        AbstractAnnotationMetadataBuilder.addMutatedMetadata(declaringTypeName, element, annotationMetadata);
+        AnnotationUtils.invalidateMetadata(element);
+    }
+
+    private String resolveDeclaringTypeName() {
         String declaringTypeName;
         if (this instanceof MemberElement) {
             declaringTypeName = ((MemberElement) this).getOwningType().getName();
@@ -92,10 +148,7 @@ public abstract class AbstractJavaElement implements io.micronaut.inject.ast.Ele
         } else {
             declaringTypeName = getName();
         }
-
-        AbstractAnnotationMetadataBuilder.addMutatedMetadata(declaringTypeName, element, annotationMetadata);
-        AnnotationUtils.invalidateMetadata(element);
-        return this;
+        return declaringTypeName;
     }
 
     @Override

--- a/inject-java/src/test/groovy/io/micronaut/inject/annotation/RemoveAnnotationSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/annotation/RemoveAnnotationSpec.groovy
@@ -1,0 +1,240 @@
+package io.micronaut.inject.annotation
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.annotation.Prototype
+import io.micronaut.core.annotation.AnnotationUtil
+import io.micronaut.inject.AdvisedBeanType
+import io.micronaut.inject.annotation.repeatable.Topic
+import io.micronaut.inject.annotation.repeatable.Topics
+import io.micronaut.inject.ast.ClassElement
+import io.micronaut.inject.visitor.TypeElementVisitor
+import io.micronaut.inject.visitor.VisitorContext
+
+class RemoveAnnotationSpec extends AbstractTypeElementSpec {
+    Collection<TypeElementVisitor> visitors = []
+    def cleanup() {
+        visitors.clear()
+    }
+
+    void 'test replace simple annotation'() {
+        given:
+        visitors.add(new ReplacingTypeElementVisitor(ScopeOne.name, Prototype.name))
+        def definition = buildBeanDefinition('removeann.Test', '''
+package removeann;
+
+import io.micronaut.inject.annotation.ScopeOne;
+import io.micronaut.context.annotation.Bean;
+
+@ScopeOne
+@Bean
+class Test {
+
+}    
+''')
+        expect:
+        definition
+        definition.hasStereotype(AnnotationUtil.SCOPE)
+        definition.hasDeclaredAnnotation(Prototype)
+        !definition.hasDeclaredAnnotation(ScopeOne)
+        def stereotypes = definition.getAnnotationNamesByStereotype(AnnotationUtil.SCOPE)
+        stereotypes.contains(Prototype.name)
+        stereotypes.size() == 1
+    }
+
+    void 'test remove simple annotation'() {
+        given:
+        visitors.add(new RemovingTypeElementVisitor(ScopeOne.name))
+        def definition = buildBeanDefinition('removeann.Test', '''
+package removeann;
+
+import io.micronaut.inject.annotation.ScopeOne;
+import io.micronaut.context.annotation.Bean;
+
+@ScopeOne
+@Bean
+class Test {
+
+}    
+''')
+        expect:
+        definition
+        !definition.hasStereotype(AnnotationUtil.SCOPE)
+        !definition.hasDeclaredAnnotation(Prototype)
+        !definition.hasDeclaredAnnotation(ScopeOne)
+        def stereotypes = definition.getAnnotationNamesByStereotype(AnnotationUtil.SCOPE)
+        stereotypes.size() == 0
+    }
+
+    void "test remove stereotype"() {
+        given:
+        visitors.add(new RemoveStereotypeVisitor(ScopeOne.name))
+        def definition = buildBeanDefinition('removeann.Test', '''
+package removeann;
+
+import io.micronaut.inject.annotation.ScopeTwo;
+import io.micronaut.context.annotation.Bean;
+
+@ScopeTwo
+@Bean
+class Test {
+
+}    
+''')
+        expect:"The ScopeOne stereotype was removed but Scope remains as it was not removed"
+        definition
+        !definition.hasDeclaredAnnotation(Prototype)
+        !definition.hasStereotype(ScopeOne)
+        !definition.hasDeclaredStereotype(ScopeOne)
+        def stereotypes = definition.getAnnotationNamesByStereotype(AnnotationUtil.SCOPE)
+        stereotypes.size() == 1
+        stereotypes.contains(ScopeTwo.name)
+    }
+
+    void 'test remove if simple annotation'() {
+        given:
+        visitors.add(new RemovingIfTypeElementVisitor(ScopeOne.name))
+        def definition = buildBeanDefinition('removeann.Test', '''
+package removeann;
+
+import io.micronaut.inject.annotation.ScopeOne;
+import io.micronaut.context.annotation.Bean;
+
+@ScopeOne
+@Bean
+class Test {
+
+}    
+''')
+        expect:
+        definition
+        !definition.hasStereotype(AnnotationUtil.SCOPE)
+        !definition.hasDeclaredAnnotation(Prototype)
+        !definition.hasDeclaredAnnotation(ScopeOne)
+        def stereotypes = definition.getAnnotationNamesByStereotype(AnnotationUtil.SCOPE)
+        stereotypes.size() == 0
+    }
+
+    void "test remove interceptor binding"() {
+        given:
+        visitors.add(new RemovingTypeElementVisitor(Trace.name))
+        def definition = buildBeanDefinition('removeann.Test', '''
+package removeann;
+
+import io.micronaut.inject.annotation.Trace;
+import io.micronaut.context.annotation.Bean;
+
+@Trace(type = String.class, types = String.class) 
+@Bean
+class Test {
+
+}    
+''')
+        expect:
+        definition
+        !(definition instanceof AdvisedBeanType)
+        !definition.hasStereotype(AnnotationUtil.ANN_AROUND)
+        !definition.hasAnnotation(AnnotationUtil.ANN_AROUND)
+        !definition.hasAnnotation(AnnotationUtil.ANN_INTERCEPTOR_BINDINGS)
+    }
+
+    void "test remove interceptor binding results in it no longer being a bean if no bean defining annotation present"() {
+        given:
+        visitors.add(new RemovingTypeElementVisitor(Trace.name))
+        def definition = buildBeanDefinition('removeann.Test', '''
+package removeann;
+
+import io.micronaut.inject.annotation.Trace;
+import io.micronaut.context.annotation.Bean;
+
+@Trace(type = String.class, types = String.class) 
+class Test {
+
+}    
+''')
+        expect:
+        definition == null
+    }
+
+    void "test removing a repeatable type removes all"() {
+        given:
+        visitors.add(new RemovingTypeElementVisitor(Topic.name))
+        def definition = buildBeanDefinition('removeann.Test', '''
+package removeann;
+
+import io.micronaut.inject.annotation.ScopeOne;
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.inject.annotation.repeatable.Topic;
+
+@Topic("one")
+@Topic("two")
+@Bean
+class Test {
+
+}    
+''')
+        expect:
+        definition
+        !definition.hasDeclaredAnnotation(Topics)
+        !definition.hasDeclaredAnnotation(Topic)
+    }
+
+    @Override
+    protected Collection<TypeElementVisitor> getLocalTypeElementVisitors() {
+        return visitors
+    }
+
+    static class RemovingTypeElementVisitor implements TypeElementVisitor<Object, Object> {
+        private final String annotationName;
+
+        RemovingTypeElementVisitor(String annotationName) {
+            this.annotationName = annotationName
+        }
+
+        @Override
+        void visitClass(ClassElement element, VisitorContext context) {
+            element.removeAnnotation(annotationName)
+        }
+    }
+
+    static class RemovingIfTypeElementVisitor implements TypeElementVisitor<Object, Object> {
+        private final String annotationName;
+
+        RemovingIfTypeElementVisitor(String annotationName) {
+            this.annotationName = annotationName
+        }
+
+        @Override
+        void visitClass(ClassElement element, VisitorContext context) {
+            element.removeAnnotationIf({  it.annotationName == annotationName })
+        }
+    }
+
+    static class ReplacingTypeElementVisitor implements TypeElementVisitor<Object, Object> {
+        private final String annotationName;
+        private final String replacement;
+
+        ReplacingTypeElementVisitor(String annotationName, String replacement) {
+            this.annotationName = annotationName
+            this.replacement = replacement
+        }
+
+        @Override
+        void visitClass(ClassElement element, VisitorContext context) {
+            element.removeAnnotation(annotationName)
+            element.annotate(replacement)
+        }
+    }
+
+    static class RemoveStereotypeVisitor implements TypeElementVisitor<Object, Object> {
+        private final String annotationName;
+
+        RemoveStereotypeVisitor(String annotationName) {
+            this.annotationName = annotationName
+        }
+
+        @Override
+        void visitClass(ClassElement element, VisitorContext context) {
+            element.removeStereotype(annotationName)
+        }
+    }
+}

--- a/inject/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -33,6 +33,7 @@ import java.lang.annotation.Annotation;
 import java.lang.annotation.RetentionPolicy;
 import java.util.*;
 import java.util.function.BiConsumer;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
@@ -1843,6 +1844,122 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                 return new AnnotationMetadataHierarchy(ref, newMetadata);
             } else {
                 return newMetadata;
+            }
+        }
+        return annotationMetadata;
+    }
+
+    /**
+     * Removes an annotation from the given annotation metadata.
+     * @param annotationMetadata The annotation metadata
+     * @param annotationType The annotation type
+     * @return The updated metadata
+     * @since 3.0.0
+     */
+    public AnnotationMetadata removeAnnotation(AnnotationMetadata annotationMetadata, String annotationType) {
+        // we only care if the metadata is an hierarchy or default mutable
+        final boolean isHierarchy = annotationMetadata instanceof AnnotationMetadataHierarchy;
+        AnnotationMetadata declaredMetadata = annotationMetadata;
+        if (isHierarchy) {
+            declaredMetadata = ((AnnotationMetadataHierarchy) annotationMetadata).getDeclaredMetadata();
+        }
+        // if it is anything else other than DefaultAnnotationMetadata here it is probably empty
+        // in which case nothing needs to be done
+        if (declaredMetadata instanceof DefaultAnnotationMetadata) {
+            final DefaultAnnotationMetadata defaultMetadata = (DefaultAnnotationMetadata) declaredMetadata;
+            T annotationMirror = getAnnotationMirror(annotationType).orElse(null);
+            if (annotationMirror != null) {
+                String repeatableName = getRepeatableNameForType(annotationMirror);
+                if (repeatableName != null) {
+                    defaultMetadata.removeAnnotation(repeatableName);
+                } else {
+                    defaultMetadata.removeAnnotation(annotationType);
+                }
+            } else {
+                defaultMetadata.removeAnnotation(annotationType);
+            }
+
+            if (isHierarchy) {
+                return ((AnnotationMetadataHierarchy) annotationMetadata).createSibling(
+                        declaredMetadata
+                );
+            } else {
+                return declaredMetadata;
+            }
+        }
+        return annotationMetadata;
+    }
+
+    /**
+     * Removes an annotation from the given annotation metadata.
+     * @param annotationMetadata The annotation metadata
+     * @param annotationType The annotation type
+     * @return The updated metadata
+     * @since 3.0.0
+     */
+    public AnnotationMetadata removeStereotype(AnnotationMetadata annotationMetadata, String annotationType) {
+        // we only care if the metadata is an hierarchy or default mutable
+        final boolean isHierarchy = annotationMetadata instanceof AnnotationMetadataHierarchy;
+        AnnotationMetadata declaredMetadata = annotationMetadata;
+        if (isHierarchy) {
+            declaredMetadata = ((AnnotationMetadataHierarchy) annotationMetadata).getDeclaredMetadata();
+        }
+        // if it is anything else other than DefaultAnnotationMetadata here it is probably empty
+        // in which case nothing needs to be done
+        if (declaredMetadata instanceof DefaultAnnotationMetadata) {
+            final DefaultAnnotationMetadata defaultMetadata = (DefaultAnnotationMetadata) declaredMetadata;
+            T annotationMirror = getAnnotationMirror(annotationType).orElse(null);
+            if (annotationMirror != null) {
+                String repeatableName = getRepeatableNameForType(annotationMirror);
+                if (repeatableName != null) {
+                    defaultMetadata.removeStereotype(repeatableName);
+                } else {
+                    defaultMetadata.removeStereotype(annotationType);
+                }
+            } else {
+                defaultMetadata.removeStereotype(annotationType);
+            }
+
+            if (isHierarchy) {
+                return ((AnnotationMetadataHierarchy) annotationMetadata).createSibling(
+                        declaredMetadata
+                );
+            } else {
+                return declaredMetadata;
+            }
+        }
+        return annotationMetadata;
+    }
+
+    /**
+     * Removes an annotation from the metadata for the given predicate.
+     * @param annotationMetadata The annotation metadata
+     * @param predicate The predicate
+     * @param <T1> The annotation type
+     * @return The potentially modified metadata
+     */
+    public @NonNull <T1 extends Annotation> AnnotationMetadata removeAnnotationIf(
+            @NonNull AnnotationMetadata annotationMetadata,
+            @NonNull Predicate<AnnotationValue<T1>> predicate) {
+        // we only care if the metadata is an hierarchy or default mutable
+        final boolean isHierarchy = annotationMetadata instanceof AnnotationMetadataHierarchy;
+        AnnotationMetadata declaredMetadata = annotationMetadata;
+        if (isHierarchy) {
+            declaredMetadata = ((AnnotationMetadataHierarchy) annotationMetadata).getDeclaredMetadata();
+        }
+        // if it is anything else other than DefaultAnnotationMetadata here it is probably empty
+        // in which case nothing needs to be done
+        if (declaredMetadata instanceof DefaultAnnotationMetadata) {
+            final DefaultAnnotationMetadata defaultMetadata = (DefaultAnnotationMetadata) declaredMetadata;
+
+            defaultMetadata.removeAnnotationIf(predicate);
+
+            if (isHierarchy) {
+                return ((AnnotationMetadataHierarchy) annotationMetadata).createSibling(
+                        declaredMetadata
+                );
+            } else {
+                return declaredMetadata;
             }
         }
         return annotationMetadata;

--- a/inject/src/main/java/io/micronaut/inject/ast/Element.java
+++ b/inject/src/main/java/io/micronaut/inject/ast/Element.java
@@ -17,14 +17,17 @@ package io.micronaut.inject.ast;
 
 import io.micronaut.core.annotation.AnnotatedElement;
 import io.micronaut.core.annotation.AnnotationMetadataDelegate;
+import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.AnnotationValueBuilder;
 import io.micronaut.core.naming.Described;
 import io.micronaut.core.util.ArgumentUtils;
 
 import io.micronaut.core.annotation.NonNull;
 import java.lang.annotation.Annotation;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 /**
  * Stores data about a compile time element. The underlying object can be a class, field, or method.
@@ -84,6 +87,66 @@ public interface Element extends AnnotationMetadataDelegate, AnnotatedElement, D
     @NonNull
     default <T extends Annotation> Element annotate(@NonNull String annotationType, @NonNull Consumer<AnnotationValueBuilder<T>> consumer) {
         throw new UnsupportedOperationException("Element of type [" + getClass() + "] does not support adding annotations at compilation time");
+    }
+
+    /**
+     * Removes an annotation of the given type from the element.
+     *
+     * <p>If the annotation features any stereotypes these will also be removed unless there are other
+     * annotations that reference the stereotype to be removed.</p>
+     *
+     * <p>In the case of repeatable annotations this method will remove all repeated annotations, effectively
+     * clearing out all declared repeated annotations of the given type.</p>
+     *
+     * @param annotationType The annotation type
+     * @return This element
+     * @since 3.0.0
+     */
+    default  Element removeAnnotation(@NonNull String annotationType) {
+        throw new UnsupportedOperationException("Element of type [" + getClass() + "] does not support removing annotations at compilation time");
+    }
+
+    /**
+     * @see #removeAnnotation(String)
+     * @param annotationType The annotation type
+     * @param <T> The annotation generic type
+     * @return This element
+     * @since 3.0.0
+     */
+    default <T extends Annotation> Element removeAnnotation(@NonNull Class<T> annotationType) {
+        return removeAnnotation(Objects.requireNonNull(annotationType).getName());
+    }
+
+    /**
+     * Removes all annotations that pass the given predicate.
+     * @param predicate The predicate
+     * @param <T> The annotation generic type
+     * @return This element
+     * @since 3.0.0
+     */
+    default <T extends Annotation> Element removeAnnotationIf(@NonNull Predicate<AnnotationValue<T>> predicate) {
+        throw new UnsupportedOperationException("Element of type [" + getClass() + "] does not support removing annotations at compilation time");
+    }
+
+    /**
+     * Removes a stereotype of the given name from the element.
+     * @param annotationType The annotation type
+     * @return This element
+     * @since 3.0.0
+     */
+    default  Element removeStereotype(@NonNull String annotationType) {
+        throw new UnsupportedOperationException("Element of type [" + getClass() + "] does not support removing annotations at compilation time");
+    }
+
+    /**
+     * Removes a stereotype annotation of the given type from the element.
+     * @param annotationType The annotation type
+     * @param <T> The annotation generic type
+     * @return This element
+     * @since 3.0.0
+     */
+    default <T extends Annotation> Element removeStereotype(@NonNull Class<T> annotationType) {
+        return removeStereotype(Objects.requireNonNull(annotationType).getName());
     }
 
     /**


### PR DESCRIPTION
Currently the only way to remove an annotation is via a transformer or remapper.

The upcoming CDI lite extension API allows removing annotations and this is going to be modelled has to be modelled as a visitor: https://github.com/eclipse-ee4j/cdi/pull/451/files#diff-3d490e4abf43e5fab2e19bef0cf850ab840c779715fd1c52100c758e4c7314b1R20

This PR adds methods like `removeAnnotation`, `removeStereotype`, `removeAnnotationIf` that allow implementing this part and also solves a use case I have right now implementing support for CDI interceptors.