### PR TITLE
Use nanoTime for durations

### DIFF
--- a/context/src/main/java/io/micronaut/runtime/Micronaut.java
+++ b/context/src/main/java/io/micronaut/runtime/Micronaut.java
@@ -36,6 +36,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 /**
@@ -62,7 +63,7 @@ public class Micronaut extends DefaultApplicationContextBuilder implements Appli
      */
     @Override
     public @NonNull ApplicationContext start() {
-        long start = System.currentTimeMillis();
+        long start = System.nanoTime();
         printBanner();
         ApplicationContext applicationContext = super.build();
 
@@ -79,8 +80,7 @@ public class Micronaut extends DefaultApplicationContextBuilder implements Appli
                     boolean keepAlive = false;
                     if (embeddedApplication instanceof Described) {
                         if (LOG.isInfoEnabled()) {
-                            long end = System.currentTimeMillis();
-                            long took = end - start;
+                            long took = elapsedMillis(start);
                             String desc = ((Described) embeddedApplication).getDescription();
                             LOG.info("Startup completed in {}ms. Server Running: {}", took, desc);
                         }
@@ -90,16 +90,14 @@ public class Micronaut extends DefaultApplicationContextBuilder implements Appli
 
                             final EmbeddedServer embeddedServer = (EmbeddedServer) embeddedApplication;
                             if (LOG.isInfoEnabled()) {
-                                long end = System.currentTimeMillis();
-                                long took = end - start;
+                                long took = elapsedMillis(start);
                                 URL url = embeddedServer.getURL();
                                 LOG.info("Startup completed in {}ms. Server Running: {}", took, url);
                             }
                             keepAlive = embeddedServer.isKeepAlive();
                         } else {
                             if (LOG.isInfoEnabled()) {
-                                long end = System.currentTimeMillis();
-                                long took = end - start;
+                                long took = elapsedMillis(start);
                                 LOG.info("Startup completed in {}ms.", took);
                             }
                             keepAlive = embeddedApplication.isServer();
@@ -161,6 +159,10 @@ public class Micronaut extends DefaultApplicationContextBuilder implements Appli
             handleStartupException(applicationContext.getEnvironment(), e);
             return null;
         }
+    }
+
+    private static long elapsedMillis(long startNanos) {
+        return TimeUnit.MILLISECONDS.convert(System.nanoTime() - startNanos, TimeUnit.NANOSECONDS);
     }
 
     @Override


### PR DESCRIPTION
The previous code was using `System.currentTimeMillis()` for time
measurement but this method is not guaranteed to be monotonic. For
duration measurements on a single VM, the `nanoTime()` method should
be used instead.