### PR TITLE
Set up coroutine context for WebSocket handler invocations

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/websocket/NettyWebSocketClientHandler.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/websocket/NettyWebSocketClientHandler.java
@@ -108,6 +108,8 @@ public class NettyWebSocketClientHandler<T> extends AbstractNettyWebSocketHandle
         String clientPath = webSocketBean.getBeanDefinition().stringValue(ClientWebSocket.class).orElse("");
         UriMatchTemplate matchTemplate = UriMatchTemplate.of(clientPath);
         this.matchInfo = matchTemplate.match(request.getPath()).orElse(null);
+
+        callOpenMethod(null);
     }
 
     @Override

--- a/http-client/src/main/java/io/micronaut/http/client/netty/websocket/NettyWebSocketClientHandler.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/websocket/NettyWebSocketClientHandler.java
@@ -46,6 +46,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker;
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;
 import io.netty.handler.ssl.SslHandler;
@@ -160,9 +161,9 @@ public class NettyWebSocketClientHandler<T> extends AbstractNettyWebSocketHandle
                 try {
                     emitter.error(new WebSocketClientException("Error finishing WebSocket handshake: " + e.getMessage(), e));
                 } finally {
-                    if (getSession().isOpen()) {
-                        getSession().close(CloseReason.INTERNAL_ERROR);
-                    }
+                    // clientSession isn't set yet, so we do the close manually instead of through session.close
+                    ch.writeAndFlush(new CloseWebSocketFrame(CloseReason.INTERNAL_ERROR.getCode(), CloseReason.INTERNAL_ERROR.getReason()));
+                    ch.close();
                 }
                 return;
             }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
@@ -42,6 +42,7 @@ import io.micronaut.http.netty.channel.converters.ChannelOptionFactory;
 import io.micronaut.http.netty.stream.HttpStreamsServerHandler;
 import io.micronaut.http.netty.stream.StreamingInboundHttp2ToHttpAdapter;
 import io.micronaut.http.netty.websocket.WebSocketSessionRepository;
+import io.micronaut.http.server.CoroutineHelper;
 import io.micronaut.http.server.HttpServerConfiguration;
 import io.micronaut.http.server.exceptions.ServerStartupException;
 import io.micronaut.http.server.netty.configuration.NettyHttpServerConfiguration;
@@ -808,8 +809,8 @@ public class NettyHttpServer implements NettyEmbeddedServer {
             handlers.put(HttpResponseEncoder.ID, responseEncoder);
             handlers.put(NettyServerWebSocketUpgradeHandler.ID, new NettyServerWebSocketUpgradeHandler(
                     nettyEmbeddedServices,
-                    getWebSocketSessionRepository()
-            ));
+                    getWebSocketSessionRepository(),
+                    getApplicationContext().findBean(CoroutineHelper.class)));
             handlers.put(ChannelPipelineCustomizer.HANDLER_MICRONAUT_INBOUND, routingHandler);
             return handlers;
         }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
@@ -42,7 +42,6 @@ import io.micronaut.http.netty.channel.converters.ChannelOptionFactory;
 import io.micronaut.http.netty.stream.HttpStreamsServerHandler;
 import io.micronaut.http.netty.stream.StreamingInboundHttp2ToHttpAdapter;
 import io.micronaut.http.netty.websocket.WebSocketSessionRepository;
-import io.micronaut.http.server.CoroutineHelper;
 import io.micronaut.http.server.HttpServerConfiguration;
 import io.micronaut.http.server.exceptions.ServerStartupException;
 import io.micronaut.http.server.netty.configuration.NettyHttpServerConfiguration;
@@ -809,8 +808,7 @@ public class NettyHttpServer implements NettyEmbeddedServer {
             handlers.put(HttpResponseEncoder.ID, responseEncoder);
             handlers.put(NettyServerWebSocketUpgradeHandler.ID, new NettyServerWebSocketUpgradeHandler(
                     nettyEmbeddedServices,
-                    getWebSocketSessionRepository(),
-                    getApplicationContext().findBean(CoroutineHelper.class)));
+                    getWebSocketSessionRepository()));
             handlers.put(ChannelPipelineCustomizer.HANDLER_MICRONAUT_INBOUND, routingHandler);
             return handlers;
         }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/websocket/NettyServerWebSocketHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/websocket/NettyServerWebSocketHandler.java
