### PR TITLE
Update testcontainers to 1.16.2 to fix race condition bug

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -147,7 +147,7 @@ managed-spring = "5.3.9"
 managed-springboot = "2.5.3"
 managed-swagger = "2.1.10"
 managed-validation = "2.0.1.Final"
-managed-testcontainers = "1.16.1"
+managed-testcontainers = "1.16.2"
 managed-snakeyaml = "1.29"
 managed-zipkin-reporter = "2.16.3"
 


### PR DESCRIPTION
There is a fairly major bug in the testcontainers 1.16.1 version used by the latest version of Micronaut, so this PR updates to the patched version.

`1.16.2 fixes a race condition that was inadvertently added in 1.16.1. This bug can potentially cause unstable builds in some environments, manifesting as port wait timeouts at container startup.`

https://github.com/testcontainers/testcontainers-java/releases/tag/1.16.2