### PR TITLE
Fix names of inner annotations in metadata

### DIFF
--- a/inject-groovy/src/test/groovy/io/micronaut/inject/annotation/AnnotationMetadataWriterSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/annotation/AnnotationMetadataWriterSpec.groovy
@@ -35,6 +35,28 @@ import java.lang.annotation.Retention
  */
 class AnnotationMetadataWriterSpec extends AbstractBeanDefinitionSpec {
 
+    void "test inner annotations in metadata"() {
+        given:
+        def annotationMetadata = buildTypeAnnotationMetadata("inneranntest.Test","""
+package inneranntest;
+
+import java.lang.annotation.Retention;
+import static java.lang.annotation.RetentionPolicy.*;
+import io.micronaut.inject.annotation.Outer;
+
+@Outer.Inner
+class Test {
+    
+}
+""")
+
+        annotationMetadata = writeAndLoadMetadata('annmetadatatest.Test', annotationMetadata)
+
+        expect:
+        annotationMetadata.hasAnnotation(Outer.Inner)
+        annotationMetadata.hasDeclaredAnnotation(Outer.Inner)
+    }
+
     void "test annotation metadata with primitive arrays"() {
         given:
         AnnotationMetadata toWrite = buildTypeAnnotationMetadata('annmetawriter1.Test','''\

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/annotation/Outer.java
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/annotation/Outer.java
@@ -1,0 +1,6 @@
+package io.micronaut.inject.annotation;
+
+public class Outer {
+
+    public @interface Inner {}
+}

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/JavaAnnotationMetadataBuilder.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/JavaAnnotationMetadataBuilder.java
@@ -448,7 +448,7 @@ public class JavaAnnotationMetadataBuilder extends AbstractAnnotationMetadataBui
     @Override
     protected String getElementName(Element element) {
         if (element instanceof TypeElement) {
-            return ((TypeElement) element).getQualifiedName().toString();
+            return elementUtils.getBinaryName(((TypeElement) element)).toString();
         }
         return element.getSimpleName().toString();
     }

--- a/inject-java/src/test/groovy/io/micronaut/inject/annotation/AnnotationMetadataWriterSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/annotation/AnnotationMetadataWriterSpec.groovy
@@ -47,6 +47,28 @@ import java.lang.annotation.Retention
  */
 class AnnotationMetadataWriterSpec extends AbstractTypeElementSpec {
 
+    void "test inner annotations in metadata"() {
+        given:
+        def annotationMetadata = buildTypeAnnotationMetadata("""
+package inneranntest;
+
+import java.lang.annotation.Retention;
+import static java.lang.annotation.RetentionPolicy.*;
+import io.micronaut.inject.annotation.Outer;
+
+@Outer.Inner
+class Test {
+    
+}
+""")
+
+        annotationMetadata = writeAndLoadMetadata('annmetadatatest.Test', annotationMetadata)
+
+        expect:
+        annotationMetadata.hasAnnotation(Outer.Inner)
+        annotationMetadata.hasDeclaredAnnotation(Outer.Inner)
+    }
+
     @Unroll
     void "test read/write annotation array type #type"() {
         given:

--- a/inject-java/src/test/groovy/io/micronaut/inject/annotation/Outer.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/annotation/Outer.java
@@ -1,0 +1,6 @@
+package io.micronaut.inject.annotation;
+
+public class Outer {
+
+    public @interface Inner {}
+}


### PR DESCRIPTION
Annotation names are currently stored using the canonical name of the type instead of the binary name. This makes them impossible to retrieve if they are inner classes.

This PR changes Micronaut so annotation names are stored using the binary class name so that lookup with `Outer.Inner.class.getName()` works as expected.

Fixes #6045