### PR TITLE
docs: clarify return values in isEmpty/isNotEmpty/hasText

### DIFF
--- a/core/src/main/java/io/micronaut/core/util/StringUtils.java
+++ b/core/src/main/java/io/micronaut/core/util/StringUtils.java
@@ -69,7 +69,7 @@ public final class StringUtils {
      * Return whether the given string is empty.
      *
      * @param str The string
-     * @return True if is
+     * @return True if str is empty or null
      */
     public static boolean isEmpty(@Nullable CharSequence str) {
         return str == null || str.length() == 0;
@@ -79,7 +79,7 @@ public final class StringUtils {
      * Return whether the given string is not empty.
      *
      * @param str The string
-     * @return True if is
+     * @return True if str is not null and not empty
      */
     public static boolean isNotEmpty(@Nullable CharSequence str) {
         return !isEmpty(str);
@@ -89,7 +89,7 @@ public final class StringUtils {
      * Return whether the given string has non whitespace characters.
      *
      * @param str The string
-     * @return True if is
+     * @return True if str contains any non whitespace characters
      */
     public static boolean hasText(@Nullable CharSequence str) {
         if (isEmpty(str)) {


### PR DESCRIPTION
Firstly, thanks for all your hard work on Micronaut! It's much appreciated.

I noticed that the `StringUtils` javadoc isn't clear about how nulls are handled, so I ended up reading the source for the version we're using.

This PR makes the return values clearer in the documentation so that reading the source isn't necessary in the future.
