### PR TITLE
Fix BOM property substitution

### DIFF
--- a/bom/build.gradle
+++ b/bom/build.gradle
@@ -57,6 +57,12 @@ tasks.named("generateCatalogAsToml") {
     modelConverter.populateModel()
 }
 
+def bomPropertyName = { String alias ->
+    alias = alias - 'managed.'
+    String baseName = legacyVersionNames[alias] ?: toPropertyName(alias)
+    "${baseName}.version"
+}
+
 publishing {
     publications {
         maven(MavenPublication) {
@@ -69,14 +75,26 @@ publishing {
                     xml.children().find {
                         it.name().localPart == 'packaging'
                     } + project.ext.pomInfo
+                    modelConverter.model.librariesTable.each { library ->
+                        def alias = library.version.reference.replaceAll('-', '.')
+                        if (alias != null && library.alias.replaceAll('-', '.').startsWith("managed.")) {
+                            def pomDep = xml.dependencyManagement.dependencies.dependency.find {
+                                it.artifactId.text() == library.name
+                                        && it.groupId.text() == library.group
+                            }
+                            if (pomDep != null) {
+                                pomDep.version.first().setValue("\${${bomPropertyName(alias)}}")
+                            } else {
+                                println "[WARNING] Didn't find dependency ${library.group}:${library.name} in BOM file"
+                            }
+                        }
+                    }
                 }
             }
             libsCatalog.versionAliases.each { alias ->
                 if (alias.startsWith('managed.')) {
                     libsCatalog.findVersion(alias).ifPresent { version ->
-                        alias = alias - 'managed.'
-                        String baseName = legacyVersionNames[alias] ?: toPropertyName(alias)
-                        String propertyName = "${baseName}.version"
+                        String propertyName = bomPropertyName(alias)
                         pom.properties.put(propertyName, version.requiredVersion)
                     }
                 }

--- a/buildSrc/src/main/groovy/io/micronaut/build/internal/pom/VersionCatalogConverter.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/build/internal/pom/VersionCatalogConverter.groovy
@@ -2,9 +2,9 @@ package io.micronaut.build.internal.pom
 
 import groovy.transform.Canonical
 import io.micronaut.build.catalogs.internal.LenientVersionCatalogParser
+import io.micronaut.build.catalogs.internal.VersionCatalogTomlModel
 import org.gradle.api.InvalidUserCodeException
 import org.gradle.api.plugins.catalog.CatalogPluginExtension
-import org.gradle.api.tasks.TaskAction
 /**
  * This is an internal task which responsibility is to parse
  * the Micronaut version catalog used internally, extract components
@@ -23,11 +23,18 @@ class VersionCatalogConverter {
     final Map<String, String> extraVersions = [:]
     final Map<String, Library> extraLibraries = [:]
 
-    @TaskAction
+    private VersionCatalogTomlModel model
+
+    VersionCatalogTomlModel getModel() {
+        if (model == null) {
+            def parser = new LenientVersionCatalogParser()
+            parser.parse(catalogFile.newInputStream())
+            model = parser.model
+        }
+        model
+    }
+
     void populateModel() {
-        def parser = new LenientVersionCatalogParser()
-        parser.parse(catalogFile.newInputStream())
-        def model = parser.model
         catalogExtension.versionCatalog {builder ->
             extraVersions.forEach { alias, version ->
                 builder.version(alias, version)


### PR DESCRIPTION
The generated BOM file didn't substitute the managed dependency
versions with their corresponding property.

Fixes #6330