### PR TITLE
Allow @Inherited annotations for nullability

### DIFF
--- a/core/src/main/java/io/micronaut/core/annotation/AnnotatedElement.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotatedElement.java
@@ -29,27 +29,27 @@ public interface AnnotatedElement extends AnnotationMetadataProvider, Named {
      * @return Whether the element is nullable.
      */
     default boolean isDeclaredNullable() {
-        return getAnnotationMetadata().hasDeclaredAnnotation(AnnotationUtil.NULLABLE);
+        return getAnnotationMetadata().hasDeclaredStereotype(AnnotationUtil.NULLABLE);
     }
 
     /**
      * @return Whether the element is nullable.
      */
     default boolean isNullable() {
-        return getAnnotationMetadata().hasAnnotation(AnnotationUtil.NULLABLE);
+        return getAnnotationMetadata().hasStereotype(AnnotationUtil.NULLABLE);
     }
 
     /**
      * @return Whether the element is declared as not being null
      */
     default boolean isNonNull() {
-        return getAnnotationMetadata().hasAnnotation(AnnotationUtil.NON_NULL);
+        return getAnnotationMetadata().hasStereotype(AnnotationUtil.NON_NULL);
     }
 
     /**
      * @return Whether the element is declared as not being null
      */
     default boolean isDeclaredNonNull() {
-        return getAnnotationMetadata().hasDeclaredAnnotation(AnnotationUtil.NON_NULL);
+        return getAnnotationMetadata().hasDeclaredStereotype(AnnotationUtil.NON_NULL);
     }
 }

--- a/core/src/test/groovy/io/micronaut/core/bind/ExecutableBinderSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/bind/ExecutableBinderSpec.groovy
@@ -74,7 +74,7 @@ class ExecutableBinderSpec extends Specification {
         given:
 
         AnnotationMetadata annotationMetadata = Mock(AnnotationMetadata)
-        annotationMetadata.hasAnnotation(AnnotationUtil.NULLABLE) >> true
+        annotationMetadata.hasStereotype(AnnotationUtil.NULLABLE) >> true
         annotationMetadata.getAnnotationTypeByStereotype(_) >> Optional.empty()
 
         Executable executable = new Executable() {

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/annotation/InheritedNullableAnnotationSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/annotation/InheritedNullableAnnotationSpec.groovy
@@ -1,0 +1,59 @@
+package io.micronaut.inject.annotation
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+
+class InheritedNullableAnnotationSpec extends AbstractTypeElementSpec {
+
+    def "custom inherited nullable annotations can be defined and used"() {
+        given:
+        def introspection = buildBeanDefinition('test.ControllerImplementation', '''
+package test;
+
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Header;
+import io.micronaut.core.annotation.Nullable;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Controller
+class ControllerImplementation implements ControllerInterface {
+    @Get("/defined")
+    public String defined(@Nullable @Header(value = "header1") String header1) {
+        return header1;
+    }
+
+    @Override
+    public String inherited(String header1) {
+        return header1;
+    }
+}
+
+@Controller
+interface ControllerInterface {
+
+    @Get(value = "/inherited", produces = { "application/json" })
+    default String inherited(@InheritedNullable @Header(value = "header1") String header1) {
+        return header1;
+    }
+}
+
+@Inherited
+@Target({ElementType.METHOD, ElementType.PARAMETER, ElementType.FIELD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Nullable
+@interface InheritedNullable {
+}
+''')
+        def definedArgument = introspection.findMethod('defined', String).get().arguments.first()
+        def inheritedArgument = introspection.findMethod('inherited', String).get().arguments.first()
+
+        expect:
+        definedArgument.isNullable()
+        inheritedArgument.isNullable()
+    }
+}


### PR DESCRIPTION
Defining a @Nullable @Inherited annotation class does not mean the nullability
was inherited by sub classes.

The issue is that we were not checking the stereotypes when checking for
nullability.

Fixes #6590