### PR TITLE
DefaultHttpHostResolver should not return port -1 when HOST header is missing (#6139)

### DIFF
--- a/http-server/src/main/java/io/micronaut/http/server/util/DefaultHttpHostResolver.java
+++ b/http-server/src/main/java/io/micronaut/http/server/util/DefaultHttpHostResolver.java
@@ -121,7 +121,11 @@ public class DefaultHttpHostResolver implements HttpHostResolver {
 
         URI uri = request.getUri();
         if (uri.getHost() != null) {
-            return createHost(uri.getScheme(), uri.getHost(), uri.getPort());
+            Integer port = uri.getPort();
+            if (port < 0) {
+                port = null;
+            }
+            return createHost(uri.getScheme(), uri.getHost(), port);
         }
 
         return getEmbeddedHost();

--- a/http-server/src/test/groovy/io/micronaut/http/server/util/DefaultHttpHostResolverSpec.groovy
+++ b/http-server/src/test/groovy/io/micronaut/http/server/util/DefaultHttpHostResolverSpec.groovy
@@ -18,4 +18,16 @@ class DefaultHttpHostResolverSpec extends Specification {
         hostResolver.resolve(request) == "http://localhost"
         hostResolver.resolve(null) == "http://localhost"
     }
+
+    void "test host resolver with no headers and no embedded server with a full url"() {
+        ApplicationContext applicationContext = ApplicationContext.run()
+        HttpHostResolver hostResolver = applicationContext.getBean(HttpHostResolver)
+        def request = Stub(HttpRequest) {
+            getHeaders() >> new MockHttpHeaders([:])
+            getUri() >> new URI("https://www.example.com/test")
+        }
+
+        expect:
+        hostResolver.resolve(request) == "https://www.example.com"
+    }
 }


### PR DESCRIPTION
Fixes issue (#6139) with the DefaultHttpHostResolver returning port -1 when there is no HOST header set e.g.  "https://www.example.com:-1".