### PR TITLE
Add slf4j-simple as a dependency to inject-java and inject-groovy

### DIFF
--- a/inject-groovy/build.gradle
+++ b/inject-groovy/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     api project(":inject")
     api project(':aop')
     api libs.managed.groovy
+    implementation(libs.slf4j.simple)
 
 //    testImplementation 'javax.validation:validation-api:1.1.0.Final'
     testImplementation project(":context")

--- a/inject-groovy/build.gradle
+++ b/inject-groovy/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     api project(":inject")
     api project(':aop')
     api libs.managed.groovy
-    implementation(libs.slf4j.simple)
+    implementation(libs.managed.slf4j.simple)
 
 //    testImplementation 'javax.validation:validation-api:1.1.0.Final'
     testImplementation project(":context")

--- a/inject-java/build.gradle
+++ b/inject-java/build.gradle
@@ -2,7 +2,7 @@ dependencies {
     api project(":inject")
     api project(':aop')
 
-    implementation(libs.slf4j.simple
+    implementation(libs.managed.slf4j.simple)
     if (!JavaVersion.current().isJava9Compatible()) {
         compileOnly files(org.gradle.internal.jvm.Jvm.current().toolsJar)
     }

--- a/inject-java/build.gradle
+++ b/inject-java/build.gradle
@@ -2,6 +2,7 @@ dependencies {
     api project(":inject")
     api project(':aop')
 
+    implementation(libs.slf4j.simple
     if (!JavaVersion.current().isJava9Compatible()) {
         compileOnly files(org.gradle.internal.jvm.Jvm.current().toolsJar)
     }


### PR DESCRIPTION
This is an alternative fix that adds slf4j-simple to the compiler modules. Note that this has one issue in that if either `inject-java` or `inject-groovy` appear on the runtime classpath (which they shouldn't) then you can get multiple bindings errors from SLF4J

Fixes #6570