### PR TITLE
Update jaeger.adoc

### DIFF
--- a/src/main/docs/guide/cloud/distributedTracing/jaeger.adoc
+++ b/src/main/docs/guide/cloud/distributedTracing/jaeger.adoc
@@ -71,4 +71,16 @@ tracing:
       maxQueueSize: 200
 ----
 
+Furthermore, you can set codecs as configuration property to allow propagation. Refer to the Javadoc for available option and more details.
+
+.Setting Jaeger Codec Configuration
+[source, yaml]
+----
+tracing:
+  jaeger:
+    enabled: true
+    codecs: W3C
+----
+
 You can also optionally dependency-inject common configuration classes into api:tracing.jaeger.JaegerConfiguration[] such as `io.jaegertracing.Configuration.SamplerConfiguration` just by defining them as beans. See the API for api:tracing.jaeger.JaegerConfiguration[] for available injection points.
+


### PR DESCRIPTION
Setting Jaeger Codec Configuration property to allow propagation. Refer to Javadoc for more details.