### PR TITLE
fix: if proxy request is not mutable call mutate

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -2569,6 +2569,10 @@ public class DefaultHttpClient implements
                 .orElse(MediaType.APPLICATION_JSON_TYPE);
 
         boolean permitsBody = io.micronaut.http.HttpMethod.permitsRequestBody(request.getMethod());
+
+        if (!(request instanceof MutableHttpRequest)) {
+            throw new IllegalArgumentException("A MutableHttpRequest is required");
+        }
         MutableHttpRequest clientHttpRequest = (MutableHttpRequest) request;
         NettyRequestWriter requestWriter = buildNettyRequest(
                 clientHttpRequest,
@@ -2694,7 +2698,7 @@ public class DefaultHttpClient implements
     public Publisher<MutableHttpResponse<?>> proxy(io.micronaut.http.HttpRequest<?> request) {
         return Flux.from(resolveRequestURI(request))
                 .flatMap(requestURI -> {
-                    AtomicReference<io.micronaut.http.HttpRequest> requestWrapper = new AtomicReference<>(request);
+                    AtomicReference<io.micronaut.http.HttpRequest> requestWrapper = new AtomicReference<>(request instanceof MutableHttpRequest ? request : request.mutate());
                     Flux<MutableHttpResponse<Object>> proxyResponsePublisher = Flux.create(emitter -> {
                         SslContext sslContext = buildSslContext(requestURI);
                         ChannelFuture channelFuture;

--- a/http-client/src/test/groovy/io/micronaut/http/client/ProxyHttpClientMutableRequestSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/ProxyHttpClientMutableRequestSpec.groovy
@@ -1,0 +1,99 @@
+package io.micronaut.http.client
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.*
+import io.micronaut.core.io.socket.SocketUtils
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Filter
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Produces
+import io.micronaut.http.filter.FilterChain
+import io.micronaut.http.filter.HttpFilter
+import io.micronaut.runtime.server.EmbeddedServer
+import jakarta.inject.Named
+import org.reactivestreams.Publisher
+import spock.lang.Issue
+import spock.lang.Specification
+
+import static io.micronaut.http.annotation.Filter.MATCH_ALL_PATTERN
+
+class ProxyHttpClientMutableRequestSpec extends Specification {
+
+    @Issue("https://github.com/micronaut-projects/micronaut-core/issues/6073")
+    void "ProxyHttpClient will mutate a request if necessary"() {
+        given:
+        int helloServerPort = SocketUtils.findAvailableTcpPort()
+        EmbeddedServer helloEmbeddedServer = ApplicationContext.run(EmbeddedServer.class, [
+                'micronaut.server.port': helloServerPort,
+                'spec.name': 'ProxyHttpClientMutableRequestSpec.hello',
+        ])
+        EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer.class, [
+                'spec.name': 'ProxyHttpClientMutableRequestSpec',
+                'proxies.hello.url': "http://localhost:$helloServerPort".toString(),
+        ])
+
+        HttpClient httpClient = embeddedServer.applicationContext.createBean(HttpClient, embeddedServer.URL)
+        BlockingHttpClient client = httpClient.toBlocking()
+
+        when:
+        String result = client.retrieve(HttpRequest.GET('/hello/john').accept(MediaType.TEXT_PLAIN))
+
+        then:
+        'Hello john' == result
+
+        cleanup:
+        helloEmbeddedServer.close()
+        client.close()
+        httpClient.close()
+        embeddedServer.close()
+    }
+
+    @Requires(property = 'spec.name', value = 'ProxyHttpClientMutableRequestSpec')
+    @EachProperty("proxies")
+    static class ProxyConfig {
+        private final String name
+        URI url
+        ProxyConfig(@Parameter String name) {
+            this.name = name;
+        }
+
+        String getName() {
+            this.name
+        }
+    }
+    @Requires(property = 'spec.name', value = 'ProxyHttpClientMutableRequestSpec')
+    @Factory
+    static class ProxyClientFactory {
+        @EachBean(ProxyConfig)
+        ProxyHttpClient create(ProxyConfig config) {
+            ProxyHttpClient.create(config.getUrl().toURL())
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'ProxyHttpClientMutableRequestSpec')
+    @Filter(MATCH_ALL_PATTERN)
+    static class ApiGatewayFilter implements HttpFilter {
+        private final ProxyHttpClient proxyHttpClient
+        ApiGatewayFilter(@Named("hello") ProxyHttpClient proxyHttpClient) {
+            this.proxyHttpClient = proxyHttpClient
+        }
+
+        @Override
+        Publisher<? extends HttpResponse<?>> doFilter(HttpRequest<?> request, FilterChain chain) {
+            proxyHttpClient.proxy(request)
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'ProxyHttpClientMutableRequestSpec.hello')
+    @Controller("/hello")
+    static class HelloWorldController {
+        @Produces(MediaType.TEXT_PLAIN)
+        @Get("/john")
+        String john() {
+            "Hello john"
+        }
+    }
+}


### PR DESCRIPTION
Closes #6073

I intially try to replace `DefaultHttpClient::prepareRequest` line: 

`MutableHttpRequest clientHttpRequest = (MutableHttpRequest) request;`

with: 

`MutableHttpRequest clientHttpRequest = request instanceof MutableHttpRequest ? (MutableHttpRequest) request : request.mutate();`

but it fails with: 

```
10:04:54.690 [multithreadEventLoopGroup-4-1] WARN  i.n.util.concurrent.DefaultPromise - An exception was thrown by io.micronaut.http.client.netty.DefaultHttpClient$$Lambda$686/0x0000000800801c40.operationComplete()
java.lang.IllegalArgumentException: URI is not absolute
	at java.base/java.net.URL.fromURI(URL.java:692)
	at java.base/java.net.URI.toURL(URI.java:1116)
	at io.micronaut.http.client.netty.DefaultHttpClient.buildNettyRequest(DefaultHttpClient.java:1661)
	at io.micronaut.http.client.netty.DefaultHttpClient.prepareRequest(DefaultHttpClient.java:2574)
	at io.micronaut.http.client.netty.DefaultHttpClient.streamRequestThroughChannel(DefaultHttpClient.java:1884)
	at io.micronaut.http.client.netty.DefaultHttpClient.lambda$proxy$51(DefaultHttpClient.java:2727)
	at io.micronaut.http.client.netty.DefaultHttpClient.lambda$addInstrumentedListener$54(DefaultHttpClient.java:2783)
	at io.netty.util.concurrent.DefaultPromise.notifyListener0(DefaultPromise.java:578)
	at io.netty.util.concurrent.DefaultPromise.notifyListeners0(DefaultPromise.java:571)
	at io.netty.util.concurrent.DefaultPromise.notifyListenersNow(DefaultPromise.java:550)
	at io.netty.util.concurrent.DefaultPromise.notifyListeners(DefaultPromise.java:491)
	at io.netty.util.concurrent.DefaultPromise.setValue0(DefaultPromise.java:616)
	at io.netty.util.concurrent.DefaultPromise.setSuccess0(DefaultPromise.java:605)
	at io.netty.util.concurrent.DefaultPromise.trySuccess(DefaultPromise.java:104)
	at io.netty.channel.DefaultChannelPromise.trySuccess(DefaultChannelPromise.java:84)
	at io.netty.channel.nio.AbstractNioChannel$AbstractNioUnsafe.fulfillConnectPromise(AbstractNioChannel.java:300)
	at io.netty.channel.nio.AbstractNioChannel$AbstractNioUnsafe.finishConnect(AbstractNioChannel.java:335)
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:707)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:655)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:581)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:493)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

I have moved the `mutate()` inovcation to `AtomicReference` creation. 