### PR TITLE
Use the owning type name for child factory beans. Fixes #5704

### DIFF
--- a/inject-groovy/src/test/groovy/io/micronaut/inject/factory/inheritance/FactoryAbstractInheritanceSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/factory/inheritance/FactoryAbstractInheritanceSpec.groovy
@@ -1,0 +1,58 @@
+package io.micronaut.inject.factory.inheritance
+
+import io.micronaut.aop.InterceptedProxy
+import io.micronaut.ast.transform.test.AbstractBeanDefinitionSpec
+import io.micronaut.inject.BeanDefinition
+
+class FactoryAbstractInheritanceSpec extends AbstractBeanDefinitionSpec {
+    void "test that beans are generated for child factories but not parent"() {
+        given:
+        def context = buildContext('''
+package factinhertest;
+
+import jakarta.inject.Singleton;
+import io.micronaut.runtime.context.scope.Refreshable;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Replaces;
+
+
+@Factory
+class MyMockPublisherFactory extends MockPublisherFactory {
+    
+}
+
+abstract class MockPublisherFactory {
+    @Refreshable
+    @Singleton
+    @Replaces(PublisherFactory.class)
+    Publisher createPublisher() {
+        return new MockPublisher();
+    }
+}
+
+class MockPublisher implements Publisher {}
+
+interface Publisher {}
+interface PublisherFactory {
+    Publisher createPublisher();
+}   
+class ConcretePublisher implements Publisher {}
+
+@Singleton
+class DefaultPublisherFactory implements PublisherFactory {
+    public Publisher createPublisher() {
+        return new ConcretePublisher();
+    }
+}
+''')
+        def bean = getBean(context, 'factinhertest.Publisher')
+        BeanDefinition definition = context.getBeanDefinition(
+                context.classLoader.loadClass('factinhertest.Publisher')
+        )
+
+        expect:
+        bean instanceof InterceptedProxy
+        bean.interceptedTarget().getClass().simpleName == 'MockPublisher'
+        definition.getClass().name.contains('MyMockPublisherFactory')
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/factory/inheritance/FactoryAbstractInheritanceSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/factory/inheritance/FactoryAbstractInheritanceSpec.groovy
@@ -1,0 +1,59 @@
+package io.micronaut.inject.factory.inheritance
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.aop.InterceptedProxy
+import io.micronaut.inject.BeanDefinition
+
+class FactoryAbstractInheritanceSpec extends AbstractTypeElementSpec {
+
+    void "test that beans are generated for child factories but not parent"() {
+        given:
+        def context = buildContext('''
+package factinhertest;
+
+import jakarta.inject.Singleton;
+import io.micronaut.runtime.context.scope.Refreshable;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Replaces;
+
+
+@Factory
+class MyMockPublisherFactory extends MockPublisherFactory {
+    
+}
+
+abstract class MockPublisherFactory {
+    @Refreshable
+    @Singleton
+    @Replaces(PublisherFactory.class)
+    Publisher createPublisher() {
+        return new MockPublisher();
+    }
+}
+
+class MockPublisher implements Publisher {}
+
+interface Publisher {}
+interface PublisherFactory {
+    Publisher createPublisher();
+}   
+class ConcretePublisher implements Publisher {}
+
+@Singleton
+class DefaultPublisherFactory implements PublisherFactory {
+    public Publisher createPublisher() {
+        return new ConcretePublisher();
+    }
+}
+''')
+        def bean = getBean(context, 'factinhertest.Publisher')
+        BeanDefinition definition = context.getBeanDefinition(
+                context.classLoader.loadClass('factinhertest.Publisher')
+        )
+
+        expect:
+        bean instanceof InterceptedProxy
+        bean.interceptedTarget().getClass().simpleName == 'MockPublisher'
+        definition.getClass().name.contains('MyMockPublisherFactory')
+    }
+}

--- a/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -365,7 +365,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
             if (uniqueIdentifier == null) {
                 throw new IllegalArgumentException("Factory methods require passing a unique identifier");
             }
-            final ClassElement declaringType = factoryMethodElement.getDeclaringType();
+            final ClassElement declaringType = factoryMethodElement.getOwningType();
             this.beanDefinitionName = declaringType.getPackageName() + ".$" + declaringType.getSimpleName() + "$" + upperCaseMethodName + uniqueIdentifier + "Definition";
         } else if (beanProducingElement instanceof FieldElement) {
             inheritTypeLevelRequirements(beanProducingElement);
@@ -382,7 +382,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
             if (uniqueIdentifier == null) {
                 throw new IllegalArgumentException("Factory fields require passing a unique identifier");
             }
-            final ClassElement declaringType = factoryMethodElement.getDeclaringType();
+            final ClassElement declaringType = factoryMethodElement.getOwningType();
             this.beanDefinitionName = declaringType.getPackageName() + ".$" + declaringType.getSimpleName() + "$" + fieldName + uniqueIdentifier + "Definition";
         } else if (beanProducingElement instanceof BeanElementBuilder) {
             BeanElementBuilder beanElementBuilder = (BeanElementBuilder) beanProducingElement;


### PR DESCRIPTION
Fixes #5704