### PR TITLE
Consider `@JsonView` annotation for request body deserialization

### DIFF
--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/jackson/JsonViewController.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/jackson/JsonViewController.groovy
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonView
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Post
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
@@ -66,5 +67,11 @@ class JsonViewController {
     @Get("/reactive/multiple")
     Flux<TestModel> publicReactiveViewMultiple() {
         return Flux.just(TEST_MODEL, TEST_MODEL)
+    }
+
+    @JsonView(Views.Admin)
+    @Post("/asBody")
+    HttpResponse<TestModel> asBody(@JsonView(Views.Public) TestModel model) {
+        return HttpResponse.ok(model)
     }
 }

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/jackson/JsonViewServerFilterSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/jackson/JsonViewServerFilterSpec.groovy
@@ -115,4 +115,15 @@ class JsonViewServerFilterSpec extends Specification {
         then:
         rsp.body() == JsonViewController.TEST_MODEL
     }
+
+    def "hidden properties on the post body to asBody are ignored"() {
+        when:
+        HttpResponse<TestModel> rsp = client.toBlocking().exchange(HttpRequest.POST('/jsonview/asBody', JsonViewController.TEST_MODEL), TestModel)
+
+        then:
+        rsp.body().firstName == JsonViewController.TEST_MODEL.firstName
+        rsp.body().lastName == JsonViewController.TEST_MODEL.lastName
+        rsp.body().birthdate == null
+        rsp.body().password == null
+    }
 }

--- a/http/src/main/java/io/micronaut/http/bind/binders/ParameterAnnotationBinder.java
+++ b/http/src/main/java/io/micronaut/http/bind/binders/ParameterAnnotationBinder.java
@@ -72,11 +72,11 @@ public class ParameterAnnotationBinder<T> extends AbstractAnnotatedArgumentBinde
             result = doBind(context, source.getAttributes(), parameterName, BindingResult.UNSATISFIED);
         }
 
-        Class argumentType;
+        Argument<?> argumentType;
         if (argument.getType() == Optional.class) {
-            argumentType = argument.getFirstTypeVariable().orElse(argument).getType();
+            argumentType = argument.getFirstTypeVariable().orElse(argument);
         } else {
-            argumentType = argument.getType();
+            argumentType = argument;
         }
 
         // If there is still no value at this point and no annotation is specified and
@@ -86,11 +86,11 @@ public class ParameterAnnotationBinder<T> extends AbstractAnnotatedArgumentBinde
             if (body.isPresent()) {
                 result = doBind(context, body.get(), parameterName);
                 if (!result.getValue().isPresent()) {
-                    if (ClassUtils.isJavaLangType(argumentType)) {
+                    if (ClassUtils.isJavaLangType(argumentType.getType())) {
                         return Optional::empty;
                     } else {
                         //noinspection unchecked
-                        return () -> source.getBody(argumentType);
+                        return () -> (Optional<T>) source.getBody(argumentType);
                     }
                 }
             } else {

--- a/jackson-databind/src/main/java/io/micronaut/jackson/databind/JacksonDatabindMapper.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/databind/JacksonDatabindMapper.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.core.annotation.AnnotationMetadata;
-import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
@@ -86,7 +85,7 @@ public final class JacksonDatabindMapper implements JsonMapper {
     public <T> T readValueFromTree(@NonNull JsonNode tree, @NonNull Argument<T> type) throws IOException {
         JsonParser tokens = treeCodec.treeAsTokens(tree);
         JavaType javaType = JacksonConfiguration.constructType(type, objectMapper.getTypeFactory());
-        Optional<Class<?>> view = type.findAnnotation(JsonView.class).flatMap(AnnotationValue::classValue);
+        Optional<Class> view = type.getAnnotationMetadata().classValue(JsonView.class);
         if (view.isPresent()) {
             return objectMapper.readerWithView(view.get()).readValue(tokens, javaType);
         } else {

--- a/json-core/src/main/java/io/micronaut/json/convert/JsonConverterRegistrar.java
+++ b/json-core/src/main/java/io/micronaut/json/convert/JsonConverterRegistrar.java
@@ -211,7 +211,7 @@ public final class JsonConverterRegistrar implements TypeConverterRegistrar {
                     return Optional.of(new String(objectCodec.get().writeValueAsBytes(node), StandardCharsets.UTF_8));
                 } else {
                     Argument<?> argument = null;
-                    if (context instanceof ArgumentConversionContext && targetType.getTypeParameters().length != 0) {
+                    if (context instanceof ArgumentConversionContext) {
                         argument = ((ArgumentConversionContext<?>) context).getArgument();
                     }
                     if (argument == null) {

--- a/json-core/src/main/java/io/micronaut/json/convert/JsonConverterRegistrar.java
+++ b/json-core/src/main/java/io/micronaut/json/convert/JsonConverterRegistrar.java
@@ -213,6 +213,9 @@ public final class JsonConverterRegistrar implements TypeConverterRegistrar {
                     Argument<?> argument = null;
                     if (context instanceof ArgumentConversionContext) {
                         argument = ((ArgumentConversionContext<?>) context).getArgument();
+                        if (targetType != argument.getType()) {
+                            argument = null;
+                        }
                     }
                     if (argument == null) {
                         argument = Argument.of(targetType);


### PR DESCRIPTION
Propagate the annotations on a `@Body` parameter to a controller through the deserialization stack, and use that annotation information in JacksonDatabindMapper to select the json view used for deserialization.

Resolves #5046

---

To propagate the `@JsonView` all the way to the mapper, I had to make some of the intermediates use `Argument` properly. This may have unintended consequences.