### PR TITLE
Allow file watcher restarts for messaging apps

### DIFF
--- a/context/src/main/java/io/micronaut/runtime/server/watch/event/FileWatchRestartListener.java
+++ b/context/src/main/java/io/micronaut/runtime/server/watch/event/FileWatchRestartListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2022 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package io.micronaut.runtime.server.watch.event;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.event.ApplicationEventListener;
 import io.micronaut.core.util.StringUtils;
-import io.micronaut.runtime.server.EmbeddedServer;
+import io.micronaut.runtime.EmbeddedApplication;
 import io.micronaut.scheduling.io.watch.FileWatchConfiguration;
 import io.micronaut.scheduling.io.watch.event.FileChangedEvent;
 import jakarta.inject.Singleton;
@@ -34,25 +34,25 @@ import org.slf4j.LoggerFactory;
  * @since 1.1.0
  */
 @Singleton
-@Requires(beans = EmbeddedServer.class)
+@Requires(beans = EmbeddedApplication.class)
 @Requires(property = FileWatchConfiguration.RESTART, value = StringUtils.TRUE, defaultValue = StringUtils.FALSE)
 public class FileWatchRestartListener implements ApplicationEventListener<FileChangedEvent> {
 
     private static final Logger LOG = LoggerFactory.getLogger(FileWatchRestartListener.class);
 
-    private final EmbeddedServer embeddedServer;
+    private final EmbeddedApplication<?> embeddedApplication;
 
     /**
      * Default constructor.
-     * @param embeddedServer The embedded server
+     * @param embeddedApplication The embedded application
      */
-    public FileWatchRestartListener(EmbeddedServer embeddedServer) {
-        this.embeddedServer = embeddedServer;
+    public FileWatchRestartListener(EmbeddedApplication<?> embeddedApplication) {
+        this.embeddedApplication = embeddedApplication;
     }
 
     @Override
     public void onApplicationEvent(FileChangedEvent event) {
-        embeddedServer.stop();
+        embeddedApplication.stop();
         if (LOG.isInfoEnabled()) {
             LOG.info("Shutting down server following file change.");
         }


### PR DESCRIPTION
The file watcher required an EmbeddedServer to be enabled.

If you create a Kafka app with no http enabled, ie:

```
mn create-messaging-app messaging-test --features kafka
```

then you get a MessagingApplication in place of an EmbeddedServer.

This change moves the requirement up to an EmbeddedApplication<?> instead of a specific
EmbeddedServer implementation of it, so we listen for restart events for that type.

Targeting v3.3.0 as it's a breaking change to the public API