### PR TITLE
Fix regression: ServerRequestContext not accessible in WebSocket filters

### DIFF
--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/ContextAwareChatClientWebSocket.java
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/ContextAwareChatClientWebSocket.java
@@ -1,0 +1,66 @@
+package io.micronaut.http.server.netty.websocket;
+
+import io.micronaut.http.HttpRequest;
+import io.micronaut.websocket.WebSocketSession;
+import io.micronaut.websocket.annotation.ClientWebSocket;
+import io.micronaut.websocket.annotation.OnMessage;
+import io.micronaut.websocket.annotation.OnOpen;
+import io.reactivex.Single;
+import java.util.Collection;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Future;
+
+@ClientWebSocket("/context/chat/{topic}/{username}")
+public abstract class ContextAwareChatClientWebSocket implements AutoCloseable {
+
+    private WebSocketSession session;
+    private HttpRequest request;
+    private String topic;
+    private String username;
+    private Collection<String> replies = new ConcurrentLinkedQueue<>();
+    private String subProtocol;
+
+    @OnOpen
+    public void onOpen(String topic, String username, WebSocketSession session, HttpRequest request) {
+        this.topic = topic;
+        this.username = username;
+        this.session = session;
+        this.request = request;
+        this.subProtocol = session.getSubprotocol().orElse(null);
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public Collection<String> getReplies() {
+        return replies;
+    }
+
+    public WebSocketSession getSession() {
+        return session;
+    }
+
+    public HttpRequest getRequest() {
+        return request;
+    }
+
+    @OnMessage
+    public void onMessage(String message) {
+        replies.add(message);
+    }
+
+    public abstract void send(String message);
+
+    public abstract Future<String> sendAsync(String message);
+
+    public abstract Single<String> sendRx(String message);
+
+    public String getSubProtocol() {
+        return subProtocol;
+    }
+}

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/ContextAwareChatServerWebSocket.java
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/ContextAwareChatServerWebSocket.java
@@ -1,0 +1,63 @@
+package io.micronaut.http.server.netty.websocket;
+
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.context.ServerRequestContext;
+import io.micronaut.websocket.WebSocketBroadcaster;
+import io.micronaut.websocket.WebSocketSession;
+import io.micronaut.websocket.annotation.OnClose;
+import io.micronaut.websocket.annotation.OnMessage;
+import io.micronaut.websocket.annotation.OnOpen;
+import io.micronaut.websocket.annotation.ServerWebSocket;
+import java.util.function.Predicate;
+
+@ServerWebSocket("/context/chat/{topic}/{username}")
+public class ContextAwareChatServerWebSocket {
+    private WebSocketBroadcaster broadcaster;
+    private String subProtocol;
+
+    public ContextAwareChatServerWebSocket(WebSocketBroadcaster broadcaster) {
+        this.broadcaster = broadcaster;
+    }
+
+    @OnOpen
+    public void onOpen(String topic, String username, WebSocketSession session) {
+        this.subProtocol = session.getSubprotocol().orElse(null);
+        String msg = "[" + username + "] Joined! Request URI: " + getRequestUri();
+        broadcaster.broadcastSync(msg, isValid(topic, session));
+    }
+
+    @OnMessage
+    public void onMessage(
+            String topic,
+            String username,
+            String message,
+            WebSocketSession session) {
+        String msg = "[" + username + "] " + message + " Request URI: " + getRequestUri();
+        broadcaster.broadcastSync(msg, isValid(topic, session));
+    }
+
+    @OnClose
+    public void onClose(
+            String topic,
+            String username,
+            WebSocketSession session) {
+        String msg = "[" + username + "] Disconnected! Request URI: " + getRequestUri();
+        broadcaster.broadcastSync(msg, isValid(topic, session));
+    }
+
+    private Predicate<WebSocketSession> isValid(String topic, WebSocketSession session) {
+        return s -> s != session && topic.equalsIgnoreCase(s.getUriVariables().get("topic", String.class, null));
+    }
+
+    private String getRequestUri() {
+        HttpRequest<Object> currentRequest = ServerRequestContext.currentRequest().orElse(null);
+        if (currentRequest == null) {
+            return "<no-context>";
+        }
+        return currentRequest.getUri().toString();
+    }
+
+    public String getSubProtocol() {
+        return subProtocol;
+    }
+}

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/ContextAwareWebSocketSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/ContextAwareWebSocketSpec.groovy
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.netty.websocket
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.websocket.RxWebSocketClient
+import spock.lang.Retry
+import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+class ContextAwareWebSocketSpec extends Specification {
+
+    @Retry
+    void "test context-aware websocket exchange"() {
+        given:
+        EmbeddedServer embeddedServer = ApplicationContext.builder('micronaut.server.netty.log-level':'TRACE').run(EmbeddedServer)
+        PollingConditions conditions = new PollingConditions(timeout: 15, delay: 0.5)
+
+        when: "a websocket connection is established"
+        RxWebSocketClient wsClient = embeddedServer.applicationContext.createBean(RxWebSocketClient, embeddedServer.getURI())
+        ContextAwareChatClientWebSocket fred = wsClient.connect(ContextAwareChatClientWebSocket, "/context/chat/stuff/fred").blockingFirst()
+        ContextAwareChatClientWebSocket bob = wsClient.connect(ContextAwareChatClientWebSocket, [topic:"stuff",username:"bob"]).blockingFirst()
+
+        then:"The connection is valid"
+        fred.session != null
+        fred.session.id != null
+        fred.request != null
+        fred.subProtocol == null
+
+        then:"A session is established"
+        fred.session != null
+        fred.session.id != null
+        fred.session.id != bob.session.id
+        fred.request != null
+        fred.topic == 'stuff'
+        fred.username == 'fred'
+        bob.username == 'bob'
+        conditions.eventually {
+            fred.replies.contains("[bob] Joined! Request URI: " + bob.request.uri)
+            fred.replies.size() == 1
+        }
+
+
+        when:"A message is sent"
+        fred.send("Hello bob!")
+
+        then:
+        conditions.eventually {
+            bob.replies.contains("[fred] Hello bob! Request URI: " + fred.request.uri)
+            bob.replies.size() == 1
+        }
+
+        when:
+        bob.send("Hi fred. How are things?")
+
+        then:
+        conditions.eventually {
+
+            fred.replies.contains("[bob] Hi fred. How are things? Request URI: " + bob.request.uri)
+            fred.replies.size() == 2
+            bob.replies.contains("[fred] Hello bob! Request URI: " + fred.request.uri)
+            bob.replies.size() == 1
+        }
+        fred.sendAsync("foo").get() == 'foo'
+        fred.sendRx("bar").blockingGet() == 'bar'
+
+        when:
+        bob.close()
+        fred.close()
+
+        then:
+        conditions.eventually {
+            !bob.session.isOpen()
+            !fred.session.isOpen()
+        }
+
+        when:"A bean is retrieved that injects a websocket client"
+        MyBean myBean = embeddedServer.applicationContext.getBean(MyBean)
+
+        then:
+        myBean.myClient != null
+
+        cleanup:
+        wsClient.close()
+        embeddedServer.close()
+    }
+
+    @Retry
+    void "test context-aware websocket connection over SSL"() {
+        given:
+        EmbeddedServer embeddedServer = ApplicationContext.builder([
+                'micronaut.server.netty.log-level':'TRACE',
+                'micronaut.ssl.enabled':true,
+                'micronaut.ssl.build-self-signed':true
+                ]).run(EmbeddedServer)
+        PollingConditions conditions = new PollingConditions(timeout: 15    , delay: 0.5)
+
+        when: "a websocket connection is established"
+        RxWebSocketClient wsClient = embeddedServer.applicationContext.createBean(RxWebSocketClient, embeddedServer.getURI())
+        ContextAwareChatClientWebSocket fred = wsClient.connect(ContextAwareChatClientWebSocket, "/context/chat/stuff/fred").blockingFirst()
+        ContextAwareChatClientWebSocket bob = wsClient.connect(ContextAwareChatClientWebSocket, [topic:"stuff",username:"bob"]).blockingFirst()
+        ContextAwareChatServerWebSocket server = embeddedServer.applicationContext.getBean(ContextAwareChatServerWebSocket)
+
+        then:"The connection is valid"
+        fred.session != null
+        fred.session.id != null
+        fred.request != null
+        fred.subProtocol == null
+        server.subProtocol == null
+
+        then:"A session is established"
+        fred.session != null
+        fred.session.id != null
+        fred.session.id != bob.session.id
+        fred.request != null
+        fred.topic == 'stuff'
+        fred.username == 'fred'
+        bob.username == 'bob'
+        conditions.eventually {
+            fred.replies.contains("[bob] Joined! Request URI: " + bob.request.uri)
+            fred.replies.size() == 1
+        }
+
+
+        when:"A message is sent"
+        fred.send("Hello bob!")
+
+        then:
+        conditions.eventually {
+            bob.replies.contains("[fred] Hello bob! Request URI: " + fred.request.uri)
+            bob.replies.size() == 1
+        }
+
+        when:
+        bob.send("Hi fred. How are things?")
+
+        then:
+        conditions.eventually {
+
+            fred.replies.contains("[bob] Hi fred. How are things? Request URI: " + bob.request.uri)
+            fred.replies.size() == 2
+            bob.replies.contains("[fred] Hello bob! Request URI: " + fred.request.uri)
+            bob.replies.size() == 1
+        }
+        fred.sendAsync("foo").get() == 'foo'
+        fred.sendRx("bar").blockingGet() == 'bar'
+
+        when:
+        bob.close()
+        fred.close()
+
+        then:
+        conditions.eventually {
+            !bob.session.isOpen()
+            !fred.session.isOpen()
+        }
+
+        when:"A bean is retrieved that injects a websocket client"
+        MyBean myBean = embeddedServer.applicationContext.getBean(MyBean)
+
+        then:
+        myBean.myClient != null
+
+        cleanup:
+        wsClient.close()
+        embeddedServer.close()
+    }
+
+    @Singleton
+    static class MyBean {
+        @Inject
+        @Client("http://localhost:8080")
+        RxWebSocketClient myClient
+    }
+}

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/WebSocketContextValidationFilter.java
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/WebSocketContextValidationFilter.java
@@ -10,15 +10,20 @@ import io.micronaut.http.filter.HttpFilter;
 import java.util.Objects;
 import org.reactivestreams.Publisher;
 
-@Filter(patterns = {"/chat/**", "/binary/chat/**", "/pojo/chat/**"})
+@Filter("/context/chat/**")
 public class WebSocketContextValidationFilter implements HttpFilter {
 
     @Override
     public Publisher<? extends HttpResponse<?>> doFilter(HttpRequest<?> request, FilterChain chain) {
-        HttpRequest<Object> currentRequest = ServerRequestContext.currentRequest().orElse(null);
-        if (!Objects.equals(currentRequest, request)) {
-            return Publishers.just(new IllegalStateException("Current request is not set properly: " + currentRequest));
+        if (!request.getAttribute(MARKER).isPresent()) {
+            request.setAttribute(MARKER, true);
+            HttpRequest<Object> currentRequest = ServerRequestContext.currentRequest().orElse(null);
+            if (!Objects.equals(currentRequest, request)) {
+                return Publishers.just(new IllegalStateException("Current request is not set properly: " + currentRequest));
+            }
         }
         return chain.proceed(request);
     }
+
+    private static final String MARKER = WebSocketContextValidationFilter.class.getName();
 }

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/WebSocketContextValidationFilter.java
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/WebSocketContextValidationFilter.java
@@ -1,0 +1,24 @@
+package io.micronaut.http.server.netty.websocket;
+
+import io.micronaut.core.async.publisher.Publishers;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.annotation.Filter;
+import io.micronaut.http.context.ServerRequestContext;
+import io.micronaut.http.filter.FilterChain;
+import io.micronaut.http.filter.HttpFilter;
+import java.util.Objects;
+import org.reactivestreams.Publisher;
+
+@Filter(patterns = {"/chat/**", "/binary/chat/**", "/pojo/chat/**"})
+public class WebSocketContextValidationFilter implements HttpFilter {
+
+    @Override
+    public Publisher<? extends HttpResponse<?>> doFilter(HttpRequest<?> request, FilterChain chain) {
+        HttpRequest<Object> currentRequest = ServerRequestContext.currentRequest().orElse(null);
+        if (!Objects.equals(currentRequest, request)) {
+            return Publishers.just(new IllegalStateException("Current request is not set properly: " + currentRequest));
+        }
+        return chain.proceed(request);
+    }
+}


### PR DESCRIPTION
Closes #5900

Posting this as draft for now to demonstrate the regression in the tests.
Note: I know this is not the nicest way to extend the tests as I did not create new cases but modified the existing test suite to demonstrate this behaviour. I was happy I could reproduce this, but I am open to suggestions on how to separate it properly into new test cases, if needed.