### PR TITLE
Fix input file normalization for functional tests

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.bom-checker.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.bom-checker.gradle
@@ -1,10 +1,15 @@
 import io.micronaut.build.internal.pom.PomChecker
 
+plugins {
+    // used to get the "clean" task
+    id 'base'
+}
+
 def catalog = project.extensions.findByType(VersionCatalogsExtension).named("libs")
 
 def checkBoms = tasks.register("checkBom")
 
-tasks.register("check") {
+tasks.named("check") {
     dependsOn(checkBoms)
 }
 

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.functional-test.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.functional-test.gradle
@@ -1,0 +1,44 @@
+import groovy.transform.CompileStatic
+
+plugins {
+    id 'java-library'
+}
+
+sourceSets {
+    functionalTest
+}
+
+configurations {
+    functionalTestImplementation {
+        extendsFrom(testImplementation)
+    }
+}
+
+def functionalTest = tasks.register("functionalTest", FunctionalTest) {
+    appUnderTestCompileClasspath.from(configurations.testCompileClasspath)
+    appUnderTestAnnotationProcessor.from(configurations.testAnnotationProcessor)
+    testClassesDirs = sourceSets.functionalTest.output.classesDirs
+    classpath = sourceSets.functionalTest.runtimeClasspath
+}
+
+tasks.named("check") {
+    dependsOn functionalTest
+}
+
+@CacheableTask
+@CompileStatic
+abstract class FunctionalTest extends Test {
+    @CompileClasspath
+    abstract ConfigurableFileCollection getAppUnderTestCompileClasspath()
+
+    @CompileClasspath
+    abstract ConfigurableFileCollection getAppUnderTestAnnotationProcessor()
+
+    @Override
+    @TaskAction
+    void executeTests() {
+        systemProperty("testapp.compile.classpath", appUnderTestCompileClasspath.asPath)
+        systemProperty("testapp.annotationprocessor.path", appUnderTestAnnotationProcessor.asPath)
+        super.executeTests()
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -47,3 +47,6 @@ geckodriverVersion=0.26.0
 webdriverBinariesVersion=1.4
 kotlinVersion=1.6.0
 kotlin.stdlib.default.dependency=false
+
+org.gradle.caching=true
+org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -48,5 +48,5 @@ webdriverBinariesVersion=1.4
 kotlinVersion=1.6.0
 kotlin.stdlib.default.dependency=false
 
-org.gradle.caching=true
-org.gradle.parallel=true
+#org.gradle.caching=true
+#org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -48,5 +48,5 @@ webdriverBinariesVersion=1.4
 kotlinVersion=1.6.0
 kotlin.stdlib.default.dependency=false
 
-#org.gradle.caching=true
-#org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.parallel=true

--- a/inject-groovy/build.gradle
+++ b/inject-groovy/build.gradle
@@ -1,26 +1,5 @@
-sourceSets {
-    functionalTest
-}
-
-configurations {
-    functionalTestImplementation {
-        extendsFrom(testImplementation)
-    }
-}
-
-def functionalTest = tasks.register("functionalTest", Test) {
-    inputs.files(configurations.testCompileClasspath)
-    inputs.files(configurations.testAnnotationProcessor)
-    testClassesDirs = sourceSets.functionalTest.output.classesDirs
-    classpath = sourceSets.functionalTest.runtimeClasspath
-    doFirst {
-        systemProperty("testapp.compile.classpath", configurations.testCompileClasspath.asPath)
-        systemProperty("testapp.annotationprocessor.path", configurations.testAnnotationProcessor.asPath)
-    }
-}
-
-tasks.named("check") {
-    dependsOn functionalTest
+plugins {
+    id 'io.micronaut.build.internal.functional-test'
 }
 
 dependencies {

--- a/test-suite/build.gradle
+++ b/test-suite/build.gradle
@@ -8,34 +8,14 @@ buildscript {
         classpath "gradle.plugin.com.energizedwork.webdriver-binaries:webdriver-binaries-gradle-plugin:$webdriverBinariesVersion"
     }
 }
+
+plugins {
+    id 'io.micronaut.build.internal.functional-test'
+}
+
 apply plugin: 'java-test-fixtures'
 apply from: "${rootProject.projectDir}/gradle/geb.gradle"
 apply from: "${rootProject.projectDir}/gradle/webdriverbinaries.gradle"
-
-sourceSets {
-    functionalTest
-}
-
-configurations {
-    functionalTestImplementation {
-        extendsFrom(testImplementation)
-    }
-}
-
-def functionalTest = tasks.register("functionalTest", Test) {
-    inputs.files(configurations.testCompileClasspath)
-    inputs.files(configurations.testAnnotationProcessor)
-    testClassesDirs = sourceSets.functionalTest.output.classesDirs
-    classpath = sourceSets.functionalTest.runtimeClasspath
-    doFirst {
-        systemProperty("testapp.compile.classpath", configurations.testCompileClasspath.asPath)
-        systemProperty("testapp.annotationprocessor.path", configurations.testAnnotationProcessor.asPath)
-    }
-}
-
-tasks.named("check") {
-    dependsOn functionalTest
-}
 
 dependencies {
     annotationProcessor project(":inject-java")


### PR DESCRIPTION
See the first commit message for details. This is **not** a blocker for the 3.2 release, it's a build optimization, so this can be merged after the release.

@wolfs kindly asking you as a reviewer as suggested by Etienne during the GE trial.