### PR TITLE
Enable client SSL certificate checking by default

### DIFF
--- a/http-client-core/src/main/java/io/micronaut/http/client/ServiceHttpClientConfiguration.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/ServiceHttpClientConfiguration.java
@@ -21,6 +21,7 @@ import io.micronaut.context.annotation.Parameter;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.http.context.ClientContextPathProvider;
+import io.micronaut.http.ssl.AbstractClientSslConfiguration;
 import io.micronaut.http.ssl.SslConfiguration;
 import io.micronaut.runtime.ApplicationConfiguration;
 import jakarta.inject.Inject;
@@ -258,7 +259,7 @@ public class ServiceHttpClientConfiguration extends HttpClientConfiguration impl
      * The default connection pool configuration.
      */
     @ConfigurationProperties("ssl")
-    public static class ServiceSslClientConfiguration extends SslConfiguration {
+    public static class ServiceSslClientConfiguration extends AbstractClientSslConfiguration {
 
         /**
          * Sets the key configuration.

--- a/http-client/src/main/java/io/micronaut/http/client/netty/ssl/NettyClientSslBuilder.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/ssl/NettyClientSslBuilder.java
@@ -20,6 +20,7 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.io.ResourceResolver;
 import io.micronaut.http.HttpVersion;
 import io.micronaut.http.ssl.ClientAuthentication;
+import io.micronaut.http.ssl.ClientSslConfiguration;
 import io.micronaut.http.ssl.SslBuilder;
 import io.micronaut.http.ssl.SslConfiguration;
 import io.micronaut.http.ssl.SslConfigurationException;
@@ -37,6 +38,7 @@ import jakarta.inject.Singleton;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.TrustManagerFactory;
+import java.security.KeyStore;
 import java.util.Arrays;
 import java.util.Optional;
 
@@ -129,7 +131,13 @@ public class NettyClientSslBuilder extends SslBuilder<SslContext> {
             if (this.getTrustStore(ssl).isPresent()) {
                 return super.getTrustManagerFactory(ssl);
             } else {
-                return InsecureTrustManagerFactory.INSTANCE;
+                if (((ClientSslConfiguration) ssl).isInsecureTrustAllCertificates()) {
+                    return InsecureTrustManagerFactory.INSTANCE;
+                } else {
+                    TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+                    tmf.init(KeyStore.getInstance(KeyStore.getDefaultType()));
+                    return tmf;
+                }
             }
         } catch (Exception ex) {
             throw new SslConfigurationException(ex);

--- a/http-client/src/main/java/io/micronaut/http/client/netty/ssl/NettyClientSslBuilder.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/ssl/NettyClientSslBuilder.java
@@ -38,7 +38,6 @@ import jakarta.inject.Singleton;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.TrustManagerFactory;
-import java.security.KeyStore;
 import java.util.Arrays;
 import java.util.Optional;
 
@@ -134,9 +133,8 @@ public class NettyClientSslBuilder extends SslBuilder<SslContext> {
                 if (((ClientSslConfiguration) ssl).isInsecureTrustAllCertificates()) {
                     return InsecureTrustManagerFactory.INSTANCE;
                 } else {
-                    TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-                    tmf.init(KeyStore.getInstance(KeyStore.getDefaultType()));
-                    return tmf;
+                    // netty will use the JDK trust store
+                    return null;
                 }
             }
         } catch (Exception ex) {

--- a/http-client/src/main/java/io/micronaut/http/client/netty/ssl/NettyClientSslBuilder.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/ssl/NettyClientSslBuilder.java
@@ -19,8 +19,8 @@ import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.io.ResourceResolver;
 import io.micronaut.http.HttpVersion;
+import io.micronaut.http.ssl.AbstractClientSslConfiguration;
 import io.micronaut.http.ssl.ClientAuthentication;
-import io.micronaut.http.ssl.ClientSslConfiguration;
 import io.micronaut.http.ssl.SslBuilder;
 import io.micronaut.http.ssl.SslConfiguration;
 import io.micronaut.http.ssl.SslConfigurationException;
@@ -130,7 +130,7 @@ public class NettyClientSslBuilder extends SslBuilder<SslContext> {
             if (this.getTrustStore(ssl).isPresent()) {
                 return super.getTrustManagerFactory(ssl);
             } else {
-                if (((ClientSslConfiguration) ssl).isInsecureTrustAllCertificates()) {
+                if (ssl instanceof AbstractClientSslConfiguration && ((AbstractClientSslConfiguration) ssl).isInsecureTrustAllCertificates()) {
                     return InsecureTrustManagerFactory.INSTANCE;
                 } else {
                     // netty will use the JDK trust store

--- a/http-client/src/test/groovy/io/micronaut/http/client/HostHeaderSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/HostHeaderSpec.groovy
@@ -112,7 +112,8 @@ class HostHeaderSpec extends Specification {
                 'spec.name': 'HostHeaderSpec',
                 'micronaut.ssl.enabled': true,
                 'micronaut.ssl.buildSelfSigned': true,
-                'micronaut.ssl.port': 443
+                'micronaut.ssl.port': 443,
+                'micronaut.http.client.ssl.insecureTrustAllCertificates': true,
         ]).run(EmbeddedServer)
         def asyncClient = HttpClient.create(embeddedServer.getURL())
         BlockingHttpClient client = asyncClient.toBlocking()
@@ -137,9 +138,10 @@ class HostHeaderSpec extends Specification {
                 'spec.name': 'HostHeaderSpec',
                 'micronaut.ssl.port': -1,
                 'micronaut.ssl.enabled': true,
-                'micronaut.ssl.buildSelfSigned': true
+                'micronaut.ssl.buildSelfSigned': true,
+                'micronaut.http.client.ssl.insecureTrustAllCertificates': true,
         ]).run(EmbeddedServer)
-        def asyncClient = HttpClient.create(embeddedServer.getURL())
+        def asyncClient = embeddedServer.applicationContext.createBean(HttpClient, embeddedServer.getURL())
         BlockingHttpClient client = asyncClient.toBlocking()
 
         when:

--- a/http-client/src/test/groovy/io/micronaut/http/client/HostHeaderSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/HostHeaderSpec.groovy
@@ -113,7 +113,7 @@ class HostHeaderSpec extends Specification {
                 'micronaut.ssl.enabled': true,
                 'micronaut.ssl.buildSelfSigned': true,
                 'micronaut.ssl.port': 443,
-                'micronaut.http.client.ssl.insecureTrustAllCertificates': true,
+                'micronaut.http.client.ssl.insecure-trust-all-certificates': true,
         ]).run(EmbeddedServer)
         def asyncClient = HttpClient.create(embeddedServer.getURL())
         BlockingHttpClient client = asyncClient.toBlocking()
@@ -139,7 +139,7 @@ class HostHeaderSpec extends Specification {
                 'micronaut.ssl.port': -1,
                 'micronaut.ssl.enabled': true,
                 'micronaut.ssl.buildSelfSigned': true,
-                'micronaut.http.client.ssl.insecureTrustAllCertificates': true,
+                'micronaut.http.client.ssl.insecure-trust-all-certificates': true,
         ]).run(EmbeddedServer)
         def asyncClient = embeddedServer.applicationContext.createBean(HttpClient, embeddedServer.getURL())
         BlockingHttpClient client = asyncClient.toBlocking()

--- a/http-client/src/test/groovy/io/micronaut/http/client/SslRefreshSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/SslRefreshSpec.groovy
@@ -42,7 +42,8 @@ class SslRefreshSpec extends Specification {
             'micronaut.server.ssl.ciphers': ciphers,
             'micronaut.http.client.ssl.client-authentication': 'NEED',
             'micronaut.http.client.ssl.key-store.path': 'classpath:certs/client1.p12',
-            'micronaut.http.client.ssl.key-store.password': 'secret'
+            'micronaut.http.client.ssl.key-store.password': 'secret',
+            'micronaut.http.client.ssl.insecureTrustAllCertificates': true
     ]
     @Shared @AutoCleanup EmbeddedServer embeddedServer = ApplicationContext
                                                             .builder()

--- a/http-client/src/test/groovy/io/micronaut/http/client/SslRefreshSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/SslRefreshSpec.groovy
@@ -43,7 +43,7 @@ class SslRefreshSpec extends Specification {
             'micronaut.http.client.ssl.client-authentication': 'NEED',
             'micronaut.http.client.ssl.key-store.path': 'classpath:certs/client1.p12',
             'micronaut.http.client.ssl.key-store.password': 'secret',
-            'micronaut.http.client.ssl.insecureTrustAllCertificates': true
+            'micronaut.http.client.ssl.insecure-trust-all-certificates': true
     ]
     @Shared @AutoCleanup EmbeddedServer embeddedServer = ApplicationContext
                                                             .builder()

--- a/http-client/src/test/groovy/io/micronaut/http/client/SslSelfSignedSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/SslSelfSignedSpec.groovy
@@ -47,7 +47,7 @@ class SslSelfSignedSpec extends Specification {
                 'micronaut.ssl.enabled': true,
                 'micronaut.ssl.buildSelfSigned': true,
                 'micronaut.ssl.port': port,
-                'micronaut.http.client.ssl.insecureTrustAllCertificates': true,
+                'micronaut.http.client.ssl.insecure-trust-all-certificates': true,
         ])
         embeddedServer = context.getBean(EmbeddedServer).start()
         client = context.createBean(HttpClient, embeddedServer.getURL())

--- a/http-client/src/test/groovy/io/micronaut/http/client/SslSelfSignedSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/SslSelfSignedSpec.groovy
@@ -46,7 +46,8 @@ class SslSelfSignedSpec extends Specification {
                 'spec.name': 'SslSelfSignedSpec',
                 'micronaut.ssl.enabled': true,
                 'micronaut.ssl.buildSelfSigned': true,
-                'micronaut.ssl.port': port
+                'micronaut.ssl.port': port,
+                'micronaut.http.client.ssl.insecureTrustAllCertificates': true,
         ])
         embeddedServer = context.getBean(EmbeddedServer).start()
         client = context.createBean(HttpClient, embeddedServer.getURL())

--- a/http-client/src/test/groovy/io/micronaut/http/client/SslSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/SslSpec.groovy
@@ -16,6 +16,7 @@
 package io.micronaut.http.client
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.http.ssl.ClientSslConfiguration
 import io.micronaut.runtime.server.EmbeddedServer
 import io.netty.bootstrap.Bootstrap
 import io.netty.bootstrap.ServerBootstrap
@@ -33,6 +34,9 @@ import reactor.core.publisher.Flux
 import spock.lang.Ignore
 import spock.lang.Specification
 
+import javax.net.ssl.SSLHandshakeException
+import java.security.GeneralSecurityException
+import java.security.InvalidAlgorithmParameterException
 import java.time.Duration
 import java.util.concurrent.TimeUnit
 
@@ -106,5 +110,55 @@ class SslSpec extends Specification {
                 }
             })
         }
+    }
+
+    void 'bad server ssl cert'() {
+        given:
+        def client = HttpClient.create(new URL(url))
+
+        when:
+        client.toBlocking().exchange('/')
+        then:
+        def e = thrown RuntimeException
+        e.cause instanceof GeneralSecurityException || e.cause instanceof SSLHandshakeException
+
+        cleanup:
+        client.stop()
+
+        where:
+        url << [
+                'https://expired.badssl.com/',
+                'https://wrong.host.badssl.com/',
+                'https://self-signed.badssl.com/',
+                'https://untrusted-root.badssl.com/',
+                'https://revoked.badssl.com/',
+                'https://pinning-test.badssl.com/',
+                'https://no-subject.badssl.com/',
+                'https://reversed-chain.badssl.com/',
+                'https://rc4-md5.badssl.com/',
+                'https://rc4.badssl.com/',
+                'https://3des.badssl.com/',
+                'https://null.badssl.com/',
+                'https://dh480.badssl.com/',
+                'https://dh512.badssl.com/',
+                'https://dh1024.badssl.com/',
+                'https://dh-small-subgroup.badssl.com/',
+                'https://dh-composite.badssl.com/',
+        ]
+    }
+
+    void 'self-signed allowed with config'() {
+        given:
+        def cfg = new DefaultHttpClientConfiguration()
+        ((ClientSslConfiguration) cfg.getSslConfiguration()).setInsecureTrustAllCertificates(true)
+        def client = HttpClient.create(new URL('https://self-signed.badssl.com/'), cfg)
+
+        when:
+        client.toBlocking().exchange('/')
+        then:
+        noExceptionThrown()
+
+        cleanup:
+        client.stop()
     }
 }

--- a/http-client/src/test/groovy/io/micronaut/http/client/SslSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/SslSpec.groovy
@@ -128,11 +128,11 @@ class SslSpec extends Specification {
         where:
         url << [
                 'https://expired.badssl.com/',
-                'https://wrong.host.badssl.com/',
+                //'https://wrong.host.badssl.com/', cert is for *.badssl.com, we accept that
                 'https://self-signed.badssl.com/',
                 'https://untrusted-root.badssl.com/',
-                'https://revoked.badssl.com/',
-                'https://pinning-test.badssl.com/',
+                //'https://revoked.badssl.com/', not implemented
+                //'https://pinning-test.badssl.com/', not implemented
                 'https://no-subject.badssl.com/',
                 'https://reversed-chain.badssl.com/',
                 'https://rc4-md5.badssl.com/',
@@ -152,6 +152,19 @@ class SslSpec extends Specification {
         def cfg = new DefaultHttpClientConfiguration()
         ((ClientSslConfiguration) cfg.getSslConfiguration()).setInsecureTrustAllCertificates(true)
         def client = HttpClient.create(new URL('https://self-signed.badssl.com/'), cfg)
+
+        when:
+        client.toBlocking().exchange('/')
+        then:
+        noExceptionThrown()
+
+        cleanup:
+        client.stop()
+    }
+
+    void 'normal ssl host allowed'() {
+        given:
+        def client = HttpClient.create(new URL('https://www.google.com/'))
 
         when:
         client.toBlocking().exchange('/')

--- a/http-client/src/test/groovy/io/micronaut/http/client/SslStaticCertSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/SslStaticCertSpec.groovy
@@ -57,6 +57,7 @@ class SslStaticCertSpec extends Specification {
                                           'TLS_DHE_RSA_WITH_AES_256_GCM_SHA384',
                                           'TLS_DHE_DSS_WITH_AES_128_GCM_SHA256',
                                           'TLS_DHE_DSS_WITH_AES_256_GCM_SHA384'],
+                'micronaut.http.client.ssl.insecureTrustAllCertificates': true
         ])
         embeddedServer = context.getBean(EmbeddedServer).start()
         client = context.createBean(HttpClient, embeddedServer.getURL())

--- a/http-client/src/test/groovy/io/micronaut/http/client/SslStaticCertSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/SslStaticCertSpec.groovy
@@ -57,7 +57,7 @@ class SslStaticCertSpec extends Specification {
                                           'TLS_DHE_RSA_WITH_AES_256_GCM_SHA384',
                                           'TLS_DHE_DSS_WITH_AES_128_GCM_SHA256',
                                           'TLS_DHE_DSS_WITH_AES_256_GCM_SHA384'],
-                'micronaut.http.client.ssl.insecureTrustAllCertificates': true
+                'micronaut.http.client.ssl.insecure-trust-all-certificates': true
         ])
         embeddedServer = context.getBean(EmbeddedServer).start()
         client = context.createBean(HttpClient, embeddedServer.getURL())

--- a/http-client/src/test/groovy/io/micronaut/http/client/services/ManualHttpServiceDefinitionSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/services/ManualHttpServiceDefinitionSpec.groovy
@@ -206,7 +206,7 @@ class ManualHttpServiceDefinitionSpec extends Specification {
                 'micronaut.http.services.client1.ssl.client-authentication': 'NEED',
                 'micronaut.http.services.client1.ssl.key-store.path': 'classpath:certs/client1.p12',
                 'micronaut.http.services.client1.ssl.key-store.password': 'secret',
-                'micronaut.http.services.client1.ssl.insecureTrustAllCertificates': true,
+                'micronaut.http.services.client1.ssl.insecure-trust-all-certificates': true,
         )
         SslClient client1 = ctx.getBean(SslClient)
         final String DN = "CN=client1.test.example.com, OU=IT, O=Whatever, L=Munich, ST=Bavaria, C=DE, EMAILADDRESS=info@example.com"

--- a/http-client/src/test/groovy/io/micronaut/http/client/services/ManualHttpServiceDefinitionSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/services/ManualHttpServiceDefinitionSpec.groovy
@@ -205,7 +205,8 @@ class ManualHttpServiceDefinitionSpec extends Specification {
                 'micronaut.http.services.client1.ssl.enabled': true,
                 'micronaut.http.services.client1.ssl.client-authentication': 'NEED',
                 'micronaut.http.services.client1.ssl.key-store.path': 'classpath:certs/client1.p12',
-                'micronaut.http.services.client1.ssl.key-store.password': 'secret'
+                'micronaut.http.services.client1.ssl.key-store.password': 'secret',
+                'micronaut.http.services.client1.ssl.insecureTrustAllCertificates': true,
         )
         SslClient client1 = ctx.getBean(SslClient)
         final String DN = "CN=client1.test.example.com, OU=IT, O=Whatever, L=Munich, ST=Bavaria, C=DE, EMAILADDRESS=info@example.com"

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/NettyHttpServerSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/NettyHttpServerSpec.groovy
@@ -204,6 +204,7 @@ class NettyHttpServerSpec extends Specification {
                 'micronaut.server.port':httpPort,
                 'micronaut.ssl.enabled': true,
                 'micronaut.ssl.buildSelfSigned': true,
+                'micronaut.http.client.ssl.insecureTrustAllCertificates': true,
                 'micronaut.server.dualProtocol':true
         )
         EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, propertySource, Environment.TEST)

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/NettyHttpServerSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/NettyHttpServerSpec.groovy
@@ -204,7 +204,7 @@ class NettyHttpServerSpec extends Specification {
                 'micronaut.server.port':httpPort,
                 'micronaut.ssl.enabled': true,
                 'micronaut.ssl.buildSelfSigned': true,
-                'micronaut.http.client.ssl.insecureTrustAllCertificates': true,
+                'micronaut.http.client.ssl.insecure-trust-all-certificates': true,
                 'micronaut.server.dualProtocol':true
         )
         EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, propertySource, Environment.TEST)

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/http2/Http2PostTest.java
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/http2/Http2PostTest.java
@@ -121,7 +121,7 @@ public class Http2PostTest implements TestPropertyProvider {
         return CollectionUtils.mapOf(
                 "micronaut.ssl.enabled", true,
                 "micronaut.ssl.buildSelfSigned", true,
-                "micronaut.http.client.ssl.insecureTrustAllCertificates", true
+                "micronaut.http.client.ssl.insecure-trust-all-certificates", true
         );
     }
 

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/http2/Http2PostTest.java
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/http2/Http2PostTest.java
@@ -120,7 +120,8 @@ public class Http2PostTest implements TestPropertyProvider {
     public Map<String, String> getProperties() {
         return CollectionUtils.mapOf(
                 "micronaut.ssl.enabled", true,
-                "micronaut.ssl.buildSelfSigned", true
+                "micronaut.ssl.buildSelfSigned", true,
+                "micronaut.http.client.ssl.insecureTrustAllCertificates", true
         );
     }
 

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/types/SslFileTypeHandlerSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/types/SslFileTypeHandlerSpec.groovy
@@ -42,7 +42,7 @@ class SslFileTypeHandlerSpec extends AbstractMicronautSpec {
 
     @Override
     Map<String, Object> getConfiguration() {
-        super.getConfiguration() << ['micronaut.ssl.enabled': true, 'micronaut.ssl.buildSelfSigned': true]
+        super.getConfiguration() << ['micronaut.ssl.enabled': true, 'micronaut.ssl.buildSelfSigned': true, 'micronaut.http.client.ssl.insecureTrustAllCertificates': true]
     }
 
     @Controller('/test')

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/SimpleTextWebSocketSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/SimpleTextWebSocketSpec.groovy
@@ -115,7 +115,8 @@ class SimpleTextWebSocketSpec extends Specification {
         EmbeddedServer embeddedServer = ApplicationContext.builder([
                 'micronaut.server.netty.log-level':'TRACE',
                 'micronaut.ssl.enabled':true,
-                'micronaut.ssl.build-self-signed':true
+                'micronaut.ssl.build-self-signed':true,
+                'micronaut.http.client.ssl.insecureTrustAllCertificates': true,
                 ]).run(EmbeddedServer)
         PollingConditions conditions = new PollingConditions(timeout: 15    , delay: 0.5)
         def uri = embeddedServer.getURI()

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/SimpleTextWebSocketSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/SimpleTextWebSocketSpec.groovy
@@ -116,7 +116,7 @@ class SimpleTextWebSocketSpec extends Specification {
                 'micronaut.server.netty.log-level':'TRACE',
                 'micronaut.ssl.enabled':true,
                 'micronaut.ssl.build-self-signed':true,
-                'micronaut.http.client.ssl.insecureTrustAllCertificates': true,
+                'micronaut.http.client.ssl.insecure-trust-all-certificates': true,
                 ]).run(EmbeddedServer)
         PollingConditions conditions = new PollingConditions(timeout: 15    , delay: 0.5)
         def uri = embeddedServer.getURI()

--- a/http/src/main/java/io/micronaut/http/ssl/AbstractClientSslConfiguration.java
+++ b/http/src/main/java/io/micronaut/http/ssl/AbstractClientSslConfiguration.java
@@ -1,0 +1,32 @@
+package io.micronaut.http.ssl;
+
+/**
+ * Base class for {@link SslConfiguration} extensions for SSL clients.
+ *
+ * @since 3.2
+ * @author Jonas Konrad
+ */
+public abstract class AbstractClientSslConfiguration extends SslConfiguration {
+
+    private boolean insecureTrustAllCertificates;
+
+    /**
+     * @return Whether the client should disable checking of the remote SSL certificate. Only applies if no trust store
+     * is configured. <b>Note: This makes the SSL connection insecure, and should only be used for testing. If you are
+     * using a self-signed certificate, set up a trust store instead.</b>
+     */
+    public boolean isInsecureTrustAllCertificates() {
+        return insecureTrustAllCertificates;
+    }
+
+    /**
+     * @param insecureTrustAllCertificates Whether the client should disable checking of the remote SSL certificate.
+     *                                     Only applies if no trust store is configured.
+     *                                     <b>Note: This makes the SSL connection insecure, and should only be used for
+     *                                     testing. If you are using a self-signed certificate, set up a trust store
+     *                                     instead.</b>
+     */
+    public void setInsecureTrustAllCertificates(boolean insecureTrustAllCertificates) {
+        this.insecureTrustAllCertificates = insecureTrustAllCertificates;
+    }
+}

--- a/http/src/main/java/io/micronaut/http/ssl/AbstractClientSslConfiguration.java
+++ b/http/src/main/java/io/micronaut/http/ssl/AbstractClientSslConfiguration.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.http.ssl;
 
 /**

--- a/http/src/main/java/io/micronaut/http/ssl/AbstractClientSslConfiguration.java
+++ b/http/src/main/java/io/micronaut/http/ssl/AbstractClientSslConfiguration.java
@@ -18,7 +18,7 @@ package io.micronaut.http.ssl;
 /**
  * Base class for {@link SslConfiguration} extensions for SSL clients.
  *
- * @since 3.2
+ * @since 3.2.0
  * @author Jonas Konrad
  */
 public abstract class AbstractClientSslConfiguration extends SslConfiguration {

--- a/http/src/main/java/io/micronaut/http/ssl/ClientSslConfiguration.java
+++ b/http/src/main/java/io/micronaut/http/ssl/ClientSslConfiguration.java
@@ -103,9 +103,9 @@ public class ClientSslConfiguration extends SslConfiguration {
     }
 
     /**
-     * @return Whether the client should disable checking of the remote SSL certificate. <b>Note: This makes the SSL
-     * connection insecure, and should only be used for testing. If you are using a self-signed certificate, set up a
-     * trust store instead.</b>
+     * @return Whether the client should disable checking of the remote SSL certificate. Only applies if no trust store
+     * is configured. <b>Note: This makes the SSL connection insecure, and should only be used for testing. If you are
+     * using a self-signed certificate, set up a trust store instead.</b>
      */
     public boolean isInsecureTrustAllCertificates() {
         return insecureTrustAllCertificates;
@@ -113,6 +113,7 @@ public class ClientSslConfiguration extends SslConfiguration {
 
     /**
      * @param insecureTrustAllCertificates Whether the client should disable checking of the remote SSL certificate.
+     *                                     Only applies if no trust store is configured.
      *                                     <b>Note: This makes the SSL connection insecure, and should only be used for
      *                                     testing. If you are using a self-signed certificate, set up a trust store
      *                                     instead.</b>

--- a/http/src/main/java/io/micronaut/http/ssl/ClientSslConfiguration.java
+++ b/http/src/main/java/io/micronaut/http/ssl/ClientSslConfiguration.java
@@ -29,14 +29,12 @@ import jakarta.inject.Inject;
  */
 @ConfigurationProperties(ClientSslConfiguration.PREFIX)
 @BootstrapContextCompatible
-public class ClientSslConfiguration extends SslConfiguration {
+public class ClientSslConfiguration extends AbstractClientSslConfiguration {
 
     /**
      * The prefix used to resolve this configuration.
      */
     public static final String PREFIX = "micronaut.http.client.ssl";
-
-    private boolean insecureTrustAllCertificates;
 
     /**
      * Overrides the default constructor and sets {@link #isEnabled()} to true.
@@ -100,26 +98,6 @@ public class ClientSslConfiguration extends SslConfiguration {
         if (trustStore != null) {
             super.setTrustStore(trustStore);
         }
-    }
-
-    /**
-     * @return Whether the client should disable checking of the remote SSL certificate. Only applies if no trust store
-     * is configured. <b>Note: This makes the SSL connection insecure, and should only be used for testing. If you are
-     * using a self-signed certificate, set up a trust store instead.</b>
-     */
-    public boolean isInsecureTrustAllCertificates() {
-        return insecureTrustAllCertificates;
-    }
-
-    /**
-     * @param insecureTrustAllCertificates Whether the client should disable checking of the remote SSL certificate.
-     *                                     Only applies if no trust store is configured.
-     *                                     <b>Note: This makes the SSL connection insecure, and should only be used for
-     *                                     testing. If you are using a self-signed certificate, set up a trust store
-     *                                     instead.</b>
-     */
-    public void setInsecureTrustAllCertificates(boolean insecureTrustAllCertificates) {
-        this.insecureTrustAllCertificates = insecureTrustAllCertificates;
     }
 
     /**

--- a/http/src/main/java/io/micronaut/http/ssl/ClientSslConfiguration.java
+++ b/http/src/main/java/io/micronaut/http/ssl/ClientSslConfiguration.java
@@ -36,6 +36,8 @@ public class ClientSslConfiguration extends SslConfiguration {
      */
     public static final String PREFIX = "micronaut.http.client.ssl";
 
+    private boolean insecureTrustAllCertificates;
+
     /**
      * Overrides the default constructor and sets {@link #isEnabled()} to true.
      *
@@ -98,6 +100,25 @@ public class ClientSslConfiguration extends SslConfiguration {
         if (trustStore != null) {
             super.setTrustStore(trustStore);
         }
+    }
+
+    /**
+     * @return Whether the client should disable checking of the remote SSL certificate. <b>Note: This makes the SSL
+     * connection insecure, and should only be used for testing. If you are using a self-signed certificate, set up a
+     * trust store instead.</b>
+     */
+    public boolean isInsecureTrustAllCertificates() {
+        return insecureTrustAllCertificates;
+    }
+
+    /**
+     * @param insecureTrustAllCertificates Whether the client should disable checking of the remote SSL certificate.
+     *                                     <b>Note: This makes the SSL connection insecure, and should only be used for
+     *                                     testing. If you are using a self-signed certificate, set up a trust store
+     *                                     instead.</b>
+     */
+    public void setInsecureTrustAllCertificates(boolean insecureTrustAllCertificates) {
+        this.insecureTrustAllCertificates = insecureTrustAllCertificates;
     }
 
     /**

--- a/http/src/main/java/io/micronaut/http/ssl/SslBuilder.java
+++ b/http/src/main/java/io/micronaut/http/ssl/SslBuilder.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.http.ssl;
 
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.io.ResourceResolver;
 import io.micronaut.http.HttpVersion;
 
@@ -59,8 +60,9 @@ public abstract class SslBuilder<T> {
     /**
      * @param ssl The ssl configuration
      *
-     * @return The {@link TrustManagerFactory}
+     * @return The {@link TrustManagerFactory}, or {@code null} for the default JDK trust store
      */
+    @Nullable
     protected TrustManagerFactory getTrustManagerFactory(SslConfiguration ssl) {
         try {
             Optional<KeyStore> store = getTrustStore(ssl);

--- a/src/main/docs/guide/appendix/breaks.adoc
+++ b/src/main/docs/guide/appendix/breaks.adoc
@@ -2,6 +2,8 @@ This section documents breaking changes between Micronaut versions
 
 == 3.2.0
 
+- The HTTP client now does SSL certificate verification by default. The old insecure behavior can be re-enabled by setting the `micronaut.http.client.ssl.insecureTrustAllCertificates` property to `true`, but consider using a trust store instead if you're using self-signed certificates.
+
 - Maven GraalVM Native Image plugin has new GAV coordinates. If you have declared it in your `pom.xml` please update the coordinates to:
 
 [source,xml]

--- a/test-suite/src/test/groovy/io/micronaut/http/client/http2/Http2RequestSpec.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/http/client/http2/Http2RequestSpec.groovy
@@ -18,6 +18,7 @@ import io.micronaut.http.client.HttpClientConfiguration
 import io.micronaut.http.client.StreamingHttpClient
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.http.sse.Event
+import io.micronaut.http.ssl.AbstractClientSslConfiguration
 import io.micronaut.runtime.server.EmbeddedServer
 import org.reactivestreams.Publisher
 import reactor.core.publisher.Flux
@@ -42,7 +43,8 @@ class Http2RequestSpec extends Specification {
             'micronaut.ssl.buildSelfSigned': true,
             'micronaut.ssl.port': -1,
             "micronaut.http.client.log-level" : "TRACE",
-            "micronaut.server.netty.log-level" : "TRACE"
+            "micronaut.server.netty.log-level" : "TRACE",
+            'micronaut.http.client.ssl.insecureTrustAllCertificates': true
     ])
     HttpClient client = server.getApplicationContext().getBean(HttpClient)
 
@@ -151,7 +153,8 @@ class Http2RequestSpec extends Specification {
                 'micronaut.ssl.buildSelfSigned': true,
                 'micronaut.ssl.port': -1,
                 "micronaut.http.client.log-level" : "TRACE",
-                "micronaut.server.netty.log-level" : "TRACE"
+                "micronaut.server.netty.log-level" : "TRACE",
+                'micronaut.http.client.ssl.insecureTrustAllCertificates': true
         ])
         HttpClient client = server.getApplicationContext().getBean(HttpClient)
         String result = client.toBlocking().retrieve("${server.URL}/http2")
@@ -176,6 +179,7 @@ class Http2RequestSpec extends Specification {
         ])
         HttpClientConfiguration configuration = server.getApplicationContext().getBean(HttpClientConfiguration);
         configuration.setHttpVersion(HttpVersion.HTTP_2_0);
+        ((AbstractClientSslConfiguration) configuration.sslConfiguration).insecureTrustAllCertificates = true
         HttpClient client = HttpClient.create(null, configuration);
         String result = client.toBlocking().retrieve("${server.URL}/http2")
 
@@ -198,6 +202,7 @@ class Http2RequestSpec extends Specification {
                 "micronaut.server.netty.log-level" : "TRACE"
         ])
         HttpClientConfiguration configuration = server.getApplicationContext().getBean(HttpClientConfiguration);
+        ((AbstractClientSslConfiguration) configuration.sslConfiguration).insecureTrustAllCertificates = true
         HttpClient client = HttpClient.create(null, configuration);
         String result = client.toBlocking().retrieve("${server.URL}/http2")
 

--- a/test-suite/src/test/groovy/io/micronaut/http/client/http2/Http2RequestSpec.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/http/client/http2/Http2RequestSpec.groovy
@@ -44,7 +44,7 @@ class Http2RequestSpec extends Specification {
             'micronaut.ssl.port': -1,
             "micronaut.http.client.log-level" : "TRACE",
             "micronaut.server.netty.log-level" : "TRACE",
-            'micronaut.http.client.ssl.insecureTrustAllCertificates': true
+            'micronaut.http.client.ssl.insecure-trust-all-certificates': true
     ])
     HttpClient client = server.getApplicationContext().getBean(HttpClient)
 
@@ -154,7 +154,7 @@ class Http2RequestSpec extends Specification {
                 'micronaut.ssl.port': -1,
                 "micronaut.http.client.log-level" : "TRACE",
                 "micronaut.server.netty.log-level" : "TRACE",
-                'micronaut.http.client.ssl.insecureTrustAllCertificates': true
+                'micronaut.http.client.ssl.insecure-trust-all-certificates': true
         ])
         HttpClient client = server.getApplicationContext().getBean(HttpClient)
         String result = client.toBlocking().retrieve("${server.URL}/http2")

--- a/test-suite/src/test/groovy/io/micronaut/http2/Http2AccessLoggerSpec.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/http2/Http2AccessLoggerSpec.groovy
@@ -39,7 +39,7 @@ class Http2AccessLoggerSpec extends Specification {
             "micronaut.http.client.log-level" : "TRACE",
             "micronaut.server.netty.log-level" : "TRACE",
             'micronaut.server.netty.access-logger.enabled': true,
-            'micronaut.http.client.ssl.insecureTrustAllCertificates': true
+            'micronaut.http.client.ssl.insecure-trust-all-certificates': true
     ])
     HttpClient client = server.getApplicationContext().getBean(HttpClient)
     static MemoryAppender appender = new MemoryAppender()
@@ -146,7 +146,7 @@ class Http2AccessLoggerSpec extends Specification {
                 "micronaut.http.client.log-level" : "TRACE",
                 "micronaut.server.netty.log-level" : "TRACE",
                 'micronaut.server.netty.access-logger.enabled': true,
-                'micronaut.http.client.ssl.insecureTrustAllCertificates': true
+                'micronaut.http.client.ssl.insecure-trust-all-certificates': true
         ])
         HttpClient client = server.getApplicationContext().getBean(HttpClient)
         appender.events.clear()

--- a/test-suite/src/test/groovy/io/micronaut/http2/Http2AccessLoggerSpec.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/http2/Http2AccessLoggerSpec.groovy
@@ -38,7 +38,8 @@ class Http2AccessLoggerSpec extends Specification {
             'micronaut.ssl.port': -1,
             "micronaut.http.client.log-level" : "TRACE",
             "micronaut.server.netty.log-level" : "TRACE",
-            'micronaut.server.netty.access-logger.enabled': true
+            'micronaut.server.netty.access-logger.enabled': true,
+            'micronaut.http.client.ssl.insecureTrustAllCertificates': true
     ])
     HttpClient client = server.getApplicationContext().getBean(HttpClient)
     static MemoryAppender appender = new MemoryAppender()
