### PR TITLE
Mark some properties on Resource classes with their correct property names

### DIFF
--- a/http/build.gradle
+++ b/http/build.gradle
@@ -11,6 +11,8 @@ dependencies {
     compileOnly libs.kotlinx.coroutines.core
     compileOnly libs.kotlinx.coroutines.reactor
 
+    compileOnly libs.managed.jackson.annotations
+
     testCompileOnly project(":inject-groovy")
     testAnnotationProcessor project(":inject-java")
     testImplementation project(":inject")

--- a/http/src/main/java/io/micronaut/http/hateoas/AbstractResource.java
+++ b/http/src/main/java/io/micronaut/http/hateoas/AbstractResource.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.http.hateoas;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.ReflectiveAccess;
@@ -121,11 +122,13 @@ public abstract class AbstractResource<Impl extends AbstractResource> implements
         return (Impl) this;
     }
 
+    @JsonProperty(LINKS)
     @Override
     public OptionalMultiValues<Link> getLinks() {
         return OptionalMultiValues.of(linkMap);
     }
 
+    @JsonProperty(EMBEDDED)
     @Override
     public OptionalMultiValues<Resource> getEmbedded() {
         return OptionalMultiValues.of(embeddedMap);
@@ -139,7 +142,8 @@ public abstract class AbstractResource<Impl extends AbstractResource> implements
     @SuppressWarnings("unchecked")
     @Internal
     @ReflectiveAccess
-    protected final void setLinks(Map<String, Object> links) {
+    @JsonProperty(LINKS)
+    public final void setLinks(Map<String, Object> links) {
         for (Map.Entry<String, Object> entry : links.entrySet()) {
             String name = entry.getKey();
             Object value = entry.getValue();
@@ -159,7 +163,8 @@ public abstract class AbstractResource<Impl extends AbstractResource> implements
     @SuppressWarnings("unchecked")
     @Internal
     @ReflectiveAccess
-    protected final void setEmbedded(Map<String, List<Resource>> embedded) {
+    @JsonProperty(EMBEDDED)
+    public final void setEmbedded(Map<String, Object> embedded) {
         int x = 1;
 /*        for (Map.Entry<String, Object> entry : embedded.entrySet()) {
             String name = entry.getKey();

--- a/http/src/main/java/io/micronaut/http/hateoas/AbstractResource.java
+++ b/http/src/main/java/io/micronaut/http/hateoas/AbstractResource.java
@@ -165,36 +165,7 @@ public abstract class AbstractResource<Impl extends AbstractResource> implements
     @ReflectiveAccess
     @JsonProperty(EMBEDDED)
     public final void setEmbedded(Map<String, Object> embedded) {
-        int x = 1;
-/*        for (Map.Entry<String, Object> entry : embedded.entrySet()) {
-            String name = entry.getKey();
-            Object value = entry.getValue();
-            if (value instanceof Collection) {
-                List<Resource> resources = new ArrayList<>();
-                for (Object obj: (Collection) value) {
-                    Resource resource = createResource(obj);
-                    if (resource != null) {
-                        resources.add(resource);
-                    }
-                }
-                embedded(name, resources);
-            } else {
-                Resource resource = createResource(value);
-                if (resource != null) {
-                    embedded(name, resource);
-                }
-            }
-        }*/
     }
-
-//    private Resource createResource(Object resource) {
-//        if (resource instanceof Map) {
-//            Map<Object, Object> map = (Map<Object, Object>) resource;
-//            if (map.containsKey("message")) {
-//                JsonError jsonError = new JsonError("")
-//            }
-//        }
-//    }
 
     private void link(String name, Map<String, Object> linkMap) {
         ConvertibleValues<Object> values = ConvertibleValues.of(linkMap);

--- a/http/src/main/java/io/micronaut/http/hateoas/JsonError.java
+++ b/http/src/main/java/io/micronaut/http/hateoas/JsonError.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.http.hateoas;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.type.Argument;
 import io.micronaut.http.MediaType;
@@ -74,6 +75,7 @@ public class JsonError extends AbstractResource<JsonError> {
     /**
      * @return The logref
      */
+    @JsonProperty("logref")
     public Optional<String> getLogref() {
         return logref == null ? Optional.empty() : Optional.of(logref);
     }
@@ -81,6 +83,7 @@ public class JsonError extends AbstractResource<JsonError> {
     /**
      * @return The path
      */
+    @JsonProperty("path")
     public Optional<String> getPath() {
         return path == null ? Optional.empty() : Optional.of(path);
     }
@@ -91,6 +94,7 @@ public class JsonError extends AbstractResource<JsonError> {
      * @param path The path
      * @return This error object
      */
+    @JsonProperty
     public JsonError path(@Nullable String path) {
         this.path = path;
         return this;
@@ -102,6 +106,7 @@ public class JsonError extends AbstractResource<JsonError> {
      * @param logref The logref
      * @return This error object
      */
+    @JsonProperty
     public JsonError logref(@Nullable String logref) {
         this.logref = logref;
         return this;

--- a/http/src/main/java/io/micronaut/http/hateoas/Resource.java
+++ b/http/src/main/java/io/micronaut/http/hateoas/Resource.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.http.hateoas;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.micronaut.core.value.OptionalMultiValues;
 
 /**
@@ -38,6 +39,7 @@ public interface Resource {
     /**
      * @return The links for this resource
      */
+    @JsonProperty(LINKS)
     default OptionalMultiValues<? extends Link> getLinks() {
         return OptionalMultiValues.empty();
     }
@@ -45,6 +47,7 @@ public interface Resource {
     /**
      * @return The embedded resources
      */
+    @JsonProperty(EMBEDDED)
     default OptionalMultiValues<? extends Resource> getEmbedded() {
         return OptionalMultiValues.empty();
     }


### PR DESCRIPTION
This PR marks some of the properties on Resource, AbstractResource and JsonError using `@JsonProperty`. These properties are already special cased in `BeanIntrospectionModule` and `ResourceSerializerModifier`, so this has no impact on jackson-based serialization, but it avoids having to implement the special case in generated serializers as well.

This change only adds a compileOnly dependency on jackson-annotations.

`setLinks` and `setEmbedded` have been marked public so that they can be accessed by deserializers generated for subclasses that are in a different package. `setEmbedded` has its parameter type changed to `Map<String, Object>` because there can be no generic deserializer for `Resource` anyway, and it doesn't matter because `setEmbedded` doesn't do anything anyway. 