### PR TITLE
Fix GraalVM warning

### DIFF
--- a/validation/src/main/resources/META-INF/native-image/io.micronaut.validation/micronaut-validation/native-image.properties
+++ b/validation/src/main/resources/META-INF/native-image/io.micronaut.validation/micronaut-validation/native-image.properties
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-Args = --initialize-at-run-time=io.micronaut.validation.exceptions.ValidationExceptionHandler,io.micronaut.validation.exceptions.$ValidationExceptionHandler$Definition,io.micronaut.validation.exceptions.$ConstraintExceptionHandler$Definition,io.micronaut.validation.exceptions.ConstraintExceptionHandler
+Args = --initialize-at-run-time=io.micronaut.validation.exceptions.ValidationExceptionHandler,io.micronaut.validation.exceptions.$ValidationExceptionHandler$Definition,io.micronaut.validation.exceptions.$ValidationExceptionHandler$Definition$Exec,io.micronaut.validation.exceptions.$ConstraintExceptionHandler$Definition,io.micronaut.validation.exceptions.ConstraintExceptionHandler


### PR DESCRIPTION
This PR fixes the following GraalVM warning:

```
...
[security-basic-auth:234]        setup:   2,213.55 ms,  0.96 GB
Warning: class initialization of class io.micronaut.validation.exceptions.$ValidationExceptionHandler$Definition$Exec failed with exception java.lang.NoClassDefFoundError: org/grails/datastore/mapping/validation/ValidationException. This class will be initialized at run time because option --allow-incomplete-classpath is used for image building. Use the option --initialize-at-run-time=io.micronaut.validation.exceptions.$ValidationExceptionHandler$Definition$Exec to explicitly request delayed initialization of this class.
[security-basic-auth:234]     (clinit):   1,112.46 ms,  4.03 GB
...
```