### PR TITLE
Support interleaved requests in access logger

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
@@ -968,6 +968,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
                         toNettyResponse(response),
                         mapToHttpContent(nettyRequest, response, body, context)
                 );
+                nettyRequest.prepareHttp2ResponseIfNecessary(streamedResponse);
                 context.writeAndFlush(streamedResponse);
                 context.read();
             } else {

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/HttpAccessLogHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/HttpAccessLogHandler.java
@@ -183,7 +183,8 @@ public class HttpAccessLogHandler extends ChannelDuplexHandler {
             if (!createIfMissing) {
                 return null;
             }
-            attr.set(holder = new AccessLogHolder());
+            holder = new AccessLogHolder();
+            attr.set(holder);
         }
         return holder;
     }
@@ -237,7 +238,8 @@ public class HttpAccessLogHandler extends ChannelDuplexHandler {
                     currentPendingResponseStreamId++;
                 }
             } else {
-                currentPendingResponseStreamId = streamId = Long.parseLong(streamIdHeader);
+                streamId = Long.parseLong(streamIdHeader);
+                currentPendingResponseStreamId = streamId; // in case future HttpContent objects arrive without a stream_id header
             }
             if (finishResponse) {
                 AccessLog accessLog = liveAccessLogsByStreamId.remove(streamId);

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/HttpAccessLogHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/HttpAccessLogHandler.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.http.server.netty.handler.accesslog;
 
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.server.netty.handler.accesslog.element.AccessLog;
 import io.micronaut.http.server.netty.handler.accesslog.element.AccessLogFormatParser;
 import io.netty.buffer.ByteBuf;
@@ -25,6 +26,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMessage;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -33,9 +35,12 @@ import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.HttpConversionUtil.ExtensionHeaderNames;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
+import org.jetbrains.annotations.Contract;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.function.Predicate;
 
 /**
@@ -52,7 +57,7 @@ public class HttpAccessLogHandler extends ChannelDuplexHandler {
      */
     public static final String HTTP_ACCESS_LOGGER = "HTTP_ACCESS_LOGGER";
 
-    private static final AttributeKey<AccessLog> ACCESS_LOGGER = AttributeKey.valueOf("ACCESS_LOGGER");
+    private static final AttributeKey<AccessLogHolder> ACCESS_LOGGER = AttributeKey.valueOf("ACCESS_LOGGER");
     private static final String H2_PROTOCOL_NAME = "HTTP/2.0";
 
     private final Logger logger;
@@ -109,7 +114,7 @@ public class HttpAccessLogHandler extends ChannelDuplexHandler {
         if (logger.isInfoEnabled() && msg instanceof HttpRequest) {
             final SocketChannel channel = (SocketChannel) ctx.channel();
             final HttpRequest request = (HttpRequest) msg;
-            AccessLog accessLog = accessLog(channel);
+            AccessLogHolder accessLogHolder = getAccessLogHolder(ctx, true);
             if (uriInclusion == null || uriInclusion.test(request.uri())) {
                 final HttpHeaders headers = request.headers();
                 // Trying to detect http/2
@@ -119,9 +124,9 @@ public class HttpAccessLogHandler extends ChannelDuplexHandler {
                 } else {
                     protocol = request.protocolVersion().text();
                 }
-                accessLog.onRequestHeaders(channel, request.method().name(), request.headers(), request.uri(), protocol);
+                accessLogHolder.createLogForRequest(request).onRequestHeaders(channel, request.method().name(), request.headers(), request.uri(), protocol);
             } else {
-                accessLog.exclude();
+                accessLogHolder.excludeRequest(request);
             }
         }
         ctx.fireChannelRead(msg);
@@ -136,18 +141,6 @@ public class HttpAccessLogHandler extends ChannelDuplexHandler {
         }
     }
 
-    private AccessLog accessLog(SocketChannel channel) {
-        final Attribute<AccessLog> attr = channel.attr(ACCESS_LOGGER);
-        AccessLog accessLog = attr.get();
-        if (accessLog == null) {
-            accessLog = accessLogFormatParser.newAccessLogger();
-            attr.set(accessLog);
-        } else {
-            accessLog.reset();
-        }
-        return accessLog;
-    }
-
     private void log(ChannelHandlerContext ctx, Object msg, ChannelPromise promise, AccessLog accessLog) {
         ctx.write(msg, promise.unvoid()).addListener(future -> {
             if (future.isSuccess()) {
@@ -156,32 +149,103 @@ public class HttpAccessLogHandler extends ChannelDuplexHandler {
         });
     }
 
-    private static boolean processHttpResponse(HttpResponse response, AccessLog accessLogger, ChannelHandlerContext ctx, ChannelPromise promise) {
-        final HttpResponseStatus status = response.status();
-        if (status.equals(HttpResponseStatus.CONTINUE)) {
-            ctx.write(response, promise);
-            return true;
-        }
-        accessLogger.onResponseHeaders(ctx, response.headers(), status.codeAsText().toString());
-        return false;
-    }
-
     private void processWriteEvent(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
-        final AccessLog accessLogger = ctx.channel().attr(ACCESS_LOGGER).get();
-        if (accessLogger != null) {
-            if (msg instanceof HttpResponse && processHttpResponse((HttpResponse) msg, accessLogger, ctx, promise)) {
-                return;
-            }
-            if (msg instanceof LastHttpContent) {
-                accessLogger.onLastResponseWrite(((LastHttpContent) msg).content().readableBytes());
-                log(ctx, msg, promise, accessLogger);
-                return;
-            } else if (msg instanceof ByteBufHolder) {
-                accessLogger.onResponseWrite(((ByteBufHolder) msg).content().readableBytes());
-            } else if (msg instanceof ByteBuf) {
-                accessLogger.onResponseWrite(((ByteBuf) msg).readableBytes());
+        AccessLogHolder accessLogHolder = getAccessLogHolder(ctx, false);
+        if (accessLogHolder != null) {
+            boolean isContinueResponse = msg instanceof HttpResponse && ((HttpResponse) msg).status().equals(HttpResponseStatus.CONTINUE);
+            AccessLog accessLogger = accessLogHolder.getLogForResponse(
+                    msg instanceof HttpMessage ? (HttpMessage) msg : null,
+                    msg instanceof LastHttpContent && !isContinueResponse);
+            if (accessLogger != null && !isContinueResponse) {
+                if (msg instanceof HttpResponse) {
+                    accessLogger.onResponseHeaders(ctx, ((HttpResponse) msg).headers(), ((HttpResponse) msg).status().codeAsText().toString());
+                }
+                if (msg instanceof LastHttpContent) {
+                    accessLogger.onLastResponseWrite(((LastHttpContent) msg).content().readableBytes());
+                    log(ctx, msg, promise, accessLogger);
+                    return;
+                } else if (msg instanceof ByteBufHolder) {
+                    accessLogger.onResponseWrite(((ByteBufHolder) msg).content().readableBytes());
+                } else if (msg instanceof ByteBuf) {
+                    accessLogger.onResponseWrite(((ByteBuf) msg).readableBytes());
+                }
             }
         }
         super.write(ctx, msg, promise);
+    }
+
+    @Nullable
+    @Contract("_, true -> !null") // can only return null when createIfMissing is false
+    private AccessLogHolder getAccessLogHolder(ChannelHandlerContext ctx, boolean createIfMissing) {
+        final Attribute<AccessLogHolder> attr = ctx.channel().attr(ACCESS_LOGGER);
+        AccessLogHolder holder = attr.get();
+        if (holder == null) {
+            if (!createIfMissing) {
+                return null;
+            }
+            attr.set(holder = new AccessLogHolder());
+        }
+        return holder;
+    }
+
+    /**
+     * Holder for {@link AccessLog} instances. {@link AccessLog} can only handle one concurrent request at a time, this
+     * class multiplexes access where necessary.
+     */
+    private final class AccessLogHolder {
+        private final Map<Long, AccessLog> liveAccessLogsByStreamId = new HashMap<>();
+        // HTTP1 does not have stream IDs. To emulate them, we have two counters. One counts up on every request, and
+        // the other counts up on every *completed* response.
+        private long http1NextRequestStreamId = 0;
+        private long http1CurrentPendingResponseStreamId = 0;
+
+        private AccessLog logForReuse;
+
+        AccessLog createLogForRequest(HttpRequest request) {
+            long streamId = getOrCreateStreamId(request);
+            AccessLog log = logForReuse;
+            logForReuse = null;
+            if (log != null) {
+                log.reset();
+            } else {
+                log = accessLogFormatParser.newAccessLogger();
+            }
+            liveAccessLogsByStreamId.put(streamId, log);
+            return log;
+        }
+
+        void excludeRequest(HttpRequest request) {
+            getOrCreateStreamId(request); // claim stream id, but no access logger
+        }
+
+        private long getOrCreateStreamId(HttpRequest request) {
+            String streamIdHeader = request.headers().get(ExtensionHeaderNames.STREAM_ID.text());
+            if (streamIdHeader == null) {
+                return http1NextRequestStreamId++;
+            } else {
+                return Long.parseLong(streamIdHeader);
+            }
+        }
+
+        @Nullable
+        AccessLog getLogForResponse(@Nullable HttpMessage msg, boolean finishResponse) {
+            String streamIdHeader = msg == null ? null : msg.headers().get(ExtensionHeaderNames.STREAM_ID.text());
+            long streamId;
+            if (streamIdHeader == null) {
+                streamId = http1CurrentPendingResponseStreamId;
+                if (finishResponse) {
+                    http1CurrentPendingResponseStreamId++;
+                }
+            } else {
+                streamId = Long.parseLong(streamIdHeader);
+            }
+            if (finishResponse) {
+                AccessLog accessLog = liveAccessLogsByStreamId.remove(streamId);
+                logForReuse = accessLog;
+                return accessLog;
+            } else {
+                return liveAccessLogsByStreamId.get(streamId);
+            }
+        }
     }
 }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/HttpAccessLogHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/HttpAccessLogHandler.java
@@ -35,7 +35,6 @@ import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.HttpConversionUtil.ExtensionHeaderNames;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
-import org.jetbrains.annotations.Contract;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -115,6 +114,7 @@ public class HttpAccessLogHandler extends ChannelDuplexHandler {
             final SocketChannel channel = (SocketChannel) ctx.channel();
             final HttpRequest request = (HttpRequest) msg;
             AccessLogHolder accessLogHolder = getAccessLogHolder(ctx, true);
+            assert accessLogHolder != null; // can only return null when createIfMissing is false
             if (uriInclusion == null || uriInclusion.test(request.uri())) {
                 final HttpHeaders headers = request.headers();
                 // Trying to detect http/2
@@ -175,7 +175,6 @@ public class HttpAccessLogHandler extends ChannelDuplexHandler {
     }
 
     @Nullable
-    @Contract("_, true -> !null") // can only return null when createIfMissing is false
     private AccessLogHolder getAccessLogHolder(ChannelHandlerContext ctx, boolean createIfMissing) {
         final Attribute<AccessLogHolder> attr = ctx.channel().attr(ACCESS_LOGGER);
         AccessLogHolder holder = attr.get();

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/HttpAccessLogHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/HttpAccessLogHandler.java
@@ -197,7 +197,7 @@ public class HttpAccessLogHandler extends ChannelDuplexHandler {
         // HTTP1 does not have stream IDs. To emulate them, we have two counters. One counts up on every request, and
         // the other counts up on every *completed* response.
         private long http1NextRequestStreamId = 0;
-        private long http1CurrentPendingResponseStreamId = 0;
+        private long currentPendingResponseStreamId = 0;
 
         private AccessLog logForReuse;
 
@@ -232,12 +232,12 @@ public class HttpAccessLogHandler extends ChannelDuplexHandler {
             String streamIdHeader = msg == null ? null : msg.headers().get(ExtensionHeaderNames.STREAM_ID.text());
             long streamId;
             if (streamIdHeader == null) {
-                streamId = http1CurrentPendingResponseStreamId;
+                streamId = currentPendingResponseStreamId;
                 if (finishResponse) {
-                    http1CurrentPendingResponseStreamId++;
+                    currentPendingResponseStreamId++;
                 }
             } else {
-                streamId = Long.parseLong(streamIdHeader);
+                currentPendingResponseStreamId = streamId = Long.parseLong(streamIdHeader);
             }
             if (finishResponse) {
                 AccessLog accessLog = liveAccessLogsByStreamId.remove(streamId);

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/AccessLog.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/AccessLog.java
@@ -35,7 +35,6 @@ public class AccessLog {
     private final List<IndexedLogElement> onResponseWriteElements;
     private final List<IndexedLogElement> onLastResponseWriteElements;
     private final String[] elements;
-    private boolean excluded;
 
     /**
      * Creates an AccessLog.
@@ -52,7 +51,6 @@ public class AccessLog {
         this.onResponseWriteElements = onResponseWriteElements;
         this.onLastResponseWriteElements = onLastResponseWriteElements;
         this.elements = elements;
-        this.excluded = false;
     }
 
     /**
@@ -63,7 +61,6 @@ public class AccessLog {
         onResponseHeadersElements.forEach(this::resetIndexedLogElement);
         onResponseWriteElements.forEach(this::resetIndexedLogElement);
         onLastResponseWriteElements.forEach(this::resetIndexedLogElement);
-        excluded = false;
     }
 
    /**
@@ -76,10 +73,8 @@ public class AccessLog {
     * @param protocol The protocol.
     */
     public void onRequestHeaders(SocketChannel channel, String method, HttpHeaders headers, String uri, String protocol) {
-        if (!excluded) {
-            for (IndexedLogElement element: onRequestHeadersElements) {
-                elements[element.index] = element.onRequestHeaders(channel, method, headers, uri, protocol);
-            }
+        for (IndexedLogElement element: onRequestHeadersElements) {
+            elements[element.index] = element.onRequestHeaders(channel, method, headers, uri, protocol);
         }
     }
 
@@ -91,10 +86,8 @@ public class AccessLog {
      * @param status The response status.
      */
     public void onResponseHeaders(ChannelHandlerContext ctx, HttpHeaders headers, String status) {
-        if (!excluded) {
-            for (IndexedLogElement element: onResponseHeadersElements) {
-                elements[element.index] = element.onResponseHeaders(ctx, headers, status);
-            }
+        for (IndexedLogElement element: onResponseHeadersElements) {
+            elements[element.index] = element.onResponseHeaders(ctx, headers, status);
         }
     }
 
@@ -103,10 +96,8 @@ public class AccessLog {
      * @param bytesSent The number of bytes sent.
      */
     public void onResponseWrite(int bytesSent) {
-        if (!excluded) {
-            for (IndexedLogElement element: onResponseWriteElements) {
-                element.onResponseWrite(bytesSent);
-            }
+        for (IndexedLogElement element: onResponseWriteElements) {
+            element.onResponseWrite(bytesSent);
         }
     }
 
@@ -115,10 +106,8 @@ public class AccessLog {
      * @param bytesSent The number of bytes sent.
      */
     public void onLastResponseWrite(int bytesSent) {
-        if (!excluded) {
-            for (IndexedLogElement element: onLastResponseWriteElements) {
-                elements[element.index] = element.onLastResponseWrite(bytesSent);
-            }
+        for (IndexedLogElement element: onLastResponseWriteElements) {
+            elements[element.index] = element.onLastResponseWrite(bytesSent);
         }
     }
 
@@ -128,7 +117,7 @@ public class AccessLog {
      * @param accessLogger A logger.
      */
     public void log(Logger accessLogger) {
-        if (accessLogger.isInfoEnabled() && !excluded) {
+        if (accessLogger.isInfoEnabled()) {
             final StringBuilder b = new StringBuilder(elements.length * 5);
             for (int i = 0; i < elements.length; ++i) {
                 b.append(elements[i] == null ? ConstantElement.UNKNOWN_VALUE : elements[i]);
@@ -140,12 +129,5 @@ public class AccessLog {
     private void resetIndexedLogElement(IndexedLogElement elt) {
         elements[elt.index] = null;
         elt.reset();
-    }
-
-    /**
-     * Mark the current AccessLog as excluded (if for example, it is excluded by the access log exclusions).
-     */
-    public void exclude() {
-        this.excluded = true;
     }
 }

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/handler/accesslog/AccessLogSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/handler/accesslog/AccessLogSpec.groovy
@@ -124,6 +124,69 @@ class AccessLogSpec extends Specification {
     }
 
     @Issue('https://github.com/micronaut-projects/micronaut-core/issues/6782')
+    def 'http1.1 concurrent pipelined requests with exclusions'() {
+        given:
+        def ctx = ApplicationContext.run([
+                'spec.name': 'AccessLogSpec',
+                'micronaut.server.netty.access-logger.enabled': true,
+                'micronaut.server.netty.access-logger.logger-name': 'http-access-log',
+                'micronaut.server.netty.access-logger.exclusions[0]': '/interleave/open',
+        ])
+        def server = ctx.getBean(EmbeddedServer)
+        server.start()
+
+        def responses = new CopyOnWriteArrayList<FullHttpResponse>()
+        Bootstrap bootstrap = new Bootstrap()
+                .group(new NioEventLoopGroup(1))
+                .channel(NioSocketChannel)
+                .option(ChannelOption.AUTO_READ, true)
+                .handler(new ChannelInitializer<Channel>() {
+                    @Override
+                    protected void initChannel(@NotNull Channel ch) throws Exception {
+                        ch.pipeline()
+                                .addLast(new HttpClientCodec())
+                                .addLast(new HttpObjectAggregator(1024))
+                                .addLast(new ChannelInboundHandlerAdapter() {
+                                    @Override
+                                    void channelRead(@NotNull ChannelHandlerContext ctx_, @NotNull Object msg) throws Exception {
+                                        responses.add(msg)
+                                    }
+                                })
+                    }
+                })
+                .remoteAddress(server.host, server.port)
+
+        def request1 = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, '/interleave/open')
+        request1.headers().add(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE)
+        def request2 = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, '/interleave/finish')
+        request2.headers().add(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE)
+
+        def listAppender = new ListAppender<ILoggingEvent>()
+        listAppender.start()
+        ((Logger) LoggerFactory.getLogger('http-access-log')).addAppender(listAppender)
+
+        when:
+        def channel = bootstrap.connect().sync().channel()
+        channel.write(request1)
+        channel.writeAndFlush(request2)
+
+        then:
+        new PollingConditions(timeout: 5).eventually {
+            responses.size() == 2
+        }
+        responses[0].content().toString(StandardCharsets.UTF_8) == 'open'
+        responses[1].content().toString(StandardCharsets.UTF_8) == 'finish'
+
+        listAppender.list.size() == 1
+        listAppender.list[0].message.contains('/interleave/finish')
+
+        cleanup:
+        server.close()
+        channel.close()
+        bootstrap.config().group().shutdownGracefully()
+    }
+
+    @Issue('https://github.com/micronaut-projects/micronaut-core/issues/6782')
     def 'http1.1 continue status'() {
         given:
         def ctx = ApplicationContext.run([
@@ -387,6 +450,99 @@ class AccessLogSpec extends Specification {
         listAppender.list[1].message.contains('/interleave/simple')
         listAppender.list[2].message.contains('/interleave/open')
         listAppender.list[3].message.contains('/interleave/finish')
+
+        cleanup:
+        server.close()
+        channel.close()
+        bootstrap.config().group().shutdownGracefully()
+    }
+
+    @Issue('https://github.com/micronaut-projects/micronaut-core/issues/6782')
+    def 'h2c truly concurrent requests with http1 upgrade with exclusions'() {
+        given:
+        def ctx = ApplicationContext.run([
+                'spec.name': 'AccessLogSpec',
+                'micronaut.server.http-version': '2.0',
+                'micronaut.ssl.enabled': false,
+                'micronaut.server.netty.access-logger.enabled': true,
+                'micronaut.server.netty.access-logger.logger-name': 'http-access-log',
+                'micronaut.server.netty.access-logger.exclusions[0]': '/interleave/.i.*', // exclude simple and finish
+        ])
+        def server = ctx.getBean(EmbeddedServer)
+        server.start()
+
+        def request1 = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, '/interleave/simple')
+        request1.headers().add(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), ':https')
+        def request2 = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, '/interleave/open')
+        request2.headers().add(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), ':https')
+        request2.headers().add(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), 3)
+        def request3 = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, '/interleave/simple')
+        request3.headers().add(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), 5)
+        request3.headers().add(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), ':https')
+        def request4 = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, '/interleave/finish')
+        request4.headers().add(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), 7)
+        request4.headers().add(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), ':https')
+
+        def responses = new CopyOnWriteArrayList<FullHttpResponse>()
+        Bootstrap bootstrap = new Bootstrap()
+                .group(new NioEventLoopGroup(1))
+                .channel(NioSocketChannel)
+                .option(ChannelOption.AUTO_READ, true)
+                .handler(new ChannelInitializer<Channel>() {
+                    @Override
+                    protected void initChannel(@NotNull Channel ch) throws Exception {
+                        def connection = new DefaultHttp2Connection(false)
+                        def connectionHandler = new HttpToHttp2ConnectionHandlerBuilder()
+                                .initialSettings(Http2Settings.defaultSettings())
+                                .frameListener(new DelegatingDecompressorFrameListener(
+                                        connection,
+                                        new InboundHttp2ToHttpAdapterBuilder(connection)
+                                                .maxContentLength(Integer.MAX_VALUE)
+                                                .propagateSettings(false)
+                                                .build()
+                                ))
+                                .connection(connection)
+                                .build()
+                        def clientCodec = new HttpClientCodec()
+                        def upgradeCodec = new Http2ClientUpgradeCodec(ChannelPipelineCustomizer.HANDLER_HTTP2_CONNECTION, connectionHandler)
+                        def upgradeHandler = new HttpClientUpgradeHandler(clientCodec, upgradeCodec, 1000000)
+                        ch.pipeline()
+                                .addLast(ChannelPipelineCustomizer.HANDLER_HTTP_CLIENT_CODEC, clientCodec)
+                                .addLast(upgradeHandler)
+                                .addLast(new ChannelInboundHandlerAdapter() {
+                                    @Override
+                                    void channelRead(@NotNull ChannelHandlerContext ctx_, @NotNull Object msg) throws Exception {
+                                        if (responses.isEmpty()) {
+                                            ctx_.channel().write(request2)
+                                            ctx_.channel().write(request3)
+                                            ctx_.channel().writeAndFlush(request4)
+                                        }
+                                        responses.add(msg)
+                                    }
+                                })
+                    }
+                })
+                .remoteAddress(server.host, server.port)
+
+        def listAppender = new ListAppender<ILoggingEvent>()
+        listAppender.start()
+        ((Logger) LoggerFactory.getLogger('http-access-log')).addAppender(listAppender)
+
+        when:
+        def channel = bootstrap.connect().sync().channel()
+        channel.writeAndFlush(request1)
+
+        then:
+        new PollingConditions(timeout: 5).eventually {
+            responses.size() == 4
+        }
+        responses[0].content().toString(StandardCharsets.UTF_8) == 'simple'
+        responses[1].content().toString(StandardCharsets.UTF_8) == 'simple'
+        responses[2].content().toString(StandardCharsets.UTF_8) == 'open'
+        responses[3].content().toString(StandardCharsets.UTF_8) == 'finish'
+
+        listAppender.list.size() == 1
+        listAppender.list[0].message.contains('/interleave/open')
 
         cleanup:
         server.close()

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/handler/accesslog/AccessLogSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/handler/accesslog/AccessLogSpec.groovy
@@ -1,0 +1,428 @@
+package io.micronaut.http.server.netty.handler.accesslog
+
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Post
+import io.micronaut.http.netty.channel.ChannelPipelineCustomizer
+import io.micronaut.runtime.server.EmbeddedServer
+import io.netty.bootstrap.Bootstrap
+import io.netty.buffer.Unpooled
+import io.netty.channel.Channel
+import io.netty.channel.ChannelHandlerContext
+import io.netty.channel.ChannelInboundHandlerAdapter
+import io.netty.channel.ChannelInitializer
+import io.netty.channel.ChannelOption
+import io.netty.channel.nio.NioEventLoopGroup
+import io.netty.channel.socket.nio.NioSocketChannel
+import io.netty.handler.codec.http.DefaultFullHttpRequest
+import io.netty.handler.codec.http.FullHttpResponse
+import io.netty.handler.codec.http.HttpClientCodec
+import io.netty.handler.codec.http.HttpClientUpgradeHandler
+import io.netty.handler.codec.http.HttpHeaderNames
+import io.netty.handler.codec.http.HttpHeaderValues
+import io.netty.handler.codec.http.HttpMessage
+import io.netty.handler.codec.http.HttpMethod
+import io.netty.handler.codec.http.HttpObjectAggregator
+import io.netty.handler.codec.http.HttpResponseStatus
+import io.netty.handler.codec.http.HttpVersion
+import io.netty.handler.codec.http2.DefaultHttp2Connection
+import io.netty.handler.codec.http2.DelegatingDecompressorFrameListener
+import io.netty.handler.codec.http2.Http2ClientUpgradeCodec
+import io.netty.handler.codec.http2.Http2SecurityUtil
+import io.netty.handler.codec.http2.Http2Settings
+import io.netty.handler.codec.http2.HttpConversionUtil
+import io.netty.handler.codec.http2.HttpToHttp2ConnectionHandlerBuilder
+import io.netty.handler.codec.http2.InboundHttp2ToHttpAdapterBuilder
+import io.netty.handler.ssl.ApplicationProtocolConfig
+import io.netty.handler.ssl.ApplicationProtocolNames
+import io.netty.handler.ssl.ApplicationProtocolNegotiationHandler
+import io.netty.handler.ssl.SslContextBuilder
+import io.netty.handler.ssl.SupportedCipherSuiteFilter
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory
+import io.netty.util.ReferenceCountUtil
+import jakarta.inject.Singleton
+import org.jetbrains.annotations.NotNull
+import org.slf4j.LoggerFactory
+import reactor.core.publisher.Mono
+import spock.lang.Issue
+import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
+
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CopyOnWriteArrayList
+
+class AccessLogSpec extends Specification {
+    @Issue('https://github.com/micronaut-projects/micronaut-core/issues/6782')
+    def 'http1.1 concurrent pipelined requests'() {
+        given:
+        def ctx = ApplicationContext.run([
+                'spec.name': 'AccessLogSpec',
+                'micronaut.server.netty.access-logger.enabled': true,
+                'micronaut.server.netty.access-logger.logger-name': 'http-access-log',
+        ])
+        def server = ctx.getBean(EmbeddedServer)
+        server.start()
+
+        def responses = new CopyOnWriteArrayList<FullHttpResponse>()
+        Bootstrap bootstrap = new Bootstrap()
+                .group(new NioEventLoopGroup(1))
+                .channel(NioSocketChannel)
+                .option(ChannelOption.AUTO_READ, true)
+                .handler(new ChannelInitializer<Channel>() {
+                    @Override
+                    protected void initChannel(@NotNull Channel ch) throws Exception {
+                        ch.pipeline()
+                                .addLast(new HttpClientCodec())
+                                .addLast(new HttpObjectAggregator(1024))
+                                .addLast(new ChannelInboundHandlerAdapter() {
+                                    @Override
+                                    void channelRead(@NotNull ChannelHandlerContext ctx_, @NotNull Object msg) throws Exception {
+                                        responses.add(msg)
+                                    }
+                                })
+                    }
+                })
+                .remoteAddress(server.host, server.port)
+
+        def request1 = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, '/interleave/open')
+        request1.headers().add(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE)
+        def request2 = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, '/interleave/finish')
+        request2.headers().add(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE)
+
+        def listAppender = new ListAppender<ILoggingEvent>()
+        listAppender.start()
+        ((Logger) LoggerFactory.getLogger('http-access-log')).addAppender(listAppender)
+
+        when:
+        def channel = bootstrap.connect().sync().channel()
+        channel.write(request1)
+        channel.writeAndFlush(request2)
+
+        then:
+        new PollingConditions(timeout: 5).eventually {
+            responses.size() == 2
+        }
+        responses[0].content().toString(StandardCharsets.UTF_8) == 'open'
+        responses[1].content().toString(StandardCharsets.UTF_8) == 'finish'
+
+        listAppender.list.size() == 2
+        listAppender.list[0].message.contains('/interleave/open')
+        listAppender.list[1].message.contains('/interleave/finish')
+
+        cleanup:
+        server.close()
+        channel.close()
+        bootstrap.config().group().shutdownGracefully()
+    }
+
+    @Issue('https://github.com/micronaut-projects/micronaut-core/issues/6782')
+    def 'http1.1 continue status'() {
+        given:
+        def ctx = ApplicationContext.run([
+                'spec.name': 'AccessLogSpec',
+                'micronaut.server.netty.access-logger.enabled': true,
+                'micronaut.server.netty.access-logger.logger-name': 'http-access-log',
+        ])
+        def server = ctx.getBean(EmbeddedServer)
+        server.start()
+
+        def responses = new CopyOnWriteArrayList<FullHttpResponse>()
+        Bootstrap bootstrap = new Bootstrap()
+                .group(new NioEventLoopGroup(1))
+                .channel(NioSocketChannel)
+                .option(ChannelOption.AUTO_READ, true)
+                .handler(new ChannelInitializer<Channel>() {
+                    @Override
+                    protected void initChannel(@NotNull Channel ch) throws Exception {
+                        ch.pipeline()
+                                .addLast(new HttpClientCodec())
+                                .addLast(new HttpObjectAggregator(1024))
+                                .addLast(new ChannelInboundHandlerAdapter() {
+                                    @Override
+                                    void channelRead(@NotNull ChannelHandlerContext ctx_, @NotNull Object msg) throws Exception {
+                                        responses.add(msg)
+                                    }
+                                })
+                    }
+                })
+                .remoteAddress(server.host, server.port)
+
+        def request1 = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, '/interleave/post', Unpooled.wrappedBuffer('foo'.getBytes(StandardCharsets.UTF_8)))
+        request1.headers().add(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE)
+        request1.headers().add(HttpHeaderNames.EXPECT, HttpHeaderValues.CONTINUE)
+        request1.headers().add(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.TEXT_PLAIN)
+        request1.headers().add(HttpHeaderNames.CONTENT_LENGTH, 3)
+        def request2 = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, '/interleave/simple')
+        request2.headers().add(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE)
+
+        def listAppender = new ListAppender<ILoggingEvent>()
+        listAppender.start()
+        ((Logger) LoggerFactory.getLogger('http-access-log')).addAppender(listAppender)
+
+        when:
+        def channel = bootstrap.connect().sync().channel()
+        channel.write(request1)
+        channel.writeAndFlush(request2)
+
+        then:
+        new PollingConditions(timeout: 5).eventually {
+            responses.size() == 3
+        }
+        responses[0].status() == HttpResponseStatus.CONTINUE
+        responses[1].content().toString(StandardCharsets.UTF_8) == 'post: foo'
+        responses[2].content().toString(StandardCharsets.UTF_8) == 'simple'
+
+        listAppender.list.size() == 2
+        listAppender.list[0].message.contains('/interleave/post')
+        listAppender.list[1].message.contains('/interleave/simple')
+
+        cleanup:
+        server.close()
+        channel.close()
+        bootstrap.config().group().shutdownGracefully()
+    }
+
+    @Issue('https://github.com/micronaut-projects/micronaut-core/issues/6782')
+    def 'http2 truly concurrent requests'() {
+        given:
+        def ctx = ApplicationContext.run([
+                'spec.name': 'AccessLogSpec',
+                'micronaut.server.http-version': '2.0',
+                'micronaut.ssl.enabled': true,
+                'micronaut.ssl.port': -1,
+                'micronaut.ssl.buildSelfSigned': true,
+                'micronaut.server.netty.access-logger.enabled': true,
+                'micronaut.server.netty.access-logger.logger-name': 'http-access-log',
+        ])
+        def server = ctx.getBean(EmbeddedServer)
+        server.start()
+
+        def request1 = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, '/interleave/open')
+        request1.headers().add(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), 1)
+        request1.headers().add(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), ':https')
+        def request2 = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, '/interleave/simple')
+        request2.headers().add(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), 3)
+        request2.headers().add(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), ':https')
+        def request3 = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, '/interleave/finish')
+        request3.headers().add(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), 5)
+        request3.headers().add(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), ':https')
+
+        def responses = new CopyOnWriteArrayList<FullHttpResponse>()
+        def sslContext = SslContextBuilder.forClient()
+                .ciphers(Http2SecurityUtil.CIPHERS, SupportedCipherSuiteFilter.INSTANCE)
+                .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                .applicationProtocolConfig(new ApplicationProtocolConfig(
+                        ApplicationProtocolConfig.Protocol.ALPN,
+                        // NO_ADVERTISE is currently the only mode supported by both OpenSsl and JDK providers.
+                        ApplicationProtocolConfig.SelectorFailureBehavior.NO_ADVERTISE,
+                        // ACCEPT is currently the only mode supported by both OpenSsl and JDK providers.
+                        ApplicationProtocolConfig.SelectedListenerFailureBehavior.ACCEPT,
+                        ApplicationProtocolNames.HTTP_2))
+                .build()
+        Bootstrap bootstrap = new Bootstrap()
+                .group(new NioEventLoopGroup(1))
+                .channel(NioSocketChannel)
+                .option(ChannelOption.AUTO_READ, true)
+                .handler(new ChannelInitializer<Channel>() {
+                    @Override
+                    protected void initChannel(@NotNull Channel ch) throws Exception {
+                        def connection = new DefaultHttp2Connection(false)
+                        def connectionHandler = new HttpToHttp2ConnectionHandlerBuilder()
+                                .initialSettings(Http2Settings.defaultSettings())
+                                .frameListener(new DelegatingDecompressorFrameListener(
+                                        connection,
+                                        new InboundHttp2ToHttpAdapterBuilder(connection)
+                                                .maxContentLength(Integer.MAX_VALUE)
+                                                .propagateSettings(false)
+                                                .build()
+                                ))
+                                .connection(connection)
+                                .build()
+                        ch.pipeline()
+                                .addLast(sslContext.newHandler(ch.alloc(), server.host, server.port))
+                                .addLast(new ApplicationProtocolNegotiationHandler('') {
+                                    @Override
+                                    protected void configurePipeline(ChannelHandlerContext ctx_, String protocol) throws Exception {
+                                        if (ApplicationProtocolNames.HTTP_2 != protocol) {
+                                            throw new AssertionError((Object) protocol)
+                                        }
+                                        ctx_.pipeline()
+                                                .addLast(connectionHandler)
+                                                .addLast(new ChannelInboundHandlerAdapter() {
+                                                    @Override
+                                                    void channelRead(@NotNull ChannelHandlerContext ctx__, @NotNull Object msg) throws Exception {
+                                                        responses.add(msg)
+                                                    }
+                                                })
+
+
+                                        ctx_.channel().write(request1)
+                                        ctx_.channel().write(request2)
+                                        ctx_.channel().writeAndFlush(request3)
+                                    }
+                                })
+                    }
+                })
+                .remoteAddress(server.host, server.port)
+
+        def listAppender = new ListAppender<ILoggingEvent>()
+        listAppender.start()
+        ((Logger) LoggerFactory.getLogger('http-access-log')).addAppender(listAppender)
+
+        when:
+        def channel = bootstrap.connect().sync().channel()
+
+        then:
+        new PollingConditions(timeout: 5).eventually {
+            responses.size() == 3
+        }
+        responses[0].content().toString(StandardCharsets.UTF_8) == 'simple'
+        responses[1].content().toString(StandardCharsets.UTF_8) == 'open'
+        responses[2].content().toString(StandardCharsets.UTF_8) == 'finish'
+
+        listAppender.list.size() == 3
+        listAppender.list[0].message.contains('/interleave/simple')
+        listAppender.list[1].message.contains('/interleave/open')
+        listAppender.list[2].message.contains('/interleave/finish')
+
+        cleanup:
+        server.close()
+        channel.close()
+        bootstrap.config().group().shutdownGracefully()
+    }
+
+    @Issue('https://github.com/micronaut-projects/micronaut-core/issues/6782')
+    def 'h2c truly concurrent requests with http1 upgrade'() {
+        given:
+        def ctx = ApplicationContext.run([
+                'spec.name': 'AccessLogSpec',
+                'micronaut.server.http-version': '2.0',
+                'micronaut.ssl.enabled': false,
+                'micronaut.server.netty.access-logger.enabled': true,
+                'micronaut.server.netty.access-logger.logger-name': 'http-access-log',
+        ])
+        def server = ctx.getBean(EmbeddedServer)
+        server.start()
+
+        def request1 = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, '/interleave/simple')
+        request1.headers().add(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), ':https')
+        def request2 = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, '/interleave/open')
+        request2.headers().add(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), ':https')
+        request2.headers().add(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), 3)
+        def request3 = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, '/interleave/simple')
+        request3.headers().add(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), 5)
+        request3.headers().add(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), ':https')
+        def request4 = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, '/interleave/finish')
+        request4.headers().add(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), 7)
+        request4.headers().add(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), ':https')
+
+        def responses = new CopyOnWriteArrayList<FullHttpResponse>()
+        Bootstrap bootstrap = new Bootstrap()
+                .group(new NioEventLoopGroup(1))
+                .channel(NioSocketChannel)
+                .option(ChannelOption.AUTO_READ, true)
+                .handler(new ChannelInitializer<Channel>() {
+                    @Override
+                    protected void initChannel(@NotNull Channel ch) throws Exception {
+                        def connection = new DefaultHttp2Connection(false)
+                        def connectionHandler = new HttpToHttp2ConnectionHandlerBuilder()
+                                .initialSettings(Http2Settings.defaultSettings())
+                                .frameListener(new DelegatingDecompressorFrameListener(
+                                        connection,
+                                        new InboundHttp2ToHttpAdapterBuilder(connection)
+                                                .maxContentLength(Integer.MAX_VALUE)
+                                                .propagateSettings(false)
+                                                .build()
+                                ))
+                                .connection(connection)
+                                .build()
+                        def clientCodec = new HttpClientCodec()
+                        def upgradeCodec = new Http2ClientUpgradeCodec(ChannelPipelineCustomizer.HANDLER_HTTP2_CONNECTION, connectionHandler)
+                        def upgradeHandler = new HttpClientUpgradeHandler(clientCodec, upgradeCodec, 1000000)
+                        ch.pipeline()
+                                .addLast(ChannelPipelineCustomizer.HANDLER_HTTP_CLIENT_CODEC, clientCodec)
+                                .addLast(upgradeHandler)
+                                .addLast(new ChannelInboundHandlerAdapter() {
+                                    @Override
+                                    void channelRead(@NotNull ChannelHandlerContext ctx_, @NotNull Object msg) throws Exception {
+                                        if (responses.isEmpty()) {
+                                            ctx_.channel().write(request2)
+                                            ctx_.channel().write(request3)
+                                            ctx_.channel().writeAndFlush(request4)
+                                        }
+                                        responses.add(msg)
+                                    }
+                                })
+                    }
+                })
+                .remoteAddress(server.host, server.port)
+
+        def listAppender = new ListAppender<ILoggingEvent>()
+        listAppender.start()
+        ((Logger) LoggerFactory.getLogger('http-access-log')).addAppender(listAppender)
+
+        when:
+        def channel = bootstrap.connect().sync().channel()
+        channel.writeAndFlush(request1)
+
+        then:
+        new PollingConditions(timeout: 5).eventually {
+            responses.size() == 4
+        }
+        responses[0].content().toString(StandardCharsets.UTF_8) == 'simple'
+        responses[1].content().toString(StandardCharsets.UTF_8) == 'simple'
+        responses[2].content().toString(StandardCharsets.UTF_8) == 'open'
+        responses[3].content().toString(StandardCharsets.UTF_8) == 'finish'
+
+        listAppender.list.size() == 4
+        listAppender.list[0].message.contains('/interleave/simple')
+        listAppender.list[1].message.contains('/interleave/simple')
+        listAppender.list[2].message.contains('/interleave/open')
+        listAppender.list[3].message.contains('/interleave/finish')
+
+        cleanup:
+        server.close()
+        channel.close()
+        bootstrap.config().group().shutdownGracefully()
+    }
+
+    @Requires(property = 'spec.name', value = 'AccessLogSpec')
+    @Controller('/interleave')
+    @Singleton
+    static class InterleavingController {
+        CompletableFuture<HttpResponse<?>> lastFuture
+
+        // this endpoint completes when `/finish` is requested
+        @Get('/open')
+        def open() {
+            return Mono.fromFuture(lastFuture = new CompletableFuture<>())
+        }
+
+        // this endpoint completes a previous request made to `/open`, and then returns normally
+        @Get('/finish')
+        def finish() {
+            lastFuture.complete(HttpResponse.ok('open'))
+            return HttpResponse.ok('finish')
+        }
+
+        // this endpoint does nothing special
+        @Get('/simple')
+        def simple() {
+            return HttpResponse.ok('simple')
+        }
+
+        // this endpoint does nothing special
+        @Post(value = '/post', consumes = 'text/plain')
+        def post(@Body String body) {
+            return HttpResponse.ok('post: ' + body)
+        }
+    }
+}


### PR DESCRIPTION
`HttpAccessLogHandler` used a channel attribute to manage the `AccessLog` instance for a request. Because `AccessLog` does not support concurrent requests, this breaks on HTTP1 pipelining and on concurrent HTTP2 streams.

This patch multiplexes the requests onto multiple `AccessLog` instances.

Fixes #6782

---

I built this PR based on the branch of #6753 to avoid merge conflicts, that needs to be merged first. I'm making this a separate PR because it's a bug that's independent of the exclusion feature.