### PR TITLE
Delegate overridden method in AOP proxy

### DIFF
--- a/aop/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
+++ b/aop/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
@@ -528,15 +528,13 @@ public class AopProxyWriter extends AbstractClassFileWriter implements ProxyingB
     public void visitAroundMethod(TypedElement beanType,
                                   MethodElement methodElement) {
 
-        final List<MethodElement> overridden = methodElement.getOwningType()
-                .getEnclosedElements(ElementQuery.ALL_METHODS
-                        .filter(el -> el.getName().equals(methodElement.getName()) && el.overrides(methodElement)));
+        final Optional<MethodElement> overridden = methodElement.getOwningType()
+                .getEnclosedElement(ElementQuery.ALL_METHODS
+                        .named(name -> name.equals(methodElement.getName()))
+                        .filter(el -> el.overrides(methodElement)));
 
-        if (!overridden.isEmpty()) {
-            if (overridden.size() != 1) {
-                throw new IllegalStateException("Expected exactly one overridden method!");
-            }
-            MethodElement overriddenBy = overridden.iterator().next();
+        if (!overridden.isPresent()) {
+            MethodElement overriddenBy = overridden.get();
 
             String methodElementKey = methodElement.getName() +
                     Arrays.stream(methodElement.getSuspendParameters())

--- a/aop/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
+++ b/aop/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
@@ -530,6 +530,7 @@ public class AopProxyWriter extends AbstractClassFileWriter implements ProxyingB
 
         final Optional<MethodElement> overridden = methodElement.getOwningType()
                 .getEnclosedElement(ElementQuery.ALL_METHODS
+                        .onlyInstance()
                         .named(name -> name.equals(methodElement.getName()))
                         .filter(el -> el.overrides(methodElement)));
 

--- a/aop/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
+++ b/aop/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
@@ -530,14 +530,28 @@ public class AopProxyWriter extends AbstractClassFileWriter implements ProxyingB
 
         final List<MethodElement> overridden = methodElement.getOwningType()
                 .getEnclosedElements(ElementQuery.ALL_METHODS
-                        .filter(el -> el.overrides(methodElement)));
+                        .filter(el -> el.getName().equals(methodElement.getName()) && el.overrides(methodElement)));
 
         if (!overridden.isEmpty()) {
             if (overridden.size() != 1) {
                 throw new IllegalStateException("Expected exactly one overridden method!");
             }
-            buildMethodDelegate(methodElement, overridden.iterator().next());
-            return;
+            MethodElement overriddenBy = overridden.iterator().next();
+
+            String methodElementKey = methodElement.getName() +
+                    Arrays.stream(methodElement.getSuspendParameters())
+                            .map(p -> p.getGenericType().getName())
+                            .collect(Collectors.joining(","));
+
+            String overriddenByKey = overriddenBy.getName() +
+                    Arrays.stream(methodElement.getSuspendParameters())
+                            .map(p -> p.getGenericType().getName())
+                            .collect(Collectors.joining(","));
+
+            if (!methodElementKey.equals(overriddenByKey)) {
+                buildMethodDelegate(methodElement, overriddenBy);
+                return;
+            }
         }
 
         String methodName = methodElement.getName();

--- a/aop/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
+++ b/aop/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
@@ -533,7 +533,7 @@ public class AopProxyWriter extends AbstractClassFileWriter implements ProxyingB
                         .named(name -> name.equals(methodElement.getName()))
                         .filter(el -> el.overrides(methodElement)));
 
-        if (!overridden.isPresent()) {
+        if (overridden.isPresent()) {
             MethodElement overriddenBy = overridden.get();
 
             String methodElementKey = methodElement.getName() +

--- a/aop/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
+++ b/aop/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
@@ -540,7 +540,7 @@ public class AopProxyWriter extends AbstractClassFileWriter implements ProxyingB
 
             String methodElementKey = methodElement.getName() +
                     Arrays.stream(methodElement.getSuspendParameters())
-                            .map(p -> p.getGenericType().getName())
+                            .map(p -> p.getType().getName())
                             .collect(Collectors.joining(","));
 
             String overriddenByKey = overriddenBy.getName() +

--- a/inject-groovy/src/test/groovy/io/micronaut/aop/introduction/AbstractCrudRepo.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/aop/introduction/AbstractCrudRepo.groovy
@@ -1,0 +1,7 @@
+package io.micronaut.aop.introduction
+
+abstract class AbstractCrudRepo<E, ID> {
+
+   abstract Optional<E> findById(ID id)
+
+}

--- a/inject-groovy/src/test/groovy/io/micronaut/aop/introduction/AbstractCustomAbstractCrudRepo.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/aop/introduction/AbstractCustomAbstractCrudRepo.groovy
@@ -1,0 +1,9 @@
+package io.micronaut.aop.introduction
+
+@RepoDef
+abstract class AbstractCustomAbstractCrudRepo extends AbstractCrudRepo<String, Long> {
+
+    @Override
+    @Marker
+    abstract Optional<String> findById(Long aLong)
+}

--- a/inject-groovy/src/test/groovy/io/micronaut/aop/introduction/AbstractCustomCrudRepo.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/aop/introduction/AbstractCustomCrudRepo.groovy
@@ -1,0 +1,9 @@
+package io.micronaut.aop.introduction
+
+@RepoDef
+abstract class AbstractCustomCrudRepo implements CrudRepo<String, Long> {
+
+    @Override
+    @Marker
+    abstract Optional<String> findById(Long aLong)
+}

--- a/inject-groovy/src/test/groovy/io/micronaut/aop/introduction/CrudRepo.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/aop/introduction/CrudRepo.groovy
@@ -1,0 +1,7 @@
+package io.micronaut.aop.introduction
+
+interface CrudRepo<E, ID> {
+
+    Optional<E> findById(ID id)
+
+}

--- a/inject-groovy/src/test/groovy/io/micronaut/aop/introduction/CustomCrudRepo.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/aop/introduction/CustomCrudRepo.groovy
@@ -1,0 +1,9 @@
+package io.micronaut.aop.introduction
+
+@RepoDef
+interface CustomCrudRepo extends CrudRepo<String, Long> {
+
+    @Override
+    @Marker
+    Optional<String> findById(Long aLong)
+}

--- a/inject-groovy/src/test/groovy/io/micronaut/aop/introduction/Marker.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/aop/introduction/Marker.groovy
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.introduction
+
+import java.lang.annotation.Documented
+import java.lang.annotation.Retention
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME
+
+@Documented
+@Retention(RUNTIME)
+@interface Marker {
+}

--- a/inject-groovy/src/test/groovy/io/micronaut/aop/introduction/MyRepo.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/aop/introduction/MyRepo.groovy
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.introduction
+
+@RepoDef
+interface MyRepo extends SuperRepo {
+
+    String aBefore()
+
+    @Override
+    List<Integer> findAll()
+
+    String xAfter()
+
+}

--- a/inject-groovy/src/test/groovy/io/micronaut/aop/introduction/MyRepoIntroducer.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/aop/introduction/MyRepoIntroducer.groovy
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.introduction
+
+import io.micronaut.aop.MethodInterceptor
+import io.micronaut.aop.MethodInvocationContext
+import io.micronaut.core.annotation.Nullable
+import jakarta.inject.Singleton
+
+import java.lang.reflect.Method
+
+@Singleton
+class MyRepoIntroducer implements MethodInterceptor<Object, Object> {
+
+    public static final List<Method> EXECUTED_METHODS = new ArrayList<>()
+
+    @Override
+    int getOrder() {
+        return 0
+    }
+
+    @Nullable
+    @Override
+    Object intercept(MethodInvocationContext<Object, Object> context) {
+        EXECUTED_METHODS.add(context.getExecutableMethod().getTargetMethod())
+        return null
+    }
+}

--- a/inject-groovy/src/test/groovy/io/micronaut/aop/introduction/MyRepoIntroductionSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/aop/introduction/MyRepoIntroductionSpec.groovy
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.introduction
+
+import io.micronaut.context.ApplicationContext
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.util.stream.Collectors
+
+class MyRepoIntroductionSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    ApplicationContext applicationContext = ApplicationContext.run()
+
+    void "test generated introduction methods"() {
+        when:
+            def bean = applicationContext.getBean(MyRepo)
+            def interceptorDeclaredMethods = Arrays.stream(bean.getClass().getMethods()).filter(m -> m.getDeclaringClass() == bean.getClass()).collect(Collectors.toList())
+            def repoDeclaredMethods = Arrays.stream(MyRepo.class.getMethods()).filter(m -> m.getDeclaringClass() == MyRepo.class).collect(Collectors.toList())
+        then:
+            repoDeclaredMethods.size() == 3
+            interceptorDeclaredMethods.size() == 3
+            bean.getClass().getName().contains("Intercepted")
+            MyRepoIntroducer.EXECUTED_METHODS.isEmpty()
+        when:
+            bean.aBefore()
+            bean.xAfter()
+            bean.findAll()
+        then:
+            MyRepoIntroducer.EXECUTED_METHODS.size() == 3
+            MyRepoIntroducer.EXECUTED_METHODS.contains repoDeclaredMethods.find { method -> method.name == "aBefore" }
+            MyRepoIntroducer.EXECUTED_METHODS.contains repoDeclaredMethods.find { method -> method.name == "xAfter" }
+            MyRepoIntroducer.EXECUTED_METHODS.contains repoDeclaredMethods.find { method -> method.name == "findAll" && method.returnType == List.class }
+            MyRepoIntroducer.EXECUTED_METHODS.clear()
+    }
+
+    void "test interface overridden method"() {
+        when:
+            def bean = applicationContext.getBean(CustomCrudRepo)
+            def beanDef = applicationContext.getBeanDefinition(CustomCrudRepo)
+            def findByIdMethods = beanDef.getExecutableMethods().findAll(m -> m.getName() == "findById")
+        then:
+            MyRepoIntroducer.EXECUTED_METHODS.size() == 0
+            findByIdMethods.size() == 2
+            findByIdMethods[0].hasAnnotation(Marker)
+        when:
+            Object id = 111
+            bean.findById(id)
+        then:
+            MyRepoIntroducer.EXECUTED_METHODS.size() == 1
+            MyRepoIntroducer.EXECUTED_METHODS.clear()
+        when:
+            CrudRepo<Object, Object> crudRepo = bean
+            crudRepo.findById(id)
+        then:
+            MyRepoIntroducer.EXECUTED_METHODS.size() == 1
+            MyRepoIntroducer.EXECUTED_METHODS.clear()
+    }
+
+    void "test interface abstract overridden method"() {
+        when:
+            def bean = applicationContext.getBean(AbstractCustomCrudRepo)
+            def beanDef = applicationContext.getBeanDefinition(AbstractCustomCrudRepo)
+            def findByIdMethods = beanDef.getExecutableMethods().findAll(m -> m.getName() == "findById")
+        then:
+            MyRepoIntroducer.EXECUTED_METHODS.size() == 0
+            findByIdMethods.size() == 2
+            findByIdMethods[0].hasAnnotation(Marker)
+        when:
+            Object id = 111
+            bean.findById(id)
+        then:
+            MyRepoIntroducer.EXECUTED_METHODS.size() == 1
+            MyRepoIntroducer.EXECUTED_METHODS.clear()
+        when:
+            CrudRepo<Object, Object> crudRepo = bean
+            crudRepo.findById(id)
+        then:
+            MyRepoIntroducer.EXECUTED_METHODS.size() == 1
+            MyRepoIntroducer.EXECUTED_METHODS.clear()
+    }
+
+    void "test abstract overridden method"() {
+        when:
+            def bean = applicationContext.getBean(AbstractCustomAbstractCrudRepo)
+            def beanDef = applicationContext.getBeanDefinition(AbstractCustomAbstractCrudRepo)
+            def findByIdMethods = beanDef.getExecutableMethods().findAll(m -> m.getName() == "findById")
+        then:
+            MyRepoIntroducer.EXECUTED_METHODS.size() == 0
+            findByIdMethods.size() == 2
+            findByIdMethods[0].hasAnnotation(Marker)
+        when:
+            def id = 111
+            bean.findById(id)
+        then:
+            MyRepoIntroducer.EXECUTED_METHODS.size() == 1
+            MyRepoIntroducer.EXECUTED_METHODS.clear()
+        when:
+            AbstractCrudRepo<Object, Object> crudRepo = bean
+            crudRepo.findById(id)
+        then:
+            MyRepoIntroducer.EXECUTED_METHODS.size() == 1
+            MyRepoIntroducer.EXECUTED_METHODS.clear()
+    }
+
+}

--- a/inject-groovy/src/test/groovy/io/micronaut/aop/introduction/RepoDef.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/aop/introduction/RepoDef.groovy
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.introduction
+
+import io.micronaut.aop.Introduction
+import io.micronaut.context.annotation.Type
+
+import java.lang.annotation.Documented
+import java.lang.annotation.Retention
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME
+
+@Introduction
+@Type(MyRepoIntroducer.class)
+@Documented
+@Retention(RUNTIME)
+@interface RepoDef {
+}

--- a/inject-groovy/src/test/groovy/io/micronaut/aop/introduction/SuperRepo.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/aop/introduction/SuperRepo.groovy
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.introduction
+
+interface SuperRepo {
+
+    Iterable<Integer> findAll()
+
+}

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaMethodElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaMethodElement.java
@@ -77,11 +77,14 @@ public class JavaMethodElement extends AbstractJavaElement implements MethodElem
 
     @Override
     public boolean overrides(MethodElement methodElement) {
-        return visitorContext.getElements().overrides(
-                executableElement,
-                ((JavaMethodElement) methodElement).executableElement,
-                declaringClass.classElement
-        );
+        if (methodElement instanceof JavaMethodElement) {
+            return visitorContext.getElements().overrides(
+                    executableElement,
+                    ((JavaMethodElement) methodElement).executableElement,
+                    declaringClass.classElement
+            );
+        }
+        return false;
     }
 
     @NonNull

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaMethodElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaMethodElement.java
@@ -75,6 +75,15 @@ public class JavaMethodElement extends AbstractJavaElement implements MethodElem
         return executableElement.isDefault();
     }
 
+    @Override
+    public boolean overrides(MethodElement methodElement) {
+        return visitorContext.getElements().overrides(
+                executableElement,
+                ((JavaMethodElement) methodElement).executableElement,
+                declaringClass.classElement
+        );
+    }
+
     @NonNull
     @Override
     public ClassElement getGenericReturnType() {

--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/AbstractCrudRepo.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/AbstractCrudRepo.java
@@ -1,0 +1,9 @@
+package io.micronaut.aop.introduction;
+
+import java.util.Optional;
+
+public abstract class AbstractCrudRepo<E, ID> {
+
+   public abstract Optional<E> findById(ID id);
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/AbstractCustomAbstractCrudRepo.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/AbstractCustomAbstractCrudRepo.java
@@ -1,0 +1,11 @@
+package io.micronaut.aop.introduction;
+
+import java.util.Optional;
+
+@RepoDef
+public abstract class AbstractCustomAbstractCrudRepo extends AbstractCrudRepo<String, Long> {
+
+    @Override
+    @Marker
+    public abstract Optional<String> findById(Long aLong);
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/AbstractCustomCrudRepo.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/AbstractCustomCrudRepo.java
@@ -1,0 +1,11 @@
+package io.micronaut.aop.introduction;
+
+import java.util.Optional;
+
+@RepoDef
+public abstract class AbstractCustomCrudRepo implements CrudRepo<String, Long> {
+
+    @Override
+    @Marker
+    public abstract Optional<String> findById(Long aLong);
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/CrudRepo.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/CrudRepo.java
@@ -1,0 +1,9 @@
+package io.micronaut.aop.introduction;
+
+import java.util.Optional;
+
+public interface CrudRepo<E, ID> {
+
+    Optional<E> findById(ID id);
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/CustomCrudRepo.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/CustomCrudRepo.java
@@ -1,0 +1,11 @@
+package io.micronaut.aop.introduction;
+
+import java.util.Optional;
+
+@RepoDef
+public interface CustomCrudRepo extends CrudRepo<String, Long> {
+
+    @Override
+    @Marker
+    Optional<String> findById(Long aLong);
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/Marker.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/Marker.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.introduction;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Documented
+@Retention(RUNTIME)
+public @interface Marker {
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/MyRepoIntroductionSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/MyRepoIntroductionSpec.groovy
@@ -44,8 +44,76 @@ class MyRepoIntroductionSpec extends Specification {
             bean.findAll()
         then:
             MyRepoIntroducer.EXECUTED_METHODS.size() == 3
-            MyRepoIntroducer.EXECUTED_METHODS.contains repoDeclaredMethods.find {method -> method.name == "aBefore" }
-            MyRepoIntroducer.EXECUTED_METHODS.contains repoDeclaredMethods.find {method -> method.name == "xAfter" }
-            MyRepoIntroducer.EXECUTED_METHODS.contains repoDeclaredMethods.find {method -> method.name == "findAll" && method.returnType == List.class }
+            MyRepoIntroducer.EXECUTED_METHODS.contains repoDeclaredMethods.find { method -> method.name == "aBefore" }
+            MyRepoIntroducer.EXECUTED_METHODS.contains repoDeclaredMethods.find { method -> method.name == "xAfter" }
+            MyRepoIntroducer.EXECUTED_METHODS.contains repoDeclaredMethods.find { method -> method.name == "findAll" && method.returnType == List.class }
+            MyRepoIntroducer.EXECUTED_METHODS.clear()
     }
+
+    void "test interface overridden method"() {
+        when:
+            def bean = applicationContext.getBean(CustomCrudRepo)
+            def beanDef = applicationContext.getBeanDefinition(CustomCrudRepo)
+            def findByIdMethods = beanDef.getExecutableMethods().findAll(m -> m.getName() == "findById")
+        then:
+            MyRepoIntroducer.EXECUTED_METHODS.size() == 0
+            findByIdMethods.size() == 1
+            findByIdMethods[0].hasAnnotation(Marker)
+        when:
+            bean.findById(111)
+        then:
+            MyRepoIntroducer.EXECUTED_METHODS.size() == 1
+            MyRepoIntroducer.EXECUTED_METHODS.clear()
+        when:
+            CrudRepo<Object, Object> crudRepo = bean
+            crudRepo.findById(111)
+        then:
+            MyRepoIntroducer.EXECUTED_METHODS.size() == 1
+            MyRepoIntroducer.EXECUTED_METHODS.clear()
+    }
+
+    void "test interface abstract overridden method"() {
+        when:
+            def bean = applicationContext.getBean(AbstractCustomCrudRepo)
+            def beanDef = applicationContext.getBeanDefinition(AbstractCustomCrudRepo)
+            def findByIdMethods = beanDef.getExecutableMethods().findAll(m -> m.getName() == "findById")
+        then:
+            MyRepoIntroducer.EXECUTED_METHODS.size() == 0
+            findByIdMethods.size() == 1
+            findByIdMethods[0].hasAnnotation(Marker)
+        when:
+            bean.findById(111)
+        then:
+            MyRepoIntroducer.EXECUTED_METHODS.size() == 1
+            MyRepoIntroducer.EXECUTED_METHODS.clear()
+        when:
+            CrudRepo<Object, Object> crudRepo = bean
+            crudRepo.findById(111)
+        then:
+            MyRepoIntroducer.EXECUTED_METHODS.size() == 1
+            MyRepoIntroducer.EXECUTED_METHODS.clear()
+    }
+
+    void "test abstract overridden method"() {
+        when:
+            def bean = applicationContext.getBean(AbstractCustomAbstractCrudRepo)
+            def beanDef = applicationContext.getBeanDefinition(AbstractCustomAbstractCrudRepo)
+            def findByIdMethods = beanDef.getExecutableMethods().findAll(m -> m.getName() == "findById")
+        then:
+            MyRepoIntroducer.EXECUTED_METHODS.size() == 0
+            findByIdMethods.size() == 1
+            findByIdMethods[0].hasAnnotation(Marker)
+        when:
+            bean.findById(111)
+        then:
+            MyRepoIntroducer.EXECUTED_METHODS.size() == 1
+            MyRepoIntroducer.EXECUTED_METHODS.clear()
+        when:
+            AbstractCrudRepo<Object, Object> crudRepo = bean
+            crudRepo.findById(111)
+        then:
+            MyRepoIntroducer.EXECUTED_METHODS.size() == 1
+            MyRepoIntroducer.EXECUTED_METHODS.clear()
+    }
+
 }

--- a/inject/src/main/java/io/micronaut/inject/ast/MethodElement.java
+++ b/inject/src/main/java/io/micronaut/inject/ast/MethodElement.java
@@ -126,7 +126,7 @@ public interface MethodElement extends MemberElement {
      * @return true if this overrides passed method element
      * @since 3.1
      */
-    default boolean overrides(MethodElement overridden) {
+    default boolean overrides(@NonNull MethodElement overridden) {
         return false;
     }
 

--- a/inject/src/main/java/io/micronaut/inject/ast/MethodElement.java
+++ b/inject/src/main/java/io/micronaut/inject/ast/MethodElement.java
@@ -121,6 +121,16 @@ public interface MethodElement extends MemberElement {
     }
 
     /**
+     * Checks if this method element overrides another.
+     * @param overridden Possible overridden method
+     * @return true if this overrides passed method element
+     * @since 3.1
+     */
+    default boolean overrides(MethodElement overridden) {
+        return false;
+    }
+
+    /**
      * Creates a {@link MethodElement} for the given parameters.
      * @param declaredType The declaring type
      * @param annotationMetadata The annotation metadata


### PR DESCRIPTION
This changed the AOP class to skip executable method for overridden method and delegate to the override just like it's generated by Javac:

```java
public class CustomCrudRepoImpl implements CustomCrudRepo {
   public Optional<String> findById(Long aLong) {
      return Optional.empty();
   }

   // $FF: synthetic method
   // $FF: bridge method
   public Optional findById(Object var1) {
      return this.findById((Long)var1);
   }
}
```

Fixes issues where the behavior was different when repositories were accessed by the superclass.

Implemented only for Java. I don't know how to implement overridden checks for Groovy methods.

Fixes https://github.com/micronaut-projects/micronaut-data/issues/1186
