### PR TITLE
Forward h2c upgrade request downstream so that it gets a response [Fixes #5005]

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -3104,7 +3104,7 @@ public class DefaultHttpClient implements
                 @Override
                 protected boolean isValidInMessage(Object msg) {
                     // ignore data on stream 1, that is the response to our initial upgrade request
-                    return super.isValidInMessage(msg) && (sslContext != null || discardH2cStream((HttpMessage) msg));
+                    return super.isValidInMessage(msg) && (sslContext != null || !discardH2cStream((HttpMessage) msg));
                 }
             });
         }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
@@ -852,6 +852,7 @@ public class NettyHttpServer implements NettyEmbeddedServer {
                                         pipelineListener.onConnect(p);
                                     }
                                     super.upgradeTo(ctx, upgradeRequest);
+                                    ctx.fireChannelRead(ReferenceCountUtil.retain(upgradeRequest));
                                 }
                             };
                         } else {

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
@@ -115,6 +115,7 @@ import io.netty.handler.codec.http2.Http2Connection;
 import io.netty.handler.codec.http2.Http2FrameListener;
 import io.netty.handler.codec.http2.Http2FrameLogger;
 import io.netty.handler.codec.http2.Http2ServerUpgradeCodec;
+import io.netty.handler.codec.http2.HttpConversionUtil;
 import io.netty.handler.codec.http2.HttpToHttp2ConnectionHandler;
 import io.netty.handler.codec.http2.HttpToHttp2ConnectionHandlerBuilder;
 import io.netty.handler.flow.FlowControlHandler;
@@ -852,6 +853,8 @@ public class NettyHttpServer implements NettyEmbeddedServer {
                                         pipelineListener.onConnect(p);
                                     }
                                     super.upgradeTo(ctx, upgradeRequest);
+                                    // HTTP1 request is on the implicit stream 1
+                                    upgradeRequest.headers().set(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), 1);
                                     ctx.fireChannelRead(ReferenceCountUtil.retain(upgradeRequest));
                                 }
                             };

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/http2/H2cSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/http2/H2cSpec.groovy
@@ -22,6 +22,7 @@ import io.netty.handler.codec.http.HttpVersion
 import io.netty.handler.codec.http2.DefaultHttp2Connection
 import io.netty.handler.codec.http2.DelegatingDecompressorFrameListener
 import io.netty.handler.codec.http2.Http2ClientUpgradeCodec
+import io.netty.handler.codec.http2.HttpConversionUtil
 import io.netty.handler.codec.http2.HttpToHttp2ConnectionHandlerBuilder
 import io.netty.handler.codec.http2.InboundHttp2ToHttpAdapterBuilder
 import jakarta.inject.Inject
