### PR TITLE
Document and test literal placeholder syntax with no expansion

### DIFF
--- a/inject/src/main/java/io/micronaut/context/env/DefaultPropertyPlaceholderResolver.java
+++ b/inject/src/main/java/io/micronaut/context/env/DefaultPropertyPlaceholderResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2022 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -109,8 +109,22 @@ public class DefaultPropertyPlaceholderResolver implements PropertyPlaceholderRe
         String value = str;
         int i = value.indexOf(PREFIX);
         while (i > -1) {
-            //the text before the prefix
-            if (i > 0) {
+            if (isDoubleEscaped(value, i)) {
+                RawSegment rawSegment = new RawSegment(value.substring(0, i - 1));
+                segments.add(rawSegment);
+                value = value.substring(i);
+                i = value.indexOf(PREFIX);
+                continue;
+            }
+            else if (isEscaped(value, i)) {
+                RawSegment rawSegment = new RawSegment(value.substring(0, i - 1));
+                segments.add(rawSegment);
+                segments.add(new RawSegment(PREFIX));
+                value = value.substring(i + PREFIX.length());
+                i = value.indexOf(PREFIX);
+                continue;
+            } else if (i > 0) {
+                //the text before the prefix
                 String rawSegment = value.substring(0, i);
                 segments.add(new RawSegment(rawSegment));
             }
@@ -132,6 +146,14 @@ public class DefaultPropertyPlaceholderResolver implements PropertyPlaceholderRe
             segments.add(new RawSegment(value));
         }
         return segments;
+    }
+
+    private boolean isDoubleEscaped(String value, int i) {
+        return i > 1 && value.charAt(i - 2) == '$';
+    }
+
+    private boolean isEscaped(String value, int i) {
+        return i > 0 && value.charAt(i - 1) == '$';
     }
 
     /**

--- a/inject/src/main/java/io/micronaut/context/env/DefaultPropertyPlaceholderResolver.java
+++ b/inject/src/main/java/io/micronaut/context/env/DefaultPropertyPlaceholderResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 original authors
+ * Copyright 2017-2020 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -109,22 +109,8 @@ public class DefaultPropertyPlaceholderResolver implements PropertyPlaceholderRe
         String value = str;
         int i = value.indexOf(PREFIX);
         while (i > -1) {
-            if (isDoubleEscaped(value, i)) {
-                RawSegment rawSegment = new RawSegment(value.substring(0, i - 1));
-                segments.add(rawSegment);
-                value = value.substring(i);
-                i = value.indexOf(PREFIX);
-                continue;
-            }
-            else if (isEscaped(value, i)) {
-                RawSegment rawSegment = new RawSegment(value.substring(0, i - 1));
-                segments.add(rawSegment);
-                segments.add(new RawSegment(PREFIX));
-                value = value.substring(i + PREFIX.length());
-                i = value.indexOf(PREFIX);
-                continue;
-            } else if (i > 0) {
-                //the text before the prefix
+            //the text before the prefix
+            if (i > 0) {
                 String rawSegment = value.substring(0, i);
                 segments.add(new RawSegment(rawSegment));
             }
@@ -146,14 +132,6 @@ public class DefaultPropertyPlaceholderResolver implements PropertyPlaceholderRe
             segments.add(new RawSegment(value));
         }
         return segments;
-    }
-
-    private boolean isDoubleEscaped(String value, int i) {
-        return i > 1 && value.charAt(i - 2) == '$';
-    }
-
-    private boolean isEscaped(String value, int i) {
-        return i > 0 && value.charAt(i - 1) == '$';
     }
 
     /**

--- a/inject/src/test/groovy/io/micronaut/context/env/PropertySourcePropertyResolverSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/env/PropertySourcePropertyResolverSpec.groovy
@@ -477,6 +477,19 @@ class PropertySourcePropertyResolverSpec extends Specification {
         resolver.getProperty("start", String).get() == "`startswithtick"
     }
 
+    void 'test escaping a literal ${value}'() {
+        given:
+        def values = [
+                'foo.bar': '${:$}{some-value}'
+        ]
+        PropertySourcePropertyResolver resolver = new PropertySourcePropertyResolver(
+                PropertySource.of("test", values)
+        )
+
+        expect:
+        resolver.getProperty("foo.bar", String).get() == '${some-value}'
+    }
+
     void "test properties starting with z"() {
         given:
         def values = [

--- a/inject/src/test/groovy/io/micronaut/context/env/PropertySourcePropertyResolverSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/env/PropertySourcePropertyResolverSpec.groovy
@@ -477,35 +477,17 @@ class PropertySourcePropertyResolverSpec extends Specification {
         resolver.getProperty("start", String).get() == "`startswithtick"
     }
 
-    void 'test escaping #desc "#test"'() {
+    void 'test escaping a literal ${value}'() {
         given:
         def values = [
-                'some-value': 'testing',
-                test        : test,
+                'foo.bar': '${:$}{some-value}'
         ]
-
         PropertySourcePropertyResolver resolver = new PropertySourcePropertyResolver(
                 PropertySource.of("test", values)
         )
 
         expect:
-        resolver.getProperty("test", String).get() == expected
-
-        where:
-        desc             | test                                     | expected
-        'raw'            | '$${some-value}'                         | '${some-value}'
-        'prefix'         | 'value $${some-value}'                   | 'value ${some-value}'
-        'suffix'         | '$${some-value} value'                   | '${some-value} value'
-        'wrapped'        | 'one $${some-value} value'               | 'one ${some-value} value'
-        'embedded'       | '$${some-value-${some-value}}'           | '${some-value-testing}'
-        'escaped path'   | '\\path\\to\\$${some-value}\\readme.txt' | '\\path\\to\\${some-value}\\readme.txt'
-        'path'           | '\\path\\to\\${some-value}\\readme.txt'  | '\\path\\to\\testing\\readme.txt'
-        'double escaped' | '$$${some-value}'                        | '$testing'
-        'double prefix'  | 'value $$${some-value}'                  | 'value $testing'
-        'double suffix'  | '$$${some-value} value'                  | '$testing value'
-        'double wrapped' | 'one $$${some-value} value'              | 'one $testing value'
-        'overrun'        | '$${'                                    | '${'
-        'incomplete'     | 'test $${ inline'                        | 'test ${ inline'
+        resolver.getProperty("foo.bar", String).get() == '${some-value}'
     }
 
     void "test properties starting with z"() {

--- a/src/main/docs/guide/config/propertySource.adoc
+++ b/src/main/docs/guide/config/propertySource.adoc
@@ -92,12 +92,10 @@ The above example looks for a `server.address` property and defaults to `http://
 [source,yaml]
 ----
 myapp:
-  value: a
-  escaped: $${value} // evaluates to literal `${value}`
-  prefixed: $$${value} // evaluates to literal `$a`
+  value: ${:$}{value}
 ----
 
-If you require a literal `${value}` string in your configuration without any resolution of `value`, you can escape the initial dollar by prefixing it with another.
+If you require a literal `${value}` string in your configuration without any resolution of `value`, you need to use `${:$}` to generate the initial dollar symbol, and avoid resolution of `value` as above.
 
 === Property Value Binding
 

--- a/src/main/docs/guide/config/propertySource.adoc
+++ b/src/main/docs/guide/config/propertySource.adoc
@@ -92,10 +92,12 @@ The above example looks for a `server.address` property and defaults to `http://
 [source,yaml]
 ----
 myapp:
-  value: ${:$}{value}
+  value: a
+  escaped: $${value} // evaluates to literal `${value}`
+  prefixed: $$${value} // evaluates to literal `$a`
 ----
 
-If you require a literal `${value}` string in your configuration without any resolution of `value`, you need to use `${:$}` to generate the initial dollar symbol, and avoid resolution of `value` as above.
+If you require a literal `${value}` string in your configuration without any resolution of `value`, you can escape the initial dollar by prefixing it with another.
 
 === Property Value Binding
 

--- a/src/main/docs/guide/config/propertySource.adoc
+++ b/src/main/docs/guide/config/propertySource.adoc
@@ -88,6 +88,15 @@ myapp:
 
 The above example looks for a `server.address` property and defaults to `http://localhost:8080`. This default value is escaped with backticks since it has a `:` character.
 
+.Literal placeholder syntax
+[source,yaml]
+----
+myapp:
+  value: ${:$}{value}
+----
+
+If you require a literal `${value}` string in your configuration without any resolution of `value`, you need to use `${:$}` to generate the initial dollar symbol, and avoid resolution of `value` as above.
+
 === Property Value Binding
 
 Note that these property references should be in kebab case (lowercase and hyphen-separated) when placing references in code or in placeholder values. For example, use `micronaut.server.default-charset` and not `micronaut.server.defaultCharset`.


### PR DESCRIPTION
We didn't document how to add a literal ${value} to the configuration.

This adds the docs, plus a test to ensure it keeps working.