### PR TITLE
Copy setter annotations for bean properties

### DIFF
--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/utils/AstAnnotationUtils.groovy
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/utils/AstAnnotationUtils.groovy
@@ -69,12 +69,12 @@ class AstAnnotationUtils {
      * Get the {@link AnnotationMetadata} for the given annotated node
      *
      * @param sourceUnit the source unit
-     * @param parent the parent
+     * @param parents the parents
      * @param annotatedNode The node
      * @return The metadata
      */
-    static AnnotationMetadata getAnnotationMetadata(SourceUnit sourceUnit, CompilationUnit compilationUnit, AnnotatedNode parent, AnnotatedNode annotatedNode) {
-        new GroovyAnnotationMetadataBuilder(sourceUnit, compilationUnit).buildForParent(parent, annotatedNode)
+    static AnnotationMetadata getAnnotationMetadata(SourceUnit sourceUnit, CompilationUnit compilationUnit, List<AnnotatedNode> parents, AnnotatedNode annotatedNode) {
+        new GroovyAnnotationMetadataBuilder(sourceUnit, compilationUnit).buildForParents(parents, annotatedNode)
     }
 
 

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyClassElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyClassElement.java
@@ -832,8 +832,15 @@ public class GroovyClassElement extends AbstractGroovyElement implements Arrayab
                     final AnnotationMetadata annotationMetadata;
                     final GroovyAnnotationMetadataBuilder groovyAnnotationMetadataBuilder = new GroovyAnnotationMetadataBuilder(sourceUnit, compilationUnit);
                     final FieldNode field = this.classNode.getField(propertyName);
+                    final List<AnnotatedNode> parents = new ArrayList<>();
                     if (field != null) {
-                        annotationMetadata = AstAnnotationUtils.getAnnotationMetadata(sourceUnit, compilationUnit, field, value.getter);
+                        parents.add(field);
+                    }
+                    if (value.setter != null) {
+                        parents.add(value.setter);
+                    }
+                    if (!parents.isEmpty()) {
+                        annotationMetadata = AstAnnotationUtils.getAnnotationMetadata(sourceUnit, compilationUnit, parents, value.getter);
                     } else {
                         annotationMetadata = groovyAnnotationMetadataBuilder.buildForMethod(value.getter);
                     }

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
@@ -2,6 +2,7 @@ package io.micronaut.inject.visitor.beans
 
 import com.blazebit.persistence.impl.function.entity.ValuesEntity
 import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.micronaut.annotation.processing.TypeElementVisitorProcessor
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
@@ -2867,6 +2868,63 @@ class Author {
         noExceptionThrown()
         beanIntrospection != null
         beanIntrospection.getBeanProperties().size() == 1
+    }
+
+    void "test annotation on setter"() {
+        when:
+        BeanIntrospection beanIntrospection = buildBeanIntrospection("test.Test", """
+package test;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+public class Test {
+    public String getFoo() {
+        return "bar";
+    }
+    
+    @JsonProperty
+    public void setFoo(String s) {
+    }
+}
+""")
+
+        then:
+        noExceptionThrown()
+        beanIntrospection != null
+        beanIntrospection.getBeanProperties().size() == 1
+        beanIntrospection.getBeanProperties()[0].annotationMetadata.hasAnnotation(JsonProperty)
+    }
+
+    void "test annotation on field"() {
+        when:
+        BeanIntrospection beanIntrospection = buildBeanIntrospection("test.Test", """
+package test;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+public class Test {
+    @JsonProperty
+    String foo;
+    
+    public String getFoo() {
+        return foo;
+    }
+    
+    public void setFoo(String s) {
+        this.foo = s;
+    }
+}
+""")
+
+        then:
+        noExceptionThrown()
+        beanIntrospection != null
+        beanIntrospection.getBeanProperties().size() == 1
+        beanIntrospection.getBeanProperties()[0].annotationMetadata.hasAnnotation(JsonProperty)
     }
 
     @Override

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
@@ -2927,6 +2927,69 @@ public class Test {
         beanIntrospection.getBeanProperties()[0].annotationMetadata.hasAnnotation(JsonProperty)
     }
 
+    void "test getter annotation overrides setter and field"() {
+        when:
+        BeanIntrospection beanIntrospection = buildBeanIntrospection("test.Test", """
+package test;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+public class Test {
+    @JsonProperty("field")
+    String foo;
+    
+    @JsonProperty("getter")
+    public String getFoo() {
+        return foo;
+    }
+    
+    @JsonProperty("setter")
+    public void setFoo(String s) {
+        this.foo = s;
+    }
+}
+""")
+
+        then:
+        noExceptionThrown()
+        beanIntrospection != null
+        beanIntrospection.getBeanProperties().size() == 1
+        beanIntrospection.getBeanProperties()[0].annotationMetadata.getAnnotation(JsonProperty).stringValue().get() == 'getter'
+    }
+
+    void "test field annotation overrides setter"() {
+        when:
+        BeanIntrospection beanIntrospection = buildBeanIntrospection("test.Test", """
+package test;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+public class Test {
+    @JsonProperty("field")
+    String foo;
+    
+    public String getFoo() {
+        return foo;
+    }
+    
+    @JsonProperty("setter")
+    public void setFoo(String s) {
+        this.foo = s;
+    }
+}
+""")
+
+        then:
+        noExceptionThrown()
+        beanIntrospection != null
+        beanIntrospection.getBeanProperties().size() == 1
+        beanIntrospection.getBeanProperties()[0].annotationMetadata.getAnnotation(JsonProperty).stringValue().get() == 'field'
+    }
+
     @Override
     protected JavaParser newJavaParser() {
         return new JavaParser() {

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/AnnotationUtils.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/AnnotationUtils.java
@@ -228,6 +228,20 @@ public class AnnotationUtils {
     }
 
     /**
+     * Get the annotation metadata for the given element and the given parents.
+     * This method is used for cases when you need to combine annotation metadata for
+     * two elements, for example a JavaBean property where the field and the method metadata
+     * need to be combined.
+     *
+     * @param parents The parents
+     * @param element The element
+     * @return The {@link AnnotationMetadata}
+     */
+    public AnnotationMetadata getAnnotationMetadata(List<Element> parents, Element element) {
+        return newAnnotationBuilder().buildForParents(parents, element);
+    }
+
+    /**
      * Check whether the method is annotated.
      *
      * @param declaringType The declaring type

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
@@ -26,6 +26,8 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.core.util.StringUtils;
+import io.micronaut.inject.annotation.DefaultAnnotationMetadata;
+import io.micronaut.inject.annotation.MutableAnnotationMetadata;
 import io.micronaut.inject.ast.*;
 import io.micronaut.inject.ast.PackageElement;
 import io.micronaut.inject.processing.JavaModelUtils;
@@ -432,8 +434,15 @@ public class JavaClassElement extends AbstractJavaElement implements ArrayableCl
 
                     if (value.getter != null) {
                         final AnnotationMetadata annotationMetadata;
+                        List<Element> parents = new ArrayList<>();
                         if (fieldElement != null) {
-                            annotationMetadata = visitorContext.getAnnotationUtils().getAnnotationMetadata(fieldElement, value.getter);
+                            parents.add(fieldElement);
+                        }
+                        if (value.setter != null) {
+                            parents.add(value.setter);
+                        }
+                        if (!parents.isEmpty()) {
+                            annotationMetadata = visitorContext.getAnnotationUtils().getAnnotationMetadata(parents, value.getter);
                         } else {
                             annotationMetadata = visitorContext
                                     .getAnnotationUtils()

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
@@ -26,8 +26,6 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.core.util.StringUtils;
-import io.micronaut.inject.annotation.DefaultAnnotationMetadata;
-import io.micronaut.inject.annotation.MutableAnnotationMetadata;
 import io.micronaut.inject.ast.*;
 import io.micronaut.inject.ast.PackageElement;
 import io.micronaut.inject.processing.JavaModelUtils;

--- a/inject/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -678,7 +678,18 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
      */
     protected abstract Optional<T> getAnnotationMirror(String annotationName);
 
-
+    /**
+     * Populate the annotation data for the given annotation.
+     *
+     * @param originatingElement The element the annotation data originates from
+     * @param parent             The parent element
+     * @param annotationMirror   The annotation
+     * @param metadata           the metadata
+     * @param isDeclared         Is the annotation a declared annotation
+     * @param retentionPolicy    The retention policy
+     * @param allowAliases       Whether aliases are allowed
+     * @return The annotation values
+     */
     protected Map<CharSequence, Object> populateAnnotationData(
             T originatingElement,
             @Nullable T parent,
@@ -702,7 +713,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
      * Populate the annotation data for the given annotation.
      *
      * @param originatingElement The element the annotation data originates from
-     * @param originatingElementIsSameParent  The parent element
+     * @param originatingElementIsSameParent Whether the originating element is considered a parent element
      * @param annotationMirror   The annotation
      * @param metadata           the metadata
      * @param isDeclared         Is the annotation a declared annotation

--- a/inject/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -169,7 +169,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         }
 
         try {
-            includeAnnotations(annotationMetadata, element, null, true, annotations, true);
+            includeAnnotations(annotationMetadata, element, false, true, annotations, true);
             if (annotationMetadata.isEmpty()) {
                 return AnnotationMetadata.EMPTY_METADATA;
             }
@@ -302,8 +302,22 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
      * @return The {@link AnnotationMetadata}
      */
     public AnnotationMetadata buildForParent(T parent, T element) {
+        return buildForParents(parent == null ? Collections.emptyList() : Collections.singletonList(parent), element);
+    }
+
+    /**
+     * Get the annotation metadata for the given element and the given parents.
+     * This method is used for cases when you need to combine annotation metadata for
+     * two elements, for example a JavaBean property where the field and the method metadata
+     * need to be combined.
+     *
+     * @param parents The parent elements
+     * @param element The element
+     * @return The {@link AnnotationMetadata}
+     */
+    public AnnotationMetadata buildForParents(List<T> parents, T element) {
         String declaringType = getDeclaringType(element);
-        return buildForParent(declaringType, parent, element);
+        return buildForParents(declaringType, parents, element);
     }
 
     /**
@@ -315,6 +329,18 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
      * @return The {@link AnnotationMetadata}
      */
     public AnnotationMetadata buildForParent(String declaringType, T parent, T element) {
+        return buildForParents(declaringType, parent == null ? Collections.emptyList() : Collections.singletonList(parent), element);
+    }
+
+    /**
+     * Build the meta data for the given parents and method element excluding any class metadata.
+     *
+     * @param declaringType The declaring type
+     * @param parents       The parent elements
+     * @param element       The element
+     * @return The {@link AnnotationMetadata}
+     */
+    public AnnotationMetadata buildForParents(String declaringType, List<T> parents, T element) {
         final AnnotationMetadata existing = lookupExisting(declaringType, element);
         DefaultAnnotationMetadata annotationMetadata;
         if (existing instanceof DefaultAnnotationMetadata) {
@@ -330,7 +356,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         } else {
             annotationMetadata = new MutableAnnotationMetadata();
         }
-        return buildInternal(parent, element, annotationMetadata, false, false, true);
+        return buildInternalMulti(parents, element, annotationMetadata, false, false, true);
     }
 
     /**
@@ -652,11 +678,31 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
      */
     protected abstract Optional<T> getAnnotationMirror(String annotationName);
 
+
+    protected Map<CharSequence, Object> populateAnnotationData(
+            T originatingElement,
+            @Nullable T parent,
+            A annotationMirror,
+            DefaultAnnotationMetadata metadata,
+            boolean isDeclared,
+            RetentionPolicy retentionPolicy,
+            boolean allowAliases) {
+        return populateAnnotationData(
+                originatingElement,
+                parent == originatingElement,
+                annotationMirror,
+                metadata,
+                isDeclared,
+                retentionPolicy,
+                allowAliases
+        );
+    }
+
     /**
      * Populate the annotation data for the given annotation.
      *
      * @param originatingElement The element the annotation data originates from
-     * @param parent  The parent element
+     * @param originatingElementIsSameParent  The parent element
      * @param annotationMirror   The annotation
      * @param metadata           the metadata
      * @param isDeclared         Is the annotation a declared annotation
@@ -666,7 +712,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
      */
     protected Map<CharSequence, Object> populateAnnotationData(
             T originatingElement,
-            @Nullable T parent,
+            boolean originatingElementIsSameParent,
             A annotationMirror,
             DefaultAnnotationMetadata metadata,
             boolean isDeclared,
@@ -700,7 +746,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                     final List<? extends A> annotationsForMember = getAnnotationsForType(member)
                             .stream().filter((a) -> !getAnnotationTypeName(a).equals(annotationName))
                             .collect(Collectors.toList());
-                    includeAnnotations(memberMetadata, member, null, true, annotationsForMember, false);
+                    includeAnnotations(memberMetadata, member, false, true, annotationsForMember, false);
 
                     boolean isInstantiatedMember = memberMetadata.hasAnnotation(InstantiatedMember.class);
 
@@ -824,7 +870,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                                         mappedAnnotationName,
                                         metadata,
                                         isDeclared,
-                                        isInheritedAnnotationType(annMirror) || originatingElement == parent);
+                                        isInheritedAnnotationType(annMirror) || originatingElementIsSameParent);
 
                             });
                         }
@@ -1073,8 +1119,22 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
             boolean inheritTypeAnnotations,
             boolean declaredOnly,
             boolean allowAliases) {
+        return buildInternalMulti(
+                parent == null ? Collections.emptyList() : Collections.singletonList(parent),
+                element,
+                annotationMetadata, inheritTypeAnnotations, declaredOnly, allowAliases
+        );
+    }
+
+    private AnnotationMetadata buildInternalMulti(
+            List<T> parents,
+            T element,
+            DefaultAnnotationMetadata annotationMetadata,
+            boolean inheritTypeAnnotations,
+            boolean declaredOnly,
+            boolean allowAliases) {
         List<T> hierarchy = buildHierarchy(element, inheritTypeAnnotations, declaredOnly);
-        if (parent != null) {
+        for (T parent : parents) {
             final List<T> parentHierarchy = buildHierarchy(parent, inheritTypeAnnotations, declaredOnly);
             if (hierarchy.isEmpty() && !parentHierarchy.isEmpty()) {
                 hierarchy = parentHierarchy;
@@ -1092,13 +1152,12 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
             if (annotationHierarchy.isEmpty()) {
                 continue;
             }
-            boolean isDeclared = currentElement == element;
 
             includeAnnotations(
                     annotationMetadata,
                     currentElement,
-                    parent,
-                    isDeclared,
+                    parents.contains(currentElement),
+                    currentElement == element,
                     annotationHierarchy,
                     allowAliases
             );
@@ -1113,7 +1172,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
 
     private void includeAnnotations(DefaultAnnotationMetadata annotationMetadata,
                                     T element,
-                                    @Nullable T parent,
+                                    boolean originatingElementIsSameParent,
                                     boolean isDeclared,
                                     List<? extends A> annotationHierarchy,
                                     boolean allowAliases) {
@@ -1133,7 +1192,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
             RetentionPolicy retentionPolicy = getRetentionPolicy(annotationType);
             Map<CharSequence, Object> annotationValues = populateAnnotationData(
                     element,
-                    parent,
+                    originatingElementIsSameParent,
                     annotationMirror,
                     annotationMetadata,
                     isDeclared,
@@ -1153,7 +1212,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                         annotationMetadata::addDeclaredRepeatable,
                         annotationMetadata::addDeclaredAnnotation);
             } else {
-                if (isInheritedAnnotation(annotationMirror) || element == parent) {
+                if (isInheritedAnnotation(annotationMirror) || originatingElementIsSameParent) {
                     applyTransformations(
                             listIterator,
                             annotationMetadata,
@@ -1173,7 +1232,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
             String annotationTypeName = getAnnotationTypeName(annotationMirror);
             String packageName = NameUtils.getPackageName(annotationTypeName);
             if (!AnnotationUtil.STEREOTYPE_EXCLUDES.contains(packageName)) {
-                processAnnotationStereotype(element, parent, annotationMirror, annotationMetadata, isDeclared);
+                processAnnotationStereotype(element, originatingElementIsSameParent, annotationMirror, annotationMetadata, isDeclared);
             }
         }
     }
@@ -1508,7 +1567,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
 
     private void processAnnotationStereotype(
             T element,
-            T parent,
+            boolean originatingElementIsSameParent,
             A annotationMirror,
             DefaultAnnotationMetadata annotationMetadata,
             boolean isDeclared) {
@@ -1518,7 +1577,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
             processAnnotationStereotypes(
                     annotationMetadata,
                     isDeclared,
-                    isInheritedAnnotation(annotationMirror) || element == parent,
+                    isInheritedAnnotation(annotationMirror) || originatingElementIsSameParent,
                     annotationType,
                     parentAnnotationName,
                     Collections.emptyList()

--- a/jackson-databind/src/test/groovy/io/micronaut/jackson/modules/BeanIntrospectionModuleSpec.groovy
+++ b/jackson-databind/src/test/groovy/io/micronaut/jackson/modules/BeanIntrospectionModuleSpec.groovy
@@ -463,6 +463,21 @@ class BeanIntrospectionModuleSpec extends Specification {
         outerArray.wrapper.inner.length == 0
     }
 
+    @Issue("https://github.com/micronaut-projects/micronaut-core/issues/6472")
+    void "@JsonProperty annotation on setter"() {
+        given:
+        ApplicationContext ctx = ApplicationContext.run()
+        ctx.getBean(BeanIntrospectionModule).ignoreReflectiveProperties = ignoreReflectiveProperties
+        ObjectMapper objectMapper = ctx.getBean(ObjectMapper)
+
+        expect:
+        objectMapper.readValue('{"bar":"baz"}', JsonPropertyOnSetter.class).foo == 'baz'
+        objectMapper.writeValueAsString(new JsonPropertyOnSetter(foo: 'baz')) == '{"bar":"baz"}'
+
+        where:
+        ignoreReflectiveProperties << [true, false]
+    }
+
     @Introspected
     static class Book {
         @JsonProperty("book_title")
@@ -684,6 +699,20 @@ class BeanIntrospectionModuleSpec extends Specification {
         @JsonCreator
         OuterArray(WrapperArray wrapper) {
             this.wrapper = wrapper
+        }
+    }
+
+    @Introspected
+    static class JsonPropertyOnSetter {
+        private String foo
+
+        public String getFoo() {
+            return foo
+        }
+
+        @JsonProperty("bar")
+        public void setFoo(String foo) {
+            this.foo = foo
         }
     }
 }


### PR DESCRIPTION
Copy annotations for bean properties not only from the field and getter, but also from the setter.

Fixes #6472