### PR TITLE
Support public-only fields and methods for introspections

### DIFF
--- a/core/src/main/java/io/micronaut/core/annotation/Introspected.java
+++ b/core/src/main/java/io/micronaut/core/annotation/Introspected.java
@@ -193,7 +193,7 @@ public @interface Introspected {
     }
 
     /**
-     * The access type for bean properties and fields.
+     * Visibility policy for bean properties and fields.
      *
      * @since 3.2.0
      */

--- a/core/src/main/java/io/micronaut/core/annotation/Introspected.java
+++ b/core/src/main/java/io/micronaut/core/annotation/Introspected.java
@@ -71,6 +71,14 @@ public @interface Introspected {
     AccessKind[] accessKind() default { AccessKind.METHOD };
 
     /**
+     * Allows specifying the visibility policy to use to control which fields and methods are included.
+     *
+     * @return The visibility policies
+     * @since 3.2.0
+     */
+    Visibility[] visibility() default  { Visibility.DEFAULT };
+
+    /**
      * <p>By default {@link Introspected} applies to the class it is applied on. However if packages are specified
      * introspections will instead be generated for each classes in the given package. Note this only applies to already compiled
      * classes, and classpath scanning will be used to find them. If the class is not compiled then apply the annotation directly
@@ -182,5 +190,24 @@ public @interface Introspected {
          * The default behaviour which is to favour public getters for bean properties.
          */
         METHOD
+    }
+
+    /**
+     * The access type for bean properties and fields.
+     *
+     * @since 3.2.0
+     */
+    enum Visibility {
+
+        /**
+         * Only public methods and/or fields are included.
+         */
+        PUBLIC,
+
+        /**
+         * The default behaviour which in addition to public getters and setters will also include package protected fields if an {@link io.micronaut.core.annotation.Introspected.AccessKind} of {@link io.micronaut.core.annotation.Introspected.AccessKind#FIELD} is specified.
+         *
+         */
+        DEFAULT
     }
 }

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
@@ -167,6 +167,44 @@ class Test {
         two.get(instance) == 20
     }
 
