### PR TITLE
Java time default formatters

### DIFF
--- a/context/src/main/java/io/micronaut/runtime/converters/time/TimeConverterRegistrar.java
+++ b/context/src/main/java/io/micronaut/runtime/converters/time/TimeConverterRegistrar.java
@@ -145,7 +145,7 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
                 try {
                     return Optional.of(resolveFormatter(context)
                             .map(formatter -> LocalDateTime.parse(object, formatter))
-                            .orElse(LocalDateTime.parse(object)));
+                            .orElseGet(() -> LocalDateTime.parse(object)));
                 } catch (DateTimeParseException e) {
                     context.reject(object, e);
                     return Optional.empty();
@@ -158,7 +158,7 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
             try {
                 return Optional.of(resolveFormatter(context)
                         .map(formatter -> formatter.format(object))
-                        .orElse(object.toString()));
+                        .orElseGet(() -> object.toString()));
             } catch (DateTimeParseException e) {
                 context.reject(object, e);
                 return Optional.empty();
@@ -178,7 +178,7 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
                 try {
                     return Optional.of(resolveFormatter(context)
                             .map(formatter -> LocalDate.parse(object, formatter))
-                            .orElse(LocalDate.parse(object)));
+                            .orElseGet(() -> LocalDate.parse(object)));
                 } catch (DateTimeParseException e) {
                     context.reject(object, e);
                     return Optional.empty();
@@ -195,7 +195,7 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
                 try {
                     return Optional.of(resolveFormatter(context)
                             .map(formatter -> ZonedDateTime.parse(object, formatter))
-                            .orElse(ZonedDateTime.parse(object)));
+                            .orElseGet(() -> ZonedDateTime.parse(object)));
                 } catch (DateTimeParseException e) {
                     context.reject(object, e);
                     return Optional.empty();
@@ -211,7 +211,7 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
                     try {
                         return Optional.of(resolveFormatter(context)
                                 .map(formatter -> OffsetDateTime.parse(object, formatter))
-                                .orElse(OffsetDateTime.parse(object)));
+                                .orElseGet(() -> OffsetDateTime.parse(object)));
                     } catch (DateTimeParseException e) {
                         context.reject(object, e);
                         return Optional.empty();

--- a/context/src/main/java/io/micronaut/runtime/converters/time/TimeConverterRegistrar.java
+++ b/context/src/main/java/io/micronaut/runtime/converters/time/TimeConverterRegistrar.java
@@ -143,9 +143,9 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
             LocalDateTime.class,
             (object, targetType, context) -> {
                 try {
-                    DateTimeFormatter formatter = resolveFormatter(context);
-                    LocalDateTime result = LocalDateTime.parse(object, formatter);
-                    return Optional.of(result);
+                    return Optional.of(resolveFormatter(context)
+                            .map(formatter -> LocalDateTime.parse(object, formatter))
+                            .orElse(LocalDateTime.parse(object)));
                 } catch (DateTimeParseException e) {
                     context.reject(object, e);
                     return Optional.empty();
@@ -156,8 +156,9 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
         // TemporalAccessor - CharSequence
         final TypeConverter<TemporalAccessor, CharSequence> temporalConverter = (object, targetType, context) -> {
             try {
-                DateTimeFormatter formatter = resolveFormatter(context);
-                return Optional.of(formatter.format(object));
+                return Optional.of(resolveFormatter(context)
+                        .map(formatter -> formatter.format(object))
+                        .orElse(object.toString()));
             } catch (DateTimeParseException e) {
                 context.reject(object, e);
                 return Optional.empty();
@@ -175,9 +176,9 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
             LocalDate.class,
             (object, targetType, context) -> {
                 try {
-                    DateTimeFormatter formatter = resolveFormatter(context);
-                    LocalDate result = LocalDate.parse(object, formatter);
-                    return Optional.of(result);
+                    return Optional.of(resolveFormatter(context)
+                            .map(formatter -> LocalDate.parse(object, formatter))
+                            .orElse(LocalDate.parse(object)));
                 } catch (DateTimeParseException e) {
                     context.reject(object, e);
                     return Optional.empty();
@@ -192,9 +193,9 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
             ZonedDateTime.class,
             (object, targetType, context) -> {
                 try {
-                    DateTimeFormatter formatter = resolveFormatter(context);
-                    ZonedDateTime result = ZonedDateTime.parse(object, formatter);
-                    return Optional.of(result);
+                    return Optional.of(resolveFormatter(context)
+                            .map(formatter -> ZonedDateTime.parse(object, formatter))
+                            .orElse(ZonedDateTime.parse(object)));
                 } catch (DateTimeParseException e) {
                     context.reject(object, e);
                     return Optional.empty();
@@ -208,9 +209,9 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
                 OffsetDateTime.class,
                 (object, targetType, context) -> {
                     try {
-                        DateTimeFormatter formatter = resolveFormatter(context);
-                        OffsetDateTime result = OffsetDateTime.parse(object, formatter);
-                        return Optional.of(result);
+                        return Optional.of(resolveFormatter(context)
+                                .map(formatter -> OffsetDateTime.parse(object, formatter))
+                                .orElse(OffsetDateTime.parse(object)));
                     } catch (DateTimeParseException e) {
                         context.reject(object, e);
                         return Optional.empty();
@@ -219,10 +220,9 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
         );
     }
 
-    private DateTimeFormatter resolveFormatter(ConversionContext context) {
+    private Optional<DateTimeFormatter> resolveFormatter(ConversionContext context) {
         Optional<String> format = context.getAnnotationMetadata().stringValue(Format.class);
         return format
-            .map(pattern -> DateTimeFormatter.ofPattern(pattern, context.getLocale()))
-            .orElse(DateTimeFormatter.RFC_1123_DATE_TIME);
+            .map(pattern -> DateTimeFormatter.ofPattern(pattern, context.getLocale()));
     }
 }

--- a/runtime/src/test/groovy/io/micronaut/runtime/converters/time/TimeConverterRegistrarSpec.groovy
+++ b/runtime/src/test/groovy/io/micronaut/runtime/converters/time/TimeConverterRegistrarSpec.groovy
@@ -21,6 +21,10 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 import java.time.Duration
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 
 class TimeConverterRegistrarSpec extends Specification {
 
@@ -42,6 +46,45 @@ class TimeConverterRegistrarSpec extends Specification {
         '10d'  | Duration.ofDays(10)
         '10h'  | Duration.ofHours(10)
         '10ns' | Duration.ofNanos(10)
+
+    }
+
+    void "test convert offsetdatetime"() {
+        given:
+        ConversionService conversionService = new DefaultConversionService()
+        new TimeConverterRegistrar().register(conversionService)
+
+        when:
+        OffsetDateTime result = conversionService.convert('2021-11-26T21:19+01:00', OffsetDateTime).get();
+
+        then:
+        result == OffsetDateTime.of(LocalDateTime.of(2021, 11, 26, 21, 19), ZoneOffset.ofHours(1))
+
+    }
+
+    void "test convert localdatetime"() {
+        given:
+        ConversionService conversionService = new DefaultConversionService()
+        new TimeConverterRegistrar().register(conversionService)
+
+        when:
+        LocalDateTime result = conversionService.convert('2021-11-26T21:19', LocalDateTime).get();
+
+        then:
+        result == LocalDateTime.of(2021, 11, 26, 21, 19)
+
+    }
+
+    void "test convert localdate"() {
+        given:
+        ConversionService conversionService = new DefaultConversionService()
+        new TimeConverterRegistrar().register(conversionService)
+
+        when:
+        LocalDate result = conversionService.convert('2021-11-26', LocalDate).get();
+
+        then:
+        result == LocalDate.of(2021, 11, 26)
 
     }
 }


### PR DESCRIPTION
The Java Time classes have default formatters built in which use the ISO formats. So if in micronaut somewhere a string is to be converted to one of those classes we expect the default format to be the default format of the classes.

Up to now micronaut used RFC_1123_DATE_TIME as the default format for converting but this is a rather human readable format and does not use the defaults that are already there.

Another advantage of the built in defaults is, that they the classes do use the same format in .toString(). So i.e. OffsetDateTime.toString() is compatible with OffsetDateTime.parse() without thinking about the format.