### PR TITLE
Consistently generate reports

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,12 +112,6 @@ subprojects { Project subproject ->
         options.compilerArgs.add("-Amicronaut.processing.module=micronaut-$project.name")
         groovyOptions.forkOptions.memoryMaximumSize = "2g"
     }
-    tasks.withType(Checkstyle).configureEach {
-        reports {
-            xml.required = !System.getenv("GITHUB_ACTIONS")
-            html.required = !System.getenv("GITHUB_ACTIONS")
-        }
-    }
 
     configurations {
         shadowCompile


### PR DESCRIPTION
This is so that we can reuse cache entries: by not generating reports,
we can't cache the outputs, so the checkstyle tasks are always re-executed.