### PR TITLE
Ignore accessors with explicit `JsonIgnore`

### DIFF
--- a/jackson-databind/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
@@ -306,7 +306,9 @@ public class BeanIntrospectionModule extends SimpleModule {
                         } else {
                             property = introspection.getProperty(existingName);
                         }
-                        if (property.isPresent()) {
+                        // ignore properties that are @JsonIgnore, so that we don't replace other properties of the
+                        // same name
+                        if (property.isPresent() && !property.get().isAnnotationPresent(JsonIgnore.class)) {
                             final BeanProperty<Object, Object> beanProperty = property.get();
                             if (isResource) {
                                 if ("embedded".equals(beanProperty.getName())) {
@@ -389,6 +391,12 @@ public class BeanIntrospectionModule extends SimpleModule {
                 } else {
                     Map<String, BeanProperty<Object, Object>> remainingProperties = new LinkedHashMap<>();
                     for (BeanProperty<Object, Object> beanProperty : introspection.getBeanProperties()) {
+                        // ignore properties that are @JsonIgnore, so that we don't replace other properties of the
+                        // same name
+                        if (beanProperty.isAnnotationPresent(JsonIgnore.class)) {
+                            continue;
+                        }
+
                         remainingProperties.put(beanProperty.getName(), beanProperty);
                     }
                     while (properties.hasNext()) {


### PR DESCRIPTION
Change `BeanIntrospectionModule` to ignore properties that are explicitly annotated with `@JsonIgnore`. Normally this is handled by jackson, but if there is another `@JsonProperty` of the same name, the accessors for the ignored property could override those accessors.
This change ignores any accessors with `@JsonIgnore` on a property.

There is a potential pitfall with this change, in that introspections have the annotation at the property level, while jackson considers it at the method level. This means that with this change, an accessor that was previously seen correctly by the BeanIntrospectionModule may now be ignored. However this is only relevant in scenarios where reflection is enabled, and in those cases, jackson should simply fall back on the reflection-based accessor. I've added a test to verify this as well.

Method-specific ignore is broken in native-image (reflectionless) mode, because we can't tell what method the `@JsonIgnore` is on, but there's nothing we can do about that. I didn't touch that behavior in this patch.

Fixes #6625