### PR TITLE
Improve support for primitive arrays in annotation metadata

### DIFF
--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationValue.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationValue.java
@@ -61,6 +61,7 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
      * @param values         The values
      */
     @UsedByGeneratedCode
+    @Internal
     public AnnotationValue(String annotationName, Map<CharSequence, Object> values) {
         this(annotationName, values, Collections.emptyMap());
     }
@@ -70,6 +71,7 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
      * @param values          The values
      * @param retentionPolicy The retention policy
      */
+    @Internal
     public AnnotationValue(String annotationName, Map<CharSequence, Object> values, RetentionPolicy retentionPolicy) {
         this(annotationName, values, Collections.emptyMap(), retentionPolicy, null);
     }
@@ -80,6 +82,7 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
      * @param retentionPolicy The retention policy
      * @param stereotypes     The stereotypes of the annotation
      */
+    @Internal
     public AnnotationValue(String annotationName, Map<CharSequence, Object> values, RetentionPolicy retentionPolicy, List<AnnotationValue<?>> stereotypes) {
         this(annotationName, values, Collections.emptyMap(), retentionPolicy, stereotypes);
     }
@@ -91,6 +94,7 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
      * @param defaultValues  The default values
      */
     @UsedByGeneratedCode
+    @Internal
     public AnnotationValue(String annotationName, Map<CharSequence, Object> values, Map<String, Object> defaultValues) {
         this(annotationName, values, defaultValues, RetentionPolicy.RUNTIME, null);
     }
@@ -102,6 +106,7 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
      * @param retentionPolicy The retention policy
      */
     @UsedByGeneratedCode
+    @Internal
     public AnnotationValue(String annotationName, Map<CharSequence, Object> values, Map<String, Object> defaultValues, RetentionPolicy retentionPolicy) {
         this(annotationName, values, defaultValues, retentionPolicy, null);
     }
@@ -113,6 +118,7 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
      * @param retentionPolicy The retention policy
      * @param stereotypes     The stereotypes of the annotation
      */
