### PR TITLE
Improve Bean Introspection compilation

### DIFF
--- a/core/src/main/java/io/micronaut/core/beans/AbstractBeanIntrospection.java
+++ b/core/src/main/java/io/micronaut/core/beans/AbstractBeanIntrospection.java
@@ -169,6 +169,11 @@ public abstract class AbstractBeanIntrospection<T> implements BeanIntrospection<
         return Optional.ofNullable(beanProperties.get(name));
     }
 
+    @Override
+    public int propertyIndexOf(String name) {
+        return new ArrayList<>(beanProperties.keySet()).indexOf(name);
+    }
+
     @NonNull
     @Override
     public Collection<BeanProperty<T, Object>> getIndexedProperties(@NonNull Class<? extends Annotation> annotationType) {

--- a/core/src/main/java/io/micronaut/core/beans/BeanIntrospection.java
+++ b/core/src/main/java/io/micronaut/core/beans/BeanIntrospection.java
@@ -153,6 +153,24 @@ public interface BeanIntrospection<T> extends AnnotationMetadataDelegate {
     }
 
     /**
+     * Obtain the property index position.
+     *
+     * @param name The name of the property
+     * @return A property index or -1 of not found.
+     * @since 3.1
+     */
+    default int propertyIndexOf(@NonNull String name) {
+        int index = 0;
+        for (BeanProperty<T, Object> property : getBeanProperties()) {
+            if (property.getName().equals(name)) {
+                return index;
+            }
+            index++;
+        }
+        return -1;
+    }
+
+    /**
      * Gets a property of the given name and type or throws {@link IntrospectionException} if the property is not present.
      * @param name The name
      * @param type The type

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
@@ -1657,6 +1657,7 @@ class Test {
         bi.getConstructorArguments()[1].getAnnotationMetadata().hasAnnotation(Size)
         bi.getIndexedProperties(Id).size() == 1
         bi.getIndexedProperty(Id).isPresent()
+        !bi.getIndexedProperty(Column, null).isPresent()
         bi.getIndexedProperty(Column, "test_name").isPresent()
         bi.getIndexedProperty(Column, "test_name").get().name == 'name'
         bi.getProperty("version").get().hasAnnotation(Version)

--- a/inject/src/main/java/io/micronaut/inject/beans/AbstractInitializableBeanIntrospection.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/AbstractInitializableBeanIntrospection.java
@@ -107,19 +107,6 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements BeanI
     protected abstract B instantiateInternal(@Nullable Object[] arguments);
 
     /**
-     * Obtain a property by name.
-     *
-     * @param name The name of the property
-     * @return A bean property if found
-     */
-    @Nullable
-    @Internal
-    @UsedByGeneratedCode
-    protected BeanProperty<B, Object> findProperty(@NonNull String name) {
-        return null;
-    }
-
-    /**
      * Obtain a property by its index.
      *
      * @param index The index of the property
@@ -289,7 +276,8 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements BeanI
     @Override
     public Optional<BeanProperty<B, Object>> getProperty(@NonNull String name) {
         ArgumentUtils.requireNonNull("name", name);
-        return Optional.ofNullable(findProperty(name));
+        int index = propertyIndexOf(name);
+        return index == -1 ? Optional.empty() : Optional.of(beanProperties.get(index));
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/inject/writer/AbstractAnnotationMetadataWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/AbstractAnnotationMetadataWriter.java
@@ -124,13 +124,21 @@ public abstract class AbstractAnnotationMetadataWriter extends AbstractClassFile
      * @param classWriter The {@link ClassWriter}
      */
     protected void writeAnnotationMetadataStaticInitializer(ClassWriter classWriter) {
+        writeAnnotationMetadataStaticInitializer(classWriter, defaults);
+    }
+
+    /**
+     * @param classWriter The {@link ClassWriter}
+     * @param defaults    The annotation defaults
+     */
+    protected void writeAnnotationMetadataStaticInitializer(ClassWriter classWriter, Map<String, Integer> defaults) {
         if (!(annotationMetadata instanceof AnnotationMetadataReference)) {
 
             // write the static initializers for the annotation metadata
             GeneratorAdapter staticInit = visitStaticInitializer(classWriter);
             staticInit.visitCode();
             staticInit.visitLabel(new Label());
-            initializeAnnotationMetadata(staticInit, classWriter);
+            initializeAnnotationMetadata(staticInit, classWriter, defaults);
             if (writeAnnotationDefault && annotationMetadata instanceof DefaultAnnotationMetadata) {
                 DefaultAnnotationMetadata dam = (DefaultAnnotationMetadata) annotationMetadata;
                 AnnotationMetadataWriter.writeAnnotationDefaults(
@@ -152,8 +160,9 @@ public abstract class AbstractAnnotationMetadataWriter extends AbstractClassFile
     /**
      * @param staticInit  The {@link GeneratorAdapter}
      * @param classWriter The {@link ClassWriter}
+     * @param defaults    The annotation defaults
      */
-    protected void initializeAnnotationMetadata(GeneratorAdapter staticInit, ClassWriter classWriter) {
+    protected void initializeAnnotationMetadata(GeneratorAdapter staticInit, ClassWriter classWriter, Map<String, Integer> defaults) {
         Type annotationMetadataType = Type.getType(AnnotationMetadata.class);
         classWriter.visitField(ACC_PUBLIC | ACC_FINAL | ACC_STATIC, FIELD_ANNOTATION_METADATA, annotationMetadataType.getDescriptor(), null, null);
 

--- a/inject/src/main/java/io/micronaut/inject/writer/StringSwitchWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/StringSwitchWriter.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.writer;
+
+import org.objectweb.asm.Label;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.GeneratorAdapter;
+import org.objectweb.asm.commons.Method;
+import org.objectweb.asm.commons.TableSwitchGenerator;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * String switch writer.
+ *
+ * @author Denis Stepanov
+ * @since 3.1
+ */
+public abstract class StringSwitchWriter {
+
+    /**
+     * @return Get cases keys
+     */
+    protected abstract Set<String> getKeys();
+
+    /**
+     * Push the string value that is being evaluated.
+     */
+    protected abstract void pushStringValue();
+
+    /**
+     * Generate on case matches statement.
+     *
+     * @param value The string that matched
+     * @param end   The end label
+     */
+    protected abstract void onMatch(String value, Label end);
+
+    /**
+     * Generate default statement.
+     */
+    protected void generateDefault() {
+    }
+
+    /**
+     * Write the string switch implementation.
+     *
+     * @param writer The writer
+     */
+    public void write(GeneratorAdapter writer) {
+        Set<String> keys = getKeys();
+        if (keys.isEmpty()) {
+            return;
+        }
+        if (keys.size() == 1) {
+            Label end = new Label();
+            String key = keys.iterator().next();
+            generateValueCase(writer, key, end);
+            writer.visitLabel(end);
+            return;
+        }
+        Map<Integer, Set<String>> hashToValue = new HashMap<>();
+        for (String string : keys) {
+            hashToValue.computeIfAbsent(string.hashCode(), hashCode -> new TreeSet<>()).add(string);
+        }
+        int[] hashCodeArray = hashToValue.keySet().stream().mapToInt(i -> i).toArray();
+        Arrays.sort(hashCodeArray);
+        pushStringValue();
+        writer.invokeVirtual(Type.getType(Object.class), new Method("hashCode", Type.INT_TYPE, new Type[]{}));
+        writer.tableSwitch(hashCodeArray, new TableSwitchGenerator() {
+            @Override
+            public void generateCase(int hashCode, Label end) {
+                for (String string : hashToValue.get(hashCode)) {
+                    generateValueCase(writer, string, end);
+                }
+                writer.goTo(end);
+            }
+
+            @Override
+            public void generateDefault() {
+                StringSwitchWriter.this.generateDefault();
+            }
+        });
+    }
+
+    /**
+     * Generate the switch case.
+     *
+     * @param writer The writer
+     * @param string The string matched
+     * @param end    The end label
+     */
+    protected void generateValueCase(GeneratorAdapter writer, String string, Label end) {
+        pushStringValue();
+        writer.push(string);
+        writer.invokeVirtual(Type.getType(Object.class), new Method("equals", Type.BOOLEAN_TYPE, new Type[]{Type.getType(Object.class)}));
+        writer.push(true);
+        Label falseLabel = new Label();
+        writer.ifCmp(Type.BOOLEAN_TYPE, GeneratorAdapter.NE, falseLabel);
+        onMatch(string, end);
+        writer.visitLabel(falseLabel);
+    }
+
+}

--- a/inject/src/main/java/io/micronaut/inject/writer/StringSwitchWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/StringSwitchWriter.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.inject.writer;
 
+import io.micronaut.core.annotation.Internal;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.GeneratorAdapter;
@@ -33,6 +34,7 @@ import java.util.TreeSet;
  * @author Denis Stepanov
  * @since 3.1
  */
+@Internal
 public abstract class StringSwitchWriter {
 
     /**


### PR DESCRIPTION
I have analyzed the new introspection classes in Micronaut Data and come up with a few improvements:
- Introduce `propertyIndexOf` that is well optimized by the generated class and can be reused for direct property mapping.
- Improve and extract string switch writer
- Store static indexes