### PR TITLE
Fix reactor instrumentation

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -507,6 +507,7 @@ kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-c
 kotlinx-coroutines-jdk8 = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8", version.ref = "kotlin-coroutines" }
 kotlinx-coroutines-reactive = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-reactive", version.ref = "kotlin-coroutines" }
 kotlinx-coroutines-rx2 = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-rx2", version.ref = "kotlin-coroutines" }
+kotlinx-coroutines-slf4j = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-slf4j", version.ref = "kotlin-coroutines" }
 
 log4j = { module = "org.apache.logging.log4j:log4j-core", version.ref = "log4j" }
 

--- a/runtime/src/main/java/io/micronaut/reactive/reactor/instrument/ReactorInstrumentation.java
+++ b/runtime/src/main/java/io/micronaut/reactive/reactor/instrument/ReactorInstrumentation.java
@@ -15,7 +15,6 @@
  */
 package io.micronaut.reactive.reactor.instrument;
 
-import io.micronaut.context.BeanContext;
 import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.env.Environment;
@@ -26,6 +25,8 @@ import io.micronaut.scheduling.instrument.Instrumentation;
 import io.micronaut.scheduling.instrument.InvocationInstrumenter;
 import io.micronaut.scheduling.instrument.ReactiveInvocationInstrumenterFactory;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Hooks;
+import reactor.core.publisher.Operators;
 import reactor.core.scheduler.Schedulers;
 
 import javax.annotation.PostConstruct;
