### PR TITLE
Run graal annotation processor for jackson-databind module [Fixes #6205]

### DIFF
--- a/jackson-databind/build.gradle
+++ b/jackson-databind/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     annotationProcessor project(":inject-java")
+    annotationProcessor project(":graal")
 
     api project(":jackson-core")
 


### PR DESCRIPTION
The issue was caused by the `@TypeHint` annotation on `JacksonConfiguration` not being processed after it was moved to its own module.

Couldn't find a way to create a test case for this unfortunately.