+    @Internal
     public AnnotationValue(String annotationName, Map<CharSequence, Object> values, Map<String, Object> defaultValues, RetentionPolicy retentionPolicy, List<AnnotationValue<?>> stereotypes) {
         this.annotationName = annotationName;
         this.convertibleValues = newConvertibleValues(values);
@@ -128,6 +134,7 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
      */
     @SuppressWarnings("unchecked")
     @UsedByGeneratedCode
+    @Internal
     public AnnotationValue(String annotationName) {
         this(annotationName, Collections.emptyMap(), Collections.emptyMap());
     }
@@ -136,6 +143,7 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
      * @param annotationName    The annotation name
      * @param convertibleValues The convertible values
      */
+    @Internal
     public AnnotationValue(String annotationName, ConvertibleValues<Object> convertibleValues) {
         this.annotationName = annotationName;
         this.convertibleValues = convertibleValues;
@@ -377,6 +385,188 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
         return stringValues(member, valueMapper);
     }
 
+    @Override
+    public boolean[] booleanValues(String member) {
+        Object v = values.get(member);
+        if (v != null) {
+            if (v instanceof boolean[]) {
+                return (boolean[]) v;
+            } else if (v instanceof Boolean) {
+                return new boolean[] { (Boolean) v };
+            } else {
+                String[] strings = resolveStringValues(v, this.valueMapper);
+                if (ArrayUtils.isNotEmpty(strings)) {
+                    boolean[] booleans = new boolean[strings.length];
+                    for (int i = 0; i < strings.length; i++) {
+                        String string = strings[i];
+                        booleans[i] = Boolean.parseBoolean(string);
+                    }
+                    return booleans;
+                }
+            }
+        }
+        return ArrayUtils.EMPTY_BOOLEAN_ARRAY;
+    }
+
+    @Override
+    public byte[] byteValues(String member) {
+        Object v = values.get(member);
+        if (v != null) {
+            if (v instanceof byte[]) {
+                return (byte[]) v;
+            } else if (v instanceof Number) {
+                return new byte[] { ((Number) v).byteValue() };
+            } else {
+                String[] strings = resolveStringValues(v, this.valueMapper);
+                if (ArrayUtils.isNotEmpty(strings)) {
+                    byte[] bytes = new byte[strings.length];
+                    for (int i = 0; i < strings.length; i++) {
+                        String string = strings[i];
+                        bytes[i] = Byte.parseByte(string);
+                    }
+                    return bytes;
+                }
+            }
+        }
+        return ArrayUtils.EMPTY_BYTE_ARRAY;
+    }
+
+    @Override
+    public char[] charValues(String member) {
+        Object v = values.get(member);
+        if (v != null) {
+            if (v instanceof char[]) {
+                return (char[]) v;
+            } else if (v instanceof Character[]) {
+                Character[] v2 = (Character[]) v;
+                char[] chars = new char[v2.length];
+                for (int i = 0; i < v2.length; i++) {
+                    Character character = v2[i];
+                    chars[i] = character;
+                }
+                return chars;
+            } else if (v instanceof Character) {
+                return new char[] { (Character) v };
+            }
+        }
+        return ArrayUtils.EMPTY_CHAR_ARRAY;
+    }
+
+    @Override
+    public int[] intValues(String member) {
+        Object v = values.get(member);
+        if (v != null) {
+            if (v instanceof int[]) {
+                return (int[]) v;
+            } else if (v instanceof Number) {
+                return new int[] { ((Number) v).intValue() };
+            } else {
+                String[] strings = resolveStringValues(v, this.valueMapper);
+                if (ArrayUtils.isNotEmpty(strings)) {
+                    int[] integers = new int[strings.length];
+                    for (int i = 0; i < strings.length; i++) {
+                        String string = strings[i];
+                        integers[i] = Integer.parseInt(string);
+                    }
+                    return integers;
+                }
+            }
+        }
+        return ArrayUtils.EMPTY_INT_ARRAY;
+    }
+
+    @Override
+    public double[] doubleValues(String member) {
+        Object v = values.get(member);
+        if (v != null) {
+            if (v instanceof double[]) {
+                return (double[]) v;
+            } else if (v instanceof Number) {
+                return new double[] { ((Number) v).doubleValue() };
+            } else {
+                String[] strings = resolveStringValues(v, this.valueMapper);
+                if (ArrayUtils.isNotEmpty(strings)) {
+                    double[] doubles = new double[strings.length];
+                    for (int i = 0; i < strings.length; i++) {
+                        String string = strings[i];
+                        doubles[i] = Double.parseDouble(string);
+                    }
+                    return doubles;
+                }
+            }
+        }
+        return ArrayUtils.EMPTY_DOUBLE_ARRAY;
+    }
+
+    @Override
+    public long[] longValues(String member) {
+        Object v = values.get(member);
+        if (v != null) {
+            if (v instanceof long[]) {
+                return (long[]) v;
+            } else if (v instanceof Number) {
+                return new long[] { ((Number) v).longValue() };
+            } else {
+                String[] strings = resolveStringValues(v, this.valueMapper);
+                if (ArrayUtils.isNotEmpty(strings)) {
+                    long[] longs = new long[strings.length];
+                    for (int i = 0; i < strings.length; i++) {
+                        String string = strings[i];
+                        longs[i] = Long.parseLong(string);
+                    }
+                    return longs;
+                }
+            }
+        }
+        return ArrayUtils.EMPTY_LONG_ARRAY;
+    }
+
+    @Override
+    public float[] floatValues(String member) {
+        Object v = values.get(member);
+        if (v != null) {
+            if (v instanceof float[]) {
+                return (float[]) v;
+            } else if (v instanceof Number) {
+                return new float[] { ((Number) v).floatValue() };
+            } else {
+                String[] strings = resolveStringValues(v, this.valueMapper);
+                if (ArrayUtils.isNotEmpty(strings)) {
+                    float[] floats = new float[strings.length];
+                    for (int i = 0; i < strings.length; i++) {
+                        String string = strings[i];
+                        floats[i] = Float.parseFloat(string);
+                    }
+                    return floats;
+                }
+            }
+        }
+        return ArrayUtils.EMPTY_FLOAT_ARRAY;
+    }
+
+    @Override
+    public short[] shortValues(String member) {
+        Object v = values.get(member);
+        if (v != null) {
+            if (v instanceof short[]) {
+                return (short[]) v;
+            } else if (v instanceof Number) {
+                return new short[] { ((Number) v).shortValue() };
+            } else {
+                String[] strings = resolveStringValues(v, this.valueMapper);
+                if (ArrayUtils.isNotEmpty(strings)) {
+                    short[] shorts = new short[strings.length];
+                    for (int i = 0; i < strings.length; i++) {
+                        String string = strings[i];
+                        shorts[i] = Short.parseShort(string);
+                    }
+                    return shorts;
+                }
+            }
+        }
+        return ArrayUtils.EMPTY_SHORT_ARRAY;
+    }
+
     /**
      * The string values for the given member and mapper.
      *
@@ -472,6 +662,34 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
         return OptionalInt.empty();
     }
 
+    @Override
+    public Optional<Byte> byteValue(String member) {
+        if (StringUtils.isNotEmpty(member)) {
+            Object o = getRawSingleValue(member, valueMapper);
+            if (o instanceof Number) {
+                return Optional.of(((Number) o).byteValue());
+            } else if (o instanceof CharSequence) {
+                try {
+                    return Optional.of(Byte.parseByte(o.toString()));
+                } catch (NumberFormatException e) {
+                    return Optional.empty();
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Character> charValue(String member) {
+        if (StringUtils.isNotEmpty(member)) {
+            Object o = getRawSingleValue(member, valueMapper);
+            if (o instanceof Character) {
+                return Optional.of(((Character) o));
+            }
+        }
+        return Optional.empty();
+    }
+
     /**
      * The integer value of the given member.
      *
@@ -488,11 +706,11 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
     }
 
     /**
-     * The integer value of the given member.
+     * The long value of the given member.
      *
      * @param member      The annotation member
      * @param valueMapper The value mapper
-     * @return An {@link OptionalInt}
+     * @return An {@link OptionalLong}
      */
     public OptionalLong longValue(@NonNull String member, @Nullable Function<Object, Object> valueMapper) {
         if (StringUtils.isNotEmpty(member)) {
@@ -508,6 +726,34 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
             }
         }
         return OptionalLong.empty();
+    }
+
+    @Override
+    public Optional<Short> shortValue(@NonNull String member) {
+        return shortValue(member, null);
+    }
+
+    /**
+     * The short value of the given member.
+     *
+     * @param member      The annotation member
+     * @param valueMapper The value mapper
+     * @return An {@link Optional} of {@link Short}
+     */
+    public Optional<Short> shortValue(@NonNull String member, @Nullable Function<Object, Object> valueMapper) {
+        if (StringUtils.isNotEmpty(member)) {
+            Object o = getRawSingleValue(member, valueMapper);
+            if (o instanceof Number) {
+                return Optional.of((((Number) o).shortValue()));
+            } else if (o instanceof CharSequence) {
+                try {
+                    return Optional.of(Short.parseShort(o.toString()));
+                } catch (NumberFormatException e) {
+                    return Optional.empty();
+                }
+            }
+        }
+        return Optional.empty();
     }
 
     /**
@@ -561,6 +807,34 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
             }
         }
         return OptionalDouble.empty();
+    }
+
+    @Override
+    public Optional<Float> floatValue(String member) {
+        return floatValue(member, valueMapper);
+    }
+
+    /**
+     * The double value of the given member.
+     *
+     * @param member      The annotation member
+     * @param valueMapper The value mapper
+     * @return An {@link OptionalDouble}
+     */
+    public Optional<Float> floatValue(@NonNull String member, @Nullable Function<Object, Object> valueMapper) {
+        if (StringUtils.isNotEmpty(member)) {
+            Object o = getRawSingleValue(member, valueMapper);
+            if (o instanceof Number) {
+                return Optional.of(((Number) o).floatValue());
+            } else if (o instanceof CharSequence) {
+                try {
+                    return Optional.of(Float.parseFloat(o.toString()));
+                } catch (NumberFormatException e) {
+                    return Optional.empty();
+                }
+            }
+        }
+        return Optional.empty();
     }
 
     /**

--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationValueBuilder.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationValueBuilder.java
@@ -201,6 +201,42 @@ public class AnnotationValueBuilder<T extends Annotation> {
     }
 
     /**
+     * Sets the value member to the given char value.
+     *
+     * @param character The char
+     * @return This builder
+     * @since 3.0.0
+     */
+    @NonNull
+    public AnnotationValueBuilder<T> value(char character) {
+        return member(AnnotationMetadata.VALUE_MEMBER, character);
+    }
+
+    /**
+     * Sets the value member to the given double value.
+     *
+     * @param number The double
+     * @return This builder
+     * @since 3.0.0
+     */
+    @NonNull
+    public AnnotationValueBuilder<T> value(double number) {
+        return member(AnnotationMetadata.VALUE_MEMBER, number);
+    }
+
+    /**
+     * Sets the value member to the given float value.
+     *
+     * @param f The float
+     * @return This builder
+     * @since 3.0.0
+     */
+    @NonNull
+    public AnnotationValueBuilder<T> value(float f) {
+        return member(AnnotationMetadata.VALUE_MEMBER, f);
+    }
+
+    /**
      * Sets the value member to the given enum object.
      *
      * @param enumObj The enum
@@ -278,7 +314,7 @@ public class AnnotationValueBuilder<T extends Annotation> {
     }
 
     /**
-     * Sets the value member to the given integer value.
+     * Sets the given member to the given integer value.
      *
      * @param name The name of the member
      * @param i The integer
@@ -291,7 +327,105 @@ public class AnnotationValueBuilder<T extends Annotation> {
     }
 
     /**
-     * Sets the value member to the given integer[] value.
+     * Sets the given member to the given byte value.
+     *
+     * @param name The name of the member
+     * @param b The byte
+     * @return This builder
+     * @since 3.0.0
+     */
+    @NonNull
+    public AnnotationValueBuilder<T> member(@NonNull String name, byte b) {
+        values.put(name, b);
+        return this;
+    }
+
+    /**
+     * Sets the given member to the given char value.
+     *
+     * @param name The name of the member
+     * @param c The char
+     * @return This builder
+     * @since 3.0.0
+     */
+    @NonNull
+    public AnnotationValueBuilder<T> member(@NonNull String name, char c) {
+        values.put(name, c);
+        return this;
+    }
+
+    /**
+     * Sets the given member to the given char[] value.
+     *
+     * @param name The name of the member
+     * @param chars The chars
+     * @return This builder
+     * @since 3.0.0
+     */
+    @NonNull
+    public AnnotationValueBuilder<T> member(@NonNull String name, char... chars) {
+        values.put(name, chars);
+        return this;
+    }
+
+    /**
+     * Sets the given member to the given double value.
+     *
+     * @param name The name of the member
+     * @param d The double
+     * @return This builder
+     * @since 3.0.0
+     */
+    @NonNull
+    public AnnotationValueBuilder<T> member(@NonNull String name, double d) {
+        values.put(name, d);
+        return this;
+    }
+
+    /**
+     * Sets the given member to the given double[] value.
+     *
+     * @param name The name of the member
+     * @param doubles The double[]
+     * @return This builder
+     * @since 3.0.0
+     */
+    @NonNull
+    public AnnotationValueBuilder<T> member(@NonNull String name, double... doubles) {
+        values.put(name, doubles);
+        return this;
+    }
+
+    /**
+     * Sets the given member to the given float value.
+     *
+     * @param name The name of the member
+     * @param f The float
+     * @return This builder
+     * @since 3.0.0
+     */
+    @NonNull
+    public AnnotationValueBuilder<T> member(@NonNull String name, float f) {
+        values.put(name, f);
+        return this;
+    }
+
+    /**
+     * Sets the given member to the given float[] value.
+     *
+     * @param name The name of the member
+     * @param floats The float[]
+     * @return This builder
+     * @since 3.0.0
+     */
+    @NonNull
+    public AnnotationValueBuilder<T> member(@NonNull String name, float... floats) {
+        values.put(name, floats);
+        return this;
+    }
+
+    /**
+     * Sets the given member to the given integer[] value.
      *
      * @param name The name of the member
      * @param ints The integer[]
@@ -306,7 +440,23 @@ public class AnnotationValueBuilder<T extends Annotation> {
     }
 
     /**
-     * Sets the value member to the given long value.
+     * Sets the given member to the given byte[] value.
+     *
+     * @param name The name of the member
+     * @param bytes The byte[]
+     * @return This builder
+     * @since 3.0.0
+     */
+    @NonNull
+    public AnnotationValueBuilder<T> member(@NonNull String name, @Nullable byte... bytes) {
+        if (bytes != null) {
+            values.put(name, bytes);
+        }
+        return this;
+    }
+
+    /**
+     * Sets the given member to the given long value.
      *
      * @param name The name of the member
      * @param i The long
@@ -319,7 +469,33 @@ public class AnnotationValueBuilder<T extends Annotation> {
     }
 
     /**
-     * Sets the value member to the given long[] value.
+     * Sets the given member to the given short value.
+     *
+     * @param name The name of the member
+     * @param i The short
+     * @return This builder
+     */
+    @NonNull
+    public AnnotationValueBuilder<T> member(@NonNull String name, short i) {
+        values.put(name, i);
+        return this;
+    }
+
+    /**
+     * Sets the given member to the given short[] value.
+     *
+     * @param name The name of the member
+     * @param shorts The short[]
+     * @return This builder
+     */
+    @NonNull
+    public AnnotationValueBuilder<T> member(@NonNull String name, short... shorts) {
+        values.put(name, shorts);
+        return this;
+    }
+
+    /**
+     * Sets the given member to the given long[] value.
      *
      * @param name The name of the member
      * @param longs The long[]
@@ -334,7 +510,7 @@ public class AnnotationValueBuilder<T extends Annotation> {
     }
 
     /**
-     * Sets the value member to the given string value.
+     * Sets the given member to the given string value.
      *
      * @param name The name of the member
      * @param str The string
@@ -349,7 +525,7 @@ public class AnnotationValueBuilder<T extends Annotation> {
     }
 
     /**
-     * Sets the value member to the given String[] values.
+     * Sets the given member to the given String[] values.
      *
      * @param name The name of the member
      * @param strings The String[]
@@ -364,7 +540,7 @@ public class AnnotationValueBuilder<T extends Annotation> {
     }
 
     /**
-     * Sets the value member to the given boolean value.
+     * Sets the given member to the given boolean value.
      *
      * @param name The name of the member
      * @param bool The boolean
@@ -377,7 +553,21 @@ public class AnnotationValueBuilder<T extends Annotation> {
     }
 
     /**
-     * Sets the value member to the given enum object.
+     * Sets the given member to the given boolean value array.
+     *
+     * @param name The name of the member
+     * @param booleans The booleans
+     * @return This builder
+     * @since 3.0.0
+     */
+    @NonNull
+    public AnnotationValueBuilder<T> member(@NonNull String name, boolean... booleans) {
+        values.put(name, booleans);
+        return this;
+    }
+
+    /**
+     * Sets the given member to the given enum object.
      *
      * @param name The name of the member
      * @param enumObj The enum
@@ -392,7 +582,7 @@ public class AnnotationValueBuilder<T extends Annotation> {
     }
 
     /**
-     * Sets the value member to the given enum objects.
+     * Sets the given member to the given enum objects.
      *
      * @param name The name of the member
      * @param enumObjs The enum[]
@@ -407,7 +597,7 @@ public class AnnotationValueBuilder<T extends Annotation> {
     }
 
     /**
-     * Sets the value member to the given type object.
+     * Sets the given member to the given type object.
      *
      * @param name The name of the member
      * @param type The type
@@ -422,7 +612,7 @@ public class AnnotationValueBuilder<T extends Annotation> {
     }
 
     /**
-     * Sets the value member to the given type objects.
+     * Sets the given member to the given type objects.
      *
      * @param name The name of the member
      * @param types The type[]
@@ -431,7 +621,7 @@ public class AnnotationValueBuilder<T extends Annotation> {
     @NonNull
     public AnnotationValueBuilder<T> member(@NonNull String name, @Nullable Class<?>... types) {
         if (types != null) {
-            AnnotationClassValue[] classValues = new AnnotationClassValue[types.length];
+            AnnotationClassValue<?>[] classValues = new AnnotationClassValue[types.length];
             for (int i = 0; i < types.length; i++) {
                 Class<?> type = types[i];
                 classValues[i] = new AnnotationClassValue<>(type);
@@ -442,7 +632,7 @@ public class AnnotationValueBuilder<T extends Annotation> {
     }
 
     /**
-     * Sets the value member to the given annotation value.
+     * Sets the given member to the given annotation value.
      *
      * @param name The name of the member
      * @param annotation The annotation
@@ -457,7 +647,7 @@ public class AnnotationValueBuilder<T extends Annotation> {
     }
 
     /**
-     * Sets the value member to the given annotation values.
+     * Sets the given member to the given annotation values.
      *
      * @param name The name of the member
      * @param annotations The annotation[]
@@ -472,7 +662,7 @@ public class AnnotationValueBuilder<T extends Annotation> {
     }
 
     /**
-     * Sets the value member to the given annotation class values.
+     * Sets the given member to the given annotation class values.
      *
      * @param name The name of the member
      * @param classValues The annotation[]

--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationValueResolver.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationValueResolver.java
@@ -129,6 +129,44 @@ public interface AnnotationValueResolver extends ValueResolver<CharSequence> {
     OptionalInt intValue(@NonNull String member);
 
     /**
+     * The byte value of the given member.
+     *
+     * @return An {@link Optional} of {@link Byte}
+     * @since 3.0.0
+     */
+    default Optional<Byte> byteValue() {
+        return byteValue(AnnotationMetadata.VALUE_MEMBER);
+    }
+
+    /**
+     * The byte value of the given member.
+     *
+     * @param member The annotation member
+     * @return An {@link Optional} of {@link Byte}
+     * @since 3.0.0
+     */
+    Optional<Byte> byteValue(@NonNull String member);
+
+    /**
+     * The char value of the given member.
+     *
+     * @return An {@link Optional} of {@link Character}
+     * @since 3.0.0
+     */
+    default Optional<Character> charValue() {
+        return charValue(AnnotationMetadata.VALUE_MEMBER);
+    }
+
+    /**
+     * The char value of the given member.
+     *
+     * @param member The annotation member
+     * @return An {@link Optional} of {@link Character}
+     * @since 3.0.0
+     */
+    Optional<Character> charValue(@NonNull String member);
+
+    /**
      * The integer value of the given member.
      *
      * @return An {@link OptionalInt}
@@ -146,12 +184,29 @@ public interface AnnotationValueResolver extends ValueResolver<CharSequence> {
     OptionalLong longValue(@NonNull String member);
 
     /**
-     * The integer value of the given member.
+     * The long value of the given member.
      *
      * @return An {@link OptionalLong}
      */
     default OptionalLong longValue() {
         return longValue(AnnotationMetadata.VALUE_MEMBER);
+    }
+
+    /**
+     * The short value of the given member.
+     *
+     * @param member The annotation member
+     * @return An {@link Optional} of {@link Short}
+     */
+    Optional<Short> shortValue(@NonNull String member);
+
+    /**
+     * The integer value of the given member.
+     *
+     * @return An {@link Optional} of
+     */
+    default Optional<Short> shortValue() {
+        return shortValue(AnnotationMetadata.VALUE_MEMBER);
     }
 
     /**
@@ -161,6 +216,25 @@ public interface AnnotationValueResolver extends ValueResolver<CharSequence> {
      * @return An {@link OptionalDouble}
      */
     OptionalDouble doubleValue(@NonNull String member);