@@ -75,6 +76,9 @@ class H2cSpec extends Specification {
                                 void channelRead(@NotNull ChannelHandlerContext ctx, @NotNull Object msg) throws Exception {
                                     ctx.read()
                                     if (msg instanceof HttpMessage) {
+                                        if (msg.headers().getInt(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), -1) != 1) {
+                                            responseFuture.completeExceptionally(new AssertionError("Response must be on stream 1"));
+                                        }
                                         responseFuture.complete(msg)
                                     }
                                     super.channelRead(ctx, msg)

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/http2/H2cSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/http2/H2cSpec.groovy
@@ -1,0 +1,111 @@
+package io.micronaut.http.server.netty.http2
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.netty.channel.ChannelPipelineCustomizer
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.netty.bootstrap.Bootstrap
+import io.netty.channel.ChannelHandlerContext
+import io.netty.channel.ChannelInboundHandlerAdapter
+import io.netty.channel.ChannelInitializer
+import io.netty.channel.nio.NioEventLoopGroup
+import io.netty.channel.socket.SocketChannel
+import io.netty.channel.socket.nio.NioSocketChannel
+import io.netty.handler.codec.http.DefaultFullHttpRequest
+import io.netty.handler.codec.http.HttpClientCodec
+import io.netty.handler.codec.http.HttpClientUpgradeHandler
+import io.netty.handler.codec.http.HttpMessage
+import io.netty.handler.codec.http.HttpMethod
+import io.netty.handler.codec.http.HttpVersion
+import io.netty.handler.codec.http2.DefaultHttp2Connection
+import io.netty.handler.codec.http2.DelegatingDecompressorFrameListener
+import io.netty.handler.codec.http2.Http2ClientUpgradeCodec
+import io.netty.handler.codec.http2.HttpToHttp2ConnectionHandlerBuilder
+import io.netty.handler.codec.http2.InboundHttp2ToHttpAdapterBuilder
+import jakarta.inject.Inject
+import org.jetbrains.annotations.NotNull
+import spock.lang.Issue
+import spock.lang.Requires
+import spock.lang.Specification
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+
+@MicronautTest
+@Property(name = "micronaut.server.http-version", value = "2.0")
+@Property(name = "micronaut.server.port", value = "8912")
+@Property(name = "micronaut.ssl.enabled", value = "false")
+@Requires({ jvm.current.isJava11Compatible() })
+class H2cSpec extends Specification {
+    @Inject
+    EmbeddedServer embeddedServer;
+
+    @Issue('https://github.com/micronaut-projects/micronaut-core/issues/5005')
+    void 'test http2 over clear text is supported even when request data is only sent once'() {
+        given:
+        def responseFuture = new CompletableFuture()
+        def bootstrap = new Bootstrap()
+            .remoteAddress(embeddedServer.host, embeddedServer.port)
+            .group(new NioEventLoopGroup())
+            .channel(NioSocketChannel.class)
+            .handler(new ChannelInitializer<SocketChannel>() {
+                @Override
+                protected void initChannel(@NotNull SocketChannel ch) throws Exception {
+                    def http2Connection = new DefaultHttp2Connection(false)
+                    def inboundAdapter = new InboundHttp2ToHttpAdapterBuilder(http2Connection)
+                            .maxContentLength(1000000)
+                            .validateHttpHeaders(true)
+                            .propagateSettings(true)
+                            .build()
+                    def connectionHandler = new HttpToHttp2ConnectionHandlerBuilder()
+                            .connection(http2Connection)
+                            .frameListener(new DelegatingDecompressorFrameListener(http2Connection, inboundAdapter))
+                            .build()
+                    def clientCodec = new HttpClientCodec()
+                    def upgradeCodec = new Http2ClientUpgradeCodec(ChannelPipelineCustomizer.HANDLER_HTTP2_CONNECTION, connectionHandler)
+                    def upgradeHandler = new HttpClientUpgradeHandler(clientCodec, upgradeCodec, 1000000)
+
+                    ch.pipeline()
+                            .addLast(ChannelPipelineCustomizer.HANDLER_HTTP_CLIENT_CODEC, clientCodec)
+                            .addLast(upgradeHandler)
+                            .addLast(new ChannelInboundHandlerAdapter() {
+                                @Override
+                                void channelRead(@NotNull ChannelHandlerContext ctx, @NotNull Object msg) throws Exception {
+                                    ctx.read()
+                                    if (msg instanceof HttpMessage) {
+                                        responseFuture.complete(msg)
+                                    }
+                                    super.channelRead(ctx, msg)
+                                }
+
+                                @Override
+                                void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                                    super.exceptionCaught(ctx, cause)
+                                    cause.printStackTrace()
+                                    responseFuture.completeExceptionally(cause)
+                                }
+                            })
+
+                }
+            })
+
+        def channel = (SocketChannel) bootstrap.connect().await().channel()
+
+        def request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, '/h2c/test')
+        channel.writeAndFlush(request)
+        channel.read()
+
+        expect:
+        responseFuture.get(10, TimeUnit.SECONDS) != null
+    }
+
+    @Controller("/h2c")
+    static class TestController {
+        @Get("/test")
+        String test() {
+            return 'foo'
+        }
+    }
+}


### PR DESCRIPTION
From NettyServerUpgradeHandler: "The upgrade was successful, remove the message from the output list so that it's not propagated to the next handler. This request will be propagated as a user event instead."

So, the first request is discarded. This patch sends it downstream for normal handling.

---

Build is failing locally but that seems unrelated, so we'll see what CI says.

I'm not 100% on whether this patch could duplicate the request, but since it is a `FullHttpRequest` that is being forwarded, it should be safe – no partial data to worry about or anything. The fact that the `upgradeRequest` will still contain headers related to the upgrade may also be a concern, since it allows an attacker to send these headers further downstream than before. But I think that after the upgrade is complete, an attacker could send the same headers anyway.