### PR TITLE
#6181 Handle exception thrown from http filter.

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -181,7 +181,6 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.*;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -1518,7 +1517,7 @@ public class DefaultHttpClient implements
             if (parentRequest != null) {
                 responsePublisher = ServerRequestContext.with(parentRequest, (Supplier<Publisher<io.micronaut.http.HttpResponse<O>>>) () ->
                          Flux.from((Publisher<io.micronaut.http.HttpResponse<O>>) filters.get(0).doFilter(request, filterChain))
-                                .contextWrite(ctx-> ctx.put(ServerRequestContext.KEY, parentRequest)));
+                                .contextWrite(ctx -> ctx.put(ServerRequestContext.KEY, parentRequest)));
             } else {
                 try {
                     responsePublisher = (Publisher<io.micronaut.http.HttpResponse<O>>) filters.get(0).doFilter(request, filterChain);

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -1519,8 +1519,7 @@ public class DefaultHttpClient implements
                          Flux.from((Publisher<io.micronaut.http.HttpResponse<O>>) filters.get(0).doFilter(request, filterChain))
                                 .contextWrite(ctx-> ctx.put(ServerRequestContext.KEY, parentRequest)));
             } else {
-                responsePublisher = (Publisher<io.micronaut.http.HttpResponse<O>>) filters.get(0)
-                        .doFilter(request, filterChain);
+                responsePublisher = Flux.defer(() -> (Publisher<io.micronaut.http.HttpResponse<O>>) filters.get(0).doFilter(request, filterChain));
             }
         }
 
@@ -2417,7 +2416,7 @@ public class DefaultHttpClient implements
                     throw new IllegalStateException("The FilterChain.proceed(..) method should be invoked exactly once per filter execution. The method has instead been invoked multiple times by an erroneous filter definition.");
                 }
                 HttpClientFilter httpFilter = filters.get(pos);
-                return httpFilter.doFilter(requestWrapper.getAndSet(request), this);
+                return Flux.defer(() -> httpFilter.doFilter(requestWrapper.getAndSet(request), this));
             }
         };
     }

--- a/runtime/src/main/java/io/micronaut/runtime/http/scope/RequestCustomScope.java
+++ b/runtime/src/main/java/io/micronaut/runtime/http/scope/RequestCustomScope.java
@@ -27,8 +27,6 @@ import io.micronaut.http.context.ServerRequestContext;
 import io.micronaut.http.context.event.HttpRequestTerminatedEvent;
 import io.micronaut.inject.BeanIdentifier;
 import jakarta.inject.Singleton;
-
-import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 


### PR DESCRIPTION
When the exception thrown from filter is not handle, the request does not complete and client get timeout.
Wrapping the filter call in `Flux.defer` wrap the exception thrown from function call into a Flux which
completes with error signal and `onErrorResume` then handle that.

Signed-off-by: ashishku <ashishku@thoughtworks.com>

closes: #6181 