### PR TITLE
build:  micronaut-rxjava3-http-client in the bom

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -507,8 +507,9 @@ ext {
             'micronaut.rxjava3'        : [
                     version: micronautRxJava3Version,
                     group  : 'io.micronaut.rxjava3',
-                    name   : 'micronaut-rxjava3'
+                    modules : ['micronaut-rxjava3', 'micronaut-rxjava3-http-client']
             ],
+
             'micronaut.rxjava1'        : [
                     version: micronautRxJava1Version,
                     group  : 'io.micronaut.rxjava1',


### PR DESCRIPTION
There are two Micronaut Rx Java 3 artifacts:

- `io.micronaut.rxjava3:micronaut-rxjava3`
- `io.micronaut.rxjava3:micronaut-rxjava3-http-client`

However, nowadays only `io.micronaut.rxjava3:micronaut-rxjava3` is present in Micronaut's BOM.