### PR TITLE
Remove calling Closeable.close() automatically

### DIFF
--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -54,7 +54,6 @@ import jakarta.inject.Singleton;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.Closeable;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.*;
@@ -4271,13 +4270,6 @@ public class DefaultBeanContext implements BeanContext {
             final BT beanToDestroy = getBean();
             if (definition instanceof DisposableBeanDefinition) {
                 ((DisposableBeanDefinition<BT>) definition).dispose(DefaultBeanContext.this, beanToDestroy);
-            }
-            if (beanToDestroy instanceof Closeable) {
-                try {
-                    ((Closeable) beanToDestroy).close();
-                } catch (Throwable e) {
-                    throw new BeanDestructionException(definition, e);
-                }
             }
             if (beanToDestroy instanceof LifeCycle) {
                 try {


### PR DESCRIPTION
When implementing the disposable bean logic for 3.0.x I misinterpreted the code in 2.5.x the called `Closeable.close()`:

https://github.com/micronaut-projects/micronaut-core/blob/83c2af30d3076e5bba461024b6638321e8c9d1b5/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java#L295-L303

The `instanceof` check applies to the bean definition and not the bean itself. I am not sure there is ever a case whereby a `BeanDefinition` implements `Closeable` so this logic seems completely unnecessary. In general we should not be calling `close()` automatically without the presence of a `@PreDestroy` annotation.

This is causing exceptions in the cache module so I simply removed this logic completely since it seems pointless.