### PR TITLE
Apple M1 chipset results in correct classifier

### DIFF
--- a/http-server-netty/build.gradle
+++ b/http-server-netty/build.gradle
@@ -1,3 +1,4 @@
+import org.apache.tools.ant.taskdefs.condition.Os
 
 internalSanityChecks {
     expectedServiceCount.put('io.micronaut.inject.BeanDefinitionReference', 24)
@@ -56,7 +57,7 @@ dependencies {
     }
     testImplementation(libs.managed.netty.transport.native.kqueue) {
         artifact {
-            classifier = "osx-x86_64"
+            classifier = Os.isArch("aarch64") ? "osx-aarch_64" : "osx-x86_64"
         }
     }
     testImplementation libs.managed.logback

--- a/src/main/docs/guide/httpServer/http2Server.adoc
+++ b/src/main/docs/guide/httpServer/http2Server.adoc
@@ -31,16 +31,16 @@ For production, see the <<https, configuring HTTPS>> section of the documentatio
 
 Note that if your deployment environment uses JDK 8, or for improved support for OpenSSL, define the following dependencies on Netty Tomcat Native:
 
-dependency:io.netty:netty-tcnative:2.0.40.Final[scope="runtimeOnly"]
+dependency:io.netty:netty-tcnative:2.0.46.Final[scope="runtimeOnly"]
 
-dependency:io.netty:netty-tcnative-boringssl-static:2.0.40.Final[scope="runtimeOnly"]
+dependency:io.netty:netty-tcnative-boringssl-static:2.0.46.Final[scope="runtimeOnly"]
 
 In addition to a dependency on the appropriate native library for your architecture. For example:
 
 .Configuring Tomcat Native
 [source,groovy]
 ----
-runtimeOnly "io.netty:netty-tcnative-boringssl-static:2.0.40.Final:${Os.isFamily(Os.FAMILY_MAC) ? 'osx-x86_64' : 'linux-x86_64'}"
+runtimeOnly "io.netty:netty-tcnative-boringssl-static:2.0.46.Final:${Os.isFamily(Os.FAMILY_MAC) ? (Os.isArch("aarch64") ? "osx-aarch_64" : "osx-x86_64") : 'linux-x86_64'}"
 ----
 
 See the documentation on https://netty.io/wiki/forked-tomcat-native.html[Tomcat Native] for more information.

--- a/src/main/docs/guide/httpServer/serverConfiguration.adoc
+++ b/src/main/docs/guide/httpServer/serverConfiguration.adoc
@@ -29,9 +29,13 @@ The native Netty transports add features specific to a particular platform, gene
 
 To enable native transports, first add a dependency:
 
-For macOS:
+For macOS on x86:
 
 dependency:netty-transport-native-kqueue[groupId="io.netty",scope="runtime",classifier="osx-x86_64"]
+
+For macOS on M1:
+
+dependency:netty-transport-native-kqueue[groupId="io.netty",scope="runtime",classifier="osx-aarch_64"]
 
 For Linux on x86:
 

--- a/test-suite/build.gradle
+++ b/test-suite/build.gradle
@@ -71,7 +71,7 @@ dependencies {
     testImplementation libs.netty.tcnative.boringssl
     testImplementation(libs.netty.tcnative.boringssl) {
         artifact {
-            classifier = Os.isFamily(Os.FAMILY_MAC) ? 'osx-x86_64' : 'linux-x86_64'
+            classifier = Os.isFamily(Os.FAMILY_MAC) ? (Os.isArch("aarch64") ? "osx-aarch_64" : "osx-x86_64") : 'linux-x86_64'
         }
     }
     testImplementation libs.logbook.netty


### PR DESCRIPTION
When running `./gradlew check` on an Apple M1 laptop (using an ARM JVM),
the build fails as netty falls-back to using the NioServerSocketChannel

https://ge.micronaut.io/s/2pwala4fjpkfw/tests/:http-server-netty:test/io.micronaut.http.server.netty.nativetransport.MacNativeTransportSpec/test%20a%20basic%20request%20works%20with%20mac%20native%20transport?top-execution=1

By adding calls to `Os.isArch("aarch64")` when running on a Mac,  and setting
the classifier accordingly, this test passes again.

https://ge.micronaut.io/s/pd7at77bweeng/tests/overview?test=test%20a%20basic%20request%20works%20with%20mac%20native%20transport

I believe this Os.isArch() call reads the value from the JVM, so people
running a x86 JVM through Rosetta will still pull the wrong native library.

I also updated the docs to include M1 instructions, and [increased the version in the http2Server.adoc](https://github.com/micronaut-projects/micronaut-core/commit/e522544e41c046255ef22b60d2c7197900663abf#diff-d6ee970e417e951d930c0aa80825b4b95b6f60fe40575e5b12a6131d6a2194a4) to the latest (`2.0.40.Final` did not have an aarch_64 build)