### PR TITLE
Add Improvements BeanBuilder API (factory beans, lifecycle methods for BeanElemenVisitor)

### DIFF
--- a/aop/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
+++ b/aop/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
@@ -36,6 +36,7 @@ import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.StringUtils;
+import io.micronaut.core.util.Toggleable;
 import io.micronaut.core.value.OptionalValues;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.ExecutableMethod;
@@ -94,7 +95,7 @@ import java.util.stream.Collectors;
  * @author Graeme Rocher
  * @since 1.0
  */
-public class AopProxyWriter extends AbstractClassFileWriter implements ProxyingBeanDefinitionVisitor {
+public class AopProxyWriter extends AbstractClassFileWriter implements ProxyingBeanDefinitionVisitor, Toggleable {
     public static final int MAX_LOCALS = 3;
 
     public static final Method METHOD_GET_PROXY_TARGET = Method.getMethod(
@@ -333,6 +334,11 @@ public class AopProxyWriter extends AbstractClassFileWriter implements ProxyingB
             proxyBeanDefinitionWriter.setInterceptedType(targetClassFullName);
         }
         startClass(classWriter, proxyInternalName, getTypeReferenceForName(targetClassFullName));
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return proxyBeanDefinitionWriter.isEnabled();
     }
 
     /**

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/TypeElementVisitorEnd.groovy
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/TypeElementVisitorEnd.groovy
@@ -78,26 +78,17 @@ class TypeElementVisitorEnd implements ASTTransformation, CompilationUnitAware {
             } else {
                 classWriterOutputVisitor = new DirectoryClassWriterOutputVisitor(classesDir)
             }
-            for (AbstractBeanDefinitionBuilder beanDefinitionBuilder : beanDefinitionBuilders) {
-                final BeanDefinitionWriter beanDefinitionWriter = beanDefinitionBuilder.build()
-                if (beanDefinitionWriter != null) {
-                    try {
-                        beanDefinitionWriter.accept(classWriterOutputVisitor)
-                        String beanTypeName = beanDefinitionWriter.getBeanTypeName()
-                        BeanDefinitionReferenceWriter beanDefinitionReferenceWriter =
-                                new BeanDefinitionReferenceWriter(beanTypeName, beanDefinitionWriter)
-                        beanDefinitionReferenceWriter
-                                .setRequiresMethodProcessing(beanDefinitionWriter.requiresMethodProcessing())
-                        beanDefinitionReferenceWriter.accept(classWriterOutputVisitor)
-                    } catch (IOException e) {
-                        // raise a compile error
-                        AstMessageUtils.error(
-                                source,
-                                source.getAST(),
-                                "Error writing bean definitions: $e.message")
-
-                    }
-                }
+            try {
+                AbstractBeanDefinitionBuilder.writeBeanDefinitionBuilders(
+                        classWriterOutputVisitor,
+                        beanDefinitionBuilders
+                )
+            } catch (IOException e) {
+                // raise a compile error
+                AstMessageUtils.error(
+                        source,
+                        source.getAST(),
+                        "Error writing bean definitions: $e.message")
             }
             classWriterOutputVisitor.finish()
         }

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyBeanDefinitionBuilder.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyBeanDefinitionBuilder.java
@@ -77,6 +77,16 @@ class GroovyBeanDefinitionBuilder extends AbstractBeanDefinitionBuilder {
                 GroovyBeanDefinitionBuilder.this.visitorContext
         ) {
             @Override
+            public Element getProducingElement() {
+                return producerField;
+            }
+
+            @Override
+            public ClassElement getDeclaringElement() {
+                return producerField.getDeclaringType();
+            }
+
+            @Override
             protected BeanDefinitionWriter createBeanDefinitionWriter() {
                 final BeanDefinitionWriter writer = super.createBeanDefinitionWriter();
                 final GroovyElementFactory elementFactory = ((GroovyVisitorContext) visitorContext).getElementFactory();
@@ -103,6 +113,16 @@ class GroovyBeanDefinitionBuilder extends AbstractBeanDefinitionBuilder {
                 GroovyBeanDefinitionBuilder.this.metadataBuilder,
                 GroovyBeanDefinitionBuilder.this.visitorContext
         ) {
+            @Override
+            public Element getProducingElement() {
+                return producerMethod;
+            }
+
+            @Override
+            public ClassElement getDeclaringElement() {
+                return producerMethod.getDeclaringType();
+            }
+
             @Override
             protected BeanDefinitionWriter createBeanDefinitionWriter() {
                 final BeanDefinitionWriter writer = super.createBeanDefinitionWriter();

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/beanbuilder/BeanElementBuilderFactorySpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/beanbuilder/BeanElementBuilderFactorySpec.groovy
@@ -1,0 +1,38 @@
+package io.micronaut.inject.beanbuilder
+
+import io.micronaut.ast.groovy.TypeElementVisitorStart
+import io.micronaut.ast.transform.test.AbstractBeanDefinitionSpec
+import io.micronaut.inject.visitor.AllElementsVisitor
+
+class BeanElementBuilderFactorySpec extends AbstractBeanDefinitionSpec {
+
+    def setup() {
+        System.setProperty(TypeElementVisitorStart.ELEMENT_VISITORS_PROPERTY, TestBeanFactoryDefiningVisitor.name)
+    }
+
+    def cleanup() {
+        System.setProperty(TypeElementVisitorStart.ELEMENT_VISITORS_PROPERTY, "")
+        AllElementsVisitor.clearVisited()
+    }
+
+    void "test add associated factory bean"() {
+        given:
+        def context = buildContext('''
+package factorybuilder;
+
+import io.micronaut.context.annotation.Prototype;
+
+@Prototype
+class Foo {
+    
+}
+''')
+        expect:
+        context.getBean(TestBeanProducer.BeanB) instanceof TestBeanProducer.BeanB
+        context.getBean(TestBeanProducer.BeanA) instanceof TestBeanProducer.BeanA
+
+        cleanup:
+        context.close()
+    }
+
+}

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/beanbuilder/BeanElementBuilderSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/beanbuilder/BeanElementBuilderSpec.groovy
@@ -11,6 +11,7 @@ class BeanElementBuilderSpec extends AbstractBeanDefinitionSpec {
     }
 
     def cleanup() {
+        System.setProperty(TypeElementVisitorStart.ELEMENT_VISITORS_PROPERTY, "")
         AllElementsVisitor.clearVisited()
     }
 

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/beanbuilder/TestBeanFactoryDefiningVisitor.java
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/beanbuilder/TestBeanFactoryDefiningVisitor.java
@@ -1,0 +1,36 @@
+package io.micronaut.inject.beanbuilder;
+
+import io.micronaut.context.annotation.Prototype;
+import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.ast.ElementQuery;
+import io.micronaut.inject.ast.FieldElement;
+import io.micronaut.inject.ast.MethodElement;
+import io.micronaut.inject.ast.beans.BeanElementBuilder;
+import io.micronaut.inject.visitor.TypeElementVisitor;
+import io.micronaut.inject.visitor.VisitorContext;
+
+public class TestBeanFactoryDefiningVisitor implements TypeElementVisitor<Prototype, Object> {
+
+    @Override
+    public void visitClass(ClassElement element, VisitorContext context) {
+        if (element.hasAnnotation(Prototype.class)){
+
+            context.getClassElement(TestBeanProducer.class)
+                    .ifPresent((producer) -> {
+                        final BeanElementBuilder beanElementBuilder = element.addAssociatedBean(producer);
+                        final ElementQuery<MethodElement> query = ElementQuery.ALL_METHODS
+                                .annotated((am) -> am.hasAnnotation(TestProduces.class));
+                        beanElementBuilder.produceBeans(query);
+
+                        final ElementQuery<FieldElement> fields = ElementQuery.ALL_FIELDS
+                                .annotated((am) -> am.hasAnnotation(TestProduces.class));
+                        beanElementBuilder.produceBeans(fields);
+                    });
+        }
+    }
+
+    @Override
+    public VisitorKind getVisitorKind() {
+        return VisitorKind.ISOLATING;
+    }
+}

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/beanbuilder/TestBeanProducer.java
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/beanbuilder/TestBeanProducer.java
@@ -1,0 +1,22 @@
+package io.micronaut.inject.beanbuilder;
+
+import io.micronaut.context.annotation.Prototype;
+
+@Prototype
+public class TestBeanProducer {
+    @TestProduces
+    public BeanA beanA = new BeanA();
+
+    @TestProduces
+    public BeanB beanB() {
+        return new BeanB();
+    }
+
+    public static class BeanA {
+
+    }
+
+    public static class BeanB {
+
+    }
+}

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/beanbuilder/TestProduces.java
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/beanbuilder/TestProduces.java
@@ -1,0 +1,8 @@
+package io.micronaut.inject.beanbuilder;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestProduces {
+}

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/AbstractInjectAnnotationProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/AbstractInjectAnnotationProcessor.java
@@ -22,9 +22,6 @@ import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.annotation.AbstractAnnotationMetadataBuilder;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.inject.visitor.TypeElementVisitor;
-import io.micronaut.inject.writer.AbstractBeanDefinitionBuilder;
-import io.micronaut.inject.writer.BeanDefinitionReferenceWriter;
-import io.micronaut.inject.writer.BeanDefinitionWriter;
 
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Filer;
@@ -36,7 +33,6 @@ import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 import javax.tools.Diagnostic;
 
-import java.io.IOException;
 import java.util.*;
 
 /**
@@ -354,24 +350,4 @@ abstract class AbstractInjectAnnotationProcessor extends AbstractProcessor {
         return false;
     }
 
-    protected void writeBeanDefinitionBuilders(List<AbstractBeanDefinitionBuilder> beanDefinitionBuilders) {
-        for (AbstractBeanDefinitionBuilder beanDefinitionBuilder : beanDefinitionBuilders) {
-            final BeanDefinitionWriter beanDefinitionWriter = beanDefinitionBuilder.build();
-            if (beanDefinitionWriter != null) {
-                try {
-                    beanDefinitionWriter.accept(classWriterOutputVisitor);
-                    String beanTypeName = beanDefinitionWriter.getBeanTypeName();
-                    BeanDefinitionReferenceWriter beanDefinitionReferenceWriter =
-                            new BeanDefinitionReferenceWriter(beanTypeName, beanDefinitionWriter);
-                    beanDefinitionReferenceWriter
-                            .setRequiresMethodProcessing(beanDefinitionWriter.requiresMethodProcessing());
-                    beanDefinitionReferenceWriter.accept(classWriterOutputVisitor);
-                } catch (IOException e) {
-                    // raise a compile error
-                    String message = e.getMessage();
-                    error("Unexpected error: %s", message != null ? message : e.getClass().getSimpleName());
-                }
-            }
-        }
-    }
 }

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -259,7 +259,13 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                 }
                 final List<AbstractBeanDefinitionBuilder> beanElementBuilders = javaVisitorContext.getBeanElementBuilders();
                 if (CollectionUtils.isNotEmpty(beanElementBuilders)) {
-                    writeBeanDefinitionBuilders(beanElementBuilders);
+                    try {
+                        AbstractBeanDefinitionBuilder.writeBeanDefinitionBuilders(classWriterOutputVisitor, beanElementBuilders);
+                    } catch (IOException e) {
+                        // raise a compile error
+                        String message = e.getMessage();
+                        error("Unexpected error: %s", message != null ? message : e.getClass().getSimpleName());
+                    }
                 }
             } finally {
                 AnnotationUtils.invalidateCache();

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -229,7 +229,7 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                         visitor.getBeanDefinitionWriters().forEach((name, writer) -> {
                             String beanDefinitionName = writer.getBeanDefinitionName();
                             if (processed.add(beanDefinitionName)) {
-                                processBeanDefinitions(refreshedClassElement, writer);
+                                processBeanDefinitions(writer);
                             }
                         });
                         AnnotationUtils.invalidateMetadata(refreshedClassElement);
@@ -288,21 +288,23 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
         }
     }
 
-    private void processBeanDefinitions(TypeElement beanClassElement, BeanDefinitionVisitor beanDefinitionWriter) {
+    private void processBeanDefinitions(BeanDefinitionVisitor beanDefinitionWriter) {
         try {
             beanDefinitionWriter.visitBeanDefinitionEnd();
-            beanDefinitionWriter.accept(classWriterOutputVisitor);
-            String beanTypeName = beanDefinitionWriter.getBeanTypeName();
-            BeanDefinitionReferenceWriter beanDefinitionReferenceWriter =
-                    new BeanDefinitionReferenceWriter(beanTypeName, beanDefinitionWriter);
-            beanDefinitionReferenceWriter.setRequiresMethodProcessing(beanDefinitionWriter.requiresMethodProcessing());
+            if (beanDefinitionWriter.isEnabled()) {
+                beanDefinitionWriter.accept(classWriterOutputVisitor);
+                String beanTypeName = beanDefinitionWriter.getBeanTypeName();
+                BeanDefinitionReferenceWriter beanDefinitionReferenceWriter =
+                        new BeanDefinitionReferenceWriter(beanTypeName, beanDefinitionWriter);
+                beanDefinitionReferenceWriter.setRequiresMethodProcessing(beanDefinitionWriter.requiresMethodProcessing());
 
-            String className = beanDefinitionReferenceWriter.getBeanDefinitionQualifiedClassName();
-            processed.add(className);
-            beanDefinitionReferenceWriter.setContextScope(
-                    beanDefinitionWriter.getAnnotationMetadata().hasDeclaredAnnotation(Context.class));
+                String className = beanDefinitionReferenceWriter.getBeanDefinitionQualifiedClassName();
+                processed.add(className);
+                beanDefinitionReferenceWriter.setContextScope(
+                        beanDefinitionWriter.getAnnotationMetadata().hasDeclaredAnnotation(Context.class));
 
-            beanDefinitionReferenceWriter.accept(classWriterOutputVisitor);
+                beanDefinitionReferenceWriter.accept(classWriterOutputVisitor);
+            }
         } catch (IOException e) {
             // raise a compile error
             String message = e.getMessage();

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
@@ -34,8 +34,6 @@ import io.micronaut.inject.visitor.TypeElementVisitor;
 import io.micronaut.inject.visitor.VisitorContext;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.inject.writer.AbstractBeanDefinitionBuilder;
-import io.micronaut.inject.writer.BeanDefinitionReferenceWriter;
-import io.micronaut.inject.writer.BeanDefinitionWriter;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
@@ -250,7 +248,13 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
 
         final List<AbstractBeanDefinitionBuilder> beanDefinitionBuilders = javaVisitorContext.getBeanElementBuilders();
         if (CollectionUtils.isNotEmpty(beanDefinitionBuilders)) {
-            writeBeanDefinitionBuilders(beanDefinitionBuilders);
+            try {
+                AbstractBeanDefinitionBuilder.writeBeanDefinitionBuilders(classWriterOutputVisitor, beanDefinitionBuilders);
+            } catch (IOException e) {
+                // raise a compile error
+                String message = e.getMessage();
+                error("Unexpected error: %s", message != null ? message : e.getClass().getSimpleName());
+            }
         }
 
         if (roundEnv.processingOver()) {

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
@@ -250,24 +250,7 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
 
         final List<AbstractBeanDefinitionBuilder> beanDefinitionBuilders = javaVisitorContext.getBeanElementBuilders();
         if (CollectionUtils.isNotEmpty(beanDefinitionBuilders)) {
-            for (AbstractBeanDefinitionBuilder beanDefinitionBuilder : beanDefinitionBuilders) {
-                final BeanDefinitionWriter beanDefinitionWriter = beanDefinitionBuilder.build();
-                if (beanDefinitionWriter != null) {
-                    try {
-                        beanDefinitionWriter.accept(classWriterOutputVisitor);
-                        String beanTypeName = beanDefinitionWriter.getBeanTypeName();
-                        BeanDefinitionReferenceWriter beanDefinitionReferenceWriter =
-                                new BeanDefinitionReferenceWriter(beanTypeName, beanDefinitionWriter);
-                        beanDefinitionReferenceWriter
-                                .setRequiresMethodProcessing(beanDefinitionWriter.requiresMethodProcessing());
-                        beanDefinitionReferenceWriter.accept(classWriterOutputVisitor);
-                    } catch (IOException e) {
-                        // raise a compile error
-                        String message = e.getMessage();
-                        error("Unexpected error: %s", message != null ? message : e.getClass().getSimpleName());
-                    }
-                }
-            }
+            writeBeanDefinitionBuilders(beanDefinitionBuilders);
         }
 
         if (roundEnv.processingOver()) {

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaBeanDefinitionBuilder.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaBeanDefinitionBuilder.java
@@ -77,6 +77,16 @@ class JavaBeanDefinitionBuilder extends AbstractBeanDefinitionBuilder {
                 (JavaVisitorContext) JavaBeanDefinitionBuilder.this.visitorContext
         ) {
             @Override
+            public Element getProducingElement() {
+                return producerField;
+            }
+
+            @Override
+            public ClassElement getDeclaringElement() {
+                return producerField.getDeclaringType();
+            }
+
+            @Override
             protected BeanDefinitionWriter createBeanDefinitionWriter() {
                 final BeanDefinitionWriter writer = super.createBeanDefinitionWriter();
                 final JavaElementFactory elementFactory = ((JavaVisitorContext) visitorContext).getElementFactory();
@@ -108,6 +118,16 @@ class JavaBeanDefinitionBuilder extends AbstractBeanDefinitionBuilder {
                 JavaBeanDefinitionBuilder.this.metadataBuilder,
                 (JavaVisitorContext) JavaBeanDefinitionBuilder.this.visitorContext
         ) {
+            @Override
+            public Element getProducingElement() {
+                return producerMethod;
+            }
+
+            @Override
+            public ClassElement getDeclaringElement() {
+                return producerMethod.getDeclaringType();
+            }
+
             @Override
             protected BeanDefinitionWriter createBeanDefinitionWriter() {
                 final BeanDefinitionWriter writer = super.createBeanDefinitionWriter();

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaVisitorContext.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaVisitorContext.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.annotation.processing.visitor;
 
+import io.micronaut.annotation.processing.JavaConfigurationMetadataBuilder;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.annotation.processing.AnnotationProcessingOutputVisitor;
@@ -31,7 +32,9 @@ import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.beans.BeanElement;
+import io.micronaut.inject.ast.beans.BeanElementBuilder;
 import io.micronaut.inject.util.VisitorContextUtils;
+import io.micronaut.inject.visitor.BeanElementVisitorContext;
 import io.micronaut.inject.visitor.TypeElementVisitor;
 import io.micronaut.inject.visitor.VisitorContext;
 import io.micronaut.inject.writer.AbstractBeanDefinitionBuilder;
@@ -63,7 +66,7 @@ import java.util.stream.Stream;
  * @since 1.0
  */
 @Internal
-public class JavaVisitorContext implements VisitorContext {
+public class JavaVisitorContext implements VisitorContext, BeanElementVisitorContext {
 
     private final Messager messager;
     private final Elements elements;
@@ -434,5 +437,16 @@ public class JavaVisitorContext implements VisitorContext {
     @Internal
     void addBeanDefinitionBuilder(JavaBeanDefinitionBuilder javaBeanDefinitionBuilder) {
         this.beanDefinitionBuilders.add(javaBeanDefinitionBuilder);
+    }
+
+    @Override
+    public BeanElementBuilder addAssociatedBean(io.micronaut.inject.ast.Element originatingElement, ClassElement type) {
+        JavaBeanDefinitionBuilder javaBeanDefinitionBuilder = new JavaBeanDefinitionBuilder(
+                originatingElement,
+                type,
+                new JavaConfigurationMetadataBuilder(elements, types, annotationUtils),
+                this
+        );
+        return javaBeanDefinitionBuilder;
     }
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/ast/beans/BeanElementVisitorSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/ast/beans/BeanElementVisitorSpec.groovy
@@ -1,7 +1,6 @@
 package io.micronaut.inject.ast.beans
 
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
-import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Prototype
 import io.micronaut.inject.visitor.BeanElementVisitor
 
@@ -77,7 +76,7 @@ class Test implements Runnable {
         TestBeanElementVisitor visitor = BeanElementVisitor.VISITORS.first()
         BeanElement beanElement = visitor.theBeanElement
         visitor.terminated
-        visitor.intialized
+        visitor.initialized
         beanElement != null
         beanElement.scope.get() == Prototype.name
         beanElement.qualifiers.size() == 1

--- a/inject-java/src/test/groovy/io/micronaut/inject/ast/beans/BeanElementVisitorSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/ast/beans/BeanElementVisitorSpec.groovy
@@ -32,11 +32,17 @@ class Test implements Runnable {
     
     }
 }
+
+@Prototype
+class Excluded {
+    
+}
 ''')
 
         expect:
         getBean(context, 'testbe2.Test')
         context.getBean(String) == 'test' // produced from TestBeanElementVisitor
+        !context.containsBean(context.classLoader.loadClass('testbe2.Excluded'))
 
         cleanup:
         context.close()
@@ -121,6 +127,7 @@ class TestFactory implements Runnable {
 }
 
 class Test {}
+
 ''')
 
         expect:

--- a/inject-java/src/test/groovy/io/micronaut/inject/ast/beans/BeanElementVisitorSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/ast/beans/BeanElementVisitorSpec.groovy
@@ -89,7 +89,7 @@ class Test implements Runnable {
         beanElement.injectionPoints.size() == 2
         beanElement.declaringClass.name == 'testbe.Test'
         beanElement.producingElement.name == 'testbe.Test'
-        beanElement.beanTypes == ['testbe.Test', 'java.lang.Runnable'] as Set
+        beanElement.beanTypes*.getName() as Set == ['testbe.Test', 'java.lang.Runnable'] as Set
 
     }
 
@@ -140,7 +140,7 @@ class Test {}
         beanElement.injectionPoints.size() == 0
         beanElement.declaringClass.name == 'testbe.TestFactory'
         beanElement.producingElement.name == 'test'
-        beanElement.beanTypes == ['testbe.Test'] as Set
+        beanElement.beanTypes*.getName() as Set == ['testbe.Test'] as Set
 
     }
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/ast/beans/SecondBeanElementVisitor.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/ast/beans/SecondBeanElementVisitor.java
@@ -14,7 +14,7 @@ public class SecondBeanElementVisitor implements BeanElementVisitor<Annotation> 
     }
 
     @Override
-    public void visitBeanElement(BeanElement beanElement, VisitorContext visitorContext) {
-        // noop
+    public BeanElement visitBeanElement(BeanElement beanElement, VisitorContext visitorContext) {
+        return beanElement;
     }
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/ast/beans/TestBeanElementVisitor.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/ast/beans/TestBeanElementVisitor.java
@@ -1,14 +1,39 @@
 package io.micronaut.inject.ast.beans;
 
 import io.micronaut.context.annotation.Prototype;
+import io.micronaut.inject.ast.ConstructorElement;
+import io.micronaut.inject.ast.ElementQuery;
 import io.micronaut.inject.visitor.BeanElementVisitor;
 import io.micronaut.inject.visitor.VisitorContext;
 
 public class TestBeanElementVisitor implements BeanElementVisitor<Prototype> {
-    static BeanElement theBeanElement;
+    public BeanElement theBeanElement;
+    public boolean intialized = false;
+    public boolean terminated = false;
+
 
     @Override
     public void visitBeanElement(BeanElement beanElement, VisitorContext visitorContext) {
         theBeanElement = beanElement;
+    }
+
+    @Override
+    public void start(VisitorContext visitorContext) {
+        intialized = true;
+    }
+
+    @Override
+    public void finish(VisitorContext visitorContext) {
+        visitorContext.getClassElement(String.class)
+                .ifPresent(e -> theBeanElement.addAssociatedBean(e)
+                        .createWith(
+                                e.getEnclosedElement(
+                                        ElementQuery.of(ConstructorElement.class)
+                                            .filter(ce -> ce.hasParameters() && ce.getParameters()[0].getType().isAssignable(String.class))
+                                )
+                                .orElseThrow(() -> new IllegalStateException("Unknown constructor"))
+                        )
+                        .withParameters((params) -> params[0].injectValue("test")));
+        terminated = true;
     }
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/ast/beans/TestBeanElementVisitor.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/ast/beans/TestBeanElementVisitor.java
@@ -15,14 +15,20 @@ public class TestBeanElementVisitor implements BeanElementVisitor<Prototype> {
 
 
     @Override
-    public void visitBeanElement(BeanElement beanElement, VisitorContext visitorContext) {
+    public BeanElement visitBeanElement(BeanElement beanElement, VisitorContext visitorContext) {
         Element producingElement = beanElement.getProducingElement();
         if (producingElement instanceof MemberElement) {
             producingElement = ((MemberElement) producingElement).getDeclaringType();
         }
-        if (producingElement.getName().startsWith("testbe")) {
+        final String name = producingElement.getName();
+        if (name.startsWith("testbe")) {
             theBeanElement = beanElement;
         }
+        if (name.equals("testbe2.Excluded")) {
+            // tests bean veto
+            return null;
+        }
+        return beanElement;
     }
 
     @Override

--- a/inject-java/src/test/groovy/io/micronaut/inject/ast/beans/TestBeanElementVisitor.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/ast/beans/TestBeanElementVisitor.java
@@ -2,38 +2,49 @@ package io.micronaut.inject.ast.beans;
 
 import io.micronaut.context.annotation.Prototype;
 import io.micronaut.inject.ast.ConstructorElement;
+import io.micronaut.inject.ast.Element;
 import io.micronaut.inject.ast.ElementQuery;
+import io.micronaut.inject.ast.MemberElement;
 import io.micronaut.inject.visitor.BeanElementVisitor;
 import io.micronaut.inject.visitor.VisitorContext;
 
 public class TestBeanElementVisitor implements BeanElementVisitor<Prototype> {
     public BeanElement theBeanElement;
-    public boolean intialized = false;
+    public boolean initialized = false;
     public boolean terminated = false;
 
 
     @Override
     public void visitBeanElement(BeanElement beanElement, VisitorContext visitorContext) {
-        theBeanElement = beanElement;
+        Element producingElement = beanElement.getProducingElement();
+        if (producingElement instanceof MemberElement) {
+            producingElement = ((MemberElement) producingElement).getDeclaringType();
+        }
+        if (producingElement.getName().startsWith("testbe")) {
+            theBeanElement = beanElement;
+        }
     }
 
     @Override
     public void start(VisitorContext visitorContext) {
-        intialized = true;
+        initialized = true;
     }
 
     @Override
     public void finish(VisitorContext visitorContext) {
-        visitorContext.getClassElement(String.class)
-                .ifPresent(e -> theBeanElement.addAssociatedBean(e)
-                        .createWith(
-                                e.getEnclosedElement(
-                                        ElementQuery.of(ConstructorElement.class)
-                                            .filter(ce -> ce.hasParameters() && ce.getParameters()[0].getType().isAssignable(String.class))
-                                )
-                                .orElseThrow(() -> new IllegalStateException("Unknown constructor"))
-                        )
-                        .withParameters((params) -> params[0].injectValue("test")));
+        if (theBeanElement != null) {
+
+            visitorContext.getClassElement(String.class)
+                    .ifPresent(e -> theBeanElement.addAssociatedBean(e)
+                            .createWith(
+                                    e.getEnclosedElement(
+                                            ElementQuery.of(ConstructorElement.class)
+                                                    .filter(ce -> ce.hasParameters() && ce.getParameters()[0].getType().isAssignable(String.class))
+                                    )
+                                            .orElseThrow(() -> new IllegalStateException("Unknown constructor"))
+                            )
+                            .withParameters((params) -> params[0].injectValue("test")));
+        }
         terminated = true;
     }
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/ast/beans/TestBeanElementVisitor.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/ast/beans/TestBeanElementVisitor.java
@@ -27,6 +27,7 @@ public class TestBeanElementVisitor implements BeanElementVisitor<Prototype> {
 
     @Override
     public void start(VisitorContext visitorContext) {
+        theBeanElement = null;
         initialized = true;
     }
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/ast/beans/TestBeanElementVisitor.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/ast/beans/TestBeanElementVisitor.java
@@ -42,7 +42,7 @@ public class TestBeanElementVisitor implements BeanElementVisitor<Prototype> {
         if (theBeanElement != null) {
 
             visitorContext.getClassElement(String.class)
-                    .ifPresent(e -> theBeanElement.addAssociatedBean(e)
+                    .ifPresent(e -> theBeanElement.addAssociatedBean(e, visitorContext)
                             .createWith(
                                     e.getEnclosedElement(
                                             ElementQuery.of(ConstructorElement.class)

--- a/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/BeanElementBuilderFactorySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/BeanElementBuilderFactorySpec.groovy
@@ -1,0 +1,32 @@
+package io.micronaut.inject.beanbuilder
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.inject.visitor.TypeElementVisitor
+
+class BeanElementBuilderFactorySpec extends AbstractTypeElementSpec {
+
+    void "test add associated factory bean"() {
+        given:
+        def context = buildContext('''
+package factorybuilder;
+
+import io.micronaut.context.annotation.Prototype;
+
+@Prototype
+class Foo {
+    
+}
+''')
+        expect:
+        context.getBean(TestBeanProducer.BeanB) instanceof TestBeanProducer.BeanB
+        context.getBean(TestBeanProducer.BeanA) instanceof TestBeanProducer.BeanA
+
+        cleanup:
+        context.close()
+    }
+
+    @Override
+    protected Collection<TypeElementVisitor> getLocalTypeElementVisitors() {
+        [new TestBeanFactoryDefiningVisitor()]
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/TestBeanFactoryDefiningVisitor.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/TestBeanFactoryDefiningVisitor.java
@@ -1,0 +1,36 @@
+package io.micronaut.inject.beanbuilder;
+
+import io.micronaut.context.annotation.Prototype;
+import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.ast.ElementQuery;
+import io.micronaut.inject.ast.FieldElement;
+import io.micronaut.inject.ast.MethodElement;
+import io.micronaut.inject.ast.beans.BeanElementBuilder;
+import io.micronaut.inject.visitor.TypeElementVisitor;
+import io.micronaut.inject.visitor.VisitorContext;
+
+public class TestBeanFactoryDefiningVisitor implements TypeElementVisitor<Prototype, Object> {
+
+    @Override
+    public void visitClass(ClassElement element, VisitorContext context) {
+        if (element.hasAnnotation(Prototype.class)){
+
+            context.getClassElement(TestBeanProducer.class)
+                    .ifPresent((producer) -> {
+                        final BeanElementBuilder beanElementBuilder = element.addAssociatedBean(producer);
+                        final ElementQuery<MethodElement> query = ElementQuery.ALL_METHODS
+                                .annotated((am) -> am.hasAnnotation(TestProduces.class));
+                        beanElementBuilder.produceBeans(query);
+
+                        final ElementQuery<FieldElement> fields = ElementQuery.ALL_FIELDS
+                                .annotated((am) -> am.hasAnnotation(TestProduces.class));
+                        beanElementBuilder.produceBeans(fields);
+                    });
+        }
+    }
+
+    @Override
+    public VisitorKind getVisitorKind() {
+        return VisitorKind.ISOLATING;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/TestBeanProducer.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/TestBeanProducer.java
@@ -1,0 +1,22 @@
+package io.micronaut.inject.beanbuilder;
+
+import io.micronaut.context.annotation.Prototype;
+
+@Prototype
+public class TestBeanProducer {
+    @TestProduces
+    public BeanA beanA = new BeanA();
+
+    @TestProduces
+    public BeanB beanB() {
+        return new BeanB();
+    }
+
+    public static class BeanA {
+
+    }
+
+    public static class BeanB {
+
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/TestProduces.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/TestProduces.java
@@ -1,0 +1,8 @@
+package io.micronaut.inject.beanbuilder;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestProduces {
+}

--- a/inject/src/main/java/io/micronaut/inject/ast/DefaultElementQuery.java
+++ b/inject/src/main/java/io/micronaut/inject/ast/DefaultElementQuery.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.inject.ast;
 
+import io.micronaut.context.annotation.Bean;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationUtil;
 import io.micronaut.core.annotation.Internal;
@@ -171,7 +172,9 @@ final class DefaultElementQuery<T extends Element> implements ElementQuery<T>, E
     @Override
     public ElementQuery<T> onlyInjected() {
         final List<Predicate<AnnotationMetadata>> annotationPredicates = this.annotationPredicates != null ? new ArrayList<>(this.annotationPredicates) : new ArrayList<>(1);
-        annotationPredicates.add((metadata) -> metadata.hasDeclaredAnnotation(AnnotationUtil.INJECT) ||
+        annotationPredicates.add((metadata) ->
+                metadata.hasDeclaredAnnotation(AnnotationUtil.INJECT) ||
+                (metadata.hasDeclaredStereotype(AnnotationUtil.QUALIFIER) && !metadata.hasDeclaredAnnotation(Bean.class)) ||
                 metadata.hasDeclaredAnnotation(PreDestroy.class) ||
                 metadata.hasDeclaredAnnotation(PostConstruct.class));
         return new DefaultElementQuery<>(

--- a/inject/src/main/java/io/micronaut/inject/ast/beans/BeanConstructorElement.java
+++ b/inject/src/main/java/io/micronaut/inject/ast/beans/BeanConstructorElement.java
@@ -21,6 +21,12 @@ import java.util.function.Consumer;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.inject.ast.ConstructorElement;
 
+/**
+ * Represents the current bean constructor when used through the {@link io.micronaut.inject.ast.beans.BeanElementBuilder} API.
+ *
+ * @author graemerocher
+ * @since 3.0.0
+ */
 public interface BeanConstructorElement extends ConstructorElement {
 
     /**

--- a/inject/src/main/java/io/micronaut/inject/ast/beans/BeanConstructorElement.java
+++ b/inject/src/main/java/io/micronaut/inject/ast/beans/BeanConstructorElement.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.inject.ast.beans;
 
 import java.util.Objects;

--- a/inject/src/main/java/io/micronaut/inject/ast/beans/BeanConstructorElement.java
+++ b/inject/src/main/java/io/micronaut/inject/ast/beans/BeanConstructorElement.java
@@ -1,0 +1,26 @@
+package io.micronaut.inject.ast.beans;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.inject.ast.ConstructorElement;
+
+public interface BeanConstructorElement extends ConstructorElement {
+
+    /**
+     * Process the bean parameters.
+     *
+     * @param parameterConsumer The parameter consumer
+     * @return This bean method
+     */
+    default @NonNull BeanConstructorElement withParameters(@NonNull Consumer<BeanParameterElement[]> parameterConsumer) {
+        Objects.requireNonNull(parameterConsumer, "The parameter consumer cannot be null");
+        parameterConsumer.accept(getParameters());
+        return this;
+    }
+
+    @NonNull
+    @Override
+    BeanParameterElement[] getParameters();
+}

--- a/inject/src/main/java/io/micronaut/inject/ast/beans/BeanElement.java
+++ b/inject/src/main/java/io/micronaut/inject/ast/beans/BeanElement.java
@@ -63,7 +63,7 @@ public interface BeanElement extends Element {
      * @return A set of types
      */
     @NonNull
-    Set<String> getBeanTypes();
+    Set<ClassElement> getBeanTypes();
 
     /**
      * The scope of the bean.

--- a/inject/src/main/java/io/micronaut/inject/ast/beans/BeanElement.java
+++ b/inject/src/main/java/io/micronaut/inject/ast/beans/BeanElement.java
@@ -41,6 +41,12 @@ public interface BeanElement extends Element {
     Collection<Element> getInjectionPoints();
 
     /**
+     * @return The originating element.
+     */
+    @NonNull
+    Element getOriginatingElement();
+
+    /**
      * Returns the declaring {@link io.micronaut.inject.ast.ClassElement} which may differ
      * from the {@link #getBeanTypes()} in the case of factory beans.
      *

--- a/inject/src/main/java/io/micronaut/inject/ast/beans/BeanElement.java
+++ b/inject/src/main/java/io/micronaut/inject/ast/beans/BeanElement.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.Element;
+import io.micronaut.inject.visitor.VisitorContext;
 
 /**
  * Models a bean that will be produced by Micronaut.
@@ -90,10 +91,11 @@ public interface BeanElement extends Element {
      * <p>Note that this method can only be called on classes being directly compiled by Micronaut. If the ClassElement is
      * loaded from pre-compiled code an {@link UnsupportedOperationException} will be thrown.</p>
      * @param type The type of the bean
+     * @param visitorContext The visitor context
      * @return A bean builder
      */
     default @NonNull
-    BeanElementBuilder addAssociatedBean(@NonNull ClassElement type) {
+    BeanElementBuilder addAssociatedBean(@NonNull ClassElement type, @NonNull VisitorContext visitorContext) {
         throw new UnsupportedOperationException("Element of type [" + getClass() + "] does not support adding associated beans at compilation time");
     }
 }

--- a/inject/src/main/java/io/micronaut/inject/ast/beans/BeanElement.java
+++ b/inject/src/main/java/io/micronaut/inject/ast/beans/BeanElement.java
@@ -77,4 +77,17 @@ public interface BeanElement extends Element {
      */
     @NonNull
     Collection<String> getQualifiers();
+
+    /**
+     * This method adds an associated bean using this class element as the originating element.
+     *
+     * <p>Note that this method can only be called on classes being directly compiled by Micronaut. If the ClassElement is
+     * loaded from pre-compiled code an {@link UnsupportedOperationException} will be thrown.</p>
+     * @param type The type of the bean
+     * @return A bean builder
+     */
+    default @NonNull
+    BeanElementBuilder addAssociatedBean(@NonNull ClassElement type) {
+        throw new UnsupportedOperationException("Element of type [" + getClass() + "] does not support adding associated beans at compilation time");
+    }
 }

--- a/inject/src/main/java/io/micronaut/inject/ast/beans/BeanElementBuilder.java
+++ b/inject/src/main/java/io/micronaut/inject/ast/beans/BeanElementBuilder.java
@@ -54,6 +54,24 @@ public interface BeanElementBuilder extends ConfigurableElement {
     ClassElement getBeanType();
 
     /**
+     * @return The element that produces the bean.
+     */
+    @NonNull
+    default Element getProducingElement() {
+        return getBeanType();
+    }
+
+    /**
+     * Returns the class that declares the bean. In case of a bean defined by a class, that is the bean class directly. In case of a producer method or field, that is the class that declares the producer method or field.
+     *
+     * @return The element declares the bean.
+     */
+    @NonNull
+    default ClassElement getDeclaringElement() {
+        return getBeanType();
+    }
+
+    /**
      * Specifies the bean will created with the given method element. If
      * not specified the bean will be created with {@link ClassElement#getPrimaryConstructor()}.
      *

--- a/inject/src/main/java/io/micronaut/inject/ast/beans/BeanElementBuilder.java
+++ b/inject/src/main/java/io/micronaut/inject/ast/beans/BeanElementBuilder.java
@@ -24,6 +24,7 @@ import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.Element;
 import io.micronaut.inject.ast.ElementQuery;
 import io.micronaut.inject.ast.FieldElement;
+import io.micronaut.inject.ast.MemberElement;
 import io.micronaut.inject.ast.MethodElement;
 
 import java.lang.annotation.Annotation;
@@ -52,7 +53,6 @@ public interface BeanElementBuilder extends ConfigurableElement {
     @NonNull
     ClassElement getBeanType();
 
-
     /**
      * Specifies the bean will created with the given method element. If
      * not specified the bean will be created with {@link ClassElement#getPrimaryConstructor()}.
@@ -62,20 +62,21 @@ public interface BeanElementBuilder extends ConfigurableElement {
      * <ul>
      *     <li>An accessible constructor on the bean type being generated</li>
      *     <li>An accessible static method on the bean type being generated</li>
-     *     <li>An accessible instance method on a concrete type that returns the bean type and is present on another type that represents the factory for creating the instance.</li>
      * </ul>
      *
      * @param element The element
      * @return This bean builder
      */
-    @NonNull BeanElementBuilder createWith(@NonNull MethodElement element);
+    @NonNull
+    BeanElementBuilder createWith(@NonNull MethodElement element);
 
     /**
      * Alters the exposed types for the bean limiting the exposed type to the given types.
      * @param types 1 or more types to expose
      * @return This builder
      */
-    @NonNull BeanElementBuilder typed(ClassElement...types);
+    @NonNull
+    BeanElementBuilder typed(ClassElement... types);
 
     /**
      * Fills the type arguments for the bean with the given types.
@@ -83,8 +84,8 @@ public interface BeanElementBuilder extends ConfigurableElement {
      * @return This bean builder
      */
     @Override
-    @NonNull BeanElementBuilder typeArguments(@NonNull ClassElement...types);
-
+    @NonNull
+    BeanElementBuilder typeArguments(@NonNull ClassElement... types);
 
     /**
      * Fills the type arguments for the given interface or super class with the given types.
@@ -92,7 +93,8 @@ public interface BeanElementBuilder extends ConfigurableElement {
      * @param types The types
      * @return This bean builder
      */
-    @NonNull BeanElementBuilder typeArgumentsForType(@Nullable ClassElement type, @NonNull ClassElement...types);
+    @NonNull
+    BeanElementBuilder typeArgumentsForType(@Nullable ClassElement type, @NonNull ClassElement... types);
 
     /**
      * Adds a scope for the given annotation value to the bean.
@@ -100,7 +102,8 @@ public interface BeanElementBuilder extends ConfigurableElement {
      * @param scope The scope
      * @return This bean element builder
      */
-    default @NonNull BeanElementBuilder scope(@NonNull AnnotationValue<?> scope) {
+    default @NonNull
+    BeanElementBuilder scope(@NonNull AnnotationValue<?> scope) {
         Objects.requireNonNull(scope, "Scope cannot be null");
         annotate(scope.getAnnotationName(), (builder) -> builder.members(scope.getValues()));
         return this;
@@ -112,7 +115,8 @@ public interface BeanElementBuilder extends ConfigurableElement {
      * @param scope The full qualified scope annotation name
      * @return This bean element builder
      */
-    default @NonNull BeanElementBuilder scope(@NonNull String scope) {
+    default @NonNull
+    BeanElementBuilder scope(@NonNull String scope) {
         Objects.requireNonNull(scope, "Scope cannot be null");
         annotate(scope);
         return this;
@@ -123,7 +127,8 @@ public interface BeanElementBuilder extends ConfigurableElement {
      * @param constructorElement The constructor element
      * @return This bean builder
      */
-    @NonNull BeanElementBuilder withConstructor(@NonNull Consumer<BeanConstructorElement> constructorElement);
+    @NonNull
+    BeanElementBuilder withConstructor(@NonNull Consumer<BeanConstructorElement> constructorElement);
 
     /**
      * Allows configuring methods of the bean.
@@ -131,7 +136,8 @@ public interface BeanElementBuilder extends ConfigurableElement {
      * @param beanMethods A consumer that receives each {@link BeanMethodElement}
      * @return This builder
      */
-    @NonNull BeanElementBuilder withMethods(
+    @NonNull
+    BeanElementBuilder withMethods(
             @NonNull ElementQuery<MethodElement> methods,
             @NonNull Consumer<BeanMethodElement> beanMethods);
 
@@ -141,7 +147,8 @@ public interface BeanElementBuilder extends ConfigurableElement {
      * @param beanFields The bean fields
      * @return This builder
      */
-    @NonNull BeanElementBuilder withFields(
+    @NonNull
+    BeanElementBuilder withFields(
             @NonNull ElementQuery<FieldElement> fields,
             @NonNull Consumer<BeanFieldElement> beanFields);
 
@@ -150,7 +157,8 @@ public interface BeanElementBuilder extends ConfigurableElement {
      * @param parameters The parameters
      * @return This builder
      */
-    @NonNull BeanElementBuilder withParameters(Consumer<BeanParameterElement[]> parameters);
+    @NonNull
+    BeanElementBuilder withParameters(Consumer<BeanParameterElement[]> parameters);
 
     @NonNull
     @Override
@@ -166,7 +174,8 @@ public interface BeanElementBuilder extends ConfigurableElement {
 
     @NonNull
     @Override
-    default <T extends Annotation> BeanElementBuilder annotate(@NonNull String annotationType, @NonNull Consumer<AnnotationValueBuilder<T>> consumer) {
+    default <T extends Annotation> BeanElementBuilder annotate(@NonNull String annotationType,
+                                                               @NonNull Consumer<AnnotationValueBuilder<T>> consumer) {
         return (BeanElementBuilder) ConfigurableElement.super.annotate(annotationType, consumer);
     }
 
@@ -203,7 +212,8 @@ public interface BeanElementBuilder extends ConfigurableElement {
 
     @NonNull
     @Override
-    default <T extends Annotation> BeanElementBuilder annotate(@NonNull Class<T> annotationType, @NonNull Consumer<AnnotationValueBuilder<T>> consumer) {
+    default <T extends Annotation> BeanElementBuilder annotate(@NonNull Class<T> annotationType,
+                                                               @NonNull Consumer<AnnotationValueBuilder<T>> consumer) {
         return (BeanElementBuilder) ConfigurableElement.super.annotate(annotationType, consumer);
     }
 
@@ -218,4 +228,23 @@ public interface BeanElementBuilder extends ConfigurableElement {
      * @return this bean builder
      */
     BeanElementBuilder inject();
+
+    /**
+     * Produce additional beans from the given methods.
+     * @param methodsOrFields The {@link io.micronaut.inject.ast.ElementQuery} representing the methods or fields
+     * @param childBeanBuilder Configure the child bean builder
+     * @return This bean builder
+     * @param <E> A type variable to
+     */
+    <E extends MemberElement> BeanElementBuilder produceBeans(ElementQuery<E> methodsOrFields, @Nullable Consumer<BeanElementBuilder> childBeanBuilder);
+
+    /**
+     * Produce additional beans from the given methods.
+     * @param methodsOrFields The {@link io.micronaut.inject.ast.ElementQuery} representing the methods or fields
+     * @return This bean builder
+     * @param <E> A type variable to
+     */
+    default <E extends MemberElement> BeanElementBuilder produceBeans(ElementQuery<E> methodsOrFields) {
+        return produceBeans(methodsOrFields, null);
+    }
 }

--- a/inject/src/main/java/io/micronaut/inject/ast/beans/BeanElementBuilder.java
+++ b/inject/src/main/java/io/micronaut/inject/ast/beans/BeanElementBuilder.java
@@ -119,6 +119,13 @@ public interface BeanElementBuilder extends ConfigurableElement {
     }
 
     /**
+     * Allows configuring the bean constructor.
+     * @param constructorElement The constructor element
+     * @return This bean builder
+     */
+    @NonNull BeanElementBuilder withConstructor(@NonNull Consumer<BeanConstructorElement> constructorElement);
+
+    /**
      * Allows configuring methods of the bean.
      * @param methods The {@link ElementQuery} to locate selected methods.
      * @param beanMethods A consumer that receives each {@link BeanMethodElement}

--- a/inject/src/main/java/io/micronaut/inject/visitor/BeanElementVisitor.java
+++ b/inject/src/main/java/io/micronaut/inject/visitor/BeanElementVisitor.java
@@ -47,6 +47,24 @@ public interface BeanElementVisitor<A extends Annotation> extends Ordered, Toggl
     void visitBeanElement(@NonNull BeanElement beanElement, @NonNull VisitorContext visitorContext);
 
     /**
+     * Called once when visitor processing starts.
+     *
+     * @param visitorContext The visitor context
+     */
+    default void start(VisitorContext visitorContext) {
+        // no-op
+    }
+
+    /**
+     * Called once when visitor processing finishes.
+     *
+     * @param visitorContext The visitor context
+     */
+    default void finish(VisitorContext visitorContext) {
+        // no-op
+    }
+
+    /**
      * Returns whether this visitor supports visiting the specified element.
      * @param beanElement The bean element
      * @return True if it does

--- a/inject/src/main/java/io/micronaut/inject/visitor/BeanElementVisitor.java
+++ b/inject/src/main/java/io/micronaut/inject/visitor/BeanElementVisitor.java
@@ -19,6 +19,7 @@ import java.lang.annotation.Annotation;
 import java.util.List;
 
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.order.Ordered;
 import io.micronaut.core.reflect.GenericTypeUtils;
 import io.micronaut.core.util.Toggleable;
@@ -43,8 +44,9 @@ public interface BeanElementVisitor<A extends Annotation> extends Ordered, Toggl
      *
      * @param beanElement The bean element
      * @param visitorContext The visitor context
+     * @return The bean element or {@code null} if the bean should not be written
      */
-    void visitBeanElement(@NonNull BeanElement beanElement, @NonNull VisitorContext visitorContext);
+    @Nullable BeanElement visitBeanElement(@NonNull BeanElement beanElement, @NonNull VisitorContext visitorContext);
 
     /**
      * Called once when visitor processing starts.

--- a/inject/src/main/java/io/micronaut/inject/visitor/BeanElementVisitorContext.java
+++ b/inject/src/main/java/io/micronaut/inject/visitor/BeanElementVisitorContext.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.visitor;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.ast.Element;
+import io.micronaut.inject.ast.beans.BeanElementBuilder;
+
+/**
+ * Internal interface for adding associated beans.
+ *
+ * @author graemerocher
+ * @since 3.0.0
+ */
+@Internal
+public interface BeanElementVisitorContext extends VisitorContext {
+    BeanElementBuilder addAssociatedBean(Element originatingElement, ClassElement type);
+}

--- a/inject/src/main/java/io/micronaut/inject/visitor/VisitorContext.java
+++ b/inject/src/main/java/io/micronaut/inject/visitor/VisitorContext.java
@@ -262,4 +262,5 @@ public interface VisitorContext extends MutableConvertibleValues<Object>, ClassW
     default void addGeneratedResource(String resource) {
         info("EXPERIMENTAL: Compile time resource contribution to the context is experimental", null);
     }
+
 }

--- a/inject/src/main/java/io/micronaut/inject/writer/AbstractBeanDefinitionBuilder.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/AbstractBeanDefinitionBuilder.java
@@ -16,6 +16,7 @@
 package io.micronaut.inject.writer;
 
 import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Value;
 import io.micronaut.core.annotation.AnnotationClassValue;
 import io.micronaut.core.annotation.AnnotationMetadata;
@@ -622,7 +623,7 @@ public abstract class AbstractBeanDefinitionBuilder implements BeanElementBuilde
     private void visitField(BeanDefinitionWriter beanDefinitionWriter,
                            BeanFieldElement injectedField,
                            InternalBeanElementField ibf) {
-        if (injectedField.hasAnnotation(Value.class)) {
+        if (injectedField.hasAnnotation(Value.class) || injectedField.hasAnnotation(Property.class)) {
             beanDefinitionWriter.visitFieldValue(
                     injectedField.getDeclaringType(),
                     injectedField,

--- a/inject/src/main/java/io/micronaut/inject/writer/AbstractClassFileWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/AbstractClassFileWriter.java
@@ -651,7 +651,6 @@ public abstract class AbstractClassFileWriter implements Opcodes, OriginatingEle
     /**
      * @return The originating element
      */
-    @Deprecated
     public @Nullable
     Element getOriginatingElement() {
         Element[] originatingElements = getOriginatingElements();

--- a/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionVisitor.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionVisitor.java
@@ -16,6 +16,7 @@
 package io.micronaut.inject.writer;
 
 import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.util.Toggleable;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.ast.*;
 import io.micronaut.inject.configuration.ConfigurationMetadataBuilder;
@@ -36,7 +37,7 @@ import java.util.Optional;
  * @author Graeme Rocher
  * @since 1.0
  */
-public interface BeanDefinitionVisitor extends OriginatingElements {
+public interface BeanDefinitionVisitor extends OriginatingElements, Toggleable {
 
     /**
      * The suffix use for generated AOP intercepted types.

--- a/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionVisitor.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionVisitor.java
@@ -46,9 +46,7 @@ public interface BeanDefinitionVisitor extends OriginatingElements, Toggleable {
 
     /**
      * @return The element where the bean definition originated from.
-     * @deprecated Use {@link #getOriginatingElements()} instead
      */
-    @Deprecated
     @Nullable
     Element getOriginatingElement();
 

--- a/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -3411,8 +3411,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
         } else if (beanProducingElement instanceof MemberElement) {
             return ((MemberElement) beanProducingElement).getDeclaringType();
         } else if (beanProducingElement instanceof BeanElementBuilder) {
-            final Element originatingElement = ((BeanElementBuilder) beanProducingElement).getOriginatingElement();
-            return getDeclaringType(originatingElement);
+            return ((BeanElementBuilder) beanProducingElement).getDeclaringElement();
         } else {
             return this.beanTypeElement;
         }

--- a/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -3476,13 +3476,13 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
     }
 
     @Override
-    public BeanElementBuilder addAssociatedBean(ClassElement type) {
+    public BeanElementBuilder addAssociatedBean(ClassElement type, VisitorContext visitorContext) {
         if (visitorContext instanceof BeanElementVisitorContext) {
             final Element[] originatingElements = getOriginatingElements();
-            return ((BeanElementVisitorContext) this.visitorContext)
+            return ((BeanElementVisitorContext) visitorContext)
                         .addAssociatedBean(originatingElements[0], type);
         }
-        return BeanElement.super.addAssociatedBean(type);
+        return BeanElement.super.addAssociatedBean(type, visitorContext);
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -86,6 +86,7 @@ import io.micronaut.inject.configuration.PropertyMetadata;
 import io.micronaut.inject.processing.JavaModelUtils;
 import io.micronaut.inject.qualifiers.Qualifiers;
 import io.micronaut.inject.visitor.BeanElementVisitor;
+import io.micronaut.inject.visitor.BeanElementVisitorContext;
 import io.micronaut.inject.visitor.VisitorContext;
 import jakarta.inject.Singleton;
 import org.jetbrains.annotations.NotNull;
@@ -3454,6 +3455,21 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
     @Override
     public Collection<String> getQualifiers() {
         return Collections.unmodifiableList(annotationMetadata.getAnnotationNamesByStereotype(AnnotationUtil.QUALIFIER));
+    }
+
+    @Override
+    public BeanElementBuilder addAssociatedBean(ClassElement type) {
+        if (visitorContext instanceof BeanElementVisitorContext) {
+            final Element[] originatingElements = getOriginatingElements();
+            return ((BeanElementVisitorContext) this.visitorContext)
+                        .addAssociatedBean(originatingElements[0], type);
+        }
+        return BeanElement.super.addAssociatedBean(type);
+    }
+
+    @Override
+    public Element[] getOriginatingElements() {
+        return this.originatingElements.getOriginatingElements();
     }
 
     @Internal


### PR DESCRIPTION
This PR addresses a few things I overlooked in the new BeanBuilder API:

* Lifecycle `start`/ `finish` methods for `BeanElementVisitor` API
* Associate additional beans from a `BeanElement` using this API
* Adding factory beans from methods/fields with `BeanElementBuilder`