### PR TITLE
Update bootstrap.adoc

### DIFF
--- a/src/main/docs/guide/config/bootstrap.adoc
+++ b/src/main/docs/guide/config/bootstrap.adoc
@@ -4,16 +4,18 @@ But during application startup, before the application context is created, a "bo
 
 The bootstrap context is enabled depending on the following conditions. The conditions are checked in the following order:
 
-- If The api:context.env.Environment#BOOTSTRAP_CONTEXT_PROPERTY[micronaut.bootstrap.context^] system property is set, that value determines if the bootstrap context is enabled.
+- If The api:context.env.Environment#BOOTSTRAP_CONTEXT_PROPERTY[micronaut.bootstrap.context] system property is set, that value determines if the bootstrap context is enabled.
 - If The application context builder option api:micronaut.context.ApplicationContextBuilder#bootstrapEnvironment[bootstrapEnvironment] is set, that value determines if the bootstrap context is enabled.
 - If a api:context.env.BootstrapPropertySourceLocator[] bean is present the bootstrap context is enabled. Normally this comes from the `micronaut-discovery-client` dependency.
 
 Configuration properties that must be present before application context configuration properties are resolved, for example when using distributed configuration, are stored in a bootstrap configuration file. Once it is determined the bootstrap context is enabled (as described above), the bootstrap configuration files are read using the same rules as regular application configuration.
 See the <<propertySource, property source>> documentation for the details. The only difference is the prefix (`bootstrap` instead of `application`).
 
-The file name prefix `bootstrap` is configurable with a system property link:{api}/io/micronaut/context/env/Environment.html#BOOTSTRAP_NAME_PROPERTY[micronaut.bootstrap.name^].
+The file name prefix `bootstrap` is configurable with a system property link:{api}/io/micronaut/context/env/Environment.html#BOOTSTRAP_NAME_PROPERTY[micronaut.bootstrap.name].
 
-NOTE: Any configuration in the bootstrap context is not necessary to be duplicated in the main context. The bootstrap context configuration is carried over to the main context automatically. That means if a configuration property is needed in both places, it should go into the bootstrap context configuration.
+NOTE: The bootstrap context configuration is carried over to the main context automatically, so it is not necessary for configuration properties to be duplicated in the main context. In addition, the bootstrap context configuration has a higher precendence than the main context, meaning if a configuration property appears in both contexts, then the value will be taken from the bootstrap context first.
+
+That means if a configuration property is needed in both places, it should go into the bootstrap context configuration.
 
 See the <<distributedConfiguration, distributed configuration>> section of the documentation for the list of integrations with common distributed configuration solutions.
 


### PR DESCRIPTION
Remove errant carrots (`^`) that were being rendered in links

Clarify load order of bootstrap and main contexts