### PR TITLE
Introduce sanity check for generated services

### DIFF
--- a/buffer-netty/build.gradle
+++ b/buffer-netty/build.gradle
@@ -1,3 +1,8 @@
+
+internalSanityChecks {
+    expectedServiceCount.put('io.micronaut.inject.BeanDefinitionReference', 1)
+}           
+
 dependencies {
     api project(":core")
     api project(":inject")

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.sanity-checks.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.sanity-checks.gradle
@@ -1,0 +1,17 @@
+import io.micronaut.build.internal.sanity.InternalSanityChecks
+import io.micronaut.build.internal.sanity.VerifyServiceCountTask
+
+def sanity = extensions.create('internalSanityChecks', InternalSanityChecks)
+sanity.failOnMismatch.convention(true)
+
+def verifyServiceCount = tasks.register("verifyServiceCount", VerifyServiceCountTask) {
+    classesDirectory = tasks.named('compileJava', JavaCompile).flatMap { it.destinationDirectory }
+    expectedServiceCount = sanity.expectedServiceCount
+    failOnMismatch = sanity.failOnMismatch
+    outputFile = layout.buildDirectory.file("sanity-checks/$name")
+    gradleEnterprise = gradle.settings.gradleEnterprise
+}
+
+tasks.named("compileJava") {
+    finalizedBy(verifyServiceCount)
+}

--- a/buildSrc/src/main/groovy/io/micronaut/build/internal/sanity/InternalSanityChecks.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/build/internal/sanity/InternalSanityChecks.groovy
@@ -1,0 +1,18 @@
+package io.micronaut.build.internal.sanity
+
+import groovy.transform.CompileStatic
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+
+/**
+ * An internal extension aimed at verifying
+ * the state of the Micronaut build itself.
+ * It's aimed at debugging issues like the
+ * annotation processors not being executed
+ * properly.
+ */
+@CompileStatic
+abstract class InternalSanityChecks {
+    abstract MapProperty<String, Integer> getExpectedServiceCount()
+    abstract Property<Boolean> getFailOnMismatch()
+}

--- a/buildSrc/src/main/groovy/io/micronaut/build/internal/sanity/VerifyServiceCountTask.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/build/internal/sanity/VerifyServiceCountTask.groovy
@@ -1,0 +1,77 @@
+package io.micronaut.build.internal.sanity
+
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+
+@CacheableTask
+abstract class VerifyServiceCountTask extends DefaultTask {
+
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
+    abstract DirectoryProperty getClassesDirectory()
+
+    @Input
+    abstract MapProperty<String, Integer> getExpectedServiceCount()
+
+    @Input
+    abstract Property<Boolean> getFailOnMismatch()
+
+    @OutputFile
+    abstract RegularFileProperty getOutputFile()
+
+    @Internal
+    abstract Property<Object> getGradleEnterprise()
+
+    @TaskAction
+    void check() {
+        boolean failed = false
+        def error = { String service, String message ->
+            failed = true
+            logger.error("""=======
+WARNING
+=======
+$message
+=======
+""")
+            gradleEnterprise.get().buildScan {
+                it.tag 'ANNOTATION_PROCESSING_FAILURE'
+                it.value "${path}: Annotation processor service file $service", message
+            }
+        }
+        def baseDir = classesDirectory.dir("META-INF/services").get().asFile
+        expectedServiceCount.get().each { String k, Integer expectedCount ->
+            def serviceFile = new File(baseDir, k)
+            if (serviceFile.exists()) {
+                def relativePath = classesDirectory.get().asFile.toPath().relativize(serviceFile.toPath()).toString()
+                def actualCount = serviceFile.readLines().findAll { it.trim() }.size()
+                if (actualCount < expectedCount) {
+                    error(k, "Expected $expectedCount services of type $k to be registed but only found $actualCount in $relativePath")
+                } else if (actualCount > expectedCount) {
+                    error(k, "Expected $expectedCount services of type $k to be registed but found more ($actualCount) in $relativePath. Consider updating the internalSanityChecks count.")
+                }
+            } else {
+                error(k, "Expected a service file ${serviceFile} to be generated but it's absent!")
+            }
+        }
+        if (failed && failOnMismatch.get()) {
+            throw new GradleException("Sanity check for service file generation failed")
+        }
+        def outputFile = outputFile.get().asFile
+        if (outputFile.parentFile.exists() || outputFile.parentFile.mkdirs()) {
+            outputFile.text = "ok"
+        }
+    }
+}

--- a/context/build.gradle
+++ b/context/build.gradle
@@ -1,3 +1,9 @@
+
+internalSanityChecks {
+    expectedServiceCount.put('io.micronaut.inject.BeanDefinitionReference', 30)
+    expectedServiceCount.put('io.micronaut.core.beans.BeanIntrospectionReference', 2)
+}           
+
 dependencies {
     annotationProcessor project(":inject-java")
     annotationProcessor project(":graal")

--- a/function-client/build.gradle
+++ b/function-client/build.gradle
@@ -1,3 +1,8 @@
+
+internalSanityChecks {
+    expectedServiceCount.put('io.micronaut.inject.BeanDefinitionReference', 5)
+}           
+
 dependencies {
     annotationProcessor project(":inject-java")
     api project(":function")

--- a/function-web/build.gradle
+++ b/function-web/build.gradle
@@ -1,3 +1,8 @@
+
+internalSanityChecks {
+    expectedServiceCount.put('io.micronaut.inject.BeanDefinitionReference', 1)
+}           
+
 dependencies {
     annotationProcessor project(":inject-java")
     api project(":function")

--- a/function/build.gradle
+++ b/function/build.gradle
@@ -1,3 +1,8 @@
+
+internalSanityChecks {
+    expectedServiceCount.put('io.micronaut.inject.BeanDefinitionReference', 1)
+}           
+
 dependencies {
 	annotationProcessor project(":inject-java")
 

--- a/http-client-core/build.gradle
+++ b/http-client-core/build.gradle
@@ -1,3 +1,10 @@
+
+internalSanityChecks {
+    expectedServiceCount.put('io.micronaut.inject.BeanDefinitionReference', 20)
+    expectedServiceCount.put('io.micronaut.core.beans.BeanIntrospectionReference', 1)
+    expectedServiceCount.put('io.micronaut.inject.BeanConfiguration', 1)
+}           
+
 dependencies {
     annotationProcessor project(":inject-java")
 

--- a/http-client/build.gradle
+++ b/http-client/build.gradle
@@ -1,3 +1,8 @@
+
+internalSanityChecks {
+    expectedServiceCount.put('io.micronaut.inject.BeanDefinitionReference', 3)
+}           
+
 dependencies {
     annotationProcessor project(":inject-java")
     api project(":runtime")

--- a/http-netty/build.gradle
+++ b/http-netty/build.gradle
@@ -1,3 +1,9 @@
+
+internalSanityChecks {
+    expectedServiceCount.put('io.micronaut.inject.BeanDefinitionReference', 16)
+    expectedServiceCount.put('io.micronaut.core.beans.BeanIntrospectionReference', 2)
+}           
+
 dependencies {
     annotationProcessor project(":inject-java")
     annotationProcessor project(":graal")

--- a/http-server-netty/build.gradle
+++ b/http-server-netty/build.gradle
@@ -1,3 +1,8 @@
+
+internalSanityChecks {
+    expectedServiceCount.put('io.micronaut.inject.BeanDefinitionReference', 24)
+}           
+
 dependencies {
     annotationProcessor project(":inject-java")
     annotationProcessor project(":graal")

--- a/http-server/build.gradle
+++ b/http-server/build.gradle
@@ -1,4 +1,10 @@
 
+
+internalSanityChecks {
+    expectedServiceCount.put('io.micronaut.inject.BeanDefinitionReference', 29)
+    expectedServiceCount.put('io.micronaut.inject.BeanConfiguration', 1)
+}           
+
 dependencies {
     api project(":websocket")
     api project(":runtime")

--- a/http/build.gradle
+++ b/http/build.gradle
@@ -2,6 +2,17 @@ plugins {
     id "org.jetbrains.kotlin.jvm"
 }
 
+internalSanityChecks {
+    expectedServiceCount.put('io.micronaut.core.beans.BeanIntrospectionReference', 4)
+    expectedServiceCount.put('io.micronaut.inject.BeanDefinitionReference', 21)
+}
+
+
+internalSanityChecks {
+    expectedServiceCount.put('io.micronaut.inject.BeanDefinitionReference', 21)
+    expectedServiceCount.put('io.micronaut.core.beans.BeanIntrospectionReference', 4)
+}           
+
 dependencies {
     annotationProcessor project(":inject-java")
     annotationProcessor project(":graal")

--- a/jackson-databind/build.gradle
+++ b/jackson-databind/build.gradle
@@ -1,3 +1,9 @@
+
+internalSanityChecks {
+    expectedServiceCount.put('io.micronaut.inject.BeanDefinitionReference', 18)
+    expectedServiceCount.put('io.micronaut.inject.BeanConfiguration', 1)
+}           
+
 dependencies {
     annotationProcessor project(":inject-java")
     annotationProcessor project(":graal")

--- a/json-core/build.gradle
+++ b/json-core/build.gradle
@@ -1,3 +1,8 @@
+
+internalSanityChecks {
+    expectedServiceCount.put('io.micronaut.inject.BeanDefinitionReference', 5)
+}           
+
 dependencies {
     annotationProcessor project(":inject-java")
 

--- a/management/build.gradle
+++ b/management/build.gradle
@@ -1,3 +1,10 @@
+
+internalSanityChecks {
+    expectedServiceCount.put('io.micronaut.inject.BeanDefinitionReference', 41)
+    expectedServiceCount.put('io.micronaut.core.beans.BeanIntrospectionReference', 2)
+    expectedServiceCount.put('io.micronaut.inject.BeanConfiguration', 1)
+}           
+
 dependencies {
     annotationProcessor project(":inject-java")
     annotationProcessor project(":graal")

--- a/messaging/build.gradle
+++ b/messaging/build.gradle
@@ -1,3 +1,8 @@
+
+internalSanityChecks {
+    expectedServiceCount.put('io.micronaut.inject.BeanDefinitionReference', 1)
+}           
+
 dependencies {
     annotationProcessor project(":inject-java")
     api project(":inject")

--- a/router/build.gradle
+++ b/router/build.gradle
@@ -1,3 +1,8 @@
+
+internalSanityChecks {
+    expectedServiceCount.put('io.micronaut.inject.BeanDefinitionReference', 16)
+}           
+
 dependencies {
     annotationProcessor project(":inject-java")
 

--- a/runtime-osx/build.gradle
+++ b/runtime-osx/build.gradle
@@ -1,3 +1,8 @@
+
+internalSanityChecks {
+    expectedServiceCount.put('io.micronaut.inject.BeanDefinitionReference', 3)
+}           
+
 dependencies {
     annotationProcessor project(":inject-java")
 

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -2,6 +2,12 @@ ext {
     shadowJarEnabled = true
 }
 
+
+internalSanityChecks {
+    expectedServiceCount.put('io.micronaut.inject.BeanDefinitionReference', 20)
+    expectedServiceCount.put('io.micronaut.core.beans.BeanIntrospectionReference', 5)
+}           
+
 dependencies {
     annotationProcessor project(":inject-java")
     annotationProcessor project(":graal")

--- a/session/build.gradle
+++ b/session/build.gradle
@@ -1,6 +1,12 @@
 ext {
     shadowJarEnabled = true
 }
+
+internalSanityChecks {
+    expectedServiceCount.put('io.micronaut.inject.BeanDefinitionReference', 14)
+    expectedServiceCount.put('io.micronaut.inject.BeanConfiguration', 1)
+}           
+
 dependencies {
     annotationProcessor project(":inject-java")
     api project(":runtime")

--- a/settings.gradle
+++ b/settings.gradle
@@ -71,3 +71,9 @@ include "test-utils"
 
 // benchmarks
 include "benchmarks"
+
+gradle.beforeProject { p ->
+    p.pluginManager.withPlugin('java-library') {
+        p.plugins.apply('io.micronaut.build.internal.sanity-checks')
+    }
+}

--- a/tracing/build.gradle
+++ b/tracing/build.gradle
@@ -1,3 +1,9 @@
+
+internalSanityChecks {
+    expectedServiceCount.put('io.micronaut.inject.BeanDefinitionReference', 38)
+    expectedServiceCount.put('io.micronaut.inject.BeanConfiguration', 2)
+}           
+
 dependencies {
     annotationProcessor project(":inject-java")
     api libs.managed.opentracing

--- a/validation/build.gradle
+++ b/validation/build.gradle
@@ -1,3 +1,9 @@
+
+internalSanityChecks {
+    expectedServiceCount.put('io.micronaut.inject.BeanDefinitionReference', 12)
+    expectedServiceCount.put('io.micronaut.core.beans.BeanIntrospectionReference', 2)
+}           
+
 dependencies {
     annotationProcessor project(":inject-java")
 

--- a/websocket/build.gradle
+++ b/websocket/build.gradle
@@ -1,5 +1,10 @@
 import java.time.Duration
 
+
+internalSanityChecks {
+    expectedServiceCount.put('io.micronaut.inject.BeanDefinitionReference', 1)
+}           
+
 dependencies {
 	annotationProcessor project(":inject-java")
     api project(":http")


### PR DESCRIPTION
This commit introduces an _internal_ sanity check for generated
services. It happens that during the build, annotation processing
fails and doesn't generate the expected number of services. When
this happens it's pretty hard to figure out, and you can realize
late.

To workaround this, we introduce an extension which asks for the
number of expected services. If after compilation there's a mismatch
the build will fail (this can be disabled).