### PR TITLE
Make JsonNode converters more robust for different target types

### DIFF
--- a/jackson-databind/src/test/groovy/io/micronaut/jackson/convert/JsonConverterRegistrarSpec.groovy
+++ b/jackson-databind/src/test/groovy/io/micronaut/jackson/convert/JsonConverterRegistrarSpec.groovy
@@ -17,7 +17,7 @@ class JsonConverterRegistrarSpec extends Specification {
         converter.convert(JsonNode.createArrayNode([JsonNode.createStringNode("foo")]), Argument.of(List, String)).get() == ['foo']
         converter.convert(JsonNode.createArrayNode([JsonNode.createStringNode("foo")]), Argument.of(Set, String)).get() == new HashSet(['foo'])
         // SortedSet not supported
-        converter.convert(JsonNode.createArrayNode([JsonNode.createStringNode("foo")]), Argument.of(SortedSet, String)).isEmpty()
+        !converter.convert(JsonNode.createArrayNode([JsonNode.createStringNode("foo")]), Argument.of(SortedSet, String)).isPresent()
     }
 
     def 'json node to ConvertibleValues'() {
@@ -26,8 +26,8 @@ class JsonConverterRegistrarSpec extends Specification {
         def converter = ctx.getBean(ConversionService)
 
         expect:
-        converter.convert(JsonNode.createArrayNode([JsonNode.createStringNode("foo")]), Argument.of(ConvertibleValues, String)).isEmpty()
+        !converter.convert(JsonNode.createArrayNode([JsonNode.createStringNode("foo")]), Argument.of(ConvertibleValues, String)).isPresent()
         converter.convert(JsonNode.createObjectNode(['bar': JsonNode.createStringNode("foo")]), Argument.of(ConvertibleValues, String)).get().asMap(String, String) == ['bar': 'foo']
-        converter.convert(JsonNode.createStringNode("foo"), Argument.of(ConvertibleValues, String)).isEmpty()
+        !converter.convert(JsonNode.createStringNode("foo"), Argument.of(ConvertibleValues, String)).isPresent()
     }
 }

--- a/jackson-databind/src/test/groovy/io/micronaut/jackson/convert/JsonConverterRegistrarSpec.groovy
+++ b/jackson-databind/src/test/groovy/io/micronaut/jackson/convert/JsonConverterRegistrarSpec.groovy
@@ -1,0 +1,33 @@
+package io.micronaut.jackson.convert
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.convert.ConversionService
+import io.micronaut.core.convert.value.ConvertibleValues
+import io.micronaut.core.type.Argument
+import io.micronaut.json.tree.JsonNode
+import spock.lang.Specification
+
+class JsonConverterRegistrarSpec extends Specification {
+    def 'array node to collection'() {
+        given:
+        def ctx = ApplicationContext.run()
+        def converter = ctx.getBean(ConversionService)
+
+        expect:
+        converter.convert(JsonNode.createArrayNode([JsonNode.createStringNode("foo")]), Argument.of(List, String)).get() == ['foo']
+        converter.convert(JsonNode.createArrayNode([JsonNode.createStringNode("foo")]), Argument.of(Set, String)).get() == new HashSet(['foo'])
+        // SortedSet not supported
+        converter.convert(JsonNode.createArrayNode([JsonNode.createStringNode("foo")]), Argument.of(SortedSet, String)).isEmpty()
+    }
+
+    def 'json node to ConvertibleValues'() {
+        given:
+        def ctx = ApplicationContext.run()
+        def converter = ctx.getBean(ConversionService)
+
+        expect:
+        converter.convert(JsonNode.createArrayNode([JsonNode.createStringNode("foo")]), Argument.of(ConvertibleValues, String)).isEmpty()
+        converter.convert(JsonNode.createObjectNode(['bar': JsonNode.createStringNode("foo")]), Argument.of(ConvertibleValues, String)).get().asMap(String, String) == ['bar': 'foo']
+        converter.convert(JsonNode.createStringNode("foo"), Argument.of(ConvertibleValues, String)).isEmpty()
+    }
+}

