### PR TITLE
Support for receiver type & throws clause in MethodElement API

### DIFF
--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyMethodElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyMethodElement.java
@@ -64,6 +64,20 @@ public class GroovyMethodElement extends AbstractGroovyElement implements Method
     }
 
     @Override
+    public ClassElement[] getThrownTypes() {
+        final ClassNode[] exceptions = methodNode.getExceptions();
+        if (ArrayUtils.isNotEmpty(exceptions)) {
+            return Arrays.stream(exceptions)
+                    .map(cn -> getGenericElement(cn, visitorContext.getElementFactory().newClassElement(
+                            cn,
+                            AnnotationMetadata.EMPTY_METADATA,
+                            Collections.emptyMap()
+                    ))).toArray(ClassElement[]::new);
+        }
+        return ClassElement.ZERO_CLASS_ELEMENTS;
+    }
+
+    @Override
     public Set<ElementModifier> getModifiers() {
         return resolveModifiers(this.methodNode);
     }

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaMethodElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaMethodElement.java
@@ -71,6 +71,36 @@ public class JavaMethodElement extends AbstractJavaElement implements MethodElem
     }
 
     @Override
+    public Optional<ClassElement> getReceiverType() {
+        final TypeMirror receiverType = executableElement.getReceiverType();
+        if (receiverType != null) {
+            if (receiverType.getKind() != TypeKind.NONE) {
+                final ClassElement classElement = mirrorToClassElement(receiverType,
+                                                                       visitorContext,
+                                                                       declaringClass.getGenericTypeInfo());
+                return Optional.of(classElement);
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    @NonNull
+    public ClassElement[] getThrownTypes() {
+        final List<? extends TypeMirror> thrownTypes = executableElement.getThrownTypes();
+        if (!thrownTypes.isEmpty()) {
+            return thrownTypes.stream()
+                    .map(tm -> mirrorToClassElement(
+                            tm,
+                            visitorContext,
+                            declaringClass.getGenericTypeInfo()
+                    )).toArray(ClassElement[]::new);
+        }
+
+        return ClassElement.ZERO_CLASS_ELEMENTS;
+    }
+
+    @Override
     public boolean isDefault() {
         return executableElement.isDefault();
     }

--- a/inject/src/main/java/io/micronaut/inject/ast/ClassElement.java
+++ b/inject/src/main/java/io/micronaut/inject/ast/ClassElement.java
@@ -36,6 +36,11 @@ import static io.micronaut.inject.writer.BeanDefinitionVisitor.PROXY_SUFFIX;
  * @since 1.0
  */
 public interface ClassElement extends TypedElement {
+    /**
+     * Constant for an empty class element array.
+     * @since 3.1.0
+     */
+    ClassElement[] ZERO_CLASS_ELEMENTS = new ClassElement[0];
 
     /**
      * Tests whether one type is assignable to another.

--- a/inject/src/main/java/io/micronaut/inject/ast/ElementQuery.java
+++ b/inject/src/main/java/io/micronaut/inject/ast/ElementQuery.java
@@ -34,6 +34,13 @@ import java.util.function.Predicate;
 public interface ElementQuery<T extends Element> {
 
     /**
+     * Constant to retrieve inner classes.
+     *
+     * @since 3.1.0
+     */
+    ElementQuery<ClassElement> ALL_INNER_CLASSES = ElementQuery.of(ClassElement.class);
+
+    /**
      * Constant to retrieve all fields.
      */
     ElementQuery<FieldElement> ALL_FIELDS = ElementQuery.of(FieldElement.class);

--- a/inject/src/main/java/io/micronaut/inject/ast/MethodElement.java
+++ b/inject/src/main/java/io/micronaut/inject/ast/MethodElement.java
@@ -21,6 +21,7 @@ import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.inject.ast.beans.BeanElementBuilder;
 
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -36,6 +37,31 @@ public interface MethodElement extends MemberElement {
      */
     @NonNull
     ClassElement getReturnType();
+
+    /**
+     * <p>Returns the receiver type of this executable, or empty if the method has no receiver type.</p>
+     *
+     * <p>A MethodElement which is an instance method, or a constructor of an inner class, has a receiver type derived from the declaring type.</p>
+     *
+     * <p>A MethodElement which is a static method, or a constructor of a non-inner class, or an initializer (static or instance), has no receiver type.</p>
+     *
+     * @return The receiver type for the method if one exists.
+     * @since 3.1.0
+     */
+    default Optional<ClassElement> getReceiverType() {
+        return Optional.empty();
+    }
+
+    /**
+     * Returns the types declared in the {@code throws} declaration of a method.
+     *
+     * @return The {@code throws} types, if any. Never {@code null}.
+     * @since 3.1.0
+     */
+    @NonNull
+    default ClassElement[] getThrownTypes() {
+        return ClassElement.ZERO_CLASS_ELEMENTS;
+    }
 
     /**
      * @return The method parameters


### PR DESCRIPTION
CDI lite spec has methods to resolve the receiver type and the throws declaration which we don't have an API for:

https://github.com/eclipse-ee4j/cdi/blob/602f89c84a1e20e6a802ac18e2d2144365193249/api/src/main/java/jakarta/enterprise/lang/model/declarations/MethodInfo.java#L43-L51

This adds methods for the receiver type (this is a Java-only feature that Groovy doesn't appear to support) and the exceptions declared in the `throws` declaration