### PR TITLE
Fix support for generics and factory beans. Fixes #5786

### DIFF
--- a/core/src/main/java/io/micronaut/core/type/Argument.java
+++ b/core/src/main/java/io/micronaut/core/type/Argument.java
@@ -144,6 +144,15 @@ public interface Argument<T> extends TypeInformation<T>, AnnotatedElement, Type 
     int typeHashCode();
 
     /**
+     * Whether this argument is a type variable used in generics.
+     * @return True if it is a variable
+     * @since 3.0.0
+     */
+    default boolean isVariable() {
+        return false;
+    }
+
+    /**
      * Whether the given argument is an instance.
      * @param o The object
      * @return True if it is an instance of this type
@@ -223,7 +232,43 @@ public interface Argument<T> extends TypeInformation<T>, AnnotatedElement, Type 
         return new DefaultArgument<>(type, name, AnnotationMetadata.EMPTY_METADATA, typeParameters);
     }
 
+    /**
+     * Creates a new argument for the given type and name that is at type variable.
+     *
+     * @param type           The type
+     * @param name           The name
+     * @param annotationMetadata The annotation metadata
+     * @param typeParameters the type parameters
+     * @param <T>            The generic type
+     * @return The argument instance
+     * @since 3.0.0
+     */
+    @UsedByGeneratedCode
+    @NonNull
+    static <T> Argument<T> ofTypeVariable(
+            @NonNull Class<T> type,
+            @Nullable String name,
+            @Nullable AnnotationMetadata annotationMetadata,
+            @Nullable Argument<?>... typeParameters) {
+        return new DefaultArgument<>(type, name, annotationMetadata, true, typeParameters);
+    }
 
+    /**
+     * Creates a new argument for the given type and name that is at type variable.
+     *
+     * @param type           The type
+     * @param name           The name
+     * @param <T>            The generic type
+     * @return The argument instance
+     * @since 3.0.0
+     */
+    @UsedByGeneratedCode
+    @NonNull
+    static <T> Argument<T> ofTypeVariable(
+            @NonNull Class<T> type,
+            @Nullable String name) {
+        return new DefaultArgument<>(type, name, AnnotationMetadata.EMPTY_METADATA, true);
+    }
 
     /**
      * Creates a new argument for the given type and name.

--- a/core/src/main/java/io/micronaut/core/type/Argument.java
+++ b/core/src/main/java/io/micronaut/core/type/Argument.java
@@ -148,7 +148,7 @@ public interface Argument<T> extends TypeInformation<T>, AnnotatedElement, Type 
      * @return True if it is a variable
      * @since 3.0.0
      */
