### PR TITLE
Fix Reactor support for GraalVM

### DIFF
--- a/core-reactive/src/main/resources/META-INF/native-image/io.micronaut/micronaut-core-reactive/native-image.properties
+++ b/core-reactive/src/main/resources/META-INF/native-image/io.micronaut/micronaut-core-reactive/native-image.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2017-2021 original authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Args = --initialize-at-run-time=io.micronaut.core.async.publisher.Publishers


### PR DESCRIPTION
Follow up on #5749 

@graemerocher With the changes you did in the previous PR I'm unable to build the native image for the "management" application for Micronaut 3.0.x. With this PR I can.

I'm targeting `2.5.x` branch because the original PR also targets it.
