### PR TITLE
Add link for CLA agreement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing Code or Documentation to Micronaut
 
+Sign the [Contributor License Agreement (CLA)](https://cla-assistant.io/micronaut-projects/micronaut-core). This is required before any of your code or pull-requests are accepted.
+
 ## Finding Issues to Work on
 
 If you are interested in contributing to Micronaut and are looking for issues to work on, take a look at the issues tagged with [help wanted](https://github.com/micronaut-projects/micronaut-core/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22).


### PR DESCRIPTION
CLA is a mandatory step for doing any code contribution to micronaut, but this information is not mentioned in CONTRIBUTING.md, I think it will be better for new contributors to know this upfront so that it does not come up as surprise when they submit pull request.

Signed-off-by: ashishku <ashishku@thoughtworks.com>