### PR TITLE
Moving `NotNull` annotation in front of FQN.

### DIFF
--- a/management/src/main/java/io/micronaut/management/endpoint/loggers/impl/DefaultLoggersManager.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/loggers/impl/DefaultLoggersManager.java
@@ -62,7 +62,7 @@ public class DefaultLoggersManager implements LoggersManager<Map<String, Object>
     }
 
     @Override
-    public void setLogLevel(ManagedLoggingSystem loggingSystem, @NotBlank String name, io.micronaut.logging.@NotNull LogLevel level) {
+    public void setLogLevel(ManagedLoggingSystem loggingSystem, @NotBlank String name, @NotNull io.micronaut.logging.LogLevel level) {
         loggingSystem.setLogLevel(name, level);
     }
 


### PR DESCRIPTION
In a "wow, didn't know you could do that in Java" moment, we had a parsing error in OpenRewrite. Apparently, you can embed annotations INSIDE a fully qualified name. I suspect this was just an IDE refactor gone wrong. This PR just moves the annotations outside the FQN for readability.
 