### PR TITLE
Use argument context to determine conversion type even for scalar values

### DIFF
--- a/json-core/src/main/java/io/micronaut/json/convert/JsonConverterRegistrar.java
+++ b/json-core/src/main/java/io/micronaut/json/convert/JsonConverterRegistrar.java
@@ -210,7 +210,7 @@ public final class JsonConverterRegistrar implements TypeConverterRegistrar {
                     return Optional.of(node.toString());
                 } else {
                     Argument<?> argument = null;
-                    if (node.isContainerNode() && context instanceof ArgumentConversionContext && targetType.getTypeParameters().length != 0) {
+                    if (context instanceof ArgumentConversionContext && targetType.getTypeParameters().length != 0) {
                         argument = ((ArgumentConversionContext<?>) context).getArgument();
                     }
                     if (argument == null) {


### PR DESCRIPTION
For some reason, `JsonConverterRegistrar` does not consider the argument context when deserializing scalar nodes. This is particularly relevant for converting to `Optional`, where the actual target type (the type the `Optional` wraps) is lost. In practice, this is rarely an issue, because jackson falls back on deserializing to `Object`, which defaults to sensible types. For example, conversion to `Optional<String>` would still give a compatible value when parsing a json string even though the `String` type isn't considered.