### PR TITLE
Properly consume content of full HTTP requests [Fixes #6299]

### DIFF
--- a/http-netty/src/main/java/io/micronaut/http/netty/stream/HttpStreamsHandler.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/stream/HttpStreamsHandler.java
@@ -27,6 +27,7 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.FullHttpMessage;
+import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpMessage;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -202,7 +203,7 @@ abstract class HttpStreamsHandler<In extends HttpMessage, Out extends HttpMessag
 
             if (inMsg instanceof FullHttpMessage) {
                 FullHttpMessage fullMessage = (FullHttpMessage) inMsg;
-                if (fullMessage.content().readableBytes() == 0) {
+                if (!(fullMessage instanceof FullHttpRequest) || fullMessage.content().readableBytes() == 0) {
                     // Forward as is
                     ctx.fireChannelRead(inMsg);
                 } else {

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/decoders/HttpRequestDecoder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/decoders/HttpRequestDecoder.java
@@ -28,7 +28,6 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToMessageDecoder;
 import io.netty.handler.codec.http.DefaultHttpRequest;
-import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -78,9 +77,6 @@ public class HttpRequestDecoder extends MessageToMessageDecoder<HttpRequest> imp
         }
         try {
             NettyHttpRequest<Object> request = new NettyHttpRequest<>(msg, ctx, conversionService, configuration);
-            if (msg instanceof HttpContent && ((HttpContent) msg).content().readableBytes() > 0) {
-                request.addContent(((HttpContent) msg).retain());
-            }
             if (httpRequestReceivedEventPublisher != ApplicationEventPublisher.NO_OP) {
                 try {
                     ctx.executor().execute(() -> {


### PR DESCRIPTION
The h2c upgrade requests case from #6350 seems to be the only case where our server has to handle FullHttpRequests that have non-empty content. My [previous fix](https://github.com/micronaut-projects/micronaut-core/pull/6350/files#diff-80171c172c037b0610a42407a946eda5504eeefb4db5e63e31867c5a8532fecaR81-R83) simply used `NettyHttpRequest.addContent` to add the data to the micronaut request. This works fine for `@Body` parameters that can convert directly from `ByteBuf`, but it seems to bypass the `HttpContentProcessor` logic that is also responsible for json parsing.

This patch replaces the `addContent` approach from the previous PR. Instead, further downstream in the `HttpStreamsHandler`, it creates a "fake" `StreamedHttpRequest` that, as the input publisher, just uses the body already present on the request.

I'm not 100% sure why the `inMsg` does not need an additional `retain` call when also used as the message body, but it seems to work fine this way, and it matches the behavior of `HandlerPublisher`.