### PR TITLE
Configure content length for h2c upgrade request [Fixes #6299]

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
@@ -904,7 +904,8 @@ public class NettyHttpServer implements NettyEmbeddedServer {
                     final HttpServerCodec sourceCodec = http2OrHttpHandler.createServerCodec();
                     final HttpServerUpgradeHandler upgradeHandler = new HttpServerUpgradeHandler(
                             sourceCodec,
-                            upgradeCodecFactory
+                            upgradeCodecFactory,
+                            serverConfiguration.getMaxH2cUpgradeRequestSize()
                     );
                     final CleartextHttp2ServerUpgradeHandler cleartextHttp2ServerUpgradeHandler =
                             new CleartextHttp2ServerUpgradeHandler(sourceCodec, upgradeHandler, connectionHandler);

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/configuration/NettyHttpServerConfiguration.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/configuration/NettyHttpServerConfiguration.java
@@ -122,6 +122,7 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
     private int maxInitialLineLength = DEFAULT_MAXINITIALLINELENGTH;
     private int maxHeaderSize = DEFAULT_MAXHEADERSIZE;
     private int maxChunkSize = DEFAULT_MAXCHUNKSIZE;
+    private int maxH2cUpgradeRequestSize = DEFAULT_MAXCHUNKSIZE; // same default as maxChunkSize, we don't want to buffer super long bodies
     private boolean chunkedSupported = DEFAULT_CHUNKSUPPORTED;
     private boolean validateHeaders = DEFAULT_VALIDATEHEADERS;
     private int initialBufferSize = DEFAULT_INITIALBUFFERSIZE;
@@ -256,6 +257,21 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
      */
     public int getMaxChunkSize() {
         return maxChunkSize;
+    }
+
+    /**
+     * The maximum size of the body of the HTTP1.1 request used to upgrade a connection to HTTP2 clear-text (h2c).
+     * This initial request cannot be streamed and is instead buffered in full, so the default value
+     * ({@value #DEFAULT_MAXCHUNKSIZE}) is relatively small. <i>If this value is too small for your use case,
+     * instead consider using an empty initial "upgrade request" (e.g. {@code OPTIONS /}), or switch to normal
+     * HTTP2.</i>
+     * <p>
+     * <i>Does not affect normal HTTP2 (TLS).</i>
+     *
+     * @return The maximum content length of the request.
+     */
+    public int getMaxH2cUpgradeRequestSize() {
+        return maxH2cUpgradeRequestSize;
     }
 
     /**
@@ -424,6 +440,20 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
      */
     public void setMaxChunkSize(@ReadableBytes int maxChunkSize) {
         this.maxChunkSize = maxChunkSize;
+    }
+
+    /**
+     * Sets the maximum size of the body of the HTTP1.1 request used to upgrade a connection to HTTP2 clear-text (h2c).
+     * This initial request cannot be streamed and is instead buffered in full, so the default value
+     * ({@value #DEFAULT_MAXCHUNKSIZE}) is relatively small. <i>If this value is too small for your use case,
+     * instead consider using an empty initial "upgrade request" (e.g. {@code OPTIONS /}), or switch to normal
+     * HTTP2.</i>
+     * <p>
+     * <i>Does not affect normal HTTP2 (TLS).</i>
+     * @param maxH2cUpgradeRequestSize The maximum content length of the request.
+     */
+    public void setMaxH2cUpgradeRequestSize(int maxH2cUpgradeRequestSize) {
+        this.maxH2cUpgradeRequestSize = maxH2cUpgradeRequestSize;
     }
 
     /**

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/decoders/HttpRequestDecoder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/decoders/HttpRequestDecoder.java
@@ -28,6 +28,7 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToMessageDecoder;
 import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -77,6 +78,9 @@ public class HttpRequestDecoder extends MessageToMessageDecoder<HttpRequest> imp
         }
         try {
             NettyHttpRequest<Object> request = new NettyHttpRequest<>(msg, ctx, conversionService, configuration);
+            if (msg instanceof HttpContent) {
+                request.addContent(((HttpContent) msg).retain());
+            }
             if (httpRequestReceivedEventPublisher != ApplicationEventPublisher.NO_OP) {
                 try {
                     ctx.executor().execute(() -> {

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/decoders/HttpRequestDecoder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/decoders/HttpRequestDecoder.java
@@ -78,7 +78,7 @@ public class HttpRequestDecoder extends MessageToMessageDecoder<HttpRequest> imp
         }
         try {
             NettyHttpRequest<Object> request = new NettyHttpRequest<>(msg, ctx, conversionService, configuration);
-            if (msg instanceof HttpContent) {
+            if (msg instanceof HttpContent && ((HttpContent) msg).content().readableBytes() > 0) {
                 request.addContent(((HttpContent) msg).retain());
             }
             if (httpRequestReceivedEventPublisher != ApplicationEventPublisher.NO_OP) {


### PR DESCRIPTION
Also small modification to `HttpRequestDecoder` to handle `FullHttpRequest`s properly as returned by the upgrade handler.