-    default boolean isVariable() {
+    default boolean isTypeVariable() {
         return false;
     }
 

--- a/core/src/main/java/io/micronaut/core/type/DefaultArgument.java
+++ b/core/src/main/java/io/micronaut/core/type/DefaultArgument.java
@@ -173,7 +173,7 @@ public class DefaultArgument<T> implements Argument<T>, ArgumentCoercible<T> {
     }
 
     @Override
-    public boolean isVariable() {
+    public boolean isTypeVariable() {
         return isTypeVar;
     }
 

--- a/core/src/main/java/io/micronaut/core/type/DefaultArgument.java
+++ b/core/src/main/java/io/micronaut/core/type/DefaultArgument.java
@@ -57,6 +57,7 @@ public class DefaultArgument<T> implements Argument<T>, ArgumentCoercible<T> {
     private final Map<String, Argument<?>> typeParameters;
     private final Argument<?>[] typeParameterArray;
     private final AnnotationMetadata annotationMetadata;
+    private final boolean isTypeVar;
 
     /**
      * @param type               The type
@@ -64,7 +65,7 @@ public class DefaultArgument<T> implements Argument<T>, ArgumentCoercible<T> {
      * @param annotationMetadata The annotation metadata
      * @param genericTypes       The generic types
      */
-    public DefaultArgument(Class<T> type, String name, AnnotationMetadata annotationMetadata, Argument... genericTypes) {
+    public DefaultArgument(Class<T> type, String name, AnnotationMetadata annotationMetadata, Argument<?>... genericTypes) {
         this(type,
              name,
              annotationMetadata,
@@ -78,7 +79,7 @@ public class DefaultArgument<T> implements Argument<T>, ArgumentCoercible<T> {
      * @param annotationMetadata The annotation metadata
      * @param genericTypes       The generic types
      */
-    public DefaultArgument(Class<T> type, AnnotationMetadata annotationMetadata, Argument... genericTypes) {
+    public DefaultArgument(Class<T> type, AnnotationMetadata annotationMetadata, Argument<?>... genericTypes) {
         this(type,
                 null,
                 annotationMetadata,
@@ -95,11 +96,41 @@ public class DefaultArgument<T> implements Argument<T>, ArgumentCoercible<T> {
      * @param typeParameterArray The array of arguments
      */
     public DefaultArgument(Class<T> type, String name, AnnotationMetadata annotationMetadata, Map<String, Argument<?>> typeParameters, Argument<?>[] typeParameterArray) {
+        this(type, name, annotationMetadata, typeParameters, typeParameterArray, false);
+    }
+
+    /**
+     * @param type               The type
+     * @param name               The name
+     * @param annotationMetadata The annotation metadata
+     * @param isTypeVariable     Is this argument a type variable
+     * @param genericTypes       The generic types
+     */
+    public DefaultArgument(Class<T> type, String name, AnnotationMetadata annotationMetadata, boolean isTypeVariable, Argument<?>... genericTypes) {
+        this(type,
+                name,
+                annotationMetadata,
+                ArrayUtils.isNotEmpty(genericTypes) ? initializeTypeParameters(genericTypes) : Collections.emptyMap(),
+                genericTypes,
+                isTypeVariable
+        );
+    }
+
+    /**
+     * @param type               The type
+     * @param name               The name
+     * @param annotationMetadata The annotation metadata
+     * @param typeParameters     The map of parameters
+     * @param typeParameterArray The array of arguments
+     * @param isTypeVariable     Is the argument a type variable
+     */
+    protected DefaultArgument(Class<T> type, String name, AnnotationMetadata annotationMetadata, Map<String, Argument<?>> typeParameters, Argument<?>[] typeParameterArray, boolean isTypeVariable) {
         this.type = Objects.requireNonNull(type, "Type cannot be null");
         this.name = name;
         this.annotationMetadata = annotationMetadata != null ? annotationMetadata : AnnotationMetadata.EMPTY_METADATA;
         this.typeParameters = typeParameters;
         this.typeParameterArray = typeParameterArray;
+        this.isTypeVar = isTypeVariable;
     }
 
     /**
@@ -136,11 +167,14 @@ public class DefaultArgument<T> implements Argument<T>, ArgumentCoercible<T> {
         } else {
             throw new IllegalArgumentException(type.getClass().getSimpleName() + " types are not supported");
         }
-        if (name == null) {
-            name = this.type.getSimpleName();
-        }
         this.name = name;
         this.typeParameters = initializeTypeParameters(this.typeParameterArray);
+        this.isTypeVar = false;
+    }
+
+    @Override
+    public boolean isVariable() {
+        return isTypeVar;
     }
 
     @Override

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
@@ -15,7 +15,6 @@
  */
 package io.micronaut.http.server.netty;
 
-import com.github.benmanes.caffeine.cache.CacheLoader;
 import io.micronaut.buffer.netty.NettyByteBufferFactory;
 import io.micronaut.context.BeanContext;
 import io.micronaut.context.exceptions.BeanCreationException;

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyClassElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyClassElement.java
@@ -71,6 +71,7 @@ public class GroovyClassElement extends AbstractGroovyElement implements Arrayab
     };
     protected final ClassNode classNode;
     private final int arrayDimensions;
+    private final boolean isTypeVar;
     private Map<String, Map<String, ClassNode>> genericInfo;
 
     /**
@@ -95,6 +96,24 @@ public class GroovyClassElement extends AbstractGroovyElement implements Arrayab
             AnnotationMetadata annotationMetadata,
             Map<String, Map<String, ClassNode>> genericInfo,
             int arrayDimensions) {
+        this(visitorContext, classNode, annotationMetadata, genericInfo, arrayDimensions, false);
+    }
+
+    /**
+     * @param visitorContext     The visitor context
+     * @param classNode          The {@link ClassNode}
+     * @param annotationMetadata The annotation metadata
+     * @param genericInfo        The generic info
+     * @param arrayDimensions    The number of array dimensions
+     * @param isTypeVar          Is the element a type variable
+     */
+    GroovyClassElement(
+            GroovyVisitorContext visitorContext,
+            ClassNode classNode,
+            AnnotationMetadata annotationMetadata,
+            Map<String, Map<String, ClassNode>> genericInfo,
+            int arrayDimensions,
+            boolean isTypeVar) {
         super(visitorContext, classNode, annotationMetadata);
         this.classNode = classNode;
         this.genericInfo = genericInfo;
@@ -102,6 +121,12 @@ public class GroovyClassElement extends AbstractGroovyElement implements Arrayab
         if (classNode.isArray()) {
             classNode.setName(classNode.getComponentType().getName());
         }
+        this.isTypeVar = isTypeVar;
+    }
+
+    @Override
+    public boolean isTypeVariable() {
+        return isTypeVar;
     }
 
     @Override
@@ -519,7 +544,8 @@ public class GroovyClassElement extends AbstractGroovyElement implements Arrayab
                                     cn,
                                     annotationMetadata,
                                     Collections.singletonMap(cn.getName(), newInfo),
-                                    cn.isArray() ? computeDimensions(cn) : 0
+                                    cn.isArray() ? computeDimensions(cn) : 0,
+                                    true
                             ));
                         }
                     } else {

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/factory/generics/GenericFactorySpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/factory/generics/GenericFactorySpec.groovy
@@ -1,0 +1,63 @@
+package io.micronaut.inject.factory.generics
+
+import io.micronaut.ast.transform.test.AbstractBeanDefinitionSpec
+
+class GenericFactorySpec extends AbstractBeanDefinitionSpec {
+
+    void "test generic factory with type variables"() {
+        given:
+        def context = buildContext('''
+package genfact;
+
+import io.micronaut.context.annotation.*;
+import io.micronaut.inject.ArgumentInjectionPoint;
+import jakarta.inject.*;
+import io.micronaut.core.type.ArgumentCoercible;
+
+@Singleton
+class MyBean {
+    @Inject
+    public Cache<String, Integer> fieldInject;
+    public Cache<StringBuilder, Float> methodInject;
+    
+    @Inject
+    void setCache(Cache<StringBuilder, Float> methodInject) {
+        this.methodInject = methodInject;
+    }
+}
+
+@Factory
+class CacheFactory {
+    @Bean
+    <K extends CharSequence, V> Cache<K, V> buildCache(ArgumentInjectionPoint<?, ?> ip) {
+        Class<?> keyType = ip.asArgument().getTypeVariable("K").get().getType();
+        Class<?> valueType = ip.asArgument().getTypeVariable("V").get().getType();
+        
+        return new CacheImpl(keyType, valueType);
+    }
+}
+
+interface Cache<K extends CharSequence, V> {}
+
+class CacheImpl implements Cache {
+    public final Class<?> keyType;
+    public final Class<?> valueType;
+    
+    CacheImpl(Class<?> k, Class<?> v) {
+        keyType = k;
+        valueType = v;
+    }
+}
+''')
+        def bean = getBean(context, "genfact.MyBean")
+
+        expect:
+        bean.fieldInject.keyType == String
+        bean.fieldInject.valueType == Integer
+        bean.methodInject.keyType == StringBuilder
+        bean.methodInject.valueType == Float
+
+        cleanup:
+        context.close()
+    }
+}

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/AbstractJavaElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/AbstractJavaElement.java
@@ -261,6 +261,25 @@ public abstract class AbstractJavaElement implements io.micronaut.inject.ast.Ele
      * @return The class element
      */
     protected @NonNull ClassElement mirrorToClassElement(TypeMirror returnType, JavaVisitorContext visitorContext, Map<String, Map<String, TypeMirror>> genericsInfo, boolean includeTypeAnnotations) {
+        return mirrorToClassElement(returnType, visitorContext, genericsInfo, includeTypeAnnotations, returnType instanceof TypeVariable);
+    }
+
+    /**
+     * Obtain the ClassElement for the given mirror.
+     *
+     * @param returnType The return type
+     * @param visitorContext The visitor context
+     * @param genericsInfo The generic information.
+     * @param includeTypeAnnotations Whether to include type level annotations in the metadata for the element
+     * @param isTypeVariable is the type a type variable
+     * @return The class element
+     */
+    protected @NonNull ClassElement mirrorToClassElement(
+            TypeMirror returnType,
+            JavaVisitorContext visitorContext,
+            Map<String, Map<String, TypeMirror>> genericsInfo,
+            boolean includeTypeAnnotations,
+            boolean isTypeVariable) {
         if (genericsInfo == null) {
             genericsInfo = Collections.emptyMap();
         }
@@ -301,7 +320,8 @@ public abstract class AbstractJavaElement implements io.micronaut.inject.ast.Ele
                                 typeElement,
                                 newAnnotationMetadata,
                                 visitorContext,
-                                genericsInfo
+                                genericsInfo,
+                                isTypeVariable
                         );
                     }
                 }
@@ -315,9 +335,9 @@ public abstract class AbstractJavaElement implements io.micronaut.inject.ast.Ele
 
             TypeMirror bound = boundGenerics.get(tv.toString());
             if (bound != null && bound != tv) {
-                return mirrorToClassElement(bound, visitorContext, genericsInfo, includeTypeAnnotations);
+                return mirrorToClassElement(bound, visitorContext, genericsInfo, includeTypeAnnotations, true);
             } else {
-                return mirrorToClassElement(upperBound, visitorContext, genericsInfo, includeTypeAnnotations);
+                return mirrorToClassElement(upperBound, visitorContext, genericsInfo, includeTypeAnnotations, true);
             }
 
         } else if (returnType instanceof ArrayType) {

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
@@ -53,6 +53,7 @@ public class JavaClassElement extends AbstractJavaElement implements ArrayableCl
     protected final TypeElement classElement;
     protected final JavaVisitorContext visitorContext;
     private final int arrayDimensions;
+    private final boolean isTypeVariable;
     private List<PropertyElement> beanProperties;
     private Map<String, Map<String, TypeMirror>> genericTypeInfo;
     private List<? extends Element> enclosedElements;
@@ -67,7 +68,7 @@ public class JavaClassElement extends AbstractJavaElement implements ArrayableCl
      */
     @Internal
     public JavaClassElement(TypeElement classElement, AnnotationMetadata annotationMetadata, JavaVisitorContext visitorContext) {
-        this(classElement, annotationMetadata, visitorContext, null, 0);
+        this(classElement, annotationMetadata, visitorContext, null, 0, false);
     }
 
     /**
@@ -81,7 +82,23 @@ public class JavaClassElement extends AbstractJavaElement implements ArrayableCl
             AnnotationMetadata annotationMetadata,
             JavaVisitorContext visitorContext,
             Map<String, Map<String, TypeMirror>> genericsInfo) {
-        this(classElement, annotationMetadata, visitorContext, genericsInfo, 0);
+        this(classElement, annotationMetadata, visitorContext, genericsInfo, 0, false);
+    }
+
+    /**
+     * @param classElement       The {@link TypeElement}
+     * @param annotationMetadata The annotation metadata
+     * @param visitorContext     The visitor context
+     * @param genericsInfo       The generic type info
+     * @param isTypeVariable     Is the class element a type variable
+     */
+    JavaClassElement(
+            TypeElement classElement,
+            AnnotationMetadata annotationMetadata,
+            JavaVisitorContext visitorContext,
+            Map<String, Map<String, TypeMirror>> genericsInfo,
+            boolean isTypeVariable) {
+        this(classElement, annotationMetadata, visitorContext, genericsInfo, 0, isTypeVariable);
     }
 
     /**
@@ -90,18 +107,26 @@ public class JavaClassElement extends AbstractJavaElement implements ArrayableCl
      * @param visitorContext     The visitor context
      * @param genericsInfo       The generic type info
      * @param arrayDimensions    The number of array dimensions
+     * @param isTypeVariable     Is the type a type variable
      */
     JavaClassElement(
             TypeElement classElement,
             AnnotationMetadata annotationMetadata,
             JavaVisitorContext visitorContext,
             Map<String, Map<String, TypeMirror>> genericsInfo,
-            int arrayDimensions) {
+            int arrayDimensions,
+            boolean isTypeVariable) {
         super(classElement, annotationMetadata, visitorContext);
         this.classElement = classElement;
         this.visitorContext = visitorContext;
         this.genericTypeInfo = genericsInfo;
         this.arrayDimensions = arrayDimensions;
+        this.isTypeVariable = isTypeVariable;
+    }
+
+    @Override
+    public boolean isTypeVariable() {
+        return isTypeVariable;
     }
 
     @Override
@@ -734,7 +759,7 @@ public class JavaClassElement extends AbstractJavaElement implements ArrayableCl
 
     @Override
     public ClassElement withArrayDimensions(int arrayDimensions) {
-        return new JavaClassElement(classElement, getAnnotationMetadata(), visitorContext, getGenericTypeInfo(), arrayDimensions);
+        return new JavaClassElement(classElement, getAnnotationMetadata(), visitorContext, getGenericTypeInfo(), arrayDimensions, false);
     }
 
     @Override
@@ -869,7 +894,8 @@ public class JavaClassElement extends AbstractJavaElement implements ArrayableCl
         Map<String, TypeMirror> map = new LinkedHashMap<>();
         while (tpi.hasNext()) {
             TypeParameterElement tpe = tpi.next();
-            JavaClassElement classElement = (JavaClassElement) mirrorToClassElement(tpe.asType(), visitorContext, this.genericTypeInfo, false);
+            TypeMirror t = tpe.asType();
+            JavaClassElement classElement = (JavaClassElement) mirrorToClassElement(t, visitorContext, this.genericTypeInfo, false);
 
             map.put(tpe.toString(), ((TypeElement) classElement.getNativeType()).asType());
         }

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaEnumElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaEnumElement.java
@@ -50,7 +50,7 @@ class JavaEnumElement extends JavaClassElement implements EnumElement {
      * @param arrayDimensions    The number of array dimensions
      */
     JavaEnumElement(TypeElement classElement, AnnotationMetadata annotationMetadata, JavaVisitorContext visitorContext, int arrayDimensions) {
-        super(classElement, annotationMetadata, visitorContext, Collections.emptyMap(), arrayDimensions);
+        super(classElement, annotationMetadata, visitorContext, Collections.emptyMap(), arrayDimensions, false);
     }
 
     @Override

--- a/inject-java/src/test/groovy/io/micronaut/inject/factory/generics/GenericFactorySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/factory/generics/GenericFactorySpec.groovy
@@ -1,0 +1,79 @@
+package io.micronaut.inject.factory.generics
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.exceptions.DependencyInjectionException
+import io.micronaut.context.exceptions.NoSuchBeanException
+
+class GenericFactorySpec extends AbstractTypeElementSpec {
+
+    void "test generic factory with type variables"() {
+        given:
+        def context = buildContext('''
+package genfact;
+
+import io.micronaut.context.annotation.*;
+import io.micronaut.inject.ArgumentInjectionPoint;
+import jakarta.inject.*;
+import io.micronaut.core.type.ArgumentCoercible;
+
+@Singleton
+class MyBean {
+    @Inject
+    public Cache<String, Integer> fieldInject;
+    public Cache<StringBuilder, Float> methodInject;
+    
+    @Inject
+    void setCache(Cache<StringBuilder, Float> methodInject) {
+        this.methodInject = methodInject;
+    }
+}
+
+@Singleton
+class OtherBean {
+    @Inject
+    public Cache<Boolean, Integer> invalid;
+}
+
+@Factory
+class CacheFactory {
+    @Bean
+    <K extends CharSequence, V> Cache<K, V> buildCache(ArgumentInjectionPoint<?, ?> ip) {
+        Class<?> keyType = ip.asArgument().getTypeVariable("K").get().getType();
+        Class<?> valueType = ip.asArgument().getTypeVariable("V").get().getType();
+        
+        return new CacheImpl(keyType, valueType);
+    }
+}
+
+interface Cache<K, V> {}
+
+class CacheImpl implements Cache {
+    public final Class<?> keyType;
+    public final Class<?> valueType;
+    
+    CacheImpl(Class<?> k, Class<?> v) {
+        keyType = k;
+        valueType = v;
+    }
+}
+''')
+        when:
+        def bean = getBean(context, "genfact.MyBean")
+
+        then:
+        bean.fieldInject.keyType == String
+        bean.fieldInject.valueType == Integer
+        bean.methodInject.keyType == StringBuilder
+        bean.methodInject.valueType == Float
+
+        when:
+        getBean(context, "genfact.OtherBean")
+
+        then:
+        def e  = thrown(DependencyInjectionException)
+        e.message.contains("No bean of type [genfact.Cache<java.lang.Boolean,java.lang.Integer>] exists")
+
+        cleanup:
+        context.close()
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/AbstractBeanResolutionContext.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractBeanResolutionContext.java
@@ -314,10 +314,11 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
     /**
      * A segment that represents a constructor.
      */
-    public static class ConstructorSegment extends AbstractSegment {
+    public static class ConstructorSegment extends AbstractSegment implements ArgumentInjectionPoint {
 
         private final String methodName;
         private final Argument[] arguments;
+        private final BeanDefinition declaringClass;
 
         /**
          * @param declaringClass The declaring class
@@ -329,6 +330,7 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
             super(declaringClass, declaringClass.getBeanType().getName(), argument);
             this.methodName = methodName;
             this.arguments = arguments;
+            this.declaringClass = declaringClass;
         }
 
         @Override
@@ -376,6 +378,21 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
                     return getArgument().getAnnotationMetadata();
                 }
             };
+        }
+
+        @Override
+        public CallableInjectionPoint getOuterInjectionPoint() {
+            throw new UnsupportedOperationException("Outer injection point not retrievable from here");
+        }
+
+        @Override
+        public BeanDefinition getDeclaringBean() {
+            return declaringClass;
+        }
+
+        @Override
+        public boolean requiresReflection() {
+            return false;
         }
     }
 
@@ -443,7 +460,7 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
     /**
      * A segment that represents a field.
      */
-    public static class FieldSegment extends AbstractSegment implements InjectionPoint, ArgumentCoercible {
+    public static class FieldSegment extends AbstractSegment implements InjectionPoint, ArgumentCoercible, ArgumentInjectionPoint {
 
         private final boolean requiresReflection;
 
@@ -475,6 +492,11 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
         @Override
         public boolean requiresReflection() {
             return requiresReflection;
+        }
+
+        @Override
+        public CallableInjectionPoint getOuterInjectionPoint() {
+            throw new UnsupportedOperationException("Outer injection point not retrievable from here");
         }
 
         @Override

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -2633,7 +2633,7 @@ public class DefaultBeanContext implements BeanContext {
             return (T) this;
         }
 
-        if (beanClass == InjectionPoint.class) {
+        if (InjectionPoint.class.isAssignableFrom(beanClass)) {
             final BeanResolutionContext.Path path = resolutionContext != null ? resolutionContext.getPath() : null;
 
             if (CollectionUtils.isNotEmpty(path)) {
@@ -2653,16 +2653,21 @@ public class DefaultBeanContext implements BeanContext {
                             segment = i.next();
                         }
                     }
-                    return (T) segment.getInjectionPoint();
+                    T ip = (T) segment.getInjectionPoint();
+                    if (beanClass.isInstance(ip)) {
+                        return ip;
+                    } else {
+                        throw new DependencyInjectionException(resolutionContext, "Failed to obtain injection point. No valid injection path present in path: " + path);
+                    }
                 } else {
                     if (!injectionPointSegment.getArgument().isNullable()) {
-                        throw new BeanContextException("Failed to obtain injection point. No valid injection path present in path: " + path);
+                        throw new DependencyInjectionException(resolutionContext, "Failed to obtain injection point. No valid injection path present in path: " + path);
                     } else {
                         return null;
                     }
                 }
             } else {
-                throw new BeanContextException("Failed to obtain injection point. No valid injection path present in path: " + path);
+                throw new DependencyInjectionException(resolutionContext, "Failed to obtain injection point. No valid injection path present in path: " + path);
             }
         }
         BeanKey<T> beanKey = new BeanKey<>(beanType, qualifier);

--- a/inject/src/main/java/io/micronaut/inject/BeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/inject/BeanDefinition.java
@@ -137,7 +137,7 @@ public interface BeanDefinition<T> extends AnnotationMetadataDelegate, Named, Be
                         Argument<?> candidateParameter = beanTypeParameters[i];
                         final Argument<?> requestedParameter = typeArguments[i];
                         if (!requestedParameter.isAssignableFrom(candidateParameter.getType())) {
-                            if (!(candidateParameter.isVariable() && candidateParameter.isAssignableFrom(requestedParameter.getType()))) {
+                            if (!(candidateParameter.isTypeVariable() && candidateParameter.isAssignableFrom(requestedParameter.getType()))) {
                                 return false;
                             }
                         }

--- a/inject/src/main/java/io/micronaut/inject/ast/ClassElement.java
+++ b/inject/src/main/java/io/micronaut/inject/ast/ClassElement.java
@@ -44,6 +44,17 @@ public interface ClassElement extends TypedElement {
     boolean isAssignable(String type);
 
     /**
+     * In this case of calling {@link #getTypeArguments()} a returned {@link ClassElement} may represent a type variable
+     * in which case this method will return {@code true}.
+     *
+     * @return Is this type a type variable.
+     * @since 3.0.0
+     */
+    default boolean isTypeVariable() {
+        return false;
+    }
+
+    /**
      * Tests whether one type is assignable to another.
      *
      * @param type The type to check

--- a/inject/src/main/java/io/micronaut/inject/writer/AbstractClassFileWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/AbstractClassFileWriter.java
@@ -97,10 +97,28 @@ public abstract class AbstractClassFileWriter implements Opcodes, OriginatingEle
                     String.class
             )
     );
+    protected static final Method METHOD_CREATE_TYPE_VARIABLE_SIMPLE = Method.getMethod(
+            ReflectionUtils.getRequiredInternalMethod(
+                    Argument.class,
+                    "ofTypeVariable",
+                    Class.class,
+                    String.class
+            )
+    );
     private static final Method METHOD_CREATE_ARGUMENT_WITH_ANNOTATION_METADATA_GENERICS = Method.getMethod(
             ReflectionUtils.getRequiredInternalMethod(
                     Argument.class,
                     "of",
+                    Class.class,
+                    String.class,
+                    AnnotationMetadata.class,
+                    Argument[].class
+            )
+    );
+    private static final Method METHOD_CREATE_TYPE_VAR_WITH_ANNOTATION_METADATA_GENERICS = Method.getMethod(
+            ReflectionUtils.getRequiredInternalMethod(
+                    Argument.class,
+                    "ofTypeVariable",
                     Class.class,
                     String.class,
                     AnnotationMetadata.class,
@@ -252,7 +270,7 @@ public abstract class AbstractClassFileWriter implements Opcodes, OriginatingEle
                             loadTypeMethods
                     );
                 } else {
-                    buildArgument(generatorAdapter, argumentName, classReference);
+                    buildArgument(generatorAdapter, argumentName, classElement);
                 }
 
                 // store the type reference
@@ -284,6 +302,27 @@ public abstract class AbstractClassFileWriter implements Opcodes, OriginatingEle
                 generatorAdapter,
                 Argument.class,
                 METHOD_CREATE_ARGUMENT_SIMPLE
+        );
+    }
+
+    /**
+     * Builds an argument instance.
+     *
+     * @param generatorAdapter The generator adapter.
+     * @param argumentName     The argument name
+     * @param objectType       The object type
+     */
+    protected static void buildArgument(GeneratorAdapter generatorAdapter, String argumentName, ClassElement objectType) {
+        // 1st argument: the type
+        generatorAdapter.push(getTypeReference(objectType));
+        // 2nd argument: the name
+        generatorAdapter.push(argumentName);
+
+        // Argument.create( .. )
+        invokeInterfaceStaticMethod(
+                generatorAdapter,
+                Argument.class,
+                objectType.isTypeVariable() ? METHOD_CREATE_TYPE_VARIABLE_SIMPLE : METHOD_CREATE_ARGUMENT_SIMPLE
         );
     }
 
@@ -359,7 +398,7 @@ public abstract class AbstractClassFileWriter implements Opcodes, OriginatingEle
         invokeInterfaceStaticMethod(
                 generatorAdapter,
                 Argument.class,
-                METHOD_CREATE_ARGUMENT_WITH_ANNOTATION_METADATA_GENERICS
+                classElement.isTypeVariable() ? METHOD_CREATE_TYPE_VAR_WITH_ANNOTATION_METADATA_GENERICS : METHOD_CREATE_ARGUMENT_WITH_ANNOTATION_METADATA_GENERICS
         );
     }
 
@@ -575,7 +614,7 @@ public abstract class AbstractClassFileWriter implements Opcodes, OriginatingEle
         invokeInterfaceStaticMethod(
                 generatorAdapter,
                 Argument.class,
-                METHOD_CREATE_ARGUMENT_WITH_ANNOTATION_METADATA_GENERICS
+                classElement.isTypeVariable() ? METHOD_CREATE_TYPE_VAR_WITH_ANNOTATION_METADATA_GENERICS : METHOD_CREATE_ARGUMENT_WITH_ANNOTATION_METADATA_GENERICS
         );
     }
 

--- a/runtime/src/main/java/io/micronaut/jackson/convert/JacksonConverterRegistrar.java
+++ b/runtime/src/main/java/io/micronaut/jackson/convert/JacksonConverterRegistrar.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.node.ContainerNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import io.micronaut.context.BeanProvider;
+import io.micronaut.context.annotation.Any;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.bind.ArgumentBinder;

--- a/runtime/src/main/java/io/micronaut/jackson/convert/JacksonConverterRegistrar.java
+++ b/runtime/src/main/java/io/micronaut/jackson/convert/JacksonConverterRegistrar.java
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.databind.node.ContainerNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import io.micronaut.context.BeanProvider;
-import io.micronaut.context.annotation.Any;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.bind.ArgumentBinder;


### PR DESCRIPTION
The support for factory beans that use generics is semi broken since there is much stricter generic matching. In order to support the case where type variables are used in factory beans we have propagate the fact that a variable is used and alter the check in `BeanDefinition` to allow the bean definition to match as a candidate. This includes information on the computed metadata as to whether an `Argument` is a type variable allowing that to happen.