### PR TITLE
Select constructor with most arguments

### DIFF
--- a/buffer-netty/src/main/java/io/micronaut/buffer/netty/NettyByteBufferFactory.java
+++ b/buffer-netty/src/main/java/io/micronaut/buffer/netty/NettyByteBufferFactory.java
@@ -23,6 +23,7 @@ import io.micronaut.core.io.buffer.ByteBufferFactory;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
+import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
 /**
@@ -56,6 +57,7 @@ public class NettyByteBufferFactory implements ByteBufferFactory<ByteBufAllocato
     /**
      * Default constructor.
      */
+    @Inject
     public NettyByteBufferFactory() {
         this.allocator = ByteBufAllocator.DEFAULT;
     }

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/ModelUtils.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/ModelUtils.java
@@ -221,7 +221,10 @@ public class ModelUtils {
 
             Optional<ExecutableElement> element = findAnnotatedConstructor(annotationUtils, constructors);
             if (!element.isPresent()) {
-                element = constructors.stream().filter(ctor ->
+                final Comparator<ExecutableElement> comparator = Comparator.comparingInt(e -> e.getParameters().size());
+                element = constructors.stream()
+                        .sorted(comparator.reversed())
+                        .filter(ctor ->
                         ctor.getModifiers().contains(PUBLIC)
                 ).findFirst();
             }

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
@@ -833,15 +833,20 @@ public class JavaClassElement extends AbstractJavaElement implements ArrayableCl
     @NonNull
     @Override
     public Optional<MethodElement> getPrimaryConstructor() {
+        return getPrimaryConstructor(ConstructorSelectionStrategy.FIRST_FOUND);
+    }
+
+    @Override
+    public Optional<MethodElement> getPrimaryConstructor(ConstructorSelectionStrategy selectionStrategy) {
         final AnnotationUtils annotationUtils = visitorContext.getAnnotationUtils();
         final ModelUtils modelUtils = visitorContext.getModelUtils();
-        ExecutableElement method = modelUtils.staticCreatorFor(classElement, annotationUtils);
+        ExecutableElement method = modelUtils.staticCreatorFor(classElement, annotationUtils, selectionStrategy);
         if (method == null) {
             if (isInner() && !isStatic()) {
                 // only static inner classes can be constructed
                 return Optional.empty();
             }
-            method = modelUtils.concreteConstructorFor(classElement, annotationUtils);
+            method = modelUtils.concreteConstructorFor(classElement, annotationUtils, selectionStrategy);
         }
 
         return createMethodElement(annotationUtils, method);

--- a/inject/src/main/java/io/micronaut/inject/ast/ClassElement.java
+++ b/inject/src/main/java/io/micronaut/inject/ast/ClassElement.java
@@ -126,6 +126,15 @@ public interface ClassElement extends TypedElement {
     }
 
     /**
+     * Same as {@link #getPrimaryConstructor()} except allows to customize which constructor is selected in the case where multiple candidates exist.
+     *
+     * @return The primary constructor if one is present
+     */
+    default @NonNull Optional<MethodElement> getPrimaryConstructor(@Nullable ConstructorSelectionStrategy selectionStrategy) {
+        return getPrimaryConstructor();
+    }
+
+    /**
      * Find and return a single default constructor. A default constructor is one
      * without arguments that is accessible.
      *
@@ -411,5 +420,19 @@ public interface ClassElement extends TypedElement {
     @Internal
     static @NonNull ClassElement of(@NonNull String typeName, boolean isInterface, @Nullable AnnotationMetadata annotationMetadata, Map<String, ClassElement> typeArguments) {
         return new SimpleClassElement(typeName, isInterface, annotationMetadata);
+    }
+
+    /**
+     * Enum used to dictate how a constructor is selected given multiple candidates.
+     */
+    enum ConstructorSelectionStrategy {
+        /**
+         * The constructor with the most arguments is selected.
+         */
+        MOST_ARGUMENTS,
+        /**
+         * The first found as defined by the order in the class definition is selected.
+         */
+        FIRST_FOUND
     }
 }

--- a/inject/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
@@ -293,7 +293,7 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
             ClassElement ce,
             BeanIntrospectionWriter writer,
             Introspected.AccessKind...accessKinds) {
-        Optional<MethodElement> constructorElement = ce.getPrimaryConstructor();
+        Optional<MethodElement> constructorElement = ce.getPrimaryConstructor(ClassElement.ConstructorSelectionStrategy.MOST_ARGUMENTS);
         if (ce.isAbstract() && !constructorElement.isPresent() && ce.hasStereotype(Introspected.class)) {
             currentAbstractIntrospection = new AbstractIntrospection(
                     writer,


### PR DESCRIPTION
The issue is that Kotlin 1.5 changed the constructor order in KAPT and now the no args constructor is first. This changes the logic so the constructor with the most arguments is selected, however this has implications since some code may break (I had to change `NettyByteBufferFactory` therefore probably needs discussion.

Fixes #5852