### PR TITLE
Introduce a static optimizations loader

### DIFF
--- a/core/src/main/java/io/micronaut/core/optim/StaticOptimizations.java
+++ b/core/src/main/java/io/micronaut/core/optim/StaticOptimizations.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -36,9 +37,26 @@ import java.util.concurrent.ConcurrentHashMap;
 @Internal
 public abstract class StaticOptimizations {
     private static final Logger LOGGER = LoggerFactory.getLogger(StaticOptimizations.class);
+    private static final boolean CAPTURE_STACKTRACE_ON_READ = Boolean.getBoolean("micronaut.optimizations.capture.read.trace");
 
     private static final Map<Class<?>, Object> OPTIMIZATIONS = new ConcurrentHashMap<>();
+    private static final Map<Class<?>, StackTraceElement[]> CHECKED = new ConcurrentHashMap<>();
+
     private static boolean cacheEnvironment = false;
+
+    static {
+        reset();
+    }
+
+    /**
+     * Resets the internal state of the optimization container.
+     * Visible for testing.
+     */
+    static void reset() {
+        OPTIMIZATIONS.clear();
+        CHECKED.clear();
+        ServiceLoader.load(Loader.class).forEach(loader -> set(loader.load()));
+    }
 
     /**
      * Enables environment caching. If enabled, both the environment variables
@@ -59,6 +77,7 @@ public abstract class StaticOptimizations {
      */
     @NonNull
     public static <T> Optional<T> get(@NonNull Class<T> optimizationClass) {
+        CHECKED.put(optimizationClass, maybeCaptureStackTrace());
         T value = (T) OPTIMIZATIONS.get(optimizationClass);
         if (value != null) {
             LOGGER.debug("Found optimizations {}", optimizationClass);
@@ -66,6 +85,13 @@ public abstract class StaticOptimizations {
             LOGGER.debug("No optimizations {} found", optimizationClass);
         }
         return Optional.ofNullable(value);
+    }
+
+    private static StackTraceElement[] maybeCaptureStackTrace() {
+        if (CAPTURE_STACKTRACE_ON_READ) {
+            return new Exception().getStackTrace();
+        }
+        return new StackTraceElement[0];
     }
 
     /**
@@ -77,6 +103,17 @@ public abstract class StaticOptimizations {
      */
     public static <T> void set(@NonNull T value) {
         Class<?> optimizationClass = value.getClass();
+        if (CHECKED.containsKey(optimizationClass)) {
+            if (!CAPTURE_STACKTRACE_ON_READ) {
+                throw new IllegalStateException("Optimization state for " + optimizationClass + " was read before it was set. Run with -Dmicronaut.optimizations.capture.read.trace=true to enable stack trace capture.");
+            }
+            StringBuilder sb = new StringBuilder("Optimization state for " + optimizationClass + " was read before it was set. Stack trace:\n");
+            StackTraceElement[] stackTrace = CHECKED.get(optimizationClass);
+            for (StackTraceElement element : stackTrace) {
+                sb.append("\t").append(element.toString()).append("\n");
+            }
+            throw new IllegalStateException(sb.toString());
+        }
         LOGGER.debug("Setting optimizations for {}", optimizationClass);
         OPTIMIZATIONS.put(optimizationClass, value);
     }
@@ -89,5 +126,22 @@ public abstract class StaticOptimizations {
      */
     public static boolean isEnvironmentCached() {
         return cacheEnvironment;
+    }
+
+    /**
+     * Interface for an optimization which will be injected via
+     * service loading.
+     *
+     * @param <T> the type of the optimization
+     * @since 3.3.0
+     */
+    @FunctionalInterface
+    public interface Loader<T> {
+        /**
+         * The static optimization to be injected. The {@link StaticOptimizations#set(Object)} method
+         * will automatically be called with the value returned by this method.
+         * @return the optimization value.
+         */
+        T load();
     }
 }

--- a/core/src/test/groovy/io/micronaut/core/optim/StaticOptimizationsTest.groovy
+++ b/core/src/test/groovy/io/micronaut/core/optim/StaticOptimizationsTest.groovy
@@ -3,6 +3,10 @@ package io.micronaut.core.optim
 import spock.lang.Specification
 
 class StaticOptimizationsTest extends Specification {
+    def setup() {
+        StaticOptimizations.reset()
+    }
+
     void "environment isn't cached by default"() {
         expect:
         !StaticOptimizations.environmentCached
@@ -16,6 +20,7 @@ class StaticOptimizationsTest extends Specification {
 
         then:
         !opt.present
+        StaticOptimizations.reset()
 
         when:
         StaticOptimizations.set(testOptimizations)
@@ -35,9 +40,45 @@ class StaticOptimizationsTest extends Specification {
         !StaticOptimizations.get(TestOptimizations2).present
     }
 
+    def "writing optimizations after reading is disallowed"() {
+        def testOptimizations = new TestOptimizations()
+
+        when:
+        def opt = StaticOptimizations.get(TestOptimizations)
+
+        then:
+        !opt.present
+
+        when:
+        StaticOptimizations.set(testOptimizations)
+
+        then:
+        RuntimeException ex = thrown()
+        ex.message.contains("Optimization state for class io.micronaut.core.optim.StaticOptimizationsTest\$TestOptimizations was read before it was set.")
+
+    }
+
+    def "optimizations are loaded via service loading"() {
+        when:
+        def opt = StaticOptimizations.get(TestOptimizations3)
+
+        then:
+        opt.present
+    }
+
     static class TestOptimizations {
     }
 
     static class TestOptimizations2 {
+    }
+
+    static class TestOptimizations3 {
+    }
+
+    static class TestOptimizationsLoader implements StaticOptimizations.Loader<TestOptimizations3> {
+        @Override
+        TestOptimizations3 load() {
+            new TestOptimizations3()
+        }
     }
 }

--- a/core/src/test/resources/META-INF/services/io.micronaut.core.optim.StaticOptimizations$Loader
+++ b/core/src/test/resources/META-INF/services/io.micronaut.core.optim.StaticOptimizations$Loader
@@ -1,0 +1,1 @@
+io.micronaut.core.optim.StaticOptimizationsTest$TestOptimizationsLoader


### PR DESCRIPTION
This commit introduces loading of "static optimizations" via service loading.
The reason we have to do this is, again, _ordering_. When implementing AOT
optimizations for lambdas, we realized that it was possible for some classes
on classpath to call the `SoftServiceLoader` in a static initializer, _before_
the static optimizations were set. The consequence of doing this is that once
the AOT optimizer has optimized service loading, then no service would be
found because when this call is made, the optimizations are not injected yet.

As a consequence, we also introduced a sanity check to make sure that the
static optimizations `get()` method are only called _after_ the `set()`
method was called. It is illegal to set an optimization after the first
consumer has read its state.

Ideally, we should get rid of static initializers in beans, but there's a
long way to go. This commit therefore introduces a pragmatic solution to
make sure that optimizations are always set before any consumer accesses
them.

This will also require a change in Micronaut AOT to use this new API,
instead of injecting optimizations via a static block in a generated
context configurer.