### PR TITLE
Use java.util.function.Supplier instead of directly initializing LOGGER

### DIFF
--- a/core/src/main/java/io/micronaut/core/io/service/SoftServiceLoader.java
+++ b/core/src/main/java/io/micronaut/core/io/service/SoftServiceLoader.java
@@ -19,6 +19,7 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.optim.StaticOptimizations;
 import io.micronaut.core.reflect.ClassUtils;
+import io.micronaut.core.util.SupplierUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,7 +63,7 @@ import java.util.stream.Stream;
 public final class SoftServiceLoader<S> implements Iterable<ServiceDefinition<S>> {
     public static final String META_INF_SERVICES = "META-INF/services";
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(SoftServiceLoader.class);
+    private static final Supplier<Logger> LOGGER = SupplierUtil.memoized(() -> LoggerFactory.getLogger(SoftServiceLoader.class));
 
     private static final Map<String, SoftServiceLoader.StaticServiceLoader<?>> STATIC_SERVICES =
             StaticOptimizations.get(Optimizations.class)
@@ -160,7 +161,7 @@ public final class SoftServiceLoader<S> implements Iterable<ServiceDefinition<S>
             op.run();
         } finally {
             long dur = System.nanoTime() - sd;
-            LOGGER.debug(label + " took " + TimeUnit.MILLISECONDS.convert(dur, TimeUnit.NANOSECONDS) + "ms");
+            LOGGER.get().debug(label + " took " + TimeUnit.MILLISECONDS.convert(dur, TimeUnit.NANOSECONDS) + "ms");
         }
     }
 
@@ -180,7 +181,7 @@ public final class SoftServiceLoader<S> implements Iterable<ServiceDefinition<S>
             } else {
                 collectDynamicServices(values, predicate, name);
             }
-            LOGGER.debug("Loaded {} services of type {}", values.size(), name);
+            LOGGER.get().debug("Loaded {} services of type {}", values.size(), name);
         });
     }
 


### PR DESCRIPTION
The problem with the current implementation is that in Grails® framework applicatio (version 5.1.1), the compilation fails because the class `SoftServiceLoader` will try to initialize LOGGER during compilation and result in `MultipleCompilationErrorsException`. Please check https://github.com/grails/grails-core/issues/12291 for more information. In this commit, we are using `java.util.function.Supplier` instead of directly initializing the LOGGER which will make sure it is initialized after compilation.

Fixes #6691 and so grails/grails-core#12291