### PR TITLE
Rename `Customizer` to `Configurer`

### DIFF
--- a/inject-groovy/src/functionalTest/groovy/io/micronaut/context/ApplicationContextConfigurerSpec.groovy
+++ b/inject-groovy/src/functionalTest/groovy/io/micronaut/context/ApplicationContextConfigurerSpec.groovy
@@ -4,8 +4,8 @@ import io.micronaut.fixtures.context.MicronautApplicationTest
 import io.micronaut.inject.BeanDefinitionReference
 import org.codehaus.groovy.GroovyBugError
 
-class ApplicationContextCustomizerSpec extends MicronautApplicationTest {
-    def "no service file is generated if application doesn't provide a customizer"() {
+class ApplicationContextConfigurerSpec extends MicronautApplicationTest {
+    def "no service file is generated if application doesn't provide a configurer"() {
         groovySourceFile("Application.groovy", """
 import io.micronaut.context.annotation.ContextConfigurer
 
@@ -22,16 +22,16 @@ class Application {}
     def "generates a service file"() {
         groovySourceFile("Application.groovy", """
 import io.micronaut.context.annotation.ContextConfigurer
-import io.micronaut.context.ApplicationContextCustomizer
+import io.micronaut.context.ApplicationContextConfigurer
 
 @ContextConfigurer
-class Application implements ApplicationContextCustomizer {}
+class Application implements ApplicationContextConfigurer {}
 """)
         when:
         compile()
 
         then:
-        hasServiceFileFor(ApplicationContextCustomizer) {
+        hasServiceFileFor(ApplicationContextConfigurer) {
             withImplementations 'Application'
         }
     }
@@ -40,7 +40,7 @@ class Application implements ApplicationContextCustomizer {}
         groovySourceFile("demo/app/Application.groovy", """package demo.app;
 
 import io.micronaut.context.annotation.ContextConfigurer;
-import io.micronaut.context.ApplicationContextCustomizer;
+import io.micronaut.context.ApplicationContextConfigurer;
 import io.micronaut.context.ApplicationContextBuilder;
 import jakarta.inject.Singleton;
 import java.util.Collections;
@@ -48,9 +48,9 @@ import java.util.Collections;
 @Singleton
 class Application {
     @ContextConfigurer
-    static class Configurer implements ApplicationContextCustomizer {
+    static class Configurer implements ApplicationContextConfigurer {
         @Override
-        void customize(ApplicationContextBuilder builder) {
+        void configure(ApplicationContextBuilder builder) {
             builder.deduceEnvironment(false)
             builder.environments("dummy")
         }
@@ -61,7 +61,7 @@ class Application {
         compile()
 
         then:
-        hasServiceFileFor(ApplicationContextCustomizer) {
+        hasServiceFileFor(ApplicationContextConfigurer) {
             withImplementations 'demo.app.Application$Configurer'
         }
         hasServiceFileFor(BeanDefinitionReference) {

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/ServiceDescriptionProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/ServiceDescriptionProcessor.java
@@ -16,7 +16,7 @@
 package io.micronaut.annotation.processing;
 
 import io.micronaut.annotation.processing.visitor.JavaClassElement;
-import io.micronaut.context.ApplicationContextCustomizer;
+import io.micronaut.context.ApplicationContextConfigurer;
 import io.micronaut.context.annotation.ContextConfigurer;
 import io.micronaut.context.visitor.ContextConfigurerVisitor;
 import io.micronaut.core.annotation.AnnotationMetadata;
@@ -62,7 +62,7 @@ public class ServiceDescriptionProcessor extends AbstractInjectAnnotationProcess
             }}
     );
     private static final Set<String> SUPPORTED_SERVICE_TYPES = Collections.singleton(
-            ApplicationContextCustomizer.class.getName()
+            ApplicationContextConfigurer.class.getName()
     );
 
     private final Map<String, Set<String>> serviceDescriptors = new HashMap<>();

--- a/inject/src/main/java/io/micronaut/context/ApplicationContextConfigurer.java
+++ b/inject/src/main/java/io/micronaut/context/ApplicationContextConfigurer.java
@@ -20,11 +20,11 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.order.Ordered;
 
 /**
- * An application context customizer is responsible
+ * An application context configurer is responsible
  * for configuring an application context before the
  * application/function is started.
  *
- * Application context customizers must be registered
+ * Application context configurers must be registered
  * as services. Those services are automatically called
  * whenever a new application context builder is created.
  *
@@ -35,19 +35,19 @@ import io.micronaut.core.order.Ordered;
  * @since 3.2
  */
 @Experimental
-public interface ApplicationContextCustomizer extends Ordered {
+public interface ApplicationContextConfigurer extends Ordered {
 
     /**
-     * A default customizer which does nothing.
+     * A default configurer which does nothing.
      */
-    ApplicationContextCustomizer NO_OP = new ApplicationContextCustomizer() {
+    ApplicationContextConfigurer NO_OP = new ApplicationContextConfigurer() {
     };
 
     /**
-     * Customizes the application context builder.
-     * @param builder the builder to customize
+     * Configures the application context builder.
+     * @param builder the builder to configure
      */
-    default void customize(@NonNull ApplicationContextBuilder builder) {
+    default void configure(@NonNull ApplicationContextBuilder builder) {
 
     }
 }

--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContextBuilder.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContextBuilder.java
@@ -73,7 +73,7 @@ public class DefaultApplicationContextBuilder implements ApplicationContextBuild
      * Default constructor.
      */
     protected DefaultApplicationContextBuilder() {
-        loadApplicationContextCustomizer().customize(this);
+        loadApplicationContextCustomizer().configure(this);
     }
 
     @Override
@@ -374,25 +374,25 @@ public class DefaultApplicationContextBuilder implements ApplicationContextBuild
      * @return an application customizer
      */
     @NonNull
-    private static ApplicationContextCustomizer loadApplicationContextCustomizer() {
-        ServiceLoader<ApplicationContextCustomizer> loader = ServiceLoader.load(
-                ApplicationContextCustomizer.class
+    private static ApplicationContextConfigurer loadApplicationContextCustomizer() {
+        ServiceLoader<ApplicationContextConfigurer> loader = ServiceLoader.load(
+                ApplicationContextConfigurer.class
         );
-        List<ApplicationContextCustomizer> customizers = StreamSupport.stream(loader.spliterator(), false)
+        List<ApplicationContextConfigurer> configurers = StreamSupport.stream(loader.spliterator(), false)
                 .collect(Collectors.toList());
-        if (customizers.isEmpty()) {
-            return ApplicationContextCustomizer.NO_OP;
+        if (configurers.isEmpty()) {
+            return ApplicationContextConfigurer.NO_OP;
         }
-        if (customizers.size() == 1) {
-            return customizers.get(0);
+        if (configurers.size() == 1) {
+            return configurers.get(0);
         }
-        OrderUtil.sort(customizers);
-        return new ApplicationContextCustomizer() {
+        OrderUtil.sort(configurers);
+        return new ApplicationContextConfigurer() {
 
             @Override
-            public void customize(ApplicationContextBuilder builder) {
-                for (ApplicationContextCustomizer customizer : customizers) {
-                    customizer.customize(builder);
+            public void configure(ApplicationContextBuilder builder) {
+                for (ApplicationContextConfigurer customizer : configurers) {
+                    customizer.configure(builder);
                 }
             }
 

--- a/inject/src/main/java/io/micronaut/context/visitor/ContextConfigurerVisitor.java
+++ b/inject/src/main/java/io/micronaut/context/visitor/ContextConfigurerVisitor.java
@@ -15,7 +15,7 @@
  */
 package io.micronaut.context.visitor;
 
-import io.micronaut.context.ApplicationContextCustomizer;
+import io.micronaut.context.ApplicationContextConfigurer;
 import io.micronaut.context.annotation.ContextConfigurer;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.Element;
@@ -35,7 +35,7 @@ import java.util.Set;
  */
 public class ContextConfigurerVisitor implements TypeElementVisitor<ContextConfigurer, Object> {
     private static final Set<String> SUPPORTED_SERVICE_TYPES = Collections.singleton(
-            ApplicationContextCustomizer.class.getName()
+            ApplicationContextConfigurer.class.getName()
     );
 
     @Override

--- a/test-suite/src/functionalTest/groovy/io/micronaut/context/ApplicationContextConfigurerSpec.groovy
+++ b/test-suite/src/functionalTest/groovy/io/micronaut/context/ApplicationContextConfigurerSpec.groovy
@@ -7,8 +7,8 @@ import io.micronaut.inject.BeanDefinitionReference
  * NOTE: If you edit this test case it's likely that you also want to
  * edit its Groovy counterpart found in `inject-groovy`.
  */
-class ApplicationContextCustomizerSpec extends MicronautApplicationTest {
-    def "no service file is generated if application doesn't provide a customizer"() {
+class ApplicationContextConfigurerSpec extends MicronautApplicationTest {
+    def "no service file is generated if application doesn't provide a configurer"() {
         javaSourceFile("Application.java", """
 import io.micronaut.context.annotation.ContextConfigurer;
 
@@ -25,25 +25,25 @@ class Application {}
     def "generates a service file"() {
         javaSourceFile("Application.java", """
 import io.micronaut.context.annotation.ContextConfigurer;
-import io.micronaut.context.ApplicationContextCustomizer;
+import io.micronaut.context.ApplicationContextConfigurer;
 
 @ContextConfigurer
-class Application implements ApplicationContextCustomizer {}
+class Application implements ApplicationContextConfigurer {}
 """)
         when:
         compile()
 
         then:
-        hasServiceFileFor(ApplicationContextCustomizer) {
+        hasServiceFileFor(ApplicationContextConfigurer) {
             withImplementations 'Application'
         }
     }
 
-    def "can configure application via an inner customizer"() {
+    def "can configure application via an inner configurer"() {
         javaSourceFile("demo/app/Application.java", """package demo.app;
 
 import io.micronaut.context.annotation.ContextConfigurer;
-import io.micronaut.context.ApplicationContextCustomizer;
+import io.micronaut.context.ApplicationContextConfigurer;
 import io.micronaut.context.ApplicationContextBuilder;
 import jakarta.inject.Singleton;
 import java.util.Collections;
@@ -51,9 +51,9 @@ import java.util.Collections;
 @Singleton
 class Application {
     @ContextConfigurer
-    public static class Configurer implements ApplicationContextCustomizer {
+    public static class Configurer implements ApplicationContextConfigurer {
         @Override
-        public void customize(ApplicationContextBuilder builder) {
+        public void configure(ApplicationContextBuilder builder) {
             builder.deduceEnvironment(false);
             builder.environments("dummy");
         }
@@ -64,7 +64,7 @@ class Application {
         compile()
 
         then:
-        hasServiceFileFor(ApplicationContextCustomizer) {
+        hasServiceFileFor(ApplicationContextConfigurer) {
             withImplementations 'demo.app.Application$Configurer'
         }
         hasServiceFileFor(BeanDefinitionReference) {


### PR DESCRIPTION
For consistency, we now have `ApplicationContextConfigurer` alongside
with the `@ContextConfigurer` annotation. There's a bit of repetition
in code since you have to annotate with `@ContextConfigurer` *and*
use the `ApplicationContextConfigurer` interface, but at least now
the names are consistent.

Closes #6447