### PR TITLE
Filter out @Any beans for Object lookup. Fixes #5639

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/any/AnyProviderSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/any/AnyProviderSpec.groovy
@@ -30,6 +30,7 @@ class AnyProviderSpec extends Specification {
         )
 
         then:
+        beanContext.getBean(Object, Qualifiers.byName("poodle")) instanceof Poodle
         owner.dog instanceof Dog
         dogBeanProvider.get(Qualifiers.byName("poodle")) instanceof Dog
         dogBeanProvider.stream().collect(Collectors.toList()).size() == 2

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -2380,7 +2380,14 @@ public class DefaultBeanContext implements BeanContext {
         if (qualifier instanceof AnyQualifier) {
             return candidates.iterator().next();
         } else {
-            throw new NonUniqueBeanException(beanType, candidates.iterator());
+            final List<BeanDefinition<T>> withoutAnyBeans =
+                    candidates.stream().filter(bd -> !bd.hasDeclaredAnnotation(Any.class))
+                    .collect(Collectors.toList());
+            if (withoutAnyBeans.size() == 1) {
+                return withoutAnyBeans.iterator().next();
+            } else {
+                throw new NonUniqueBeanException(beanType, candidates.iterator());
+            }
         }
     }
 


### PR DESCRIPTION
When the case where `Object` is used this ends up matching `BeanProvider`, `Provider` factories etc. that handle `@Any` qualifier. This change filters those out such that they are not included when finding a concrete candidate
