### PR TITLE
Fix binding mixed attributes to body parameters

### DIFF
--- a/test-suite/src/test/groovy/io/micronaut/upload/MixedUploadSpec.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/upload/MixedUploadSpec.groovy
@@ -430,6 +430,28 @@ class MixedUploadSpec extends AbstractMicronautSpec {
         result == 'data.json: 16'
     }
 
+    void "test normal form items"() {
+        given:
+        MultipartBody requestBody = MultipartBody.builder()
+                .addPart("title", "foo")
+                .build()
+
+
+        when:
+        Mono<HttpResponse<String>> flowable = Mono.from(client.exchange(
+                HttpRequest.POST("/upload/receive-multipart", requestBody)
+                        .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+                        .accept(MediaType.TEXT_PLAIN_TYPE),
+                String
+        ))
+        HttpResponse<String> response = flowable.block()
+        def result = response.getBody().get()
+
+        then:
+        response.code() == HttpStatus.OK.code
+        result == "Data{title='foo'}"
+    }
+
     @Override
     Map<String, Object> getConfiguration() {
         super.getConfiguration() << ['micronaut.http.client.read-timeout': 300,

--- a/test-suite/src/test/groovy/io/micronaut/upload/UploadController.java
+++ b/test-suite/src/test/groovy/io/micronaut/upload/UploadController.java
@@ -75,6 +75,11 @@ public class UploadController {
         return title + ": " + data.length;
     }
 
+    @Post(value = "/receive-multipart", consumes = MediaType.MULTIPART_FORM_DATA, produces = MediaType.TEXT_PLAIN)
+    public String receiveMultipart(@Body Data data) {
+        return data.toString();
+    }
+
     @Post(value = "/receive-file-upload", consumes = MediaType.MULTIPART_FORM_DATA, produces = MediaType.TEXT_PLAIN)
     public Publisher<MutableHttpResponse<?>> receiveFileUpload(StreamingFileUpload data, String title) {
         long size = data.getDefinedSize();


### PR DESCRIPTION
`NettyHttpRequest.buildBody` distinguishes between requests with "received data" and "received content", where the former only applies when `AbstractHttpData` instances are present. `AbstractHttpData` is a base class of both `DiskAttribute` and `MemoryAttribute`, but not of `MixedAttribute`. This makes `buildBody` use the "content" path for mixed requests.

This change adds an exception for `MixedAttribute` so that it is also covered by the "data" path.

Fixes #6705