### PR TITLE
Clear caches from previous compilation round to avoid hiding test failures

### DIFF
--- a/inject-java-test/src/main/groovy/io/micronaut/annotation/processing/test/AbstractTypeElementSpec.groovy
+++ b/inject-java-test/src/main/groovy/io/micronaut/annotation/processing/test/AbstractTypeElementSpec.groovy
@@ -30,10 +30,12 @@ import io.micronaut.core.annotation.Nullable
 import io.micronaut.core.beans.BeanIntrospection
 import io.micronaut.core.convert.value.MutableConvertibleValuesMap
 import io.micronaut.core.naming.NameUtils
+import io.micronaut.core.reflect.ReflectionUtils
 import io.micronaut.inject.BeanConfiguration
 import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.BeanDefinitionReference
 import io.micronaut.inject.annotation.AnnotationMapper
+import io.micronaut.inject.annotation.AnnotationMetadataSupport
 import io.micronaut.inject.annotation.AnnotationMetadataWriter
 import io.micronaut.inject.annotation.AnnotationTransformer
 import io.micronaut.inject.ast.ClassElement
@@ -55,6 +57,7 @@ import javax.lang.model.element.TypeElement
 import javax.lang.model.element.VariableElement
 import javax.tools.JavaFileObject
 import java.lang.annotation.Annotation
+import java.lang.reflect.Field
 import java.util.stream.Collectors
 import java.util.stream.StreamSupport
 /**
@@ -65,6 +68,15 @@ import java.util.stream.StreamSupport
  * @since 1.0
  */
 abstract class AbstractTypeElementSpec extends Specification {
+
+    def setup() {
+        // clear static data structures to ensure we don't get false positives in compilation tests
+        for(fieldName in ["ANNOTATION_DEFAULTS", 'REPEATABLE_ANNOTATIONS', 'ANNOTATION_TYPES']) {
+            def f = ReflectionUtils.getRequiredField(AnnotationMetadataSupport, fieldName)
+            f.setAccessible(true)
+            f.get(AnnotationMetadataSupport).clear()
+        }
+    }
 
     /**
      * Builds a class element for the given source code.


### PR DESCRIPTION
This PR should be part of the resolution for #6508 since what is happening is tests are passing incorrectly because previous compilation phases are populating static state that is then present in later tests around known default annotations and repeated annotations. This is ugly but I don't know of a better solution given what we have today.