### PR TITLE
Add New Relic Micrometer registry to BOM

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -342,6 +342,7 @@ ext {
                             'micronaut-micrometer-registry-jmx',
                             'micronaut-micrometer-registry-kairos',
                             'micronaut-micrometer-registry-new-relic',
+                            'micronaut-micrometer-registry-new-relic-telemetry',
                             'micronaut-micrometer-registry-prometheus',
                             'micronaut-micrometer-registry-signalfx',
                             'micronaut-micrometer-registry-stackdriver',


### PR DESCRIPTION
New Relic's Micrometer registry is documented here:

https://micronaut-projects.github.io/micronaut-micrometer/latest/guide/#metricsAndReportersNewRelicTelemetry

But it's not included in the BOM like all of the other registries.