### PR TITLE
Support NaN and Infinity for JsonNodeTreeCodec

### DIFF
--- a/jackson-core/src/main/java/io/micronaut/jackson/core/tree/JsonNodeTreeCodec.java
+++ b/jackson-core/src/main/java/io/micronaut/jackson/core/tree/JsonNodeTreeCodec.java
@@ -94,7 +94,12 @@ public final class JsonNodeTreeCodec {
                 }
             case VALUE_NUMBER_FLOAT:
                 if (config.useBigDecimalForFloats()) {
-                    return JsonNode.createNumberNode(p.getDecimalValue());
+                    // NaN and Inf can't be represented by BigDecimal. Note: isNaN returns true for Inf, too.
+                    if (p.isNaN()) {
+                        return JsonNode.createNumberNode(p.getFloatValue());
+                    } else {
+                        return JsonNode.createNumberNode(p.getDecimalValue());
+                    }
                 } else {
                     // technically, we could get an unsupported number value here.
                     return JsonNode.createNumberNodeImpl(p.getNumberValue());

--- a/jackson-core/src/test/groovy/io/micronaut/jackson/core/tree/JsonNodeTreeCodecSpec.groovy
+++ b/jackson-core/src/test/groovy/io/micronaut/jackson/core/tree/JsonNodeTreeCodecSpec.groovy
@@ -1,6 +1,8 @@
 package io.micronaut.jackson.core.tree
 
 import com.fasterxml.jackson.core.JsonFactory
+import com.fasterxml.jackson.core.json.JsonReadFeature
+import com.fasterxml.jackson.core.json.JsonWriteFeature
 import io.micronaut.json.JsonStreamConfig
 import spock.lang.Specification
 
@@ -42,7 +44,7 @@ class JsonNodeTreeCodecSpec extends Specification {
         def treeCodec = JsonNodeTreeCodec.getInstance().withConfig(JsonStreamConfig.DEFAULT
                 .withUseBigIntegerForInts(true)
                 .withUseBigDecimalForFloats(true))
-        def factory = new JsonFactory()
+        def factory = JsonFactory.builder().enable(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS).disable(JsonWriteFeature.WRITE_NAN_AS_STRINGS).build()
 
         def parsed = treeCodec.readTree(factory.createParser(json))
 
@@ -54,12 +56,15 @@ class JsonNodeTreeCodecSpec extends Specification {
         expect:
         json == emitted.toString()
 
-        parsed.numberValue instanceof BigInteger || parsed.numberValue instanceof BigDecimal
+        parsed.numberValue instanceof BigInteger ||
+                parsed.numberValue instanceof BigDecimal ||
+                (parsed.numberValue instanceof Float && !Float.isFinite(parsed.numberValue))
 
         where:
         json << [
                 '12459561964195489518297537451',
-                '12459561964195489518297537451.5'
+                '12459561964195489518297537451.5',
+                'NaN', 'Infinity', '-Infinity'
         ]
     }
 }

--- a/json-core/src/main/java/io/micronaut/json/JsonStreamConfig.java
+++ b/json-core/src/main/java/io/micronaut/json/JsonStreamConfig.java
@@ -46,6 +46,10 @@ public final class JsonStreamConfig {
     }
 
     /**
+     * Whether all normal floating point literals should be represented as {@link java.math.BigDecimal}. Note that
+     * {@link Float#NaN}, {@link Float#POSITIVE_INFINITY} and {@link Float#NEGATIVE_INFINITY} may still be represented
+     * as float, if the input supports those literals.
+     *
      * @param useBigDecimalForFloats The new value for {@link #useBigDecimalForFloats}
      * @return A copy of this config instance, with {@link #useBigDecimalForFloats} set to the new value.
      */


### PR DESCRIPTION
Add support for NaN and Infinity even when `useBigDecimalForFloats` is enabled (`BigDecimal` does not support these numbers). The input `JsonParser` still has to have support enabled (`JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS`).