### PR TITLE
Fix custom validator with non object class during cascade from a list

### DIFF
--- a/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java
@@ -1112,7 +1112,7 @@ public class DefaultValidator implements Validator, ExecutableMethodValidator, R
                     null,
                     context,
                     overallViolations,
-                    rootBeanClass,
+                    introspection.getBeanType(),
                     object,
                     pojoConstraint,
                     introspection.getAnnotation(pojoConstraint));

--- a/validation/src/test/groovy/io/micronaut/validation/validator/constraints/custom/AlwaysInvalidTypeConstraint.java
+++ b/validation/src/test/groovy/io/micronaut/validation/validator/constraints/custom/AlwaysInvalidTypeConstraint.java
@@ -1,0 +1,12 @@
+package io.micronaut.validation.validator.constraints.custom;
+
+import java.lang.annotation.Retention;
+import javax.validation.Constraint;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Constraint(validatedBy = { })
+@interface AlwaysInvalidTypeConstraint {
+    String message() default "custom invalid type";
+}

--- a/validation/src/test/groovy/io/micronaut/validation/validator/constraints/custom/CustomConstraintsSpec.groovy
+++ b/validation/src/test/groovy/io/micronaut/validation/validator/constraints/custom/CustomConstraintsSpec.groovy
@@ -119,6 +119,19 @@ class CustomConstraintsSpec extends Specification {
         violations[1].message == "custom invalid"
     }
 
+    void "test validation where pojo with cascade from list and custom validation with type"() {
+        given:
+        CustomTestListInvalid testInvalid = new CustomTestListInvalid(
+                invalidOuter: List.of(new CustomTypeInvalidOuter()))
+
+        when:
+        def violations = validator.validate(testInvalid)
+
+        then:
+        violations.size() == 1
+        violations[0].message == "custom invalid type"
+    }
+
     void "test validation where inner custom message constraint fails"() {
         given:
         CustomTestInvalid.CustomInvalidInner invalidInner = new CustomTestInvalid.CustomInvalidInner()
@@ -177,3 +190,13 @@ class CustomTestInvalid {
 @Introspected
 @CustomMessageConstraint
 class CustomInvalidOuter {}
+
+@Introspected
+class CustomTestListInvalid {
+    @Valid
+    List<CustomTypeInvalidOuter> invalidOuter
+}
+
+@Introspected
+@AlwaysInvalidTypeConstraint
+class CustomTypeInvalidOuter {}

--- a/validation/src/test/groovy/io/micronaut/validation/validator/constraints/custom/CustomConstraintsValidatorFactory.java
+++ b/validation/src/test/groovy/io/micronaut/validation/validator/constraints/custom/CustomConstraintsValidatorFactory.java
@@ -8,6 +8,11 @@ import javax.inject.Singleton;
 @Factory
 class CustomConstraintsValidatorFactory {
     @Singleton
+    ConstraintValidator<AlwaysInvalidTypeConstraint, CustomTypeInvalidOuter> alwaysInvalidTypeConstraintValidator() {
+        return (value, annotationMetadata, context) -> false;
+    }
+
+    @Singleton
     ConstraintValidator<AlwaysInvalidConstraint, Object> alwaysInvalidConstraintValidator() {
         return (value, annotationMetadata, context) -> false;
     }


### PR DESCRIPTION
When using a custom validation at class Level and a type different than Object, the validator is never triggered.

Example : 
```java 
@Retention(RetentionPolicy.RUNTIME)
@Constraint(validatedBy = { })
public @interface TaskDefault {
    String message() default "invalid taskDefaults expression ({validatedValue})";
}

@Value
@Introspected
public class Flow {
    @Valid
    private List<TaskDefault> taskDefaults;
}

@Value
@io.kestra.core.validations.TaskDefault
@Introspected
public class TaskDefault {
    private final String type;
}

ConstraintValidator<TaskDefault, io.kestra.core.models.flows.TaskDefault> taskDefaultValidator() {
    return (value, annotationMetadata, context) -> 
        return true;
    };
}
```
`taskDefaultValidator` will be never triggered when I do `modelValidator.isValid(flow) `

As I understand, the bug is here : 
https://github.com/micronaut-projects/micronaut-core/blob/764eb376a1213c436d7dec75cdeecc53cfeea596/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java#L1123-L1134

it's the 6 args `rootBeanClass` that is passed and must be the current object type `introspection.getBeanType()` in order to trigger the validation.

Tell what do you think ? or if it's a mistake from my side on Bean Validation specs 