### PR TITLE
Fix dead link in graal.adoc

### DIFF
--- a/src/main/docs/guide/languageSupport/graal.adoc
+++ b/src/main/docs/guide/languageSupport/graal.adoc
@@ -1,6 +1,6 @@
 https://www.graalvm.org[GraalVM] is a new universal virtual machine from Oracle that supports a polyglot runtime environment and the ability to compile Java applications to native machine code.
 
-Any Micronaut application can be run using the GraalVM JVM, however special support has been added to Micronaut to support running Micronaut applications using https://www.graalvm.org/docs/reference-manual/aot-compilation/[GraalVM's `native-image` tool].
+Any Micronaut application can be run using the GraalVM JVM, however special support has been added to Micronaut to support running Micronaut applications using https://www.graalvm.org/reference-manual/native-image/[GraalVM's `native-image` tool].
 
 Micronaut currently supports GraalVM version {graalVersion} and the team is improving the support in every new release. Don't hesitate to https://github.com/micronaut-projects/micronaut-core/issues[report issues] however if you find any problem.
 


### PR DESCRIPTION
There is a dead link in graal.adoc.
With the wayback machine I found out that the page used to look like [this](http://web.archive.org/web/20180420043824/https://www.graalvm.org/docs/reference-manual/aot-compilation/).
It seems like the graal docs have been refactored, I figured that [this](https://www.graalvm.org/reference-manual/native-image/) is probably the best page to link to now.