### PR TITLE
feat: disable endpoints filter via configuration

### DIFF
--- a/management/src/main/java/io/micronaut/management/endpoint/EndpointsFilter.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/EndpointsFilter.java
@@ -15,7 +15,9 @@
  */
 package io.micronaut.management.endpoint;
 
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.async.publisher.Publishers;
+import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
@@ -29,7 +31,6 @@ import io.micronaut.web.router.MethodBasedRouteMatch;
 import io.micronaut.web.router.RouteMatch;
 import io.micronaut.web.router.RouteMatchUtils;
 import org.reactivestreams.Publisher;
-
 import java.util.Map;
 import java.util.Optional;
 
@@ -39,6 +40,7 @@ import java.util.Optional;
  * @author Sergio del Amo
  * @since 1.0
  */
+@Requires(property = EndpointsFilterConfigurationProperties.PREFIX + ".enabled", notEquals = StringUtils.FALSE, defaultValue = StringUtils.TRUE)
 @Filter("/**")
 public class EndpointsFilter extends OncePerRequestHttpServerFilter {
 

--- a/management/src/main/java/io/micronaut/management/endpoint/EndpointsFilterConfiguration.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/EndpointsFilterConfiguration.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.management.endpoint;
+
+import io.micronaut.core.util.Toggleable;
+
+/**
+ * Configuration for the {@link EndpointsFilter}.
+ * @author Sergio del Amo
+ * @since 3.1.0
+ */
+public interface EndpointsFilterConfiguration extends Toggleable {
+}

--- a/management/src/main/java/io/micronaut/management/endpoint/EndpointsFilterConfigurationProperties.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/EndpointsFilterConfigurationProperties.java
@@ -1,0 +1,35 @@
+package io.micronaut.management.endpoint;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+
+@ConfigurationProperties(EndpointsFilterConfigurationProperties.PREFIX)
+public class EndpointsFilterConfigurationProperties implements EndpointsFilterConfiguration {
+    /**
+     * The prefix for the {@link EndpointsFilter} configuration
+     */
+    public static final String PREFIX = "endpoints.filter";
+
+    /**
+     * The default enable value.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static final boolean DEFAULT_ENABLED = true;
+
+    private boolean enabled = DEFAULT_ENABLED;
+
+    /**
+     * @return Whether the {@link EndpointsFilter} is enabled
+     */
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Default value ({@value #DEFAULT_ENABLED}).
+     * @param enabled Enable or disable the {@link EndpointsFilter}
+     */
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/management/src/main/java/io/micronaut/management/endpoint/EndpointsFilterConfigurationProperties.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/EndpointsFilterConfigurationProperties.java
@@ -1,7 +1,27 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.management.endpoint;
 
 import io.micronaut.context.annotation.ConfigurationProperties;
 
+/**
+ * {@link ConfigurationProperties} implementation of {@link io.micronaut.management.endpoint.EndpointsFilterConfiguration}.
+ * @author Sergio del Amo
+ * @since 3.1.0
+ */
 @ConfigurationProperties(EndpointsFilterConfigurationProperties.PREFIX)
 public class EndpointsFilterConfigurationProperties implements EndpointsFilterConfiguration {
     /**

--- a/management/src/test/groovy/io/micronaut/management/endpoint/EndpointsFilterConfigurationSpec.groovy
+++ b/management/src/test/groovy/io/micronaut/management/endpoint/EndpointsFilterConfigurationSpec.groovy
@@ -1,0 +1,18 @@
+package io.micronaut.management.endpoint
+
+import io.micronaut.context.ApplicationContext
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class EndpointsFilterConfigurationSpec extends Specification {
+
+    @AutoCleanup
+    @Shared
+    ApplicationContext applicationContext = ApplicationContext.run(['endpoints.filter.enabled': false])
+
+    void "Bean of type EndpointsFilter not present if endpoints.filter.enabled is false"() {
+        expect:
+        !applicationContext.containsBean(EndpointsFilter.class)
+    }
+}


### PR DESCRIPTION
This is useful if you want to avoid loading the endpoints filter because you are going to handle security with your own filter. 