### PR TITLE
Fix sharing of annotation class value loading between introspection and its ref

### DIFF
--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
@@ -2789,6 +2789,48 @@ abstract class Test {
         beanIntrospection.getBeanProperties().size() == 3
     }
 
+    void "test class loading is not shared between the introspection and the ref"() {
+        when:
+        BeanIntrospection beanIntrospection = buildBeanIntrospection("test.Test", """
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+
+import java.util.Set;
+
+@Introspected(excludedAnnotations = Deprecated.class)
+public class Test {
+
+    private Set<Author> authors;
+    
+    public Set<Author> getAuthors() {
+        return authors;
+    }
+
+    public void setAuthors(Set<Author> authors) {
+        this.authors = authors;
+    }
+}
+@Introspected(excludedAnnotations = Deprecated.class)
+class Author {
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}
+""")
+
+        then:
+        noExceptionThrown()
+        beanIntrospection != null
+        beanIntrospection.getBeanProperties().size() == 1
+    }
+
     @Override
     protected JavaParser newJavaParser() {
         return new JavaParser() {

--- a/inject/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
@@ -306,6 +306,7 @@ final class BeanIntrospectionWriter extends AbstractAnnotationMetadataWriter {
 
             // write the reference
             writeIntrospectionReference(classWriterOutputVisitor);
+            loadTypeMethods.clear();
             // write the introspection
             writeIntrospectionClass(classWriterOutputVisitor);
 


### PR DESCRIPTION
Issue was introduced by https://github.com/micronaut-projects/micronaut-core/issues/6217

The `loadTypeMethods` variable was not cleared between writing the introspection and the ref and thus if both the ref and the introspection needed to load the same class the method would only be written to the ref, but attempt to be called from the introspection.

I think ideally we could only have the methods written to the ref, however the current code is not setup for that type of thing at all as far as I can tell. The result is that if both are loading the same class the load method will be duplicated in both classes.