### PR TITLE
Enrich object encoding with more generic information

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -1708,7 +1708,7 @@ public class DefaultHttpClient implements
                             } else if (mediaTypeCodecRegistry != null) {
                                 Optional<MediaTypeCodec> registeredCodec = mediaTypeCodecRegistry.findCodec(requestContentType);
                                 ByteBuf encoded = registeredCodec.map(codec -> {
-                                            if (bodyType != null) {
+                                            if (bodyType != null && bodyType.isInstance(o)) {
                                                 return codec.encode((Argument<Object>) bodyType, o, byteBufferFactory).asNativeBuffer();
                                             } else {
                                                 return codec.encode(o, byteBufferFactory).asNativeBuffer();
@@ -1744,7 +1744,7 @@ public class DefaultHttpClient implements
                     } else if (mediaTypeCodecRegistry != null) {
                         Optional<MediaTypeCodec> registeredCodec = mediaTypeCodecRegistry.findCodec(requestContentType);
                         bodyContent = registeredCodec.map(codec -> {
-                                    if (bodyType != null) {
+                                    if (bodyType != null && bodyType.isInstance(bodyValue)) {
                                         return codec.encode((Argument<Object>) bodyType, bodyValue, byteBufferFactory).asNativeBuffer();
                                     } else {
                                         return codec.encode(bodyValue, byteBufferFactory).asNativeBuffer();

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/AbstractHttpContentProcessor.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/AbstractHttpContentProcessor.java
@@ -27,7 +27,7 @@ import org.reactivestreams.Subscriber;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
- * Abtract implementation of the {@link HttpContentProcessor} interface that deals with limiting file upload sizes.
+ * Abstract implementation of the {@link HttpContentProcessor} interface that deals with limiting file upload sizes.
  *
  * @param <T> The type
  * @author Graeme Rocher

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
@@ -681,7 +681,7 @@ public class NettyHttpServer implements NettyEmbeddedServer {
      * Negotiates with the browser if HTTP2 or HTTP is going to be used. Once decided, the Netty
      * pipeline is setup with the correct handlers for the selected protocol.
      *
-     * @implNote Unfortunately, this handler cannot be {@link io.netty.channel.ChannelHandler.Sharable shared} because
+     * NOTE: Unfortunately, this handler cannot be {@link io.netty.channel.ChannelHandler.Sharable shared} because
      * {@link ApplicationProtocolNegotiationHandler} does not support it.
      */
     private final class Http2OrHttpHandler extends ApplicationProtocolNegotiationHandler {

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
@@ -1012,7 +1012,12 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
                 ByteBuffer<ByteBuf> encoded;
                 if (hasRouteInfo) {
                     //noinspection unchecked
-                    encoded = codec.encode((Argument<Object>) routeInfo.getBodyType(), message, byteBufferFactory);
+                    final Argument<Object> bodyType = (Argument<Object>) routeInfo.getBodyType();
+                    if (bodyType.isInstance(message)) {
+                        encoded = codec.encode(bodyType, message, byteBufferFactory);
+                    } else {
+                        encoded = codec.encode(message, byteBufferFactory);
+                    }
                 } else {
                     encoded = codec.encode(message, byteBufferFactory);
                 }
@@ -1333,7 +1338,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
             if (LOG.isTraceEnabled()) {
                 LOG.trace("Encoding emitted response object [{}] using codec: {}", body, codec);
             }
-            if (bodyType != null) {
+            if (bodyType != null && bodyType.isInstance(body)) {
                 byteBuf = codec.encode(bodyType, body, new NettyByteBufferFactory(context.alloc())).asNativeBuffer();
             } else {
                 byteBuf = codec.encode(body, new NettyByteBufferFactory(context.alloc())).asNativeBuffer();

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
@@ -19,6 +19,7 @@ import io.micronaut.buffer.netty.NettyByteBufferFactory;
 import io.micronaut.context.event.ApplicationEventPublisher;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.core.async.subscriber.CompletionAwareSubscriber;
 import io.micronaut.core.convert.ConversionService;
@@ -480,6 +481,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
                                 channelContext,
                                 request,
                                 response,
+                                null,
                                 response.body()
                         );
                         subscription.request(1);
@@ -493,6 +495,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
                                 channelContext,
                                 request,
                                 response,
+                                null,
                                 response.body()
                         );
                     }
@@ -573,6 +576,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
                         context,
                         request,
                         toMutableResponse(message),
+                        (Argument<Object>) route.getBodyType(),
                         message.body()
                 );
                 subscription.request(1);
@@ -586,6 +590,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
                         context,
                         request,
                         defaultErrorResponse,
+                        (Argument<Object>) route.getBodyType(),
                         defaultErrorResponse.body()
                 );
             }
@@ -898,6 +903,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
             ChannelHandlerContext context,
             NettyHttpRequest<?> nettyRequest,
             MutableHttpResponse<?> response,
+            @Nullable Argument<Object> bodyType,
             Object body) {
         boolean isNotHead = nettyRequest.getMethod() != HttpMethod.HEAD;
 
@@ -941,6 +947,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
                         context,
                         nettyRequest,
                         response,
+                        bodyType,
                         body
                 );
 
@@ -965,15 +972,19 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
                                                MutableHttpResponse<?> response,
                                                Object body,
                                                ChannelHandlerContext context) {
-        final Optional<RouteInfo> optionalRoute = response.getAttribute(HttpAttributes.ROUTE_INFO, RouteInfo.class);
-        MediaType mediaType = response.getContentType().orElseGet(() -> optionalRoute
-                    .map(routeInfo -> routeExecutor.resolveDefaultResponseContentType(request, routeInfo))
-                    .orElse(null));
-        boolean isJson = mediaType != null && mediaType.getExtension().equals(MediaType.EXTENSION_JSON) && isJsonFormattable(optionalRoute.map(RouteInfo::getBodyType).orElse(null));
+        final RouteInfo<?> routeInfo = response.getAttribute(HttpAttributes.ROUTE_INFO, RouteInfo.class).orElse(null);
+        final boolean hasRouteInfo = routeInfo != null;
+        MediaType mediaType = response.getContentType().orElse(null);
+        if (mediaType == null && hasRouteInfo) {
+            mediaType = routeExecutor.resolveDefaultResponseContentType(request, routeInfo);
+        }
+        boolean isJson = mediaType != null && mediaType.getExtension().equals(MediaType.EXTENSION_JSON) &&
+                isJsonFormattable(hasRouteInfo ? routeInfo.getBodyType() : null);
         NettyByteBufferFactory byteBufferFactory = new NettyByteBufferFactory(context.alloc());
 
         Flux<Object> bodyPublisher = Flux.from(Publishers.convertPublisher(body, Publisher.class));
 
+        MediaType finalMediaType = mediaType;
         Flux<HttpContent> httpContentPublisher = bodyPublisher.map(message -> {
             HttpContent httpContent;
             if (message instanceof ByteBuf) {
@@ -992,13 +1003,19 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
                 httpContent = (HttpContent) message;
             } else {
 
-                MediaTypeCodec codec = mediaTypeCodecRegistry.findCodec(mediaType, message.getClass()).orElse(
+                MediaTypeCodec codec = mediaTypeCodecRegistry.findCodec(finalMediaType, message.getClass()).orElse(
                         new TextPlainCodec(serverConfiguration.getDefaultCharset()));
 
                 if (LOG.isTraceEnabled()) {
                     LOG.trace("Encoding emitted response object [{}] using codec: {}", message, codec);
                 }
-                ByteBuffer<ByteBuf> encoded = codec.encode(message, byteBufferFactory);
+                ByteBuffer<ByteBuf> encoded;
+                if (hasRouteInfo) {
+                    //noinspection unchecked
+                    encoded = codec.encode((Argument<Object>) routeInfo.getBodyType(), message, byteBufferFactory);
+                } else {
+                    encoded = codec.encode(message, byteBufferFactory);
+                }
                 httpContent = new DefaultHttpContent(encoded.asNativeBuffer());
             }
             return httpContent;
@@ -1038,6 +1055,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
             ChannelHandlerContext context,
             HttpRequest<?> request,
             MutableHttpResponse<?> message,
+            @Nullable Argument<Object> bodyType,
             Object body) {
         if (body == null) {
             return;
@@ -1075,10 +1093,10 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
                 Optional<MediaTypeCodec> registeredCodec = mediaTypeCodecRegistry.findCodec(mediaType, body.getClass());
                 if (registeredCodec.isPresent()) {
                     MediaTypeCodec codec = registeredCodec.get();
-                    encodeBodyWithCodec(message, body, codec, context, request);
+                    encodeBodyWithCodec(message, bodyType, body, codec, context, request);
                 } else {
                     MediaTypeCodec defaultCodec = new TextPlainCodec(serverConfiguration.getDefaultCharset());
-                    encodeBodyWithCodec(message, body, defaultCodec, context, request);
+                    encodeBodyWithCodec(message, bodyType, body, defaultCodec, context, request);
                 }
             }
         }
@@ -1250,13 +1268,14 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
     }
 
     private MutableHttpResponse<?> encodeBodyWithCodec(MutableHttpResponse<?> response,
+                                                       @Nullable Argument<Object> bodyType,
                                                        Object body,
                                                        MediaTypeCodec codec,
                                                        ChannelHandlerContext context,
                                                        HttpRequest<?> request) {
         ByteBuf byteBuf;
         try {
-            byteBuf = encodeBodyAsByteBuf(body, codec, context, request);
+            byteBuf = encodeBodyAsByteBuf(bodyType, body, codec, context, request);
             setResponseBody(response, byteBuf);
             return response;
         } catch (LinkageError e) {
@@ -1279,7 +1298,12 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
         return res;
     }
 
-    private ByteBuf encodeBodyAsByteBuf(Object body, MediaTypeCodec codec, ChannelHandlerContext context, HttpRequest<?> request) {
+    private ByteBuf encodeBodyAsByteBuf(
+            @Nullable Argument<Object> bodyType,
+            Object body,
+            MediaTypeCodec codec,
+            ChannelHandlerContext context,
+            HttpRequest<?> request) {
         ByteBuf byteBuf;
         if (body instanceof ByteBuf) {
             byteBuf = (ByteBuf) body;
@@ -1309,7 +1333,11 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
             if (LOG.isTraceEnabled()) {
                 LOG.trace("Encoding emitted response object [{}] using codec: {}", body, codec);
             }
-            byteBuf = codec.encode(body, new NettyByteBufferFactory(context.alloc())).asNativeBuffer();
+            if (bodyType != null) {
+                byteBuf = codec.encode(bodyType, body, new NettyByteBufferFactory(context.alloc())).asNativeBuffer();
+            } else {
+                byteBuf = codec.encode(body, new NettyByteBufferFactory(context.alloc())).asNativeBuffer();
+            }
         }
         return byteBuf;
     }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/jackson/JsonViewServerFilter.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/jackson/JsonViewServerFilter.java
@@ -17,7 +17,6 @@ package io.micronaut.http.server.netty.jackson;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import io.micronaut.context.annotation.Requires;
-import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.core.type.Argument;

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/jackson/JsonViewServerFilter.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/jackson/JsonViewServerFilter.java
@@ -18,7 +18,9 @@ package io.micronaut.http.server.netty.jackson;
 import com.fasterxml.jackson.annotation.JsonView;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.async.publisher.Publishers;
+import io.micronaut.core.type.Argument;
 import io.micronaut.http.HttpAttributes;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.MutableHttpResponse;
@@ -29,6 +31,7 @@ import io.micronaut.http.filter.ServerFilterChain;
 import io.micronaut.http.filter.ServerFilterPhase;
 import io.micronaut.json.JsonConfiguration;
 import io.micronaut.scheduling.TaskExecutors;
+import io.micronaut.web.router.RouteInfo;
 import jakarta.inject.Named;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
@@ -72,32 +75,37 @@ public class JsonViewServerFilter implements HttpServerFilter {
 
     @Override
     public Publisher<MutableHttpResponse<?>> doFilter(HttpRequest<?> request, ServerFilterChain chain) {
-        Optional<Class> viewClass = request.getAttribute(HttpAttributes.ROUTE_MATCH, AnnotationMetadata.class)                                                          .flatMap(ann -> ann.classValue(JsonView.class));
+        final RouteInfo<?> routeInfo = request.getAttribute(HttpAttributes.ROUTE_INFO, RouteInfo.class).orElse(null);
         final Publisher<MutableHttpResponse<?>> responsePublisher = chain.proceed(request);
-        if (viewClass.isPresent()) {
-            return Flux.from(responsePublisher).switchMap(response -> {
-                final Optional<?> optionalBody = response.getBody();
-                if (optionalBody.isPresent()) {
-                    Object body = optionalBody.get();
-                    MediaTypeCodec codec = codecFactory.resolveJsonViewCodec(viewClass.get());
-                    if (Publishers.isConvertibleToPublisher(body)) {
-                        Publisher<?> pub = Publishers.convertPublisher(body, Publisher.class);
-                        response.body(Flux.from(pub)
-                                .map(codec::encode)
-                                .subscribeOn(Schedulers.fromExecutorService(executorService)));
-                    } else {
-                        return Mono.fromCallable(() -> {
-                            final byte[] encoded = codec.encode(body);
-                            response.body(encoded);
-                            return response;
-                        }).subscribeOn(Schedulers.fromExecutorService(executorService));
+        if (routeInfo != null) {
+            final Optional<Class<?>> viewClass = routeInfo.findAnnotation(JsonView.class)
+                    .flatMap(AnnotationValue::classValue);
+            if (viewClass.isPresent()) {
+
+                return Flux.from(responsePublisher).switchMap(response -> {
+                    final Optional<?> optionalBody = response.getBody();
+                    if (optionalBody.isPresent()) {
+                        Object body = optionalBody.get();
+                        MediaTypeCodec codec = codecFactory.resolveJsonViewCodec(viewClass.get());
+                        if (Publishers.isConvertibleToPublisher(body)) {
+                            Publisher<?> pub = Publishers.convertPublisher(body, Publisher.class);
+                            response.body(Flux.from(pub)
+                                                  .map(o -> codec.encode((Argument) routeInfo.getBodyType(), o))
+                                                  .subscribeOn(Schedulers.fromExecutorService(executorService)));
+                        } else {
+                            return Mono.fromCallable(() -> {
+                                @SuppressWarnings({"unchecked", "rawtypes"})
+                                final byte[] encoded = codec.encode((Argument) routeInfo.getBodyType(), body);
+                                response.body(encoded);
+                                return response;
+                            }).subscribeOn(Schedulers.fromExecutorService(executorService));
+                        }
                     }
-                }
-                return Flux.just(response);
-            });
-        } else {
-            return responsePublisher;
+                    return Flux.just(response);
+                });
+            }
         }
+        return responsePublisher;
     }
 
     @Override

--- a/http/src/main/java/io/micronaut/http/codec/MediaTypeCodec.java
+++ b/http/src/main/java/io/micronaut/http/codec/MediaTypeCodec.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.http.codec;
 
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.io.buffer.ByteBuffer;
 import io.micronaut.core.io.buffer.ByteBufferFactory;
 import io.micronaut.core.type.Argument;
@@ -81,6 +82,52 @@ public interface MediaTypeCodec {
      * @throws CodecException When the result cannot be encoded
      */
     <T, B> ByteBuffer<B> encode(T object, ByteBufferFactory<?, B> allocator) throws CodecException;
+
+
+    /**
+     * Encode the given type to the given {@link OutputStream}.
+     *
+     * @param type         The type including any generics and/or metadata.
+     * @param object       The object to encode
+     * @param outputStream The output stream
+     * @param <T>          The generic type
+     * @throws CodecException When the result cannot be encoded
+     * @since 3.2.0
+     */
+    default <T> void encode(@NonNull Argument<T> type, @NonNull T object, @NonNull OutputStream outputStream) throws CodecException {
+        encode(object, outputStream);
+    }
+
+    /**
+     * Encode the given type returning the object as a byte[].
+     *
+     * @param type   The type including any generics and/or metadata
+     * @param object The object to encode
+     * @param <T>    The generic type
+     * @return The decoded result
+     * @throws CodecException When the result cannot be encoded
+     * @since 3.2.0
+     */
+    @NonNull
+    default <T> byte[] encode(@NonNull Argument<T> type, T object) throws CodecException {
+        return encode(object);
+    }
+
+    /**
+     * Encode the given type returning the object as a {@link ByteBuffer}.
+     *
+     * @param type      The type including any generics and/or metadata
+     * @param object    The object to encode
+     * @param allocator The allocator
+     * @param <T>       The generic type
+     * @param <B>       The buffer type
+     * @return The decoded result
+     * @throws CodecException When the result cannot be encoded
+     * @since 3.2.0
+     */
+    default @NonNull <T, B> ByteBuffer<B> encode(@NonNull Argument<T> type, T object, @NonNull ByteBufferFactory<?, B> allocator) throws CodecException {
+        return encode(object, allocator);
+    }
 
     /**
      * Decode the given type from the given {@link InputStream}.

--- a/jackson-databind/src/main/java/io/micronaut/jackson/databind/JacksonDatabindMapper.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/databind/JacksonDatabindMapper.java
@@ -104,6 +104,11 @@ public final class JacksonDatabindMapper implements JsonMapper {
     }
 
     @Override
+    public <T> JsonNode writeValueToTree(Argument<T> type, T value) throws IOException {
+        return writeValueToTree(value);
+    }
+
+    @Override
     public <T> T readValue(@NonNull InputStream inputStream, @NonNull Argument<T> type) throws IOException {
         return objectMapper.readValue(inputStream, JacksonConfiguration.constructType(type, objectMapper.getTypeFactory()));
     }
@@ -119,8 +124,18 @@ public final class JacksonDatabindMapper implements JsonMapper {
     }
 
     @Override
+    public <T> void writeValue(OutputStream outputStream, Argument<T> type, T object) throws IOException {
+        writeValue(outputStream, object);
+    }
+
+    @Override
     public byte[] writeValueAsBytes(@Nullable Object object) throws IOException {
         return objectMapper.writeValueAsBytes(object);
+    }
+
+    @Override
+    public <T> byte[] writeValueAsBytes(Argument<T> type, T object) throws IOException {
+        return writeValueAsBytes(object);
     }
 
     @Override

--- a/json-core/src/main/java/io/micronaut/json/JsonMapper.java
+++ b/json-core/src/main/java/io/micronaut/json/JsonMapper.java
@@ -113,6 +113,17 @@ public interface JsonMapper {
     JsonNode writeValueToTree(@Nullable Object value) throws IOException;
 
     /**
+     * Transform an object value to a json tree.
+     *
+     * @param type The object type
+     * @param value The object value to transform.
+     * @return The json representation.
+     * @throws IOException If there are any mapping exceptions (e.g. illegal values).
+     */
+    @NonNull
+    <T> JsonNode writeValueToTree(@NonNull Argument<T> type, @Nullable T value) throws IOException;
+
+    /**
      * Write an object as json.
      *
      * @param outputStream The stream to write to.
@@ -123,10 +134,30 @@ public interface JsonMapper {
     /**
      * Write an object as json.
      *
+     * @param outputStream The stream to write to.
+     * @param type         The object type
+     * @param object       The object to serialize.
+     * @param <T>  The generic type
+     */
+    <T> void writeValue(@NonNull OutputStream outputStream, @NonNull Argument<T> type, @Nullable T object) throws IOException;
+
+    /**
+     * Write an object as json.
+     *
      * @param object The object to serialize.
      * @return The serialized encoded json.
      */
     byte[] writeValueAsBytes(@Nullable Object object) throws IOException;
+
+    /**
+     * Write an object as json.
+     *
+     * @param type   The object type
+     * @param object The object to serialize.
+     * @return The serialized encoded json.
+     * @param <T> The generidc type
+     */
+    <T> byte[] writeValueAsBytes(@NonNull Argument<T> type, @Nullable T object) throws IOException;
 
     /**
      * Update an object from json data.


### PR DESCRIPTION
This PR adds the ability for a `JsonMapper` to obtain richer generic information about the object that is to be encoded.

Currently the Jackson implementation doesn't use this information and re-materialized everything via reflection downstream but a future object encoder could use this information.