### PR TITLE
Fixes field injection that has both Value/Property and Inject for Java

### DIFF
--- a/inject-groovy/src/test/groovy/io/micronaut/inject/property/PropertyAnnotationSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/property/PropertyAnnotationSpec.groovy
@@ -124,6 +124,7 @@ class FieldPropertyInject {
     String str
 
     @Property(name = "my.int")
+    @jakarta.inject.Inject
     int integer
 
     @Property(name = "my.nullable")

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -1617,8 +1617,7 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
 
             AnnotationMetadata fieldAnnotationMetadata = annotationUtils.getAnnotationMetadata(variable);
             boolean isInjected = fieldAnnotationMetadata.hasStereotype(AnnotationUtil.INJECT);
-            boolean isValue = !isInjected &&
-                    (fieldAnnotationMetadata.hasStereotype(Value.class) || fieldAnnotationMetadata.hasStereotype(Property.class));
+            boolean isValue = (fieldAnnotationMetadata.hasStereotype(Value.class) || fieldAnnotationMetadata.hasStereotype(Property.class));
 
             if (isInjected || isValue) {
                 BeanDefinitionVisitor writer = getOrCreateBeanDefinitionWriter(concreteClass, concreteClass.getQualifiedName());

--- a/inject-java/src/test/groovy/io/micronaut/inject/property/FieldPropertyInject.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/property/FieldPropertyInject.java
@@ -20,6 +20,7 @@ import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.convert.format.MapFormat;
 
+import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.util.List;
 import java.util.Map;
@@ -40,6 +41,7 @@ public class FieldPropertyInject {
     Map<String, List<String>> multiMap;
 
     @Property(name = "my.string")
+    @Inject
     String str;
 
     @Property(name = "my.int")

--- a/inject-java/src/test/groovy/io/micronaut/inject/property/PropertyAnnotationSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/property/PropertyAnnotationSpec.groovy
@@ -15,10 +15,32 @@
  */
 package io.micronaut.inject.property
 
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.micronaut.context.ApplicationContext
 import spock.lang.Specification
 
-class PropertyAnnotationSpec extends Specification {
+class PropertyAnnotationSpec extends AbstractTypeElementSpec {
+
+    void "test inject with property"() {
+        given:
+        def context = buildContext('''
+package injectwithcontext;
+
+import io.micronaut.context.annotation.Property;
+import jakarta.inject.Inject;
+
+class Test {
+    @Inject
+    @Property(name="foo", defaultValue = "10")
+    public int value;
+}
+''')
+        expect:
+        getBean(context, 'injectwithcontext.Test').value == 10
+
+        cleanup:
+        context.close()
+    }
 
     void "test inject properties"() {
         given:


### PR DESCRIPTION
If you define a field that has both `@Inject` and `@Value` or `@Property` then it fails for Java only. This is surprising and a bug IMO, in addition it is inconsistent with the Groovy implementation.