### PR TITLE
Use ChannelPipelineCustomizer.HANDLER_SSL from ssl handler on server

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
@@ -832,7 +832,7 @@ public class NettyHttpServer implements EmbeddedServer, WebSocketSessionReposito
             int port = ch.localAddress().getPort();
             boolean ssl = sslContext != null && sslConfiguration != null && port == serverPort;
             if (ssl) {
-                pipeline.addLast(sslContext.newHandler(ch.alloc()));
+                pipeline.addLast(ChannelPipelineCustomizer.HANDLER_SSL, sslContext.newHandler(ch.alloc()));
             }
 
             if (loggingHandler != null) {


### PR DESCRIPTION
The server should use `ChannelPipelineCustomizer.HANDLER_SSL` for the SSL handler name