### PR TITLE
Replace use of @Overrides with caching

### DIFF
--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -270,6 +270,7 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
             } finally {
                 AnnotationUtils.invalidateCache();
                 AbstractAnnotationMetadataBuilder.clearMutated();
+                JavaAnnotationMetadataBuilder.clearCaches();
             }
         }
 

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/JavaAnnotationMetadataBuilder.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/JavaAnnotationMetadataBuilder.java
@@ -21,6 +21,7 @@ import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
+import io.micronaut.core.util.clhm.ConcurrentLinkedHashMap;
 import io.micronaut.core.value.OptionalValues;
 import io.micronaut.inject.annotation.AbstractAnnotationMetadataBuilder;
 import io.micronaut.inject.annotation.AnnotatedElementValidator;
@@ -35,7 +36,9 @@ import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.AbstractAnnotationValueVisitor8;
+import javax.lang.model.util.ElementFilter;
 import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
 import javax.tools.Diagnostic;
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Inherited;
@@ -45,7 +48,6 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.Array;
 import java.util.*;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * A {@link io.micronaut.core.annotation.AnnotationMetadata} for builder for Java to be used at compile time.
@@ -56,6 +58,7 @@ import java.util.stream.Stream;
 public class JavaAnnotationMetadataBuilder extends AbstractAnnotationMetadataBuilder<Element, AnnotationMirror> {
 
     private static final Map<String, Map<Element, javax.lang.model.element.AnnotationValue>> ANNOTATION_DEFAULTS = new HashMap<>();
+    private static final Map<ExecutableElement, List<ExecutableElement>> OVERRIDDEN_METHOD_CACHE = new ConcurrentLinkedHashMap.Builder<ExecutableElement, List<ExecutableElement>>().maximumWeightedCapacity(100).build();
 
     private final Elements elementUtils;
     private final Messager messager;
@@ -265,9 +268,7 @@ public class JavaAnnotationMetadataBuilder extends AbstractAnnotationMetadataBui
             } else {
                 hierarchy = new ArrayList<>();
             }
