### PR TITLE
Return proper type from JavaVisitorContext.getClassElement for enum elements

### DIFF
--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaVisitorContext.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaVisitorContext.java
@@ -167,7 +167,7 @@ public class JavaVisitorContext implements VisitorContext, BeanElementVisitorCon
             typeElement = elements.getTypeElement(name.replace('$', '.'));
         }
         return Optional.ofNullable(typeElement).map(typeElement1 ->
-                new JavaClassElement(typeElement1, annotationUtils.getAnnotationMetadata(typeElement1), this, Collections.emptyMap())
+                elementFactory.newClassElement(typeElement1, annotationUtils.getAnnotationMetadata(typeElement1))
         );
     }
 
@@ -373,11 +373,7 @@ public class JavaVisitorContext implements VisitorContext, BeanElementVisitorCon
             if (enclosedElement instanceof TypeElement) {
                 final AnnotationMetadata annotationMetadata = annotationUtils.getAnnotationMetadata(enclosedElement);
                 if (includeAll || Arrays.stream(stereotypes).anyMatch(annotationMetadata::hasStereotype)) {
-                    JavaClassElement classElement = new JavaClassElement(
-                            (TypeElement) enclosedElement,
-                            annotationMetadata,
-                            this
-                    );
+                    JavaClassElement classElement = elementFactory.newClassElement((TypeElement) enclosedElement, annotationMetadata);
 
                     if (!classElement.isAbstract()) {
                         classElements.add(classElement);

--- a/inject-java/src/test/groovy/io/micronaut/annotation/processing/visitor/JavaVisitorContextSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/annotation/processing/visitor/JavaVisitorContextSpec.groovy
@@ -1,0 +1,63 @@
+package io.micronaut.annotation.processing.visitor
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.inject.ast.ClassElement
+import io.micronaut.inject.visitor.TypeElementVisitor
+import io.micronaut.inject.visitor.VisitorContext
+
+class JavaVisitorContextSpec extends AbstractTypeElementSpec {
+    private List<TypeElementVisitor> localTypeElementVisitors
+
+    def 'return enum from getClassElement'() {
+        given:
+        ClassElement original
+        Optional<ClassElement> lookedUp
+        def enumVisitor = new TypeElementVisitor<Object, Object>() {
+            @Override
+            void visitClass(ClassElement element, VisitorContext context) {
+                original = element
+                lookedUp = context.getClassElement(element.name)
+            }
+        }
+        localTypeElementVisitors = [enumVisitor]
+
+        buildClassLoader('example.Foo', '''
+package example;
+enum Foo {}
+''')
+
+        expect:
+        lookedUp.isPresent()
+        lookedUp.get().enum
+
+        original.name == 'example.Foo'
+        lookedUp.get().name == 'example.Foo'
+    }
+
+    def 'return enum from getClassElements'() {
+        given:
+        ClassElement[] lookedUp
+        def enumVisitor = new TypeElementVisitor<Object, Object>() {
+            @Override
+            void visitClass(ClassElement element, VisitorContext context) {
+                lookedUp = context.getClassElements(element.packageName, '*')
+            }
+        }
+        localTypeElementVisitors = [enumVisitor]
+
+        buildClassLoader('example.Foo', '''
+package example;
+enum Foo {}
+''')
+
+        expect:
+        lookedUp.size() == 1
+        lookedUp[0].enum
+        lookedUp[0].name == 'example.Foo'
+    }
+
+    @Override
+    protected Collection<TypeElementVisitor> getLocalTypeElementVisitors() {
+        return localTypeElementVisitors
+    }
+}


### PR DESCRIPTION
This PR changes `getClassElement` and `getClassElements` to delegate to the `elementFactory` instead of creating `JavaClassElement` directly. The factory returns the right type for enum elements.

There is a behavior change in that `getClassElement` now returns a type that does generics lookup, but this does not break any tests in core and seems to be the right behavior anyway. It's the reason why this PR is for 3.1, though, along with the fact that it doesn't seem to be an issue for current users of `getClassElement` (it is relevant for #5822).

As for the unit test, registering a visitor directly was not as difficult as I'd thought, so I used that approach after all.