### PR TITLE
Constant property sources shouldn't all be loaded

### DIFF
--- a/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
+++ b/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
@@ -99,7 +99,6 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
     private static final String DO_SYS_VENDOR_FILE = "/sys/devices/virtual/dmi/id/sys_vendor";
     private static final Boolean DEDUCE_ENVIRONMENT_DEFAULT = true;
     private static final List<String> DEFAULT_CONFIG_LOCATIONS = Arrays.asList("classpath:/", "file:config/");
-    private static final String DEFAULT_ENVIRONMENT_NAME = "default";
     protected final ClassPathResourceLoader resourceLoader;
     protected final List<PropertySource> refreshablePropertySources = new ArrayList<>(10);
 
@@ -430,13 +429,7 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
     }
 
     private void readConstantPropertySources(String name, List<PropertySource> propertySources) {
-        Set<String> propertySourceNames = Stream.concat(Stream.of(DEFAULT_ENVIRONMENT_NAME), getActiveNames().stream())
-                .map(env -> {
-                    if (DEFAULT_ENVIRONMENT_NAME.equals(env)) {
-                        return name;
-                    }
-                    return name + "-" + env;
-                })
+        Set<String> propertySourceNames = Stream.concat(Stream.of(name), getActiveNames().stream().map(env -> name + "-" + env))
                 .collect(Collectors.toSet());
         getConstantPropertySources().stream()
                 .filter(p -> propertySourceNames.contains(p.getName()))

--- a/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
+++ b/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
@@ -438,9 +438,13 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
                     return name + "-" + env;
                 })
                 .collect(Collectors.toSet());
-        CONSTANT_PROPERTY_SOURCES.stream()
+        getConstantPropertySources().stream()
                 .filter(p -> propertySourceNames.contains(p.getName()))
                 .forEach(propertySources::add);
+    }
+
+    protected List<PropertySource> getConstantPropertySources() {
+        return CONSTANT_PROPERTY_SOURCES;
     }
 
     /**

--- a/inject/src/test/groovy/io/micronaut/context/env/ConstantPropertySourceSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/env/ConstantPropertySourceSpec.groovy
@@ -1,0 +1,47 @@
+package io.micronaut.context.env
+
+import io.micronaut.runtime.Micronaut
+import spock.lang.Specification
+
+class ConstantPropertySourceSpec extends Specification {
+    def "constant property sources are loaded conditionally based on the active environments"() {
+        def env = new DefaultEnvironment(Micronaut.build().environments(name)) {
+            @Override
+            protected List<PropertySource> getConstantPropertySources() {
+                [
+                        propertySource('application'),
+                        propertySource('application-dev'),
+                        propertySource('application-cloud'),
+                        propertySource('application-other', ['other':'value'])
+                ]
+            }
+        }
+        env.start()
+
+        expect:
+        def property = env.getProperty("some.conf", String)
+        property.present
+        property.get() == expectedValue
+        !env.getProperty('other', String).present
+
+        cleanup:
+        env.stop()
+
+        where:
+        name      | expectedValue
+        "default" | 'application'
+        "dev"     | "application-dev"
+        "cloud"   | "application-cloud"
+
+    }
+
+    private static TestPropertySource propertySource(String name, Map<String, String> values = [:]) {
+        return new TestPropertySource(name, values)
+    }
+
+    private static class TestPropertySource extends MapPropertySource {
+        TestPropertySource(String name, Map<String, String> values) {
+            super(name, ['some.conf': name] + values)
+        }
+    }
+}


### PR DESCRIPTION
This commit fixes a bug in how "constant" property sources are loaded.
Constant property sources are property sources which are generated by
Micronaut AOT, for example by converting YAML configuration files to
Java.

Once they are converted, they are added as property sources. However,
if more than one configuration file is converted, for example if
we convert `application.yml` and `application-test.yml`, then both
configurations would be applied at startup, even if the `test`
environment isn't set.

This commit fixes the bug by making sure that the constant property
sources are filtered by active environments.

See https://github.com/micronaut-projects/micronaut-aot/pull/37