### PR TITLE
Added more configuration options to websockets

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/websocket/NettyServerWebSocketUpgradeHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/websocket/NettyServerWebSocketUpgradeHandler.java
@@ -54,6 +54,7 @@ import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.WebSocketDecoderConfig;
 import io.netty.handler.codec.http.websocketx.WebSocketServerHandshaker;
 import io.netty.handler.codec.http.websocketx.WebSocketServerHandshakerFactory;
 import io.netty.handler.ssl.SslHandler;
@@ -211,18 +212,41 @@ public class NettyServerWebSocketUpgradeHandler extends SimpleChannelInboundHand
      **/
     protected ChannelFuture handleHandshake(ChannelHandlerContext ctx, NettyHttpRequest req, WebSocketBean<?> webSocketBean, MutableHttpResponse<?> response) {
         int maxFramePayloadLength = webSocketBean.messageMethod()
-                .map(m -> m.intValue(OnMessage.class, "maxPayloadLength")
-                .orElse(65536)).orElse(65536);
+                .map(m -> m.intValue(OnMessage.class, "maxPayloadLength").orElse(65536))
+                .orElse(65536);
+        boolean expectMaskedFrames = webSocketBean.messageMethod()
+                .map(m -> m.booleanValue(OnMessage.class, "expectMaskedFrames").orElse(true))
+                .orElse(true);
+        boolean allowMaskMismatch = webSocketBean.messageMethod()
+                .map(m -> m.booleanValue(OnMessage.class, "allowMaskMismatch").orElse(false))
+                .orElse(false);
+        boolean allowExtensions = webSocketBean.messageMethod()
+                .map(m -> m.booleanValue(OnMessage.class, "allowExtensions").orElse(false))
+                .orElse(false);
+        boolean closeOnProtocolViolation = webSocketBean.messageMethod()
+                .map(m -> m.booleanValue(OnMessage.class, "closeOnProtocolViolation").orElse(true))
+                .orElse(true);
+        boolean withUTF8Validator = webSocketBean.messageMethod()
+                .map(m -> m.booleanValue(OnMessage.class, "withUTF8Validator").orElse(true))
+                .orElse(true);
+
         String subprotocols = webSocketBean.getBeanDefinition().stringValue(ServerWebSocket.class, "subprotocols")
-                                           .filter(s -> !StringUtils.isEmpty(s))
-                                           .orElse(null);
-        WebSocketServerHandshakerFactory wsFactory =
-                new WebSocketServerHandshakerFactory(
-                        getWebSocketURL(ctx, req),
-                        subprotocols,
-                        true,
-                        maxFramePayloadLength
-                );
+                .filter(s -> !StringUtils.isEmpty(s))
+                .orElse(null);
+
+        WebSocketServerHandshakerFactory wsFactory = new WebSocketServerHandshakerFactory(
+                getWebSocketURL(ctx, req),
+                subprotocols,
+                WebSocketDecoderConfig.newBuilder()
+                        .maxFramePayloadLength(maxFramePayloadLength)
+                        .expectMaskedFrames(expectMaskedFrames)
+                        .allowMaskMismatch(allowMaskMismatch)
+                        .allowExtensions(allowExtensions)
+                        .closeOnProtocolViolation(closeOnProtocolViolation)
+                        .withUTF8Validator(withUTF8Validator)
+                        .build()
+        );
+
         handshaker = wsFactory.newHandshaker(req.getNativeRequest());
         MutableHttpHeaders headers = response.getHeaders();
         io.netty.handler.codec.http.HttpHeaders nettyHeaders;

--- a/websocket/src/main/java/io/micronaut/websocket/annotation/OnMessage.java
+++ b/websocket/src/main/java/io/micronaut/websocket/annotation/OnMessage.java
@@ -42,4 +42,39 @@ public @interface OnMessage {
      * @return The max size
      */
     int maxPayloadLength() default 65536;
+
+    /**
+     * Web socket servers must set this to true processed incoming masked payload. Client implementations must set this to false.
+     *
+     * @return will the server expect masked frames
+     */
+    boolean expectMaskedFrames() default true;
+
+    /**
+     * When set to true, frames which are not masked properly according to the standard will still be  accepted.
+     *
+     * @return are mask mismatches allowed
+     */
+    boolean allowMaskMismatch() default false;
+
+    /**
+     * Flag to allow reserved extension bits to be used or not
+     *
+     * @return are extension bits allowed
+     */
+    boolean allowExtensions() default false;
+
+    /**
+     * Should the connection close on any type of protocol violations
+     *
+     * @return will connections close on exceptions
+     */
+    boolean closeOnProtocolViolation() default true;
+
+    /**
+     * Checks if the message bytes are encoded using UTF-8
+     *
+     * @return is validator enabled
+     */
+    boolean withUTF8Validator() default true;
 }

--- a/websocket/src/main/java/io/micronaut/websocket/annotation/OnMessage.java
+++ b/websocket/src/main/java/io/micronaut/websocket/annotation/OnMessage.java
@@ -58,21 +58,21 @@ public @interface OnMessage {
     boolean allowMaskMismatch() default false;
 
     /**
-     * Flag to allow reserved extension bits to be used or not
+     * Flag to allow reserved extension bits to be used or not.
      *
      * @return are extension bits allowed
      */
     boolean allowExtensions() default false;
 
     /**
-     * Should the connection close on any type of protocol violations
+     * Should the connection close on any type of protocol violations.
      *
      * @return will connections close on exceptions
      */
     boolean closeOnProtocolViolation() default true;
 
     /**
-     * Checks if the message bytes are encoded using UTF-8
+     * Checks if the message bytes are encoded using UTF-8.
      *
      * @return is validator enabled
      */


### PR DESCRIPTION
The following parameters from the `WebSocketDecoderConfig` were not configureable from the `ServerWebSocket` 

```
boolean expectMaskedFrames;
boolean allowMaskMismatch;
boolean allowExtensions;
boolean closeOnProtocolViolation;
boolean withUTF8Validator;
```

So I've added the possibility to configure them from the `OnMessage` annotation let me know if anything needs to be changed I tried to follow the code style as close as possible 😄 