### PR TITLE
System and environment properties not overriding application.yml for logger configuration

### DIFF
--- a/runtime/src/main/java/io/micronaut/logging/PropertiesLoggingLevelsConfigurer.java
+++ b/runtime/src/main/java/io/micronaut/logging/PropertiesLoggingLevelsConfigurer.java
@@ -80,9 +80,14 @@ final class PropertiesLoggingLevelsConfigurer implements ApplicationEventListene
     }
 
     private void configureLogLevels() {
-        Map<String, Object> properties = new HashMap<>(environment.getProperties(LOGGER_LEVELS_PROPERTY_PREFIX));
         // Using raw keys here allows configuring log levels for camelCase package names in application.yml
-        properties.putAll(environment.getProperties(LOGGER_LEVELS_PROPERTY_PREFIX, StringConvention.RAW));
+        final Map<String, Object> rawProperties = environment.getProperties(LOGGER_LEVELS_PROPERTY_PREFIX, StringConvention.RAW);
+        // Adding the generated properties allows environment variables and system properties to override names in application.yaml
+        final Map<String, Object> generatedProperties = environment.getProperties(LOGGER_LEVELS_PROPERTY_PREFIX);
+
+        final Map<String, Object> properties = new HashMap<>(generatedProperties.size() + rawProperties.size(), 1f);
+        properties.putAll(rawProperties);
+        properties.putAll(generatedProperties);
         properties.forEach(this::configureLogLevelForPrefix);
     }
 


### PR DESCRIPTION
The original logging code putAlls the generated properties (those returned by getProperties(String)) first and then putAlls the raw properties (those returned by getProperties(String, RAW))

This causes properties set in application.yaml to override environment variables which violates expectations

This fix gets both properties and putAlls them in opposite order

Still working on a test (am getting environment issues when running locally); will update once I get it worked out