### PR TITLE
Introduce an internal interface for finalizing context configuration

### DIFF
--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -148,7 +148,7 @@ import java.util.stream.Stream;
  * @since 1.0
  */
 @SuppressWarnings("MagicNumber")
-public class DefaultBeanContext implements BeanContext {
+public class DefaultBeanContext implements IntrospectableBeanContext {
 
     protected static final Logger LOG = LoggerFactory.getLogger(DefaultBeanContext.class);
     protected static final Logger LOG_LIFECYCLE = LoggerFactory.getLogger(DefaultBeanContext.class.getPackage().getName() + ".lifecycle");
@@ -326,8 +326,7 @@ public class DefaultBeanContext implements BeanContext {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("Starting BeanContext");
                 }
-                readAllBeanConfigurations();
-                readAllBeanDefinitionClasses();
+                finalizeConfiguration();
                 if (LOG.isDebugEnabled()) {
                     String activeConfigurations = beanConfigurations
                             .values()
@@ -3876,6 +3875,12 @@ public class DefaultBeanContext implements BeanContext {
             return Optional.of((T) o);
         }
         return Optional.empty();
+    }
+
+    @Override
+    public void finalizeConfiguration() {
+        readAllBeanConfigurations();
+        readAllBeanDefinitionClasses();
     }
 
     /**

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -148,7 +148,7 @@ import java.util.stream.Stream;
  * @since 1.0
  */
 @SuppressWarnings("MagicNumber")
-public class DefaultBeanContext implements IntrospectableBeanContext {
+public class DefaultBeanContext implements InitializableBeanContext {
 
     protected static final Logger LOG = LoggerFactory.getLogger(DefaultBeanContext.class);
     protected static final Logger LOG_LIFECYCLE = LoggerFactory.getLogger(DefaultBeanContext.class.getPackage().getName() + ".lifecycle");

--- a/inject/src/main/java/io/micronaut/context/InitializableBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/InitializableBeanContext.java
@@ -25,7 +25,7 @@ import io.micronaut.core.annotation.Internal;
  * @since 3.2.2
  */
 @Internal
-public interface IntrospectableBeanContext extends BeanContext {
+public interface InitializableBeanContext extends BeanContext {
     /**
      * Performs operations required before starting the application
      * context, such as reading bean configurations.

--- a/inject/src/main/java/io/micronaut/context/IntrospectableBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/IntrospectableBeanContext.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context;
+
+import io.micronaut.core.annotation.Internal;
+
+/**
+ * A marker interface for {@link BeanContext} implementations that can be introspected,
+ * that is to say for context which can be created and need to be fully configured,
+ * but not necessarily started yet.
+ *
+ * @since 3.2.2
+ */
+@Internal
+public interface IntrospectableBeanContext extends BeanContext {
+    /**
+     * Performs operations required before starting the application
+     * context, such as reading bean configurations.
+     */
+    void finalizeConfiguration();
+}


### PR DESCRIPTION
During debugging of Micronaut AOT, we discovered that some bean requirements
weren't met, because bean configurations were not read. This happened because
those beans are only read when the context is actually started. In AOT, we
don't want to start the context, only introspect it, so we missed an operation
to perform the finalization of configuration, while keeping the context in
an unstarted state.

For this purpose, we introduce a new internal interface, which AOT will be
able to check for, and call this method instead of using reflection to
call the `readAllXXX` methods.

This shouldn't be a breaking change so I'm tentatively setting 3.2.2 as the milestone version.