+    void 'test field access only - public only'() {
+        given:
+        BeanIntrospection introspection = buildBeanIntrospection('fieldaccess.Test','''\
+package fieldaccess;
+
+import io.micronaut.core.annotation.*;
+
+
+@Introspected(
+    accessKind=Introspected.AccessKind.FIELD,
+    visibility = Introspected.Visibility.PUBLIC
+)
+class Test {
+    public String one; // read/write
+    public final int two; // read-only
+    String three; // package protected
+    protected String four; // not included since protected
+    private String five; // not included since private
+    
+    Test(int two) {
+        this.two = two;
+    }
+}
+''');
+        when:
+        def properties = introspection.getBeanProperties()
+
+        then:
+        properties.size() == 2
+
+        def one = introspection.getRequiredProperty("one", String)
+        one.isReadWrite()
+
+        def two = introspection.getRequiredProperty("two", int.class)
+        two.isReadOnly()
+
+    }
+
     void 'test bean constructor'() {
         given:
         BeanIntrospection introspection = buildBeanIntrospection('beanctor.Test','''\

--- a/inject/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
@@ -344,7 +344,7 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
             );
             abstractIntrospections.add(currentAbstractIntrospection);
         } else {
-            final Set<Introspected.AccessKind> accessKindSet = CollectionUtils.setOf(accessKinds);
+            final List<Introspected.AccessKind> accessKindSet = Arrays.asList(accessKinds);
             final Set<Introspected.Visibility> visibilitySet = CollectionUtils.setOf(visibilities);
             List<PropertyElement> beanProperties = accessKindSet.contains(Introspected.AccessKind.METHOD) ? ce.getBeanProperties() : Collections.emptyList();
 

--- a/inject/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
@@ -62,6 +62,7 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
             .member("annotation", new AnnotationClassValue<>(JAVAX_VALIDATION_VALID))
             .build();
     private static final Introspected.AccessKind[] DEFAULT_ACCESS_KIND = { Introspected.AccessKind.METHOD };
+    private static final Introspected.Visibility[] DEFAULT_VISIBILITY = { Introspected.Visibility.DEFAULT };
 
     private Map<String, BeanIntrospectionWriter> writers = new LinkedHashMap<>(10);
     private List<AbstractIntrospection> abstractIntrospections = new ArrayList<>();
@@ -168,10 +169,16 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
 
         final Set<AnnotationValue> toIndex = CollectionUtils.setOf(introspected.get("indexed", AnnotationValue[].class, new AnnotationValue[0]));
         Introspected.AccessKind[] accessKinds = introspected.enumValues("accessKind", Introspected.AccessKind.class);
+        Introspected.Visibility[] visibilities =
+                introspected.enumValues("visibility", Introspected.Visibility.class);
         if (ArrayUtils.isEmpty(accessKinds)) {
             accessKinds = DEFAULT_ACCESS_KIND;
         }
+        if (ArrayUtils.isEmpty(visibilities)) {
+            visibilities = DEFAULT_VISIBILITY;
+        }
         Introspected.AccessKind[] finalAccessKinds = accessKinds;
+        Introspected.Visibility[] finalVisibilities = visibilities;
 
         if (CollectionUtils.isEmpty(toIndex)) {
             indexedAnnotations = CollectionUtils.setOf(
@@ -193,6 +200,7 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
             for (AnnotationClassValue aClass : classes) {
                 final Optional<ClassElement> classElement = context.getClassElement(aClass.getName());
 
+
                 classElement.ifPresent(ce -> {
                     if (ce.isPublic() && !isIntrospected(context, ce)) {
                         final BeanIntrospectionWriter writer = new BeanIntrospectionWriter(
@@ -203,7 +211,17 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                                 metadata ? element.getAnnotationMetadata() : null
                         );
 
-                        processElement(metadata, includes, excludes, excludedAnnotations, indexedAnnotations, ce, writer, finalAccessKinds);
+                        processElement(
+                                metadata,
+                                includes,
+                                excludes,
+                                excludedAnnotations,
+                                indexedAnnotations,
+                                ce,
+                                writer,
+                                finalVisibilities,
+                                finalAccessKinds
+                        );
                     }
                 });
             }
@@ -227,7 +245,17 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                                 metadata ? element.getAnnotationMetadata() : null
                         );
 
-                        processElement(metadata, includes, excludes, excludedAnnotations, indexedAnnotations, classElement, writer, finalAccessKinds);
+                        processElement(
+                                metadata,
+                                includes,
+                                excludes,
+                                excludedAnnotations,
+                                indexedAnnotations,
+                                classElement,
+                                writer,
+                                finalVisibilities,
+                                finalAccessKinds
+                        );
                     }
                 }
             }
@@ -238,7 +266,17 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                     metadata ? element.getAnnotationMetadata() : null
             );
 
-            processElement(metadata, includes, excludes, excludedAnnotations, indexedAnnotations, element, writer, finalAccessKinds);
+            processElement(
+                    metadata,
+                    includes,
+                    excludes,
+                    excludedAnnotations,
+                    indexedAnnotations,
+                    element,
+                    writer,
+                    finalVisibilities,
+                    finalAccessKinds
+            );
         }
     }
 
@@ -292,6 +330,7 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
             Set<AnnotationValue> indexedAnnotations,
             ClassElement ce,
             BeanIntrospectionWriter writer,
+            Introspected.Visibility[] visibilities,
             Introspected.AccessKind...accessKinds) {
         Optional<MethodElement> constructorElement = ce.getPrimaryConstructor();
         if (ce.isAbstract() && !constructorElement.isPresent() && ce.hasStereotype(Introspected.class)) {
@@ -305,14 +344,15 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
             );
             abstractIntrospections.add(currentAbstractIntrospection);
         } else {
-            final List<Introspected.AccessKind> accessKindList = Arrays.asList(accessKinds);
-            List<PropertyElement> beanProperties = accessKindList.contains(Introspected.AccessKind.METHOD) ? ce.getBeanProperties() : Collections.emptyList();
+            final Set<Introspected.AccessKind> accessKindSet = CollectionUtils.setOf(accessKinds);
+            final Set<Introspected.Visibility> visibilitySet = CollectionUtils.setOf(visibilities);
+            List<PropertyElement> beanProperties = accessKindSet.contains(Introspected.AccessKind.METHOD) ? ce.getBeanProperties() : Collections.emptyList();
 
             final List<FieldElement> beanFields;
 
-            if (accessKindList.contains(Introspected.AccessKind.FIELD)) {
+            if (accessKindSet.contains(Introspected.AccessKind.FIELD)) {
                 Predicate<String> nameFilter = null;
-                if (accessKindList.iterator().next() == Introspected.AccessKind.METHOD) {
+                if (accessKindSet.iterator().next() == Introspected.AccessKind.METHOD) {
                     // prioritize methods
                     List<PropertyElement> finalBeanProperties = beanProperties;
                     nameFilter = (name) -> {
@@ -324,9 +364,19 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                         return true;
                     };
                 }
-                ElementQuery<FieldElement> query = ElementQuery.of(FieldElement.class)
-                        .onlyAccessible()
-                        .modifiers((modifiers) -> !modifiers.contains(ElementModifier.STATIC) && !modifiers.contains(ElementModifier.PROTECTED));
+                ElementQuery<FieldElement> query;
+                if (visibilitySet.contains(Introspected.Visibility.DEFAULT)) {
+                    query = ElementQuery.of(FieldElement.class)
+                            .onlyAccessible()
+                            .modifiers((modifiers) -> !modifiers.contains(ElementModifier.STATIC) && !modifiers.contains(ElementModifier.PROTECTED));
+
+                } else {
+                    query = ElementQuery.of(FieldElement.class)
+                            .modifiers((modifiers) ->
+                                   !modifiers.contains(ElementModifier.STATIC) &&
+                                   visibilitySet.stream().anyMatch(v ->
+                                           modifiers.contains(ElementModifier.valueOf(v.name()))));
+                }
                 if (nameFilter != null) {
                     query = query.named(nameFilter);
                 }


### PR DESCRIPTION
Adds a new `Visibility` enum such that it can be configured that only public fields and methods are taken into account.