### PR TITLE
Fix infinite loop when requesting demand in SingleThreadedBufferingSubscriber

### DIFF
--- a/core-reactive/src/test/groovy/io/micronaut/core/async/subscriber/SingleThreadedBufferingSubscriberSpec.groovy
+++ b/core-reactive/src/test/groovy/io/micronaut/core/async/subscriber/SingleThreadedBufferingSubscriberSpec.groovy
@@ -1,0 +1,53 @@
+package io.micronaut.core.async.subscriber
+
+import org.reactivestreams.Subscription
+import spock.lang.Specification
+import spock.lang.Timeout
+
+class SingleThreadedBufferingSubscriberSpec extends Specification {
+    // this timeout doesn't actually work, because it only calls .interrupt() which SingleThreadedBufferingSubscriber
+    // doesn't handle, but it at least prints a message.
+    @Timeout(10)
+    def 'receive demand in buffering state'() {
+        given:
+        def seen = new ArrayList<String>()
+        def subscriber = new SingleThreadedBufferingSubscriber<String>() {
+            @Override
+            protected void doOnSubscribe(Subscription subscription) {
+            }
+
+            @Override
+            protected void doOnNext(String message) {
+                seen.add(message)
+            }
+
+            @Override
+            protected void doOnError(Throwable t) {
+            }
+
+            @Override
+            protected void doOnComplete() {
+            }
+        }
+        def downstreamSubscription = subscriber.newDownstreamSubscription()
+        subscriber.onSubscribe(new Subscription() {
+            @Override
+            void request(long n) {
+            }
+
+            @Override
+            void cancel() {
+            }
+        })
+
+        when:
+        subscriber.onNext('foo')
+        then:
+        seen == []
+
+        when:
+        downstreamSubscription.request(1)
+        then:
+        seen == ['foo']
+    }
+}


### PR DESCRIPTION
I found this issue when debugging #6100. It is definitely a bug, but I am not sure yet how important it is to that issue.

Before this patch, requesting data from a `SingleThreadedBufferingSubscriber` when it is in `BUFFERING` state would cause an infinite loop. 

`request` first registers the new demand, and then calls `flushBuffer` to fulfill some of the new demand using currently buffered data. If there was no previous demand, this happens in `BUFFERING` state. `flushBuffer` then tries to remove data from the buffer and submit it using `onNext`, until the buffer is empty or there is no more demand. However, in `BUFFERING` state, `onNext` simply readds the data to the buffer and does not touch the demand, so this is an infinite loop.

This fix extracts the "forwarding logic" in `onNext` to its own method, that does not consider the current state. `flushBuffer` now uses that method instead of `onNext`.