### PR TITLE
Do not replace creator properties from introspection

### DIFF
--- a/jackson-databind/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
@@ -389,12 +389,15 @@ public class BeanIntrospectionModule extends SimpleModule {
                     // add any remaining properties. This can happen if the supertype has reflection-visible properties
                     // so `properties` isn't empty, but the subtype doesn't have reflection enabled.
                     for (Map.Entry<String, BeanProperty<Object, Object>> entry : remainingProperties.entrySet()) {
-                        builder.addOrReplaceProperty(new VirtualSetter(
-                                        beanDesc.getClassInfo(),
-                                        config.getTypeFactory(),
-                                        entry.getValue(),
-                                        findSerializerFromAnnotation(entry.getValue(), JsonDeserialize.class)),
-                                true);
+                        SettableBeanProperty existing = builder.findProperty(PropertyName.construct(entry.getKey()));
+                        if (existing == null) {
+                            builder.addOrReplaceProperty(new VirtualSetter(
+                                            beanDesc.getClassInfo(),
+                                            config.getTypeFactory(),
+                                            entry.getValue(),
+                                            findSerializerFromAnnotation(entry.getValue(), JsonDeserialize.class)),
+                                    true);
+                        }
                     }
                 }
 

--- a/jackson-databind/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
@@ -358,12 +358,14 @@ public class BeanIntrospectionModule extends SimpleModule {
                 if ((ignoreReflectiveProperties || !properties.hasNext()) && introspection.getPropertyNames().length > 0) {
                     // mismatch, probably GraalVM reflection not enabled for bean. Try recreate
                     for (BeanProperty<Object, Object> beanProperty : introspection.getBeanProperties()) {
-                        builder.addOrReplaceProperty(new VirtualSetter(
-                                        beanDesc.getClassInfo(),
-                                        config.getTypeFactory(),
-                                        beanProperty,
-                                        findSerializerFromAnnotation(beanProperty, JsonDeserialize.class)),
-                                true);
+                        if (!beanProperty.isReadOnly()) {
+                            builder.addOrReplaceProperty(new VirtualSetter(
+                                            beanDesc.getClassInfo(),
+                                            config.getTypeFactory(),
+                                            beanProperty,
+                                            findSerializerFromAnnotation(beanProperty, JsonDeserialize.class)),
+                                    true);
+                        }
                     }
                 } else {
                     Map<String, BeanProperty<Object, Object>> remainingProperties = new LinkedHashMap<>();

--- a/jackson-databind/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
@@ -389,14 +389,16 @@ public class BeanIntrospectionModule extends SimpleModule {
                     // add any remaining properties. This can happen if the supertype has reflection-visible properties
                     // so `properties` isn't empty, but the subtype doesn't have reflection enabled.
                     for (Map.Entry<String, BeanProperty<Object, Object>> entry : remainingProperties.entrySet()) {
-                        SettableBeanProperty existing = builder.findProperty(PropertyName.construct(entry.getKey()));
-                        if (existing == null) {
-                            builder.addOrReplaceProperty(new VirtualSetter(
-                                            beanDesc.getClassInfo(),
-                                            config.getTypeFactory(),
-                                            entry.getValue(),
-                                            findSerializerFromAnnotation(entry.getValue(), JsonDeserialize.class)),
-                                    true);
+                        if (!entry.getValue().isReadOnly()) {
+                            SettableBeanProperty existing = builder.findProperty(PropertyName.construct(entry.getKey()));
+                            if (existing == null) {
+                                builder.addOrReplaceProperty(new VirtualSetter(
+                                                beanDesc.getClassInfo(),
+                                                config.getTypeFactory(),
+                                                entry.getValue(),
+                                                findSerializerFromAnnotation(entry.getValue(), JsonDeserialize.class)),
+                                        true);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
23adb4bdaa55dac0d5ac74cf937e3f26f181ec4b introduced a regression that would replace any creator properties that do not have a corresponding getter with a new VirtualSetter. This patch ignores these properties.