### PR TITLE
Only error if enum actually declared bean. Fixes #5611

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/visitors/ClassElementSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/ClassElementSpec.groovy
@@ -17,17 +17,38 @@ package io.micronaut.visitors
 
 import io.micronaut.annotation.processing.visitor.JavaClassElement
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.ApplicationContext
 import io.micronaut.inject.ast.ClassElement
 import io.micronaut.inject.ast.ElementModifier
 import io.micronaut.inject.ast.ElementQuery
 import io.micronaut.inject.ast.EnumElement
 import io.micronaut.inject.ast.MethodElement
 import spock.lang.IgnoreIf
+import spock.lang.Issue
 import spock.util.environment.Jvm
 
 import java.util.function.Supplier
 
 class ClassElementSpec extends AbstractTypeElementSpec {
+
+    @Issue('https://github.com/micronaut-projects/micronaut-core/issues/5611')
+    void 'test visit enum with custom annotation'() {
+        when:"An enum has an annotation that is visited by CustomAnnVisitor"
+        def context = buildContext('''
+package test;
+
+@io.micronaut.visitors.CustomAnn
+enum EnumTest {
+
+}
+''')
+
+        then:"No compilation error occurs"
+        context != null
+
+        cleanup:
+        context.close()
+    }
 
     void 'test find matching methods on abstract class'() {
         given:

--- a/inject-java/src/test/groovy/io/micronaut/visitors/CustomAnn.java
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/CustomAnn.java
@@ -1,0 +1,8 @@
+package io.micronaut.visitors;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CustomAnn {
+}

--- a/inject-java/src/test/groovy/io/micronaut/visitors/CustomAnnMapper.java
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/CustomAnnMapper.java
@@ -1,0 +1,21 @@
+package io.micronaut.visitors;
+
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.inject.annotation.TypedAnnotationMapper;
+import io.micronaut.inject.visitor.TypeElementVisitor;
+import io.micronaut.inject.visitor.VisitorContext;
+
+import java.util.Collections;
+import java.util.List;
+
+public class CustomAnnMapper implements TypedAnnotationMapper<CustomAnn> {
+    @Override
+    public List<AnnotationValue<?>> map(AnnotationValue<CustomAnn> annotation, VisitorContext visitorContext) {
+        return Collections.singletonList(annotation);
+    }
+
+    @Override
+    public Class<CustomAnn> annotationType() {
+        return CustomAnn.class;
+    }
+}

--- a/inject-java/src/test/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationMapper
+++ b/inject-java/src/test/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationMapper
@@ -1,3 +1,4 @@
+io.micronaut.visitors.CustomAnnMapper
 io.micronaut.aop.factory.mapped.TestConfigurationMapper
 io.micronaut.inject.annotation.CustomHeaderMapper
 io.micronaut.aop.introduction.ListenerAdviceMarkerMapper

--- a/inject/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -1665,7 +1665,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         return annotationName != null &&
                 (ANNOTATION_MAPPERS.containsKey(annotationName) ||
                         ANNOTATION_TRANSFORMERS.containsKey(annotationName) ||
-                        ANNOTATION_TRANSFORMERS.keySet().stream().anyMatch(pkg -> annotationName.startsWith(pkg)));
+                        ANNOTATION_TRANSFORMERS.keySet().stream().anyMatch(annotationName::startsWith));
     }
 
     /**


### PR DESCRIPTION
The logic to fail on enums wasn't checking if the type was actually declared a bean. This changes the logic to instead only fail compilation if the type is declared a bean otherwise just ignore the enum type. Fixes #5611