### PR TITLE
Add a new InjectScope annotation for beans scoped to the injection point

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/injectscope/InjectScopeSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/injectscope/InjectScopeSpec.groovy
@@ -1,0 +1,78 @@
+package io.micronaut.inject.injectscope
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+
+class InjectScopeSpec extends AbstractTypeElementSpec {
+
+    void "test inject scope"() {
+        given:
+        def context = buildContext('''
+package injectscopetest;
+
+import io.micronaut.context.annotation.Bean;
+import jakarta.annotation.PreDestroy;import jakarta.inject.*;
+import io.micronaut.context.annotation.InjectScope;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.Assertions;
+import java.util.*;
+
+interface Connection extends AutoCloseable {
+    @Override void close();
+    
+    boolean isOpen();
+}
+
+@Bean
+class TestConnection implements Connection {
+    public final Other other;
+    TestConnection(Other o) {
+        this.other = o;
+    }
+    public boolean isOpen = true;
+    @Override public boolean isOpen() {
+        return isOpen && other.isOpen;
+    }
+    @PreDestroy
+    @Override public void close() {
+        isOpen = false;    
+    }
+}
+
+@Bean
+class Other {
+    boolean isOpen = true;
+    @PreDestroy
+    void close() {
+        isOpen = false;
+    }
+}
+
+@Singleton
+class Test {
+    public List<Connection> createdConnections = new ArrayList<injectscopetest.Connection>();
+    
+    Test(@InjectScope Connection conn1, @InjectScope Connection conn2) {
+        Assertions.assertTrue(conn1.isOpen());
+        Assertions.assertTrue(conn2.isOpen());
+        createdConnections.add(conn1);
+        createdConnections.add(conn2);
+    }
+    
+    @Inject
+    void init(@InjectScope Connection conn3) {
+        Assertions.assertTrue(conn3.isOpen());
+        createdConnections.add(conn3);
+    }
+}
+''')
+        def bean = getBean(context, 'injectscopetest.Test')
+
+        expect:
+        bean.createdConnections.size()
+        bean.createdConnections.every { it.isOpen == false }
+        bean.createdConnections.every { it.other.isOpen == false }
+
+        cleanup:
+        context.close()
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/AbstractBeanResolutionContext.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractBeanResolutionContext.java
@@ -15,7 +15,9 @@
  */
 package io.micronaut.context;
 
+import io.micronaut.context.annotation.InjectScope;
 import io.micronaut.context.exceptions.CircularDependencyException;
+import io.micronaut.context.scope.CustomScope;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
@@ -73,6 +75,16 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
             dependentBeans = new ArrayList<>(3);
         }
         dependentBeans.add(new BeanRegistration<>(identifier, definition, bean));
+    }
+
+    @Override
+    public void destroyInjectScopedBeans() {
+        final CustomScope<?> injectScope = ((DefaultBeanContext) context).getCustomScopeRegistry()
+                .findScope(InjectScope.class.getName())
+                .orElse(null);
+        if (injectScope instanceof LifeCycle<?>) {
+            ((LifeCycle<?>) injectScope).stop();
+        }
     }
 
     @NonNull

--- a/inject/src/main/java/io/micronaut/context/AbstractInitializableBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractInitializableBeanDefinition.java
@@ -1549,7 +1549,12 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
         return resolveBean(resolutionContext, context, argument, qualifier, false);
     }
 
