### PR TITLE
Add missing properties when deserializing type with partial reflective access

### DIFF
--- a/jackson-databind/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
@@ -327,7 +327,7 @@ public class BeanIntrospectionModule extends SimpleModule {
                 return builder;
             } else {
                 final Iterator<SettableBeanProperty> properties = builder.getProperties();
-                if (!properties.hasNext() && introspection.getPropertyNames().length > 0) {
+                if ((ignoreReflectiveProperties || !properties.hasNext()) && introspection.getPropertyNames().length > 0) {
                     // mismatch, probably GraalVM reflection not enabled for bean. Try recreate
                     for (BeanProperty<Object, Object> beanProperty : introspection.getBeanProperties()) {
                         builder.addOrReplaceProperty(new VirtualSetter(
@@ -337,24 +337,34 @@ public class BeanIntrospectionModule extends SimpleModule {
                             true);
                     }
                 } else {
+                    Map<String, BeanProperty<Object, Object>> remainingProperties = new LinkedHashMap<>();
+                    for (BeanProperty<Object, Object> beanProperty : introspection.getBeanProperties()) {
+                        remainingProperties.put(beanProperty.getName(), beanProperty);
+                    }
                     while (properties.hasNext()) {
                         final SettableBeanProperty settableBeanProperty = properties.next();
                         if (settableBeanProperty instanceof MethodProperty) {
                             MethodProperty methodProperty = (MethodProperty) settableBeanProperty;
-                            final Optional<BeanProperty<Object, Object>> beanProperty =
-                                    introspection.getProperty(settableBeanProperty.getName());
+                            final BeanProperty<Object, Object> beanProperty =
+                                    remainingProperties.remove(settableBeanProperty.getName());
 
-                            if (beanProperty.isPresent()) {
-                                BeanProperty<Object, Object> bp = beanProperty.get();
-                                if (!bp.isReadOnly()) {
-                                    SettableBeanProperty newProperty = new BeanIntrospectionSetter(
-                                            methodProperty,
-                                            bp
-                                    );
-                                    builder.addOrReplaceProperty(newProperty, true);
-                                }
+                            if (beanProperty != null && !beanProperty.isReadOnly()) {
+                                SettableBeanProperty newProperty = new BeanIntrospectionSetter(
+                                        methodProperty,
+                                        beanProperty
+                                );
+                                builder.addOrReplaceProperty(newProperty, true);
                             }
                         }
+                    }
+                    // add any remaining properties. This can happen if the supertype has reflection-visible properties
+                    // so `properties` isn't empty, but the subtype doesn't have reflection enabled.
+                    for (Map.Entry<String, BeanProperty<Object, Object>> entry : remainingProperties.entrySet()) {
+                        builder.addOrReplaceProperty(new VirtualSetter(
+                                        beanDesc.getClassInfo(),
+                                        config.getTypeFactory(),
+                                        entry.getValue()),
+                                true);
                     }
                 }
 

--- a/jackson-databind/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
@@ -392,7 +392,8 @@ public class BeanIntrospectionModule extends SimpleModule {
                         builder.addOrReplaceProperty(new VirtualSetter(
                                         beanDesc.getClassInfo(),
                                         config.getTypeFactory(),
-                                        entry.getValue()),
+                                        entry.getValue(),
+                                        findSerializerFromAnnotation(entry.getValue(), JsonDeserialize.class)),
                                 true);
                     }
                 }


### PR DESCRIPTION
BeanIntrospectionModule correctly handled the case where a bean had no reflection-visible properties at all, but did not handle the case where some but not all properties are visible. The invisible properties would then be dropped. This can happen if the supertype of a bean is marked as `@ReflectiveAccess` but the subtype is not.

Fixes #6421

--- 

This is very difficult to test without graal. `ignoreReflectiveProperties` isn't selective enough, since we need to only disable reflection for one class. For local testing without graal, I put breakpoints on `Class.getMethods` and friends, and made them return empty arrays for the class in question. This is also how I verified the patch works.

I don't know how to make this a unit test without some fairly intrusive modifications to BeanIntrospectionModule that could add overhead to production code.