### PR TITLE
Expose modifiers to element API

### DIFF
--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/AbstractGroovyElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/AbstractGroovyElement.java
@@ -369,7 +369,7 @@ public abstract class AbstractGroovyElement implements AnnotationMetadataDelegat
 
     /**
      * Resolve modifiers for a method node.
-     * @param classNode The method node
+     * @param methodNode The method node
      * @return The modifiers
      */
     protected Set<ElementModifier> resolveModifiers(MethodNode methodNode) {
@@ -378,7 +378,7 @@ public abstract class AbstractGroovyElement implements AnnotationMetadataDelegat
 
     /**
      * Resolve modifiers for a field node.
-     * @param classNode The field node
+     * @param fieldNode The field node
      * @return The modifiers
      */
     protected Set<ElementModifier> resolveModifiers(FieldNode fieldNode) {

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/AbstractGroovyElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/AbstractGroovyElement.java
@@ -30,15 +30,19 @@ import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.annotation.AbstractAnnotationMetadataBuilder;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.Element;
+import io.micronaut.inject.ast.ElementModifier;
 import io.micronaut.inject.ast.MemberElement;
 import org.codehaus.groovy.ast.AnnotatedNode;
 import org.codehaus.groovy.ast.ClassNode;
+import org.codehaus.groovy.ast.MethodNode;
+import org.codehaus.groovy.ast.FieldNode;
 import org.codehaus.groovy.ast.GenericsType;
 import org.codehaus.groovy.control.CompilationUnit;
 import org.codehaus.groovy.control.SourceUnit;
 
 import io.micronaut.core.annotation.NonNull;
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Modifier;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -361,6 +365,38 @@ public abstract class AbstractGroovyElement implements AnnotationMetadataDelegat
     @Override
     public int hashCode() {
         return Objects.hash(annotatedNode);
+    }
+
+    protected Set<ElementModifier> resolveModifiers(MethodNode methodNode) {
+        return resolveModifiers(methodNode.getModifiers());
+    }
+
+    protected Set<ElementModifier> resolveModifiers(FieldNode fieldNode) {
+        return resolveModifiers(fieldNode.getModifiers());
+    }
+
+    protected Set<ElementModifier> resolveModifiers(ClassNode classNode) {
+        return resolveModifiers(classNode.getModifiers());
+    }
+
+    private Set<ElementModifier> resolveModifiers(int mod) {
+        Set<ElementModifier> modifiers = new HashSet<>(5);
+        if (Modifier.isPrivate(mod)) {
+            modifiers.add(ElementModifier.PRIVATE);
+        } else if (Modifier.isProtected(mod)) {
+            modifiers.add(ElementModifier.PROTECTED);
+        } else if (Modifier.isPublic(mod)) {
+            modifiers.add(ElementModifier.PUBLIC);
+        }
+        if (Modifier.isAbstract(mod)) {
+            modifiers.add(ElementModifier.ABSTRACT);
+        } else if (Modifier.isStatic(mod)) {
+            modifiers.add(ElementModifier.STATIC);
+        }
+        if (Modifier.isFinal(mod)) {
+            modifiers.add(ElementModifier.FINAL);
+        }
+        return modifiers;
     }
 }
 

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/AbstractGroovyElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/AbstractGroovyElement.java
@@ -367,14 +367,29 @@ public abstract class AbstractGroovyElement implements AnnotationMetadataDelegat
         return Objects.hash(annotatedNode);
     }
 
+    /**
+     * Resolve modifiers for a method node.
+     * @param classNode The method node
+     * @return The modifiers
+     */
     protected Set<ElementModifier> resolveModifiers(MethodNode methodNode) {
         return resolveModifiers(methodNode.getModifiers());
     }
 
+    /**
+     * Resolve modifiers for a field node.
+     * @param classNode The field node
+     * @return The modifiers
+     */
     protected Set<ElementModifier> resolveModifiers(FieldNode fieldNode) {
         return resolveModifiers(fieldNode.getModifiers());
     }
 
