### PR TITLE
Use javax Nullable instead of Nonnull

### DIFF
--- a/core/src/main/java/io/micronaut/core/annotation/Nullable.java
+++ b/core/src/main/java/io/micronaut/core/annotation/Nullable.java
@@ -15,7 +15,6 @@
  */
 package io.micronaut.core.annotation;
 
-import javax.annotation.Nonnull;
 import javax.annotation.meta.TypeQualifierNickname;
 import javax.annotation.meta.When;
 import java.lang.annotation.Documented;
@@ -38,7 +37,7 @@ import java.lang.annotation.Target;
 @Target({ElementType.METHOD, ElementType.PARAMETER, ElementType.FIELD, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@Nonnull(when = When.MAYBE)
+@javax.annotation.Nullable
 @TypeQualifierNickname
 public @interface Nullable {
 }


### PR DESCRIPTION
Fixes #5323 

This is the simplest fix to eliminate the warning, by using the existing `javax.annotation.Nullable`.

This essentially punts the jsr305 issue down the road a bit until we can determine an alternative.