### PR TITLE
Make GroovyVisitorContext.getCompilationUnit visible

### DIFF
--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyVisitorContext.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyVisitorContext.java
@@ -243,7 +243,8 @@ public class GroovyVisitorContext implements VisitorContext {
     /**
      * @return The compilation unit
      */
-    CompilationUnit getCompilationUnit() {
+    @Internal
+    public CompilationUnit getCompilationUnit() {
         return compilationUnit;
     }
 


### PR DESCRIPTION
This change is necessary for the serializer generator for groovy, so that it can access the compile classpath for java source compilation.