### PR TITLE
Avoid double-free in content branch of NettyHttpRequest.buildBody

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpRequest.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpRequest.java
@@ -304,7 +304,8 @@ public class NettyHttpRequest<T> extends AbstractNettyHttpRequest<T> implements 
             for (ByteBufHolder holder : receivedContent) {
                 ByteBuf content = holder.content();
                 if (content != null) {
-                    byteBufs.addComponent(true, content);
+                    // need to retain content, because for addComponent "ownership of buffer is transferred to this CompositeByteBuf."
+                    byteBufs.addComponent(true, content.retain());
                 }
             }
             return byteBufs;

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/FormDataDiskSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/FormDataDiskSpec.groovy
@@ -41,6 +41,31 @@ class FormDataDiskSpec extends Specification {
         client.stop()
     }
 
+    @Issue('https://github.com/micronaut-projects/micronaut-core/issues/6705')
+    void "test parsing form to map with mixed attributes"() {
+        given:
+        def server = (EmbeddedServer) ApplicationContext.run(EmbeddedServer, [
+                'micronaut.server.multipart.mixed': true,
+                'micronaut.server.thread-selection': 'IO',
+                'netty.resource-leak-detector-level': 'paranoid'
+        ])
+        def client = server.applicationContext.createBean(HttpClient, server.URI)
+
+        when:
+        HttpResponse<?> response = Flux.from(client.exchange(HttpRequest.POST('/form-disk/object', [
+                name:"Fred",
+        ]).contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE), String)).blockFirst()
+
+        then:
+        response.status == HttpStatus.OK
+        response.body.isPresent()
+        response.body.get() == 'Fred'
+
+        cleanup:
+        server.stop()
+        client.stop()
+    }
+
     @Controller(value = '/form-disk', consumes = MediaType.APPLICATION_FORM_URLENCODED)
     static class FormController {
         @Post('/object')


### PR DESCRIPTION
When concatenating `receivedContent` data into a CompositeByteBuf, we call `addComponent` with the content buffers of the individual `receivedContent` items. `addComponent` takes "ownership" of the buffers, so we need to retain them once so that freeing the composite buffer does not free the `receivedContent` items.