### PR TITLE
Fix bug with resolving bindings from AnnotationMetadataHierarchy

### DIFF
--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationMetadata.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationMetadata.java
@@ -181,6 +181,18 @@ public interface AnnotationMetadata extends AnnotationSource {
     }
 
     /**
+     * Gets all the annotation values by the given repeatable type name.
+     *
+     * @param annotationType The annotation type
+     * @param <T> The annotation type
+     * @return A list of values
+     * @since 3.3.0
+     */
+    default @NonNull <T extends Annotation> List<AnnotationValue<T>> getAnnotationValuesByName(@NonNull String annotationType) {
+        return Collections.emptyList();
+    }
+
+    /**
      * Gets only declared annotation values by the given repeatable type.
      *
      * @param annotationType The annotation type
@@ -188,6 +200,18 @@ public interface AnnotationMetadata extends AnnotationSource {
      * @return A list of values
      */
     default @NonNull <T extends Annotation> List<AnnotationValue<T>> getDeclaredAnnotationValuesByType(@NonNull Class<T> annotationType) {
+        return Collections.emptyList();
+    }
+
+    /**
+     * Gets only declared annotation values by the given repeatable type name.
+     *
+     * @param annotationType The annotation type
+     * @param <T> The annotation type
+     * @return A list of values
+     * @since 3.3.0
+     */
+    default @NonNull <T extends Annotation> List<AnnotationValue<T>> getDeclaredAnnotationValuesByName(@NonNull String annotationType) {
         return Collections.emptyList();
     }
 

