### PR TITLE
Makes the behaviour of a missing provider configurable

### DIFF
--- a/inject-java-test/src/main/groovy/io/micronaut/annotation/processing/test/AbstractTypeElementSpec.groovy
+++ b/inject-java-test/src/main/groovy/io/micronaut/annotation/processing/test/AbstractTypeElementSpec.groovy
@@ -22,6 +22,8 @@ import io.micronaut.annotation.processing.visitor.JavaElementFactory
 import io.micronaut.annotation.processing.visitor.JavaVisitorContext
 import io.micronaut.aop.internal.InterceptorRegistryBean
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.ApplicationContextBuilder
+import io.micronaut.context.ApplicationContextConfiguration
 import io.micronaut.context.DefaultApplicationContext
 import io.micronaut.context.Qualifier
 import io.micronaut.core.annotation.AnnotationMetadata
@@ -29,7 +31,6 @@ import io.micronaut.core.annotation.NonNull
 import io.micronaut.core.annotation.Nullable
 import io.micronaut.core.beans.BeanIntrospection
 import io.micronaut.core.convert.value.MutableConvertibleValuesMap
-import io.micronaut.core.io.scan.ClassPathResourceLoader
 import io.micronaut.core.naming.NameUtils
 import io.micronaut.inject.BeanConfiguration
 import io.micronaut.inject.BeanDefinition
@@ -220,7 +221,11 @@ class Test {
             }
         }
 
