### PR TITLE
Fix javadoc link to @Format

### DIFF
--- a/src/main/docs/guide/introduction/whatsNew.adoc
+++ b/src/main/docs/guide/introduction/whatsNew.adoc
@@ -44,7 +44,7 @@ The way the server binds to random ports has improved and should result in fewer
 
 ==== Client Data Formatting
 
-The ann:core.convert.Format[] annotation now supports several new values that can be used in conjunction with the declarative HTTP client to support formatting data in several new ways. See the <<clientParameters, client parameters>> documentation for more information.
+The ann:core.convert.format.Format[] annotation now supports several new values that can be used in conjunction with the declarative HTTP client to support formatting data in several new ways. See the <<clientParameters, client parameters>> documentation for more information.
 
 ==== StreamingFileUpload
 


### PR DESCRIPTION
Correct link is: 

https://docs.micronaut.io/snapshot/api/io/micronaut/core/convert/format/Format.html

not: 

https://docs.micronaut.io/snapshot/api/io/micronaut/core/convert/Format.html