### PR TITLE
Use fully-featured BeanPropertyWriter constructor for introspection-only properties [Fixes #6387]

### DIFF
--- a/jackson-databind/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
@@ -143,7 +143,7 @@ public class BeanIntrospectionModule extends SimpleModule {
     }
 
     // copied from VirtualBeanPropertyWriter
-    private static boolean _suppressNulls(JsonInclude.Value inclusion) {
+    private static boolean suppressNulls(JsonInclude.Value inclusion) {
         if (inclusion == null) {
             return false;
         }
@@ -151,9 +151,8 @@ public class BeanIntrospectionModule extends SimpleModule {
         return (incl != JsonInclude.Include.ALWAYS) && (incl != JsonInclude.Include.USE_DEFAULTS);
     }
 
-
     // copied from VirtualBeanPropertyWriter
-    private static Object _suppressableValue(JsonInclude.Value inclusion) {
+    private static Object suppressableValue(JsonInclude.Value inclusion) {
         if (inclusion == null) {
             return false; // [sic]
         }
@@ -710,8 +709,8 @@ public class BeanIntrospectionModule extends SimpleModule {
                     virtualMember,
                     AnnotationCollector.emptyAnnotations(),
                     null, null, null, null,
-                    _suppressNulls(config.getDefaultPropertyInclusion()),
-                    _suppressableValue(config.getDefaultPropertyInclusion()),
+                    suppressNulls(config.getDefaultPropertyInclusion()),
+                    suppressableValue(config.getDefaultPropertyInclusion()),
                     null
             );
             beanProperty = introspection;

--- a/jackson-databind/src/test/groovy/io/micronaut/jackson/modules/BeanIntrospectionModuleSpec.groovy
+++ b/jackson-databind/src/test/groovy/io/micronaut/jackson/modules/BeanIntrospectionModuleSpec.groovy
@@ -10,13 +10,13 @@ import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.fasterxml.jackson.annotation.JsonView
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.PropertyNamingStrategies
-import com.fasterxml.jackson.databind.PropertyNamingStrategy
 import com.fasterxml.jackson.databind.annotation.JsonNaming
 import groovy.transform.EqualsAndHashCode
 import groovy.transform.PackageScope
 import io.micronaut.context.ApplicationContext
 import io.micronaut.core.annotation.Introspected
 import io.micronaut.http.hateoas.JsonError
+import io.micronaut.http.hateoas.Link
 import io.micronaut.jackson.JacksonConfiguration
 import io.micronaut.jackson.modules.testcase.EmailTemplate
 import io.micronaut.jackson.modules.testcase.Notification
@@ -125,6 +125,27 @@ class BeanIntrospectionModuleSpec extends Specification {
 
         cleanup:
         ctx.close()
+    }
+
+    void "Bean introspection with empty optional"() {
+        given:
+        ApplicationContext ctx = ApplicationContext.run()
+        ctx.getBean(BeanIntrospectionModule).ignoreReflectiveProperties = ignoreReflectiveProperties
+        ObjectMapper objectMapper = ctx.getBean(ObjectMapper)
+
+        when:
+        def value = new OptionalAuthor(name: Optional.<String>empty())
+        String json = objectMapper.writeValueAsString(value)
+
+        then:
+        noExceptionThrown()
+        json == '{}'
+
+        cleanup:
+        ctx.close()
+
+        where:
+        ignoreReflectiveProperties << [true, false]
     }
 
     void "test that introspected serialization works"() {
@@ -492,6 +513,11 @@ class BeanIntrospectionModuleSpec extends Specification {
     @Introspected
     static class Author {
         String name
+    }
+
+    @Introspected
+    static class OptionalAuthor {
+        Optional<String> name
     }
 
     @Introspected


### PR DESCRIPTION
Fixes #6387

Another bug that only appears in graal because the code path without reflective member access isn't tested well. The previous bug related to this was #6218 / #6219. This time, instead of `_suppressNulls` not being properly initialized, it was `_suppressableValue`, breaking the `JsonInclude` handling for `Optional.empty()`.

This time, instead of adding another override property like in the last PR, I decided to bite the bullet and use the "proper" `BeanPropertyWriter` constructor that actually allows customizing this setting. This is just less hacky. It shouldn't change much in practice, but it aligns the pure-introspection code path (the native-image-only code path) more closely with the reflection+introspection code path (the normal code path).

Unfortunately the unit test coverage of the former code path is basically non-existent except for the now two test cases that set `ignoreReflectiveProperties`, but it works where I tested it.