### PR TITLE
[docs] fix small typo in rx http client dependency in upgrading doc

### DIFF
--- a/src/main/docs/guide/introduction/upgrading.adoc
+++ b/src/main/docs/guide/introduction/upgrading.adoc
@@ -58,7 +58,7 @@ dependency:io.micronaut.rxjava2:micronaut-rxjava2[gradleScope="implementation"]
 
 In addition, if any of the `Rx` HTTP client interfaces were used, a dependency must be added and the imports must be updated.
 
-dependency:io.micronaut.rxjava2:micronaut-rxjava2-http-clent[gradleScope="implementation"]
+dependency:io.micronaut.rxjava2:micronaut-rxjava2-http-client[gradleScope="implementation"]
 
 .RxJava2 HTTP Client Imports
 |===


### PR DESCRIPTION
Found this when upgrading to 3.0.0-RC1