### PR TITLE
Fix record serialization for native image

### DIFF
--- a/jackson-databind/src/main/java/io/micronaut/jackson/ObjectMapperFactory.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/ObjectMapperFactory.java
@@ -26,7 +26,10 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.KeyDeserializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.cfg.DeserializerFactoryConfig;
+import com.fasterxml.jackson.databind.deser.BeanDeserializerFactory;
 import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;
+import com.fasterxml.jackson.databind.deser.DefaultDeserializationContext;
 import com.fasterxml.jackson.databind.deser.std.StringDeserializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
@@ -111,7 +114,7 @@ public class ObjectMapperFactory {
     public ObjectMapper objectMapper(@Nullable JacksonConfiguration jacksonConfiguration,
                                      @Nullable JsonFactory jsonFactory) {
 
-        ObjectMapper objectMapper = jsonFactory != null ? new ObjectMapper(jsonFactory) : new ObjectMapper();
+        ObjectMapper objectMapper = new ObjectMapper(jsonFactory, null, new DefaultDeserializationContext.Impl(new ResilientBeanDeserializerFactory(new DeserializerFactoryConfig())));
 
         final boolean hasConfiguration = jacksonConfiguration != null;
         if (!hasConfiguration || jacksonConfiguration.isModuleScan()) {

--- a/jackson-databind/src/main/java/io/micronaut/jackson/ResilientBeanDeserializerFactory.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/ResilientBeanDeserializerFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.jackson;
 
 import com.fasterxml.jackson.databind.BeanDescription;

--- a/jackson-databind/src/main/java/io/micronaut/jackson/ResilientBeanDeserializerFactory.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/ResilientBeanDeserializerFactory.java
@@ -1,0 +1,44 @@
+package io.micronaut.jackson;
+
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.DeserializationConfig;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.cfg.DeserializerFactoryConfig;
+import com.fasterxml.jackson.databind.deser.BeanDeserializerFactory;
+import com.fasterxml.jackson.databind.deser.DeserializerFactory;
+import com.fasterxml.jackson.databind.deser.ValueInstantiator;
+import com.fasterxml.jackson.databind.deser.impl.CreatorCollector;
+
+/**
+ * This class hooks {@link BeanDeserializerFactory} to fix an exception in {@link #_constructDefaultValueInstantiator}
+ * that happens when jackson attempts to access record member info in a native-image without reflective access for the
+ * record class.
+ *
+ * @author yawkat
+ * @since 3.3.0
+ */
+final class ResilientBeanDeserializerFactory extends BeanDeserializerFactory {
+    public ResilientBeanDeserializerFactory(DeserializerFactoryConfig config) {
+        super(config);
+    }
+
+    @Override
+    public DeserializerFactory withConfig(DeserializerFactoryConfig config) {
+        return new ResilientBeanDeserializerFactory(config);
+    }
+
+    @Override
+    protected ValueInstantiator _constructDefaultValueInstantiator(DeserializationContext ctxt, BeanDescription beanDesc) throws JsonMappingException {
+        try {
+            return super._constructDefaultValueInstantiator(ctxt, beanDesc);
+        } catch (IllegalArgumentException e) {
+            if (e.getMessage().startsWith("Failed to access RecordComponents of type ")) {
+                final DeserializationConfig config = ctxt.getConfig();
+                return new CreatorCollectionState(ctxt, beanDesc, config.getDefaultVisibilityChecker(beanDesc.getBeanClass(), beanDesc.getClassInfo()),
+                        new CreatorCollector(beanDesc, config), _findCreatorsFromProperties(ctxt, beanDesc)).creators.constructValueInstantiator(ctxt);
+            }
+            throw e;
+        }
+    }
+}

--- a/jackson-databind/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
@@ -41,7 +41,6 @@ import com.fasterxml.jackson.databind.deser.impl.MethodProperty;
 import com.fasterxml.jackson.databind.deser.std.StdValueInstantiator;
 import com.fasterxml.jackson.databind.introspect.AccessorNamingStrategy;
 import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
-import com.fasterxml.jackson.databind.introspect.AnnotatedField;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMethod;
 import com.fasterxml.jackson.databind.introspect.AnnotationCollector;

--- a/jackson-databind/src/test/groovy/io/micronaut/jackson/modules/BeanIntrospectionModuleRecordSpec.groovy
+++ b/jackson-databind/src/test/groovy/io/micronaut/jackson/modules/BeanIntrospectionModuleRecordSpec.groovy
@@ -1,0 +1,49 @@
+package io.micronaut.jackson.modules
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Replaces
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.beans.BeanIntrospection
+import jakarta.inject.Singleton
+import spock.lang.IgnoreIf
+
+@IgnoreIf({ !jvm.isJava14Compatible() })
+class BeanIntrospectionModuleRecordSpec extends AbstractTypeElementSpec {
+    def 'test record support'() {
+        given:
+        BeanIntrospection introspection = buildBeanIntrospection('test.Test', '''
+package test;
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+record Test(String foo, String bar) {
+}
+''')
+        def ctx = ApplicationContext.run(['spec.name': 'BeanIntrospectionModuleRecordSpec'])
+        ctx.getBean(StaticBeanIntrospectionModule).introspectionMap[introspection.beanType] = introspection
+        ctx.getBean(BeanIntrospectionModule).ignoreReflectiveProperties = ignoreReflectiveProperties
+        def mapper = ctx.getBean(ObjectMapper)
+
+        when:
+        def value = mapper.readValue('{"foo":"1","bar":"2"}', introspection.beanType)
+        then:
+        value.foo == '1'
+        value.bar == '2'
+
+        where:
+        ignoreReflectiveProperties << [true, false]
+    }
+
+    @Singleton
+    @Replaces(BeanIntrospectionModule)
+    @Requires(property = "spec.name", value = 'BeanIntrospectionModuleRecordSpec')
+    static class StaticBeanIntrospectionModule extends BeanIntrospectionModule {
+        Map<Class, BeanIntrospection> introspectionMap = [:]
+        @Override
+        protected BeanIntrospection<Object> findIntrospection(Class<?> beanClass) {
+            return introspectionMap.get(beanClass)
+        }
+    }
+}


### PR DESCRIPTION
Without `@ReflectiveAccess` on native-image, jackson fails serialization and deserialization of record types with an exception message `Failed to access RecordComponents of type ...` (see issue). This happens before the `BeanIntrospectionModule` comes into play, so mapping is not possible even though the `BeanIntrospectionModule` could have replaced the missing reflection information.

This patch hooks the jackson `AccessorNamingStrategy` to bypass the relevant code for serialization. This seems reasonable enough. It also hooks `BeanDeserializerFactory` for deserialization, but both the approach in patching `_constructDefaultValueInstantiator` and the way the factory is inserted (can't be done in the `BeanIntrospectionModule`) are very hacky.

I hope to fix this upstream in jackson at some point, once I get CLA approval, but we're still on 2.12 so we couldn't take advantage of that for a while still.

Fixes #6277