### PR TITLE
Allow refreshing the server SSL configuration using a RefreshEvent

### DIFF
--- a/context/src/main/java/io/micronaut/runtime/context/scope/refresh/RefreshEventListener.java
+++ b/context/src/main/java/io/micronaut/runtime/context/scope/refresh/RefreshEventListener.java
@@ -34,6 +34,9 @@ public interface RefreshEventListener extends ApplicationEventListener<RefreshEv
         if (event != null) {
             final Map<String, Object> source = event.getSource();
             if (source != null) {
+                if (source == RefreshEvent.ALL_KEYS) {
+                    return true;
+                }
                 final Set<String> keys = source.keySet();
                 Set<String> prefixes = getObservedConfigurationPrefixes();
                 if (CollectionUtils.isNotEmpty(prefixes)) {

--- a/context/src/main/java/io/micronaut/runtime/context/scope/refresh/RefreshEventListener.java
+++ b/context/src/main/java/io/micronaut/runtime/context/scope/refresh/RefreshEventListener.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.runtime.context.scope.refresh;
+
+import java.util.Map;
+import java.util.Set;
+
+import io.micronaut.context.event.ApplicationEventListener;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.util.CollectionUtils;
+
+/**
+ * A convenience interface that can be implemented if a component needs to listen for {@link io.micronaut.runtime.context.scope.refresh.RefreshEvent} where the implementation is only interested in a limited set of configuration prefixes.
+ *
+ * @author graemerocher
+ * @since 3.1.0
+ */
+public interface RefreshEventListener extends ApplicationEventListener<RefreshEvent> {
+    @Override
+    default boolean supports(RefreshEvent event) {
+        if (event != null) {
+            final Map<String, Object> source = event.getSource();
+            if (source != null) {
+                final Set<String> keys = source.keySet();
+                Set<String> prefixes = getObservedConfigurationPrefixes();
+                if (CollectionUtils.isNotEmpty(prefixes)) {
+                    for (String prefix : prefixes) {
+                        if (keys.stream().anyMatch(k -> k.startsWith(prefix))) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns the set of observed configuration prefixes that the event listener should listen for.
+     * @return A set of prefixes
+     */
+    @NonNull
+    Set<String> getObservedConfigurationPrefixes();
+}

--- a/context/src/main/java/io/micronaut/runtime/context/scope/refresh/RefreshEventListener.java
+++ b/context/src/main/java/io/micronaut/runtime/context/scope/refresh/RefreshEventListener.java
@@ -20,6 +20,7 @@ import java.util.Set;
 
 import io.micronaut.context.event.ApplicationEventListener;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.order.Ordered;
 import io.micronaut.core.util.CollectionUtils;
 
 /**
@@ -28,7 +29,13 @@ import io.micronaut.core.util.CollectionUtils;
  * @author graemerocher
  * @since 3.1.0
  */
-public interface RefreshEventListener extends ApplicationEventListener<RefreshEvent> {
+public interface RefreshEventListener extends ApplicationEventListener<RefreshEvent>, Ordered {
+
+    /**
+     * The default position as defined by {@link io.micronaut.core.order.Ordered#getOrder()}
+     */
+    int DEFAULT_POSITION = Ordered.HIGHEST_PRECEDENCE + 200;
+
     @Override
     default boolean supports(RefreshEvent event) {
         if (event != null) {
@@ -57,4 +64,10 @@ public interface RefreshEventListener extends ApplicationEventListener<RefreshEv
      */
     @NonNull
     Set<String> getObservedConfigurationPrefixes();
+
+    @Override
+    default int getOrder() {
+        // run after configuration properties refresh
+        return DEFAULT_POSITION;
+    }
 }

--- a/context/src/test/groovy/io/micronaut/runtime/context/scope/refresh/RefreshEventListenerSpec.groovy
+++ b/context/src/test/groovy/io/micronaut/runtime/context/scope/refresh/RefreshEventListenerSpec.groovy
@@ -1,0 +1,73 @@
+package io.micronaut.runtime.context.scope.refresh
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.env.Environment
+import io.micronaut.context.env.PropertySource
+import io.micronaut.context.event.ApplicationEventPublisher
+import io.micronaut.core.type.Argument
+import jakarta.inject.Singleton
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class RefreshEventListenerSpec extends Specification {
+    @Shared Map<String, Object> config = ['foo.bar': 'initial-value']
+    @Shared @AutoCleanup ApplicationContext context = ApplicationContext
+            .builder()
+            .propertySources(PropertySource.of(config))
+            .start()
+
+    void 'test refresh event listener'() {
+        given:
+        def env = context.getEnvironment()
+        MyRefreshListener listener = context.getBean(MyRefreshListener)
+
+        when:
+        def val = env.getRequiredProperty("foo.bar", String)
+
+        then:
+        val == 'initial-value'
+        !env.getProperty('some.other', String).isPresent()
+
+        when:
+        config.put('some.other', 'changed')
+        doRefresh(env)
+        val = env.getRequiredProperty("foo.bar", String)
+
+        then:
+        val == 'initial-value'
+        env.getProperty('some.other', String).isPresent()
+        listener.lastEvent == null
+
+        when:
+        config.put('foo.bar', 'changed')
+        doRefresh(env)
+        val = env.getRequiredProperty("foo.bar", String)
+
+        then:
+        val == 'changed'
+        env.getProperty('some.other', String).isPresent()
+        listener.lastEvent != null
+
+    }
+
+    private void doRefresh(Environment env) {
+        def diff = env.refreshAndDiff()
+        context.getBean(Argument.of(ApplicationEventPublisher, RefreshEvent))
+                .publishEvent(new RefreshEvent(diff))
+    }
+
+    @Singleton
+    static class MyRefreshListener implements RefreshEventListener {
+        RefreshEvent lastEvent
+        @Override
+        Set<String> getObservedConfigurationPrefixes() {
+            ['foo.bar']
+        }
+
+        @Override
+        void onApplicationEvent(RefreshEvent event) {
+            lastEvent = event
+        }
+    }
+}

--- a/http-client/src/test/groovy/io/micronaut/http/client/SslRefreshSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/SslRefreshSpec.groovy
@@ -1,0 +1,95 @@
+package io.micronaut.http.client
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.env.PropertySource
+import io.micronaut.context.event.ApplicationEventPublisher
+import io.micronaut.core.type.Argument
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.server.netty.NettyHttpRequest
+import io.micronaut.runtime.context.scope.refresh.RefreshEvent
+import io.micronaut.runtime.server.EmbeddedServer
+import io.netty.handler.ssl.SslHandler
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.security.cert.X509Certificate
+
+class SslRefreshSpec extends Specification {
+
+    @Shared List<String> ciphers = ['TLS_RSA_WITH_AES_128_CBC_SHA',
+                                    'TLS_RSA_WITH_AES_256_CBC_SHA',
+                                    'TLS_RSA_WITH_AES_128_GCM_SHA256',
+                                    'TLS_RSA_WITH_AES_256_GCM_SHA384',
+                                    'TLS_DHE_RSA_WITH_AES_128_GCM_SHA256',
+                                    'TLS_DHE_RSA_WITH_AES_256_GCM_SHA384',
+                                    'TLS_DHE_DSS_WITH_AES_128_GCM_SHA256',
+                                    'TLS_DHE_DSS_WITH_AES_256_GCM_SHA384']
+    @Shared Map<String, Object> config = [
+            'spec.name': 'SslRefreshSpec',
+            'micronaut.ssl.enabled': true,
+            'micronaut.server.ssl.client-authentication': 'NEED',
+            'micronaut.server.ssl.key-store.path': 'classpath:certs/server.p12',
+            'micronaut.server.ssl.key-store.password': 'secret',
+            'micronaut.server.ssl.trust-store.path': 'classpath:certs/truststore',
+            'micronaut.server.ssl.trust-store.password': 'secret',
+            'micronaut.server.ssl.ciphers': ciphers,
+            'micronaut.http.client.ssl.client-authentication': 'NEED',
+            'micronaut.http.client.ssl.key-store.path': 'classpath:certs/client1.p12',
+            'micronaut.http.client.ssl.key-store.password': 'secret'
+    ]
+    @Shared @AutoCleanup EmbeddedServer embeddedServer = ApplicationContext
+                                                            .builder()
+                                                            .propertySources(PropertySource.of(config))
+                                                            .run(EmbeddedServer)
+    @Shared @AutoCleanup HttpClient client = embeddedServer.applicationContext
+                                                        .createBean(HttpClient, embeddedServer.getURI())
+
+    void "test ssl refresh"() {
+        when:
+        def response = client.toBlocking().exchange(HttpRequest.GET('/ssl/refresh'), Map)
+
+        then:
+        response.status() == HttpStatus.OK
+        response.body().ciphers == ciphers
+        response.body().subjectDN == 'CN=test.example.com, OU=IT, O=Whatever, L=Munich, ST=Bavaria, C=DE, EMAILADDRESS=info@example.com'
+
+        when:
+        config.putAll(  'micronaut.server.ssl.key-store.path': 'classpath:keystore.p12',
+                        'micronaut.server.ssl.key-store.password': 'foobar',
+                        'micronaut.server.ssl.key-store.type': 'PKCS12',
+                        'micronaut.server.ssl.ciphers': ciphers[0..4])
+        def diff = embeddedServer.applicationContext.environment.refreshAndDiff()
+        embeddedServer.applicationContext
+                .getBean(Argument.of(ApplicationEventPublisher, RefreshEvent))
+                .publishEvent(new RefreshEvent(diff))
+        response = client.toBlocking().exchange(HttpRequest.GET('/ssl/refresh'), Map)
+
+        then:
+        response.status() == HttpStatus.OK
+        response.body().ciphers == ciphers[0..4]
+        response.body().subjectDN == 'CN=example.local, OU=IT Department, O=Global Security, L=London, ST=London, C=GB'
+    }
+
+    @Controller("/ssl/refresh")
+    @Requires(property = 'spec.name',value = 'SslRefreshSpec')
+    static class TestSslRefresh {
+        @Get
+        HttpResponse<Map<String, Object>> test(HttpRequest request) {
+            def pipeline = (request as NettyHttpRequest).getChannelHandlerContext().pipeline()
+            def sslHandler = pipeline.get(SslHandler)
+
+            def engine = sslHandler.engine()
+            X509Certificate cert = engine.getSession().getLocalCertificates()[0]
+            return HttpResponse.ok([
+                    ciphers: engine.enabledCipherSuites,
+                    subjectDN: cert.subjectDN.toString()
+            ] as Map<String, Object>)
+        }
+    }
+}

--- a/management/src/main/java/io/micronaut/management/endpoint/refresh/RefreshEndpoint.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/refresh/RefreshEndpoint.java
@@ -38,13 +38,13 @@ import java.util.Set;
 public class RefreshEndpoint {
 
     private final Environment environment;
-    private final ApplicationEventPublisher eventPublisher;
+    private final ApplicationEventPublisher<RefreshEvent> eventPublisher;
 
     /**
      * @param environment    The Environment
-     * @param eventPublisher The Application event publiser
+     * @param eventPublisher The Application event publisher
      */
-    public RefreshEndpoint(Environment environment, ApplicationEventPublisher eventPublisher) {
+    public RefreshEndpoint(Environment environment, ApplicationEventPublisher<RefreshEvent> eventPublisher) {
         this.environment = environment;
         this.eventPublisher = eventPublisher;
     }

--- a/src/main/docs/guide/httpServer/serverConfiguration/https.adoc
+++ b/src/main/docs/guide/httpServer/serverConfiguration/https.adoc
@@ -106,3 +106,31 @@ micronaut:
 ----
 
 Start Micronaut, and the application will run on `https://localhost:8443` using the certificate in the keystore.
+
+== Refreshing/Reloading HTTPS Certificates
+
+Keeping HTTPS certificates up-to-date after expiry can be a challenge. A great solution to this is https://en.wikipedia.org/wiki/Automated_Certificate_Management_Environment[Automated Certificate Management Environment] (ACME) and the https://micronaut-projects.github.io/micronaut-acme/latest/guide/index.html[Micronaut ACME Module] which provides support for automatically refreshing certificates from a certificate authority.
+
+If the use of a certificate authority is not possible and you need to manually update certificates from disk then you should fire a api:runtime.context.scope.refresh.RefreshEvent[] using Micronaut's support for <<events, Application Events>> containing the keys where your HTTPS configuration is defined and Micronaut will reload the certificates from disk and apply the new configuration to the server.
+
+NOTE: You can also use the <<refreshEndpoint, Refresh Management Endpoint>>, however this will only apply if the physical location of certificate on disk has changed
+
+For example the following will reload the previously listed HTTPS configuration from disk and apply it to new incoming requests (this code could run for a <<scheduling, scheduled job>> that polled certificates for changes for example):
+
+.Manually Refreshing HTTPS configuration
+[source,java]
+----
+import jakarta.inject.Inject;
+import io.micronaut.context.event.ApplicationEventPublisher;
+import io.micronaut.runtime.context.scope.refresh.RefreshEvent;
+import java.util.Collections;
+...
+
+@Inject ApplicationEventPublisher<RefreshEvent> eventPublisher;
+
+...
+
+eventPublisher.publishEvent(new RefreshEvent(
+    Collections.singletonMap("micronaut.ssl", "*")
+));
+----


### PR DESCRIPTION
* Introduces a new `RefreshEventListener` interface to simplify writing listeners
* Makes refresh event processing in RefreshScope synchronous otherwise multiple ordered listeners not possible
* Rebuilds the server SSL context and handlers when configuration changes

Fixes #6112