### PR TITLE
Support WebSocket permessage-deflate extension

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -136,6 +136,7 @@ import io.netty.handler.codec.http.multipart.HttpPostRequestEncoder;
 import io.netty.handler.codec.http.multipart.InterfaceHttpData;
 import io.netty.handler.codec.http.websocketx.WebSocketClientHandshakerFactory;
 import io.netty.handler.codec.http.websocketx.WebSocketVersion;
+import io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketClientCompressionHandler;
 import io.netty.handler.codec.http2.*;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.proxy.HttpProxyHandler;
@@ -907,10 +908,11 @@ public class DefaultHttpClient implements
                                 request,
                                 finalWebSocketBean,
                                 WebSocketClientHandshakerFactory.newHandshaker(
-                                        webSocketURL, protocolVersion, subprotocol, false, customHeaders, maxFramePayloadLength),
+                                        webSocketURL, protocolVersion, subprotocol, true, customHeaders, maxFramePayloadLength),
                                 requestBinderRegistry,
                                 mediaTypeCodecRegistry,
                                 emitter);
+                        pipeline.addLast(WebSocketClientCompressionHandler.INSTANCE);
                         pipeline.addLast(ChannelPipelineCustomizer.HANDLER_MICRONAUT_WEBSOCKET_CLIENT, webSocketHandler);
                     } catch (Throwable e) {
                         emitter.error(new WebSocketSessionException("Error opening WebSocket client session: " + e.getMessage(), e));

--- a/http-netty/src/main/java/io/micronaut/http/netty/websocket/WebSocketMessageEncoder.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/websocket/WebSocketMessageEncoder.java
@@ -63,7 +63,7 @@ public class WebSocketMessageEncoder {
             String s = message.toString();
             return new TextWebSocketFrame(s);
         } else if (message instanceof ByteBuf) {
-            return new BinaryWebSocketFrame((ByteBuf) message);
+            return new BinaryWebSocketFrame(((ByteBuf) message).slice());
         } else if (message instanceof ByteBuffer) {
             return new BinaryWebSocketFrame(Unpooled.wrappedBuffer((ByteBuffer) message));
         } else {

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
@@ -84,6 +84,7 @@ import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.codec.http.HttpServerKeepAliveHandler;
 import io.netty.handler.codec.http.HttpServerUpgradeHandler;
 import io.netty.handler.codec.http.multipart.DiskFileUpload;
+import io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketServerCompressionHandler;
 import io.netty.handler.codec.http2.CleartextHttp2ServerUpgradeHandler;
 import io.netty.handler.codec.http2.DefaultHttp2Connection;
 import io.netty.handler.codec.http2.Http2CodecUtil;
@@ -793,6 +794,7 @@ public class NettyHttpServer implements NettyEmbeddedServer {
                 ));
                 handlers.put(HANDLER_HTTP_DECOMPRESSOR, new HttpContentDecompressor());
             }
+            handlers.put(NettyServerWebSocketUpgradeHandler.COMPRESSION_HANDLER, new WebSocketServerCompressionHandler());
             handlers.put(HANDLER_HTTP_STREAM, new HttpStreamsServerHandler());
             handlers.put(HANDLER_HTTP_CHUNK, new ChunkedWriteHandler());
             handlers.put(HttpRequestDecoder.ID, requestDecoder);

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/ssl/HttpRequestCertificateHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/ssl/HttpRequestCertificateHandler.java
@@ -49,8 +49,8 @@ public class HttpRequestCertificateHandler extends ChannelInboundHandlerAdapter 
             } else {
                 request.removeAttribute(HttpAttributes.X509_CERTIFICATE, Certificate.class);
             }
-            super.channelRead(ctx, msg);
         }
