### PR TITLE
Introduce an index in immutable sorted maps

### DIFF
--- a/core/src/test/groovy/io/micronaut/core/annotation/ImmutableSortedStringsArrayMapTest.groovy
+++ b/core/src/test/groovy/io/micronaut/core/annotation/ImmutableSortedStringsArrayMapTest.groovy
@@ -1,0 +1,57 @@
+package io.micronaut.core.annotation
+
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class ImmutableSortedStringsArrayMapTest extends Specification {
+    private static <V> ImmutableSortedStringsArrayMap<V> build(Map<String, V> source) {
+        SortedMap<String, V> sorted = new TreeMap<>(source)
+        new ImmutableSortedStringsArrayMap<V>(sorted.keySet() as String[], sorted.values() as Object[])
+    }
+
+    private static final Random SEED = new Random(20211004)
+    private static final Set<String> KEYS = (0..65536).collect {
+        int len = 1+SEED.nextInt(32)
+        StringBuilder sb = new StringBuilder()
+        len.times {
+            sb.append((char) (48 + SEED.nextInt(120)))
+        }
+        sb.toString()
+    } as Set<String>
+
+    private static final Set<String> PRESENT = KEYS.indexed().collect([] as Set) { i, v ->
+        if (i < KEYS.size()/10) {
+            return v
+        }
+        null
+    }.findAll() as Set<String>
+
+    private static final Set<String> ABSENT = KEYS - PRESENT
+
+    @Unroll("Verifies correct behavior of map of size #size")
+    void verifyMapBehavior() {
+        given:
+        Map<String, Object> source = [:]
+        size.times { idx ->
+            source[PRESENT[idx]] = "value for $idx".toString()
+        }
+        def sorted = build(source)
+
+        expect:
+        sorted.size() == source.size()
+        sorted.keySet() == source.keySet()
+        source.keySet().each {k ->
+            assert sorted.containsKey(k)
+            assert sorted[k] == source[k] : "Value returned for key $k is incorrect. Expected ${source[k]} but was: ${sorted[k]}"
+        }
+
+        and:
+        ABSENT.each {
+            assert !sorted.containsKey(it)
+        }
+
+        where:
+        size << (1..384).findAll { it%3 == 0 }
+    }
+}


### PR DESCRIPTION
The `ImmutableSortedStringsArrayMap` implementation is more memory
efficient than a traditional hashmap, but key lookups are typically
slower, because they rely on a binary search, which is O(log(n))
where in a hash map lookup would be O(1).

When optimizing native images, it became obvious that this lookup
was causing some slowdowns in bean initialization because of many
calls to `hasStereotype`. Profiling shows that most of those calls
actually fail, which means that we do a binary search for nothing.

Most of the maps are also actually pretty small, with just a few
entries (2 or 3). Therefore, this commit introduces a "bloom-filter"
like idea, where we precompute an index based on the strings hash
codes. For every key in the map, we compute a "reduced" hash which
is from 0 to the size of the index map. Then we store at the reduced
hash position of the index, the index of the key itself.

This allows us to reduce most lookups to constant time lookups: when
a key is searched, we compute the reduced hash and look into the index
if there's a positive value, in which case it means that something
has the same reduced hash. All we need to do then is to check if the
key found at this index is the same. If not, then there are 2 possible
outcomes:

- either the reduced hash for key we search for has a collision with
a key in the map
- or two keys in the map have the same reduced hashes

In both cases, a binary search will determine if the key is present
or not.

Last but not least, this optimization is more efficient when the
index is sparse, that is to say that it can quickly determine if a
key is _not_ in the map. For that reason we construct an index which
size is 8 times the number of entries in the map. Because we use
integers, it means that the cost of this optimization for a map of 3
entries is 3*8*4 (3 ints) + 1 (size of array) = 97 bytes. For a map
of 100 entries, that would be 3200 bytes, which is obviously more but
unlikely to happen and probably less than what a hashmap of the same
size would use.

All in all, this compromise algorith has both reduced memory footprint
_and_ better performance, as I was able to eliminate all binary searches
from the startup of a Micronaut app (in other words the hotspot is gone
with this change).