### PR TITLE
Fix for custom reason phrase is inaccessible in filters when using Netty runtime

### DIFF
--- a/http-netty/src/main/java/io/micronaut/http/netty/NettyMutableHttpResponse.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/NettyMutableHttpResponse.java
@@ -229,6 +229,16 @@ public class NettyMutableHttpResponse<B> implements MutableHttpResponse<B>, Nett
     }
 
     @Override
+    public int code() {
+        return httpResponseStatus.code();
+    }
+
+    @Override
+    public String reason() {
+        return httpResponseStatus.reasonPhrase();
+    }
+
+    @Override
     public MutableHttpResponse<B> cookie(Cookie cookie) {
         if (cookie instanceof NettyCookie) {
             NettyCookie nettyCookie = (NettyCookie) cookie;

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/HttpResponseFactorySpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/HttpResponseFactorySpec.groovy
@@ -2,10 +2,8 @@ package io.micronaut.http.server.netty
 
 import io.micronaut.http.HttpResponseFactory
 import io.micronaut.http.HttpStatus
-import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import spock.lang.Specification
 
-@MicronautTest
 class HttpResponseFactorySpec extends Specification {
 
     void "custom reason phrase set in MutableHttpResponse is accessible"() {

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/HttpResponseFactorySpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/HttpResponseFactorySpec.groovy
@@ -1,0 +1,24 @@
+package io.micronaut.http.server.netty
+
+import io.micronaut.http.HttpResponseFactory
+import io.micronaut.http.HttpStatus
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import spock.lang.Specification
+
+@MicronautTest
+class HttpResponseFactorySpec extends Specification {
+
+    void "custom reason phrase set in MutableHttpResponse is accessible"() {
+        given:
+        def httpStatus = HttpStatus.INTERNAL_SERVER_ERROR
+        def customReason = 'The application failed'
+
+
+        when:
+        def response = HttpResponseFactory.INSTANCE.status(httpStatus, customReason)
+
+        then:
+        response.status() == httpStatus
+        response.reason() == customReason
+    }
+}

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/HttpResponseFactorySpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/HttpResponseFactorySpec.groovy
@@ -13,7 +13,6 @@ class HttpResponseFactorySpec extends Specification {
         def httpStatus = HttpStatus.INTERNAL_SERVER_ERROR
         def customReason = 'The application failed'
 
-
         when:
         def response = HttpResponseFactory.INSTANCE.status(httpStatus, customReason)
 


### PR DESCRIPTION
Closes #5544

Regression test is added to demonstrate the failure first. Fix will follow soon. 