-        return new DefaultApplicationContext(ClassPathResourceLoader.defaultLoader(classLoader), "test") {
+        def builder = ApplicationContext.builder()
+        builder.classLoader(classLoader)
+        builder.environments("test")
+        configureContext(builder)
+        return new DefaultApplicationContext((ApplicationContextConfiguration) builder) {
             @Override
             protected List<BeanDefinitionReference> resolveBeanDefinitionReferences(Predicate<BeanDefinitionReference> predicate) {
                 def references = StreamSupport.stream(files.spliterator(), false)
@@ -526,6 +531,13 @@ class Test {
             }
         }
         return builder
+    }
+
+    /**
+     * Allows configuring the context
+     * @param contextBuilder The context builder
+     */
+    protected void configureContext(ApplicationContextBuilder contextBuilder) {
     }
 
     static class TypeElementInfo {

--- a/inject-java/src/test/groovy/io/micronaut/inject/provider/BeanProviderSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/provider/BeanProviderSpec.groovy
@@ -16,13 +16,16 @@
 package io.micronaut.inject.provider
 
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.BeanContext
+import io.micronaut.context.BeanContextConfiguration
+import io.micronaut.context.DefaultBeanContext
 import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.BeanDefinitionReference
 import io.micronaut.inject.annotation.TestCachePuts
 
 class BeanProviderSpec extends AbstractTypeElementSpec {
 
-    void "test bean definition reference references correct bean type for jakarta.inject.Provider"() {
+     void "test bean definition reference references correct bean type for jakarta.inject.Provider"() {
         given:
         BeanDefinitionReference definition = buildBeanDefinitionReference('test.Test','''\
 package test;

--- a/inject-java/src/test/groovy/io/micronaut/inject/provider/DisableErrorOnMissingBeanProviderSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/provider/DisableErrorOnMissingBeanProviderSpec.groovy
@@ -1,7 +1,6 @@
 package io.micronaut.inject.provider
 
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
-import io.micronaut.context.ApplicationContext
 import io.micronaut.context.ApplicationContextBuilder
 import io.micronaut.context.exceptions.BeanInstantiationException
 import io.micronaut.context.exceptions.NoSuchBeanException
@@ -10,7 +9,7 @@ import spock.lang.Stepwise
 @Stepwise
 class DisableErrorOnMissingBeanProviderSpec extends AbstractTypeElementSpec {
 
-    boolean shouldError = false
+    boolean allowEmptyProviders = true
 
     void "test should not error on missing bean provider if disabled"() {
         given:
@@ -122,7 +121,7 @@ class Test {
 
     void "test default error on missing bean provider"() {
         given:
-        shouldError = true
+        allowEmptyProviders = false
         def context = buildContext('''
 package missingprov;
 
@@ -146,6 +145,6 @@ class Test {
 
     @Override
     protected void configureContext(ApplicationContextBuilder contextBuilder) {
-        contextBuilder.errorOnMissingBeanProvider(shouldError)
+        contextBuilder.allowEmptyProviders(allowEmptyProviders)
     }
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/provider/DisableErrorOnMissingBeanProviderSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/provider/DisableErrorOnMissingBeanProviderSpec.groovy
@@ -1,0 +1,73 @@
+package io.micronaut.inject.provider
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.ApplicationContextBuilder
+import io.micronaut.context.exceptions.BeanInstantiationException
+import io.micronaut.context.exceptions.NoSuchBeanException
+import spock.lang.Stepwise
+
+@Stepwise
+class DisableErrorOnMissingBeanProviderSpec extends AbstractTypeElementSpec {
+
+    boolean shouldError = false
+
+    void "test should error on missing bean provider"() {
+        given:
+        def context = buildContext('''
+package missingprov;
+
+import jakarta.inject.*;
+
+@Singleton
+class Test {
+    @Inject
+    Provider<String> stringProvider;
+}
+''')
+        when:
+        def bean = getBean(context, 'missingprov.Test')
+
+        then:
+        bean
+        bean.stringProvider
+
+        when:
+        bean.stringProvider.get()
+
+        then:
+        thrown(NoSuchBeanException)
+
+        cleanup:
+        context.close()
+    }
+
+    void "test default error on missing bean provider"() {
+        given:
+        shouldError = true
+        def context = buildContext('''
+package missingprov;
+
+import jakarta.inject.*;
+
+@Singleton
+class Test {
+    @Inject
+    Provider<String> stringProvider;
+}
+''')
+        when:
+        def bean = getBean(context, 'missingprov.Test')
+
+        then:
+        thrown(BeanInstantiationException)
+
+        cleanup:
+        context.close()
+    }
+
+    @Override
+    protected void configureContext(ApplicationContextBuilder contextBuilder) {
+        contextBuilder.errorOnMissingBeanProvider(shouldError)
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/ApplicationContextBuilder.java
+++ b/inject/src/main/java/io/micronaut/context/ApplicationContextBuilder.java
@@ -206,13 +206,13 @@ public interface ApplicationContextBuilder {
     @NonNull ApplicationContextBuilder banner(boolean isEnabled);
 
     /**
-     * Whether to error on a missing bean provider.
+     * Whether to error on an empty bean provider. Defaults to {@code false}.
      *
-     * @param shouldError True if an error should occur
+     * @param shouldAllow True if empty {@link jakarta.inject.Provider} instances are allowed
      * @return This application
      * @since 3.0.0
      */
-    @NonNull ApplicationContextBuilder errorOnMissingBeanProvider(boolean shouldError);
+    @NonNull ApplicationContextBuilder allowEmptyProviders(boolean shouldAllow);
 
     /**
      * Set the command line arguments.

--- a/inject/src/main/java/io/micronaut/context/ApplicationContextBuilder.java
+++ b/inject/src/main/java/io/micronaut/context/ApplicationContextBuilder.java
@@ -206,6 +206,15 @@ public interface ApplicationContextBuilder {
     @NonNull ApplicationContextBuilder banner(boolean isEnabled);
 
     /**
+     * Whether to error on a missing bean provider.
+     *
+     * @param shouldError True if an error should occur
+     * @return This application
+     * @since 3.0.0
+     */
+    @NonNull ApplicationContextBuilder errorOnMissingBeanProvider(boolean shouldError);
+
+    /**
      * Set the command line arguments.
      *
      * @param args The arguments

--- a/inject/src/main/java/io/micronaut/context/BeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/BeanContext.java
@@ -50,6 +50,13 @@ public interface BeanContext extends
         MutableAttributeHolder {
 
     /**
+     * Obtains the configuration for this context.
+     * @return The {@link io.micronaut.context.BeanContextConfiguration}
+     * @since 3.0.0
+     */
+    @NonNull BeanContextConfiguration getContextConfiguration();
+
+    /**
      * Publish the given event. The event will be published synchronously and only return once all listeners have consumed the event.
      *
      * @deprecated Preferred way is to use event typed {@code ApplicationEventPublisher<MyEventType>}

--- a/inject/src/main/java/io/micronaut/context/BeanContextConfiguration.java
+++ b/inject/src/main/java/io/micronaut/context/BeanContextConfiguration.java
@@ -33,6 +33,14 @@ import java.util.Set;
 public interface BeanContextConfiguration {
 
     /**
+     * @return If a {@link io.micronaut.context.exceptions.NoSuchBeanException} should be thrown on a missing {@link io.micronaut.context.BeanProvider} or {@link jakarta.inject.Provider}
+     * @since 3.0.0
+     */
+    default boolean isErrorOnMissingProvider() {
+        return true;
+    }
+
+    /**
      * The class loader to use.
      * @return The class loader.
      */

--- a/inject/src/main/java/io/micronaut/context/BeanContextConfiguration.java
+++ b/inject/src/main/java/io/micronaut/context/BeanContextConfiguration.java
@@ -36,8 +36,8 @@ public interface BeanContextConfiguration {
      * @return If a {@link io.micronaut.context.exceptions.NoSuchBeanException} should be thrown on a missing {@link io.micronaut.context.BeanProvider} or {@link jakarta.inject.Provider}
      * @since 3.0.0
      */
-    default boolean isErrorOnMissingProvider() {
-        return true;
+    default boolean isAllowEmptyProviders() {
+        return false;
     }
 
     /**

--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContextBuilder.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContextBuilder.java
@@ -53,7 +53,7 @@ public class DefaultApplicationContextBuilder implements ApplicationContextBuild
     private String[] overrideConfigLocations;
     private boolean banner = true;
     private ClassPathResourceLoader classPathResourceLoader;
-    private boolean errorOnMissingProvider = true;
+    private boolean allowEmptyProviders = false;
 
     /**
      * Default constructor.
@@ -62,8 +62,8 @@ public class DefaultApplicationContextBuilder implements ApplicationContextBuild
     }
 
     @Override
-    public boolean isErrorOnMissingProvider() {
-        return errorOnMissingProvider;
+    public boolean isAllowEmptyProviders() {
+        return allowEmptyProviders;
     }
 
     @NonNull
@@ -337,8 +337,8 @@ public class DefaultApplicationContextBuilder implements ApplicationContextBuild
     }
 
     @Override
-    public ApplicationContextBuilder errorOnMissingBeanProvider(boolean shouldError) {
-        this.errorOnMissingProvider = shouldError;
+    public ApplicationContextBuilder allowEmptyProviders(boolean shouldAllow) {
+        this.allowEmptyProviders = shouldAllow;
         return this;
     }
 }

--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContextBuilder.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContextBuilder.java
@@ -53,11 +53,17 @@ public class DefaultApplicationContextBuilder implements ApplicationContextBuild
     private String[] overrideConfigLocations;
     private boolean banner = true;
     private ClassPathResourceLoader classPathResourceLoader;
+    private boolean errorOnMissingProvider = true;
 
     /**
      * Default constructor.
      */
     protected DefaultApplicationContextBuilder() {
+    }
+
+    @Override
+    public boolean isErrorOnMissingProvider() {
+        return errorOnMissingProvider;
     }
 
     @NonNull
@@ -327,6 +333,12 @@ public class DefaultApplicationContextBuilder implements ApplicationContextBuild
     @Override
     public @NonNull ApplicationContextBuilder banner(boolean isEnabled) {
         this.banner = isEnabled;
+        return this;
+    }
+
+    @Override
+    public ApplicationContextBuilder errorOnMissingBeanProvider(boolean shouldError) {
+        this.errorOnMissingProvider = shouldError;
         return this;
     }
 }

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -110,9 +110,9 @@ public class DefaultBeanContext implements BeanContext {
     final Map<BeanKey, BeanRegistration> singletonObjects = new ConcurrentHashMap<>(100);
     final Map<BeanIdentifier, Object> singlesInCreation = new ConcurrentHashMap<>(5);
     final Map<BeanKey, Provider<Object>> scopedProxies = new ConcurrentHashMap<>(20);
-
     Set<Map.Entry<Class, List<BeanInitializedEventListener>>> beanInitializedEventListeners;
-
+    
+    private final BeanContextConfiguration beanContextConfiguration;
     private final Collection<BeanDefinitionReference> beanDefinitionsClasses = new ConcurrentLinkedQueue<>();
     private final Map<String, BeanConfiguration> beanConfigurations = new HashMap<>(10);
     private final Map<BeanKey, Boolean> containsBeanCache = new ConcurrentHashMap<>(30);
@@ -209,6 +209,7 @@ public class DefaultBeanContext implements BeanContext {
         this.eagerInitStereotypes = eagerInitStereotypes.toArray(new String[0]);
         this.eagerInitStereotypesPresent = !eagerInitStereotypes.isEmpty();
         this.eagerInitSingletons = eagerInitStereotypesPresent && (eagerInitStereotypes.contains(AnnotationUtil.SINGLETON) || eagerInitStereotypes.contains(Singleton.class.getName()));
+        this.beanContextConfiguration = contextConfiguration;
     }
 
     /**
@@ -1635,6 +1636,11 @@ public class DefaultBeanContext implements BeanContext {
             }
             return Optional.empty();
         }
+    }
+
+    @Override
+    public BeanContextConfiguration getContextConfiguration() {
+        return this.beanContextConfiguration;
     }
 
     @SuppressWarnings("unchecked")

--- a/inject/src/main/java/io/micronaut/inject/provider/AbstractProviderDefinition.java
+++ b/inject/src/main/java/io/micronaut/inject/provider/AbstractProviderDefinition.java
@@ -154,7 +154,7 @@ public abstract class AbstractProviderDefinition<T> implements BeanDefinition<T>
                         } else if (injectionPointArgument.isNullable()) {
                             throw new DisabledBeanException("Nullable bean doesn't exist");
                         } else {
-                            if (qualifier instanceof AnyQualifier || isAllowMissingProviders(context)) {
+                            if (qualifier instanceof AnyQualifier || isAllowEmptyProviders(context)) {
                                 return buildProvider(
                                         resolutionContext,
                                         context,
@@ -179,8 +179,8 @@ public abstract class AbstractProviderDefinition<T> implements BeanDefinition<T>
      * @param context The context
      * @return Returns {@code true} if missing providers are allowed
      */
-    protected boolean isAllowMissingProviders(BeanContext context) {
-        return !context.getContextConfiguration().isErrorOnMissingProvider();
+    protected boolean isAllowEmptyProviders(BeanContext context) {
+        return context.getContextConfiguration().isAllowEmptyProviders();
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/inject/provider/AbstractProviderDefinition.java
+++ b/inject/src/main/java/io/micronaut/inject/provider/AbstractProviderDefinition.java
@@ -154,7 +154,7 @@ public abstract class AbstractProviderDefinition<T> implements BeanDefinition<T>
                         } else if (injectionPointArgument.isNullable()) {
                             throw new DisabledBeanException("Nullable bean doesn't exist");
                         } else {
-                            if (qualifier instanceof AnyQualifier || !context.getContextConfiguration().isErrorOnMissingProvider()) {
+                            if (qualifier instanceof AnyQualifier || isAllowMissingProviders(context)) {
                                 return buildProvider(
                                         resolutionContext,
                                         context,
@@ -172,6 +172,15 @@ public abstract class AbstractProviderDefinition<T> implements BeanDefinition<T>
             }
         }
         throw new UnsupportedOperationException("Cannot inject provider for Object type");
+    }
+
+    /**
+     * Return whether missing providers are allowed for this implementation. If {@code false} a {@link io.micronaut.context.exceptions.NoSuchBeanException} is thrown.
+     * @param context The context
+     * @return Returns {@code true} if missing providers are allowed
+     */
+    protected boolean isAllowMissingProviders(BeanContext context) {
+        return !context.getContextConfiguration().isErrorOnMissingProvider();
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/inject/provider/AbstractProviderDefinition.java
+++ b/inject/src/main/java/io/micronaut/inject/provider/AbstractProviderDefinition.java
@@ -154,7 +154,7 @@ public abstract class AbstractProviderDefinition<T> implements BeanDefinition<T>
                         } else if (injectionPointArgument.isNullable()) {
                             throw new DisabledBeanException("Nullable bean doesn't exist");
                         } else {
-                            if (qualifier instanceof AnyQualifier) {
+                            if (qualifier instanceof AnyQualifier || !context.getContextConfiguration().isErrorOnMissingProvider()) {
                                 return buildProvider(
                                         resolutionContext,
                                         context,

--- a/inject/src/main/java/io/micronaut/inject/provider/BeanProviderDefinition.java
+++ b/inject/src/main/java/io/micronaut/inject/provider/BeanProviderDefinition.java
@@ -99,7 +99,7 @@ public final class BeanProviderDefinition extends AbstractProviderDefinition<Bea
     }
 
     @Override
-    protected final boolean isAllowMissingProviders(BeanContext context) {
+    protected boolean isAllowMissingProviders(BeanContext context) {
         return true;
     }
 }

--- a/inject/src/main/java/io/micronaut/inject/provider/BeanProviderDefinition.java
+++ b/inject/src/main/java/io/micronaut/inject/provider/BeanProviderDefinition.java
@@ -99,7 +99,7 @@ public final class BeanProviderDefinition extends AbstractProviderDefinition<Bea
     }
 
     @Override
-    protected boolean isAllowMissingProviders(BeanContext context) {
+    protected boolean isAllowEmptyProviders(BeanContext context) {
         return true;
     }
 }

--- a/inject/src/main/java/io/micronaut/inject/provider/BeanProviderDefinition.java
+++ b/inject/src/main/java/io/micronaut/inject/provider/BeanProviderDefinition.java
@@ -97,4 +97,9 @@ public final class BeanProviderDefinition extends AbstractProviderDefinition<Bea
             }
         };
     }
+
+    @Override
+    protected final boolean isAllowMissingProviders(BeanContext context) {
+        return true;
+    }
 }

--- a/inject/src/main/java/io/micronaut/inject/qualifiers/AnnotationMetadataQualifier.java
+++ b/inject/src/main/java/io/micronaut/inject/qualifiers/AnnotationMetadataQualifier.java
@@ -104,6 +104,9 @@ class AnnotationMetadataQualifier<T> extends NameQualifier<T> {
             if (qualifierAnn != null) {
                 return reduced
                         .filter(candidate -> {
+                            if (beanType != Object.class && candidate.getAnnotationMetadata().hasDeclaredAnnotation(Any.class)) {
+                                return true;
+                            }
                             final AnnotationMetadata annotationMetadata = candidate.getAnnotationMetadata();
                             final AnnotationValue<Annotation> av = candidate.getAnnotation(qualifiedName);
                             if (av != null) {
@@ -168,6 +171,11 @@ class AnnotationMetadataQualifier<T> extends NameQualifier<T> {
 
     @Override
     public String toString() {
-        return annotationType == null ? super.toString() : "@" + annotationType.getSimpleName();
+        String annName = annotationType == null ? super.toString() : "@" + annotationType.getSimpleName();
+        if (this.qualifierAnn != null) {
+            final Map<CharSequence, Object> values = qualifierAnn.getValues();
+            annName += "(" + values.entrySet().stream().map(entry -> entry.getKey() + "=" + entry.getValue()).collect(Collectors.joining(", ")) + ")";
+        }
+        return annName;
     }
 }


### PR DESCRIPTION
In CDI a missing provider does not result an exception on injection but instead only when the provider's get() method is called. This differs from Micronaut and in order to make it compliant this behaviour needs to be configurable.