### PR TITLE
Release FileUpload, not the wrapped buffer, in NettyCompletedFileUpload

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/multipart/NettyCompletedFileUpload.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/multipart/NettyCompletedFileUpload.java
@@ -106,7 +106,7 @@ public class NettyCompletedFileUpload implements CompletedFileUpload {
             return ByteBufUtil.getBytes(byteBuf);
         } finally {
             if (controlRelease) {
-                byteBuf.release();
+                fileUpload.release();
             }
         }
     }
@@ -130,7 +130,7 @@ public class NettyCompletedFileUpload implements CompletedFileUpload {
             return byteBuf.nioBuffer();
         } finally {
             if (controlRelease) {
-                byteBuf.release();
+                fileUpload.release();
             }
         }
     }


### PR DESCRIPTION
When `controlRelease` is set, `NettyCompletedFileUpload` will `retain()` the `FileUpload` instance, however before this patch, it would `release` the `FileUpload.getByteBuf()`, not the `FileUpload` itself.

This bug can be reproduced using `UploadSpec#test upload CompletedFileUpload object`, but unfortunately does not yield a test failure, only a log message.

Fixes #6710