### PR TITLE
Add find and getBeanDefinition methods to BeanProvider interface

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/provider/BeanProviderSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/provider/BeanProviderSpec.groovy
@@ -20,6 +20,7 @@ import io.micronaut.context.ApplicationContext
 import io.micronaut.context.BeanContext
 import io.micronaut.context.BeanContextConfiguration
 import io.micronaut.context.DefaultBeanContext
+import io.micronaut.context.exceptions.NoSuchBeanException
 import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.BeanDefinitionReference
 import io.micronaut.inject.annotation.TestCachePuts
@@ -169,11 +170,32 @@ class Foo {}
 
 class Bar {}
 ''')
+        when:
         def bean = getBean(context, 'test.Test')
 
-        expect:
+        then:
         bean.provider.isPresent()
         !bean.barProvider.isPresent()
+        bean.provider.find(null).isPresent()
+        !bean.barProvider.find(null).isPresent()
+
+        when:
+        bean.barProvider.get()
+
+        then:
+        thrown(NoSuchBeanException)
+
+        when:
+        bean.barProvider.getDefinition()
+
+        then:
+        thrown(NoSuchBeanException)
+
+        when:
+        BeanDefinition definition = bean.provider.getDefinition()
+
+        then:
+        definition != null
 
         cleanup:
         context.close()

--- a/inject/src/main/java/io/micronaut/inject/provider/BeanProviderDefinition.java
+++ b/inject/src/main/java/io/micronaut/inject/provider/BeanProviderDefinition.java
@@ -21,9 +21,11 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.type.Argument;
+import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.qualifiers.AnyQualifier;
 
 import java.util.Iterator;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 /**
@@ -64,6 +66,16 @@ public final class BeanProviderDefinition extends AbstractProviderDefinition<Bea
             @Override
             public Object get() {
                 return ((DefaultBeanContext) context).getBean(resolutionContext, argument, finalQualifier);
+            }
+
+            @Override
+            public Optional<Object> find(Qualifier<Object> qualifier) {
+                return ((DefaultBeanContext) context).findBean(resolutionContext, argument, finalQualifier);
+            }
+
+            @Override
+            public BeanDefinition<Object> getDefinition() {
+                return context.getBeanDefinition(argument, finalQualifier);
             }
 
             @Override


### PR DESCRIPTION
Small improvement to make it easier to get the `BeanDefinition` and a method that returns `Optional` for bean discovery.