### PR TITLE
Document BigDecimal deserialization behavior

### DIFF
--- a/src/main/docs/guide/httpServer/jsonBinding.adoc
+++ b/src/main/docs/guide/httpServer/jsonBinding.adoc
@@ -111,3 +111,17 @@ In addition to configuration, beans can be registered to customize Jackson. All 
 === Service Loader
 
 Any modules registered via the service loader are also added to the default object mapper.
+
+=== Number Precision
+
+During JSON parsing, the framework may convert any incoming data to an intermediate object model. By default, this model uses `BigInteger`, `long` and `double` for numeric values. This means some information that could be represented by `BigDecimal` may be lost. For example, numbers with many decimal places that cannot be represented by `double` may be truncated, even if the target type for deserialization uses `BigDecimal`. Metadata on the number of trailing zeroes (`BigDecimal.precision()`), e.g. the difference between `0.12` and `0.120`, is also discarded.
+
+If you need full accuracy for number types, use the following configuration:
+
+[source,yaml]
+----
+jackson:
+  deserialization:
+    useBigIntegerForInts: true
+    useBigDecimalForFloats: true
+----


### PR DESCRIPTION
JacksonCoreProcessor does not use BigDecimal by default for storing numeric values for efficiency reasons. This patch documents this behavior.

Closes #6429