### PR TITLE
feat: allow SameSite case insensitive binding

### DIFF
--- a/http-server-netty/src/test/groovy/io/micronaut/http/cookie/SameSiteCaseInsensitiveViaConfigurationSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/cookie/SameSiteCaseInsensitiveViaConfigurationSpec.groovy
@@ -1,0 +1,43 @@
+package io.micronaut.http.cookie
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.ConfigurationProperties
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.annotation.Nullable
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class SameSiteCaseInsensitiveViaConfigurationSpec extends Specification {
+
+    @Unroll
+    void "SameSite allows for case insensitive configuration binding"(String sameSiteValue, SameSite expected) {
+        given:
+        ApplicationContext context = ApplicationContext.run([
+                "spec.name": "SameSiteCaseInsensitiveViaConfigurationSpec",
+                "mock.same-site": sameSiteValue,
+        ])
+        MockConfigurationProperties props = context.getBean(MockConfigurationProperties)
+
+        expect:
+        expected == props.sameSite
+
+        cleanup:
+        context.close()
+
+        where:
+        sameSiteValue || expected
+        'Strict'      || SameSite.Strict
+        'strict'      || SameSite.Strict
+        'sTrict'      || SameSite.Strict
+        'bogus'       || null
+
+    }
+
+    @Requires(property = "spec.name", value = "SameSiteCaseInsensitiveViaConfigurationSpec")
+    @ConfigurationProperties("mock")
+    static class MockConfigurationProperties {
+        @Nullable
+        SameSite sameSite
+    }
+
+}

--- a/http-server-netty/src/test/groovy/io/micronaut/http/cookie/SameSiteJsonValueSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/cookie/SameSiteJsonValueSpec.groovy
@@ -1,0 +1,59 @@
+package io.micronaut.http.cookie
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Produces
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+import spock.lang.Unroll
+
+@MicronautTest
+@Property(name = "spec.name", value = "SameSiteJsonValueSpec")
+class SameSiteJsonValueSpec extends Specification {
+    @Inject
+    @Client("/")
+    HttpClient httpClient
+
+    @Unroll
+    void "SameSite is render as Json value with Lax None and Strict"(String path) {
+        when:
+        Map<String, Object> json = httpClient.toBlocking().retrieve(HttpRequest.GET(path), Map)
+
+        then:
+        noExceptionThrown()
+        expected == json.samesite
+
+        where:
+        path                || expected
+        '/samesite/lax'     || 'Lax'
+        '/samesite/strict'  || 'Strict'
+        '/samesite/none'    || 'None'
+    }
+
+    @Requires(property = "spec.name", value = "SameSiteJsonValueSpec")
+    @Controller("/samesite")
+    static class SameSiteController {
+
+        @Get("/lax")
+        Map<String, Object> lax() {
+            Collections.singletonMap("samesite", SameSite.Lax)
+        }
+
+        @Get("/strict")
+        Map<String, Object> strict() {
+            Collections.singletonMap("samesite", SameSite.Strict)
+        }
+
+        @Get("/none")
+        Map<String, Object> none() {
+            Collections.singletonMap("samesite", SameSite.None)
+        }
+    }
+}

--- a/http/src/main/java/io/micronaut/http/cookie/SameSiteConverter.java
+++ b/http/src/main/java/io/micronaut/http/cookie/SameSiteConverter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.cookie;
+
+import io.micronaut.core.convert.ConversionContext;
+import io.micronaut.core.convert.TypeConverter;
+import io.micronaut.core.util.StringUtils;
+import jakarta.inject.Singleton;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Converts a string to a {@link SameSite}.
+ *
+ * @author Sergio del Amo
+ * @since 3.1.0
+ */
+@Singleton
+public class SameSiteConverter implements TypeConverter<CharSequence, SameSite> {
+    private static final Map<CharSequence, SameSite> CONVERSIONS = new ConcurrentHashMap<>();
+
+    /**
+     *
+     * @param object     e.g. strict
+     * @param targetType The target type being converted to {@link SameSite}
+     * @param context    The {@link io.micronaut.core.convert.ConversionContext}
+     * @return  {@link SameSite}
+     */
+    @Override
+    public Optional<SameSite> convert(CharSequence object, Class<SameSite> targetType, ConversionContext context) {
+        return Optional.ofNullable(CONVERSIONS.computeIfAbsent(object, charSequence -> {
+            if (object == null) {
+                return null;
+            }
+            try {
+                return SameSite.valueOf(StringUtils.capitalize(object.toString().toLowerCase()));
+            } catch (IllegalArgumentException e) {
+                return null;
+            }
+        }));
+    }
+}

--- a/http/src/main/java/io/micronaut/http/cookie/SameSiteConverter.java
+++ b/http/src/main/java/io/micronaut/http/cookie/SameSiteConverter.java
@@ -27,7 +27,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * Converts a string to a {@link SameSite}.
  *
  * @author Sergio del Amo
- * @since 3.1.0
+ * @since 3.0.1
  */
 @Singleton
 public class SameSiteConverter implements TypeConverter<CharSequence, SameSite> {


### PR DESCRIPTION
Close #6092

enum `SameSite` is:

```java
package io.micronaut.http.cookie;

public enum SameSite {
  Lax,
  Strict,
  None;
}
```

I think it should have been something like:

```java
package io.micronaut.http.cookie;

import com.fasterxml.jackson.annotation.JsonValue;

public enum SameSite {
    LAX("Lax"),
    STRICT("Strict"),
    NONE("None");

    private final String value;
    SameSite(String value) {
        this.value = value;
    }

    @JsonValue
    public String toString() {
        return this.value;
    }
}
```

However, changing the enum is a breaking change. Henche, I have introduced a type converter to allow for lowercase binding.

IntelliJ IDEA suggests lowercase values.

Users type a lowercase value as their IDE suggests and they are confused because it does not work.

See: https://github.com/micronaut-projects/micronaut-security/issues/755

Also, test SameSite JSON rendering