### PR TITLE
Fix multiple factory replacements

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/D3.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/D3.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.qualifiers.replaces;
+
+public class D3 implements D {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/DSecondFactoryMethodReplacement.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/DSecondFactoryMethodReplacement.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.qualifiers.replaces;
+
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Replaces;
+import io.micronaut.context.annotation.Requirements;
+import io.micronaut.context.annotation.Requires;
+
+import javax.inject.Singleton;
+
+@Factory
+@Requires(env = "factory-replacement-chain")
+public class DSecondFactoryMethodReplacement {
+
+    @Singleton
+    @Replaces(value = D.class, factory = DFactoryMethodReplacement.class)
+    D getD() {
+        return new D3();
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/ReplacesSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/ReplacesSpec.groovy
@@ -153,4 +153,18 @@ class ReplacesSpec extends Specification {
         cleanup:
         ctx.close()
     }
+
+    void "test replacing a chain of factory methods"() {
+        given:
+        def ctx = ApplicationContext.run("factory-replacement-chain")
+
+        when:
+        D d = ctx.getBean(D)
+
+        then:
+        d instanceof D3
+
+        cleanup:
+        ctx.close()
+    }
 }

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -2183,8 +2183,6 @@ public class DefaultBeanContext implements BeanContext {
                                 if (comparisonFunction.apply(beanType)) {
                                     return true;
                                 }
-                            } else {
-                                return false;
                             }
                         } else {
                             if (comparisonFunction.apply(beanType)) {


### PR DESCRIPTION
The performance improvements in 2.5.0 changed existing functionality for when you have a factory replacing another factory and a further one replacing that one. This fixes this change to be in line with 2.4.x behaviour. Whether this is the desired behaviour it up for debate, but I think it's intuitive to be able to chain @Replaces annotations. 