@@ -144,7 +145,8 @@ class Http2AccessLoggerSpec extends Specification {
                 'micronaut.ssl.port': -1,
                 "micronaut.http.client.log-level" : "TRACE",
                 "micronaut.server.netty.log-level" : "TRACE",
-                'micronaut.server.netty.access-logger.enabled': true
+                'micronaut.server.netty.access-logger.enabled': true,
+                'micronaut.http.client.ssl.insecureTrustAllCertificates': true
         ])
         HttpClient client = server.getApplicationContext().getBean(HttpClient)
         appender.events.clear()

--- a/test-suite/src/test/groovy/io/micronaut/http2/Http2StaticResourceResolutionSpec.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/http2/Http2StaticResourceResolutionSpec.groovy
@@ -48,7 +48,8 @@ class Http2StaticResourceResolutionSpec extends Specification implements TestPro
                 "micronaut.http.client.log-level" : "TRACE",
                 "micronaut.server.netty.log-level" : "TRACE",
                 'micronaut.ssl.buildSelfSigned': true,
-                'micronaut.ssl.port': -1
+                'micronaut.ssl.port': -1,
+                'micronaut.http.client.ssl.insecureTrustAllCertificates': true
         ]
     }
 

--- a/test-suite/src/test/groovy/io/micronaut/http2/Http2StaticResourceResolutionSpec.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/http2/Http2StaticResourceResolutionSpec.groovy
@@ -49,7 +49,7 @@ class Http2StaticResourceResolutionSpec extends Specification implements TestPro
                 "micronaut.server.netty.log-level" : "TRACE",
                 'micronaut.ssl.buildSelfSigned': true,
                 'micronaut.ssl.port': -1,
-                'micronaut.http.client.ssl.insecureTrustAllCertificates': true
+                'micronaut.http.client.ssl.insecure-trust-all-certificates': true
         ]
     }
 


### PR DESCRIPTION
This patch enables SSL cert checking by default. The old behavior without checking can be enabled using the `insecureTrustAllCertificates` option.
Fixes #4116