### PR TITLE
replace deprecated Jackson PropertyNamingStrategy

### DIFF
--- a/runtime/src/main/java/io/micronaut/jackson/JacksonConfiguration.java
+++ b/runtime/src/main/java/io/micronaut/jackson/JacksonConfiguration.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.type.TypeFactory;
@@ -52,7 +53,7 @@ import java.util.TimeZone;
 @ConfigurationProperties("jackson")
 @TypeHint(
         value = {
-                PropertyNamingStrategy.UpperCamelCaseStrategy.class,
+                PropertyNamingStrategies.UpperCamelCaseStrategy.class,
                 ArrayList.class,
                 LinkedHashMap.class,
                 HashSet.class

--- a/runtime/src/main/java/io/micronaut/jackson/convert/JacksonConverterRegistrar.java
+++ b/runtime/src/main/java/io/micronaut/jackson/convert/JacksonConverterRegistrar.java
@@ -136,6 +136,9 @@ public class JacksonConverterRegistrar implements TypeConverterRegistrar {
                                 case "LOWER_CAMEL_CASE":
                                     propertyNamingStrategy = PropertyNamingStrategies.LOWER_CAMEL_CASE;
                                     break;
+                                case "LOWER_DOT_CASE":
+                                    propertyNamingStrategy = PropertyNamingStrategies.LOWER_DOT_CASE;
+                                    break;
                                 default:
                                     break;
                             }

--- a/runtime/src/main/java/io/micronaut/jackson/convert/JacksonConverterRegistrar.java
+++ b/runtime/src/main/java/io/micronaut/jackson/convert/JacksonConverterRegistrar.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ContainerNode;
@@ -121,19 +122,19 @@ public class JacksonConverterRegistrar implements TypeConverterRegistrar {
                         if (StringUtils.isNotEmpty(stringValue)) {
                             switch (stringValue) {
                                 case "SNAKE_CASE":
-                                    propertyNamingStrategy = PropertyNamingStrategy.SNAKE_CASE;
+                                    propertyNamingStrategy = PropertyNamingStrategies.SNAKE_CASE;
                                     break;
                                 case "UPPER_CAMEL_CASE":
-                                    propertyNamingStrategy = PropertyNamingStrategy.UPPER_CAMEL_CASE;
+                                    propertyNamingStrategy = PropertyNamingStrategies.UPPER_CAMEL_CASE;
                                     break;
                                 case "LOWER_CASE":
-                                    propertyNamingStrategy = PropertyNamingStrategy.LOWER_CASE;
+                                    propertyNamingStrategy = PropertyNamingStrategies.LOWER_CASE;
                                     break;
                                 case "KEBAB_CASE":
-                                    propertyNamingStrategy = PropertyNamingStrategy.KEBAB_CASE;
+                                    propertyNamingStrategy = PropertyNamingStrategies.KEBAB_CASE;
                                     break;
                                 case "LOWER_CAMEL_CASE":
-                                    propertyNamingStrategy = PropertyNamingStrategy.LOWER_CAMEL_CASE;
+                                    propertyNamingStrategy = PropertyNamingStrategies.LOWER_CAMEL_CASE;
                                     break;
                                 default:
                                     break;

--- a/runtime/src/main/java/io/micronaut/jackson/convert/JacksonConverterRegistrar.java
+++ b/runtime/src/main/java/io/micronaut/jackson/convert/JacksonConverterRegistrar.java
@@ -27,6 +27,8 @@ import com.fasterxml.jackson.databind.node.ContainerNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import io.micronaut.context.BeanProvider;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.bind.ArgumentBinder;
 import io.micronaut.core.bind.BeanPropertyBinder;
 import io.micronaut.core.convert.ArgumentConversionContext;
@@ -114,42 +116,14 @@ public class JacksonConverterRegistrar implements TypeConverterRegistrar {
                 CharSequence.class,
                 PropertyNamingStrategy.class,
                 (charSequence, targetType, context) -> {
-                    PropertyNamingStrategy propertyNamingStrategy = null;
 
-                    if (charSequence != null) {
-                        String stringValue = NameUtils.environmentName(charSequence.toString());
+                    Optional<PropertyNamingStrategy> propertyNamingStrategy = resolvePropertyNamingStrategy(charSequence);
 
-                        if (StringUtils.isNotEmpty(stringValue)) {
-                            switch (stringValue) {
-                                case "SNAKE_CASE":
-                                    propertyNamingStrategy = PropertyNamingStrategies.SNAKE_CASE;
-                                    break;
-                                case "UPPER_CAMEL_CASE":
-                                    propertyNamingStrategy = PropertyNamingStrategies.UPPER_CAMEL_CASE;
-                                    break;
-                                case "LOWER_CASE":
-                                    propertyNamingStrategy = PropertyNamingStrategies.LOWER_CASE;
-                                    break;
-                                case "KEBAB_CASE":
-                                    propertyNamingStrategy = PropertyNamingStrategies.KEBAB_CASE;
-                                    break;
-                                case "LOWER_CAMEL_CASE":
-                                    propertyNamingStrategy = PropertyNamingStrategies.LOWER_CAMEL_CASE;
-                                    break;
-                                case "LOWER_DOT_CASE":
-                                    propertyNamingStrategy = PropertyNamingStrategies.LOWER_DOT_CASE;
-                                    break;
-                                default:
-                                    break;
-                            }
-                        }
-                    }
-
-                    if (propertyNamingStrategy == null) {
+                    if (!propertyNamingStrategy.isPresent()) {
                         context.reject(charSequence, new IllegalArgumentException(String.format("Unable to convert '%s' to a com.fasterxml.jackson.databind.PropertyNamingStrategy", charSequence)));
                     }
 
-                    return Optional.ofNullable(propertyNamingStrategy);
+                    return propertyNamingStrategy;
                 }
         );
     }
@@ -282,5 +256,31 @@ public class JacksonConverterRegistrar implements TypeConverterRegistrar {
                 return Optional.empty();
             }
         };
+    }
+
+    @NonNull
+    private Optional<PropertyNamingStrategy> resolvePropertyNamingStrategy(@Nullable CharSequence charSequence) {
+        if (charSequence != null) {
+            String stringValue = NameUtils.environmentName(charSequence.toString());
+            if (StringUtils.isNotEmpty(stringValue)) {
+                switch (stringValue) {
+                    case "SNAKE_CASE":
+                        return Optional.of(PropertyNamingStrategies.SNAKE_CASE);
+                    case "UPPER_CAMEL_CASE":
+                        return Optional.of(PropertyNamingStrategies.UPPER_CAMEL_CASE);
+                    case "LOWER_CASE":
+                        return Optional.of(PropertyNamingStrategies.LOWER_CASE);
+                    case "KEBAB_CASE":
+                        return Optional.of(PropertyNamingStrategies.KEBAB_CASE);
+                    case "LOWER_CAMEL_CASE":
+                        return Optional.of(PropertyNamingStrategies.LOWER_CAMEL_CASE);
+                    case "LOWER_DOT_CASE":
+                        return Optional.of(PropertyNamingStrategies.LOWER_DOT_CASE);
+                    default:
+                        return Optional.empty();
+                }
+            }
+        }
+        return Optional.empty();
     }
 }

--- a/runtime/src/test/groovy/io/micronaut/jackson/JacksonSetupSpec.groovy
+++ b/runtime/src/test/groovy/io/micronaut/jackson/JacksonSetupSpec.groovy
@@ -122,6 +122,7 @@ class JacksonSetupSpec extends Specification {
         'SNAKE_CASE'                           | PropertyNamingStrategies.SNAKE_CASE
         'UPPER_CAMEL_CASE'                     | PropertyNamingStrategies.UPPER_CAMEL_CASE
         'LOWER_CAMEL_CASE'                     | PropertyNamingStrategies.LOWER_CAMEL_CASE
+        'LOWER_DOT_CASE'                       | PropertyNamingStrategies.LOWER_DOT_CASE
         'LOWER_CASE'                           | PropertyNamingStrategies.LOWER_CASE
         'KEBAB_CASE'                           | PropertyNamingStrategies.KEBAB_CASE
     }

--- a/runtime/src/test/groovy/io/micronaut/jackson/JacksonSetupSpec.groovy
+++ b/runtime/src/test/groovy/io/micronaut/jackson/JacksonSetupSpec.groovy
@@ -16,7 +16,7 @@
 package io.micronaut.jackson
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.PropertyNamingStrategy
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
 import com.fasterxml.jackson.databind.SerializationFeature
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.DefaultApplicationContext
@@ -119,18 +119,18 @@ class JacksonSetupSpec extends Specification {
 
         where:
         configuredJackonPropertyNamingStrategy | expectedPropertyNamingStrategy
-        'SNAKE_CASE'                           | PropertyNamingStrategy.SNAKE_CASE
-        'UPPER_CAMEL_CASE'                     | PropertyNamingStrategy.UPPER_CAMEL_CASE
-        'LOWER_CAMEL_CASE'                     | PropertyNamingStrategy.LOWER_CAMEL_CASE
-        'LOWER_CASE'                           | PropertyNamingStrategy.LOWER_CASE
-        'KEBAB_CASE'                           | PropertyNamingStrategy.KEBAB_CASE
+        'SNAKE_CASE'                           | PropertyNamingStrategies.SNAKE_CASE
+        'UPPER_CAMEL_CASE'                     | PropertyNamingStrategies.UPPER_CAMEL_CASE
+        'LOWER_CAMEL_CASE'                     | PropertyNamingStrategies.LOWER_CAMEL_CASE
+        'LOWER_CASE'                           | PropertyNamingStrategies.LOWER_CASE
+        'KEBAB_CASE'                           | PropertyNamingStrategies.KEBAB_CASE
     }
 
     void "test property naming strategy from yml"() {
         ApplicationContext applicationContext = ApplicationContext.run("jackson")
 
         expect:
-        applicationContext.getBean(JacksonConfiguration).propertyNamingStrategy == PropertyNamingStrategy.SNAKE_CASE
+        applicationContext.getBean(JacksonConfiguration).propertyNamingStrategy == PropertyNamingStrategies.SNAKE_CASE
     }
 
     void "verify trim strings with custom property enabled"() {

--- a/runtime/src/test/groovy/io/micronaut/jackson/bind/CharSequencePropertyNamingStrategyConverterSpec.groovy
+++ b/runtime/src/test/groovy/io/micronaut/jackson/bind/CharSequencePropertyNamingStrategyConverterSpec.groovy
@@ -49,6 +49,7 @@ class CharSequencePropertyNamingStrategyConverterSpec extends Specification {
         'SNAKE_CASE'                | PropertyNamingStrategies.SNAKE_CASE
         'UPPER_CAMEL_CASE'          | PropertyNamingStrategies.UPPER_CAMEL_CASE
         'LOWER_CAMEL_CASE'          | PropertyNamingStrategies.LOWER_CAMEL_CASE
+        'LOWER_DOT_CASE'            | PropertyNamingStrategies.LOWER_DOT_CASE
         'LOWER_CASE'                | PropertyNamingStrategies.LOWER_CASE
         'KEBAB_CASE'                | PropertyNamingStrategies.KEBAB_CASE
     }

--- a/runtime/src/test/groovy/io/micronaut/jackson/bind/CharSequencePropertyNamingStrategyConverterSpec.groovy
+++ b/runtime/src/test/groovy/io/micronaut/jackson/bind/CharSequencePropertyNamingStrategyConverterSpec.groovy
@@ -15,6 +15,7 @@
  */
 package io.micronaut.jackson.bind
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
 import com.fasterxml.jackson.databind.PropertyNamingStrategy
 import io.micronaut.context.ApplicationContext
 import io.micronaut.core.convert.ArgumentConversionContext
@@ -45,11 +46,11 @@ class CharSequencePropertyNamingStrategyConverterSpec extends Specification {
 
         where:
         propertyNaminStrategyString | expectedPropertyNamingStrategy
-        'SNAKE_CASE'                | PropertyNamingStrategy.SNAKE_CASE
-        'UPPER_CAMEL_CASE'          | PropertyNamingStrategy.UPPER_CAMEL_CASE
-        'LOWER_CAMEL_CASE'          | PropertyNamingStrategy.LOWER_CAMEL_CASE
-        'LOWER_CASE'                | PropertyNamingStrategy.LOWER_CASE
-        'KEBAB_CASE'                | PropertyNamingStrategy.KEBAB_CASE
+        'SNAKE_CASE'                | PropertyNamingStrategies.SNAKE_CASE
+        'UPPER_CAMEL_CASE'          | PropertyNamingStrategies.UPPER_CAMEL_CASE
+        'LOWER_CAMEL_CASE'          | PropertyNamingStrategies.LOWER_CAMEL_CASE
+        'LOWER_CASE'                | PropertyNamingStrategies.LOWER_CASE
+        'KEBAB_CASE'                | PropertyNamingStrategies.KEBAB_CASE
     }
 
     @Unroll

--- a/runtime/src/test/groovy/io/micronaut/jackson/modules/BeanIntrospectionModuleSpec.groovy
+++ b/runtime/src/test/groovy/io/micronaut/jackson/modules/BeanIntrospectionModuleSpec.groovy
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.annotation.JsonView
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
 import com.fasterxml.jackson.databind.PropertyNamingStrategy
 import com.fasterxml.jackson.databind.annotation.JsonNaming
 import groovy.transform.EqualsAndHashCode
@@ -540,7 +541,7 @@ class BeanIntrospectionModuleSpec extends Specification {
     static class AllView extends PublicView {}
 
     @Introspected
-    @JsonNaming(PropertyNamingStrategy.UpperCamelCaseStrategy.class)
+    @JsonNaming(value = PropertyNamingStrategies.UpperCamelCaseStrategy.class)
     static class NamingStrategy {
 
         @PackageScope


### PR DESCRIPTION
use Jackson `PropertyNamingStrategies` instead. 

Adds conversion for `PropertyNamingStrategies.LOWER_DOT_CASE` which was previously not covered. 