### PR TITLE
Fix support for secondary servers with custom SSL config

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/DelegateNettyEmbeddedServices.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/DelegateNettyEmbeddedServices.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.netty;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.event.ApplicationEventPublisher;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.http.codec.MediaTypeCodecRegistry;
+import io.micronaut.http.netty.channel.EventLoopGroupConfiguration;
+import io.micronaut.http.netty.channel.EventLoopGroupRegistry;
+import io.micronaut.http.netty.channel.converters.ChannelOptionFactory;
+import io.micronaut.http.server.RouteExecutor;
+import io.micronaut.http.server.netty.ssl.ServerSslBuilder;
+import io.micronaut.web.router.resource.StaticResourceResolver;
+import io.micronaut.websocket.context.WebSocketBeanRegistry;
+import io.netty.channel.ChannelOutboundHandler;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.socket.ServerSocketChannel;
+
+/**
+ * A delegating Netty embedded services instance.
+ *
+ * @since 3.1.4
+ * @author graemerocher
+ */
+@Internal
+interface DelegateNettyEmbeddedServices extends NettyEmbeddedServices {
+    /**
+     * @return The instance to delegate to.
+     */
+    @NonNull
+    NettyEmbeddedServices getDelegate();
+
+    @Override
+    default List<ChannelOutboundHandler> getOutboundHandlers() {
+        return getDelegate().getOutboundHandlers();
+    }
+
+    @Override
+    default ApplicationContext getApplicationContext() {
+        return getDelegate().getApplicationContext();
+    }
+
+    @Override
+    default RouteExecutor getRouteExecutor() {
+        return getDelegate().getRouteExecutor();
+    }
+
+    @Override
+    default MediaTypeCodecRegistry getMediaTypeCodecRegistry() {
+        return getDelegate().getMediaTypeCodecRegistry();
+    }
+
+    @Override
+    default StaticResourceResolver getStaticResourceResolver() {
+        return getDelegate().getStaticResourceResolver();
+    }
+
+    @Override
+    default ServerSslBuilder getServerSslBuilder() {
+        return getDelegate().getServerSslBuilder();
+    }
+
+    @Override
+    default ChannelOptionFactory getChannelOptionFactory() {
+        return getDelegate().getChannelOptionFactory();
+    }
+
+    @Override
+    default HttpCompressionStrategy getHttpCompressionStrategy() {
+        return getDelegate().getHttpCompressionStrategy();
+    }
+
+    @Override
+    default WebSocketBeanRegistry getWebSocketBeanRegistry() {
+        return getDelegate().getWebSocketBeanRegistry();
+    }
+
+    @Override
+    default EventLoopGroupRegistry getEventLoopGroupRegistry() {
+        return getDelegate().getEventLoopGroupRegistry();
+    }
+
+    @Override
+    default EventLoopGroup createEventLoopGroup(EventLoopGroupConfiguration config) {
+        return getDelegate().createEventLoopGroup(config);
+    }
+
+    @Override
+    default EventLoopGroup createEventLoopGroup(int numThreads, ExecutorService executorService, Integer ioRatio) {
+        return getDelegate().createEventLoopGroup(numThreads, executorService, ioRatio);
+    }
+
+    @Override
+    default ServerSocketChannel getServerSocketChannelInstance(EventLoopGroupConfiguration workerConfig) {
+        return getDelegate().getServerSocketChannelInstance(workerConfig);
+    }
+
+    @Override
+    default <E> ApplicationEventPublisher<E> getEventPublisher(Class<E> eventClass) {
+        return getDelegate().getEventPublisher(eventClass);
+    }
+}

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyEmbeddedServerFactory.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyEmbeddedServerFactory.java
@@ -16,7 +16,9 @@
 package io.micronaut.http.server.netty;
 
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.server.netty.configuration.NettyHttpServerConfiguration;
+import io.micronaut.http.ssl.ServerSslConfiguration;
 
 /**
  * A factory / strategy interface for creating instances of {@link io.micronaut.http.server.netty.NettyEmbeddedServer}.
@@ -29,9 +31,26 @@ public interface NettyEmbeddedServerFactory {
     /**
      * Builds a {@link io.micronaut.http.server.netty.NettyEmbeddedServer} for the given configuration.
      *
+     * <p>Note that the returned server instance should be closed gracefully by calling the {@link NettyEmbeddedServer#stop()} method.</p>
+     *
      * @param configuration The configuration, never {@code null}
      * @return A {@link io.micronaut.http.server.netty.NettyEmbeddedServer} instance
      */
     @NonNull
     NettyEmbeddedServer build(@NonNull NettyHttpServerConfiguration configuration);
