### PR TITLE
Attempt to load all possible property sources to determine if the bootstrap env should be started

### DIFF
--- a/context/src/main/java/io/micronaut/runtime/Micronaut.java
+++ b/context/src/main/java/io/micronaut/runtime/Micronaut.java
@@ -253,6 +253,11 @@ public class Micronaut extends DefaultApplicationContextBuilder implements Appli
         return (Micronaut) super.packages(packages);
     }
 
+    @Override
+    public @NonNull Micronaut bootstrapEnvironment(boolean bootstrapEnv) {
+        return (Micronaut) super.bootstrapEnvironment(bootstrapEnv);
+    }
+
     /**
      * Maps an exception to the given error code.
      *

--- a/inject/src/main/java/io/micronaut/context/ApplicationContextBuilder.java
+++ b/inject/src/main/java/io/micronaut/context/ApplicationContextBuilder.java
@@ -220,7 +220,18 @@ public interface ApplicationContextBuilder {
      * @param args The arguments
      * @return This application
      */
-    default  @NonNull ApplicationContextBuilder args(@Nullable String... args) {
+    default @NonNull ApplicationContextBuilder args(@Nullable String... args) {
+        return this;
+    }
+
+    /**
+     * Sets whether the bootstrap environment should be initialized.
+     *
+     * @param bootstrapEnv True if it should be initialized. Default true
+     * @return This application
+     * @since 3.1.0
+     */
+    default @NonNull ApplicationContextBuilder bootstrapEnvironment(boolean bootstrapEnv) {
         return this;
     }
 

--- a/inject/src/main/java/io/micronaut/context/ApplicationContextConfiguration.java
+++ b/inject/src/main/java/io/micronaut/context/ApplicationContextConfiguration.java
@@ -111,7 +111,8 @@ public interface ApplicationContextConfiguration extends BeanContextConfiguratio
         return true;
     }
 
-    default boolean isBootstrapEnvironmentEnabled() {
+    @Nullable
+    default Boolean isBootstrapEnvironmentEnabled() {
         return true;
     }
 }

--- a/inject/src/main/java/io/micronaut/context/ApplicationContextConfiguration.java
+++ b/inject/src/main/java/io/micronaut/context/ApplicationContextConfiguration.java
@@ -110,4 +110,8 @@ public interface ApplicationContextConfiguration extends BeanContextConfiguratio
     default boolean isBannerEnabled() {
         return true;
     }
+
+    default boolean isBootstrapEnvironmentEnabled() {
+        return true;
+    }
 }

--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
@@ -695,7 +695,7 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
         private final ApplicationContextConfiguration configuration;
         private BootstrapPropertySourceLocator bootstrapPropertySourceLocator;
         private BootstrapEnvironment bootstrapEnvironment;
-        private boolean bootstrapEnabled;
+        private Boolean bootstrapEnabled;
 
         RuntimeConfiguredEnvironment(ApplicationContextConfiguration configuration) {
             super(configuration);
@@ -718,9 +718,9 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
             if (bootstrapEnabled == null) {
                 bootstrapEnabled = this.bootstrapEnabled;
             }
-            if (bootstrapEnvironment == null && bootstrapEnabled) {
+            if (bootstrapEnvironment == null && (bootstrapEnabled == null || bootstrapEnabled)) {
                 BootstrapEnvironment bootstrapEnv = createBootstrapEnvironment(getActiveNames().toArray(new String[0]));
-                if (CollectionUtils.isNotEmpty(bootstrapEnv.readPropertySourceList(bootstrapEnv.getPropertySourceRootName()))) {
+                if (bootstrapEnabled != null || CollectionUtils.isNotEmpty(bootstrapEnv.readPropertySourceList(bootstrapEnv.getPropertySourceRootName()))) {
                     bootstrapEnvironment = startBootstrapEnvironment(bootstrapEnv);
                 } else {
                     if (LOG.isInfoEnabled()) {

--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContextBuilder.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContextBuilder.java
@@ -54,7 +54,7 @@ public class DefaultApplicationContextBuilder implements ApplicationContextBuild
     private boolean banner = true;
     private ClassPathResourceLoader classPathResourceLoader;
     private boolean allowEmptyProviders = false;
-    private boolean bootstrapEnvironment = true;
+    private Boolean bootstrapEnvironment = null;
 
     /**
      * Default constructor.
@@ -93,8 +93,9 @@ public class DefaultApplicationContextBuilder implements ApplicationContextBuild
         return banner;
     }
 
+    @Nullable
     @Override
-    public boolean isBootstrapEnvironmentEnabled() {
+    public Boolean isBootstrapEnvironmentEnabled() {
         return bootstrapEnvironment;
     }
 

--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContextBuilder.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContextBuilder.java
@@ -54,6 +54,7 @@ public class DefaultApplicationContextBuilder implements ApplicationContextBuild
     private boolean banner = true;
     private ClassPathResourceLoader classPathResourceLoader;
     private boolean allowEmptyProviders = false;
+    private boolean bootstrapEnvironment = true;
 
     /**
      * Default constructor.
@@ -90,6 +91,11 @@ public class DefaultApplicationContextBuilder implements ApplicationContextBuild
     @Override
     public boolean isBannerEnabled() {
         return banner;
+    }
+
+    @Override
+    public boolean isBootstrapEnvironmentEnabled() {
+        return bootstrapEnvironment;
     }
 
     @Override
@@ -252,6 +258,12 @@ public class DefaultApplicationContextBuilder implements ApplicationContextBuild
     }
 
     @Override
+    public @NonNull ApplicationContextBuilder bootstrapEnvironment(boolean bootstrapEnv) {
+        this.bootstrapEnvironment = bootstrapEnv;
+        return this;
+    }
+
+    @Override
     @SuppressWarnings("MagicNumber")
     public @NonNull ApplicationContext build() {
         ApplicationContext applicationContext = newApplicationContext();
@@ -337,7 +349,7 @@ public class DefaultApplicationContextBuilder implements ApplicationContextBuild
     }
 
     @Override
-    public ApplicationContextBuilder allowEmptyProviders(boolean shouldAllow) {
+    public @NonNull ApplicationContextBuilder allowEmptyProviders(boolean shouldAllow) {
         this.allowEmptyProviders = shouldAllow;
         return this;
     }


### PR DESCRIPTION
Fixes #6226 
Fixes #6066 

This should attempt to load all variants of `bootstrap.{ext}` and `bootstrap-{env}.{ext}`. If any are found then the bootstrap environment will be started. The loading of those files is then cached so it won't be done twice. This fixes the hack that was in place that only checked for `bootstrap.yml` and `bootstrap.properties`.