### PR TITLE
Improve v3 class generating

### DIFF
--- a/aop/src/main/java/io/micronaut/aop/Interceptor.java
+++ b/aop/src/main/java/io/micronaut/aop/Interceptor.java
@@ -16,7 +16,6 @@
 package io.micronaut.aop;
 
 import io.micronaut.core.annotation.Indexed;
-import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.order.Ordered;
 import io.micronaut.core.type.Argument;
 

--- a/benchmarks/src/jmh/java/io/micronaut/aop/around/AroundCompileBenchmark.java
+++ b/benchmarks/src/jmh/java/io/micronaut/aop/around/AroundCompileBenchmark.java
@@ -20,6 +20,7 @@ import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.reflect.InstantiationUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.BeanDefinition;
+import io.micronaut.inject.writer.BeanDefinitionWriter;
 import org.codehaus.groovy.runtime.IOGroovyMethods;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Scope;
@@ -70,7 +71,7 @@ public class AroundCompileBenchmark {
     }
 
     BeanDefinition buildBeanDefinition(String className, String cls) {
-        String beanDefName= '$' + NameUtils.getSimpleName(className) + "Definition";
+        String beanDefName= '$' + NameUtils.getSimpleName(className) + BeanDefinitionWriter.CLASS_SUFFIX;
         String packageName = NameUtils.getPackageName(className);
         String beanFullName = packageName + "." + beanDefName;
 

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -6,7 +6,7 @@
 
 <suppressions>
     <suppress checks="FileLength"
-              files="DefaultBeanContext.java|BeanDefinitionWriter.java|DefaultHttpClient.java|BeanDefinitionInjectProcessor.java|AbstractBeanDefinition.java|DefaultValidator.java|RoutingInBoundHandler.java|DefaultAnnotationMetadata.java|AbstractAnnotationMetadataBuilder.java"/>
+              files="DefaultBeanContext.java|BeanDefinitionWriter.java|DefaultHttpClient.java|BeanDefinitionInjectProcessor.java|AbstractBeanDefinition.java|AbstractBeanDefinition2.java|DefaultValidator.java|RoutingInBoundHandler.java|DefaultAnnotationMetadata.java|AbstractAnnotationMetadataBuilder.java"/>
     <suppress checks="DeclarationOrder"
               files="UriTemplate.java"/>
     <suppress checks="Header"

--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationUtil.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationUtil.java
@@ -38,19 +38,19 @@ public class AnnotationUtil {
     public static final String KOTLIN_METADATA = "kotlin.Metadata";
 
     public static final List<String> INTERNAL_ANNOTATION_NAMES = Arrays.asList(
-        Retention.class.getName(),
-        "javax.annotation.meta.TypeQualifier",
-        "javax.annotation.meta.TypeQualifierNickname",
-        "kotlin.annotation.Retention",
-        Inherited.class.getName(),
-        SuppressWarnings.class.getName(),
-        Override.class.getName(),
-        Repeatable.class.getName(),
-        Documented.class.getName(),
-        "kotlin.annotation.MustBeDocumented",
-        Target.class.getName(),
-        "kotlin.annotation.Target",
-        KOTLIN_METADATA
+            Retention.class.getName(),
+            "javax.annotation.meta.TypeQualifier",
+            "javax.annotation.meta.TypeQualifierNickname",
+            "kotlin.annotation.Retention",
+            Inherited.class.getName(),
+            SuppressWarnings.class.getName(),
+            Override.class.getName(),
+            Repeatable.class.getName(),
+            Documented.class.getName(),
+            "kotlin.annotation.MustBeDocumented",
+            Target.class.getName(),
+            "kotlin.annotation.Target",
+            KOTLIN_METADATA
     );
 
     /**
@@ -227,22 +227,381 @@ public class AnnotationUtil {
 
         // if the length is 2 then only a single annotation is defined, so tried use internal pool
         if (len == 2) {
-            Object value = values[1];
-            if (value == Collections.EMPTY_MAP) {
-                String key = values[0].toString();
-                return INTERN_MAP_POOL.computeIfAbsent(key, s ->
-                        Collections.singletonMap(s, Collections.emptyMap())
-                );
-            } else {
-                return Collections.singletonMap(
-                        values[0].toString(),
-                        value
-                );
-            }
-
+            return internMapOf((String) values[0], values[1]);
         } else {
             return StringUtils.internMapOf(values);
         }
+    }
+
+    /**
+     * Converts the given objects into a map of potentially cached and interned strings where the keys and values are alternating entries in the passed array. See {@link String#intern()}.
+     *
+     * <p>The values stored at even number positions will be converted to strings and interned.</p>
+     *
+     * @param key   The key
+     * @param value The value
+     * @return An unmodifiable set of strings
+     * @since 3.0
+     */
+    @SuppressWarnings("unused")
+    @UsedByGeneratedCode
+    public static Map<String, Object> internMapOf(String key, Object value) {
+        Objects.requireNonNull(key);
+        Objects.requireNonNull(value);
+        if (value == Collections.EMPTY_MAP) {
+            return INTERN_MAP_POOL.computeIfAbsent(key, s -> Collections.singletonMap(s, Collections.emptyMap()));
+        }
+        return Collections.singletonMap(key, value);
+    }
+
+    /**
+     * Create a new immutable {@link Map} from an array of values.
+     * String values must be sorted!
+     *
+     * @param array The key,value array
+     * @return The created map
+     */
+    @UsedByGeneratedCode
+    public static Map<String, Object> mapOf(Object... array) {
+        int len = array.length;
+        if (len % 2 != 0) {
+            throw new IllegalArgumentException("Number of arguments should be an even number representing the keys and values");
+        }
+        if (array.length == 0) {
+            return Collections.EMPTY_MAP;
+        }
+        int size = len / 2;
+        String[] keys = new String[size];
+        Object[] values = new Object[size];
+        int k = 0;
+        for (int i = 0, arrayLength = array.length; i < arrayLength; i += 2) {
+            keys[k] = (String) array[i];
+            values[k] = array[i + 1];
+            k++;
+        }
+        return new ImmutableSortedStringsArrayMap(keys, values);
+    }
+
+    /**
+     * Create a new immutable {@link Map}.
+     * String values must be sorted!
+     *
+     * @param key1   The key 1
+     * @param value1 The value 1
+     * @return The created map
+     */
+    @UsedByGeneratedCode
+    public static Map<String, Object> mapOf(String key1, Object value1) {
+        return Collections.singletonMap(key1, value1);
+    }
+
+    /**
+     * Create a new immutable {@link Map}.
+     * String values must be sorted!
+     *
+     * @param key1   The key1
+     * @param value1 The value1
+     * @param key2   The key2
+     * @param value2 The value2
+     * @return The created map
+     */
+    @UsedByGeneratedCode
+    public static Map<String, Object> mapOf(String key1, Object value1, String key2, Object value2) {
+        String[] keys = {
+                key1, key2
+        };
+        Object[] values = {
+                value1, value2
+        };
+        return new ImmutableSortedStringsArrayMap(keys, values);
+    }
+
+    /**
+     * Create a new immutable {@link Map}.
+     * String values must be sorted!
+     *
+     * @param key1   The key1
+     * @param value1 The value1
+     * @param key2   The key2
+     * @param value2 The value2
+     * @param key3   The key3
+     * @param value3 The value3
+     * @return The created map
+     */
+    @UsedByGeneratedCode
+    public static Map<String, Object> mapOf(String key1, Object value1,
+                                            String key2, Object value2,
+                                            String key3, Object value3) {
+        String[] keys = {
+                key1, key2, key3
+        };
+        Object[] values = {
+                value1, value2, value3
+        };
+        return new ImmutableSortedStringsArrayMap(keys, values);
+    }
+
+    /**
+     * Create a new immutable {@link Map}.
+     * String values must be sorted!
+     *
+     * @param key1   The key1
+     * @param value1 The value1
+     * @param key2   The key2
+     * @param value2 The value2
+     * @param key3   The key3
+     * @param value3 The value3
+     * @param key4   The key4
+     * @param value4 The value4
+     * @return The created map
+     */
+    @UsedByGeneratedCode
+    public static Map<String, Object> mapOf(String key1, Object value1,
+                                            String key2, Object value2,
+                                            String key3, Object value3,
+                                            String key4, Object value4) {
+        String[] keys = {
+                key1, key2, key3, key4
+        };
+        Object[] values = {
+                value1, value2, value3, value4
+        };
+        return new ImmutableSortedStringsArrayMap(keys, values);
+    }
+
+    /**
+     * Create a new immutable {@link Map}.
+     * String values must be sorted!
+     *
+     * @param key1   The key1
+     * @param value1 The value1
+     * @param key2   The key2
+     * @param value2 The value2
+     * @param key3   The key3
+     * @param value3 The value3
+     * @param key4   The key4
+     * @param value4 The value4
+     * @param key5   The key5
+     * @param value5 The value5
+     * @return The created map
+     */
+    @UsedByGeneratedCode
+    public static Map<String, Object> mapOf(String key1, Object value1,
+                                            String key2, Object value2,
+                                            String key3, Object value3,
+                                            String key4, Object value4,
+                                            String key5, Object value5) {
+        String[] keys = {
+                key1, key2, key3, key4, key5
+        };
+        Object[] values = {
+                value1, value2, value3, value4, value5
+        };
+        return new ImmutableSortedStringsArrayMap(keys, values);
+    }
+
+    /**
+     * Create a new immutable {@link Map}.
+     * String values must be sorted!
+     *
+     * @param key1   The key1
+     * @param value1 The value1
+     * @param key2   The key2
+     * @param value2 The value2
+     * @param key3   The key3
+     * @param value3 The value3
+     * @param key4   The key4
+     * @param value4 The value4
+     * @param key5   The key5
+     * @param value5 The value5
+     * @param key6   The key6
+     * @param value6 The value6
+     * @return The created map
+     */
+    @UsedByGeneratedCode
+    public static Map<String, Object> mapOf(String key1, Object value1,
+                                            String key2, Object value2,
+                                            String key3, Object value3,
+                                            String key4, Object value4,
+                                            String key5, Object value5,
+                                            String key6, Object value6) {
+        String[] keys = {
+                key1, key2, key3, key4, key5, key6
+        };
+        Object[] values = {
+                value1, value2, value3, value4, value5, value6
+        };
+        return new ImmutableSortedStringsArrayMap(keys, values);
+    }
+
+    /**
+     * Create a new immutable {@link Map}.
+     * String values must be sorted!
+     *
+     * @param key1   The key1
+     * @param value1 The value1
+     * @param key2   The key2
+     * @param value2 The value2
+     * @param key3   The key3
+     * @param value3 The value3
+     * @param key4   The key4
+     * @param value4 The value4
+     * @param key5   The key5
+     * @param value5 The value5
+     * @param key6   The key6
+     * @param value6 The value6
+     * @param key7   The key7
+     * @param value7 The value7
+     * @return The created map
+     */
+    @SuppressWarnings("ParameterNumber")
+    @UsedByGeneratedCode
+    public static Map<String, Object> mapOf(String key1, Object value1,
+                                            String key2, Object value2,
+                                            String key3, Object value3,
+                                            String key4, Object value4,
+                                            String key5, Object value5,
+                                            String key6, Object value6,
+                                            String key7, Object value7) {
+        String[] keys = {
+                key1, key2, key3, key4, key5, key6, key7
+        };
+        Object[] values = {
+                value1, value2, value3, value4, value5, value6, value7
+        };
+        return new ImmutableSortedStringsArrayMap(keys, values);
+    }
+
+    /**
+     * Create a new immutable {@link Map}.
+     * String values must be sorted!
+     *
+     * @param key1   The key1
+     * @param value1 The value1
+     * @param key2   The key2
+     * @param value2 The value2
+     * @param key3   The key3
+     * @param value3 The value3
+     * @param key4   The key4
+     * @param value4 The value4
+     * @param key5   The key5
+     * @param value5 The value5
+     * @param key6   The key6
+     * @param value6 The value6
+     * @param key7   The key7
+     * @param value7 The value7
+     * @param key8   The key8
+     * @param value8 The value8
+     * @return The created map
+     */
+    @SuppressWarnings("ParameterNumber")
+    @UsedByGeneratedCode
+    public static Map<String, Object> mapOf(String key1, Object value1,
+                                            String key2, Object value2,
+                                            String key3, Object value3,
+                                            String key4, Object value4,
+                                            String key5, Object value5,
+                                            String key6, Object value6,
+                                            String key7, Object value7,
+                                            String key8, Object value8) {
+        String[] keys = {
+                key1, key2, key3, key4, key5, key6, key7, key8
+        };
+        Object[] values = {
+                value1, value2, value3, value4, value5, value6, value7, value8
+        };
+        return new ImmutableSortedStringsArrayMap(keys, values);
+    }
+
+    /**
+     * Create a new immutable {@link Map}.
+     * String values must be sorted!
+     *
+     * @param key1   The key1
+     * @param value1 The value1
+     * @param key2   The key2
+     * @param value2 The value2
+     * @param key3   The key3
+     * @param value3 The value3
+     * @param key4   The key4
+     * @param value4 The value4
+     * @param key5   The key5
+     * @param value5 The value5
+     * @param key6   The key6
+     * @param value6 The value6
+     * @param key7   The key7
+     * @param value7 The value7
+     * @param key8   The key8
+     * @param value8 The value8
+     * @param key9   The key9
+     * @param value9 The value9
+     * @return The created map
+     */
+    @SuppressWarnings("ParameterNumber")
+    @UsedByGeneratedCode
+    public static Map<String, Object> mapOf(String key1, Object value1,
+                                            String key2, Object value2,
+                                            String key3, Object value3,
+                                            String key4, Object value4,
+                                            String key5, Object value5,
+                                            String key6, Object value6,
+                                            String key7, Object value7,
+                                            String key8, Object value8,
+                                            String key9, Object value9) {
+        String[] keys = {
+                key1, key2, key3, key4, key5, key6, key7, key8, key9
+        };
+        Object[] values = {
+                value1, value2, value3, value4, value5, value6, value7, value8, value9
+        };
+        return new ImmutableSortedStringsArrayMap(keys, values);
+    }
+
+    /**
+     * Create a new immutable {@link Map}.
+     * String values must be sorted!
+     *
+     * @param key1    The key1
+     * @param value1  The value1
+     * @param key2    The key2
+     * @param value2  The value2
+     * @param key3    The key3
+     * @param value3  The value3
+     * @param key4    The key4
+     * @param value4  The value4
+     * @param key5    The key5
+     * @param value5  The value5
+     * @param key6    The key6
+     * @param value6  The value6
+     * @param key7    The key7
+     * @param value7  The value7
+     * @param key8    The key8
+     * @param value8  The value8
+     * @param key9    The key9
+     * @param value9  The value9
+     * @param key10   The key10
+     * @param value10 The value10
+     * @return The created map
+     */
+    @SuppressWarnings("ParameterNumber")
+    @UsedByGeneratedCode
+    public static Map<String, Object> mapOf(String key1, Object value1,
+                                            String key2, Object value2,
+                                            String key3, Object value3,
+                                            String key4, Object value4,
+                                            String key5, Object value5,
+                                            String key6, Object value6,
+                                            String key7, Object value7,
+                                            String key8, Object value8,
+                                            String key9, Object value9,
+                                            String key10, Object value10) {
+        String[] keys = {
+                key1, key2, key3, key4, key5, key6, key7, key8, key9, key10
+        };
+        Object[] values = {
+                value1, value2, value3, value4, value5, value6, value7, value8, value9, value10
+        };
+        return new ImmutableSortedStringsArrayMap(keys, values);
     }
 
     /**
@@ -261,19 +620,19 @@ public class AnnotationUtil {
             int nameHashCode = member.getKey().hashCode();
 
             int valueHashCode =
-                !value.getClass().isArray() ? value.hashCode() :
-                    value.getClass() == boolean[].class ? Arrays.hashCode((boolean[]) value) :
-                        value.getClass() == byte[].class ? Arrays.hashCode((byte[]) value) :
-                            value.getClass() == char[].class ? Arrays.hashCode((char[]) value) :
-                                value.getClass() == double[].class ? Arrays.hashCode((double[]) value) :
-                                    value.getClass() == float[].class ? Arrays.hashCode((float[]) value) :
-                                        value.getClass() == int[].class ? Arrays.hashCode((int[]) value) :
-                                            value.getClass() == long[].class ? Arrays.hashCode(
-                                                (long[]) value
-                                            ) :
-                                                value.getClass() == short[].class ? Arrays
-                                                    .hashCode((short[]) value) :
-                                                    Arrays.hashCode((Object[]) value);
+                    !value.getClass().isArray() ? value.hashCode() :
+                            value.getClass() == boolean[].class ? Arrays.hashCode((boolean[]) value) :
+                                    value.getClass() == byte[].class ? Arrays.hashCode((byte[]) value) :
+                                            value.getClass() == char[].class ? Arrays.hashCode((char[]) value) :
+                                                    value.getClass() == double[].class ? Arrays.hashCode((double[]) value) :
+                                                            value.getClass() == float[].class ? Arrays.hashCode((float[]) value) :
+                                                                    value.getClass() == int[].class ? Arrays.hashCode((int[]) value) :
+                                                                            value.getClass() == long[].class ? Arrays.hashCode(
+                                                                                    (long[]) value
+                                                                            ) :
+                                                                                    value.getClass() == short[].class ? Arrays
+                                                                                            .hashCode((short[]) value) :
+                                                                                            Arrays.hashCode((Object[]) value);
 
             hashCode += 127 * nameHashCode ^ valueHashCode;
         }
@@ -290,33 +649,33 @@ public class AnnotationUtil {
      */
     public static boolean areEqual(Object o1, Object o2) {
         return
-            !o1.getClass().isArray() ? o1.equals(o2) :
-                o1.getClass() == boolean[].class ? Arrays.equals((boolean[]) o1, (boolean[]) o2) :
-                    o1.getClass() == byte[].class ? Arrays.equals((byte[]) o1, (byte[]) o2) :
-                        o1.getClass() == char[].class ? Arrays.equals((char[]) o1, (char[]) o2) :
-                            o1.getClass() == double[].class ? Arrays.equals(
-                                (double[]) o1,
-                                (double[]) o2
-                            ) :
-                                o1.getClass() == float[].class ? Arrays.equals(
-                                    (float[]) o1,
-                                    (float[]) o2
-                                ) :
-                                    o1.getClass() == int[].class ? Arrays.equals(
-                                        (int[]) o1,
-                                        (int[]) o2
-                                    ) :
-                                        o1.getClass() == long[].class ? Arrays.equals(
-                                            (long[]) o1,
-                                            (long[]) o2
-                                        ) :
-                                            o1.getClass() == short[].class ? Arrays.equals(
-                                                (short[]) o1,
-                                                (short[]) o2
-                                            ) :
-                                                Arrays.equals(
-                                                    (Object[]) o1,
-                                                    (Object[]) o2
-                                                );
+                !o1.getClass().isArray() ? o1.equals(o2) :
+                        o1.getClass() == boolean[].class ? Arrays.equals((boolean[]) o1, (boolean[]) o2) :
+                                o1.getClass() == byte[].class ? Arrays.equals((byte[]) o1, (byte[]) o2) :
+                                        o1.getClass() == char[].class ? Arrays.equals((char[]) o1, (char[]) o2) :
+                                                o1.getClass() == double[].class ? Arrays.equals(
+                                                        (double[]) o1,
+                                                        (double[]) o2
+                                                ) :
+                                                        o1.getClass() == float[].class ? Arrays.equals(
+                                                                (float[]) o1,
+                                                                (float[]) o2
+                                                        ) :
+                                                                o1.getClass() == int[].class ? Arrays.equals(
+                                                                        (int[]) o1,
+                                                                        (int[]) o2
+                                                                ) :
+                                                                        o1.getClass() == long[].class ? Arrays.equals(
+                                                                                (long[]) o1,
+                                                                                (long[]) o2
+                                                                        ) :
+                                                                                o1.getClass() == short[].class ? Arrays.equals(
+                                                                                        (short[]) o1,
+                                                                                        (short[]) o2
+                                                                                ) :
+                                                                                        Arrays.equals(
+                                                                                                (Object[]) o1,
+                                                                                                (Object[]) o2
+                                                                                        );
     }
 }

--- a/core/src/main/java/io/micronaut/core/annotation/ImmutableSortedStringsArrayMap.java
+++ b/core/src/main/java/io/micronaut/core/annotation/ImmutableSortedStringsArrayMap.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.core.annotation;
+
+import java.util.AbstractCollection;
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+/**
+ * The immutable map which is using the advantage of compile-time processing an ability to have
+ * map's keys sorted.
+ * <p>
+ * The implementation is using two arrays and should be memory evitient.
+ * The lookup is implemented using {@link Arrays#binarySearch(Object[], Object)}
+ * which should guarantee performance of O(log N).
+ *
+ * @param <V> The value type
+ * @author Denis Stepanov
+ * @since 3.0
+ */
+@SuppressWarnings("ParameterNumber")
+@Internal
+@UsedByGeneratedCode
+final class ImmutableSortedStringsArrayMap<V> implements Map<String, V> {
+
+    private final String[] keys;
+    private final Object[] values;
+
+    ImmutableSortedStringsArrayMap(String[] keys, Object[] values) {
+        this.keys = keys;
+        this.values = values;
+    }
+
+    private int findKeyIndex(Object key) {
+        if (!(key instanceof Comparable)) {
+            return -1;
+        }
+        return Arrays.binarySearch(keys, key);
+    }
+
+    @Override
+    public int size() {
+        return keys.length;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return keys.length == 0;
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return findKeyIndex(key) > -1;
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        Objects.requireNonNull(value);
+        for (int i = 0; i < values.length; i += 1) {
+            Object tableValue = values[i];
+            if (tableValue.equals(value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public V get(Object key) {
+        Objects.requireNonNull(key);
+        int keyIndex = findKeyIndex(key);
+        if (keyIndex < 0) {
+            return null;
+        }
+        return (V) values[keyIndex];
+    }
+
+    @Nullable
+    @Override
+    public V put(String key, V value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public V remove(Object key) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void putAll(Map<? extends String, ? extends V> m) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void clear() {
+        throw new UnsupportedOperationException();
+    }
+
+    @NonNull
+    @Override
+    public Set<String> keySet() {
+        return new HashSet<>(Arrays.asList(keys));
+    }
+
+    @NonNull
+    @Override
+    public Collection<V> values() {
+        return new AbstractCollection<V>() {
+            public Iterator<V> iterator() {
+                return new Iterator<V>() {
+                    private int index = 0;
+
+                    public boolean hasNext() {
+                        return index < values.length;
+                    }
+
+                    public V next() {
+                        if (hasNext()) {
+                            V v = (V) values[index];
+                            index += 1;
+                            return v;
+                        }
+                        throw new NoSuchElementException();
+                    }
+
+                    public void remove() {
+                        throw new UnsupportedOperationException();
+                    }
+                };
+            }
+
+            public int size() {
+                return ImmutableSortedStringsArrayMap.this.size();
+            }
+
+            public boolean isEmpty() {
+                return ImmutableSortedStringsArrayMap.this.isEmpty();
+            }
+
+            public void clear() {
+                ImmutableSortedStringsArrayMap.this.clear();
+            }
+
+            public boolean contains(Object v) {
+                return ImmutableSortedStringsArrayMap.this.containsValue(v);
+            }
+        };
+    }
+
+    @Override
+    public void forEach(BiConsumer<? super String, ? super V> action) {
+        for (int i = 0; i < keys.length; i += 1) {
+            action.accept(keys[i], (V) values[i]);
+        }
+    }
+
+    @NonNull
+    @Override
+    public Set<Entry<String, V>> entrySet() {
+        Set<Entry<String, V>> set = new HashSet<>();
+        for (int i = 0; i < keys.length; i += 1) {
+            set.add(new AbstractMap.SimpleEntry<>(keys[i], (V) values[i]));
+        }
+        return set;
+    }
+
+}

--- a/core/src/main/java/io/micronaut/core/reflect/InstantiationUtils.java
+++ b/core/src/main/java/io/micronaut/core/reflect/InstantiationUtils.java
@@ -221,9 +221,10 @@ public class InstantiationUtils {
     /**
      * Instantiate the given class rethrowing any exceptions as {@link InstantiationException}.
      *
-     * @param type The type
-     * @param args The arguments
-     * @param <T>  The generic type
+     * @param type     The type
+     * @param argTypes The arguments
+     * @param args     The values of arguments
+     * @param <T>      The generic type
      * @return The instantiated instance
      * @throws InstantiationException When an error occurs
      * @since 3.0.0

--- a/core/src/main/java/io/micronaut/core/util/ArrayUtils.java
+++ b/core/src/main/java/io/micronaut/core/util/ArrayUtils.java
@@ -16,6 +16,8 @@
 package io.micronaut.core.util;
 
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.annotation.UsedByGeneratedCode;
+
 import java.lang.reflect.Array;
 import java.util.*;
 import java.util.function.IntFunction;
@@ -31,6 +33,7 @@ public class ArrayUtils {
     /**
      * An empty object array.
      */
+    @UsedByGeneratedCode
     public static final Object[] EMPTY_OBJECT_ARRAY = new Object[0];
 
     /**
@@ -170,6 +173,18 @@ public class ArrayUtils {
     public static <T> T[] toArray(Collection<T> collection, IntFunction<T[]> createArrayFn) {
         T[] array = createArrayFn.apply(collection.size());
         return collection.toArray(array);
+    }
+
+    /**
+     * Returns an array containing all of the elements in this collection, using the item class.
+     *
+     * @param collection The collection
+     * @param arrayItemClass The array item class
+     * @param <T> The type of the array
+     * @return The array
+     */
+    public static <T> T[] toArray(Collection<T> collection, Class<T> arrayItemClass) {
+        return (T[]) collection.toArray((Object[]) Array.newInstance(arrayItemClass, collection.size()));
     }
 
     /**

--- a/core/src/main/java/io/micronaut/core/util/ArrayUtils.java
+++ b/core/src/main/java/io/micronaut/core/util/ArrayUtils.java
@@ -182,6 +182,7 @@ public class ArrayUtils {
      * @param arrayItemClass The array item class
      * @param <T> The type of the array
      * @return The array
+     * @since 3.0
      */
     public static <T> T[] toArray(Collection<T> collection, Class<T> arrayItemClass) {
         return (T[]) collection.toArray((Object[]) Array.newInstance(arrayItemClass, collection.size()));

--- a/inject-groovy-test/src/main/groovy/io/micronaut/ast/transform/test/AbstractBeanDefinitionSpec.groovy
+++ b/inject-groovy-test/src/main/groovy/io/micronaut/ast/transform/test/AbstractBeanDefinitionSpec.groovy
@@ -29,7 +29,9 @@ import io.micronaut.core.io.scan.ClassPathResourceLoader
 import io.micronaut.inject.BeanDefinitionReference
 import io.micronaut.inject.ast.ClassElement
 import io.micronaut.inject.provider.BeanProviderDefinition
+import io.micronaut.inject.writer.BeanDefinitionReferenceWriter
 import io.micronaut.inject.writer.BeanDefinitionVisitor
+import io.micronaut.inject.writer.BeanDefinitionWriter
 import org.codehaus.groovy.ast.ASTNode
 import org.codehaus.groovy.ast.ClassNode
 import org.codehaus.groovy.ast.MethodNode
@@ -95,7 +97,8 @@ abstract class AbstractBeanDefinitionSpec extends Specification {
 
     @CompileStatic
     BeanDefinition buildBeanDefinition(String className, String classStr) {
-        def beanDefName= '$' + NameUtils.getSimpleName(className) + 'Definition'
+        def classSimpleName = NameUtils.getSimpleName(className)
+        def beanDefName= (classSimpleName.startsWith('$') ? '' : '$') + classSimpleName + BeanDefinitionWriter.CLASS_SUFFIX
         def packageName = NameUtils.getPackageName(className)
         String beanFullName = "${packageName}.${beanDefName}"
 
@@ -110,7 +113,7 @@ abstract class AbstractBeanDefinitionSpec extends Specification {
 
     @CompileStatic
     BeanDefinition buildBeanDefinition(String packageName, String className, String classStr) {
-        def beanDefName= '$' + className + 'Definition'
+        def beanDefName= (className.startsWith('$') ? '' : '$') + className + BeanDefinitionWriter.CLASS_SUFFIX
         String beanFullName = "${packageName}.${beanDefName}"
 
         def classLoader = new InMemoryByteCodeGroovyClassLoader()
@@ -129,7 +132,8 @@ abstract class AbstractBeanDefinitionSpec extends Specification {
      * @return The bean definition
      */
     protected BeanDefinition buildInterceptedBeanDefinition(String className, String cls) {
-        def beanDefName= '$$' + NameUtils.getSimpleName(className) + 'Definition' + BeanDefinitionVisitor.PROXY_SUFFIX + 'Definition'
+        def classSimpleName = NameUtils.getSimpleName(className)
+        def beanDefName= (classSimpleName.startsWith('$') ? '' : '$') + classSimpleName + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionVisitor.PROXY_SUFFIX + BeanDefinitionWriter.CLASS_SUFFIX
         def packageName = NameUtils.getPackageName(className)
         String beanFullName = "${packageName}.${beanDefName}"
 
@@ -144,7 +148,8 @@ abstract class AbstractBeanDefinitionSpec extends Specification {
      * @return The bean definition
      */
     protected BeanDefinitionReference buildInterceptedBeanDefinitionReference(String className, String cls) {
-        def beanDefName= '$$' + NameUtils.getSimpleName(className) + 'Definition' + BeanDefinitionVisitor.PROXY_SUFFIX + 'DefinitionClass'
+        def classSimpleName = NameUtils.getSimpleName(className)
+        def beanDefName= (classSimpleName.startsWith('$') ? '' : '$') + classSimpleName + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionVisitor.PROXY_SUFFIX + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionReferenceWriter.REF_SUFFIX
         def packageName = NameUtils.getPackageName(className)
         String beanFullName = "${packageName}.${beanDefName}"
 
@@ -249,7 +254,7 @@ abstract class AbstractBeanDefinitionSpec extends Specification {
             protected List<BeanDefinitionReference> resolveBeanDefinitionReferences(Predicate<BeanDefinitionReference> predicate) {
                 def references =  classLoader.generatedClasses.keySet()
                     .stream()
-                    .filter({ name -> name.endsWith("DefinitionClass") })
+                    .filter({ name -> name.endsWith(BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionReferenceWriter.REF_SUFFIX) })
                     .map({ name -> (BeanDefinitionReference) classLoader.loadClass(name).newInstance() })
                     .filter({ bdr -> predicate == null || predicate.test(bdr) })
                     .collect(Collectors.toList())

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/InjectVisitor.groovy
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/InjectVisitor.groovy
@@ -66,7 +66,6 @@ import io.micronaut.inject.ast.PrimitiveElement
 import io.micronaut.inject.configuration.ConfigurationMetadata
 import io.micronaut.inject.configuration.ConfigurationMetadataBuilder
 import io.micronaut.inject.configuration.PropertyMetadata
-import io.micronaut.inject.processing.ProcessedTypes
 import io.micronaut.inject.visitor.VisitorConfiguration
 import io.micronaut.inject.writer.BeanDefinitionReferenceWriter
 import io.micronaut.inject.writer.BeanDefinitionVisitor
@@ -538,11 +537,7 @@ final class InjectVisitor extends ClassCodeVisitorSupport {
 
                     if (isDeclaredBean && methodAnnotationMetadata.hasDeclaredAnnotation(AnnotationUtil.POST_CONSTRUCT)) {
                         defineBeanDefinition(concreteClass)
-                        def beanWriter = getBeanWriter()
-                        if (aopProxyWriter instanceof AopProxyWriter && !((AopProxyWriter)aopProxyWriter).isProxyTarget()) {
-                            beanWriter = aopProxyWriter
-                        }
-                        beanWriter.visitPostConstructMethod(
+                        getBeanWriter().visitPostConstructMethod(
                                 declaringElement,
                                 groovyMethodElement,
                                 requiresReflection,
@@ -550,16 +545,20 @@ final class InjectVisitor extends ClassCodeVisitorSupport {
                         )
                     } else if (isDeclaredBean && methodAnnotationMetadata.hasDeclaredAnnotation(AnnotationUtil.PRE_DESTROY)) {
                         defineBeanDefinition(concreteClass)
-                        def beanWriter = getBeanWriter()
-                        if (aopProxyWriter instanceof AopProxyWriter && !((AopProxyWriter)aopProxyWriter).isProxyTarget()) {
-                            beanWriter = aopProxyWriter
-                        }
                         beanWriter.visitPreDestroyMethod(
                                 declaringElement,
                                 groovyMethodElement,
                                 requiresReflection,
                                 groovyVisitorContext
                         )
+                        if (aopProxyWriter instanceof AopProxyWriter && !((AopProxyWriter)aopProxyWriter).isProxyTarget()) {
+                            aopProxyWriter.visitPreDestroyMethod(
+                                    declaringElement,
+                                    groovyMethodElement,
+                                    requiresReflection,
+                                    groovyVisitorContext
+                            )
+                        }
                     } else if (methodAnnotationMetadata.hasStereotype(AnnotationUtil.INJECT)) {
                         defineBeanDefinition(concreteClass)
                         getBeanWriter().visitMethodInjectionPoint(

--- a/inject-groovy/src/test/groovy/io/micronaut/aop/compile/AroundCompileSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/aop/compile/AroundCompileSpec.groovy
@@ -13,6 +13,7 @@ import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.BeanDefinitionReference
 import io.micronaut.inject.annotation.NamedAnnotationMapper
 import io.micronaut.inject.visitor.VisitorContext
+import io.micronaut.inject.writer.BeanDefinitionWriter
 import spock.lang.Issue
 
 import java.lang.annotation.Annotation
@@ -577,7 +578,7 @@ class TestInterceptor implements Interceptor {
 
     void "test validated on class with generics"() {
         when:
-        BeanDefinition beanDefinition = buildBeanDefinition('aroundctest4.$BaseEntityServiceDefinition$Intercepted', """
+        BeanDefinition beanDefinition = buildBeanDefinition('aroundctest4.$BaseEntityService' + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionWriter.PROXY_SUFFIX, """
 package aroundctest4;
 
 @io.micronaut.validation.Validated

--- a/inject-groovy/src/test/groovy/io/micronaut/aop/compile/FinalModifierSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/aop/compile/FinalModifierSpec.groovy
@@ -16,11 +16,12 @@
 package io.micronaut.aop.compile
 
 import io.micronaut.ast.transform.test.AbstractBeanDefinitionSpec
+import io.micronaut.inject.writer.BeanDefinitionWriter
 
 class FinalModifierSpec extends AbstractBeanDefinitionSpec {
     void "test final modifier with AOP advice doesn't compile"() {
         when:
-        buildBeanDefinition('test.$FinalModifierMyBean1Definition$Intercepted', '''
+        buildBeanDefinition('test.$FinalModifierMyBean1' + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionWriter.PROXY_SUFFIX, '''
 package test;
 
 import io.micronaut.aop.proxytarget.*;
@@ -49,7 +50,7 @@ final class FinalModifierMyBean1 {
 
     void "test final modifier on method with AOP advice doesn't compile"() {
         when:
-        buildBeanDefinition('test.$FinalModifierMyBean2Definition$Intercepted', '''
+        buildBeanDefinition('test.$FinalModifierMyBean2' + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionWriter.PROXY_SUFFIX, '''
 package test;
 
 import io.micronaut.aop.proxytarget.*;
@@ -78,7 +79,7 @@ class FinalModifierMyBean2 {
 
     void "test final modifier on method with explicit AOP advice doesn't compile"() {
         when:
-        buildBeanDefinition('test.$FinalModifierMyBean2Definition$Intercepted', '''
+        buildBeanDefinition('test.$FinalModifierMyBean2' + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionWriter.PROXY_SUFFIX, '''
 package test;
 
 import io.micronaut.aop.proxytarget.*;

--- a/inject-groovy/src/test/groovy/io/micronaut/aop/compile/InheritedAnnotationMetadataSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/aop/compile/InheritedAnnotationMetadataSpec.groovy
@@ -20,6 +20,7 @@ import io.micronaut.context.ApplicationContext
 import io.micronaut.core.annotation.Blocking
 import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.writer.BeanDefinitionVisitor
+import io.micronaut.inject.writer.BeanDefinitionWriter
 
 /**
  * @author graemerocher
@@ -59,7 +60,7 @@ interface MyInterface {
 
     void "test that annotation metadata is inherited from overridden methods for around advice"() {
         when:
-        BeanDefinition beanDefinition = buildBeanDefinition('inheritmetadatatest2.$MyBean2Definition$Intercepted', '''
+        BeanDefinition beanDefinition = buildBeanDefinition('inheritmetadatatest2.$MyBean2' + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionWriter.PROXY_SUFFIX, '''
 package inheritmetadatatest2;
 
 import io.micronaut.aop.interceptors.*;
@@ -157,19 +158,19 @@ class SomeInterceptor implements MethodInterceptor<Object, Object>, Ordered {
         ctx.getBean(clazz)
 
         when:
-        ctx.classLoader.loadClass("inheritmetadatatest3.\$BaseServiceDefinition\$Intercepted")
+        ctx.classLoader.loadClass("inheritmetadatatest3.\$BaseService" + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionWriter.PROXY_SUFFIX)
 
         then:
         thrown(ClassNotFoundException)
 
         when:
-        ctx.classLoader.loadClass("inheritmetadatatest3.\$BaseServiceDefinition")
+        ctx.classLoader.loadClass("inheritmetadatatest3.\$BaseService" + BeanDefinitionWriter.CLASS_SUFFIX)
 
         then:
         thrown(ClassNotFoundException)
 
         when:
-        ctx.classLoader.loadClass("inheritmetadatatest3.\$BaseAnnotatedServiceDefinition")
+        ctx.classLoader.loadClass("inheritmetadatatest3.\$BaseAnnotatedService" + BeanDefinitionWriter.CLASS_SUFFIX)
 
         then:
         thrown(ClassNotFoundException)

--- a/inject-groovy/src/test/groovy/io/micronaut/aop/compile/LifeCycleWithProxySpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/aop/compile/LifeCycleWithProxySpec.groovy
@@ -4,11 +4,12 @@ import io.micronaut.ast.transform.test.AbstractBeanDefinitionSpec
 import io.micronaut.context.ApplicationContext
 import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.BeanFactory
+import io.micronaut.inject.writer.BeanDefinitionWriter
 
 class LifeCycleWithProxySpec extends AbstractBeanDefinitionSpec {
     void "test that a simple AOP definition lifecycle hooks are invoked - annotation at class level"() {
         when:
-        BeanDefinition beanDefinition = buildBeanDefinition('lifecycleproxy1.$MyBeanDefinition$Intercepted', '''
+        BeanDefinition beanDefinition = buildBeanDefinition('lifecycleproxy1.$MyBean' + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionWriter.PROXY_SUFFIX, '''
 package lifecycleproxy1;
 
 import io.micronaut.aop.interceptors.*;
@@ -60,7 +61,7 @@ class MyBean {
 
     void "test that a simple AOP definition lifecycle hooks are invoked - annotation at method level with hooks last"() {
         when:
-        BeanDefinition beanDefinition = buildBeanDefinition('lifecycleproxy2.$MyBeanDefinition$Intercepted', '''
+        BeanDefinition beanDefinition = buildBeanDefinition('lifecycleproxy2.$MyBean' + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionWriter.PROXY_SUFFIX, '''
 package lifecycleproxy2;
 
 import io.micronaut.aop.interceptors.*;
@@ -111,7 +112,7 @@ class MyBean {
 
     void "test that a simple AOP definition lifecycle hooks are invoked - annotation at method level"() {
         when:
-        BeanDefinition beanDefinition = buildBeanDefinition('lifecycleproxy3.$MyBeanDefinition$Intercepted', '''
+        BeanDefinition beanDefinition = buildBeanDefinition('lifecycleproxy3.$MyBean' + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionWriter.PROXY_SUFFIX, '''
 package lifecycleproxy3;
 
 import io.micronaut.aop.interceptors.*;

--- a/inject-groovy/src/test/groovy/io/micronaut/aop/compile/PropertyAdviceSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/aop/compile/PropertyAdviceSpec.groovy
@@ -4,11 +4,12 @@ import io.micronaut.ast.transform.test.AbstractBeanDefinitionSpec
 import io.micronaut.context.ApplicationContext
 import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.BeanFactory
+import io.micronaut.inject.writer.BeanDefinitionWriter
 
 class PropertyAdviceSpec extends AbstractBeanDefinitionSpec {
     void 'test advice can be applied to bean properties'() {
         when:"An introduction advice type is compiled that includes a concrete method that is annotated with around advice"
-        BeanDefinition beanDefinition = buildBeanDefinition('test.$MyPropertyBeanDefinition$Intercepted', '''
+        BeanDefinition beanDefinition = buildBeanDefinition('test.$MyPropertyBean' + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionWriter.PROXY_SUFFIX, '''
 package test;
 
 import io.micronaut.aop.interceptors.*;

--- a/inject-groovy/src/test/groovy/io/micronaut/aop/factory/SessionProxySpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/aop/factory/SessionProxySpec.groovy
@@ -19,6 +19,7 @@ import io.micronaut.ast.transform.test.AbstractBeanDefinitionSpec
 import io.micronaut.core.reflect.ReflectionUtils
 import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.writer.BeanDefinitionVisitor
+import io.micronaut.inject.writer.BeanDefinitionWriter
 import org.hibernate.Session
 import org.hibernate.SessionFactory
 
@@ -26,7 +27,7 @@ class SessionProxySpec extends AbstractBeanDefinitionSpec {
 
     void "test create session proxy"() {
         when:
-        BeanDefinition beanDefinition = buildBeanDefinition('test.$AbstractBean$CurrentSession0Definition' + BeanDefinitionVisitor.PROXY_SUFFIX, '''
+        BeanDefinition beanDefinition = buildBeanDefinition('test.$AbstractBean$CurrentSession0' + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionVisitor.PROXY_SUFFIX, '''
 package test;
 
 import io.micronaut.aop.introduction.*;
@@ -67,7 +68,7 @@ class AbstractBean {
 
     void "test create session factory proxy"() {
         when:
-        BeanDefinition beanDefinition = buildBeanDefinition('test.$AbstractBean$SessionFactory0Definition' + BeanDefinitionVisitor.PROXY_SUFFIX, '''
+        BeanDefinition beanDefinition = buildBeanDefinition('test.$AbstractBean$SessionFactory0' + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionVisitor.PROXY_SUFFIX, '''
 package test;
 
 import io.micronaut.aop.introduction.*;

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/annotation/GroovyAnnotationInheritanceSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/annotation/GroovyAnnotationInheritanceSpec.groovy
@@ -8,6 +8,7 @@ import io.micronaut.context.annotation.Requires
 import io.micronaut.core.annotation.AnnotationUtil
 import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.qualifiers.Qualifiers
+import io.micronaut.inject.writer.BeanDefinitionWriter
 
 class GroovyAnnotationInheritanceSpec extends AbstractBeanDefinitionSpec {
 
@@ -74,7 +75,7 @@ class ParentFactory {
 }
 
 ''')
-        BeanDefinition definition = classLoader.loadClass('anntest.$TestFactory$Test0Definition').newInstance()
+        BeanDefinition definition = classLoader.loadClass('anntest.$TestFactory$Test0' + BeanDefinitionWriter.CLASS_SUFFIX).newInstance()
 
         expect:"Is a bean"
         definition != null
@@ -480,7 +481,7 @@ class ParentFactory {
 @jakarta.inject.Scope
 @interface MyS {}
 ''')
-        BeanDefinition definition = classLoader.loadClass('anntest.$TestFactory$Test0Definition').newInstance()
+        BeanDefinition definition = classLoader.loadClass('anntest.$TestFactory$Test0' + BeanDefinitionWriter.CLASS_SUFFIX).newInstance()
 
         expect:"inherits annotations declared @Inherited"
         definition.hasAnnotation("anntest.MyQ")
@@ -554,7 +555,7 @@ class ParentFactory {
 @Inherited
 @interface MyAnn {}
 ''')
-        BeanDefinition definition = classLoader.loadClass('anntest.$TestFactory$Test0Definition').newInstance()
+        BeanDefinition definition = classLoader.loadClass('anntest.$TestFactory$Test0' + BeanDefinitionWriter.CLASS_SUFFIX).newInstance()
 
         expect:"inherits the stereotype annotation as an annotation"
         definition.hasAnnotation('anntest.MyAnn')
@@ -628,7 +629,7 @@ class ParentFactory {
 }
 
 ''')
-        BeanDefinition definition = classLoader.loadClass('anntest.$TestFactory$Test0Definition').newInstance()
+        BeanDefinition definition = classLoader.loadClass('anntest.$TestFactory$Test0' + BeanDefinitionWriter.CLASS_SUFFIX).newInstance()
 
         expect:"The type is a bean with a single declared annotation"
         definition.hasDeclaredAnnotation(Prototype)
@@ -688,7 +689,7 @@ class ParentFactory {
 
 ''')
         when:"No bean since no declared scopes/qualifiers"
-        classLoader.loadClass('anntest.$TestFactory$Test0Definition')
+        classLoader.loadClass('anntest.$TestFactory$Test0' + BeanDefinitionWriter.CLASS_SUFFIX)
 
         then:"No bean exists"
         thrown(ClassNotFoundException)

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/executable/ExecutableSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/executable/ExecutableSpec.groovy
@@ -15,18 +15,16 @@
  */
 package io.micronaut.inject.executable
 
-import io.micronaut.context.AbstractExecutableMethod
+
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.DefaultApplicationContext
-import io.micronaut.inject.ExecutionHandle
-import io.micronaut.inject.ExecutableMethod
-import io.micronaut.inject.MethodExecutionHandle
 import io.micronaut.context.annotation.Executable
-import spock.lang.Specification
-
+import io.micronaut.inject.ExecutableMethod
+import io.micronaut.inject.ExecutionHandle
+import io.micronaut.inject.MethodExecutionHandle
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
-
+import spock.lang.Specification
 /**
  * @author Graeme Rocher
  * @since 1.0
@@ -50,7 +48,6 @@ class ExecutableSpec extends Specification {
         then:
         executionHandle.returnType.type == String
         executionHandle.invoke(1L) == "1 - The Stand"
-        executableMethod.getClass().getSuperclass() == AbstractExecutableMethod
 
         when:
         executionHandle.invoke("bad")

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/executable/inheritance/InheritedExecutableSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/executable/inheritance/InheritedExecutableSpec.groovy
@@ -73,20 +73,7 @@ abstract class GenericController<T> {
         definition.getExecutableMethods().any { it.methodName == "getPath" }
         definition.getExecutableMethods().any { it.methodName == "save" && it.argumentTypes == [String] as Class[] }
         definition.getExecutableMethods().any { it.methodName == "save" && it.argumentTypes.length == 0 }
-
-        when:
-        definition.getClass().getClassLoader().loadClass('test.$StatusControllerDefinition$$exec1')
-        definition.getClass().getClassLoader().loadClass('test.$StatusControllerDefinition$$exec2')
-        definition.getClass().getClassLoader().loadClass('test.$StatusControllerDefinition$$exec3')
-
-        then:
-        noExceptionThrown()
-
-        when: //there should only be 2 executable methods
-        definition.getClass().getClassLoader().loadClass('test.$StatusControllerDefinition$$exec4')
-
-        then:
-        thrown(ClassNotFoundException)
+        definition.getExecutableMethods().size() == 3
     }
 
     void "test with multiple generics"() {
@@ -126,20 +113,7 @@ class StatusController extends GenericController<String, Integer> {
         definition.getExecutableMethods().any { it.methodName == "create" && it.argumentTypes == [Integer] as Class[] }
         definition.getExecutableMethods().any { it.methodName == "save" && it.argumentTypes == [String] as Class[] }
         definition.getExecutableMethods().any { it.methodName == "find" && it.argumentTypes == [Integer] as Class[] }
-
-        when:
-        definition.getClass().getClassLoader().loadClass('test.$StatusControllerDefinition$$exec1')
-        definition.getClass().getClassLoader().loadClass('test.$StatusControllerDefinition$$exec2')
-        definition.getClass().getClassLoader().loadClass('test.$StatusControllerDefinition$$exec3')
-
-        then:
-        noExceptionThrown()
-
-        when: //there should only be 2 executable methods
-        definition.getClass().getClassLoader().loadClass('test.$StatusControllerDefinition$$exec4')
-
-        then:
-        thrown(ClassNotFoundException)
+        definition.getExecutableMethods().size() == 3
     }
 
     void "test multiple inheritance"() {

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/failures/FieldDependencyMissingFailureSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/failures/FieldDependencyMissingFailureSpec.groovy
@@ -38,10 +38,8 @@ class FieldDependencyMissingFailureSpec extends Specification {
 
         then:"The implementation is injected"
         def e = thrown(DependencyInjectionException)
-        e.message.normalize() == '''\
-Failed to inject value for field [a] of class: io.micronaut.inject.failures.FieldDependencyMissingFailureSpec$B
-
-Path Taken: new B() --> B.a'''
+        e.message.normalize().contains 'Failed to inject value for field [a] of class: io.micronaut.inject.failures.FieldDependencyMissingFailureSpec$B'
+        e.message.normalize().contains 'Path Taken: new B() --> B.a'
     }
 
     static interface A {

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/failures/PropertyDependencyMissingSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/failures/PropertyDependencyMissingSpec.groovy
@@ -38,11 +38,9 @@ class PropertyDependencyMissingSpec  extends Specification {
 
         then:"The correct error is thrown"
         def e = thrown(DependencyInjectionException)
-        e.message.normalize() == '''\
-Failed to inject value for parameter [a] of class: io.micronaut.inject.failures.PropertyDependencyMissingSpec$B
-
-Message: No bean of type [io.micronaut.inject.failures.PropertyDependencyMissingSpec$A] exists. Make sure the bean is not disabled by bean requirements (enable trace logging for 'io.micronaut.context.condition' to check) and if the bean is enabled then ensure the class is declared a bean and annotation processing is enabled (for Java and Kotlin the 'micronaut-inject-java' dependency should be configured as an annotation processor).
-Path Taken: new B() --> B.setA([A a])'''
+        e.message.normalize().contains 'Failed to inject value for parameter [a] of method [setA] of class: io.micronaut.inject.failures.PropertyDependencyMissingSpec$B'
+        e.message.normalize().contains '''Message: No bean of type [io.micronaut.inject.failures.PropertyDependencyMissingSpec$A] exists. Make sure the bean is not disabled by bean requirements (enable trace logging for 'io.micronaut.context.condition' to check) and if the bean is enabled then ensure the class is declared a bean and annotation processing is enabled (for Java and Kotlin the 'micronaut-inject-java' dependency should be configured as an annotation processor).'''
+        e.message.normalize().contains '''Path Taken: new B() --> B.setA([A a])'''
     }
 
     static interface A {

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/field/FieldInjectionSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/field/FieldInjectionSpec.groovy
@@ -2,17 +2,14 @@ package io.micronaut.inject.field
 
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.BeanContext
-import io.micronaut.context.DefaultApplicationContext
-import io.micronaut.context.DefaultBeanContext
 import io.micronaut.context.annotation.Property
 import io.micronaut.context.annotation.Value
-import io.micronaut.context.event.BeanContextEvent
 import io.micronaut.context.exceptions.BeanContextException
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
 import spock.lang.Specification
 
 import javax.annotation.Nullable
-import jakarta.inject.Inject
-import jakarta.inject.Singleton
 
 class FieldInjectionSpec extends Specification {
 
@@ -66,8 +63,8 @@ class FieldInjectionSpec extends Specification {
 
         then:
         e.d == null
-        e.value == "Default greeting"
-        e.property == "Default greeting"
+        e.value == null
+        e.property == null
 
         when:
         context.getBean(C2)
@@ -86,6 +83,21 @@ class FieldInjectionSpec extends Specification {
 
         then:
         thrown(BeanContextException)
+
+        cleanup:
+        context.close()
+    }
+
+    void "test injection with no bean/property found and not nullable and protected fields"() {
+        BeanContext context = ApplicationContext.run()
+
+        when:
+        E e = context.getBean(E)
+
+        then:
+        e.d == null
+        e.value == null
+        e.property == null
 
         cleanup:
         context.close()
@@ -148,6 +160,32 @@ class FieldInjectionSpec extends Specification {
         @Nullable
         @Value('${greeting}')
         private String value = "Default greeting"
+
+        @Nullable
+        @Property(name = 'greeting')
+        private String property = "Default greeting"
+
+        D getD() {
+            return d
+        }
+
+        String getValue() {
+            return value
+        }
+
+        String getProperty() {
+            return property
+        }
+    }
+
+    static class F {
+        @Inject
+        @Nullable
+        protected D d
+
+        @Nullable
+        @Value('${greeting}')
+        protected String value = "Default greeting"
 
         @Nullable
         @Property(name = 'greeting')

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/field/FieldInjectionSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/field/FieldInjectionSpec.groovy
@@ -92,7 +92,7 @@ class FieldInjectionSpec extends Specification {
         BeanContext context = ApplicationContext.run()
 
         when:
-        E e = context.getBean(E)
+        F e = context.getBean(F)
 
         then:
         e.d == null

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/generics/GenericTypeArgumentsSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/generics/GenericTypeArgumentsSpec.groovy
@@ -19,6 +19,7 @@ import io.micronaut.ast.transform.test.AbstractBeanDefinitionSpec
 import io.micronaut.context.event.BeanCreatedEventListener
 import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.ExecutableMethod
+import io.micronaut.inject.writer.BeanDefinitionWriter
 import spock.lang.Unroll
 
 import javax.validation.ConstraintViolationException
@@ -255,7 +256,7 @@ class TestFactory {
 
     void "test type arguments for factory with AOP advice applied"() {
         given:
-        BeanDefinition definition = buildBeanDefinition('generictest6.$TestFactory$MyFunc0Definition$Intercepted', '''\
+        BeanDefinition definition = buildBeanDefinition('generictest6.$TestFactory$MyFunc0' + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionWriter.PROXY_SUFFIX, '''\
 package generictest6;
 
 import io.micronaut.inject.annotation.*;

--- a/inject-groovy/src/test/groovy/io/micronaut/validation/ValidatedParseSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/validation/ValidatedParseSpec.groovy
@@ -5,13 +5,14 @@ import io.micronaut.aop.Around
 import io.micronaut.core.beans.BeanIntrospection
 import io.micronaut.inject.ProxyBeanDefinition
 import io.micronaut.inject.writer.BeanDefinitionVisitor
+import io.micronaut.inject.writer.BeanDefinitionWriter
 
 import java.time.LocalDate
 
 class ValidatedParseSpec extends AbstractBeanDefinitionSpec {
     void "test constraints on beans make them @Validated"() {
         given:
-        def definition = buildBeanDefinition('validateparse1.$TestDefinition' + BeanDefinitionVisitor.PROXY_SUFFIX,'''
+        def definition = buildBeanDefinition('validateparse1.$Test' + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionVisitor.PROXY_SUFFIX,'''
 package validateparse1;
 
 @jakarta.inject.Singleton

--- a/inject-java-test/src/main/groovy/io/micronaut/annotation/processing/test/AbstractTypeElementSpec.groovy
+++ b/inject-java-test/src/main/groovy/io/micronaut/annotation/processing/test/AbstractTypeElementSpec.groovy
@@ -17,14 +17,7 @@ package io.micronaut.annotation.processing.test
 
 import com.sun.source.util.JavacTask
 import groovy.transform.CompileStatic
-import io.micronaut.annotation.processing.AggregatingTypeElementVisitorProcessor
-import io.micronaut.annotation.processing.AnnotationUtils
-import io.micronaut.annotation.processing.BeanDefinitionInjectProcessor
-import io.micronaut.annotation.processing.GenericUtils
-import io.micronaut.annotation.processing.JavaAnnotationMetadataBuilder
-import io.micronaut.annotation.processing.ModelUtils
-import io.micronaut.annotation.processing.TypeElementVisitorProcessor
-import io.micronaut.annotation.processing.visitor.JavaClassElement
+import io.micronaut.annotation.processing.*
 import io.micronaut.annotation.processing.visitor.JavaElementFactory
 import io.micronaut.annotation.processing.visitor.JavaVisitorContext
 import io.micronaut.aop.internal.InterceptorRegistryBean
@@ -49,10 +42,11 @@ import io.micronaut.inject.provider.BeanProviderDefinition
 import io.micronaut.inject.provider.JakartaProviderBeanDefinition
 import io.micronaut.inject.visitor.TypeElementVisitor
 import io.micronaut.inject.writer.BeanConfigurationWriter
+import io.micronaut.inject.writer.BeanDefinitionReferenceWriter
 import io.micronaut.inject.writer.BeanDefinitionVisitor
+import io.micronaut.inject.writer.BeanDefinitionWriter
 import spock.lang.Specification
 
-import javax.annotation.processing.ProcessingEnvironment
 import javax.lang.model.element.Element
 import javax.lang.model.element.ExecutableElement
 import javax.lang.model.element.TypeElement
@@ -62,7 +56,6 @@ import java.lang.annotation.Annotation
 import java.util.function.Predicate
 import java.util.stream.Collectors
 import java.util.stream.StreamSupport
-
 /**
  * Base class to extend from to allow compilation of Java sources
  * at runtime to allow testing of compile time behavior.
@@ -142,7 +135,7 @@ abstract class AbstractTypeElementSpec extends Specification {
     * @return the introspection if it is correct
     **/
     protected BeanIntrospection buildBeanIntrospection(String className, String cls) {
-        def beanDefName= '$' + NameUtils.getSimpleName(className) + '$Introspection'
+        def beanDefName= (className.startsWith('$') ? '' : '$') + NameUtils.getSimpleName(className) + '$Introspection'
         def packageName = NameUtils.getPackageName(className)
         String beanFullName = "${packageName}.${beanDefName}"
 
@@ -231,7 +224,7 @@ class Test {
             protected List<BeanDefinitionReference> resolveBeanDefinitionReferences(Predicate<BeanDefinitionReference> predicate) {
                 def references = StreamSupport.stream(files.spliterator(), false)
                         .filter({ JavaFileObject jfo ->
-                            jfo.kind == JavaFileObject.Kind.CLASS && jfo.name.endsWith("DefinitionClass.class")
+                            jfo.kind == JavaFileObject.Kind.CLASS && jfo.name.endsWith(BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionReferenceWriter.REF_SUFFIX + ".class")
                         })
                         .map({ JavaFileObject jfo ->
                             def name = jfo.toUri().toString().substring("mem:///CLASS_OUTPUT/".length())
@@ -342,7 +335,8 @@ class Test {
     }
 
     protected BeanDefinition buildBeanDefinition(String className, String cls) {
-        def beanDefName= '$' + NameUtils.getSimpleName(className) + 'Definition'
+        def classSimpleName = NameUtils.getSimpleName(className)
+        def beanDefName = (classSimpleName.startsWith('$') ? '' : '$') + classSimpleName + BeanDefinitionWriter.CLASS_SUFFIX
         def packageName = NameUtils.getPackageName(className)
         String beanFullName = "${packageName}.${beanDefName}"
 
@@ -355,7 +349,7 @@ class Test {
     }
 
     protected BeanDefinition buildBeanDefinition(String packageName, String className, String cls) {
-        def beanDefName= '$' + className + 'Definition'
+        def beanDefName= (className.startsWith('$') ? '' : '$') + className + BeanDefinitionWriter.CLASS_SUFFIX
         String beanFullName = "${packageName}.${beanDefName}"
 
         ClassLoader classLoader = buildClassLoader(className, cls)
@@ -373,7 +367,8 @@ class Test {
      * @return The bean definition
      */
     protected BeanDefinition buildInterceptedBeanDefinition(String className, String cls) {
-        def beanDefName= '$$' + NameUtils.getSimpleName(className) + 'Definition' + BeanDefinitionVisitor.PROXY_SUFFIX + 'Definition'
+        def classSimpleName = NameUtils.getSimpleName(className)
+        def beanDefName = (classSimpleName.startsWith('$') ? '' : '$') + classSimpleName + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionVisitor.PROXY_SUFFIX + BeanDefinitionWriter.CLASS_SUFFIX
         def packageName = NameUtils.getPackageName(className)
         String beanFullName = "${packageName}.${beanDefName}"
 
@@ -414,7 +409,8 @@ class Test {
      * @return The bean definition
      */
     protected BeanDefinitionReference buildInterceptedBeanDefinitionReference(String className, String cls) {
-        def beanDefName= '$$' + NameUtils.getSimpleName(className) + 'Definition' + BeanDefinitionVisitor.PROXY_SUFFIX + 'DefinitionClass'
+        def classSimpleName = NameUtils.getSimpleName(className)
+        def beanDefName = (classSimpleName.startsWith('$') ? '' : '$') + classSimpleName + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionVisitor.PROXY_SUFFIX + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionReferenceWriter.REF_SUFFIX
         def packageName = NameUtils.getPackageName(className)
         String beanFullName = "${packageName}.${beanDefName}"
 
@@ -423,7 +419,8 @@ class Test {
     }
 
     protected BeanDefinitionReference buildBeanDefinitionReference(String className, String cls) {
-        def beanDefName= '$' + NameUtils.getSimpleName(className) + 'DefinitionClass'
+        def classSimpleName = NameUtils.getSimpleName(className)
+        def beanDefName= (classSimpleName.startsWith('$') ? '' : '$') + classSimpleName + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionReferenceWriter.REF_SUFFIX
         def packageName = NameUtils.getPackageName(className)
         String beanFullName = "${packageName}.${beanDefName}"
 

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -39,10 +39,8 @@ import io.micronaut.inject.configuration.ConfigurationMetadataBuilder;
 import io.micronaut.inject.configuration.PropertyMetadata;
 import io.micronaut.inject.processing.JavaModelUtils;
 import io.micronaut.inject.visitor.VisitorConfiguration;
-import io.micronaut.inject.writer.BeanDefinitionReferenceWriter;
-import io.micronaut.inject.writer.BeanDefinitionVisitor;
-import io.micronaut.inject.writer.BeanDefinitionWriter;
-import io.micronaut.inject.writer.OriginatingElements;
+import io.micronaut.inject.writer.*;
+
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedOptions;
@@ -1534,10 +1532,6 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
 
             if (javaMethodElement.hasDeclaredAnnotation(AnnotationUtil.POST_CONSTRUCT)) {
                 BeanDefinitionVisitor writer = getOrCreateBeanDefinitionWriter(concreteClass, concreteClass.getQualifiedName());
-                final AopProxyWriter aopWriter = resolveAopWriter(writer);
-                if (aopWriter != null && !aopWriter.isProxyTarget()) {
-                    writer = aopWriter;
-                }
                 addOriginatingElementIfNecessary(writer, declaringClass);
                 writer.visitPostConstructMethod(
                         declaringClass,
@@ -1547,10 +1541,6 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                 );
             } else if (javaMethodElement.hasDeclaredAnnotation(AnnotationUtil.PRE_DESTROY)) {
                 BeanDefinitionVisitor writer = getOrCreateBeanDefinitionWriter(concreteClass, concreteClass.getQualifiedName());
-                final AopProxyWriter aopWriter = resolveAopWriter(writer);
-                if (aopWriter != null && !aopWriter.isProxyTarget()) {
-                    writer = aopWriter;
-                }
                 addOriginatingElementIfNecessary(writer, declaringClass);
                 writer.visitPreDestroyMethod(
                         declaringClass,

--- a/inject-java/src/test/groovy/io/micronaut/aop/compile/AnnotatedConstructorArgumentSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/compile/AnnotatedConstructorArgumentSpec.groovy
@@ -19,12 +19,11 @@ import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.micronaut.aop.InterceptorBinding
 import io.micronaut.aop.simple.Mutating
 import io.micronaut.context.ApplicationContext
-import io.micronaut.context.annotation.Type
 import io.micronaut.core.annotation.AnnotationMetadata
 import io.micronaut.core.annotation.AnnotationUtil
 import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.BeanFactory
-
+import io.micronaut.inject.writer.BeanDefinitionWriter
 /**
  * @author graemerocher
  * @since 1.0
@@ -34,7 +33,7 @@ class AnnotatedConstructorArgumentSpec extends AbstractTypeElementSpec{
 
     void "test that constructor arguments propagate annotation metadata"() {
         when:
-        BeanDefinition beanDefinition = buildBeanDefinition('test.$MyBeanDefinition$Intercepted', '''
+        BeanDefinition beanDefinition = buildBeanDefinition('test.$MyBean' + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionWriter.PROXY_SUFFIX, '''
 package test;
 
 import io.micronaut.aop.simple.*;
@@ -87,7 +86,7 @@ class MyBean {
 
     void "test that constructor arguments propagate annotation metadata - method level AOP"() {
         when:
-        BeanDefinition beanDefinition = buildBeanDefinition('test.$MyBeanDefinition$Intercepted', '''
+        BeanDefinition beanDefinition = buildBeanDefinition('test.$MyBean' + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionWriter.PROXY_SUFFIX, '''
 package test;
 
 import io.micronaut.aop.simple.*;

--- a/inject-java/src/test/groovy/io/micronaut/aop/compile/AroundCompileSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/compile/AroundCompileSpec.groovy
@@ -13,6 +13,7 @@ import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.BeanDefinitionReference
 import io.micronaut.inject.annotation.NamedAnnotationMapper
 import io.micronaut.inject.visitor.VisitorContext
+import io.micronaut.inject.writer.BeanDefinitionWriter
 import spock.lang.Issue
 
 import java.lang.annotation.Annotation
@@ -556,7 +557,7 @@ class TestInterceptor implements Interceptor {
 
     void "test validated on class with generics"() {
         when:
-        BeanDefinition beanDefinition = buildBeanDefinition('test.$BaseEntityServiceDefinition$Intercepted', """
+        BeanDefinition beanDefinition = buildBeanDefinition('test.$BaseEntityService' + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionWriter.PROXY_SUFFIX, """
 package test;
 
 @io.micronaut.validation.Validated

--- a/inject-java/src/test/groovy/io/micronaut/aop/compile/FinalModifierSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/compile/FinalModifierSpec.groovy
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import io.micronaut.aop.Intercepted
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.micronaut.inject.qualifiers.Qualifiers
+import io.micronaut.inject.writer.BeanDefinitionWriter
 import spock.lang.Issue
 
 class FinalModifierSpec extends AbstractTypeElementSpec {
@@ -180,7 +181,7 @@ final class MyBean {
 
     void "test final modifier on class with AOP advice doesn't compile"() {
         when:
-        buildBeanDefinition('test.$MyBeanDefinition$Intercepted', '''
+        buildBeanDefinition('test.$MyBean' + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionWriter.PROXY_SUFFIX, '''
 package test;
 
 import io.micronaut.aop.simple.*;
@@ -209,7 +210,7 @@ final class MyBean {
 
     void "test final modifier on method with AOP advice doesn't compile"() {
         when:
-        buildBeanDefinition('test.$MyBeanDefinition$Intercepted', '''
+        buildBeanDefinition('test.$MyBean' + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionWriter.PROXY_SUFFIX, '''
 package test;
 
 import io.micronaut.aop.simple.*;
@@ -238,7 +239,7 @@ class MyBean {
 
     void "test final modifier on method with AOP advice on method doesn't compile"() {
         when:
-        buildBeanDefinition('test.$MyBeanDefinition$Intercepted', '''
+        buildBeanDefinition('test.$MyBean' + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionWriter.PROXY_SUFFIX, '''
 package test;
 
 import io.micronaut.aop.simple.*;

--- a/inject-java/src/test/groovy/io/micronaut/aop/compile/GeneratedAnnotationSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/compile/GeneratedAnnotationSpec.groovy
@@ -2,6 +2,7 @@ package io.micronaut.aop.compile
 
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.micronaut.annotation.processing.test.Parser
+import io.micronaut.inject.writer.BeanDefinitionWriter
 import org.objectweb.asm.AnnotationVisitor
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassVisitor
@@ -31,7 +32,7 @@ class FooController {
     }
 }
 ''')
-        JavaFileObject f = files.find { it -> it.name.contains('FooControllerDefinition$Intercepted.class') }
+        JavaFileObject f = files.find { it -> it.name.contains('FooController' + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionWriter.PROXY_SUFFIX + '.class') }
         def bytes = f.openInputStream().withCloseable {it.bytes }
         ClassReader reader = new ClassReader(bytes)
         int generatedAnnotations = 0

--- a/inject-java/src/test/groovy/io/micronaut/aop/compile/InheritedAnnotationMetadataSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/compile/InheritedAnnotationMetadataSpec.groovy
@@ -21,6 +21,7 @@ import io.micronaut.core.annotation.Blocking
 import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.BeanFactory
 import io.micronaut.inject.writer.BeanDefinitionVisitor
+import io.micronaut.inject.writer.BeanDefinitionWriter
 
 /**
  * @author graemerocher
@@ -63,7 +64,7 @@ interface MyInterface {
 
     void "test that annotation metadata is inherited from overridden methods for around advice"() {
         when:
-        BeanDefinition beanDefinition = buildBeanDefinition('test.$MyBeanDefinition$Intercepted', '''
+        BeanDefinition beanDefinition = buildBeanDefinition('test.$MyBean' + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionWriter.PROXY_SUFFIX, '''
 package test;
 
 import io.micronaut.aop.simple.*;
@@ -111,7 +112,7 @@ interface MyInterface {
 
     void "test that a bean definition is not created for an abstract class"() {
         when:
-        ApplicationContext ctx = buildContext('test.$ServiceDefinition$Intercepted', '''
+        ApplicationContext ctx = buildContext('test.$Service' + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionWriter.PROXY_SUFFIX, '''
 package test;
 
 import io.micronaut.aop.*;
@@ -169,19 +170,19 @@ class SomeInterceptor implements MethodInterceptor<Object, Object>, Ordered {
         ctx.getBean(clazz)
 
         when:
-        ctx.classLoader.loadClass("test.\$BaseServiceDefinition")
+        ctx.classLoader.loadClass("test.\$BaseService" + BeanDefinitionWriter.CLASS_SUFFIX)
 
         then:
         thrown(ClassNotFoundException)
 
         when:
-        ctx.classLoader.loadClass("test.\$BaseServiceDefinition\$Intercepted")
+        ctx.classLoader.loadClass("test.\$BaseService" + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionWriter.PROXY_SUFFIX)
 
         then:
         thrown(ClassNotFoundException)
 
         when:
-        ctx.classLoader.loadClass("test.\$BaseAnnotatedServiceDefinition")
+        ctx.classLoader.loadClass("test.\$BaseAnnotatedService" + BeanDefinitionWriter.CLASS_SUFFIX)
 
         then:
         thrown(ClassNotFoundException)

--- a/inject-java/src/test/groovy/io/micronaut/aop/compile/LifeCycleWithProxySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/compile/LifeCycleWithProxySpec.groovy
@@ -4,6 +4,7 @@ import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.micronaut.context.ApplicationContext
 import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.BeanFactory
+import io.micronaut.inject.writer.BeanDefinitionWriter
 
 class LifeCycleWithProxySpec extends AbstractTypeElementSpec {
     void "test that a proxy target AOP definition lifecycle hooks are invoked - annotation at class level"() {
@@ -56,7 +57,7 @@ class MyBean {
 
     void "test that a simple AOP definition lifecycle hooks are invoked - annotation at class level"() {
         when:
-        BeanDefinition beanDefinition = buildBeanDefinition('test.$MyBeanDefinition$Intercepted', '''
+        BeanDefinition beanDefinition = buildBeanDefinition('test.$MyBean' + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionWriter.PROXY_SUFFIX, '''
 package test;
 
 import io.micronaut.aop.simple.*;
@@ -109,7 +110,7 @@ class MyBean {
 
     void "test that a simple AOP definition lifecycle hooks are invoked - annotation at method level with hooks last"() {
         when:
-        BeanDefinition beanDefinition = buildBeanDefinition('test.$MyBeanDefinition$Intercepted', '''
+        BeanDefinition beanDefinition = buildBeanDefinition('test.$MyBean' + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionWriter.PROXY_SUFFIX, '''
 package test;
 
 import io.micronaut.aop.simple.*;
@@ -160,7 +161,7 @@ class MyBean {
 
     void "test that a simple AOP definition lifecycle hooks are invoked - annotation at method level"() {
         when:
-        BeanDefinition beanDefinition = buildBeanDefinition('test.$MyBeanDefinition$Intercepted', '''
+        BeanDefinition beanDefinition = buildBeanDefinition('test.$MyBean' + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionWriter.PROXY_SUFFIX, '''
 package test;
 
 import io.micronaut.aop.simple.*;

--- a/inject-java/src/test/groovy/io/micronaut/aop/compile/LifeCycleWithProxyTargetSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/compile/LifeCycleWithProxyTargetSpec.groovy
@@ -2,12 +2,13 @@ package io.micronaut.aop.compile
 
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.writer.BeanDefinitionWriter
 
 class LifeCycleWithProxyTargetSpec extends AbstractTypeElementSpec {
 
     void "test that a proxy target AOP definition lifecycle hooks are invoked - annotation at class level"() {
         when:
-        BeanDefinition beanDefinition = buildBeanDefinition('test.$MyBeanDefinition$Intercepted', '''
+        BeanDefinition beanDefinition = buildBeanDefinition('test.$MyBean' + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionWriter.PROXY_SUFFIX, '''
 package test;
 
 import io.micronaut.aop.proxytarget.*;
@@ -47,7 +48,7 @@ class MyBean {
 
     void "test that a proxy target AOP definition lifecycle hooks are invoked - annotation at method level with hooks last"() {
         when:
-        BeanDefinition beanDefinition = buildBeanDefinition('test.$MyBeanDefinition$Intercepted', '''
+        BeanDefinition beanDefinition = buildBeanDefinition('test.$MyBean' + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionWriter.PROXY_SUFFIX, '''
 package test;
 
 import io.micronaut.aop.proxytarget.*;
@@ -86,7 +87,7 @@ class MyBean {
 
     void "test that a proxy target AOP definition lifecycle hooks are invoked - annotation at method level"() {
         when:
-        BeanDefinition beanDefinition = buildBeanDefinition('test.$MyBeanDefinition$Intercepted', '''
+        BeanDefinition beanDefinition = buildBeanDefinition('test.$MyBean' + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionWriter.PROXY_SUFFIX, '''
 package test;
 
 import io.micronaut.aop.proxytarget.*;

--- a/inject-java/src/test/groovy/io/micronaut/aop/compile/PostConstructInterceptorCompileSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/compile/PostConstructInterceptorCompileSpec.groovy
@@ -113,7 +113,7 @@ class AnotherInterceptor implements Interceptor {
 
         then:"The interceptors that apply to post construction are invoked"
         interceptor.invoked == 1
-        proxyTarget ? instance.interceptedTarget().invoked : instance.invoked == 1
+        (proxyTarget ? instance.interceptedTarget() : instance).invoked == 1
         constructorInterceptor.invoked == 1
         anotherInterceptor.invoked == 0
         destroyInterceptor.invoked == 0

--- a/inject-java/src/test/groovy/io/micronaut/aop/factory/AdviceDefinedOnFactorySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/factory/AdviceDefinedOnFactorySpec.groovy
@@ -18,11 +18,12 @@ package io.micronaut.aop.factory
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.writer.BeanDefinitionVisitor
+import io.micronaut.inject.writer.BeanDefinitionWriter
 
 class AdviceDefinedOnFactorySpec extends AbstractTypeElementSpec {
     void "test advice defined at the class level of a  factory"() {
         when:"Advice is defined at the class level of the factory"
-        BeanDefinition beanDefinition = buildBeanDefinition('test.$MyFactoryDefinition' + BeanDefinitionVisitor.PROXY_SUFFIX, '''
+        BeanDefinition beanDefinition = buildBeanDefinition('test.$MyFactory' + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionVisitor.PROXY_SUFFIX, '''
 package test;
 
 import io.micronaut.aop.introduction.*;

--- a/inject-java/src/test/groovy/io/micronaut/aop/factory/SessionProxySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/factory/SessionProxySpec.groovy
@@ -19,6 +19,7 @@ import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.micronaut.core.reflect.ReflectionUtils
 import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.writer.BeanDefinitionVisitor
+import io.micronaut.inject.writer.BeanDefinitionWriter
 import org.hibernate.Session
 import org.hibernate.SessionFactory
 
@@ -26,7 +27,7 @@ class SessionProxySpec extends AbstractTypeElementSpec {
 
     void "test create session proxy"() {
         when:
-        BeanDefinition beanDefinition = buildBeanDefinition('test.$AbstractBean$CurrentSession0Definition' + BeanDefinitionVisitor.PROXY_SUFFIX, '''
+        BeanDefinition beanDefinition = buildBeanDefinition('test.$AbstractBean$CurrentSession0' + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionVisitor.PROXY_SUFFIX, '''
 package test;
 
 import io.micronaut.aop.introduction.*;
@@ -67,7 +68,7 @@ class AbstractBean {
 
     void "test create session factory proxy"() {
         when:
-        BeanDefinition beanDefinition = buildBeanDefinition('test.$AbstractBean$SessionFactory0Definition' + BeanDefinitionVisitor.PROXY_SUFFIX, '''
+        BeanDefinition beanDefinition = buildBeanDefinition('test.$AbstractBean$SessionFactory0' + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionVisitor.PROXY_SUFFIX, '''
 package test;
 
 import io.micronaut.aop.introduction.*;

--- a/inject-java/src/test/groovy/io/micronaut/aop/proxytarget/ProxyingMethodLevelAopSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/proxytarget/ProxyingMethodLevelAopSpec.groovy
@@ -36,7 +36,9 @@ class ProxyingMethodLevelAopSpec extends Specification {
 
         expect:
         args.isEmpty() ? foo."$method"() : foo."$method"(*args) == result
-        foo.lifeCycleCount == 1
+        foo.lifeCycleCount == 0
+        foo instanceof InterceptedProxy
+        foo.interceptedTarget().lifeCycleCount == 1
 
         where:
         method                        | args                   | result

--- a/inject-java/src/test/groovy/io/micronaut/inject/annotation/AnnotationInheritanceSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/annotation/AnnotationInheritanceSpec.groovy
@@ -1,6 +1,5 @@
 package io.micronaut.inject.annotation
 
-
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.micronaut.aop.Intercepted
 import io.micronaut.context.annotation.Prototype
@@ -9,7 +8,7 @@ import io.micronaut.context.annotation.Requires
 import io.micronaut.core.annotation.AnnotationUtil
 import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.qualifiers.Qualifiers
-import org.junit.jupiter.api.Assertions
+import io.micronaut.inject.writer.BeanDefinitionWriter
 
 class AnnotationInheritanceSpec extends AbstractTypeElementSpec {
 
@@ -77,7 +76,7 @@ class ParentFactory {
 }
 
 ''')
-        BeanDefinition definition = classLoader.loadClass('anntest.$TestFactory$Test0Definition').newInstance()
+        BeanDefinition definition = classLoader.loadClass('anntest.$TestFactory$Test0' + BeanDefinitionWriter.CLASS_SUFFIX).newInstance()
 
         expect:"Is a bean"
         definition != null
@@ -555,7 +554,7 @@ class ParentFactory {
 @jakarta.inject.Scope
 @interface MyS {}
 ''')
-        BeanDefinition definition = classLoader.loadClass('anntest.$TestFactory$Test0Definition').newInstance()
+        BeanDefinition definition = classLoader.loadClass('anntest.$TestFactory$Test0' + BeanDefinitionWriter.CLASS_SUFFIX).newInstance()
 
         expect:"inherits annotations declared @Inherited"
         definition.hasAnnotation("anntest.MyQ")
@@ -629,7 +628,7 @@ class ParentFactory {
 @Inherited
 @interface MyAnn {}
 ''')
-        BeanDefinition definition = classLoader.loadClass('anntest.$TestFactory$Test0Definition').newInstance()
+        BeanDefinition definition = classLoader.loadClass('anntest.$TestFactory$Test0' + BeanDefinitionWriter.CLASS_SUFFIX).newInstance()
 
         expect:"inherits the stereotype annotation as an annotation"
         definition.hasAnnotation('anntest.MyAnn')
@@ -703,7 +702,7 @@ class ParentFactory {
 }
 
 ''')
-        BeanDefinition definition = classLoader.loadClass('anntest.$TestFactory$Test0Definition').newInstance()
+        BeanDefinition definition = classLoader.loadClass('anntest.$TestFactory$Test0' + BeanDefinitionWriter.CLASS_SUFFIX).newInstance()
 
         expect:"The type is a bean with a single declared annotation"
         definition.hasDeclaredAnnotation(Prototype)
@@ -763,7 +762,7 @@ class ParentFactory {
 
 ''')
         when:"No bean since no declared scopes/qualifiers"
-        classLoader.loadClass('anntest.$TestFactory$Test0Definition')
+        classLoader.loadClass('anntest.$TestFactory$Test0' + BeanDefinitionWriter.CLASS_SUFFIX)
 
         then:"No bean exists"
         thrown(ClassNotFoundException)

--- a/inject-java/src/test/groovy/io/micronaut/inject/annotation/BeanDefinitionAnnotationMetadataSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/annotation/BeanDefinitionAnnotationMetadataSpec.groovy
@@ -15,25 +15,15 @@
  */
 package io.micronaut.inject.annotation
 
-import io.micronaut.context.annotation.Bean
-import io.micronaut.context.annotation.EachBean
-import io.micronaut.context.annotation.Executable
-import io.micronaut.context.annotation.Factory
-import io.micronaut.context.annotation.Primary
-import io.micronaut.context.annotation.Requirements
-import io.micronaut.context.annotation.Requires
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.annotation.*
 import io.micronaut.core.annotation.AnnotationUtil
 import io.micronaut.core.annotation.AnnotationValueProvider
 import io.micronaut.inject.BeanConfiguration
 import io.micronaut.inject.BeanDefinition
-import io.micronaut.inject.ExecutableMethod
+import io.micronaut.inject.writer.BeanDefinitionWriter
 import jakarta.inject.Named
 import spock.lang.Issue
-
-import jakarta.inject.Scope
-import jakarta.inject.Singleton
-
 /**
  * @author Graeme Rocher
  * @since 1.0
@@ -245,7 +235,7 @@ class Test {
 }
 
 ''')
-        BeanDefinition definition = classLoader.loadClass('test.$Test$ExecutorService0Definition').newInstance()
+        BeanDefinition definition = classLoader.loadClass('test.$Test$ExecutorService0' + BeanDefinitionWriter.CLASS_SUFFIX).newInstance()
         expect:
         definition != null
         definition.hasStereotype(Factory) // inherits the factory annotations as stereotypes
@@ -279,7 +269,7 @@ interface Foo {
 }
 
 ''')
-        BeanDefinition definition = classLoader.loadClass('test.$Test$Foo0Definition').newInstance()
+        BeanDefinition definition = classLoader.loadClass('test.$Test$Foo0' + BeanDefinitionWriter.CLASS_SUFFIX).newInstance()
         expect:
         definition != null
         definition.hasAnnotation(AnnotationUtil.SINGLETON)
@@ -316,7 +306,7 @@ interface Bar {
 
 
 ''')
-        BeanDefinition definition = classLoader.loadClass('test.$Test$Foo0Definition').newInstance()
+        BeanDefinition definition = classLoader.loadClass('test.$Test$Foo0' + BeanDefinitionWriter.CLASS_SUFFIX).newInstance()
         expect:
         definition != null
         definition.hasStereotype(AnnotationUtil.SINGLETON)

--- a/inject-java/src/test/groovy/io/micronaut/inject/configproperties/ChildConfigPropertiesX.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configproperties/ChildConfigPropertiesX.java
@@ -1,0 +1,18 @@
+package io.micronaut.inject.configproperties;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.inject.configproperties.other.ParentConfigProperties;
+
+@ConfigurationProperties("child")
+public class ChildConfigPropertiesX extends ParentConfigProperties {
+
+    private Integer age;
+
+    public Integer getAge() {
+        return age;
+    }
+
+    public void setAge(Integer age) {
+        this.age = age;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/executable/ExecutableSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/executable/ExecutableSpec.groovy
@@ -15,10 +15,9 @@
  */
 package io.micronaut.inject.executable
 
-import io.micronaut.context.AbstractExecutableMethod
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.DefaultApplicationContext
-import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.micronaut.core.annotation.AnnotationUtil
 import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.ExecutableMethod
@@ -75,7 +74,6 @@ class MyBean {
         then:
         executionHandle.returnType.type == String
         executionHandle.invoke(1L) == "1 - The Stand"
-        executableMethod.getClass().getSuperclass() == AbstractExecutableMethod
 
         when:
         executionHandle.invoke("bad")

--- a/inject-java/src/test/groovy/io/micronaut/inject/executable/inheritance/InheritedExecutableSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/executable/inheritance/InheritedExecutableSpec.groovy
@@ -73,20 +73,7 @@ abstract class GenericController<T> {
         definition.getExecutableMethods().any { it.methodName == "getPath" }
         definition.getExecutableMethods().any { it.methodName == "save" && it.argumentTypes == [String] as Class[] }
         definition.getExecutableMethods().any { it.methodName == "save" && it.argumentTypes.length == 0 }
-
-        when:
-        definition.getClass().getClassLoader().loadClass('test.$StatusControllerDefinition$$exec1')
-        definition.getClass().getClassLoader().loadClass('test.$StatusControllerDefinition$$exec2')
-        definition.getClass().getClassLoader().loadClass('test.$StatusControllerDefinition$$exec3')
-
-        then:
-        noExceptionThrown()
-
-        when: //there should only be 2 executable methods
-        definition.getClass().getClassLoader().loadClass('test.$StatusControllerDefinition$$exec4')
-
-        then:
-        thrown(ClassNotFoundException)
+        definition.getExecutableMethods().size() == 3
     }
 
     void "test with multiple generics"() {
@@ -127,20 +114,7 @@ class StatusController extends GenericController<String, Integer> {
         definition.getExecutableMethods().any { it.methodName == "create" && it.argumentTypes == [Integer] as Class[] }
         definition.getExecutableMethods().any { it.methodName == "save" && it.argumentTypes == [String] as Class[] }
         definition.getExecutableMethods().any { it.methodName == "find" && it.argumentTypes == [Integer] as Class[] }
-
-        when:
-        definition.getClass().getClassLoader().loadClass('test.$StatusControllerDefinition$$exec1')
-        definition.getClass().getClassLoader().loadClass('test.$StatusControllerDefinition$$exec2')
-        definition.getClass().getClassLoader().loadClass('test.$StatusControllerDefinition$$exec3')
-
-        then:
-        noExceptionThrown()
-
-        when: //there should only be 2 executable methods
-        definition.getClass().getClassLoader().loadClass('test.$StatusControllerDefinition$$exec4')
-
-        then:
-        thrown(ClassNotFoundException)
+        definition.getExecutableMethods().size() == 3
     }
 
     void "test multiple inheritance"() {

--- a/inject-java/src/test/groovy/io/micronaut/inject/factory/multiple/MethodSameNameSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/factory/multiple/MethodSameNameSpec.groovy
@@ -2,6 +2,7 @@ package io.micronaut.inject.factory.multiple
 
 import io.micronaut.context.ApplicationContext
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.inject.writer.BeanDefinitionWriter
 
 class MethodSameNameSpec extends AbstractTypeElementSpec {
 
@@ -52,8 +53,8 @@ class Y { }
 ''')
 
         when:
-        context.classLoader.loadClass('test.$AFactory$A0Definition')
-        context.classLoader.loadClass('test.$AFactory$A1Definition')
+        context.classLoader.loadClass('test.$AFactory$A0' + BeanDefinitionWriter.CLASS_SUFFIX)
+        context.classLoader.loadClass('test.$AFactory$A1' + BeanDefinitionWriter.CLASS_SUFFIX)
 
         then:
         noExceptionThrown()

--- a/inject-java/src/test/groovy/io/micronaut/inject/failures/fielddependencymissing/FieldDependencyMissingFailureSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/failures/fielddependencymissing/FieldDependencyMissingFailureSpec.groovy
@@ -33,10 +33,10 @@ class FieldDependencyMissingFailureSpec extends Specification {
 
         then:"The implementation is injected"
         def e = thrown(DependencyInjectionException)
-        e.message.normalize() == '''\
+        e.message.normalize().contains('''\
 Failed to inject value for field [a] of class: io.micronaut.inject.failures.fielddependencymissing.B
-
-Path Taken: new B() --> B.a'''
+''')
+        e.message.normalize().contains('''Path Taken: new B() --> B.a''')
 
         cleanup:
         context.close()

--- a/inject-java/src/test/groovy/io/micronaut/inject/field/arrayinjection/B.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/field/arrayinjection/B.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.inject.field.arrayinjection;
 
+import io.micronaut.context.BeanContext;
 import jakarta.inject.Inject;
 import java.util.Arrays;
 import java.util.List;
@@ -22,6 +23,10 @@ import java.util.List;
 public class B {
     @Inject
     private A[] all;
+    @Inject
+    protected A[] all2;
+    @Inject
+    protected BeanContext beanContext;
 
     List<A> getAll() {
         return Arrays.asList(this.all);

--- a/inject-java/src/test/groovy/io/micronaut/inject/field/inheritance/FieldInheritanceInjectionSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/field/inheritance/FieldInheritanceInjectionSpec.groovy
@@ -2,6 +2,7 @@ package io.micronaut.inject.field.inheritance
 
 import io.micronaut.context.ApplicationContext
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.inject.writer.BeanDefinitionWriter
 
 class FieldInheritanceInjectionSpec extends AbstractTypeElementSpec {
 
@@ -30,7 +31,7 @@ class Listener extends AbstractListener {
         noExceptionThrown()
 
         when:
-        context.classLoader.loadClass('test.$AbstractListenerDefinition')
+        context.classLoader.loadClass('test.$AbstractListener' + BeanDefinitionWriter.CLASS_SUFFIX)
 
         then:
         thrown(ClassNotFoundException)

--- a/inject-java/src/test/groovy/io/micronaut/inject/field/setinjection/B.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/field/setinjection/B.java
@@ -16,6 +16,7 @@
 package io.micronaut.inject.field.setinjection;
 
 import jakarta.inject.Inject;
+
 import java.util.Set;
 
 public class B {

--- a/inject-java/src/test/groovy/io/micronaut/inject/field/simpleinjection/D.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/field/simpleinjection/D.java
@@ -1,0 +1,24 @@
+package io.micronaut.inject.field.simpleinjection;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Value;
+
+import javax.annotation.Nullable;
+
+public class D {
+    @Nullable
+    @Value("${greeting}")
+    protected String value = "Default greeting";
+
+    @Nullable
+    @Property(name = "greeting")
+    protected String property = "Default greeting";
+
+    String getValue() {
+        return value;
+    }
+
+    String getProperty() {
+        return property;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/field/simpleinjection/E.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/field/simpleinjection/E.java
@@ -1,0 +1,24 @@
+package io.micronaut.inject.field.simpleinjection;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Value;
+
+import javax.annotation.Nullable;
+
+public class E {
+    @Nullable
+    @Value("${greeting}")
+    private String value = "Default greeting";
+
+    @Nullable
+    @Property(name = "greeting")
+    private String property = "Default greeting";
+
+    String getValue() {
+        return value;
+    }
+
+    String getProperty() {
+        return property;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/field/simpleinjection/FieldInjectionSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/field/simpleinjection/FieldInjectionSpec.groovy
@@ -15,11 +15,10 @@
  */
 package io.micronaut.inject.field.simpleinjection
 
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.ApplicationContext
 import io.micronaut.context.BeanContext
 import io.micronaut.context.DefaultBeanContext
-import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
-import io.micronaut.inject.qualifiers.Qualifiers
-import spock.lang.Specification
 
 class FieldInjectionSpec extends AbstractTypeElementSpec {
 
@@ -54,6 +53,34 @@ class Bar {
 
         then:"The implementation is injected"
         b.a != null
+    }
+
+    void "test values injection with private fields"() {
+        BeanContext context = ApplicationContext.run()
+
+        when:
+            E e = context.getBean(E)
+
+        then:
+            e.value == null
+            e.property == null
+
+        cleanup:
+            context.close()
+    }
+
+    void "test values injection with protected fields"() {
+        BeanContext context = ApplicationContext.run()
+
+        when:
+            D e = context.getBean(D)
+
+        then:
+            e.value == null
+            e.property == null
+
+        cleanup:
+            context.close()
     }
 }
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/generics/GenericTypeArgumentsSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/generics/GenericTypeArgumentsSpec.groovy
@@ -17,11 +17,9 @@ package io.micronaut.inject.generics
 
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.micronaut.context.event.BeanCreatedEventListener
-import io.micronaut.core.annotation.AnnotationMetadataProvider
-import io.micronaut.http.filter.HttpClientFilterResolver
 import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.ExecutableMethod
-import io.micronaut.inject.qualifiers.Qualifiers
+import io.micronaut.inject.writer.BeanDefinitionWriter
 import spock.lang.Unroll
 import zipkin2.Span
 import zipkin2.reporter.AsyncReporter
@@ -30,7 +28,6 @@ import zipkin2.reporter.Reporter
 import javax.validation.ConstraintViolationException
 import java.util.function.Function
 import java.util.function.Supplier
-import java.util.stream.Stream
 
 class GenericTypeArgumentsSpec extends AbstractTypeElementSpec {
 
@@ -483,14 +480,13 @@ class Test {
 ''')
         expect:
         definition != null
-        definition.getTypeArgumentsMap().size() == 2
         definition.getTypeParameters(Reporter) == [Span] as Class[]
         definition.getTypeParameters(AsyncReporter) == [Span] as Class[]
     }
 
     void "test type arguments for factory with AOP advice applied"() {
         given:
-        BeanDefinition definition = buildBeanDefinition('test.$TestFactory$MyFunc0Definition$Intercepted', '''\
+        BeanDefinition definition = buildBeanDefinition('test.$TestFactory$MyFunc0' + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionWriter.PROXY_SUFFIX, '''\
 package test;
 
 import io.micronaut.inject.annotation.*;

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/beanwithprivatepostconstruct/A.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/beanwithprivatepostconstruct/A.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.lifecycle.beanwithprivatepostconstruct;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+public class A {
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/beanwithprivatepostconstruct/B.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/beanwithprivatepostconstruct/B.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.lifecycle.beanwithprivatepostconstruct;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import javax.annotation.PostConstruct;
+
+@Singleton
+public class B {
+
+    boolean setupComplete = false;
+    boolean injectedFirst = false;
+
+    @Inject
+    protected A another;
+    private A a;
+
+    @Inject
+    public void setA(A a ) {
+        this.a = a;
+    }
+
+    public A getA() {
+        return a;
+    }
+
+    @PostConstruct
+    private void setup() {
+        if(a != null && another != null) {
+            injectedFirst = true;
+        }
+        setupComplete = true;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/beanwithprivatepostconstruct/BeanWithPostConstructSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/beanwithprivatepostconstruct/BeanWithPostConstructSpec.groovy
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.lifecycle.beanwithprivatepostconstruct
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.BeanContext
+import io.micronaut.context.DefaultBeanContext
+import io.micronaut.inject.BeanDefinition
+
+class BeanWithPostConstructSpec extends AbstractTypeElementSpec {
+
+    void "test @PreDestroy and @PostConstruct injection compile"() {
+        given:"A bean that has life cycle annotations"
+        when:
+        BeanDefinition beanDefinition = buildBeanDefinition('test.MyBean', '''
+package test;
+import javax.annotation.*;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import io.micronaut.context.annotation.*;
+
+@Executable
+class MyBean {
+    
+    Foo foo;
+    
+    public Foo getFoo() { return this.foo; }
+    
+    @PostConstruct
+    public void init(Foo foo) {
+        this.foo = foo;
+    }
+    
+    @PreDestroy
+    public void setFoo(Foo foo) {
+        this.foo = null;
+    }
+    @PreDestroy
+    public void close() {}
+}
+
+
+@jakarta.inject.Singleton
+class Foo {}
+
+''')
+        then:"the state is correct"
+        beanDefinition.injectedMethods.size() == 3
+        beanDefinition.preDestroyMethods.size() == 2
+        beanDefinition.postConstructMethods.size() == 1
+
+    }
+
+    void "test that a bean with a protected post construct hook that the hook is invoked"() {
+        given:
+        BeanContext context = new DefaultBeanContext()
+        context.start()
+
+        when:
+        B b = context.getBean(B)
+
+        then:
+        b.a != null
+        b.injectedFirst
+        b.setupComplete
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/beanwithprivatepredestroy/A.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/beanwithprivatepredestroy/A.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.lifecycle.beanwithprivatepredestroy;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+public class A {
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/beanwithprivatepredestroy/B.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/beanwithprivatepredestroy/B.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.lifecycle.beanwithprivatepredestroy;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import javax.annotation.PreDestroy;
+import java.io.Closeable;
+
+@Singleton
+public class B implements Closeable {
+
+    boolean noArgsDestroyCalled = false;
+    boolean injectedDestroyCalled = false;
+
+    @Inject
+    protected A another;
+    private A a;
+
+    @Inject
+    void setA(A a ) {
+        this.a = a;
+    }
+
+    A getA() {
+        return a;
+    }
+
+    @Override
+    @PreDestroy
+    public void close() {
+        noArgsDestroyCalled = true;
+    }
+
+    @PreDestroy
+    private void another(C c) {
+        if(c != null) {
+            injectedDestroyCalled = true;
+        }
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/beanwithprivatepredestroy/BeanWithPreDestroySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/beanwithprivatepredestroy/BeanWithPreDestroySpec.groovy
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.lifecycle.beanwithprivatepredestroy
+
+import io.micronaut.context.BeanContext
+import io.micronaut.context.DefaultBeanContext
+import spock.lang.Specification
+
+class BeanWithPreDestroySpec extends Specification{
+
+    void "test that a bean with a pre-destroy hook works"() {
+        given:
+        BeanContext context = new DefaultBeanContext()
+        context.start()
+
+        when:
+            B b = context.getBean(B)
+
+        then:
+        b.a != null
+        !b.noArgsDestroyCalled
+        !b.injectedDestroyCalled
+
+        when:
+        context.destroyBean(B)
+
+        then:
+        b.noArgsDestroyCalled
+        b.injectedDestroyCalled
+
+        cleanup:
+        context.close()
+    }
+
+    void "test that a bean with a pre-destroy hook works closed on close"() {
+        given:
+        BeanContext context = new DefaultBeanContext()
+        context.start()
+
+        when:
+            B b = context.getBean(B)
+
+        then:
+        b.a != null
+        !b.noArgsDestroyCalled
+        !b.injectedDestroyCalled
+
+        when:
+        context.close()
+
+        then:
+        b.noArgsDestroyCalled
+        b.injectedDestroyCalled
+    }
+
+    void "test that destroy events run in the right phase"() {
+        given:
+        BeanContext context = new DefaultBeanContext()
+        context.start()
+
+
+        when:
+        def pre = context.getBean(CPreDestroyEventListener)
+        def post = context.getBean(CDestroyedListener)
+        def c = context.getBean(C)
+
+        then:
+        !c.isClosed()
+
+        when:
+        context.close()
+
+        then:
+        pre.called
+        post.called
+        c.isClosed()
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/beanwithprivatepredestroy/C.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/beanwithprivatepredestroy/C.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.lifecycle.beanwithprivatepredestroy;
+
+import jakarta.inject.Singleton;
+
+import javax.annotation.PreDestroy;
+
+@Singleton
+public class C implements AutoCloseable {
+
+    private boolean closed;
+
+    @Override
+    @PreDestroy
+    public void close() throws Exception {
+        this.closed = true;
+    }
+
+    public boolean isClosed() {
+        return closed;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/beanwithprivatepredestroy/CDestroyedListener.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/beanwithprivatepredestroy/CDestroyedListener.java
@@ -1,0 +1,20 @@
+package io.micronaut.inject.lifecycle.beanwithprivatepredestroy;
+
+import io.micronaut.context.event.BeanDestroyedEvent;
+import io.micronaut.context.event.BeanDestroyedEventListener;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.Assertions;
+
+@Singleton
+public class CDestroyedListener implements BeanDestroyedEventListener<C> {
+    private boolean called = true;
+    @Override
+    public void onDestroyed(BeanDestroyedEvent<C> event) {
+        this.called = called;
+        Assertions.assertTrue(event.getBean().isClosed());
+    }
+
+    public boolean isCalled() {
+        return called;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/beanwithprivatepredestroy/CPreDestroyEventListener.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/beanwithprivatepredestroy/CPreDestroyEventListener.java
@@ -1,0 +1,22 @@
+package io.micronaut.inject.lifecycle.beanwithprivatepredestroy;
+
+import io.micronaut.context.event.BeanPreDestroyEvent;
+import io.micronaut.context.event.BeanPreDestroyEventListener;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.Assertions;
+
+@Singleton
+public class CPreDestroyEventListener implements BeanPreDestroyEventListener<C> {
+    private boolean called = false;
+    @Override
+    public C onPreDestroy(BeanPreDestroyEvent<C> event) {
+        this.called = true;
+        Assertions.assertFalse(event.getBean().isClosed());
+        return event.getBean();
+    }
+
+    public boolean isCalled() {
+        return called;
+    }
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/method/setinjection/B.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/method/setinjection/B.java
@@ -15,20 +15,37 @@
  */
 package io.micronaut.inject.method.setinjection;
 
+import io.micronaut.context.BeanContext;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+
 import java.util.Set;
 
 @Singleton
 public class B {
     private Set<A> all;
+    private Set<A> allPrivate;
+    private BeanContext beanContext;
 
     @Inject
     void setA(Set<A> a) {
         this.all = a;
     }
 
+    @Inject
+    private void setPrivate(Set<A> a, BeanContext beanContext) {
+        this.all = a;
+    }
+
     Set<A> getAll() {
         return this.all;
+    }
+
+    public Set<A> getAllPrivate() {
+        return allPrivate;
+    }
+
+    public BeanContext getBeanContext() {
+        return beanContext;
     }
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/scope/DefaultScopeSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/scope/DefaultScopeSpec.groovy
@@ -19,7 +19,7 @@ import io.micronaut.context.annotation.Prototype
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.micronaut.core.annotation.AnnotationUtil
 import io.micronaut.inject.BeanDefinition
-
+import io.micronaut.inject.writer.BeanDefinitionWriter
 import jakarta.inject.Singleton
 
 /**
@@ -117,7 +117,7 @@ class MyBean {
 }
 ''')
         BeanDefinition beanDefinition = classLoader
-                .loadClass('test.$MyBeanFactory$MyBean0Definition')
+                .loadClass('test.$MyBeanFactory$MyBean0' + BeanDefinitionWriter.CLASS_SUFFIX)
                 .newInstance()
 
         then:"the default scope is singleton"
@@ -145,7 +145,7 @@ class MyBean {
 }
 ''')
         BeanDefinition beanDefinition = classLoader
-                .loadClass('test.$MyBeanFactory$MyBean0Definition')
+                .loadClass('test.$MyBeanFactory$MyBean0' + BeanDefinitionWriter.CLASS_SUFFIX)
                 .newInstance()
 
         then:"the default scope is singleton"

--- a/inject/src/main/java/io/micronaut/context/AbstractBeanDefinition2.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractBeanDefinition2.java
@@ -1,0 +1,1846 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.EachProperty;
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Value;
+import io.micronaut.context.env.Environment;
+import io.micronaut.context.event.BeanInitializedEventListener;
+import io.micronaut.context.event.BeanInitializingEvent;
+import io.micronaut.context.exceptions.BeanContextException;
+import io.micronaut.context.exceptions.BeanInstantiationException;
+import io.micronaut.context.exceptions.DependencyInjectionException;
+import io.micronaut.context.exceptions.DisabledBeanException;
+import io.micronaut.context.exceptions.NoSuchBeanException;
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.AnnotationUtil;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.annotation.UsedByGeneratedCode;
+import io.micronaut.core.bind.annotation.Bindable;
+import io.micronaut.core.convert.ArgumentConversionContext;
+import io.micronaut.core.convert.ConversionContext;
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.naming.Named;
+import io.micronaut.core.reflect.ClassUtils;
+import io.micronaut.core.reflect.ReflectionUtils;
+import io.micronaut.core.type.Argument;
+import io.micronaut.core.type.DefaultArgument;
+import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.core.value.PropertyResolver;
+import io.micronaut.inject.BeanDefinition;
+import io.micronaut.inject.ConstructorInjectionPoint;
+import io.micronaut.inject.ExecutableMethod;
+import io.micronaut.inject.ExecutableMethodsDefinition;
+import io.micronaut.inject.FieldInjectionPoint;
+import io.micronaut.inject.MethodInjectionPoint;
+import io.micronaut.inject.ValidatedBeanDefinition;
+import io.micronaut.inject.annotation.AbstractEnvironmentAnnotationMetadata;
+import io.micronaut.inject.qualifiers.InterceptorBindingQualifier;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import io.micronaut.inject.qualifiers.TypeAnnotationQualifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+/**
+ * <p>Default implementation of the {@link BeanDefinition} interface. This class is generally not used directly in user
+ * code.
+ * Instead a build time tool does analysis of source code and dynamically produces subclasses of this class containing
+ * information about the available injection points for a given class.</p>
+ * <p>
+ * <p>For technical reasons the class has to be marked as public, but is regarded as internal and should be used by
+ * compiler tools and plugins (such as AST transformation frameworks)</p>
+ * <p>
+ * <p>The {@link io.micronaut.inject.writer.BeanDefinitionWriter} class can be used to produce bean definitions at
+ * compile or runtime</p>
+ *
+ * @param <T> The Bean definition type
+ * @author Graeme Rocher
+ * @author Denis Stepanov
+ * @see io.micronaut.inject.writer.BeanDefinitionWriter
+ * @since 3.0
+ */
+@Internal
+public class AbstractBeanDefinition2<T> extends AbstractBeanContextConditional implements BeanDefinition<T>, EnvironmentConfigurable {
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractBeanDefinition2.class);
+    private static final String NAMED_ATTRIBUTE = Named.class.getName();
+
+    private final Class<T> type;
+    private final AnnotationMetadata annotationMetadata;
+    private final Optional<String> scope;
+    private final boolean isProvided;
+    private final boolean isIterable;
+    private final boolean isSingleton;
+    private final boolean isPrimary;
+    private final boolean isAbstract;
+    private final boolean isConfigurationProperties;
+    private final boolean hasExposedTypes;
+    private final boolean requiresMethodProcessing;
+    @Nullable
+    private final MethodOrFieldReference constructor;
+    @Nullable
+    private final MethodReference[] methodInjection;
+    @Nullable
+    private final FieldReference[] fieldInjection;
+    @Nullable
+    private final ExecutableMethodsDefinition<T> executableMethodsDefinition;
+    @Nullable
+    private final Map<String, Argument<?>[]> typeArgumentsMap;
+    @Nullable
+    private Environment environment;
+    private Set<Class<?>> exposedTypes;
+    private Optional<Argument<?>> containerElement;
+
+    @Nullable
+    private ConstructorInjectionPoint<T> constructorInjectionPoint;
+    @Nullable
+    private List<MethodInjectionPoint<T, ?>> methodInjectionPoints;
+    @Nullable
+    private List<FieldInjectionPoint<T, ?>> fieldInjectionPoints;
+    @Nullable
+    private List<MethodInjectionPoint<T, ?>> postConstructMethods;
+    @Nullable
+    private List<MethodInjectionPoint<T, ?>> preDestroyMethods;
+    @Nullable
+    private Collection<Class<?>> requiredComponents;
+    @Nullable
+    private Argument<?>[] requiredParametrizedArguments;
+
+    @SuppressWarnings("ParameterNumber")
+    @Internal
+    @UsedByGeneratedCode
+    protected AbstractBeanDefinition2(
+            Class<T> beanType,
+            @Nullable MethodOrFieldReference constructor,
+            @Nullable AnnotationMetadata annotationMetadata,
+            @Nullable MethodReference[] methodInjection,
+            @Nullable FieldReference[] fieldInjection,
+            @Nullable ExecutableMethodsDefinition<T> executableMethodsDefinition,
+            @Nullable Map<String, Argument<?>[]> typeArgumentsMap,
+            Optional<String> scope,
+            boolean isAbstract,
+            boolean isProvided,
+            boolean isIterable,
+            boolean isSingleton,
+            boolean isPrimary,
+            boolean isConfigurationProperties,
+            boolean hasExposedTypes,
+            boolean requiresMethodProcessing) {
+        this.scope = scope;
+        this.type = beanType;
+        if (annotationMetadata == null || annotationMetadata == AnnotationMetadata.EMPTY_METADATA) {
+            this.annotationMetadata = AnnotationMetadata.EMPTY_METADATA;
+        } else {
+            if (annotationMetadata.hasPropertyExpressions()) {
+                // we make a copy of the result of annotation metadata which is normally a reference
+                // to the class metadata
+                this.annotationMetadata = new BeanAnnotationMetadata(annotationMetadata);
+            } else {
+                this.annotationMetadata = annotationMetadata;
+            }
+        }
+        this.isProvided = isProvided;
+        this.isIterable = isIterable;
+        this.isSingleton = isSingleton;
+        this.isPrimary = isPrimary;
+        this.isAbstract = isAbstract;
+        this.constructor = constructor;
+        this.methodInjection = methodInjection;
+        this.fieldInjection = fieldInjection;
+        this.executableMethodsDefinition = executableMethodsDefinition;
+        this.typeArgumentsMap = typeArgumentsMap;
+        this.isConfigurationProperties = isConfigurationProperties;
+        this.hasExposedTypes = hasExposedTypes;
+        this.requiresMethodProcessing = requiresMethodProcessing;
+        Optional<Argument<?>> containerElement = Optional.empty();
+        if (isContainerType()) {
+            final List<Argument<?>> iterableArguments = getTypeArguments(Iterable.class);
+            if (!iterableArguments.isEmpty()) {
+                containerElement = Optional.of(iterableArguments.iterator().next());
+            }
+        }
+        this.containerElement = containerElement;
+    }
+
+    @Override
+    public Optional<Argument<?>> getContainerElement() {
+        return containerElement;
+    }
+
+    @Override
+    public final boolean hasPropertyExpressions() {
+        return getAnnotationMetadata().hasPropertyExpressions();
+    }
+
+    @Override
+    public @NonNull
+    List<Argument<?>> getTypeArguments(String type) {
+        if (type == null || typeArgumentsMap == null) {
+            return Collections.emptyList();
+        }
+        Argument<?>[] arguments = typeArgumentsMap.get(type);
+        if (arguments != null) {
+            return Arrays.asList(arguments);
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    @NonNull
+    public AnnotationMetadata getAnnotationMetadata() {
+        return annotationMetadata;
+    }
+
+    @Override
+    public boolean isAbstract() {
+        return isAbstract;
+    }
+
+    @Override
+    public boolean isIterable() {
+        return isIterable;
+    }
+
+    @Override
+    public boolean isPrimary() {
+        return isPrimary;
+    }
+
+    @Override
+    public boolean isProvided() {
+        return isProvided;
+    }
+
+    @Override
+    public boolean requiresMethodProcessing() {
+        return requiresMethodProcessing;
+    }
+
+    @Override
+    public <R> Optional<ExecutableMethod<T, R>> findMethod(String name, Class<?>... argumentTypes) {
+        if (executableMethodsDefinition == null) {
+            return Optional.empty();
+        }
+        return executableMethodsDefinition.findMethod(name, argumentTypes);
+    }
+
+    @Override
+    public <R> Stream<ExecutableMethod<T, R>> findPossibleMethods(String name) {
+        if (executableMethodsDefinition == null) {
+            return Stream.empty();
+        }
+        return executableMethodsDefinition.findPossibleMethods(name);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        return o != null && getClass() == o.getClass();
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
+
+    @Override
+    public String toString() {
+        Class declaringType = constructor == null ? type : constructor.declaringType;
+        return "Definition: " + declaringType.getName();
+    }
+
+    @Override
+    public boolean isSingleton() {
+        return isSingleton;
+    }
+
+    @Override
+    public Optional<Class<? extends Annotation>> getScope() {
+        return scope.flatMap(scopeClassName -> (Optional) ClassUtils.forName(scopeClassName, getClass().getClassLoader()));
+    }
+
+    @Override
+    public Optional<String> getScopeName() {
+        return scope;
+    }
+
+    @Override
+    public final Class<T> getBeanType() {
+        return type;
+    }
+
+    @Override
+    @NonNull
+    public final Set<Class<?>> getExposedTypes() {
+        if (!hasExposedTypes) {
+            return Collections.EMPTY_SET;
+        }
+        if (this.exposedTypes == null) {
+            this.exposedTypes = BeanDefinition.super.getExposedTypes();
+        }
+        return this.exposedTypes;
+    }
+
+    @Override
+    public final Optional<Class<?>> getDeclaringType() {
+        if (constructor == null) {
+            return Optional.of(type);
+        }
+        return Optional.of(constructor.declaringType);
+    }
+
+    @Override
+    public final ConstructorInjectionPoint<T> getConstructor() {
+        if (constructor == null) {
+            constructorInjectionPoint = null;
+        } else {
+            if (constructor instanceof MethodReference) {
+                MethodReference methodConstructor = (MethodReference) constructor;
+                if ("<init>".equals(methodConstructor.methodName)) {
+                    if (methodConstructor.requiresReflection) {
+                        this.constructorInjectionPoint = new ReflectionConstructorInjectionPoint<>(
+                                this,
+                                methodConstructor.declaringType,
+                                methodConstructor.annotationMetadata,
+                                methodConstructor.arguments);
+                    } else {
+                        this.constructorInjectionPoint = new DefaultConstructorInjectionPoint<>(
+                                this,
+                                methodConstructor.declaringType,
+                                methodConstructor.annotationMetadata,
+                                methodConstructor.arguments
+                        );
+                    }
+                } else {
+                    if (methodConstructor.requiresReflection) {
+                        this.constructorInjectionPoint = new ReflectionMethodConstructorInjectionPoint(
+                                this,
+                                methodConstructor.declaringType,
+                                methodConstructor.methodName,
+                                methodConstructor.arguments,
+                                methodConstructor.annotationMetadata
+                        );
+                    } else {
+                        this.constructorInjectionPoint = new DefaultMethodConstructorInjectionPoint(
+                                this,
+                                methodConstructor.declaringType,
+                                methodConstructor.methodName,
+                                methodConstructor.arguments,
+                                methodConstructor.annotationMetadata
+                        );
+                    }
+                }
+            } else if (constructor instanceof FieldReference) {
+                FieldReference fieldConstructor = (FieldReference) constructor;
+                constructorInjectionPoint = new DefaultFieldConstructorInjectionPoint<>(
+                        this,
+                        fieldConstructor.declaringType,
+                        type,
+                        fieldConstructor.argument.getName(),
+                        fieldConstructor.argument.getAnnotationMetadata()
+                );
+            }
+            if (environment != null && constructorInjectionPoint instanceof EnvironmentConfigurable) {
+                ((EnvironmentConfigurable) constructorInjectionPoint).configure(environment);
+            }
+        }
+        return constructorInjectionPoint;
+    }
+
+    @Override
+    public Collection<Class<?>> getRequiredComponents() {
+        if (requiredComponents != null) {
+            return requiredComponents;
+        }
+        Set<Class<?>> requiredComponents = new HashSet<>();
+        Consumer<Argument> argumentConsumer = argument -> {
+            if (argument.isContainerType() || argument.isProvider()) {
+                argument.getFirstTypeVariable()
+                        .map(Argument::getType)
+                        .ifPresent(requiredComponents::add);
+            } else {
+                requiredComponents.add(argument.getType());
+            }
+        };
+        if (constructor != null) {
+            if (constructor instanceof MethodReference) {
+                MethodReference methodConstructor = (MethodReference) constructor;
+                if (methodConstructor.arguments != null && methodConstructor.arguments.length > 0) {
+                    for (Argument<?> argument : methodConstructor.arguments) {
+                        argumentConsumer.accept(argument);
+                    }
+                }
+            }
+        }
+        if (methodInjection != null) {
+            for (MethodReference methodReference : methodInjection) {
+                if (methodReference.arguments != null && methodReference.arguments.length > 0) {
+                    for (Argument<?> argument : methodReference.arguments) {
+                        argumentConsumer.accept(argument);
+                    }
+                }
+            }
+        }
+        if (fieldInjection != null) {
+            for (FieldReference fieldReference : fieldInjection) {
+                if (annotationMetadata != null && annotationMetadata.hasDeclaredAnnotation(AnnotationUtil.INJECT)) {
+                    argumentConsumer.accept(fieldReference.argument);
+                }
+            }
+        }
+        this.requiredComponents = Collections.unmodifiableSet(requiredComponents);
+        return this.requiredComponents;
+    }
+
+    @Override
+    public final List<MethodInjectionPoint<T, ?>> getInjectedMethods() {
+        if (methodInjection == null) {
+            return Collections.emptyList();
+        }
+        if (methodInjectionPoints != null) {
+            return methodInjectionPoints;
+        }
+        List<MethodInjectionPoint<T, ?>> methodInjectionPoints = new ArrayList<>(methodInjection.length);
+        for (MethodReference methodReference : methodInjection) {
+            MethodInjectionPoint<T, ?> methodInjectionPoint;
+            if (methodReference.requiresReflection) {
+                methodInjectionPoint = new ReflectionMethodInjectionPoint(
+                        this,
+                        methodReference.declaringType,
+                        methodReference.methodName,
+                        methodReference.arguments,
+                        methodReference.annotationMetadata
+                );
+            } else {
+                methodInjectionPoint = new DefaultMethodInjectionPoint<>(
+                        this,
+                        methodReference.declaringType,
+                        methodReference.methodName,
+                        methodReference.arguments,
+                        methodReference.annotationMetadata
+                );
+            }
+            methodInjectionPoints.add(methodInjectionPoint);
+            if (environment != null) {
+                ((EnvironmentConfigurable) methodInjectionPoint).configure(environment);
+            }
+        }
+        this.methodInjectionPoints = Collections.unmodifiableList(methodInjectionPoints);
+        return this.methodInjectionPoints;
+    }
+
+    @Override
+    public final List<FieldInjectionPoint<T, ?>> getInjectedFields() {
+        if (fieldInjection == null) {
+            return Collections.emptyList();
+        }
+        if (fieldInjectionPoints != null) {
+            return fieldInjectionPoints;
+        }
+        List<FieldInjectionPoint<T, ?>> fieldInjectionPoints = new ArrayList<>(fieldInjection.length);
+        for (FieldReference fieldReference : fieldInjection) {
+            FieldInjectionPoint<T, ?> fieldInjectionPoint;
+            if (fieldReference.requiresReflection) {
+                fieldInjectionPoint = new ReflectionFieldInjectionPoint<>(
+                        this,
+                        fieldReference.declaringType,
+                        fieldReference.argument.getType(),
+                        fieldReference.argument.getName(),
+                        fieldReference.argument.getAnnotationMetadata(),
+                        fieldReference.argument.getTypeParameters()
+                );
+            } else {
+                fieldInjectionPoint = new DefaultFieldInjectionPoint<>(
+                        this,
+                        fieldReference.declaringType,
+                        fieldReference.argument.getType(),
+                        fieldReference.argument.getName(),
+                        fieldReference.argument.getAnnotationMetadata(),
+                        fieldReference.argument.getTypeParameters()
+                );
+            }
+            if (environment != null) {
+                ((EnvironmentConfigurable) fieldInjectionPoint).configure(environment);
+            }
+            fieldInjectionPoints.add(fieldInjectionPoint);
+        }
+        this.fieldInjectionPoints = Collections.unmodifiableList(fieldInjectionPoints);
+        return this.fieldInjectionPoints;
+    }
+
+    @Override
+    public final List<MethodInjectionPoint<T, ?>> getPostConstructMethods() {
+        if (methodInjection == null) {
+            return Collections.emptyList();
+        }
+        if (postConstructMethods != null) {
+            return postConstructMethods;
+        }
+        List<MethodInjectionPoint<T, ?>> postConstructMethods = new ArrayList<>(1);
+        for (MethodInjectionPoint<T, ?> methodInjectionPoint : getInjectedMethods()) {
+            if (methodInjectionPoint.isPostConstructMethod()) {
+                postConstructMethods.add(methodInjectionPoint);
+            }
+        }
+        this.postConstructMethods = Collections.unmodifiableList(postConstructMethods);
+        return this.postConstructMethods;
+    }
+
+    @Override
+    public final List<MethodInjectionPoint<T, ?>> getPreDestroyMethods() {
+        if (methodInjection == null) {
+            return Collections.emptyList();
+        }
+        if (preDestroyMethods != null) {
+            return preDestroyMethods;
+        }
+        List<MethodInjectionPoint<T, ?>> preDestroyMethods = new ArrayList<>(1);
+        for (MethodInjectionPoint<T, ?> methodInjectionPoint : getInjectedMethods()) {
+            if (methodInjectionPoint.isPreDestroyMethod()) {
+                preDestroyMethods.add(methodInjectionPoint);
+            }
+        }
+        this.preDestroyMethods = Collections.unmodifiableList(preDestroyMethods);
+        return this.preDestroyMethods;
+    }
+
+    @Override
+    @NonNull
+    public String getName() {
+        return getBeanType().getName();
+    }
+
+    @Override
+    public T inject(BeanContext context, T bean) {
+        return (T) injectBean(new DefaultBeanResolutionContext(context, this), context, bean);
+    }
+
+    @Override
+    public T inject(BeanResolutionContext resolutionContext, BeanContext context, T bean) {
+        return (T) injectBean(resolutionContext, context, bean);
+    }
+
+    @Override
+    public Collection<ExecutableMethod<T, ?>> getExecutableMethods() {
+        if (executableMethodsDefinition == null) {
+            return Collections.emptyList();
+        }
+        return executableMethodsDefinition.getExecutableMethods();
+    }
+
+    /**
+     * Configures the bean for the given {@link BeanContext}. If the context features an
+     * {@link Environment} this method configures the annotation metadata such that
+     * environment aware values are returned.
+     *
+     * @param environment The environment
+     */
+    @Internal
+    @Override
+    public final void configure(Environment environment) {
+        if (environment != null) {
+            this.environment = environment;
+            if (constructorInjectionPoint instanceof EnvironmentConfigurable) {
+                ((EnvironmentConfigurable) constructorInjectionPoint).configure(environment);
+            }
+            if (methodInjectionPoints != null) {
+                for (MethodInjectionPoint<T, ?> methodInjectionPoint : methodInjectionPoints) {
+                    if (methodInjectionPoint instanceof EnvironmentConfigurable) {
+                        ((EnvironmentConfigurable) methodInjectionPoint).configure(environment);
+                    }
+                }
+            }
+            if (fieldInjectionPoints != null) {
+                for (FieldInjectionPoint<T, ?> fieldInjectionPoint : fieldInjectionPoints) {
+                    if (fieldInjectionPoint instanceof EnvironmentConfigurable) {
+                        ((EnvironmentConfigurable) fieldInjectionPoint).configure(environment);
+                    }
+                }
+            }
+            if (executableMethodsDefinition instanceof EnvironmentConfigurable) {
+                ((EnvironmentConfigurable) executableMethodsDefinition).configure(environment);
+            }
+        }
+    }
+
+    /**
+     * Allows printing warning messages produced by the compiler.
+     *
+     * @param message The message
+     */
+    @Internal
+    protected final void warn(String message) {
+        if (LOG.isWarnEnabled()) {
+            LOG.warn(message);
+        }
+    }
+
+    /**
+     * Allows printing warning messages produced by the compiler.
+     *
+     * @param type     The type
+     * @param method   The method
+     * @param property The property
+     */
+    @SuppressWarnings("unused")
+    @Internal
+    protected final void warnMissingProperty(Class type, String method, String property) {
+        if (LOG.isWarnEnabled()) {
+            LOG.warn("Configuration property [{}] could not be set as the underlying method [{}] does not exist on builder [{}]. This usually indicates the configuration option was deprecated and has been removed by the builder implementation (potentially a third-party library).", property, method, type);
+        }
+    }
+
+    /**
+     * Resolves the proxied bean instance for this bean.
+     *
+     * @param beanContext The {@link BeanContext}
+     * @return The proxied bean
+     */
+    @SuppressWarnings({"unchecked", "unused"})
+    @Internal
+    protected final Object getProxiedBean(BeanContext beanContext) {
+        DefaultBeanContext defaultBeanContext = (DefaultBeanContext) beanContext;
+        Optional<String> qualifier = getAnnotationMetadata().getAnnotationNameByStereotype(AnnotationUtil.QUALIFIER);
+        return defaultBeanContext.getProxyTargetBean(
+                getBeanType(),
+                (Qualifier<T>) qualifier.map(q -> Qualifiers.byAnnotation(getAnnotationMetadata(), q)).orElse(null)
+        );
+    }
+
+    /**
+     * Implementing possible {@link io.micronaut.inject.ParametrizedBeanFactory#getRequiredArguments()}.
+     *
+     * @return The arguments required to construct parametrized bean
+     */
+    public final Argument<?>[] getRequiredArguments() {
+        if (requiredParametrizedArguments != null) {
+            return requiredParametrizedArguments;
+        }
+        requiredParametrizedArguments = Arrays.stream(getConstructor().getArguments())
+                .filter(arg -> {
+                    Optional<String> qualifierType = arg.getAnnotationMetadata().getAnnotationNameByStereotype(AnnotationUtil.QUALIFIER);
+                    return qualifierType.isPresent() && qualifierType.get().equals(Parameter.class.getName());
+                })
+                .toArray(Argument[]::new);
+        return requiredParametrizedArguments;
+    }
+
+    /**
+     * Implementing possible {@link io.micronaut.inject.ParametrizedBeanFactory#build(BeanResolutionContext, BeanContext, BeanDefinition)}.
+     *
+     * @param resolutionContext      The {@link BeanResolutionContext}
+     * @param context                The {@link BeanContext}
+     * @param definition             The {@link BeanDefinition}
+     * @param requiredArgumentValues The required arguments values. The keys should match the names of the arguments
+     *                               returned by {@link #getRequiredArguments()}
+     * @return The instantiated bean
+     * @throws BeanInstantiationException If the bean cannot be instantiated for the arguments supplied
+     */
+    public final T build(BeanResolutionContext resolutionContext,
+                         BeanContext context,
+                         BeanDefinition<T> definition,
+                         Map<String, Object> requiredArgumentValues) throws BeanInstantiationException {
+
+        requiredArgumentValues = requiredArgumentValues != null ? new LinkedHashMap<>(requiredArgumentValues) : Collections.emptyMap();
+        Optional<Class> eachBeanType = null;
+        for (Argument<?> requiredArgument : getRequiredArguments()) {
+            try (BeanResolutionContext.Path ignored = resolutionContext.getPath().pushConstructorResolve(this, requiredArgument)) {
+                String argumentName = requiredArgument.getName();
+                Object value = requiredArgumentValues.get(argumentName);
+                if (value == null && !requiredArgument.isNullable()) {
+                    if (eachBeanType == null) {
+                        eachBeanType = definition.classValue(EachBean.class);
+                    }
+                    if (eachBeanType.filter(type -> type == requiredArgument.getType()).isPresent()) {
+                        throw new DisabledBeanException("@EachBean parameter disabled for argument: " + requiredArgument.getName());
+                    }
+                    throw new BeanInstantiationException(resolutionContext, "Missing bean argument value: " + argumentName);
+                }
+                boolean requiresConversion = value != null && !requiredArgument.getType().isInstance(value);
+                if (requiresConversion) {
+                    Optional<?> converted = ConversionService.SHARED.convert(value, requiredArgument.getType(), ConversionContext.of(requiredArgument));
+                    Object finalValue = value;
+                    value = converted.orElseThrow(() -> new BeanInstantiationException(resolutionContext, "Invalid value [" + finalValue + "] for argument: " + argumentName));
+                    requiredArgumentValues.put(argumentName, value);
+                }
+            }
+        }
+        return doBuild(resolutionContext, context, definition, requiredArgumentValues);
+    }
+
+    /**
+     * Method to be implemented by the generated code if the bean definition is implementing {@link io.micronaut.inject.ParametrizedBeanFactory}.
+     *
+     * @param resolutionContext      The resolution context
+     * @param context                The bean context
+     * @param definition             The bean definition
+     * @param requiredArgumentValues The required arguments
+     * @return The built instance
+     */
+    @Internal
+    @UsedByGeneratedCode
+    protected T doBuild(BeanResolutionContext resolutionContext, BeanContext context, BeanDefinition<T> definition, Map<String, Object> requiredArgumentValues) {
+        throw new IllegalStateException("Method must be implemented for 'ParametrizedBeanFactory' instance!");
+    }
+
+    /**
+     * The default implementation which provides no injection. To be overridden by compile time tooling.
+     *
+     * @param resolutionContext The resolution context
+     * @param context           The bean context
+     * @param bean              The bean
+     * @return The injected bean
+     */
+    @Internal
+    @SuppressWarnings({"WeakerAccess", "unused"})
+    @UsedByGeneratedCode
+    protected Object injectBean(BeanResolutionContext resolutionContext, BeanContext context, Object bean) {
+        return bean;
+    }
+
+    /**
+     * Inject another bean, for example one created via factory.
+     *
+     * @param resolutionContext The reslution context
+     * @param context           The context
+     * @param bean              The bean
+     * @return The bean
+     */
+    @Internal
+    @SuppressWarnings({"unused"})
+    @UsedByGeneratedCode
+    protected Object injectAnother(BeanResolutionContext resolutionContext, BeanContext context, Object bean) {
+        if (bean == null) {
+            throw new BeanInstantiationException(resolutionContext, "Bean factory returned null");
+        }
+        DefaultBeanContext defaultContext = (DefaultBeanContext) context;
+        return defaultContext.inject(resolutionContext, this, bean);
+    }
+
+    /**
+     * Default postConstruct hook that only invokes methods that require reflection. Generated subclasses should
+     * override to call methods that don't require reflection.
+     *
+     * @param resolutionContext The resolution hook
+     * @param context           The context
+     * @param bean              The bean
+     * @return The bean
+     */
+    @SuppressWarnings({"unused", "unchecked"})
+    @Internal
+    @UsedByGeneratedCode
+    protected Object postConstruct(BeanResolutionContext resolutionContext, BeanContext context, Object bean) {
+        final Set<Map.Entry<Class, List<BeanInitializedEventListener>>> beanInitializedEventListeners
+                = ((DefaultBeanContext) context).beanInitializedEventListeners;
+        if (CollectionUtils.isNotEmpty(beanInitializedEventListeners)) {
+            for (Map.Entry<Class, List<BeanInitializedEventListener>> entry : beanInitializedEventListeners) {
+                if (entry.getKey().isAssignableFrom(getBeanType())) {
+                    for (BeanInitializedEventListener listener : entry.getValue()) {
+                        bean = listener.onInitialized(new BeanInitializingEvent(context, this, bean));
+                        if (bean == null) {
+                            throw new BeanInstantiationException(resolutionContext, "Listener [" + listener + "] returned null from onInitialized event");
+                        }
+                    }
+                }
+            }
+        }
+        if (bean instanceof LifeCycle) {
+            bean = ((LifeCycle) bean).start();
+        }
+        return bean;
+    }
+
+    /**
+     * Default preDestroy hook that only invokes methods that require reflection. Generated subclasses should override
+     * to call methods that don't require reflection.
+     *
+     * @param resolutionContext The resolution hook
+     * @param context           The context
+     * @param bean              The bean
+     * @return The bean
+     */
+    @Internal
+    @UsedByGeneratedCode
+    protected Object preDestroy(BeanResolutionContext resolutionContext, BeanContext context, Object bean) {
+        if (bean instanceof LifeCycle) {
+            bean = ((LifeCycle) bean).stop();
+        }
+        return bean;
+    }
+
+    /**
+     * Check if the class is an inner configuration.
+     *
+     * @param clazz The class to check
+     * @return true if the inner configuration
+     */
+    @Internal
+    @UsedByGeneratedCode
+    protected boolean isInnerConfiguration(Class<?> clazz) {
+        return false;
+    }
+
+    /**
+     * Invoke a bean method that requires reflection.
+     *
+     * @param resolutionContext The resolution context
+     * @param context           The bean context
+     * @param methodIndex       The method index
+     * @param bean              The bean
+     * @param methodArgs        The method args
+     */
+    @Internal
+    @SuppressWarnings("WeakerAccess")
+    protected final void invokeMethodWithReflection(BeanResolutionContext resolutionContext, BeanContext context, int methodIndex, Object bean, Object[] methodArgs) {
+        MethodReference methodRef = methodInjection[methodIndex];
+        Argument[] methodArgumentTypes = methodRef.arguments == null ? Argument.ZERO_ARGUMENTS : methodRef.arguments;
+        if (ClassUtils.REFLECTION_LOGGER.isDebugEnabled()) {
+            ClassUtils.REFLECTION_LOGGER.debug("Bean of type [" + getBeanType() + "] uses reflection to inject method: '" + methodRef.methodName + "'");
+        }
+        try {
+            Method method = ReflectionUtils.getMethod(
+                    methodRef.declaringType,
+                    methodRef.methodName,
+                    Argument.toClassArray(methodArgumentTypes)
+            ).orElseThrow(() -> ReflectionUtils.newNoSuchMethodError(methodRef.declaringType, methodRef.methodName, Argument.toClassArray(methodArgumentTypes)));
+            method.setAccessible(true);
+            ReflectionUtils.invokeMethod(bean, method, methodArgs);
+        } catch (Throwable e) {
+            if (e instanceof BeanContextException) {
+                throw (BeanContextException) e;
+            } else {
+                throw new DependencyInjectionException(resolutionContext, "Error invoking method: " + methodRef.methodName, e);
+            }
+        }
+    }
+
+    /**
+     * Sets the value of a field of a object that requires reflection.
+     *
+     * @param resolutionContext The resolution context
+     * @param context           The object context
+     * @param index             The index of the field
+     * @param object            The object whose field should be modifie
+     * @param value             The instance being set
+     */
+    @SuppressWarnings("unused")
+    @Internal
+    protected final void setFieldWithReflection(BeanResolutionContext resolutionContext, BeanContext context, int index, Object object, Object value) {
+        FieldReference fieldRef = fieldInjection[index];
+        try {
+            if (ClassUtils.REFLECTION_LOGGER.isDebugEnabled()) {
+                ClassUtils.REFLECTION_LOGGER.debug("Bean of type [" + getBeanType() + "] uses reflection to inject field: '" + fieldRef.argument.getName() + "'");
+            }
+            Field field = ReflectionUtils.getRequiredField(fieldRef.declaringType, fieldRef.argument.getName());
+            field.setAccessible(true);
+            field.set(object, value);
+        } catch (Throwable e) {
+            if (e instanceof BeanContextException) {
+                throw (BeanContextException) e;
+            } else {
+                throw new DependencyInjectionException(resolutionContext, "Error setting field value: " + e.getMessage(), e);
+            }
+        }
+    }
+
+    /**
+     * Obtains a value for the given method argument.
+     *
+     * @param resolutionContext The resolution context
+     * @param context           The bean context
+     * @param methodIndex       The method index
+     * @param argIndex          The argument index
+     * @param qualifier         The qualifier
+     * @return The value
+     */
+    @SuppressWarnings({"unused", "unchecked"})
+    @Internal
+    protected final Object getValueForMethodArgument(BeanResolutionContext resolutionContext, BeanContext context, int methodIndex, int argIndex, Qualifier qualifier) {
+        MethodReference methodRef = methodInjection[methodIndex];
+        Argument argument = methodRef.arguments[argIndex];
+        try (BeanResolutionContext.Path ignored = resolutionContext.getPath()
+                .pushMethodArgumentResolve(this, methodRef.methodName, argument, methodRef.arguments, methodRef.requiresReflection)) {
+            return resolveValue(resolutionContext, context, methodRef.annotationMetadata, argument, qualifier);
+        }
+    }
+
+    /**
+     * Obtains a value for the given method argument.
+     *
+     * @param resolutionContext The resolution context
+     * @param context           The bean context
+     * @param methodIndex       The method index
+     * @param argIndex          The argument index
+     * @param isValuePrefix     Is value prefix in cases when beans are requested
+     * @return The value
+     */
+    @Internal
+    @UsedByGeneratedCode
+    protected final boolean containsValueForMethodArgument(BeanResolutionContext resolutionContext, BeanContext context, int methodIndex, int argIndex, boolean isValuePrefix) {
+        MethodReference methodRef = methodInjection[methodIndex];
+        AnnotationMetadata parentAnnotationMetadata = methodRef.annotationMetadata;
+        Argument argument = methodRef.arguments[argIndex];
+        return resolveContainsValue(resolutionContext, context, parentAnnotationMetadata, argument, isValuePrefix);
+    }
+
+    /**
+     * Obtains a bean definition for the method at the given index and the argument at the given index
+     * <p>
+     * Warning: this method is used by internal generated code and should not be called by user code.
+     *
+     * @param resolutionContext The resolution context
+     * @param context           The context
+     * @param methodIndex       The method index
+     * @param argIndex          The argument index
+     * @param qualifier         The qualifier
+     * @return The resolved bean
+     */
+    @Internal
+    @SuppressWarnings("WeakerAccess")
+    @UsedByGeneratedCode
+    protected final Object getBeanForMethodArgument(BeanResolutionContext resolutionContext, BeanContext context, int methodIndex, int argIndex, Qualifier qualifier) {
+        MethodReference methodRef = methodInjection[methodIndex];
+        Argument argument = resolveArgument(context, argIndex, methodRef.arguments);
+        try (BeanResolutionContext.Path ignored = resolutionContext.getPath()
+                .pushMethodArgumentResolve(this, methodRef.methodName, argument, methodRef.arguments, methodRef.requiresReflection)) {
+            return resolveBean(resolutionContext, context, argument, qualifier);
+        }
+    }
+
+    /**
+     * Obtains all bean definitions for a method argument at the given index.
+     * <p>
+     *
+     * @param resolutionContext The resolution context
+     * @param context           The context
+     * @param methodIndex       The method index
+     * @param argumentIndex     The argument index
+     * @param genericType       The generic type
+     * @param qualifier         The qualifier
+     * @return The resolved bean
+     */
+    @Internal
+    @UsedByGeneratedCode
+    protected final Collection<Object> getBeansOfTypeForMethodArgument(BeanResolutionContext resolutionContext, BeanContext context, int methodIndex, int argumentIndex, Argument genericType, Qualifier qualifier) {
+        MethodReference methodRef = methodInjection[methodIndex];
+        Argument argument = resolveArgument(context, argumentIndex, methodRef.arguments);
+        try (BeanResolutionContext.Path ignored =
+                     resolutionContext.getPath().pushMethodArgumentResolve(this, methodRef.methodName, argument, methodRef.arguments, methodRef.requiresReflection)) {
+            return resolveBeansOfType(resolutionContext, context, argument, resolveEnvironmentArgument(context, genericType), qualifier);
+        }
+    }
+
+    /**
+     * Obtains an optional bean for the method at the given index and the argument at the given index
+     * <p>
+     * Warning: this method is used by internal generated code and should not be called by user code.
+     *
+     * @param resolutionContext The resolution context
+     * @param context           The context
+     * @param methodIndex       The method index
+     * @param argIndex          The argument index
+     * @param genericType       The generic type
+     * @param qualifier         The qualifier
+     * @return The resolved bean
+     */
+    @Internal
+    @UsedByGeneratedCode
+    protected final Optional findBeanForMethodArgument(BeanResolutionContext resolutionContext, BeanContext context, int methodIndex, int argIndex, Argument genericType, Qualifier qualifier) {
+        MethodReference methodRef = methodInjection[methodIndex];
+        Argument<?> argument = resolveArgument(context, argIndex, methodRef.arguments);
+        try (BeanResolutionContext.Path ignored =
+                     resolutionContext.getPath().pushMethodArgumentResolve(this, methodRef.methodName, argument, methodRef.arguments, methodRef.requiresReflection)) {
+            return resolveOptionalBean(resolutionContext, context, argument, resolveEnvironmentArgument(context, genericType), qualifier);
+        }
+    }
+
+    /**
+     * Obtains all bean definitions for the method at the given index and the argument at the given index
+     * <p>
+     * Warning: this method is used by internal generated code and should not be called by user code.
+     *
+     * @param resolutionContext The resolution context
+     * @param context           The context
+     * @param methodIndex       The method index
+     * @param argIndex          The argument index
+     * @param genericType       The generic type
+     * @param qualifier         The qualifier
+     * @return The resolved bean
+     */
+    @Internal
+    @UsedByGeneratedCode
+    protected final Stream<?> getStreamOfTypeForMethodArgument(BeanResolutionContext resolutionContext, BeanContext context, int methodIndex, int argIndex, Argument genericType, Qualifier qualifier) {
+        MethodReference methodRef = methodInjection[methodIndex];
+        Argument<?> argument = resolveArgument(context, argIndex, methodRef.arguments);
+        try (BeanResolutionContext.Path ignored =
+                     resolutionContext.getPath().pushMethodArgumentResolve(this, methodRef.methodName, argument, methodRef.arguments, methodRef.requiresReflection)) {
+            return resolveStreamOfType(resolutionContext, context, argument, resolveEnvironmentArgument(context, genericType), qualifier);
+        }
+    }
+
+    /**
+     * Obtains a bean definition for a constructor at the given index
+     * <p>
+     * Warning: this method is used by internal generated code and should not be called by user code.
+     *
+     * @param resolutionContext The resolution context
+     * @param context           The context
+     * @param argIndex          The argument index
+     * @param qualifier         The qualifier
+     * @return The resolved bean
+     */
+    @Internal
+    @UsedByGeneratedCode
+    protected final Object getBeanForConstructorArgument(BeanResolutionContext resolutionContext, BeanContext context, int argIndex, Qualifier qualifier) {
+        MethodReference constructorMethodRef = (MethodReference) constructor;
+        Argument<?> argument = resolveArgument(context, argIndex, constructorMethodRef.arguments);
+        if (argument.isDeclaredNullable()) {
+            BeanResolutionContext.Segment current = resolutionContext.getPath().peek();
+            if (current != null && current.getArgument().equals(argument)) {
+                return null;
+            }
+        }
+        try (BeanResolutionContext.Path ignored = resolutionContext.getPath()
+                .pushConstructorResolve(this, argument)) {
+            return resolveBean(resolutionContext, context, argument, qualifier, true);
+        }
+    }
+
+    /**
+     * Obtains a value for a bean definition for a constructor at the given index
+     * <p>
+     * Warning: this method is used by internal generated code and should not be called by user code.
+     *
+     * @param resolutionContext The resolution context
+     * @param context           The context
+     * @param argIndex          The argument index
+     * @param qualifier         The qualifier
+     * @return The resolved bean
+     */
+    @Internal
+    @UsedByGeneratedCode
+    protected final Object getValueForConstructorArgument(BeanResolutionContext resolutionContext, BeanContext context, int argIndex, Qualifier qualifier) {
+        MethodReference constructorRef = (MethodReference) constructor;
+        Argument<?> argument = constructorRef.arguments[argIndex];
+        try (BeanResolutionContext.Path ignored = resolutionContext.getPath().pushConstructorResolve(this, argument)) {
+            try {
+                Object result = resolveValue(resolutionContext, context, constructorRef.annotationMetadata, argument, qualifier);
+
+                if (this instanceof ValidatedBeanDefinition) {
+                    ((ValidatedBeanDefinition) this).validateBeanArgument(
+                            resolutionContext,
+                            getConstructor(),
+                            argument,
+                            argIndex,
+                            result
+                    );
+                }
+
+                return result;
+            } catch (NoSuchBeanException | BeanInstantiationException e) {
+                throw new DependencyInjectionException(resolutionContext, argument, e);
+            }
+        }
+    }
+
+    /**
+     * Obtains all bean definitions for a constructor argument at the given index.
+     * <p>
+     *
+     * @param resolutionContext The resolution context
+     * @param context           The context
+     * @param argumentIndex     The argument index
+     * @param genericType       The generic type
+     * @param qualifier         The qualifier
+     * @return The resolved bean
+     */
+    @Internal
+    @UsedByGeneratedCode
+    protected final Collection<Object> getBeansOfTypeForConstructorArgument(BeanResolutionContext resolutionContext, BeanContext context, int argumentIndex, Argument genericType, Qualifier qualifier) {
+        MethodReference constructorMethodRef = (MethodReference) constructor;
+        Argument argument = resolveArgument(context, argumentIndex, constructorMethodRef.arguments);
+        try (BeanResolutionContext.Path ignored = resolutionContext.getPath().pushConstructorResolve(this, argument)) {
+            return resolveBeansOfType(resolutionContext, context, argument, resolveEnvironmentArgument(context, genericType), qualifier);
+        }
+    }
+
+    /**
+     * Obtains all bean definitions for a constructor argument at the given index
+     * <p>
+     * Warning: this method is used by internal generated code and should not be called by user code.
+     *
+     * @param resolutionContext The resolution context
+     * @param context           The context
+     * @param argumentIndex     The argument index
+     * @param genericType       The generic type
+     * @param qualifier         The qualifier
+     * @return The resolved bean
+     */
+    @Internal
+    @UsedByGeneratedCode
+    protected final Collection<BeanRegistration<Object>> getBeanRegistrationsForConstructorArgument(BeanResolutionContext resolutionContext, BeanContext context, int argumentIndex, Argument genericType, Qualifier qualifier) {
+        MethodReference constructorMethodRef = (MethodReference) constructor;
+        Argument<?> argument = resolveArgument(context, argumentIndex, constructorMethodRef.arguments);
+        try (BeanResolutionContext.Path ignored = resolutionContext.getPath().pushConstructorResolve(this, argument)) {
+            return resolveBeanRegistrations(resolutionContext, context, argument, resolveEnvironmentArgument(context, genericType), qualifier);
+        }
+    }
+
+    /**
+     * Obtains a bean registration for a method injection point.
+     * <p>
+     * Warning: this method is used by internal generated code and should not be called by user code.
+     *
+     * @param resolutionContext The resolution context
+     * @param context           The context
+     * @param argumentIndex     The arg index
+     * @param genericType       The generic type
+     * @param qualifier         The qualifier
+     * @return The resolved bean registration
+     */
+    @Internal
+    @UsedByGeneratedCode
+    protected final BeanRegistration<?> getBeanRegistrationForConstructorArgument(BeanResolutionContext resolutionContext, BeanContext context, int argumentIndex, Argument genericType, Qualifier qualifier) {
+        MethodReference constructorMethodRef = (MethodReference) constructor;
+        Argument<?> argument = resolveArgument(context, argumentIndex, constructorMethodRef.arguments);
+        try (BeanResolutionContext.Path ignored = resolutionContext.getPath().pushConstructorResolve(this, argument)) {
+            return resolveBeanRegistration(resolutionContext, context, argument, resolveEnvironmentArgument(context, genericType), qualifier);
+        }
+    }
+
+    /**
+     * Obtains all bean definitions for a method injection point.
+     * <p>
+     * Warning: this method is used by internal generated code and should not be called by user code.
+     *
+     * @param resolutionContext The resolution context
+     * @param context           The context
+     * @param methodIndex       The method index
+     * @param argIndex          The arg index
+     * @param genericType       The generic type
+     * @param qualifier         The qualifier
+     * @return The resolved bean
+     */
+    @Internal
+    @UsedByGeneratedCode
+    protected final Collection<BeanRegistration<Object>> getBeanRegistrationsForMethodArgument(BeanResolutionContext resolutionContext, BeanContext context, int methodIndex, int argIndex, Argument genericType, Qualifier qualifier) {
+        MethodReference methodReference = methodInjection[methodIndex];
+        Argument<?> argument = resolveArgument(context, argIndex, methodReference.arguments);
+        try (BeanResolutionContext.Path ignored = resolutionContext.getPath()
+                .pushMethodArgumentResolve(this, methodReference.methodName, argument, methodReference.arguments, methodReference.requiresReflection)) {
+            return resolveBeanRegistrations(resolutionContext, context, argument, resolveEnvironmentArgument(context, genericType), qualifier);
+        }
+    }
+
+    /**
+     * Obtains a bean registration for a method injection point.
+     * <p>
+     * Warning: this method is used by internal generated code and should not be called by user code.
+     *
+     * @param resolutionContext The resolution context
+     * @param context           The context
+     * @param methodIndex       The method index
+     * @param argIndex          The arg index
+     * @param genericType       The generic type
+     * @param qualifier         The qualifier
+     * @return The resolved bean registration
+     */
+    @Internal
+    @UsedByGeneratedCode
+    protected final BeanRegistration<?> getBeanRegistrationForMethodArgument(BeanResolutionContext resolutionContext, BeanContext context, int methodIndex, int argIndex, Argument genericType, Qualifier qualifier) {
+        MethodReference methodRef = methodInjection[methodIndex];
+        Argument<?> argument = resolveArgument(context, argIndex, methodRef.arguments);
+        try (BeanResolutionContext.Path ignored = resolutionContext.getPath()
+                .pushMethodArgumentResolve(this, methodRef.methodName, argument, methodRef.arguments, methodRef.requiresReflection)) {
+            return resolveBeanRegistration(resolutionContext, context, argument, resolveEnvironmentArgument(context, genericType), qualifier);
+        }
+    }
+
+    /**
+     * Obtains all bean definitions for a constructor argument at the given index
+     * <p>
+     * Warning: this method is used by internal generated code and should not be called by user code.
+     *
+     * @param resolutionContext The resolution context
+     * @param context           The context
+     * @param argIndex          The argument index
+     * @param genericType       The generic type
+     * @param qualifier         The qualifier
+     * @return The resolved bean
+     */
+    @Internal
+    @UsedByGeneratedCode
+    protected final Stream<?> getStreamOfTypeForConstructorArgument(BeanResolutionContext resolutionContext, BeanContext context, int argIndex, Argument genericType, Qualifier qualifier) {
+        MethodReference constructorMethodRef = (MethodReference) constructor;
+        Argument<?> argument = resolveArgument(context, argIndex, constructorMethodRef.arguments);
+        try (BeanResolutionContext.Path ignored = resolutionContext.getPath().pushConstructorResolve(this, argument)) {
+            return resolveStreamOfType(resolutionContext, context, argument, resolveEnvironmentArgument(context, genericType), qualifier);
+        }
+    }
+
+    /**
+     * Obtains all bean definitions for a constructor argument at the given index
+     * <p>
+     * Warning: this method is used by internal generated code and should not be called by user code.
+     *
+     * @param resolutionContext The resolution context
+     * @param context           The context
+     * @param argIndex          The argument index
+     * @param genericType       The generic type
+     * @param qualifier         The qualifier
+     * @return The resolved bean
+     */
+    @Internal
+    @UsedByGeneratedCode
+    protected final Optional<?> findBeanForConstructorArgument(BeanResolutionContext resolutionContext, BeanContext context, int argIndex, Argument genericType, Qualifier qualifier) {
+        MethodReference constructorMethodRef = (MethodReference) constructor;
+        Argument<?> argument = resolveArgument(context, argIndex, constructorMethodRef.arguments);
+        try (BeanResolutionContext.Path ignored = resolutionContext.getPath().pushConstructorResolve(this, argument)) {
+            return resolveOptionalBean(resolutionContext, context, argument, resolveEnvironmentArgument(context, genericType), qualifier);
+        }
+    }
+
+    /**
+     * Obtains a bean definition for the field at the given index and the argument at the given index
+     * <p>
+     * Warning: this method is used by internal generated code and should not be called by user code.
+     *
+     * @param resolutionContext The resolution context
+     * @param context           The context
+     * @param fieldIndex        The field index
+     * @param qualifier         The qualifier
+     * @return The resolved bean
+     */
+    @Internal
+    @UsedByGeneratedCode
+    protected final Object getBeanForField(BeanResolutionContext resolutionContext, BeanContext context, int fieldIndex, Qualifier qualifier) {
+        final Argument argument = resolveEnvironmentArgument(context, fieldInjection[fieldIndex].argument);
+        try (BeanResolutionContext.Path ignored = resolutionContext.getPath()
+                .pushFieldResolve(this, argument, fieldInjection[fieldIndex].requiresReflection)) {
+            return resolveBean(resolutionContext, context, argument, qualifier);
+        }
+    }
+
+    /**
+     * Obtains a value for the given field from the bean context
+     * <p>
+     * Warning: this method is used by internal generated code and should not be called by user code.
+     *
+     * @param resolutionContext The resolution context
+     * @param context           The context
+     * @param fieldIndex        The index of the field
+     * @param qualifier         The qualifier
+     * @return The resolved bean
+     */
+    @Internal
+    @UsedByGeneratedCode
+    protected final Object getValueForField(BeanResolutionContext resolutionContext, BeanContext context, int fieldIndex, Qualifier qualifier) {
+        FieldReference fieldRef = fieldInjection[fieldIndex];
+        try (BeanResolutionContext.Path ignored = resolutionContext.getPath().pushFieldResolve(this, fieldRef.argument, fieldRef.requiresReflection)) {
+            return resolveValue(resolutionContext, context, fieldRef.argument.getAnnotationMetadata(), fieldRef.argument, qualifier);
+        }
+    }
+
+    /**
+     * Resolve a value for the given field of the given type and path.
+     *
+     * @param resolutionContext The resolution context
+     * @param context           The bean context
+     * @param propertyType      The required property type
+     * @param propertyPath      The property path
+     * @param <T1>              The generic type
+     * @return An optional value
+     */
+    @Internal
+    @UsedByGeneratedCode
+    protected final <T1> Optional<T1> getValueForPath(
+            BeanResolutionContext resolutionContext,
+            BeanContext context,
+            Argument<T1> propertyType,
+            String propertyPath) {
+        if (context instanceof PropertyResolver) {
+            PropertyResolver propertyResolver = (PropertyResolver) context;
+            String valString = substituteWildCards(resolutionContext, propertyPath);
+
+            return propertyResolver.getProperty(valString, ConversionContext.of(propertyType));
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Obtains a value for the given field argument.
+     *
+     * @param resolutionContext The resolution context
+     * @param context           The bean context
+     * @param fieldIndex        The field index
+     * @param isValuePrefix     Is value prefix in cases when beans are requested
+     * @return True if it does
+     */
+    @Internal
+    @UsedByGeneratedCode
+    protected final boolean containsValueForField(BeanResolutionContext resolutionContext, BeanContext context, int fieldIndex, boolean isValuePrefix) {
+        FieldReference fieldRef = fieldInjection[fieldIndex];
+        return resolveContainsValue(resolutionContext, context, fieldRef.argument.getAnnotationMetadata(), fieldRef.argument, isValuePrefix);
+    }
+
+    /**
+     * If this bean is a {@link ConfigurationProperties} bean return whether any properties for it are configured
+     * within the context.
+     *
+     * @param resolutionContext the resolution context
+     * @param context           The context
+     * @return True if it does
+     */
+    @Internal
+    @UsedByGeneratedCode
+    protected final boolean containsProperties(BeanResolutionContext resolutionContext, BeanContext context) {
+        return containsProperties(resolutionContext, context, null);
+    }
+
+    /**
+     * If this bean is a {@link ConfigurationProperties} bean return whether any properties for it are configured
+     * within the context.
+     *
+     * @param resolutionContext the resolution context
+     * @param context           The context
+     * @param subProperty       The subproperty to check
+     * @return True if it does
+     */
+    @Internal
+    @UsedByGeneratedCode
+    protected final boolean containsProperties(@SuppressWarnings("unused") BeanResolutionContext resolutionContext, BeanContext context, String subProperty) {
+        return isConfigurationProperties;
+    }
+
+    /**
+     * Obtains all bean definitions for the field at the given index.
+     * <p>
+     *
+     * @param resolutionContext The resolution context
+     * @param context           The context
+     * @param fieldIndex        The field index
+     * @param genericType       The generic type
+     * @param qualifier         The qualifier
+     * @return The resolved bean
+     */
+    @Internal
+    @UsedByGeneratedCode
+    protected final Object getBeansOfTypeForField(BeanResolutionContext resolutionContext, BeanContext context, int fieldIndex, Argument genericType, Qualifier qualifier) {
+        final FieldReference fieldRef = fieldInjection[fieldIndex];
+        final Argument<?> argument = resolveEnvironmentArgument(context, fieldRef.argument);
+        try (BeanResolutionContext.Path ignored = resolutionContext.getPath().pushFieldResolve(this, argument, fieldRef.requiresReflection)) {
+            return resolveBeansOfType(resolutionContext, context, argument, resolveEnvironmentArgument(context, genericType), qualifier);
+        }
+    }
+
+    /**
+     * Obtains all bean definitions for a field injection point.
+     * <p>
+     * Warning: this method is used by internal generated code and should not be called by user code.
+     *
+     * @param resolutionContext The resolution context
+     * @param context           The context
+     * @param fieldIndex        The field index
+     * @param genericType       The generic type
+     * @param qualifier         The qualifier
+     * @return The resolved bean
+     */
+    @Internal
+    @UsedByGeneratedCode
+    protected final Object getBeanRegistrationsForField(BeanResolutionContext resolutionContext, BeanContext context, int fieldIndex, Argument genericType, Qualifier qualifier) {
+        FieldReference fieldRef = fieldInjection[fieldIndex];
+        Argument argument = resolveEnvironmentArgument(context, fieldRef.argument);
+        try (BeanResolutionContext.Path ignored = resolutionContext.getPath()
+                .pushFieldResolve(this, argument, fieldRef.requiresReflection)) {
+            return resolveBeanRegistrations(resolutionContext, context, argument, resolveEnvironmentArgument(context, genericType), qualifier);
+        }
+    }
+
+    /**
+     * Obtains a bean registration for a field injection point.
+     * <p>
+     * Warning: this method is used by internal generated code and should not be called by user code.
+     *
+     * @param resolutionContext The resolution context
+     * @param context           The context
+     * @param fieldIndex        The field index
+     * @param genericType       The generic type
+     * @param qualifier         The qualifier
+     * @return The resolved bean registration
+     */
+    @Internal
+    @UsedByGeneratedCode
+    protected final BeanRegistration<?> getBeanRegistrationForField(BeanResolutionContext resolutionContext, BeanContext context, int fieldIndex, Argument genericType, Qualifier qualifier) {
+        FieldReference fieldRef = fieldInjection[fieldIndex];
+        Argument argument = resolveEnvironmentArgument(context, fieldRef.argument);
+        try (BeanResolutionContext.Path ignored = resolutionContext.getPath()
+                .pushFieldResolve(this, argument, fieldRef.requiresReflection)) {
+            return resolveBeanRegistration(resolutionContext, context, argument, resolveEnvironmentArgument(context, genericType), qualifier);
+        }
+    }
+
+    /**
+     * Obtains a an optional for the field at the given index and the argument at the given index
+     * <p>
+     * Warning: this method is used by internal generated code and should not be called by user code.
+     *
+     * @param resolutionContext The resolution context
+     * @param context           The context
+     * @param fieldIndex        The field index
+     * @param genericType       The generic type
+     * @param qualifier         The qualifier
+     * @return The resolved bean
+     */
+    @Internal
+    @UsedByGeneratedCode
+    protected final Optional findBeanForField(BeanResolutionContext resolutionContext, BeanContext context, int fieldIndex, Argument genericType, Qualifier qualifier) {
+        FieldReference fieldRef = fieldInjection[fieldIndex];
+        Argument argument = resolveEnvironmentArgument(context, fieldRef.argument);
+        try (BeanResolutionContext.Path ignored = resolutionContext.getPath()
+                .pushFieldResolve(this, argument, fieldRef.requiresReflection)) {
+            return resolveOptionalBean(resolutionContext, context, argument, resolveEnvironmentArgument(context, genericType), qualifier);
+        }
+    }
+
+    /**
+     * Obtains a bean definition for the field at the given index and the argument at the given index
+     * <p>
+     * Warning: this method is used by internal generated code and should not be called by user code.
+     *
+     * @param resolutionContext The resolution context
+     * @param context           The context
+     * @param fieldIndex        The field index
+     * @param genericType       The generic type
+     * @param qualifier         The qualifier
+     * @return The resolved bean
+     */
+    @Internal
+    @UsedByGeneratedCode
+    protected final Stream getStreamOfTypeForField(BeanResolutionContext resolutionContext, BeanContext context, int fieldIndex, Argument genericType, Qualifier qualifier) {
+        FieldReference fieldRef = fieldInjection[fieldIndex];
+        Argument argument = resolveEnvironmentArgument(context, fieldRef.argument);
+        try (BeanResolutionContext.Path ignored = resolutionContext.getPath()
+                .pushFieldResolve(this, argument, fieldRef.requiresReflection)) {
+            return resolveStreamOfType(resolutionContext, context, argument, resolveEnvironmentArgument(context, genericType), qualifier);
+        }
+    }
+
+    private boolean resolveContainsValue(BeanResolutionContext resolutionContext, BeanContext context, AnnotationMetadata parentAnnotationMetadata, Argument argument, boolean isValuePrefix) {
+        if (!(context instanceof ApplicationContext)) {
+            return false;
+        }
+        ApplicationContext applicationContext = (ApplicationContext) context;
+        String valueAnnStr = argument.getAnnotationMetadata().stringValue(Value.class).orElse(null);
+        String valString = resolvePropertyValueName(resolutionContext, parentAnnotationMetadata, argument, valueAnnStr);
+        boolean result = isValuePrefix ? applicationContext.containsProperties(valString) : applicationContext.containsProperty(valString);
+        if (!result && isConfigurationProperties) {
+            String cliOption = resolveCliOption(argument.getName());
+            if (cliOption != null) {
+                result = applicationContext.containsProperty(cliOption);
+            }
+        }
+        return result;
+    }
+
+    private Object resolveValue(BeanResolutionContext resolutionContext, BeanContext context, AnnotationMetadata parentAnnotationMetadata, Argument<?> argument, Qualifier qualifier) {
+        if (!(context instanceof PropertyResolver)) {
+            throw new DependencyInjectionException(resolutionContext, "@Value requires a BeanContext that implements PropertyResolver");
+        }
+        String valueAnnVal = argument.getAnnotationMetadata().stringValue(Value.class).orElse(null);
+        Argument<?> argumentType;
+        boolean isCollection = false;
+        if (Collection.class.isAssignableFrom(argument.getType())) {
+            argumentType = argument.getFirstTypeVariable().orElse(Argument.OBJECT_ARGUMENT);
+            isCollection = true;
+        } else {
+            argumentType = argument;
+        }
+        if (isInnerConfiguration(argumentType.getType())) {
+            qualifier = qualifier == null ? resolveQualifierWithInnerConfiguration(resolutionContext, argument, true) : qualifier;
+            if (isCollection) {
+                Collection beans = ((DefaultBeanContext) context).getBeansOfType(resolutionContext, argumentType, qualifier);
+                return coerceCollectionToCorrectType((Class) argument.getType(), beans, resolutionContext, argument);
+            } else {
+                return ((DefaultBeanContext) context).getBean(resolutionContext, argumentType, qualifier);
+            }
+        } else {
+            String valString = resolvePropertyValueName(resolutionContext, parentAnnotationMetadata, argument.getAnnotationMetadata(), valueAnnVal);
+            ArgumentConversionContext conversionContext = ConversionContext.of(argument);
+            Optional value = resolveValue((ApplicationContext) context, conversionContext, valueAnnVal != null, valString);
+            if (argumentType.isOptional()) {
+                if (!value.isPresent()) {
+                    return value;
+                } else {
+                    Object convertedOptional = value.get();
+                    if (convertedOptional instanceof Optional) {
+                        return convertedOptional;
+                    } else {
+                        return value;
+                    }
+                }
+            } else {
+                if (value.isPresent()) {
+                    return value.get();
+                } else {
+                    if (argument.isDeclaredNullable()) {
+                        return null;
+                    }
+                    return argument.getAnnotationMetadata().getValue(Bindable.class, "defaultValue", argument)
+                            .orElseThrow(() -> DependencyInjectionException.missingProperty(resolutionContext, conversionContext, valString));
+                }
+            }
+        }
+    }
+
+    private Object resolveBean(BeanResolutionContext resolutionContext, BeanContext context, Argument argument, @Nullable Qualifier qualifier) {
+        return resolveBean(resolutionContext, context, argument, qualifier, false);
+    }
+
+    private Object resolveBean(BeanResolutionContext resolutionContext, BeanContext context, Argument argument, @Nullable Qualifier qualifier, boolean resolveIsInnerConfiguration) {
+        qualifier = qualifier == null ? resolveQualifier(resolutionContext, argument, resolveIsInnerConfiguration) : qualifier;
+        if (Qualifier.class.isAssignableFrom(argument.getType())) {
+            return qualifier;
+        }
+        try {
+            Object previous = !argument.isAnnotationPresent(Parameter.class) ? resolutionContext.removeAttribute(NAMED_ATTRIBUTE) : null;
+            try {
+                //noinspection unchecked
+                return ((DefaultBeanContext) context).getBean(resolutionContext, argument, qualifier);
+            } finally {
+                if (previous != null) {
+                    resolutionContext.setAttribute(NAMED_ATTRIBUTE, previous);
+                }
+            }
+        } catch (DisabledBeanException e) {
+            if (AbstractBeanContextConditional.LOG.isDebugEnabled()) {
+                AbstractBeanContextConditional.LOG.debug("Bean of type [{}] disabled for reason: {}", argument.getTypeName(), e.getMessage());
+            }
+            if (isIterable() && getAnnotationMetadata().hasDeclaredAnnotation(EachBean.class)) {
+                throw new DisabledBeanException("Bean [" + getBeanType().getSimpleName() + "] disabled by parent: " + e.getMessage());
+            } else {
+                if (argument.isDeclaredNullable()) {
+                    return null;
+                }
+                throw new DependencyInjectionException(resolutionContext, e);
+            }
+        } catch (NoSuchBeanException e) {
+            if (argument.isDeclaredNullable()) {
+                return null;
+            }
+            throw new DependencyInjectionException(resolutionContext, e);
+        }
+    }
+
+    private Optional resolveValue(
+            ApplicationContext context,
+            ArgumentConversionContext<?> argument,
+            boolean hasValueAnnotation,
+            String valString) {
+
+        if (hasValueAnnotation) {
+            return context.resolvePlaceholders(valString).flatMap(v -> context.getConversionService().convert(v, argument));
+        } else {
+            Optional<?> value = context.getProperty(valString, argument);
+            if (!value.isPresent() && isConfigurationProperties) {
+                String cliOption = resolveCliOption(argument.getArgument().getName());
+                if (cliOption != null) {
+                    return context.getProperty(cliOption, argument);
+                }
+            }
+            return value;
+        }
+    }
+
+    private String resolvePropertyValueName(BeanResolutionContext resolutionContext, AnnotationMetadata parentAnnotationMetadata, Argument argument, String valueAnnStr) {
+        return resolvePropertyValueName(resolutionContext, parentAnnotationMetadata, argument.getAnnotationMetadata(), valueAnnStr);
+    }
+
+    private String resolvePropertyValueName(BeanResolutionContext resolutionContext, AnnotationMetadata parentAnnotationMetadata, AnnotationMetadata annotationMetadata, String valueAnnStr) {
+        if (valueAnnStr != null) {
+            return valueAnnStr;
+        }
+        String valString = getProperty(resolutionContext, parentAnnotationMetadata, annotationMetadata);
+        return substituteWildCards(resolutionContext, valString);
+    }
+
+    private String getProperty(BeanResolutionContext resolutionContext, AnnotationMetadata parentAnnotationMetadata, AnnotationMetadata annotationMetadata) {
+        Optional<String> property = parentAnnotationMetadata.stringValue(Property.class, "name");
+        if (property.isPresent()) {
+            return property.get();
+        }
+        if (parentAnnotationMetadata != annotationMetadata) {
+            property = annotationMetadata.stringValue(Property.class, "name");
+            if (property.isPresent()) {
+                return property.get();
+            }
+        }
+        throw new DependencyInjectionException(resolutionContext, "Value resolution attempted but @Value annotation is missing");
+    }
+
+    private String substituteWildCards(BeanResolutionContext resolutionContext, String valString) {
+        if (valString.indexOf('*') > -1) {
+            Optional<String> namedBean = resolutionContext.get(Named.class.getName(), ConversionContext.STRING);
+            if (namedBean.isPresent()) {
+                valString = valString.replace("*", namedBean.get());
+            }
+        }
+        return valString;
+    }
+
+    private String resolveCliOption(String name) {
+        String attr = "cliPrefix";
+        AnnotationMetadata annotationMetadata = getAnnotationMetadata();
+        if (annotationMetadata.isPresent(ConfigurationProperties.class, attr)) {
+            return annotationMetadata.stringValue(ConfigurationProperties.class, attr).map(val -> val + name).orElse(null);
+        }
+        return null;
+    }
+
+    private Collection<Object> resolveBeansOfType(BeanResolutionContext resolutionContext, BeanContext context, Argument argument, Argument resultGenericType, Qualifier qualifier) {
+        DefaultBeanContext beanContext = (DefaultBeanContext) context;
+        if (resultGenericType == null) {
+            throw new DependencyInjectionException(resolutionContext, "Type " + argument.getType() + " has no generic argument");
+        }
+        qualifier = qualifier == null ? resolveQualifier(resolutionContext, argument) : qualifier;
+        Collection beansOfType = beanContext.getBeansOfType(resolutionContext, resolveEnvironmentArgument(context, resultGenericType), qualifier);
+        return coerceCollectionToCorrectType(argument.getType(), beansOfType, resolutionContext, argument);
+    }
+
+    private Stream<?> resolveStreamOfType(BeanResolutionContext resolutionContext, BeanContext context, Argument<?> argument, Argument<?> resultGenericType, Qualifier qualifier) {
+        if (resultGenericType == null) {
+            throw new DependencyInjectionException(resolutionContext, "Type " + argument.getType() + " has no generic argument");
+        }
+        qualifier = qualifier == null ? resolveQualifier(resolutionContext, argument) : qualifier;
+        return ((DefaultBeanContext) context).streamOfType(resolutionContext, resultGenericType, qualifier);
+    }
+
+    private Optional<?> resolveOptionalBean(BeanResolutionContext resolutionContext, BeanContext context, Argument<?> argument, Argument<?> resultGenericType, Qualifier qualifier) {
+        if (resultGenericType == null) {
+            throw new DependencyInjectionException(resolutionContext, "Type " + argument.getType() + " has no generic argument");
+        }
+        qualifier = qualifier == null ? resolveQualifier(resolutionContext, argument) : qualifier;
+        return ((DefaultBeanContext) context).findBean(resolutionContext, resultGenericType, qualifier);
+    }
+
+    private <B> Collection<BeanRegistration<B>> resolveBeanRegistrations(BeanResolutionContext resolutionContext, BeanContext beanContext, Argument argument, Argument genericArgument, Qualifier qualifier) {
+        try {
+            if (genericArgument == null) {
+                throw new DependencyInjectionException(resolutionContext, "Cannot resolve bean registrations. Argument [" + argument + "] missing generic type information.");
+            }
+            qualifier = qualifier == null ? resolveQualifier(resolutionContext, argument) : qualifier;
+            Collection beanRegistrations = ((DefaultBeanContext) beanContext).getBeanRegistrations(resolutionContext, genericArgument, qualifier);
+            return coerceCollectionToCorrectType(argument.getType(), beanRegistrations, resolutionContext, argument);
+        } catch (NoSuchBeanException e) {
+            if (argument.isNullable()) {
+                return null;
+            }
+            throw new DependencyInjectionException(resolutionContext, e);
+        }
+    }
+
+    private Argument<?> resolveArgument(BeanContext context, int argIndex, Argument<?>[] arguments) {
+        if (arguments == null) {
+            return null;
+        }
+        return resolveEnvironmentArgument(context, arguments[argIndex]);
+    }
+
+    private Argument<?> resolveEnvironmentArgument(BeanContext context, Argument<?> argument) {
+        if (argument instanceof DefaultArgument) {
+            if (argument.getAnnotationMetadata().hasPropertyExpressions()) {
+                argument = new EnvironmentAwareArgument<>((DefaultArgument) argument);
+                instrumentAnnotationMetadata(context, argument);
+            }
+        }
+        return argument;
+    }
+
+    private <B> BeanRegistration<B> resolveBeanRegistration(BeanResolutionContext resolutionContext, BeanContext context,
+                                                            Argument<?> argument, Argument<?> genericArgument, Qualifier qualifier) {
+        try {
+            if (genericArgument == null) {
+                throw new DependencyInjectionException(resolutionContext, "Cannot resolve bean registration. Argument [" + argument + "] missing generic type information.");
+            }
+            qualifier = qualifier == null ? resolveQualifier(resolutionContext, argument) : qualifier;
+            return context.getBeanRegistration(genericArgument, qualifier);
+        } catch (NoSuchBeanException e) {
+            if (argument.isNullable()) {
+                return null;
+            }
+            throw new DependencyInjectionException(resolutionContext, argument, e);
+        }
+    }
+
+    private Qualifier resolveQualifier(BeanResolutionContext resolutionContext, Argument argument) {
+        return resolveQualifier(resolutionContext, argument, false);
+    }
+
+    private Qualifier resolveQualifier(BeanResolutionContext resolutionContext, Argument argument, boolean resolveIsInnerConfiguration) {
+        boolean innerConfiguration = resolveIsInnerConfiguration && isInnerConfiguration(argument.getType());
+        return resolveQualifierWithInnerConfiguration(resolutionContext, argument, innerConfiguration);
+    }
+
+    private Qualifier resolveQualifierWithInnerConfiguration(BeanResolutionContext resolutionContext, Argument argument, boolean innerConfiguration) {
+        boolean hasMetadata = argument.getAnnotationMetadata() != AnnotationMetadata.EMPTY_METADATA;
+        Qualifier qualifier = null;
+        boolean isIterable = isIterable() || resolutionContext.get(EachProperty.class.getName(), Class.class).map(getBeanType()::equals).orElse(false);
+        if (isIterable) {
+            Optional<Qualifier> optional = resolutionContext.get(AnnotationUtil.QUALIFIER, Map.class)
+                    .map(map -> (Qualifier) map.get(argument));
+            qualifier = optional.orElse(null);
+        }
+        if (qualifier == null) {
+            if ((hasMetadata && argument.isAnnotationPresent(Parameter.class)) ||
+                    (innerConfiguration && isIterable) ||
+                    Qualifier.class == argument.getType()) {
+                final Qualifier<?> currentQualifier = resolutionContext.getCurrentQualifier();
+                if (currentQualifier != null &&
+                        currentQualifier.getClass() != InterceptorBindingQualifier.class &&
+                        currentQualifier.getClass() != TypeAnnotationQualifier.class) {
+                    qualifier = currentQualifier;
+                } else {
+                    final Optional<String> n = resolutionContext.get(NAMED_ATTRIBUTE, ConversionContext.STRING);
+                    qualifier = n.map(Qualifiers::byName).orElse(null);
+                }
+            }
+        }
+        return qualifier;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <I, K extends Collection<I>> Collection coerceCollectionToCorrectType(Class<K> collectionType, Collection<I> beansOfType, BeanResolutionContext resolutionContext, Argument argument) {
+        if (argument.isArray() || collectionType.isInstance(beansOfType)) {
+            // Arrays are converted by compile-time code
+            return beansOfType;
+        } else {
+            return (Collection) CollectionUtils.convertCollection(collectionType, beansOfType)
+                    .orElseThrow(() -> new DependencyInjectionException(resolutionContext, "Cannot create a collection of type: " + collectionType.getName()));
+        }
+    }
+
+    private void instrumentAnnotationMetadata(BeanContext context, Object object) {
+        if (object instanceof EnvironmentConfigurable && context instanceof ApplicationContext) {
+            final EnvironmentConfigurable ec = (EnvironmentConfigurable) object;
+            if (ec.hasPropertyExpressions()) {
+                ec.configure(((ApplicationContext) context).getEnvironment());
+            }
+        }
+    }
+
+    /**
+     * Internal environment aware annotation metadata delegate.
+     */
+    private final class BeanAnnotationMetadata extends AbstractEnvironmentAnnotationMetadata {
+        BeanAnnotationMetadata(AnnotationMetadata targetMetadata) {
+            super(targetMetadata);
+        }
+
+        @Nullable
+        @Override
+        protected Environment getEnvironment() {
+            return environment;
+        }
+    }
+
+    /**
+     * The data class containing all method reference information.
+     */
+    @Internal
+    @SuppressWarnings("VisibilityModifier")
+    public static final class MethodReference extends MethodOrFieldReference {
+        public final String methodName;
+        public final Argument[] arguments;
+        public final AnnotationMetadata annotationMetadata;
+        public final boolean isPreDestroyMethod;
+        public final boolean isPostConstructMethod;
+
+        public MethodReference(Class declaringType,
+                               String methodName,
+                               Argument[] arguments,
+                               @Nullable AnnotationMetadata annotationMetadata,
+                               boolean requiresReflection) {
+            this(declaringType, methodName, arguments, annotationMetadata, requiresReflection, false, false);
+        }
+
+        public MethodReference(Class declaringType,
+                               String methodName,
+                               Argument[] arguments,
+                               @Nullable AnnotationMetadata annotationMetadata,
+                               boolean requiresReflection,
+                               boolean isPostConstructMethod,
+                               boolean isPreDestroyMethod) {
+            super(declaringType, requiresReflection);
+            this.methodName = methodName;
+            this.arguments = arguments;
+            this.annotationMetadata = annotationMetadata == null ? AnnotationMetadata.EMPTY_METADATA : annotationMetadata;
+            this.isPostConstructMethod = isPostConstructMethod;
+            this.isPreDestroyMethod = isPreDestroyMethod;
+        }
+    }
+
+    /**
+     * The data class containing all filed reference information.
+     */
+    @Internal
+    @SuppressWarnings("VisibilityModifier")
+    public static final class FieldReference extends MethodOrFieldReference {
+        public final Argument argument;
+
+        public FieldReference(Class declaringType, Argument argument, boolean requiresReflection) {
+            super(declaringType, requiresReflection);
+            this.argument = argument;
+        }
+
+    }
+
+    /**
+     * The shared data class between method and field reference.
+     */
+    @Internal
+    public abstract static class MethodOrFieldReference {
+        final Class declaringType;
+        final boolean requiresReflection;
+
+        public MethodOrFieldReference(Class declaringType, boolean requiresReflection) {
+            this.declaringType = declaringType;
+            this.requiresReflection = requiresReflection;
+        }
+
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/AbstractBeanDefinitionReference2.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractBeanDefinitionReference2.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context;
+
+import io.micronaut.context.exceptions.BeanContextException;
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.inject.BeanDefinition;
+import io.micronaut.inject.BeanDefinitionReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * An uninitialized and unloaded component definition with basic information available regarding its requirements.
+ *
+ * @param <T> The bean type
+ * @author Denis Stepanov
+ * @since 3.0
+ */
+@Internal
+public abstract class AbstractBeanDefinitionReference2<T> extends AbstractBeanContextConditional implements BeanDefinitionReference<T> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractBeanDefinitionReference2.class);
+    private final String beanTypeName;
+    private final String beanDefinitionTypeName;
+    private final AnnotationMetadata annotationMetadata;
+    private final boolean isPrimary;
+    private final boolean isContextScope;
+    private final boolean isConditional;
+    private final boolean isContainerType;
+    private final boolean isSingleton;
+    private final boolean isConfigurationProperties;
+    private final boolean hasExposedTypes;
+    private final boolean requiresMethodProcessing;
+
+    private Boolean present;
+    private Set<Class<?>> exposedTypes;
+
+    /**
+     * @param beanTypeName              The bean type name
+     * @param beanDefinitionTypeName    The bean definition type name
+     * @param annotationMetadata        The annotationMetadata
+     * @param isPrimary                 Is primary bean?
+     * @param isContextScope            Is context scope?
+     * @param isConditional             Is conditional? = No @Requires
+     * @param isContainerType           Is container type?
+     * @param isSingleton               Is singleton?
+     * @param isConfigurationProperties Is configuration properties?
+     * @param hasExposedTypes           Has exposed types?
+     * @param requiresMethodProcessing  Is requires method processing?
+     */
+    public AbstractBeanDefinitionReference2(String beanTypeName, String beanDefinitionTypeName, AnnotationMetadata annotationMetadata,
+                                            boolean isPrimary, boolean isContextScope, boolean isConditional,
+                                            boolean isContainerType, boolean isSingleton, boolean isConfigurationProperties,
+                                            boolean hasExposedTypes, boolean requiresMethodProcessing) {
+        this.beanTypeName = beanTypeName;
+        this.beanDefinitionTypeName = beanDefinitionTypeName;
+        this.annotationMetadata = annotationMetadata;
+        this.isPrimary = isPrimary;
+        this.isContextScope = isContextScope;
+        this.isConditional = isConditional;
+        this.isContainerType = isContainerType;
+        this.isSingleton = isSingleton;
+        this.isConfigurationProperties = isConfigurationProperties;
+        this.hasExposedTypes = hasExposedTypes;
+        this.requiresMethodProcessing = requiresMethodProcessing;
+    }
+
+    @Override
+    public String getName() {
+        return beanTypeName;
+    }
+
+    @Override
+    public String getBeanDefinitionName() {
+        return beanDefinitionTypeName;
+    }
+
+    @Override
+    public AnnotationMetadata getAnnotationMetadata() {
+        return annotationMetadata;
+    }
+
+    @Override
+    public boolean isPrimary() {
+        return isPrimary;
+    }
+
+    @Override
+    public boolean isSingleton() {
+        return isSingleton;
+    }
+
+    @Override
+    public boolean isConfigurationProperties() {
+        return isConfigurationProperties;
+    }
+
+    @Override
+    public boolean isContainerType() {
+        return isContainerType;
+    }
+
+    @Override
+    public boolean isContextScope() {
+        return isContextScope;
+    }
+
+    @Override
+    public boolean requiresMethodProcessing() {
+        return requiresMethodProcessing;
+    }
+
+    @Override
+    @NonNull
+    public final Set<Class<?>> getExposedTypes() {
+        if (!hasExposedTypes) {
+            return Collections.EMPTY_SET;
+        }
+        if (exposedTypes == null) {
+            this.exposedTypes = BeanDefinitionReference.super.getExposedTypes();
+        }
+        return this.exposedTypes;
+    }
+
+    @Override
+    public BeanDefinition load(BeanContext context) {
+        BeanDefinition definition = load();
+        if (context instanceof ApplicationContext && definition instanceof EnvironmentConfigurable) {
+            ((EnvironmentConfigurable) definition).configure(((ApplicationContext) context).getEnvironment());
+        }
+        return definition;
+    }
+
+    @Override
+    public boolean isPresent() {
+        if (present == null) {
+            try {
+                getBeanDefinitionType();
+                getBeanType();
+                present = true;
+            } catch (Throwable e) {
+                if (e instanceof TypeNotPresentException || e instanceof ClassNotFoundException || e instanceof NoClassDefFoundError) {
+                    if (LOG.isTraceEnabled()) {
+                        LOG.trace("Bean definition for type [" + beanTypeName + "] not loaded since it is not on the classpath", e);
+                    }
+                } else {
+                    throw new BeanContextException("Unexpected error loading bean definition [" + beanDefinitionTypeName + "]: " + e.getMessage(), e);
+                }
+                present = false;
+            }
+        }
+        return present;
+    }
+
+    @Override
+    public boolean isEnabled(BeanContext context) {
+        return isPresent() && (!isConditional || super.isEnabled(context, null));
+    }
+
+    @Override
+    public boolean isEnabled(BeanContext context, BeanResolutionContext resolutionContext) {
+        return isPresent() && (!isConditional || super.isEnabled(context, resolutionContext));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        AbstractBeanDefinitionReference2 that = (AbstractBeanDefinitionReference2) o;
+        return beanDefinitionTypeName.equals(that.beanDefinitionTypeName);
+    }
+
+    @Override
+    public String toString() {
+        return beanDefinitionTypeName;
+    }
+
+    @Override
+    public int hashCode() {
+        return beanDefinitionTypeName.hashCode();
+    }
+
+    /**
+     * Implementors should provide an implementation of this method that returns the bean definition type.
+     *
+     * @return The bean definition type.
+     */
+    protected abstract Class<? extends BeanDefinition<?>> getBeanDefinitionType();
+}

--- a/inject/src/main/java/io/micronaut/context/AbstractExecutableMethodsDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractExecutableMethodsDefinition.java
@@ -1,0 +1,381 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context;
+
+import io.micronaut.context.env.Environment;
+import io.micronaut.core.annotation.*;
+import io.micronaut.core.type.Argument;
+import io.micronaut.core.type.ReturnType;
+import io.micronaut.core.util.ArgumentUtils;
+import io.micronaut.inject.ExecutableMethod;
+import io.micronaut.inject.ExecutableMethodsDefinition;
+import io.micronaut.inject.annotation.AbstractEnvironmentAnnotationMetadata;
+
+import java.lang.reflect.Method;
+import java.util.*;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+/**
+ * Abstract base class for for {@link ExecutableMethodsDefinition}.
+ *
+ * @param <T> The type
+ * @author Denis Stepanov
+ * @since 3.0
+ */
+@Internal
+public abstract class AbstractExecutableMethodsDefinition<T> implements ExecutableMethodsDefinition<T>, EnvironmentConfigurable {
+
+    private final MethodReference[] methodsReferences;
+    private final DispatchedExecutableMethod<T, ?>[] executableMethods;
+    private Environment environment;
+    private List<DispatchedExecutableMethod<T, ?>> executableMethodsList;
+
+    protected AbstractExecutableMethodsDefinition(MethodReference[] methodsReferences) {
+        this.methodsReferences = methodsReferences;
+        this.executableMethods = new DispatchedExecutableMethod[methodsReferences.length];
+    }
+
+    @Override
+    public void configure(Environment environment) {
+        this.environment = environment;
+        for (DispatchedExecutableMethod<T, ?> executableMethod : executableMethods) {
+            if (executableMethod != null) {
+                executableMethod.configure(environment);
+            }
+        }
+    }
+
+    @Override
+    public Collection<ExecutableMethod<T, ?>> getExecutableMethods() {
+        if (executableMethodsList == null) {
+            // Initialize the collection
+            for (int i = 0, methodsReferencesLength = methodsReferences.length; i < methodsReferencesLength; i++) {
+                getExecutableMethodByIndex(i);
+            }
+            executableMethodsList = Arrays.asList(executableMethods);
+        }
+        return (Collection) executableMethodsList;
+    }
+
+    @Override
+    public <R> Optional<ExecutableMethod<T, R>> findMethod(String name, Class<?>... argumentTypes) {
+        return Optional.ofNullable(getMethod(name, argumentTypes));
+    }
+
+    @Override
+    public <R> Stream<ExecutableMethod<T, R>> findPossibleMethods(String name) {
+        return IntStream.range(0, methodsReferences.length)
+                .filter(i -> methodsReferences[i].methodName.equals(name))
+                .mapToObj(this::getExecutableMethodByIndex);
+    }
+
+    /**
+     * Gets {@link ExecutableMethod} method by it's index.
+     *
+     * @param index The method index
+     * @param <R>   The result type
+     * @return The {@link ExecutableMethod}
+     */
+    @UsedByGeneratedCode
+    public <R> ExecutableMethod<T, R> getExecutableMethodByIndex(int index) {
+        DispatchedExecutableMethod<T, R> executableMethod = (DispatchedExecutableMethod<T, R>) executableMethods[index];
+        if (executableMethod == null) {
+            MethodReference methodsReference = methodsReferences[index];
+            executableMethod = new DispatchedExecutableMethod<>(this, index, methodsReference, methodsReference.annotationMetadata);
+            if (environment != null) {
+                executableMethod.configure(environment);
+            }
+            executableMethods[index] = executableMethod;
+        }
+        return executableMethod;
+    }
+
+    /**
+     * Finds executable method or returns a null otherwise.
+     *
+     * @param name          The method name
+     * @param argumentTypes The method arguments
+     * @param <R>           The return type
+     * @return The {@link ExecutableMethod}
+     */
+    @UsedByGeneratedCode
+    @Nullable
+    protected <R> ExecutableMethod<T, R> getMethod(String name, Class<?>... argumentTypes) {
+        for (int i = 0; i < methodsReferences.length; i++) {
+            MethodReference methodReference = methodsReferences[i];
+            if (methodReference.methodName.equals(name)
+                    && methodReference.arguments.length == argumentTypes.length
+                    && argumentsTypesMatch(argumentTypes, methodReference.arguments)) {
+                return getExecutableMethodByIndex(i);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Triggers the invocation of the method at index. Used by {@link ExecutableMethod#invoke(Object, Object...)}.
+     *
+     * @param index  The method index
+     * @param target The target
+     * @param args   The arguments
+     * @return The result
+     */
+    @UsedByGeneratedCode
+    protected abstract Object dispatch(int index, T target, Object[] args);
+
+    /**
+     * Find {@link Method} representation at the method by index. Used by {@link ExecutableMethod#getTargetMethod()}.
+     *
+     * @param index The index
+     * @return The method
+     */
+    @UsedByGeneratedCode
+    protected abstract Method getTargetMethodByIndex(int index);
+
+    /**
+     * Creates a new exception when the method at index is not found.
+     *
+     * @param index The method index
+     * @return The exception
+     */
+    @UsedByGeneratedCode
+    protected final Throwable unknownMethodAtIndexException(int index) {
+        return new IllegalStateException("Unknown method at index: " + index);
+    }
+
+    /**
+     * Checks if the method at index matches name and argument types.
+     *
+     * @param index         The method index
+     * @param name          The method name
+     * @param argumentTypes The method arguments
+     * @return true if matches
+     */
+    @UsedByGeneratedCode
+    protected final boolean methodAtIndexMatches(int index, String name, Class[] argumentTypes) {
+        MethodReference methodReference = methodsReferences[index];
+        Argument<?>[] arguments = methodReference.arguments;
+        if (arguments.length != argumentTypes.length || !methodReference.methodName.equals(name)) {
+            return false;
+        }
+        return argumentsTypesMatch(argumentTypes, arguments);
+    }
+
+    private boolean argumentsTypesMatch(Class[] argumentTypes, Argument<?>[] arguments) {
+        for (int i = 0; i < arguments.length; i++) {
+            if (!argumentTypes[i].equals(arguments[i].getType())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Internal class representing method's metadata.
+     */
+    @Internal
+    public static final class MethodReference {
+        final AnnotationMetadata annotationMetadata;
+        final Class<?> declaringType;
+        final String methodName;
+        @Nullable
+        final Argument<?> returnArgument;
+        final Argument<?>[] arguments;
+        final boolean isAbstract;
+        final boolean isSuspend;
+
+        /**
+         * The constructor.
+         *
+         * @param declaringType      The declaring type
+         * @param annotationMetadata The metadata
+         * @param methodName         The method name
+         * @param returnArgument     The return argument
+         * @param arguments          The arguments
+         * @param isAbstract         Is abstract
+         * @param isSuspend          Is suspend
+         */
+        public MethodReference(Class<?> declaringType, AnnotationMetadata annotationMetadata, String methodName, Argument<?> returnArgument, Argument<?>[] arguments, boolean isAbstract, boolean isSuspend) {
+            this.declaringType = declaringType;
+            this.annotationMetadata = annotationMetadata == null ? AnnotationMetadata.EMPTY_METADATA : annotationMetadata;
+            this.methodName = methodName;
+            this.returnArgument = returnArgument;
+            this.arguments = arguments == null ? Argument.ZERO_ARGUMENTS : arguments;
+            this.isAbstract = isAbstract;
+            this.isSuspend = isSuspend;
+        }
+    }
+
+    /**
+     * An {@link ExecutableMethod} instance based on dispatching by index.
+     *
+     * @param <T> The type
+     * @param <R> The result type
+     */
+    private static final class DispatchedExecutableMethod<T, R> implements ExecutableMethod<T, R>, ReturnType<R>, EnvironmentConfigurable {
+
+        private final AbstractExecutableMethodsDefinition dispatcher;
+        private final int index;
+        private final MethodReference methodReference;
+        private AnnotationMetadata annotationMetadata;
+
+        private DispatchedExecutableMethod(AbstractExecutableMethodsDefinition dispatcher, int index,
+                                           MethodReference methodReference, AnnotationMetadata annotationMetadata) {
+            this.dispatcher = dispatcher;
+            this.index = index;
+            this.methodReference = methodReference;
+            this.annotationMetadata = annotationMetadata;
+        }
+
+        @Override
+        public void configure(Environment environment) {
+            if (annotationMetadata.hasPropertyExpressions()) {
+                annotationMetadata = new MethodAnnotationMetadata(annotationMetadata, environment);
+            }
+        }
+
+        @Override
+        public boolean hasPropertyExpressions() {
+            return annotationMetadata.hasPropertyExpressions();
+        }
+
+        @Override
+        public boolean isAbstract() {
+            return methodReference.isAbstract;
+        }
+
+        @Override
+        public boolean isSuspend() {
+            return methodReference.isSuspend;
+        }
+
+        @Override
+        public Class<T> getDeclaringType() {
+            return (Class<T>) methodReference.declaringType;
+        }
+
+        @Override
+        public String getMethodName() {
+            return methodReference.methodName;
+        }
+
+        @Override
+        public Argument<?>[] getArguments() {
+            return methodReference.arguments;
+        }
+
+        @Override
+        public Method getTargetMethod() {
+            return dispatcher.getTargetMethodByIndex(index);
+        }
+
+        @Override
+        public ReturnType<R> getReturnType() {
+            return this;
+        }
+
+        @Override
+        public Class<R> getType() {
+            if (methodReference.returnArgument == null) {
+                return (Class<R>) void.class;
+            }
+            return (Class<R>) methodReference.returnArgument.getType();
+        }
+
+        @Override
+        public boolean isSuspended() {
+            return methodReference.isSuspend;
+        }
+
+        @NonNull
+        @Override
+        public AnnotationMetadata getAnnotationMetadata() {
+            return annotationMetadata;
+        }
+
+        @Override
+        public Argument[] getTypeParameters() {
+            if (methodReference.returnArgument != null) {
+                return methodReference.returnArgument.getTypeParameters();
+            }
+            return Argument.ZERO_ARGUMENTS;
+        }
+
+        @Override
+        public Map<String, Argument<?>> getTypeVariables() {
+            if (methodReference.returnArgument != null) {
+                return methodReference.returnArgument.getTypeVariables();
+            }
+            return Collections.emptyMap();
+        }
+
+        @Override
+        @NonNull
+        public Argument asArgument() {
+            Map<String, Argument<?>> typeVariables = getTypeVariables();
+            Collection<Argument<?>> values = typeVariables.values();
+            final AnnotationMetadata annotationMetadata = getAnnotationMetadata();
+            return Argument.of(getType(), annotationMetadata, values.toArray(Argument.ZERO_ARGUMENTS));
+        }
+
+        @Override
+        public R invoke(T instance, Object... arguments) {
+            ArgumentUtils.validateArguments(this, methodReference.arguments, arguments);
+            return (R) dispatcher.dispatch(index, instance, arguments);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof AbstractExecutableMethodsDefinition.DispatchedExecutableMethod)) {
+                return false;
+            }
+            DispatchedExecutableMethod that = (DispatchedExecutableMethod) o;
+            return Objects.equals(methodReference.declaringType, that.methodReference.declaringType) &&
+                    Objects.equals(methodReference.methodName, that.methodReference.methodName) &&
+                    Arrays.equals(methodReference.arguments, that.methodReference.arguments);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(
+                    methodReference.declaringType,
+                    methodReference.methodName,
+                    Arrays.hashCode(methodReference.arguments)
+            );
+        }
+    }
+
+    private static final class MethodAnnotationMetadata extends AbstractEnvironmentAnnotationMetadata {
+
+        private final Environment environment;
+
+        MethodAnnotationMetadata(AnnotationMetadata targetMetadata, Environment environment) {
+            super(targetMetadata);
+            this.environment = environment;
+        }
+
+        @Nullable
+        @Override
+        protected Environment getEnvironment() {
+            return environment;
+        }
+    }
+
+}

--- a/inject/src/main/java/io/micronaut/context/BeanDefinitionDelegate.java
+++ b/inject/src/main/java/io/micronaut/context/BeanDefinitionDelegate.java
@@ -119,16 +119,10 @@ class BeanDefinitionDelegate<T> extends AbstractBeanContextConditional implement
                             fulfilled.put(argumentName, result.get());
                         } else {
                             Qualifier qualifier = Qualifiers.byName(named.toString());
-                            final BeanResolutionContext.Path path = resolutionContext.getPath();
-                            path.pushConstructorResolve(
-                                    definition,
-                                    argument
-                            );
                             Optional bean;
-                            try {
+                            try (BeanResolutionContext.Path ignored = resolutionContext.getPath()
+                                    .pushConstructorResolve(definition, argument)) {
                                 bean = ((DefaultBeanContext) context).findBean(resolutionContext, argument, qualifier);
-                            } finally {
-                                path.pop();
                             }
                             if (bean.isPresent()) {
                                 fulfilled.put(argumentName, bean.get());

--- a/inject/src/main/java/io/micronaut/context/BeanResolutionContext.java
+++ b/inject/src/main/java/io/micronaut/context/BeanResolutionContext.java
@@ -133,15 +133,27 @@ public interface BeanResolutionContext extends ValueResolver<CharSequence>, Auto
     /**
      * Represents a path taken to resolve a bean definitions dependencies.
      */
-    interface Path extends Deque<Segment<?>> {
+    interface Path extends Deque<Segment<?>>, AutoCloseable {
         /**
          * Push an unresolved constructor call onto the queue.
          *
          * @param declaringType The type
-         * @param beanType      The bena type
+         * @param beanType      The bean type
          * @return This path
          */
         Path pushBeanCreate(BeanDefinition<?> declaringType, Argument<?> beanType);
+
+        /**
+         * Push an unresolved constructor call onto the queue.
+         *
+         * @param declaringType        The type
+         * @param methodName           The method name
+         * @param argument             The unresolved argument
+         * @param arguments            The arguments
+         * @param requiresReflection  is requires reflection
+         * @return This path
+         */
+        Path pushConstructorResolve(BeanDefinition declaringType, String methodName, Argument argument, Argument[] arguments, boolean requiresReflection);
 
         /**
          * Push an unresolved constructor call onto the queue.
@@ -163,6 +175,18 @@ public interface BeanResolutionContext extends ValueResolver<CharSequence>, Auto
         Path pushMethodArgumentResolve(BeanDefinition declaringType, MethodInjectionPoint methodInjectionPoint, Argument argument);
 
         /**
+         * Push an unresolved method call onto the queue.
+         *
+         * @param declaringType        The type
+         * @param methodName           The method name
+         * @param argument             The unresolved argument
+         * @param arguments            The arguments
+         * @param requiresReflection  is requires reflection
+         * @return This path
+         */
+        Path pushMethodArgumentResolve(BeanDefinition declaringType, String methodName, Argument argument, Argument[] arguments, boolean requiresReflection);
+
+        /**
          * Push an unresolved field onto the queue.
          *
          * @param declaringType       declaring type
@@ -170,6 +194,16 @@ public interface BeanResolutionContext extends ValueResolver<CharSequence>, Auto
          * @return This path
          */
         Path pushFieldResolve(BeanDefinition declaringType, FieldInjectionPoint fieldInjectionPoint);
+
+        /**
+         * Push an unresolved field onto the queue.
+         *
+         * @param declaringType       declaring type
+         * @param fieldAsArgument     The field as argument
+         * @param requiresReflection  is requires reflection
+         * @return This path
+         */
+        Path pushFieldResolve(BeanDefinition declaringType, Argument fieldAsArgument, boolean requiresReflection);
 
         /**
          * Converts the path to a circular string.
@@ -182,6 +216,11 @@ public interface BeanResolutionContext extends ValueResolver<CharSequence>, Auto
          * @return The current path segment
          */
         Optional<Segment<?>> currentSegment();
+
+        @Override
+        default void close() {
+            pop();
+        }
     }
 
     /**

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1024,13 +1024,10 @@ public class DefaultBeanContext implements BeanContext {
             }
             Argument[] requiredArguments = ((ParametrizedBeanFactory) definition).getRequiredArguments();
             argumentValues = new LinkedHashMap<>(requiredArguments.length);
-            BeanResolutionContext.Path path = resolutionContext.getPath();
+            BeanResolutionContext.Path currentPath = resolutionContext.getPath();
             for (int i = 0; i < requiredArguments.length; i++) {
                 Argument<?> requiredArgument = requiredArguments[i];
-                try {
-                    path.pushConstructorResolve(
-                            definition, requiredArgument
-                    );
+                try (BeanResolutionContext.Path ignored = currentPath.pushConstructorResolve(definition, requiredArgument)) {
                     Class<?> argumentType = requiredArgument.getType();
                     if (args.length > i) {
                         Object val = args[i];
@@ -1058,8 +1055,6 @@ public class DefaultBeanContext implements BeanContext {
                             }
                         }
                     }
-                } finally {
-                    path.pop();
                 }
             }
         } else {
@@ -2338,7 +2333,7 @@ public class DefaultBeanContext implements BeanContext {
 
         if (bean != null) {
             Qualifier<T> finalQualifier = qualifier != null ? qualifier : declaredQualifier;
-            if (!BeanCreatedEventListener.class.isInstance(bean) && CollectionUtils.isNotEmpty(beanCreationEventListeners)) {
+            if (!(bean instanceof BeanCreatedEventListener) && CollectionUtils.isNotEmpty(beanCreationEventListeners)) {
                 for (Map.Entry<Class, List<BeanCreatedEventListener>> entry : beanCreationEventListeners) {
                     if (entry.getKey().isAssignableFrom(beanType)) {
                         BeanKey<T> beanKey = new BeanKey<>(beanDefinition, finalQualifier);

--- a/inject/src/main/java/io/micronaut/context/exceptions/CircularDependencyException.java
+++ b/inject/src/main/java/io/micronaut/context/exceptions/CircularDependencyException.java
@@ -17,6 +17,7 @@ package io.micronaut.context.exceptions;
 
 import io.micronaut.context.BeanResolutionContext;
 import io.micronaut.core.type.Argument;
+import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.FieldInjectionPoint;
 import io.micronaut.inject.MethodInjectionPoint;
 
@@ -47,6 +48,16 @@ public class CircularDependencyException extends DependencyInjectionException {
     }
 
     /**
+     * @param resolutionContext   The resolution context
+     * @param declaringType       The declaring type
+     * @param fieldName           The field name
+     * @param message             The message
+     */
+    public CircularDependencyException(BeanResolutionContext resolutionContext, BeanDefinition declaringType, String fieldName, String message) {
+        super(resolutionContext, declaringType, fieldName, message, true);
+    }
+
+    /**
      * @param resolutionContext    The resolution context
      * @param methodInjectionPoint The method injection point
      * @param argument             The argument
@@ -54,5 +65,16 @@ public class CircularDependencyException extends DependencyInjectionException {
      */
     public CircularDependencyException(BeanResolutionContext resolutionContext, MethodInjectionPoint methodInjectionPoint, Argument argument, String message) {
         super(resolutionContext, methodInjectionPoint, argument, message, true);
+    }
+
+    /**
+     * @param resolutionContext    The resolution context
+     * @param declaringType        The declaring type
+     * @param methodName           The method name
+     * @param argument             The argument
+     * @param message              The message
+     */
+    public CircularDependencyException(BeanResolutionContext resolutionContext, BeanDefinition declaringType, String methodName, Argument argument, String message) {
+        super(resolutionContext, declaringType, methodName, argument, message, true);
     }
 }

--- a/inject/src/main/java/io/micronaut/context/exceptions/DependencyInjectionException.java
+++ b/inject/src/main/java/io/micronaut/context/exceptions/DependencyInjectionException.java
@@ -19,6 +19,7 @@ import io.micronaut.context.BeanResolutionContext;
 import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.ConversionError;
 import io.micronaut.core.type.Argument;
+import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.FieldInjectionPoint;
 import io.micronaut.inject.MethodInjectionPoint;
 
@@ -34,11 +35,36 @@ public class DependencyInjectionException extends BeanCreationException {
 
     /**
      * @param resolutionContext The resolution context
+     * @param cause             The throwable
+     */
+    public DependencyInjectionException(BeanResolutionContext resolutionContext, Throwable cause) {
+        super(resolutionContext, MessageUtils.buildMessage(resolutionContext, !(cause instanceof BeanInstantiationException) ? cause.getMessage() : null, false), cause);
+    }
+
+    /**
+     * @param resolutionContext The resolution context
      * @param argument          The argument
      * @param cause             The throwable
      */
     public DependencyInjectionException(BeanResolutionContext resolutionContext, Argument argument, Throwable cause) {
         super(resolutionContext, MessageUtils.buildMessage(resolutionContext, argument, !(cause instanceof BeanInstantiationException) ? cause.getMessage() : null, false), cause);
+    }
+
+    /**
+     * @param resolutionContext The resolution context
+     * @param message           The message
+     * @param cause             The throwable
+     */
+    public DependencyInjectionException(BeanResolutionContext resolutionContext, String message, Throwable cause) {
+        super(resolutionContext, MessageUtils.buildMessage(resolutionContext, message), cause);
+    }
+
+    /**
+     * @param resolutionContext The resolution context
+     * @param message           The message
+     */
+    public DependencyInjectionException(BeanResolutionContext resolutionContext, String message) {
+        super(resolutionContext, MessageUtils.buildMessage(resolutionContext, message, false));
     }
 
     /**
@@ -56,7 +82,17 @@ public class DependencyInjectionException extends BeanCreationException {
      * @param cause               The throwable
      */
     public DependencyInjectionException(BeanResolutionContext resolutionContext, FieldInjectionPoint fieldInjectionPoint, Throwable cause) {
-        super(resolutionContext, MessageUtils.buildMessage(resolutionContext, fieldInjectionPoint, null, false), cause);
+        this(resolutionContext, fieldInjectionPoint.getDeclaringBean(), fieldInjectionPoint.getName(), cause);
+    }
+
+    /**
+     * @param resolutionContext   The resolution context
+     * @param declaringBean       The declaring type
+     * @param fieldName           The field name
+     * @param cause               The throwable
+     */
+    public DependencyInjectionException(BeanResolutionContext resolutionContext, BeanDefinition declaringBean, String fieldName, Throwable cause) {
+        super(resolutionContext, MessageUtils.buildMessageForField(resolutionContext, declaringBean, fieldName, null, false), cause);
     }
 
     /**
@@ -65,7 +101,17 @@ public class DependencyInjectionException extends BeanCreationException {
      * @param message             The message
      */
     public DependencyInjectionException(BeanResolutionContext resolutionContext, FieldInjectionPoint fieldInjectionPoint, String message) {
-        super(resolutionContext, MessageUtils.buildMessage(resolutionContext, fieldInjectionPoint, message, false));
+        this(resolutionContext, fieldInjectionPoint.getDeclaringBean(), fieldInjectionPoint.getName(), message);
+    }
+
+    /**
+     * @param resolutionContext   The resolution context
+     * @param declaringBean       The declaring bean
+     * @param fieldName           The field name
+     * @param message             The message
+     */
+    public DependencyInjectionException(BeanResolutionContext resolutionContext, BeanDefinition declaringBean, String fieldName, String message) {
+        super(resolutionContext, MessageUtils.buildMessageForField(resolutionContext, declaringBean, fieldName, message, false));
     }
 
     /**
@@ -75,7 +121,18 @@ public class DependencyInjectionException extends BeanCreationException {
      * @param cause               The throwable
      */
     public DependencyInjectionException(BeanResolutionContext resolutionContext, FieldInjectionPoint fieldInjectionPoint, String message, Throwable cause) {
-        super(resolutionContext, MessageUtils.buildMessage(resolutionContext, fieldInjectionPoint, message, false), cause);
+        this(resolutionContext, fieldInjectionPoint.getDeclaringBean(), fieldInjectionPoint.getName(), message, cause);
+    }
+
+    /**
+     * @param resolutionContext   The resolution context
+     * @param declaringBean       The declaring bean
+     * @param fieldName           The field name
+     * @param message             The message
+     * @param cause               The throwable
+     */
+    public DependencyInjectionException(BeanResolutionContext resolutionContext, BeanDefinition declaringBean, String fieldName, String message, Throwable cause) {
+        super(resolutionContext, MessageUtils.buildMessageForField(resolutionContext, declaringBean, fieldName, message, false), cause);
     }
 
     /**
@@ -85,7 +142,18 @@ public class DependencyInjectionException extends BeanCreationException {
      * @param cause                The throwable
      */
     public DependencyInjectionException(BeanResolutionContext resolutionContext, MethodInjectionPoint methodInjectionPoint, Argument argument, Throwable cause) {
-        super(resolutionContext, MessageUtils.buildMessage(resolutionContext, methodInjectionPoint, argument, null, false), cause);
+        super(resolutionContext, MessageUtils.buildMessageForMethod(resolutionContext, methodInjectionPoint.getDeclaringBean(), methodInjectionPoint.getName(), argument, null, false), cause);
+    }
+
+    /**
+     * @param resolutionContext    The resolution context
+     * @param declaringType        The declaring type
+     * @param methodName           The method name
+     * @param argument             The argument
+     * @param cause                The throwable
+     */
+    public DependencyInjectionException(BeanResolutionContext resolutionContext, BeanDefinition declaringType, String methodName, Argument argument, Throwable cause) {
+        super(resolutionContext, MessageUtils.buildMessageForMethod(resolutionContext, declaringType, methodName, argument, null, false), cause);
     }
 
     /**
@@ -95,7 +163,18 @@ public class DependencyInjectionException extends BeanCreationException {
      * @param message              The message
      */
     public DependencyInjectionException(BeanResolutionContext resolutionContext, MethodInjectionPoint methodInjectionPoint, Argument argument, String message) {
-        super(resolutionContext, MessageUtils.buildMessage(resolutionContext, methodInjectionPoint, argument, message, false));
+        this(resolutionContext, methodInjectionPoint.getDeclaringBean(), methodInjectionPoint.getName(), argument, message);
+    }
+
+    /**
+     * @param resolutionContext    The resolution context
+     * @param declaringType        The declaring type
+     * @param methodName           The method name
+     * @param argument             The argument
+     * @param message              The message
+     */
+    public DependencyInjectionException(BeanResolutionContext resolutionContext, BeanDefinition declaringType, String methodName, Argument argument, String message) {
+        super(resolutionContext, MessageUtils.buildMessageForMethod(resolutionContext, declaringType, methodName, argument, message, false));
     }
 
     /**
@@ -123,7 +202,25 @@ public class DependencyInjectionException extends BeanCreationException {
         MethodInjectionPoint methodInjectionPoint,
         ArgumentConversionContext conversionContext,
         String property) {
-        super(resolutionContext, MessageUtils.buildMessage(resolutionContext, methodInjectionPoint, conversionContext.getArgument(), buildConversionMessage(property, conversionContext), false));
+        this(resolutionContext, methodInjectionPoint.getDeclaringBean(), methodInjectionPoint.getName(), conversionContext, property);
+    }
+
+    /**
+     * Builds an error message for attempted argument conversion on a method.
+     *
+     * @param resolutionContext    The resolution context
+     * @param declaringBean        The declaring bean
+     * @param methodName           The method name
+     * @param conversionContext    The conversion context
+     * @param property             The property being resolved
+     */
+    public DependencyInjectionException(
+        BeanResolutionContext resolutionContext,
+        BeanDefinition declaringBean,
+        String methodName,
+        ArgumentConversionContext conversionContext,
+        String property) {
+        super(resolutionContext, MessageUtils.buildMessageForMethod(resolutionContext, declaringBean, methodName, conversionContext.getArgument(), buildConversionMessage(property, conversionContext), false));
     }
 
     /**
@@ -134,7 +231,19 @@ public class DependencyInjectionException extends BeanCreationException {
      * @param circular             Is the path circular
      */
     protected DependencyInjectionException(BeanResolutionContext resolutionContext, MethodInjectionPoint methodInjectionPoint, Argument argument, String message, boolean circular) {
-        super(resolutionContext, MessageUtils.buildMessage(resolutionContext, methodInjectionPoint, argument, message, circular));
+        this(resolutionContext, methodInjectionPoint.getDeclaringBean(), methodInjectionPoint.getName(), argument, message, circular);
+    }
+
+    /**
+     * @param resolutionContext    The resolution context
+     * @param declaringType        The method declaring type
+     * @param methodName           The method name
+     * @param argument             The argument
+     * @param message              The message
+     * @param circular             Is the path circular
+     */
+    protected DependencyInjectionException(BeanResolutionContext resolutionContext, BeanDefinition declaringType, String methodName, Argument argument, String message, boolean circular) {
+        super(resolutionContext, MessageUtils.buildMessageForMethod(resolutionContext, declaringType, methodName, argument, message, circular));
     }
 
     /**
@@ -144,7 +253,18 @@ public class DependencyInjectionException extends BeanCreationException {
      * @param circular            Is the path circular
      */
     protected DependencyInjectionException(BeanResolutionContext resolutionContext, FieldInjectionPoint fieldInjectionPoint, String message, boolean circular) {
-        super(resolutionContext, MessageUtils.buildMessage(resolutionContext, fieldInjectionPoint, message, circular));
+        this(resolutionContext, fieldInjectionPoint.getDeclaringBean(), fieldInjectionPoint.getName(), message, circular);
+    }
+
+    /**
+     * @param resolutionContext   The resolution context
+     * @param declaringType       The field declaringType
+     * @param fieldName       The field name
+     * @param message             The message
+     * @param circular            Is the path circular
+     */
+    protected DependencyInjectionException(BeanResolutionContext resolutionContext, BeanDefinition declaringType, String fieldName, String message, boolean circular) {
+        super(resolutionContext, MessageUtils.buildMessageForField(resolutionContext, declaringType, fieldName, message, circular));
     }
 
     /**
@@ -155,6 +275,18 @@ public class DependencyInjectionException extends BeanCreationException {
      */
     protected DependencyInjectionException(BeanResolutionContext resolutionContext, Argument argument, String message, boolean circular) {
         super(resolutionContext, MessageUtils.buildMessage(resolutionContext, argument, message, circular));
+    }
+
+    /**
+     * Builds an error message for attempted argument conversion on a method.
+     *
+     * @param resolutionContext    The resolution context
+     * @param conversionContext    The conversion context
+     * @param property             The property being resolved
+     * @return new instance of {@link DependencyInjectionException}
+     */
+    public static DependencyInjectionException missingProperty(BeanResolutionContext resolutionContext, ArgumentConversionContext conversionContext, String property) {
+        return new DependencyInjectionException(resolutionContext, MessageUtils.buildMessage(resolutionContext, buildConversionMessage(property, conversionContext), false));
     }
 
     private static String buildConversionMessage(String property, ArgumentConversionContext conversionContext) {

--- a/inject/src/main/java/io/micronaut/inject/BeanDefinitionReference.java
+++ b/inject/src/main/java/io/micronaut/inject/BeanDefinitionReference.java
@@ -106,7 +106,7 @@ public interface BeanDefinitionReference<T> extends BeanType<T> {
      * @return Is this bean a configuration properties.
      * @since 2.0
      */
-    default  boolean isConfigurationProperties() {
+    default boolean isConfigurationProperties() {
         return getAnnotationMetadata().hasDeclaredStereotype(ConfigurationReader.class);
     }
 }

--- a/inject/src/main/java/io/micronaut/inject/ExecutableMethodsDefinition.java
+++ b/inject/src/main/java/io/micronaut/inject/ExecutableMethodsDefinition.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * Collects a set of executable methods {@link ExecutableMethod}.
+ *
+ * @param <T> The bean type
+ * @author Denis Stepanov
+ * @since 3.0
+ */
+@Internal
+public interface ExecutableMethodsDefinition<T> {
+
+    /**
+     * Finds a single {@link ExecutableMethod} for the given name and argument types.
+     *
+     * @param name          The method name
+     * @param argumentTypes The argument types
+     * @param <R>           The return type
+     * @return An optional {@link ExecutableMethod}
+     */
+    @NonNull
+    <R> Optional<ExecutableMethod<T, R>> findMethod(@NonNull String name, @NonNull Class<?>... argumentTypes);
+
+    /**
+     * Finds possible methods for the given method name.
+     *
+     * @param name The method name
+     * @param <R>  The return type
+     * @return The possible methods
+     */
+    @NonNull
+    <R> Stream<ExecutableMethod<T, R>> findPossibleMethods(@NonNull String name);
+
+
+    /**
+     * @return The {@link ExecutableMethod} instances for this definition
+     */
+    @NonNull
+    Collection<ExecutableMethod<T, ?>> getExecutableMethods();
+
+}

--- a/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataHierarchy.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataHierarchy.java
@@ -834,4 +834,14 @@ public final class AnnotationMetadataHierarchy implements AnnotationMetadata, En
         }
         return Optional.empty();
     }
+
+    @Override
+    public boolean isEmpty() {
+        for (AnnotationMetadata metadata : hierarchy) {
+            if (!metadata.isEmpty()) {
+                return false;
+            }
+        }
+        return true;
+    }
 }

--- a/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataWriter.java
@@ -15,22 +15,41 @@
  */
 package io.micronaut.inject.annotation;
 
-import io.micronaut.core.annotation.*;
+import io.micronaut.core.annotation.AnnotationClassValue;
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.AnnotationUtil;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.UsedByGeneratedCode;
 import io.micronaut.core.reflect.ReflectionUtils;
+import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.writer.AbstractAnnotationMetadataWriter;
 import io.micronaut.inject.writer.AbstractClassFileWriter;
 import io.micronaut.inject.writer.ClassGenerationException;
 import io.micronaut.inject.writer.ClassWriterOutputVisitor;
-import org.objectweb.asm.*;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.GeneratorAdapter;
 import org.objectweb.asm.commons.Method;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.Array;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Responsible for writing class files that are instances of {@link AnnotationMetadata}.
@@ -44,13 +63,6 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
     private static final Type TYPE_DEFAULT_ANNOTATION_METADATA = Type.getType(DefaultAnnotationMetadata.class);
     private static final Type TYPE_DEFAULT_ANNOTATION_METADATA_HIERARCHY = Type.getType(AnnotationMetadataHierarchy.class);
     private static final Type TYPE_ANNOTATION_CLASS_VALUE = Type.getType(AnnotationClassValue.class);
-    private static final org.objectweb.asm.commons.Method METHOD_MAP_OF = org.objectweb.asm.commons.Method.getMethod(
-            ReflectionUtils.getRequiredInternalMethod(
-                    AnnotationUtil.class,
-                    "internMapOf",
-                    Object[].class
-            )
-    );
 
     private static final org.objectweb.asm.commons.Method METHOD_LIST_OF = org.objectweb.asm.commons.Method.getMethod(
             ReflectionUtils.getRequiredInternalMethod(
@@ -134,13 +146,14 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
             )
     );
 
-    private static final Type EMPTY_MAP_TYPE = Type.getType(Map.class);
-    private static final String EMPTY_MAP = "EMPTY_MAP";
+    private static final Type ANNOTATION_UTIL_TYPE = Type.getType(AnnotationUtil.class);
+    private static final Type LIST_TYPE = Type.getType(List.class);
+    private static final String EMPTY_LIST = "EMPTY_LIST";
+
     private static final String LOAD_CLASS_PREFIX = "$micronaut_load_class_value_";
 
     private final String className;
     private final AnnotationMetadata annotationMetadata;
-    private final AnnotationMetadata parent;
     private final boolean writeAnnotationDefaults;
 
     /**
@@ -161,12 +174,10 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
         super(originatingElement);
         this.className = className + AnnotationMetadata.CLASS_NAME_SUFFIX;
         if (annotationMetadata instanceof DefaultAnnotationMetadata) {
-            this.parent = null;
             this.annotationMetadata = annotationMetadata;
         } else if (annotationMetadata instanceof AnnotationMetadataHierarchy) {
             final AnnotationMetadataHierarchy hierarchy = (AnnotationMetadataHierarchy) annotationMetadata;
             this.annotationMetadata = hierarchy.getDeclaredMetadata();
-           this.parent = hierarchy.getRootMetadata();
         } else {
             throw new ClassGenerationException("Compile time metadata required to generate class: " + className);
         }
@@ -235,22 +246,24 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
      * @param declaringClassWriter The declaring class writer
      * @param generatorAdapter     The generator adapter
      * @param annotationMetadata   The annotation metadata
+     * @param defaultsStorage      The annotation defaults
      * @param loadTypeMethods      The generated load type methods
      */
     @Internal
     @UsedByGeneratedCode
-    public static void instantiateNewMetadata(Type owningType, ClassWriter declaringClassWriter, GeneratorAdapter generatorAdapter, DefaultAnnotationMetadata annotationMetadata, Map<String, GeneratorAdapter> loadTypeMethods) {
-        instantiateInternal(owningType, declaringClassWriter, generatorAdapter, annotationMetadata, true, loadTypeMethods);
+    public static void instantiateNewMetadata(Type owningType, ClassWriter declaringClassWriter, GeneratorAdapter generatorAdapter, DefaultAnnotationMetadata annotationMetadata, Map<String, Integer> defaultsStorage, Map<String, GeneratorAdapter> loadTypeMethods) {
+        instantiateInternal(owningType, declaringClassWriter, generatorAdapter, annotationMetadata, true, defaultsStorage, loadTypeMethods);
     }
 
     /**
      * Writes out the byte code necessary to instantiate the given {@link AnnotationMetadataHierarchy}.
      *
-     * @param owningType           The owning type
-     * @param classWriter The declaring class writer
-     * @param generatorAdapter     The generator adapter
-     * @param hierarchy   The annotation metadata
-     * @param loadTypeMethods      The generated load type methods
+     * @param owningType       The owning type
+     * @param classWriter      The declaring class writer
+     * @param generatorAdapter The generator adapter
+     * @param hierarchy        The annotation metadata
+     * @param defaultsStorage  The annotation defaults
+     * @param loadTypeMethods  The generated load type methods
      */
     @Internal
     @UsedByGeneratedCode
@@ -259,18 +272,31 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
             ClassWriter classWriter,
             GeneratorAdapter generatorAdapter,
             AnnotationMetadataHierarchy hierarchy,
+            Map<String, Integer> defaultsStorage,
             Map<String, GeneratorAdapter> loadTypeMethods) {
-            generatorAdapter.visitTypeInsn(NEW, TYPE_DEFAULT_ANNOTATION_METADATA_HIERARCHY.getInternalName());
-            generatorAdapter.visitInsn(DUP);
+
+        if (hierarchy.isEmpty()) {
+            generatorAdapter.getStatic(Type.getType(AnnotationMetadata.class), "EMPTY_METADATA", Type.getType(AnnotationMetadata.class));
+            return;
+        }
+        List<AnnotationMetadata> notEmpty = CollectionUtils.iterableToList(hierarchy)
+                .stream().filter(h -> !h.isEmpty()).collect(Collectors.toList());
+        if (notEmpty.size() == 1) {
+            pushNewAnnotationMetadataOrReference(owningType, classWriter, generatorAdapter, defaultsStorage, loadTypeMethods, notEmpty.get(0));
+            return;
+        }
+
+        generatorAdapter.visitTypeInsn(NEW, TYPE_DEFAULT_ANNOTATION_METADATA_HIERARCHY.getInternalName());
+        generatorAdapter.visitInsn(DUP);
 
         pushNewArray(generatorAdapter, AnnotationMetadata.class, 2);
         pushStoreInArray(generatorAdapter, 0, 2, () -> {
             final AnnotationMetadata rootMetadata = hierarchy.getRootMetadata();
-            pushNewAnnotationMetadataOrReference(owningType, classWriter, generatorAdapter, loadTypeMethods, rootMetadata);
+            pushNewAnnotationMetadataOrReference(owningType, classWriter, generatorAdapter, defaultsStorage, loadTypeMethods, rootMetadata);
         });
         pushStoreInArray(generatorAdapter, 1, 2, () -> {
             final AnnotationMetadata declaredMetadata = hierarchy.getDeclaredMetadata();
-            pushNewAnnotationMetadataOrReference(owningType, classWriter, generatorAdapter, loadTypeMethods, declaredMetadata);
+            pushNewAnnotationMetadataOrReference(owningType, classWriter, generatorAdapter, defaultsStorage, loadTypeMethods, declaredMetadata);
         });
 
         // invoke the constructor
@@ -279,7 +305,8 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
 
     /**
      * Pushes an annotation metadata reference.
-     * @param generatorAdapter The generator adapter
+     *
+     * @param generatorAdapter   The generator adapter
      * @param annotationMetadata The metadata
      */
     @Internal
@@ -294,6 +321,7 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
             Type owningType,
             ClassWriter classWriter,
             GeneratorAdapter generatorAdapter,
+            Map<String, Integer> defaultsStorage,
             Map<String, GeneratorAdapter> loadTypeMethods,
             AnnotationMetadata annotationMetadata) {
         if (annotationMetadata instanceof DefaultAnnotationMetadata) {
@@ -302,6 +330,7 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
                     classWriter,
                     generatorAdapter,
                     (DefaultAnnotationMetadata) annotationMetadata,
+                    defaultsStorage,
                     loadTypeMethods
             );
         } else if (annotationMetadata instanceof AnnotationMetadataReference) {
@@ -314,20 +343,21 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
     /**
      * Writes out the byte code necessary to instantiate the given {@link DefaultAnnotationMetadata}.
      *
-     * @param annotationMetadata   The annotation metadata
-     * @param classWriter          The class writer
-     * @param owningType           The owning type
-     * @param loadTypeMethods      The generated load type methods
+     * @param annotationMetadata The annotation metadata
+     * @param classWriter        The class writer
+     * @param owningType         The owning type
+     * @param defaultsStorage    The annotation defaults
+     * @param loadTypeMethods    The generated load type methods
      */
     @Internal
-    public static void writeAnnotationDefaults(DefaultAnnotationMetadata annotationMetadata, ClassWriter classWriter, Type owningType, Map<String, GeneratorAdapter> loadTypeMethods) {
+    public static void writeAnnotationDefaults(DefaultAnnotationMetadata annotationMetadata, ClassWriter classWriter, Type owningType, Map<String, Integer> defaultsStorage, Map<String, GeneratorAdapter> loadTypeMethods) {
         final Map<String, Map<CharSequence, Object>> annotationDefaultValues = annotationMetadata.annotationDefaultValues;
         if (CollectionUtils.isNotEmpty(annotationDefaultValues)) {
 
             MethodVisitor si = classWriter.visitMethod(ACC_STATIC, "<clinit>", "()V", null, null);
             GeneratorAdapter staticInit = new GeneratorAdapter(si, ACC_STATIC, "<clinit>", "()V");
 
-            writeAnnotationDefaults(owningType, classWriter, staticInit, annotationMetadata, loadTypeMethods);
+            writeAnnotationDefaults(owningType, classWriter, staticInit, annotationMetadata, defaultsStorage, loadTypeMethods);
             staticInit.visitInsn(RETURN);
 
             staticInit.visitMaxs(1, 1);
@@ -337,11 +367,13 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
 
     /**
      * Write annotation defaults into the given static init block.
-     * @param owningType The owning type
-     * @param classWriter The class writer
-     * @param staticInit The staitc init
+     *
+     * @param owningType         The owning type
+     * @param classWriter        The class writer
+     * @param staticInit         The staitc init
      * @param annotationMetadata The annotation metadata
-     * @param loadTypeMethods The load type methods
+     * @param defaultsStorage    The annotation defaults
+     * @param loadTypeMethods    The load type methods
      */
     @Internal
     public static void writeAnnotationDefaults(
@@ -349,6 +381,7 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
             ClassWriter classWriter,
             GeneratorAdapter staticInit,
             DefaultAnnotationMetadata annotationMetadata,
+            Map<String, Integer> defaultsStorage,
             Map<String, GeneratorAdapter> loadTypeMethods) {
         final Map<String, Map<CharSequence, Object>> annotationDefaultValues = annotationMetadata.annotationDefaultValues;
         if (CollectionUtils.isNotEmpty(annotationDefaultValues)) {
@@ -373,7 +406,7 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
                 invokeLoadClassValueMethod(owningType, classWriter, staticInit, loadTypeMethods, new AnnotationClassValue(annotationName));
 
                 if (!typeOnly) {
-                    pushAnnotationAttributes(owningType, classWriter, staticInit, annotationValues, loadTypeMethods);
+                    pushStringMapOf(staticInit, annotationValues, true, null, v -> pushValue(owningType, classWriter, staticInit, v, defaultsStorage, loadTypeMethods));
                     staticInit.invokeStatic(TYPE_DEFAULT_ANNOTATION_METADATA, METHOD_REGISTER_ANNOTATION_DEFAULTS);
                 } else {
                     staticInit.invokeStatic(TYPE_DEFAULT_ANNOTATION_METADATA, METHOD_REGISTER_ANNOTATION_TYPE);
@@ -383,32 +416,25 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
         }
     }
 
-    /**
-     * Writes annotation attributes to the given generator.
-     *
-     * @param declaringClassWriter The declaring class
-     * @param generatorAdapter     The generator adapter
-     * @param annotationData       The annotation data
-     * @param loadTypeMethods      Generated methods that load types
-     */
-    @Internal
-    private static void pushAnnotationAttributes(Type declaringType, ClassVisitor declaringClassWriter, GeneratorAdapter generatorAdapter, Map<? extends CharSequence, Object> annotationData, Map<String, GeneratorAdapter> loadTypeMethods) {
-        int totalSize = annotationData.size() * 2;
+    private static void pushListOfString(GeneratorAdapter methodVisitor, List<String> names) {
+        if (names != null) {
+            names = names.stream().filter(Objects::nonNull).collect(Collectors.toList());
+        }
+        if (names == null || names.isEmpty()) {
+            methodVisitor.getStatic(Type.getType(Collections.class), EMPTY_LIST, LIST_TYPE);
+            return;
+        }
+        int totalSize = names.size();
         // start a new array
-        pushNewArray(generatorAdapter, Object.class, totalSize);
+        pushNewArray(methodVisitor, Object.class, totalSize);
         int i = 0;
-        for (Map.Entry<? extends CharSequence, Object> entry : annotationData.entrySet()) {
+        for (String name : names) {
             // use the property name as the key
-            String memberName = entry.getKey().toString();
-            pushStoreStringInArray(generatorAdapter, i++, totalSize, memberName);
+            pushStoreStringInArray(methodVisitor, i++, totalSize, name);
             // use the property type as the value
-            Object value = entry.getValue();
-            pushStoreInArray(generatorAdapter, i++, totalSize, () ->
-                    pushValue(declaringType, declaringClassWriter, generatorAdapter, value, loadTypeMethods)
-            );
         }
         // invoke the AbstractBeanDefinition.createMap method
-        generatorAdapter.invokeStatic(Type.getType(AnnotationUtil.class), METHOD_MAP_OF);
+        methodVisitor.invokeStatic(ANNOTATION_UTIL_TYPE, METHOD_LIST_OF);
     }
 
     private static void instantiateInternal(
@@ -417,6 +443,7 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
             GeneratorAdapter generatorAdapter,
             DefaultAnnotationMetadata annotationMetadata,
             boolean isNew,
+            Map<String, Integer> defaultsStorage,
             Map<String, GeneratorAdapter> loadTypeMethods) {
         if (isNew) {
             generatorAdapter.visitTypeInsn(NEW, TYPE_DEFAULT_ANNOTATION_METADATA.getInternalName());
@@ -425,15 +452,15 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
             generatorAdapter.loadThis();
         }
         // 1st argument: the declared annotations
-        pushCreateAnnotationData(owningType, declaringClassWriter, generatorAdapter, annotationMetadata.declaredAnnotations, loadTypeMethods, annotationMetadata.getSourceRetentionAnnotations());
+        pushCreateAnnotationData(owningType, declaringClassWriter, generatorAdapter, annotationMetadata.declaredAnnotations, defaultsStorage, loadTypeMethods, annotationMetadata.getSourceRetentionAnnotations());
         // 2nd argument: the declared stereotypes
-        pushCreateAnnotationData(owningType, declaringClassWriter, generatorAdapter, annotationMetadata.declaredStereotypes, loadTypeMethods, annotationMetadata.getSourceRetentionAnnotations());
+        pushCreateAnnotationData(owningType, declaringClassWriter, generatorAdapter, annotationMetadata.declaredStereotypes, defaultsStorage, loadTypeMethods, annotationMetadata.getSourceRetentionAnnotations());
         // 3rd argument: all stereotypes
-        pushCreateAnnotationData(owningType, declaringClassWriter, generatorAdapter, annotationMetadata.allStereotypes, loadTypeMethods, annotationMetadata.getSourceRetentionAnnotations());
+        pushCreateAnnotationData(owningType, declaringClassWriter, generatorAdapter, annotationMetadata.allStereotypes, defaultsStorage, loadTypeMethods, annotationMetadata.getSourceRetentionAnnotations());
         // 4th argument: all annotations
-        pushCreateAnnotationData(owningType, declaringClassWriter, generatorAdapter, annotationMetadata.allAnnotations, loadTypeMethods, annotationMetadata.getSourceRetentionAnnotations());
+        pushCreateAnnotationData(owningType, declaringClassWriter, generatorAdapter, annotationMetadata.allAnnotations, defaultsStorage, loadTypeMethods, annotationMetadata.getSourceRetentionAnnotations());
         // 5th argument: annotations by stereotype
-        pushCreateAnnotationsByStereotypeData(generatorAdapter, annotationMetadata.annotationsByStereotype);
+        pushStringMapOf(generatorAdapter, annotationMetadata.annotationsByStereotype, false, Collections.emptyList(), list -> pushListOfString(generatorAdapter, list));
         // 6th argument: has property expressions
         generatorAdapter.push(annotationMetadata.hasPropertyExpressions());
 
@@ -450,6 +477,7 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
         GeneratorAdapter constructor = startConstructor(classWriter);
         DefaultAnnotationMetadata annotationMetadata = (DefaultAnnotationMetadata) this.annotationMetadata;
 
+        Map<String, Integer> defaultsStorage = new HashMap<>(3);
         final HashMap<String, GeneratorAdapter> loadTypeMethods = new HashMap<>(5);
         instantiateInternal(
                 owningType,
@@ -457,12 +485,13 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
                 constructor,
                 annotationMetadata,
                 false,
+                defaultsStorage,
                 loadTypeMethods);
         constructor.visitInsn(RETURN);
         constructor.visitMaxs(1, 1);
         constructor.visitEnd();
         if (writeAnnotationDefaults) {
-            writeAnnotationDefaults(annotationMetadata, classWriter, owningType, loadTypeMethods);
+            writeAnnotationDefaults(annotationMetadata, classWriter, owningType, defaultsStorage, loadTypeMethods);
         }
         for (GeneratorAdapter adapter : loadTypeMethods.values()) {
             adapter.visitMaxs(3, 1);
@@ -472,53 +501,12 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
         return classWriter;
     }
 
-    private static void pushCreateListCall(GeneratorAdapter methodVisitor, List<String> names) {
-        int totalSize = names == null ? 0 : names.size();
-        if (totalSize > 0) {
-
-            // start a new array
-            pushNewArray(methodVisitor, Object.class, totalSize);
-            int i = 0;
-            for (String name : names) {
-                // use the property name as the key
-                pushStoreStringInArray(methodVisitor, i++, totalSize, name);
-                // use the property type as the value
-            }
-            // invoke the AbstractBeanDefinition.createMap method
-            methodVisitor.invokeStatic(Type.getType(AnnotationUtil.class), METHOD_LIST_OF);
-        } else {
-            methodVisitor.visitInsn(ACONST_NULL);
-        }
-    }
-
-    private static void pushCreateAnnotationsByStereotypeData(GeneratorAdapter methodVisitor, Map<String, List<String>> annotationData) {
-        int totalSize = annotationData == null ? 0 : annotationData.size() * 2;
-        if (totalSize > 0) {
-
-            // start a new array
-            pushNewArray(methodVisitor, Object.class, totalSize);
-            int i = 0;
-            for (Map.Entry<String, List<String>> entry : annotationData.entrySet()) {
-                // use the property name as the key
-                String annotationName = entry.getKey();
-                pushStoreStringInArray(methodVisitor, i++, totalSize, annotationName);
-                // use the property type as the value
-                pushStoreInArray(methodVisitor, i++, totalSize, () ->
-                        pushCreateListCall(methodVisitor, entry.getValue())
-                );
-            }
-            // invoke the AbstractBeanDefinition.createMap method
-            methodVisitor.invokeStatic(Type.getType(AnnotationUtil.class), METHOD_MAP_OF);
-        } else {
-            methodVisitor.visitInsn(ACONST_NULL);
-        }
-    }
-
     private static void pushCreateAnnotationData(
             Type declaringType,
             ClassWriter declaringClassWriter,
             GeneratorAdapter methodVisitor,
             Map<String, Map<CharSequence, Object>> annotationData,
+            Map<String, Integer> defaultsStorage,
             Map<String, GeneratorAdapter> loadTypeMethods,
             Set<String> sourceRetentionAnnotations) {
         if (annotationData != null) {
@@ -527,38 +515,18 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
                 annotationData.remove(sourceRetentionAnnotation);
             }
         }
-        int totalSize = annotationData == null ? 0 : annotationData.size() * 2;
-        if (totalSize > 0) {
 
-            // start a new array
-            pushNewArray(methodVisitor, Object.class, totalSize);
-            int i = 0;
-            for (Map.Entry<String, Map<CharSequence, Object>> entry : annotationData.entrySet()) {
-                // use the property name as the key
-                String annotationName = entry.getKey();
-                pushStoreStringInArray(methodVisitor, i++, totalSize, annotationName);
-                // use the property type as the value
-                Map<CharSequence, Object> attributes = entry.getValue();
-                if (attributes.isEmpty()) {
-                    pushStoreInArray(methodVisitor, i++, totalSize, () ->
-                            methodVisitor.getStatic(Type.getType(Collections.class), EMPTY_MAP, EMPTY_MAP_TYPE)
-                    );
-                } else {
-                    pushStoreInArray(methodVisitor, i++, totalSize, () ->
-                            pushAnnotationAttributes(declaringType, declaringClassWriter, methodVisitor, attributes, loadTypeMethods)
-                    );
-                }
-            }
-            // invoke the StringUtils.mapOf method
-            methodVisitor.invokeStatic(Type.getType(AnnotationUtil.class), METHOD_MAP_OF);
-        } else {
-            methodVisitor.visitInsn(ACONST_NULL);
-        }
+        pushStringMapOf(methodVisitor, annotationData, false, Collections.emptyMap(), attributes -> {
+            pushStringMapOf(methodVisitor, attributes, true, null, v -> pushValue(declaringType, declaringClassWriter, methodVisitor, v, defaultsStorage, loadTypeMethods));
+        });
     }
 
-    private static void pushValue(Type declaringType, ClassVisitor declaringClassWriter, GeneratorAdapter methodVisitor, Object value, Map<String, GeneratorAdapter> loadTypeMethods) {
+    private static void pushValue(Type declaringType, ClassVisitor declaringClassWriter,
+                                  GeneratorAdapter methodVisitor, Object value,
+                                  Map<String, Integer> defaultsStorage,
+                                  Map<String, GeneratorAdapter> loadTypeMethods) {
         if (value == null) {
-            methodVisitor.visitInsn(ACONST_NULL);
+            throw new IllegalStateException("Cannot map null value in: " + declaringType.getClassName());
         } else if (value instanceof Boolean) {
             methodVisitor.push((Boolean) value);
             pushBoxPrimitiveIfNecessary(boolean.class, methodVisitor);
@@ -584,19 +552,23 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
         } else if (value.getClass().isArray()) {
             final Class<?> componentType = ReflectionUtils.getWrapperType(value.getClass().getComponentType());
             int len = Array.getLength(value);
-            pushNewArray(methodVisitor, componentType, len);
-            for (int i = 0; i < len; i++) {
-                final Object v = Array.get(value, i);
-                pushStoreInArray(methodVisitor, i, len, () ->
-                        pushValue(declaringType, declaringClassWriter, methodVisitor, v, loadTypeMethods)
-                );
+            if (Object.class == componentType && len == 0) {
+                pushEmptyObjectsArray(methodVisitor);
+            } else {
+                pushNewArray(methodVisitor, componentType, len);
+                for (int i = 0; i < len; i++) {
+                    final Object v = Array.get(value, i);
+                    pushStoreInArray(methodVisitor, i, len, () ->
+                            pushValue(declaringType, declaringClassWriter, methodVisitor, v, defaultsStorage, loadTypeMethods)
+                    );
+                }
             }
         } else if (value instanceof Collection) {
-            List array = Arrays.asList(((Collection) value).toArray());
-            int len = array.size();
-            if (len == 0) {
-                pushNewArray(methodVisitor, Object.class, len);
+            if (((Collection<?>) value).isEmpty()) {
+                pushEmptyObjectsArray(methodVisitor);
             } else {
+                List array = Arrays.asList(((Collection) value).toArray());
+                int len = array.size();
                 boolean first = true;
                 for (int i = 0; i < len; i++) {
                     Object v = array.get(i);
@@ -605,7 +577,7 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
                         pushNewArray(methodVisitor, type, len);
                         first = false;
                     }
-                    pushStoreInArray(methodVisitor, i, len, () -> pushValue(declaringType, declaringClassWriter, methodVisitor, v, loadTypeMethods));
+                    pushStoreInArray(methodVisitor, i, len, () -> pushValue(declaringType, declaringClassWriter, methodVisitor, v, defaultsStorage, loadTypeMethods));
                 }
             }
         } else if (value instanceof Long) {
@@ -629,17 +601,27 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
             methodVisitor.dup();
             methodVisitor.push(annotationName);
 
-            if (CollectionUtils.isNotEmpty(values)) {
-                pushAnnotationAttributes(declaringType, declaringClassWriter, methodVisitor, values, loadTypeMethods);
+            pushStringMapOf(methodVisitor, values, true, null, v -> pushValue(declaringType, declaringClassWriter, methodVisitor, v, defaultsStorage, loadTypeMethods));
+
+            Integer defaultIndex = defaultsStorage.get(annotationName);
+            if (defaultIndex == null) {
+                methodVisitor.push(annotationName);
+                methodVisitor.invokeStatic(Type.getType(AnnotationMetadataSupport.class), METHOD_GET_DEFAULT_VALUES);
+                methodVisitor.dup();
+                int localIndex = methodVisitor.newLocal(Type.getType(Map.class));
+                methodVisitor.storeLocal(localIndex);
+                defaultsStorage.put(annotationName, localIndex);
             } else {
-                methodVisitor.getStatic(Type.getType(Collections.class), "EMPTY_MAP", Type.getType(Map.class));
+                methodVisitor.loadLocal(defaultIndex);
             }
-            methodVisitor.push(annotationName);
-            methodVisitor.invokeStatic(Type.getType(AnnotationMetadataSupport.class), METHOD_GET_DEFAULT_VALUES);
             methodVisitor.invokeConstructor(annotationValueType, CONSTRUCTOR_ANNOTATION_VALUE_AND_MAP);
         } else {
-            methodVisitor.visitInsn(ACONST_NULL);
+            throw new IllegalStateException("Cannot map unknown value: " + value + " in: " + declaringType.getClassName());
         }
+    }
+
+    private static void pushEmptyObjectsArray(GeneratorAdapter methodVisitor) {
+        methodVisitor.getStatic(Type.getType(ArrayUtils.class), "EMPTY_OBJECT_ARRAY", Type.getType(Object[].class));
     }
 
     private static void invokeLoadClassValueMethod(
@@ -685,7 +667,7 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
             loadTypeGenerator.visitLabel(tryEnd);
             loadTypeGenerator.returnValue();
             loadTypeGenerator.visitLabel(exceptionHandler);
-            loadTypeGenerator.visitFrame(Opcodes.F_NEW, 0, new Object[] {}, 1, new Object[] {"java/lang/Throwable"});
+            loadTypeGenerator.visitFrame(Opcodes.F_NEW, 0, new Object[]{}, 1, new Object[]{"java/lang/Throwable"});
             // Try load the class
 
             // fallback to return a class value that is just a string

--- a/inject/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
@@ -298,6 +298,7 @@ final class BeanIntrospectionWriter extends AbstractAnnotationMetadataWriter {
                         introspectionWriter,
                         constructorWriter,
                         Arrays.asList(constructor.getParameters()),
+                        new HashMap<>(),
                         localLoadTypeMethods
                 );
 
@@ -363,6 +364,7 @@ final class BeanIntrospectionWriter extends AbstractAnnotationMetadataWriter {
                             introspectionWriter,
                             constructorMetadata,
                             (DefaultAnnotationMetadata) annotationMetadata,
+                            new HashMap<>(),
                             localLoadTypeMethods
                     );
                     constructorMetadata.returnValue();

--- a/inject/src/main/java/io/micronaut/inject/beans/visitor/BeanMethodWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/visitor/BeanMethodWriter.java
@@ -39,10 +39,7 @@ import org.objectweb.asm.commons.GeneratorAdapter;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
+import java.util.*;
 
 /**
  * Writes {@link io.micronaut.core.beans.BeanMethod} instances for introspections.
@@ -60,6 +57,7 @@ final class BeanMethodWriter extends AbstractClassFileWriter implements Named {
     private final ClassWriter classWriter;
     private final BeanIntrospectionWriter introspectionWriter;
     private final HashMap<String, GeneratorAdapter> loadTypeMethods = new HashMap<>();
+    private final Map<String, Integer> defaults = new HashMap<>();
 
     /**
      * Default constructor.
@@ -167,6 +165,7 @@ final class BeanMethodWriter extends AbstractClassFileWriter implements Named {
                     genericReturnType,
                     genericReturnType.getAnnotationMetadata(),
                     genericReturnType.getTypeArguments(),
+                    new HashMap<>(),
                     loadTypeMethods
             );
         }
@@ -188,7 +187,7 @@ final class BeanMethodWriter extends AbstractClassFileWriter implements Named {
             if (defaultMetadata.isEmpty()) {
                 constructor.visitInsn(ACONST_NULL);
             } else {
-                AnnotationMetadataWriter.instantiateNewMetadata(type, classWriter, constructor, defaultMetadata, loadTypeMethods);
+                AnnotationMetadataWriter.instantiateNewMetadata(type, classWriter, constructor, defaultMetadata, defaults, loadTypeMethods);
             }
         } else {
             constructor.visitInsn(ACONST_NULL);
@@ -201,6 +200,7 @@ final class BeanMethodWriter extends AbstractClassFileWriter implements Named {
                 classWriter,
                 constructor,
                 Arrays.asList(methodElement.getParameters()),
+                new HashMap<>(),
                 loadTypeMethods
         );
 

--- a/inject/src/main/java/io/micronaut/inject/beans/visitor/BeanPropertyWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/visitor/BeanPropertyWriter.java
@@ -71,6 +71,7 @@ class BeanPropertyWriter extends AbstractClassFileWriter implements Named {
     private final MethodElement writeMethod;
     private final MethodElement withMethod;
     private final HashMap<String, GeneratorAdapter> loadTypeMethods = new HashMap<>();
+    private final Map<String, Integer> defaults = new HashMap<>();
     private final TypedElement typeElement;
     private final ClassElement declaringElement;
     private final Type propertyGenericType;
@@ -470,7 +471,7 @@ class BeanPropertyWriter extends AbstractClassFileWriter implements Named {
             if (annotationMetadata.isEmpty()) {
                 constructor.visitInsn(ACONST_NULL);
             } else {
-                AnnotationMetadataWriter.instantiateNewMetadata(type, classWriter, constructor, annotationMetadata, loadTypeMethods);
+                AnnotationMetadataWriter.instantiateNewMetadata(type, classWriter, constructor, annotationMetadata, defaults, loadTypeMethods);
             }
         } else {
             constructor.visitInsn(ACONST_NULL);
@@ -484,6 +485,7 @@ class BeanPropertyWriter extends AbstractClassFileWriter implements Named {
                     constructor,
                     typeElement.getName(),
                     typeArguments,
+                    new HashMap<>(),
                     loadTypeMethods
             );
         } else {

--- a/inject/src/main/java/io/micronaut/inject/beans/visitor/EntityIntrospectedAnnotationMapper.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/visitor/EntityIntrospectedAnnotationMapper.java
@@ -25,7 +25,6 @@ import io.micronaut.inject.visitor.VisitorContext;
 import io.micronaut.core.annotation.NonNull;
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 /**

--- a/inject/src/main/java/io/micronaut/inject/qualifiers/Qualifiers.java
+++ b/inject/src/main/java/io/micronaut/inject/qualifiers/Qualifiers.java
@@ -77,12 +77,12 @@ public class Qualifiers {
                         qualifierTypes.iterator().next()
                 );
             } else {
-                final Qualifier[] qualifiers = qualifierTypes
-                        .stream().map((type) -> Qualifiers.byAnnotation(annotationMetadata, type))
-                        .toArray(Qualifier[]::new);
-                return Qualifiers.byQualifiers(
-                        qualifiers
-                );
+                Qualifier[] qualifiers = new Qualifier[qualifierTypes.size()];
+                int i = 0;
+                for (String type : qualifierTypes) {
+                    qualifiers[i++] = Qualifiers.byAnnotation(annotationMetadata, type);
+                }
+                return Qualifiers.byQualifiers(qualifiers);
             }
         }
 

--- a/inject/src/main/java/io/micronaut/inject/writer/AbstractAnnotationMetadataWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/AbstractAnnotationMetadataWriter.java
@@ -49,6 +49,7 @@ public abstract class AbstractAnnotationMetadataWriter extends AbstractClassFile
     protected final Type targetClassType;
     protected final AnnotationMetadata annotationMetadata;
     protected final Map<String, GeneratorAdapter> loadTypeMethods = new HashMap<>();
+    protected final Map<String, Integer> defaults = new HashMap<>();
     private final boolean writeAnnotationDefault;
 
     /**
@@ -137,6 +138,7 @@ public abstract class AbstractAnnotationMetadataWriter extends AbstractClassFile
                         classWriter,
                         staticInit,
                         dam,
+                        defaults,
                         loadTypeMethods
                 );
 
@@ -161,6 +163,7 @@ public abstract class AbstractAnnotationMetadataWriter extends AbstractClassFile
                     classWriter,
                     staticInit,
                     (DefaultAnnotationMetadata) annotationMetadata,
+                    defaults,
                     loadTypeMethods
             );
         } else if (annotationMetadata instanceof AnnotationMetadataHierarchy) {
@@ -169,6 +172,7 @@ public abstract class AbstractAnnotationMetadataWriter extends AbstractClassFile
                     classWriter,
                     staticInit,
                     (AnnotationMetadataHierarchy) annotationMetadata,
+                    defaults,
                     loadTypeMethods
             );
         } else {

--- a/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionReferenceWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionReferenceWriter.java
@@ -15,16 +15,17 @@
  */
 package io.micronaut.inject.writer;
 
-import io.micronaut.context.AbstractBeanDefinitionReference;
-import io.micronaut.context.annotation.ConfigurationReader;
-import io.micronaut.context.annotation.DefaultScope;
+import io.micronaut.context.AbstractBeanDefinitionReference2;
+import io.micronaut.context.annotation.*;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationUtil;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.type.DefaultArgument;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.AdvisedBeanType;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.BeanDefinitionReference;
+import io.micronaut.inject.annotation.AnnotationMetadataReference;
 import jakarta.inject.Singleton;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Type;
@@ -37,6 +38,7 @@ import java.io.OutputStream;
  * Writes the bean definition class file to disk.
  *
  * @author Graeme Rocher
+ * @author Denis Stepanov
  * @see BeanDefinitionReference
  * @since 1.0
  */
@@ -46,7 +48,21 @@ public class BeanDefinitionReferenceWriter extends AbstractAnnotationMetadataWri
     /**
      * Suffix for reference classes.
      */
-    public static final String REF_SUFFIX = "Class";
+    public static final String REF_SUFFIX = "$Reference";
+
+    private static final org.objectweb.asm.commons.Method BEAN_DEFINITION_REF_CLASS_CONSTRUCTOR = new org.objectweb.asm.commons.Method(CONSTRUCTOR_NAME, getConstructorDescriptor(
+            String.class, // beanTypeName
+            String.class, // beanDefinitionTypeName
+            AnnotationMetadata.class, // annotationMetadata
+            boolean.class, // isPrimary
+            boolean.class, // isContextScope
+            boolean.class, // isConditional
+            boolean.class, // isContainerType
+            boolean.class, // isSingleton
+            boolean.class, // isConfigurationProperties
+            boolean.class,  // hasExposedTypes
+            boolean.class  // requiresMethodProcessing
+    ));
 
     private final String beanTypeName;
     private final String beanDefinitionName;
@@ -148,7 +164,7 @@ public class BeanDefinitionReferenceWriter extends AbstractAnnotationMetadataWri
     private ClassWriter generateClassBytes() {
         ClassWriter classWriter = new ClassWriter(ClassWriter.COMPUTE_MAXS);
 
-        Type superType = Type.getType(AbstractBeanDefinitionReference.class);
+        Type superType = Type.getType(AbstractBeanDefinitionReference2.class);
         String[] interfaceInternalNames;
         if (interceptedType != null) {
             interfaceInternalNames = new String[] { Type.getType(AdvisedBeanType.class).getInternalName() };
@@ -167,15 +183,52 @@ public class BeanDefinitionReferenceWriter extends AbstractAnnotationMetadataWri
 
         GeneratorAdapter cv = startConstructor(classWriter);
 
-        // ALOAD 0
         cv.loadThis();
-        // LDC "..class name.."
+        // 1: beanTypeName
         cv.push(beanTypeName);
+        // 2: beanDefinitionTypeName
         cv.push(beanDefinitionName);
-
-        // INVOKESPECIAL AbstractBeanDefinitionReference.<init> (Ljava/lang/String;)V
-        invokeConstructor(cv, AbstractBeanDefinitionReference.class, String.class, String.class);
-
+        // 3: annotationMetadata
+        if (annotationMetadata == AnnotationMetadata.EMPTY_METADATA || annotationMetadata.isEmpty()) {
+            cv.getStatic(Type.getType(AnnotationMetadata.class), "EMPTY_METADATA", Type.getType(AnnotationMetadata.class));
+        } else if (annotationMetadata instanceof AnnotationMetadataReference) {
+            AnnotationMetadataReference reference = (AnnotationMetadataReference) annotationMetadata;
+            String className = reference.getClassName();
+            cv.getStatic(getTypeReferenceForName(className), AbstractAnnotationMetadataWriter.FIELD_ANNOTATION_METADATA, Type.getType(AnnotationMetadata.class));
+        } else {
+            cv.getStatic(targetClassType, AbstractAnnotationMetadataWriter.FIELD_ANNOTATION_METADATA, Type.getType(AnnotationMetadata.class));
+        }
+        // 4: isPrimary
+        cv.push(annotationMetadata.hasDeclaredStereotype(Primary.class));
+        // 5: isContextScope
+        cv.push(contextScope);
+        // 6: isConditional
+        cv.push(annotationMetadata.hasStereotype(Requires.class));
+        // 7: isContainerType
+        cv.push(DefaultArgument.CONTAINER_TYPES.stream().anyMatch(clazz -> clazz.getName().equals(beanTypeName)));
+        // 8: isSingleton
+        cv.push(
+                annotationMetadata.hasDeclaredStereotype(AnnotationUtil.SINGLETON) ||
+                        (!annotationMetadata.hasDeclaredStereotype(AnnotationUtil.SCOPE) &&
+                                annotationMetadata.hasDeclaredStereotype(DefaultScope.class) &&
+                                annotationMetadata.stringValue(DefaultScope.class)
+                                        .map(t -> t.equals(Singleton.class.getName()) || t.equals(AnnotationUtil.SINGLETON))
+                                        .orElse(false))
+        );
+        // 9: isConfigurationProperties
+        cv.push(annotationMetadata.hasDeclaredStereotype(ConfigurationReader.class));
+        // 10: hasExposedTypes
+        cv.push(
+                annotationMetadata.hasDeclaredAnnotation(Bean.class)
+                        && annotationMetadata.stringValues(Bean.class, "typed").length > 0
+        );
+        // 10: requiresMethodProcessing
+        cv.push(requiresMethodProcessing);
+        // (...)
+        cv.invokeConstructor(
+                Type.getType(AbstractBeanDefinitionReference2.class),
+                BEAN_DEFINITION_REF_CLASS_CONSTRUCTOR
+        );
         // RETURN
         cv.visitInsn(RETURN);
         // MAXSTACK = 2
@@ -184,21 +237,11 @@ public class BeanDefinitionReferenceWriter extends AbstractAnnotationMetadataWri
 
         // start method: BeanDefinition load()
         GeneratorAdapter loadMethod = startPublicMethodZeroArgs(classWriter, BeanDefinition.class, "load");
-
         // return new BeanDefinition()
         pushNewInstance(loadMethod, beanDefinitionType);
-
         // RETURN
         loadMethod.returnValue();
         loadMethod.visitMaxs(2, 1);
-
-        // start method: boolean isContextScope()
-        if (contextScope) {
-            GeneratorAdapter isContextScopeMethod = startPublicMethodZeroArgs(classWriter, boolean.class, "isContextScope");
-            isContextScopeMethod.push(true);
-            isContextScopeMethod.returnValue();
-            isContextScopeMethod.visitMaxs(1, 1);
-        }
 
         // start method: Class getBeanDefinitionType()
         GeneratorAdapter getBeanDefinitionType = startPublicMethodZeroArgs(classWriter, Class.class, "getBeanDefinitionType");
@@ -211,26 +254,6 @@ public class BeanDefinitionReferenceWriter extends AbstractAnnotationMetadataWri
         getBeanType.push(getTypeReferenceForName(beanTypeName));
         getBeanType.returnValue();
         getBeanType.visitMaxs(2, 1);
-
-        //noinspection Duplicates
-        if (requiresMethodProcessing) {
-            GeneratorAdapter requiresMethodProcessing = startPublicMethod(classWriter, "requiresMethodProcessing", boolean.class.getName());
-            requiresMethodProcessing.push(true);
-            requiresMethodProcessing.visitInsn(IRETURN);
-            requiresMethodProcessing.visitMaxs(1, 1);
-            requiresMethodProcessing.visitEnd();
-        }
-
-        writeGetAnnotationMetadataMethod(classWriter);
-        writeBooleanMethod(classWriter, "isSingleton", () ->
-                annotationMetadata.hasDeclaredStereotype(AnnotationUtil.SINGLETON) ||
-                        (!annotationMetadata.hasDeclaredStereotype(AnnotationUtil.SCOPE) &&
-                                annotationMetadata.hasDeclaredStereotype(DefaultScope.class) &&
-                                annotationMetadata.stringValue(DefaultScope.class)
-                                .map(t -> t.equals(Singleton.class.getName()) || t.equals(AnnotationUtil.SINGLETON))
-                                .orElse(false)));
-        writeBooleanMethod(classWriter, "isConfigurationProperties", () ->
-                annotationMetadata.hasDeclaredStereotype(ConfigurationReader.class));
 
         if (interceptedType != null) {
             super.implementInterceptedTypeMethod(interceptedType, classWriter);

--- a/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionVisitor.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionVisitor.java
@@ -235,9 +235,9 @@ public interface BeanDefinitionVisitor extends OriginatingElements {
      * @param declaringBean  The declaring bean of the method. Note this may differ from {@link MethodElement#getDeclaringType()} in the case of the method coming from a super class or interface.
      * @param methodElement  The method element
      * @param visitorContext The visitor context
-     * @return The {@link ExecutableMethodWriter}.
+     * @return The index of a new method
      */
-    ExecutableMethodWriter visitExecutableMethod(TypedElement declaringBean,
+    int visitExecutableMethod(TypedElement declaringBean,
                                                  MethodElement methodElement,
                                                  VisitorContext visitorContext);
 

--- a/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -15,18 +15,17 @@
  */
 package io.micronaut.inject.writer;
 
-import io.micronaut.context.AbstractBeanDefinition;
+import io.micronaut.context.AbstractBeanDefinition2;
 import io.micronaut.context.AbstractConstructorInjectionPoint;
 import io.micronaut.context.AbstractExecutableMethod;
-import io.micronaut.context.AbstractParametrizedBeanDefinition;
 import io.micronaut.context.BeanContext;
 import io.micronaut.context.BeanRegistration;
 import io.micronaut.context.BeanResolutionContext;
 import io.micronaut.context.DefaultBeanContext;
+import io.micronaut.context.Qualifier;
 import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.ConfigurationBuilder;
 import io.micronaut.context.annotation.ConfigurationInject;
-import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.context.annotation.ConfigurationReader;
 import io.micronaut.context.annotation.DefaultScope;
 import io.micronaut.context.annotation.EachBean;
@@ -35,8 +34,6 @@ import io.micronaut.context.annotation.Parameter;
 import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Provided;
-import io.micronaut.context.annotation.Requirements;
-import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.annotation.Value;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationMetadataProvider;
@@ -51,19 +48,39 @@ import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.reflect.InstantiationUtils;
 import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.type.Argument;
+import io.micronaut.core.type.TypeVariableResolver;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
-import io.micronaut.inject.*;
+import io.micronaut.inject.AdvisedBeanType;
+import io.micronaut.inject.BeanDefinition;
+import io.micronaut.inject.BeanFactory;
+import io.micronaut.inject.ConstructorInjectionPoint;
+import io.micronaut.inject.DisposableBeanDefinition;
+import io.micronaut.inject.ExecutableMethod;
+import io.micronaut.inject.ExecutableMethodsDefinition;
+import io.micronaut.inject.InitializingBeanDefinition;
+import io.micronaut.inject.ParametrizedBeanFactory;
+import io.micronaut.inject.ProxyBeanDefinition;
+import io.micronaut.inject.ValidatedBeanDefinition;
 import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
-import io.micronaut.inject.annotation.AnnotationMetadataReference;
 import io.micronaut.inject.annotation.AnnotationMetadataWriter;
 import io.micronaut.inject.annotation.DefaultAnnotationMetadata;
-import io.micronaut.inject.ast.*;
+import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.ast.ConstructorElement;
+import io.micronaut.inject.ast.Element;
+import io.micronaut.inject.ast.ElementQuery;
+import io.micronaut.inject.ast.FieldElement;
+import io.micronaut.inject.ast.MethodElement;
+import io.micronaut.inject.ast.ParameterElement;
+import io.micronaut.inject.ast.PrimitiveElement;
+import io.micronaut.inject.ast.PropertyElement;
+import io.micronaut.inject.ast.TypedElement;
 import io.micronaut.inject.ast.beans.BeanElementBuilder;
 import io.micronaut.inject.configuration.ConfigurationMetadataBuilder;
 import io.micronaut.inject.configuration.PropertyMetadata;
 import io.micronaut.inject.processing.JavaModelUtils;
+import io.micronaut.inject.qualifiers.Qualifiers;
 import io.micronaut.inject.visitor.VisitorContext;
 import jakarta.inject.Singleton;
 import org.jetbrains.annotations.NotNull;
@@ -82,9 +99,23 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.time.Duration;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 /**
  * <p>Responsible for building {@link BeanDefinition} instances at compile time. Uses ASM build the class definition.</p>
@@ -105,100 +136,91 @@ import java.util.stream.Collectors;
  * </pre>
  *
  * @author Graeme Rocher
+ * @author Denis Stepanov
  * @see BeanDefinition
  * @since 1.0
  */
 @Internal
 public class BeanDefinitionWriter extends AbstractClassFileWriter implements BeanDefinitionVisitor {
+    public static final String CLASS_SUFFIX = "$Definition";
     private static final String ANN_CONSTRAINT = "javax.validation.Constraint";
-    private static final Constructor<AbstractBeanDefinition> CONSTRUCTOR_ABSTRACT_BEAN_DEFINITION = ReflectionUtils.findConstructor(
-            AbstractBeanDefinition.class,
-            Class.class,
-            AnnotationMetadata.class,
-            boolean.class,
-            Argument[].class)
-            .orElseThrow(() -> new ClassGenerationException("Invalid version of Micronaut present on the class path"));
 
     private static final Constructor<AbstractConstructorInjectionPoint> CONSTRUCTOR_ABSTRACT_CONSTRUCTOR_IP = ReflectionUtils.findConstructor(
             AbstractConstructorInjectionPoint.class,
             BeanDefinition.class)
             .orElseThrow(() -> new ClassGenerationException("Invalid version of Micronaut present on the class path"));
 
-    private static final org.objectweb.asm.commons.Method METHOD_MAP_OF = org.objectweb.asm.commons.Method.getMethod(
-            ReflectionUtils.getRequiredInternalMethod(
-                    CollectionUtils.class,
-                    "mapOf",
-                    Object[].class
-            )
-    );
-    private static final Method POST_CONSTRUCT_METHOD = ReflectionUtils.getRequiredInternalMethod(AbstractBeanDefinition.class, "postConstruct", BeanResolutionContext.class, BeanContext.class, Object.class);
+    private static final Method POST_CONSTRUCT_METHOD = ReflectionUtils.getRequiredInternalMethod(AbstractBeanDefinition2.class, "postConstruct", BeanResolutionContext.class, BeanContext.class, Object.class);
 
-    private static final Method INJECT_BEAN_METHOD = ReflectionUtils.getRequiredInternalMethod(AbstractBeanDefinition.class, "injectBean", BeanResolutionContext.class, BeanContext.class, Object.class);
+    private static final Method INJECT_BEAN_METHOD = ReflectionUtils.getRequiredInternalMethod(AbstractBeanDefinition2.class, "injectBean", BeanResolutionContext.class, BeanContext.class, Object.class);
 
-    private static final Method PRE_DESTROY_METHOD = ReflectionUtils.getRequiredInternalMethod(AbstractBeanDefinition.class, "preDestroy", BeanResolutionContext.class, BeanContext.class, Object.class);
+    private static final Method PRE_DESTROY_METHOD = ReflectionUtils.getRequiredInternalMethod(AbstractBeanDefinition2.class, "preDestroy", BeanResolutionContext.class, BeanContext.class, Object.class);
 
-    private static final Method ADD_FIELD_INJECTION_POINT_METHOD = ReflectionUtils.getRequiredInternalMethod(AbstractBeanDefinition.class, "addInjectionPoint", Class.class, Class.class, String.class, AnnotationMetadata.class, Argument[].class, boolean.class);
+    private static final Method GET_BEAN_FOR_CONSTRUCTOR_ARGUMENT = getBeanLookupMethod("getBeanForConstructorArgument", false);
 
-    private static final Method ADD_METHOD_INJECTION_POINT_METHOD = ReflectionUtils.getRequiredInternalMethod(AbstractBeanDefinition.class, "addInjectionPoint", Class.class, String.class, Argument[].class, AnnotationMetadata.class, boolean.class);
+    private static final Method GET_BEAN_REGISTRATIONS_FOR_CONSTRUCTOR_ARGUMENT = getBeanLookupMethod("getBeanRegistrationsForConstructorArgument", true);
 
-    private static final Method ADD_POST_CONSTRUCT_METHOD = ReflectionUtils.getRequiredInternalMethod(AbstractBeanDefinition.class, "addPostConstruct", Class.class, String.class, Argument[].class, AnnotationMetadata.class, boolean.class);
+    private static final Method GET_BEAN_REGISTRATION_FOR_CONSTRUCTOR_ARGUMENT = getBeanLookupMethod("getBeanRegistrationForConstructorArgument", true);
 
-    private static final Method ADD_PRE_DESTROY_METHOD = ReflectionUtils.getRequiredInternalMethod(AbstractBeanDefinition.class, "addPreDestroy", Class.class, String.class, Argument[].class, AnnotationMetadata.class, boolean.class);
+    private static final Method GET_BEANS_OF_TYPE_FOR_CONSTRUCTOR_ARGUMENT = getBeanLookupMethod("getBeansOfTypeForConstructorArgument", true);
 
-    private static final Method ADD_EXECUTABLE_METHOD = ReflectionUtils.getRequiredInternalMethod(AbstractBeanDefinition.class, "addExecutableMethod", ExecutableMethod.class);
+    private static final Method GET_VALUE_FOR_CONSTRUCTOR_ARGUMENT = getBeanLookupMethod("getValueForConstructorArgument", false);
 
-    private static final Method GET_BEAN_FOR_CONSTRUCTOR_ARGUMENT = getBeanLookupMethod("getBeanForConstructorArgument");
+    private static final Method GET_STREAM_OF_TYPE_FOR_CONSTRUCTOR_ARGUMENT = getBeanLookupMethod("getStreamOfTypeForConstructorArgument", true);
 
-    private static final Method GET_BEAN_REGISTRATIONS_FOR_CONSTRUCTOR_ARGUMENT = getBeanLookupMethod("getBeanRegistrationsForConstructorArgument");
+    private static final Method FIND_BEAN_FOR_CONSTRUCTOR_ARGUMENT = getBeanLookupMethod("findBeanForConstructorArgument", true);
 
-    private static final Method GET_BEAN_REGISTRATION_FOR_CONSTRUCTOR_ARGUMENT = getBeanLookupMethod("getBeanRegistrationForConstructorArgument");
+    private static final Method GET_BEAN_FOR_FIELD = getBeanLookupMethod("getBeanForField", false);
 
-    private static final Method GET_BEANS_OF_TYPE_FOR_CONSTRUCTOR_ARGUMENT = getBeanLookupMethod("getBeansOfTypeForConstructorArgument");
+    private static final Method GET_BEAN_REGISTRATIONS_FOR_FIELD = getBeanLookupMethod("getBeanRegistrationsForField", true);
 
-    private static final Method GET_VALUE_FOR_CONSTRUCTOR_ARGUMENT = getBeanLookupMethod("getValueForConstructorArgument");
+    private static final Method GET_BEAN_REGISTRATION_FOR_FIELD = getBeanLookupMethod("getBeanRegistrationForField", true);
 
-    private static final Method GET_BEAN_FOR_FIELD = getBeanLookupMethod("getBeanForField");
+    private static final Method GET_BEANS_OF_TYPE_FOR_FIELD = getBeanLookupMethod("getBeansOfTypeForField", true);
 
-    private static final Method GET_BEAN_REGISTRATIONS_FOR_FIELD = getBeanLookupMethod("getBeanRegistrationsForField");
+    private static final Method GET_VALUE_FOR_FIELD = getBeanLookupMethod("getValueForField", false);
 
-    private static final Method GET_BEAN_REGISTRATION_FOR_FIELD = getBeanLookupMethod("getBeanRegistrationForField");
+    private static final Method GET_STREAM_OF_TYPE_FOR_FIELD = getBeanLookupMethod("getStreamOfTypeForField", true);
 
-    private static final Method GET_BEANS_OF_TYPE_FOR_FIELD = getBeanLookupMethod("getBeansOfTypeForField");
+    private static final Method FIND_BEAN_FOR_FIELD = getBeanLookupMethod("findBeanForField", true);
 
-    private static final Method GET_VALUE_FOR_FIELD = getBeanLookupMethod("getValueForField");
+    private static final Method GET_VALUE_FOR_PATH = ReflectionUtils.getRequiredInternalMethod(AbstractBeanDefinition2.class, "getValueForPath", BeanResolutionContext.class, BeanContext.class, Argument.class, String.class);
 
-    private static final Method GET_VALUE_FOR_PATH = ReflectionUtils.getRequiredInternalMethod(AbstractBeanDefinition.class, "getValueForPath", BeanResolutionContext.class, BeanContext.class, Argument.class, String.class);
+    private static final Method CONTAINS_VALUE_FOR_FIELD = ReflectionUtils.getRequiredInternalMethod(
+            AbstractBeanDefinition2.class,
+            "containsValueForField",
+            BeanResolutionContext.class,
+            BeanContext.class,
+            int.class,
+            boolean.class);
 
-    private static final Method CONTAINS_VALUE_FOR_FIELD = getBeanLookupMethod("containsValueForField");
+    private static final Method CONTAINS_PROPERTIES_METHOD = ReflectionUtils.getRequiredInternalMethod(AbstractBeanDefinition2.class, "containsProperties", BeanResolutionContext.class, BeanContext.class);
 
-    private static final Method CONTAINS_PROPERTIES_METHOD = ReflectionUtils.getRequiredInternalMethod(AbstractBeanDefinition.class, "containsProperties", BeanResolutionContext.class, BeanContext.class);
+    private static final Method GET_BEAN_FOR_METHOD_ARGUMENT = getBeanLookupMethodForArgument("getBeanForMethodArgument", false);
 
-    private static final Method GET_BEAN_FOR_METHOD_ARGUMENT = getBeanLookupMethodForArgument("getBeanForMethodArgument");
+    private static final Method GET_BEAN_REGISTRATIONS_FOR_METHOD_ARGUMENT = getBeanLookupMethodForArgument("getBeanRegistrationsForMethodArgument", true);
 
-    private static final Method GET_BEAN_REGISTRATIONS_FOR_METHOD_ARGUMENT = getBeanLookupMethodForArgument("getBeanRegistrationsForMethodArgument");
+    private static final Method GET_BEAN_REGISTRATION_FOR_METHOD_ARGUMENT = getBeanLookupMethodForArgument("getBeanRegistrationForMethodArgument", true);
 
-    private static final Method GET_BEAN_REGISTRATION_FOR_METHOD_ARGUMENT = getBeanLookupMethodForArgument("getBeanRegistrationForMethodArgument");
+    private static final Method GET_BEANS_OF_TYPE_FOR_METHOD_ARGUMENT = getBeanLookupMethodForArgument("getBeansOfTypeForMethodArgument", true);
 
-    private static final Method GET_BEANS_OF_TYPE_FOR_METHOD_ARGUMENT = getBeanLookupMethodForArgument("getBeansOfTypeForMethodArgument");
+    private static final Method GET_STREAM_OF_TYPE_FOR_METHOD_ARGUMENT = getBeanLookupMethodForArgument("getStreamOfTypeForMethodArgument", true);
 
-    private static final Method GET_VALUE_FOR_METHOD_ARGUMENT = getBeanLookupMethodForArgument("getValueForMethodArgument");
+    private static final Method FIND_BEAN_FOR_METHOD_ARGUMENT = getBeanLookupMethodForArgument("findBeanForMethodArgument", true);
 
-    private static final Method CONTAINS_VALUE_FOR_METHOD_ARGUMENT = getBeanLookupMethodForArgument("containsValueForMethodArgument");
+    private static final Method GET_VALUE_FOR_METHOD_ARGUMENT = getBeanLookupMethodForArgument("getValueForMethodArgument", false);
 
-    private static final org.objectweb.asm.commons.Method BEAN_DEFINITION_CLASS_CONSTRUCTOR = new org.objectweb.asm.commons.Method(CONSTRUCTOR_NAME, getConstructorDescriptor(
-            Class.class, AnnotationMetadata.class, boolean.class, Argument[].class
-    ));
+    private static final Method CONTAINS_VALUE_FOR_METHOD_ARGUMENT = ReflectionUtils.getRequiredInternalMethod(
+            AbstractBeanDefinition2.class,
+            "containsValueForMethodArgument",
+            BeanResolutionContext.class,
+            BeanContext.class,
+            int.class,
+            int.class,
+            boolean.class);
 
-    private static final org.objectweb.asm.commons.Method BEAN_DEFINITION_METHOD_CONSTRUCTOR = new org.objectweb.asm.commons.Method(CONSTRUCTOR_NAME, getConstructorDescriptor(
-            Class.class, Class.class, String.class, AnnotationMetadata.class, boolean.class, Argument[].class
-    ));
+    private static final Type TYPE_ABSTRACT_BEAN_DEFINITION = Type.getType(AbstractBeanDefinition2.class);
 
-    private static final org.objectweb.asm.commons.Method BEAN_DEFINITION_FIELD_CONSTRUCTOR = new org.objectweb.asm.commons.Method(CONSTRUCTOR_NAME, getConstructorDescriptor(
-            Class.class, Class.class, String.class, AnnotationMetadata.class, boolean.class
-    ));
-
-    private static final Type TYPE_ABSTRACT_BEAN_DEFINITION = Type.getType(AbstractBeanDefinition.class);
-    private static final Type TYPE_ABSTRACT_PARAMETRIZED_BEAN_DEFINITION = Type.getType(AbstractParametrizedBeanDefinition.class);
     private static final org.objectweb.asm.commons.Method METHOD_OPTIONAL_EMPTY = org.objectweb.asm.commons.Method.getMethod(
             ReflectionUtils.getRequiredMethod(Optional.class, "empty")
     );
@@ -227,10 +249,76 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
             Object.class
     ));
     private static final Method METHOD_GET_BEAN = ReflectionUtils.getRequiredInternalMethod(DefaultBeanContext.class, "getBean", BeanResolutionContext.class, Class.class);
+    private static final org.objectweb.asm.commons.Method COLLECTION_TO_ARRAY = org.objectweb.asm.commons.Method.getMethod(
+            ReflectionUtils.getRequiredInternalMethod(Collection.class, "toArray", Object[].class)
+    );
     private static final Type TYPE_RESOLUTION_CONTEXT = Type.getType(BeanResolutionContext.class);
     private static final Type TYPE_BEAN_CONTEXT = Type.getType(BeanContext.class);
     private static final Type TYPE_BEAN_DEFINITION = Type.getType(BeanDefinition.class);
     private static final String METHOD_DESCRIPTOR_INITIALIZE = Type.getMethodDescriptor(Type.getType(Object.class), Type.getType(BeanResolutionContext.class), Type.getType(BeanContext.class), Type.getType(Object.class));
+
+    private static final org.objectweb.asm.commons.Method PROTECTED_ABSTRACT_BEAN_DEFINITION_CONSTRUCTOR = new org.objectweb.asm.commons.Method(CONSTRUCTOR_NAME, getConstructorDescriptor(
+            Class.class, // beanType
+            AbstractBeanDefinition2.MethodOrFieldReference.class // constructor
+    ));
+
+    private static final org.objectweb.asm.commons.Method SET_FIELD_WITH_REFLECTION_METHOD = org.objectweb.asm.commons.Method.getMethod(
+            ReflectionUtils.getRequiredMethod(AbstractBeanDefinition2.class, "setFieldWithReflection", BeanResolutionContext.class, BeanContext.class, int.class, Object.class, Object.class)
+    );
+
+    private static final org.objectweb.asm.commons.Method INVOKE_WITH_REFLECTION_METHOD = org.objectweb.asm.commons.Method.getMethod(
+            ReflectionUtils.getRequiredMethod(AbstractBeanDefinition2.class, "invokeMethodWithReflection", BeanResolutionContext.class, BeanContext.class, int.class, Object.class, Object[].class)
+    );
+
+    private static final org.objectweb.asm.commons.Method BEAN_DEFINITION_CLASS_CONSTRUCTOR = new org.objectweb.asm.commons.Method(CONSTRUCTOR_NAME, getConstructorDescriptor(
+            Class.class, // beanType
+            AbstractBeanDefinition2.MethodOrFieldReference.class, // constructor
+            AnnotationMetadata.class, // annotationMetadata
+            AbstractBeanDefinition2.MethodReference[].class, // methodInjection
+            AbstractBeanDefinition2.FieldReference[].class, // fieldInjection
+            ExecutableMethodsDefinition.class, // executableMethodsDefinition
+            Map.class, // typeArgumentsMap
+            Optional.class, // scope
+            boolean.class, // isAbstract
+            boolean.class, // isProvided
+            boolean.class, // isIterable
+            boolean.class, // isSingleton
+            boolean.class, // isPrimary
+            boolean.class, // isConfigurationProperties
+            boolean.class, // hasExposedTypes
+            boolean.class  // requiresMethodProcessing
+    ));
+
+    private static final String FIELD_CONSTRUCTOR = "$CONSTRUCTOR";
+    private static final String FIELD_INJECTION_METHODS = "$INJECTION_METHODS";
+    private static final String FIELD_INJECTION_FIELDS = "$INJECTION_FIELDS";
+    private static final String FIELD_TYPE_ARGUMENTS = "$TYPE_ARGUMENTS";
+    private static final String FIELD_INNER_CLASSES = "$INNER_CONFIGURATION_CLASSES";
+
+    private static final org.objectweb.asm.commons.Method METHOD_REFERENCE_CONSTRUCTOR = new org.objectweb.asm.commons.Method(CONSTRUCTOR_NAME, getConstructorDescriptor(
+            Class.class, // declaringType,
+            String.class, // methodName
+            Argument[].class, // arguments
+            AnnotationMetadata.class, // annotationMetadata
+            boolean.class // boolean requiresReflection
+    ));
+
+    private static final org.objectweb.asm.commons.Method METHOD_REFERENCE_CONSTRUCTOR_POST_PRE = new org.objectweb.asm.commons.Method(CONSTRUCTOR_NAME, getConstructorDescriptor(
+            Class.class, // declaringType,
+            String.class, // methodName
+            Argument[].class, // arguments
+            AnnotationMetadata.class, // annotationMetadata
+            boolean.class, // boolean requiresReflection
+            boolean.class, // isPostConstructMethod
+            boolean.class // isPreDestroyMethod,
+    ));
+
+    private static final org.objectweb.asm.commons.Method FIELD_REFERENCE_CONSTRUCTOR = new org.objectweb.asm.commons.Method(CONSTRUCTOR_NAME, getConstructorDescriptor(
+            Class.class, // declaringType;
+            Argument.class, // argument;
+            boolean.class // requiresReflection;
+    ));
+
     private final ClassWriter classWriter;
     private final String beanFullClassName;
     private final String beanDefinitionName;
@@ -238,61 +326,54 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
     private final Type beanType;
     private final Type providedType;
     private final Set<Class> interfaceTypes;
+    private final Map<String, Integer> defaultsStorage = new HashMap<>();
     private final Map<String, GeneratorAdapter> loadTypeMethods = new LinkedHashMap<>();
-    private final Map<String, ExecutableMethodWriter> methodExecutors = new LinkedHashMap<>();
     private final Map<String, ClassWriter> innerClasses = new LinkedHashMap<>(2);
     private final String providedBeanClassName;
     private final String packageName;
     private final String beanSimpleClassName;
     private final Type beanDefinitionType;
     private final boolean isInterface;
+    private final boolean isAbstract;
     private final boolean isConfigurationProperties;
     private final ConfigurationMetadataBuilder<?> metadataBuilder;
     private final Element beanProducingElement;
     private final ClassElement beanTypeElement;
-    private GeneratorAdapter constructorVisitor;
     private GeneratorAdapter buildMethodVisitor;
     private GeneratorAdapter injectMethodVisitor;
     private Label injectEnd = null;
     private GeneratorAdapter preDestroyMethodVisitor;
     private GeneratorAdapter postConstructMethodVisitor;
+    private boolean postConstructAdded;
     private GeneratorAdapter interceptedDisposeMethod;
-    private int methodExecutorIndex = 0;
     private int currentFieldIndex = 0;
     private int currentMethodIndex = 0;
 
-    // 0 is this, while 1,2 and 3 are the first 3 parameters in the "build" method signature. See BeanFactory
-    private int buildMethodLocalCount = 4;
-
-    // 0 is this, while 1,2 and 3 are the first 3 parameters in the "injectBean" method signature. See AbstractBeanDefinition
-    private int injectMethodLocalCount = 4;
-
-    // 0 is this, while 1,2 and 3 are the first 3 parameters in the "initialize" method signature. See InitializingBeanDefinition
-    private int postConstructMethodLocalCount = 4;
-
-    // 0 is this, while 1,2 and 3 are the first 3 parameters in the "dispose" method signature. See DisposableBeanDefinition
-    private int preDestroyMethodLocalCount = 4;
-
-    // the instance being built position in the index
-    private int buildInstanceIndex;
-    private int argsIndex = -1;
-    private int injectInstanceIndex;
-    private int postConstructInstanceIndex;
-    private int preDestroyInstanceIndex;
+    private int buildInstanceLocalVarIndex = -1;
+    private int injectInstanceLocalVarIndex = -1;
+    private int postConstructInstanceLocalVarIndex = -1;
+    private int preDestroyInstanceLocalVarIndex = -1;
     private boolean beanFinalized = false;
     private Type superType = TYPE_ABSTRACT_BEAN_DEFINITION;
+    private boolean isParametrized = false;
+    private boolean superBeanDefinition = false;
     private boolean isSuperFactory = false;
     private final AnnotationMetadata annotationMetadata;
     private ConfigBuilderState currentConfigBuilderState;
-    private int optionalInstanceIndex;
     private boolean preprocessMethods = false;
     private Map<String, Map<String, ClassElement>> typeArguments;
-    private List<MethodVisitData> postConstructMethodVisits = new ArrayList<>(2);
-    private List<MethodVisitData> preDestroyMethodVisits = new ArrayList<>(2);
     private String interceptedType;
 
-    private List<Runnable> deferredInjectionPoints = new ArrayList<>();
     private int innerClassIndex;
+
+    private final List<FieldVisitData> fieldInjectionPoints = new ArrayList<>(2);
+    private final List<MethodVisitData> methodInjectionPoints = new ArrayList<>(2);
+    private final List<MethodVisitData> postConstructMethodVisits = new ArrayList<>(2);
+    private final List<MethodVisitData> preDestroyMethodVisits = new ArrayList<>(2);
+    private ExecutableMethodsDefinitionWriter executableMethodsDefinitionWriter;
+
+    private Object constructor; // MethodElement or FieldElement
+    private boolean constructorRequiresReflection;
 
     /**
      * Creates a bean definition writer.
@@ -346,19 +427,19 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
             this.beanTypeElement = classElement;
             this.packageName = classElement.getPackageName();
             this.isInterface = classElement.isInterface();
+            this.isAbstract = classElement.isAbstract();
             this.beanFullClassName = classElement.getName();
             this.beanSimpleClassName = classElement.getSimpleName();
             this.providedBeanClassName = beanFullClassName;
             this.beanDefinitionName = getBeanDefinitionName(packageName, beanSimpleClassName);
         } else if (beanProducingElement instanceof MethodElement) {
-            // copy the requirements from the factory class to the method
-            inheritTypeLevelRequirements(beanProducingElement);
             autoApplyNamedToBeanProducingElement(beanProducingElement);
             MethodElement factoryMethodElement = (MethodElement) beanProducingElement;
             final ClassElement producedElement = factoryMethodElement.getGenericReturnType();
             this.beanTypeElement = producedElement;
             this.packageName = producedElement.getPackageName();
             this.isInterface = producedElement.isInterface();
+            this.isAbstract = false;
             this.beanFullClassName = producedElement.getName();
             this.beanSimpleClassName = producedElement.getSimpleName();
             this.providedBeanClassName = producedElement.getName();
@@ -367,15 +448,15 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
                 throw new IllegalArgumentException("Factory methods require passing a unique identifier");
             }
             final ClassElement declaringType = factoryMethodElement.getOwningType();
-            this.beanDefinitionName = declaringType.getPackageName() + ".$" + declaringType.getSimpleName() + "$" + upperCaseMethodName + uniqueIdentifier + "Definition";
+            this.beanDefinitionName = declaringType.getPackageName() + "." + prefixClassName(declaringType.getSimpleName()) + "$" + upperCaseMethodName + uniqueIdentifier + CLASS_SUFFIX;
         } else if (beanProducingElement instanceof FieldElement) {
-            inheritTypeLevelRequirements(beanProducingElement);
             autoApplyNamedToBeanProducingElement(beanProducingElement);
             FieldElement factoryMethodElement = (FieldElement) beanProducingElement;
             final ClassElement producedElement = factoryMethodElement.getGenericField();
             this.beanTypeElement = producedElement;
             this.packageName = producedElement.getPackageName();
             this.isInterface = producedElement.isInterface();
+            this.isAbstract = false;
             this.beanFullClassName = producedElement.getName();
             this.beanSimpleClassName = producedElement.getSimpleName();
             this.providedBeanClassName = producedElement.getName();
@@ -384,12 +465,13 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
                 throw new IllegalArgumentException("Factory fields require passing a unique identifier");
             }
             final ClassElement declaringType = factoryMethodElement.getOwningType();
-            this.beanDefinitionName = declaringType.getPackageName() + ".$" + declaringType.getSimpleName() + "$" + fieldName + uniqueIdentifier + "Definition";
+            this.beanDefinitionName = declaringType.getPackageName() + "." + prefixClassName(declaringType.getSimpleName()) + "$" + fieldName + uniqueIdentifier + CLASS_SUFFIX;
         } else if (beanProducingElement instanceof BeanElementBuilder) {
             BeanElementBuilder beanElementBuilder = (BeanElementBuilder) beanProducingElement;
             this.beanTypeElement = beanElementBuilder.getBeanType();
             this.packageName = this.beanTypeElement.getPackageName();
             this.isInterface = this.beanTypeElement.isInterface();
+            this.isAbstract = this.beanTypeElement.isAbstract();
             this.beanFullClassName = this.beanTypeElement.getName();
             this.beanSimpleClassName = this.beanTypeElement.getSimpleName();
             this.providedBeanClassName = this.beanFullClassName;
@@ -416,24 +498,24 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
         this.beanDefinitionInternalName = getInternalName(this.beanDefinitionName);
         this.interfaceTypes = new TreeSet<>(Comparator.comparing(Class::getName));
         this.interfaceTypes.add(BeanFactory.class);
-        this.isConfigurationProperties = annotationMetadata.hasDeclaredStereotype(ConfigurationProperties.class);
+        this.isConfigurationProperties = isConfigurationProperties(annotationMetadata);
         validateExposedTypes(annotationMetadata, visitorContext);
 
     }
 
-    private void inheritTypeLevelRequirements(Element beanProducingElement) {
-        final List<AnnotationValue<Requires>> requirements = ((MemberElement) beanProducingElement).getDeclaringType()
-                                                                        .getDeclaredAnnotationValuesByType(Requires.class);
-        if (!requirements.isEmpty()) {
-            beanProducingElement.annotate(Requirements.class, (builder) ->
-                    builder.member(AnnotationMetadata.VALUE_MEMBER, requirements.toArray(new AnnotationValue[0]))
-            );
-        }
+    /**
+     * Returns {@link ExecutableMethodsDefinitionWriter} of one exists.
+     *
+     * @return An instance of {@link ExecutableMethodsDefinitionWriter}
+     */
+    @Nullable
+    public ExecutableMethodsDefinitionWriter getExecutableMethodsWriter() {
+        return executableMethodsDefinitionWriter;
     }
 
     @NonNull
     private String getAssociatedBeanName(@NonNull Integer uniqueIdentifier, ClassElement originatingClass) {
-        return originatingClass.getPackageName() + ".$" + originatingClass.getSimpleName() + "$" + beanSimpleClassName + uniqueIdentifier + "Definition";
+        return originatingClass.getPackageName() + "." + prefixClassName(originatingClass.getSimpleName()) + prefixClassName(beanSimpleClassName) + uniqueIdentifier + CLASS_SUFFIX;
     }
 
     private void autoApplyNamedToBeanProducingElement(Element beanProducingElement) {
@@ -459,7 +541,14 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
 
     @NonNull
     private static String getBeanDefinitionName(String packageName, String className) {
-        return packageName + ".$" + className + "Definition";
+        return packageName + "." + prefixClassName(className) + CLASS_SUFFIX;
+    }
+
+    private static String prefixClassName(String className) {
+        if (className.startsWith("$")) {
+            return className;
+        }
+        return "$" + className;
     }
 
     @NonNull
@@ -489,13 +578,6 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
     }
 
     /**
-     * @return The data for any pre destroy methods that were visited
-     */
-    public List<MethodVisitData> getPreDestroyMethodVisits() {
-        return Collections.unmodifiableList(preDestroyMethodVisits);
-    }
-
-    /**
      * @return The underlying class writer
      */
     public ClassVisitor getClassWriter() {
@@ -509,8 +591,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
 
     @Override
     public boolean isSingleton() {
-        String scope = annotationMetadata.getAnnotationNameByStereotype(AnnotationUtil.SCOPE).orElse(null);
-        return isSingleton(scope);
+        return annotationMetadata.hasDeclaredStereotype(AnnotationUtil.SINGLETON);
     }
 
     @Override
@@ -520,12 +601,14 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
 
     @Override
     public void visitSuperBeanDefinition(String name) {
+        this.superBeanDefinition = true;
         this.superType = getTypeReferenceForName(name);
     }
 
     @Override
     public void visitSuperBeanDefinitionFactory(String beanName) {
         visitSuperBeanDefinition(beanName);
+        this.superBeanDefinition = false;
         this.isSuperFactory = true;
     }
 
@@ -573,37 +656,21 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
     }
 
     /**
-     * @return The name of the bean definition class
-     */
-    public String getBeanDefinitionClassFile() {
-        String className = getBeanDefinitionName();
-        return getClassFileName(className);
-    }
-
-    /**
      * <p>In the case where the produced class is produced by a factory method annotated with
-     * {@link io.micronaut.context.annotation.Bean} this method should be called.</p>
+     * {@link Bean} this method should be called.</p>
      *
      * @param factoryClass  The factory class
      * @param factoryMethod The factory method
      */
     public void visitBeanFactoryMethod(ClassElement factoryClass,
                                        MethodElement factoryMethod) {
-        if (constructorVisitor != null) {
+        if (constructor != null) {
             throw new IllegalStateException("Only a single call to visitBeanFactoryMethod(..) is permitted");
         } else {
+            constructor = factoryMethod;
+
             // now prepare the implementation of the build method. See BeanFactory interface
             visitBuildFactoryMethodDefinition(factoryClass, factoryMethod);
-
-            // now implement the constructor
-            buildFactoryMethodClassConstructor(
-                    factoryClass,
-                    factoryMethod.getGenericReturnType(),
-                    factoryMethod.getName(),
-                    factoryMethod.getAnnotationMetadata(),
-                    Arrays.asList(factoryMethod.getParameters())
-            );
-
             // now override the injectBean method
             visitInjectMethodDefinition();
         }
@@ -611,33 +678,24 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
 
     /**
      * <p>In the case where the produced class is produced by a factory field annotated with
-     * {@link io.micronaut.context.annotation.Bean} this method should be called.</p>
+     * {@link Bean} this method should be called.</p>
      *
-     * @param factoryClass  The factory class
+     * @param factoryClass The factory class
      * @param factoryField The factory field
      */
     public void visitBeanFactoryField(ClassElement factoryClass, FieldElement factoryField) {
-        if (constructorVisitor != null) {
+        if (constructor != null) {
             throw new IllegalStateException("Only a single call to visitBeanFactoryMethod(..) is permitted");
         } else {
+            constructor = factoryField;
+
             autoApplyNamed(factoryField);
             // now prepare the implementation of the build method. See BeanFactory interface
             visitBuildFactoryMethodDefinition(factoryClass, factoryField);
-
-            // now implement the constructor
-            buildFactoryFieldClassConstructor(
-                    factoryClass,
-                    factoryField.getGenericField(),
-                    factoryField.getName(),
-                    factoryField.getAnnotationMetadata(),
-                    factoryField.isFinal()
-            );
-
             // now override the injectBean method
             visitInjectMethodDefinition();
         }
     }
-
 
     /**
      * Visits the constructor used to create the bean definition.
@@ -650,13 +708,11 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
     public void visitBeanDefinitionConstructor(MethodElement constructor,
                                                boolean requiresReflection,
                                                VisitorContext visitorContext) {
-        if (constructorVisitor == null) {
+        if (this.constructor == null) {
             applyConfigurationInjectionIfNecessary(constructor);
-            // first build the constructor
-            visitBeanDefinitionConstructorInternal(
-                    constructor,
-                    requiresReflection
-            );
+
+            this.constructor = constructor;
+            this.constructorRequiresReflection = requiresReflection;
 
             // now prepare the implementation of the build method. See BeanFactory interface
             visitBuildMethodDefinition(constructor, requiresReflection);
@@ -732,24 +788,19 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
 
     @Override
     public void visitDefaultConstructor(AnnotationMetadata annotationMetadata, VisitorContext visitorContext) {
-        if (constructorVisitor == null) {
+        if (this.constructor == null) {
             ClassElement bean = ClassElement.of(beanType.getClassName());
-            MethodElement constructor = MethodElement.of(
+            MethodElement defaultConstructor = MethodElement.of(
                     bean,
                     annotationMetadata,
                     bean,
                     bean,
                     "<init>"
             );
-            // first build the constructor
-            visitBeanDefinitionConstructorInternal(
-                    constructor,
-                    false
-            );
+            constructor = defaultConstructor;
 
             // now prepare the implementation of the build method. See BeanFactory interface
-            visitBuildMethodDefinition(constructor, false);
-
+            visitBuildMethodDefinition(defaultConstructor, false);
             // now override the injectBean method
             visitInjectMethodDefinition();
         }
@@ -763,6 +814,16 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
     public void visitBeanDefinitionEnd() {
         if (classWriter == null) {
             throw new IllegalStateException("At least one called to visitBeanDefinitionConstructor(..) is required");
+        }
+
+        if (constructor instanceof MethodElement) {
+            MethodElement methodElement = (MethodElement) constructor;
+            boolean isParametrized = Arrays.stream(methodElement.getParameters())
+                    .map(AnnotationMetadataProvider::getAnnotationMetadata)
+                    .anyMatch(this::isAnnotatedWithParameter);
+            if (isParametrized) {
+                interfaceTypes.add(ParametrizedBeanFactory.class);
+            }
         }
 
         String[] interfaceInternalNames = new String[interfaceTypes.size()];
@@ -782,41 +843,128 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
             throw new IllegalStateException("At least one call to visitBeanDefinitionConstructor() is required");
         }
 
-        finalizeInjectMethod();
+        GeneratorAdapter staticInit = visitStaticInitializer(classWriter);
+
+        classWriter.visitField(ACC_PRIVATE | ACC_FINAL | ACC_STATIC, FIELD_CONSTRUCTOR,
+                Type.getType(AbstractBeanDefinition2.MethodOrFieldReference.class).getDescriptor(), null, null);
+
+        int methodsLength = methodInjectionPoints.size() + postConstructMethodVisits.size() + preDestroyMethodVisits.size();
+        if (!superBeanDefinition && methodsLength > 0) {
+            Type methodsFieldType = Type.getType(AbstractBeanDefinition2.MethodReference[].class);
+            classWriter.visitField(ACC_PRIVATE | ACC_FINAL | ACC_STATIC, FIELD_INJECTION_METHODS, methodsFieldType.getDescriptor(), null, null);
+            pushNewArray(staticInit, AbstractBeanDefinition2.MethodReference.class, methodsLength);
+            int i = 0;
+            for (MethodVisitData methodVisitData : methodInjectionPoints) {
+                pushStoreInArray(staticInit, i++, methodsLength, () ->
+                        pushNewMethodReference(
+                                staticInit,
+                                JavaModelUtils.getTypeReference(methodVisitData.beanType),
+                                methodVisitData.methodElement,
+                                methodVisitData.requiresReflection,
+                                false, false
+                        )
+                );
+            }
+            for (MethodVisitData methodVisitData : postConstructMethodVisits) {
+                pushStoreInArray(staticInit, i++, methodsLength, () ->
+                        pushNewMethodReference(
+                                staticInit,
+                                JavaModelUtils.getTypeReference(methodVisitData.beanType),
+                                methodVisitData.methodElement,
+                                methodVisitData.requiresReflection,
+                                true, false
+                        )
+                );
+            }
+            for (MethodVisitData methodVisitData : preDestroyMethodVisits) {
+                pushStoreInArray(staticInit, i++, methodsLength, () ->
+                        pushNewMethodReference(
+                                staticInit,
+                                JavaModelUtils.getTypeReference(methodVisitData.beanType),
+                                methodVisitData.methodElement,
+                                methodVisitData.requiresReflection,
+                                false, true
+                        )
+                );
+            }
+            staticInit.putStatic(beanDefinitionType, FIELD_INJECTION_METHODS, methodsFieldType);
+        }
+
+        if (!fieldInjectionPoints.isEmpty()) {
+            Type fieldsFieldType = Type.getType(AbstractBeanDefinition2.FieldReference[].class);
+            classWriter.visitField(ACC_PRIVATE | ACC_FINAL | ACC_STATIC, FIELD_INJECTION_FIELDS, fieldsFieldType.getDescriptor(), null, null);
+            int length = fieldInjectionPoints.size();
+            pushNewArray(staticInit, AbstractBeanDefinition2.FieldReference.class, length);
+            for (int i = 0; i < length; i++) {
+                FieldVisitData fieldVisitData = fieldInjectionPoints.get(i);
+                pushStoreInArray(staticInit, i, length, () ->
+                        pushNewFieldReference(
+                                staticInit,
+                                JavaModelUtils.getTypeReference(fieldVisitData.beanType),
+                                fieldVisitData.fieldElement,
+                                fieldVisitData.requiresReflection
+                        )
+                );
+            }
+            staticInit.putStatic(beanDefinitionType, FIELD_INJECTION_FIELDS, fieldsFieldType);
+        }
+
+        if (!superBeanDefinition && hasTypeArguments()) {
+            Type typeArgumentsFieldType = Type.getType(Map.class);
+            classWriter.visitField(ACC_PRIVATE | ACC_FINAL | ACC_STATIC, FIELD_TYPE_ARGUMENTS, typeArgumentsFieldType.getDescriptor(), null, null);
+            pushStringMapOf(staticInit, typeArguments, true, null, new Consumer<Map<String, ClassElement>>() {
+                @Override
+                public void accept(Map<String, ClassElement> stringClassElementMap) {
+                    pushTypeArgumentElements(
+                            beanDefinitionType,
+                            classWriter,
+                            staticInit,
+                            beanDefinitionName,
+                            stringClassElementMap,
+                            defaultsStorage,
+                            loadTypeMethods
+                    );
+                }
+            });
+            staticInit.putStatic(beanDefinitionType, FIELD_TYPE_ARGUMENTS, typeArgumentsFieldType);
+        }
+
+        // first build the constructor
+        visitBeanDefinitionConstructorInternal(
+                staticInit,
+                constructor,
+                constructorRequiresReflection
+        );
+
+        addInnerConfigurationMethod(staticInit);
+
+        staticInit.returnValue();
+        staticInit.visitMaxs(DEFAULT_MAX_STACK, defaultsStorage.size() + 3);
+        staticInit.visitEnd();
+
         finalizeBuildMethod();
-        finalizeAnnotationMetadata();
-        finalizeTypeArguments();
 
-        if (preprocessMethods) {
-            GeneratorAdapter requiresMethodProcessing = startPublicMethod(classWriter, "requiresMethodProcessing", boolean.class.getName());
-            requiresMethodProcessing.push(true);
-            requiresMethodProcessing.visitInsn(IRETURN);
-            requiresMethodProcessing.visitMaxs(1, 1);
-            requiresMethodProcessing.visitEnd();
-        }
-
-        for (Runnable fieldInjectionPoint : deferredInjectionPoints) {
-            fieldInjectionPoint.run();
-        }
-
-        constructorVisitor.visitInsn(RETURN);
-        constructorVisitor.visitMaxs(DEFAULT_MAX_STACK, 1);
         if (buildMethodVisitor != null) {
-            buildMethodVisitor.visitInsn(ARETURN);
-            buildMethodVisitor.visitMaxs(DEFAULT_MAX_STACK, buildMethodLocalCount);
+            buildMethodVisitor.returnValue();
+            buildMethodVisitor.visitMaxs(DEFAULT_MAX_STACK, 10);
         }
         if (injectMethodVisitor != null) {
-            injectMethodVisitor.visitMaxs(DEFAULT_MAX_STACK, injectMethodLocalCount);
+            if (injectEnd != null) {
+                injectMethodVisitor.visitLabel(injectEnd);
+            }
+            invokeSuperInjectMethod(injectMethodVisitor, INJECT_BEAN_METHOD);
+            injectMethodVisitor.returnValue();
+            injectMethodVisitor.visitMaxs(DEFAULT_MAX_STACK, 10);
         }
         if (postConstructMethodVisitor != null) {
-            postConstructMethodVisitor.visitVarInsn(ALOAD, postConstructInstanceIndex);
-            postConstructMethodVisitor.visitInsn(ARETURN);
-            postConstructMethodVisitor.visitMaxs(DEFAULT_MAX_STACK, postConstructMethodLocalCount);
+            postConstructMethodVisitor.loadLocal(postConstructInstanceLocalVarIndex);
+            postConstructMethodVisitor.returnValue();
+            postConstructMethodVisitor.visitMaxs(DEFAULT_MAX_STACK, 10);
         }
         if (preDestroyMethodVisitor != null) {
-            preDestroyMethodVisitor.visitVarInsn(ALOAD, preDestroyInstanceIndex);
-            preDestroyMethodVisitor.visitInsn(ARETURN);
-            preDestroyMethodVisitor.visitMaxs(DEFAULT_MAX_STACK, preDestroyMethodLocalCount);
+            preDestroyMethodVisitor.loadLocal(preDestroyInstanceLocalVarIndex);
+            preDestroyMethodVisitor.returnValue();
+            preDestroyMethodVisitor.visitMaxs(DEFAULT_MAX_STACK, 10);
         }
         if (interceptedDisposeMethod != null) {
             interceptedDisposeMethod.visitMaxs(1, 1);
@@ -833,110 +981,54 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
         this.beanFinalized = true;
     }
 
-    private void finalizeTypeArguments() {
-        if (CollectionUtils.isNotEmpty(typeArguments)) {
-            GeneratorAdapter visitor = startPublicMethodZeroArgs(classWriter, Map.class, "getTypeArgumentsMap");
-            int totalSize = typeArguments.size() * 2;
-            // start a new array
-            pushNewArray(visitor, Object.class, totalSize);
-            int i = 0;
-            for (Map.Entry<String, Map<String, ClassElement>> entry : typeArguments.entrySet()) {
-                // use the property name as the key
-                String typeName = entry.getKey();
-                pushStoreStringInArray(visitor, i++, totalSize, typeName);
-                // use the property type as the value
-                pushStoreInArray(visitor, i++, totalSize, () ->
-                        pushTypeArgumentElements(
-                                beanDefinitionType,
-                                classWriter,
-                                visitor,
-                                beanDefinitionName,
-                                entry.getValue(),
-                                loadTypeMethods
-                        )
-                );
+    private void addInnerConfigurationMethod(GeneratorAdapter staticInit) {
+        if (isConfigurationProperties) {
+            String[] innerClasses = beanTypeElement.getEnclosedElements(ElementQuery.of(ClassElement.class))
+                    .stream()
+                    .filter(this::isConfigurationProperties)
+                    .map(Element::getName)
+                    .toArray(String[]::new);
+
+            if (innerClasses.length > 0) {
+                classWriter.visitField(ACC_PRIVATE | ACC_FINAL | ACC_STATIC, FIELD_INNER_CLASSES, Type.getType(Collection.class).getDescriptor(), null, null);
+                if (innerClasses.length > 3) {
+                    staticInit.newInstance(Type.getType(HashSet.class));
+                    staticInit.dup();
+                    pushArrayOfClasses(staticInit, innerClasses);
+                    staticInit.invokeStatic(Type.getType(Arrays.class), org.objectweb.asm.commons.Method.getMethod(
+                            ReflectionUtils.getRequiredMethod(Arrays.class, "asList", Object[].class)
+                    ));
+                    staticInit.invokeConstructor(Type.getType(HashSet.class), org.objectweb.asm.commons.Method.getMethod(
+                            ReflectionUtils.findConstructor(HashSet.class, Collection.class).get()
+                    ));
+                } else if (innerClasses.length == 1) {
+                    pushClass(staticInit, innerClasses[0]);
+                    staticInit.invokeStatic(Type.getType(Collections.class), org.objectweb.asm.commons.Method.getMethod(
+                            ReflectionUtils.getRequiredMethod(Collections.class, "singleton", Object.class)
+                    ));
+                } else {
+                    pushArrayOfClasses(staticInit, innerClasses);
+                    staticInit.invokeStatic(Type.getType(Arrays.class), org.objectweb.asm.commons.Method.getMethod(
+                            ReflectionUtils.getRequiredMethod(Arrays.class, "asList", Object[].class)
+                    ));
+                }
+                staticInit.putStatic(beanDefinitionType, FIELD_INNER_CLASSES, Type.getType(Collection.class));
+
+                GeneratorAdapter isInnerConfigurationMethod = startProtectedMethod(classWriter, "isInnerConfiguration", boolean.class.getName(), Class.class.getName());
+                isInnerConfigurationMethod.getStatic(beanDefinitionType, FIELD_INNER_CLASSES, Type.getType(Collection.class));
+                isInnerConfigurationMethod.loadArg(0);
+                isInnerConfigurationMethod.invokeInterface(Type.getType(Collection.class), org.objectweb.asm.commons.Method.getMethod(
+                        ReflectionUtils.getRequiredMethod(Collection.class, "contains", Object.class)
+                ));
+                isInnerConfigurationMethod.returnValue();
+                isInnerConfigurationMethod.visitMaxs(1, 1);
+                isInnerConfigurationMethod.visitEnd();
             }
-            // invoke the AbstractBeanDefinition.createMap method
-            visitor.invokeStatic(Type.getType(CollectionUtils.class), METHOD_MAP_OF);
-            visitor.returnValue();
-            visitor.visitMaxs(1, 1);
-            visitor.visitEnd();
         }
     }
 
-    private void finalizeAnnotationMetadata() {
-        if (annotationMetadata != null) {
-            GeneratorAdapter annotationMetadataMethod = startProtectedMethod(
-                    classWriter,
-                    "resolveAnnotationMetadata",
-                    AnnotationMetadata.class.getName()
-            );
-            lookupReferenceAnnotationMetadata(annotationMetadataMethod);
-        }
-
-        // method: boolean isSingleton()
-        AnnotationMetadata annotationMetadata = this.annotationMetadata != null ? this.annotationMetadata : AnnotationMetadata.EMPTY_METADATA;
-        String scope = annotationMetadata.getAnnotationNameByStereotype(AnnotationUtil.SCOPE).orElse(null);
-        writeBooleanMethod(classWriter, "isSingleton", () ->
-                isSingleton(scope)
-        );
-
-        // method: boolean isIterable()
-        writeBooleanMethod(classWriter, "isIterable", () ->
-                annotationMetadata.hasDeclaredStereotype(EachProperty.class) ||
-                        annotationMetadata.hasDeclaredStereotype(EachBean.class));
-
-        // method: boolean isPrimary()
-        writeBooleanMethod(classWriter, "isPrimary", () ->
-                annotationMetadata.hasDeclaredStereotype(Primary.class));
-
-        // method: boolean isProvided()
-        writeBooleanMethod(classWriter, "isProvided", () ->
-                annotationMetadata.hasDeclaredStereotype(Provided.class));
-
-
-
-        // method: Optional<String> getScopeName()
-        // method: Optional<Class> getScope()
-        GeneratorAdapter getScopeMethod = startPublicMethodZeroArgs(
-                classWriter,
-                Optional.class,
-                "getScope"
-        );
-        GeneratorAdapter getScopeNameMethod = startPublicMethodZeroArgs(
-                classWriter,
-                Optional.class,
-                "getScopeName"
-        );
-        getScopeMethod.loadThis();
-        getScopeNameMethod.loadThis();
-
-        if (scope != null) {
-            getScopeMethod.push(getTypeReferenceForName(scope));
-            getScopeMethod.invokeStatic(
-                    TYPE_OPTIONAL,
-                    METHOD_OPTIONAL_OF
-            );
-            getScopeNameMethod.push(scope);
-            getScopeNameMethod.invokeStatic(
-                    TYPE_OPTIONAL,
-                    METHOD_OPTIONAL_OF
-            );
-        } else {
-            getScopeMethod.invokeStatic(TYPE_OPTIONAL, METHOD_OPTIONAL_EMPTY);
-            getScopeNameMethod.invokeStatic(TYPE_OPTIONAL, METHOD_OPTIONAL_EMPTY);
-        }
-
-
-
-        getScopeMethod.returnValue();
-        getScopeMethod.visitMaxs(1, 1);
-        getScopeMethod.visitEnd();
-        getScopeNameMethod.returnValue();
-        getScopeNameMethod.visitMaxs(1, 1);
-        getScopeNameMethod.visitEnd();
-
-
+    private boolean hasTypeArguments() {
+        return typeArguments != null && !typeArguments.isEmpty() && typeArguments.entrySet().stream().anyMatch(e -> !e.getValue().isEmpty());
     }
 
     private boolean isSingleton(String scope) {
@@ -990,8 +1082,8 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
                 }
             }
             try {
-                for (ExecutableMethodWriter methodWriter : methodExecutors.values()) {
-                    methodWriter.accept(visitor);
+                if (executableMethodsDefinitionWriter != null) {
+                    executableMethodsDefinitionWriter.accept(visitor);
                 }
             } catch (RuntimeException e) {
                 Throwable cause = e.getCause();
@@ -1012,55 +1104,16 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
             boolean requiresReflection,
             boolean isOptional) {
 
-        ParameterElement[] parameters = methodElement.getParameters();
-        if (parameters.length != 1) {
-            throw new IllegalArgumentException("Method must have exactly 1 argument");
-        }
-        Type declaringTypeRef = JavaModelUtils.getTypeReference(declaringType);
-
-        // load 'this'
-        constructorVisitor.visitVarInsn(ALOAD, 0);
-
-        // 1st argument: The declaring type
-        constructorVisitor.push(declaringTypeRef);
-
-        // 2nd argument: The method name
-        constructorVisitor.push(methodElement.getName());
-
-        // 3rd argument: the argument types
-        pushBuildArgumentsForMethod(
-                declaringTypeRef.getClassName(),
-                beanDefinitionType,
-                classWriter,
-                constructorVisitor,
-                Arrays.asList(parameters),
-                loadTypeMethods
+        final MethodVisitData methodVisitData = new MethodVisitData(
+                declaringType,
+                methodElement,
+                requiresReflection
         );
 
-        // 4th argument: The annotation metadata
-        AnnotationMetadata annotationMetadata = methodElement.getAnnotationMetadata();
-        if (annotationMetadata == AnnotationMetadata.EMPTY_METADATA) {
-            constructorVisitor.visitInsn(ACONST_NULL);
-        } else {
-            AnnotationMetadataWriter.instantiateNewMetadata(
-                    beanDefinitionType,
-                    classWriter,
-                    constructorVisitor,
-                    (DefaultAnnotationMetadata) annotationMetadata,
-                    loadTypeMethods
-            );
-        }
-
-        // 5th  argument to addInjectionPoint: do we need reflection?
-        constructorVisitor.visitInsn(requiresReflection ? ICONST_1 : ICONST_0);
-
-        // invoke add injection point method
-        pushInvokeMethodOnSuperClass(constructorVisitor, ADD_METHOD_INJECTION_POINT_METHOD);
+        methodInjectionPoints.add(methodVisitData);
 
         if (!requiresReflection) {
-            resolveBeanOrValueForSetter(
-                    declaringTypeRef,
-                    methodElement.getReturnType(), methodElement.getName(), parameters[0].getType(), GET_VALUE_FOR_METHOD_ARGUMENT, isOptional);
+            resolveBeanOrValueForSetter(declaringType, methodElement, isOptional);
         }
         currentMethodIndex++;
 
@@ -1072,18 +1125,12 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
                                          boolean requiresReflection, VisitorContext visitorContext) {
 
         visitPostConstructMethodDefinition(false);
-
-        final MethodVisitData methodVisitData = new MethodVisitData(
-                declaringType,
-                methodElement,
-                requiresReflection
-        );
-        postConstructMethodVisits.add(methodVisitData);
-        visitMethodInjectionPointInternal(methodVisitData,
-                constructorVisitor,
-                postConstructMethodVisitor,
-                postConstructInstanceIndex,
-                ADD_POST_CONSTRUCT_METHOD);
+        // for "super bean definitions" we just delegate to super
+        if (!superBeanDefinition) {
+            MethodVisitData methodVisitData = new MethodVisitData(declaringType, methodElement, requiresReflection);
+            postConstructMethodVisits.add(methodVisitData);
+            visitMethodInjectionPointInternal(methodVisitData, postConstructMethodVisitor, postConstructInstanceLocalVarIndex);
+        }
     }
 
     @Override
@@ -1091,19 +1138,14 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
                                       MethodElement methodElement,
                                       boolean requiresReflection,
                                       VisitorContext visitorContext) {
+        // for "super bean definitions" we just delegate to super
+        if (!superBeanDefinition) {
+            visitPreDestroyMethodDefinition(false);
 
-        visitPreDestroyMethodDefinition(false);
-        final MethodVisitData methodVisitData = new MethodVisitData(declaringType,
-                methodElement,
-                requiresReflection
-        );
-        preDestroyMethodVisits.add(methodVisitData);
-        visitMethodInjectionPointInternal(
-                methodVisitData,
-                constructorVisitor,
-                preDestroyMethodVisitor,
-                preDestroyInstanceIndex,
-                ADD_PRE_DESTROY_METHOD);
+            MethodVisitData methodVisitData = new MethodVisitData(declaringType, methodElement, requiresReflection);
+            preDestroyMethodVisits.add(methodVisitData);
+            visitMethodInjectionPointInternal(methodVisitData, preDestroyMethodVisitor, preDestroyInstanceLocalVarIndex);
+        }
     }
 
     @Override
@@ -1111,25 +1153,15 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
                                           MethodElement methodElement,
                                           boolean requiresReflection, VisitorContext visitorContext) {
         applyConfigurationInjectionIfNecessary(methodElement);
-        GeneratorAdapter constructorVisitor = this.constructorVisitor;
-        GeneratorAdapter injectMethodVisitor = this.injectMethodVisitor;
-        int injectInstanceIndex = this.injectInstanceIndex;
 
-        visitMethodInjectionPointInternal(
-                new MethodVisitData(
-                        declaringType,
-                        methodElement,
-                        requiresReflection),
-                constructorVisitor,
-                injectMethodVisitor,
-                injectInstanceIndex,
-                ADD_METHOD_INJECTION_POINT_METHOD);
+        MethodVisitData methodVisitData = new MethodVisitData(declaringType, methodElement, requiresReflection);
+        methodInjectionPoints.add(methodVisitData);
+        visitMethodInjectionPointInternal(methodVisitData, injectMethodVisitor, injectInstanceLocalVarIndex);
     }
 
     @Override
-    public ExecutableMethodWriter visitExecutableMethod(TypedElement declaringBean,
-                                                        MethodElement methodElement, VisitorContext visitorContext) {
-
+    public int visitExecutableMethod(TypedElement declaringBean,
+                                     MethodElement methodElement, VisitorContext visitorContext) {
         return visitExecutableMethod(
                 declaringBean,
                 methodElement,
@@ -1146,90 +1178,30 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
      * @param methodElement                    The method element
      * @param interceptedProxyClassName        The intercepted proxy class name
      * @param interceptedProxyBridgeMethodName The intercepted proxy bridge method name
-     * @return The {@link ExecutableMethodWriter}.
+     * @return The index of a new method.
      */
-    public ExecutableMethodWriter visitExecutableMethod(TypedElement declaringType,
-                                                        MethodElement methodElement,
-                                                        String interceptedProxyClassName,
-                                                        String interceptedProxyBridgeMethodName) {
+    public int visitExecutableMethod(TypedElement declaringType,
+                                     MethodElement methodElement,
+                                     String interceptedProxyClassName,
+                                     String interceptedProxyBridgeMethodName) {
 
         AnnotationMetadata annotationMetadata = methodElement.getAnnotationMetadata();
-        String methodName = methodElement.getName();
-        List<ParameterElement> argumentTypes = Arrays.asList(methodElement.getSuspendParameters());
-        String methodKey = methodName +
-                "(" +
-                argumentTypes.stream()
-                        .map(p -> p.getType().getName())
-                        .collect(Collectors.joining(",")) +
-                ")";
-
-        if (methodExecutors.containsKey(methodKey)) {
-            return methodExecutors.get(methodKey);
-        }
 
         DefaultAnnotationMetadata.contributeDefaults(
                 this.annotationMetadata,
                 annotationMetadata
         );
-        for (ParameterElement parameterElement : argumentTypes) {
+        for (ParameterElement parameterElement : methodElement.getSuspendParameters()) {
             DefaultAnnotationMetadata.contributeDefaults(
                     this.annotationMetadata,
                     parameterElement.getAnnotationMetadata()
             );
         }
-        String methodProxyShortName = "$exec" + ++methodExecutorIndex;
-        String methodExecutorClassName = beanDefinitionName + "$" + methodProxyShortName;
-        ParameterElement last = CollectionUtils.last(argumentTypes);
-        boolean isSuspend = last != null && "kotlin.coroutines.Continuation".equals(last.getType().getName());
 
-        if (annotationMetadata instanceof AnnotationMetadataHierarchy) {
-            annotationMetadata = new AnnotationMetadataHierarchy(
-                    new AnnotationMetadataReference(getBeanDefinitionReferenceClassName(), this.annotationMetadata),
-                    annotationMetadata.getDeclaredMetadata()
-            );
+        if (executableMethodsDefinitionWriter == null) {
+            executableMethodsDefinitionWriter = new ExecutableMethodsDefinitionWriter(beanDefinitionName, getBeanDefinitionReferenceClassName(), originatingElements);
         }
-
-        boolean isInterface = declaringType.getType().isInterface();
-        ExecutableMethodWriter executableMethodWriter = new ExecutableMethodWriter(
-                methodExecutorClassName,
-                this.isInterface || isInterface,
-                (isInterface && !methodElement.isDefault()) || methodElement.isAbstract(),
-                methodElement.isDefault(),
-                isSuspend,
-                this,
-                annotationMetadata,
-                interceptedProxyClassName,
-                interceptedProxyBridgeMethodName
-        );
-
-        executableMethodWriter.visitMethod(
-                declaringType,
-                methodElement
-        );
-
-        methodExecutors.put(methodKey, executableMethodWriter);
-
-        deferredInjectionPoints.add(() -> {
-
-            if (constructorVisitor == null) {
-                throw new IllegalStateException("Method visitBeanDefinitionConstructor(..) should be called first!");
-            }
-
-            constructorVisitor.visitVarInsn(ALOAD, 0);
-            String methodExecutorInternalName = executableMethodWriter.getInternalName();
-            constructorVisitor.visitTypeInsn(NEW, methodExecutorInternalName);
-            constructorVisitor.visitInsn(DUP);
-            constructorVisitor.visitMethodInsn(INVOKESPECIAL,
-                    methodExecutorInternalName,
-                    CONSTRUCTOR_NAME,
-                    DESCRIPTOR_DEFAULT_CONSTRUCTOR,
-                    false);
-
-            pushInvokeMethodOnSuperClass(constructorVisitor, ADD_EXECUTABLE_METHOD);
-
-        });
-
-        return executableMethodWriter;
+        return executableMethodsDefinitionWriter.visitExecutableMethod(declaringType, methodElement, interceptedProxyClassName, interceptedProxyBridgeMethodName);
     }
 
     @Override
@@ -1271,7 +1243,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
         if (StringUtils.isNotEmpty(factoryMethod)) {
             Type builderType = JavaModelUtils.getTypeReference(type);
 
-            injectMethodVisitor.visitVarInsn(ALOAD, injectInstanceIndex);
+            injectMethodVisitor.loadLocal(injectInstanceLocalVarIndex, beanType);
             injectMethodVisitor.invokeStatic(
                     builderType,
                     org.objectweb.asm.commons.Method.getMethod(
@@ -1309,7 +1281,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
         if (StringUtils.isNotEmpty(factoryMethod)) {
             Type builderType = JavaModelUtils.getTypeReference(type);
 
-            injectMethodVisitor.visitVarInsn(ALOAD, injectInstanceIndex);
+            injectMethodVisitor.loadLocal(injectInstanceLocalVarIndex, beanType);
             injectMethodVisitor.invokeStatic(
                     builderType,
                     org.objectweb.asm.commons.Method.getMethod(
@@ -1390,15 +1362,14 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
             TypedElement declaringType,
             FieldElement fieldElement,
             boolean requiresReflection) {
-        // Implementation notes.
-        // This method modifies the constructor adding addInjectPoint calls for each field that is annotated with @Inject
-        // The constructor is a zero args constructor therefore there are no other local variables and "this" is stored in the 0 index.
-        // The "currentFieldIndex" variable is used as a reference point for both the position of the local variable and also
-        // for later on within the "build" method to in order to call "getBeanForField" with the appropriate index
-        Method methodToInvoke;
 
+        boolean requiresGenericType = false;
+        Method methodToInvoke;
         final ClassElement genericType = fieldElement.getGenericType();
-        if (genericType.isAssignable(Collection.class) || genericType.isArray()) {
+        boolean isArray = genericType.isArray();
+        boolean isCollection = genericType.isAssignable(Collection.class);
+        if (isCollection || isArray) {
+            requiresGenericType = true;
             ClassElement typeArgument = genericType.isArray() ? genericType.fromArray() : genericType.getFirstTypeArgument().orElse(null);
             if (typeArgument != null) {
                 if (typeArgument.isAssignable(BeanRegistration.class)) {
@@ -1407,22 +1378,31 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
                     methodToInvoke = GET_BEANS_OF_TYPE_FOR_FIELD;
                 }
             } else {
+                requiresGenericType = false;
                 methodToInvoke = GET_BEAN_FOR_FIELD;
             }
+        } else if (genericType.isAssignable(Stream.class)) {
+            requiresGenericType = true;
+            methodToInvoke = GET_STREAM_OF_TYPE_FOR_FIELD;
+        } else if (genericType.isAssignable(Optional.class)) {
+            requiresGenericType = true;
+            methodToInvoke = FIND_BEAN_FOR_FIELD;
+        } else if (genericType.isAssignable(BeanRegistration.class)) {
+            requiresGenericType = true;
+            methodToInvoke = GET_BEAN_REGISTRATION_FOR_FIELD;
         } else {
-            if (genericType.isAssignable(BeanRegistration.class)) {
-                methodToInvoke = GET_BEAN_REGISTRATION_FOR_FIELD;
-            } else {
-                methodToInvoke = GET_BEAN_FOR_FIELD;
-            }
+            methodToInvoke = GET_BEAN_FOR_FIELD;
         }
         visitFieldInjectionPointInternal(
                 declaringType,
                 fieldElement,
                 requiresReflection,
                 methodToInvoke,
-                false
+                false,
+                isArray, requiresGenericType
         );
+
+        fieldInjectionPoints.add(new FieldVisitData(declaringType, fieldElement, requiresReflection));
     }
 
     @Override
@@ -1431,17 +1411,16 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
             FieldElement fieldElement,
             boolean requiresReflection,
             boolean isOptional) {
-        // Implementation notes.
-        // This method modifies the constructor adding addInjectPoint calls for each field that is annotated with @Inject
-        // The constructor is a zero args constructor therefore there are no other local variables and "this" is stored in the 0 index.
-        // The "currentFieldIndex" variable is used as a reference point for both the position of the local variable and also
-        // for later on within the "build" method to in order to call "getBeanForField" with the appropriate index
+
         visitFieldInjectionPointInternal(
                 declaringType,
                 fieldElement,
                 requiresReflection,
                 GET_VALUE_FOR_FIELD,
-                isOptional);
+                isOptional,
+                false, false);
+
+        fieldInjectionPoints.add(new FieldVisitData(declaringType, fieldElement, requiresReflection));
     }
 
     private void visitConfigBuilderMethodInternal(
@@ -1464,7 +1443,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
             boolean zeroArgs = paramType == null;
 
             // Optional optional = AbstractBeanDefinition.getValueForPath(...)
-            pushGetValueForPathCall(injectMethodVisitor, paramType, propertyName, propertyPath, zeroArgs, generics);
+            int optionalLocalIndex = pushGetValueForPathCall(injectMethodVisitor, paramType, propertyName, propertyPath, zeroArgs, generics);
 
             Label ifEnd = new Label();
             // if(optional.isPresent())
@@ -1474,7 +1453,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
             injectMethodVisitor.push(false);
             injectMethodVisitor.ifCmp(Type.BOOLEAN_TYPE, GeneratorAdapter.EQ, ifEnd);
             if (zeroArgs) {
-                pushOptionalGet(injectMethodVisitor);
+                pushOptionalGet(injectMethodVisitor, optionalLocalIndex);
                 pushCastToType(injectMethodVisitor, boolean.class);
                 injectMethodVisitor.push(false);
                 injectMethodVisitor.ifCmp(Type.BOOLEAN_TYPE, GeneratorAdapter.EQ, ifEnd);
@@ -1498,7 +1477,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
 
             injectMethodVisitor.visitLabel(tryStart);
 
-            injectMethodVisitor.visitVarInsn(ALOAD, injectInstanceIndex);
+            injectMethodVisitor.loadLocal(injectInstanceLocalVarIndex);
             if (isResolveBuilderViaMethodCall) {
                 String desc = builderType.getClassName() + " " + builderName + "()";
                 injectMethodVisitor.invokeVirtual(beanType, org.objectweb.asm.commons.Method.getMethod(desc));
@@ -1507,7 +1486,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
             }
 
             if (!zeroArgs) {
-                pushOptionalGet(injectMethodVisitor);
+                pushOptionalGet(injectMethodVisitor, optionalLocalIndex);
                 pushCastToType(injectMethodVisitor, paramType);
             }
 
@@ -1540,15 +1519,15 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
         }
     }
 
-    private void pushOptionalGet(GeneratorAdapter injectMethodVisitor) {
-        injectMethodVisitor.visitVarInsn(ALOAD, optionalInstanceIndex);
+    private void pushOptionalGet(GeneratorAdapter injectMethodVisitor, int optionalLocalIndex) {
+        injectMethodVisitor.loadLocal(optionalLocalIndex);
         // get the value: optional.get()
         injectMethodVisitor.invokeVirtual(Type.getType(Optional.class), org.objectweb.asm.commons.Method.getMethod(
                 ReflectionUtils.getRequiredMethod(Optional.class, "get")
         ));
     }
 
-    private void pushGetValueForPathCall(GeneratorAdapter injectMethodVisitor, ClassElement propertyType, String propertyName, String propertyPath, boolean zeroArgs, Map<String, ClassElement> generics) {
+    private int pushGetValueForPathCall(GeneratorAdapter injectMethodVisitor, ClassElement propertyType, String propertyName, String propertyPath, boolean zeroArgs, Map<String, ClassElement> generics) {
         injectMethodVisitor.loadThis();
         injectMethodVisitor.loadArg(0); // the resolution context
         injectMethodVisitor.loadArg(1); // the bean context
@@ -1569,6 +1548,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
                     propertyType,
                     generics,
                     new HashSet<>(),
+                    new HashMap<>(),
                     loadTypeMethods
             );
         }
@@ -1576,112 +1556,10 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
         injectMethodVisitor.push(propertyPath);
         // Optional optional = AbstractBeanDefinition.getValueForPath(...)
         injectMethodVisitor.invokeVirtual(beanDefinitionType, org.objectweb.asm.commons.Method.getMethod(GET_VALUE_FOR_PATH));
-        injectMethodVisitor.visitVarInsn(ASTORE, optionalInstanceIndex);
-        injectMethodVisitor.visitVarInsn(ALOAD, optionalInstanceIndex);
-    }
-
-    private void buildFactoryFieldClassConstructor(
-            ClassElement factoryClass,
-            ClassElement producedType,
-            String fieldName,
-            AnnotationMetadata fieldAnnotationMetadata,
-            boolean isFinal) {
-        Type factoryTypeRef = JavaModelUtils.getTypeReference(factoryClass);
-        Type producedTypeRef = JavaModelUtils.getTypeReference(producedType);
-        this.constructorVisitor = buildProtectedConstructor(BEAN_DEFINITION_FIELD_CONSTRUCTOR);
-
-        GeneratorAdapter defaultConstructor = new GeneratorAdapter(
-                startConstructor(classWriter),
-                ACC_PUBLIC,
-                CONSTRUCTOR_NAME,
-                DESCRIPTOR_DEFAULT_CONSTRUCTOR
-        );
-
-        // ALOAD 0
-        defaultConstructor.loadThis();
-
-        // 1st argument: The factory type
-        defaultConstructor.push(producedTypeRef);
-
-        // 2nd argument: the produced type
-        defaultConstructor.push(factoryTypeRef);
-
-        // 3rd argument: The field name
-        defaultConstructor.push(fieldName);
-
-        // 4th argument: The annotation metadata
-        pushAnnotationMetadata(fieldAnnotationMetadata, defaultConstructor);
-
-        // 5th argument: is final
-        defaultConstructor.push(isFinal);
-
-        defaultConstructor.invokeConstructor(
-                beanDefinitionType,
-                BEAN_DEFINITION_FIELD_CONSTRUCTOR
-        );
-
-        defaultConstructor.visitInsn(RETURN);
-        defaultConstructor.visitMaxs(DEFAULT_MAX_STACK, 1);
-        defaultConstructor.visitEnd();
-    }
-
-    private void buildFactoryMethodClassConstructor(
-            ClassElement factoryClass,
-            ClassElement producedType,
-            String methodName,
-            AnnotationMetadata methodAnnotationMetadata,
-            List<ParameterElement> argumentTypes) {
-        Type factoryTypeRef = JavaModelUtils.getTypeReference(factoryClass);
-        Type producedTypeRef = JavaModelUtils.getTypeReference(producedType);
-        this.constructorVisitor = buildProtectedConstructor(BEAN_DEFINITION_METHOD_CONSTRUCTOR);
-
-        GeneratorAdapter defaultConstructor = new GeneratorAdapter(
-                startConstructor(classWriter),
-                ACC_PUBLIC,
-                CONSTRUCTOR_NAME,
-                DESCRIPTOR_DEFAULT_CONSTRUCTOR
-        );
-
-        // ALOAD 0
-        defaultConstructor.loadThis();
-
-        // 1st argument: The factory type
-        defaultConstructor.push(producedTypeRef);
-
-        // 2nd argument: the produced type
-        defaultConstructor.push(factoryTypeRef);
-
-        // 3rd argument: The method name
-        defaultConstructor.push(methodName);
-
-        // 4th argument: The annotation metadata
-        pushAnnotationMetadata(methodAnnotationMetadata, defaultConstructor);
-
-        // 5th argument: Does the method require reflection
-        defaultConstructor.push(false);
-
-        // 6th argument: The arguments
-        if (CollectionUtils.isNotEmpty(argumentTypes)) {
-            pushBuildArgumentsForMethod(
-                    beanDefinitionType.getClassName(),
-                    beanDefinitionType,
-                    classWriter,
-                    defaultConstructor,
-                    argumentTypes,
-                    loadTypeMethods
-            );
-        } else {
-            defaultConstructor.visitInsn(ACONST_NULL);
-        }
-
-        defaultConstructor.invokeConstructor(
-                beanDefinitionType,
-                BEAN_DEFINITION_METHOD_CONSTRUCTOR
-        );
-
-        defaultConstructor.visitInsn(RETURN);
-        defaultConstructor.visitMaxs(DEFAULT_MAX_STACK, 1);
-        defaultConstructor.visitEnd();
+        int optionalInstanceIndex = injectMethodVisitor.newLocal(Type.getType(Optional.class));
+        injectMethodVisitor.storeLocal(optionalInstanceIndex);
+        injectMethodVisitor.loadLocal(optionalInstanceIndex);
+        return optionalInstanceIndex;
     }
 
     private void visitFieldInjectionPointInternal(
@@ -1689,50 +1567,14 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
             FieldElement fieldElement,
             boolean requiresReflection,
             Method methodToInvoke,
-            boolean isValueOptional) {
+            boolean isValueOptional,
+            boolean isArray,
+            boolean requiresGenericType) {
 
         AnnotationMetadata annotationMetadata = fieldElement.getAnnotationMetadata();
         autoApplyNamedIfPresent(fieldElement, annotationMetadata);
         DefaultAnnotationMetadata.contributeDefaults(this.annotationMetadata, annotationMetadata);
-        // ready this
-        GeneratorAdapter constructorVisitor = this.constructorVisitor;
-
-        constructorVisitor.loadThis();
-
-        // 1st argument: The declaring type
         Type declaringTypeRef = JavaModelUtils.getTypeReference(declaringType);
-        constructorVisitor.push(declaringTypeRef);
-
-        // 2nd argument: The field type
-        constructorVisitor.push(JavaModelUtils.getTypeReference(fieldElement.getType()));
-
-        // 3rd argument: The field name
-        constructorVisitor.push(fieldElement.getName());
-
-        // 4th argument: The annotation metadata
-        pushAnnotationMetadata(annotationMetadata, constructorVisitor);
-
-        // 5th argument: The type arguments
-        Map<String, ClassElement> typeArguments = fieldElement.getGenericType().getTypeArguments();
-        if (CollectionUtils.isNotEmpty(typeArguments)) {
-            pushTypeArgumentElements(
-                    beanDefinitionType,
-                    classWriter,
-                    constructorVisitor,
-                    declaringType.getName(),
-                    typeArguments,
-                    loadTypeMethods
-            );
-        } else {
-            constructorVisitor.visitInsn(ACONST_NULL);
-        }
-
-        // 6th argument: is reflection required?
-        constructorVisitor.visitInsn(requiresReflection ? ICONST_1 : ICONST_0);
-
-        // invoke addInjectionPoint method
-        pushInvokeMethodOnSuperClass(constructorVisitor, ADD_FIELD_INJECTION_POINT_METHOD);
-
         GeneratorAdapter injectMethodVisitor = this.injectMethodVisitor;
 
         Label falseCondition = null;
@@ -1746,8 +1588,8 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
             injectMethodVisitor.loadArg(1);
             // 3rd argument the field index
             injectMethodVisitor.push(currentFieldIndex);
-
-            // invoke method containsValueForMethodArgument
+            // 4th argument is multi value property
+            injectMethodVisitor.push(isMultiValueProperty(fieldElement.getType()));
             injectMethodVisitor.invokeVirtual(beanDefinitionType, org.objectweb.asm.commons.Method.getMethod(CONTAINS_VALUE_FOR_FIELD));
             injectMethodVisitor.push(false);
 
@@ -1755,33 +1597,104 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
             injectMethodVisitor.visitLabel(trueCondition);
         }
 
-        if (!requiresReflection) {
-            // if reflection is not required then set the field automatically within the body of the "injectBean" method
+        injectMethodVisitor.loadLocal(injectInstanceLocalVarIndex, beanType);
 
-            injectMethodVisitor.visitVarInsn(ALOAD, injectInstanceIndex);
+        if (fieldElement.getGenericField().isAssignable(BeanContext.class)) {
+            injectMethodVisitor.loadArg(1);
+        } else {
             // first get the value of the field by calling AbstractBeanDefinition.getBeanForField(..)
             // load 'this'
             injectMethodVisitor.loadThis();
             // 1st argument load BeanResolutionContext
-            injectMethodVisitor.visitVarInsn(ALOAD, 1);
+            injectMethodVisitor.loadArg(0);
             // 2nd argument load BeanContext
-            injectMethodVisitor.visitVarInsn(ALOAD, 2);
+            injectMethodVisitor.loadArg(1);
             // 3rd argument the field index
             injectMethodVisitor.push(currentFieldIndex);
+            if (requiresGenericType) {
+                resolveFieldArgumentGenericType(injectMethodVisitor, fieldElement.getGenericType(), currentFieldIndex);
+            }
+            // push qualifier
+            pushQualifier(injectMethodVisitor, fieldElement,
+                    () -> resolveFieldArgument(injectMethodVisitor, currentFieldIndex));
             // invoke getBeanForField
             pushInvokeMethodOnSuperClass(injectMethodVisitor, methodToInvoke);
+            if (isArray) {
+                convertToArray(fieldElement.getType().fromArray(), injectMethodVisitor);
+            }
             // cast the return value to the correct type
             pushCastToType(injectMethodVisitor, fieldElement.getType());
-
-            injectMethodVisitor.visitFieldInsn(PUTFIELD, declaringTypeRef.getInternalName(), fieldElement.getName(), getTypeDescriptor(fieldElement.getType()));
+        }
+        Type fieldType = JavaModelUtils.getTypeReference(fieldElement.getType());
+        if (!requiresReflection) {
+            injectMethodVisitor.putField(declaringTypeRef, fieldElement.getName(), fieldType);
         } else {
-            // if reflection is required at reflective call
-            pushInjectMethodForIndex(injectMethodVisitor, injectInstanceIndex, currentFieldIndex, "injectBeanField");
+            pushBoxPrimitiveIfNecessary(fieldType, injectMethodVisitor);
+            int storedIndex = injectMethodVisitor.newLocal(Type.getType(Object.class));
+            injectMethodVisitor.storeLocal(storedIndex);
+            injectMethodVisitor.loadThis();
+            injectMethodVisitor.loadArg(0);
+            injectMethodVisitor.loadArg(1);
+            injectMethodVisitor.push(currentFieldIndex);
+            injectMethodVisitor.loadLocal(injectInstanceLocalVarIndex);
+            injectMethodVisitor.loadLocal(storedIndex);
+            injectMethodVisitor.invokeVirtual(superType, SET_FIELD_WITH_REFLECTION_METHOD);
+            injectMethodVisitor.pop();
         }
         if (falseCondition != null) {
             injectMethodVisitor.visitLabel(falseCondition);
         }
         currentFieldIndex++;
+    }
+
+    private boolean isMultiValueProperty(ClassElement type) {
+        return type.isAssignable(Map.class) || type.isAssignable(Collection.class) || isConfigurationProperties(type);
+    }
+
+    private void pushQualifier(GeneratorAdapter generatorAdapter, AnnotationMetadata element, Runnable resolveArgument) {
+        if (!element.getAnnotationNamesByStereotype(AnnotationUtil.QUALIFIER).isEmpty()) {
+            resolveArgument.run();
+            generatorAdapter.invokeStatic(Type.getType(Qualifiers.class), org.objectweb.asm.commons.Method.getMethod(
+                    ReflectionUtils.getRequiredMethod(Qualifiers.class, "forArgument", Argument.class)
+            ));
+        } else if (element.hasAnnotation(AnnotationUtil.ANN_INTERCEPTOR_BINDING_QUALIFIER)) {
+            resolveArgument.run();
+            generatorAdapter.invokeInterface(Type.getType(AnnotationMetadataProvider.class), org.objectweb.asm.commons.Method.getMethod(
+                    ReflectionUtils.getRequiredMethod(AnnotationMetadataProvider.class, "getAnnotationMetadata")
+            ));
+            generatorAdapter.invokeStatic(Type.getType(Qualifiers.class), org.objectweb.asm.commons.Method.getMethod(
+                    ReflectionUtils.getRequiredMethod(Qualifiers.class, "byInterceptorBinding", AnnotationMetadata.class)
+            ));
+        } else {
+            String[] byType = element.hasDeclaredAnnotation(io.micronaut.context.annotation.Type.NAME) ? element.stringValues(io.micronaut.context.annotation.Type.NAME) : null;
+            if (byType != null && byType.length > 0) {
+                pushArrayOfClasses(generatorAdapter, byType);
+                generatorAdapter.invokeStatic(Type.getType(Qualifiers.class), org.objectweb.asm.commons.Method.getMethod(
+                        ReflectionUtils.getRequiredMethod(Qualifiers.class, "byType", Class[].class)
+                ));
+            } else {
+                generatorAdapter.push((String) null);
+            }
+        }
+    }
+
+    private void pushArrayOfClasses(GeneratorAdapter writer, String[] byType) {
+        int len = byType.length;
+        pushNewArray(writer, Class.class, len);
+        for (int i = 0; i < len; i++) {
+            final String type = byType[i];
+            pushStoreInArray(writer, i, len, () -> pushClass(writer, type));
+        }
+    }
+
+    private void pushClass(GeneratorAdapter writer, String className) {
+        writer.push(Type.getObjectType(className.replace('.', '/')));
+    }
+
+    private void convertToArray(ClassElement arrayType, GeneratorAdapter injectMethodVisitor) {
+        injectMethodVisitor.push(0);
+        injectMethodVisitor.newArray(JavaModelUtils.getTypeReference(arrayType));
+        injectMethodVisitor.invokeInterface(Type.getType(Collection.class), COLLECTION_TO_ARRAY);
     }
 
     private void autoApplyNamedIfPresent(Element element, AnnotationMetadata annotationMetadata) {
@@ -1796,7 +1709,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
                 final String name;
 
                 if (element instanceof ClassElement) {
-                   name = NameUtils.decapitalize(element.getSimpleName());
+                    name = NameUtils.decapitalize(element.getSimpleName());
                 } else {
                     if (element instanceof MethodElement) {
                         final String n = element.getName();
@@ -1814,79 +1727,14 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
         }
     }
 
-    private void pushAnnotationMetadata(AnnotationMetadata annotationMetadata, GeneratorAdapter constructorVisitor) {
-        if (!(annotationMetadata instanceof DefaultAnnotationMetadata)) {
-            constructorVisitor.visitInsn(ACONST_NULL);
-        } else {
-            AnnotationMetadataWriter.instantiateNewMetadata(
-                    beanDefinitionType,
-                    classWriter,
-                    constructorVisitor,
-                    (DefaultAnnotationMetadata) annotationMetadata,
-                    loadTypeMethods
-            );
-        }
-    }
-
-    private void addInjectionPointForSetterInternal(
-            AnnotationMetadata fieldAnnotationMetadata,
-            boolean requiresReflection,
-            String setterName,
-            Map<String, ClassElement> genericTypes,
-            Type declaringTypeRef) {
-
-        // load 'this'
-        GeneratorAdapter constructorVisitor = this.constructorVisitor;
-        constructorVisitor.visitVarInsn(ALOAD, 0);
-
-
-        // 1st argument: The declaring type
-        constructorVisitor.push(declaringTypeRef);
-
-        // 2nd argument: The method name
-        constructorVisitor.push(setterName);
-
-        // 3rd argument: the argument types
-        pushTypeArgumentElements(
-                beanDefinitionType,
-                classWriter,
-                constructorVisitor,
-                declaringTypeRef.getClassName(),
-                genericTypes,
-                loadTypeMethods
-        );
-
-        // 4th argument: the annotation metadata
-        if (fieldAnnotationMetadata == null || fieldAnnotationMetadata == AnnotationMetadata.EMPTY_METADATA) {
-            constructorVisitor.visitInsn(ACONST_NULL);
-        } else {
-            AnnotationMetadataWriter.instantiateNewMetadata(
-                    beanDefinitionType,
-                    classWriter,
-                    constructorVisitor,
-                    (DefaultAnnotationMetadata) fieldAnnotationMetadata,
-                    loadTypeMethods
-            );
-        }
-        // 5th  argument to addInjectionPoint: do we need reflection?
-        constructorVisitor.visitInsn(requiresReflection ? ICONST_1 : ICONST_0);
-
-        // invoke add injection point method
-        pushInvokeMethodOnSuperClass(constructorVisitor, ADD_METHOD_INJECTION_POINT_METHOD);
-    }
-
     /**
-     * @param methodVisitData               The data for the method
-     * @param constructorVisitor            The constructor visitor
-     * @param injectMethodVisitor           The inject method visitor
-     * @param injectInstanceIndex           The inject instance index
-     * @param addMethodInjectionPointMethod The add method inject point method
+     * @param methodVisitData     The data for the method
+     * @param injectMethodVisitor The inject method visitor
+     * @param injectInstanceIndex The inject instance index
      */
     private void visitMethodInjectionPointInternal(MethodVisitData methodVisitData,
-                                                   GeneratorAdapter constructorVisitor,
                                                    GeneratorAdapter injectMethodVisitor,
-                                                   int injectInstanceIndex,
-                                                   Method addMethodInjectionPointMethod) {
+                                                   int injectInstanceIndex) {
 
 
         MethodElement methodElement = methodVisitData.getMethodElement();
@@ -1902,50 +1750,15 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
         int argCount = hasArguments ? argumentTypes.size() : 0;
         Type declaringTypeRef = JavaModelUtils.getTypeReference(declaringType);
 
-        // load 'this'
-        constructorVisitor.visitVarInsn(ALOAD, 0);
-
-        // 1st argument: The declaring type
-        constructorVisitor.push(declaringTypeRef);
-
-        // 2nd argument: The method name
-        constructorVisitor.push(methodName);
-
-        // 3rd argument: the argument types
-        if (hasArguments) {
-            pushBuildArgumentsForMethod(
-                    declaringType.getName(),
-                    beanDefinitionType,
-                    classWriter,
-                    constructorVisitor,
-                    argumentTypes,
-                    loadTypeMethods
-            );
-            for (ParameterElement value : argumentTypes) {
-                DefaultAnnotationMetadata.contributeDefaults(this.annotationMetadata, value.getAnnotationMetadata());
-            }
-        } else {
-            constructorVisitor.visitInsn(ACONST_NULL);
+        for (ParameterElement value : argumentTypes) {
+            DefaultAnnotationMetadata.contributeDefaults(this.annotationMetadata, value.getAnnotationMetadata());
         }
-
-        // 4th argument: the annotation metadata
-        AnnotationMetadata am = annotationMetadata.isEmpty()
-                ? AnnotationMetadata.EMPTY_METADATA
-                : annotationMetadata;
-        pushAnnotationMetadata(am, constructorVisitor);
-
-        // 5th  argument to addInjectionPoint: do we need reflection?
-        constructorVisitor.visitInsn(requiresReflection ? ICONST_1 : ICONST_0);
-
-
-        // invoke add injection point method
-        pushInvokeMethodOnSuperClass(constructorVisitor, addMethodInjectionPointMethod);
 
         if (!requiresReflection) {
             // if the method doesn't require reflection then invoke it directly
 
             // invoke the method on this injected instance
-            injectMethodVisitor.visitVarInsn(ALOAD, injectInstanceIndex);
+            injectMethodVisitor.loadLocal(injectInstanceIndex, beanType);
 
             String methodDescriptor;
             if (hasArguments) {
@@ -1953,25 +1766,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
                 Iterator<ParameterElement> argIterator = argumentTypes.iterator();
                 for (int i = 0; i < argCount; i++) {
                     ParameterElement entry = argIterator.next();
-                    AnnotationMetadata argMetadata = entry.getAnnotationMetadata();
-
-                    // first get the value of the field by calling AbstractBeanDefinition.getBeanForMethod(..)
-                    // load 'this'
-                    injectMethodVisitor.visitVarInsn(ALOAD, 0);
-                    // 1st argument load BeanResolutionContext
-                    injectMethodVisitor.visitVarInsn(ALOAD, 1);
-                    // 2nd argument load BeanContext
-                    injectMethodVisitor.visitVarInsn(ALOAD, 2);
-                    // 3rd argument the method index
-                    injectMethodVisitor.push(currentMethodIndex);
-                    // 4th argument the argument index
-                    injectMethodVisitor.push(i);
-                    // invoke getBeanForField
-
-                    Method methodToInvoke = argMetadata.hasDeclaredStereotype(Value.class) || argMetadata.hasDeclaredStereotype(Property.class) ? GET_VALUE_FOR_METHOD_ARGUMENT : getInjectMethodForParameter(entry);
-                    pushInvokeMethodOnSuperClass(injectMethodVisitor, methodToInvoke);
-                    // cast the return value to the correct type
-                    pushCastToType(injectMethodVisitor, entry);
+                    pushMethodParameterValue(injectMethodVisitor, i, entry);
                 }
             } else {
                 methodDescriptor = getMethodDescriptor(returnType, Collections.emptyList());
@@ -1983,12 +1778,96 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
                 injectMethodVisitor.pop();
             }
         } else {
-            // otherwise use injectBeanMethod instead which triggers reflective injection
-            pushInjectMethodForIndex(injectMethodVisitor, injectInstanceIndex, currentMethodIndex, "injectBeanMethod");
+            injectMethodVisitor.loadThis();
+            injectMethodVisitor.loadArg(0);
+            injectMethodVisitor.loadArg(1);
+            injectMethodVisitor.push(currentMethodIndex);
+            injectMethodVisitor.loadLocal(injectInstanceLocalVarIndex, beanType);
+            if (hasArguments) {
+                pushNewArray(injectMethodVisitor, Object.class, argumentTypes.size());
+                Iterator<ParameterElement> argIterator = argumentTypes.iterator();
+                for (int i = 0; i < argCount; i++) {
+                    int finalI = i;
+                    pushStoreInArray(injectMethodVisitor, i, argumentTypes.size(), () -> {
+                        ParameterElement entry = argIterator.next();
+                        pushMethodParameterValue(injectMethodVisitor, finalI, entry);
+                        pushBoxPrimitiveIfNecessary(entry.getType(), injectMethodVisitor);
+                    });
+                }
+            } else {
+                pushNewArray(injectMethodVisitor, Object.class, 0);
+            }
+            injectMethodVisitor.invokeVirtual(superType, INVOKE_WITH_REFLECTION_METHOD);
         }
 
         // increment the method index
         currentMethodIndex++;
+    }
+
+    private void pushMethodParameterValue(GeneratorAdapter injectMethodVisitor, int i, ParameterElement entry) {
+        AnnotationMetadata argMetadata = entry.getAnnotationMetadata();
+        if (entry.getGenericType().isAssignable(BeanResolutionContext.class)) {
+            injectMethodVisitor.loadArg(0);
+        } else if (entry.getGenericType().isAssignable(BeanContext.class)) {
+            injectMethodVisitor.loadArg(1);
+        } else {
+            // first get the value of the field by calling AbstractBeanDefinition.getBeanForMethod(..)
+            // load 'this'
+            injectMethodVisitor.loadThis();
+            // 1st argument load BeanResolutionContext
+            injectMethodVisitor.loadArg(0);
+            // 2nd argument load BeanContext
+            injectMethodVisitor.loadArg(1);
+            // 3rd argument the method index
+            injectMethodVisitor.push(currentMethodIndex);
+            // 4th argument the argument index
+            injectMethodVisitor.push(i);
+            // invoke getBeanForField
+            boolean requiresGenericType = false;
+            final ClassElement genericType = entry.getGenericType();
+            Method methodToInvoke;
+            boolean isCollection = genericType.isAssignable(Collection.class);
+            boolean isArray = genericType.isArray();
+            if (argMetadata.hasDeclaredStereotype(Value.class) || argMetadata.hasDeclaredStereotype(Property.class)) {
+                methodToInvoke = GET_VALUE_FOR_METHOD_ARGUMENT;
+            } else if (isCollection || isArray) {
+                requiresGenericType = true;
+                ClassElement typeArgument = genericType.isArray() ? genericType.fromArray() : genericType.getFirstTypeArgument().orElse(null);
+                if (typeArgument != null) {
+                    if (typeArgument.isAssignable(BeanRegistration.class)) {
+                        methodToInvoke = GET_BEAN_REGISTRATIONS_FOR_METHOD_ARGUMENT;
+                    } else {
+                        methodToInvoke = GET_BEANS_OF_TYPE_FOR_METHOD_ARGUMENT;
+                    }
+                } else {
+                    methodToInvoke = GET_BEAN_FOR_METHOD_ARGUMENT;
+                    requiresGenericType = false;
+                }
+            } else if (genericType.isAssignable(Stream.class)) {
+                requiresGenericType = true;
+                methodToInvoke = GET_STREAM_OF_TYPE_FOR_METHOD_ARGUMENT;
+            } else if (genericType.isAssignable(Optional.class)) {
+                requiresGenericType = true;
+                methodToInvoke = FIND_BEAN_FOR_METHOD_ARGUMENT;
+            } else if (genericType.isAssignable(BeanRegistration.class)) {
+                requiresGenericType = true;
+                methodToInvoke = GET_BEAN_REGISTRATION_FOR_METHOD_ARGUMENT;
+            } else {
+                methodToInvoke = GET_BEAN_FOR_METHOD_ARGUMENT;
+            }
+
+            if (requiresGenericType) {
+                resolveMethodArgumentGenericType(injectMethodVisitor, genericType, currentMethodIndex, i);
+            }
+            pushQualifier(injectMethodVisitor, entry, () -> resolveMethodArgument(injectMethodVisitor, currentMethodIndex, i));
+
+            pushInvokeMethodOnSuperClass(injectMethodVisitor, methodToInvoke);
+            if (isArray) {
+                convertToArray(genericType.fromArray(), injectMethodVisitor);
+            }
+            // cast the return value to the correct type
+            pushCastToType(injectMethodVisitor, entry);
+        }
     }
 
     private void applyDefaultNamedToParameters(List<ParameterElement> argumentTypes) {
@@ -1999,30 +1878,6 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
         }
     }
 
-    private Method getInjectMethodForParameter(ParameterElement parameterElement) {
-        final ClassElement genericType = parameterElement.getGenericType();
-        Method methodToInvoke;
-        if (genericType.isAssignable(Collection.class) || genericType.isArray()) {
-            ClassElement typeArgument = genericType.isArray() ? genericType.fromArray() : genericType.getFirstTypeArgument().orElse(null);
-            if (typeArgument != null) {
-                if (typeArgument.isAssignable(BeanRegistration.class)) {
-                    methodToInvoke = GET_BEAN_REGISTRATIONS_FOR_METHOD_ARGUMENT;
-                } else {
-                    methodToInvoke = GET_BEANS_OF_TYPE_FOR_METHOD_ARGUMENT;
-                }
-            } else {
-                methodToInvoke = GET_BEAN_FOR_METHOD_ARGUMENT;
-            }
-        } else {
-            if (genericType.isAssignable(BeanRegistration.class)) {
-                methodToInvoke = GET_BEAN_REGISTRATION_FOR_METHOD_ARGUMENT;
-            } else {
-                methodToInvoke = GET_BEAN_FOR_METHOD_ARGUMENT;
-            }
-        }
-        return methodToInvoke;
-    }
-
     private void pushInvokeMethodOnSuperClass(MethodVisitor constructorVisitor, Method methodToInvoke) {
         constructorVisitor.visitMethodInsn(INVOKESPECIAL,
                 isSuperFactory ? TYPE_ABSTRACT_BEAN_DEFINITION.getInternalName() : superType.getInternalName(),
@@ -2031,63 +1886,76 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
                 false);
     }
 
-    private void resolveBeanOrValueForSetter(Type declaringTypeRef, ClassElement returnType, String setterName, ClassElement fieldType, Method resolveMethod, boolean isValueOptional) {
-        GeneratorAdapter injectVisitor = this.injectMethodVisitor;
+    private void resolveBeanOrValueForSetter(TypedElement declaringType, MethodElement methodElement, boolean isOptional) {
+
+        ParameterElement[] parameters = methodElement.getParameters();
+        if (parameters.length != 1) {
+            throw new IllegalArgumentException("Method must have exactly 1 argument");
+        }
+        Type declaringTypeRef = JavaModelUtils.getTypeReference(declaringType);
+
+        ClassElement returnType = methodElement.getReturnType();
+        ClassElement fieldType = parameters[0].getType();
+        Method resolveMethod = GET_VALUE_FOR_METHOD_ARGUMENT;
 
         Label falseCondition = null;
-        if (isValueOptional) {
+        if (isOptional) {
             Label trueCondition = new Label();
             falseCondition = new Label();
-            injectVisitor.loadThis();
+            injectMethodVisitor.loadThis();
             // 1st argument load BeanResolutionContext
-            injectVisitor.loadArg(0);
+            injectMethodVisitor.loadArg(0);
             // 2nd argument load BeanContext
-            injectVisitor.loadArg(1);
+            injectMethodVisitor.loadArg(1);
             // 3rd argument the field index
-            injectVisitor.push(currentMethodIndex);
+            injectMethodVisitor.push(currentMethodIndex);
             // 4th argument the argument index
-            injectVisitor.push(0);
-
+            injectMethodVisitor.push(0);
+            // 5th argument is multi value property
+            injectMethodVisitor.push(isMultiValueProperty(fieldType));
             // invoke method containsValueForMethodArgument
-            injectVisitor.invokeVirtual(beanDefinitionType, org.objectweb.asm.commons.Method.getMethod(CONTAINS_VALUE_FOR_METHOD_ARGUMENT));
-            injectVisitor.push(false);
+            injectMethodVisitor.invokeVirtual(beanDefinitionType, org.objectweb.asm.commons.Method.getMethod(CONTAINS_VALUE_FOR_METHOD_ARGUMENT));
+            injectMethodVisitor.push(false);
 
-            injectVisitor.ifCmp(Type.BOOLEAN_TYPE, GeneratorAdapter.EQ, falseCondition);
-            injectVisitor.visitLabel(trueCondition);
+            injectMethodVisitor.ifCmp(Type.BOOLEAN_TYPE, GeneratorAdapter.EQ, falseCondition);
+            injectMethodVisitor.visitLabel(trueCondition);
         }
         // invoke the method on this injected instance
-        injectVisitor.visitVarInsn(ALOAD, injectInstanceIndex);
+        injectMethodVisitor.loadLocal(injectInstanceLocalVarIndex, beanType);
         String methodDescriptor = getMethodDescriptor(returnType, Collections.singletonList(fieldType));
         // first get the value of the field by calling AbstractBeanDefinition.getBeanForField(..)
         // load 'this'
-        injectMethodVisitor.visitVarInsn(ALOAD, 0);
+        injectMethodVisitor.loadThis();
         // 1st argument load BeanResolutionContext
-        injectMethodVisitor.visitVarInsn(ALOAD, 1);
+        injectMethodVisitor.loadArg(0);
         // 2nd argument load BeanContext
-        injectMethodVisitor.visitVarInsn(ALOAD, 2);
+        injectMethodVisitor.loadArg(1);
         // 3rd argument the field index
         injectMethodVisitor.push(currentMethodIndex);
         // 4th argument the argument index
         // 5th argument is the default value
-        injectVisitor.push(0);
+        injectMethodVisitor.push(0);
+        // push qualifier
+        pushQualifier(injectMethodVisitor, parameters[0],
+                () -> resolveMethodArgument(injectMethodVisitor, currentMethodIndex, 0));
         // invoke getBeanForField
-        pushInvokeMethodOnSuperClass(injectVisitor, resolveMethod);
+        pushInvokeMethodOnSuperClass(injectMethodVisitor, resolveMethod);
         // cast the return value to the correct type
-        pushCastToType(injectVisitor, fieldType);
-        injectVisitor.visitMethodInsn(INVOKEVIRTUAL,
-                declaringTypeRef.getInternalName(), setterName,
+        pushCastToType(injectMethodVisitor, fieldType);
+        injectMethodVisitor.visitMethodInsn(INVOKEVIRTUAL,
+                declaringTypeRef.getInternalName(), methodElement.getName(),
                 methodDescriptor, false);
         if (returnType != PrimitiveElement.VOID) {
-            injectVisitor.pop();
+            injectMethodVisitor.pop();
         }
         if (falseCondition != null) {
-            injectVisitor.visitLabel(falseCondition);
+            injectMethodVisitor.visitLabel(falseCondition);
         }
     }
 
     @SuppressWarnings("MagicNumber")
     private void visitInjectMethodDefinition() {
-        if (injectMethodVisitor == null) {
+        if (!superBeanDefinition && injectMethodVisitor == null) {
             String desc = getMethodDescriptor(Object.class.getName(), BeanResolutionContext.class.getName(), BeanContext.class.getName(), Object.class.getName());
             injectMethodVisitor = new GeneratorAdapter(classWriter.visitMethod(
                     ACC_PROTECTED,
@@ -2110,49 +1978,49 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
                 injectMethodVisitor.visitLabel(new Label());
             }
             // The object being injected is argument 3 of the inject method
-            injectMethodVisitor.visitVarInsn(ALOAD, 3);
+            injectMethodVisitor.loadArg(2);
             // store it in a local variable
             injectMethodVisitor.visitTypeInsn(CHECKCAST, beanType.getInternalName());
-            injectInstanceIndex = pushNewInjectLocalVariable();
-            injectMethodVisitor.visitInsn(ACONST_NULL);
-            optionalInstanceIndex = pushNewInjectLocalVariable();
+            injectInstanceLocalVarIndex = injectMethodVisitor.newLocal(beanType);
+            injectMethodVisitor.storeLocal(injectInstanceLocalVarIndex);
         }
     }
 
     @SuppressWarnings("MagicNumber")
     private void visitPostConstructMethodDefinition(boolean intercepted) {
-        if (postConstructMethodVisitor == null) {
-            interfaceTypes.add(InitializingBeanDefinition.class);
-
+        if (!postConstructAdded) {
             // override the post construct method
             final String lifeCycleMethodName = "initialize";
-            GeneratorAdapter postConstructMethodVisitor = newLifeCycleMethod(lifeCycleMethodName);
 
-            this.postConstructMethodVisitor = postConstructMethodVisitor;
-            // The object being injected is argument 3 of the inject method
-            postConstructMethodVisitor.visitVarInsn(ALOAD, 3);
-            // store it in a local variable
-            postConstructMethodVisitor.visitTypeInsn(CHECKCAST, beanType.getInternalName());
-            postConstructInstanceIndex = pushNewPostConstructLocalVariable();
+            //  for "super bean definition" we only add code to trigger "initialize"
+            if (!superBeanDefinition) {
+                interfaceTypes.add(InitializingBeanDefinition.class);
 
-            invokeSuperInjectMethod(postConstructMethodVisitor, POST_CONSTRUCT_METHOD);
+                GeneratorAdapter postConstructMethodVisitor = newLifeCycleMethod(lifeCycleMethodName);
+                this.postConstructMethodVisitor = postConstructMethodVisitor;
+                // The object being injected is argument 3 of the inject method
+                postConstructMethodVisitor.loadArg(2);
+                // store it in a local variable
+                postConstructMethodVisitor.visitTypeInsn(CHECKCAST, beanType.getInternalName());
+                postConstructInstanceLocalVarIndex = postConstructMethodVisitor.newLocal(beanType);
+                postConstructMethodVisitor.storeLocal(postConstructInstanceLocalVarIndex);
+                invokeSuperInjectMethod(postConstructMethodVisitor, POST_CONSTRUCT_METHOD);
+            }
 
             if (intercepted) {
                 // store executable method in local variable
-                final int postConstructorMethodVar = pushNewBuildLocalVariable();
                 writeInterceptedLifecycleMethod(
                         lifeCycleMethodName,
                         lifeCycleMethodName,
                         buildMethodVisitor,
-                        buildInstanceIndex,
-                        postConstructorMethodVar
+                        buildInstanceLocalVarIndex
                 );
             } else {
                 pushBeanDefinitionMethodInvocation(buildMethodVisitor, lifeCycleMethodName);
             }
             pushCastToType(buildMethodVisitor, beanType);
-            buildMethodVisitor.visitVarInsn(ASTORE, buildInstanceIndex);
-
+            buildMethodVisitor.loadLocal(buildInstanceLocalVarIndex);
+            postConstructAdded = true;
         }
     }
 
@@ -2160,8 +2028,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
             String lifeCycleMethodName,
             String dispatchMethodName,
             GeneratorAdapter targetMethodVisitor,
-            int instanceIndex,
-            int executableInstanceIndex) {
+            int instanceLocalIndex) {
         // if there is method interception in place we need to construct an inner executable method class that invokes the "initialize"
         // method and apply interception
         final InnerClassDef postConstructInnerMethod = newInnerClass(AbstractExecutableMethod.class);
@@ -2178,10 +2045,10 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
         newFinalField(postConstructInnerWriter, beanType, fieldBean);
         // constructor will be AbstractExecutableMethod(BeanDefinition, BeanResolutionContext, BeanContext, T beanType)
         final String constructorDescriptor = getConstructorDescriptor(new Type[]{
-            beanDefinitionType,
-            TYPE_RESOLUTION_CONTEXT,
-            TYPE_BEAN_CONTEXT,
-            beanType
+                beanDefinitionType,
+                TYPE_RESOLUTION_CONTEXT,
+                TYPE_BEAN_CONTEXT,
+                beanType
         });
         GeneratorAdapter protectedConstructor = new GeneratorAdapter(
                 postConstructInnerWriter.visitMethod(
@@ -2196,19 +2063,19 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
         );
         // set field $beanDef
         protectedConstructor.loadThis();
-        protectedConstructor.visitVarInsn(ALOAD, 1);
+        protectedConstructor.loadArg(0);
         protectedConstructor.putField(postConstructInnerClassType, fieldBeanDef, beanDefinitionType);
         // set field $resolutionContext
         protectedConstructor.loadThis();
-        protectedConstructor.visitVarInsn(ALOAD, 2);
+        protectedConstructor.loadArg(1);
         protectedConstructor.putField(postConstructInnerClassType, fieldResContext, TYPE_RESOLUTION_CONTEXT);
         // set field $beanContext
         protectedConstructor.loadThis();
-        protectedConstructor.visitVarInsn(ALOAD, 3);
+        protectedConstructor.loadArg(2);
         protectedConstructor.putField(postConstructInnerClassType, fieldBeanContext, TYPE_BEAN_CONTEXT);
         // set field $bean
         protectedConstructor.loadThis();
-        protectedConstructor.visitVarInsn(ALOAD, 4);
+        protectedConstructor.loadArg(3);
         protectedConstructor.putField(postConstructInnerClassType, fieldBean, beanType);
 
         protectedConstructor.loadThis();
@@ -2261,13 +2128,13 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
         targetMethodVisitor.loadThis();
 
         // 2nd argument: resolution context
-        targetMethodVisitor.visitVarInsn(ALOAD, 1);
+        targetMethodVisitor.loadArg(0);
 
         // 3rd argument: bean context
-        targetMethodVisitor.visitVarInsn(ALOAD, 2);
+        targetMethodVisitor.loadArg(1);
 
         // 4th argument: bean instance
-        targetMethodVisitor.visitVarInsn(ALOAD, instanceIndex);
+        targetMethodVisitor.loadLocal(instanceLocalIndex);
         pushCastToType(targetMethodVisitor, beanType);
         targetMethodVisitor.visitMethodInsn(
                 INVOKESPECIAL,
@@ -2276,18 +2143,19 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
                 constructorDescriptor,
                 false
         );
-        targetMethodVisitor.visitVarInsn(ASTORE, executableInstanceIndex);
+        final int executableInstanceIndex = targetMethodVisitor.newLocal(Type.getType(ExecutableMethod.class));
+        targetMethodVisitor.storeLocal(executableInstanceIndex);
         // now invoke MethodInterceptorChain.initialize or dispose
         // 1st argument: resolution context
-        targetMethodVisitor.visitVarInsn(ALOAD, 1);
+        targetMethodVisitor.loadArg(0);
         // 2nd argument: bean context
-        targetMethodVisitor.visitVarInsn(ALOAD, 2);
+        targetMethodVisitor.loadArg(1);
         // 3rd argument: this definition
         targetMethodVisitor.loadThis();
         // 4th argument: executable method instance
-        targetMethodVisitor.visitVarInsn(ALOAD, executableInstanceIndex);
+        targetMethodVisitor.loadLocal(executableInstanceIndex);
         // 5th argument: the bean instance
-        targetMethodVisitor.visitVarInsn(ALOAD, instanceIndex);
+        targetMethodVisitor.loadLocal(instanceLocalIndex);
         pushCastToType(targetMethodVisitor, beanType);
         targetMethodVisitor.visitMethodInsn(
                 INVOKESTATIC,
@@ -2296,24 +2164,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
                 METHOD_DESCRIPTOR_INTERCEPTED_LIFECYCLE,
                 false
         );
-        targetMethodVisitor.visitVarInsn(ALOAD, instanceIndex);
-    }
-
-    private void pushInjectMethodForIndex(GeneratorAdapter methodVisitor, int instanceIndex, int injectIndex, String injectMethodName) {
-        Method injectBeanMethod = ReflectionUtils.getRequiredMethod(AbstractBeanDefinition.class, injectMethodName, BeanResolutionContext.class, DefaultBeanContext.class, int.class, Object.class);
-        // load 'this'
-        methodVisitor.visitVarInsn(ALOAD, 0);
-        // 1st argument load BeanResolutionContext
-        methodVisitor.visitVarInsn(ALOAD, 1);
-        // 2nd argument load BeanContext
-        methodVisitor.visitVarInsn(ALOAD, 2);
-        pushCastToType(methodVisitor, DefaultBeanContext.class);
-        // 3rd argument the method index
-        methodVisitor.push(injectIndex);
-        // 4th argument: the instance being injected
-        methodVisitor.visitVarInsn(ALOAD, instanceIndex);
-
-        pushInvokeMethodOnSuperClass(methodVisitor, injectBeanMethod);
+        targetMethodVisitor.loadLocal(instanceLocalIndex);
     }
 
     @SuppressWarnings("MagicNumber")
@@ -2325,14 +2176,16 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
             GeneratorAdapter preDestroyMethodVisitor;
             if (intercepted) {
                 preDestroyMethodVisitor = newLifeCycleMethod("doDispose");
-
                 final GeneratorAdapter disposeMethod = newLifeCycleMethod("dispose");
+                disposeMethod.loadArg(2);
+                int instanceLocalIndex = disposeMethod.newLocal(beanType);
+                disposeMethod.storeLocal(instanceLocalIndex);
+
                 writeInterceptedLifecycleMethod(
                         "doDispose",
                         "dispose",
                         disposeMethod,
-                        3,
-                        4
+                        instanceLocalIndex
                 );
                 disposeMethod.returnValue();
 
@@ -2344,10 +2197,11 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
 
             this.preDestroyMethodVisitor = preDestroyMethodVisitor;
             // The object being injected is argument 3 of the inject method
-            preDestroyMethodVisitor.visitVarInsn(ALOAD, 3);
+            preDestroyMethodVisitor.loadArg(2);
             // store it in a local variable
             preDestroyMethodVisitor.visitTypeInsn(CHECKCAST, beanType.getInternalName());
-            preDestroyInstanceIndex = pushNewPreDestroyLocalVariable();
+            preDestroyInstanceLocalVarIndex = preDestroyMethodVisitor.newLocal(beanType);
+            preDestroyMethodVisitor.storeLocal(preDestroyInstanceLocalVarIndex);
 
             invokeSuperInjectMethod(preDestroyMethodVisitor, PRE_DESTROY_METHOD);
         }
@@ -2371,41 +2225,30 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
         // if this is a provided bean then execute "get"
         if (!providedBeanClassName.equals(beanFullClassName)) {
 
-            buildMethodVisitor.visitVarInsn(ASTORE, buildInstanceIndex);
-            buildMethodVisitor.visitVarInsn(ALOAD, buildInstanceIndex);
+            buildMethodVisitor.storeLocal(buildInstanceLocalVarIndex);
+            buildMethodVisitor.loadLocal(buildInstanceLocalVarIndex);
             buildMethodVisitor.visitMethodInsn(INVOKEVIRTUAL,
                     beanType.getInternalName(),
                     "get",
                     Type.getMethodDescriptor(Type.getType(Object.class)),
                     false);
             pushCastToType(buildMethodVisitor, providedType);
-            buildMethodVisitor.visitVarInsn(ASTORE, buildInstanceIndex);
+            buildMethodVisitor.loadLocal(buildInstanceLocalVarIndex);
             pushBeanDefinitionMethodInvocation(buildMethodVisitor, "injectAnother");
             pushCastToType(buildMethodVisitor, providedType);
         }
     }
 
-    private void finalizeInjectMethod() {
-        if (injectEnd != null) {
-            injectMethodVisitor.visitLabel(injectEnd);
-        }
-
-        invokeSuperInjectMethod(injectMethodVisitor, INJECT_BEAN_METHOD);
-        injectMethodVisitor.visitInsn(ARETURN);
-    }
-
     @SuppressWarnings("MagicNumber")
-    private void invokeSuperInjectMethod(MethodVisitor methodVisitor, Method methodToInvoke) {
+    private void invokeSuperInjectMethod(GeneratorAdapter methodVisitor, Method methodToInvoke) {
         // load this
-        methodVisitor.visitVarInsn(ALOAD, 0);
+        methodVisitor.loadThis();
         // load BeanResolutionContext arg 1
-        methodVisitor.visitVarInsn(ALOAD, 1);
+        methodVisitor.loadArg(0);
         // load BeanContext arg 2
-        methodVisitor.visitVarInsn(ALOAD, 2);
-        pushCastToType(methodVisitor, DefaultBeanContext.class);
-
+        methodVisitor.loadArg(1);
         // load object being inject arg 3
-        methodVisitor.visitVarInsn(ALOAD, 3);
+        methodVisitor.loadArg(2);
         pushInvokeMethodOnSuperClass(methodVisitor, methodToInvoke);
     }
 
@@ -2435,10 +2278,10 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
             // the below code looks up the factory bean.
 
             // Load the BeanContext for the method call
-            buildMethodVisitor.visitVarInsn(ALOAD, 2);
+            buildMethodVisitor.loadArg(1);
             pushCastToType(buildMethodVisitor, DefaultBeanContext.class);
             // load the first argument of the method (the BeanResolutionContext) to be passed to the method
-            buildMethodVisitor.visitVarInsn(ALOAD, 1);
+            buildMethodVisitor.loadArg(0);
             // second argument is the bean type
             buildMethodVisitor.push(factoryType);
             buildMethodVisitor.invokeVirtual(
@@ -2447,17 +2290,17 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
             );
 
             // store a reference to the bean being built at index 3
-            int factoryVar = pushNewBuildLocalVariable();
-            buildMethodVisitor.visitVarInsn(ALOAD, factoryVar);
+            int factoryVar = buildMethodVisitor.newLocal(JavaModelUtils.getTypeReference(factoryClass));
+            buildMethodVisitor.storeLocal(factoryVar);
+            buildMethodVisitor.loadLocal(factoryVar);
             pushCastToType(buildMethodVisitor, factoryClass);
             String methodDescriptor = getMethodDescriptorForReturnType(beanType, parameterList);
             if (isIntercepted) {
-                initInterceptedConstructorWriter(
+                int constructorIndex = initInterceptedConstructorWriter(
                         buildMethodVisitor,
                         parameterList,
                         new FactoryMethodDef(factoryType, factoryMethod, methodDescriptor, factoryVar)
                 );
-                final int constructorIndex = pushNewBuildLocalVariable();
                 // populate an Object[] of all constructor arguments
                 final int parametersIndex = createParameterArray(parameterList, buildMethodVisitor);
                 invokeConstructorChain(buildMethodVisitor, constructorIndex, parametersIndex, parameterList);
@@ -2481,11 +2324,12 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
             }
 
 
-            this.buildInstanceIndex = pushNewBuildLocalVariable();
+            this.buildInstanceLocalVarIndex = buildMethodVisitor.newLocal(beanType);
+            buildMethodVisitor.storeLocal(buildInstanceLocalVarIndex);
             pushBeanDefinitionMethodInvocation(buildMethodVisitor, "injectBean");
             pushCastToType(buildMethodVisitor, beanType);
-            buildMethodVisitor.visitVarInsn(ASTORE, buildInstanceIndex);
-            buildMethodVisitor.visitVarInsn(ALOAD, buildInstanceIndex);
+            buildMethodVisitor.storeLocal(buildInstanceLocalVarIndex);
+            buildMethodVisitor.loadLocal(buildInstanceLocalVarIndex);
             initLifeCycleMethodsIfNecessary();
         }
     }
@@ -2504,8 +2348,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
             // if there is constructor interception present then we have to
             // build the parameters into an Object[] and build a constructor invocation
             if (isIntercepted) {
-                initInterceptedConstructorWriter(buildMethodVisitor, parameters, null);
-                final int constructorIndex = pushNewBuildLocalVariable();
+                final int constructorIndex = initInterceptedConstructorWriter(buildMethodVisitor, parameters, null);
                 // populate an Object[] of all constructor arguments
                 final int parametersIndex = createParameterArray(parameters, buildMethodVisitor);
                 invokeConstructorChain(buildMethodVisitor, constructorIndex, parametersIndex, parameters);
@@ -2519,11 +2362,11 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
                     );
                 } else {
                     if (requiresReflection) {
-                        final int parameterArrayIndex = createParameterArray(parameters, buildMethodVisitor);
-                        final int parameterTypeArrayIndex = createParameterTypeArray(parameters, buildMethodVisitor);
+                        final int parameterArrayLocalVarIndex = createParameterArray(parameters, buildMethodVisitor);
+                        final int parameterTypeArrayLocalVarIndex = createParameterTypeArray(parameters, buildMethodVisitor);
                         buildMethodVisitor.push(beanType);
-                        buildMethodVisitor.visitVarInsn(ALOAD, parameterTypeArrayIndex);
-                        buildMethodVisitor.visitVarInsn(ALOAD, parameterArrayIndex);
+                        buildMethodVisitor.loadLocal(parameterTypeArrayLocalVarIndex);
+                        buildMethodVisitor.loadLocal(parameterArrayLocalVarIndex);
                         buildMethodVisitor.invokeStatic(
                                 Type.getType(InstantiationUtils.class),
                                 org.objectweb.asm.commons.Method.getMethod(
@@ -2538,22 +2381,21 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
                         );
                         pushCastToType(buildMethodVisitor, beanType);
                     } else {
-                        buildMethodVisitor.visitTypeInsn(NEW, beanType.getInternalName());
-                        buildMethodVisitor.visitInsn(DUP);
+                        buildMethodVisitor.newInstance(beanType);
+                        buildMethodVisitor.dup();
                         pushConstructorArguments(buildMethodVisitor, parameterArray);
-
                         String constructorDescriptor = getConstructorDescriptor(parameters);
-                        buildMethodVisitor.visitMethodInsn(INVOKESPECIAL, beanType.getInternalName(), "<init>", constructorDescriptor, false);
+                        buildMethodVisitor.invokeConstructor(beanType, new org.objectweb.asm.commons.Method("<init>", constructorDescriptor));
                     }
                 }
             }
 
-            // store a reference to the bean being built at index 3
-            this.buildInstanceIndex = pushNewBuildLocalVariable();
+            this.buildInstanceLocalVarIndex = buildMethodVisitor.newLocal(beanType);
+            buildMethodVisitor.storeLocal(buildInstanceLocalVarIndex);
             pushBeanDefinitionMethodInvocation(buildMethodVisitor, "injectBean");
             pushCastToType(buildMethodVisitor, beanType);
-            buildMethodVisitor.visitVarInsn(ASTORE, buildInstanceIndex);
-            buildMethodVisitor.visitVarInsn(ALOAD, buildInstanceIndex);
+            buildMethodVisitor.storeLocal(buildInstanceLocalVarIndex);
+            buildMethodVisitor.loadLocal(buildInstanceLocalVarIndex);
             initLifeCycleMethodsIfNecessary();
         }
     }
@@ -2562,20 +2404,20 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
         if (isInterceptedLifeCycleByType(this.annotationMetadata, "POST_CONSTRUCT")) {
             visitPostConstructMethodDefinition(true);
         }
-        if (isInterceptedLifeCycleByType(this.annotationMetadata, "PRE_DESTROY")) {
+        if (!superBeanDefinition && isInterceptedLifeCycleByType(this.annotationMetadata, "PRE_DESTROY")) {
             visitPreDestroyMethodDefinition(true);
         }
     }
 
-    private void invokeConstructorChain(GeneratorAdapter generatorAdapter, int constructorIndex, int parametersIndex, List<ParameterElement> parameters) {
+    private void invokeConstructorChain(GeneratorAdapter generatorAdapter, int constructorLocalIndex, int parametersLocalIndex, List<ParameterElement> parameters) {
         // 1st argument: The resolution context
-        generatorAdapter.visitVarInsn(ALOAD, 1);
+        generatorAdapter.loadArg(0);
         // 2nd argument: The bean context
-        generatorAdapter.visitVarInsn(ALOAD, 2);
+        generatorAdapter.loadArg(1);
         // 3rd argument: The interceptors if present
         if (StringUtils.isNotEmpty(interceptedType)) {
             // interceptors will be last entry in parameter list for interceptors types
-            generatorAdapter.visitVarInsn(ALOAD, parametersIndex);
+            generatorAdapter.loadLocal(parametersLocalIndex);
             // array index for last parameter
             generatorAdapter.push(parameters.size() - 1);
             generatorAdapter.arrayLoad(TYPE_OBJECT);
@@ -2587,9 +2429,9 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
         // 4th argument: the bean definition
         generatorAdapter.loadThis();
         // 5th argument: The constructor
-        generatorAdapter.visitVarInsn(ALOAD, constructorIndex);
+        generatorAdapter.loadLocal(constructorLocalIndex);
         // 6th argument:  load the Object[] for the parameters
-        generatorAdapter.visitVarInsn(ALOAD, parametersIndex);
+        generatorAdapter.loadLocal(parametersLocalIndex);
 
         generatorAdapter.visitMethodInsn(
                 INVOKESTATIC,
@@ -2600,7 +2442,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
         );
     }
 
-    private void initInterceptedConstructorWriter(
+    private int initInterceptedConstructorWriter(
             GeneratorAdapter buildMethodVisitor,
             List<ParameterElement> parameters,
             @Nullable FactoryMethodDef factoryMethodDef) {
@@ -2618,7 +2460,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
             // for factory methods we have to store the factory instance in a field and modify the constructor pass the factory instance
             newFinalField(interceptedConstructorWriter, factoryType, factoryFieldName);
 
-            interceptedConstructorDescriptor = getConstructorDescriptor(new Type[] {
+            interceptedConstructorDescriptor = getConstructorDescriptor(new Type[]{
                     TYPE_BEAN_DEFINITION,
                     factoryType
             });
@@ -2709,7 +2551,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
         buildMethodVisitor.loadThis();
 
         if (hasFactoryMethod) {
-            buildMethodVisitor.visitVarInsn(ALOAD, factoryMethodDef.factoryVar);
+            buildMethodVisitor.loadLocal(factoryMethodDef.factoryVar);
             pushCastToType(buildMethodVisitor, factoryType);
         }
 
@@ -2720,6 +2562,10 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
                 interceptedConstructorDescriptor,
                 false
         );
+
+        final int constructorIndex = buildMethodVisitor.newLocal(Type.getType(AbstractConstructorInjectionPoint.class));
+        buildMethodVisitor.storeLocal(constructorIndex);
+        return constructorIndex;
     }
 
     private void newFinalField(ClassWriter classWriter, Type fieldType, String fieldName) {
@@ -2753,10 +2599,10 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
         );
         classWriter.visitInnerClass(constructorInternalName, beanDefinitionInternalName, null, ACC_PRIVATE);
         return new InnerClassDef(
-            interceptedConstructorWriterName,
-            interceptedConstructorWriter,
-            constructorInternalName,
-            interceptedConstructorType
+                interceptedConstructorWriterName,
+                interceptedConstructorWriter,
+                constructorInternalName,
+                interceptedConstructorType
         );
     }
 
@@ -2774,7 +2620,9 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
                     buildMethodVisitor.push(getTypeReference(parameter))
             );
         }
-        return pushNewBuildLocalVariable();
+        int local = buildMethodVisitor.newLocal(Type.getType(Object[].class));
+        buildMethodVisitor.storeLocal(local);
+        return local;
     }
 
     private int createParameterArray(List<ParameterElement> parameters, GeneratorAdapter buildMethodVisitor) {
@@ -2793,7 +2641,9 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
                     )
             );
         }
-        return pushNewBuildLocalVariable();
+        int local = buildMethodVisitor.newLocal(Type.getType(Object[].class));
+        buildMethodVisitor.storeLocal(local);
+        return local;
     }
 
     private boolean isConstructorIntercepted(Element constructor) {
@@ -2818,7 +2668,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
         final boolean isAopType = StringUtils.isNotEmpty(interceptedType);
         final boolean isConstructorInterceptionCandidate = (isProxyTarget && !isAopType) || (isAopType && !isProxyTarget);
         final boolean hasAroundConstruct;
-        final io.micronaut.core.annotation.AnnotationValue<Annotation> interceptorBindings
+        final AnnotationValue<Annotation> interceptorBindings
                 = annotationMetadata.getAnnotation(AnnotationUtil.ANN_INTERCEPTOR_BINDINGS);
         final List<AnnotationValue<Annotation>> interceptorBindingAnnotations;
         if (interceptorBindings != null) {
@@ -2859,30 +2709,28 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
                                          ParameterElement argumentType,
                                          AnnotationMetadata annotationMetadata,
                                          int index) {
-        if (isAnnotatedWithParameter(annotationMetadata) && argsIndex > -1) {
+        if (isAnnotatedWithParameter(annotationMetadata) && isParametrized) {
             // load the args
-            buildMethodVisitor.visitVarInsn(ALOAD, argsIndex);
+            buildMethodVisitor.loadArg(3);
             // the argument name
             buildMethodVisitor.push(argumentName);
             buildMethodVisitor.invokeInterface(Type.getType(Map.class), org.objectweb.asm.commons.Method.getMethod(ReflectionUtils.getRequiredMethod(Map.class, "get", Object.class)));
             pushCastToType(buildMethodVisitor, argumentType);
+        } else if (argumentType.getGenericType().isAssignable(BeanContext.class)) {
+            buildMethodVisitor.loadArg(1);
+        } else if (argumentType.getGenericType().isAssignable(BeanResolutionContext.class)) {
+            buildMethodVisitor.loadArg(0);
         } else {
-            // Load this for method call
-            buildMethodVisitor.visitVarInsn(ALOAD, 0);
-
-            // load the first two arguments of the method (the BeanResolutionContext and the BeanContext) to be passed to the method
-            buildMethodVisitor.visitVarInsn(ALOAD, 1);
-            buildMethodVisitor.visitVarInsn(ALOAD, 2);
-            // pass the index of the method as the third argument
-            buildMethodVisitor.push(index);
-            // invoke the getBeanForConstructorArgument method
+            boolean isArray = false;
+            boolean hasGenericType = false;
             Method methodToInvoke;
-
             if (isValueType(annotationMetadata)) {
                 methodToInvoke = GET_VALUE_FOR_CONSTRUCTOR_ARGUMENT;
             } else {
                 final ClassElement genericType = argumentType.getGenericType();
-                if (genericType.isAssignable(Collection.class) || genericType.isArray()) {
+                isArray = genericType.isArray();
+                if (genericType.isAssignable(Collection.class) || isArray) {
+                    hasGenericType = true;
                     ClassElement typeArgument = genericType.isArray() ? genericType.fromArray() : genericType.getFirstTypeArgument().orElse(null);
                     if (typeArgument != null) {
                         if (typeArgument.isAssignable(BeanRegistration.class)) {
@@ -2892,18 +2740,132 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
                         }
                     } else {
                         methodToInvoke = GET_BEAN_FOR_CONSTRUCTOR_ARGUMENT;
+                        hasGenericType = false;
                     }
+                } else if (genericType.isAssignable(Stream.class)) {
+                    hasGenericType = true;
+                    methodToInvoke = GET_STREAM_OF_TYPE_FOR_CONSTRUCTOR_ARGUMENT;
+                } else if (genericType.isAssignable(Optional.class)) {
+                    hasGenericType = true;
+                    methodToInvoke = FIND_BEAN_FOR_CONSTRUCTOR_ARGUMENT;
+                } else if (genericType.isAssignable(BeanRegistration.class)) {
+                    hasGenericType = true;
+                    methodToInvoke = GET_BEAN_REGISTRATION_FOR_CONSTRUCTOR_ARGUMENT;
                 } else {
-                    if (genericType.isAssignable(BeanRegistration.class)) {
-                        methodToInvoke = GET_BEAN_REGISTRATION_FOR_CONSTRUCTOR_ARGUMENT;
-                    } else {
-                        methodToInvoke = GET_BEAN_FOR_CONSTRUCTOR_ARGUMENT;
-                    }
+                    methodToInvoke = GET_BEAN_FOR_CONSTRUCTOR_ARGUMENT;
                 }
             }
+            // Load this for method call
+            buildMethodVisitor.loadThis();
+            // load the first two arguments of the method (the BeanResolutionContext and the BeanContext) to be passed to the method
+            buildMethodVisitor.loadArg(0);
+            buildMethodVisitor.loadArg(1);
+            // pass the index of the method as the third argument
+            buildMethodVisitor.push(index);
+            if (hasGenericType) {
+                resolveConstructorArgumentGenericType(buildMethodVisitor, argumentType.getGenericType(), index);
+            }
+            // push qualifier
+            pushQualifier(buildMethodVisitor, argumentType, () -> {
+                resolveConstructorArgument(buildMethodVisitor, index);
+            });
+            // invoke method
             pushInvokeMethodOnSuperClass(buildMethodVisitor, methodToInvoke);
+            if (isArray) {
+                convertToArray(argumentType.getGenericType().fromArray(), buildMethodVisitor);
+            }
             pushCastToType(buildMethodVisitor, argumentType);
         }
+    }
+
+    private void resolveConstructorArgumentGenericType(GeneratorAdapter visitor, ClassElement type, int argumentIndex) {
+        if (!resolveArgumentGenericType(visitor, type)) {
+            resolveConstructorArgument(visitor, argumentIndex);
+            resolveFirstTypeArgument(visitor);
+            resolveInnerTypeArgumentIfNeeded(visitor, type);
+        }
+    }
+
+    private void resolveConstructorArgument(GeneratorAdapter visitor, int argumentIndex) {
+        Type constructorField = Type.getType(AbstractBeanDefinition2.MethodOrFieldReference.class);
+        Type methodRefType = Type.getType(AbstractBeanDefinition2.MethodReference.class);
+        visitor.getStatic(beanDefinitionType, FIELD_CONSTRUCTOR, constructorField);
+        pushCastToType(visitor, methodRefType);
+        visitor.getField(methodRefType, "arguments", Type.getType(Argument[].class));
+        visitor.push(argumentIndex);
+        visitor.arrayLoad(Type.getType(Argument.class));
+    }
+
+    private void resolveMethodArgumentGenericType(GeneratorAdapter visitor, ClassElement type, int methodIndex, int argumentIndex) {
+        if (!resolveArgumentGenericType(visitor, type)) {
+            resolveMethodArgument(visitor, methodIndex, argumentIndex);
+            resolveFirstTypeArgument(visitor);
+            resolveInnerTypeArgumentIfNeeded(visitor, type);
+        }
+    }
+
+    private void resolveMethodArgument(GeneratorAdapter visitor, int methodIndex, int argumentIndex) {
+        Type methodsRef = Type.getType(AbstractBeanDefinition2.MethodReference[].class);
+        Type methodRefType = Type.getType(AbstractBeanDefinition2.MethodReference.class);
+        visitor.getStatic(beanDefinitionType, FIELD_INJECTION_METHODS, methodsRef);
+        visitor.push(methodIndex);
+        visitor.arrayLoad(methodsRef);
+        visitor.getField(methodRefType, "arguments", Type.getType(Argument[].class));
+        visitor.push(argumentIndex);
+        visitor.arrayLoad(Type.getType(Argument.class));
+    }
+
+    private void resolveFieldArgumentGenericType(GeneratorAdapter visitor, ClassElement type, int fieldIndex) {
+        if (!resolveArgumentGenericType(visitor, type)) {
+            resolveFieldArgument(visitor, fieldIndex);
+            resolveFirstTypeArgument(visitor);
+            resolveInnerTypeArgumentIfNeeded(visitor, type);
+        }
+    }
+
+    private void resolveFieldArgument(GeneratorAdapter visitor, int fieldIndex) {
+        visitor.getStatic(beanDefinitionType, FIELD_INJECTION_FIELDS, Type.getType(AbstractBeanDefinition2.FieldReference[].class));
+        visitor.push(fieldIndex);
+        visitor.arrayLoad(Type.getType(AbstractBeanDefinition2.FieldReference.class));
+        visitor.getField(Type.getType(AbstractBeanDefinition2.FieldReference.class), "argument", Type.getType(Argument.class));
+    }
+
+    private boolean resolveArgumentGenericType(GeneratorAdapter visitor, ClassElement type) {
+        if (type.isArray()) {
+            if (!type.getTypeArguments().isEmpty() && isInternalGenericTypeContainer(type.fromArray())) {
+                // skip for arrays of BeanRegistration
+                return false;
+            }
+            visitor.push(JavaModelUtils.getTypeReference(type.fromArray()));
+            visitor.push((String) null);
+            invokeInterfaceStaticMethod(
+                    visitor,
+                    Argument.class,
+                    METHOD_CREATE_ARGUMENT_SIMPLE
+            );
+            return true;
+        } else if (type.getTypeArguments().isEmpty()) {
+            visitor.visitInsn(ACONST_NULL);
+            return true;
+        }
+        return false;
+    }
+
+    private void resolveInnerTypeArgumentIfNeeded(GeneratorAdapter visitor, ClassElement type) {
+        if (isInternalGenericTypeContainer(type.getFirstTypeArgument().get())) {
+            resolveFirstTypeArgument(visitor);
+        }
+    }
+
+    private boolean isInternalGenericTypeContainer(ClassElement type) {
+        return type.isAssignable(BeanRegistration.class);
+    }
+
+    private void resolveFirstTypeArgument(GeneratorAdapter visitor) {
+        visitor.invokeInterface(Type.getType(TypeVariableResolver.class),
+                org.objectweb.asm.commons.Method.getMethod(ReflectionUtils.findMethod(TypeVariableResolver.class, "getTypeParameters").get()));
+        visitor.push(0);
+        visitor.arrayLoad(Type.getType(Argument.class));
     }
 
     private boolean isValueType(AnnotationMetadata annotationMetadata) {
@@ -2920,14 +2882,13 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
         return false;
     }
 
-    private boolean isParametrized(ParameterElement...parameters) {
+    private boolean isParametrized(ParameterElement... parameters) {
         return Arrays.stream(parameters).anyMatch(p -> isAnnotatedWithParameter(p.getAnnotationMetadata()));
     }
 
     private void defineBuilderMethod(boolean isParametrized) {
         if (isParametrized) {
-            superType = TYPE_ABSTRACT_PARAMETRIZED_BEAN_DEFINITION;
-            argsIndex = buildMethodLocalCount++;
+            this.isParametrized = true;
         }
 
         String methodDescriptor;
@@ -2973,174 +2934,271 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
                 null), ACC_PUBLIC, methodName, methodDescriptor);
     }
 
-    private void pushBeanDefinitionMethodInvocation(MethodVisitor buildMethodVisitor, String methodName) {
-        buildMethodVisitor.visitVarInsn(ALOAD, 0);
-        buildMethodVisitor.visitVarInsn(ALOAD, 1);
-        buildMethodVisitor.visitVarInsn(ALOAD, 2);
-        buildMethodVisitor.visitVarInsn(ALOAD, buildInstanceIndex);
+    private void pushBeanDefinitionMethodInvocation(GeneratorAdapter buildMethodVisitor, String methodName) {
+        buildMethodVisitor.loadThis();
+        buildMethodVisitor.loadArg(0);
+        buildMethodVisitor.loadArg(1);
+        buildMethodVisitor.loadLocal(buildInstanceLocalVarIndex);
 
         buildMethodVisitor.visitMethodInsn(INVOKEVIRTUAL,
-                beanDefinitionInternalName,
+                superBeanDefinition ? superType.getInternalName() : beanDefinitionInternalName,
                 methodName,
                 METHOD_DESCRIPTOR_INITIALIZE,
                 false);
     }
 
-    private int pushNewBuildLocalVariable() {
-        buildMethodVisitor.visitVarInsn(ASTORE, buildMethodLocalCount);
-        return buildMethodLocalCount++;
-    }
-
-    private int pushNewInjectLocalVariable() {
-        injectMethodVisitor.visitVarInsn(ASTORE, injectMethodLocalCount);
-        return injectMethodLocalCount++;
-    }
-
-    private int pushNewPostConstructLocalVariable() {
-        postConstructMethodVisitor.visitVarInsn(ASTORE, postConstructMethodLocalCount);
-        return postConstructMethodLocalCount++;
-    }
-
-    private int pushNewPreDestroyLocalVariable() {
-        preDestroyMethodVisitor.visitVarInsn(ASTORE, preDestroyMethodLocalCount);
-        return preDestroyMethodLocalCount++;
-    }
-
     private void visitBeanDefinitionConstructorInternal(
-            MethodElement methodElement,
+            GeneratorAdapter staticInit, Object constructor,
             boolean requiresReflection) {
-        if (constructorVisitor == null) {
+
+        if (constructor instanceof MethodElement) {
+            MethodElement methodElement = (MethodElement) constructor;
             AnnotationMetadata constructorMetadata = methodElement.getAnnotationMetadata();
             DefaultAnnotationMetadata.contributeDefaults(this.annotationMetadata, constructorMetadata);
             ParameterElement[] parameters = methodElement.getParameters();
             List<ParameterElement> parameterList = Arrays.asList(parameters);
             applyDefaultNamedToParameters(parameterList);
-            Optional<AnnotationMetadata> argumentQualifier = parameterList
-                    .stream()
-                    .map(AnnotationMetadataProvider::getAnnotationMetadata)
-                    .filter(this::isAnnotatedWithParameter).findFirst();
-            boolean isParametrized = argumentQualifier.isPresent();
-            if (isParametrized) {
-                superType = TYPE_ABSTRACT_PARAMETRIZED_BEAN_DEFINITION;
-            }
 
+            pushNewMethodReference(staticInit, JavaModelUtils.getTypeReference(methodElement.getDeclaringType()), methodElement, requiresReflection, false, false);
+        } else if (constructor instanceof FieldElement) {
+            FieldElement fieldConstructor = (FieldElement) constructor;
+            pushNewFieldReference(staticInit, JavaModelUtils.getTypeReference(fieldConstructor.getDeclaringType()), fieldConstructor, constructorRequiresReflection);
+        } else {
+            throw new IllegalArgumentException("Unexpected constructor: " + constructor);
+        }
 
-            // create the BeanDefinition constructor for subclasses of AbstractBeanDefinition
-            org.objectweb.asm.commons.Method constructorMethod = org.objectweb.asm.commons.Method.getMethod(CONSTRUCTOR_ABSTRACT_BEAN_DEFINITION);
+        staticInit.putStatic(beanDefinitionType, FIELD_CONSTRUCTOR, Type.getType(AbstractBeanDefinition2.MethodOrFieldReference.class));
+
+        GeneratorAdapter publicConstructor = new GeneratorAdapter(
+                classWriter.visitMethod(ACC_PUBLIC, CONSTRUCTOR_NAME, DESCRIPTOR_DEFAULT_CONSTRUCTOR, null, null),
+                ACC_PUBLIC,
+                CONSTRUCTOR_NAME,
+                DESCRIPTOR_DEFAULT_CONSTRUCTOR
+        );
+        publicConstructor.loadThis();
+        publicConstructor.push(beanType);
+        publicConstructor.getStatic(beanDefinitionType, FIELD_CONSTRUCTOR, Type.getType(AbstractBeanDefinition2.MethodOrFieldReference.class));
+        publicConstructor.invokeConstructor(superBeanDefinition ? superType : beanDefinitionType, PROTECTED_ABSTRACT_BEAN_DEFINITION_CONSTRUCTOR);
+        publicConstructor.visitInsn(RETURN);
+        publicConstructor.visitMaxs(5, 1);
+        publicConstructor.visitEnd();
+
+        // Call protected super constructor if definition is extending another one
+
+        if (!superBeanDefinition) {
+            // create protected constructor for subclasses of AbstractBeanDefinition
             GeneratorAdapter protectedConstructor = new GeneratorAdapter(
-                    classWriter.visitMethod(ACC_PROTECTED, CONSTRUCTOR_NAME, constructorMethod.getDescriptor(), null, null),
+                    classWriter.visitMethod(ACC_PROTECTED,
+                            PROTECTED_ABSTRACT_BEAN_DEFINITION_CONSTRUCTOR.getName(),
+                            PROTECTED_ABSTRACT_BEAN_DEFINITION_CONSTRUCTOR.getDescriptor(), null, null),
                     ACC_PROTECTED,
-                    CONSTRUCTOR_NAME,
-                    constructorMethod.getDescriptor()
+                    PROTECTED_ABSTRACT_BEAN_DEFINITION_CONSTRUCTOR.getName(),
+                    PROTECTED_ABSTRACT_BEAN_DEFINITION_CONSTRUCTOR.getDescriptor()
             );
-            constructorVisitor = protectedConstructor;
 
-            Type[] beanDefinitionConstructorArgumentTypes = constructorMethod.getArgumentTypes();
+            AnnotationMetadata annotationMetadata = this.annotationMetadata != null ? this.annotationMetadata : AnnotationMetadata.EMPTY_METADATA;
+
             protectedConstructor.loadThis();
-            for (int i = 0; i < beanDefinitionConstructorArgumentTypes.length; i++) {
-                protectedConstructor.loadArg(i);
-            }
-            protectedConstructor.invokeConstructor(isSuperFactory ? TYPE_ABSTRACT_BEAN_DEFINITION : superType, BEAN_DEFINITION_CLASS_CONSTRUCTOR);
-
-            GeneratorAdapter defaultConstructor = startConstructor(classWriter);
-            GeneratorAdapter defaultConstructorVisitor = new GeneratorAdapter(
-                    defaultConstructor,
-                    ACC_PUBLIC,
-                    CONSTRUCTOR_NAME,
-                    DESCRIPTOR_DEFAULT_CONSTRUCTOR
-            );
-            // ALOAD 0
-            defaultConstructor.visitVarInsn(ALOAD, 0);
-
-            // 1st argument: pass the bean definition type as the third argument to super(..)
-            defaultConstructor.visitLdcInsn(this.beanType);
-
-            // 2nd Argument: the annotation metadata
-            if (constructorMetadata == AnnotationMetadata.EMPTY_METADATA) {
-                defaultConstructor.visitInsn(ACONST_NULL);
+            // 1: beanType
+            protectedConstructor.loadArg(0);
+            // 2: `AbstractBeanDefinition2.MethodOrFieldReference.class` constructor
+            protectedConstructor.loadArg(1);
+            // 3: annotationMetadata
+            if (this.annotationMetadata == null) {
+                protectedConstructor.push((String) null);
             } else {
-                if (constructorMetadata instanceof AnnotationMetadataHierarchy) {
-                    AnnotationMetadataWriter.instantiateNewMetadataHierarchy(
-                            beanDefinitionType,
-                            classWriter,
-                            defaultConstructor,
-                            (AnnotationMetadataHierarchy) constructorMetadata,
-                            loadTypeMethods);
-                } else {
-
-                    AnnotationMetadataWriter.instantiateNewMetadata(
-                            beanDefinitionType,
-                            classWriter,
-                            defaultConstructor,
-                            (DefaultAnnotationMetadata) constructorMetadata,
-                            loadTypeMethods);
-                }
+                protectedConstructor.getStatic(getTypeReferenceForName(getBeanDefinitionReferenceClassName()), AbstractAnnotationMetadataWriter.FIELD_ANNOTATION_METADATA, Type.getType(AnnotationMetadata.class));
             }
-
-            // 3rd argument: Is reflection required
-            defaultConstructor.visitInsn(requiresReflection ? ICONST_1 : ICONST_0);
-
-            // 4th argument: The arguments
-            if (parameterList.isEmpty()) {
-                defaultConstructor.visitInsn(ACONST_NULL);
+            // 4: `AbstractBeanDefinition2.MethodReference[].class` methodInjection
+            if (methodInjectionPoints.isEmpty() && preDestroyMethodVisits.isEmpty() && postConstructMethodVisits.isEmpty()) {
+                protectedConstructor.push((String) null);
             } else {
-                pushBuildArgumentsForMethod(
-                        beanFullClassName,
-                        beanDefinitionType,
-                        classWriter,
-                        defaultConstructorVisitor,
-                        parameterList,
-                        loadTypeMethods
+                protectedConstructor.getStatic(beanDefinitionType, FIELD_INJECTION_METHODS, Type.getType(AbstractBeanDefinition2.MethodReference[].class));
+            }
+            // 5: `AbstractBeanDefinition2.FieldReference[].class` fieldInjection
+            if (fieldInjectionPoints.isEmpty()) {
+                protectedConstructor.push((String) null);
+            } else {
+                protectedConstructor.getStatic(beanDefinitionType, FIELD_INJECTION_FIELDS, Type.getType(AbstractBeanDefinition2.FieldReference[].class));
+            }
+            // 6: `ExecutableMethod[]` executableMethods
+            if (executableMethodsDefinitionWriter == null) {
+                protectedConstructor.push((String) null);
+            } else {
+                protectedConstructor.newInstance(executableMethodsDefinitionWriter.getClassType());
+                protectedConstructor.dup();
+                protectedConstructor.invokeConstructor(executableMethodsDefinitionWriter.getClassType(), METHOD_DEFAULT_CONSTRUCTOR);
+            }
+            // 7: `Map<String, Argument<?>[]>` typeArgumentsMap
+            if (!hasTypeArguments()) {
+                protectedConstructor.push((String) null);
+            } else {
+                protectedConstructor.getStatic(beanDefinitionType, FIELD_TYPE_ARGUMENTS, Type.getType(Map.class));
+            }
+            // 8: `Optional` scope
+            String scope = annotationMetadata.getAnnotationNameByStereotype(AnnotationUtil.SCOPE).orElse(null);
+            if (scope != null) {
+                protectedConstructor.push(scope);
+                protectedConstructor.invokeStatic(
+                        TYPE_OPTIONAL,
+                        METHOD_OPTIONAL_OF
                 );
-                for (ParameterElement value : parameterList) {
-                    DefaultAnnotationMetadata.contributeDefaults(this.annotationMetadata, value.getAnnotationMetadata());
-                }
+            } else {
+                protectedConstructor.invokeStatic(TYPE_OPTIONAL, METHOD_OPTIONAL_EMPTY);
             }
 
-            defaultConstructorVisitor.invokeConstructor(
-                    beanDefinitionType,
+            // 9: `boolean` isAbstract
+            protectedConstructor.push(isAbstract);
+            // 10: `boolean` isProvided
+            protectedConstructor.push(
+                    annotationMetadata.hasDeclaredStereotype(Provided.class)
+            );
+            // 11: `boolean` isIterable
+            protectedConstructor.push(isIterable(annotationMetadata));
+            // 12: `boolean` isSingleton
+            protectedConstructor.push(
+                    isSingleton(scope)
+            );
+            // 13: `boolean` isPrimary
+            protectedConstructor.push(
+                    annotationMetadata.hasDeclaredStereotype(Primary.class)
+            );
+            // 14: `boolean` isConfigurationProperties
+            protectedConstructor.push(isConfigurationProperties);
+            // 15: hasExposedTypes
+            protectedConstructor.push(
+                    annotationMetadata.hasDeclaredAnnotation(Bean.class)
+                            && annotationMetadata.stringValues(Bean.class, "typed").length > 0
+            );
+            // 16: requiresMethodProcessing
+            protectedConstructor.push(preprocessMethods);
+
+            protectedConstructor.invokeConstructor(
+                    isSuperFactory ? TYPE_ABSTRACT_BEAN_DEFINITION : superType,
                     BEAN_DEFINITION_CLASS_CONSTRUCTOR
             );
 
-            defaultConstructorVisitor.visitInsn(RETURN);
-            defaultConstructorVisitor.visitMaxs(DEFAULT_MAX_STACK, 1);
-            defaultConstructorVisitor.visitEnd();
+            protectedConstructor.visitInsn(RETURN);
+            protectedConstructor.visitMaxs(20, 1);
+            protectedConstructor.visitEnd();
         }
     }
 
-    private GeneratorAdapter buildProtectedConstructor(org.objectweb.asm.commons.Method constructorType) {
-        GeneratorAdapter protectedConstructor = new GeneratorAdapter(
-                classWriter.visitMethod(ACC_PROTECTED, CONSTRUCTOR_NAME, constructorType.getDescriptor(), null, null),
-                ACC_PROTECTED,
-                CONSTRUCTOR_NAME,
-                constructorType.getDescriptor()
-        );
+    private boolean isConfigurationProperties(AnnotationMetadata annotationMetadata) {
+        return isIterable(annotationMetadata) || annotationMetadata.hasStereotype(ConfigurationReader.class);
+    }
 
-        Type[] arguments = constructorType.getArgumentTypes();
-        protectedConstructor.loadThis();
-        for (int i = 0; i < arguments.length; i++) {
-            protectedConstructor.loadArg(i);
+    private boolean isIterable(AnnotationMetadata annotationMetadata) {
+        return annotationMetadata.hasDeclaredStereotype(EachProperty.class) || annotationMetadata.hasDeclaredStereotype(EachBean.class);
+    }
+
+    private void pushNewMethodReference(GeneratorAdapter staticInit, Type beanType, MethodElement methodElement,
+                                        boolean requiresReflection,
+                                        boolean isPostConstructMethod,
+                                        boolean isPreDestroyMethod) {
+        for (ParameterElement value : methodElement.getParameters()) {
+            DefaultAnnotationMetadata.contributeDefaults(this.annotationMetadata, value.getAnnotationMetadata());
         }
-        if (isSuperFactory) {
-            protectedConstructor.invokeConstructor(TYPE_ABSTRACT_BEAN_DEFINITION, constructorType);
+        staticInit.newInstance(Type.getType(AbstractBeanDefinition2.MethodReference.class));
+        staticInit.dup();
+        // 1: declaringType
+        staticInit.push(beanType);
+        // 2: methodName
+        staticInit.push(methodElement.getName());
+        // 3: arguments
+        if (!methodElement.hasParameters()) {
+            staticInit.visitInsn(ACONST_NULL);
         } else {
-            protectedConstructor.invokeConstructor(superType, constructorType);
+            pushBuildArgumentsForMethod(
+                    beanFullClassName,
+                    beanDefinitionType,
+                    classWriter,
+                    staticInit,
+                    Arrays.asList(methodElement.getParameters()),
+                    defaultsStorage,
+                    loadTypeMethods
+            );
         }
-        return protectedConstructor;
+        // 4: annotationMetadata
+        pushAnnotationMetadata(staticInit, methodElement.getAnnotationMetadata());
+        // 5: requiresReflection
+        staticInit.push(requiresReflection);
+        if (isPreDestroyMethod || isPostConstructMethod) {
+            // 6: isPostConstructMethod
+            staticInit.push(isPostConstructMethod);
+            // 7: isPreDestroyMethod
+            staticInit.push(isPreDestroyMethod);
+            staticInit.invokeConstructor(Type.getType(AbstractBeanDefinition2.MethodReference.class), METHOD_REFERENCE_CONSTRUCTOR_POST_PRE);
+        } else {
+            staticInit.invokeConstructor(Type.getType(AbstractBeanDefinition2.MethodReference.class), METHOD_REFERENCE_CONSTRUCTOR);
+        }
+    }
+
+    private void pushNewFieldReference(GeneratorAdapter staticInit, Type declaringType, FieldElement fieldElement, boolean requiresReflection) {
+        staticInit.newInstance(Type.getType(AbstractBeanDefinition2.FieldReference.class));
+        staticInit.dup();
+        // 1: declaringType
+        staticInit.push(declaringType);
+        // 2: argument
+        pushCreateArgument(
+                beanFullClassName,
+                beanDefinitionType,
+                classWriter,
+                staticInit,
+                fieldElement.getName(),
+                fieldElement.getGenericType(),
+                fieldElement.getAnnotationMetadata(),
+                fieldElement.getGenericType().getTypeArguments(),
+                defaultsStorage,
+                loadTypeMethods
+        );
+        // 3: requiresReflection
+        staticInit.push(requiresReflection);
+        staticInit.invokeConstructor(Type.getType(AbstractBeanDefinition2.FieldReference.class), FIELD_REFERENCE_CONSTRUCTOR);
+    }
+
+    private void pushAnnotationMetadata(GeneratorAdapter staticInit, AnnotationMetadata annotationMetadata) {
+        if (annotationMetadata == AnnotationMetadata.EMPTY_METADATA || annotationMetadata.isEmpty()) {
+            staticInit.push((String) null);
+        } else if (annotationMetadata instanceof AnnotationMetadataHierarchy) {
+            AnnotationMetadataWriter.instantiateNewMetadataHierarchy(
+                    beanDefinitionType,
+                    classWriter,
+                    staticInit,
+                    (AnnotationMetadataHierarchy) annotationMetadata,
+                    defaultsStorage,
+                    loadTypeMethods);
+        } else if (annotationMetadata instanceof DefaultAnnotationMetadata) {
+            AnnotationMetadataWriter.instantiateNewMetadata(
+                    beanDefinitionType,
+                    classWriter,
+                    staticInit,
+                    (DefaultAnnotationMetadata) annotationMetadata,
+                    defaultsStorage,
+                    loadTypeMethods);
+        } else {
+            staticInit.push((String) null);
+        }
     }
 
     private String generateBeanDefSig(String typeParameter) {
         SignatureVisitor sv = new SignatureWriter();
         visitSuperTypeParameters(sv, typeParameter);
 
-        String beanTypeInternalName = getInternalName(typeParameter);
+        final String beanTypeInternalName = getInternalName(typeParameter);
         // visit BeanFactory interface
         for (Class<?> interfaceType : interfaceTypes) {
+            String param;
+            if (ProxyBeanDefinition.class == interfaceType || AdvisedBeanType.class == interfaceType) {
+                param = getInterceptedType().map(Type::getInternalName).orElse(beanTypeInternalName);
+            } else {
+                param = beanTypeInternalName;
+            }
 
             SignatureVisitor bfi = sv.visitInterface();
             bfi.visitClassType(Type.getInternalName(interfaceType));
             SignatureVisitor iisv = bfi.visitTypeArgument('=');
-            iisv.visitClassType(beanTypeInternalName);
+            iisv.visitClassType(param);
             iisv.visitEnd();
             bfi.visitEnd();
         }
@@ -3151,7 +3209,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
         // visit super class
         SignatureVisitor psv = sv.visitSuperclass();
         psv.visitClassType(isSuperFactory ? TYPE_ABSTRACT_BEAN_DEFINITION.getInternalName() : superType.getInternalName());
-        if (superType == TYPE_ABSTRACT_BEAN_DEFINITION || superType == TYPE_ABSTRACT_PARAMETRIZED_BEAN_DEFINITION || isSuperFactory) {
+        if (superType == TYPE_ABSTRACT_BEAN_DEFINITION || isSuperFactory) {
             for (String typeParameter : typeParameters) {
 
                 SignatureVisitor ppsv = psv.visitTypeArgument('=');
@@ -3164,25 +3222,65 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
         psv.visitEnd();
     }
 
-    private static Method getBeanLookupMethod(String methodName) {
-        return ReflectionUtils.getRequiredInternalMethod(
-                AbstractBeanDefinition.class,
-                methodName,
-                BeanResolutionContext.class,
-                BeanContext.class,
-                int.class
-        );
+    private static Method getBeanLookupMethod(String methodName, boolean requiresGenericType) {
+        if (requiresGenericType) {
+            return ReflectionUtils.getRequiredInternalMethod(
+                    AbstractBeanDefinition2.class,
+                    methodName,
+                    BeanResolutionContext.class,
+                    BeanContext.class,
+                    int.class,
+                    Argument.class,
+                    Qualifier.class);
+        } else {
+            return ReflectionUtils.getRequiredInternalMethod(
+                    AbstractBeanDefinition2.class,
+                    methodName,
+                    BeanResolutionContext.class,
+                    BeanContext.class,
+                    int.class,
+                    Qualifier.class
+            );
+        }
     }
 
-    private static Method getBeanLookupMethodForArgument(String methodName) {
+    private static Method getBeanLookupMethodForArgument(String methodName, boolean requiresGenericType) {
+        if (requiresGenericType) {
+            return ReflectionUtils.getRequiredInternalMethod(
+                    AbstractBeanDefinition2.class,
+                    methodName,
+                    BeanResolutionContext.class,
+                    BeanContext.class,
+                    int.class,
+                    int.class,
+                    Argument.class,
+                    Qualifier.class);
+        }
         return ReflectionUtils.getRequiredInternalMethod(
-                AbstractBeanDefinition.class,
+                AbstractBeanDefinition2.class,
                 methodName,
                 BeanResolutionContext.class,
                 BeanContext.class,
                 int.class,
-                int.class
-        );
+                int.class,
+                Qualifier.class);
+    }
+
+    @Internal
+    private static final class FieldVisitData {
+        final TypedElement beanType;
+        final FieldElement fieldElement;
+        final boolean requiresReflection;
+
+        FieldVisitData(
+                TypedElement beanType,
+                FieldElement fieldElement,
+                boolean requiresReflection) {
+            this.beanType = beanType;
+            this.fieldElement = fieldElement;
+            this.requiresReflection = requiresReflection;
+        }
+
     }
 
     /**

--- a/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -15,7 +15,7 @@
  */
 package io.micronaut.inject.writer;
 
-import io.micronaut.context.AbstractBeanDefinition2;
+import io.micronaut.context.AbstractInitializableBeanDefinition;
 import io.micronaut.context.AbstractConstructorInjectionPoint;
 import io.micronaut.context.AbstractExecutableMethod;
 import io.micronaut.context.BeanContext;
@@ -48,6 +48,7 @@ import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.reflect.InstantiationUtils;
 import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.type.Argument;
+import io.micronaut.core.type.DefaultArgument;
 import io.micronaut.core.type.TypeVariableResolver;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
@@ -150,11 +151,11 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
             BeanDefinition.class)
             .orElseThrow(() -> new ClassGenerationException("Invalid version of Micronaut present on the class path"));
 
-    private static final Method POST_CONSTRUCT_METHOD = ReflectionUtils.getRequiredInternalMethod(AbstractBeanDefinition2.class, "postConstruct", BeanResolutionContext.class, BeanContext.class, Object.class);
+    private static final Method POST_CONSTRUCT_METHOD = ReflectionUtils.getRequiredInternalMethod(AbstractInitializableBeanDefinition.class, "postConstruct", BeanResolutionContext.class, BeanContext.class, Object.class);
 
-    private static final Method INJECT_BEAN_METHOD = ReflectionUtils.getRequiredInternalMethod(AbstractBeanDefinition2.class, "injectBean", BeanResolutionContext.class, BeanContext.class, Object.class);
+    private static final Method INJECT_BEAN_METHOD = ReflectionUtils.getRequiredInternalMethod(AbstractInitializableBeanDefinition.class, "injectBean", BeanResolutionContext.class, BeanContext.class, Object.class);
 
-    private static final Method PRE_DESTROY_METHOD = ReflectionUtils.getRequiredInternalMethod(AbstractBeanDefinition2.class, "preDestroy", BeanResolutionContext.class, BeanContext.class, Object.class);
+    private static final Method PRE_DESTROY_METHOD = ReflectionUtils.getRequiredInternalMethod(AbstractInitializableBeanDefinition.class, "preDestroy", BeanResolutionContext.class, BeanContext.class, Object.class);
 
     private static final Method GET_BEAN_FOR_CONSTRUCTOR_ARGUMENT = getBeanLookupMethod("getBeanForConstructorArgument", false);
 
@@ -184,17 +185,17 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
 
     private static final Method FIND_BEAN_FOR_FIELD = getBeanLookupMethod("findBeanForField", true);
 
-    private static final Method GET_VALUE_FOR_PATH = ReflectionUtils.getRequiredInternalMethod(AbstractBeanDefinition2.class, "getValueForPath", BeanResolutionContext.class, BeanContext.class, Argument.class, String.class);
+    private static final Method GET_VALUE_FOR_PATH = ReflectionUtils.getRequiredInternalMethod(AbstractInitializableBeanDefinition.class, "getValueForPath", BeanResolutionContext.class, BeanContext.class, Argument.class, String.class);
 
     private static final Method CONTAINS_VALUE_FOR_FIELD = ReflectionUtils.getRequiredInternalMethod(
-            AbstractBeanDefinition2.class,
+            AbstractInitializableBeanDefinition.class,
             "containsValueForField",
             BeanResolutionContext.class,
             BeanContext.class,
             int.class,
             boolean.class);
 
-    private static final Method CONTAINS_PROPERTIES_METHOD = ReflectionUtils.getRequiredInternalMethod(AbstractBeanDefinition2.class, "containsProperties", BeanResolutionContext.class, BeanContext.class);
+    private static final Method CONTAINS_PROPERTIES_METHOD = ReflectionUtils.getRequiredInternalMethod(AbstractInitializableBeanDefinition.class, "containsProperties", BeanResolutionContext.class, BeanContext.class);
 
     private static final Method GET_BEAN_FOR_METHOD_ARGUMENT = getBeanLookupMethodForArgument("getBeanForMethodArgument", false);
 
@@ -211,7 +212,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
     private static final Method GET_VALUE_FOR_METHOD_ARGUMENT = getBeanLookupMethodForArgument("getValueForMethodArgument", false);
 
     private static final Method CONTAINS_VALUE_FOR_METHOD_ARGUMENT = ReflectionUtils.getRequiredInternalMethod(
-            AbstractBeanDefinition2.class,
+            AbstractInitializableBeanDefinition.class,
             "containsValueForMethodArgument",
             BeanResolutionContext.class,
             BeanContext.class,
@@ -219,7 +220,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
             int.class,
             boolean.class);
 
-    private static final Type TYPE_ABSTRACT_BEAN_DEFINITION = Type.getType(AbstractBeanDefinition2.class);
+    private static final Type TYPE_ABSTRACT_BEAN_DEFINITION = Type.getType(AbstractInitializableBeanDefinition.class);
 
     private static final org.objectweb.asm.commons.Method METHOD_OPTIONAL_EMPTY = org.objectweb.asm.commons.Method.getMethod(
             ReflectionUtils.getRequiredMethod(Optional.class, "empty")
@@ -259,23 +260,23 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
 
     private static final org.objectweb.asm.commons.Method PROTECTED_ABSTRACT_BEAN_DEFINITION_CONSTRUCTOR = new org.objectweb.asm.commons.Method(CONSTRUCTOR_NAME, getConstructorDescriptor(
             Class.class, // beanType
-            AbstractBeanDefinition2.MethodOrFieldReference.class // constructor
+            AbstractInitializableBeanDefinition.MethodOrFieldReference.class // constructor
     ));
 
     private static final org.objectweb.asm.commons.Method SET_FIELD_WITH_REFLECTION_METHOD = org.objectweb.asm.commons.Method.getMethod(
-            ReflectionUtils.getRequiredMethod(AbstractBeanDefinition2.class, "setFieldWithReflection", BeanResolutionContext.class, BeanContext.class, int.class, Object.class, Object.class)
+            ReflectionUtils.getRequiredMethod(AbstractInitializableBeanDefinition.class, "setFieldWithReflection", BeanResolutionContext.class, BeanContext.class, int.class, Object.class, Object.class)
     );
 
     private static final org.objectweb.asm.commons.Method INVOKE_WITH_REFLECTION_METHOD = org.objectweb.asm.commons.Method.getMethod(
-            ReflectionUtils.getRequiredMethod(AbstractBeanDefinition2.class, "invokeMethodWithReflection", BeanResolutionContext.class, BeanContext.class, int.class, Object.class, Object[].class)
+            ReflectionUtils.getRequiredMethod(AbstractInitializableBeanDefinition.class, "invokeMethodWithReflection", BeanResolutionContext.class, BeanContext.class, int.class, Object.class, Object[].class)
     );
 
     private static final org.objectweb.asm.commons.Method BEAN_DEFINITION_CLASS_CONSTRUCTOR = new org.objectweb.asm.commons.Method(CONSTRUCTOR_NAME, getConstructorDescriptor(
             Class.class, // beanType
-            AbstractBeanDefinition2.MethodOrFieldReference.class, // constructor
+            AbstractInitializableBeanDefinition.MethodOrFieldReference.class, // constructor
             AnnotationMetadata.class, // annotationMetadata
-            AbstractBeanDefinition2.MethodReference[].class, // methodInjection
-            AbstractBeanDefinition2.FieldReference[].class, // fieldInjection
+            AbstractInitializableBeanDefinition.MethodReference[].class, // methodInjection
+            AbstractInitializableBeanDefinition.FieldReference[].class, // fieldInjection
             ExecutableMethodsDefinition.class, // executableMethodsDefinition
             Map.class, // typeArgumentsMap
             Optional.class, // scope
@@ -285,7 +286,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
             boolean.class, // isSingleton
             boolean.class, // isPrimary
             boolean.class, // isConfigurationProperties
-            boolean.class, // hasExposedTypes
+            boolean.class, // isContainerType
             boolean.class  // requiresMethodProcessing
     ));
 
@@ -294,6 +295,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
     private static final String FIELD_INJECTION_FIELDS = "$INJECTION_FIELDS";
     private static final String FIELD_TYPE_ARGUMENTS = "$TYPE_ARGUMENTS";
     private static final String FIELD_INNER_CLASSES = "$INNER_CONFIGURATION_CLASSES";
+    private static final String FIELD_EXPOSED_TYPES = "$EXPOSED_TYPES";
 
     private static final org.objectweb.asm.commons.Method METHOD_REFERENCE_CONSTRUCTOR = new org.objectweb.asm.commons.Method(CONSTRUCTOR_NAME, getConstructorDescriptor(
             Class.class, // declaringType,
@@ -846,13 +848,13 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
         GeneratorAdapter staticInit = visitStaticInitializer(classWriter);
 
         classWriter.visitField(ACC_PRIVATE | ACC_FINAL | ACC_STATIC, FIELD_CONSTRUCTOR,
-                Type.getType(AbstractBeanDefinition2.MethodOrFieldReference.class).getDescriptor(), null, null);
+                Type.getType(AbstractInitializableBeanDefinition.MethodOrFieldReference.class).getDescriptor(), null, null);
 
         int methodsLength = methodInjectionPoints.size() + postConstructMethodVisits.size() + preDestroyMethodVisits.size();
         if (!superBeanDefinition && methodsLength > 0) {
-            Type methodsFieldType = Type.getType(AbstractBeanDefinition2.MethodReference[].class);
+            Type methodsFieldType = Type.getType(AbstractInitializableBeanDefinition.MethodReference[].class);
             classWriter.visitField(ACC_PRIVATE | ACC_FINAL | ACC_STATIC, FIELD_INJECTION_METHODS, methodsFieldType.getDescriptor(), null, null);
-            pushNewArray(staticInit, AbstractBeanDefinition2.MethodReference.class, methodsLength);
+            pushNewArray(staticInit, AbstractInitializableBeanDefinition.MethodReference.class, methodsLength);
             int i = 0;
             for (MethodVisitData methodVisitData : methodInjectionPoints) {
                 pushStoreInArray(staticInit, i++, methodsLength, () ->
@@ -891,10 +893,10 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
         }
 
         if (!fieldInjectionPoints.isEmpty()) {
-            Type fieldsFieldType = Type.getType(AbstractBeanDefinition2.FieldReference[].class);
+            Type fieldsFieldType = Type.getType(AbstractInitializableBeanDefinition.FieldReference[].class);
             classWriter.visitField(ACC_PRIVATE | ACC_FINAL | ACC_STATIC, FIELD_INJECTION_FIELDS, fieldsFieldType.getDescriptor(), null, null);
             int length = fieldInjectionPoints.size();
-            pushNewArray(staticInit, AbstractBeanDefinition2.FieldReference.class, length);
+            pushNewArray(staticInit, AbstractInitializableBeanDefinition.FieldReference.class, length);
             for (int i = 0; i < length; i++) {
                 FieldVisitData fieldVisitData = fieldInjectionPoints.get(i);
                 pushStoreInArray(staticInit, i, length, () ->
@@ -937,6 +939,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
         );
 
         addInnerConfigurationMethod(staticInit);
+        addGetExposedTypes(staticInit);
 
         staticInit.returnValue();
         staticInit.visitMaxs(DEFAULT_MAX_STACK, defaultsStorage.size() + 3);
@@ -990,32 +993,12 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
                     .toArray(String[]::new);
 
             if (innerClasses.length > 0) {
-                classWriter.visitField(ACC_PRIVATE | ACC_FINAL | ACC_STATIC, FIELD_INNER_CLASSES, Type.getType(Collection.class).getDescriptor(), null, null);
-                if (innerClasses.length > 3) {
-                    staticInit.newInstance(Type.getType(HashSet.class));
-                    staticInit.dup();
-                    pushArrayOfClasses(staticInit, innerClasses);
-                    staticInit.invokeStatic(Type.getType(Arrays.class), org.objectweb.asm.commons.Method.getMethod(
-                            ReflectionUtils.getRequiredMethod(Arrays.class, "asList", Object[].class)
-                    ));
-                    staticInit.invokeConstructor(Type.getType(HashSet.class), org.objectweb.asm.commons.Method.getMethod(
-                            ReflectionUtils.findConstructor(HashSet.class, Collection.class).get()
-                    ));
-                } else if (innerClasses.length == 1) {
-                    pushClass(staticInit, innerClasses[0]);
-                    staticInit.invokeStatic(Type.getType(Collections.class), org.objectweb.asm.commons.Method.getMethod(
-                            ReflectionUtils.getRequiredMethod(Collections.class, "singleton", Object.class)
-                    ));
-                } else {
-                    pushArrayOfClasses(staticInit, innerClasses);
-                    staticInit.invokeStatic(Type.getType(Arrays.class), org.objectweb.asm.commons.Method.getMethod(
-                            ReflectionUtils.getRequiredMethod(Arrays.class, "asList", Object[].class)
-                    ));
-                }
-                staticInit.putStatic(beanDefinitionType, FIELD_INNER_CLASSES, Type.getType(Collection.class));
+                classWriter.visitField(ACC_PRIVATE | ACC_FINAL | ACC_STATIC, FIELD_INNER_CLASSES, Type.getType(Set.class).getDescriptor(), null, null);
+                pushStoreClassesAsSet(staticInit, innerClasses);
+                staticInit.putStatic(beanDefinitionType, FIELD_INNER_CLASSES, Type.getType(Set.class));
 
                 GeneratorAdapter isInnerConfigurationMethod = startProtectedMethod(classWriter, "isInnerConfiguration", boolean.class.getName(), Class.class.getName());
-                isInnerConfigurationMethod.getStatic(beanDefinitionType, FIELD_INNER_CLASSES, Type.getType(Collection.class));
+                isInnerConfigurationMethod.getStatic(beanDefinitionType, FIELD_INNER_CLASSES, Type.getType(Set.class));
                 isInnerConfigurationMethod.loadArg(0);
                 isInnerConfigurationMethod.invokeInterface(Type.getType(Collection.class), org.objectweb.asm.commons.Method.getMethod(
                         ReflectionUtils.getRequiredMethod(Collection.class, "contains", Object.class)
@@ -1024,6 +1007,47 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
                 isInnerConfigurationMethod.visitMaxs(1, 1);
                 isInnerConfigurationMethod.visitEnd();
             }
+        }
+    }
+
+    private void addGetExposedTypes(GeneratorAdapter staticInit) {
+        if (annotationMetadata.hasDeclaredAnnotation(Bean.class.getName())) {
+            final String[] exposedTypes = annotationMetadata.stringValues(Bean.class.getName(), "typed");
+            if (exposedTypes.length > 0) {
+                classWriter.visitField(ACC_PRIVATE | ACC_FINAL | ACC_STATIC, FIELD_EXPOSED_TYPES, Type.getType(Set.class).getDescriptor(), null, null);
+                pushStoreClassesAsSet(staticInit, exposedTypes);
+                staticInit.putStatic(beanDefinitionType, FIELD_EXPOSED_TYPES, Type.getType(Set.class));
+
+                GeneratorAdapter getExposedTypesMethod = startPublicMethod(classWriter, "getExposedTypes", Set.class.getName());
+                getExposedTypesMethod.getStatic(beanDefinitionType, FIELD_EXPOSED_TYPES, Type.getType(Set.class));
+                getExposedTypesMethod.returnValue();
+                getExposedTypesMethod.visitMaxs(1, 1);
+                getExposedTypesMethod.visitEnd();
+            }
+        }
+    }
+
+    private void pushStoreClassesAsSet(GeneratorAdapter writer, String[] classes) {
+        if (classes.length > 3) {
+            writer.newInstance(Type.getType(HashSet.class));
+            writer.dup();
+            pushArrayOfClasses(writer, classes);
+            writer.invokeStatic(Type.getType(Arrays.class), org.objectweb.asm.commons.Method.getMethod(
+                    ReflectionUtils.getRequiredMethod(Arrays.class, "asList", Object[].class)
+            ));
+            writer.invokeConstructor(Type.getType(HashSet.class), org.objectweb.asm.commons.Method.getMethod(
+                    ReflectionUtils.findConstructor(HashSet.class, Collection.class).get()
+            ));
+        } else if (classes.length == 1) {
+            pushClass(writer, classes[0]);
+            writer.invokeStatic(Type.getType(Collections.class), org.objectweb.asm.commons.Method.getMethod(
+                    ReflectionUtils.getRequiredMethod(Collections.class, "singleton", Object.class)
+            ));
+        } else {
+            pushArrayOfClasses(writer, classes);
+            writer.invokeStatic(Type.getType(Arrays.class), org.objectweb.asm.commons.Method.getMethod(
+                    ReflectionUtils.getRequiredMethod(Arrays.class, "asList", Object[].class)
+            ));
         }
     }
 
@@ -2787,8 +2811,8 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
     }
 
     private void resolveConstructorArgument(GeneratorAdapter visitor, int argumentIndex) {
-        Type constructorField = Type.getType(AbstractBeanDefinition2.MethodOrFieldReference.class);
-        Type methodRefType = Type.getType(AbstractBeanDefinition2.MethodReference.class);
+        Type constructorField = Type.getType(AbstractInitializableBeanDefinition.MethodOrFieldReference.class);
+        Type methodRefType = Type.getType(AbstractInitializableBeanDefinition.MethodReference.class);
         visitor.getStatic(beanDefinitionType, FIELD_CONSTRUCTOR, constructorField);
         pushCastToType(visitor, methodRefType);
         visitor.getField(methodRefType, "arguments", Type.getType(Argument[].class));
@@ -2805,8 +2829,8 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
     }
 
     private void resolveMethodArgument(GeneratorAdapter visitor, int methodIndex, int argumentIndex) {
-        Type methodsRef = Type.getType(AbstractBeanDefinition2.MethodReference[].class);
-        Type methodRefType = Type.getType(AbstractBeanDefinition2.MethodReference.class);
+        Type methodsRef = Type.getType(AbstractInitializableBeanDefinition.MethodReference[].class);
+        Type methodRefType = Type.getType(AbstractInitializableBeanDefinition.MethodReference.class);
         visitor.getStatic(beanDefinitionType, FIELD_INJECTION_METHODS, methodsRef);
         visitor.push(methodIndex);
         visitor.arrayLoad(methodsRef);
@@ -2824,10 +2848,10 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
     }
 
     private void resolveFieldArgument(GeneratorAdapter visitor, int fieldIndex) {
-        visitor.getStatic(beanDefinitionType, FIELD_INJECTION_FIELDS, Type.getType(AbstractBeanDefinition2.FieldReference[].class));
+        visitor.getStatic(beanDefinitionType, FIELD_INJECTION_FIELDS, Type.getType(AbstractInitializableBeanDefinition.FieldReference[].class));
         visitor.push(fieldIndex);
-        visitor.arrayLoad(Type.getType(AbstractBeanDefinition2.FieldReference.class));
-        visitor.getField(Type.getType(AbstractBeanDefinition2.FieldReference.class), "argument", Type.getType(Argument.class));
+        visitor.arrayLoad(Type.getType(AbstractInitializableBeanDefinition.FieldReference.class));
+        visitor.getField(Type.getType(AbstractInitializableBeanDefinition.FieldReference.class), "argument", Type.getType(Argument.class));
     }
 
     private boolean resolveArgumentGenericType(GeneratorAdapter visitor, ClassElement type) {
@@ -2967,7 +2991,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
             throw new IllegalArgumentException("Unexpected constructor: " + constructor);
         }
 
-        staticInit.putStatic(beanDefinitionType, FIELD_CONSTRUCTOR, Type.getType(AbstractBeanDefinition2.MethodOrFieldReference.class));
+        staticInit.putStatic(beanDefinitionType, FIELD_CONSTRUCTOR, Type.getType(AbstractInitializableBeanDefinition.MethodOrFieldReference.class));
 
         GeneratorAdapter publicConstructor = new GeneratorAdapter(
                 classWriter.visitMethod(ACC_PUBLIC, CONSTRUCTOR_NAME, DESCRIPTOR_DEFAULT_CONSTRUCTOR, null, null),
@@ -2977,7 +3001,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
         );
         publicConstructor.loadThis();
         publicConstructor.push(beanType);
-        publicConstructor.getStatic(beanDefinitionType, FIELD_CONSTRUCTOR, Type.getType(AbstractBeanDefinition2.MethodOrFieldReference.class));
+        publicConstructor.getStatic(beanDefinitionType, FIELD_CONSTRUCTOR, Type.getType(AbstractInitializableBeanDefinition.MethodOrFieldReference.class));
         publicConstructor.invokeConstructor(superBeanDefinition ? superType : beanDefinitionType, PROTECTED_ABSTRACT_BEAN_DEFINITION_CONSTRUCTOR);
         publicConstructor.visitInsn(RETURN);
         publicConstructor.visitMaxs(5, 1);
@@ -3013,13 +3037,13 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
             if (methodInjectionPoints.isEmpty() && preDestroyMethodVisits.isEmpty() && postConstructMethodVisits.isEmpty()) {
                 protectedConstructor.push((String) null);
             } else {
-                protectedConstructor.getStatic(beanDefinitionType, FIELD_INJECTION_METHODS, Type.getType(AbstractBeanDefinition2.MethodReference[].class));
+                protectedConstructor.getStatic(beanDefinitionType, FIELD_INJECTION_METHODS, Type.getType(AbstractInitializableBeanDefinition.MethodReference[].class));
             }
             // 5: `AbstractBeanDefinition2.FieldReference[].class` fieldInjection
             if (fieldInjectionPoints.isEmpty()) {
                 protectedConstructor.push((String) null);
             } else {
-                protectedConstructor.getStatic(beanDefinitionType, FIELD_INJECTION_FIELDS, Type.getType(AbstractBeanDefinition2.FieldReference[].class));
+                protectedConstructor.getStatic(beanDefinitionType, FIELD_INJECTION_FIELDS, Type.getType(AbstractInitializableBeanDefinition.FieldReference[].class));
             }
             // 6: `ExecutableMethod[]` executableMethods
             if (executableMethodsDefinitionWriter == null) {
@@ -3065,11 +3089,8 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
             );
             // 14: `boolean` isConfigurationProperties
             protectedConstructor.push(isConfigurationProperties);
-            // 15: hasExposedTypes
-            protectedConstructor.push(
-                    annotationMetadata.hasDeclaredAnnotation(Bean.class)
-                            && annotationMetadata.stringValues(Bean.class, "typed").length > 0
-            );
+            // 15: isContainerType
+            protectedConstructor.push(isContainerType());
             // 16: requiresMethodProcessing
             protectedConstructor.push(preprocessMethods);
 
@@ -3082,6 +3103,10 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
             protectedConstructor.visitMaxs(20, 1);
             protectedConstructor.visitEnd();
         }
+    }
+
+    private boolean isContainerType() {
+        return DefaultArgument.CONTAINER_TYPES.stream().map(Class::getName).anyMatch(c -> c.equals(beanFullClassName));
     }
 
     private boolean isConfigurationProperties(AnnotationMetadata annotationMetadata) {
@@ -3099,7 +3124,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
         for (ParameterElement value : methodElement.getParameters()) {
             DefaultAnnotationMetadata.contributeDefaults(this.annotationMetadata, value.getAnnotationMetadata());
         }
-        staticInit.newInstance(Type.getType(AbstractBeanDefinition2.MethodReference.class));
+        staticInit.newInstance(Type.getType(AbstractInitializableBeanDefinition.MethodReference.class));
         staticInit.dup();
         // 1: declaringType
         staticInit.push(beanType);
@@ -3128,14 +3153,14 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
             staticInit.push(isPostConstructMethod);
             // 7: isPreDestroyMethod
             staticInit.push(isPreDestroyMethod);
-            staticInit.invokeConstructor(Type.getType(AbstractBeanDefinition2.MethodReference.class), METHOD_REFERENCE_CONSTRUCTOR_POST_PRE);
+            staticInit.invokeConstructor(Type.getType(AbstractInitializableBeanDefinition.MethodReference.class), METHOD_REFERENCE_CONSTRUCTOR_POST_PRE);
         } else {
-            staticInit.invokeConstructor(Type.getType(AbstractBeanDefinition2.MethodReference.class), METHOD_REFERENCE_CONSTRUCTOR);
+            staticInit.invokeConstructor(Type.getType(AbstractInitializableBeanDefinition.MethodReference.class), METHOD_REFERENCE_CONSTRUCTOR);
         }
     }
 
     private void pushNewFieldReference(GeneratorAdapter staticInit, Type declaringType, FieldElement fieldElement, boolean requiresReflection) {
-        staticInit.newInstance(Type.getType(AbstractBeanDefinition2.FieldReference.class));
+        staticInit.newInstance(Type.getType(AbstractInitializableBeanDefinition.FieldReference.class));
         staticInit.dup();
         // 1: declaringType
         staticInit.push(declaringType);
@@ -3154,7 +3179,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
         );
         // 3: requiresReflection
         staticInit.push(requiresReflection);
-        staticInit.invokeConstructor(Type.getType(AbstractBeanDefinition2.FieldReference.class), FIELD_REFERENCE_CONSTRUCTOR);
+        staticInit.invokeConstructor(Type.getType(AbstractInitializableBeanDefinition.FieldReference.class), FIELD_REFERENCE_CONSTRUCTOR);
     }
 
     private void pushAnnotationMetadata(GeneratorAdapter staticInit, AnnotationMetadata annotationMetadata) {
@@ -3225,7 +3250,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
     private static Method getBeanLookupMethod(String methodName, boolean requiresGenericType) {
         if (requiresGenericType) {
             return ReflectionUtils.getRequiredInternalMethod(
-                    AbstractBeanDefinition2.class,
+                    AbstractInitializableBeanDefinition.class,
                     methodName,
                     BeanResolutionContext.class,
                     BeanContext.class,
@@ -3234,7 +3259,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
                     Qualifier.class);
         } else {
             return ReflectionUtils.getRequiredInternalMethod(
-                    AbstractBeanDefinition2.class,
+                    AbstractInitializableBeanDefinition.class,
                     methodName,
                     BeanResolutionContext.class,
                     BeanContext.class,
@@ -3247,7 +3272,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
     private static Method getBeanLookupMethodForArgument(String methodName, boolean requiresGenericType) {
         if (requiresGenericType) {
             return ReflectionUtils.getRequiredInternalMethod(
-                    AbstractBeanDefinition2.class,
+                    AbstractInitializableBeanDefinition.class,
                     methodName,
                     BeanResolutionContext.class,
                     BeanContext.class,
@@ -3257,7 +3282,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
                     Qualifier.class);
         }
         return ReflectionUtils.getRequiredInternalMethod(
-                AbstractBeanDefinition2.class,
+                AbstractInitializableBeanDefinition.class,
                 methodName,
                 BeanResolutionContext.class,
                 BeanContext.class,

--- a/inject/src/main/java/io/micronaut/inject/writer/ExecutableMethodWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/ExecutableMethodWriter.java
@@ -252,6 +252,7 @@ public class ExecutableMethodWriter extends AbstractAnnotationMetadataWriter imp
                     genericReturnType,
                     genericReturnType.getAnnotationMetadata(),
                     genericReturnType.getTypeArguments(),
+                    new HashMap<>(),
                     loadTypeMethods
             );
         }
@@ -264,6 +265,7 @@ public class ExecutableMethodWriter extends AbstractAnnotationMetadataWriter imp
                     classWriter,
                     constructorWriter,
                     argumentTypes,
+                    new HashMap<>(),
                     loadTypeMethods
             );
 

--- a/inject/src/main/java/io/micronaut/inject/writer/ExecutableMethodsDefinitionWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/ExecutableMethodsDefinitionWriter.java
@@ -1,0 +1,654 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.writer;
+
+import io.micronaut.context.AbstractExecutableMethodsDefinition;
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.reflect.ReflectionUtils;
+import io.micronaut.core.type.Argument;
+import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
+import io.micronaut.inject.annotation.AnnotationMetadataReference;
+import io.micronaut.inject.annotation.AnnotationMetadataWriter;
+import io.micronaut.inject.annotation.DefaultAnnotationMetadata;
+import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.ast.MethodElement;
+import io.micronaut.inject.ast.ParameterElement;
+import io.micronaut.inject.ast.TypedElement;
+import io.micronaut.inject.processing.JavaModelUtils;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.GeneratorAdapter;
+import org.objectweb.asm.commons.Method;
+import org.objectweb.asm.commons.TableSwitchGenerator;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Writes out a {@link io.micronaut.inject.ExecutableMethodsDefinition} class.
+ *
+ * @author Denis Stepanov
+ * @since 3.0
+ */
+@Internal
+public class ExecutableMethodsDefinitionWriter extends AbstractClassFileWriter implements Opcodes {
+    public static final String CLASS_SUFFIX = "$Exec";
+
+    public static final Method GET_EXECUTABLE_AT_INDEX_METHOD = Method.getMethod(
+            ReflectionUtils.findMethod(AbstractExecutableMethodsDefinition.class, "getExecutableMethodByIndex", int.class).get()
+    );
+
+    private static final Type SUPER_TYPE = Type.getType(AbstractExecutableMethodsDefinition.class);
+
+    private static final Method SUPER_CONSTRUCTOR = Method.getMethod(ReflectionUtils.findConstructor(
+            AbstractExecutableMethodsDefinition.class,
+            AbstractExecutableMethodsDefinition.MethodReference[].class)
+            .get());
+
+    private static final Method WITH_INTERCEPTED_CONSTRUCTOR = new Method(CONSTRUCTOR_NAME, getConstructorDescriptor(boolean.class));
+
+    private static final Method DISPATCH_METHOD = Method.getMethod(
+            ReflectionUtils.findMethod(AbstractExecutableMethodsDefinition.class, "dispatch", int.class, Object.class, Object[].class).get()
+    );
+
+    private static final Method GET_TARGET_METHOD = Method.getMethod(
+            ReflectionUtils.findMethod(AbstractExecutableMethodsDefinition.class, "getTargetMethodByIndex", int.class).get()
+    );
+
+    private static final Method GET_METHOD = Method.getMethod(
+            ReflectionUtils.findMethod(AbstractExecutableMethodsDefinition.class, "getMethod", String.class, Class[].class).get()
+    );
+
+    private static final Method AT_INDEX_MATCHED_METHOD = Method.getMethod(
+            ReflectionUtils.findMethod(AbstractExecutableMethodsDefinition.class, "methodAtIndexMatches", int.class, String.class, Class[].class).get()
+    );
+
+    private static final Method UNKNOWN_METHOD_AT_INDEX = Method.getMethod(
+            ReflectionUtils.findMethod(AbstractExecutableMethodsDefinition.class, "unknownMethodAtIndexException", int.class).get()
+    );
+
+    private static final Type TYPE_REFLECTION_UTILS = Type.getType(ReflectionUtils.class);
+
+    private static final org.objectweb.asm.commons.Method METHOD_GET_REQUIRED_METHOD = org.objectweb.asm.commons.Method.getMethod(
+            ReflectionUtils.getRequiredInternalMethod(ReflectionUtils.class, "getRequiredMethod", Class.class, String.class, Class[].class));
+
+    private static final String FIELD_METHODS_REFERENCES = "$METHODS_REFERENCES";
+    private static final String FIELD_INTERCEPTABLE = "$interceptable";
+
+    private static final int MIN_METHODS_TO_GENERATE_GET_METHOD = 5;
+
+    private final String className;
+    private final String internalName;
+    private final Type thisType;
+    private final String beanDefinitionReferenceClassName;
+
+    private final List<ExecutableMethodVisitData> executableMethodsVisits = new ArrayList<>(10);
+    private final Map<String, Integer> defaultsStorage = new HashMap<>();
+    private final Map<String, GeneratorAdapter> loadTypeMethods = new LinkedHashMap<>();
+    private final List<String> addedMethods = new ArrayList<>();
+
+    public ExecutableMethodsDefinitionWriter(String beanDefinitionClassName,
+                                             String beanDefinitionReferenceClassName,
+                                             OriginatingElements originatingElements) {
+        super(originatingElements);
+        this.className = beanDefinitionClassName + CLASS_SUFFIX;
+        this.internalName = getInternalName(className);
+        this.thisType = Type.getObjectType(internalName);
+        this.beanDefinitionReferenceClassName = beanDefinitionReferenceClassName;
+    }
+
+    /**
+     * @return The generated class name.
+     */
+    public String getClassName() {
+        return className;
+    }
+
+    /**
+     * @return The generated class type.
+     */
+    public Type getClassType() {
+        return thisType;
+    }
+
+    private MethodElement getMethodElement(int index) {
+        return executableMethodsVisits.get(index).methodElement;
+    }
+
+    /**
+     * Does method supports intercepted proxy.
+     *
+     * @return Does method supports intercepted proxy
+     */
+    public boolean isSupportsInterceptedProxy() {
+        return executableMethodsVisits.stream().anyMatch(it -> it.interceptedProxyClassName != null);
+    }
+
+    /**
+     * Is the method abstract.
+     *
+     * @param index The method index
+     * @return Is the method abstract
+     */
+    public boolean isAbstract(int index) {
+        MethodElement methodElement = getMethodElement(index);
+        return (isInterface(index) && !methodElement.isDefault()) || methodElement.isAbstract();
+    }
+
+    /**
+     * Is the method in an interface.
+     *
+     * @param index The method index
+     * @return Is the method in an interface
+     */
+    public boolean isInterface(int index) {
+        return getMethodElement(index).getDeclaringType().isInterface();
+    }
+
+    /**
+     * Is the method a default method.
+     *
+     * @param index The method index
+     * @return Is the method a default method
+     */
+    public boolean isDefault(int index) {
+        return getMethodElement(index).isDefault();
+    }
+
+    /**
+     * Is the method suspend.
+     *
+     * @param index The method index
+     * @return Is the method suspend
+     */
+    public boolean isSuspend(int index) {
+        return getMethodElement(index).isSuspend();
+    }
+
+    /**
+     * Visit a method that is to be made executable allow invocation of said method without reflection.
+     *
+     * @param declaringType                    The declaring type of the method. Either a Class or a string representing the
+     *                                         name of the type
+     * @param methodElement                    The method element
+     * @param interceptedProxyClassName        The intercepted proxy class name
+     * @param interceptedProxyBridgeMethodName The intercepted proxy bridge method name
+     * @return The method index
+     */
+    public int visitExecutableMethod(TypedElement declaringType,
+                                     MethodElement methodElement,
+                                     String interceptedProxyClassName,
+                                     String interceptedProxyBridgeMethodName) {
+
+        String methodKey = methodElement.getName() +
+                "(" +
+                Arrays.stream(methodElement.getSuspendParameters())
+                        .map(p -> p.getType().getName())
+                        .collect(Collectors.joining(",")) +
+                ")";
+
+        int index = addedMethods.indexOf(methodKey);
+        if (index > -1) {
+            return index;
+        }
+        addedMethods.add(methodKey);
+
+        executableMethodsVisits.add(new ExecutableMethodVisitData(declaringType, methodElement, interceptedProxyClassName, interceptedProxyBridgeMethodName));
+        return addedMethods.size() - 1;
+    }
+
+    @Override
+    public void accept(ClassWriterOutputVisitor classWriterOutputVisitor) throws IOException {
+        ClassWriter classWriter = new ClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES);
+        classWriter.visit(V1_8, ACC_SYNTHETIC | ACC_FINAL,
+                internalName,
+                null,
+                SUPER_TYPE.getInternalName(),
+                null);
+        classWriter.visitAnnotation(TYPE_GENERATED.getDescriptor(), false);
+
+        Type methodsFieldType = Type.getType(AbstractExecutableMethodsDefinition.MethodReference[].class);
+
+        buildStaticInit(classWriter, methodsFieldType);
+        buildConstructor(classWriter, methodsFieldType);
+        buildDispatchMethod(classWriter);
+        buildGetTargetMethodByIndex(classWriter);
+        if (executableMethodsVisits.size() > MIN_METHODS_TO_GENERATE_GET_METHOD) {
+            buildGetMethod(classWriter);
+        }
+
+        for (GeneratorAdapter method : loadTypeMethods.values()) {
+            method.visitMaxs(3, 1);
+            method.visitEnd();
+        }
+
+        classWriter.visitEnd();
+
+        try (OutputStream outputStream = classWriterOutputVisitor.visitClass(className, getOriginatingElements())) {
+            outputStream.write(classWriter.toByteArray());
+        }
+    }
+
+    private void buildStaticInit(ClassWriter classWriter, Type methodsFieldType) {
+        GeneratorAdapter staticInit = visitStaticInitializer(classWriter);
+        classWriter.visitField(ACC_PRIVATE | ACC_FINAL | ACC_STATIC, FIELD_METHODS_REFERENCES, methodsFieldType.getDescriptor(), null, null);
+        pushNewArray(staticInit, AbstractExecutableMethodsDefinition.MethodReference.class, executableMethodsVisits.size());
+        int i = 0;
+        for (ExecutableMethodVisitData method : executableMethodsVisits) {
+            pushStoreInArray(staticInit, i++, executableMethodsVisits.size(), () ->
+                    pushNewMethodReference(
+                            classWriter,
+                            staticInit,
+                            method.declaringType,
+                            method.methodElement
+                    )
+            );
+        }
+        staticInit.putStatic(thisType, FIELD_METHODS_REFERENCES, methodsFieldType);
+        staticInit.returnValue();
+        staticInit.visitMaxs(DEFAULT_MAX_STACK, 1);
+        staticInit.visitEnd();
+    }
+
+    private void buildConstructor(ClassWriter classWriter, Type methodsFieldType) {
+        boolean includeInterceptedField = executableMethodsVisits.stream().anyMatch(it -> it.interceptedProxyClassName != null);
+        if (includeInterceptedField) {
+            classWriter.visitField(ACC_FINAL | ACC_PRIVATE, FIELD_INTERCEPTABLE, Type.getType(boolean.class).getDescriptor(), null, null);
+
+            // Create default constructor call other one with 'false'
+            GeneratorAdapter defaultConstructorWriter = startConstructor(classWriter);
+            defaultConstructorWriter.loadThis();
+            defaultConstructorWriter.push(false);
+            defaultConstructorWriter.invokeConstructor(thisType, WITH_INTERCEPTED_CONSTRUCTOR);
+            defaultConstructorWriter.returnValue();
+            defaultConstructorWriter.visitMaxs(1, 1);
+            defaultConstructorWriter.visitEnd();
+
+            GeneratorAdapter withInterceptedConstructor = startConstructor(classWriter, boolean.class);
+            withInterceptedConstructor.loadThis();
+            withInterceptedConstructor.getStatic(thisType, FIELD_METHODS_REFERENCES, methodsFieldType);
+            withInterceptedConstructor.invokeConstructor(SUPER_TYPE, SUPER_CONSTRUCTOR);
+            withInterceptedConstructor.loadThis();
+            withInterceptedConstructor.loadArg(0);
+            withInterceptedConstructor.putField(thisType, FIELD_INTERCEPTABLE, Type.getType(boolean.class));
+            withInterceptedConstructor.returnValue();
+            withInterceptedConstructor.visitMaxs(1, 1);
+            withInterceptedConstructor.visitEnd();
+        } else {
+            GeneratorAdapter constructorWriter = startConstructor(classWriter);
+            constructorWriter.loadThis();
+            constructorWriter.getStatic(thisType, FIELD_METHODS_REFERENCES, methodsFieldType);
+            constructorWriter.invokeConstructor(SUPER_TYPE, SUPER_CONSTRUCTOR);
+            constructorWriter.returnValue();
+            constructorWriter.visitMaxs(1, 1);
+            constructorWriter.visitEnd();
+        }
+    }
+
+    private void buildDispatchMethod(ClassWriter classWriter) {
+        GeneratorAdapter dispatchMethod = new GeneratorAdapter(classWriter.visitMethod(
+                Opcodes.ACC_PROTECTED | Opcodes.ACC_FINAL,
+                DISPATCH_METHOD.getName(),
+                DISPATCH_METHOD.getDescriptor(),
+                null,
+                null),
+                ACC_PROTECTED | Opcodes.ACC_FINAL,
+                DISPATCH_METHOD.getName(),
+                DISPATCH_METHOD.getDescriptor()
+        );
+        dispatchMethod.loadArg(0);
+        dispatchMethod.tableSwitch(IntStream.range(0, executableMethodsVisits.size()).toArray(), new TableSwitchGenerator() {
+            @Override
+            public void generateCase(int key, Label end) {
+                ExecutableMethodVisitData method = executableMethodsVisits.get(key);
+
+                TypedElement declaringType = method.declaringType;
+                MethodElement methodElement = method.methodElement;
+                String interceptedProxyClassName = method.interceptedProxyClassName;
+                String interceptedProxyBridgeMethodName = method.interceptedProxyBridgeMethodName;
+
+                String methodName = methodElement.getName();
+
+                List<ParameterElement> argumentTypes = Arrays.asList(methodElement.getSuspendParameters());
+                Type declaringTypeObject = JavaModelUtils.getTypeReference(declaringType);
+
+                ClassElement returnType = methodElement.isSuspend() ? ClassElement.of(Object.class) : methodElement.getReturnType();
+                boolean isInterface = declaringType.getType().isInterface();
+                buildInvokeMethod(declaringTypeObject, methodName, isInterface,
+                        returnType, argumentTypes, dispatchMethod, interceptedProxyClassName, interceptedProxyBridgeMethodName);
+
+                dispatchMethod.returnValue();
+            }
+
+            @Override
+            public void generateDefault() {
+                dispatchMethod.loadThis();
+                dispatchMethod.loadArg(0);
+                dispatchMethod.invokeVirtual(thisType, UNKNOWN_METHOD_AT_INDEX);
+                dispatchMethod.throwException();
+            }
+        }, true);
+        dispatchMethod.visitMaxs(DEFAULT_MAX_STACK, 1);
+        dispatchMethod.visitEnd();
+    }
+
+    private void buildGetTargetMethodByIndex(ClassWriter classWriter) {
+        GeneratorAdapter getTargetMethodByIndex = new GeneratorAdapter(classWriter.visitMethod(
+                Opcodes.ACC_PROTECTED | Opcodes.ACC_FINAL,
+                GET_TARGET_METHOD.getName(),
+                GET_TARGET_METHOD.getDescriptor(),
+                null,
+                null),
+                ACC_PROTECTED | Opcodes.ACC_FINAL,
+                GET_TARGET_METHOD.getName(),
+                GET_TARGET_METHOD.getDescriptor()
+        );
+        getTargetMethodByIndex.loadArg(0);
+        getTargetMethodByIndex.tableSwitch(IntStream.range(0, executableMethodsVisits.size()).toArray(), new TableSwitchGenerator() {
+            @Override
+            public void generateCase(int key, Label end) {
+                ExecutableMethodVisitData method = executableMethodsVisits.get(key);
+                Type declaringTypeObject = JavaModelUtils.getTypeReference(method.declaringType);
+                List<ParameterElement> argumentTypes = Arrays.asList(method.methodElement.getSuspendParameters());
+
+                getTargetMethodByIndex.push(declaringTypeObject);
+                getTargetMethodByIndex.push(method.methodElement.getName());
+                if (!argumentTypes.isEmpty()) {
+                    int len = argumentTypes.size();
+                    Iterator<ParameterElement> iter = argumentTypes.iterator();
+                    pushNewArray(getTargetMethodByIndex, Class.class, len);
+                    for (int i = 0; i < len; i++) {
+                        ParameterElement type = iter.next();
+                        pushStoreInArray(
+                                getTargetMethodByIndex,
+                                i,
+                                len,
+                                () -> getTargetMethodByIndex.push(JavaModelUtils.getTypeReference(type))
+                        );
+
+                    }
+                } else {
+                    getTargetMethodByIndex.getStatic(TYPE_REFLECTION_UTILS, "EMPTY_CLASS_ARRAY", Type.getType(Class[].class));
+                }
+                getTargetMethodByIndex.invokeStatic(TYPE_REFLECTION_UTILS, METHOD_GET_REQUIRED_METHOD);
+                getTargetMethodByIndex.returnValue();
+            }
+
+            @Override
+            public void generateDefault() {
+                getTargetMethodByIndex.loadThis();
+                getTargetMethodByIndex.loadArg(0);
+                getTargetMethodByIndex.invokeVirtual(thisType, UNKNOWN_METHOD_AT_INDEX);
+                getTargetMethodByIndex.throwException();
+            }
+        }, true);
+        getTargetMethodByIndex.visitMaxs(DEFAULT_MAX_STACK, 1);
+        getTargetMethodByIndex.visitEnd();
+    }
+
+    private void buildGetMethod(ClassWriter classWriter) {
+        GeneratorAdapter findMethod = new GeneratorAdapter(classWriter.visitMethod(
+                Opcodes.ACC_PRIVATE | Opcodes.ACC_FINAL,
+                GET_METHOD.getName(),
+                GET_METHOD.getDescriptor(),
+                null,
+                null),
+                ACC_PRIVATE | Opcodes.ACC_FINAL,
+                GET_METHOD.getName(),
+                GET_METHOD.getDescriptor()
+        );
+        findMethod.loadThis();
+        findMethod.loadArg(0);
+        findMethod.invokeVirtual(Type.getType(Object.class), new Method("hashCode", Type.INT_TYPE, new Type[]{}));
+
+        Map<Integer, List<ExecutableMethodVisitData>> hashToMethods = new TreeMap<>();
+        for (ExecutableMethodVisitData em : executableMethodsVisits) {
+            int hash = em.methodElement.getName().hashCode();
+            hashToMethods.computeIfAbsent(hash, h -> new ArrayList<>()).add(em);
+        }
+        int[] hashCodeArray = hashToMethods.keySet().stream().mapToInt(i -> i).toArray();
+        findMethod.tableSwitch(hashCodeArray, new TableSwitchGenerator() {
+            @Override
+            public void generateCase(int hashCode, Label end) {
+                for (ExecutableMethodVisitData em : hashToMethods.get(hashCode)) {
+                    int index = executableMethodsVisits.indexOf(em);
+                    if (index < 0) {
+                        throw new IllegalStateException();
+                    }
+                    findMethod.loadThis();
+                    findMethod.push(index);
+                    findMethod.loadArg(0);
+                    findMethod.loadArg(1);
+                    findMethod.invokeVirtual(SUPER_TYPE, AT_INDEX_MATCHED_METHOD);
+                    findMethod.push(true);
+                    Label falseLabel = new Label();
+                    findMethod.ifCmp(Type.BOOLEAN_TYPE, GeneratorAdapter.NE, falseLabel);
+                    findMethod.loadThis();
+                    findMethod.push(index);
+                    findMethod.invokeVirtual(SUPER_TYPE, GET_EXECUTABLE_AT_INDEX_METHOD);
+                    findMethod.returnValue();
+                    findMethod.visitLabel(falseLabel);
+                }
+                findMethod.goTo(end);
+            }
+
+            @Override
+            public void generateDefault() {
+            }
+        });
+        findMethod.push((String) null);
+        findMethod.returnValue();
+        findMethod.visitMaxs(DEFAULT_MAX_STACK, 1);
+        findMethod.visitEnd();
+    }
+
+    private void pushNewMethodReference(ClassWriter classWriter,
+                                        GeneratorAdapter staticInit,
+                                        TypedElement declaringType,
+                                        MethodElement methodElement) {
+        staticInit.newInstance(Type.getType(AbstractExecutableMethodsDefinition.MethodReference.class));
+        staticInit.dup();
+        // 1: declaringType
+        Type typeReference = JavaModelUtils.getTypeReference(declaringType.getType());
+        staticInit.push(typeReference);
+        // 2: annotationMetadata
+        AnnotationMetadata annotationMetadata = methodElement.getAnnotationMetadata();
+
+        if (annotationMetadata instanceof AnnotationMetadataHierarchy) {
+            annotationMetadata = new AnnotationMetadataHierarchy(
+                    new AnnotationMetadataReference(beanDefinitionReferenceClassName, annotationMetadata),
+                    annotationMetadata.getDeclaredMetadata()
+            );
+        }
+
+        pushAnnotationMetadata(classWriter, staticInit, annotationMetadata);
+        // 3: methodName
+        staticInit.push(methodElement.getName());
+        // 4: return argument
+        ClassElement genericReturnType = methodElement.getGenericReturnType();
+        pushArgument(thisType, classWriter, staticInit, declaringType.getName(), genericReturnType, defaultsStorage, loadTypeMethods);
+        // 5: arguments
+        ParameterElement[] parameters = methodElement.getSuspendParameters();
+        if (parameters.length == 0) {
+            staticInit.visitInsn(ACONST_NULL);
+        } else {
+            pushBuildArgumentsForMethod(
+                    typeReference.getClassName(),
+                    typeReference,
+                    classWriter,
+                    staticInit,
+                    Arrays.asList(parameters),
+                    defaultsStorage,
+                    loadTypeMethods
+            );
+        }
+        // 6: isAbstract
+        staticInit.push(methodElement.isAbstract());
+        // 7: isSuspend
+        staticInit.push(methodElement.isSuspend());
+
+        invokeConstructor(
+                staticInit,
+                AbstractExecutableMethodsDefinition.MethodReference.class,
+                Class.class,
+                AnnotationMetadata.class,
+                String.class,
+                Argument.class,
+                Argument[].class,
+                boolean.class,
+                boolean.class);
+    }
+
+    private void pushAnnotationMetadata(ClassWriter classWriter, GeneratorAdapter staticInit, AnnotationMetadata annotationMetadata) {
+        if (annotationMetadata == AnnotationMetadata.EMPTY_METADATA || annotationMetadata.isEmpty()) {
+            staticInit.push((String) null);
+        } else if (annotationMetadata instanceof AnnotationMetadataReference) {
+            AnnotationMetadataReference reference = (AnnotationMetadataReference) annotationMetadata;
+            String className = reference.getClassName();
+            staticInit.getStatic(getTypeReferenceForName(className), AbstractAnnotationMetadataWriter.FIELD_ANNOTATION_METADATA, Type.getType(AnnotationMetadata.class));
+        } else if (annotationMetadata instanceof AnnotationMetadataHierarchy) {
+            AnnotationMetadataWriter.instantiateNewMetadataHierarchy(
+                    thisType,
+                    classWriter,
+                    staticInit,
+                    (AnnotationMetadataHierarchy) annotationMetadata,
+                    defaultsStorage,
+                    loadTypeMethods);
+        } else if (annotationMetadata instanceof DefaultAnnotationMetadata) {
+            AnnotationMetadataWriter.instantiateNewMetadata(
+                    thisType,
+                    classWriter,
+                    staticInit,
+                    (DefaultAnnotationMetadata) annotationMetadata,
+                    defaultsStorage,
+                    loadTypeMethods);
+        } else {
+            staticInit.push((String) null);
+        }
+    }
+
+    private void buildInvokeMethod(
+            Type declaringTypeObject,
+            String methodName,
+            boolean isInterface,
+            ClassElement returnType,
+            Collection<ParameterElement> argumentTypes,
+            GeneratorAdapter invokeMethodVisitor,
+            String interceptedProxyClassName,
+            String interceptedProxyBridgeMethodName
+    ) {
+        Type returnTypeObject = JavaModelUtils.getTypeReference(returnType);
+
+        // load this
+        invokeMethodVisitor.loadArg(1);
+        // duplicate target
+        invokeMethodVisitor.dup();
+
+        String methodDescriptor = getMethodDescriptor(returnType, argumentTypes);
+        if (interceptedProxyClassName != null) {
+            Label invokeTargetBlock = new Label();
+
+            Type interceptedProxyType = getObjectType(interceptedProxyClassName);
+
+            // load this.$interceptable field value
+            invokeMethodVisitor.loadThis();
+            invokeMethodVisitor.getField(Type.getObjectType(internalName), FIELD_INTERCEPTABLE, Type.getType(boolean.class));
+            // check if it equals true
+            invokeMethodVisitor.push(true);
+            invokeMethodVisitor.ifCmp(Type.BOOLEAN_TYPE, GeneratorAdapter.NE, invokeTargetBlock);
+
+            // target instanceOf intercepted proxy
+            invokeMethodVisitor.loadArg(1);
+            invokeMethodVisitor.instanceOf(interceptedProxyType);
+            // check if instanceOf
+            invokeMethodVisitor.push(true);
+            invokeMethodVisitor.ifCmp(Type.BOOLEAN_TYPE, GeneratorAdapter.NE, invokeTargetBlock);
+
+            pushCastToType(invokeMethodVisitor, interceptedProxyType);
+
+            // load arguments
+            Iterator<ParameterElement> iterator = argumentTypes.iterator();
+            for (int i = 0; i < argumentTypes.size(); i++) {
+                invokeMethodVisitor.loadArg(2);
+                invokeMethodVisitor.push(i);
+                invokeMethodVisitor.visitInsn(AALOAD);
+
+                pushCastToType(invokeMethodVisitor, iterator.next());
+            }
+
+            invokeMethodVisitor.visitMethodInsn(INVOKEVIRTUAL,
+                    interceptedProxyType.getInternalName(), interceptedProxyBridgeMethodName,
+                    methodDescriptor, false);
+
+            if (returnTypeObject.equals(Type.VOID_TYPE)) {
+                invokeMethodVisitor.visitInsn(ACONST_NULL);
+            } else {
+                pushBoxPrimitiveIfNecessary(returnType, invokeMethodVisitor);
+            }
+            invokeMethodVisitor.returnValue();
+
+            invokeMethodVisitor.visitLabel(invokeTargetBlock);
+
+            // remove parent
+            invokeMethodVisitor.pop();
+        }
+
+        pushCastToType(invokeMethodVisitor, declaringTypeObject);
+        boolean hasArgs = !argumentTypes.isEmpty();
+        if (hasArgs) {
+            int argCount = argumentTypes.size();
+            Iterator<ParameterElement> argIterator = argumentTypes.iterator();
+            for (int i = 0; i < argCount; i++) {
+                invokeMethodVisitor.loadArg(2);
+                invokeMethodVisitor.push(i);
+                invokeMethodVisitor.visitInsn(AALOAD);
+                // cast the return value to the correct type
+                pushCastToType(invokeMethodVisitor, argIterator.next());
+            }
+        }
+
+        invokeMethodVisitor.visitMethodInsn(isInterface ? INVOKEINTERFACE : INVOKEVIRTUAL,
+                declaringTypeObject.getInternalName(), methodName,
+                methodDescriptor, isInterface);
+
+        if (returnTypeObject.equals(Type.VOID_TYPE)) {
+            invokeMethodVisitor.visitInsn(ACONST_NULL);
+        } else {
+            pushBoxPrimitiveIfNecessary(returnType, invokeMethodVisitor);
+        }
+    }
+
+    @Internal
+    private static final class ExecutableMethodVisitData {
+        final TypedElement declaringType;
+        final MethodElement methodElement;
+        final String interceptedProxyClassName;
+        final String interceptedProxyBridgeMethodName;
+
+        private ExecutableMethodVisitData(TypedElement declaringType, MethodElement methodElement, String interceptedProxyClassName, String interceptedProxyBridgeMethodName) {
+            this.declaringType = declaringType;
+            this.methodElement = methodElement;
+            this.interceptedProxyClassName = interceptedProxyClassName;
+            this.interceptedProxyBridgeMethodName = interceptedProxyBridgeMethodName;
+        }
+    }
+}

--- a/management/src/test/groovy/io/micronaut/management/endpoint/beans/BeansEndpointSpec.groovy
+++ b/management/src/test/groovy/io/micronaut/management/endpoint/beans/BeansEndpointSpec.groovy
@@ -20,6 +20,7 @@ import io.micronaut.context.env.Environment
 import io.micronaut.http.HttpResponse
 import io.micronaut.core.annotation.AnnotationUtil
 import io.micronaut.http.HttpStatus
+import io.micronaut.inject.writer.BeanDefinitionWriter
 import io.micronaut.http.client.HttpClient
 import io.micronaut.runtime.server.EmbeddedServer
 import spock.lang.Specification
@@ -42,10 +43,10 @@ class BeansEndpointSpec extends Specification {
 
         then:
         response.code() == HttpStatus.OK.code
-        beans["io.micronaut.management.endpoint.beans.\$BeansEndpointDefinition"].dependencies.contains("io.micronaut.context.BeanContext")
-        beans["io.micronaut.management.endpoint.beans.\$BeansEndpointDefinition"].dependencies.contains("io.micronaut.management.endpoint.beans.BeanDefinitionDataCollector")
-        beans["io.micronaut.management.endpoint.beans.\$BeansEndpointDefinition"].scope == AnnotationUtil.SINGLETON
-        beans["io.micronaut.management.endpoint.beans.\$BeansEndpointDefinition"].type == "io.micronaut.management.endpoint.beans.BeansEndpoint"
+        beans["io.micronaut.management.endpoint.beans.\$BeansEndpoint" + BeanDefinitionWriter.CLASS_SUFFIX].dependencies.contains("io.micronaut.context.BeanContext")
+        beans["io.micronaut.management.endpoint.beans.\$BeansEndpoint" + BeanDefinitionWriter.CLASS_SUFFIX].dependencies.contains("io.micronaut.management.endpoint.beans.BeanDefinitionDataCollector")
+        beans["io.micronaut.management.endpoint.beans.\$BeansEndpoint" + BeanDefinitionWriter.CLASS_SUFFIX].scope == AnnotationUtil.SINGLETON
+        beans["io.micronaut.management.endpoint.beans.\$BeansEndpoint" + BeanDefinitionWriter.CLASS_SUFFIX].type == "io.micronaut.management.endpoint.beans.BeansEndpoint"
 
         cleanup:
         rxClient.close()

--- a/runtime/src/test/groovy/io/micronaut/support/AbstractBeanDefinitionSpec.groovy
+++ b/runtime/src/test/groovy/io/micronaut/support/AbstractBeanDefinitionSpec.groovy
@@ -22,6 +22,7 @@ import io.micronaut.core.annotation.AnnotationMetadata
 import io.micronaut.core.naming.NameUtils
 import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.annotation.AnnotationMetadataWriter
+import io.micronaut.inject.writer.BeanDefinitionWriter
 import org.codehaus.groovy.ast.ASTNode
 import org.codehaus.groovy.ast.ClassNode
 import org.codehaus.groovy.ast.MethodNode
@@ -36,7 +37,7 @@ abstract class AbstractBeanDefinitionSpec extends Specification {
 
     @CompileStatic
     BeanDefinition buildBeanDefinition(String className, String classStr) {
-        def beanDefName= '$' + NameUtils.getSimpleName(className) + 'Definition'
+        def beanDefName= '$' + NameUtils.getSimpleName(className) + BeanDefinitionWriter.CLASS_SUFFIX
         def packageName = NameUtils.getPackageName(className)
         String beanFullName = "${packageName}.${beanDefName}"
 

--- a/src/main/docs/guide/appendix/breaks.adoc
+++ b/src/main/docs/guide/appendix/breaks.adoc
@@ -404,3 +404,19 @@ Another change is regarding the GraalVM resources created at compile-time. In pr
 
 The classes in Micronaut Cassandra have been moved from `io.micronaut.configuration.cassandra` to `io.micronaut.cassandra` package.
 
+==== Groovy changes
+
+In previous version the missing property wouldn't set the field value to `null` as it would do for the Java code, in the version 3 it should behave in the same way.
+
+Please refactor to use the default value in the `@Value` annotation:
+
+[source,groovy]
+----
+@Nullable
+@Value('${greeting}')
+protected String before = "Default greeting"
+
+@Nullable
+@Value('${greeting:Default greeting}')
+protected String after
+----

--- a/validation/src/test/groovy/io/micronaut/validation/ValidatedParseSpec.groovy
+++ b/validation/src/test/groovy/io/micronaut/validation/ValidatedParseSpec.groovy
@@ -4,13 +4,14 @@ import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.micronaut.aop.Around
 import io.micronaut.inject.ProxyBeanDefinition
 import io.micronaut.inject.writer.BeanDefinitionVisitor
+import io.micronaut.inject.writer.BeanDefinitionWriter
 
 import java.time.LocalDate
 
 class ValidatedParseSpec extends AbstractTypeElementSpec {
     void "test constraints on beans make them @Validated"() {
         given:
-        def definition = buildBeanDefinition('test.$TestDefinition' + BeanDefinitionVisitor.PROXY_SUFFIX,'''
+        def definition = buildBeanDefinition('test.$Test' + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionVisitor.PROXY_SUFFIX,'''
 package test;
 
 @jakarta.inject.Singleton


### PR DESCRIPTION
Introducing `AbstractBeanDefinition2`, `AbstractBeanDefinitionReference2` with improvements:
- passing most of the parameters in the constructor instead of overriding methods
- initializing method/field injection in the static block allowing Graal to perform build-time optimizations
- generating annotation metadata with shared annotation default variables, reducing significantly duplicate calls mostly for config classes
- improving how annotation metadata are generated
- use try-resource syntax for bean context push/pop
- `AbstractBeanDefinitionReference2` includes more precompilated variables at compile-time
- bean references are generated with prefix `$Reference` instead of the previous `Class` for better understanding what does the class represent
- generate all executable methods in one class prefixed "$Exec" instead of the previous one class per method
- changed to generate bean definition classes with prefix "$Definition" instead of previous "Definition" to better distinguish generated class
- use new map implementation `ImmutableSortedStringsArrayMap` for annotation classes instead of `Map.of`. The implementation is using a sorted `String` keys array for lookup and an extra array for keys. The size of the collection should be the same as in `Map.of`
- Refactored a lot of original `AbstractBeanDefinition`, most of the resolve code is now shared between field/constructor/methods methods
- Moved most of the code that decided how to resolve the argument to the compile-time
- Including `AbstractParametrizedBeanDefinition` main methods inside `AbstractBeanDefinition2` for the benefit of simplicity to have one super-class
- Resolving generic types, known qualifiers, and inner configuration types at the compile-time