### PR TITLE
Allow jackson to be fully removed

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/jackson/JsonViewServerFilter.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/jackson/JsonViewServerFilter.java
@@ -46,6 +46,7 @@ import java.util.concurrent.ExecutorService;
  * @author graemerocher
  */
 @Requires(beans = JsonConfiguration.class)
+@Requires(classes = JsonView.class)
 @Requires(property = JsonViewServerFilter.PROPERTY_JSON_VIEW_ENABLED)
 @Filter("/**")
 public class JsonViewServerFilter implements HttpServerFilter {

--- a/http-server/src/main/java/io/micronaut/http/server/exceptions/JsonExceptionHandler.java
+++ b/http-server/src/main/java/io/micronaut/http/server/exceptions/JsonExceptionHandler.java
@@ -16,6 +16,7 @@
 package io.micronaut.http.server.exceptions;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
@@ -37,6 +38,7 @@ import java.util.Optional;
  */
 @Produces
 @Singleton
+@Requires(classes = JsonProcessingException.class)
 public class JsonExceptionHandler implements ExceptionHandler<JsonProcessingException, Object> {
 
     private final ErrorResponseProcessor<?> responseProcessor;

--- a/jackson-core/src/main/resources/META-INF/native-image/io.micronaut/micronaut-jackson-core/native-image.properties
+++ b/jackson-core/src/main/resources/META-INF/native-image/io.micronaut/micronaut-jackson-core/native-image.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2020 original authors
+# Copyright 2017-2021 original authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,4 @@
 # limitations under the License.
 #
 
-Args = --install-exit-handlers \
-       --initialize-at-run-time=io.micronaut.reactive.reactor.ReactorInstrumentation \
-       --initialize-at-build-time=ch.qos.logback,io.micronaut,io.reactivex,org.reactivestreams,org.slf4j,org.yaml.snakeyaml,javax.xml \
-       --initialize-at-build-time=com.sun.org.apache.xerces.internal.util,com.sun.org.apache.xerces.internal.impl,jdk.xml.internal,com.sun.xml.internal.stream.util,com.sun.org.apache.xerces.internal.xni,com.sun.org.apache.xerces.internal.utils
+Args = --initialize-at-build-time=com.fasterxml.jackson


### PR DESCRIPTION
If an error occurs and jackson is not on the classpath an exception occurs because `JsonProcessingException` is not listed in the bean requirements