### PR TITLE
Support regex-style patterns in `@Filter`

### DIFF
--- a/core/src/main/java/io/micronaut/core/util/PathMatcher.java
+++ b/core/src/main/java/io/micronaut/core/util/PathMatcher.java
@@ -25,9 +25,13 @@ package io.micronaut.core.util;
  */
 public interface PathMatcher {
     /**
-     * The default Ant style patch matcher.
+     * The default Ant style path matcher.
      */
     AntPathMatcher ANT = new AntPathMatcher();
+    /**
+     * The default regex style path matcher.
+     */
+    RegexPathMatcher REGEX = new RegexPathMatcher();
 
     /**
      * Returns <code>true</code> if the given <code>source</code> matches the specified <code>pattern</code>,

--- a/core/src/main/java/io/micronaut/core/util/RegexPathMatcher.java
+++ b/core/src/main/java/io/micronaut/core/util/RegexPathMatcher.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.core.util;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+
+/**
+ * PathMatcher implementation for regex-style patterns.
+ * @author Rafael Acevedo
+ * @since 3.1
+ */
+public class RegexPathMatcher implements PathMatcher {
+  private final Map<String, Pattern> compiledPatterns = new ConcurrentHashMap<>();
+
+  @Override
+  public boolean matches(String pattern, String source) {
+    if (pattern == null || source == null) return false;
+    return compiledPatterns.computeIfAbsent(pattern, Pattern::compile).matcher(source).matches();
+  }
+}

--- a/core/src/test/groovy/io/micronaut/core/util/RegexPathMatcherTest.groovy
+++ b/core/src/test/groovy/io/micronaut/core/util/RegexPathMatcherTest.groovy
@@ -1,0 +1,14 @@
+package io.micronaut.core.util
+
+import spock.lang.Specification
+
+class RegexPathMatcherTest extends Specification {
+
+    void 'test matches()'() {
+        given:
+        def matcher = new RegexPathMatcher()
+        expect:
+        matcher.matches('^.*$', "/api/v2/endpoint")
+        !matcher.matches('^/api/v1/.*', "/api/v2/endpoint")
+    }
+}

--- a/http/src/main/java/io/micronaut/http/annotation/Filter.java
+++ b/http/src/main/java/io/micronaut/http/annotation/Filter.java
@@ -17,6 +17,7 @@ package io.micronaut.http.annotation;
 
 import io.micronaut.context.annotation.AliasFor;
 import io.micronaut.http.HttpMethod;
+import io.micronaut.http.filter.FilterPatternStyle;
 import jakarta.inject.Singleton;
 
 import java.lang.annotation.Documented;
@@ -50,6 +51,11 @@ public @interface Filter {
      * @return The patterns this filter should match
      */
     String[] value() default {};
+
+    /**
+     * @return The style of pattern this filter uses
+     */
+    FilterPatternStyle patternStyle() default FilterPatternStyle.ANT;
 
     /**
      * Same as {@link #value()}.

--- a/http/src/main/java/io/micronaut/http/filter/DefaultFilterEntry.java
+++ b/http/src/main/java/io/micronaut/http/filter/DefaultFilterEntry.java
@@ -39,23 +39,27 @@ final class DefaultFilterEntry<T extends HttpFilter> implements HttpFilterResolv
     private final String[] patterns;
     private final boolean hasMethods;
     private final boolean hasPatterns;
+    private final FilterPatternStyle patternStyle;
 
     /**
      * Default constructor.
      * @param filter The filter
      * @param annotationMetadata The annotation metadata
      * @param httpMethods The methods
+     * @param patternStyle the pattern style
      * @param patterns THe patterns
      */
     DefaultFilterEntry(
             T filter,
             AnnotationMetadata annotationMetadata,
             Set<HttpMethod> httpMethods,
+            FilterPatternStyle patternStyle,
             String[] patterns) {
         this.httpFilter = filter;
         this.annotationMetadata = annotationMetadata;
         this.filterMethods = httpMethods != null ? Collections.unmodifiableSet(httpMethods) : Collections.emptySet();
         this.patterns = patterns != null ? patterns : StringUtils.EMPTY_STRING_ARRAY;
+        this.patternStyle = patternStyle != null ? patternStyle : FilterPatternStyle.defaultStyle();
         this.hasMethods = CollectionUtils.isNotEmpty(filterMethods);
         this.hasPatterns = ArrayUtils.isNotEmpty(patterns);
     }
@@ -79,6 +83,11 @@ final class DefaultFilterEntry<T extends HttpFilter> implements HttpFilterResolv
     @Override
     public String[] getPatterns() {
         return patterns;
+    }
+
+    @Override
+    public FilterPatternStyle getPatternStyle() {
+        return patternStyle;
     }
 
     @Override

--- a/http/src/main/java/io/micronaut/http/filter/FilterPatternStyle.java
+++ b/http/src/main/java/io/micronaut/http/filter/FilterPatternStyle.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.filter;
+
+import io.micronaut.core.util.PathMatcher;
+
+public enum FilterPatternStyle {
+  /**
+   * Ant-style pattern matching.
+   * @see io.micronaut.core.util.AntPathMatcher
+   */
+  ANT,
+  /**
+   * Regex-style pattern matching.
+   * @see io.micronaut.core.util.RegexPathMatcher
+   */
+  REGEX;
+
+  public PathMatcher getPathMatcher() {
+    return this.equals(FilterPatternStyle.REGEX) ? PathMatcher.REGEX : PathMatcher.ANT;
+  }
+
+  public static FilterPatternStyle defaultStyle() {
+    return ANT;
+  }
+}

--- a/http/src/main/java/io/micronaut/http/filter/HttpFilterResolver.java
+++ b/http/src/main/java/io/micronaut/http/filter/HttpFilterResolver.java
@@ -78,6 +78,13 @@ public interface HttpFilterResolver<F extends HttpFilter, T extends AnnotationMe
         @NonNull String[] getPatterns();
 
         /**
+         * @return The filter patterns
+         */
+        default FilterPatternStyle getPatternStyle() {
+            return FilterPatternStyle.defaultStyle();
+        }
+
+        /**
          * @return Does the entry define any methods.
          */
         default boolean hasMethods() {
@@ -103,12 +110,38 @@ public interface HttpFilterResolver<F extends HttpFilter, T extends AnnotationMe
         static <FT extends HttpFilter> FilterEntry<FT> of(
                 @NonNull FT filter,
                 @Nullable AnnotationMetadata annotationMetadata,
-                @Nullable Set<HttpMethod> methods, String...patterns) {
+                @Nullable Set<HttpMethod> methods,
+                String...patterns) {
             return new DefaultFilterEntry<>(
                     Objects.requireNonNull(filter, "Filter cannot be null"),
                     annotationMetadata != null ? annotationMetadata : AnnotationMetadata.EMPTY_METADATA,
                     methods,
+                    null,
                     patterns
+            );
+        }
+
+        /**
+         * Creates a filter entry for the given arguments.
+         * @param filter The filter
+         * @param annotationMetadata The annotation metadata
+         * @param methods The methods
+         * @param patternStyle the pattern style
+         * @param patterns The patterns
+         * @return The filter entry
+         * @param <FT> the filter type
+         */
+        static <FT extends HttpFilter> FilterEntry<FT> of(
+            @NonNull FT filter,
+            @Nullable AnnotationMetadata annotationMetadata,
+            @Nullable Set<HttpMethod> methods,
+            @NonNull FilterPatternStyle patternStyle, String...patterns) {
+            return new DefaultFilterEntry<>(
+                Objects.requireNonNull(filter, "Filter cannot be null"),
+                annotationMetadata != null ? annotationMetadata : AnnotationMetadata.EMPTY_METADATA,
+                methods,
+                patternStyle,
+                patterns
             );
         }
     }

--- a/router/src/main/java/io/micronaut/web/router/AnnotatedFilterRouteBuilder.java
+++ b/router/src/main/java/io/micronaut/web/router/AnnotatedFilterRouteBuilder.java
@@ -25,6 +25,7 @@ import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.HttpMethod;
 import io.micronaut.http.annotation.Filter;
 import io.micronaut.http.context.ServerContextPathProvider;
+import io.micronaut.http.filter.FilterPatternStyle;
 import io.micronaut.http.filter.HttpClientFilter;
 import io.micronaut.http.filter.HttpFilter;
 import io.micronaut.inject.BeanDefinition;
@@ -71,6 +72,8 @@ public class AnnotatedFilterRouteBuilder extends DefaultRouteBuilder implements 
         String[] patterns = getPatterns(beanDefinition);
         if (ArrayUtils.isNotEmpty(patterns)) {
             HttpMethod[] methods = beanDefinition.enumValues(Filter.class, "methods", HttpMethod.class);
+            FilterPatternStyle patternStyle = beanDefinition.enumValue(Filter.class, "patternStyle",
+                FilterPatternStyle.class).orElse(FilterPatternStyle.ANT);
             String first = patterns[0];
             @SuppressWarnings("unchecked")
             FilterRoute filterRoute = addFilter(first, beanContext, (BeanDefinition<? extends HttpFilter>) beanDefinition);
@@ -83,6 +86,7 @@ public class AnnotatedFilterRouteBuilder extends DefaultRouteBuilder implements 
             if (ArrayUtils.isNotEmpty(methods)) {
                 filterRoute.methods(methods);
             }
+            filterRoute.patternStyle(patternStyle);
         }
     }
 

--- a/router/src/main/java/io/micronaut/web/router/DefaultFilterRoute.java
+++ b/router/src/main/java/io/micronaut/web/router/DefaultFilterRoute.java
@@ -20,6 +20,7 @@ import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationMetadataResolver;
 import io.micronaut.core.util.*;
 import io.micronaut.http.HttpMethod;
+import io.micronaut.http.filter.FilterPatternStyle;
 import io.micronaut.http.filter.HttpFilter;
 
 import java.net.URI;
@@ -44,6 +45,7 @@ class DefaultFilterRoute implements FilterRoute {
     private final Supplier<HttpFilter> filterSupplier;
     private final AnnotationMetadataResolver annotationMetadataResolver;
     private Set<HttpMethod> httpMethods;
+    private FilterPatternStyle patternStyle;
     private HttpFilter filter;
     private AnnotationMetadata annotationMetadata;
 
@@ -112,12 +114,17 @@ class DefaultFilterRoute implements FilterRoute {
     }
 
     @Override
+    public FilterPatternStyle getPatternStyle() {
+        return patternStyle != null ? patternStyle : FilterPatternStyle.defaultStyle();
+    }
+
+    @Override
     public Optional<HttpFilter> match(HttpMethod method, URI uri) {
         if (httpMethods != null && !httpMethods.contains(method)) {
             return Optional.empty();
         }
         String uriStr = uri.getPath();
-        AntPathMatcher matcher = PathMatcher.ANT;
+        PathMatcher matcher = getPatternStyle().getPathMatcher();
         for (String pattern : patterns) {
             if (matcher.matches(pattern, uriStr)) {
                 HttpFilter filter = getFilter();
@@ -146,6 +153,12 @@ class DefaultFilterRoute implements FilterRoute {
             }
             httpMethods.addAll(Arrays.asList(methods));
         }
+        return this;
+    }
+
+    @Override
+    public FilterRoute patternStyle(FilterPatternStyle patternStyle) {
+        this.patternStyle = patternStyle;
         return this;
     }
 }

--- a/router/src/main/java/io/micronaut/web/router/DefaultRouter.java
+++ b/router/src/main/java/io/micronaut/web/router/DefaultRouter.java
@@ -21,11 +21,11 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.order.OrderUtil;
 import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.core.util.CollectionUtils;
-import io.micronaut.core.util.PathMatcher;
 import io.micronaut.core.util.SupplierUtil;
 import io.micronaut.http.*;
 import io.micronaut.http.annotation.Filter;
 import io.micronaut.http.annotation.FilterMatcher;
+import io.micronaut.http.filter.FilterPatternStyle;
 import io.micronaut.http.filter.HttpFilter;
 import io.micronaut.http.filter.HttpServerFilterResolver;
 import io.micronaut.http.uri.UriMatchTemplate;
@@ -550,12 +550,15 @@ public class DefaultRouter implements Router, HttpServerFilterResolver<RouteMatc
             if (entry.hasPatterns()) {
                 String path = request.getPath();
                 String[] patterns = entry.getPatterns();
+                FilterPatternStyle patternStyle = entry.getAnnotationMetadata()
+                    .enumValue("patternStyle", FilterPatternStyle.class)
+                    .orElse(FilterPatternStyle.ANT);
                 boolean matches = true;
                 for (String pattern : patterns) {
                     if (!matches) {
                         break;
                     }
-                    matches = Filter.MATCH_ALL_PATTERN.equals(pattern) || PathMatcher.ANT.matches(pattern, path);
+                    matches = Filter.MATCH_ALL_PATTERN.equals(pattern) || patternStyle.getPathMatcher().matches(pattern, path);
                 }
                 if (!matches) {
                     continue;

--- a/router/src/main/java/io/micronaut/web/router/FilterRoute.java
+++ b/router/src/main/java/io/micronaut/web/router/FilterRoute.java
@@ -16,6 +16,7 @@
 package io.micronaut.web.router;
 
 import io.micronaut.http.HttpMethod;
+import io.micronaut.http.filter.FilterPatternStyle;
 import io.micronaut.http.filter.HttpFilter;
 import io.micronaut.http.filter.HttpFilterResolver;
 
@@ -60,4 +61,12 @@ public interface FilterRoute extends HttpFilterResolver.FilterEntry<HttpFilter> 
      * @return This route
      */
     FilterRoute methods(HttpMethod... methods);
+
+    /**
+     * Sets the pattern style that this filter route matches.
+     *
+     * @param patternStyle The pattern style
+     * @return This route
+     */
+    FilterRoute patternStyle(FilterPatternStyle patternStyle);
 }

--- a/router/src/test/groovy/io/micronaut/web/router/DefaultFilterRouteSpec.groovy
+++ b/router/src/test/groovy/io/micronaut/web/router/DefaultFilterRouteSpec.groovy
@@ -19,6 +19,7 @@ import io.micronaut.http.HttpMethod
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.filter.FilterChain
+import io.micronaut.http.filter.FilterPatternStyle
 import io.micronaut.http.filter.HttpFilter
 import org.reactivestreams.Publisher
 import spock.lang.Specification
@@ -71,5 +72,28 @@ class DefaultFilterRouteSpec extends Specification {
         !route.match(HttpMethod.GET, URI.create('/foo')).isPresent()
         route.match(HttpMethod.POST, URI.create('/foo')).isPresent()
         route.match(HttpMethod.PUT, URI.create('/foo')).isPresent()
+    }
+
+    void "test filter route matching with regex pattern style specified"() {
+        given:
+        def filter = new HttpFilter() {
+            @Override
+            Publisher<? extends HttpResponse<?>> doFilter(HttpRequest<?> request, FilterChain chain) {
+                return null
+            }
+        }
+
+        when:
+        def route = new DefaultFilterRoute('/fo(a|o)$', new Supplier<HttpFilter>() {
+            @Override
+            HttpFilter get() {
+                return filter
+            }
+        }).patternStyle(FilterPatternStyle.REGEX)
+
+        then: //get does not match
+        route.match(HttpMethod.GET, URI.create('/foo')).isPresent()
+        !route.match(HttpMethod.POST, URI.create('/foe')).isPresent()
+        route.match(HttpMethod.PUT, URI.create('/foa')).isPresent()
     }
 }

--- a/src/main/docs/guide/httpServer/filters.adoc
+++ b/src/main/docs/guide/httpServer/filters.adoc
@@ -52,13 +52,13 @@ The previous example demonstrates some key concepts such as executing logic in a
 
 TIP: The examples use https://projectreactor.io[Project Reactor], however you can use any reactive framework that supports the Reactive streams specifications
 
-The api:http.annotation.Filter[] annotation uses api:core.util.AntPathMatcher[] for path matching. The mapping matches URLs using the following rules:
+The api:http.annotation.Filter[] can use different styles of pattern for path matching by setting `patternStyle`. By default, it uses api:core.util.AntPathMatcher[] for path matching. When using Ant, the mapping matches URLs using the following rules:
 
 * ? matches one character
 * * matches zero or more characters
 * ** matches zero or more subdirectories in a path
 
-.@Fitler Annotation Path Matching Examples
+.@Filter Annotation Path Matching Examples
 |===
 |Pattern|Example Matched Paths
 
@@ -76,6 +76,11 @@ The api:http.annotation.Filter[] annotation uses api:core.util.AntPathMatcher[] 
 
 |`customer/**/*.html`
 |customer/index.html, customer/adam/profile.html, customer/adam/job/description.html
+
+
+When using `patternStyle = FilterPatternStyle.REGEX`, the `pattern` attribute is expected to contain a regular expression which will be matched against the URLs.
+
+NOTE: Using `FilterPatternStyle.ANT` is preferred as the pattern matching is more performant than using regular expressions. `FilterPatternStyle.REGEX` should be used when your pattern cannot be written properly using Ant.
 
 == Error States
 


### PR DESCRIPTION
Adds a attribute to the `Filter` annotation, specifying which style of
pattern to use, keeping Ant as the default (avoiding breaking changes).

Fixes #5842
