### PR TITLE
build: add micronaut-reactor-http-client to bom

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -514,10 +514,10 @@ ext {
                     group  : 'io.micronaut.rxjava1',
                     name   : 'micronaut-rxjava1'
             ],
-            'micronaut.reactor'        : [
+            'micronaut.reactor': [
                     version: micronautReactorVersion,
-                    group  : 'io.micronaut.reactor',
-                    name   : 'micronaut-reactor'
+                    group:'io.micronaut.reactor',
+                    modules : ['micronaut-reactor', 'micronaut-reactor-http-client']
             ],
             'micronaut.problem': [
                     version: micronautProblemJsonVersion,


### PR DESCRIPTION
There are two Micronaut reactor artifacts:

- `io.micronaut.reactor:micronaut-reactor`
- `io.micronaut.reactor:micronaut-reactor-http-client`

However, nowadays only `io.micronaut.reactor:micronaut-reactor` is present in Micronaut's BOM.