### PR TITLE
`AnnotationMetadataHierarchy` improvements

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/annotation/AnnotationMetadataHierarchySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/annotation/AnnotationMetadataHierarchySpec.groovy
@@ -1,13 +1,11 @@
 package io.micronaut.inject.annotation
 
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.micronaut.context.annotation.Executable
 import io.micronaut.context.annotation.Property
 import io.micronaut.core.annotation.AnnotationMetadata
 import io.micronaut.core.annotation.AnnotationUtil
 import io.micronaut.core.annotation.AnnotationValue
-import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
-
-import jakarta.inject.Singleton
 
 class AnnotationMetadataHierarchySpec extends AbstractTypeElementSpec{
 
@@ -90,6 +88,10 @@ class Test {
         properties[3].get("name", String).get() == "prop1"
         properties[4].get("name", String).get() == "prop3"
         properties[4].getValue(String).get() == "value3"
+        hierarchy.synthesizeAll().length == 2
+        hierarchy.synthesizeDeclared().length == 2
+        hierarchy.synthesizeAnnotationsByType(Property).length == 5
+        hierarchy.synthesizeDeclaredAnnotationsByType(Property).length == 5
     }
 
     void "test default values are propagated"() {

--- a/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataHierarchy.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataHierarchy.java
@@ -16,6 +16,7 @@
 package io.micronaut.inject.annotation;
 
 import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.AnnotationUtil;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
@@ -23,8 +24,10 @@ import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.value.OptionalValues;
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Array;
 import java.util.*;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 /**
  * Used to represent an annotation metadata hierarchy. The first {@link AnnotationMetadata} instance passed
@@ -140,6 +143,41 @@ public final class AnnotationMetadataHierarchy implements AnnotationMetadata, En
             }
         }
         return null;
+    }
+
+    @Override
+    public Annotation[] synthesizeAll() {
+        return Stream.of(hierarchy).flatMap(am -> Arrays.stream(am.synthesizeAll())).toArray(Annotation[]::new);
+    }
+
+    @Override
+    public Annotation[] synthesizeDeclared() {
+        return Stream.of(hierarchy).flatMap(am -> Arrays.stream(am.synthesizeDeclared())).toArray(Annotation[]::new);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T extends Annotation> T[] synthesizeAnnotationsByType(Class<T> annotationClass) {
+        if (annotationClass == null) {
+            return (T[]) AnnotationUtil.ZERO_ANNOTATIONS;
+        }
+        return Stream.of(hierarchy)
+                .flatMap(am -> am.getAnnotationValuesByType(annotationClass).stream())
+                .distinct()
+                .map(entries -> AnnotationMetadataSupport.buildAnnotation(annotationClass, entries))
+                        .toArray(value -> (T[]) Array.newInstance(annotationClass, value));
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T extends Annotation> T[] synthesizeDeclaredAnnotationsByType(Class<T> annotationClass) {
+        if (annotationClass == null) {
+            return (T[]) AnnotationUtil.ZERO_ANNOTATIONS;
+        }
+        return Stream.of(hierarchy)
+                .flatMap(am -> am.getAnnotationValuesByType(annotationClass).stream())
+                .distinct()
+                .map(entries -> AnnotationMetadataSupport.buildAnnotation(annotationClass, entries))
+                .toArray(value -> (T[]) Array.newInstance(annotationClass, value));
     }
 
     @Nullable


### PR DESCRIPTION
Adds different `synthesize` methods to `AnnotationMetadataHierarchy` and method constructor that's able to avoid creating a hierarchy instance if one is not needed.