### PR TITLE
Implement (de)serialization of new JsonNode class [Fixes #6295]

### DIFF
--- a/http-client/src/test/groovy/io/micronaut/http/client/HttpPostSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/HttpPostSpec.groovy
@@ -29,6 +29,7 @@ import io.micronaut.http.client.annotation.Client
 import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.http.client.multipart.MultipartBody
 import io.micronaut.http.multipart.CompletedFileUpload
+import io.micronaut.json.tree.JsonObject
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
 import reactor.core.publisher.Flux
@@ -376,6 +377,14 @@ class HttpPostSpec extends Specification {
 
         then:
         res.status == HttpStatus.NO_CONTENT
+    }
+
+    void "test http post getBody should return right type"() {
+        when:
+        def request = HttpRequest.POST('/', JsonObject.createObjectNode([:]))
+
+        then:
+        request.getBody(String).get() == '{}'
     }
 
     @Requires(property = 'spec.name', value = 'HttpPostSpec')

--- a/jackson-databind/src/main/java/io/micronaut/jackson/serialize/JsonNodeDeserializer.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/serialize/JsonNodeDeserializer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.jackson.serialize;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import io.micronaut.jackson.core.tree.JsonNodeTreeCodec;
+import io.micronaut.json.tree.JsonNode;
+import jakarta.inject.Singleton;
+
+import java.io.IOException;
+
+/**
+ * Deserializer for {@link JsonNode}.
+ *
+ * @author Jonas Konrad
+ * @since 3.1
+ */
+@Singleton
+final class JsonNodeDeserializer extends JsonDeserializer<JsonNode> {
+    @Override
+    public JsonNode deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        return JsonNodeTreeCodec.getInstance().readTree(p);
+    }
+}

--- a/jackson-databind/src/main/java/io/micronaut/jackson/serialize/JsonNodeSerializer.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/serialize/JsonNodeSerializer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.jackson.serialize;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import io.micronaut.jackson.core.tree.JsonNodeTreeCodec;
+import io.micronaut.json.tree.JsonNode;
+import jakarta.inject.Singleton;
+
+import java.io.IOException;
+
+/**
+ * Serializer for {@link JsonNode}.
+ *
+ * @author Jonas Konrad
+ * @since 3.1
+ */
+@Singleton
+final class JsonNodeSerializer extends JsonSerializer<JsonNode> {
+    @Override
+    public void serialize(JsonNode value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        if (value == null) {
+            gen.writeNull();
+        } else {
+            JsonNodeTreeCodec.getInstance().writeTree(gen, value);
+        }
+    }
+}

--- a/jackson-databind/src/test/groovy/io/micronaut/jackson/databind/JacksonDatabindMapperSpec.groovy
+++ b/jackson-databind/src/test/groovy/io/micronaut/jackson/databind/JacksonDatabindMapperSpec.groovy
@@ -1,0 +1,21 @@
+package io.micronaut.jackson.databind
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.type.Argument
+import io.micronaut.json.JsonMapper
+import io.micronaut.json.tree.JsonNode
+import spock.lang.Specification
+
+class JacksonDatabindMapperSpec extends Specification {
+    def 'parsing to JsonNode'() {
+        given:
+        def ctx = ApplicationContext.run()
+        def mapper = ctx.getBean(JsonMapper)
+
+        expect:
+        mapper.readValue('{}', Argument.of(JsonNode)) == JsonNode.createObjectNode([:])
+
+        cleanup:
+        ctx.close()
+    }
+}

--- a/jackson-databind/src/test/groovy/io/micronaut/jackson/databind/convert/JsonNodeToObjectConverterSpec.groovy
+++ b/jackson-databind/src/test/groovy/io/micronaut/jackson/databind/convert/JsonNodeToObjectConverterSpec.groovy
@@ -77,4 +77,21 @@ class JsonNodeToObjectConverterSpec extends Specification {
             this.value = value
         }
     }
+
+    void "test the converter converts to string properly"() {
+        given:
+        def ctx = ApplicationContext.run()
+        def converter = ctx.getBean(ConversionService)
+
+        when:
+        Optional optional = converter.convert(JsonNode.createObjectNode([:]), String)
+
+        then:
+        noExceptionThrown()
+        optional.isPresent()
+        optional.get() == '{}'
+
+        cleanup:
+        ctx.close()
+    }
 }

--- a/json-core/src/main/java/io/micronaut/json/convert/JsonConverterRegistrar.java
+++ b/json-core/src/main/java/io/micronaut/json/convert/JsonConverterRegistrar.java
@@ -35,6 +35,7 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -207,7 +208,7 @@ public final class JsonConverterRegistrar implements TypeConverterRegistrar {
         return (node, targetType, context) -> {
             try {
                 if (CharSequence.class.isAssignableFrom(targetType) && node.isObject()) {
-                    return Optional.of(node.toString());
+                    return Optional.of(new String(objectCodec.get().writeValueAsBytes(node), StandardCharsets.UTF_8));
                 } else {
                     Argument<?> argument = null;
                     if (context instanceof ArgumentConversionContext && targetType.getTypeParameters().length != 0) {


### PR DESCRIPTION
This fixes two issues:

- There was previously no jackson-databind (de)serializer for the new JsonNode. This is not as urgent, because JsonNode is experimental, but this is required for the second fix.
- JsonConverterRegistrar now uses the JsonMapper for stringifying JsonNode. JsonNode does not have a toString method anymore because it would necessitate a dependency on jackson-core, so the old toString approach does not work anymore.

The second point manifested in #6295 so this should definitely go into 3.1 to avoid compatibility issues.