### PR TITLE
fix: don't load endpointsfilter if securityfilter

### DIFF
--- a/management/src/main/java/io/micronaut/management/endpoint/EndpointsFilter.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/EndpointsFilter.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.management.endpoint;
 
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
@@ -39,6 +40,7 @@ import java.util.Optional;
  * @author Sergio del Amo
  * @since 1.0
  */
+@Requires(missingClasses = "io.micronaut.security.filters.SecurityFilter")
 @Filter("/**")
 public class EndpointsFilter extends OncePerRequestHttpServerFilter {
 


### PR DESCRIPTION
see: https://github.com/micronaut-projects/micronaut-security/issues/408

The goal is to remove the `@Replaces(EndpointsFilter)` from Micornaut Security `SecurityFilter`