--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationMetadata.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationMetadata.java
@@ -186,7 +186,7 @@ public interface AnnotationMetadata extends AnnotationSource {
      * @param annotationType The annotation type
      * @param <T> The annotation type
      * @return A list of values
-     * @since 3.3.0
+     * @since 3.2.4
      */
     default @NonNull <T extends Annotation> List<AnnotationValue<T>> getAnnotationValuesByName(@NonNull String annotationType) {
         return Collections.emptyList();
@@ -209,7 +209,7 @@ public interface AnnotationMetadata extends AnnotationSource {
      * @param annotationType The annotation type
      * @param <T> The annotation type
      * @return A list of values
-     * @since 3.3.0
+     * @since 3.2.4
      */
     default @NonNull <T extends Annotation> List<AnnotationValue<T>> getDeclaredAnnotationValuesByName(@NonNull String annotationType) {
         return Collections.emptyList();

--- a/inject-java/src/test/groovy/io/micronaut/inject/annotation/AnnotationMetadataWriterSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/annotation/AnnotationMetadataWriterSpec.groovy
@@ -595,6 +595,79 @@ class Test {
         properties[4].getValue(String).get() == "value3"
     }
 
+    void "test repeatable annotations are combined, lookup by name"() {
+        BeanDefinition definition = buildBeanDefinition('test.Test', '''\
+package test;
+
+import io.micronaut.inject.annotation.repeatable.*;
+import io.micronaut.context.annotation.*;
+
+@Property(name="prop1", value="value1")
+@Property(name="prop2", value="value2")
+@Property(name="prop3", value="value3")
+@jakarta.inject.Singleton
+class Test {
+
+    @Property(name="prop2", value="value2")    
+    @Property(name="prop3", value="value33")    
+    @Property(name="prop4", value="value4")    
+    @io.micronaut.context.annotation.Executable
+    void someMethod() {}
+}
+''')
+
+        when:
+        AnnotationMetadata metadata = definition.getRequiredMethod("someMethod").getAnnotationMetadata()
+
+        then:
+        List<AnnotationValue<?>> properties = metadata.getAnnotationValuesByName(Property.name)
+
+        then:
+        properties.size() == 5
+        properties[0].get("name", String).get() == "prop2"
+        properties[1].get("name", String).get() == "prop3"
+        properties[1].getValue(String).get() == "value33"
+        properties[2].get("name", String).get() == "prop4"
+        properties[3].get("name", String).get() == "prop1"
+        properties[4].get("name", String).get() == "prop3"
+        properties[4].getValue(String).get() == "value3"
+    }
+
+    void "test declared repeatable annotations are combined, lookup by name"() {
+        BeanDefinition definition = buildBeanDefinition('test.Test', '''\
+package test;
+
+import io.micronaut.inject.annotation.repeatable.*;
+import io.micronaut.context.annotation.*;
+
+@Property(name="prop1", value="value1")
+@Property(name="prop2", value="value2")
+@Property(name="prop3", value="value3")
+@jakarta.inject.Singleton
+class Test {
+
+    @Property(name="prop2", value="value2")    
+    @Property(name="prop3", value="value33")    
+    @Property(name="prop4", value="value4")    
+    @io.micronaut.context.annotation.Executable
+    void someMethod() {}
+}
+''')
+
+        when:
+        AnnotationMetadata metadata = definition.getRequiredMethod("someMethod").getAnnotationMetadata()
+
+        then:
+        List<AnnotationValue<?>> properties = metadata.getDeclaredAnnotationValuesByName(Property.name)
+
+        then:
+        properties.size() == 3
+        properties[0].get("name", String).get() == "prop2"
+        properties[1].get("name", String).get() == "prop3"
+        properties[1].getValue(String).get() == "value33"
+        properties[2].get("name", String).get() == "prop4"
+    }
+
     void "test annotation metadata string value array types"() {
         given:
         AnnotationMetadata metadata = buildTypeAnnotationMetadata('''

--- a/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataHierarchy.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataHierarchy.java
@@ -417,8 +417,8 @@ public final class AnnotationMetadataHierarchy implements AnnotationMetadata, En
     @NonNull
     @Override
     public <T extends Annotation> List<AnnotationValue<T>> getAnnotationValuesByType(@NonNull Class<T> annotationType) {
-        List<AnnotationValue<T>> list = new ArrayList<>();
-        Set<AnnotationValue<T>> uniqueValues = new HashSet<>();
+        List<AnnotationValue<T>> list = new ArrayList<>(10);
+        Set<AnnotationValue<T>> uniqueValues = new HashSet<>(10);
         for (AnnotationMetadata am : hierarchy) {
             for (AnnotationValue<T> tAnnotationValue : am.getAnnotationValuesByType(annotationType)) {
                 if (uniqueValues.add(tAnnotationValue)) {
@@ -429,10 +429,32 @@ public final class AnnotationMetadataHierarchy implements AnnotationMetadata, En
         return list;
     }
 
+    @Override
+    public <T extends Annotation> List<AnnotationValue<T>> getAnnotationValuesByName(String annotationType) {
+        if (annotationType == null) {
+            return Collections.emptyList();
+        }
+        List<AnnotationValue<T>> list = new ArrayList<>(10);
+        Set<AnnotationValue<T>> uniqueValues = new HashSet<>(10);
+        for (AnnotationMetadata am : hierarchy) {
+            for (AnnotationValue<T> tAnnotationValue : am.<T>getAnnotationValuesByName(annotationType)) {
+                if (uniqueValues.add(tAnnotationValue)) {
+                    list.add(tAnnotationValue);
+                }
+            }
+        }
+        return Collections.unmodifiableList(list);
+    }
+
     @NonNull
     @Override
     public <T extends Annotation> List<AnnotationValue<T>> getDeclaredAnnotationValuesByType(@NonNull Class<T> annotationType) {
         return hierarchy[0].getDeclaredAnnotationValuesByType(annotationType);
+    }
+
+    @Override
+    public <T extends Annotation> List<AnnotationValue<T>> getDeclaredAnnotationValuesByName(String annotationType) {
+        return hierarchy[0].getDeclaredAnnotationValuesByName(annotationType);
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/inject/annotation/DefaultAnnotationMetadata.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/DefaultAnnotationMetadata.java
@@ -94,7 +94,7 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     Map<String, Map<CharSequence, Object>> annotationDefaultValues;
     Map<String, String> repeated = null;
 
-    private Map<Class, List> annotationValuesByType = new ConcurrentHashMap<>(2);
+    private Map<String, List> annotationValuesByType = new ConcurrentHashMap<>(2);
     private Set<String> sourceRetentionAnnotations;
     private final boolean hasPropertyExpressions;
     // This should be removed in the next major version
@@ -999,16 +999,50 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     public @NonNull
     <T extends Annotation> List<AnnotationValue<T>> getAnnotationValuesByType(@Nullable Class<T> annotationType) {
         if (annotationType != null) {
-            List<AnnotationValue<T>> results = annotationValuesByType.get(annotationType);
+            final String annotationTypeName = annotationType.getName();
+            List<AnnotationValue<T>> results = annotationValuesByType.get(annotationTypeName);
             if (results == null) {
 
                 results = resolveAnnotationValuesByType(annotationType, allAnnotations, allStereotypes);
                 if (results != null) {
                     return results;
                 } else if (allAnnotations != null) {
-                    final Map<CharSequence, Object> values = allAnnotations.get(annotationType.getName());
+                    final Map<CharSequence, Object> values = allAnnotations.get(annotationTypeName);
                     if (values != null) {
-                        results = Collections.singletonList(new AnnotationValue<>(annotationType.getName(), values));
+                        results = Collections.singletonList(new AnnotationValue<>(annotationTypeName, values));
+                    }
+                }
+
+                if (results == null) {
+                    results = Collections.emptyList();
+                }
+                annotationValuesByType.put(annotationTypeName, results);
+            }
+            return results;
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public <T extends Annotation> List<AnnotationValue<T>> getAnnotationValuesByName(String annotationType) {
+        if (annotationType != null) {
+            String repeatableTypeName = getRepeatedName(annotationType);
+            if (repeatableTypeName == null) {
+                repeatableTypeName = AnnotationMetadataSupport.getRepeatableAnnotation(annotationType);
+            }
+            if (repeatableTypeName != null) {
+
+                List<AnnotationValue<T>> results =
+                        resolveRepeatableAnnotations(repeatableTypeName,
+                                                     allAnnotations,
+                                                     allStereotypes
+                );
+                if (results != null) {
+                    return results;
+                } else if (allAnnotations != null) {
+                    final Map<CharSequence, Object> values = allAnnotations.get(annotationType);
+                    if (values != null) {
+                        results = Collections.singletonList(new AnnotationValue<>(annotationType, values));
                     }
                 }
 
@@ -1017,7 +1051,6 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
                 }
                 annotationValuesByType.put(annotationType, results);
             }
-            return results;
         }
         return Collections.emptyList();
     }
@@ -1030,6 +1063,27 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
             Map<String, Map<CharSequence, Object>> sourceStereotypes = this.declaredStereotypes;
 
             List<AnnotationValue<T>> results = resolveAnnotationValuesByType(annotationType, sourceAnnotations, sourceStereotypes);
+            if (results != null) {
+                return results;
+            }
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public <T extends Annotation> List<AnnotationValue<T>> getDeclaredAnnotationValuesByName(String annotationType) {
+        if (annotationType != null) {
+            Map<String, Map<CharSequence, Object>> sourceAnnotations = this.declaredAnnotations;
+            Map<String, Map<CharSequence, Object>> sourceStereotypes = this.declaredStereotypes;
+            String repeatableTypeName = getRepeatedName(annotationType);
+            if (repeatableTypeName == null) {
+                repeatableTypeName = AnnotationMetadataSupport.getRepeatableAnnotation(annotationType);
+            }
+            List<AnnotationValue<T>> results =
+                    resolveRepeatableAnnotations(repeatableTypeName,
+                                                 sourceAnnotations,
+                                                 sourceStereotypes
+                    );
             if (results != null) {
                 return results;
             }
@@ -1756,20 +1810,32 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
         Repeatable repeatable = annotationType.getAnnotation(Repeatable.class);
         if (repeatable != null) {
             Class<? extends Annotation> repeatableType = repeatable.value();
-            if (hasStereotype(repeatableType)) {
-                List<io.micronaut.core.annotation.AnnotationValue<T>> results = new ArrayList<>();
-                if (sourceAnnotations != null) {
-                    Map<CharSequence, Object> values = sourceAnnotations.get(repeatableType.getName());
-                    addAnnotationValuesFromData(results, values);
-                }
+            final String repeatableTypeName = repeatableType.getName();
+            return resolveRepeatableAnnotations(repeatableTypeName,
+                                                sourceStereotypes,
+                                                sourceAnnotations
+            );
+        }
+        return null;
+    }
 
-                if (sourceStereotypes != null) {
-                    Map<CharSequence, Object> values = sourceStereotypes.get(repeatableType.getName());
-                    addAnnotationValuesFromData(results, values);
-                }
-
-                return results;
+    @Nullable
+    private <T extends Annotation> List<AnnotationValue<T>> resolveRepeatableAnnotations(String repeatableTypeName,
+                                                                                         Map<String, Map<CharSequence, Object>> sourceStereotypes,
+                                                                                         Map<String, Map<CharSequence, Object>> sourceAnnotations) {
+        if (hasStereotype(repeatableTypeName)) {
+            List<AnnotationValue<T>> results = new ArrayList<>();
+            if (sourceAnnotations != null) {
+                Map<CharSequence, Object> values = sourceAnnotations.get(repeatableTypeName);
+                addAnnotationValuesFromData(results, values);
             }
+
+            if (sourceStereotypes != null) {
+                Map<CharSequence, Object> values = sourceStereotypes.get(repeatableTypeName);
+                addAnnotationValuesFromData(results, values);
+            }
+
+            return results;
         }
         return null;
     }

--- a/inject/src/main/java/io/micronaut/inject/qualifiers/InterceptorBindingQualifier.java
+++ b/inject/src/main/java/io/micronaut/inject/qualifiers/InterceptorBindingQualifier.java
@@ -107,18 +107,19 @@ public final class InterceptorBindingQualifier<T> implements Qualifier<T> {
     }
 
     public static List<String> resolveInterceptorValues(AnnotationMetadata annotationMetadata, @Nullable String kind) {
-        AnnotationValue<?> bindings = annotationMetadata
-                .getAnnotation(AnnotationUtil.ANN_INTERCEPTOR_BINDINGS);
-        if (bindings != null) {
-            return bindings.getAnnotations(AnnotationMetadata.VALUE_MEMBER)
+        List<AnnotationValue<Annotation>> bindings = annotationMetadata
+                .getAnnotationValuesByName(AnnotationUtil.ANN_INTERCEPTOR_BINDING);
+        if (CollectionUtils.isNotEmpty(bindings)) {
+            return bindings
                     .stream()
                     .filter(av -> {
                         final String specifiedkind = av.stringValue("kind").orElse(null);
                         return kind == null || specifiedkind == null || specifiedkind.equals(kind);
                     })
-                    .map(AnnotationValue::stringValue)
-                    .filter(Optional::isPresent)
-                    .map(Optional::get)
+                    .flatMap(av -> {
+                        final String v = av.stringValue().orElse(null);
+                        return v != null ? Stream.of(v) : Stream.empty();
+                    })
                     .collect(Collectors.toList());
         } else {
             return Collections.emptyList();


### PR DESCRIPTION
`InterceptorBindingQualifier` uses the `getAnnotation` method which doesn't resolve the interceptor bindings from type level correctly. Because this type is in the `inject` module it can't reference the `getAnnotationValuesByType` so this PR adds `getAnnotationValuesByName` that allows to use the repeatable name only to resolve the correct values.

I considered targeting 3.3.x for this but this is also a genuine bug so IMO should go into the next 3.2.x release.