### PR TITLE
Mark some jackson-related classes as internal

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/jackson/JsonViewCodecResolver.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/jackson/JsonViewCodecResolver.java
@@ -24,7 +24,7 @@ import io.micronaut.jackson.codec.JsonMediaTypeCodec;
  * @author graemerocher
  * @since 1.1
  */
-public interface JsonViewCodecResolver {
+interface JsonViewCodecResolver {
     /**
      * Resolves a {@link JsonMediaTypeCodec} for the view class (specified as the JsonView annotation value).
      * @param viewClass The view class

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/jackson/JsonViewMediaTypeCodecFactory.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/jackson/JsonViewMediaTypeCodecFactory.java
@@ -18,7 +18,6 @@ package io.micronaut.http.server.netty.jackson;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.annotation.Requires;
-import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.util.ArgumentUtils;
@@ -45,9 +44,8 @@ import static io.micronaut.jackson.codec.JsonMediaTypeCodec.CONFIGURATION_QUALIF
 @Requires(beans = JacksonConfiguration.class)
 @Requires(property = JsonViewServerFilter.PROPERTY_JSON_VIEW_ENABLED)
 @Singleton
-@Internal
 @Primary
-public class JsonViewMediaTypeCodecFactory implements JsonViewCodecResolver {
+class JsonViewMediaTypeCodecFactory implements JsonViewCodecResolver {
 
     private final ObjectMapper objectMapper;
     private final ApplicationConfiguration applicationConfiguration;
@@ -59,7 +57,7 @@ public class JsonViewMediaTypeCodecFactory implements JsonViewCodecResolver {
      * @param applicationConfiguration The common application configurations
      * @param codecConfiguration       The configuration for the codec
      */
-    protected JsonViewMediaTypeCodecFactory(ObjectMapper objectMapper,
+    JsonViewMediaTypeCodecFactory(ObjectMapper objectMapper,
                           ApplicationConfiguration applicationConfiguration,
                           @Named(CONFIGURATION_QUALIFIER) @Nullable CodecConfiguration codecConfiguration) {
         this.objectMapper = objectMapper;

--- a/runtime/src/main/java/io/micronaut/jackson/bind/JacksonBeanPropertyBinder.java
+++ b/runtime/src/main/java/io/micronaut/jackson/bind/JacksonBeanPropertyBinder.java
@@ -51,7 +51,7 @@ import java.util.Set;
  */
 @Singleton
 @Primary
-public class JacksonBeanPropertyBinder implements BeanPropertyBinder {
+class JacksonBeanPropertyBinder implements BeanPropertyBinder {
 
     private final ObjectMapper objectMapper;
     private final int arraySizeThreshhold;
@@ -60,7 +60,7 @@ public class JacksonBeanPropertyBinder implements BeanPropertyBinder {
      * @param objectMapper  To read/write JSON
      * @param configuration The configuration for Jackson JSON parser
      */
-    public JacksonBeanPropertyBinder(ObjectMapper objectMapper, JacksonConfiguration configuration) {
+    JacksonBeanPropertyBinder(ObjectMapper objectMapper, JacksonConfiguration configuration) {
         this.objectMapper = objectMapper;
         this.arraySizeThreshhold = configuration.getArraySizeThreshold();
     }

--- a/runtime/src/main/java/io/micronaut/jackson/convert/JacksonConverterRegistrar.java
+++ b/runtime/src/main/java/io/micronaut/jackson/convert/JacksonConverterRegistrar.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.node.ContainerNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import io.micronaut.context.BeanProvider;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.bind.ArgumentBinder;
@@ -58,6 +59,7 @@ import java.util.Optional;
  * @since 2.0
  */
 @Singleton
+@Internal
 public class JacksonConverterRegistrar implements TypeConverterRegistrar {
 
     private final BeanProvider<ObjectMapper> objectMapper;

--- a/runtime/src/main/java/io/micronaut/jackson/convert/ObjectNodeConvertibleValues.java
+++ b/runtime/src/main/java/io/micronaut/jackson/convert/ObjectNodeConvertibleValues.java
@@ -17,6 +17,7 @@ package io.micronaut.jackson.convert;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.value.ConvertibleValues;
@@ -38,6 +39,7 @@ import java.util.Set;
  * @author Graeme Rocher
  * @since 1.0
  */
+@Internal
 public class ObjectNodeConvertibleValues<V> implements ConvertibleValues<V> {
 
     private final ObjectNode objectNode;

--- a/runtime/src/main/java/io/micronaut/jackson/env/CloudFoundryVcapApplicationPropertySourceLoader.java
+++ b/runtime/src/main/java/io/micronaut/jackson/env/CloudFoundryVcapApplicationPropertySourceLoader.java
@@ -18,6 +18,7 @@ package io.micronaut.jackson.env;
 import com.fasterxml.jackson.core.JsonParseException;
 import io.micronaut.context.env.MapPropertySource;
 import io.micronaut.context.exceptions.ConfigurationException;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.io.ResourceLoader;
 
 import java.io.IOException;
@@ -34,6 +35,7 @@ import java.util.Set;
  * @author Fabian Nonnenmacher
  * @since 2.0
  */
+@Internal
 public class CloudFoundryVcapApplicationPropertySourceLoader extends EnvJsonPropertySourceLoader {
 
     /**

--- a/runtime/src/main/java/io/micronaut/jackson/env/CloudFoundryVcapServicesPropertySourceLoader.java
+++ b/runtime/src/main/java/io/micronaut/jackson/env/CloudFoundryVcapServicesPropertySourceLoader.java
@@ -18,6 +18,7 @@ package io.micronaut.jackson.env;
 import com.fasterxml.jackson.core.JsonParseException;
 import io.micronaut.context.env.MapPropertySource;
 import io.micronaut.context.exceptions.ConfigurationException;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.io.ResourceLoader;
 
 import java.io.IOException;
@@ -35,6 +36,7 @@ import java.util.Set;
  * @author Fabian Nonnenmacher
  * @since 2.0
  */
+@Internal
 public class CloudFoundryVcapServicesPropertySourceLoader extends EnvJsonPropertySourceLoader {
 
     /**

--- a/runtime/src/main/java/io/micronaut/jackson/env/EnvJsonPropertySourceLoader.java
+++ b/runtime/src/main/java/io/micronaut/jackson/env/EnvJsonPropertySourceLoader.java
@@ -16,6 +16,7 @@
 package io.micronaut.jackson.env;
 
 import io.micronaut.context.env.SystemPropertiesPropertySource;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.io.ResourceLoader;
 
 import java.io.ByteArrayInputStream;
@@ -30,6 +31,7 @@ import java.util.Optional;
  * @author Graeme Rocher
  * @since 1.0
  */
+@Internal
 public class EnvJsonPropertySourceLoader extends JsonPropertySourceLoader {
 
     /**


### PR DESCRIPTION
This PR makes some classes related to jackson-databind internal. Getting this into 3.0 will make it easier to replace jackson-databind without needing compatibility classes in the future.

Using github code search, I have verified that none of these classes are used in the micronaut-projects organization, outside of micronaut-core. Should someone rely on these classes not being internal, they will get a warning so they can either migrate away or notify us so that we can make them usable again.

@graemerocher : I mentioned most of these classes yesterday, but I added some more: The SPI property source loader implementations and ObjectNodeConvertibleValues.