### PR TITLE
Retry flaky test

### DIFF
--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/stream/InputStreamBodySpec2.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/stream/InputStreamBodySpec2.groovy
@@ -24,6 +24,7 @@ import io.micronaut.scheduling.annotation.ExecuteOn
 import jakarta.inject.Inject
 import spock.lang.AutoCleanup
 import spock.lang.Issue
+import spock.lang.Retry
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -39,6 +40,7 @@ class InputStreamBodySpec2 extends Specification {
              'micronaut.http.client.read-timeout': '30s',
              'micronaut.netty.event-loops.default.num-threads': '1'])
 
+    @Retry
     @Issue('https://github.com/micronaut-projects/micronaut-core/issues/6100')
     void "test apply load to InputStream read"() {
         given:


### PR DESCRIPTION
Can't make this test fail locally for debugging, unfortunately. CI logs show 'RTE outer', which makes sense for the failure, but I'm not sure why it would time out.