### PR TITLE
Implement content negotiation for Accept header

### DIFF
--- a/router/src/main/java/io/micronaut/web/router/AbstractRouteMatch.java
+++ b/router/src/main/java/io/micronaut/web/router/AbstractRouteMatch.java
@@ -336,16 +336,29 @@ abstract class AbstractRouteMatch<T, R> implements MethodBasedRouteMatch<T, R> {
 
     @Override
     public boolean doesProduce(@Nullable MediaType acceptableType) {
-        return abstractRoute.producesMediaTypesContainsAll || acceptableType == null || acceptableType.equals(MediaType.ALL_TYPE) || producedMediaTypes.contains(acceptableType);
+        if (acceptableType == null || acceptableType.equals(MediaType.ALL_TYPE) || producedMediaTypes.contains(acceptableType)) {
+            return true;
+        }
+        for (MediaType producedType : producedMediaTypes) {
+            if (acceptableType.matches(producedType)) {
+                return true;
+            }
+        }
+        return false;
     }
 
-    private boolean anyMediaTypesMatch(List<MediaType> producedMediaTypes, Collection<MediaType> acceptableTypes) {
+    private static boolean anyMediaTypesMatch(List<MediaType> producedMediaTypes, Collection<MediaType> acceptableTypes) {
         if (CollectionUtils.isEmpty(acceptableTypes)) {
             return true;
         }
         for (MediaType acceptableType : acceptableTypes) {
             if (acceptableType.equals(MediaType.ALL_TYPE) || producedMediaTypes.contains(acceptableType)) {
                 return true;
+            }
+            for (MediaType producedType : producedMediaTypes) {
+                if (acceptableType.matches(producedType)) {
+                    return true;
+                }
             }
         }
         return false;

--- a/router/src/main/java/io/micronaut/web/router/DefaultRouter.java
+++ b/router/src/main/java/io/micronaut/web/router/DefaultRouter.java
@@ -305,6 +305,7 @@ public class DefaultRouter implements Router, HttpServerFilterResolver<RouteMatc
                                 routeAdded = true;
                             }
                         }
+                        // acceptList is sorted, so this match was the type with the highest precedence.
                         break;
                     }
                 }
@@ -312,7 +313,6 @@ public class DefaultRouter implements Router, HttpServerFilterResolver<RouteMatc
         }
         return bestMatches;
     }
-
 
     @NonNull
     @Override

--- a/router/src/test/groovy/io/micronaut/context/router/GroovyRouteBuilderSpec.groovy
+++ b/router/src/test/groovy/io/micronaut/context/router/GroovyRouteBuilderSpec.groovy
@@ -19,6 +19,7 @@ import io.micronaut.context.ApplicationContext
 import io.micronaut.context.DefaultApplicationContext
 import io.micronaut.context.annotation.Executable
 import io.micronaut.http.HttpMethod
+import io.micronaut.http.HttpRequest
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Error
@@ -200,4 +201,45 @@ class GroovyRouteBuilderSpec extends Specification {
     static class C extends D {}
     static class D extends E {}
     static class E extends RuntimeException {}
+
+    def 'content negotiation on accept header'() {
+        given:
+        def context = new DefaultApplicationContext("test").start()
+        Router router = context.getBean(Router)
+
+        def request = HttpRequest.GET('/accept').header('Accept', accept)
+
+        expect:
+        router.findAllClosest(request).collectMany { it.produces }.collect { it.toString() }.toSet() == produced.toSet()
+
+        cleanup:
+        context.stop()
+
+        where:
+        accept                     | produced
+        'application/json'         | ['application/json']
+        'application/*'            | ['application/json']
+        'text/*'                   | ['text/plain', 'text/html']
+        // "If more than one media range applies to a given type, the most specific reference has precedence."
+        'text/*, text/plain'       | ['text/plain']
+        'text/*, text/plain;q=0.5' | ['text/html']
+        'text/*;q=0.5, */*'        | ['image/svg', 'application/json']
+    }
+
+    @Controller('/accept')
+    @Executable
+    static class AcceptController {
+        @Get(produces = 'application/json')
+        def json() {}
+
+        @Get(produces = 'text/html')
+        def html() {}
+
+        @Get(produces = 'text/plain')
+        def plain() {}
+
+        @Get(produces = 'image/svg')
+        def svg() {}
+    }
+
 }


### PR DESCRIPTION
This patch adds support for proper content negotiation using the `Accept` header. This includes new support for:
- "Partial" matches, like text/*
- Quality parameters
- Correct matching by precedence, e.g. matching text/plain over \*/*.

Compatibility considerations:
- MediaType now considers parameters in `matches`, if specified
- Overloaded routes that relied on the old, incorrect matching behavior will now match differently.

Resolves #6637