--- a/json-core/src/main/java/io/micronaut/json/convert/JsonConverterRegistrar.java
+++ b/json-core/src/main/java/io/micronaut/json/convert/JsonConverterRegistrar.java
@@ -122,7 +122,6 @@ public final class JsonConverterRegistrar implements TypeConverterRegistrar {
      */
     public TypeConverter<JsonArray, Iterable> arrayNodeToIterableConverter() {
         return (node, targetType, context) -> {
-            Map<String, Argument<?>> typeVariables = context.getTypeVariables();
             Collection<Object> results;
             if (targetType.isAssignableFrom(ArrayList.class)) {
                 results = new ArrayList<>();
@@ -132,6 +131,7 @@ public final class JsonConverterRegistrar implements TypeConverterRegistrar {
                 // don't know how to convert to that collection type
                 return Optional.empty();
             }
+            Map<String, Argument<?>> typeVariables = context.getTypeVariables();
             Class elementType = typeVariables.isEmpty() ? Map.class : typeVariables.values().iterator().next().getType();
             for (int i = 0; i < node.size(); i++) {
                 Optional<?> converted = conversionService.convert(node.get(i), elementType, context);

--- a/json-core/src/main/java/io/micronaut/json/convert/JsonConverterRegistrar.java
+++ b/json-core/src/main/java/io/micronaut/json/convert/JsonConverterRegistrar.java
@@ -37,7 +37,9 @@ import jakarta.inject.Singleton;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -74,14 +76,14 @@ public final class JsonConverterRegistrar implements TypeConverterRegistrar {
                 arrayNodeToObjectConverter()
         );
         conversionService.addConverter(
-                JsonArray.class,
-                Iterable.class,
-                arrayNodeToIterableConverter()
-        );
-        conversionService.addConverter(
                 JsonNode.class,
                 ConvertibleValues.class,
                 objectNodeToConvertibleValuesConverter()
+        );
+        conversionService.addConverter(
+                JsonArray.class,
+                Iterable.class,
+                arrayNodeToIterableConverter()
         );
         conversionService.addConverter(
                 JsonNode.class,
@@ -105,7 +107,14 @@ public final class JsonConverterRegistrar implements TypeConverterRegistrar {
      */
     @Internal
     public TypeConverter<JsonNode, ConvertibleValues> objectNodeToConvertibleValuesConverter() {
-        return (object, targetType, context) -> Optional.of(new JsonNodeConvertibleValues<>(object, conversionService));
+        return (object, targetType, context) -> {
+            if (object.isObject()) {
+                return Optional.of(new JsonNodeConvertibleValues<>(object, conversionService));
+            } else {
+                // ConvertibleValues only works for objects
+                return Optional.empty();
+            }
+        };
     }
 
     /**
@@ -114,13 +123,19 @@ public final class JsonConverterRegistrar implements TypeConverterRegistrar {
     public TypeConverter<JsonArray, Iterable> arrayNodeToIterableConverter() {
         return (node, targetType, context) -> {
             Map<String, Argument<?>> typeVariables = context.getTypeVariables();
+            Collection<Object> results;
+            if (targetType.isAssignableFrom(ArrayList.class)) {
+                results = new ArrayList<>();
+            } else if (targetType.isAssignableFrom(LinkedHashSet.class)) {
+                results = new LinkedHashSet<>();
+            } else {
+                // don't know how to convert to that collection type
+                return Optional.empty();
+            }
             Class elementType = typeVariables.isEmpty() ? Map.class : typeVariables.values().iterator().next().getType();
-            List results = new ArrayList();
             for (int i = 0; i < node.size(); i++) {
-                Optional converted = conversionService.convert(node.get(i), elementType, context);
-                if (converted.isPresent()) {
-                    results.add(converted.get());
-                }
+                Optional<?> converted = conversionService.convert(node.get(i), elementType, context);
+                converted.ifPresent(results::add);
             }
             return Optional.of(results);
         };


### PR DESCRIPTION
This patch changes the JsonNode converters so that:
- ArrayNode->Iterable conversion picks a collection type that is compatible with the requested `targetType`, and fails if the `targetType` isn't workable
- JsonNode->ConvertibleValues fails gracefully when attempted on a non-object JsonNode
Fixes #6526