### PR TITLE
Handle void return type from Function clients

### DIFF
--- a/function-client/src/main/java/io/micronaut/function/client/http/HttpFunctionExecutor.java
+++ b/function-client/src/main/java/io/micronaut/function/client/http/HttpFunctionExecutor.java
@@ -88,6 +88,9 @@ public class HttpFunctionExecutor<I, O> implements FunctionInvoker<I, O>, Closea
                 return ConversionService.SHARED.convert(publisher, outputType).orElseThrow(() ->
                     new FunctionExecutionException("Unsupported Reactive type: " + outputJavaType)
                 );
+            } else if (outputType.isVoid()) {
+                httpClient.toBlocking().exchange(request);
+                return null;
             } else {
                 return (O) httpClient.toBlocking().retrieve(request, outputType);
             }

--- a/test-suite/src/test/groovy/io/micronaut/function/web/NullReturningConsumerFunctionSpec.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/function/web/NullReturningConsumerFunctionSpec.groovy
@@ -1,0 +1,47 @@
+package io.micronaut.function.web
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.env.Environment
+import io.micronaut.function.FunctionBean
+import io.micronaut.function.client.FunctionClient
+import io.micronaut.runtime.server.EmbeddedServer
+import jakarta.inject.Named
+import spock.lang.Issue
+import spock.lang.Specification
+
+import java.util.function.Consumer
+
+class NullReturningConsumerFunctionSpec extends Specification {
+
+    @Issue("https://github.com/micronaut-projects/micronaut-core/issues/2024")
+    def "test a client with a void return type"() {
+        given:
+        def embeddedServer = ApplicationContext.run(EmbeddedServer)
+        def client = embeddedServer.applicationContext.getBean(MicronautFunctionProblemsClient)
+
+        when:
+        client.sendVoid("woo")
+
+        then:
+        PojoConsumer.LAST_VALUE == "woo"
+    }
+
+    @FunctionClient
+    static interface MicronautFunctionProblemsClient {
+
+        @Named("consumer/void")
+        void sendVoid(String message)
+    }
+
+    @FunctionBean("consumer/void")
+    static class PojoConsumer implements Consumer<String> {
+
+        static String LAST_VALUE
+
+        @Override
+        void accept(String book) {
+            LAST_VALUE = book
+        }
+    }
+}


### PR DESCRIPTION
Calling a client method with a `void` return type failed with a `NullPointerException` when
we tried to make the request.

This change checks for a void return type and instead calls `exchange` if it is found