### PR TITLE
WebSocket ping API [Adds #5680]

### DIFF
--- a/http-netty/src/main/java/io/micronaut/http/netty/websocket/NettyWebSocketSession.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/websocket/NettyWebSocketSession.java
@@ -16,6 +16,7 @@
 package io.micronaut.http.netty.websocket;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.value.ConvertibleMultiValues;
@@ -219,8 +220,9 @@ public class NettyWebSocketSession implements WebSocketSession {
         }, FluxSink.OverflowStrategy.ERROR);
     }
 
+    @NonNull
     @Override
-    public CompletableFuture<?> sendPingAsync(byte[] content) {
+    public CompletableFuture<?> sendPingAsync(@NonNull byte[] content) {
         if (isOpen()) {
             ByteBuf messageBuffer = channel.alloc().buffer(content.length);
             messageBuffer.writeBytes(content);

--- a/src/main/docs/guide/httpServer/websocket/websocketServer.adoc
+++ b/src/main/docs/guide/httpServer/websocket/websocketServer.adoc
@@ -27,6 +27,7 @@ The ann:websocket.annotation.OnMessage[] method can define a parameter for the m
 * Any Java primitive or simple type (such as `String`). In fact, any type that can be converted from `ByteBuf` (you can register additional api:core.convert.TypeConverter[] beans to support a custom type).
 * A `byte[]`, a `ByteBuf` or a Java NIO `ByteBuffer`.
 * A POJO. In this case, it will be decoded by default as JSON using api:jackson.codec.JsonMediaTypeCodec[]. You can register a custom codec and define the content type of the handler using the ann:http.annotation.Consumes[] annotation.
+* A api:websocket.WebSocketPongMessage[]. This is a special case: The method will not receive regular messages, but instead handle WebSocket pongs that arrive as a reply to a ping sent to the client.
 
 === The @OnError Method
 

--- a/websocket/src/main/java/io/micronaut/websocket/WebSocketPongMessage.java
+++ b/websocket/src/main/java/io/micronaut/websocket/WebSocketPongMessage.java
@@ -15,11 +15,17 @@
  */
 package io.micronaut.websocket;
 
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.io.buffer.ByteBuffer;
+
+import java.util.Objects;
 
 /**
  * Special message class that can be accepted by a {@link io.micronaut.websocket.annotation.OnMessage @OnMessage}
  * method to listen to WebSocket pongs.
+ *
+ * @since 3.1
+ * @author Jonas Konrad
  */
 public final class WebSocketPongMessage {
     private final ByteBuffer<?> content;
@@ -27,13 +33,15 @@ public final class WebSocketPongMessage {
     /**
      * @param content The content of the pong message.
      */
-    public WebSocketPongMessage(ByteBuffer<?> content) {
+    public WebSocketPongMessage(@NonNull ByteBuffer<?> content) {
+        Objects.requireNonNull(content, "content");
         this.content = content;
     }
 
     /**
      * @return The content of the pong message. This buffer may be released after the message handler has completed.
      */
+    @NonNull
     public ByteBuffer<?> getContent() {
         return content;
     }

--- a/websocket/src/main/java/io/micronaut/websocket/WebSocketPongMessage.java
+++ b/websocket/src/main/java/io/micronaut/websocket/WebSocketPongMessage.java
@@ -1,0 +1,25 @@
+package io.micronaut.websocket;
+
+import io.micronaut.core.io.buffer.ByteBuffer;
+
+/**
+ * Special message class that can be accepted by a {@link io.micronaut.websocket.annotation.OnMessage @OnMessage}
+ * method to listen to WebSocket pongs.
+ */
+public final class WebSocketPongMessage {
+    private final ByteBuffer<?> content;
+
+    /**
+     * @param content The content of the pong message.
+     */
+    public WebSocketPongMessage(ByteBuffer<?> content) {
+        this.content = content;
+    }
+
+    /**
+     * @return The content of the pong message. This buffer may be released after the message handler has completed.
+     */
+    public ByteBuffer<?> getContent() {
+        return content;
+    }
+}

--- a/websocket/src/main/java/io/micronaut/websocket/WebSocketPongMessage.java
+++ b/websocket/src/main/java/io/micronaut/websocket/WebSocketPongMessage.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.websocket;
 
 import io.micronaut.core.io.buffer.ByteBuffer;

--- a/websocket/src/main/java/io/micronaut/websocket/WebSocketSession.java
+++ b/websocket/src/main/java/io/micronaut/websocket/WebSocketSession.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.websocket;
 
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.convert.value.ConvertibleMultiValues;
 import io.micronaut.core.convert.value.ConvertibleValues;
 import io.micronaut.core.convert.value.MutableConvertibleValues;
@@ -171,7 +172,8 @@ public interface WebSocketSession extends MutableConvertibleValues<Object>, Auto
      * {@link WebSocketPongMessage}.
      * @return A future that completes when the ping has been sent. (Not when the pong has been received!)
      */
-    default CompletableFuture<?> sendPingAsync(byte[] content) {
+    @NonNull
+    default CompletableFuture<?> sendPingAsync(@NonNull byte[] content) {
         throw new UnsupportedOperationException("Ping not supported by this implementation");
     }
 

--- a/websocket/src/main/java/io/micronaut/websocket/WebSocketSession.java
+++ b/websocket/src/main/java/io/micronaut/websocket/WebSocketSession.java
@@ -163,6 +163,19 @@ public interface WebSocketSession extends MutableConvertibleValues<Object>, Auto
     }
 
     /**
+     * Send a ping through this WebSocket. The pong reply can be intercepted using a
+     * {@link io.micronaut.websocket.annotation.OnMessage @OnMessage} method that accepts a
+     * {@link WebSocketPongMessage}.
+     *
+     * @param content The content of the ping. The remote should return the same content in its
+     * {@link WebSocketPongMessage}.
+     * @return A future that completes when the ping has been sent. (Not when the pong has been received!)
+     */
+    default CompletableFuture<?> sendPingAsync(byte[] content) {
+        throw new UnsupportedOperationException("Ping not supported by this implementation");
+    }
+
+    /**
      * The subprotocol if one is used.
      * @return The subprotocol
      */

--- a/websocket/src/main/java/io/micronaut/websocket/context/DefaultWebSocketBeanRegistry.java
+++ b/websocket/src/main/java/io/micronaut/websocket/context/DefaultWebSocketBeanRegistry.java
@@ -22,10 +22,12 @@ import io.micronaut.inject.ExecutableMethod;
 import io.micronaut.inject.ExecutionHandle;
 import io.micronaut.inject.MethodExecutionHandle;
 import io.micronaut.inject.qualifiers.Qualifiers;
+import io.micronaut.websocket.WebSocketPongMessage;
 import io.micronaut.websocket.annotation.*;
 import io.micronaut.websocket.exceptions.WebSocketException;
 
 import java.lang.annotation.Annotation;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
@@ -67,6 +69,7 @@ class DefaultWebSocketBeanRegistry implements WebSocketBeanRegistry {
             MethodExecutionHandle<T, ?> onOpen = null;
             MethodExecutionHandle<T, ?> onClose = null;
             MethodExecutionHandle<T, ?> onMessage = null;
+            MethodExecutionHandle<T, ?> onPong = null;
             MethodExecutionHandle<T, ?> onError = null;
             for (ExecutableMethod<T, ?> method : executableMethods) {
                 if (method.isAnnotationPresent(OnOpen.class)) {
@@ -94,16 +97,23 @@ class DefaultWebSocketBeanRegistry implements WebSocketBeanRegistry {
                 }
 
                 if (method.isAnnotationPresent(OnMessage.class)) {
-                    onMessage = ExecutionHandle.of(
-                            bean,
-                            method
-                    );
+                    if (Arrays.asList(method.getArgumentTypes()).contains(WebSocketPongMessage.class)) {
+                        onPong = ExecutionHandle.of(
+                                bean,
+                                method
+                        );
+                    } else {
+                        onMessage = ExecutionHandle.of(
+                                bean,
+                                method
+                        );
+                    }
                 }
             }
             if (onMessage == null) {
                 throw new WebSocketException("WebSocket handler must specify an @OnMessage handler: " + bean);
             }
-            DefaultWebSocketBean<T> newWebSocketBean = new DefaultWebSocketBean<>(bean, beanDefinition, onOpen, onClose, onMessage, onError);
+            DefaultWebSocketBean<T> newWebSocketBean = new DefaultWebSocketBean<>(bean, beanDefinition, onOpen, onClose, onMessage, onPong, onError);
             if (beanDefinition.isSingleton()) {
                 webSocketBeanMap.put(type, newWebSocketBean);
             }
@@ -123,14 +133,16 @@ class DefaultWebSocketBeanRegistry implements WebSocketBeanRegistry {
         private final MethodExecutionHandle<T, ?> onOpen;
         private final MethodExecutionHandle<T, ?> onClose;
         private final MethodExecutionHandle<T, ?> onMessage;
+        private final MethodExecutionHandle<T, ?> onPong;
         private final MethodExecutionHandle<T, ?> onError;
 
-        DefaultWebSocketBean(T bean, BeanDefinition<T> definition, MethodExecutionHandle<T, ?> onOpen, MethodExecutionHandle<T, ?> onClose, MethodExecutionHandle<T, ?> onMessage, MethodExecutionHandle<T, ?> onError) {
+        DefaultWebSocketBean(T bean, BeanDefinition<T> definition, MethodExecutionHandle<T, ?> onOpen, MethodExecutionHandle<T, ?> onClose, MethodExecutionHandle<T, ?> onMessage, MethodExecutionHandle<T, ?> onPong, MethodExecutionHandle<T, ?> onError) {
             this.bean = bean;
             this.definition = definition;
             this.onOpen = onOpen;
             this.onClose = onClose;
             this.onMessage = onMessage;
+            this.onPong = onPong;
             this.onError = onError;
         }
 
@@ -147,6 +159,11 @@ class DefaultWebSocketBeanRegistry implements WebSocketBeanRegistry {
         @Override
         public Optional<MethodExecutionHandle<T, ?>> messageMethod() {
             return Optional.of(onMessage);
+        }
+
+        @Override
+        public Optional<MethodExecutionHandle<T, ?>> pongMethod() {
+            return Optional.ofNullable(onPong);
         }
 
         @Override

--- a/websocket/src/main/java/io/micronaut/websocket/context/WebSocketBean.java
+++ b/websocket/src/main/java/io/micronaut/websocket/context/WebSocketBean.java
@@ -41,11 +41,22 @@ public interface WebSocketBean<T> {
     T getTarget();
 
     /**
-     * Returns the method annotated with {@link io.micronaut.websocket.annotation.OnMessage}.
+     * Returns the method annotated with {@link io.micronaut.websocket.annotation.OnMessage} responsible for regular
+     * messages.
      *
      * @return the method
      */
     Optional<MethodExecutionHandle<T, ?>> messageMethod();
+
+    /**
+     * Returns the method annotated with {@link io.micronaut.websocket.annotation.OnMessage} responsible for pong
+     * messages.
+     *
+     * @return the method
+     */
+    default Optional<MethodExecutionHandle<T, ?>> pongMethod() {
+        return Optional.empty();
+    }
 
     /**
      * Returns the method annotated with {@link io.micronaut.websocket.annotation.OnClose}.

--- a/websocket/src/main/java/io/micronaut/websocket/context/WebSocketBean.java
+++ b/websocket/src/main/java/io/micronaut/websocket/context/WebSocketBean.java
@@ -53,6 +53,7 @@ public interface WebSocketBean<T> {
      * messages.
      *
      * @return the method
+     * @since 3.1
      */
     default Optional<MethodExecutionHandle<T, ?>> pongMethod() {
         return Optional.empty();


### PR DESCRIPTION
This API is mostly parallel to the normal message API. To stay consistent with javax.websocket, methods annotated with `@OnMessage` are used as pong handlers if they have a `WebSocketPongMessage` argument.

A `sendPingAsync` method was added to `WebSocketSession` to allow sending a ping.

Neither of these APIs does the type conversion that the normal message handling does. In my opinion it does not make much sense for ping/pong messages – you might want to put a timestamp into the message, but that's about it.