### PR TITLE
Mark attribute multipart parts for release

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
@@ -781,7 +781,14 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
                                 if (!executed) {
                                     String argumentName = argument.getName();
                                     if (!routeMatch.isSatisfied(argumentName)) {
-                                        routeMatch = routeMatch.fulfill(Collections.singletonMap(argumentName, value.get()));
+                                        Object fulfillParamter = value.get();
+                                        routeMatch = routeMatch.fulfill(Collections.singletonMap(argumentName, fulfillParamter));
+                                        // we need to release the data here. However, if the route argument is a
+                                        // ByteBuffer, we need to retain the data until the route is executed. Adding
+                                        // the data to the request ensures it is cleaned up after the route completes.
+                                        if (!alwaysAddContent && fulfillParamter instanceof ByteBufHolder) {
+                                            request.addContent((ByteBufHolder) fulfillParamter);
+                                        }
                                     }
                                     if (isPublisher && chunkedProcessing) {
                                         //accounting for the previous request


### PR DESCRIPTION
Attribute parts were not released properly when combined with streaming another part. This patch adds the attribute part to the request so that the request handles cleanup. We can't release the data immediately, because the route method may still expect it as a ByteBuffer parameter.

There is no unit test for this, because this only fixes a bytebuf leak, which can't be tested in our current setup.

Fixes #4837