### PR TITLE
Fix stackoverflow with array generics

### DIFF
--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
@@ -47,6 +47,36 @@ import java.lang.reflect.Field
 
 class BeanIntrospectionSpec extends AbstractTypeElementSpec {
 
+    void "test generics in arrays don't stack overflow"() {
+        given:
+        def introspection = buildBeanIntrospection('arraygenerics.Test', '''
+package arraygenerics;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.context.annotation.Executable;
+
+@Introspected
+class Test<T extends CharSequence> {
+    private T[] array;
+    public T[] getArray() {
+        return array;
+    }
+    public void setArray(T[] array) {
+        this.array = array;
+    }
+    
+    @Executable
+    T[] myMethod() {
+        return array;
+    }
+}
+''')
+        expect:
+        introspection.getRequiredProperty("array", CharSequence[].class)
+            .type == CharSequence[].class
+        introspection.beanMethods.first().returnType.type == CharSequence[].class
+    }
+
     void 'test favor method access'() {
         given:
         BeanIntrospection introspection = buildBeanIntrospection('fieldaccess.Test','''\

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/AbstractJavaElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/AbstractJavaElement.java
@@ -352,28 +352,24 @@ public abstract class AbstractJavaElement implements io.micronaut.inject.ast.Ele
             }
         } else if (returnType instanceof TypeVariable) {
             TypeVariable tv = (TypeVariable) returnType;
-            TypeMirror upperBound = tv.getUpperBound();
-            Map<String, TypeMirror> boundGenerics = resolveBoundGenerics(visitorContext, genericsInfo);
-
-            TypeMirror bound = boundGenerics.get(tv.toString());
-            if (bound != null && bound != tv) {
-                return mirrorToClassElement(bound, visitorContext, genericsInfo, includeTypeAnnotations, true);
-            } else {
-                // type variable is still free.
-                List<? extends TypeMirror> boundsUnresolved = upperBound instanceof IntersectionType ?
-                        ((IntersectionType) upperBound).getBounds() :
-                        Collections.singletonList(upperBound);
-                Map<String, Map<String, TypeMirror>> finalGenericsInfo = genericsInfo;
-                List<JavaClassElement> bounds = boundsUnresolved.stream()
-                        .map(tm -> (JavaClassElement) mirrorToClassElement(tm, visitorContext, finalGenericsInfo, includeTypeAnnotations))
-                        .collect(Collectors.toList());
-                return new JavaGenericPlaceholderElement(tv, bounds, 0);
-            }
+            return resolveTypeVariable(
+                    visitorContext,
+                    genericsInfo,
+                    includeTypeAnnotations,
+                    tv,
+                    tv
+            );
 
         } else if (returnType instanceof ArrayType) {
             ArrayType at = (ArrayType) returnType;
             TypeMirror componentType = at.getComponentType();
-            ClassElement arrayType = mirrorToClassElement(componentType, visitorContext, genericsInfo, includeTypeAnnotations);
+            ClassElement arrayType;
+            if (componentType instanceof TypeVariable) {
+                TypeVariable tv = (TypeVariable) componentType;
+                arrayType = resolveTypeVariable(visitorContext, genericsInfo, includeTypeAnnotations, tv, at);
+            } else {
+                arrayType = mirrorToClassElement(componentType, visitorContext, genericsInfo, includeTypeAnnotations);
+            }
             return arrayType.toArray();
         } else if (returnType instanceof PrimitiveType) {
             PrimitiveType pt = (PrimitiveType) returnType;
@@ -409,6 +405,32 @@ public abstract class AbstractJavaElement implements io.micronaut.inject.ast.Ele
             );
         }
         return PrimitiveElement.VOID;
+    }
+
+    private ClassElement resolveTypeVariable(JavaVisitorContext visitorContext,
+                                         Map<String, Map<String, TypeMirror>> genericsInfo,
+                                         boolean includeTypeAnnotations,
+                                         TypeVariable tv,
+                                         TypeMirror declaration) {
+        TypeMirror upperBound = tv.getUpperBound();
+        Map<String, TypeMirror> boundGenerics = resolveBoundGenerics(visitorContext, genericsInfo);
+
+        TypeMirror bound = boundGenerics.get(tv.toString());
+        if (bound != null && bound != declaration) {
+            return mirrorToClassElement(bound, visitorContext, genericsInfo, includeTypeAnnotations, true);
+        } else {
+            // type variable is still free.
+            List<? extends TypeMirror> boundsUnresolved = upperBound instanceof IntersectionType ?
+                    ((IntersectionType) upperBound).getBounds() :
+                    Collections.singletonList(upperBound);
+            Map<String, Map<String, TypeMirror>> finalGenericsInfo = genericsInfo;
+            List<JavaClassElement> bounds = boundsUnresolved.stream()
+                    .map(tm -> (JavaClassElement) mirrorToClassElement(tm,
+                                                                       visitorContext, finalGenericsInfo,
+                                                                       includeTypeAnnotations))
+                    .collect(Collectors.toList());
+            return new JavaGenericPlaceholderElement(tv, bounds, 0);
+        }
     }
 
     private Map<String, TypeMirror> resolveBoundGenerics(JavaVisitorContext visitorContext, Map<String, Map<String, TypeMirror>> genericsInfo) {

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/AbstractJavaElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/AbstractJavaElement.java
@@ -364,7 +364,7 @@ public abstract class AbstractJavaElement implements io.micronaut.inject.ast.Ele
             ArrayType at = (ArrayType) returnType;
             TypeMirror componentType = at.getComponentType();
             ClassElement arrayType;
-            if (componentType instanceof TypeVariable) {
+            if (componentType instanceof TypeVariable && componentType.getKind() == TypeKind.TYPEVAR) {
                 TypeVariable tv = (TypeVariable) componentType;
                 arrayType = resolveTypeVariable(visitorContext, genericsInfo, includeTypeAnnotations, tv, at);
             } else {
@@ -423,10 +423,10 @@ public abstract class AbstractJavaElement implements io.micronaut.inject.ast.Ele
             List<? extends TypeMirror> boundsUnresolved = upperBound instanceof IntersectionType ?
                     ((IntersectionType) upperBound).getBounds() :
                     Collections.singletonList(upperBound);
-            Map<String, Map<String, TypeMirror>> finalGenericsInfo = genericsInfo;
             List<JavaClassElement> bounds = boundsUnresolved.stream()
                     .map(tm -> (JavaClassElement) mirrorToClassElement(tm,
-                                                                       visitorContext, finalGenericsInfo,
+                                                                       visitorContext,
+                                                                       genericsInfo,
                                                                        includeTypeAnnotations))
                     .collect(Collectors.toList());
             return new JavaGenericPlaceholderElement(tv, bounds, 0);

--- a/inject-java/src/test/groovy/io/micronaut/inject/factory/generics/GenericFactorySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/factory/generics/GenericFactorySpec.groovy
@@ -3,8 +3,44 @@ package io.micronaut.inject.factory.generics
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.micronaut.context.exceptions.DependencyInjectionException
 import io.micronaut.context.exceptions.NoSuchBeanException
+import io.micronaut.inject.BeanDefinition
 
 class GenericFactorySpec extends AbstractTypeElementSpec {
+
+    void "test factory with generic arrays"() {
+        given:
+        def context = buildContext('''
+package genericarray;
+
+import io.micronaut.context.annotation.Factory;
+import jakarta.inject.Singleton;
+import io.micronaut.core.type.Argument;
+
+@Factory
+class SerdeFactory {
+    @Singleton
+    protected <T> Serde<T[]> arraySerde() {
+        return new Serde<T[]>() {
+        };
+    }    
+}
+
+interface Serializer<T> {
+}
+interface Deserializer<T> {
+}
+interface Serde<T> extends Serializer<T>, Deserializer<T> {}
+''')
+        when:
+        def t = context.classLoader.loadClass('genericarray.Serde')
+        BeanDefinition<?> bd = context.getBeanDefinition(t)
+
+        then:
+        bd != null
+
+        cleanup:
+        context.close()
+    }
 
     void "test generic factory with type variables"() {
         given:


### PR DESCRIPTION
Currently generics on arrays can stackoverflow as the same bounds check to break the recursion is not performed for arrays. This fixes that.