### PR TITLE
Reworks the CustomScope interface to support disposing dependent instances.

### DIFF
--- a/context/src/main/java/io/micronaut/runtime/context/scope/ThreadLocalCustomScope.java
+++ b/context/src/main/java/io/micronaut/runtime/context/scope/ThreadLocalCustomScope.java
@@ -15,17 +15,15 @@
  */
 package io.micronaut.runtime.context.scope;
 
-import io.micronaut.context.BeanResolutionContext;
-import io.micronaut.context.LifeCycle;
+import io.micronaut.context.scope.AbstractConcurrentCustomScope;
+import io.micronaut.context.scope.CreatedBean;
 import io.micronaut.context.scope.CustomScope;
-import io.micronaut.inject.BeanDefinition;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.inject.BeanIdentifier;
-import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * A {@link CustomScope} that stores values in thread local storage.
@@ -34,32 +32,21 @@ import java.util.Optional;
  * @since 1.0
  */
 @Singleton
-class ThreadLocalCustomScope implements CustomScope<ThreadLocal>, LifeCycle<ThreadLocalCustomScope> {
+final class ThreadLocalCustomScope extends AbstractConcurrentCustomScope<ThreadLocal> {
 
-    private final java.lang.ThreadLocal<Map<String, Object>> threadScope = java.lang.ThreadLocal.withInitial(HashMap::new);
+    private final java.lang.ThreadLocal<Map<BeanIdentifier, CreatedBean<?>>> threadScope = java.lang.ThreadLocal.withInitial(HashMap::new);
 
-    @Override
-    public Class<ThreadLocal> annotationType() {
-        return ThreadLocal.class;
+    /**
+     * Default constructor.
+     */
+    protected ThreadLocalCustomScope() {
+        super(ThreadLocal.class);
     }
 
+    @NonNull
     @Override
-    public <T> T get(BeanResolutionContext resolutionContext, BeanDefinition<T> beanDefinition, BeanIdentifier identifier, Provider<T> provider) {
-        Map<String, Object> values = threadScope.get();
-        String key = identifier.toString();
-        T bean = (T) values.get(key);
-        if (bean == null) {
-            bean = provider.get();
-            values.put(key, bean);
-        }
-        return bean;
-    }
-
-    @Override
-    public <T> Optional<T> remove(BeanIdentifier identifier) {
-        Map<String, Object> values = threadScope.get();
-        T previous = (T) values.remove(identifier.toString());
-        return previous != null ? Optional.of(previous) : Optional.empty();
+    protected Map<BeanIdentifier, CreatedBean<?>> getScopeMap(boolean forCreation) {
+        return threadScope.get();
     }
 
     @Override
@@ -73,8 +60,7 @@ class ThreadLocalCustomScope implements CustomScope<ThreadLocal>, LifeCycle<Thre
     }
 
     @Override
-    public ThreadLocalCustomScope stop() {
+    public void close() {
         threadScope.remove();
-        return this;
     }
 }

--- a/context/src/main/java/io/micronaut/runtime/context/scope/refresh/RefreshScope.java
+++ b/context/src/main/java/io/micronaut/runtime/context/scope/refresh/RefreshScope.java
@@ -18,23 +18,22 @@ package io.micronaut.runtime.context.scope.refresh;
 import io.micronaut.aop.InterceptedProxy;
 import io.micronaut.context.BeanContext;
 import io.micronaut.context.BeanRegistration;
-import io.micronaut.context.BeanResolutionContext;
 import io.micronaut.context.LifeCycle;
 import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.context.annotation.ConfigurationReader;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.env.Environment;
 import io.micronaut.context.event.ApplicationEventListener;
+import io.micronaut.context.scope.BeanCreationContext;
+import io.micronaut.context.scope.CreatedBean;
 import io.micronaut.context.scope.CustomScope;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.BeanIdentifier;
-import io.micronaut.inject.DisposableBeanDefinition;
 import io.micronaut.inject.qualifiers.Qualifiers;
 import io.micronaut.runtime.context.scope.Refreshable;
 import io.micronaut.scheduling.TaskExecutors;
 import jakarta.inject.Named;
-import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
 
 import java.util.Collection;
@@ -60,7 +59,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 @Requires(notEnv = {Environment.FUNCTION, Environment.ANDROID})
 public class RefreshScope implements CustomScope<Refreshable>, LifeCycle<RefreshScope>, ApplicationEventListener<RefreshEvent> {
 
-    private final Map<BeanIdentifier, BeanRegistration> refreshableBeans = new ConcurrentHashMap<>(10);
+    private final Map<BeanIdentifier, CreatedBean<?>> refreshableBeans = new ConcurrentHashMap<>(10);
     private final ConcurrentMap<Object, ReadWriteLock> locks = new ConcurrentHashMap<>();
     private final BeanContext beanContext;
     private final Executor executorService;
@@ -86,14 +85,14 @@ public class RefreshScope implements CustomScope<Refreshable>, LifeCycle<Refresh
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T> T get(BeanResolutionContext resolutionContext, BeanDefinition<T> beanDefinition, BeanIdentifier identifier, Provider<T> provider) {
-        BeanRegistration beanRegistration = refreshableBeans.computeIfAbsent(identifier, key -> {
-            T bean = provider.get();
-            BeanRegistration registration = new BeanRegistration(identifier, beanDefinition, bean);
-            locks.putIfAbsent(registration.getBean(), new ReentrantReadWriteLock());
-            return registration;
+    public <T> T getOrCreate(BeanCreationContext<T> creationContext) {
+        final BeanIdentifier id = creationContext.id();
+        CreatedBean<?> created = refreshableBeans.computeIfAbsent(id, key -> {
+            CreatedBean<T> createdBean = creationContext.create();
+            locks.putIfAbsent(createdBean.bean(), new ReentrantReadWriteLock());
+            return createdBean;
         });
-        return (T) beanRegistration.getBean();
+        return (T) created.bean();
     }
 
     @Override
@@ -106,10 +105,11 @@ public class RefreshScope implements CustomScope<Refreshable>, LifeCycle<Refresh
     @SuppressWarnings("unchecked")
     @Override
     public <T> Optional<T> remove(BeanIdentifier identifier) {
-        BeanRegistration registration = refreshableBeans.get(identifier);
-        if (registration != null) {
-            disposeOfBean(identifier);
-            return Optional.ofNullable((T) registration.getBean());
+        CreatedBean<?> createdBean = refreshableBeans.get(identifier);
+        if (createdBean != null) {
+            createdBean.close();
+            //noinspection ConstantConditions
+            return Optional.ofNullable((T) createdBean.bean());
         }
         return Optional.empty();
     }
@@ -140,9 +140,14 @@ public class RefreshScope implements CustomScope<Refreshable>, LifeCycle<Refresh
         if (bean instanceof InterceptedProxy) {
             bean = ((InterceptedProxy<T>) bean).interceptedTarget();
         }
-        for (BeanRegistration beanRegistration : refreshableBeans.values()) {
-            if (beanRegistration.getBean() == bean) {
-                return Optional.of(beanRegistration);
+        for (CreatedBean<?> created : refreshableBeans.values()) {
+            if (created.bean() == bean) {
+                //noinspection unchecked
+                return Optional.of(new BeanRegistration<>(
+                        created.id(),
+                        (BeanDefinition<T>) created.definition(),
+                        (T) created.bean()
+                ));
             }
         }
         return Optional.empty();
@@ -185,8 +190,8 @@ public class RefreshScope implements CustomScope<Refreshable>, LifeCycle<Refresh
 
     private void disposeOfBeanSubset(Collection<String> keys) {
         for (BeanIdentifier beanKey : refreshableBeans.keySet()) {
-            BeanRegistration beanRegistration = refreshableBeans.get(beanKey);
-            BeanDefinition definition = beanRegistration.getBeanDefinition();
+            CreatedBean<?> createdBean = refreshableBeans.get(beanKey);
+            BeanDefinition<?> definition = createdBean.definition();
             String[] strings = definition.stringValues(Refreshable.class);
             if (!ArrayUtils.isEmpty(strings)) {
                 for (String prefix : strings) {
@@ -209,18 +214,13 @@ public class RefreshScope implements CustomScope<Refreshable>, LifeCycle<Refresh
     }
 
     private void disposeOfBean(BeanIdentifier key) {
-        BeanRegistration registration = refreshableBeans.remove(key);
-        if (registration != null) {
-
-            Object bean = registration.getBean();
-            BeanDefinition definition = registration.getBeanDefinition();
-
+        CreatedBean<?> createdBean = refreshableBeans.remove(key);
+        if (createdBean != null) {
+            Object bean = createdBean.bean();
             Lock lock = getLock(bean).writeLock();
             try {
                 lock.lock();
-                if (definition instanceof DisposableBeanDefinition) {
-                    ((DisposableBeanDefinition) definition).dispose(beanContext, bean);
-                }
+                createdBean.close();
                 locks.remove(bean);
             } finally {
                 lock.unlock();

--- a/inject-groovy/src/test/resources/logback.xml
+++ b/inject-groovy/src/test/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/BeanB.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/BeanB.java
@@ -1,0 +1,24 @@
+package io.micronaut.inject.dependent;
+
+import io.micronaut.context.annotation.Bean;
+import jakarta.inject.Inject;
+
+import javax.annotation.PreDestroy;
+
+@Bean
+public class BeanB {
+    @Inject
+    public BeanC beanC;
+    public boolean destroyed = false;
+
+    @TestAnn // dependent interceptor
+    void test() {
+
+    }
+
+    @PreDestroy
+    void destroy() {
+        TestData.DESTRUCTION_ORDER.add(BeanB.class.getSimpleName());
+        this.destroyed = true;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/BeanC.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/BeanC.java
@@ -1,0 +1,16 @@
+package io.micronaut.inject.dependent;
+
+import io.micronaut.context.annotation.Bean;
+
+import javax.annotation.PreDestroy;
+
+@Bean
+public class BeanC {
+    public boolean destroyed = false;
+
+    @PreDestroy
+    void destroy() {
+        TestData.DESTRUCTION_ORDER.add(BeanC.class.getSimpleName());
+        this.destroyed = true;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/BeanD.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/BeanD.java
@@ -1,0 +1,16 @@
+package io.micronaut.inject.dependent;
+
+import io.micronaut.context.annotation.Bean;
+
+import javax.annotation.PreDestroy;
+
+@Bean
+public class BeanD implements InterfaceA {
+    public boolean destroyed = false;
+
+    @PreDestroy
+    void destroy() {
+        TestData.DESTRUCTION_ORDER.add(getClass().getSimpleName());
+        this.destroyed = true;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/BeanE.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/BeanE.java
@@ -1,0 +1,16 @@
+package io.micronaut.inject.dependent;
+
+import io.micronaut.context.annotation.Bean;
+
+import javax.annotation.PreDestroy;
+
+@Bean
+public class BeanE implements InterfaceA {
+    public boolean destroyed = false;
+
+    @PreDestroy
+    void destroy() {
+        TestData.DESTRUCTION_ORDER.add(getClass().getSimpleName());
+        this.destroyed = true;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/DestroyDependentBeansSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/DestroyDependentBeansSpec.groovy
@@ -9,16 +9,15 @@ import spock.lang.Specification
 
 class DestroyDependentBeansSpec extends Specification {
 
-    def cleanup() {
-        TestData.DESTRUCTION_ORDER.clear()
-    }
     void "test destroy dependent objects from singleton"() {
+        given:
+        TestData.DESTRUCTION_ORDER.clear()
+
         when:
         def context = ApplicationContext.run()
         def bean = context.getBean(SingletonBeanA)
 
         then:
-        TestData.DESTRUCTION_ORDER.isEmpty()
         !bean.beanBField.destroyed
         !bean.beanBConstructor.destroyed
         !bean.beanBMethod.destroyed
@@ -45,6 +44,9 @@ class DestroyDependentBeansSpec extends Specification {
     }
 
     void "test destroy dependent bean objects for custom scope"() {
+        given:
+        TestData.DESTRUCTION_ORDER.clear()
+        
         when:
         def context = ApplicationContext.run()
         def bean = context.getBean(ScopedBeanA)

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/DestroyDependentBeansSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/DestroyDependentBeansSpec.groovy
@@ -1,0 +1,70 @@
+package io.micronaut.inject.dependent
+
+import io.micronaut.aop.InterceptedProxy
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.scope.CustomScope
+import io.micronaut.inject.qualifiers.Qualifiers
+import io.micronaut.runtime.context.scope.Refreshable
+import spock.lang.Specification
+
+class DestroyDependentBeansSpec extends Specification {
+
+    def cleanup() {
+        TestData.DESTRUCTION_ORDER.clear()
+    }
+    void "test destroy dependent objects from singleton"() {
+        when:
+        def context = ApplicationContext.run()
+        def bean = context.getBean(SingletonBeanA)
+
+        then:
+        !bean.beanBField.destroyed
+        !bean.beanBConstructor.destroyed
+        !bean.beanBMethod.destroyed
+
+        when:"When the context is stopped"
+        context.stop()
+
+        then:"Dependent objects stored"
+        bean.destroyed
+        bean.beanBField.destroyed
+        bean.beanBConstructor.destroyed
+        bean.beanBMethod.destroyed
+        bean.beanBField.beanC.destroyed
+        bean.beanBConstructor.beanC.destroyed
+        bean.beanBMethod.beanC.destroyed
+        bean.collection.every { it.destroyed }
+        TestData.DESTRUCTION_ORDER.remove("BeanE") // don't want to depend on collection order
+        TestData.DESTRUCTION_ORDER.remove("BeanD") // don't want to depend on collection order
+        TestData.DESTRUCTION_ORDER == ['SingletonBeanA', 'BeanB', 'BeanC', 'TestInterceptor', 'BeanB', 'BeanC', 'TestInterceptor', 'BeanB', 'BeanC', 'TestInterceptor']
+    }
+
+    void "test destroy dependent bean objects for custom scope"() {
+        when:
+        def context = ApplicationContext.run()
+        def bean = context.getBean(ScopedBeanA)
+        def refreshScope = context.getBean(CustomScope, Qualifiers.byExactTypeArgumentName(Refreshable.class.name))
+
+        then:
+        refreshScope.findBeanRegistration(bean).isPresent()
+        !bean.beanBField.destroyed
+        !bean.beanBConstructor.destroyed
+        !bean.beanBMethod.destroyed
+        bean instanceof InterceptedProxy
+
+
+        when:"When the context is stopped"
+        def target = bean.interceptedTarget()
+        context.stop()
+
+        then:"Dependent objects stored"
+        target.destroyed
+        target.beanBField.destroyed
+        target.beanBConstructor.destroyed
+        target.beanBMethod.destroyed
+        target.beanBField.beanC.destroyed
+        target.beanBConstructor.beanC.destroyed
+        target.beanBMethod.beanC.destroyed
+        TestData.DESTRUCTION_ORDER == ['ScopedBeanA', 'BeanB', 'BeanC', 'TestInterceptor', 'BeanB', 'BeanC', 'TestInterceptor', 'BeanB', 'BeanC', 'TestInterceptor']
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/InterfaceA.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/InterfaceA.java
@@ -1,0 +1,4 @@
+package io.micronaut.inject.dependent;
+
+public interface InterfaceA {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/ScopedBeanA.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/ScopedBeanA.java
@@ -1,0 +1,30 @@
+package io.micronaut.inject.dependent;
+
+import io.micronaut.runtime.context.scope.Refreshable;
+import jakarta.inject.Inject;
+
+import javax.annotation.PreDestroy;
+
+@Refreshable
+public class ScopedBeanA {
+    @Inject
+    public BeanB beanBField;
+    public final BeanB beanBConstructor;
+    public BeanB beanBMethod;
+    public boolean destroyed;
+
+    public ScopedBeanA(BeanB beanBConstructor) {
+        this.beanBConstructor = beanBConstructor;
+    }
+
+    @Inject
+    public void setBeanBMethod(BeanB beanBMethod) {
+        this.beanBMethod = beanBMethod;
+    }
+
+    @PreDestroy
+    void stop() {
+        TestData.DESTRUCTION_ORDER.add(ScopedBeanA.class.getSimpleName());
+        this.destroyed = true;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/SingletonBeanA.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/SingletonBeanA.java
@@ -1,0 +1,34 @@
+package io.micronaut.inject.dependent;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import javax.annotation.PreDestroy;
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.micronaut.inject.dependent.TestData.DESTRUCTION_ORDER;
+
+@Singleton
+public class SingletonBeanA {
+    @Inject public BeanB beanBField;
+    public final BeanB beanBConstructor;
+    public BeanB beanBMethod;
+    public boolean destroyed;
+    @Inject public List<InterfaceA> collection;
+
+    public SingletonBeanA(BeanB beanBConstructor) {
+        this.beanBConstructor = beanBConstructor;
+    }
+
+    @Inject
+    public void setBeanBMethod(BeanB beanBMethod) {
+        this.beanBMethod = beanBMethod;
+    }
+
+    @PreDestroy
+    void stop() {
+        DESTRUCTION_ORDER.add(SingletonBeanA.class.getSimpleName());
+        this.destroyed = true;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/TestAnn.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/TestAnn.java
@@ -1,0 +1,12 @@
+package io.micronaut.inject.dependent;
+
+import io.micronaut.aop.InterceptorBinding;
+import io.micronaut.aop.InterceptorKind;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@InterceptorBinding(kind = InterceptorKind.AROUND)
+public @interface TestAnn {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/TestData.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/TestData.java
@@ -1,0 +1,8 @@
+package io.micronaut.inject.dependent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestData {
+    public static final List<String> DESTRUCTION_ORDER = new ArrayList<>();
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/TestInterceptor.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/TestInterceptor.java
@@ -1,0 +1,26 @@
+package io.micronaut.inject.dependent;
+
+import io.micronaut.aop.InterceptorBinding;
+import io.micronaut.aop.InterceptorKind;
+import io.micronaut.aop.MethodInterceptor;
+import io.micronaut.aop.MethodInvocationContext;
+import io.micronaut.context.annotation.Bean;
+
+import javax.annotation.PreDestroy;
+
+@Bean
+@InterceptorBinding(
+        value = TestAnn.class,
+        kind = InterceptorKind.AROUND
+)
+public class TestInterceptor implements MethodInterceptor<Object, Object> {
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        return context.proceed();
+    }
+
+    @PreDestroy
+    void close() {
+        TestData.DESTRUCTION_ORDER.add(TestInterceptor.class.getSimpleName());
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/DSecondFactoryMethodReplacement.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/replaces/DSecondFactoryMethodReplacement.java
@@ -17,10 +17,8 @@ package io.micronaut.inject.qualifiers.replaces;
 
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Replaces;
-import io.micronaut.context.annotation.Requirements;
 import io.micronaut.context.annotation.Requires;
-
-import javax.inject.Singleton;
+import jakarta.inject.Singleton;
 
 @Factory
 @Requires(env = "factory-replacement-chain")

--- a/inject/src/main/java/io/micronaut/context/AbstractBeanResolutionContext.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractBeanResolutionContext.java
@@ -40,6 +40,7 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
     private final Path path;
     private final Map<CharSequence, Object> attributes = new LinkedHashMap<>(2);
     private Qualifier<?> qualifier;
+    private final List<BeanRegistration<?>> dependentBeans = new ArrayList<>(3);
 
     /**
      * @param context        The bean context
@@ -50,6 +51,19 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
         this.context = context;
         this.rootDefinition = rootDefinition;
         this.path = new DefaultPath();
+    }
+
+    @Override
+    public <T> void addDependentBean(BeanIdentifier identifier, BeanDefinition<T> definition, T bean) {
+        dependentBeans.add(new BeanRegistration<>(identifier, definition, bean));
+    }
+
+    @NonNull
+    @Override
+    public List<BeanRegistration<?>> getAndResetDependentBeans() {
+        final List<BeanRegistration<?>> registrations = Collections.unmodifiableList(new ArrayList<>(dependentBeans));
+        dependentBeans.clear();
+        return registrations;
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/context/BeanDefinitionRegistry.java
+++ b/inject/src/main/java/io/micronaut/context/BeanDefinitionRegistry.java
@@ -374,6 +374,18 @@ public interface BeanDefinitionRegistry {
     @NonNull <T> Optional<BeanDefinition<T>> findProxyBeanDefinition(@NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier);
 
     /**
+     * Obtain the original {@link BeanDefinition} for a {@link io.micronaut.inject.ProxyBeanDefinition}.
+     *
+     * @param beanType  The type
+     * @param qualifier The qualifier
+     * @param <T>       The concrete type
+     * @return An {@link Optional} of the bean definition
+     * @throws io.micronaut.context.exceptions.NonUniqueBeanException When multiple possible bean definitions exist
+     *                                                                for the given type
+     */
+    @NonNull <T> Optional<BeanDefinition<T>> findProxyBeanDefinition(@NonNull Argument<T> beanType, @Nullable Qualifier<T> qualifier);
+
+    /**
      * <p>Registers a new singleton bean at runtime. This method expects that the bean definition data will have been
      * compiled ahead of time.</p>
      * <p>

--- a/inject/src/main/java/io/micronaut/context/BeanRegistration.java
+++ b/inject/src/main/java/io/micronaut/context/BeanRegistration.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.context;
 
+import io.micronaut.context.scope.CreatedBean;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.order.OrderUtil;
 import io.micronaut.core.order.Ordered;
 import io.micronaut.inject.BeanDefinition;
@@ -24,13 +26,13 @@ import java.util.Objects;
 
 /**
  * <p>A bean registration is an association between a {@link BeanDefinition} and a created bean, typically a
- * {@link javax.inject.Singleton}.</p>
+ * {@link jakarta.inject.Singleton}.</p>
  *
  * @param <T> The type
  * @author Graeme Rocher
  * @since 1.0
  */
-public class BeanRegistration<T> implements Ordered {
+public class BeanRegistration<T> implements Ordered, CreatedBean<T> {
     final BeanIdentifier identifier;
     final BeanDefinition<T> beanDefinition;
     final T bean;
@@ -93,5 +95,26 @@ public class BeanRegistration<T> implements Ordered {
     @Override
     public int hashCode() {
         return Objects.hash(identifier, beanDefinition);
+    }
+
+    @Override
+    public BeanDefinition<T> definition() {
+        return beanDefinition;
+    }
+
+    @NonNull
+    @Override
+    public T bean() {
+        return bean;
+    }
+
+    @Override
+    public BeanIdentifier id() {
+        return identifier;
+    }
+
+    @Override
+    public void close() {
+        // no-op
     }
 }

--- a/inject/src/main/java/io/micronaut/context/BeanResolutionContext.java
+++ b/inject/src/main/java/io/micronaut/context/BeanResolutionContext.java
@@ -16,12 +16,16 @@
 package io.micronaut.context;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.value.ValueResolver;
 import io.micronaut.inject.*;
 
 import io.micronaut.core.annotation.Nullable;
+
+import java.util.Collections;
 import java.util.Deque;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -109,6 +113,22 @@ public interface BeanResolutionContext extends ValueResolver<CharSequence>, Auto
      * @param qualifier The qualifier
      */
     void setCurrentQualifier(@Nullable Qualifier<?> qualifier);
+
+    /**
+     * Adds a dependent bean to the resolution context.
+     * @param identifier The identifier
+     * @param definition The bean definition
+     * @param bean The bean
+     * @param <T> The generic type
+     */
+    <T> void addDependentBean(BeanIdentifier identifier, BeanDefinition<T> definition, T bean);
+
+    /**
+     * @return The dependent beans that must be destroyed by an upstream bean
+     */
+    default @NonNull List<BeanRegistration<?>> getAndResetDependentBeans() {
+        return Collections.emptyList();
+    }
 
     /**
      * Represents a path taken to resolve a bean definitions dependencies.

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanResolutionContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanResolutionContext.java
@@ -41,6 +41,18 @@ public final class DefaultBeanResolutionContext extends AbstractBeanResolutionCo
         super(context, rootDefinition);
     }
 
+    /**
+     * @param context        The bean context
+     * @param rootDefinition The bean root definition
+     * @param beansInCreation the beans in creation
+     */
+    public DefaultBeanResolutionContext(BeanContext context, BeanDefinition rootDefinition, Map<BeanIdentifier, Object> beansInCreation) {
+        super(context, rootDefinition);
+        if (beansInCreation != null) {
+            this.beansInCreation.putAll(beansInCreation);
+        }
+    }
+
     @Override
     public void close() {
         beansInCreation.clear();

--- a/inject/src/main/java/io/micronaut/context/scope/AbstractConcurrentCustomScope.java
+++ b/inject/src/main/java/io/micronaut/context/scope/AbstractConcurrentCustomScope.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context.scope;
+
+import io.micronaut.context.BeanRegistration;
+import io.micronaut.context.LifeCycle;
+import io.micronaut.context.exceptions.BeanDestructionException;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.inject.BeanDefinition;
+import io.micronaut.inject.BeanIdentifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.annotation.Annotation;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * Abstract implementation of the custom scope interface that simplifies defining new scopes using the Map interface.
+ *
+ * <p>Note this implementation uses a single{@link ReentrantReadWriteLock} to lock the entire scope hence it is designed for scopes that will hold a small amount of beans. For implementations that hold many beans it is recommended to use a lock per {@link BeanIdentifier}.</p>
+ *
+ * @param <A> The annotation type
+ * @author graemerocher
+ * @since 3.0.0
+ */
+public abstract class AbstractConcurrentCustomScope<A extends Annotation> implements CustomScope<A>, LifeCycle<AbstractConcurrentCustomScope<A>>, AutoCloseable {
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractConcurrentCustomScope.class);
+    private final Class<A> annotationType;
+    private final ReentrantReadWriteLock rwl = new ReentrantReadWriteLock();
+    private final Lock r = rwl.readLock();
+    private final Lock w = rwl.writeLock();
+
+    /**
+     * A custom scope annotation.
+     * 
+     * @param annotationType The annotation type
+     */
+    protected AbstractConcurrentCustomScope(Class<A> annotationType) {
+        this.annotationType = Objects.requireNonNull(annotationType, "Annotation type cannot be null");
+    }
+
+    /**
+     * @param forCreation Whether it is for creation
+     * @return Obtains the scope map, never null
+     */
+    @NonNull
+    protected abstract Map<BeanIdentifier, CreatedBean<?>> getScopeMap(boolean forCreation);
+
+    @Override
+    public final Class<A> annotationType() {
+        return annotationType;
+    }
+
+    /**
+     * Implement the close logic for the scope.
+     */
+    @Override
+    public abstract void close();
+
+    @NonNull
+    @Override
+    public final AbstractConcurrentCustomScope<A> stop() {
+        w.lock();
+        try {
+            final Map<BeanIdentifier, CreatedBean<?>> scopeMap = getScopeMap(false);
+            destroyScope(scopeMap);
+            close();
+            return this;
+        } finally {
+            w.unlock();
+        }
+    }
+
+    /**
+     * Destroys the scope.
+     *
+     * @param scopeMap Th scope map
+     */
+    protected void destroyScope(@Nullable Map<BeanIdentifier, CreatedBean<?>> scopeMap) {
+        w.lock();
+        try {
+            if (CollectionUtils.isNotEmpty(scopeMap)) {
+
+                for (CreatedBean<?> createdBean : scopeMap.values()) {
+                    try {
+                        createdBean.close();
+                    } catch (BeanDestructionException e) {
+                        handleDestructionException(e);
+                    }
+                }
+                scopeMap.clear();
+            }
+        } finally {
+            w.unlock();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public final <T> T getOrCreate(BeanCreationContext<T> creationContext) {
+        r.lock();
+        try {
+            final Map<BeanIdentifier, CreatedBean<?>> scopeMap = getScopeMap(true);
+            final BeanIdentifier id = creationContext.id();
+            CreatedBean<?> createdBean = scopeMap.get(id);
+            if (createdBean != null) {
+                return (T) createdBean.bean();
+            } else {
+                r.unlock();
+                w.lock();
+                try {
+                    // re-check
+                    createdBean = scopeMap.get(id);
+                    if (createdBean != null) {
+                        r.lock();
+                        return (T) createdBean.bean();
+                    } else {
+                        createdBean = doCreate(creationContext);
+                        scopeMap.put(id, createdBean);
+                        r.lock();
+                        return (T) createdBean.bean();
+                    }
+                } finally {
+                    w.unlock();
+                }
+            }
+        } finally {
+            r.unlock();
+        }
+    }
+
+    /**
+     * Perform creation.
+     * @param creationContext The creation context
+     * @param <T> The generic type
+     * @return Created bean
+     */
+    @NonNull
+    protected <T> CreatedBean<T> doCreate(@NonNull BeanCreationContext<T> creationContext) {
+        return creationContext.create();
+    }
+
+    @Override
+    public final <T> Optional<T> remove(BeanIdentifier identifier) {
+        if (identifier == null) {
+            return Optional.empty();
+        }
+        w.lock();
+        try {
+            final Map<BeanIdentifier, CreatedBean<?>> scopeMap = getScopeMap(false);
+            if (CollectionUtils.isNotEmpty(scopeMap)) {
+
+                final CreatedBean<?> createdBean = scopeMap.get(identifier);
+                if (createdBean != null) {
+                    try {
+                        createdBean.close();
+                    } catch (BeanDestructionException e) {
+                        handleDestructionException(e);
+                    }
+                    //noinspection ConstantConditions
+                    return (Optional<T>) Optional.ofNullable(createdBean.bean());
+                } else {
+                    return Optional.empty();
+                }
+            } else {
+                return Optional.empty();
+            }
+        } finally {
+            w.unlock();
+        }
+    }
+
+    /**
+     * Method that can be overridden to customize what happens on a shutdown error.
+     * @param e The exception
+     */
+    protected void handleDestructionException(BeanDestructionException e) {
+        LOG.error("Error occurred destroying bean of scope @" + annotationType.getSimpleName() + ": " + e.getMessage(), e);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public final <T> Optional<BeanRegistration<T>> findBeanRegistration(T bean) {
+        r.lock();
+        try {
+            for (CreatedBean<?> createdBean : getScopeMap(false).values()) {
+                if (createdBean.bean() == bean) {
+                    return Optional.of(
+                            new BeanRegistration<>(
+                                    createdBean.id(),
+                                    (BeanDefinition<T>) createdBean.definition(),
+                                    bean
+                            )
+                    );
+                }
+            }
+            return Optional.empty();
+        } finally {
+            r.unlock();
+        }
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/scope/BeanCreationContext.java
+++ b/inject/src/main/java/io/micronaut/context/scope/BeanCreationContext.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context.scope;
+
+import io.micronaut.context.exceptions.BeanCreationException;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.inject.BeanDefinition;
+import io.micronaut.inject.BeanIdentifier;
+
+/**
+ * Context object passed to {@link CustomScope} instances for creating new beans.
+ *
+ * @param <T> The bean type
+ * @since 3.0
+ */
+public interface BeanCreationContext<T> {
+    /**
+     * @return The bean definition
+     */
+    @NonNull
+    BeanDefinition<T> definition();
+
+    /**
+     * @return An ID that can be used to store the created bean instance
+     */
+    @NonNull
+    BeanIdentifier id();
+
+    /**
+     * Create a new instance.
+     *
+     * <p>Implementations of {@link CustomScope} should call {@link CreatedBean#close()} to dispose of the bean
+     * at the appropriate moment in the lifecycle of the scope</p>
+     * @return The {@link CreatedBean} instance
+     * @throws BeanCreationException If the bean failed to create
+     */
+    @NonNull CreatedBean<T> create() throws BeanCreationException;
+}

--- a/inject/src/main/java/io/micronaut/context/scope/CreatedBean.java
+++ b/inject/src/main/java/io/micronaut/context/scope/CreatedBean.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context.scope;
+
+import io.micronaut.context.exceptions.BeanDestructionException;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.inject.BeanDefinition;
+import io.micronaut.inject.BeanIdentifier;
+
+import java.io.Closeable;
+
+/**
+ * Represents a bean that has been created from a {@link BeanCreationContext}.
+ *
+ * @param <T> The bean type
+ * @see io.micronaut.context.scope.BeanCreationContext
+ * @since 3.0.0
+ * @see BeanCreationContext
+ * @author graemerocher
+ */
+public interface CreatedBean<T> extends Closeable, AutoCloseable {
+    /**
+     * @return The bean definition.
+     */
+    BeanDefinition<T> definition();
+
+    /**
+     * @return The bean
+     */
+    @NonNull
+    T bean();
+
+    /**
+     * Returns an ID that is unique to the bean and can be used to cache the instance if necessary.
+     *
+     * @return The id
+     */
+    BeanIdentifier id();
+
+    /**
+     * Destroy the bean entry, performing any shutdown and releasing any dependent objects.
+     *
+     * @throws BeanDestructionException If an error occurs closing the created bean.
+     */
+    @Override
+    void close() throws BeanDestructionException;
+}

--- a/inject/src/main/java/io/micronaut/context/scope/CustomScope.java
+++ b/inject/src/main/java/io/micronaut/context/scope/CustomScope.java
@@ -16,11 +16,9 @@
 package io.micronaut.context.scope;
 
 import io.micronaut.context.BeanRegistration;
-import io.micronaut.context.BeanResolutionContext;
 import io.micronaut.core.annotation.Indexed;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.BeanIdentifier;
-import jakarta.inject.Provider;
 
 import java.lang.annotation.Annotation;
 import java.util.Optional;
@@ -45,25 +43,17 @@ public interface CustomScope<A extends Annotation> {
      * Resolve an object from the given scope.
      *
      * @param <T>               The bean generic type
-     * @param resolutionContext The bean resolution context
-     * @param beanDefinition    The bean definition
-     * @param identifier        The {@link BeanIdentifier}
-     * @param provider          The provider that will build the bean definition
+     * @param creationContext   The creation context
      * @return The bean instance
      */
-    <T> T get(
-        BeanResolutionContext resolutionContext,
-        BeanDefinition<T> beanDefinition,
-        BeanIdentifier identifier,
-        Provider<T> provider
-    );
+    <T> T getOrCreate(BeanCreationContext<T> creationContext);
 
     /**
      * Remove a bean definition from the scope.
      *
      * @param identifier The {@link BeanIdentifier}
      * @param <T>        The generic type
-     * @return An {@link Optional} of the instance if it exists
+     * @return An {@link Optional} of the instance that was destroyed if it exists
      */
     <T> Optional<T> remove(BeanIdentifier identifier);
 

--- a/inject/src/main/java/io/micronaut/inject/DisposableBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/inject/DisposableBeanDefinition.java
@@ -18,6 +18,7 @@ package io.micronaut.inject;
 import io.micronaut.context.BeanContext;
 import io.micronaut.context.BeanResolutionContext;
 import io.micronaut.context.DefaultBeanResolutionContext;
+import io.micronaut.core.annotation.Internal;
 
 /**
  * A bean definition that provides disposing hooks normally in the form of {@link javax.annotation.PreDestroy}
@@ -28,6 +29,7 @@ import io.micronaut.context.DefaultBeanResolutionContext;
  * @see javax.annotation.PreDestroy
  * @since 1.0
  */
+@Internal
 public interface DisposableBeanDefinition<T> extends BeanDefinition<T> {
 
     /**
@@ -38,7 +40,9 @@ public interface DisposableBeanDefinition<T> extends BeanDefinition<T> {
      * @return The bean instance
      */
     default T dispose(BeanContext context, T bean) {
-        return dispose(new DefaultBeanResolutionContext(context, this), context, bean);
+        try (DefaultBeanResolutionContext rc = new DefaultBeanResolutionContext(context, this)) {
+            return dispose(rc, context, bean);
+        }
     }
 
     /**

--- a/inject/src/main/java/io/micronaut/inject/qualifiers/ExactTypeArgumentNameQualifier.java
+++ b/inject/src/main/java/io/micronaut/inject/qualifiers/ExactTypeArgumentNameQualifier.java
@@ -106,4 +106,9 @@ final class ExactTypeArgumentNameQualifier<T> implements Qualifier<T> {
     public int hashCode() {
         return Objects.hash(generify(typeName));
     }
+
+    @Override
+    public String toString() {
+        return generify(typeName);
+    }
 }

--- a/runtime/src/main/java/io/micronaut/runtime/http/scope/RequestCustomScope.java
+++ b/runtime/src/main/java/io/micronaut/runtime/http/scope/RequestCustomScope.java
@@ -15,29 +15,22 @@
  */
 package io.micronaut.runtime.http.scope;
 
-import io.micronaut.context.BeanContext;
-import io.micronaut.context.BeanResolutionContext;
-import io.micronaut.context.LifeCycle;
 import io.micronaut.context.event.ApplicationEventListener;
-import io.micronaut.context.exceptions.NoSuchBeanException;
+import io.micronaut.context.scope.AbstractConcurrentCustomScope;
+import io.micronaut.context.scope.BeanCreationContext;
+import io.micronaut.context.scope.CreatedBean;
 import io.micronaut.context.scope.CustomScope;
 import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.convert.value.MutableConvertibleValues;
 import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.context.ServerRequestContext;
 import io.micronaut.http.context.event.HttpRequestTerminatedEvent;
-import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.BeanIdentifier;
-import io.micronaut.inject.DisposableBeanDefinition;
-import io.micronaut.inject.qualifiers.Qualifiers;
-import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.util.Optional;
+import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -48,92 +41,57 @@ import java.util.concurrent.ConcurrentHashMap;
  * @since 1.2.0
  */
 @Singleton
-class RequestCustomScope implements CustomScope<RequestScope>, LifeCycle<RequestCustomScope>, ApplicationEventListener<HttpRequestTerminatedEvent> {
+class RequestCustomScope extends AbstractConcurrentCustomScope<RequestScope> implements ApplicationEventListener<HttpRequestTerminatedEvent> {
     /**
      * The request attribute to store scoped beans in.
      */
     public static final String SCOPED_BEANS_ATTRIBUTE = "io.micronaut.http.SCOPED_BEANS";
-    public static final String SCOPED_BEAN_DEFINITIONS_ATTRIBUTE = "io.micronaut.http.SCOPED_BEAN_DEFINITIONS";
-
-    private static final Logger LOG = LoggerFactory.getLogger(RequestCustomScope.class);
-
-    private final BeanContext beanContext;
 
     /**
      * Creates the request scope for the given context.
      *
-     * @param beanContext The context
      */
-    public RequestCustomScope(BeanContext beanContext) {
-        this.beanContext = beanContext;
+    public RequestCustomScope() {
+        super(RequestScope.class);
     }
 
     @Override
-    public Class<RequestScope> annotationType() {
-        return RequestScope.class;
-    }
-
-    @Override
-    public <T> T get(BeanResolutionContext resolutionContext, BeanDefinition<T> beanDefinition,
-                     BeanIdentifier identifier, Provider<T> provider) {
-        Optional<HttpRequest<T>> currentRequest = ServerRequestContext.currentRequest();
-        if (!currentRequest.isPresent()) {
-            throw new NoSuchBeanException(beanDefinition.getBeanType(), Qualifiers.byStereotype(RequestScope.class));
-        }
-        HttpRequest<T> httpRequest = currentRequest.get();
-        return (T) getRequestScopedBeans(httpRequest, true).computeIfAbsent(identifier, i -> {
-                Object bean = provider.get();
-                if (bean instanceof RequestAware) {
-                    ((RequestAware) bean).setRequest(httpRequest);
-                }
-                getRequestScopedBeanDefinitions(httpRequest, true)
-                        .put(identifier, beanDefinition);
-                return bean;
-        });
-    }
-
-    @Override
-    public <T> Optional<T> remove(BeanIdentifier identifier) {
-        Optional<HttpRequest<Object>> request = ServerRequestContext.currentRequest();
-        if (request.isPresent()) {
-            T bean = (T) getRequestScopedBeans(request.get(), true).remove(identifier);
-            BeanDefinition<T> beanDefinition = (BeanDefinition<T>) getRequestScopedBeanDefinitions(request.get(), true).remove(identifier);
-            destroyRequestScopedBean(bean, beanDefinition);
-            return Optional.ofNullable(bean);
-        } else {
-            return Optional.empty();
-        }
-    }
-
-    private <T> void destroyRequestScopedBean(@Nullable T bean, @Nullable BeanDefinition<T> beanDefinition) {
-        if (bean != null && beanDefinition instanceof DisposableBeanDefinition) {
-            try {
-                ((DisposableBeanDefinition<T>) beanDefinition).dispose(
-                        beanContext, bean
-                );
-            } catch (Exception e) {
-                if (LOG.isErrorEnabled()) {
-                    LOG.error("Error disposing of request scoped bean: " + bean, e);
-                }
-            }
-        }
-    }
-
-    @NonNull
-    @Override
-    public RequestCustomScope stop() {
+    public void close() {
         ServerRequestContext.currentRequest().ifPresent(this::destroyBeans);
-        return this;
     }
 
     @Override
     public boolean isRunning() {
-        return true;
+        return ServerRequestContext.currentRequest().isPresent();
     }
 
     @Override
     public void onApplicationEvent(HttpRequestTerminatedEvent event) {
         destroyBeans(event.getSource());
+    }
+
+    @NonNull
+    @Override
+    protected Map<BeanIdentifier, CreatedBean<?>> getScopeMap(boolean forCreation) {
+        final HttpRequest<Object> request = ServerRequestContext.currentRequest().orElse(null);
+        if (request != null) {
+            //noinspection ConstantConditions
+            return getRequestAttributeMap(request, forCreation);
+        } else {
+            return Collections.emptyMap();
+        }
+    }
+
+    @NonNull
+    @Override
+    protected <T> CreatedBean<T> doCreate(@NonNull BeanCreationContext<T> creationContext) {
+        final HttpRequest<Object> request = ServerRequestContext.currentRequest().orElse(null);
+        final CreatedBean<T> createdBean = super.doCreate(creationContext);
+        final T bean = createdBean.bean();
+        if (bean instanceof RequestAware) {
+            ((RequestAware) bean).setRequest(request);
+        }
+        return createdBean;
     }
 
     /**
@@ -142,37 +100,22 @@ class RequestCustomScope implements CustomScope<RequestScope>, LifeCycle<Request
      */
     private void destroyBeans(HttpRequest<?> request) {
         ArgumentUtils.requireNonNull("request", request);
-        ConcurrentHashMap<BeanIdentifier, Object> requestScopedBeans = getRequestScopedBeans(request, false);
+        ConcurrentHashMap<BeanIdentifier, CreatedBean<?>> requestScopedBeans =
+                getRequestAttributeMap(request, false);
         if (requestScopedBeans != null) {
-            requestScopedBeans
-                    .forEach((beanIdentifier, instance) -> {
-                        BeanDefinition beanDefinition = getRequestScopedBeanDefinitions(request, false).get(beanIdentifier);
-                        destroyRequestScopedBean(instance, beanDefinition);
-                    });
+            destroyScope(requestScopedBeans);
         }
     }
 
-    private <T> ConcurrentHashMap<BeanIdentifier, Object> getRequestScopedBeans(HttpRequest<T> httpRequest, boolean create) {
-        synchronized (httpRequest) {
-            return getRequestAttributeMap(httpRequest, SCOPED_BEANS_ATTRIBUTE, create);
-        }
-    }
-
-    private <T> ConcurrentHashMap<BeanIdentifier, BeanDefinition> getRequestScopedBeanDefinitions(HttpRequest<T> httpRequest, boolean create) {
-        synchronized (httpRequest) {
-            return getRequestAttributeMap(httpRequest, SCOPED_BEAN_DEFINITIONS_ATTRIBUTE, create);
-        }
-    }
-
-    private <T> ConcurrentHashMap getRequestAttributeMap(HttpRequest<T> httpRequest, String attribute, boolean create) {
+    private <T> ConcurrentHashMap<BeanIdentifier, CreatedBean<?>> getRequestAttributeMap(HttpRequest<T> httpRequest, boolean create) {
         MutableConvertibleValues<Object> attrs = httpRequest.getAttributes();
-        Object o = attrs.getValue(attribute);
+        Object o = attrs.getValue(SCOPED_BEANS_ATTRIBUTE);
         if (o instanceof ConcurrentHashMap) {
-            return (ConcurrentHashMap) o;
+            return (ConcurrentHashMap<BeanIdentifier, CreatedBean<?>>) o;
         }
         if (create) {
-            ConcurrentHashMap scopedBeans = new ConcurrentHashMap(5);
-            attrs.put(attribute, scopedBeans);
+            ConcurrentHashMap<BeanIdentifier, CreatedBean<?>> scopedBeans = new ConcurrentHashMap<>(5);
+            attrs.put(SCOPED_BEANS_ATTRIBUTE, scopedBeans);
             return scopedBeans;
         }
         return null;

--- a/session/src/test/resources/logback.xml
+++ b/session/src/test/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configurations

--- a/test-suite-javax-inject/src/test/resources/logback.xml
+++ b/test-suite-javax-inject/src/test/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/test-suite/src/test/java/io/micronaut/docs/client/versioning/HelloClient.java
+++ b/test-suite/src/test/java/io/micronaut/docs/client/versioning/HelloClient.java
@@ -25,7 +25,8 @@ import io.reactivex.Single;
 // tag::clazz[]
 @Client("/hello")
 @Version("1") // <1>
-public interface HelloClient {
+public
+interface HelloClient {
 
     @Get("/greeting/{name}")
     String sayHello(String name);


### PR DESCRIPTION
Currently if a bean that is injected into another instance doesn't have a defined scope and it defines a PreDestroy method what happens is that when the parent bean is destroyed then this method is never called.

This PR alters the behaviour so that dependent instances are tracked and associated with the BeanRegistration and then when the parent bean is installed any child beans are also destroyed.

In addition to make it possible to write custom scopes that allow disposable of downstream dependent beans the CustomScope interface has been reworked introducing two new interfaces called BeanCreationContext and CreatedBean. The latter of these implements AutoCloseable such that it can be used to dispose of any downstream dependent beans.

The result of this is the removal of a lot of custom bean destruction code that existed in some of the scopes like RequestScope and RefreshableScope.
