### PR TITLE
Delay response for `Mono` bodies of `HttpResponse` return values

### DIFF
--- a/http-server-netty/src/test/groovy/io/micronaut/docs/http/server/exception/BookController.java
+++ b/http-server-netty/src/test/groovy/io/micronaut/docs/http/server/exception/BookController.java
@@ -78,6 +78,12 @@ public class BookController {
         return Publishers.just(new ReactiveException());
     }
 
+    @Get("/reactiveMulti")
+    @SingleResult
+    Publisher<String> reactiveMulti() {
+        return Publishers.just(new ReactiveMultiException());
+    }
+
     @Error(exception = NullPointerException.class)
     @Produces(MediaType.TEXT_PLAIN)
     @Status(HttpStatus.MULTI_STATUS)

--- a/http-server-netty/src/test/groovy/io/micronaut/docs/http/server/exception/BookController.java
+++ b/http-server-netty/src/test/groovy/io/micronaut/docs/http/server/exception/BookController.java
@@ -18,8 +18,10 @@ package io.micronaut.docs.http.server.exception;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.async.annotation.SingleResult;
 import io.micronaut.core.async.publisher.Publishers;
+import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.MediaType;
+import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Error;
 import io.micronaut.http.annotation.Get;
@@ -27,6 +29,7 @@ import io.micronaut.http.annotation.Produces;
 import io.micronaut.http.annotation.Status;
 import io.micronaut.http.exceptions.HttpStatusException;
 import org.reactivestreams.Publisher;
+import reactor.core.publisher.Mono;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -55,6 +58,12 @@ public class BookController {
         CompletableFuture<Integer> future = new CompletableFuture<>();
         future.completeExceptionally(new HttpStatusException(HttpStatus.OK, 1234));
         return future.get();
+    }
+
+    @Produces(MediaType.TEXT_PLAIN)
+    @Get("/stock/mono/{isbn}")
+    MutableHttpResponse<Mono<?>> stockMonoBlocking(String isbn) throws InterruptedException, ExecutionException {
+        return HttpResponse.ok(Mono.error(new HttpStatusException(HttpStatus.OK, 1234)));
     }
 
     @Produces(MediaType.TEXT_PLAIN)

--- a/http-server-netty/src/test/groovy/io/micronaut/docs/http/server/exception/ExceptionHandlerSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/docs/http/server/exception/ExceptionHandlerSpec.groovy
@@ -100,7 +100,7 @@ class ExceptionHandlerSpec extends Specification {
 
         then:
         noExceptionThrown()
-        stock.getBody(String).get() == "[reactive handler]"
+        stock.getBody(String).get() == "reactive handler"
         stock.status() == HttpStatus.OK
     }
 }

--- a/http-server-netty/src/test/groovy/io/micronaut/docs/http/server/exception/ExceptionHandlerSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/docs/http/server/exception/ExceptionHandlerSpec.groovy
@@ -103,4 +103,15 @@ class ExceptionHandlerSpec extends Specification {
         stock.getBody(String).get() == "reactive handler"
         stock.status() == HttpStatus.OK
     }
+
+    void "test exception handler returning a publisher with multiple items"() {
+        when:
+        HttpRequest request = HttpRequest.GET('/books/reactiveMulti')
+        HttpResponse<String> stock = client.toBlocking().exchange(request, String)
+
+        then:
+        noExceptionThrown()
+        stock.getBody(String).get() == '[foo,bar]'
+        stock.status() == HttpStatus.OK
+    }
 }

--- a/http-server-netty/src/test/groovy/io/micronaut/docs/http/server/exception/ExceptionHandlerSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/docs/http/server/exception/ExceptionHandlerSpec.groovy
@@ -71,6 +71,17 @@ class ExceptionHandlerSpec extends Specification {
         stock == 1234
     }
 
