### PR TITLE
doc: link to CacheEndpoint section not javadoc

### DIFF
--- a/src/main/docs/guide/management/providedEndpoints.adoc
+++ b/src/main/docs/guide/management/providedEndpoints.adoc
@@ -48,7 +48,7 @@ In addition, the following built-in endpoint(s) are provided by the `management`
 |===
 |Endpoint|URI|Description
 
-|api:management.endpoint.caches.CachesEndpoint[]
+|<<cachesEndpoint, CachesEndpoint>>
 | `/caches`
 |Returns information about the caches and permits invalidating them (see <<cachesEndpoint, CachesEndpoint>>)
 


### PR DESCRIPTION
API is no longer valid because Cache has been moved to its own module.