### PR TITLE
Add ElementType.ANNOTATION_TYPE to all tracing annotations

### DIFF
--- a/tracing/src/main/java/io/micronaut/tracing/annotation/ContinueSpan.java
+++ b/tracing/src/main/java/io/micronaut/tracing/annotation/ContinueSpan.java
@@ -36,7 +36,7 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
-@Target(value = { ElementType.METHOD })
+@Target(value = { ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 @Around
 @Type(TraceInterceptor.class)
 public @interface ContinueSpan {

--- a/tracing/src/main/java/io/micronaut/tracing/annotation/NewSpan.java
+++ b/tracing/src/main/java/io/micronaut/tracing/annotation/NewSpan.java
@@ -35,7 +35,7 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
-@Target(value = { ElementType.METHOD })
+@Target(value = { ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 @Around
 @Type(TraceInterceptor.class)
 public @interface NewSpan {

--- a/tracing/src/main/java/io/micronaut/tracing/annotation/SpanTag.java
+++ b/tracing/src/main/java/io/micronaut/tracing/annotation/SpanTag.java
@@ -31,7 +31,7 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
-@Target(value = { ElementType.PARAMETER })
+@Target(value = { ElementType.PARAMETER, ElementType.ANNOTATION_TYPE })
 public @interface SpanTag {
 
     /**


### PR DESCRIPTION
Add `ElementType.ANNOTATION_TYPE` to all tracing annotations. Discussion: #6207 