### PR TITLE
Register inner classes of classes annotated with @ReflectiveAccess

### DIFF
--- a/graal/src/main/java/io/micronaut/graal/reflect/GraalTypeElementVisitor.java
+++ b/graal/src/main/java/io/micronaut/graal/reflect/GraalTypeElementVisitor.java
@@ -130,7 +130,9 @@ public class GraalTypeElementVisitor implements TypeElementVisitor<Object, Objec
                 final String beanName = element.getName();
                 addBean(beanName);
                 resolveClassData(beanName + "[]");
-            } else if (element.hasAnnotation(TypeHint.class)) {
+            }
+
+            if (element.hasAnnotation(TypeHint.class)) {
                 originatingElements.add(element);
                 packages.add(element.getPackageName());
                 final String[] introspectedClasses = element.stringValues(TypeHint.class);
@@ -147,7 +149,9 @@ public class GraalTypeElementVisitor implements TypeElementVisitor<Object, Objec
                         String[].class).orElse(StringUtils.EMPTY_STRING_ARRAY
                         )
                 );
-            } else if (element.hasAnnotation(Import.class)) {
+            }
+
+            if (element.hasAnnotation(Import.class)) {
                 final List<ClassElement> beanElements = BeanImportVisitor.collectInjectableElements(element, context);
                 for (ClassElement beanElement : beanElements) {
                     final MethodElement constructor = beanElement.getPrimaryConstructor().orElse(null);
@@ -173,6 +177,17 @@ public class GraalTypeElementVisitor implements TypeElementVisitor<Object, Objec
                 MethodElement me = element.getPrimaryConstructor().orElse(null);
                 if (me != null && me.isPrivate() && !me.hasAnnotation(ReflectiveAccess.class)) {
                     processMethodElement(me);
+                }
+            }
+
+            if (element.isInner()) {
+                ClassElement enclosingType = element.getEnclosingType().orElse(null);
+                if (enclosingType != null && enclosingType.hasAnnotation(ReflectiveAccess.class)) {
+                    originatingElements.add(enclosingType);
+                    packages.add(enclosingType.getPackageName());
+                    final String beanName = element.getName();
+                    addBean(beanName);
+                    resolveClassData(beanName + "[]");
                 }
             }
         }

--- a/graal/src/test/groovy/io/micronaut/graal/reflect/GraalTypeElementVisitorSpec.groovy
+++ b/graal/src/test/groovy/io/micronaut/graal/reflect/GraalTypeElementVisitorSpec.groovy
@@ -283,6 +283,10 @@ package test;
 @javax.persistence.Entity
 class Test {
 
+
+    enum InnerEnum {
+        ONE, TWO;
+    }
 }
 ''')
 
@@ -300,6 +304,7 @@ class Test {
         entry.methods
         entry.methods[0].name == '<init>'
         entry.methods[0].parameterTypes == []
+        json?.find { it.name == 'test.Test$InnerEnum'}
 
         cleanup:
         reader.close()

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyClassElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyClassElement.java
@@ -358,6 +358,27 @@ public class GroovyClassElement extends AbstractGroovyElement implements Arrayab
     }
 
     @Override
+    public Optional<ClassElement> getEnclosingType() {
+        if (isInner()) {
+            ClassNode outerClass = classNode.getOuterClass();
+            if (outerClass != null) {
+                return Optional.of(
+                        visitorContext.getElementFactory()
+                            .newClassElement(
+                                    outerClass,
+                                    AstAnnotationUtils.getAnnotationMetadata(
+                                            sourceUnit,
+                                            compilationUnit,
+                                            outerClass
+                                    )
+                            )
+                );
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
     public boolean isInterface() {
         return classNode.isInterface();
     }

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
@@ -821,6 +821,20 @@ public class JavaClassElement extends AbstractJavaElement implements ArrayableCl
         return createMethodElement(annotationUtils, method);
     }
 
+    @Override
+    public Optional<ClassElement> getEnclosingType() {
+        if (isInner()) {
+            Element enclosingElement = this.classElement.getEnclosingElement();
+            if (enclosingElement instanceof TypeElement) {
+                return Optional.of(visitorContext.getElementFactory().newClassElement(
+                        ((TypeElement) enclosingElement),
+                        visitorContext.getAnnotationUtils().getAnnotationMetadata(enclosingElement)
+                ));
+            }
+        }
+        return Optional.empty();
+    }
+
     private Optional<MethodElement> createMethodElement(AnnotationUtils annotationUtils, ExecutableElement method) {
         return Optional.ofNullable(method).map(executableElement -> {
             final AnnotationMetadata annotationMetadata = annotationUtils.getAnnotationMetadata(executableElement);

--- a/inject/src/main/java/io/micronaut/inject/ast/ClassElement.java
+++ b/inject/src/main/java/io/micronaut/inject/ast/ClassElement.java
@@ -202,6 +202,16 @@ public interface ClassElement extends TypedElement {
     }
 
     /**
+     * Returns the enclosing type if {@link #isInner()} return {@code true}.
+     *
+     * @return The enclosing type if any
+     * @since 3.0.0
+     */
+    default Optional<ClassElement> getEnclosingType() {
+        return Optional.empty();
+    }
+
+    /**
      * Return the first enclosed element matching the given query.
      *
      * @param query The query to use.


### PR DESCRIPTION
In previous versions of Micronaut the handling of `@Introspected` produced reflective metadata for inner enums.

Since the changes to remove reflective access from introspected this is no longer the case. This restores the previous behaviour for `@Entity` with inner classes that is causing the Micronaut SQL tests to fail.