### PR TITLE
Add the ability to configure Netty's default allocator

### DIFF
--- a/buffer-netty/build.gradle
+++ b/buffer-netty/build.gradle
@@ -1,6 +1,6 @@
 
 internalSanityChecks {
-    expectedServiceCount.put('io.micronaut.inject.BeanDefinitionReference', 1)
+    expectedServiceCount.put('io.micronaut.inject.BeanDefinitionReference', 2)
 }           
 
 dependencies {

--- a/buffer-netty/src/main/java/io/micronaut/buffer/netty/ByteBufAllocatorConfiguration.java
+++ b/buffer-netty/src/main/java/io/micronaut/buffer/netty/ByteBufAllocatorConfiguration.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.buffer.netty;
+
+import io.micronaut.core.annotation.Nullable;
+
+/**
+ * Interface for the Netty bytebuf allocator configuration.
+ *
+ * @since 3.3.0
+ * @author graemerocher
+ */
+public interface ByteBufAllocatorConfiguration {
+    String DEFAULT_ALLOCATOR = "netty.default.allocator";
+
+    /**
+     * @param numHeapArenas The number of heap arenas
+     */
+    void setNumHeapArenas(@Nullable Integer numHeapArenas);
+
+    /**
+     * @param numDirectArenas The number of direct arenas
+     */
+    void setNumDirectArenas(@Nullable Integer numDirectArenas);
+
+    /**
+     * @param pageSize The page size
+     */
+    void setPageSize(@Nullable Integer pageSize);
+
+    /**
+     * @param maxOrder The max order
+     */
+    void setMaxOrder(@Nullable Integer maxOrder);
+
+    /**
+     * @param chunkSize The chunk size
+     */
+    void setChunkSize(@Nullable Integer chunkSize);
+
+    /**
+     * @param smallCacheSize The small cache size
+     */
+    void setSmallCacheSize(@Nullable Integer smallCacheSize);
+
+    /**
+     * @param normalCacheSize The normal cache size
+     */
+    void setNormalCacheSize(@Nullable Integer normalCacheSize);
+
+    /**
+     * @param useCacheForAllThreads Whether to use the cache for all threads
+     */
+    void setUseCacheForAllThreads(@Nullable Boolean useCacheForAllThreads);
+
+    /**
+     * @param maxCachedBufferCapacity The max cached buffer capacity
+     */
+    void setMaxCachedBufferCapacity(@Nullable Integer maxCachedBufferCapacity);
+
+    /**
+     * @param cacheTrimInterval The cache trim interval
+     */
+    void setCacheTrimInterval(@Nullable Integer cacheTrimInterval);
+
+    /**
+     * @param maxCachedByteBuffersPerChunk The max cached byte buffers per chunk
+     */
+    void setMaxCachedByteBuffersPerChunk(@Nullable Integer maxCachedByteBuffersPerChunk);
+}

--- a/buffer-netty/src/main/java/io/micronaut/buffer/netty/DefaultByteBufAllocatorConfiguration.java
+++ b/buffer-netty/src/main/java/io/micronaut/buffer/netty/DefaultByteBufAllocatorConfiguration.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.buffer.netty;
+
+import io.micronaut.context.annotation.BootstrapContextCompatible;
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.annotation.Order;
+import io.micronaut.core.order.Ordered;
+
+/**
+ * Allows configuring the default netty allocator. Note that Netty initializes the default
+ * allocator once from system properties, so once this is loaded it cannot be altered again
+ * for the lifecycle of the JVM.
+ *
+ * @see io.netty.buffer.ByteBufAllocator
+ * @author graemerocher
+ * @since 3.3.0
+ */
+@ConfigurationProperties(DefaultByteBufAllocatorConfiguration.DEFAULT_ALLOCATOR)
+@Requires(property = DefaultByteBufAllocatorConfiguration.DEFAULT_ALLOCATOR)
+@Context
+@BootstrapContextCompatible
+@Internal
+@Order(Ordered.HIGHEST_PRECEDENCE)
+final class DefaultByteBufAllocatorConfiguration implements ByteBufAllocatorConfiguration {
+
+    private static final String PROP_PREFIX = "io.netty.allocator.";
+
+    DefaultByteBufAllocatorConfiguration() {
+    }
+
+    /**
+     * @param numHeapArenas The number of heap arenas
+     */
+    @Override
+    public void setNumHeapArenas(@Nullable Integer numHeapArenas) {
+        if (numHeapArenas != null) {
+            System.setProperty(PROP_PREFIX + "numHeapArenas", numHeapArenas.toString());
+        }
+    }
+
+    /**
+     * @param numDirectArenas The number of direct arenas
+     */
+    @Override
+    public void setNumDirectArenas(@Nullable Integer numDirectArenas) {
+        if (numDirectArenas != null) {
+            System.setProperty(PROP_PREFIX + "numDirectArenas", numDirectArenas.toString());
+        }
+    }
+
+    /**
+     * @param pageSize The page size
+     */
+    @Override
+    public void setPageSize(@Nullable Integer pageSize) {
+        if (pageSize != null) {
+            System.setProperty(PROP_PREFIX + "pageSize", pageSize.toString());
+        }
+    }
+
+    /**
+     * @param maxOrder The max order
+     */
+    @Override
+    public void setMaxOrder(@Nullable Integer maxOrder) {
+        if (maxOrder != null) {
+            System.setProperty(PROP_PREFIX + "maxOrder", maxOrder.toString());
+        }
+    }
+
+    /**
+     * @param chunkSize The chunk size
+     */
+    @Override
+    public void setChunkSize(@Nullable Integer chunkSize) {
+        if (chunkSize != null) {
+            System.setProperty(PROP_PREFIX + "chunkSize", chunkSize.toString());
+        }
+    }
+
+    /**
+     * @param smallCacheSize The small cache size
+     */
+    @Override
+    public void setSmallCacheSize(@Nullable Integer smallCacheSize) {
+        if (smallCacheSize != null) {
+            System.setProperty(PROP_PREFIX + "smallCacheSize", smallCacheSize.toString());
+        }
+    }
+
+    /**
+     * @param normalCacheSize The normal cache size
+     */
+    @Override
+    public void setNormalCacheSize(@Nullable Integer normalCacheSize) {
+        if (normalCacheSize != null) {
+            System.setProperty(PROP_PREFIX + "normalCacheSize", normalCacheSize.toString());
+        }
+    }
+
+    /**
+     * @param useCacheForAllThreads Whether to use the cache for all threads
+     */
+    @Override
+    public void setUseCacheForAllThreads(@Nullable Boolean useCacheForAllThreads) {
+        if (useCacheForAllThreads != null) {
+            System.setProperty(PROP_PREFIX + "useCacheForAllThreads", useCacheForAllThreads.toString());
+        }
+    }
+
+    /**
+     * @param maxCachedBufferCapacity The max cached buffer capacity
+     */
+    @Override
+    public void setMaxCachedBufferCapacity(@Nullable Integer maxCachedBufferCapacity) {
+        if (maxCachedBufferCapacity != null) {
+            System.setProperty(PROP_PREFIX + "maxCachedBufferCapacity", maxCachedBufferCapacity.toString());
+        }
+    }
+
+    /**
+     * @param cacheTrimInterval The cache trim interval
+     */
+    @Override
+    public void setCacheTrimInterval(@Nullable Integer cacheTrimInterval) {
+        if (cacheTrimInterval != null) {
+            System.setProperty(PROP_PREFIX + "cacheTrimInterval", cacheTrimInterval.toString());
+        }
+    }
+
+    /**
+     * @param maxCachedByteBuffersPerChunk The max cached byte buffers per chunk
+     */
+    @Override
+    public void setMaxCachedByteBuffersPerChunk(@Nullable Integer maxCachedByteBuffersPerChunk) {
+        if (maxCachedByteBuffersPerChunk != null) {
+            System.setProperty(PROP_PREFIX + "maxCachedByteBuffersPerChunk", maxCachedByteBuffersPerChunk.toString());
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -224,3 +224,10 @@ tasks.named("updateVersionCatalogs") {
     // workaround Gradle variant selection problem
     ignoredModules.add("com.github.ben-manes.caffeine:caffeine")
 }
+
+allprojects {
+    tasks.withType(JavaCompile).configureEach {
+        options.fork = true
+        options.forkOptions.memoryMaximumSize = "1048m"
+    }
+}

--- a/http-netty/build.gradle
+++ b/http-netty/build.gradle
@@ -30,3 +30,7 @@ spotless {
                 '**/io/micronaut/http/netty/reactive/package-info.java'
     }
 }
+
+tasks.named("test", Test) {
+    forkEvery = 1
+}

--- a/http-netty/src/test/groovy/io/micronaut/http/netty/allocator/DefaultAllocatorSpec.groovy
+++ b/http-netty/src/test/groovy/io/micronaut/http/netty/allocator/DefaultAllocatorSpec.groovy
@@ -1,0 +1,52 @@
+package io.micronaut.http.netty.allocator
+
+import io.micronaut.context.ApplicationContext
+import io.netty.buffer.PooledByteBufAllocator
+import spock.lang.Specification
+import spock.lang.Stepwise
+import spock.lang.Unroll
+
+@Stepwise
+class DefaultAllocatorSpec extends Specification {
+
+    @Unroll
+    void "test default allocator config #name"() {
+        given:
+        def context = ApplicationContext.run(
+                ("netty.default.allocator." + name): value
+        )
+
+        expect:
+        System.getProperty("io.netty.allocator.$name") == value.toString()
+
+        cleanup:
+        context.close()
+
+        where:
+        name                           | value
+        'maxOrder'                     | 1
+        'pageSize'                     | 5
+        'chunkSize'                    | 2048
+        'smallCacheSize'               | 2048
+        'normalCacheSize'              | 2048
+        'maxCachedBufferCapacity'      | 2048
+        'useCacheForAllThreads'        | false
+        'numHeapArenas'                | 5
+        'numDirectArenas'              | 5
+        'cacheTrimInterval'            | 1000
+        'maxCachedByteBuffersPerChunk' | 20
+    }
+
+    void "test default allocator configured"() {
+        given:
+        def context = ApplicationContext.run(
+                ("netty.default.allocator.smallCacheSize"): 4096
+        )
+
+        expect:
+        PooledByteBufAllocator.DEFAULT.metric().smallCacheSize() == 4096
+
+        cleanup:
+        context.close()
+    }
+}


### PR DESCRIPTION
With the following configuration and this PR merged:

```
netty:
  default:
    allocator:
      max-order: 1
```

Memory consumption stays stable at around 24mb RSS after 5 requests. I conducted some brief benchmarking with `wrk` and it seems to make no difference performance wise for simple JSON messages.

We can perhaps consider making it a default for new apps in Launch that use Netty

Fixes #6623