### PR TITLE
Allow for multiple calls to close for the input stream returned by CompletedFileUpload when the backing data is on disk

### DIFF
--- a/test-suite/src/test/groovy/io/micronaut/upload/MixedUploadSpec.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/upload/MixedUploadSpec.groovy
@@ -405,6 +405,30 @@ class MixedUploadSpec extends AbstractMicronautSpec {
         calculateMd5(file.toPath()) == originalmd5
     }
 
+    void "test reading a CompletedFileUpload input stream and closing it multiple times"() {
+        given:
+        def data = '{"title":"Test"}'
+        MultipartBody requestBody = MultipartBody.builder()
+                .addPart("title", "bar")
+                .addPart("data", "data.json", MediaType.APPLICATION_JSON_TYPE, data.bytes)
+                .build()
+
+
+        when:
+        Flowable<HttpResponse<String>> flowable = Flowable.fromPublisher(client.exchange(
+                HttpRequest.POST("/upload/receive-completed-file-upload-stream", requestBody)
+                        .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+                        .accept(MediaType.TEXT_PLAIN_TYPE),
+                String
+        ))
+        HttpResponse<String> response = flowable.blockingFirst()
+        def result = response.getBody().get()
+
+        then:
+        response.code() == HttpStatus.OK.code
+        result == 'data.json: 16'
+    }
+
     @Override
     Map<String, Object> getConfiguration() {
         super.getConfiguration() << ['micronaut.http.client.read-timeout': 300,

--- a/test-suite/src/test/groovy/io/micronaut/upload/StreamUploadSpec.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/upload/StreamUploadSpec.groovy
@@ -563,6 +563,30 @@ class StreamUploadSpec extends AbstractMicronautSpec {
         calculateMd5(file.toPath()) == originalmd5
     }
 
+    void "test reading a CompletedFileUpload input stream and closing it multiple times"() {
+        given:
+        def data = '{"title":"Test"}'
+        MultipartBody requestBody = MultipartBody.builder()
+                .addPart("title", "bar")
+                .addPart("data", "data.json", MediaType.APPLICATION_JSON_TYPE, data.bytes)
+                .build()
+
+
+        when:
+        Flowable<HttpResponse<String>> flowable = Flowable.fromPublisher(client.exchange(
+                HttpRequest.POST("/upload/receive-completed-file-upload-stream", requestBody)
+                        .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+                        .accept(MediaType.TEXT_PLAIN_TYPE),
+                String
+        ))
+        HttpResponse<String> response = flowable.blockingFirst()
+        def result = response.getBody().get()
+
+        then:
+        response.code() == HttpStatus.OK.code
+        result == 'data.json: 16'
+    }
+
     @Override
     Map<String, Object> getConfiguration() {
         super.getConfiguration() << [

--- a/test-suite/src/test/groovy/io/micronaut/upload/UploadController.java
+++ b/test-suite/src/test/groovy/io/micronaut/upload/UploadController.java
@@ -41,6 +41,7 @@ import org.reactivestreams.Subscription;
 
 import javax.inject.Singleton;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.util.ArrayList;
@@ -87,6 +88,26 @@ public class UploadController {
             return e.getMessage();
         }
     }
+
+    @Post(value = "/receive-completed-file-upload-stream", consumes = MediaType.MULTIPART_FORM_DATA, produces = MediaType.TEXT_PLAIN)
+    public String receiveCompletedFileUploadStream(CompletedFileUpload data) {
+        try {
+            InputStream is = data.getInputStream();
+            int size = 1024;
+            byte[] buf = new byte[size];
+            int total = 0;
+            int len;
+            while ((len = is.read(buf, 0, size)) != -1) {
+                total += len;
+            }
+            is.close();
+            is.close(); //intentionally close the stream twice to ensure it doesn't throw an exception
+            return data.getFilename() + ": " + total;
+        } catch (IOException e) {
+            return e.getMessage();
+        }
+    }
+
 
     @Post(value = "/receive-publisher", consumes = MediaType.MULTIPART_FORM_DATA, produces = MediaType.TEXT_PLAIN)
     public Single<HttpResponse> receivePublisher(Flowable<byte[]> data) {


### PR DESCRIPTION
Fixes #5973