### PR TITLE
Fix javadoc publication

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'io.micronaut.build.shared.settings' version '4.1.3'
+    id 'io.micronaut.build.shared.settings' version '4.2.2'
 }
 
 enableFeaturePreview("VERSION_CATALOGS")


### PR DESCRIPTION
This commit bumps the Micronaut Build plugin to 4.2.2. This will fix
the Javadoc publication.

Fixes #6355