### PR TITLE
Do not forward onComplete before all elements have been processed

### DIFF
--- a/core-reactive/src/test/groovy/io/micronaut/core/async/subscriber/SingleThreadedBufferingSubscriberSpec.groovy
+++ b/core-reactive/src/test/groovy/io/micronaut/core/async/subscriber/SingleThreadedBufferingSubscriberSpec.groovy
@@ -50,4 +50,59 @@ class SingleThreadedBufferingSubscriberSpec extends Specification {
         then:
         seen == ['foo']
     }
+
+    def 'completion does not drop remaining buffered data'() {
+        given:
+        def seen = new ArrayList<String>()
+        def completed = false
+        def subscriber = new SingleThreadedBufferingSubscriber<String>() {
+            @Override
+            protected void doOnSubscribe(Subscription subscription) {
+            }
+
+            @Override
+            protected void doOnNext(String message) {
+                seen.add(message)
+            }
+
+            @Override
+            protected void doOnError(Throwable t) {
+            }
+
+            @Override
+            protected void doOnComplete() {
+                completed = true
+            }
+        }
+        def downstreamSubscription = subscriber.newDownstreamSubscription()
+        subscriber.onSubscribe(new Subscription() {
+            @Override
+            void request(long n) {
+            }
+
+            @Override
+            void cancel() {
+            }
+        })
+
+        when:
+        subscriber.onNext('foo')
+        downstreamSubscription.request(1)
+        then:
+        seen == ['foo']
+        !completed
+
+        when:
+        subscriber.onNext('bar')
+        subscriber.onComplete()
+        then:
+        seen == ['foo']
+        !completed
+
+        when:
+        downstreamSubscription.request(1)
+        then:
+        seen == ['foo', 'bar']
+        completed
+    }
 }


### PR DESCRIPTION
This fixes another issue that I believe to be a bug with `SingleThreadedBufferingSubscriber`: Even if `onComplete` arrives before all data has been requested by the downstream (i.e. when we're buffering), the `onComplete` would be forwarded immediately and the buffered elements would be dropped (`processDemand` does nothing in state `DONE`).

This patch delays the `doOnComplete` call until all elements have been flushed.

Unlike #6147, which was clearly a bug, this patch is technically a behavior change. But it seems like the behavior implementors would expect.