### PR TITLE
Allow exclusion of http requests from tracing

### DIFF
--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/stream/InputStreamBodySpec2.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/stream/InputStreamBodySpec2.groovy
@@ -126,4 +126,5 @@ class InputStreamBodySpec2 extends Specification {
             return "Some body content"
         }
     }
+
 }

--- a/src/main/docs/guide/cloud/distributedTracing/jaeger.adoc
+++ b/src/main/docs/guide/cloud/distributedTracing/jaeger.adoc
@@ -70,6 +70,9 @@ tracing:
       flushInterval: 2000
       maxQueueSize: 200
     codecs: W3C,B3,JAEGER
+  exclusions: # Optionally exclude http path patterns from tracing
+    - /health
+    - /admin/.*
 ----
 
 You can also optionally dependency-inject common configuration classes into api:tracing.jaeger.JaegerConfiguration[] such as `io.jaegertracing.Configuration.SamplerConfiguration` just by defining them as beans. See the API for api:tracing.jaeger.JaegerConfiguration[] for available injection points.

--- a/src/main/docs/guide/cloud/distributedTracing/zipkin.adoc
+++ b/src/main/docs/guide/cloud/distributedTracing/zipkin.adoc
@@ -90,6 +90,9 @@ tracing:
     traceId128Bit: true
     sampler:
       probability: 1
+  exclusions: # Optionally exclude http path patterns from tracing
+    - /health
+    - /admin/.*
 ----
 
 You can also optionally dependency-inject common configuration classes into api:tracing.brave.BraveTracerConfiguration[] such as `brave.sampler.Sampler` just by defining them as beans. See the API for api:tracing.brave.BraveTracerConfiguration[] for available injection points.

--- a/tracing/build.gradle
+++ b/tracing/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 internalSanityChecks {
-    expectedServiceCount.put('io.micronaut.inject.BeanDefinitionReference', 39)
+    expectedServiceCount.put('io.micronaut.inject.BeanDefinitionReference', 40)
     expectedServiceCount.put('io.micronaut.inject.BeanConfiguration', 2)
 }
 

--- a/tracing/src/main/java/io/micronaut/tracing/instrument/http/TracingExclusionsConfiguration.java
+++ b/tracing/src/main/java/io/micronaut/tracing/instrument/http/TracingExclusionsConfiguration.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.tracing.instrument.http;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.util.CollectionUtils;
+
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * @since 3.3.0
+ */
+@ConfigurationProperties(TracingExclusionsConfiguration.PREFIX)
+public class TracingExclusionsConfiguration {
+
+    public static final String PREFIX = "tracing";
+    private List<String> exclusions;
+
+    /**
+     * @return The URI patterns to exclude from the tracing.
+     */
+    @Nullable public List<String> getExclusions() {
+        return exclusions;
+    }
+
+    /**
+     * Sets the URI patterns to be excluded from tracing.
+     *
+     * @param exclusions A list of regular expression patterns to be excluded from tracing if the request URI matches.
+     *
+     * @see java.util.regex.Pattern#compile(String)
+     */
+    public void setExclusions(@Nullable List<String> exclusions) {
+        this.exclusions = exclusions;
+    }
+
+    /**
+     * @return Either null (implying everything should be included), or a Predicate which when given a URL path returns
+     *         whether that path should be included in tracing.
+     */
+    @Nullable public Predicate<String> inclusionTest() {
+        if (CollectionUtils.isEmpty(exclusions)) {
+            return null;
+        } else {
+            List<Pattern> patterns = exclusions.stream().map(Pattern::compile).collect(Collectors.toList());
+            return uri -> patterns.stream().noneMatch(pattern -> pattern.matcher(uri).matches());
+        }
+    }
+
+    /**
+     * @return Either null (implying everything should be included), or a Predicate which when given a URL path returns
+     *         whether that path should be excluded from tracing.
+     */
+    @Nullable public Predicate<String> exclusionTest() {
+        Predicate<String> inclusionTest = inclusionTest();
+        return inclusionTest == null ? null : inclusionTest.negate();
+    }
+}

--- a/tracing/src/main/java/io/micronaut/tracing/jaeger/JaegerConfiguration.java
+++ b/tracing/src/main/java/io/micronaut/tracing/jaeger/JaegerConfiguration.java
@@ -194,6 +194,17 @@ public class JaegerConfiguration implements Toggleable  {
     }
 
     /**
+     * Set codecs from string.
+     *
+     * @param codecs the codecs
+     */
+    public void setCodecs(String codecs) { // codecs = "JAEGER, B3, W3C"
+        if (codecs != null) {
+            setCodecConfiguration(Configuration.CodecConfiguration.fromString(codecs));
+        }
+    }
+
+    /**
      * The sampler configuration bean.
      */
     @ConfigurationProperties("sampler")
@@ -275,17 +286,6 @@ public class JaegerConfiguration implements Toggleable  {
          */
         public Configuration.SenderConfiguration getSenderConfiguration() {
             return configuration;
-        }
-    }
-
-    /**
-     * Set codecs from string.
-     *
-     * @param codecs the codecs
-     */
-    public void setCodecs(String codecs) { // codecs = "JAEGER, B3, W3C"
-        if (codecs != null) {
-            setCodecConfiguration(Configuration.CodecConfiguration.fromString(codecs));
         }
     }
 

--- a/tracing/src/test/groovy/io/micronaut/tracing/instrument/http/TracingExclusionsConfigurationSpec.groovy
+++ b/tracing/src/test/groovy/io/micronaut/tracing/instrument/http/TracingExclusionsConfigurationSpec.groovy
@@ -1,0 +1,44 @@
+package io.micronaut.tracing.instrument.http
+
+import io.micronaut.context.ApplicationContext
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+
+class TracingExclusionsConfigurationSpec extends Specification {
+
+    @AutoCleanup
+    ApplicationContext context = ApplicationContext.run(
+            'tracing.exclusions[0]': '.*pattern.*',
+            'tracing.exclusions[1]': '/literal',
+    )
+
+    TracingExclusionsConfiguration configuration = context.getBean(TracingExclusionsConfiguration)
+
+    def "path #input is #desc by exclusion predicate"() {
+        expect:
+        configuration.exclusionTest().test(input) == expected
+
+        where:
+        input           | expected
+        '/some/pattern' | true
+        '/another'      | false
+        '/literal'      | true
+        '/literal/sub'  | false
+
+        desc = expected ? 'excluded' : 'kept'
+    }
+
+    def "path #input is #desc by inclusion predicate"() {
+        expect:
+        configuration.inclusionTest().test(input) == expected
+
+        where:
+        input           | expected
+        '/some/pattern' | false
+        '/another'      | true
+        '/literal'      | false
+        '/literal/sub'  | true
+
+        desc = expected ? 'included' : 'excluded'
+    }
+}


### PR DESCRIPTION
This change allows configuration of a list of regular-expression patterns for tracing.

If the current path matches one of these patterns, then tracing is not performed on that
request.

Follows the same config naming strategy as #6753