+    void "test wrapped HttpStatusException in Mono is unwrapped and handled by ExceptionHandler"() {
+        when:
+        HttpRequest request = HttpRequest.GET('/books/stock/mono/1234')
+        Integer stock = client.toBlocking().retrieve(request, Integer)
+
+        then:
+        noExceptionThrown()
+        stock != null
+        stock == 1234
+    }
+
     void "test error route with @Status"() {
         when:
         HttpRequest request = HttpRequest.GET('/books/null-pointer')

--- a/http-server-netty/src/test/groovy/io/micronaut/docs/http/server/exception/ReactiveMultiException.java
+++ b/http-server-netty/src/test/groovy/io/micronaut/docs/http/server/exception/ReactiveMultiException.java
@@ -1,0 +1,4 @@
+package io.micronaut.docs.http.server.exception;
+
+public class ReactiveMultiException extends RuntimeException {
+}

--- a/http-server-netty/src/test/groovy/io/micronaut/docs/http/server/exception/ReactiveMultiExceptionHandler.java
+++ b/http-server-netty/src/test/groovy/io/micronaut/docs/http/server/exception/ReactiveMultiExceptionHandler.java
@@ -1,0 +1,18 @@
+package io.micronaut.docs.http.server.exception;
+
+import io.micronaut.core.async.publisher.Publishers;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.server.exceptions.ExceptionHandler;
+import jakarta.inject.Singleton;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+
+@Singleton
+public class ReactiveMultiExceptionHandler implements ExceptionHandler<ReactiveMultiException, Publisher<HttpResponse<Publisher<String>>>> {
+
+    @Override
+    public Publisher<HttpResponse<Publisher<String>>> handle(HttpRequest request, ReactiveMultiException exception) {
+        return Publishers.just(HttpResponse.ok(Flux.just("foo", "bar")));
+    }
+}

--- a/http-server/src/main/java/io/micronaut/http/server/RouteExecutor.java
+++ b/http-server/src/main/java/io/micronaut/http/server/RouteExecutor.java
@@ -589,19 +589,19 @@ public final class RouteExecutor {
         return mutableHttpResponse;
     }
 
-    private MutableHttpResponse<?> toMutableResponse(HttpRequest<?> request, RouteInfo<?> routeInfo, HttpStatus defaultHttpStatus, Object body) {
-        MutableHttpResponse<?> outgoingResponse;
+    private Mono<MutableHttpResponse<?>> toMutableResponse(HttpRequest<?> request, RouteInfo<?> routeInfo, HttpStatus defaultHttpStatus, Object body) {
         if (body instanceof HttpResponse) {
-            outgoingResponse = toMutableResponse((HttpResponse<?>) body);
+            MutableHttpResponse<?> outgoingResponse = toMutableResponse((HttpResponse<?>) body);
             final Argument<?> bodyArgument = routeInfo.getReturnType().getFirstTypeVariable().orElse(Argument.OBJECT_ARGUMENT);
             if (bodyArgument.isAsyncOrReactive()) {
-                outgoingResponse = processPublisherBody(request, outgoingResponse, routeInfo);
+                return processPublisherBody(request, outgoingResponse, routeInfo);
+            } else {
+                return Mono.just(outgoingResponse);
             }
         } else {
-            outgoingResponse = forStatus(routeInfo, defaultHttpStatus)
-                    .body(body);
+            return Mono.just(forStatus(routeInfo, defaultHttpStatus)
+                    .body(body));
         }
-        return outgoingResponse;
     }
 
     private Flux<MutableHttpResponse<?>> buildRouteResponsePublisher(AtomicReference<HttpRequest<?>> requestReference,
@@ -668,16 +668,17 @@ public final class RouteExecutor {
     private Flux<MutableHttpResponse<?>> createResponseForBody(HttpRequest<?> request,
                                                                Object body,
                                                                RouteInfo<?> routeInfo) {
-        return Flux.defer(() -> {
-            MutableHttpResponse<?> outgoingResponse;
+        return Flux.<MutableHttpResponse<?>>defer(() -> {
+            Mono<MutableHttpResponse<?>> outgoingResponse;
             if (body == null) {
                 if (routeInfo.isVoid()) {
-                    outgoingResponse = forStatus(routeInfo);
+                    MutableHttpResponse<Object> data = forStatus(routeInfo);
                     if (HttpMethod.permitsRequestBody(request.getMethod())) {
-                        outgoingResponse.header(HttpHeaders.CONTENT_LENGTH, "0");
+                        data.header(HttpHeaders.CONTENT_LENGTH, "0");
                     }
+                    outgoingResponse = Mono.just(data);
                 } else {
-                    outgoingResponse = newNotFoundError(request);
+                    outgoingResponse = Mono.just(newNotFoundError(request));
                 }
             } else {
                 HttpStatus defaultHttpStatus = routeInfo.isErrorRoute() ? HttpStatus.INTERNAL_SERVER_ERROR : HttpStatus.OK;
@@ -700,14 +701,14 @@ public final class RouteExecutor {
                             return singleResponse;
                         };
                         return Flux.from(publisher)
-                                .map(o -> {
+                                .flatMap(o -> {
                                     MutableHttpResponse<?> singleResponse;
                                     if (o instanceof Optional) {
                                         Optional optional = (Optional) o;
                                         if (optional.isPresent()) {
                                             o = ((Optional<?>) o).get();
                                         } else {
-                                            return emptyResponse.get();
+                                            return Flux.just(emptyResponse.get());
                                         }
                                     }
                                     if (o instanceof HttpResponse) {
@@ -716,7 +717,7 @@ public final class RouteExecutor {
                                                 .getFirstTypeVariable().orElse(Argument.OBJECT_ARGUMENT) //HttpResponse
                                                 .getFirstTypeVariable().orElse(Argument.OBJECT_ARGUMENT); //Mono
                                         if (bodyArgument.isAsyncOrReactive()) {
-                                            singleResponse = processPublisherBody(request, singleResponse, routeInfo);
+                                            return processPublisherBody(request, singleResponse, routeInfo);
                                         }
                                     } else if (o instanceof HttpStatus) {
                                         singleResponse = forStatus(routeInfo, (HttpStatus) o);
@@ -724,7 +725,7 @@ public final class RouteExecutor {
                                         singleResponse = forStatus(routeInfo, defaultHttpStatus)
                                                 .body(o);
                                     }
-                                    return singleResponse;
+                                    return Flux.just(singleResponse);
                                 })
                                 .switchIfEmpty(Mono.fromSupplier(emptyResponse));
                     } else {
@@ -737,19 +738,19 @@ public final class RouteExecutor {
                                     .map(this::toMutableResponse);
                             Argument<?> bodyArgument = typeArgument.getFirstTypeVariable().orElse(Argument.OBJECT_ARGUMENT);
                             if (bodyArgument.isAsyncOrReactive()) {
-                                return response.map((resp) ->
+                                return response.flatMap((resp) ->
                                         processPublisherBody(request, resp, routeInfo));
                             }
                             return response;
                         } else {
                             MutableHttpResponse<?> response = forStatus(routeInfo, defaultHttpStatus).body(body);
-                            return Flux.just(processPublisherBody(request, response, routeInfo));
+                            return processPublisherBody(request, response, routeInfo);
                         }
                     }
                 }
                 // now we have the raw result, transform it as necessary
                 if (body instanceof HttpStatus) {
-                    outgoingResponse = HttpResponse.status((HttpStatus) body);
+                    outgoingResponse = Mono.just(HttpResponse.status((HttpStatus) body));
                 } else {
                     if (routeInfo.isSuspended()) {
                         boolean isKotlinFunctionReturnTypeUnit =
@@ -758,13 +759,13 @@ public final class RouteExecutor {
                         final Supplier<CompletableFuture<?>> supplier = ContinuationArgumentBinder.extractContinuationCompletableFutureSupplier(request);
                         if (isKotlinCoroutineSuspended(body)) {
                             return Mono.fromCompletionStage(supplier)
-                                    .<MutableHttpResponse<?>>map(obj -> {
+                                    .<MutableHttpResponse<?>>flatMap(obj -> {
                                         MutableHttpResponse<?> response;
                                         if (obj instanceof HttpResponse) {
                                             response = toMutableResponse((HttpResponse<?>) obj);
                                             final Argument<?> bodyArgument = routeInfo.getReturnType().getFirstTypeVariable().orElse(Argument.OBJECT_ARGUMENT);
                                             if (bodyArgument.isAsyncOrReactive()) {
-                                                response = processPublisherBody(request, response, routeInfo);
+                                                return processPublisherBody(request, response, routeInfo);
                                             }
                                         } else {
                                             response = forStatus(routeInfo, defaultHttpStatus);
@@ -772,7 +773,7 @@ public final class RouteExecutor {
                                                 response = response.body(obj);
                                             }
                                         }
-                                        return response;
+                                        return Mono.just(response);
                                     })
                                     .switchIfEmpty(createNotFoundErrorResponsePublisher(request));
                         } else {
@@ -791,14 +792,17 @@ public final class RouteExecutor {
             }
             // for head request we never emit the body
             if (request != null && request.getMethod().equals(HttpMethod.HEAD)) {
-                final Object o = outgoingResponse.getBody().orElse(null);
-                if (o instanceof ReferenceCounted) {
-                    ((ReferenceCounted) o).release();
-                }
-                outgoingResponse.body(null);
+                outgoingResponse = outgoingResponse.map(r -> {
+                    final Object o = r.getBody().orElse(null);
+                    if (o instanceof ReferenceCounted) {
+                        ((ReferenceCounted) o).release();
+                    }
+                    r.body(null);
+                    return r;
+                });
             }
 
-            return Flux.just(outgoingResponse);
+            return outgoingResponse;
         })
                 .doOnNext((response) -> {
                     applyConfiguredHeaders(response.getHeaders());
@@ -809,22 +813,28 @@ public final class RouteExecutor {
                 });
     }
 
-    private MutableHttpResponse<?> processPublisherBody(HttpRequest<?> request,
+    private Mono<MutableHttpResponse<?>> processPublisherBody(HttpRequest<?> request,
                                                         MutableHttpResponse<?> response,
                                                         RouteInfo<?> routeInfo) {
-        if (response.body() == null) {
-            return response;
+        Object body = response.body();
+        if (body == null) {
+            return Mono.just(response);
+        } else if (Publishers.isSingle(body.getClass())) {
+            return Mono.from(Publishers.convertPublisher(body, Publisher.class)).map(b -> {
+                response.body(b);
+                return response;
+            });
         } else {
             MediaType mediaType = response.getContentType().orElseGet(() -> resolveDefaultResponseContentType(request, routeInfo));
 
             Flux<Object> bodyPublisher = applyExecutorToPublisher(
-                    Publishers.convertPublisher(response.body(), Publisher.class),
+                    Publishers.convertPublisher(body, Publisher.class),
                     findExecutor(routeInfo));
 
-            return response
+            return Mono.just(response
                     .header(HttpHeaders.TRANSFER_ENCODING, "chunked")
                     .header(HttpHeaders.CONTENT_TYPE, mediaType)
-                    .body(bodyPublisher);
+                    .body(bodyPublisher));
         }
     }
 


### PR DESCRIPTION
Before this patch, Mono handling would only be applied when Mono is used as a direct return type, not when it is wrapped in a `HttpResponse`, such as `HttpResponse.ok(Mono.just("foo"))`. This patch delays the response until the wrapped Mono has completed, to match the behavior of returning `Mono.just("foo")` directly.

The purpose of this change is that errors in the Mono will now be handled by the `ExceptionHandler`, not as a write error.

Fixes #6677