+    /**
+     * Resolve modifiers for a class node.
+     * @param classNode The class node
+     * @return The modifiers
+     */
     protected Set<ElementModifier> resolveModifiers(ClassNode classNode) {
         return resolveModifiers(classNode.getModifiers());
     }

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyBeanDefinitionBuilder.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyBeanDefinitionBuilder.java
@@ -35,8 +35,6 @@ import java.lang.annotation.Annotation;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
-import javax.lang.model.element.VariableElement;
-
 /**
  * Groovy version implementation of {@link AbstractBeanDefinitionBuilder}.
  *

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyClassElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyClassElement.java
@@ -346,36 +346,9 @@ public class GroovyClassElement extends AbstractGroovyElement implements Arrayab
         return (fn.getModifiers() & (ACC_PUBLIC | ACC_PRIVATE | ACC_PROTECTED)) == 0;
     }
 
-    private Set<ElementModifier> resolveModifiers(MethodNode methodNode) {
-        return resolveModifiers(methodNode.getModifiers());
-    }
-
-    private Set<ElementModifier> resolveModifiers(FieldNode fieldNode) {
-        return resolveModifiers(fieldNode.getModifiers());
-    }
-
-    private Set<ElementModifier> resolveModifiers(ClassNode classNode) {
-        return resolveModifiers(classNode.getModifiers());
-    }
-
-    private Set<ElementModifier> resolveModifiers(int mod) {
-        Set<ElementModifier> modifiers = new HashSet<>(5);
-        if (Modifier.isPrivate(mod)) {
-            modifiers.add(ElementModifier.PRIVATE);
-        } else if (Modifier.isProtected(mod)) {
-            modifiers.add(ElementModifier.PROTECTED);
-        } else if (Modifier.isPublic(mod)) {
-            modifiers.add(ElementModifier.PUBLIC);
-        }
-        if (Modifier.isAbstract(mod)) {
-            modifiers.add(ElementModifier.ABSTRACT);
-        } else if (Modifier.isStatic(mod)) {
-            modifiers.add(ElementModifier.STATIC);
-        }
-        if (Modifier.isFinal(mod)) {
-            modifiers.add(ElementModifier.FINAL);
-        }
-        return modifiers;
+    @Override
+    public Set<ElementModifier> getModifiers() {
+        return resolveModifiers(this.classNode);
     }
 
     @Override

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyFieldElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyFieldElement.java
@@ -19,6 +19,7 @@ import io.micronaut.ast.groovy.utils.AstAnnotationUtils;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.ast.ElementModifier;
 import io.micronaut.inject.ast.FieldElement;
 import org.codehaus.groovy.ast.*;
 import org.codehaus.groovy.control.SourceUnit;
@@ -26,6 +27,8 @@ import org.codehaus.groovy.control.SourceUnit;
 import io.micronaut.core.annotation.NonNull;
 
 import java.lang.reflect.Modifier;
+import java.util.Collections;
+import java.util.Set;
 
 /**
  * A field element returning data from a {@link Variable}. The
@@ -51,6 +54,15 @@ public class GroovyFieldElement extends AbstractGroovyElement implements FieldEl
         super(visitorContext, annotatedNode, annotationMetadata);
         this.variable = variable;
         this.sourceUnit = visitorContext.getSourceUnit();
+    }
+
+    @Override
+    public Set<ElementModifier> getModifiers() {
+        if (variable instanceof FieldNode) {
+            return super.resolveModifiers(((FieldNode) variable));
+        } else {
+            return Collections.emptySet();
+        }
     }
 
     @Override

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyMethodElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyMethodElement.java
@@ -22,6 +22,7 @@ import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.ast.ElementModifier;
 import io.micronaut.inject.ast.MethodElement;
 import io.micronaut.inject.ast.ParameterElement;
 import org.codehaus.groovy.ast.ClassNode;
@@ -30,10 +31,8 @@ import org.codehaus.groovy.ast.Parameter;
 import org.codehaus.groovy.control.SourceUnit;
 
 import io.micronaut.core.annotation.NonNull;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+
+import java.util.*;
 import java.util.function.Function;
 
 /**
@@ -62,6 +61,11 @@ public class GroovyMethodElement extends AbstractGroovyElement implements Method
         this.methodNode = methodNode;
         this.sourceUnit = visitorContext.getSourceUnit();
         this.declaringClass = declaringClass;
+    }
+
+    @Override
+    public Set<ElementModifier> getModifiers() {
+        return resolveModifiers(this.methodNode);
     }
 
     @Override

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyPropertyElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyPropertyElement.java
@@ -17,9 +17,14 @@ package io.micronaut.ast.groovy.visitor;
 
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.ast.ElementModifier;
 import io.micronaut.inject.ast.PropertyElement;
 import org.codehaus.groovy.ast.AnnotatedNode;
+
+import java.util.Collections;
+import java.util.Set;
 
 /**
  * Implementation of {@link PropertyElement} for Groovy.
@@ -58,6 +63,15 @@ abstract class GroovyPropertyElement extends AbstractGroovyElement implements Pr
         this.readOnly = readOnly;
         this.nativeType = nativeType;
         this.declaringElement = declaringElement;
+    }
+
+    @Override
+    public Set<ElementModifier> getModifiers() {
+        if (isReadOnly()) {
+            return CollectionUtils.setOf(ElementModifier.FINAL, ElementModifier.PUBLIC);
+        } else {
+            return Collections.singleton(ElementModifier.PUBLIC);
+        }
     }
 
     @Override

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/ClassElementSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/ClassElementSpec.groovy
@@ -38,6 +38,30 @@ class ClassElementSpec extends AbstractBeanDefinitionSpec {
         AllElementsVisitor.clearVisited()
     }
 
+    void "test modifiers #modifiers"() {
+        given:
+        def element = buildClassElement("""
+package modtest;
+
+class Test {
+    ${modifiers*.toString().join(' ')} String test = "test";
+
+    ${modifiers*.toString().join(' ')} void test() {};
+}
+""")
+
+        expect:
+        element.getEnclosedElement(ElementQuery.ALL_FIELDS).get().modifiers == modifiers
+        element.getEnclosedElement(ElementQuery.ALL_METHODS).get().modifiers == modifiers
+
+        where:
+        modifiers << [
+                [ElementModifier.PUBLIC] as Set,
+                [ElementModifier.PUBLIC, ElementModifier.STATIC] as Set,
+                [ElementModifier.PUBLIC, ElementModifier.STATIC, ElementModifier.FINAL] as Set,
+        ]
+    }
+
     void "test get package element"() {
         given:
         def element = buildClassElement('''

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/AbstractJavaElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/AbstractJavaElement.java
@@ -22,14 +22,12 @@ import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.AnnotationValueBuilder;
 import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.inject.annotation.AbstractAnnotationMetadataBuilder;
-import io.micronaut.inject.ast.ClassElement;
-import io.micronaut.inject.ast.MemberElement;
+import io.micronaut.inject.ast.*;
 
 import io.micronaut.core.annotation.NonNull;
-import io.micronaut.inject.ast.ParameterElement;
-import io.micronaut.inject.ast.PrimitiveElement;
 
 import javax.lang.model.element.*;
+import javax.lang.model.element.Element;
 import javax.lang.model.type.*;
 import java.lang.annotation.Annotation;
 import java.util.Collections;
@@ -39,6 +37,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import static javax.lang.model.element.Modifier.*;
 
@@ -177,6 +176,14 @@ public abstract class AbstractJavaElement implements io.micronaut.inject.ast.Ele
     @Override
     public String getName() {
         return element.getSimpleName().toString();
+    }
+
+    @Override
+    public Set<ElementModifier> getModifiers() {
+        return this.element
+                .getModifiers().stream()
+                .map(m -> ElementModifier.valueOf(m.name()))
+                .collect(Collectors.toSet());
     }
 
     @Override

--- a/inject-java/src/test/groovy/io/micronaut/visitors/ClassElementSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/ClassElementSpec.groovy
@@ -34,6 +34,30 @@ import java.util.function.Supplier
 
 class ClassElementSpec extends AbstractTypeElementSpec {
 
+    void "test modifiers #modifiers"() {
+        given:
+        def element = buildClassElement("""
+package modtest;
+
+class Test {
+    ${modifiers*.toString().join(' ')} String test = "test";
+
+    ${modifiers*.toString().join(' ')} void test() {};
+}
+""")
+
+        expect:
+        element.getEnclosedElement(ElementQuery.ALL_FIELDS).get().modifiers == modifiers
+        element.getEnclosedElement(ElementQuery.ALL_METHODS).get().modifiers == modifiers
+
+        where:
+        modifiers << [
+                [ElementModifier.PUBLIC] as Set,
+                [ElementModifier.PUBLIC, ElementModifier.STATIC] as Set,
+                [ElementModifier.PUBLIC, ElementModifier.STATIC, ElementModifier.FINAL] as Set,
+        ]
+    }
+
     void "test annotate applies transformations"() {
         when:
         def element = buildClassElement('''

--- a/inject/src/main/java/io/micronaut/inject/ast/Element.java
+++ b/inject/src/main/java/io/micronaut/inject/ast/Element.java
@@ -24,8 +24,10 @@ import io.micronaut.core.util.ArgumentUtils;
 
 import io.micronaut.core.annotation.NonNull;
 import java.lang.annotation.Annotation;
+import java.util.Collections;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -74,6 +76,14 @@ public interface Element extends AnnotationMetadataDelegate, AnnotatedElement, D
      * @return The native type
      */
     @NonNull Object getNativeType();
