### PR TITLE
fix: onError emit closeBracket if openBracket sent

### DIFF
--- a/http-client/src/test/groovy/io/micronaut/http/client/StreamRequestSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/StreamRequestSpec.groovy
@@ -233,8 +233,8 @@ class StreamRequestSpec extends Specification {
         )), Book).toList().blockingGet()
 
         then:
-        def e= thrown(RuntimeException) // TODO: this should be HttpClientException
-        e != null
+        noExceptionThrown()
+        result.size() == 3
 
     }
 

--- a/http-netty/src/main/java/io/micronaut/http/netty/stream/JsonSubscriber.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/stream/JsonSubscriber.java
@@ -57,6 +57,9 @@ public final class JsonSubscriber implements Subscriber<HttpContent> {
 
     @Override
     public void onError(Throwable t) {
+        if (!empty.get()) {
+            upstream.onNext(HttpContentUtil.closeBracket());
+        }
         upstream.onError(t);
     }
 

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/reactivesequence/ReactiveSequenceSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/reactivesequence/ReactiveSequenceSpec.groovy
@@ -44,6 +44,8 @@ class ReactiveSequenceSpec extends Specification {
         EmbeddedServer inventoryEmbeddedServer = ApplicationContext.run(EmbeddedServer, inventoryConfig)
         EmbeddedServer booksEmbeddedServer = ApplicationContext.run(EmbeddedServer, booksConfig)
         Map<String, Object> conf = gatewayConfig + [
+                'micronaut.http.client.read-idle-timeout': '5s',
+                'micronaut.http.client.read-timeout': '5s',
                 'micronaut.http.services.books.url': booksEmbeddedServer.getURL().toString(),
                 'micronaut.http.services.inventory.url': inventoryEmbeddedServer.getURL().toString(),
         ]
@@ -102,7 +104,7 @@ class ReactiveSequenceSpec extends Specification {
                 return HttpResponse.ok(2)
             } else if (isbn.equals("1680502395")) {
                 if (timeout) {
-                    sleep(35_0000) // sleep for 35 seconds to ensure HTTP Clients timeout when calling
+                    sleep(8_0000) // sleep for 8 seconds to ensure HTTP Clients timeout when calling
                 }
                 return HttpResponse.ok(3)
             } else {

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/reactivesequence/ReactiveSequenceSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/reactivesequence/ReactiveSequenceSpec.groovy
@@ -2,6 +2,7 @@ package io.micronaut.http.server.netty.reactivesequence
 
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Requires
+import io.micronaut.core.async.annotation.SingleResult
 import io.micronaut.core.type.Argument
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponse
@@ -10,42 +11,69 @@ import io.micronaut.http.annotation.Consumes
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Produces
-import io.micronaut.http.client.DefaultHttpClientConfiguration
-import io.micronaut.http.client.HttpClientConfiguration
-import io.micronaut.http.client.RxHttpClient
+import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.runtime.server.EmbeddedServer
 import io.reactivex.Flowable
-import io.reactivex.Maybe
+import org.reactivestreams.Publisher
+import spock.lang.Shared
 import spock.lang.Specification
-import java.time.Duration
 
 class ReactiveSequenceSpec extends Specification {
 
-    void "test reactive sequence"() {
+    @Shared
+    Map<String, Object> inventoryConfig = [
+            'micronaut.application.name': 'inventory',
+            "spec.name":  "ReactiveSequenceSpec.inventory",
+    ]
+
+    @Shared
+    Map<String, Object> booksConfig = [
+            'micronaut.application.name': 'books',
+            "spec.name":  "ReactiveSequenceSpec.books",
+    ]
+
+    @Shared
+    Map<String, Object> gatewayConfig = [
+            "spec.name":  "ReactiveSequenceSpec.gateway",
+            'micronaut.application.name': 'gateway',
+    ]
+
+    void "test reactive sequence with timeout"() {
         given:
-        Map<String, Object> inventoryConfig = [
-                'micronaut.application.name': 'inventory',
-                "spec.name":  "ReactiveSequenceSpec.inventory",
-        ]
         EmbeddedServer inventoryEmbeddedServer = ApplicationContext.run(EmbeddedServer, inventoryConfig)
-
-        Map<String, Object> booksConfig = [
-                'micronaut.application.name': 'books',
-                "spec.name":  "ReactiveSequenceSpec.books",
-        ]
         EmbeddedServer booksEmbeddedServer = ApplicationContext.run(EmbeddedServer, booksConfig)
-
-        Map<String, Object> gatewayConfig = [
-                "spec.name":  "ReactiveSequenceSpec.gateway",
-                'micronaut.application.name': 'gateway',
+        Map<String, Object> conf = gatewayConfig + [
                 'micronaut.http.services.books.url': booksEmbeddedServer.getURL().toString(),
                 'micronaut.http.services.inventory.url': inventoryEmbeddedServer.getURL().toString(),
         ]
-        EmbeddedServer gatewayEmbeddedServer = ApplicationContext.run(EmbeddedServer, gatewayConfig)
-        HttpClientConfiguration configuration = new DefaultHttpClientConfiguration()
-        configuration.setReadTimeout(Duration.ofSeconds(30))
-        RxHttpClient gatewayClient = gatewayEmbeddedServer.applicationContext.createBean(RxHttpClient, gatewayEmbeddedServer.getURL(), configuration)
+        EmbeddedServer gatewayEmbeddedServer = ApplicationContext.run(EmbeddedServer, conf)
+
+        when:
+        InventoryController inventoryController = inventoryEmbeddedServer.applicationContext.getBean(InventoryController)
+        inventoryController.timeout = true
+        HttpClient gatewayClient = gatewayEmbeddedServer.applicationContext.createBean(HttpClient, gatewayEmbeddedServer.getURL())
+        gatewayClient.toBlocking().retrieve(HttpRequest.GET("/api/gateway"), Argument.listOf(Book))
+
+        then:
+        noExceptionThrown()
+
+        cleanup:
+        inventoryEmbeddedServer.close()
+        booksEmbeddedServer.close()
+        gatewayEmbeddedServer.close()
+    }
+
+    void "test reactive sequence"() {
+        given:
+        EmbeddedServer inventoryEmbeddedServer = ApplicationContext.run(EmbeddedServer, inventoryConfig)
+        EmbeddedServer booksEmbeddedServer = ApplicationContext.run(EmbeddedServer, booksConfig)
+        Map<String, Object> conf = gatewayConfig + [
+                'micronaut.http.services.books.url': booksEmbeddedServer.getURL().toString(),
+                'micronaut.http.services.inventory.url': inventoryEmbeddedServer.getURL().toString(),
+        ]
+        EmbeddedServer gatewayEmbeddedServer = ApplicationContext.run(EmbeddedServer, conf)
+        HttpClient gatewayClient = gatewayEmbeddedServer.applicationContext.createBean(HttpClient, gatewayEmbeddedServer.getURL())
 
         when:
         List<Book> books = gatewayClient.toBlocking().retrieve(HttpRequest.GET("/api/gateway"), Argument.listOf(Book))
@@ -65,15 +93,20 @@ class ReactiveSequenceSpec extends Specification {
     @Controller("/api")
     static class InventoryController {
 
+        boolean timeout
+
         @Produces(MediaType.TEXT_PLAIN)
         @Get("/inventory/{isbn}")
         HttpResponse<Integer> inventory(String isbn) {
             if (isbn.equals("1491950358")) {
-                return HttpResponse.ok(2);
+                return HttpResponse.ok(2)
             } else if (isbn.equals("1680502395")) {
-                return HttpResponse.ok(3);
+                if (timeout) {
+                    sleep(35_0000) // sleep for 35 seconds to ensure HTTP Clients timeout when calling
+                }
+                return HttpResponse.ok(3)
             } else {
-                return HttpResponse.notFound();
+                return HttpResponse.notFound()
             }
         }
     }
@@ -83,8 +116,10 @@ class ReactiveSequenceSpec extends Specification {
     static class BooksController {
         @Get("/books")
         List<Book> list() {
-            return Arrays.asList(new Book("1491950358", "Building Microservices"),
-                    new Book("1680502395", "Release It!"));
+            [
+                    new Book("1491950358", "Building Microservices"),
+                    new Book("1680502395", "Release It!")
+            ]
         }
     }
 
@@ -102,16 +137,16 @@ class ReactiveSequenceSpec extends Specification {
         }
 
         @Get("/gateway")
-        Flowable<Book> findAll() {
-            return booksClient.fetchBooks()
-                    .flatMapMaybe({ b ->
-                        inventoryClient.inventory(b.getIsbn())
+        Publisher<Book> findAll() {
+            Flowable.fromPublisher(booksClient.fetchBooks())
+                    .flatMapMaybe(b -> {
+                        Flowable.fromPublisher(inventoryClient.inventory(b.getIsbn())).singleElement()
                                 .filter({ stock -> stock > 0 })
                                 .map({ stock ->
                                     b.setStock(stock);
-                                    return b;
+                                    return b
                                 })
-                    });
+                    })
         }
     }
 
@@ -119,16 +154,16 @@ class ReactiveSequenceSpec extends Specification {
     @Client("books")
     static interface BooksClient {
         @Get("/api/books")
-        Flowable<Book> fetchBooks();
+        Publisher<Book> fetchBooks()
     }
 
     @Requires(property = "spec.name", value = "ReactiveSequenceSpec.gateway")
     @Client("inventory")
     static interface InventoryClient {
-
         @Consumes(MediaType.TEXT_PLAIN)
         @Get("/api/inventory/{isbn}")
-        Maybe<Integer> inventory(String isbn);
+        @SingleResult
+        Publisher<Integer> inventory(String isbn)
     }
 
     static class Book {


### PR DESCRIPTION
- test: extract config to @Shared
- rewrite test to avoid rxjava2 types in controller

This PR changes JsonSubscriber to emit the close bracket `]` when an error happens if an open bracket was already emitted `[`. 

Without this change the test added in this PR fails with: 

```
12:39:15.385 [default-nioEventLoopGroup-4-7] ERROR i.m.h.n.stream.HttpStreamsHandler - Error occurred writing stream response: Read Timeout
io.micronaut.http.client.exceptions.ReadTimeoutException: Read Timeout
	at io.micronaut.http.client.exceptions.ReadTimeoutException.<clinit>(ReadTimeoutException.java:26)
	at io.micronaut.http.client.netty.DefaultHttpClient$11.exceptionCaught(DefaultHttpClient.java:2301)
	at io.netty.channel.AbstractChannelHandlerContext.invokeExceptionCaught(AbstractChannelHandlerContext.java:302)
	at io.netty.channel.AbstractChannelHandlerContext.invokeExceptionCaught(AbstractChannelHandlerContext.java:281)
	at io.netty.channel.AbstractChannelHandlerContext.fireExceptionCaught(AbstractChannelHandlerContext.java:273)
	at io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireExceptionCaught(CombinedChannelDuplexHandler.java:424)
	at io.netty.channel.ChannelHandlerAdapter.exceptionCaught(ChannelHandlerAdapter.java:92)
	at io.netty.channel.CombinedChannelDuplexHandler$1.fireExceptionCaught(CombinedChannelDuplexHandler.java:145)
	at io.netty.channel.ChannelInboundHandlerAdapter.exceptionCaught(ChannelInboundHandlerAdapter.java:143)
	at io.netty.channel.CombinedChannelDuplexHandler.exceptionCaught(CombinedChannelDuplexHandler.java:231)
	at io.netty.channel.AbstractChannelHandlerContext.invokeExceptionCaught(AbstractChannelHandlerContext.java:302)
	at io.netty.channel.AbstractChannelHandlerContext.invokeExceptionCaught(AbstractChannelHandlerContext.java:281)
	at io.netty.channel.AbstractChannelHandlerContext.fireExceptionCaught(AbstractChannelHandlerContext.java:273)
	at io.netty.handler.timeout.ReadTimeoutHandler.readTimedOut(ReadTimeoutHandler.java:98)
	at io.netty.handler.timeout.ReadTimeoutHandler.channelIdle(ReadTimeoutHandler.java:90)
	at io.netty.handler.timeout.IdleStateHandler$ReaderIdleTimeoutTask.run(IdleStateHandler.java:504)
	at io.netty.handler.timeout.IdleStateHandler$AbstractIdleTask.run(IdleStateHandler.java:476)
	at io.netty.util.concurrent.PromiseTask.runTask(PromiseTask.java:98)
	at io.netty.util.concurrent.ScheduledFutureTask.run(ScheduledFutureTask.java:170)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:500)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:829)

Expected no exception to be thrown, but got 'io.micronaut.http.client.exceptions.HttpClientResponseException'
Expected no exception to be thrown, but got 'io.micronaut.http.client.exceptions.HttpClientResponseException'
	at spock.lang.Specification.noExceptionThrown(Specification.java:118)
	at io.micronaut.http.server.netty.reactivesequence.ReactiveSequenceSpec.test reactive sequence with timeout(ReactiveSequenceSpec.groovy:59)
Caused by: io.micronaut.http.client.exceptions.HttpClientResponseException: Error decoding HTTP response body: Error decoding stream for type [interface java.util.List]: Unexpected end-of-input: expected close marker for Array (start marker at [Source: (byte[])"[{"isbn":"1491950358","name":"Building Microservices","stock":2}"; line: 1, column: 1])
 at [Source: (byte[])"[{"isbn":"1491950358","name":"Building Microservices","stock":2}"; line: 1, column: 65]
	at io.micronaut.http.client.netty.DefaultHttpClient$11.channelReadInstrumented(DefaultHttpClient.java:2191)
	at io.micronaut.http.client.netty.DefaultHttpClient$11.channelReadInstrumented(DefaultHttpClient.java:2061)
	at io.micronaut.http.client.netty.DefaultHttpClient$SimpleChannelInboundHandlerInstrumented.channelRead0(DefaultHttpClient.java:2765)
	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:99)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.micronaut.http.netty.stream.HttpStreamsHandler.channelRead(HttpStreamsHandler.java:194)
	at io.micronaut.http.netty.stream.HttpStreamsClientHandler.channelRead(HttpStreamsClientHandler.java:183)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireChannelRead(CombinedChannelDuplexHandler.java:436)
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:324)
	at io.netty.handler.codec.ByteToMessageDecoder.channelInputClosed(ByteToMessageDecoder.java:383)
	at io.netty.handler.codec.ByteToMessageDecoder.channelInactive(ByteToMessageDecoder.java:354)
	at io.netty.handler.codec.http.HttpClientCodec$Decoder.channelInactive(HttpClientCodec.java:311)
	at io.netty.channel.CombinedChannelDuplexHandler.channelInactive(CombinedChannelDuplexHandler.java:221)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:262)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:248)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelInactive(AbstractChannelHandlerContext.java:241)
	at io.netty.channel.ChannelInboundHandlerAdapter.channelInactive(ChannelInboundHandlerAdapter.java:81)
	at io.netty.handler.timeout.IdleStateHandler.channelInactive(IdleStateHandler.java:277)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:262)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:248)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelInactive(AbstractChannelHandlerContext.java:241)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelInactive(DefaultChannelPipeline.java:1405)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:262)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:248)
	at io.netty.channel.DefaultChannelPipeline.fireChannelInactive(DefaultChannelPipeline.java:901)
	at io.netty.channel.AbstractChannel$AbstractUnsafe$8.run(AbstractChannel.java:831)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:497)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: io.micronaut.http.codec.CodecException: Error decoding stream for type [interface java.util.List]: Unexpected end-of-input: expected close marker for Array (start marker at [Source: (byte[])"[{"isbn":"1491950358","name":"Building Microservices","stock":2}"; line: 1, column: 1])
 at [Source: (byte[])"[{"isbn":"1491950358","name":"Building Microservices","stock":2}"; line: 1, column: 65]
	at io.micronaut.jackson.codec.JacksonMediaTypeCodec.decode(JacksonMediaTypeCodec.java:209)
	at io.micronaut.http.client.netty.FullNettyClientHttpResponse.convertByteBuf(FullNettyClientHttpResponse.java:280)
	at io.micronaut.http.client.netty.FullNettyClientHttpResponse.lambda$getBody$1(FullNettyClientHttpResponse.java:218)
	at java.base/java.util.HashMap.computeIfAbsent(HashMap.java:1133)
	at io.micronaut.http.client.netty.FullNettyClientHttpResponse.getBody(FullNettyClientHttpResponse.java:192)
	at io.micronaut.http.client.netty.FullNettyClientHttpResponse.<init>(FullNettyClientHttpResponse.java:111)
	at io.micronaut.http.client.netty.DefaultHttpClient$11.channelReadInstrumented(DefaultHttpClient.java:2121)
	... 45 more
Caused by: com.fasterxml.jackson.core.io.JsonEOFException: Unexpected end-of-input: expected close marker for Array (start marker at [Source: (byte[])"[{"isbn":"1491950358","name":"Building Microservices","stock":2}"; line: 1, column: 1])
 at [Source: (byte[])"[{"isbn":"1491950358","name":"Building Microservices","stock":2}"; line: 1, column: 65]
	at com.fasterxml.jackson.core.base.ParserMinimalBase._reportInvalidEOF(ParserMinimalBase.java:662)
	at com.fasterxml.jackson.core.base.ParserBase._handleEOF(ParserBase.java:490)
	at com.fasterxml.jackson.core.base.ParserBase._eofAsNextChar(ParserBase.java:502)
	at com.fasterxml.jackson.core.json.UTF8StreamJsonParser._skipWSOrEnd(UTF8StreamJsonParser.java:2994)
	at com.fasterxml.jackson.core.json.UTF8StreamJsonParser.nextToken(UTF8StreamJsonParser.java:724)
	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer._deserializeFromArray(CollectionDeserializer.java:338)
	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:244)
	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:28)
	at com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:322)
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4593)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3643)
	at io.micronaut.jackson.codec.JacksonMediaTypeCodec.decode(JacksonMediaTypeCodec.java:204)
	... 51 more
```

After this change the test passes. It emits the closing bracket is emitted and logs the error: 

```
12:42:09.650 [Test worker] INFO  i.m.context.env.DefaultEnvironment - Established active environments: [test]
12:42:20.408 [default-nioEventLoopGroup-4-7] ERROR i.m.h.n.stream.HttpStreamsHandler - Error occurred writing stream response: Read Timeout
io.micronaut.http.client.exceptions.ReadTimeoutException: Read Timeout
	at io.micronaut.http.client.exceptions.ReadTimeoutException.<clinit>(ReadTimeoutException.java:26)
	at io.micronaut.http.client.netty.DefaultHttpClient$11.exceptionCaught(DefaultHttpClient.java:2301)
	at io.netty.channel.AbstractChannelHandlerContext.invokeExceptionCaught(AbstractChannelHandlerContext.java:302)
	at io.netty.channel.AbstractChannelHandlerContext.invokeExceptionCaught(AbstractChannelHandlerContext.java:281)
	at io.netty.channel.AbstractChannelHandlerContext.fireExceptionCaught(AbstractChannelHandlerContext.java:273)
	at io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireExceptionCaught(CombinedChannelDuplexHandler.java:424)
	at io.netty.channel.ChannelHandlerAdapter.exceptionCaught(ChannelHandlerAdapter.java:92)
	at io.netty.channel.CombinedChannelDuplexHandler$1.fireExceptionCaught(CombinedChannelDuplexHandler.java:145)
	at io.netty.channel.ChannelInboundHandlerAdapter.exceptionCaught(ChannelInboundHandlerAdapter.java:143)
	at io.netty.channel.CombinedChannelDuplexHandler.exceptionCaught(CombinedChannelDuplexHandler.java:231)
	at io.netty.channel.AbstractChannelHandlerContext.invokeExceptionCaught(AbstractChannelHandlerContext.java:302)
	at io.netty.channel.AbstractChannelHandlerContext.invokeExceptionCaught(AbstractChannelHandlerContext.java:281)
	at io.netty.channel.AbstractChannelHandlerContext.fireExceptionCaught(AbstractChannelHandlerContext.java:273)
	at io.netty.handler.timeout.ReadTimeoutHandler.readTimedOut(ReadTimeoutHandler.java:98)
	at io.netty.handler.timeout.ReadTimeoutHandler.channelIdle(ReadTimeoutHandler.java:90)
	at io.netty.handler.timeout.IdleStateHandler$ReaderIdleTimeoutTask.run(IdleStateHandler.java:504)
	at io.netty.handler.timeout.IdleStateHandler$AbstractIdleTask.run(IdleStateHandler.java:476)
	at io.netty.util.concurrent.PromiseTask.runTask(PromiseTask.java:98)
	at io.netty.util.concurrent.ScheduledFutureTask.run(ScheduledFutureTask.java:170)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:500)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:829)
[0K[1mio.micronaut.http.server.netty.reactivesequence.ReactiveSequenceSpec[22m test reactive sequence with timeout[32m PASSED[31m (12.5s)[m
[0K[1;32mSUCCESS: [39mExecuted 1 tests in 13.6s[m
BUILD SUCCESSFUL in 29s
```

This issue may be the issue that is causing the failure of the guides since 2.5.6 in CI. See: https://github.com/micronaut-projects/micronaut-core/issues/5682


I don't know what is the correct behaviour. On the one hand we should end the JSON Array properly, on the other hand with this change we are finish the sequence However, we don't signal to the HTTP Client that an error occurred in the emission. See change I did to `StreamRequestSpec`
