### PR TITLE
Create inject-kotlin-test module for directly testing kapt processing in unit tests

### DIFF
--- a/inject-kotlin-test/build.gradle
+++ b/inject-kotlin-test/build.gradle
@@ -1,0 +1,45 @@
+plugins {
+    id 'java'
+    id "org.jetbrains.kotlin.jvm"
+}
+
+dependencies {
+    annotationProcessor project(":inject-java")
+
+    api project(":inject-java")
+    api dependencyModuleVersion("groovy", "groovy")
+    api(dependencyVersion("spock")) {
+        exclude module:'groovy-all'
+    }
+    if (!JavaVersion.current().isJava9Compatible()) {
+        api files(org.gradle.internal.jvm.Jvm.current().toolsJar)
+    }
+
+    testAnnotationProcessor project(":inject-java")
+    testCompileOnly project(":inject-groovy")
+    testImplementation dependencyVersion("validation")
+    testImplementation "javax.persistence:javax.persistence-api:2.2"
+    testImplementation project(":runtime")
+    api "com.blazebit:blaze-persistence-core-impl:1.6.0-Alpha1"
+
+    implementation "org.jetbrains.kotlin:kotlin-compiler-embeddable:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-annotation-processing-embeddable:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
+}
+
+afterEvaluate {
+    sourcesJar {
+        from "$projectDir/src/main/groovy"
+        from "$projectDir/src/main/kotlin"
+    }
+}
+compileKotlin {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+compileGroovy {
+    // this allows groovy to access kotlin classes.
+    dependsOn tasks.getByPath('compileKotlin')
+    classpath += files(compileKotlin.destinationDir)
+}

--- a/inject-kotlin-test/src/main/groovy/io/micronaut/annotation/processing/test/AbstractKotlinCompilerSpec.groovy
+++ b/inject-kotlin-test/src/main/groovy/io/micronaut/annotation/processing/test/AbstractKotlinCompilerSpec.groovy
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.annotation.processing.test
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.DefaultApplicationContext
+import io.micronaut.context.Qualifier
+import io.micronaut.core.beans.BeanIntrospection
+import io.micronaut.core.io.scan.ClassPathResourceLoader
+import io.micronaut.core.naming.NameUtils
+import io.micronaut.inject.BeanDefinitionReference
+import org.intellij.lang.annotations.Language
+import spock.lang.Specification
+
+import java.util.function.Predicate
+import java.util.stream.Collectors
+
+class AbstractKotlinCompilerSpec extends Specification {
+    protected ClassLoader buildClassLoader(String className, @Language("kotlin") String cls) {
+        def result = KotlinCompileHelper.INSTANCE.run(className, cls)
+        result.classLoader
+    }
+
+    /**
+     * Build and return a {@link io.micronaut.core.beans.BeanIntrospection} for the given class name and class data.
+     *
+     * @return the introspection if it is correct
+     * */
+    protected BeanIntrospection buildBeanIntrospection(String className, @Language("kotlin") String cls) {
+        def beanDefName = '$' + NameUtils.getSimpleName(className) + '$Introspection'
+        def packageName = NameUtils.getPackageName(className)
+        String beanFullName = "${packageName}.${beanDefName}"
+
+        ClassLoader classLoader = buildClassLoader(className, cls)
+        return (BeanIntrospection) classLoader.loadClass(beanFullName).newInstance()
+    }
+
+    /**
+     * Build and return a {@link io.micronaut.core.beans.BeanIntrospection} for the given class name and class data.
+     *
+     * @return the introspection if it is correct
+     * */
+    protected ApplicationContext buildContext(String className, @Language("kotlin") String cls) {
+        def result = KotlinCompileHelper.INSTANCE.run(className, cls)
+        ClassLoader classLoader = result.classLoader
+
+        return new DefaultApplicationContext(ClassPathResourceLoader.defaultLoader(classLoader), "test") {
+            @Override
+            protected List<BeanDefinitionReference> resolveBeanDefinitionReferences(Predicate<BeanDefinitionReference> predicate) {
+                // we want only the definitions we just compiled
+                def stream = result.fileNames.stream()
+                        .filter(s -> s.endsWith("DefinitionClass.class"))
+                        .map(n -> classLoader.loadClass(n.substring(0, n.size() - 6).replace('/', '.')).newInstance())
+                if (predicate != null) stream = stream.filter(predicate)
+                return stream.collect(Collectors.toList())
+            }
+        }.start()
+    }
+
+    Object getBean(ApplicationContext context, String className, Qualifier qualifier = null) {
+        context.getBean(context.classLoader.loadClass(className), qualifier)
+    }
+}

--- a/inject-kotlin-test/src/main/groovy/io/micronaut/annotation/processing/test/AbstractKotlinCompilerSpec.groovy
+++ b/inject-kotlin-test/src/main/groovy/io/micronaut/annotation/processing/test/AbstractKotlinCompilerSpec.groovy
@@ -21,6 +21,7 @@ import io.micronaut.context.Qualifier
 import io.micronaut.core.beans.BeanIntrospection
 import io.micronaut.core.io.scan.ClassPathResourceLoader
 import io.micronaut.core.naming.NameUtils
+import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.BeanDefinitionReference
 import org.intellij.lang.annotations.Language
 import spock.lang.Specification
@@ -52,7 +53,7 @@ class AbstractKotlinCompilerSpec extends Specification {
      * Build and return a {@link io.micronaut.core.beans.BeanIntrospection} for the given class name and class data.
      *
      * @return the introspection if it is correct
-     * */
+     */
     protected ApplicationContext buildContext(String className, @Language("kotlin") String cls) {
         def result = KotlinCompileHelper.INSTANCE.run(className, cls)
         ClassLoader classLoader = result.classLoader
@@ -72,5 +73,18 @@ class AbstractKotlinCompilerSpec extends Specification {
 
     Object getBean(ApplicationContext context, String className, Qualifier qualifier = null) {
         context.getBean(context.classLoader.loadClass(className), qualifier)
+    }
+
+    protected BeanDefinition buildBeanDefinition(String className, @Language("kotlin") String cls) {
+        def beanDefName= '$' + NameUtils.getSimpleName(className) + 'Definition'
+        def packageName = NameUtils.getPackageName(className)
+        String beanFullName = "${packageName}.${beanDefName}"
+
+        ClassLoader classLoader = buildClassLoader(className, cls)
+        try {
+            return (BeanDefinition)classLoader.loadClass(beanFullName).newInstance()
+        } catch (ClassNotFoundException e) {
+            return null
+        }
     }
 }

--- a/inject-kotlin-test/src/main/kotlin/io/micronaut/annotation/processing/test/KotlinCompileHelper.kt
+++ b/inject-kotlin-test/src/main/kotlin/io/micronaut/annotation/processing/test/KotlinCompileHelper.kt
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.annotation.processing.test
+
+import org.jetbrains.kotlin.base.kapt3.DetectMemoryLeaksMode
+import org.jetbrains.kotlin.base.kapt3.KaptOptions
+import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSourceLocation
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.cli.jvm.compiler.CliBindingTrace
+import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.jetbrains.kotlin.cli.jvm.compiler.TopDownAnalyzerFacadeForJVM
+import org.jetbrains.kotlin.cli.jvm.config.JvmClasspathRoot
+import org.jetbrains.kotlin.codegen.ClassBuilderMode
+import org.jetbrains.kotlin.codegen.DefaultCodegenFactory
+import org.jetbrains.kotlin.codegen.KotlinCodegenFacade
+import org.jetbrains.kotlin.codegen.OriginCollectingClassBuilderFactory
+import org.jetbrains.kotlin.codegen.state.GenerationState
+import org.jetbrains.kotlin.com.intellij.psi.PsiFileFactory
+import org.jetbrains.kotlin.com.intellij.psi.impl.PsiFileFactoryImpl
+import org.jetbrains.kotlin.com.intellij.testFramework.LightVirtualFile
+import org.jetbrains.kotlin.config.CommonConfigurationKeys
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.config.JVMConfigurationKeys
+import org.jetbrains.kotlin.idea.KotlinLanguage
+import org.jetbrains.kotlin.kapt3.AbstractKapt3Extension
+import org.jetbrains.kotlin.kapt3.base.LoadedProcessors
+import org.jetbrains.kotlin.kapt3.base.incremental.DeclaredProcType
+import org.jetbrains.kotlin.kapt3.base.incremental.IncrementalProcessor
+import org.jetbrains.kotlin.kapt3.util.MessageCollectorBackedKaptLogger
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.resolve.AnalyzingUtils
+import org.jetbrains.kotlin.resolve.jvm.extensions.AnalysisHandlerExtension
+import java.io.File
+import java.io.IOException
+import java.net.URL
+import java.net.URLClassLoader
+import java.nio.charset.StandardCharsets
+import java.nio.file.*
+import java.nio.file.attribute.BasicFileAttributes
+import java.util.*
+import javax.annotation.processing.Processor
+
+object KotlinCompileHelper {
+    init {
+        System.setProperty("idea.ignore.disabled.plugins", "true")
+        System.setProperty("idea.io.use.nio2", "true")
+    }
+
+    fun run(className: String, code: String): Result {
+        val tmp = Files.createTempDirectory("abc")
+        try {
+            return run0(tmp, className, code)
+        } finally {
+            // delete tmp dir
+            Files.walkFileTree(tmp, object : FileVisitor<Path> {
+                override fun preVisitDirectory(dir: Path, attrs: BasicFileAttributes): FileVisitResult {
+                    return FileVisitResult.CONTINUE
+                }
+
+                override fun visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult {
+                    Files.delete(file)
+                    return FileVisitResult.CONTINUE
+                }
+
+                override fun visitFileFailed(file: Path, exc: IOException): FileVisitResult {
+                    throw exc
+                }
+
+                override fun postVisitDirectory(dir: Path, exc: IOException?): FileVisitResult {
+                    Files.delete(dir)
+                    return FileVisitResult.CONTINUE
+                }
+            })
+        }
+    }
+
+    private fun run0(
+        tmp: Path,
+        className: String,
+        code: String
+    ): Result {
+        val outDir = tmp.resolve("out")
+        Files.createDirectory(outDir)
+        val stubsDir = tmp.resolve("stubs")
+        Files.createDirectory(stubsDir)
+
+        val configuration = CompilerConfiguration()
+        configuration.put(CommonConfigurationKeys.MODULE_NAME, "test-module")
+        val messageCollector = object : MessageCollector {
+            override fun clear() {
+            }
+
+            override fun hasErrors() = false
+
+            override fun report(
+                severity: CompilerMessageSeverity,
+                message: String,
+                location: CompilerMessageSourceLocation?
+            ) {
+                if (severity == CompilerMessageSeverity.ERROR) {
+                    throw AssertionError("Error reported in processing: $message")
+                }
+            }
+        }
+        configuration.put(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, messageCollector)
+        configuration.put(JVMConfigurationKeys.IR, false)
+        configuration.put(JVMConfigurationKeys.OUTPUT_DIRECTORY, outDir.toFile())
+
+        val env =
+            KotlinCoreEnvironment.createForTests({ }, configuration, EnvironmentConfigFiles.JVM_CONFIG_FILES)
+
+        val cp = getClasspath(KotlinCompileHelper::class.java.classLoader) + getClasspathFromSystemProperty("java.class.path") + getClasspathFromSystemProperty("sun.boot.class.path")
+        env.updateClasspath(cp.map {
+            JvmClasspathRoot(it, false)
+        })
+
+        val kaptOptions = KaptOptions.Builder()
+        kaptOptions.projectBaseDir = tmp.toFile()
+        kaptOptions.sourcesOutputDir = outDir.toFile()
+        kaptOptions.classesOutputDir = outDir.toFile()
+        kaptOptions.stubsOutputDir = stubsDir.toFile()
+        kaptOptions.detectMemoryLeaks = DetectMemoryLeaksMode.NONE
+        kaptOptions.compileClasspath.addAll(cp)
+
+        class KaptExtension : AbstractKapt3Extension(
+            kaptOptions.build(),
+            MessageCollectorBackedKaptLogger(
+                isVerbose = false,
+                isInfoAsWarnings = true,
+                messageCollector = messageCollector
+            ),
+            configuration
+        ) {
+            override fun loadProcessors() = LoadedProcessors(
+                ServiceLoader.load(Processor::class.java)
+                    .map { IncrementalProcessor(it, DeclaredProcType.NON_INCREMENTAL, logger) },
+                KotlinCompileHelper::class.java.classLoader
+            )
+        }
+
+        AnalysisHandlerExtension.registerExtension(env.project, KaptExtension())
+
+        val classBuilderFactory = OriginCollectingClassBuilderFactory(ClassBuilderMode.FULL)
+        val vFile =
+            LightVirtualFile(className.substring(className.lastIndexOf('.') + 1) + ".kt", KotlinLanguage.INSTANCE, code)
+        vFile.charset = StandardCharsets.UTF_8
+        val psiFileFactory = PsiFileFactory.getInstance(env.project) as PsiFileFactoryImpl
+        val ktFile = psiFileFactory.trySetupPsiForFile(vFile, KotlinLanguage.INSTANCE, true, false) as KtFile
+
+        val trace = CliBindingTrace()
+        val analysisResult = TopDownAnalyzerFacadeForJVM.analyzeFilesWithJavaIntegration(
+            env.project,
+            listOf(ktFile),
+            trace,
+            configuration,
+            env::createPackagePartProvider
+        )
+        if (analysisResult.isError()) {
+            throw analysisResult.error
+        }
+        AnalyzingUtils.throwExceptionOnErrors(analysisResult.bindingContext)
+
+        val genState = GenerationState.Builder(
+            env.project,
+            classBuilderFactory,
+            analysisResult.moduleDescriptor,
+            trace.bindingContext,
+            listOf(ktFile),
+            configuration
+        ).codegenFactory(DefaultCodegenFactory).isIrBackend(false).build()
+        KotlinCodegenFacade.compileCorrectFiles(genState)
+
+        AnalyzingUtils.throwExceptionOnErrors(genState.collectedExtraJvmDiagnostics)
+
+        val cl = MemoryClassLoader(KotlinCompileHelper::class.java.classLoader)
+        for (outputFile in genState.factory.currentOutput) {
+            cl.files[outputFile.relativePath] = outputFile.asByteArray()
+        }
+        Files.walk(outDir).filter(Files::isRegularFile).forEach { p ->
+            cl.files[outDir.relativize(p).toString()] = Files.readAllBytes(p)
+        }
+
+        return Result(URLClassLoader(arrayOf(outDir.toUri().toURL()), cl), cl.files.keys)
+    }
+
+    private fun getClasspath(cl: ClassLoader): List<File> =
+        getClasspathSingle(cl) + (cl.parent?.let { getClasspath(it) } ?: emptyList())
+
+    private fun getClasspathSingle(cl: ClassLoader): List<File> {
+        if (cl is URLClassLoader) {
+            return cl.urLs.map { File(it.toURI()) }
+        }
+        // ideally, we'd look at the system class loaders too (jdk.internal.loader.BuiltinClassLoader), but they're
+        // protected from reflection in newer JDKs. So, we fall back to using the java.class.path system property in the
+        // code above, and ignore those class loaders here.
+
+        return emptyList()
+    }
+
+    private fun getClasspathFromSystemProperty(prop: String): List<File> {
+        val value = System.getProperty(prop) ?: return emptyList()
+        return value.split(System.getProperty("path.separator")).map { File(it) }
+    }
+
+    data class Result(
+        val classLoader: ClassLoader,
+        val fileNames: Collection<String>
+    )
+
+    private class MemoryClassLoader(parent: ClassLoader?) : ClassLoader(parent) {
+        val files = mutableMapOf<String, ByteArray>()
+
+        override fun findResource(name: String): URL? {
+            val resource = files[name] ?: return null
+            return URL("data:text/plain;base64," + Base64.getUrlEncoder().encodeToString(resource))
+        }
+
+        override fun findClass(name: String): Class<*> {
+            val path = name.replace('.', '/') + ".class"
+            val file = files[path] ?: throw ClassNotFoundException(name)
+            return defineClass(name, file, 0, file.size)
+        }
+    }
+}

--- a/inject-kotlin-test/src/main/kotlin/io/micronaut/annotation/processing/test/KotlinCompileHelper.kt
+++ b/inject-kotlin-test/src/main/kotlin/io/micronaut/annotation/processing/test/KotlinCompileHelper.kt
@@ -63,7 +63,7 @@ object KotlinCompileHelper {
     }
 
     fun run(className: String, code: String): Result {
-        val tmp = Files.createTempDirectory("abc")
+        val tmp = Files.createTempDirectory("KotlinCompileHelper")
         try {
             return run0(tmp, className, code)
         } finally {
@@ -196,7 +196,7 @@ object KotlinCompileHelper {
             cl.files[outDir.relativize(p).toString()] = Files.readAllBytes(p)
         }
 
-        return Result(URLClassLoader(arrayOf(outDir.toUri().toURL()), cl), cl.files.keys)
+        return Result(cl, cl.files.keys)
     }
 
     private fun getClasspath(cl: ClassLoader): List<File> =

--- a/inject-kotlin-test/src/test/groovy/io/micronaut/annotation/processing/test/Test.groovy
+++ b/inject-kotlin-test/src/test/groovy/io/micronaut/annotation/processing/test/Test.groovy
@@ -1,0 +1,54 @@
+package io.micronaut.annotation.processing.test
+
+class Test extends AbstractKotlinCompilerSpec {
+    void "simple class"() {
+        given:
+        def cl = buildClassLoader('example.Test', '''
+package example
+
+class Test {}
+''')
+        expect:
+        cl.loadClass("example.Test") != null
+    }
+
+    void "introspection"() {
+        given:
+        def introspection = buildBeanIntrospection('example.Test', '''
+package example
+
+import io.micronaut.core.annotation.Introspected
+
+@Introspected
+class Test {
+    val a: String
+}
+''')
+        expect:
+        introspection.propertyNames.toList() == ['a']
+    }
+
+    void "context"() {
+        given:
+        def context = buildContext('example.Foo', '''
+package example
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class Foo {
+    @Inject var bar: Bar? = null
+}
+
+@Singleton
+class Bar {
+    
+}
+''')
+        def bean = getBean(context, "example.Foo")
+
+        expect:
+        bean.bar != null
+    }
+}

--- a/inject-kotlin-test/src/test/groovy/io/micronaut/annotation/processing/test/Test.groovy
+++ b/inject-kotlin-test/src/test/groovy/io/micronaut/annotation/processing/test/Test.groovy
@@ -51,4 +51,19 @@ class Bar {
         expect:
         bean.bar != null
     }
+
+    void "build bean definition"() {
+        given:
+        def definition = buildBeanDefinition('test.Test', '''
+package test;
+import javax.inject.Singleton;
+
+@Singleton
+class Test {
+}
+''')
+
+        expect:
+        definition != null
+    }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -23,6 +23,7 @@ include "inject-groovy"
 include "inject-groovy-test"
 include "inject-java"
 include "inject-java-test"
+include 'inject-kotlin-test'
 include "inject-test-utils"
 include "management"
 include "messaging"


### PR DESCRIPTION
This new module adds a `AbstractKotlinCompilerSpec` that calls directly into the kotlin compiler, similar to the java `AbstractTypeElementSpec`. Right now, only `buildClasspath` is supported, along with `buildContext` and `buildBeanIntrospection` built on that.

The code that calls into the compiler is adapted from [kotlin project integration tests](https://github.com/JetBrains/kotlin/blob/master/plugins/kapt3/kapt3-compiler/test/org/jetbrains/kotlin/kapt3/test/AbstractKotlinKapt3IntegrationTest.kt). It goes quite deep into compiler internals, so it may not be very compatible between kotlin versions.

Another potential snag is the classpath scanning: The compiler requires a list of all dependencies, and this code builds that list from the current classpath. Because of changes to system ClassLoader infrastructure since java 9, we have to rely on parsing the `java.class.path` system property. This works fine on linux java 11, but I can't test on other OS. It'll also break if it were called in more complicated classloader setups, but that should not be a concern for code that is only used in unit/integration tests.