+
+    /**
+     * @return The {@link ElementModifier} types for this class element
+     * @since 3.0.0
+     */
+    default Set<ElementModifier> getModifiers() {
+        return Collections.emptySet();
+    }
 
     /**
      * Annotate this element with the given annotation type. If the annotation is already present then

--- a/inject/src/main/java/io/micronaut/inject/ast/ElementModifier.java
+++ b/inject/src/main/java/io/micronaut/inject/ast/ElementModifier.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.inject.ast;
 
+import java.util.Locale;
+
 /**
  * An enum of modifier names now tied to the reflection API.
  *
@@ -33,5 +35,14 @@ public enum ElementModifier {
     VOLATILE,
     SYNCHRONIZED,
     NATIVE,
-    STRICTFP
+    STRICTFP;
+
+    /**
+     * @return The name of the modifier as presented in source code.
+     * @since 3.0.0
+     */
+    @Override
+    public String toString() {
+        return name().toLowerCase(Locale.ENGLISH);
+    }
 }

--- a/inject/src/main/java/io/micronaut/inject/ast/MemberElement.java
+++ b/inject/src/main/java/io/micronaut/inject/ast/MemberElement.java
@@ -15,6 +15,9 @@
  */
 package io.micronaut.inject.ast;
 
+import java.util.Collections;
+import java.util.Set;
+
 /**
  * A member element is an element that is contained within a {@link ClassElement}.
  * The {@link #getDeclaringType()} method returns the class that declares the element.
@@ -38,5 +41,13 @@ public interface MemberElement extends Element {
      */
     default ClassElement getOwningType() {
         return getDeclaringType();
+    }
+
+    /**
+     * @return The {@link ElementModifier} types for this class element
+     * @since 3.0.0
+     */
+    default Set<ElementModifier> getModifiers() {
+        return Collections.emptySet();
     }
 }


### PR DESCRIPTION
Currently there is no way to get all the `ElementModifier` instances which adds some overhead if you need to translate these modifiers into another model