### PR TITLE
Provide unmatched MediaType extension from fileUpload

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/multipart/NettyCompletedFileUpload.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/multipart/NettyCompletedFileUpload.java
@@ -136,7 +136,11 @@ public class NettyCompletedFileUpload implements CompletedFileUpload {
 
     @Override
     public Optional<MediaType> getContentType() {
-        return Optional.of(MediaType.of(fileUpload.getContentType()));
+        Optional<String> extension = Optional.ofNullable(fileUpload.getFilename())
+                .filter(f -> f.contains("."))
+                .map(f -> f.substring(fileUpload.getFilename().lastIndexOf(".") + 1));
+        return Optional.of(extension.map(e -> MediaType.of(fileUpload.getContentType(), e))
+                .orElse(MediaType.of(fileUpload.getContentType())));
     }
 
     @Override

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/multipart/NettyCompletedFileUpload.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/multipart/NettyCompletedFileUpload.java
@@ -16,7 +16,6 @@
 package io.micronaut.http.server.netty.multipart;
 
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.core.naming.NameUtils;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.multipart.CompletedFileUpload;
 import io.netty.buffer.ByteBuf;
@@ -28,7 +27,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
-import java.util.Map;
 import java.util.Optional;
 
 /**

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/multipart/NettyCompletedFileUpload.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/multipart/NettyCompletedFileUpload.java
@@ -16,6 +16,7 @@
 package io.micronaut.http.server.netty.multipart;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.naming.NameUtils;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.multipart.CompletedFileUpload;
 import io.netty.buffer.ByteBuf;
@@ -27,6 +28,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -136,7 +138,10 @@ public class NettyCompletedFileUpload implements CompletedFileUpload {
 
     @Override
     public Optional<MediaType> getContentType() {
-        return MediaType.forMediaType(fileUpload.getContentType());
+        return Optional.of(
+                MediaType.forMediaTypeAndFilename(fileUpload.getContentType(), fileUpload.getFilename())
+                        .orElse(MediaType.of(fileUpload.getContentType()))
+        );
     }
 
     @Override

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/multipart/NettyCompletedFileUpload.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/multipart/NettyCompletedFileUpload.java
@@ -136,11 +136,7 @@ public class NettyCompletedFileUpload implements CompletedFileUpload {
 
     @Override
     public Optional<MediaType> getContentType() {
-        Optional<String> extension = Optional.ofNullable(fileUpload.getFilename())
-                .filter(f -> f.contains("."))
-                .map(f -> f.substring(fileUpload.getFilename().lastIndexOf(".") + 1));
-        return Optional.of(extension.map(e -> MediaType.of(fileUpload.getContentType(), e))
-                .orElse(MediaType.of(fileUpload.getContentType())));
+        return MediaType.forMediaType(fileUpload.getContentType());
     }
 
     @Override

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/multipart/NettyStreamingFileUpload.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/multipart/NettyStreamingFileUpload.java
@@ -73,7 +73,11 @@ public class NettyStreamingFileUpload implements StreamingFileUpload {
     @Override
     public Optional<MediaType> getContentType() {
         try {
-            return Optional.of(MediaType.of(fileUpload.getContentType()));
+            Optional<String> extension = Optional.ofNullable(fileUpload.getFilename())
+                    .filter(f -> f.contains("."))
+                    .map(f -> f.substring(fileUpload.getFilename().lastIndexOf(".") + 1));
+            return Optional.of(extension.map(e -> MediaType.of(fileUpload.getContentType(), e))
+                    .orElse(MediaType.of(fileUpload.getContentType())));
         } catch (IllegalArgumentException e) {
             return Optional.empty();
         }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/multipart/NettyStreamingFileUpload.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/multipart/NettyStreamingFileUpload.java
@@ -17,6 +17,7 @@ package io.micronaut.http.server.netty.multipart;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.async.publisher.AsyncSingleResultPublisher;
+import io.micronaut.core.naming.NameUtils;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.multipart.MultipartException;
 import io.micronaut.http.multipart.PartData;
@@ -73,7 +74,10 @@ public class NettyStreamingFileUpload implements StreamingFileUpload {
     @Override
     public Optional<MediaType> getContentType() {
         try {
-            return MediaType.forMediaType(fileUpload.getContentType());
+            return Optional.of(
+                    MediaType.forMediaTypeAndFilename(fileUpload.getContentType(), fileUpload.getFilename())
+                            .orElse(MediaType.of(fileUpload.getContentType()))
+            );
         } catch (IllegalArgumentException e) {
             return Optional.empty();
         }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/multipart/NettyStreamingFileUpload.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/multipart/NettyStreamingFileUpload.java
@@ -73,11 +73,7 @@ public class NettyStreamingFileUpload implements StreamingFileUpload {
     @Override
     public Optional<MediaType> getContentType() {
         try {
-            Optional<String> extension = Optional.ofNullable(fileUpload.getFilename())
-                    .filter(f -> f.contains("."))
-                    .map(f -> f.substring(fileUpload.getFilename().lastIndexOf(".") + 1));
-            return Optional.of(extension.map(e -> MediaType.of(fileUpload.getContentType(), e))
-                    .orElse(MediaType.of(fileUpload.getContentType())));
+            return MediaType.forMediaType(fileUpload.getContentType());
         } catch (IllegalArgumentException e) {
             return Optional.empty();
         }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/multipart/NettyStreamingFileUpload.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/multipart/NettyStreamingFileUpload.java
@@ -17,7 +17,6 @@ package io.micronaut.http.server.netty.multipart;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.async.publisher.AsyncSingleResultPublisher;
-import io.micronaut.core.naming.NameUtils;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.multipart.MultipartException;
 import io.micronaut.http.multipart.PartData;

--- a/http/src/main/java/io/micronaut/http/MediaType.java
+++ b/http/src/main/java/io/micronaut/http/MediaType.java
@@ -469,6 +469,61 @@ public class MediaType implements CharSequence {
         this.strRepr = toString0();
     }
 
+    private static Optional<MediaType> optionalOf(String mediaType) {
+        switch (mediaType) {
+            case ALL:
+                return Optional.of(ALL_TYPE);
+            case APPLICATION_FORM_URLENCODED:
+                return Optional.of(APPLICATION_FORM_URLENCODED_TYPE);
+            case MULTIPART_FORM_DATA:
+                return Optional.of(MULTIPART_FORM_DATA_TYPE);
+            case TEXT_HTML:
+                return Optional.of(TEXT_HTML_TYPE);
+            case APPLICATION_XHTML:
+                return Optional.of(APPLICATION_XHTML_TYPE);
+            case APPLICATION_XML:
+                return Optional.of(APPLICATION_XML_TYPE);
+            case APPLICATION_JSON:
+                return Optional.of(APPLICATION_JSON_TYPE);
+            case APPLICATION_YAML:
+                return Optional.of(APPLICATION_YAML_TYPE);
+            case TEXT_XML:
+                return Optional.of(TEXT_XML_TYPE);
+            case TEXT_JSON:
+                return Optional.of(TEXT_JSON_TYPE);
+            case TEXT_PLAIN:
+                return Optional.of(TEXT_PLAIN_TYPE);
+            case APPLICATION_HAL_JSON:
+                return Optional.of(APPLICATION_HAL_JSON_TYPE);
+            case APPLICATION_HAL_XML:
+                return Optional.of(APPLICATION_HAL_XML_TYPE);
+            case APPLICATION_ATOM_XML:
+                return Optional.of(APPLICATION_ATOM_XML_TYPE);
+            case APPLICATION_VND_ERROR:
+                return Optional.of(APPLICATION_VND_ERROR_TYPE);
+            case TEXT_EVENT_STREAM:
+                return Optional.of(TEXT_EVENT_STREAM_TYPE);
+            case APPLICATION_JSON_STREAM:
+                return Optional.of(APPLICATION_JSON_STREAM_TYPE);
+            case APPLICATION_OCTET_STREAM:
+                return Optional.of(APPLICATION_OCTET_STREAM_TYPE);
+            case APPLICATION_GRAPHQL:
+                return Optional.of(APPLICATION_GRAPHQL_TYPE);
+            case APPLICATION_PDF:
+                return Optional.of(APPLICATION_PDF_TYPE);
+            case IMAGE_PNG:
+                return Optional.of(IMAGE_PNG_TYPE);
+            case IMAGE_JPEG:
+                return Optional.of(IMAGE_JPEG_TYPE);
+            case IMAGE_GIF:
+                return Optional.of(IMAGE_GIF_TYPE);
+            case IMAGE_WEBP:
+                return Optional.of(IMAGE_WEBP_TYPE);
+            default:
+                return Optional.empty();
+        }
+    }
+
     /**
      * Create a new or get a {@link MediaType} from the given text.
      *
@@ -476,58 +531,18 @@ public class MediaType implements CharSequence {
      * @return The {@link MediaType}
      */
     public static MediaType of(String mediaType) {
-        switch (mediaType) {
-            case ALL:
-                return ALL_TYPE;
-            case APPLICATION_FORM_URLENCODED:
-                return APPLICATION_FORM_URLENCODED_TYPE;
-            case MULTIPART_FORM_DATA:
-                return MULTIPART_FORM_DATA_TYPE;
-            case TEXT_HTML:
-                return TEXT_HTML_TYPE;
-            case APPLICATION_XHTML:
-                return APPLICATION_XHTML_TYPE;
-            case APPLICATION_XML:
-                return APPLICATION_XML_TYPE;
-            case APPLICATION_JSON:
-                return APPLICATION_JSON_TYPE;
-            case APPLICATION_YAML:
-                return APPLICATION_YAML_TYPE;
-            case TEXT_XML:
-                return TEXT_XML_TYPE;
-            case TEXT_JSON:
-                return TEXT_JSON_TYPE;
-            case TEXT_PLAIN:
-                return TEXT_PLAIN_TYPE;
-            case APPLICATION_HAL_JSON:
-                return APPLICATION_HAL_JSON_TYPE;
-            case APPLICATION_HAL_XML:
-                return APPLICATION_HAL_XML_TYPE;
-            case APPLICATION_ATOM_XML:
-                return APPLICATION_ATOM_XML_TYPE;
-            case APPLICATION_VND_ERROR:
-                return APPLICATION_VND_ERROR_TYPE;
-            case TEXT_EVENT_STREAM:
-                return TEXT_EVENT_STREAM_TYPE;
-            case APPLICATION_JSON_STREAM:
-                return APPLICATION_JSON_STREAM_TYPE;
-            case APPLICATION_OCTET_STREAM:
-                return APPLICATION_OCTET_STREAM_TYPE;
-            case APPLICATION_GRAPHQL:
-                return APPLICATION_GRAPHQL_TYPE;
-            case APPLICATION_PDF:
-                return APPLICATION_PDF_TYPE;
-            case IMAGE_PNG:
-                return IMAGE_PNG_TYPE;
-            case IMAGE_JPEG:
-                return IMAGE_JPEG_TYPE;
-            case IMAGE_GIF:
-                return IMAGE_GIF_TYPE;
-            case IMAGE_WEBP:
-                return IMAGE_WEBP_TYPE;
-            default:
-                return new MediaType(mediaType);
-        }
+        return optionalOf(mediaType).orElse(new MediaType(mediaType));
+    }
+
+    /**
+     * Create a new or get a {@link MediaType} from the given text.
+     * If there is no match mediaType, it will also use extension to construct a new MediaType.
+     *
+     * @param mediaType The text
+     * @return The {@link MediaType}
+     */
+    public static MediaType of(String mediaType, String extension) {
+        return optionalOf(mediaType).orElse(new MediaType(mediaType, extension));
     }
 
     /**

--- a/http/src/main/java/io/micronaut/http/MediaType.java
+++ b/http/src/main/java/io/micronaut/http/MediaType.java
@@ -469,61 +469,6 @@ public class MediaType implements CharSequence {
         this.strRepr = toString0();
     }
 
-    private static Optional<MediaType> optionalOf(String mediaType) {
-        switch (mediaType) {
-            case ALL:
-                return Optional.of(ALL_TYPE);
-            case APPLICATION_FORM_URLENCODED:
-                return Optional.of(APPLICATION_FORM_URLENCODED_TYPE);
-            case MULTIPART_FORM_DATA:
-                return Optional.of(MULTIPART_FORM_DATA_TYPE);
-            case TEXT_HTML:
-                return Optional.of(TEXT_HTML_TYPE);
-            case APPLICATION_XHTML:
-                return Optional.of(APPLICATION_XHTML_TYPE);
-            case APPLICATION_XML:
-                return Optional.of(APPLICATION_XML_TYPE);
-            case APPLICATION_JSON:
-                return Optional.of(APPLICATION_JSON_TYPE);
-            case APPLICATION_YAML:
-                return Optional.of(APPLICATION_YAML_TYPE);
-            case TEXT_XML:
-                return Optional.of(TEXT_XML_TYPE);
-            case TEXT_JSON:
-                return Optional.of(TEXT_JSON_TYPE);
-            case TEXT_PLAIN:
-                return Optional.of(TEXT_PLAIN_TYPE);
-            case APPLICATION_HAL_JSON:
-                return Optional.of(APPLICATION_HAL_JSON_TYPE);
-            case APPLICATION_HAL_XML:
-                return Optional.of(APPLICATION_HAL_XML_TYPE);
-            case APPLICATION_ATOM_XML:
-                return Optional.of(APPLICATION_ATOM_XML_TYPE);
-            case APPLICATION_VND_ERROR:
-                return Optional.of(APPLICATION_VND_ERROR_TYPE);
-            case TEXT_EVENT_STREAM:
-                return Optional.of(TEXT_EVENT_STREAM_TYPE);
-            case APPLICATION_JSON_STREAM:
-                return Optional.of(APPLICATION_JSON_STREAM_TYPE);
-            case APPLICATION_OCTET_STREAM:
-                return Optional.of(APPLICATION_OCTET_STREAM_TYPE);
-            case APPLICATION_GRAPHQL:
-                return Optional.of(APPLICATION_GRAPHQL_TYPE);
-            case APPLICATION_PDF:
-                return Optional.of(APPLICATION_PDF_TYPE);
-            case IMAGE_PNG:
-                return Optional.of(IMAGE_PNG_TYPE);
-            case IMAGE_JPEG:
-                return Optional.of(IMAGE_JPEG_TYPE);
-            case IMAGE_GIF:
-                return Optional.of(IMAGE_GIF_TYPE);
-            case IMAGE_WEBP:
-                return Optional.of(IMAGE_WEBP_TYPE);
-            default:
-                return Optional.empty();
-        }
-    }
-
     /**
      * Create a new or get a {@link MediaType} from the given text.
      *
@@ -877,5 +822,66 @@ public class MediaType implements CharSequence {
         }
 
         return Collections.emptyMap();
+    }
+
+    /**
+     * Get a {@link MediaType} from the given text or empty Optional if it doesn't exist.
+     *
+     * @param mediaType The text
+     * @return An {@link Optional} of the {@link MediaType}
+     */
+    private static Optional<MediaType> optionalOf(String mediaType) {
+        switch (mediaType) {
+            case ALL:
+                return Optional.of(ALL_TYPE);
+            case APPLICATION_FORM_URLENCODED:
+                return Optional.of(APPLICATION_FORM_URLENCODED_TYPE);
+            case MULTIPART_FORM_DATA:
+                return Optional.of(MULTIPART_FORM_DATA_TYPE);
+            case TEXT_HTML:
+                return Optional.of(TEXT_HTML_TYPE);
+            case APPLICATION_XHTML:
+                return Optional.of(APPLICATION_XHTML_TYPE);
+            case APPLICATION_XML:
+                return Optional.of(APPLICATION_XML_TYPE);
+            case APPLICATION_JSON:
+                return Optional.of(APPLICATION_JSON_TYPE);
+            case APPLICATION_YAML:
+                return Optional.of(APPLICATION_YAML_TYPE);
+            case TEXT_XML:
+                return Optional.of(TEXT_XML_TYPE);
+            case TEXT_JSON:
+                return Optional.of(TEXT_JSON_TYPE);
+            case TEXT_PLAIN:
+                return Optional.of(TEXT_PLAIN_TYPE);
+            case APPLICATION_HAL_JSON:
+                return Optional.of(APPLICATION_HAL_JSON_TYPE);
+            case APPLICATION_HAL_XML:
+                return Optional.of(APPLICATION_HAL_XML_TYPE);
+            case APPLICATION_ATOM_XML:
+                return Optional.of(APPLICATION_ATOM_XML_TYPE);
+            case APPLICATION_VND_ERROR:
+                return Optional.of(APPLICATION_VND_ERROR_TYPE);
+            case TEXT_EVENT_STREAM:
+                return Optional.of(TEXT_EVENT_STREAM_TYPE);
+            case APPLICATION_JSON_STREAM:
+                return Optional.of(APPLICATION_JSON_STREAM_TYPE);
+            case APPLICATION_OCTET_STREAM:
+                return Optional.of(APPLICATION_OCTET_STREAM_TYPE);
+            case APPLICATION_GRAPHQL:
+                return Optional.of(APPLICATION_GRAPHQL_TYPE);
+            case APPLICATION_PDF:
+                return Optional.of(APPLICATION_PDF_TYPE);
+            case IMAGE_PNG:
+                return Optional.of(IMAGE_PNG_TYPE);
+            case IMAGE_JPEG:
+                return Optional.of(IMAGE_JPEG_TYPE);
+            case IMAGE_GIF:
+                return Optional.of(IMAGE_GIF_TYPE);
+            case IMAGE_WEBP:
+                return Optional.of(IMAGE_WEBP_TYPE);
+            default:
+                return Optional.empty();
+        }
     }
 }


### PR DESCRIPTION
When a fileUpload has a contentType that doesn't have a matching MediaType, it will create a MediaType with only the contentType such that extension is defaulted to contentType.

This PR proposes checking the filename for an extension and providing it for use in creating the new MediaType if no match is found. 