### PR TITLE
Support serialisation/deserialisation with @JsonAnyGetter and @JsonAnySetter

### DIFF
--- a/runtime/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
+++ b/runtime/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
@@ -159,6 +159,8 @@ public class BeanIntrospectionModule extends SimpleModule {
                         }
                     }
                 };
+                
+                newBuilder.setAnyGetter(builder.getAnyGetter());
                 final List<BeanPropertyWriter> properties = builder.getProperties();
                 final Collection<BeanProperty<Object, Object>> beanProperties = introspection.getBeanProperties();
                 if (CollectionUtils.isEmpty(properties) && CollectionUtils.isNotEmpty(beanProperties)) {


### PR DESCRIPTION
Preserve the writer for @JsonAnyGetter when updating the bean searializer using BeansIntrospectionModule.

Fixes #5002