### PR TITLE
Set --enable-preview flag only for JDK 18+

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['8', '11', '15']
+        java: ['8', '11', '17']
     steps:
       # https://github.com/actions/virtual-environments/issues/709
       - name: Free disk space

--- a/inject-java-test/src/main/java/io/micronaut/annotation/processing/test/JavaParser.java
+++ b/inject-java-test/src/main/java/io/micronaut/annotation/processing/test/JavaParser.java
@@ -282,7 +282,7 @@ public class JavaParser implements Closeable {
 
     private Set<String> getCompilerOptions() {
         Set<String> options;
-        if (Jvm.getCurrent().isJava15Compatible()) {
+        if (Jvm.getCurrent().isJava18Compatible()) {
             options = CollectionUtils.setOf(
                     "--enable-preview",
                     "-source",


### PR DESCRIPTION
I'm trying to use JDK17 in openapi module (for Records) and without this fix the build fails with:

```
  java.lang.IllegalArgumentException: error: invalid source release: --enable-preview
      at jdk.compiler/com.sun.tools.javac.main.Arguments.error(Arguments.java:905)
      at jdk.compiler/com.sun.tools.javac.main.Arguments.doProcessArgs(Arguments.java:383)
      at jdk.compiler/com.sun.tools.javac.main.Arguments.processArgs(Arguments.java:347)
      at jdk.compiler/com.sun.tools.javac.main.Arguments.init(Arguments.java:246)
      at jdk.compiler/com.sun.tools.javac.api.JavacTool.getTask(JavacTool.java:191)
      at jdk.compiler/com.sun.tools.javac.api.JavacTool.getTask(JavacTool.java:119)
      at jdk.compiler/com.sun.tools.javac.api.JavacTool.getTask(JavacTool.java:68)
      at io.micronaut.annotation.processing.test.JavaParser.getJavacTask(JavaParser.java:210)
      at io.micronaut.annotation.processing.test.JavaParser.generate(JavaParser.java:260)
      at io.micronaut.annotation.processing.test.JavaParser.generate(JavaParser.java:230)
      at io.micronaut.annotation.processing.test.AbstractTypeElementSpec.buildClassLoader(AbstractTypeElementSpec.groovy:449)
      at io.micronaut.annotation.processing.test.AbstractTypeElementSpec.buildBeanDefinition(AbstractTypeElementSpec.groovy:355)
      at io.micronaut.openapi.visitor.OpenApiRecordsSpec.test build OpenAPI returning a record from a controller(OpenApiRecordsSpec.groovy:21)
```

This PR fixes the error although I'm not sure if this is the best approach. At this moment the build uses JDK16 and until Kotlin 1.6 is out we can live with it, but after that we need to upgrade everything to JDK17.