### PR TITLE
Clear annotation defaults cache to prevent pollution from one language to another

### DIFF
--- a/inject-groovy-test/src/main/groovy/io/micronaut/ast/transform/test/AbstractBeanDefinitionSpec.groovy
+++ b/inject-groovy-test/src/main/groovy/io/micronaut/ast/transform/test/AbstractBeanDefinitionSpec.groovy
@@ -33,6 +33,7 @@ import io.micronaut.core.io.scan.ClassPathResourceLoader
 import io.micronaut.core.naming.NameUtils
 import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.BeanDefinitionReference
+import io.micronaut.inject.annotation.AbstractAnnotationMetadataBuilder
 import io.micronaut.inject.annotation.AnnotationMetadataWriter
 import io.micronaut.inject.ast.ClassElement
 import io.micronaut.inject.provider.BeanProviderDefinition
@@ -187,6 +188,7 @@ abstract class AbstractBeanDefinitionSpec extends Specification {
         sourceUnit.getErrorCollector() >> new ErrorCollector(new CompilerConfiguration())
         GroovyAnnotationMetadataBuilder builder = new GroovyAnnotationMetadataBuilder(sourceUnit, null)
         AnnotationMetadata metadata = element != null ? builder.build(element) : null
+        AbstractAnnotationMetadataBuilder.copyToRuntime()
         return metadata
     }
 
@@ -197,6 +199,7 @@ abstract class AbstractBeanDefinitionSpec extends Specification {
             getErrorCollector() >> null
         }, null)
         AnnotationMetadata metadata = method != null ? builder.build(method) : null
+        AbstractAnnotationMetadataBuilder.copyToRuntime()
         return metadata
     }
 
@@ -206,6 +209,7 @@ abstract class AbstractBeanDefinitionSpec extends Specification {
         Parameter parameter = Arrays.asList(method.getParameters()).find { it.name == fieldName }
         GroovyAnnotationMetadataBuilder builder = new GroovyAnnotationMetadataBuilder(null, null)
         AnnotationMetadata metadata = method != null ? builder.build(new ExtendedParameter(method, parameter)) : null
+        AbstractAnnotationMetadataBuilder.copyToRuntime()
         return metadata
     }
 

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/InjectTransform.groovy
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/InjectTransform.groovy
@@ -28,8 +28,7 @@ import io.micronaut.context.annotation.Configuration
 import io.micronaut.context.annotation.ConfigurationReader
 import io.micronaut.context.annotation.Context
 import io.micronaut.core.annotation.AnnotationMetadata
