### PR TITLE
Fix GraalVM warnings

### DIFF
--- a/management/src/main/resources/META-INF/native-image/io.micronaut.management/micronaut-management/native-image.properties
+++ b/management/src/main/resources/META-INF/native-image/io.micronaut.management/micronaut-management/native-image.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2020 original authors
+# Copyright 2017-2021 original authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-Args = --initialize-at-run-time=io.micronaut.validation.exceptions.ValidationExceptionHandler,io.micronaut.validation.exceptions.$ValidationExceptionHandler$Definition
+Args = --initialize-at-run-time=io.micronaut.management.health.indicator.jdbc.$JdbcIndicator$Definition


### PR DESCRIPTION
This PR fixes the following warnings when creating a GraalVM native image with 21.2.0 (to be released today):

```
[basic-app:63176]    classlist:   3,394.94 ms,  0.96 GB
[basic-app:63176]        (cap):     779.18 ms,  0.96 GB
[basic-app:63176]        setup:   3,842.71 ms,  0.96 GB
Warning: class initialization of class io.micronaut.management.health.indicator.jdbc.$JdbcIndicator$Definition failed with exception java.lang.NoClassDefFoundError: io/micronaut/jdbc/DataSourceResolver. This class will be initialized at run time because option --allow-incomplete-classpath is used for image building. Use the option --initialize-at-run-time=io.micronaut.management.health.indicator.jdbc.$JdbcIndicator$Definition to explicitly request delayed initialization of this class.
Warning: class initialization of class io.micronaut.validation.exceptions.$ValidationExceptionHandler$Definition failed with exception java.lang.NoClassDefFoundError: org/grails/datastore/mapping/validation/ValidationException. This class will be initialized at run time because option --allow-incomplete-classpath is used for image building. Use the option --initialize-at-run-time=io.micronaut.validation.exceptions.$ValidationExceptionHandler$Definition to explicitly request delayed initialization of this class.
[basic-app:63176]     (clinit):     989.90 ms,  5.48 GB
[basic-app:63176]   (typeflow):  26,717.21 ms,  5.48 GB
[basic-app:63176]    (objects):  36,669.42 ms,  5.48 GB
...
...
```