+
+    /**
+     * Builds a {@link io.micronaut.http.server.netty.NettyEmbeddedServer} for the given configuration.
+     *
+     * <p>Note that the returned server instance should be closed gracefully by calling the {@link NettyEmbeddedServer#stop()} method.</p>
+     *
+     * @param configuration The configuration, never {@code null}
+     * @param sslConfiguration The SSL configuration, can be {@code null} if SSL is not required
+     * @return A {@link io.micronaut.http.server.netty.NettyEmbeddedServer} instance
+     * @since 3.1.4
+     */
+    @NonNull
+    default NettyEmbeddedServer build(@NonNull NettyHttpServerConfiguration configuration, @Nullable ServerSslConfiguration sslConfiguration) {
+        return build(configuration, null);
+    }
 }

--- a/src/main/docs/guide/httpServer/serverConfiguration/secondaryServers.adoc
+++ b/src/main/docs/guide/httpServer/serverConfiguration/secondaryServers.adoc
@@ -1,3 +1,4 @@
+
 Micronaut supports the programmatic creation of additional Netty servers through the api:http.server.netty.NettyEmbeddedServerFactory[] interface.
 
 This is useful in cases where you, for example, need to expose distinct servers over different ports with potentially differing configurations (HTTPS, thread resources etc.).
