### PR TITLE
Correctly handle absence of request in RequestScope

### DIFF
--- a/http-server-netty/src/test/groovy/io/micronaut/runtime/http/scope/RequestScopeSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/runtime/http/scope/RequestScopeSpec.groovy
@@ -34,6 +34,19 @@ import spock.util.concurrent.PollingConditions
  */
 class RequestScopeSpec extends AbstractMicronautSpec {
 
+    void 'test request scope no request'() {
+        when:
+        RequestBean requestBean = applicationContext.getBean(RequestBean)
+        requestBean.count()
+
+        then:
+        def e = thrown(RuntimeException)
+        e.message == 'No request present'
+
+        cleanup:
+        RequestBean.BEANS_CREATED.clear()
+    }
+
     void "test @Request bean created per request"() {
         given:
         PollingConditions conditions = new PollingConditions(delay: 0.5, timeout: 3)

--- a/runtime/src/main/java/io/micronaut/runtime/http/scope/RequestCustomScope.java
+++ b/runtime/src/main/java/io/micronaut/runtime/http/scope/RequestCustomScope.java
@@ -77,7 +77,7 @@ class RequestCustomScope extends AbstractConcurrentCustomScope<RequestScope> imp
             //noinspection ConstantConditions
             return getRequestAttributeMap(request, forCreation);
         } else {
-            return Collections.emptyMap();
+            throw new IllegalStateException("No request present");
         }
     }
 


### PR DESCRIPTION
If there is no request then request scope shouldn't silently fail. This throws an exception which reveals the true problem in #6096

In additional the RouteExecutor should wrap the route execution in the current request.

Fixes #6096