### PR TITLE
EmbeddedServer.getPort improvement

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
@@ -373,6 +373,9 @@ public class NettyHttpServer implements NettyEmbeddedServer {
 
     @Override
     public int getPort() {
+        if (!isRunning() && serverPort == -1) {
+            throw new UnsupportedOperationException("Retrieving the port from the server before it has started is not supported when binding to a random port");
+        }
         return serverPort;
     }
 

--- a/src/main/docs/guide/appendix/breaks.adoc
+++ b/src/main/docs/guide/appendix/breaks.adoc
@@ -1,4 +1,10 @@
-This section documents breaking changes between Micronaut 2.x and Micronaut 3.x
+This section documents breaking changes between Micronaut versions
+
+== 3.1.0
+
+Retrieving the port from the Netty embedded server is no longer supported if the server is configured to bind to a random port and the server has not been started.
+
+== 3.0.0
 
 === Core Changes
 


### PR DESCRIPTION
This is up for discussion. I can definitely see that some folks would prefer to just get the -1 rather than handle an exception

relates to https://github.com/micronaut-projects/micronaut-core/issues/6085