### PR TITLE
Include Maven configuration for javaParameters option

### DIFF
--- a/src/main/docs/guide/languageSupport/kotlin/kotlinretainparamnames.adoc
+++ b/src/main/docs/guide/languageSupport/kotlin/kotlinretainparamnames.adoc
@@ -2,7 +2,7 @@ Like with Java, the parameter name data for method parameters is not retained at
 
 To enable retention of parameter name data with Kotlin, set the `javaParameters` option to `true` in your `build.gradle`:
 
-.build.gradle
+.configuration in Gradle
 [source,groovy]
 ----
 compileTestKotlin {
@@ -11,4 +11,30 @@ compileTestKotlin {
         javaParameters = true
     }
 }
+----
+
+Or if using Maven configure the Micronaut Maven Plugin accordingly:
+
+.configuration in Maven
+[source,xml]
+----
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <!-- ... -->
+  <build>
+    <plugins>
+      <!-- ... -->
+      <plugin>
+        <artifactId>kotlin-maven-plugin</artifactId>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <configuration>            
+            <javaParameters>true</javaParameters>
+            <!-- ... -->
+        </configuration>
+        <!-- ... -->
+      </plugin>
+      <!-- ... -->
+    </plugins>
+  </build>
+</project>
 ----


### PR DESCRIPTION
This can save people from (hard)troubleshooting especially because the micronaut-gradle-plugin automatically set the flag to `true` but not the micronaut-maven-plugin.
Working with micronaut-data and JdbcRepository results in compiler error because of this.