### PR TITLE
Fix for custom validators on nested pojos

### DIFF
--- a/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java
@@ -1112,7 +1112,7 @@ public class DefaultValidator implements Validator, ExecutableMethodValidator, R
                     null,
                     context,
                     overallViolations,
-                    rootBeanClass,
+                    object.getClass(),
                     object,
                     pojoConstraint,
                     introspection.getAnnotation(pojoConstraint));

--- a/validation/src/test/groovy/io/micronaut/validation/validator/pojo/PojoValidatorSpec.groovy
+++ b/validation/src/test/groovy/io/micronaut/validation/validator/pojo/PojoValidatorSpec.groovy
@@ -28,6 +28,7 @@ import spock.lang.Shared
 import spock.lang.Specification
 
 import javax.inject.Singleton
+import javax.validation.Valid
 
 class PojoValidatorSpec extends Specification {
 
@@ -52,6 +53,18 @@ class PojoValidatorSpec extends Specification {
         constraintViolations.size() == 1
         constraintViolations.first().message == "Both name and lastName can't be null"
     }
+
+    void "test custom constraint validator on a nested Pojo"() {
+        given:
+        SearchAny search = new SearchAny(new Search())
+
+        when:
+        def constraintViolations = validator.validate(search)
+
+        then:
+        constraintViolations.size() == 1
+        constraintViolations.first().message == "Both name and lastName can't be null"
+    }
 }
 
 @Introspected
@@ -59,6 +72,15 @@ class PojoValidatorSpec extends Specification {
 class Search {
     String name
     String lastName
+}
+
+@Introspected
+class SearchAny {
+    @Valid
+    List<Search> searches;
+    SearchAny(Search... searches) {
+        this.searches = searches;
+    }
 }
 
 @Factory


### PR DESCRIPTION
Fix for issue #5986 (validator not handling nested custom validations). Note that the example linked from that issue is also missing the @Valid annotation on the list of nested POJOs.