### PR TITLE
Add support for visiting BeanElements before they are written

### DIFF
--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyClassElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyClassElement.java
@@ -23,6 +23,7 @@ import io.micronaut.ast.groovy.utils.PublicMethodVisitor;
 import io.micronaut.core.annotation.*;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.reflect.ClassUtils;
+import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.ast.*;
 import org.apache.groovy.ast.tools.ClassNodeUtils;
@@ -411,6 +412,18 @@ public class GroovyClassElement extends AbstractGroovyElement implements Arrayab
     @Override
     public boolean isPrimitive() {
         return classNode.isArray() && ClassUtils.getPrimitiveType(classNode.getComponentType().getName()).isPresent();
+    }
+
+    @Override
+    public Collection<ClassElement> getInterfaces() {
+        final ClassNode[] interfaces = classNode.getInterfaces();
+        if (ArrayUtils.isNotEmpty(interfaces)) {
+            return Arrays.stream(interfaces).map((cn) -> visitorContext.getElementFactory().newClassElement(
+                    cn,
+                    AstAnnotationUtils.getAnnotationMetadata(sourceUnit, compilationUnit, cn)
+            )).collect(Collectors.toList());
+        }
+        return Collections.emptyList();
     }
 
     @Override

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
@@ -190,6 +190,17 @@ public class JavaClassElement extends AbstractJavaElement implements ArrayableCl
     }
 
     @Override
