### PR TITLE
Implement the ability to customize if compilation fails for proxyTarget=true

### DIFF
--- a/aop/src/main/java/io/micronaut/aop/Around.java
+++ b/aop/src/main/java/io/micronaut/aop/Around.java
@@ -45,7 +45,7 @@ import java.lang.annotation.Target;
  */
 @Documented
 @Retention(RUNTIME)
-@Target({ElementType.ANNOTATION_TYPE, ElementType.TYPE})
+@Target({ElementType.ANNOTATION_TYPE, ElementType.TYPE, ElementType.METHOD})
 @InterceptorBinding(kind = InterceptorKind.AROUND)
 public @interface Around {
 

--- a/aop/src/main/java/io/micronaut/aop/Around.java
+++ b/aop/src/main/java/io/micronaut/aop/Around.java
@@ -81,4 +81,42 @@ public @interface Around {
      * @return True if the proxy target should be resolved lazily
      */
     boolean lazy() default false;
+
+    /**
+     * Sets the {@link io.micronaut.aop.Around.ProxyTargetConstructorMode}. See the
+     * javadoc for {@link io.micronaut.aop.Around.ProxyTargetConstructorMode} for more information.
+     *
+     * @return The {@link io.micronaut.aop.Around.ProxyTargetConstructorMode}.
+     * @see io.micronaut.aop.Around.ProxyTargetConstructorMode
+     * @since 3.0.0
+     */
+    ProxyTargetConstructorMode proxyTargetMode() default ProxyTargetConstructorMode.ERROR;
+
+    /**
+     * When using {@link #proxyTarget()} on a {@link io.micronaut.context.annotation.Factory} method if the
+     * returned bean features constructor arguments this can lead to undefined behaviour since it is expected
+     * with factory methods that the developer is responsible for constructing the object.
+     *
+     * <p>For example if the type accepts an argument of type <code>String</code> then there is no way
+     * for Micronaut to know what to inject as a value for the argument and injecting <code>null</code> is inherently unsafe.</p>
+     *
+     * <p>The {@link io.micronaut.aop.Around.ProxyTargetConstructorMode} allows the developer decide if they wish to allow
+     * proxies to be constructed and if a proxy is allowed then Micronaut will either inject a bean if it is found or <code>null</code> if is not. For primitive types Micronaut will inject <code>true</code> for booleans and <code>0</code> for number types</p>
+     */
+    enum ProxyTargetConstructorMode {
+        /**
+         * Do not allow types with constructor arguments to be proxied. This is the default behaviour and compilation will fail.
+         */
+        ERROR,
+        /**
+         * Allow types to be proxied but print a warning when this feature is used.
+         *
+         * <p>In this case if a constructor parameter cannot be injected Micronaut will inject <code>null</code> for objects or <code>false</code> for boolean or <code>0</code> for any other primitive.</p>
+         */
+        WARN,
+        /**
+         * Allow types to be proxied and don't print any warnings.
+         */
+        ALLOW
+    }
 }

--- a/inject-groovy/build.gradle
+++ b/inject-groovy/build.gradle
@@ -18,7 +18,10 @@ dependencies {
     testImplementation 'org.neo4j.driver:neo4j-java-driver:1.4.5'
     testImplementation dependencyModuleVersion("groovy", "groovy-json")
     testImplementation "com.blazebit:blaze-persistence-core-impl:1.6.0-Alpha1"
-
+    testImplementation dependencyModuleVersion("micronaut.test", "micronaut-test-core"), {
+        exclude module:'micronaut-runtime'
+        exclude module:'micronaut-inject'
+    }
 }
 
 test {

--- a/inject-groovy/build.gradle
+++ b/inject-groovy/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     testImplementation dependencyModuleVersion("micronaut.test", "micronaut-test-core"), {
         exclude module:'micronaut-runtime'
         exclude module:'micronaut-inject'
+        exclude module:'micronaut-bom'
     }
 }
 

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyMethodElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyMethodElement.java
@@ -180,10 +180,11 @@ public class GroovyMethodElement extends AbstractGroovyElement implements Method
 
     @Override
     public MethodElement withNewParameters(ParameterElement... newParameters) {
+        final ParameterElement[] existing = getParameters();
         return new GroovyMethodElement(declaringClass, visitorContext, methodNode, getAnnotationMetadata()) {
             @Override
             public ParameterElement[] getParameters() {
-                return ArrayUtils.concat(super.getParameters(), newParameters);
+                return ArrayUtils.concat(existing, newParameters);
             }
         };
     }

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/factory/proxytarget/FactoryWithScopedProxySpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/factory/proxytarget/FactoryWithScopedProxySpec.groovy
@@ -1,8 +1,97 @@
 package io.micronaut.inject.factory.proxytarget
 
 import io.micronaut.ast.transform.test.AbstractBeanDefinitionSpec
+import spock.lang.Unroll
 
 class FactoryWithScopedProxySpec extends AbstractBeanDefinitionSpec {
+    void "test mock bean compiles"() {
+        expect:"mock bean to compile"
+        buildBeanDefinition('mockbeantest.TestFactory',"""
+package mockbeantest;
+
+import io.micronaut.context.annotation.*;
+import io.micronaut.aop.Around;
+import static io.micronaut.aop.Around.ProxyTargetConstructorMode.*;
+import java.lang.annotation.Retention;
+import static java.lang.annotation.RetentionPolicy.*;
+import io.micronaut.test.annotation.MockBean;
+
+@Factory
+class TestFactory {
+
+    @MockBean(Test.class)
+    Test test() {
+        return new Test("foo", 10);
+    }
+}
+
+class Test {
+    public String name;
+    Test(String name, int prim) {
+        this.name = name;
+    }
+    
+    public String name() {
+        return this.name;
+    }
+}
+""")
+
+    }
+
+    @Unroll
+    void "test a factory that defines AOP advice and constructor arguments compiled with a #type if set to do so"() {
+        when:
+        def context = buildContext("""
+package factproxy2;
+
+import io.micronaut.context.annotation.*;
+import io.micronaut.aop.Around;
+import static io.micronaut.aop.Around.ProxyTargetConstructorMode.*;
+import java.lang.annotation.Retention;
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Factory
+class TestFactory {
+
+    @Bean
+    @TestAnn
+    Test test() {
+        return new Test("foo", 10);
+    }
+}
+
+class Test {
+    public String name;
+    Test(String name, int prim) {
+        this.name = name;
+    }
+    
+    public String name() {
+        return this.name;
+    }
+}
+
+@Around(proxyTargetMode = $type, proxyTarget=true)
+@Retention(RUNTIME)
+@interface TestAnn {}
+""")
+        def bean = getBean(context, 'factproxy2.Test')
+
+        then:"Name is null because fields can't be proxied"
+        bean.name == null
+
+        and:"Method proxied onto actual instance"
+        bean.name() == 'foo'
+
+        cleanup:
+        context.close()
+
+        where:
+        type << ["WARN", "ALLOW"]
+    }
+
+
     void "test that a factory that returns a class that has constructor argument and specifies AOP advise fails to compile"() {
         when:
         buildBeanDefinition('factproxy.TestFactory', '''

--- a/inject-java/build.gradle
+++ b/inject-java/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     testImplementation dependencyVersion("zipkin.reporter")
     testImplementation dependencyModuleVersion("micronaut.test", "micronaut-test-core"), {
         exclude module:'micronaut-runtime'
+        exclude module:'micronaut-bom'
         exclude module:'micronaut-inject'
     }
     testRuntimeOnly 'org.glassfish.web:el-impl:2.2.1-b05'

--- a/inject-java/build.gradle
+++ b/inject-java/build.gradle
@@ -27,7 +27,10 @@ dependencies {
     testImplementation project(":validation")
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
     testImplementation dependencyVersion("zipkin.reporter")
-
+    testImplementation dependencyModuleVersion("micronaut.test", "micronaut-test-core"), {
+        exclude module:'micronaut-runtime'
+        exclude module:'micronaut-inject'
+    }
     testRuntimeOnly 'org.glassfish.web:el-impl:2.2.1-b05'
     testRuntimeOnly 'org.glassfish:javax.el:3.0.1-b12'
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/factory/proxytarget/FactoryWithScopedProxySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/factory/proxytarget/FactoryWithScopedProxySpec.groovy
@@ -3,6 +3,7 @@ package io.micronaut.inject.factory.proxytarget
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.micronaut.context.ApplicationContext
 import io.micronaut.core.type.Argument
+import spock.lang.Unroll
 
 class FactoryWithScopedProxySpec extends AbstractTypeElementSpec {
 
@@ -30,6 +31,94 @@ class Test {
         then:
         def e = thrown(RuntimeException)
         e.message.contains("The produced type from a factory which has AOP proxy advice specified must define an accessible no arguments constructor")
+    }
+
+
+    void "test mock bean compiles"() {
+        expect:"mock bean to compile"
+        buildBeanDefinition('mockbeantest.TestFactory',"""
+package mockbeantest;
+
+import io.micronaut.context.annotation.*;
+import io.micronaut.aop.Around;
+import static io.micronaut.aop.Around.ProxyTargetConstructorMode.*;
+import java.lang.annotation.Retention;
+import static java.lang.annotation.RetentionPolicy.*;
+import io.micronaut.test.annotation.MockBean;
+
+@Factory
+class TestFactory {
+
+    @MockBean(Test.class)
+    Test test() {
+        return new Test("foo", 10);
+    }
+}
+
+class Test {
+    public String name;
+    Test(String name, int prim) {
+        this.name = name;
+    }
+    
+    public String name() {
+        return this.name;
+    }
+}
+""")
+
+    }
+
+    @Unroll
+    void "test a factory that defines AOP advice and constructor arguments compiled with a #type if set to do so"() {
+        when:
+        def context = buildContext("""
+package factproxy2;
+
+import io.micronaut.context.annotation.*;
+import io.micronaut.aop.Around;
+import static io.micronaut.aop.Around.ProxyTargetConstructorMode.*;
+import java.lang.annotation.Retention;
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Factory
+class TestFactory {
+
+    @Bean
+    @TestAnn
+    Test test() {
+        return new Test("foo", 10);
+    }
+}
+
+class Test {
+    public String name;
+    Test(String name, int prim) {
+        this.name = name;
+    }
+    
+    public String name() {
+        return this.name;
+    }
+}
+
+@Around(proxyTargetMode = $type, proxyTarget=true)
+@Retention(RUNTIME)
+@interface TestAnn {}
+""")
+        def bean = getBean(context, 'factproxy2.Test')
+
+        then:"Name is null because fields can't be proxied"
+        bean.name == null
+
+        and:"Method proxied onto actual instance"
+        bean.name() == 'foo'
+
+        cleanup:
+        context.close()
+
+        where:
+        type << ["WARN", "ALLOW"]
     }
 
     void "test that a scoped proxy returned from a factory is lazily initialized"() {


### PR DESCRIPTION
In the case of proxyTarget=true then currently in Micronaut 3.0 this will fail. This present an issue for MockBean since MockBean works by proxing the type.

This change allows the behaviour to be customized so that users have an easier upgrade path and defaults to not fail compilation for MockBean but instead print a warning.

This is enabled through a new ProxyTargetConstructorMode enum on the Around advice type that can be used to alter the behaviour. The javadoc of this new enum has more details and documentation.