### PR TITLE
Set codec for tree-based parser

### DIFF
--- a/jackson-databind/src/main/java/io/micronaut/jackson/databind/JacksonDatabindMapper.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/databind/JacksonDatabindMapper.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.jackson.databind;
 
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micronaut.context.annotation.BootstrapContextCompatible;
@@ -80,7 +81,7 @@ public final class JacksonDatabindMapper implements JsonMapper {
 
     @Override
     public <T> T readValueFromTree(@NonNull JsonNode tree, @NonNull Argument<T> type) throws IOException {
-        return objectMapper.readValue(treeCodec.treeAsTokens(tree), JacksonConfiguration.constructType(type, objectMapper.getTypeFactory()));
+        return objectMapper.readValue(treeAsTokens(tree), JacksonConfiguration.constructType(type, objectMapper.getTypeFactory()));
     }
 
     @Override
@@ -113,7 +114,7 @@ public final class JacksonDatabindMapper implements JsonMapper {
 
     @Override
     public void updateValueFromTree(Object value, @NonNull JsonNode tree) throws IOException {
-        objectMapper.readerForUpdating(value).readValue(treeCodec.treeAsTokens(tree));
+        objectMapper.readerForUpdating(value).readValue(treeAsTokens(tree));
     }
 
     @Override
@@ -159,5 +160,11 @@ public final class JacksonDatabindMapper implements JsonMapper {
     public Optional<JsonFeatures> detectFeatures(@NonNull AnnotationMetadata annotations) {
         return Optional.ofNullable(annotations.getAnnotation(io.micronaut.jackson.annotation.JacksonFeatures.class))
                 .map(JacksonFeatures::fromAnnotation);
+    }
+
+    private JsonParser treeAsTokens(@NonNull JsonNode tree) {
+        JsonParser parser = treeCodec.treeAsTokens(tree);
+        parser.setCodec(objectMapper);
+        return parser;
     }
 }

--- a/jackson-databind/src/test/groovy/io/micronaut/jackson/databind/JacksonDatabindMapperSpec.groovy
+++ b/jackson-databind/src/test/groovy/io/micronaut/jackson/databind/JacksonDatabindMapperSpec.groovy
@@ -1,5 +1,11 @@
 package io.micronaut.jackson.databind
 
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.module.SimpleModule
 import io.micronaut.context.ApplicationContext
 import io.micronaut.core.type.Argument
 import io.micronaut.json.JsonMapper
@@ -17,5 +23,42 @@ class JacksonDatabindMapperSpec extends Specification {
 
         cleanup:
         ctx.close()
+    }
+
+    def 'parsing from JsonNode uses the right object codec'() {
+        given:
+        def objectMapper = new ObjectMapper()
+        objectMapper.registerModule(new SimpleModule() {
+            {
+                addDeserializer(TestBean, new TestDeserializer())
+            }
+        })
+        def jsonMapper = new JacksonDatabindMapper(objectMapper)
+
+        expect:
+        jsonMapper.readValueFromTree(JsonNode.createNumberNode(42), TestBean).value == BigInteger.valueOf(42)
+
+        when:
+        def testBean = new TestBean()
+        jsonMapper.updateValueFromTree(testBean, JsonNode.createNumberNode(42))
+        then:
+        testBean.value == BigInteger.valueOf(42)
+    }
+
+    private static class TestBean {
+        BigInteger value
+    }
+
+    private static class TestDeserializer extends JsonDeserializer<TestBean> {
+        @Override
+        TestBean deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+            return new TestBean(value: p.codec.readValue(p, BigInteger))
+        }
+
+        @Override
+        TestBean deserialize(JsonParser p, DeserializationContext ctxt, TestBean intoValue) throws IOException {
+            intoValue.value = p.codec.readValue(p, BigInteger)
+            return intoValue
+        }
     }
 }


### PR DESCRIPTION
Properly set the ObjectCodec for the JsonNodeTraversingParser used for parsing from the new JsonNode API.

Fixes #6420