-            if (hasAnnotation(executableElement, Override.class)) {
-                hierarchy.addAll(findOverriddenMethods(executableElement));
-            }
+            hierarchy.addAll(findOverriddenMethods(executableElement));
             hierarchy.add(element);
             return hierarchy;
         } else if (element instanceof VariableElement) {
@@ -276,11 +277,9 @@ public class JavaAnnotationMetadataBuilder extends AbstractAnnotationMetadataBui
             Element enclosingElement = variable.getEnclosingElement();
             if (enclosingElement instanceof ExecutableElement) {
                 ExecutableElement executableElement = (ExecutableElement) enclosingElement;
-                if (hasAnnotation(executableElement, Override.class)) {
-                    int variableIdx = executableElement.getParameters().indexOf(variable);
-                    for (ExecutableElement overridden: findOverriddenMethods(executableElement)) {
-                        hierarchy.add(overridden.getParameters().get(variableIdx));
-                    }
+                int variableIdx = executableElement.getParameters().indexOf(variable);
+                for (ExecutableElement overridden: findOverriddenMethods(executableElement)) {
+                    hierarchy.add(overridden.getParameters().get(variableIdx));
                 }
             }
             hierarchy.add(variable);
@@ -455,14 +454,15 @@ public class JavaAnnotationMetadataBuilder extends AbstractAnnotationMetadataBui
 
     private void populateTypeHierarchy(Element element, List<Element> hierarchy) {
         final boolean isInterface = JavaModelUtils.resolveKind(element, ElementKind.INTERFACE).isPresent();
+        final Types typeUtils = modelUtils.getTypeUtils();
         if (isInterface) {
             TypeElement typeElement = (TypeElement) element;
             List<? extends TypeMirror> interfaces = typeElement.getInterfaces();
             for (TypeMirror anInterface : interfaces) {
-                if (anInterface instanceof DeclaredType) {
-                    Element interfaceElement = ((DeclaredType) anInterface).asElement();
-                    hierarchy.add(interfaceElement);
-                    populateTypeHierarchy(interfaceElement, hierarchy);
+                final Element e = typeUtils.asElement(anInterface);
+                if (e != null) {
+                    hierarchy.add(e);
+                    populateTypeHierarchy(e, hierarchy);
                 }
             }
         } else  {
@@ -493,53 +493,50 @@ public class JavaAnnotationMetadataBuilder extends AbstractAnnotationMetadataBui
         }
     }
 
-    private List<ExecutableElement> findOverriddenMethods(ExecutableElement executableElement) {
-        List<ExecutableElement> overridden = new ArrayList<>();
-        Element enclosingElement = executableElement.getEnclosingElement();
-        if (enclosingElement instanceof TypeElement) {
-            TypeElement supertype = (TypeElement) enclosingElement;
-            while (supertype != null && !supertype.toString().equals(Object.class.getName())) {
-                Optional<ExecutableElement> result = findOverridden(executableElement, supertype);
-                if (result.isPresent()) {
-                    ExecutableElement overriddenMethod = result.get();
-                    overridden.add(overriddenMethod);
+    private List<ExecutableElement> findOverriddenMethods(ExecutableElement sourceMethod) {
+        return OVERRIDDEN_METHOD_CACHE.computeIfAbsent(sourceMethod, executableElement -> {
+            List<ExecutableElement> overridden = new ArrayList<>(3);
+            Element enclosingElement = executableElement.getEnclosingElement();
+            if (enclosingElement instanceof TypeElement) {
+                TypeElement declaringElement = (TypeElement) enclosingElement;
+                final Set<TypeElement> allInterfaces = modelUtils.getAllInterfaces(declaringElement);
+                for (TypeElement itfe : allInterfaces) {
+                    addOverriddenMethodIfNecessary(executableElement, overridden, declaringElement, itfe);
                 }
-                findOverriddenInterfaceMethod(executableElement, overridden, supertype);
-                TypeMirror superclass = supertype.getSuperclass();
-                if (superclass instanceof DeclaredType) {
-                    supertype = (TypeElement) ((DeclaredType) superclass).asElement();
-                } else {
-                    break;
+                final Types typeUtils = modelUtils.getTypeUtils();
+                TypeElement supertype = toTypeElement(declaringElement.getSuperclass(), typeUtils);
+                while (supertype != null && !supertype.toString().equals(Object.class.getName())) {
+                    addOverriddenMethodIfNecessary(executableElement, overridden, declaringElement, supertype);
+                    supertype = toTypeElement(supertype.getSuperclass(), typeUtils);
                 }
+
             }
-        }
-        return overridden;
+            return overridden;
+        });
+
     }
 
-    private void findOverriddenInterfaceMethod(ExecutableElement executableElement, List<ExecutableElement> overridden, TypeElement supertype) {
-        Optional<ExecutableElement> result;
-        List<? extends TypeMirror> interfaces = supertype.getInterfaces();
-
-        for (TypeMirror anInterface : interfaces) {
-            if (anInterface instanceof DeclaredType) {
-                DeclaredType iElement = (DeclaredType) anInterface;
-                TypeElement interfaceElement = (TypeElement) iElement.asElement();
-                result = findOverridden(executableElement, interfaceElement);
-                if (result.isPresent()) {
-                    overridden.add(result.get());
-                } else {
-                    findOverriddenInterfaceMethod(executableElement, overridden, interfaceElement);
-                }
+    private void addOverriddenMethodIfNecessary(ExecutableElement executableElement,
+                           List<ExecutableElement> overridden,
+                           TypeElement declaringElement,
+                           TypeElement supertype) {
+        final List<ExecutableElement> possibleMethods =
+                ElementFilter.methodsIn(supertype.getEnclosedElements());
+        for (ExecutableElement possibleMethod : possibleMethods) {
+            if (elementUtils.overrides(executableElement, possibleMethod, declaringElement)) {
+                overridden.add(possibleMethod);
             }
         }
     }
 
-    private Optional<ExecutableElement> findOverridden(ExecutableElement executableElement, TypeElement supertype) {
-        Stream<? extends Element> elements = supertype.getEnclosedElements().stream();
-        return elements.filter(el -> el.getKind() == ElementKind.METHOD && el.getEnclosingElement().equals(supertype))
-                .map(el -> (ExecutableElement) el)
-                .filter(method -> elementUtils.overrides(executableElement, method, (TypeElement) method.getEnclosingElement()))
-                .findFirst();
+    private TypeElement toTypeElement(TypeMirror mirror, Types typeUtils) {
+        if (mirror != null) {
+            final Element e = typeUtils.asElement(mirror);
+            if (e instanceof TypeElement) {
+                return (TypeElement) e;
+            }
+        }
+        return null;
     }
 
     /**
@@ -578,6 +575,13 @@ public class JavaAnnotationMetadataBuilder extends AbstractAnnotationMetadataBui
     @Override
     protected boolean hasAnnotations(Element element) {
         return CollectionUtils.isNotEmpty(element.getAnnotationMirrors());
+    }
+
+    /**
+     * Clears any caches from the last compilation round.
+     */
+    public static void clearCaches() {
+        OVERRIDDEN_METHOD_CACHE.clear();
     }
 
     /**

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/ModelUtils.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/ModelUtils.java
@@ -467,15 +467,14 @@ public class ModelUtils {
      */
     @SuppressWarnings("Duplicates")
     private Set<TypeElement> populateInterfaces(TypeElement aClass, Set<TypeElement> interfaces) {
-        Set<TypeElement> theInterfaces = aClass.getInterfaces()
-                .stream().map(typeUtils::asElement)
-                .filter(e -> e instanceof TypeElement)
-                .map(TypeElement.class::cast)
-                .collect(Collectors.toSet());
-        interfaces.addAll(theInterfaces);
-        for (TypeElement theInterface : theInterfaces) {
-            if (!interfaces.contains(theInterface)) {
-                populateInterfaces(theInterface, interfaces);
+        for (TypeMirror anInterface : aClass.getInterfaces()) {
+            final Element e = typeUtils.asElement(anInterface);
+            if (e instanceof TypeElement) {
+                final TypeElement te = (TypeElement) e;
+                if (!interfaces.contains(te)) {
+                    interfaces.add(te);
+                    populateInterfaces(te, interfaces);
+                }
             }
         }
         if (aClass.getKind() != ElementKind.INTERFACE) {

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/ModelUtils.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/ModelUtils.java
@@ -33,7 +33,6 @@ import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 import java.util.*;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static javax.lang.model.element.Modifier.*;
 import static javax.lang.model.type.TypeKind.NONE;
@@ -468,37 +467,25 @@ public class ModelUtils {
      */
     @SuppressWarnings("Duplicates")
     private Set<TypeElement> populateInterfaces(TypeElement aClass, Set<TypeElement> interfaces) {
-        List<? extends TypeMirror> theInterfaces = aClass.getInterfaces();
-        interfaces.addAll(theInterfaces.stream().flatMap(tm -> {
-            TypeMirror erased = typeUtils.erasure(tm);
-            if (erased instanceof DeclaredType) {
-                Element e = ((DeclaredType) erased).asElement();
-                if (e instanceof TypeElement) {
-                    return Stream.of((TypeElement) e);
-                }
-            }
-            return Stream.empty();
-        }).collect(Collectors.toSet()));
-        for (TypeMirror theInterface : theInterfaces) {
-            TypeMirror erased = typeUtils.erasure(theInterface);
-            if (erased instanceof DeclaredType) {
-                Element e = ((DeclaredType) erased).asElement();
-                if (e instanceof TypeElement) {
-                    populateInterfaces(((TypeElement) e), interfaces);
-                }
+        Set<TypeElement> theInterfaces = aClass.getInterfaces()
+                .stream().map(typeUtils::asElement)
+                .filter(e -> e instanceof TypeElement)
+                .map(TypeElement.class::cast)
+                .collect(Collectors.toSet());
+        interfaces.addAll(theInterfaces);
+        for (TypeElement theInterface : theInterfaces) {
+            if (!interfaces.contains(theInterface)) {
+                populateInterfaces(theInterface, interfaces);
             }
         }
         if (aClass.getKind() != ElementKind.INTERFACE) {
             TypeMirror superclass = aClass.getSuperclass();
             while (superclass != null) {
-                TypeMirror erased = typeUtils.erasure(superclass);
-                if (erased instanceof DeclaredType) {
-                    Element e = ((DeclaredType) erased).asElement();
-                    if (e instanceof TypeElement) {
-                        TypeElement superTypeElement = (TypeElement) e;
-                        populateInterfaces(superTypeElement, interfaces);
-                        superclass = superTypeElement.getSuperclass();
-                    }
+                final Element e = typeUtils.asElement(superclass);
+                if (e instanceof TypeElement) {
+                    TypeElement superTypeElement = (TypeElement) e;
+                    populateInterfaces(superTypeElement, interfaces);
+                    superclass = superTypeElement.getSuperclass();
                 } else {
                     break;
                 }


### PR DESCRIPTION
The root cause of #6158 is that incremental compilation doesn't work properly with source retention annotations. The reason for this is that Gradle materializes an element from compiled byte code when compiling incrementally and this element no longer has the source level annotations like `@Overrides`.

This is a bummer since it means that source level annotations cannot be used in general with incremental compilation. I am not sure if we should be printing warnings if incremental is enabled and any source level retention annotations are used.

Nevertheless we were relying on `@Overrides` to detect when to inherit annotations so when compiling incrementally these annotations disappeared from the incremental result.

The fix here replaces the reliance of `@Overrides` with a cache and optimizes the code to be more performant. This cache is cleared at the end of each compilation round to ensure it is not stale.

Fixes #6158 