### PR TITLE
Add a way to access Kotlin coroutine context from an interceptor

### DIFF
--- a/aop/src/main/java/io/micronaut/aop/InterceptedMethod.java
+++ b/aop/src/main/java/io/micronaut/aop/InterceptedMethod.java
@@ -164,9 +164,9 @@ public interface InterceptedMethod {
     }
 
     /**
-     * Get native method context.
+     * Get native context from the suspension point.
      *
-     * @return The native context for the suspension point or null
+     * @return The native context from the suspension point or null
      * @since 3.2
      */
     @Nullable

--- a/aop/src/main/java/io/micronaut/aop/InterceptedMethod.java
+++ b/aop/src/main/java/io/micronaut/aop/InterceptedMethod.java
@@ -18,7 +18,6 @@ package io.micronaut.aop;
 import io.micronaut.aop.internal.intercepted.InterceptedMethodUtil;
 import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.core.annotation.Experimental;
-import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.type.Argument;
 import org.reactivestreams.Publisher;
 
@@ -161,27 +160,6 @@ public interface InterceptedMethod {
      */
     default Object unsupported() {
         throw new ConfigurationException("Cannot intercept method invocation, missing '" + resultType() + "' interceptor configured");
-    }
-
-    /**
-     * Get native context from the suspension point.
-     *
-     * @return The native context from the suspension point or null
-     * @since 3.2
-     */
-    @Nullable
-    default Object getNativeContext() {
-        return null;
-    }
-
-    /**
-     * Update native context for the suspension point.
-     *
-     * @param context The native context
-     * @since 3.2
-     */
-    default void updateNativeContext(@Nullable Object context) {
-        throw new IllegalStateException("Updating native context not supported for interceptor: " + this);
     }
 
     /**

--- a/aop/src/main/java/io/micronaut/aop/InterceptedMethod.java
+++ b/aop/src/main/java/io/micronaut/aop/InterceptedMethod.java
@@ -18,6 +18,7 @@ package io.micronaut.aop;
 import io.micronaut.aop.internal.intercepted.InterceptedMethodUtil;
 import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.type.Argument;
 import org.reactivestreams.Publisher;
 
@@ -63,7 +64,6 @@ public interface InterceptedMethod {
      * @return The intercepted result
      */
     Object interceptResult();
-
 
     /**
      * Proceeds with invocation of {@link InvocationContext#proceed(Interceptor)} and converts result to appropriate type.
@@ -161,6 +161,27 @@ public interface InterceptedMethod {
      */
     default Object unsupported() {
         throw new ConfigurationException("Cannot intercept method invocation, missing '" + resultType() + "' interceptor configured");
+    }
+
+    /**
+     * Get native method context.
+     *
+     * @return The native context for the suspension point or null
+     * @since 3.2
+     */
+    @Nullable
+    default Object getNativeContext() {
+        return null;
+    }
+
+    /**
+     * Update native context for the suspension point.
+     *
+     * @param context The native context
+     * @since 3.2
+     */
+    default void updateNativeContext(@Nullable Object context) {
+        throw new IllegalStateException("Updating native context not supported for interceptor: " + this);
     }
 
     /**

--- a/aop/src/main/java/io/micronaut/aop/internal/intercepted/KotlinInterceptedMethod.java
+++ b/aop/src/main/java/io/micronaut/aop/internal/intercepted/KotlinInterceptedMethod.java
@@ -187,7 +187,7 @@ final class KotlinInterceptedMethod implements InterceptedMethod {
         } else if (context instanceof CoroutineContext) {
             coroutineContext = (CoroutineContext) context;
         } else {
-            throw new IllegalStateException("Expected an instance of CoroutineContext got: " + context);
+            throw new IllegalStateException("Expected an instance of CoroutineContext. Got: " + context);
         }
         continuation = new DelegatingContextContinuation(continuation, coroutineContext);
     }

--- a/aop/src/main/java/io/micronaut/aop/internal/intercepted/KotlinInterceptedMethod.java
+++ b/aop/src/main/java/io/micronaut/aop/internal/intercepted/KotlinInterceptedMethod.java
@@ -15,7 +15,6 @@
  */
 package io.micronaut.aop.internal.intercepted;
 
-import io.micronaut.aop.InterceptedMethod;
 import io.micronaut.aop.Interceptor;
 import io.micronaut.aop.MethodInvocationContext;
 import io.micronaut.aop.util.CompletableFutureContinuation;
@@ -26,7 +25,6 @@ import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.KotlinUtils;
 import kotlin.coroutines.Continuation;
 import kotlin.coroutines.CoroutineContext;
-import kotlin.coroutines.EmptyCoroutineContext;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -41,7 +39,7 @@ import java.util.function.Consumer;
  */
 @Internal
 @Experimental
-final class KotlinInterceptedMethod implements InterceptedMethod {
+final class KotlinInterceptedMethod implements io.micronaut.aop.kotlin.KotlinInterceptedMethod {
 
     private final MethodInvocationContext<?, ?> context;
     private Continuation continuation;
@@ -175,20 +173,12 @@ final class KotlinInterceptedMethod implements InterceptedMethod {
     }
 
     @Override
-    public Object getNativeContext() {
+    public CoroutineContext getCoroutineContext() {
         return continuation.getContext();
     }
 
     @Override
-    public void updateNativeContext(Object context) {
-        CoroutineContext coroutineContext;
-        if (context == null) {
-            coroutineContext = EmptyCoroutineContext.INSTANCE;
-        } else if (context instanceof CoroutineContext) {
-            coroutineContext = (CoroutineContext) context;
-        } else {
-            throw new IllegalStateException("Expected an instance of CoroutineContext. Got: " + context);
-        }
+    public void updateCoroutineContext(CoroutineContext coroutineContext) {
         continuation = new DelegatingContextContinuation(continuation, coroutineContext);
     }
 }

--- a/aop/src/main/java/io/micronaut/aop/kotlin/KotlinInterceptedMethod.java
+++ b/aop/src/main/java/io/micronaut/aop/kotlin/KotlinInterceptedMethod.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.kotlin;
+
+import io.micronaut.aop.InterceptedMethod;
+import io.micronaut.core.annotation.Experimental;
+import kotlin.coroutines.CoroutineContext;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Kotlin's {@link InterceptedMethod} with extra methods to access coroutine's context.
+ *
+ * @author Denis Stepanov
+ * @since 3.2
+ */
+@Experimental
+public interface KotlinInterceptedMethod extends InterceptedMethod {
+
+    /**
+     * @return Coroutine's context
+     */
+    @NotNull
+    CoroutineContext getCoroutineContext();
+
+    /**
+     * Update coroutine's context.
+     *
+     * @param coroutineContext The context
+     */
+    void updateCoroutineContext(@NotNull CoroutineContext coroutineContext);
+
+}

--- a/aop/src/main/kotlin/io/micronaut/aop/util/DelegatingContextContinuation.kt
+++ b/aop/src/main/kotlin/io/micronaut/aop/util/DelegatingContextContinuation.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.util
+
+import io.micronaut.core.annotation.Experimental
+import io.micronaut.core.annotation.Internal
+import java.util.concurrent.CompletableFuture
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.jvm.internal.CoroutineStackFrame
+
+/**
+ * Continuation with a new context delegating to another continuation.
+ *
+ * @author Denis Stepanov
+ * @since 3.2
+ */
+@Internal
+@Experimental
+class DelegatingContextContinuation(
+    private val continuation: Continuation<Any?>,
+    private val coroutineContext: CoroutineContext
+) : Continuation<Any?>, CoroutineStackFrame {
+
+    override val callerFrame: CoroutineStackFrame?
+        get() = continuation as? CoroutineStackFrame
+
+    override fun getStackTraceElement(): StackTraceElement? = null
+
+    override val context: CoroutineContext
+        get() = coroutineContext
+
+    override fun resumeWith(result: Result<Any?>) {
+        continuation.resumeWith(result)
+    }
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/MyContext.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/MyContext.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.server.suspend
+
+import kotlin.coroutines.CoroutineContext
+
+class MyContext(val value: String) : CoroutineContext.Element {
+
+    companion object Key : CoroutineContext.Key<MyContext>
+
+    override val key: CoroutineContext.Key<MyContext> get() = Key
+
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/MyContextInterceptorAnn.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/MyContextInterceptorAnn.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.server.suspend
+
+import io.micronaut.aop.Around
+import kotlin.annotation.AnnotationRetention.RUNTIME
+import kotlin.annotation.AnnotationTarget.CLASS
+import kotlin.annotation.AnnotationTarget.FILE
+import kotlin.annotation.AnnotationTarget.FUNCTION
+import kotlin.annotation.AnnotationTarget.PROPERTY_GETTER
+import kotlin.annotation.AnnotationTarget.PROPERTY_SETTER
+
+@MustBeDocumented
+@Retention(RUNTIME)
+@Target(CLASS, FILE, FUNCTION, PROPERTY_GETTER, PROPERTY_SETTER)
+@Around
+annotation class MyContextInterceptorAnn

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/SuspendInterceptor.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/SuspendInterceptor.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.server.suspend
+
+import io.micronaut.aop.InterceptedMethod
+import io.micronaut.aop.InterceptorBean
+import io.micronaut.aop.MethodInterceptor
+import io.micronaut.aop.MethodInvocationContext
+import jakarta.inject.Singleton
+import kotlin.coroutines.CoroutineContext
+
+@InterceptorBean(MyContextInterceptorAnn::class)
+@Singleton
+class SuspendInterceptor : MethodInterceptor<Any, Any> {
+    override fun intercept(context: MethodInvocationContext<Any, Any>): Any? {
+        val interceptedMethod = InterceptedMethod.of(context)
+        return try {
+            return if (interceptedMethod.resultType() == InterceptedMethod.ResultType.COMPLETION_STAGE) {
+                var nativeContext = interceptedMethod.nativeContext
+                if (nativeContext is CoroutineContext) {
+                    val existingContext = nativeContext[MyContext]
+                    if (existingContext == null) {
+                        nativeContext += MyContext(context.methodName)
+                        interceptedMethod.updateNativeContext(nativeContext)
+                    }
+                }
+
+                interceptedMethod.handleResult(
+                        interceptedMethod.interceptResultAsCompletionStage()
+                )
+            } else {
+                context.proceed()
+            }
+        } catch (e: Exception) {
+            interceptedMethod.handleException<Exception>(e)
+        }
+    }
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/SuspendInterceptor.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/SuspendInterceptor.kt
@@ -19,8 +19,8 @@ import io.micronaut.aop.InterceptedMethod
 import io.micronaut.aop.InterceptorBean
 import io.micronaut.aop.MethodInterceptor
 import io.micronaut.aop.MethodInvocationContext
+import io.micronaut.aop.kotlin.KotlinInterceptedMethod
 import jakarta.inject.Singleton
-import kotlin.coroutines.CoroutineContext
 
 @InterceptorBean(MyContextInterceptorAnn::class)
 @Singleton
@@ -29,12 +29,10 @@ class SuspendInterceptor : MethodInterceptor<Any, Any> {
         val interceptedMethod = InterceptedMethod.of(context)
         return try {
             return if (interceptedMethod.resultType() == InterceptedMethod.ResultType.COMPLETION_STAGE) {
-                var nativeContext = interceptedMethod.nativeContext
-                if (nativeContext is CoroutineContext) {
-                    val existingContext = nativeContext[MyContext]
+                if (interceptedMethod is KotlinInterceptedMethod && interceptedMethod.coroutineContext != null) {
+                    val existingContext = interceptedMethod.coroutineContext[MyContext]
                     if (existingContext == null) {
-                        nativeContext += MyContext(context.methodName)
-                        interceptedMethod.updateNativeContext(nativeContext)
+                        interceptedMethod.updateCoroutineContext(interceptedMethod.coroutineContext + MyContext(context.methodName))
                     }
                 }
 

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/SuspendService.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/SuspendService.kt
@@ -70,11 +70,6 @@ open class SuspendService(
     }
 
     @MyContextInterceptorAnn
-    open fun callx(): String? {
-        return "x"
-    }
-
-    @MyContextInterceptorAnn
     open suspend fun call1(): String? {
         return findMyContextValue()
     }

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/SuspendService.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/SuspendService.kt
@@ -5,6 +5,7 @@ import io.micronaut.http.context.ServerRequestContext
 import io.micronaut.retry.annotation.Retryable
 import kotlinx.coroutines.delay
 import jakarta.inject.Singleton
+import kotlin.coroutines.coroutineContext
 
 @Singleton
 open class SuspendService(
@@ -62,5 +63,33 @@ open class SuspendService(
             error("Expected a current http server request")
         }
         return currentRequest.path
+    }
+
+    suspend fun findMyContextValue(): String? {
+        return coroutineContext[MyContext]?.value
+    }
+
+    @MyContextInterceptorAnn
+    open fun callx(): String? {
+        return "x"
+    }
+
+    @MyContextInterceptorAnn
+    open suspend fun call1(): String? {
+        return findMyContextValue()
+    }
+
+    @MyContextInterceptorAnn
+    open suspend fun call2(): String? {
+        return call1()
+    }
+
+    open suspend fun call3(): String? {
+        return call1()
+    }
+
+    @MyContextInterceptorAnn
+    open suspend fun call4(): String? {
+        return call3()
     }
 }

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/SuspendServiceInterceptorSpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/SuspendServiceInterceptorSpec.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.server.suspend
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.micronaut.context.ApplicationContext
+
+class SuspendServiceInterceptorSpec : StringSpec() {
+
+    val context = autoClose(
+            ApplicationContext.run()
+    )
+
+    private var suspendService = context.getBean(SuspendService::class.java)
+
+    init {
+        "should append to context " {
+            coroutineContext[MyContext] shouldBe null
+
+            suspendService.call1() shouldBe "call1"
+            suspendService.call2() shouldBe "call2"
+            suspendService.call3() shouldBe "call1"
+            suspendService.call4() shouldBe "call4"
+        }
+    }
+}


### PR DESCRIPTION
I would like to introduce the transaction context propagation in Micronaut Data and need a way to access the coroutine's context.
