### PR TITLE
Introduce handshakeTimeout option to SslConfiguration

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -3144,11 +3144,8 @@ public class DefaultHttpClient implements
                 });
 
                 if (sslContext != null) {
-                    SslHandler sslHandler = sslContext.newHandler(
-                            ch.alloc(),
-                            host,
-                            port
-                    );
+                    SslHandler sslHandler = sslContext.newHandler(ch.alloc(), host, port);
+                    sslHandler.setHandshakeTimeoutMillis(configuration.getSslConfiguration().getHandshakeTimeout().toMillis());
                     p.addLast(ChannelPipelineCustomizer.HANDLER_SSL, sslHandler);
                 }
 

--- a/http-client/src/test/groovy/io/micronaut/http/client/SslSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/SslSpec.groovy
@@ -16,12 +16,30 @@
 package io.micronaut.http.client
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.runtime.server.EmbeddedServer
+import io.netty.bootstrap.Bootstrap
+import io.netty.bootstrap.ServerBootstrap
+import io.netty.channel.Channel
+import io.netty.channel.ChannelHandlerContext
+import io.netty.channel.ChannelInboundHandlerAdapter
+import io.netty.channel.ChannelInitializer
+import io.netty.channel.ServerChannel
+import io.netty.channel.nio.NioEventLoopGroup
+import io.netty.channel.socket.nio.NioServerSocketChannel
+import io.netty.channel.socket.nio.NioSocketChannel
+import io.netty.handler.ssl.SslHandshakeTimeoutException
+import org.jetbrains.annotations.NotNull
+import reactor.core.publisher.Flux
 import spock.lang.Ignore
 import spock.lang.Specification
 
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+
 class SslSpec extends Specification {
 
-    @Ignore // service down at the moment
+    @Ignore
+    // service down at the moment
     void "test that clients work with self signed certificates"() {
         given:
         ApplicationContext ctx = ApplicationContext.run()
@@ -33,5 +51,60 @@ class SslSpec extends Specification {
         cleanup:
         ctx.close()
         client.close()
+    }
+
+    void 'test client ssl handshakeTimeout'() {
+        given:
+        def group = new NioEventLoopGroup()
+        ServerChannel channel = (ServerChannel) new ServerBootstrap()
+                .group(group)
+                .channel(NioServerSocketChannel)
+                .childHandler(new IgnoringChannelInitializer())
+                .bind(0).sync().channel()
+        ApplicationContext cont = ApplicationContext.run(['micronaut.http.client.ssl.handshakeTimeout': '1s'])
+        def address = (InetSocketAddress) channel.localAddress()
+        when:
+        Flux.from(cont.getBean(HttpClient).exchange("https://localhost:$address.port"))
+                .blockFirst(Duration.ofSeconds(5))
+        then:
+        def e = thrown RuntimeException
+        e.cause instanceof SslHandshakeTimeoutException
+        cleanup:
+        group.shutdownGracefully()
+    }
+
+    void 'test server ssl handshakeTimeout'() {
+        given:
+        def group = new NioEventLoopGroup()
+        ApplicationContext context = ApplicationContext.run([
+                'micronaut.ssl.port'            : -1,
+                'micronaut.ssl.enabled'         : true,
+                'micronaut.ssl.buildSelfSigned' : true,
+                'micronaut.ssl.handshakeTimeout': '1s',
+        ])
+        def embeddedServer = context.getBean(EmbeddedServer)
+        embeddedServer.start()
+        def channel = new Bootstrap()
+                .channel(NioSocketChannel)
+                .group(group)
+                .handler(new IgnoringChannelInitializer())
+                .connect(embeddedServer.host, embeddedServer.port).sync().channel()
+        expect:
+        // returns false on timeout
+        channel.closeFuture().await(5, TimeUnit.SECONDS)
+        cleanup:
+        group.shutdownGracefully()
+    }
+
+    static class IgnoringChannelInitializer extends ChannelInitializer<Channel> {
+        @Override
+        protected void initChannel(@NotNull Channel ch) throws Exception {
+            ch.pipeline().addLast(new ChannelInboundHandlerAdapter() {
+                @Override
+                void channelRead(@NotNull ChannelHandlerContext ctx, @NotNull Object msg) throws Exception {
+                    // ignore
+                }
+            })
+        }
     }
 }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
@@ -99,6 +99,7 @@ import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.ssl.ApplicationProtocolNames;
 import io.netty.handler.ssl.ApplicationProtocolNegotiationHandler;
 import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
 import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.handler.timeout.IdleStateHandler;
@@ -861,7 +862,9 @@ public class NettyHttpServer implements NettyEmbeddedServer {
             int port = ch.localAddress().getPort();
             boolean ssl = sslContext != null && sslConfiguration != null && port == serverPort;
             if (ssl) {
-                pipeline.addLast(ChannelPipelineCustomizer.HANDLER_SSL, sslContext.newHandler(ch.alloc()));
+                SslHandler sslHandler = sslContext.newHandler(ch.alloc());
+                sslHandler.setHandshakeTimeoutMillis(sslConfiguration.getHandshakeTimeout().toMillis());
+                pipeline.addLast(ChannelPipelineCustomizer.HANDLER_SSL, sslHandler);
             }
 
             if (loggingHandler != null) {

--- a/http/src/main/java/io/micronaut/http/ssl/SslConfiguration.java
+++ b/http/src/main/java/io/micronaut/http/ssl/SslConfiguration.java
@@ -246,7 +246,7 @@ public class SslConfiguration implements Toggleable {
     }
 
     /**
-     * @return The timeout for the SSL handshake
+     * @param handshakeTimeout The timeout for the SSL handshake
      */
     public void setHandshakeTimeout(@NonNull Duration handshakeTimeout) {
         this.handshakeTimeout = Objects.requireNonNull(handshakeTimeout, "handshakeTimeout");

--- a/http/src/main/java/io/micronaut/http/ssl/SslConfiguration.java
+++ b/http/src/main/java/io/micronaut/http/ssl/SslConfiguration.java
@@ -15,9 +15,12 @@
  */
 package io.micronaut.http.ssl;
 
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.core.util.Toggleable;
 
+import java.time.Duration;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -66,6 +69,7 @@ public class SslConfiguration implements Toggleable {
     private String[] ciphers;
     private String[] protocols;
     private String protocol = DEFAULT_PROTOCOL;
+    private Duration handshakeTimeout = Duration.ofSeconds(10);
 
     /**
      * @return Whether SSL is enabled.
@@ -145,6 +149,14 @@ public class SslConfiguration implements Toggleable {
      */
     public Optional<String> getProtocol() {
         return Optional.ofNullable(protocol);
+    }
+
+    /**
+     * @return The timeout for the SSL handshake
+     */
+    @NonNull
+    public Duration getHandshakeTimeout() {
+        return handshakeTimeout;
     }
 
     /**
@@ -234,6 +246,13 @@ public class SslConfiguration implements Toggleable {
     }
 
     /**
+     * @return The timeout for the SSL handshake
+     */
+    public void setHandshakeTimeout(@NonNull Duration handshakeTimeout) {
+        this.handshakeTimeout = Objects.requireNonNull(handshakeTimeout, "handshakeTimeout");
+    }
+
+    /**
      * Reads an existing config.
      *
      * @param defaultSslConfiguration The default SSL config
@@ -263,6 +282,7 @@ public class SslConfiguration implements Toggleable {
             defaultSslConfiguration.getProtocol().ifPresent(protocol -> this.protocol = protocol);
             defaultSslConfiguration.getCiphers().ifPresent(ciphers -> this.ciphers = ciphers);
             defaultSslConfiguration.getClientAuthentication().ifPresent(ca -> this.clientAuthentication = ca);
+            this.handshakeTimeout = defaultSslConfiguration.getHandshakeTimeout();
         }
     }
 


### PR DESCRIPTION
Add an option for configuring the SSL handshake timeout for both the HTTP client and server.
Resolves #5501