### PR TITLE
Host header rewritten when proxy is called

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -2933,7 +2933,12 @@ public class DefaultHttpClient implements
     public Publisher<MutableHttpResponse<?>> proxy(@NonNull io.micronaut.http.HttpRequest<?> request) {
         return Flux.from(resolveRequestURI(request))
                 .flatMap(requestURI -> {
-                    AtomicReference<io.micronaut.http.HttpRequest> requestWrapper = new AtomicReference<>(request instanceof MutableHttpRequest ? request : request.mutate());
+                    io.micronaut.http.MutableHttpRequest<?> httpRequest = request instanceof MutableHttpRequest
+                            ? (io.micronaut.http.MutableHttpRequest<?>) request
+                            : request.mutate();
+                    httpRequest.headers(headers -> headers.remove(HttpHeaderNames.HOST));
+
+                    AtomicReference<io.micronaut.http.HttpRequest> requestWrapper = new AtomicReference<>(httpRequest);
                     Flux<MutableHttpResponse<Object>> proxyResponsePublisher = Flux.create(emitter -> {
                         SslContext sslContext = buildSslContext(requestURI);
                         ChannelFuture channelFuture;

--- a/http-client/src/test/groovy/io/micronaut/http/client/ProxyHttpClientMutableRequestSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/ProxyHttpClientMutableRequestSpec.groovy
@@ -10,6 +10,7 @@ import io.micronaut.http.annotation.Body
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Filter
 import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Header
 import io.micronaut.http.annotation.Post
 import io.micronaut.http.annotation.Produces
 import io.micronaut.http.filter.FilterChain
@@ -52,6 +53,12 @@ class ProxyHttpClientMutableRequestSpec extends Specification {
 
         then:
         'Hello Sally' == result
+
+        when:
+        result = client.retrieve(HttpRequest.GET('/hello/host').accept(MediaType.TEXT_PLAIN))
+
+        then:
+        result == "Host: $helloEmbeddedServer.host:$helloEmbeddedServer.port"
 
         cleanup:
         helloEmbeddedServer.close()
@@ -109,6 +116,11 @@ class ProxyHttpClientMutableRequestSpec extends Specification {
         @Post(uri = "/name", processes = MediaType.TEXT_PLAIN)
         Publisher<String> name(@Body Publisher<String> name) {
             Flux.from(name).map(str -> "Hello " + str)
+        }
+
+        @Get(uri = "/host", processes = MediaType.TEXT_PLAIN)
+        String host(@Header String host) {
+            "Host: $host"
         }
     }
 }

--- a/src/main/docs/guide/appendix/breaks.adoc
+++ b/src/main/docs/guide/appendix/breaks.adoc
@@ -1,5 +1,9 @@
 This section documents breaking changes between Micronaut versions
 
+== 3.2.4
+
+- The link:{api}/io/micronaut/http/client/ProxyHttpClient.html[ProxyHttpClient] now sends the Host header of the proxied service https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.23[as per the RFC], instead of the originating service.
+
 == 3.2.0
 
 - The HTTP client now does SSL certificate verification by default. The old insecure behavior can be re-enabled by setting the `micronaut.http.client.ssl.insecureTrustAllCertificates` property to `true`, but consider using a trust store instead if you're using self-signed certificates.


### PR DESCRIPTION
The ProxyHttpClient didn't rewrite the header when proxying as per
the RFC: https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.23

> An HTTP/1.1 proxy MUST ensure that any request message it forwards
> does contain an appropriate Host header field that identifies the
> service being requested by the proxy.