-    private Object resolveBean(BeanResolutionContext resolutionContext, BeanContext context, Argument argument, @Nullable Qualifier qualifier, boolean resolveIsInnerConfiguration) {
+    private Object resolveBean(
+            BeanResolutionContext resolutionContext,
+            BeanContext context,
+            Argument argument,
+            @Nullable Qualifier qualifier,
+            boolean resolveIsInnerConfiguration) {
         qualifier = qualifier == null ? resolveQualifier(resolutionContext, argument, resolveIsInnerConfiguration) : qualifier;
         if (Qualifier.class.isAssignableFrom(argument.getType())) {
             return qualifier;

--- a/inject/src/main/java/io/micronaut/context/BeanResolutionContext.java
+++ b/inject/src/main/java/io/micronaut/context/BeanResolutionContext.java
@@ -17,6 +17,7 @@ package io.micronaut.context;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.UsedByGeneratedCode;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.value.ValueResolver;
 import io.micronaut.inject.*;
@@ -41,6 +42,15 @@ public interface BeanResolutionContext extends ValueResolver<CharSequence>, Auto
     default void close() {
         // no-op
     }
+
+    /**
+     * Call back to destroy any {@link io.micronaut.context.annotation.InjectScope} beans.
+     *
+     * @see io.micronaut.context.annotation.InjectScope
+     * @since 3.1.0
+     */
+    @UsedByGeneratedCode
+    void destroyInjectScopedBeans();
 
     /**
      * Copy current context to be used later.

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -297,6 +297,15 @@ public class DefaultBeanContext implements BeanContext {
         return new DefaultCustomScopeRegistry(this);
     }
 
+    /**
+     * @return The custom scope registry
+     */
+    @Internal
+    @NonNull
+    CustomScopeRegistry getCustomScopeRegistry() {
+        return customScopeRegistry;
+    }
+
     @Override
     public boolean isRunning() {
         return running.get() && !initializing.get();
@@ -2821,7 +2830,7 @@ public class DefaultBeanContext implements BeanContext {
                 && (definition.getDeclaredQualifier() == null || !definition.getDeclaredQualifier().contains(AnyQualifier.INSTANCE))) {
             // With scopes proxies we have to inject a reference into the injection point
             Argument<T> proxiedType = (Argument<T>) resolveProxiedType(beanType, definition);
-            BeanKey<T> key = new BeanKey(proxiedType, qualifier);
+            BeanKey<T> key = new BeanKey<>(proxiedType, qualifier);
             BeanDefinition<T> finalDefinition = definition;
             return (T) scopedProxies.computeIfAbsent(key, beanKey -> ProviderUtils.memoized(() -> {
                 Qualifier<T> q = qualifier;
@@ -2832,13 +2841,13 @@ public class DefaultBeanContext implements BeanContext {
                 T createBean = doCreateBean(
                         resolutionContext,
                         finalDefinition,
-                        qualifier,
+                        q,
                         beanType,
                         false,
                         null
                 );
                 if (createBean instanceof Qualified) {
-                    ((Qualified) createBean).$withBeanQualifier(qualifier);
+                    ((Qualified<T>) createBean).$withBeanQualifier(q);
                 }
                 if (createBean == null && throwNoSuchBean) {
                     throw new NoSuchBeanException(finalDefinition.asArgument(), qualifier);

--- a/inject/src/main/java/io/micronaut/context/DefaultCustomScopeRegistry.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultCustomScopeRegistry.java
@@ -15,16 +15,20 @@
  */
 package io.micronaut.context;
 
+import io.micronaut.context.annotation.InjectScope;
+import io.micronaut.context.scope.BeanCreationContext;
+import io.micronaut.context.scope.CreatedBean;
 import io.micronaut.context.scope.CustomScope;
 import io.micronaut.context.scope.CustomScopeRegistry;
 import io.micronaut.core.annotation.AnnotationUtil;
-import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.type.Argument;
+import io.micronaut.inject.BeanIdentifier;
 import io.micronaut.inject.BeanType;
 import io.micronaut.inject.qualifiers.Qualifiers;
 
 import java.lang.annotation.Annotation;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -36,17 +40,20 @@ import java.util.concurrent.ConcurrentHashMap;
  * @author Graeme Rocher
  * @since 1.0
  */
-@Internal
-class DefaultCustomScopeRegistry implements CustomScopeRegistry {
-
+public class DefaultCustomScopeRegistry implements CustomScopeRegistry {
+    /**
+     * Constant to refer to inject scope.
+     */
+    static final CustomScope<InjectScope> INJECT_SCOPE = new InjectScopeImpl();
     private final BeanLocator beanLocator;
     private final Map<String, Optional<CustomScope<?>>> scopes = new ConcurrentHashMap<>(2);
 
     /**
      * @param beanLocator The bean locator
      */
-    DefaultCustomScopeRegistry(BeanLocator beanLocator) {
+    protected DefaultCustomScopeRegistry(BeanLocator beanLocator) {
         this.beanLocator = beanLocator;
+        this.scopes.put(InjectScope.class.getName(), Optional.of(INJECT_SCOPE));
     }
 
     @Override
@@ -85,4 +92,39 @@ class DefaultCustomScopeRegistry implements CustomScopeRegistry {
         });
     }
 
+    private static final class InjectScopeImpl implements CustomScope<InjectScope>, LifeCycle<InjectScopeImpl> {
+
+        private final List<CreatedBean<?>> currentCreatedBeans = new ArrayList<>(2);
+
+        @Override
+        public Class<InjectScope> annotationType() {
+            return InjectScope.class;
+        }
+
+        @Override
+        public <T> T getOrCreate(BeanCreationContext<T> creationContext) {
+            final CreatedBean<T> createdBean = creationContext.create();
+            currentCreatedBeans.add(createdBean);
+            return createdBean.bean();
+        }
+
+        @Override
+        public <T> Optional<T> remove(BeanIdentifier identifier) {
+            return Optional.empty();
+        }
+
+        @Override
+        public boolean isRunning() {
+            return true;
+        }
+
+        @Override
+        public InjectScopeImpl stop() {
+            for (CreatedBean<?> currentCreatedBean : currentCreatedBeans) {
+                currentCreatedBean.close();
+            }
+            currentCreatedBeans.clear();
+            return this;
+        }
+    }
 }

--- a/inject/src/main/java/io/micronaut/context/annotation/InjectScope.java
+++ b/inject/src/main/java/io/micronaut/context/annotation/InjectScope.java
@@ -1,0 +1,21 @@
+package io.micronaut.context.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * <p>An annotation that can be declared on a constructor or method parameter that indicates
+ * that the injected bean should be destroyed after injection completes.</p>
+ *
+ * <p>More specifically after a constructor or method which is annotated with {@link jakarta.inject.Inject} completes execution then any parameters annotated with {@link io.micronaut.context.annotation.InjectScope} which do not declare a specific scope such as {@link jakarta.inject.Singleton} will be destroyed resulting in the execution of {@link jakarta.annotation.PreDestroy} handlers.</p>
+ *
+ * @author graemerocher
+ * @since 3.1.0
+ *
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface InjectScope {
+}

--- a/inject/src/main/java/io/micronaut/context/annotation/InjectScope.java
+++ b/inject/src/main/java/io/micronaut/context/annotation/InjectScope.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.context.annotation;
 
 import java.lang.annotation.ElementType;
@@ -5,11 +20,13 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import jakarta.inject.Scope;
+
 /**
  * <p>An annotation that can be declared on a constructor or method parameter that indicates
  * that the injected bean should be destroyed after injection completes.</p>
  *
- * <p>More specifically after a constructor or method which is annotated with {@link jakarta.inject.Inject} completes execution then any parameters annotated with {@link io.micronaut.context.annotation.InjectScope} which do not declare a specific scope such as {@link jakarta.inject.Singleton} will be destroyed resulting in the execution of {@link jakarta.annotation.PreDestroy} handlers.</p>
+ * <p>More specifically after a constructor or method which is annotated with {@link jakarta.inject.Inject} completes execution then any parameters annotated with {@link io.micronaut.context.annotation.InjectScope} which do not declare a specific scope such as {@link jakarta.inject.Singleton} will be destroyed resulting in the execution of {@link jakarta.annotation.PreDestroy} handlers on the bean and any dependent beans.</p>
  *
  * @author graemerocher
  * @since 3.1.0
@@ -17,5 +34,6 @@ import java.lang.annotation.Target;
  */
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
+@Scope
 public @interface InjectScope {
 }

--- a/inject/src/main/java/io/micronaut/inject/beans/AbstractInitializableBeanIntrospection.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/AbstractInitializableBeanIntrospection.java
@@ -89,7 +89,7 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements BeanI
             for (BeanMethodRef beanMethodRef : methodsRefs) {
                 beanMethods.add(new BeanMethodImpl<>(beanMethodRef));
             }
-            this.beanMethods = Collections.unmodifiableList(beanMethods);;
+            this.beanMethods = Collections.unmodifiableList(beanMethods);
         } else {
             this.beanMethods = Collections.emptyList();
         }


### PR DESCRIPTION
To support `@TransientReference` in CDI (a name which makes no sense to me) this add `@InjectScope` which scopes the beans lifecycle to the scope of a constructor or method annotated with `@Inject`