@@ -10,10 +11,11 @@ snippet::io.micronaut.docs.http.server.secondary.SecondaryNettyServer[tags="impo
 <2> Define a ann:annotation.annotation.Context[] scoped bean using the server name and including `preDestroy="close"` to ensure the server is shutdown when the context is closed
 <3> Inject the api:http.server.netty.NettyEmbeddedServerFactory[] into a <<factories, Factory Bean>>
 <4> Programmatically create the api:http.server.netty.configuration.NettyHttpServerConfiguration[]
-<5> Use the `build` method to build the server instance
-<6> Start the server with the `start` method
-<7> Return the server instance as a managed bean
-<8> Optionally define an instance of api:discovery.ServiceInstanceList[] if you wish to inject <<httpClient, HTTP Clients>> by the server name
+<5> Optionally create the api:http.ssl.ServerSslConfiguration[]
+<6> Use the `build` method to build the server instance
+<7> Start the server with the `start` method
+<8> Return the server instance as a managed bean
+<9> Optionally define an instance of api:discovery.ServiceInstanceList[] if you wish to inject <<httpClient, HTTP Clients>> by the server name
 
 With this class in place when the api:context.ApplicationContext[] starts the server will also be started with the appropriate configuration.
 

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/http/server/secondary/SecondaryNettyServer.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/http/server/secondary/SecondaryNettyServer.groovy
@@ -6,15 +6,17 @@ import io.micronaut.context.annotation.Context
 import io.micronaut.context.annotation.Factory
 import io.micronaut.context.annotation.Requires
 import io.micronaut.context.env.Environment
+import io.micronaut.core.util.StringUtils
 import io.micronaut.discovery.ServiceInstanceList
 import io.micronaut.discovery.StaticServiceInstanceList
 import io.micronaut.http.server.netty.NettyEmbeddedServer
 import io.micronaut.http.server.netty.NettyEmbeddedServerFactory
 import io.micronaut.http.server.netty.configuration.NettyHttpServerConfiguration
+import io.micronaut.http.ssl.ServerSslConfiguration
 import jakarta.inject.Named
 // end::imports[]
 
-
+@Requires(property = "secondary.enabled", value = StringUtils.TRUE)
 // tag::class[]
 @Factory
 class SecondaryNettyServer {
@@ -27,8 +29,12 @@ class SecondaryNettyServer {
     NettyEmbeddedServer nettyEmbeddedServer(NettyEmbeddedServerFactory serverFactory) { // <3>
         def configuration =
                 new NettyHttpServerConfiguration() // <4>
+        def sslConfiguration = new ServerSslConfiguration() // <5>
+        sslConfiguration.setBuildSelfSigned(true)
+        sslConfiguration.enabled = true
+        sslConfiguration.port = -1 // random port
         // configure server programmatically
-        final NettyEmbeddedServer embeddedServer = serverFactory.build(configuration) // <5>
+        final NettyEmbeddedServer embeddedServer = serverFactory.build(configuration, sslConfiguration) // <5>
         embeddedServer.start() // <6>
         return embeddedServer // <7>
     }

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/http/server/secondary/SecondaryServerTest.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/http/server/secondary/SecondaryServerTest.groovy
@@ -1,5 +1,7 @@
 package io.micronaut.docs.http.server.secondary
 
+import io.micronaut.context.annotation.Property
+import io.micronaut.core.util.StringUtils
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
@@ -9,12 +11,10 @@ import io.micronaut.runtime.server.EmbeddedServer
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
 import jakarta.inject.Named
-import spock.lang.Ignore
-import spock.lang.PendingFeature
 import spock.lang.Specification
 
 @MicronautTest
-@Ignore
+@Property(name = "secondary.enabled", value = StringUtils.TRUE)
 class SecondaryServerTest extends Specification {
     // tag::inject[]
     @Client(path = "/", id = SecondaryNettyServer.SERVER_ID)
@@ -25,7 +25,6 @@ class SecondaryServerTest extends Specification {
     EmbeddedServer embeddedServer // <2>
     // end::inject[]
 
-    @PendingFeature(reason = "Named injection with Groovy constants broken")
     void "test secondary server"() {
         given:
         final String result = httpClient.toBlocking().retrieve("/test/secondary/server")

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/http/server/secondary/SecondaryNettyServer.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/http/server/secondary/SecondaryNettyServer.kt
@@ -6,14 +6,17 @@ import io.micronaut.context.annotation.Context
 import io.micronaut.context.annotation.Factory
 import io.micronaut.context.annotation.Requires
 import io.micronaut.context.env.Environment
+import io.micronaut.core.util.StringUtils
 import io.micronaut.discovery.ServiceInstanceList
 import io.micronaut.discovery.StaticServiceInstanceList
 import io.micronaut.http.server.netty.NettyEmbeddedServer
 import io.micronaut.http.server.netty.NettyEmbeddedServerFactory
 import io.micronaut.http.server.netty.configuration.NettyHttpServerConfiguration
+import io.micronaut.http.ssl.ServerSslConfiguration
 import jakarta.inject.Named
 // end::imports[]
 
+@Requires(property = "secondary.enabled", value = StringUtils.TRUE)
 // tag::class[]
 @Factory
 class SecondaryNettyServer {
@@ -29,14 +32,20 @@ class SecondaryNettyServer {
         serverFactory: NettyEmbeddedServerFactory // <3>
     ) : NettyEmbeddedServer {
         val configuration = NettyHttpServerConfiguration() // <4>
+        val sslConfiguration = ServerSslConfiguration() // <5>
+
+        sslConfiguration.setBuildSelfSigned(true)
+        sslConfiguration.isEnabled = true
+        sslConfiguration.port = -1 // random port
+
         // configure server programmatically
-        val embeddedServer = serverFactory.build(configuration) // <5>
-        embeddedServer.start() // <6>
-        return embeddedServer // <7>
+        val embeddedServer = serverFactory.build(configuration, sslConfiguration) // <6>
+        embeddedServer.start() // <7>
+        return embeddedServer // <8>
     }
 
     @Bean
-    fun serviceInstanceList( // <8>
+    fun serviceInstanceList( // <9>
         @Named(SERVER_ID) nettyEmbeddedServer: NettyEmbeddedServer
     ): ServiceInstanceList {
         return StaticServiceInstanceList(

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/http/server/secondary/SecondaryServerTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/http/server/secondary/SecondaryServerTest.kt
@@ -1,5 +1,7 @@
 package io.micronaut.docs.http.server.secondary
 
+import io.micronaut.context.annotation.Property
+import io.micronaut.core.util.StringUtils
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
@@ -13,7 +15,7 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
 @MicronautTest
-
+@Property(name = "secondary.enabled", value = StringUtils.TRUE)
 class SecondaryServerTest {
     // tag::inject[]
     @Inject

--- a/test-suite/src/test/java/io/micronaut/docs/http/server/secondary/SecondaryServerTest.java
+++ b/test-suite/src/test/java/io/micronaut/docs/http/server/secondary/SecondaryServerTest.java
@@ -1,5 +1,8 @@
 package io.micronaut.docs.http.server.secondary;
 
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
@@ -13,6 +16,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 @MicronautTest
+@Property(name = "secondary.enabled", value = StringUtils.TRUE)
 public class SecondaryServerTest {
     // tag::inject[]
     @Client(path = "/", id = SecondaryNettyServer.SERVER_ID)
@@ -27,6 +31,7 @@ public class SecondaryServerTest {
     void testCallSecondaryServer() {
         final String result = httpClient.toBlocking().retrieve("/test/secondary/server");
         Assertions.assertTrue(result.endsWith(String.valueOf(embeddedServer.getPort())));
+        Assertions.assertTrue(embeddedServer.getScheme().equalsIgnoreCase("https"));
     }
 
     @Controller("/test/secondary/server")


### PR DESCRIPTION
Unfortunately the secondary server support introduced in 3.1 isn't complete because the `NettyHttpServer` class always uses the `ServerSslConfiguration` provided by the `ServerSslBuilder`. To resolve this, this PR adds a second `build` method which allows specifying a custom SSL config for a secondary server.