### PR TITLE
Enable build scans

### DIFF
--- a/.github/workflows/central-sync.yml
+++ b/.github/workflows/central-sync.yml
@@ -31,6 +31,7 @@ jobs:
           GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
           GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
           GPG_FILE: ${{ secrets.GPG_FILE }}
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
         run: |
           echo $GPG_FILE | base64 -d > secring.gpg
           ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository

--- a/.github/workflows/corretto.yml
+++ b/.github/workflows/corretto.yml
@@ -29,4 +29,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-micronaut-core-wrapper-
     - name: Build with Gradle
+      env:
+        GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       run: unset HOSTNAME ; LANG=en_US.utf-8 LC_ALL=en_US.utf-8 ./gradlew check --no-daemon --parallel --continue

--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -26,9 +26,11 @@ jobs:
       - name: Export Gradle Properties
         uses: micronaut-projects/github-actions/export-gradle-properties@master
       - name: Check Dependencies
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
         run: ./gradlew useLatestVersions
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3.10.0
+        uses: peter-evans/create-pull-request@v3.10.1
         with:
           token: ${{ secrets.GH_TOKEN }}
           committer: micronaut-build <${{ secrets.MICRONAUT_BUILD_EMAIL }}>

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -41,6 +41,8 @@ jobs:
           distribution: 'adopt'
           java-version: ${{ matrix.java }}
       - name: Optional setup step
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
         run: |
           [ -f ./setup.sh ] && ./setup.sh || true
       - name: Build with Gradle

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -21,6 +21,13 @@ jobs:
       matrix:
         java: ['8', '11', '15']
     steps:
+      # https://github.com/actions/virtual-environments/issues/709
+      - name: Free disk space
+        run: |
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          sudo apt-get clean
+          df -h
       - uses: actions/checkout@v2
       - uses: actions/cache@v2.1.6
         with:
@@ -40,11 +47,13 @@ jobs:
         run: ./gradlew dependencyUpdates check --parallel --continue
         env:
           TESTCONTAINERS_RYUK_DISABLED: true
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       - name: Publish to Sonatype Snapshots
         if: success() && github.event_name == 'push' && matrix.java == '8'
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
         run: ./gradlew publishToSonatype docs --no-daemon
       - name: Determine docs target repository
         uses: haya14busa/action-cond@v1

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -27,4 +27,5 @@ jobs:
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
         run: ./gradlew publishToSonatype --no-daemon

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,10 +37,13 @@ jobs:
           GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
           GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
           GPG_FILE: ${{ secrets.GPG_FILE }}
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
         run: |
           echo $GPG_FILE | base64 -d > secring.gpg
           ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
       - name: Generate docs
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
         run: ./gradlew docs
       - name: Export Gradle Properties
         uses: micronaut-projects/github-actions/export-gradle-properties@master

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
     dependencies {
         classpath "gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0"
-        classpath "io.micronaut.build.internal:micronaut-gradle-plugins:4.1.1"
+        classpath "io.micronaut.build.internal:micronaut-gradle-plugins:4.1.3"
         classpath "org.aim42:htmlSanityCheck:${libs.versions.htmlSanityCheck.get()}"
         classpath 'javax.xml.bind:jaxb-api:2.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${libs.versions.kotlin.asProvider().get()}"

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,6 +9,10 @@ pluginManagement {
     }
 }
 
+plugins {
+    id 'io.micronaut.build.shared.settings' version '4.1.2'
+}
+
 enableFeaturePreview("VERSION_CATALOGS")
 
 rootProject.name = 'micronaut'

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,10 +7,14 @@ pluginManagement {
         id "org.jetbrains.kotlin.plugin.allopen" version getProperty("kotlinVersion")
         id "org.jetbrains.kotlin.plugin.jpa" version getProperty("kotlinVersion")
     }
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
 }
 
 plugins {
-    id 'io.micronaut.build.shared.settings' version '4.1.2'
+    id 'io.micronaut.build.shared.settings' version '4.1.3'
 }
 
 enableFeaturePreview("VERSION_CATALOGS")


### PR DESCRIPTION
This commit manually sync'es the workflow files and adds the Gradle Enterprise
plugin application (via the Micronaut settings plugin). This should enable
publishing of build scans from CI and for authenticated users.

Closes #6050