### PR TITLE
Do not discard remaining data when cancelling h2c upgrade [Fixes #4643]

### DIFF
--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/http2/H2cSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/http2/H2cSpec.groovy
@@ -3,8 +3,10 @@ package io.micronaut.http.server.netty.http2
 import io.micronaut.context.annotation.Property
 import io.micronaut.core.io.buffer.ByteBuffer
 import io.micronaut.http.HttpRequest
+import io.micronaut.http.annotation.Body
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Put
 import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.StreamingHttpClient
 import io.micronaut.http.netty.channel.ChannelPipelineCustomizer
@@ -182,6 +184,14 @@ class H2cSpec extends Specification {
         stream("http://localhost:${embeddedServer.port}/h2c/test") == 'foo'
     }
 
+    def 'http1.1 put'() {
+        given:
+        def http1Client = HttpClient.create(new URL("http://localhost:${embeddedServer.port}/"))
+
+        expect:
+        http1Client.toBlocking().exchange(HttpRequest.PUT("http://localhost:${embeddedServer.port}/h2c/put", "foo"), String).body() == 'Example response: foo'
+    }
+
     @Controller("/h2c")
     static class TestController {
         @Get("/test")
@@ -205,6 +215,11 @@ class H2cSpec extends Specification {
                     sink.complete()
                 }).start()
             }
+        }
+
+        @Put('/put')
+        String put(@Body String body) {
+            return "Example response: $body"
         }
     }
 }


### PR DESCRIPTION
#4643 is caused by removing the HttpServerCodec from the pipeline when there is no upgrade request.

In normal operation, the `getHandlerForProtocol(HTTP_1_1)` will return a new HttpServerCodec that takes over decoding. However, when the request is processed, the old HttpServerCodec may not yet have completed reading all data, and removing it causes that data to be lost.

This fix instead reuses the existing HttpServerCodec. We also have to carefully place the other relevant handlers around it in the pipeline. It would be more convenient if we could simply remove it and then readd it, but netty does not support that unfortunately.