+        super.channelRead(ctx, msg);
     }
 
     private static Optional<Certificate> getCertificate(final SslHandler handler) {

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/BinaryWebSocketSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/BinaryWebSocketSpec.groovy
@@ -16,11 +16,22 @@
 package io.micronaut.http.server.netty.websocket
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.event.BeanCreatedEvent
+import io.micronaut.context.event.BeanCreatedEventListener
+import io.micronaut.http.netty.channel.ChannelPipelineCustomizer
 import io.micronaut.runtime.server.EmbeddedServer
 import io.micronaut.websocket.WebSocketClient
 import io.netty.buffer.Unpooled
+import io.netty.channel.ChannelHandlerContext
+import io.netty.channel.ChannelOutboundHandlerAdapter
+import io.netty.channel.ChannelPipeline
+import io.netty.channel.ChannelPromise
+import io.netty.handler.codec.http.websocketx.WebSocketFrame
+import jakarta.inject.Singleton
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
+import spock.lang.Issue
 import spock.lang.Retry
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
@@ -197,6 +208,88 @@ class BinaryWebSocketSpec extends Specification {
         then:
         conditions.eventually {
             fred.pingReplies.contains('foo') && fred.pingReplies.size() == 1
+        }
+    }
+
+    @Issue('https://github.com/micronaut-projects/micronaut-core/issues/6069')
+    void "test per-message compression"() {
+        given:
+        def ctx = ApplicationContext.run([
+                'spec.name'            : 'test per-message compression',
+                'micronaut.server.port': -1
+        ])
+        def compressionDetectionCustomizer = ctx.getBean(CompressionDetectionCustomizer)
+        EmbeddedServer embeddedServer = ctx.getBean(EmbeddedServer)
+        embeddedServer.start()
+        PollingConditions conditions = new PollingConditions(timeout: 15, delay: 0.5)
+
+        when: "a websocket connection is established"
+        WebSocketClient wsClient = embeddedServer.applicationContext.createBean(WebSocketClient, embeddedServer.getURI())
+        BinaryChatClientWebSocket fred = wsClient.connect(BinaryChatClientWebSocket, "/binary/chat/stuff/fred").blockFirst()
+        BinaryChatClientWebSocket bob = wsClient.connect(BinaryChatClientWebSocket, [topic: "stuff", username: "bob"]).blockFirst()
+
+
+        then: "The connection is valid"
+        fred.session != null
+        fred.session.id != null
+        conditions.eventually {
+            fred.replies.contains("[bob] Joined!")
+            fred.replies.size() == 1
+        }
+
+        compressionDetectionCustomizer.getPipelines().size() == 4
+
+        when: "A message is sent"
+        List<MessageInterceptor> interceptors = new ArrayList<>()
+        for (ChannelPipeline pipeline : compressionDetectionCustomizer.getPipelines()) {
+            def interceptor = new MessageInterceptor()
+            if (pipeline.get('ws-encoder') != null) {
+                pipeline.addAfter('ws-encoder', 'MessageInterceptor', interceptor)
+            } else {
+                pipeline.addAfter('wsencoder', 'MessageInterceptor', interceptor)
+            }
+            interceptors.add(interceptor)
+        }
+
+        fred.sendMany()
+
+        then:
+        conditions.eventually {
+            bob.replies.contains("[fred] abcdef")
+        }
+        interceptors.any { it.seenCompressedMessage }
+
+        cleanup:
+        fred.close()
+        bob.close()
+        wsClient.close()
+        embeddedServer.close()
+    }
+
+    @Singleton
+    @Requires(property = 'spec.name', value = 'test per-message compression')
+    static class CompressionDetectionCustomizer implements BeanCreatedEventListener<ChannelPipelineCustomizer> {
+        List<ChannelPipeline> pipelines = Collections.synchronizedList(new ArrayList<>())
+
+        @Override
+        ChannelPipelineCustomizer onCreated(BeanCreatedEvent<ChannelPipelineCustomizer> event) {
+            event.getBean().doOnConnect {
+                pipelines.add(it)
+                return it
+            }
+            return event.bean
+        }
+    }
+
+    static class MessageInterceptor extends ChannelOutboundHandlerAdapter {
+        boolean seenCompressedMessage = false
+
+        @Override
+        void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+            if (msg instanceof WebSocketFrame) {
+                seenCompressedMessage |= (msg.rsv() & 0x4) != 0
+            }
+            super.write(ctx, msg, promise)
         }
     }
 }


### PR DESCRIPTION
Both for client and server.
On the server side, this requires a change in the pipeline setup logic. Because the permessage-deflate codecs are placed after the websocket codecs, but aren't always present, we can't simply place the `NettyServerWebSocketHandler` after the `wsdecoder` anymore. Instead, we place it at the old location of the upgrade handler.

Resolves #6069