@@ -47,14 +48,13 @@ class ReactorInstrumentation {
     /**
      * Initialize instrumentation for reactor with the tracer and factory.
      *
-     * @param beanContext   The bean context
      * @param instrumenterFactory The instrumenter factory
      */
     @SuppressWarnings("unchecked")
     @PostConstruct
-    void init(BeanContext beanContext, ReactorInstrumenterFactory instrumenterFactory) {
-        Schedulers.onScheduleHook("reactor-micronaut-instrumentation", runnable -> {
-            if (instrumenterFactory.hasInstrumenters()) {
+    void init(ReactorInstrumenterFactory instrumenterFactory) {
+        if (instrumenterFactory.hasInstrumenters()) {
+            Schedulers.onScheduleHook("reactor-micronaut-instrumentation", runnable -> {
                 InvocationInstrumenter instrumenter = instrumenterFactory.create();
                 if (instrumenter != null) {
                     return () -> {
@@ -63,9 +63,19 @@ class ReactorInstrumentation {
                         }
                     };
                 }
-            }
-            return runnable;
-        });
+                return runnable;
+            });
+            Hooks.onEachOperator(Environment.MICRONAUT, Operators.lift((scannable, coreSubscriber) -> {
+                if (coreSubscriber instanceof ReactorSubscriber) {
+                    return coreSubscriber;
+                }
+                InvocationInstrumenter instrumenter = instrumenterFactory.create();
+                if (instrumenter != null) {
+                    return new ReactorSubscriber<>(instrumenter, coreSubscriber);
+                }
+                return coreSubscriber;
+            }));
+        }
     }
 
     /**
@@ -74,6 +84,7 @@ class ReactorInstrumentation {
     @PreDestroy
     void removeInstrumentation() {
         Schedulers.removeExecutorServiceDecorator(Environment.MICRONAUT);
+        Hooks.resetOnEachOperator(Environment.MICRONAUT);
     }
 
 

--- a/runtime/src/main/java/io/micronaut/reactive/reactor/instrument/ReactorInstrumentation.java
+++ b/runtime/src/main/java/io/micronaut/reactive/reactor/instrument/ReactorInstrumentation.java
@@ -54,7 +54,7 @@ class ReactorInstrumentation {
     @PostConstruct
     void init(ReactorInstrumenterFactory instrumenterFactory) {
         if (instrumenterFactory.hasInstrumenters()) {
-            Schedulers.onScheduleHook("reactor-micronaut-instrumentation", runnable -> {
+            Schedulers.onScheduleHook(Environment.MICRONAUT, runnable -> {
                 InvocationInstrumenter instrumenter = instrumenterFactory.create();
                 if (instrumenter != null) {
                     return () -> {

--- a/runtime/src/main/java/io/micronaut/reactive/reactor/instrument/ReactorSubscriber.java
+++ b/runtime/src/main/java/io/micronaut/reactive/reactor/instrument/ReactorSubscriber.java
@@ -39,7 +39,8 @@ final class ReactorSubscriber<T> implements CoreSubscriber<T> {
         this.subscriber = subscriber;
     }
 
-    public Context getContext() {
+    @Override
+    public Context currentContext() {
         return subscriber.currentContext();
     }
 

--- a/runtime/src/main/java/io/micronaut/reactive/reactor/instrument/ReactorSubscriber.java
+++ b/runtime/src/main/java/io/micronaut/reactive/reactor/instrument/ReactorSubscriber.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.reactive.reactor.instrument;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.scheduling.instrument.Instrumentation;
+import io.micronaut.scheduling.instrument.InvocationInstrumenter;
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+import reactor.util.context.Context;
+
+/**
+ * An {@link CoreSubscriber} with a support of instrumentation.
+ *
+ * @param <T> The type
+ * @author Denis Stepanov
+ * @since 3.1
+ */
+@Internal
+final class ReactorSubscriber<T> implements CoreSubscriber<T> {
+    private final InvocationInstrumenter instrumenter;
+    private final CoreSubscriber<? super T> subscriber;
+
+    public ReactorSubscriber(InvocationInstrumenter instrumenter, CoreSubscriber<? super T> subscriber) {
+        this.instrumenter = instrumenter;
+        this.subscriber = subscriber;
+    }
+
+    public Context getContext() {
+        return subscriber.currentContext();
+    }
+
+    @Override
+    public void onSubscribe(Subscription s) {
+        try (Instrumentation ignore = instrumenter.newInstrumentation()) {
+            subscriber.onSubscribe(s);
+        }
+    }
+
+    @Override
+    public void onNext(T t) {
+        try (Instrumentation ignore = instrumenter.newInstrumentation()) {
+            subscriber.onNext(t);
+        }
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        try (Instrumentation ignore = instrumenter.newInstrumentation()) {
+            subscriber.onError(t);
+        }
+    }
+
+    @Override
+    public void onComplete() {
+        try (Instrumentation ignore = instrumenter.newInstrumentation()) {
+            subscriber.onComplete();
+        }
+    }
+}

--- a/test-suite-kotlin/build.gradle
+++ b/test-suite-kotlin/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     testImplementation project(":context")
     testImplementation libs.kotlin.test
     testImplementation libs.kotlinx.coroutines.rx2
+    testImplementation libs.kotlinx.coroutines.slf4j
 
     // Adding these for now since micronaut-test isnt resolving correctly ... probably need to upgrade gradle there too
     testImplementation libs.junit.jupiter.api

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/MdcPropagationSpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/MdcPropagationSpec.kt
@@ -20,6 +20,8 @@ import io.micronaut.runtime.server.EmbeddedServer
 import jakarta.inject.Singleton
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.single
+import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.reactive.awaitFirst
 import kotlinx.coroutines.slf4j.MDCContext
 import kotlinx.coroutines.withContext
@@ -29,6 +31,7 @@ import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
+import reactor.core.publisher.toFlux
 import java.net.URI
 import java.util.*
 
@@ -121,7 +124,7 @@ class NamingClient(@Client(id = "/") private val client: HttpClient) {
                 header("X-TrackingId", trackingId)
             }
 
-            client.exchange(request, String::class.java).awaitFirst()
+            client.exchange(request, String::class.java).asFlow().single()
         }
     }
 }

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/MdcPropagationSpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/MdcPropagationSpec.kt
@@ -1,0 +1,173 @@
+package io.micronaut
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.core.order.Ordered
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MutableHttpRequest
+import io.micronaut.http.MutableHttpResponse
+import io.micronaut.http.annotation.*
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.filter.ClientFilterChain
+import io.micronaut.http.filter.HttpClientFilter
+import io.micronaut.http.filter.HttpServerFilter
+import io.micronaut.http.filter.ServerFilterChain
+import io.micronaut.http.uri.UriBuilder
+import io.micronaut.runtime.server.EmbeddedServer
+import jakarta.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.reactive.awaitFirst
+import kotlinx.coroutines.slf4j.MDCContext
+import kotlinx.coroutines.withContext
+import org.junit.jupiter.api.Test
+import org.reactivestreams.Publisher
+import org.slf4j.LoggerFactory
+import org.slf4j.MDC
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import java.net.URI
+import java.util.*
+
+class MdcPropagationSpec {
+
+    @Test
+    fun testKotlinPropagation() {
+        val embeddedServer = ApplicationContext.run(EmbeddedServer::class.java,
+                mapOf("mdc.reactortest.enabled" to "true" as Any)
+        )
+        val client = embeddedServer.applicationContext.getBean(HttpClient::class.java)
+
+        Flux.range(1, 1000)
+                .flatMap {
+                    val tracingId = UUID.randomUUID().toString()
+                    val get = HttpRequest.POST<Any>("http://localhost:${embeddedServer.port}/trigger", NameRequestBody("sss-" + tracingId)).header("X-TrackingId", tracingId)
+                    client.retrieve(get, String::class.java)
+                }
+                .collectList()
+                .block()
+
+        embeddedServer.stop()
+    }
+
+}
+
+@Requires(property = "mdc.reactortest.enabled")
+@Controller
+class GreetController {
+
+    @Get("/greet")
+    fun greet(@QueryValue("name") name: String) : String = "Hello $name!"
+}
+
+@Requires(property = "mdc.reactortest.enabled")
+@Controller
+class NamingController(private val namingService: NamingService ) {
+
+    @Post("/trigger")
+    suspend fun trigger(request: HttpRequest<*>, @Body requestBody: NameRequestBody) : HttpResponse<String> {
+        val trackingId = request.headers["X-TrackingId"] as String
+        checkTracing(trackingId)
+        return withContext(Dispatchers.IO + MDCContext()) {
+            checkTracing(trackingId)
+            namingService.withName(requestBody.name, trackingId)
+        }
+    }
+
+    private fun checkTracing(trackingId: String) {
+        val mdcTracingId = MDC.get(TRACKING_ID)
+        if (trackingId != mdcTracingId) {
+            throw IllegalArgumentException("TrackingIds do not match! Request: $trackingId vs. Context: $mdcTracingId")
+        }
+    }
+}
+@Introspected
+class NameRequestBody(val name: String)
+
+@Requires(property = "mdc.reactortest.enabled")
+@Singleton
+class NamingService(private val namingClient: NamingClient) {
+
+    suspend fun withName(name: String, trackingId: String): HttpResponse<String> {
+        val mdcTracingId = MDC.get(TRACKING_ID)
+        if (trackingId != mdcTracingId) {
+            throw IllegalArgumentException("TrackingIds do not match! Request: $trackingId vs. Context: $mdcTracingId")
+        }
+        return withContext(Dispatchers.IO){
+            delay(50) // "forcing" the initial thread (event loop) to suspend
+            namingClient.getFor(name, trackingId)
+        }
+    }
+}
+
+@Requires(property = "mdc.reactortest.enabled")
+@Singleton
+class NamingClient(@Client(id = "/") private val client: HttpClient) {
+
+    suspend fun getFor(name: String, trackingId: String): HttpResponse<String> {
+        val mdcTracingId = MDC.get(TRACKING_ID)
+        if (trackingId != mdcTracingId) {
+            throw IllegalArgumentException("TrackingIds do not match! Request: $trackingId vs. Context: $mdcTracingId")
+        }
+        return withContext(Dispatchers.IO) {
+            val uri: URI = UriBuilder.of("/greet")
+                    .queryParam("name", name)
+                    .build()
+
+            val request = HttpRequest.GET<String>(uri).apply {
+                header("X-TrackingId", trackingId)
+            }
+
+            client.exchange(request, String::class.java).awaitFirst()
+        }
+    }
+}
+
+
+@Requires(property = "mdc.reactortest.enabled")
+@Filter("/trigger")
+class HttpApplicationEnterFilter : HttpServerFilter {
+
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    override fun doFilter(request: HttpRequest<*>, chain: ServerFilterChain): Publisher<MutableHttpResponse<*>> {
+        val trackingId = request.headers["X-TrackingId"]
+        MDC.put(TRACKING_ID, trackingId)
+        logger.info("Application enter ($trackingId).")
+
+        return Mono.from(chain.proceed(request))
+                .doOnNext() {
+                    logger.info("Application exit ($trackingId).")
+                }
+    }
+}
+
+@Requires(property = "mdc.reactortest.enabled")
+@Filter("/greet")
+class HttpClientFilter : HttpClientFilter {
+
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    override fun getOrder(): Int {
+        return Ordered.HIGHEST_PRECEDENCE
+    }
+
+    override fun doFilter(request: MutableHttpRequest<*>, chain: ClientFilterChain): Publisher<out HttpResponse<*>> {
+        val trackingId: String = request.headers["X-TrackingId"] as String
+        val mdcTracingId = MDC.get(TRACKING_ID)
+        if (trackingId != mdcTracingId) {
+            throw IllegalArgumentException("TrackingIds do not match! Request: $trackingId vs. Context: $mdcTracingId")
+        }
+        return Mono.from(chain.proceed(request))
+                .doOnNext { logRemoteRequestStatus(it, trackingId) }
+    }
+
+    private fun logRemoteRequestStatus(response: HttpResponse<*>, trackingId: String) {
+        logger.info("Response Status {} was returned ({})", response.status.code, trackingId)
+    }
+}
+
+const val TRACKING_ID: String = "trackingId"

