### PR TITLE
Support more Optional* types in config properties

### DIFF
--- a/core/src/main/java/io/micronaut/core/type/TypeInformation.java
+++ b/core/src/main/java/io/micronaut/core/type/TypeInformation.java
@@ -92,6 +92,14 @@ public interface TypeInformation<T> extends TypeVariableResolver, AnnotationMeta
     }
 
     /**
+     * Returns the wrapped type in the case where {@link #isWrapperType()} returns true.
+     * @return The wrapped type
+     */
+    default Argument<?> getWrappedType() {
+        return RuntimeTypeInformation.getWrappedType(this);
+    }
+
+    /**
      * @return Is the return the return type a reactive completable type.
      * @since 2.0.0
      */

--- a/inject-java/src/test/groovy/io/micronaut/inject/optional/BeanWithOptionals.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/optional/BeanWithOptionals.java
@@ -1,0 +1,39 @@
+package io.micronaut.inject.optional;
+
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+
+import io.micronaut.context.annotation.Property;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class BeanWithOptionals {
+    @Property(name = "string.prop")
+    Optional<String> stringOptional;
+
+    @Property(name = "integer.prop")
+    OptionalInt optionalInt;
+
+    @Property(name = "long.prop")
+    OptionalLong optionalLong;
+
+    @Property(name = "double.prop")
+    OptionalDouble optionalDouble;
+
+
+    final OptionalInt optionalIntFromConstructor;
+
+    final OptionalLong optionalLongFromConstructor;
+
+    final OptionalDouble optionalDoubleFromConstructor;
+
+    public BeanWithOptionals(@Property(name = "integer.prop") OptionalInt optionalIntFromConstructor,
+                             @Property(name = "long.prop") OptionalLong optionalLongFromConstructor,
+                             @Property(name = "double.prop") OptionalDouble optionalDoubleFromConstructor) {
+        this.optionalIntFromConstructor = optionalIntFromConstructor;
+        this.optionalLongFromConstructor = optionalLongFromConstructor;
+        this.optionalDoubleFromConstructor = optionalDoubleFromConstructor;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/optional/OptionalPropertySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/optional/OptionalPropertySpec.groovy
@@ -1,0 +1,54 @@
+package io.micronaut.inject.optional
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.ApplicationContext
+
+class OptionalPropertySpec extends AbstractTypeElementSpec {
+
+    void "test get bean with optionals not present"() {
+        given:
+        ApplicationContext context = ApplicationContext.run()
+        BeanWithOptionals opts = context.getBean(BeanWithOptionals)
+
+        expect:
+        !opts.optionalDouble.isPresent()
+        !opts.optionalInt.isPresent()
+        !opts.optionalLong.isPresent()
+        !opts.optionalDoubleFromConstructor.isPresent()
+        !opts.optionalIntFromConstructor.isPresent()
+        !opts.optionalLongFromConstructor.isPresent()
+
+        cleanup:
+        context.close()
+    }
+
+    void "test get bean with optionals present"() {
+        given:
+        ApplicationContext context = ApplicationContext.run(
+                'long.prop':Long.MAX_VALUE,
+                'double.prop':'10.5',
+                'integer.prop':'10',
+                'string.prop':'good'
+        )
+        BeanWithOptionals opts = context.getBean(BeanWithOptionals)
+
+        expect:
+        opts.stringOptional.isPresent()
+        opts.stringOptional.get() == 'good'
+        opts.optionalDouble.isPresent()
+        opts.optionalInt.isPresent()
+        opts.optionalLong.isPresent()
+        opts.optionalInt.asInt == 10
+        opts.optionalDouble.asDouble == 10.5d
+        opts.optionalLong.asLong == Long.MAX_VALUE
+        opts.optionalDoubleFromConstructor.isPresent()
+        opts.optionalIntFromConstructor.isPresent()
+        opts.optionalLongFromConstructor.isPresent()
+        opts.optionalIntFromConstructor.asInt == 10
+        opts.optionalDoubleFromConstructor.asDouble == 10.5d
+        opts.optionalLongFromConstructor.asLong == Long.MAX_VALUE
+
+        cleanup:
+        context.close()
+    }
+}


### PR DESCRIPTION
Adds support for `OptionalLong`, `OptionalDouble` and `OptionalInt` in config props