+
+    /**
+     * The float value of the given member.
+     *
+     * @return An {@link Optional} of {@link Float}
+     * @since 3.0.0
+     */
+    default Optional<Float> floatValue() {
+        return floatValue(AnnotationMetadata.VALUE_MEMBER);
+    }
+
+    /**
+     * The double value of the given member.
+     *
+     * @param member The annotation member
+     * @return An {@link OptionalDouble}
+     * @since 3.0.0
+     */
+    Optional<Float> floatValue(@NonNull String member);
 
     /**
      * The double value of the given member.
@@ -205,22 +279,173 @@ public interface AnnotationValueResolver extends ValueResolver<CharSequence> {
         return booleanValue(AnnotationMetadata.VALUE_MEMBER);
     }
 
-
     /**
-     * The string value of the given member.
+     * The string values for the given member.
      *
      * @param member The annotation member
-     * @return An {@link OptionalInt}
+     * @return An array of {@link String}
      */
     @NonNull String[] stringValues(@NonNull String member);
 
     /**
-     * The double value of the given member.
+     * The string values for the given member.
      *
-     * @return An {@link OptionalInt}
+     * @return An array of {@link String}
      */
     default @NonNull String[] stringValues() {
         return stringValues(AnnotationMetadata.VALUE_MEMBER);
+    }
+
+    /**
+     * The boolean[] value for the given member.
+     *
+     * @param member The annotation member
+     * @return An array of {@code boolean}
+     * @since 3.0.0
+     */
+    @NonNull boolean[] booleanValues(@NonNull String member);
+
+    /**
+     * The boolean[] value for the given member.
+     *
+     * @return An array of {@code boolean}
+     * @since 3.0.0
+     */
+    default @NonNull boolean[] booleanValues() {
+        return booleanValues(AnnotationMetadata.VALUE_MEMBER);
+    }
+
+    /**
+     * The byte[] value for the given member.
+     *
+     * @param member The annotation member
+     * @return An array of {@code byte}
+     * @since 3.0.0
+     */
+    @NonNull byte[] byteValues(@NonNull String member);
+
+    /**
+     * The byte[] value for the given member.
+     *
+     * @return An array of {@code byte}
+     * @since 3.0.0
+     */
+    default @NonNull byte[] byteValues() {
+        return byteValues(AnnotationMetadata.VALUE_MEMBER);
+    }
+
+    /**
+     * The char[] value for the given member.
+     *
+     * @param member The annotation member
+     * @return An array of {@code char}
+     * @since 3.0.0
+     */
+    @NonNull char[] charValues(@NonNull String member);
+
+    /**
+     * The char[] value for the given member.
+     *
+     * @return An array of {@code char}
+     * @since 3.0.0
+     */
+    default @NonNull char[] charValues() {
+        return charValues(AnnotationMetadata.VALUE_MEMBER);
+    }
+
+    /**
+     * The int[] value for the given member.
+     *
+     * @param member The annotation member
+     * @return An array of {@code int}
+     * @since 3.0.0
+     */
+    @NonNull int[] intValues(@NonNull String member);
+
+    /**
+     * The int[] value for the given member.
+     *
+     * @return An array of {@code int}
+     * @since 3.0.0
+     */
+    default @NonNull int[] intValues() {
+        return intValues(AnnotationMetadata.VALUE_MEMBER);
+    }
+
+    /**
+     * The double[] value for the given member.
+     *
+     * @param member The annotation member
+     * @return An array of {@code double}
+     * @since 3.0.0
+     */
+    @NonNull double[] doubleValues(@NonNull String member);
+
+    /**
+     * The double[] value for the given member.
+     *
+     * @return An array of {@code double}
+     * @since 3.0.0
+     */
+    default @NonNull double[] doubleValues() {
+        return doubleValues(AnnotationMetadata.VALUE_MEMBER);
+    }
+
+    /**
+     * The long[] value for the given member.
+     *
+     * @param member The annotation member
+     * @return An array of {@code long}
+     * @since 3.0.0
+     */
+    @NonNull long[] longValues(@NonNull String member);
+
+    /**
+     * The long[] value for the given member.
+     *
+     * @return An array of {@code long}
+     * @since 3.0.0
+     */
+    default @NonNull long[] longValues() {
+        return longValues(AnnotationMetadata.VALUE_MEMBER);
+    }
+
+    /**
+     * The float[] value for the given member.
+     *
+     * @param member The annotation member
+     * @return An array of {@code float}
+     * @since 3.0.0
+     */
+    @NonNull float[] floatValues(@NonNull String member);
+
+    /**
+     * The float[] value for the given member.
+     *
+     * @return An array of {@code float}
+     * @since 3.0.0
+     */
+    default @NonNull float[] floatValues() {
+        return floatValues(AnnotationMetadata.VALUE_MEMBER);
+    }
+
+    /**
+     * The short[] value for the given member.
+     *
+     * @param member The annotation member
+     * @return An array of {@code short}
+     * @since 3.0.0
+     */
+    @NonNull short[] shortValues(@NonNull String member);
+
+    /**
+     * The short[] value for the given member.
+     *
+     * @return An array of {@code short}
+     * @since 3.0.0
+     */
+    default @NonNull short[] shortValues() {
+        return shortValues(AnnotationMetadata.VALUE_MEMBER);
     }
 
     /**

--- a/core/src/main/java/io/micronaut/core/convert/DefaultConversionService.java
+++ b/core/src/main/java/io/micronaut/core/convert/DefaultConversionService.java
@@ -180,28 +180,23 @@ public class DefaultConversionService implements ConversionService<DefaultConver
      */
     @SuppressWarnings({"OptionalIsPresent", "unchecked"})
     protected void registerDefaultConverters() {
-
+        // primitive array to wrapper array
+        @SuppressWarnings("rawtypes")
+        Function primitiveArrayToWrapperArray = ArrayUtils::toWrapperArray;
+        addConverter(double[].class, Double[].class, primitiveArrayToWrapperArray);
+        addConverter(byte[].class, Byte[].class, primitiveArrayToWrapperArray);
+        addConverter(short[].class, Short[].class, primitiveArrayToWrapperArray);
+        addConverter(boolean[].class, Boolean[].class, primitiveArrayToWrapperArray);
+        addConverter(int[].class, Integer[].class, primitiveArrayToWrapperArray);
+        addConverter(float[].class, Float[].class, primitiveArrayToWrapperArray);
+        addConverter(double[].class, Double[].class, primitiveArrayToWrapperArray);
+        addConverter(char[].class, Character[].class, primitiveArrayToWrapperArray);
         // wrapper to primitive array converters
-        addConverter(Double[].class, double[].class, (object, targetType, context) -> {
-            double[] doubles = new double[object.length];
-            for (int i = 0; i < object.length; i++) {
-                Double aDouble = object[i];
-                if (aDouble != null) {
-                    doubles[i] = aDouble;
-                }
-            }
-            return Optional.of(doubles);
-        });
-        addConverter(Integer[].class, int[].class, (object, targetType, context) -> {
-            int[] integers = new int[object.length];
-            for (int i = 0; i < object.length; i++) {
-                Integer o = object[i];
-                if (o != null) {
-                    integers[i] = o;
-                }
-            }
-            return Optional.of(integers);
-        });
+        Function<Object[], Object> wrapperArrayToPrimitiveArray = ArrayUtils::toPrimitiveArray;
+        //noinspection rawtypes
+        addConverter(Double[].class, double[].class, (Function) wrapperArrayToPrimitiveArray);
+        //noinspection rawtypes
+        addConverter(Integer[].class, int[].class, (Function) wrapperArrayToPrimitiveArray);
 
         // Object -> List
         addConverter(Object.class, List.class, (object, targetType, context) -> {

--- a/core/src/main/java/io/micronaut/core/util/ArrayUtils.java
+++ b/core/src/main/java/io/micronaut/core/util/ArrayUtils.java
@@ -17,6 +17,7 @@ package io.micronaut.core.util;
 
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.annotation.UsedByGeneratedCode;
+import io.micronaut.core.reflect.ReflectionUtils;
 
 import java.lang.reflect.Array;
 import java.util.*;
@@ -35,6 +36,46 @@ public class ArrayUtils {
      */
     @UsedByGeneratedCode
     public static final Object[] EMPTY_OBJECT_ARRAY = new Object[0];
+
+    /**
+     * An empty boolean array.
+     */
+    public static final boolean[] EMPTY_BOOLEAN_ARRAY = new boolean[0];
+
+    /**
+     * An empty byte array.
+     */
+    public static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
+
+    /**
+     * An empty char array.
+     */
+    public static final char[] EMPTY_CHAR_ARRAY = new char[0];
+
+    /**
+     * An empty int array.
+     */
+    public static final int[] EMPTY_INT_ARRAY = new int[0];
+
+    /**
+     * An empty double array.
+     */
+    public static final double[] EMPTY_DOUBLE_ARRAY = new double[0];
+
+    /**
+     * An empty long array.
+     */
+    public static final long[] EMPTY_LONG_ARRAY = new long[0];
+
+    /**
+     * An empty float array.
+     */
+    public static final float[] EMPTY_FLOAT_ARRAY = new float[0];
+
+    /**
+     * An empty short array.
+     */
+    public static final short[] EMPTY_SHORT_ARRAY = new short[0];
 
     /**
      * Concatenate two arrays.
@@ -186,6 +227,56 @@ public class ArrayUtils {
      */
     public static <T> T[] toArray(Collection<T> collection, Class<T> arrayItemClass) {
         return (T[]) collection.toArray((Object[]) Array.newInstance(arrayItemClass, collection.size()));
+    }
+
+    /**
+     * Converts a primitive array to the equivalent wrapper such as int[] to Integer[].
+     * @param primitiveArray The primitive array
+     * @return The primitive array wrapper.
+     * @since 3.0.0
+     */
+    public static Object[] toWrapperArray(final Object primitiveArray) {
+        Objects.requireNonNull(primitiveArray, "Primitive array cannot be null");
+        final Class<?> cls = primitiveArray.getClass();
+        Class<?> componentType = cls.getComponentType();
+        if (!cls.isArray() || !componentType.isPrimitive()) {
+            throw new IllegalArgumentException(
+                    "Only primitive arrays are supported");
+        }
+        final int length = Array.getLength(primitiveArray);
+        Object[] arr = (Object[]) Array.newInstance(ReflectionUtils.getWrapperType(componentType), length);
+        for (int i = 0; i < length; i++) {
+            arr[i] = Array.get(primitiveArray, i);
+        }
+        return arr;
+    }
+
+    /**
+     * Converts a primitive wrapper array to the equivalent primitive array such as Integer[] to int[].
+     * @param wrapperArray The wrapper array
+     * @return The primitive array.
+     * @since 3.0.0
+     */
+    public static Object toPrimitiveArray(final Object[] wrapperArray) {
+        Objects.requireNonNull(wrapperArray, "Wrapper array cannot be null");
+        final Class<?> cls = wrapperArray.getClass();
+        Class<?> ct = cls.getComponentType();
+        Class<?> componentType = ReflectionUtils.getPrimitiveType(ct);
+        if (componentType == ct) {
+            return wrapperArray;
+        } else {
+
+            if (!cls.isArray() || !componentType.isPrimitive()) {
+                throw new IllegalArgumentException(
+                        "Only primitive arrays are supported");
+            }
+            final int length = wrapperArray.length;
+            Object arr = Array.newInstance(componentType, length);
+            for (int i = 0; i < length; i++) {
+                Array.set(arr, i, wrapperArray[i]);
+            }
+            return arr;
+        }
     }
 
     /**

--- a/core/src/test/groovy/io/micronaut/core/annotation/AnnotationValueBuilderSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/annotation/AnnotationValueBuilderSpec.groovy
@@ -46,8 +46,8 @@ class AnnotationValueBuilderSpec extends Specification {
     void "test custom retention policy"() {
         given:
         def av = AnnotationValue.builder(AnnotationValue.builder("Foo")
-                    .value(String.class)
-                    .build(), RetentionPolicy.SOURCE).build()
+                .value(String.class)
+                .build(), RetentionPolicy.SOURCE).build()
 
         expect:
         av.retentionPolicy == RetentionPolicy.SOURCE
@@ -65,12 +65,74 @@ class AnnotationValueBuilderSpec extends Specification {
         av.getValue(type).get() == val
 
         where:
-        val   | type
-        1     | Integer
-        1L    | Long
-        true  | Boolean
-        "str" | String
+        val                           | type
+        true                          | Boolean
+        20 as Byte                    | Byte
+        'c' as char                   | Character
+        1.1 as double                 | Double
+        1.1 as float                  | Float
+        1                             | Integer
+        1L                            | Long
+        "str"                         | String
+        1 as short                    | Short
+        String                        | Class
+        Introspected.AccessKind.FIELD | Enum
     }
+
+    @Unroll
+    void "test member for #type"() {
+        given:
+        def av = AnnotationValue.builder("Foo")
+                .member("foo", val)
+                .build()
+
+        expect:
+        av.get("foo", type).isPresent()
+        av.get("foo", type).get() == val
+        (method == 'enum' ? av.enumValue("foo", Introspected.AccessKind) : av."${method}Value"("foo")).isPresent()
+
+        where:
+        val                           | method    | type
+        true                          | "boolean" | Boolean
+        20 as Byte                    | "byte"    | Byte
+        'c' as char                   | "char"    | Character
+        Double.MAX_VALUE              | "double"  | Double
+        Float.MAX_VALUE               | "float"   | Float
+        Integer.MAX_VALUE             | "int"     | Integer
+        Long.MAX_VALUE                | "long"    | Long
+        Short.MAX_VALUE               | "short"   | Short
+        "str"                         | "string"  | String
+        String                        | "class"   | Class
+        Introspected.AccessKind.FIELD | "enum"    | Enum
+    }
+
+    @Unroll
+    void "test member for array type #type"() {
+        given:
+        def av = AnnotationValue.builder("Foo")
+                .member("foo", val)
+                .build()
+
+        expect:
+        av.get("foo", type).isPresent()
+        av.get("foo", type).get() == val
+        (method == 'enum' ? av.enumValues("foo", Introspected.AccessKind) : av."${method}Values"("foo")) == val
+
+        where:
+        val                                       | method    | type
+        [true] as boolean[]                       | "boolean" | boolean[].class
+        [20 as byte] as byte[]                    | "byte"    | byte[].class
+        ['c' as char] as char[]                   | "char"    | char[].class
+        [Double.MAX_VALUE] as double[]            | "double"  | double[].class
+        [Float.MAX_VALUE] as float[]              | "float"   | float[].class
+        [Integer.MAX_VALUE] as int[]              | "int"     | int[].class
+        [Long.MAX_VALUE] as long[]                | "long"    | long[].class
+        [Short.MAX_VALUE] as short[]              | "short"   | short[].class
+        ["str"] as String[]                       | "string"  | String[].class
+        [String] as Class[]                       | "class"   | Class[].class
+        [Introspected.AccessKind.FIELD] as Enum[] | "enum"    | Enum[].class
+    }
+
 
     void "test passing a map of members"() {
         when:
@@ -87,7 +149,7 @@ class AnnotationValueBuilderSpec extends Specification {
         when:
         av = AnnotationValue.builder("Foo")
                 .members([
-                        "multidimensional array": new int[][] { new int[] {1}, new int[] {2}}
+                        "multidimensional array": new int[][]{new int[]{1}, new int[]{2}}
                 ])
                 .build()
 
@@ -98,7 +160,7 @@ class AnnotationValueBuilderSpec extends Specification {
         when:
         av = AnnotationValue.builder("Foo")
                 .members([
-                        "primitive wrapper array": new Long[] { 1L }
+                        "primitive wrapper array": new Long[]{1L}
                 ])
                 .build()
 
@@ -109,26 +171,26 @@ class AnnotationValueBuilderSpec extends Specification {
         when:
         av = AnnotationValue.builder("Foo")
                 .members([
-                        "primitive": 1L,
-                        "primitive wrapper": Long.valueOf(1),
-                        "primitive array": new int[] {1, 2},
-                        "enum": RetentionPolicy.RUNTIME,
-                        "enum array": new RetentionPolicy[] {
+                        "primitive"             : 1L,
+                        "primitive wrapper"     : Long.valueOf(1),
+                        "primitive array"       : new int[]{1, 2},
+                        "enum"                  : RetentionPolicy.RUNTIME,
+                        "enum array"            : new RetentionPolicy[]{
                                 RetentionPolicy.RUNTIME,
                                 RetentionPolicy.SOURCE
                         },
-                        "class": String.class,
-                        "class array": new Class[] {
+                        "class"                 : String.class,
+                        "class array"           : new Class[]{
                                 String.class,
                                 Long.class
                         },
-                        "annotation class": new AnnotationClassValue<>(String.class),
-                        "annotation class array": new AnnotationClassValue<>[] {
+                        "annotation class"      : new AnnotationClassValue<>(String.class),
+                        "annotation class array": new AnnotationClassValue<>[]{
                                 new AnnotationClassValue<>(String.class),
                                 new AnnotationClassValue<>(Long.class)
                         },
-                        "annotation": AnnotationValue.builder("Bar").value(true).build(),
-                        "annotation array": new AnnotationValue[] {
+                        "annotation"            : AnnotationValue.builder("Bar").value(true).build(),
+                        "annotation array"      : new AnnotationValue[]{
                                 AnnotationValue.builder("Bar").value(true).build(),
                                 AnnotationValue.builder("Bar").value(false).build()
                         }

--- a/core/src/test/groovy/io/micronaut/core/util/ArrayUtilsSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/util/ArrayUtilsSpec.groovy
@@ -4,6 +4,19 @@ import spock.lang.Specification
 
 class ArrayUtilsSpec extends Specification {
 
+    void 'test toWrapperArray()'() {
+        expect:
+        ArrayUtils.toWrapperArray([1, 2] as int[]) == [1, 2] as Integer[]
+        ArrayUtils.toWrapperArray([1, 2] as double[]) == [1, 2] as Double[]
+        ArrayUtils.toWrapperArray([1, 2] as int[]).class == Integer[].class
+    }
+
+    void 'test toPrimitiveArray()'() {
+        expect:
+        ArrayUtils.toPrimitiveArray([1, 2] as Integer[]) == [1, 2] as int[]
+        ArrayUtils.toPrimitiveArray([1, 2] as Integer[]).class == int[].class
+    }
+
     void "test reverse iterator works"() {
         given:
         Iterator<String> reversedIterator = ArrayUtils.reverseIterator("a", "b", "c")

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/AbstractGroovyElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/AbstractGroovyElement.java
@@ -102,6 +102,17 @@ public abstract class AbstractGroovyElement implements AnnotationMetadataDelegat
     }
 
     @Override
+    public <T extends Annotation> Element annotate(AnnotationValue<T> annotationValue) {
+        ArgumentUtils.requireNonNull("annotationValue", annotationValue);
+        this.annotationMetadata = new GroovyAnnotationMetadataBuilder(sourceUnit, compilationUnit).annotate(
+                this.annotationMetadata,
+                annotationValue
+        );
+        updateAnnotationCaches();
+        return this;
+    }
+
+    @Override
     public Element removeAnnotation(@NonNull String annotationType) {
         ArgumentUtils.requireNonNull("annotationType", annotationType);
         this.annotationMetadata = new GroovyAnnotationMetadataBuilder(sourceUnit, compilationUnit).removeAnnotation(

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/AnnotationUtils.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/AnnotationUtils.java
@@ -101,7 +101,11 @@ public class AnnotationUtils {
         while (i.hasNext()) {
             final ServiceDefinition<AnnotatedElementValidator> validator = i.next();
             if (validator.isPresent()) {
-                elementValidator = validator.load();
+                try {
+                    elementValidator = validator.load();
+                } catch (Throwable e) {
+                    // probably missing required dependencies to load the validator
+                }
                 break;
             }
         }

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/AbstractJavaElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/AbstractJavaElement.java
@@ -86,6 +86,20 @@ public abstract class AbstractJavaElement implements io.micronaut.inject.ast.Ele
     }
 
     @Override
+    public <T extends Annotation> io.micronaut.inject.ast.Element annotate(AnnotationValue<T> annotationValue) {
+        ArgumentUtils.requireNonNull("annotationValue", annotationValue);
+
+        AnnotationUtils annotationUtils = visitorContext
+                .getAnnotationUtils();
+        this.annotationMetadata = annotationUtils
+                .newAnnotationBuilder()
+                .annotate(annotationMetadata, annotationValue);
+
+        updateMetadataCaches();
+        return this;
+    }
+
+    @Override
     public io.micronaut.inject.ast.Element removeAnnotation(@NonNull String annotationType) {
         ArgumentUtils.requireNonNull("annotationType", annotationType);
         try {

--- a/inject/build.gradle
+++ b/inject/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
     compileOnly dependencyVersion("validation")
 
-    testImplementation dependencyVersion("validation")
+//    testImplementation dependencyVersion("validation")
     testImplementation project(":context")
     testImplementation project(":inject-groovy")
     testImplementation project(":inject-test-utils")

--- a/inject/src/main/java/io/micronaut/context/event/ApplicationEventPublisherFactory.java
+++ b/inject/src/main/java/io/micronaut/context/event/ApplicationEventPublisherFactory.java
@@ -191,7 +191,6 @@ public final class ApplicationEventPublisherFactory<T>
         return getClass().hashCode();
     }
 
-
     private ApplicationEventPublisher<Object> createObjectEventPublisher(BeanContext beanContext) {
         return new ApplicationEventPublisher<Object>() {
             @Override

--- a/inject/src/main/java/io/micronaut/inject/ast/Element.java
+++ b/inject/src/main/java/io/micronaut/inject/ast/Element.java
@@ -168,7 +168,7 @@ public interface Element extends AnnotationMetadataDelegate, AnnotatedElement, D
      * @param annotationType The annotation type
      * @param consumer A function that receives the {@link AnnotationValueBuilder}
      * @param <T> The annotation generic type
-     * @return The {@link AnnotationValueBuilder}
+     * @return This element
      */
     @NonNull
     default <T extends Annotation> Element annotate(@NonNull Class<T> annotationType, @NonNull Consumer<AnnotationValueBuilder<T>> consumer) {
@@ -183,12 +183,26 @@ public interface Element extends AnnotationMetadataDelegate, AnnotatedElement, D
      *
      * @param annotationType The annotation type
      * @param <T> The annotation generic type
-     * @return The {@link AnnotationValueBuilder}
+     * @return This element
      */
     @NonNull
     default <T extends Annotation> Element annotate(@NonNull Class<T> annotationType) {
         ArgumentUtils.requireNonNull("annotationType", annotationType);
         return annotate(annotationType.getName(), annotationValueBuilder -> { });
+    }
+
+    /**
+     * Annotate this element with the given annotation type. If the annotation is already present then
+     * any values populated by the builder will be merged/overridden with the existing values.
+     *
+     * @param annotationValue The annotation type
+     * @param <T> The annotation generic type
+     * @return This element
+     * @since 3.0.0
+     */
+    @NonNull
+    default <T extends Annotation> Element annotate(@NonNull AnnotationValue<T> annotationValue) {
+        throw new UnsupportedOperationException("Element of type [" + getClass() + "] does not support adding annotations at compilation time");
     }
 
     /**

--- a/inject/src/main/java/io/micronaut/inject/writer/AbstractClassFileWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/AbstractClassFileWriter.java
@@ -950,7 +950,7 @@ public abstract class AbstractClassFileWriter implements Opcodes, OriginatingEle
         // the size of the array
         methodVisitor.push(size);
         // define the array
-        methodVisitor.visitTypeInsn(ANEWARRAY, Type.getInternalName(arrayType));
+        methodVisitor.newArray(Type.getType(arrayType));
         // add a reference to the array on the stack
         if (size > 0) {
             methodVisitor.visitInsn(DUP);
@@ -983,12 +983,23 @@ public abstract class AbstractClassFileWriter implements Opcodes, OriginatingEle
      * @param runnable      The runnable
      */
     protected static void pushStoreInArray(GeneratorAdapter methodVisitor, int index, int size, Runnable runnable) {
+        pushStoreInArray(methodVisitor, TYPE_OBJECT, index, size, runnable);
+    }
+
+    /**
+     * @param methodVisitor The method visitor as {@link GeneratorAdapter}
+     * @param type          The type of the array
+     * @param index         The index
+     * @param size          The size
+     * @param runnable      The runnable
+     */
+    protected static void pushStoreInArray(GeneratorAdapter methodVisitor, Type type, int index, int size, Runnable runnable) {
         // the array index position
         methodVisitor.push(index);
         // load the constant string
         runnable.run();
         // store the string in the position
-        methodVisitor.visitInsn(AASTORE);
+        methodVisitor.arrayStore(type);
         if (index != (size - 1)) {
             // if we are not at the end of the array duplicate array onto the stack
             methodVisitor.dup();


### PR DESCRIPTION
* Adds new methods to define primitive array members in `AnnotationValueBuilder`
* Adds new methods to retrieve values to `AnnotationValue`
* Previously primitive arrays were stored as their wrapper type `Integer[]` this change alters that to store them as `int[]` instead which is more memory efficient. For backwards compatibility primitive to wrapper converts are added.