### PR TITLE
Add utility method to convert `Annotation[]` to `Qualifier`

### DIFF
--- a/inject/src/main/java/io/micronaut/inject/qualifiers/Qualifiers.java
+++ b/inject/src/main/java/io/micronaut/inject/qualifiers/Qualifiers.java
@@ -134,6 +134,29 @@ public class Qualifiers {
     }
 
     /**
+     * Build a qualifier for the given annotations or return null of the array is empty.
+     *
+     * @param annotations The annotations
+     * @param <T>        The component type
+     * @return The qualifier
+     * @since 3.0.0
+     */
+    @Nullable
+    public static <T> Qualifier<T> byAnnotations(@Nullable Annotation... annotations) {
+        if (annotations == null || annotations.length == 0) {
+            return null;
+        }
+        if (annotations.length == 1) {
+            return Qualifiers.byAnnotation(annotations[0]);
+        }
+        Qualifier<T>[] qualifiers = new Qualifier[annotations.length];
+        for (int i = 0; i < annotations.length; i++) {
+            qualifiers[i] = Qualifiers.byAnnotation(annotations[i]);
+        }
+        return Qualifiers.byQualifiers(qualifiers);
+    }
+
+    /**
      * Build a qualifier for the given annotation.
      *
      * @param metadata The metadata

--- a/inject/src/test/groovy/io/micronaut/inject/qualifiers/QualifiersSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/inject/qualifiers/QualifiersSpec.groovy
@@ -1,0 +1,45 @@
+package io.micronaut.inject.qualifiers
+
+
+import jakarta.inject.Named
+import jakarta.inject.Singleton
+import spock.lang.Specification
+
+import java.lang.annotation.Annotation
+
+class QualifiersSpec extends Specification {
+
+    def "check byAnnotations"() {
+        when:
+            def annotations = Qualifiers.byAnnotations(new Named() {
+
+                @Override
+                String value() {
+                    return "test"
+                }
+
+                @Override
+                Class<? extends Annotation> annotationType() {
+                    return Named.class
+                }
+            }, new Singleton() {
+
+                @Override
+                Class<? extends Annotation> annotationType() {
+                    return Singleton.class
+                }
+            })
+        then:
+            annotations instanceof CompositeQualifier
+            annotations.qualifiers.length == 2
+        when:
+            def emptyAnnotations1 = Qualifiers.byAnnotations()
+        then:
+            emptyAnnotations1 == null
+        when:
+            def emptyAnnotations2 = Qualifiers.byAnnotations(null)
+        then:
+            emptyAnnotations2 == null
+    }
+
+}


### PR DESCRIPTION
Maybe the new method and `byAnnotation` should ignore any kind of annotation that isn't annotated with `@Qualifier`