### PR TITLE
Make javax.persistence.Entity require all access reflection

### DIFF
--- a/graal/build.gradle
+++ b/graal/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation project(":http")
     testImplementation project(":inject-java-test")
     testImplementation dependencyModuleVersion("groovy", "groovy-json")
-
+    testImplementation "javax.persistence:javax.persistence-api:2.2"
     testAnnotationProcessor project(":inject-java")
 }

--- a/graal/src/test/groovy/io/micronaut/graal/reflect/GraalTypeElementVisitorSpec.groovy
+++ b/graal/src/test/groovy/io/micronaut/graal/reflect/GraalTypeElementVisitorSpec.groovy
@@ -236,6 +236,37 @@ class Test {
         reader.close()
     }
 
+    void "test write reflect.json for @Entity with classes"() {
+        given:
+        Reader reader = readGenerated("native-image/test/test/reflect-config.json", 'test.Test', '''
+package test;
+
+
+@javax.persistence.Entity
+class Test {
+
+}
+''')
+
+        when:
+        def json = new JsonSlurper().parse(reader)
+        json = json.sort { it.name }
+        def entry = json?.find { it.name == 'test.Test'}
+
+        then:
+        entry
+        entry.name == 'test.Test'
+        entry.allDeclaredFields
+        entry.allPublicMethods
+        entry.allDeclaredConstructors
+        entry.methods
+        entry.methods[0].name == '<init>'
+        entry.methods[0].parameterTypes == []
+
+        cleanup:
+        reader.close()
+    }
+
     void "test write reflect.json for @ReflectiveAccess with enums"() {
         given:
         Reader reader = readGenerated("native-image/test/test/reflect-config.json", 'test.Test', '''

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectorSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectorSpec.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.inject.visitor.beans
 
 import io.micronaut.core.annotation.Introspected
+import io.micronaut.core.annotation.ReflectiveAccess
 import io.micronaut.core.beans.BeanIntrospection
 import io.micronaut.core.beans.BeanIntrospector
 import spock.lang.PendingFeature
@@ -42,6 +43,7 @@ class BeanIntrospectorSpec extends Specification {
         BeanIntrospection<TestEntity> introspection = BeanIntrospection.getIntrospection(TestEntity)
 
         expect:
+        introspection.hasAnnotation(ReflectiveAccess)
         introspection.getProperty("id").get().hasAnnotation(Id)
         !introspection.getProperty("id").get().hasAnnotation(Entity)
         !introspection.getProperty("id").get().hasStereotype(Entity)

--- a/inject/src/main/java/io/micronaut/inject/beans/visitor/EntityIntrospectedAnnotationMapper.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/visitor/EntityIntrospectedAnnotationMapper.java
@@ -18,11 +18,13 @@ package io.micronaut.inject.beans.visitor;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.AnnotationValueBuilder;
 import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.ReflectiveAccess;
 import io.micronaut.inject.annotation.NamedAnnotationMapper;
 import io.micronaut.inject.visitor.VisitorContext;
 
 import io.micronaut.core.annotation.NonNull;
 import java.lang.annotation.Annotation;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -45,8 +47,9 @@ public class EntityIntrospectedAnnotationMapper implements NamedAnnotationMapper
         final AnnotationValueBuilder<Introspected> builder = AnnotationValue.builder(Introspected.class)
                 // don't bother with transients properties
                 .member("excludedAnnotations", "javax.persistence.Transient"); // <2>
-        return Collections.singletonList(
-                builder.build()
+        return Arrays.asList(
+                builder.build(),
+                AnnotationValue.builder(ReflectiveAccess.class).build()
         );
     }
 }


### PR DESCRIPTION
The change to make `@Introspected` no longer require reflection broke the Hibernate integration. This change restores the behaviour that `@Entity` means you want reflective access to the entity.