--- a/tracing/src/test/groovy/io/micronaut/tracing/instrument/util/MDCReactorSpec.groovy
+++ b/tracing/src/test/groovy/io/micronaut/tracing/instrument/util/MDCReactorSpec.groovy
@@ -1,0 +1,183 @@
+package io.micronaut.tracing.instrument.util
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.core.order.Ordered
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MutableHttpRequest
+import io.micronaut.http.MutableHttpResponse
+import io.micronaut.http.annotation.*
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.filter.ClientFilterChain
+import io.micronaut.http.filter.HttpClientFilter
+import io.micronaut.http.filter.HttpServerFilter
+import io.micronaut.http.filter.ServerFilterChain
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.annotation.ExecuteOn
+import jakarta.inject.Inject
+import org.reactivestreams.Publisher
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.slf4j.MDC
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import reactor.util.function.Tuple2
+import reactor.util.function.Tuples
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.time.Duration
+
+class MDCReactorSpec extends Specification {
+
+    static final Logger LOG = LoggerFactory.getLogger(MDCReactorSpec.class)
+
+    @Shared
+    @AutoCleanup
+    EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
+            'mdc.reactortest.enabled': true
+    ])
+
+    @Shared
+    @AutoCleanup
+    HttpClient client = HttpClient.create(embeddedServer.URL)
+
+    void "test MDC propagates"() {
+        expect:
+            List<Tuple2> result = Flux.range(1, 1000)
+                    .flatMap {
+                        String tracingId = UUID.randomUUID().toString()
+                        HttpRequest<Object> request = HttpRequest.POST("/mdc/enter", new SomeBody()).header("X-TrackingId", tracingId)
+                        return Mono.from(client.retrieve(request)).map(response -> {
+                            Tuples.of(tracingId, response)
+                        })
+                    }
+                    .collectList()
+                    .block()
+            for (Tuple2 t : result)
+                assert t.getT1() == t.getT2()
+    }
+
+    @Introspected
+    static class SomeBody {
+
+    }
+
+    @Controller("/mdc")
+    @Requires(property = 'mdc.reactortest.enabled')
+    static class MDCController {
+
+        @Inject
+        @Client("/")
+        private HttpClient httpClient
+        @Inject
+        @Client
+        private MDCClient mdcClient
+
+        @Post("/enter")
+        @ExecuteOn(TaskExecutors.IO)
+        String test(@Header("X-TrackingId") String tracingId, @Body SomeBody body) {
+            LOG.info("test1")
+            checkTracing(tracingId)
+            return mdcClient.test2(tracingId)
+        }
+
+        @ExecuteOn(TaskExecutors.IO)
+        @Get("/test2")
+        Mono<String> test2(@Header("X-TrackingId") String tracingId) {
+            LOG.info("test2")
+            checkTracing(tracingId)
+            return Mono<String>.fromCallable {
+                checkTracing(tracingId)
+                mdcClient.test3(tracingId, new SomeBody())
+            }.delayElement(Duration.ofMillis(50))
+        }
+
+        @Put("/test3")
+        Mono<String> test3(@Header("X-TrackingId") String tracingId, @Body SomeBody body) {
+            LOG.info("test3")
+            checkTracing(tracingId)
+            return Mono.from(
+                    httpClient.retrieve(HttpRequest.POST("/mdc/test4", body)
+                            .header("X-TrackingId", tracingId), String.class)
+            )
+        }
+
+        @ExecuteOn(TaskExecutors.IO)
+        @Post("/test4")
+        String test4(@Header("X-TrackingId") String tracingId, @Body SomeBody body) {
+            LOG.info("test4")
+            return httpClient.toBlocking().retrieve(HttpRequest.PATCH("/mdc/test5", body)
+                    .header("X-TrackingId", tracingId), String.class)
+        }
+
+        @Patch("/test5")
+        String test5(@Header("X-TrackingId") String tracingId, @Body SomeBody body) {
+            checkTracing(tracingId)
+            LOG.info("test5")
+            return MDC.get("trackingId")
+        }
+    }
+
+    @Client("/mdc")
+    @Requires(property = 'mdc.reactortest.enabled')
+    static interface MDCClient {
+
+        @Get("/test2")
+        String test2(@Header("X-TrackingId") tracingId)
+
+        @Put("/test3")
+        String test3(@Header("X-TrackingId") tracingId, @Body SomeBody body)
+
+        @Post("/test4")
+        Mono<String> test4(@Header("X-TrackingId") tracingId, @Body SomeBody body)
+
+    }
+
+    @Filter("/**")
+    @Requires(property = 'mdc.reactortest.enabled')
+    static class TracingHttpServerFilter implements HttpServerFilter {
+
+        @Override
+        Publisher<MutableHttpResponse<?>> doFilter(HttpRequest<?> request, ServerFilterChain chain) {
+            String trackingId = request.headers.get("X-TrackingId")
+            MDC.put("trackingId", trackingId)
+            return Mono.from(chain.proceed(request))
+        }
+
+    }
+
+    @Filter("/mdc/test**")
+    @Requires(property = 'mdc.reactortest.enabled')
+    static class TracingHttpClientFilter implements HttpClientFilter {
+
+        @Override
+        Publisher<? extends HttpResponse<?>> doFilter(MutableHttpRequest<?> request, ClientFilterChain chain) {
+            checkTracing(request)
+            return Mono.from(chain.proceed(request))
+        }
+
+        @Override
+        int getOrder() {
+            return Ordered.HIGHEST_PRECEDENCE
+        }
+    }
+
+    static void checkTracing(MutableHttpRequest<?> request) {
+        String trackingId = request.headers.get("X-TrackingId") as String
+        checkTracing(trackingId)
+    }
+
+    static void checkTracing(String trackingId) {
+        String mdcTracingId = MDC.get("trackingId")
+        if (trackingId != mdcTracingId) {
+            throw new IllegalArgumentException("TrackingIds do not match! Request: $trackingId vs. Context: $mdcTracingId")
+        }
+    }
+
+}


### PR DESCRIPTION
At this moment for request body routes this code:
```java
        if (!route.isExecutable() &&
                io.micronaut.http.HttpMethod.permitsRequestBody(request.getMethod()) &&
                nativeRequest instanceof StreamedHttpRequest &&
                (!bodyArgument.isPresent() || !route.isSatisfied(bodyArgument.get().getName()))) {
            routeMatchPublisher = Mono.<RouteMatch<?>>create(emitter -> httpContentProcessorResolver.resolve(request, route)
                    .subscribe(buildSubscriber(request, route, emitter))
            ).flux();
```
It is executing the route on a different thread than the filters and causing lost context.

I have tried different approaches, but this one looks like the only way.

Fixes https://github.com/micronaut-projects/micronaut-core/issues/6113

Additionally we can also introduce Reactor context-aware `ReactiveInvocationInstrumenterFactory` and `InvocationInstrumenter` and for example to have `ServerRequestContextInvocationInstrumenter` which would store the request in the context.

Plus, I think it would be nice to propagate the reactor context to the coroutine context by default if `kotlinx-coroutines-reactor` is present on the classpath.
