### PR TITLE
Replace usages of identityHashCode to prevent collisions

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/IdentityWrapper.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/IdentityWrapper.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.netty;
+
+import io.micronaut.core.annotation.NonNull;
+
+import java.util.Objects;
+
+/**
+ * Wrapper class for any object that uses {@link System#identityHashCode} for hashCode and {@code ==} for equals. Can
+ * be used to mimic {@link java.util.IdentityHashMap} behavior for other map types.
+ */
+final class IdentityWrapper {
+    private final Object object;
+
+    IdentityWrapper(@NonNull Object object) {
+        this.object = Objects.requireNonNull(object);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof IdentityWrapper && ((IdentityWrapper) o).object == this.object;
+    }
+
+    @Override
+    public int hashCode() {
+        return System.identityHashCode(object);
+    }
+}

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpRequest.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpRequest.java
@@ -94,7 +94,7 @@ public class NettyHttpRequest<T> extends AbstractNettyHttpRequest<T> implements 
     private MutableConvertibleValues<Object> attributes;
     private NettyCookies nettyCookies;
     private List<ByteBufHolder> receivedContent = new ArrayList<>();
-    private Map<Integer, AbstractHttpData> receivedData = new LinkedHashMap<>();
+    private Map<IdentityWrapper, AbstractHttpData> receivedData = new LinkedHashMap<>();
 
     private Supplier<Optional<T>> body;
     private RouteMatch<?> matchedRoute;
@@ -345,7 +345,7 @@ public class NettyHttpRequest<T> extends AbstractNettyHttpRequest<T> implements 
     @Internal
     public void addContent(ByteBufHolder httpContent) {
         if (httpContent instanceof AbstractHttpData) {
-            receivedData.computeIfAbsent(System.identityHashCode(httpContent), key -> {
+            receivedData.computeIfAbsent(new IdentityWrapper(httpContent), key -> {
                 httpContent.retain();
                 return (AbstractHttpData) httpContent;
             });


### PR DESCRIPTION
System.identityHashCode is, by default, set to a random int by the JVM. Using it as a map key could lead to collisions. This patch replaces those usages with a new wrapper class that, on top of the identityHashCode for hashing, uses == for the equals check. This prevents any collisions in the map keys.

There is unfortunately no way to test for these collisions without a JVM option (-XX:hashCode), so there is no unit test in this patch.