### PR TITLE
Respect configured property inclusion in BeanIntrospectionPropertyWriter 

### DIFF
--- a/runtime/src/test/groovy/io/micronaut/jackson/modules/BeanIntrospectionModuleSpec.groovy
+++ b/runtime/src/test/groovy/io/micronaut/jackson/modules/BeanIntrospectionModuleSpec.groovy
@@ -48,6 +48,7 @@ class BeanIntrospectionModuleSpec extends Specification {
     void "Bean introspection works with a bean without JsonInclude annotations"() {
         given:
         ApplicationContext ctx = ApplicationContext.run()
+        ctx.getBean(BeanIntrospectionModule).ignoreReflectiveProperties = ignoreReflectiveProperties
         ObjectMapper objectMapper = ctx.getBean(ObjectMapper)
 
         when:
@@ -61,6 +62,9 @@ class BeanIntrospectionModuleSpec extends Specification {
 
         cleanup:
         ctx.close()
+
+        where:
+        ignoreReflectiveProperties << [true, false]
     }
 
     void "Bean introspection works with a bean without JsonInclude annotations - serializationInclusion ALWAYS"() {


### PR DESCRIPTION
Also added a `ignoreReflectiveProperties` field to `BeanIntrospectionModule` to be able to test the `Bean {} has no properties, while BeanIntrospection does. Recreating from introspection.` branch of the code. It previously had no test coverage.

Fixes #6218