-import io.micronaut.core.annotation.Nullable
-import io.micronaut.inject.ast.Element
+
 import io.micronaut.inject.configuration.ConfigurationMetadataBuilder
 import io.micronaut.inject.writer.*
 import org.codehaus.groovy.ast.*

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/TypeElementVisitorEnd.groovy
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/TypeElementVisitorEnd.groovy
@@ -105,7 +105,6 @@ class TypeElementVisitorEnd implements ASTTransformation, CompilationUnitAware {
         TypeElementVisitorTransform.loadedVisitors.remove()
         TypeElementVisitorTransform.beanDefinitionBuilders.remove()
         AstAnnotationUtils.invalidateCache()
-        AbstractAnnotationMetadataBuilder.clearMutated()
     }
 
     @Override

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/utils/AstAnnotationUtils.groovy
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/utils/AstAnnotationUtils.groovy
@@ -106,7 +106,7 @@ class AstAnnotationUtils {
     @Internal
     static void invalidateCache() {
         annotationMetadataCache.clear()
-        AnnotationMetadataSupport.clearDefaultValues()
+        AbstractAnnotationMetadataBuilder.clearCaches()
     }
 
     /**

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/utils/AstAnnotationUtils.groovy
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/utils/AstAnnotationUtils.groovy
@@ -22,6 +22,7 @@ import io.micronaut.core.annotation.AnnotationUtil
 import io.micronaut.core.annotation.Internal
 import io.micronaut.core.util.clhm.ConcurrentLinkedHashMap
 import io.micronaut.inject.annotation.AbstractAnnotationMetadataBuilder
+import io.micronaut.inject.annotation.AnnotationMetadataSupport
 import org.codehaus.groovy.ast.AnnotatedNode
 import org.codehaus.groovy.ast.AnnotationNode
 import org.codehaus.groovy.ast.ClassNode
@@ -105,6 +106,7 @@ class AstAnnotationUtils {
     @Internal
     static void invalidateCache() {
         annotationMetadataCache.clear()
+        AnnotationMetadataSupport.clearDefaultValues()
     }
 
     /**

--- a/inject-java-test/src/main/groovy/io/micronaut/annotation/processing/test/AbstractTypeElementSpec.groovy
+++ b/inject-java-test/src/main/groovy/io/micronaut/annotation/processing/test/AbstractTypeElementSpec.groovy
@@ -33,6 +33,7 @@ import io.micronaut.core.naming.NameUtils
 import io.micronaut.inject.BeanConfiguration
 import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.BeanDefinitionReference
+import io.micronaut.inject.annotation.AbstractAnnotationMetadataBuilder
 import io.micronaut.inject.annotation.AnnotationMapper
 import io.micronaut.inject.annotation.AnnotationMetadataWriter
 import io.micronaut.inject.annotation.AnnotationTransformer
@@ -110,6 +111,7 @@ abstract class AbstractTypeElementSpec extends Specification {
         Element element = buildTypeElement(cls)
         JavaAnnotationMetadataBuilder builder = newJavaAnnotationBuilder()
         AnnotationMetadata metadata = element != null ? builder.build(element) : null
+        AbstractAnnotationMetadataBuilder.copyToRuntime()
         return metadata
     }
 
@@ -118,6 +120,7 @@ abstract class AbstractTypeElementSpec extends Specification {
         Element method = element.getEnclosedElements().find() { it.simpleName.toString() == methodName }
         JavaAnnotationMetadataBuilder builder = newJavaAnnotationBuilder()
         AnnotationMetadata metadata = method != null ? builder.buildDeclared(method) : null
+        AbstractAnnotationMetadataBuilder.copyToRuntime()
         return metadata
     }
 
@@ -127,6 +130,7 @@ abstract class AbstractTypeElementSpec extends Specification {
         VariableElement argument = method.parameters.find() { it.simpleName.toString() == argumentName }
         JavaAnnotationMetadataBuilder builder = newJavaAnnotationBuilder()
         AnnotationMetadata metadata = argument != null ? builder.build(argument) : null
+        AbstractAnnotationMetadataBuilder.copyToRuntime()
         return metadata
     }
 

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -31,7 +31,6 @@ import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.core.value.OptionalValues;
-import io.micronaut.inject.annotation.AbstractAnnotationMetadataBuilder;
 import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
 import io.micronaut.inject.annotation.AnnotationMetadataReference;
 import io.micronaut.inject.ast.*;
@@ -269,7 +268,6 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                 }
             } finally {
                 AnnotationUtils.invalidateCache();
-                AbstractAnnotationMetadataBuilder.clearMutated();
                 JavaAnnotationMetadataBuilder.clearCaches();
             }
         }

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/JavaAnnotationMetadataBuilder.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/JavaAnnotationMetadataBuilder.java
@@ -25,7 +25,6 @@ import io.micronaut.core.util.clhm.ConcurrentLinkedHashMap;
 import io.micronaut.core.value.OptionalValues;
 import io.micronaut.inject.annotation.AbstractAnnotationMetadataBuilder;
 import io.micronaut.inject.annotation.AnnotatedElementValidator;
-import io.micronaut.inject.annotation.AnnotationMetadataSupport;
 import io.micronaut.inject.processing.JavaModelUtils;
 import io.micronaut.inject.visitor.VisitorContext;
 
@@ -586,7 +585,7 @@ public class JavaAnnotationMetadataBuilder extends AbstractAnnotationMetadataBui
      */
     public static void clearCaches() {
         OVERRIDDEN_METHOD_CACHE.clear();
-        AnnotationMetadataSupport.clearDefaultValues();
+        AbstractAnnotationMetadataBuilder.clearCaches();
     }
 
     /**

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/JavaAnnotationMetadataBuilder.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/JavaAnnotationMetadataBuilder.java
@@ -25,6 +25,7 @@ import io.micronaut.core.util.clhm.ConcurrentLinkedHashMap;
 import io.micronaut.core.value.OptionalValues;
 import io.micronaut.inject.annotation.AbstractAnnotationMetadataBuilder;
 import io.micronaut.inject.annotation.AnnotatedElementValidator;
+import io.micronaut.inject.annotation.AnnotationMetadataSupport;
 import io.micronaut.inject.processing.JavaModelUtils;
 import io.micronaut.inject.visitor.VisitorContext;
 
@@ -585,6 +586,7 @@ public class JavaAnnotationMetadataBuilder extends AbstractAnnotationMetadataBui
      */
     public static void clearCaches() {
         OVERRIDDEN_METHOD_CACHE.clear();
+        AnnotationMetadataSupport.clearDefaultValues();
     }
 
     /**

--- a/inject/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -58,7 +58,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
     private static final Map<String, List<AnnotationRemapper>> ANNOTATION_REMAPPERS = new HashMap<>(5);
     private static final Map<MetadataKey, AnnotationMetadata> MUTATED_ANNOTATION_METADATA = new HashMap<>(100);
     private static final List<String> DEFAULT_ANNOTATE_EXCLUDES = Arrays.asList(Internal.class.getName(), Experimental.class.getName());
-    private static final Map<String, Map<String, Object>> ANNOTATION_DEFAULTS = new ConcurrentHashMap<>(20);
+    private static final Map<String, Map<String, Object>> ANNOTATION_DEFAULTS = new HashMap<>(20);
 
     static {
         SoftServiceLoader<AnnotationMapper> serviceLoader = SoftServiceLoader.load(AnnotationMapper.class, AbstractAnnotationMetadataBuilder.class.getClassLoader());

--- a/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataSupport.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataSupport.java
@@ -130,6 +130,14 @@ public final class AnnotationMetadataSupport {
         return REPEATABLE_ANNOTATIONS.get(annotation);
     }
 
+
+    /**
+     * Clear any annotation default values.
+     */
+    public static void clearDefaultValues() {
+        ANNOTATION_DEFAULTS.clear();
+    }
+
     /**
      * Gets a registered annotation type.
      *

--- a/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataSupport.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataSupport.java
@@ -130,14 +130,6 @@ public final class AnnotationMetadataSupport {
         return REPEATABLE_ANNOTATIONS.get(annotation);
     }
 
-
-    /**
-     * Clear any annotation default values.
-     */
-    public static void clearDefaultValues() {
-        ANNOTATION_DEFAULTS.clear();
-    }
-
     /**
      * Gets a registered annotation type.
      *

--- a/inject/src/main/java/io/micronaut/inject/writer/AbstractAnnotationMetadataWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/AbstractAnnotationMetadataWriter.java
@@ -137,8 +137,6 @@ public abstract class AbstractAnnotationMetadataWriter extends AbstractClassFile
             // write the static initializers for the annotation metadata
             GeneratorAdapter staticInit = visitStaticInitializer(classWriter);
             staticInit.visitCode();
-            staticInit.visitLabel(new Label());
-            initializeAnnotationMetadata(staticInit, classWriter, defaults);
             if (writeAnnotationDefault && annotationMetadata instanceof DefaultAnnotationMetadata) {
                 DefaultAnnotationMetadata dam = (DefaultAnnotationMetadata) annotationMetadata;
                 AnnotationMetadataWriter.writeAnnotationDefaults(
@@ -149,8 +147,9 @@ public abstract class AbstractAnnotationMetadataWriter extends AbstractClassFile
                         defaults,
                         loadTypeMethods
                 );
-
             }
+            staticInit.visitLabel(new Label());
+            initializeAnnotationMetadata(staticInit, classWriter, defaults);
             staticInit.visitInsn(RETURN);
             staticInit.visitMaxs(1, 1);
             staticInit.visitEnd();


### PR DESCRIPTION
This also reorders the reference classes to register annotation defaults before creating annotation metadata because the creation references the defaults.