### PR TITLE
Don't initialize SLF4J in the compiler

### DIFF
--- a/core/src/main/java/io/micronaut/core/io/service/SoftServiceLoader.java
+++ b/core/src/main/java/io/micronaut/core/io/service/SoftServiceLoader.java
@@ -19,8 +19,6 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.optim.StaticOptimizations;
 import io.micronaut.core.reflect.ClassUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -43,7 +41,6 @@ import java.util.Optional;
 import java.util.ServiceConfigurationError;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.RecursiveAction;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -61,8 +58,6 @@ import java.util.stream.Stream;
  */
 public final class SoftServiceLoader<S> implements Iterable<ServiceDefinition<S>> {
     public static final String META_INF_SERVICES = "META-INF/services";
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(SoftServiceLoader.class);
 
     private static final Map<String, SoftServiceLoader.StaticServiceLoader<?>> STATIC_SERVICES =
             StaticOptimizations.get(Optimizations.class)
@@ -154,16 +149,6 @@ public final class SoftServiceLoader<S> implements Iterable<ServiceDefinition<S>
         return Optional.empty();
     }
 
-    private static void measure(String label, Runnable op) {
-        long sd = System.nanoTime();
-        try {
-            op.run();
-        } finally {
-            long dur = System.nanoTime() - sd;
-            LOGGER.debug(label + " took " + TimeUnit.MILLISECONDS.convert(dur, TimeUnit.NANOSECONDS) + "ms");
-        }
-    }
-
     /**
      * Collects all initialized instances.
      *
@@ -173,15 +158,12 @@ public final class SoftServiceLoader<S> implements Iterable<ServiceDefinition<S>
     @SuppressWarnings("unchecked")
     public void collectAll(@NonNull Collection<S> values, @Nullable Predicate<S> predicate) {
         String name = serviceType.getName();
-        measure("Loading " + name + " services", () -> {
-            SoftServiceLoader.StaticServiceLoader<?> serviceLoader = STATIC_SERVICES.get(name);
-            if (serviceLoader != null) {
-                collectStaticServices(values, predicate, (StaticServiceLoader<S>) serviceLoader);
-            } else {
-                collectDynamicServices(values, predicate, name);
-            }
-            LOGGER.debug("Loaded {} services of type {}", values.size(), name);
-        });
+        SoftServiceLoader.StaticServiceLoader<?> serviceLoader = STATIC_SERVICES.get(name);
+        if (serviceLoader != null) {
+            collectStaticServices(values, predicate, (StaticServiceLoader<S>) serviceLoader);
+        } else {
+            collectDynamicServices(values, predicate, name);
+        }
     }
 
     private void collectDynamicServices(Collection<S> values, Predicate<S> predicate, String name) {

--- a/core/src/main/java/io/micronaut/core/optim/StaticOptimizations.java
+++ b/core/src/main/java/io/micronaut/core/optim/StaticOptimizations.java
@@ -35,8 +35,6 @@ import java.util.concurrent.ConcurrentHashMap;
 @SuppressWarnings("unchecked")
 @Internal
 public abstract class StaticOptimizations {
-    private static final Logger LOGGER = LoggerFactory.getLogger(StaticOptimizations.class);
-
     private static final Map<Class<?>, Object> OPTIMIZATIONS = new ConcurrentHashMap<>();
     private static boolean cacheEnvironment = false;
 
@@ -60,11 +58,6 @@ public abstract class StaticOptimizations {
     @NonNull
     public static <T> Optional<T> get(@NonNull Class<T> optimizationClass) {
         T value = (T) OPTIMIZATIONS.get(optimizationClass);
-        if (value != null) {
-            LOGGER.debug("Found optimizations {}", optimizationClass);
-        } else {
-            LOGGER.debug("No optimizations {} found", optimizationClass);
-        }
         return Optional.ofNullable(value);
     }
 
@@ -77,7 +70,6 @@ public abstract class StaticOptimizations {
      */
     public static <T> void set(@NonNull T value) {
         Class<?> optimizationClass = value.getClass();
-        LOGGER.debug("Setting optimizations for {}", optimizationClass);
         OPTIMIZATIONS.put(optimizationClass, value);
     }
 


### PR DESCRIPTION
During compilation `Failed to load class "org.slf4j.impl.StaticLoggerBinder".` is printed because we are using logging in classes that are used within the compiler and shouldn't be. For these classes another logging strategy will need to be put in place.