### PR TITLE
Upgrade to build plugins 4.2.4

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'io.micronaut.build.shared.settings' version '4.2.2'
+    id 'io.micronaut.build.shared.settings' version '4.2.4'
 }
 
 enableFeaturePreview("VERSION_CATALOGS")


### PR DESCRIPTION
This will unblock the 3.1.2 release by making sure javadocs/sources
are published for all modules.

See https://github.com/micronaut-projects/micronaut-build/pull/220