### PR TITLE
Implement constructor element queries for GroovyClassElement

### DIFF
--- a/inject-groovy/src/test/groovy/io/micronaut/ast/groovy/visitor/GroovyEnclosedElementsSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/ast/groovy/visitor/GroovyEnclosedElementsSpec.groovy
@@ -1,0 +1,42 @@
+package io.micronaut.ast.groovy.visitor
+
+import io.micronaut.ast.transform.test.AbstractBeanDefinitionSpec
+import io.micronaut.inject.ast.ClassElement
+import io.micronaut.inject.ast.ConstructorElement
+import io.micronaut.inject.ast.ElementQuery
+
+class GroovyEnclosedElementsSpec extends AbstractBeanDefinitionSpec {
+    void "test find matching constructors using ElementQuery"() {
+        given:
+        ClassElement classElement = buildClassElement('''
+package elementquery;
+
+class Test extends SuperType {
+    static {}
+
+    Test() {}
+    
+    Test(int i) {}
+}
+
+class SuperType {
+    static {}
+
+    SuperType() {}
+    
+    SuperType(String s) {}
+}
+''')
+        when:
+        def constructors = classElement.getEnclosedElements(ElementQuery.CONSTRUCTORS)
+
+        then:
+        constructors.size() == 2
+
+        when:
+        def allConstructors = classElement.getEnclosedElements(ElementQuery.of(ConstructorElement.class))
+
+        then:
+        allConstructors.size() == 4
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/visitors/ClassElementSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/ClassElementSpec.groovy
@@ -20,6 +20,7 @@ import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.micronaut.context.ApplicationContext
 import io.micronaut.core.annotation.AnnotationUtil
 import io.micronaut.inject.ast.ClassElement
+import io.micronaut.inject.ast.ConstructorElement
 import io.micronaut.inject.ast.ElementModifier
 import io.micronaut.inject.ast.ElementQuery
 import io.micronaut.inject.ast.EnumElement
@@ -292,6 +293,40 @@ interface AnotherInterface {
         then:"we get everything"
         accessibleFields.size() == 2
         accessibleFields*.name as Set == ['s1', 't1'] as Set
+    }
+
+    void "test find matching constructors using ElementQuery"() {
+        given:
+        ClassElement classElement = buildClassElement('''
+package elementquery;
+
+class Test extends SuperType {
+    static {}
+    
+    Test() {}
+    
+    Test(int i) {}
+}
+
+class SuperType {
+    static {}
+    
+    SuperType() {}
+    
+    SuperType(String s) {}
+}
+''')
+        when:
+        def constructors = classElement.getEnclosedElements(ElementQuery.CONSTRUCTORS)
+
+        then:"only our own instance constructors"
+        constructors.size() == 2
+
+        when:
+        def allConstructors = classElement.getEnclosedElements(ElementQuery.of(ConstructorElement.class))
+
+        then:"superclass constructors, but not including static initializers"
+        allConstructors.size() == 4
     }
 
     void "test visit inherited controller classes"() {

--- a/inject/src/main/java/io/micronaut/inject/ast/ElementQuery.java
+++ b/inject/src/main/java/io/micronaut/inject/ast/ElementQuery.java
@@ -44,6 +44,12 @@ public interface ElementQuery<T extends Element> {
     ElementQuery<MethodElement> ALL_METHODS = ElementQuery.of(MethodElement.class);
 
     /**
+     * Constant to retrieve instance constructors, not including those of the parent class.
+     */
+    // static initializers are never returned, so we don't need onlyInstance()
+    ElementQuery<ConstructorElement> CONSTRUCTORS = ElementQuery.of(ConstructorElement.class).onlyDeclared();
+
+    /**
      * Indicates that only declared members should be returned and not members from parent classes.
      *
      * @return This query


### PR DESCRIPTION
No change in behavior for `JavaClassElement`, but I did add a test to fix the exact behavior w.r.t. superclass constructors and static initializers.

I also added a `CONSTRUCTORS` constant to `ElementQuery` that returns all instance constructors. I doubt many people want to query superclass constructors, but for consistency and to match the current `JavaClassElement` behavior, that's still possible by using `ElementQuery.of(ConstructorElement.class)` without `.onlyDeclared()`.