### PR TITLE
Access log can exclude defined regular expression patterns

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
@@ -847,7 +847,7 @@ public class NettyHttpServer implements NettyEmbeddedServer {
         private Predicate<String> inclusionPredicate(NettyHttpServerConfiguration.AccessLogger config) {
             List<String> exclusions = config.getExclusions();
             if (CollectionUtils.isEmpty(exclusions)) {
-                return HttpAccessLogHandler.INCLUDE_ALL;
+                return null;
             } else {
                 // Don't do this inside the predicate to avoid compiling every request
                 List<Pattern> patterns = exclusions.stream().map(Pattern::compile).collect(Collectors.toList());

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/configuration/NettyHttpServerConfiguration.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/configuration/NettyHttpServerConfiguration.java
@@ -733,7 +733,7 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
          *
          * @param exclusions A list of regular expression patterns to be excluded from the access logger if the request URI matches.
          *
-         * @see java.util.regex.Pattern#compile(String) 
+         * @see java.util.regex.Pattern#compile(String)
          */
         public void setExclusions(List<String> exclusions) {
             this.exclusions = exclusions;

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/configuration/NettyHttpServerConfiguration.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/configuration/NettyHttpServerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2022 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -671,6 +671,7 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
         private boolean enabled;
         private String loggerName;
         private String logFormat;
+        private List<String> exclusions;
 
         /**
          * Returns whether the access logger is enabled.
@@ -720,6 +721,23 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
             this.logFormat = logFormat;
         }
 
+        /**
+         * @return The URI patterns to exclude from the access log.
+         */
+        public List<String> getExclusions() {
+            return exclusions;
+        }
+
+        /**
+         * Sets the URI patterns to be excluded from the access log.
+         *
+         * @param exclusions A list of regular expression patterns to be excluded from the access logger if the request URI matches.
+         *
+         * @see java.util.regex.Pattern#compile(String) 
+         */
+        public void setExclusions(List<String> exclusions) {
+            this.exclusions = exclusions;
+        }
     }
 
     /**

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/HttpAccessLogHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/HttpAccessLogHandler.java
@@ -107,10 +107,10 @@ public class HttpAccessLogHandler extends ChannelDuplexHandler {
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Http2Exception {
         if (logger.isInfoEnabled() && msg instanceof HttpRequest) {
+            final SocketChannel channel = (SocketChannel) ctx.channel();
             final HttpRequest request = (HttpRequest) msg;
+            AccessLog accessLog = accessLog(channel);
             if (uriInclusion == null || uriInclusion.test(request.uri())) {
-
-                final SocketChannel channel = (SocketChannel) ctx.channel();
                 final HttpHeaders headers = request.headers();
                 // Trying to detect http/2
                 String protocol;
@@ -119,9 +119,9 @@ public class HttpAccessLogHandler extends ChannelDuplexHandler {
                 } else {
                     protocol = request.protocolVersion().text();
                 }
-                accessLog(channel).onRequestHeaders(channel, request.method().name(), request.headers(), request.uri(), protocol);
+                accessLog.onRequestHeaders(channel, request.method().name(), request.headers(), request.uri(), protocol);
             } else {
-                ctx.pipeline().remove(this);
+                accessLog.exclude();
             }
         }
         ctx.fireChannelRead(msg);

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/HttpAccessLogHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/HttpAccessLogHandler.java
@@ -107,10 +107,10 @@ public class HttpAccessLogHandler extends ChannelDuplexHandler {
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Http2Exception {
         if (logger.isInfoEnabled() && msg instanceof HttpRequest) {
-            final SocketChannel channel = (SocketChannel) ctx.channel();
             final HttpRequest request = (HttpRequest) msg;
-            AccessLog accessLog = accessLog(channel);
             if (uriInclusion == null || uriInclusion.test(request.uri())) {
+
+                final SocketChannel channel = (SocketChannel) ctx.channel();
                 final HttpHeaders headers = request.headers();
                 // Trying to detect http/2
                 String protocol;
@@ -119,9 +119,9 @@ public class HttpAccessLogHandler extends ChannelDuplexHandler {
                 } else {
                     protocol = request.protocolVersion().text();
                 }
-                accessLog.onRequestHeaders(channel, request.method().name(), request.headers(), request.uri(), protocol);
+                accessLog(channel).onRequestHeaders(channel, request.method().name(), request.headers(), request.uri(), protocol);
             } else {
-                accessLog.exclude();
+                ctx.pipeline().remove(this);
             }
         }
         ctx.fireChannelRead(msg);

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/HttpAccessLogHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/HttpAccessLogHandler.java
@@ -52,11 +52,6 @@ public class HttpAccessLogHandler extends ChannelDuplexHandler {
      */
     public static final String HTTP_ACCESS_LOGGER = "HTTP_ACCESS_LOGGER";
 
-    /**
-     * A lenient filter that allows all uri's to pass.
-     */
-    public static final Predicate<String> INCLUDE_ALL = uri -> true;
-
     private static final AttributeKey<AccessLog> ACCESS_LOGGER = AttributeKey.valueOf("ACCESS_LOGGER");
     private static final String H2_PROTOCOL_NAME = "HTTP/2.0";
 
@@ -71,7 +66,7 @@ public class HttpAccessLogHandler extends ChannelDuplexHandler {
      * @param spec The log format specification.
      */
     public HttpAccessLogHandler(String loggerName, String spec) {
-        this(loggerName == null || loggerName.isEmpty() ? null : LoggerFactory.getLogger(loggerName), spec, INCLUDE_ALL);
+        this(loggerName == null || loggerName.isEmpty() ? null : LoggerFactory.getLogger(loggerName), spec, null);
     }
 
     /**
@@ -92,7 +87,7 @@ public class HttpAccessLogHandler extends ChannelDuplexHandler {
      * @param spec The log format specification.
      */
     public HttpAccessLogHandler(Logger logger, String spec) {
-        this(logger, spec, INCLUDE_ALL);
+        this(logger, spec, null);
     }
 
     /**
@@ -115,7 +110,7 @@ public class HttpAccessLogHandler extends ChannelDuplexHandler {
             final SocketChannel channel = (SocketChannel) ctx.channel();
             final HttpRequest request = (HttpRequest) msg;
             AccessLog accessLog = accessLog(channel);
-            if (uriInclusion.test(request.uri())) {
+            if (uriInclusion == null || uriInclusion.test(request.uri())) {
                 final HttpHeaders headers = request.headers();
                 // Trying to detect http/2
                 String protocol;

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/HttpAccessLogHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/HttpAccessLogHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2022 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,8 @@ import io.netty.util.AttributeKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.function.Predicate;
+
 /**
  * Logging handler for HTTP access logs.
  * Access logs will be logged at info level.
@@ -50,11 +52,17 @@ public class HttpAccessLogHandler extends ChannelDuplexHandler {
      */
     public static final String HTTP_ACCESS_LOGGER = "HTTP_ACCESS_LOGGER";
 
+    /**
+     * A lenient filter that allows all uri's to pass.
+     */
+    public static final Predicate<String> INCLUDE_ALL = uri -> true;
+
     private static final AttributeKey<AccessLog> ACCESS_LOGGER = AttributeKey.valueOf("ACCESS_LOGGER");
     private static final String H2_PROTOCOL_NAME = "HTTP/2.0";
 
     private final Logger logger;
     private final AccessLogFormatParser accessLogFormatParser;
+    private final Predicate<String> uriInclusion;
 
     /**
      * Creates a HttpAccessLogHandler.
@@ -63,7 +71,18 @@ public class HttpAccessLogHandler extends ChannelDuplexHandler {
      * @param spec The log format specification.
      */
     public HttpAccessLogHandler(String loggerName, String spec) {
-        this(loggerName == null || loggerName.isEmpty() ? null : LoggerFactory.getLogger(loggerName), spec);
+        this(loggerName == null || loggerName.isEmpty() ? null : LoggerFactory.getLogger(loggerName), spec, INCLUDE_ALL);
+    }
+
+    /**
+     * Creates a HttpAccessLogHandler.
+     *
+     * @param loggerName A logger name.
+     * @param spec The log format specification.
+     * @param uriInclusion A filtering Predicate that will be checked per URI.
+     */
+    public HttpAccessLogHandler(String loggerName, String spec, Predicate<String> uriInclusion) {
+        this(loggerName == null || loggerName.isEmpty() ? null : LoggerFactory.getLogger(loggerName), spec, uriInclusion);
     }
 
     /**
@@ -73,9 +92,21 @@ public class HttpAccessLogHandler extends ChannelDuplexHandler {
      * @param spec The log format specification.
      */
     public HttpAccessLogHandler(Logger logger, String spec) {
+        this(logger, spec, INCLUDE_ALL);
+    }
+
+    /**
+     * Creates a HttpAccessLogHandler.
+     *
+     * @param logger A logger. Will log at info level.
+     * @param spec The log format specification.
+     * @param uriInclusion A filtering Predicate that will be checked per URI.
+     */
+    public HttpAccessLogHandler(Logger logger, String spec, Predicate<String> uriInclusion) {
         super();
         this.logger = logger == null ? LoggerFactory.getLogger(HTTP_ACCESS_LOGGER) : logger;
         this.accessLogFormatParser = new AccessLogFormatParser(spec);
+        this.uriInclusion = uriInclusion;
     }
 
     @Override
@@ -83,15 +114,20 @@ public class HttpAccessLogHandler extends ChannelDuplexHandler {
         if (logger.isInfoEnabled() && msg instanceof HttpRequest) {
             final SocketChannel channel = (SocketChannel) ctx.channel();
             final HttpRequest request = (HttpRequest) msg;
-            final HttpHeaders headers = request.headers();
-            // Trying to detect http/2
-            String protocol;
-            if (headers.contains(ExtensionHeaderNames.STREAM_ID.text()) || headers.contains(ExtensionHeaderNames.SCHEME.text())) {
-                protocol = H2_PROTOCOL_NAME;
+            AccessLog accessLog = accessLog(channel);
+            if (uriInclusion.test(request.uri())) {
+                final HttpHeaders headers = request.headers();
+                // Trying to detect http/2
+                String protocol;
+                if (headers.contains(ExtensionHeaderNames.STREAM_ID.text()) || headers.contains(ExtensionHeaderNames.SCHEME.text())) {
+                    protocol = H2_PROTOCOL_NAME;
+                } else {
+                    protocol = request.protocolVersion().text();
+                }
+                accessLog.onRequestHeaders(channel, request.method().name(), request.headers(), request.uri(), protocol);
             } else {
-                protocol = request.protocolVersion().text();
+                accessLog.exclude();
             }
-            accessLog(channel).onRequestHeaders(channel, request.method().name(), request.headers(), request.uri(), protocol);
         }
         ctx.fireChannelRead(msg);
     }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/AccessLog.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/AccessLog.java
@@ -143,7 +143,7 @@ public class AccessLog {
     }
 
     /**
-     * Mark the current AccessLog as excluded (if for example, it is filtered by the access log filters).
+     * Mark the current AccessLog as excluded (if for example, it is excluded by the access log exclusions).
      */
     public void exclude() {
         this.excluded = true;

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/AccessLog.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/AccessLog.java
@@ -35,7 +35,6 @@ public class AccessLog {
     private final List<IndexedLogElement> onResponseWriteElements;
     private final List<IndexedLogElement> onLastResponseWriteElements;
     private final String[] elements;
-    private boolean excluded;
 
     /**
      * Creates an AccessLog.
@@ -52,7 +51,6 @@ public class AccessLog {
         this.onResponseWriteElements = onResponseWriteElements;
         this.onLastResponseWriteElements = onLastResponseWriteElements;
         this.elements = elements;
-        this.excluded = false;
     }
 
     /**
@@ -63,7 +61,6 @@ public class AccessLog {
         onResponseHeadersElements.forEach(this::resetIndexedLogElement);
         onResponseWriteElements.forEach(this::resetIndexedLogElement);
         onLastResponseWriteElements.forEach(this::resetIndexedLogElement);
-        excluded = false;
     }
 
    /**
@@ -76,10 +73,8 @@ public class AccessLog {
     * @param protocol The protocol.
     */
     public void onRequestHeaders(SocketChannel channel, String method, HttpHeaders headers, String uri, String protocol) {
-        if (!excluded) {
-            for (IndexedLogElement element : onRequestHeadersElements) {
-                elements[element.index] = element.onRequestHeaders(channel, method, headers, uri, protocol);
-            }
+        for (IndexedLogElement element : onRequestHeadersElements) {
+            elements[element.index] = element.onRequestHeaders(channel, method, headers, uri, protocol);
         }
     }
 
@@ -91,10 +86,8 @@ public class AccessLog {
      * @param status The response status.
      */
     public void onResponseHeaders(ChannelHandlerContext ctx, HttpHeaders headers, String status) {
-        if (!excluded) {
-            for (IndexedLogElement element : onResponseHeadersElements) {
-                elements[element.index] = element.onResponseHeaders(ctx, headers, status);
-            }
+        for (IndexedLogElement element : onResponseHeadersElements) {
+            elements[element.index] = element.onResponseHeaders(ctx, headers, status);
         }
     }
 
@@ -103,10 +96,8 @@ public class AccessLog {
      * @param bytesSent The number of bytes sent.
      */
     public void onResponseWrite(int bytesSent) {
-        if (!excluded) {
-            for (IndexedLogElement element : onResponseWriteElements) {
-                element.onResponseWrite(bytesSent);
-            }
+        for (IndexedLogElement element : onResponseWriteElements) {
+            element.onResponseWrite(bytesSent);
         }
     }
 
@@ -115,10 +106,8 @@ public class AccessLog {
      * @param bytesSent The number of bytes sent.
      */
     public void onLastResponseWrite(int bytesSent) {
-        if (!excluded) {
-            for (IndexedLogElement element : onLastResponseWriteElements) {
-                elements[element.index] = element.onLastResponseWrite(bytesSent);
-            }
+        for (IndexedLogElement element : onLastResponseWriteElements) {
+            elements[element.index] = element.onLastResponseWrite(bytesSent);
         }
     }
 
@@ -128,7 +117,7 @@ public class AccessLog {
      * @param accessLogger A logger.
      */
     public void log(Logger accessLogger) {
-        if (accessLogger.isInfoEnabled() && !excluded) {
+        if (accessLogger.isInfoEnabled()) {
             final StringBuilder b = new StringBuilder(elements.length * 5);
             for (int i = 0; i < elements.length; ++i) {
                 b.append(elements[i] == null ? ConstantElement.UNKNOWN_VALUE : elements[i]);
@@ -140,12 +129,5 @@ public class AccessLog {
     private void resetIndexedLogElement(IndexedLogElement elt) {
         elements[elt.index] = null;
         elt.reset();
-    }
-
-    /**
-     * Mark the current AccessLog as excluded (if for example, it is excluded by the access log exclusions).
-     */
-    public void exclude() {
-        this.excluded = true;
     }
 }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/AccessLog.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/AccessLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2022 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ public class AccessLog {
     private final List<IndexedLogElement> onResponseWriteElements;
     private final List<IndexedLogElement> onLastResponseWriteElements;
     private final String[] elements;
+    private boolean excluded;
 
     /**
      * Creates an AccessLog.
@@ -51,6 +52,7 @@ public class AccessLog {
         this.onResponseWriteElements = onResponseWriteElements;
         this.onLastResponseWriteElements = onLastResponseWriteElements;
         this.elements = elements;
+        this.excluded = false;
     }
 
     /**
@@ -61,6 +63,7 @@ public class AccessLog {
         onResponseHeadersElements.forEach(this::resetIndexedLogElement);
         onResponseWriteElements.forEach(this::resetIndexedLogElement);
         onLastResponseWriteElements.forEach(this::resetIndexedLogElement);
+        excluded = false;
     }
 
    /**
@@ -73,8 +76,10 @@ public class AccessLog {
     * @param protocol The protocol.
     */
     public void onRequestHeaders(SocketChannel channel, String method, HttpHeaders headers, String uri, String protocol) {
-        for (IndexedLogElement element: onRequestHeadersElements) {
-            elements[element.index] = element.onRequestHeaders(channel, method, headers, uri, protocol);
+        if (!excluded) {
+            for (IndexedLogElement element : onRequestHeadersElements) {
+                elements[element.index] = element.onRequestHeaders(channel, method, headers, uri, protocol);
+            }
         }
     }
 
@@ -86,8 +91,10 @@ public class AccessLog {
      * @param status The response status.
      */
     public void onResponseHeaders(ChannelHandlerContext ctx, HttpHeaders headers, String status) {
-        for (IndexedLogElement element: onResponseHeadersElements) {
-            elements[element.index] = element.onResponseHeaders(ctx, headers, status);
+        if (!excluded) {
+            for (IndexedLogElement element : onResponseHeadersElements) {
+                elements[element.index] = element.onResponseHeaders(ctx, headers, status);
+            }
         }
     }
 
@@ -96,8 +103,10 @@ public class AccessLog {
      * @param bytesSent The number of bytes sent.
      */
     public void onResponseWrite(int bytesSent) {
-        for (IndexedLogElement element: onResponseWriteElements) {
-            element.onResponseWrite(bytesSent);
+        if (!excluded) {
+            for (IndexedLogElement element : onResponseWriteElements) {
+                element.onResponseWrite(bytesSent);
+            }
         }
     }
 
@@ -106,8 +115,10 @@ public class AccessLog {
      * @param bytesSent The number of bytes sent.
      */
     public void onLastResponseWrite(int bytesSent) {
-        for (IndexedLogElement element: onLastResponseWriteElements) {
-            elements[element.index] = element.onLastResponseWrite(bytesSent);
+        if (!excluded) {
+            for (IndexedLogElement element : onLastResponseWriteElements) {
+                elements[element.index] = element.onLastResponseWrite(bytesSent);
+            }
         }
     }
 
@@ -117,7 +128,7 @@ public class AccessLog {
      * @param accessLogger A logger.
      */
     public void log(Logger accessLogger) {
-        if (accessLogger.isInfoEnabled()) {
+        if (accessLogger.isInfoEnabled() && !excluded) {
             final StringBuilder b = new StringBuilder(elements.length * 5);
             for (int i = 0; i < elements.length; ++i) {
                 b.append(elements[i] == null ? ConstantElement.UNKNOWN_VALUE : elements[i]);
@@ -129,5 +140,12 @@ public class AccessLog {
     private void resetIndexedLogElement(IndexedLogElement elt) {
         elements[elt.index] = null;
         elt.reset();
+    }
+
+    /**
+     * Mark the current AccessLog as excluded (if for example, it is filtered by the access log filters).
+     */
+    public void exclude() {
+        this.excluded = true;
     }
 }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/AccessLog.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/AccessLog.java
@@ -73,7 +73,7 @@ public class AccessLog {
     * @param protocol The protocol.
     */
     public void onRequestHeaders(SocketChannel channel, String method, HttpHeaders headers, String uri, String protocol) {
-        for (IndexedLogElement element : onRequestHeadersElements) {
+        for (IndexedLogElement element: onRequestHeadersElements) {
             elements[element.index] = element.onRequestHeaders(channel, method, headers, uri, protocol);
         }
     }
@@ -86,7 +86,7 @@ public class AccessLog {
      * @param status The response status.
      */
     public void onResponseHeaders(ChannelHandlerContext ctx, HttpHeaders headers, String status) {
-        for (IndexedLogElement element : onResponseHeadersElements) {
+        for (IndexedLogElement element: onResponseHeadersElements) {
             elements[element.index] = element.onResponseHeaders(ctx, headers, status);
         }
     }
@@ -96,7 +96,7 @@ public class AccessLog {
      * @param bytesSent The number of bytes sent.
      */
     public void onResponseWrite(int bytesSent) {
-        for (IndexedLogElement element : onResponseWriteElements) {
+        for (IndexedLogElement element: onResponseWriteElements) {
             element.onResponseWrite(bytesSent);
         }
     }
@@ -106,7 +106,7 @@ public class AccessLog {
      * @param bytesSent The number of bytes sent.
      */
     public void onLastResponseWrite(int bytesSent) {
-        for (IndexedLogElement element : onLastResponseWriteElements) {
+        for (IndexedLogElement element: onLastResponseWriteElements) {
             elements[element.index] = element.onLastResponseWrite(bytesSent);
         }
     }

--- a/src/main/docs/guide/httpServer/serverConfiguration/accessLogger.adoc
+++ b/src/main/docs/guide/httpServer/serverConfiguration/accessLogger.adoc
@@ -14,6 +14,25 @@ micronaut:
         log-format: common # A log format, optional, default is Common Log Format
 ----
 
+==== Filtering access logs
+
+If you wish to not log access to certain paths, you can specify regular expression filters in the configuration:
+
+.Filtering the access logs
+[source,yaml]
+----
+micronaut:
+  server:
+    netty:
+      access-logger:
+        enabled: true # Enables the access logger
+        logger-name: my-access-logger # A logger name, optional, default is `HTTP_ACCESS_LOGGER`
+        log-format: common # A log format, optional, default is Common Log Format
+        exclusions:
+          - /health
+          - /path/.+
+----
+
 ==== Logback Configuration
 
 In addition to enabling the access logger, you must add a logger for the specified or default logger name. For instance using the default logger name for logback:

--- a/test-suite/src/test/groovy/io/micronaut/http/ExcludedHttpAccessLoggerSpec.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/http/ExcludedHttpAccessLoggerSpec.groovy
@@ -25,7 +25,7 @@ class ExcludedHttpAccessLoggerSpec extends Specification {
     @Client("/")
     HttpClient client
 
-    PollingConditions conditions = new PollingConditions(timeout: 3, delay: 0.5)
+    PollingConditions conditions = new PollingConditions(timeout: 5, delay: 0.5)
 
     static MemoryAppender appender = new MemoryAppender()
 
@@ -39,7 +39,7 @@ class ExcludedHttpAccessLoggerSpec extends Specification {
         appender.events.clear()
     }
 
-    def "quick"() {
+    def "test paths are excluded for specified patterns"() {
         when:
         def paths = [
                 [uri: '/prefix/a', logged: false],    // Matches /prefix.+

--- a/test-suite/src/test/groovy/io/micronaut/http/ExcludedHttpAccessLoggerSpec.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/http/ExcludedHttpAccessLoggerSpec.groovy
@@ -51,11 +51,14 @@ class ExcludedHttpAccessLoggerSpec extends Specification {
         ]
 
         and:
-        paths.each {
-            Flux.from(client.exchange(HttpRequest.GET(it.uri))).blockFirst()
+        def responses = paths.collect {
+            Flux.from(client.retrieve(HttpRequest.GET(it.uri), String)).blockFirst()
         }
 
         then:
+        responses.size() == paths.size()
+        responses.every { it == "ok" }
+
         conditions.eventually {
             def loggedUris = appender.events.collect {
                 def matcher = (it =~ /^.+GET (?<uri>\S+).+$/)

--- a/test-suite/src/test/groovy/io/micronaut/http/ExcludedHttpAccessLoggerSpec.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/http/ExcludedHttpAccessLoggerSpec.groovy
@@ -2,6 +2,7 @@ package io.micronaut.http
 
 import ch.qos.logback.classic.Logger
 import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.client.HttpClient
@@ -17,6 +18,7 @@ import spock.util.concurrent.PollingConditions
 @Property(name = 'micronaut.server.netty.access-logger.enabled', value = 'true')
 @Property(name = 'micronaut.server.netty.access-logger.exclusions[0]', value = '/some/path')
 @Property(name = 'micronaut.server.netty.access-logger.exclusions[1]', value = '/prefix.+')
+@Property(name = 'spec.name', value = 'ExcludedHttpAccessLoggerSpec')
 class ExcludedHttpAccessLoggerSpec extends Specification {
 
     @Inject
@@ -65,6 +67,7 @@ class ExcludedHttpAccessLoggerSpec extends Specification {
     }
 
     @Controller("/")
+    @Requires(property = "spec.name", value = "ExcludedHttpAccessLoggerSpec")
     static class GetController {
 
         @Get('/{+path}')

--- a/test-suite/src/test/groovy/io/micronaut/http/ExcludedHttpAccessLoggerSpec.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/http/ExcludedHttpAccessLoggerSpec.groovy
@@ -1,0 +1,77 @@
+package io.micronaut.http
+
+import ch.qos.logback.classic.Logger
+import io.micronaut.context.annotation.Property
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.slf4j.LoggerFactory
+import reactor.core.publisher.Flux
+import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
+
+@MicronautTest
+@Property(name = 'micronaut.server.netty.access-logger.enabled', value = 'true')
+@Property(name = 'micronaut.server.netty.access-logger.exclusions[0]', value = '/some/path')
+@Property(name = 'micronaut.server.netty.access-logger.exclusions[1]', value = '/prefix.+')
+class ExcludedHttpAccessLoggerSpec extends Specification {
+
+    @Inject
+    @Client("/")
+    HttpClient client
+
+    PollingConditions conditions = new PollingConditions(timeout: 3, delay: 0.5)
+
+    static MemoryAppender appender = new MemoryAppender()
+
+    static {
+        Logger l = (Logger) LoggerFactory.getLogger("HTTP_ACCESS_LOGGER")
+        l.addAppender(appender)
+        appender.start()
+    }
+
+    def setup() {
+        appender.events.clear()
+    }
+
+    def "quick"() {
+        when:
+        def paths = [
+                [uri: '/prefix/a', logged: false],    // Matches /prefix.+
+                [uri: '/prefix/b/c', logged: false],  // Matches /prefix.+
+                [uri: '/prefix', logged: true],
+                [uri: '/some/path', logged: false],   // Matches /some/path
+                [uri: '/some/path/2', logged: true],
+                [uri: '/another', logged: true],
+        ]
+
+        and:
+        paths.each {
+            Flux.from(client.exchange(HttpRequest.GET(it.uri))).blockFirst()
+        }
+
+        then:
+        conditions.eventually {
+            def loggedUris = appender.events.collect {
+                def matcher = (it =~ /^.+GET (?<uri>\S+).+$/)
+                matcher.matches() ? matcher.group('uri') : it
+            }
+
+            loggedUris == paths.findAll { it.logged }.uri
+        }
+    }
+
+    @Controller("/")
+    static class GetController {
+
+        @Get('/{+path}')
+        String simple() {
+            return "ok"
+        }
+
+    }
+
+}

--- a/test-suite/src/test/groovy/io/micronaut/http/ExcludedHttpAccessLoggerSpec.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/http/ExcludedHttpAccessLoggerSpec.groovy
@@ -62,7 +62,7 @@ class ExcludedHttpAccessLoggerSpec extends Specification {
                 matcher.matches() ? matcher.group('uri') : it
             }
 
-            loggedUris == paths.findAll { it.logged }.uri
+            loggedUris.toSet() == paths.findAll { it.logged }.uri.toSet()
         }
     }
 

--- a/test-suite/src/test/groovy/io/micronaut/http/ExcludedHttpAccessLoggerSpec.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/http/ExcludedHttpAccessLoggerSpec.groovy
@@ -51,14 +51,11 @@ class ExcludedHttpAccessLoggerSpec extends Specification {
         ]
 
         and:
-        def responses = paths.collect {
-            Flux.from(client.retrieve(HttpRequest.GET(it.uri), String)).blockFirst()
+        paths.each {
+            Flux.from(client.exchange(HttpRequest.GET(it.uri))).blockFirst()
         }
 
         then:
-        responses.size() == paths.size()
-        responses.every { it == "ok" }
-
         conditions.eventually {
             def loggedUris = appender.events.collect {
                 def matcher = (it =~ /^.+GET (?<uri>\S+).+$/)

--- a/test-suite/src/test/groovy/io/micronaut/http/HttpAccessLogger.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/http/HttpAccessLogger.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 original authors
+ * Copyright 2017-2022 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
 package io.micronaut.http
 
 import ch.qos.logback.classic.Logger
-import ch.qos.logback.classic.spi.ILoggingEvent
-import ch.qos.logback.core.AppenderBase
 import io.micronaut.context.annotation.Property
 import io.micronaut.core.type.Argument
 import io.micronaut.http.annotation.Controller
@@ -33,9 +31,6 @@ import reactor.core.publisher.Flux
 import spock.lang.Specification
 
 import jakarta.inject.Inject
-import java.util.concurrent.BlockingQueue
-import java.util.concurrent.LinkedBlockingQueue
-import java.util.concurrent.TimeUnit
 
 /**
  * @author Christophe Roudet
@@ -170,22 +165,4 @@ class HttpAccessLoggerSpec extends Specification {
         }
 
     }
-
-    private static class MemoryAppender extends AppenderBase<ILoggingEvent> {
-        private final BlockingQueue<String> events = new LinkedBlockingQueue<>()
-
-        @Override
-        protected void append(ILoggingEvent e) {
-            events.add(e.formattedMessage)
-        }
-
-        public Queue<String> getEvents() {
-            return events
-        }
-
-        public String headLog(long timeout) {
-            return events.poll(timeout, TimeUnit.SECONDS)
-        }
-    }
-
 }

--- a/test-suite/src/test/groovy/io/micronaut/http/MemoryAppender.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/http/MemoryAppender.groovy
@@ -1,0 +1,27 @@
+package io.micronaut.http
+
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.AppenderBase
+import groovy.transform.PackageScope
+
+import java.util.concurrent.BlockingQueue
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+
+@PackageScope
+class MemoryAppender extends AppenderBase<ILoggingEvent> {
+    private final BlockingQueue<String> events = new LinkedBlockingQueue<>()
+
+    @Override
+    protected void append(ILoggingEvent e) {
+        events.add(e.formattedMessage)
+    }
+
+    Queue<String> getEvents() {
+        return events
+    }
+
+    String headLog(long timeout) {
+        return events.poll(timeout, TimeUnit.SECONDS)
+    }
+}


### PR DESCRIPTION
This change allows the user to specify a list of regular expression patterns that are compiled
and matched against the current request URI.

If the request URI matches one of them, then the request does not appear in the access log.