+    public Collection<ClassElement> getInterfaces() {
+        final List<? extends TypeMirror> interfaces = classElement.getInterfaces();
+        if (!interfaces.isEmpty()) {
+            return Collections.unmodifiableList(interfaces.stream().map((mirror) ->
+                mirrorToClassElement(mirror, visitorContext, genericTypeInfo)).collect(Collectors.toList())
+            );
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
     public Optional<ClassElement> getSuperType() {
         final TypeMirror superclass = classElement.getSuperclass();
         if (superclass != null) {

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaVisitorContext.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaVisitorContext.java
@@ -30,6 +30,7 @@ import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.ast.beans.BeanElement;
 import io.micronaut.inject.util.VisitorContextUtils;
 import io.micronaut.inject.visitor.TypeElementVisitor;
 import io.micronaut.inject.visitor.VisitorContext;
@@ -212,6 +213,9 @@ public class JavaVisitorContext implements VisitorContext {
 
     private void printMessage(String message, Diagnostic.Kind kind, @Nullable io.micronaut.inject.ast.Element element) {
         if (StringUtils.isNotEmpty(message)) {
+            if (element instanceof BeanElement) {
+                element = ((BeanElement) element).getDeclaringClass();
+            }
             if (element instanceof AbstractJavaElement) {
                 Element el = (Element) element.getNativeType();
                 messager.printMessage(kind, message, el);

--- a/inject-java/src/test/groovy/io/micronaut/inject/ast/beans/BeanElementVisitorSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/ast/beans/BeanElementVisitorSpec.groovy
@@ -1,0 +1,97 @@
+package io.micronaut.inject.ast.beans
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.annotation.Prototype
+
+class BeanElementVisitorSpec extends AbstractTypeElementSpec {
+
+    void "test visit bean element for simple bean"() {
+        given:
+        buildBeanDefinition('testbe.Test', '''
+package testbe;
+
+import io.micronaut.context.annotation.Prototype;
+import io.micronaut.context.env.Environment;
+import io.micronaut.core.convert.ConversionService;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+@Prototype
+@Named("blah")
+class Test implements Runnable {
+    @Inject ConversionService<?> conversionService;
+    
+    @Inject
+    void setEnvironment(Environment environment) {
+        
+    }
+    
+    @Override public void run() {
+    
+    }
+}
+''')
+        BeanElement beanElement = TestBeanElementVisitor.theBeanElement
+
+        expect:
+        TestBeanElementVisitor.first
+        !SecondBeanElementVisitor.first
+        beanElement != null
+        beanElement.scope.get() == Prototype.name
+        beanElement.qualifiers.size() == 1
+        beanElement.injectionPoints.size() == 2
+        beanElement.declaringClass.name == 'testbe.Test'
+        beanElement.producingElement.name == 'testbe.Test'
+        beanElement.beanTypes == ['testbe.Test', 'java.lang.Runnable'] as Set
+
+    }
+
+    void "test visit bean element for factory bean"() {
+        given:
+        buildBeanDefinition('testbe.Test', '''
+package testbe;
+
+import io.micronaut.context.annotation.Bean;import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Prototype;
+import io.micronaut.context.env.Environment;
+import io.micronaut.core.convert.ConversionService;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+@Prototype
+@Factory
+class TestFactory implements Runnable {
+    @Inject ConversionService<?> conversionService;
+    
+    @Inject
+    void setEnvironment(Environment environment) {
+        
+    }
+    
+    @Bean
+    Test test() {
+        return new Test();
+    }
+    
+    @Override public void run() {
+    
+    }
+}
+
+class Test {}
+''')
+        BeanElement beanElement = TestBeanElementVisitor.theBeanElement
+
+        expect:
+        beanElement != null
+        beanElement.scope.get() == Prototype.name
+        beanElement.qualifiers.size() == 0
+        beanElement.injectionPoints.size() == 0
+        beanElement.declaringClass.name == 'testbe.TestFactory'
+        beanElement.producingElement.name == 'test'
+        beanElement.beanTypes == ['testbe.Test'] as Set
+
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/ast/beans/SecondBeanElementVisitor.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/ast/beans/SecondBeanElementVisitor.java
@@ -1,0 +1,23 @@
+package io.micronaut.inject.ast.beans;
+
+import java.lang.annotation.Annotation;
+
+import io.micronaut.core.order.Ordered;
+import io.micronaut.inject.visitor.BeanElementVisitor;
+import io.micronaut.inject.visitor.VisitorContext;
+
+public class SecondBeanElementVisitor implements BeanElementVisitor<Annotation> {
+    static Boolean first;
+
+    @Override
+    public void visitBeanElement(BeanElement beanElement, VisitorContext visitorContext) {
+        if (first == null) {
+            first = TestBeanElementVisitor.first == null;
+        }
+    }
+
+    @Override
+    public int getOrder() {
+        return Ordered.LOWEST_PRECEDENCE;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/ast/beans/TestBeanElementVisitor.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/ast/beans/TestBeanElementVisitor.java
@@ -1,0 +1,17 @@
+package io.micronaut.inject.ast.beans;
+
+import io.micronaut.context.annotation.Prototype;
+import io.micronaut.inject.visitor.BeanElementVisitor;
+import io.micronaut.inject.visitor.VisitorContext;
+
+public class TestBeanElementVisitor implements BeanElementVisitor<Prototype> {
+    static BeanElement theBeanElement;
+    static Boolean first;
+    @Override
+    public void visitBeanElement(BeanElement beanElement, VisitorContext visitorContext) {
+        if (first == null) {
+            first = SecondBeanElementVisitor.first == null;
+        }
+        theBeanElement = beanElement;
+    }
+}

--- a/inject-java/src/test/resources/META-INF/services/io.micronaut.inject.visitor.BeanElementVisitor
+++ b/inject-java/src/test/resources/META-INF/services/io.micronaut.inject.visitor.BeanElementVisitor
@@ -1,0 +1,2 @@
+io.micronaut.inject.ast.beans.TestBeanElementVisitor
+io.micronaut.inject.ast.beans.SecondBeanElementVisitor

--- a/inject/src/main/java/io/micronaut/inject/ast/ClassElement.java
+++ b/inject/src/main/java/io/micronaut/inject/ast/ClassElement.java
@@ -144,6 +144,13 @@ public interface ClassElement extends TypedElement {
         return Optional.empty();
     }
 
+    /**
+     * @return The interfaces implemented by this class element
+     */
+    default Collection<ClassElement> getInterfaces() {
+        return Collections.emptyList();
+    }
+
     @NonNull
     @Override
     default ClassElement getType() {

--- a/inject/src/main/java/io/micronaut/inject/ast/beans/BeanElement.java
+++ b/inject/src/main/java/io/micronaut/inject/ast/beans/BeanElement.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.ast.beans;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.Set;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.ast.Element;
+
+/**
+ * Models a bean that will be produced by Micronaut.
+ *
+ * @since 3.0.0
+ * @author graemerocher
+ */
+public interface BeanElement extends Element {
+
+    /**
+     * Returns all of the injection points for the bean. These
+     * will be a combination of {@link io.micronaut.inject.ast.FieldElement} and {@link io.micronaut.inject.ast.MethodElement} instances.
+     *
+     * @return The injection points for the bean.
+     */
+    @NonNull
+    Collection<Element> getInjectionPoints();
+
+    /**
+     * Returns the declaring {@link io.micronaut.inject.ast.ClassElement} which may differ
+     * from the {@link #getBeanTypes()} in the case of factory beans.
+     *
+     * @return The declaring class of the bean.
+     */
+    @NonNull
+    ClassElement getDeclaringClass();
+
+    /**
+     * The element that produces the bean, this could be a {@link io.micronaut.inject.ast.ClassElement} for regular beans,
+     * or either a {@link io.micronaut.inject.ast.MethodElement} or {@link io.micronaut.inject.ast.FieldElement} for factory beans.
+     *
+     * @return The producing element
+     */
+    @NonNull
+    Element getProducingElement();
+
+    /**
+     * The type names produced by the bean.
+     * @return A set of types
+     */
+    @NonNull
+    Set<String> getBeanTypes();
+
+    /**
+     * The scope of the bean.
+     * @return The fully qualified name of the scope or empty if no scope is defined.
+     */
+    @NonNull
+    Optional<String> getScope();
+
+    /**
+     * @return One or more fully qualified qualifier types defined by the bean.
+     */
+    @NonNull
+    Collection<String> getQualifiers();
+}

--- a/inject/src/main/java/io/micronaut/inject/visitor/BeanElementVisitor.java
+++ b/inject/src/main/java/io/micronaut/inject/visitor/BeanElementVisitor.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.visitor;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.order.Ordered;
+import io.micronaut.core.reflect.GenericTypeUtils;
+import io.micronaut.core.util.Toggleable;
+import io.micronaut.inject.ast.beans.BeanElement;
+
+/**
+ * Allows visiting a bean to perform any validation prior to when bean definitions are written out.
+ *
+ * @author graemerocher
+ * @since 3.0.0
+ * @param <A> An annotation type to limit visitation to a subset of beans
+ */
+public interface BeanElementVisitor<A extends Annotation> extends Ordered, Toggleable {
+    /**
+     * The available visitors.
+     */
+    List<BeanElementVisitor<?>> VISITORS = BeanElementVisitorLoader.load();
+
+    /**
+     * Visits a {@link io.micronaut.inject.ast.beans.BeanElement} before it is finalized and written to disk,
+     * allowing mutation of any annotation metadata before writing the bean definition.
+     *
+     * @param beanElement The bean element
+     * @param visitorContext The visitor context
+     */
+    void visitBeanElement(@NonNull BeanElement beanElement, @NonNull VisitorContext visitorContext);
+
+    /**
+     * Returns whether this visitor supports visiting the specified element.
+     * @param beanElement The bean element
+     * @return True if it does
+     */
+    default boolean supports(@NonNull BeanElement beanElement) {
+        //noinspection ConstantConditions
+        if (beanElement == null) {
+            return false;
+        }
+        final Class<?> t = GenericTypeUtils.resolveInterfaceTypeArgument(getClass(), BeanElementVisitor.class)
+                .orElse(Annotation.class);
+        if (t == Annotation.class) {
+            return true;
+        } else {
+            return beanElement.hasAnnotation(t.getName());
+        }
+    }
+
+}

--- a/inject/src/main/java/io/micronaut/inject/visitor/BeanElementVisitorLoader.java
+++ b/inject/src/main/java/io/micronaut/inject/visitor/BeanElementVisitorLoader.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.visitor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.io.service.ServiceDefinition;
+import io.micronaut.core.io.service.SoftServiceLoader;
+import io.micronaut.core.order.OrderUtil;
+
+/**
+ * Loads the {@link io.micronaut.inject.visitor.BeanElementVisitor} instances.
+ *
+ * @author graemerocher
+ * @since 3.0.0
+ */
+final class BeanElementVisitorLoader {
+    /**
+     * @return The loaded visitors
+     */
+    static @NonNull List<BeanElementVisitor<?>> load() {
+        List<BeanElementVisitor<?>> visitors = new ArrayList<>(10);
+        final SoftServiceLoader<BeanElementVisitor> serviceLoader = SoftServiceLoader.load(BeanElementVisitor.class);
+        for (ServiceDefinition<BeanElementVisitor> definition : serviceLoader) {
+            if (definition.isPresent()) {
+                try {
+                    final BeanElementVisitor<?> visitor = definition.load();
+                    if (visitor.isEnabled()) {
+                        visitors.add(visitor);
+                    }
+                } catch (Exception e) {
+                    // ignore and skip
+                }
+            }
+        }
+
+        if (visitors.isEmpty()) {
+            return Collections.emptyList();
+        } else {
+            OrderUtil.sort(visitors);
+            return Collections.unmodifiableList(visitors);
+        }
+    }
+}


### PR DESCRIPTION
CDI lite has a lifecycle method that allows to validate beans before compiling, we have no hook for this and this adds one.