### PR TITLE
Don't copy content headers for redirect from POST request

### DIFF
--- a/http-client/src/test/groovy/io/micronaut/http/client/HttpPostSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/HttpPostSpec.groovy
@@ -387,6 +387,14 @@ class HttpPostSpec extends Specification {
         request.getBody(String).get() == '{}'
     }
 
+    void "test redirect uses GET"() {
+        when:
+        def res = client.toBlocking().exchange(HttpRequest.POST('/post/redirect', 'abc'), String)
+
+        then:
+        res.getBody(String).get() == 'foo'
+    }
+
     @Requires(property = 'spec.name', value = 'HttpPostSpec')
     @Controller('/post')
     static class PostController {
@@ -490,6 +498,21 @@ class HttpPostSpec extends Specification {
         @Post(uri = "/emptyBody")
         HttpResponse emptyBody() {
             HttpResponse.noContent()
+        }
+
+        @Post(uri = "/redirect")
+        HttpResponse redirect() {
+            return HttpResponse.redirect(URI.create("/post/redirectTarget"))
+        }
+
+        @Get(uri = "/redirectTarget")
+        String redirectTargetGet() {
+            return 'foo'
+        }
+
+        @Post(uri = "/redirectTarget")
+        String redirectTargetPost() {
+            return 'bar'
         }
     }
 


### PR DESCRIPTION
Exclude headers like Content-Type and Content-Length from copying request headers when the first request gets a redirect. There is no spec on which headers should be copied, so this is a blocklist with a few relevant headers, for now.
Fixes #6417