### PR TITLE
Fix Reactor + native image

### DIFF
--- a/aop/src/main/resources/META-INF/native-image/io.micronaut/micronaut-aop/native-image.properties
+++ b/aop/src/main/resources/META-INF/native-image/io.micronaut/micronaut-aop/native-image.properties
@@ -1,0 +1,1 @@
+Args = --initialize-at-run-time=io.micronaut.aop.internal.intercepted.PublisherInterceptedMethod


### PR DESCRIPTION
Ensures `io.micronaut.aop.internal.intercepted.PublisherInterceptedMethod` is initialized at runtime in native image