@@ -17,6 +17,7 @@ package io.micronaut.http.server.netty.websocket;
 
 import io.micronaut.context.event.ApplicationEventPublisher;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.core.bind.BoundExecutable;
 import io.micronaut.core.convert.value.ConvertibleValues;
@@ -77,7 +78,8 @@ public class NettyServerWebSocketHandler extends AbstractNettyWebSocketHandler {
     public static final String ID = "websocket-handler";
 
     private final NettyEmbeddedServices nettyEmbeddedServices;
-    private final Optional<CoroutineHelper> coroutineHelper;
+    @Nullable
+    private final CoroutineHelper coroutineHelper;
 
     /**
      * Default constructor.
@@ -99,7 +101,7 @@ public class NettyServerWebSocketHandler extends AbstractNettyWebSocketHandler {
             HttpRequest<?> request,
             UriRouteMatch<Object, Object> routeMatch,
             ChannelHandlerContext ctx,
-            Optional<CoroutineHelper> coroutineHelper) {
+            @Nullable CoroutineHelper coroutineHelper) {
         super(
                 ctx,
                 nettyEmbeddedServices.getRequestArgumentSatisfier().getBinderRegistry(),
@@ -242,14 +244,14 @@ public class NettyServerWebSocketHandler extends AbstractNettyWebSocketHandler {
 
     @Override
     protected Object invokeExecutable(BoundExecutable boundExecutable, MethodExecutionHandle<?, ?> messageHandler) {
-        if (coroutineHelper.isPresent()) {
+        if (coroutineHelper != null) {
             Executable<?, ?> target = boundExecutable.getTarget();
             if (target instanceof ExecutableMethod<?, ?>) {
                 ExecutableMethod<?, ?> executableMethod = (ExecutableMethod<?, ?>) target;
                 if (executableMethod.isSuspend()) {
                     return Flux.deferContextual(ctx -> {
                         try {
-                            coroutineHelper.get().setupCoroutineContext(originatingRequest, ctx);
+                            coroutineHelper.setupCoroutineContext(originatingRequest, ctx);
 
                             Object immediateReturnValue = invokeExecutable0(boundExecutable, messageHandler);
 

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/websocket/NettyServerWebSocketHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/websocket/NettyServerWebSocketHandler.java
@@ -115,6 +115,9 @@ public class NettyServerWebSocketHandler extends AbstractNettyWebSocketHandler {
         this.coroutineHelper = coroutineHelper;
         request.setAttribute(HttpAttributes.ROUTE_MATCH, routeMatch);
         request.setAttribute(HttpAttributes.ROUTE, routeMatch.getRoute());
+
+        callOpenMethod(ctx);
+
         ApplicationEventPublisher<WebSocketSessionOpenEvent> eventPublisher =
                 nettyEmbeddedServices.getEventPublisher(WebSocketSessionOpenEvent.class);
 

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/websocket/NettyServerWebSocketHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/websocket/NettyServerWebSocketHandler.java
@@ -20,13 +20,18 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.core.bind.BoundExecutable;
 import io.micronaut.core.convert.value.ConvertibleValues;
+import io.micronaut.core.type.Executable;
+import io.micronaut.core.util.KotlinUtils;
 import io.micronaut.http.HttpAttributes;
 import io.micronaut.http.HttpRequest;
+import io.micronaut.http.bind.binders.ContinuationArgumentBinder;
 import io.micronaut.http.context.ServerRequestContext;
 import io.micronaut.http.netty.websocket.AbstractNettyWebSocketHandler;
 import io.micronaut.http.netty.websocket.NettyWebSocketSession;
 import io.micronaut.http.netty.websocket.WebSocketSessionRepository;
+import io.micronaut.http.server.CoroutineHelper;
 import io.micronaut.http.server.netty.NettyEmbeddedServices;
+import io.micronaut.inject.ExecutableMethod;
 import io.micronaut.inject.MethodExecutionHandle;
 import io.micronaut.web.router.UriRouteMatch;
 import io.micronaut.websocket.CloseReason;
@@ -46,6 +51,7 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
 import java.security.Principal;
@@ -71,16 +77,19 @@ public class NettyServerWebSocketHandler extends AbstractNettyWebSocketHandler {
     public static final String ID = "websocket-handler";
 
     private final NettyEmbeddedServices nettyEmbeddedServices;
+    private final Optional<CoroutineHelper> coroutineHelper;
 
     /**
      * Default constructor.
-     * @param nettyEmbeddedServices The netty embedded services
+     *
+     * @param nettyEmbeddedServices      The netty embedded services
      * @param webSocketSessionRepository The web socket sessions repository
-     * @param handshaker     The handshaker
-     * @param request        The request used to create the websocket
-     * @param routeMatch     The route match
-     * @param webSocketBean  The web socket bean
-     * @param ctx            The channel handler context
+     * @param handshaker                 The handshaker
+     * @param webSocketBean              The web socket bean
+     * @param request                    The request used to create the websocket
+     * @param routeMatch                 The route match
+     * @param ctx                        The channel handler context
+     * @param coroutineHelper            Helper for kotlin coroutines
      */
     NettyServerWebSocketHandler(
             NettyEmbeddedServices nettyEmbeddedServices,
@@ -89,7 +98,8 @@ public class NettyServerWebSocketHandler extends AbstractNettyWebSocketHandler {
             WebSocketBean<?> webSocketBean,
             HttpRequest<?> request,
             UriRouteMatch<Object, Object> routeMatch,
-            ChannelHandlerContext ctx) {
+            ChannelHandlerContext ctx,
+            Optional<CoroutineHelper> coroutineHelper) {
         super(
                 ctx,
                 nettyEmbeddedServices.getRequestArgumentSatisfier().getBinderRegistry(),
@@ -102,6 +112,7 @@ public class NettyServerWebSocketHandler extends AbstractNettyWebSocketHandler {
                 webSocketSessionRepository);
 
         this.nettyEmbeddedServices = nettyEmbeddedServices;
+        this.coroutineHelper = coroutineHelper;
         request.setAttribute(HttpAttributes.ROUTE_MATCH, routeMatch);
         request.setAttribute(HttpAttributes.ROUTE, routeMatch.getRoute());
         ApplicationEventPublisher<WebSocketSessionOpenEvent> eventPublisher =
@@ -228,8 +239,35 @@ public class NettyServerWebSocketHandler extends AbstractNettyWebSocketHandler {
 
     @Override
     protected Object invokeExecutable(BoundExecutable boundExecutable, MethodExecutionHandle<?, ?> messageHandler) {
+        if (coroutineHelper.isPresent()) {
+            Executable<?, ?> target = boundExecutable.getTarget();
+            if (target instanceof ExecutableMethod<?, ?>) {
+                ExecutableMethod<?, ?> executableMethod = (ExecutableMethod<?, ?>) target;
+                if (executableMethod.isSuspend()) {
+                    return Flux.deferContextual(ctx -> {
+                        try {
+                            coroutineHelper.get().setupCoroutineContext(originatingRequest, ctx);
+
+                            Object immediateReturnValue = invokeExecutable0(boundExecutable, messageHandler);
+
+                            if (KotlinUtils.isKotlinCoroutineSuspended(immediateReturnValue)) {
+                                return Mono.fromCompletionStage(ContinuationArgumentBinder.extractContinuationCompletableFutureSupplier(originatingRequest));
+                            } else {
+                                return Mono.empty();
+                            }
+                        } catch (Exception e) {
+                            return Flux.error(e);
+                        }
+                    });
+                }
+            }
+        }
+        return invokeExecutable0(boundExecutable, messageHandler);
+    }
+
+    private Object invokeExecutable0(BoundExecutable boundExecutable, MethodExecutionHandle<?, ?> messageHandler) {
         return ServerRequestContext.with(originatingRequest,
-                                         (Supplier<Object>) () -> boundExecutable.invoke(messageHandler.getTarget()));
+                (Supplier<Object>) () -> boundExecutable.invoke(messageHandler.getTarget()));
     }
 
     @Override

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/websocket/NettyServerWebSocketUpgradeHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/websocket/NettyServerWebSocketUpgradeHandler.java
@@ -104,13 +104,15 @@ public class NettyServerWebSocketUpgradeHandler extends SimpleChannelInboundHand
 
     /**
      * Default constructor.
-     *  @param embeddedServices The embedded server services
+     *
+     * @param embeddedServices The embedded server services
      * @param webSocketSessionRepository The websocket session repository
      * @param coroutineHelper Helper for kotlin coroutines
      */
     public NettyServerWebSocketUpgradeHandler(
             NettyEmbeddedServices embeddedServices,
-            WebSocketSessionRepository webSocketSessionRepository, Optional<CoroutineHelper> coroutineHelper) {
+            WebSocketSessionRepository webSocketSessionRepository,
+            Optional<CoroutineHelper> coroutineHelper) {
         this.router = embeddedServices.getRouter();
         this.binderRegistry = embeddedServices.getRequestArgumentSatisfier().getBinderRegistry();
         this.webSocketBeanRegistry = embeddedServices.getWebSocketBeanRegistry();

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/websocket/NettyServerWebSocketUpgradeHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/websocket/NettyServerWebSocketUpgradeHandler.java
@@ -99,7 +99,6 @@ public class NettyServerWebSocketUpgradeHandler extends SimpleChannelInboundHand
     private final WebSocketSessionRepository webSocketSessionRepository;
     private final RouteExecutor routeExecutor;
     private final NettyEmbeddedServices nettyEmbeddedServices;
-    private final Optional<CoroutineHelper> coroutineHelper;
     private WebSocketServerHandshaker handshaker;
 
     /**
@@ -107,12 +106,10 @@ public class NettyServerWebSocketUpgradeHandler extends SimpleChannelInboundHand
      *
      * @param embeddedServices The embedded server services
      * @param webSocketSessionRepository The websocket session repository
-     * @param coroutineHelper Helper for kotlin coroutines
      */
     public NettyServerWebSocketUpgradeHandler(
             NettyEmbeddedServices embeddedServices,
-            WebSocketSessionRepository webSocketSessionRepository,
-            Optional<CoroutineHelper> coroutineHelper) {
+            WebSocketSessionRepository webSocketSessionRepository) {
         this.router = embeddedServices.getRouter();
         this.binderRegistry = embeddedServices.getRequestArgumentSatisfier().getBinderRegistry();
         this.webSocketBeanRegistry = embeddedServices.getWebSocketBeanRegistry();
@@ -120,7 +117,6 @@ public class NettyServerWebSocketUpgradeHandler extends SimpleChannelInboundHand
         this.webSocketSessionRepository = webSocketSessionRepository;
         this.routeExecutor = embeddedServices.getRouteExecutor();
         this.nettyEmbeddedServices = embeddedServices;
-        this.coroutineHelper = coroutineHelper;
     }
 
     @Override
@@ -185,7 +181,7 @@ public class NettyServerWebSocketUpgradeHandler extends SimpleChannelInboundHand
                                     msg,
                                     routeMatch,
                                     ctx,
-                                    coroutineHelper);
+                                    routeExecutor.getCoroutineHelper().orElse(null));
                             pipeline.addBefore(ctx.name(), NettyServerWebSocketHandler.ID, webSocketHandler);
 
                             pipeline.remove(ChannelPipelineCustomizer.HANDLER_HTTP_STREAM);

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/websocket/NettyServerWebSocketUpgradeHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/websocket/NettyServerWebSocketUpgradeHandler.java
@@ -33,6 +33,7 @@ import io.micronaut.http.exceptions.HttpStatusException;
 import io.micronaut.http.netty.NettyHttpHeaders;
 import io.micronaut.http.netty.channel.ChannelPipelineCustomizer;
 import io.micronaut.http.netty.websocket.WebSocketSessionRepository;
+import io.micronaut.http.server.CoroutineHelper;
 import io.micronaut.http.server.netty.NettyEmbeddedServices;
 import io.micronaut.http.server.netty.NettyHttpRequest;
 import io.micronaut.http.server.RouteExecutor;
@@ -98,17 +99,18 @@ public class NettyServerWebSocketUpgradeHandler extends SimpleChannelInboundHand
     private final WebSocketSessionRepository webSocketSessionRepository;
     private final RouteExecutor routeExecutor;
     private final NettyEmbeddedServices nettyEmbeddedServices;
+    private final Optional<CoroutineHelper> coroutineHelper;
     private WebSocketServerHandshaker handshaker;
 
     /**
      * Default constructor.
-     *
-     * @param embeddedServices The embedded server services
+     *  @param embeddedServices The embedded server services
      * @param webSocketSessionRepository The websocket session repository
+     * @param coroutineHelper Helper for kotlin coroutines
      */
     public NettyServerWebSocketUpgradeHandler(
             NettyEmbeddedServices embeddedServices,
-            WebSocketSessionRepository webSocketSessionRepository) {
+            WebSocketSessionRepository webSocketSessionRepository, Optional<CoroutineHelper> coroutineHelper) {
         this.router = embeddedServices.getRouter();
         this.binderRegistry = embeddedServices.getRequestArgumentSatisfier().getBinderRegistry();
         this.webSocketBeanRegistry = embeddedServices.getWebSocketBeanRegistry();
@@ -116,6 +118,7 @@ public class NettyServerWebSocketUpgradeHandler extends SimpleChannelInboundHand
         this.webSocketSessionRepository = webSocketSessionRepository;
         this.routeExecutor = embeddedServices.getRouteExecutor();
         this.nettyEmbeddedServices = embeddedServices;
+        this.coroutineHelper = coroutineHelper;
     }
 
     @Override
@@ -179,8 +182,8 @@ public class NettyServerWebSocketUpgradeHandler extends SimpleChannelInboundHand
                                     webSocketBean,
                                     msg,
                                     routeMatch,
-                                    ctx
-                            );
+                                    ctx,
+                                    coroutineHelper);
                             pipeline.addBefore(ctx.name(), NettyServerWebSocketHandler.ID, webSocketHandler);
 
                             pipeline.remove(ChannelPipelineCustomizer.HANDLER_HTTP_STREAM);

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/UpgradeSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/UpgradeSpec.groovy
@@ -28,7 +28,7 @@ class UpgradeSpec extends Specification {
 
         def mock = Mock(NettyEmbeddedServices)
         mock.getRequestArgumentSatisfier() >> new RequestArgumentSatisfier(null)
-        NettyServerWebSocketUpgradeHandler handler = new NettyServerWebSocketUpgradeHandler(mock, Mock(WebSocketSessionRepository))
+        NettyServerWebSocketUpgradeHandler handler = new NettyServerWebSocketUpgradeHandler(mock, Mock(WebSocketSessionRepository), Optional.empty())
 
         when:
         HttpRequest<?> request = new NettyHttpRequest(

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/UpgradeSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/UpgradeSpec.groovy
@@ -28,7 +28,7 @@ class UpgradeSpec extends Specification {
 
         def mock = Mock(NettyEmbeddedServices)
         mock.getRequestArgumentSatisfier() >> new RequestArgumentSatisfier(null)
-        NettyServerWebSocketUpgradeHandler handler = new NettyServerWebSocketUpgradeHandler(mock, Mock(WebSocketSessionRepository), Optional.empty())
+        NettyServerWebSocketUpgradeHandler handler = new NettyServerWebSocketUpgradeHandler(mock, Mock(WebSocketSessionRepository))
 
         when:
         HttpRequest<?> request = new NettyHttpRequest(

--- a/http-server/src/main/java/io/micronaut/http/server/CoroutineHelper.java
+++ b/http-server/src/main/java/io/micronaut/http/server/CoroutineHelper.java
@@ -34,7 +34,7 @@ import java.util.List;
 @Internal
 @Singleton
 @Requires(classes = kotlin.coroutines.CoroutineContext.class)
-final class CoroutineHelper {
+public final class CoroutineHelper {
 
     private final List<HttpCoroutineContextFactory<?>> coroutineContextFactories;
 
@@ -42,7 +42,7 @@ final class CoroutineHelper {
         this.coroutineContextFactories = coroutineContextFactories;
     }
 
-    void setupCoroutineContext(HttpRequest<?> httpRequest, ContextView contextView) {
+    public void setupCoroutineContext(HttpRequest<?> httpRequest, ContextView contextView) {
         ContinuationArgumentBinder.setupCoroutineContext(httpRequest, contextView, coroutineContextFactories);
     }
 }

--- a/http-server/src/main/java/io/micronaut/http/server/RouteExecutor.java
+++ b/http-server/src/main/java/io/micronaut/http/server/RouteExecutor.java
@@ -158,6 +158,13 @@ public final class RouteExecutor {
     }
 
     /**
+     * @return The kotlin coroutine helper
+     */
+    public Optional<CoroutineHelper> getCoroutineHelper() {
+        return coroutineHelper;
+    }
+
+    /**
      * Creates a response publisher to represent the response after being handled
      * by any available error route or exception handler.
      *

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/http/server/WebSocketSuspendTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/http/server/WebSocketSuspendTest.kt
@@ -1,0 +1,65 @@
+package io.micronaut.http.server
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import io.micronaut.websocket.WebSocketClient
+import io.micronaut.websocket.WebSocketSession
+import io.micronaut.websocket.annotation.ClientWebSocket
+import io.micronaut.websocket.annotation.OnMessage
+import io.micronaut.websocket.annotation.ServerWebSocket
+import jakarta.inject.Inject
+import kotlinx.coroutines.delay
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import reactor.core.publisher.Flux
+import spock.lang.Issue
+
+@MicronautTest
+@Property(name = "spec.name", value = "WebSocketSuspendTest")
+class WebSocketSuspendTest {
+    @Inject
+    lateinit var server: EmbeddedServer
+
+    @Inject
+    lateinit var client: WebSocketClient
+
+    @Issue("https://github.com/micronaut-projects/micronaut-core/issues/6582")
+    @Test
+    @Timeout(10)
+    fun test() {
+        val cl = Flux.from(client.connect(TestWebSocketClient::class.java, server.uri.toString() + "/demo/ws")).blockFirst()!!
+        cl.send("foo")
+        while (true) {
+            Thread.sleep(100)
+            if (cl.received == "foo") {
+                break
+            }
+        }
+        cl.close()
+    }
+
+    @Requires(property = "spec.name", value = "WebSocketSuspendTest")
+    @ServerWebSocket("/demo/ws")
+    class TestWebSocketController {
+        @OnMessage
+        suspend fun messageHandler(message: String, session: WebSocketSession) {
+            delay(100)
+            session.sendSync(message)
+        }
+    }
+
+    @Requires(property = "spec.name", value = "WebSocketSuspendTest")
+    @ClientWebSocket("/demo/ws")
+    abstract class TestWebSocketClient : AutoCloseable {
+        var received: String = ""
+
+        abstract fun send(msg: String)
+
+        @OnMessage
+        fun onMessage(msg: String) {
+            this.received = msg
+        }
+    }
+}


### PR DESCRIPTION
For invocations of NettyServerWebSocketHandler kotlin suspend handler methods, the continuation was passed in, but was not fully set up. This patch mimics the setup logic for RouteExecutor. This ensures the coroutine context is complete, and also ensures any errors during coroutine execution are handled using the same logic as for other reactive methods.

Fixes #6582