### PR TITLE
Forward WebSocket `@OnOpen` validation errors to user

### DIFF
--- a/validation/build.gradle
+++ b/validation/build.gradle
@@ -25,6 +25,10 @@ dependencies {
     testImplementation project(":http-server-netty")
     testImplementation libs.managed.groovy.json
     testImplementation project(":inject-java-test")
+    testImplementation(libs.managed.micronaut.test.spock) {
+        exclude module:'micronaut-runtime'
+        exclude module:'micronaut-inject'
+    }
 
 }
 //compileTestGroovy.groovyOptions.forkOptions.jvmArgs = ['-Xdebug', '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005']

--- a/validation/src/test/groovy/io/micronaut/validation/WebSocketClientValidationSpec.groovy
+++ b/validation/src/test/groovy/io/micronaut/validation/WebSocketClientValidationSpec.groovy
@@ -1,0 +1,81 @@
+package io.micronaut.validation
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.websocket.WebSocketClient
+import io.micronaut.websocket.annotation.ClientWebSocket
+import io.micronaut.websocket.annotation.OnMessage
+import jakarta.inject.Singleton
+import reactor.core.publisher.Flux
+import spock.lang.Issue
+import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
+
+import javax.validation.ConstraintViolationException
+import javax.validation.Valid
+import javax.validation.constraints.Pattern
+
+class WebSocketClientValidationSpec extends Specification {
+
+    @Issue('https://github.com/micronaut-projects/micronaut-core/issues/5332')
+    def 'test validation of request bean'() {
+        given:
+        EmbeddedServer embeddedServer = ApplicationContext.builder('spec.name':'WebSocketClientValidationSpec').run(EmbeddedServer)
+        def client = embeddedServer.applicationContext.createBean(WebSocketClient, new URI(embeddedServer.URI.toString()))
+        def holderBean = embeddedServer.applicationContext.getBean(HolderBean)
+        def conditions = new PollingConditions(timeout: 5)
+
+        expect:
+        holderBean.seenData == null
+        holderBean.seenError == null
+
+        when:
+        Flux.from(client.connect(ClientHandler, '/validated?foo=bar')).blockFirst().close()
+        then:
+        conditions.eventually {
+            assert holderBean.seenData != null
+            assert holderBean.seenData.foo == 'bar'
+            assert holderBean.seenError == null
+        }
+
+        when:
+        Flux.from(client.connect(ClientHandler, '/validated?foo=baz')).blockFirst().close()
+        then:
+        conditions.eventually {
+            assert holderBean.seenData != null
+            assert holderBean.seenData.foo == 'bar' // unchanged
+            assert holderBean.seenError != null
+        }
+    }
+
+    @Singleton
+    @Requires(property = 'spec.name', value = 'WebSocketClientValidationSpec')
+    static class HolderBean {
+        ValidatedData seenData = null
+        ConstraintViolationException seenError = null
+    }
+
+    @ClientWebSocket('/validated')
+    @Requires(property = 'spec.name', value = 'WebSocketClientValidationSpec')
+    static abstract class ClientHandler implements Closeable {
+        @OnMessage
+        void onMessage(byte[] message) {
+        }
+    }
+
+    @Introspected
+    static class ValidatedData {
+        private String foo
+
+        void setFoo(String foo) {
+            this.foo = foo
+        }
+
+        @Pattern(regexp = 'bar')
+        String getFoo() {
+            return foo
+        }
+    }
+}

--- a/validation/src/test/groovy/io/micronaut/validation/WebSocketValidationServerHandler.groovy
+++ b/validation/src/test/groovy/io/micronaut/validation/WebSocketValidationServerHandler.groovy
@@ -1,0 +1,36 @@
+package io.micronaut.validation
+
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.annotation.RequestBean
+import io.micronaut.websocket.WebSocketSession
+import io.micronaut.websocket.annotation.OnError
+import io.micronaut.websocket.annotation.OnMessage
+import io.micronaut.websocket.annotation.OnOpen
+import io.micronaut.websocket.annotation.ServerWebSocket
+import jakarta.inject.Inject
+
+import javax.validation.ConstraintViolationException
+import javax.validation.Valid
+
+// this has to be a top-level class because groovy
+@Requires(property = 'spec.name', value = 'WebSocketClientValidationSpec')
+@ServerWebSocket('/validated')
+class WebSocketValidationServerHandler {
+    @Inject
+    WebSocketClientValidationSpec.HolderBean holderBean
+
+    @OnOpen
+    @Validated
+    def onOpen(@RequestBean @Valid WebSocketClientValidationSpec.ValidatedData data, WebSocketSession session) {
+        holderBean.seenData = data
+    }
+
+    @OnMessage
+    void onMessage(byte[] message) {
+    }
+
+    @OnError
+    def onError(ConstraintViolationException e) {
+        holderBean.seenError = e
+    }
+}


### PR DESCRIPTION
Forward any errors during the invocation of the `@OnOpen` method, including validation errors on the request parameters, to the registered `@OnError` handlers.
Resolves #5332