### PR TITLE
Updated VSCode instructions

### DIFF
--- a/src/main/docs/guide/quickStart/ideSetup/vsCodeSetup.adoc
+++ b/src/main/docs/guide/quickStart/ideSetup/vsCodeSetup.adoc
@@ -29,4 +29,6 @@ If you use Gradle, prior to opening the project in VSC run the following command
 
 NOTE: If you don't run the above command beforehand then annotation processing will not be configured correctly and the application will not work.
 
-Once the extension pack is installed and if you have setup https://code.visualstudio.com/docs/setup/mac[terminal integration] just type `code .` in any project directory and the project will be automatically setup.
+Once the extension pack is installed just type `code .` in any project directory and the project will be automatically set up.
+
+NOTE: For macOs, you need to install the `code` command https://code.visualstudio.com/docs/setup/mac[by following these instructions].


### PR DESCRIPTION
It's only for OS X you need to explicitly install the `code` command line tool, so I
moved the docs around this to a NOTE:

For Windows, this tool is automatically added to the %PATH% (so long as the installer
had a checkbox checked at installation time)

For linux, stackoverflow shows that some package managers add this code symlink automatically,
though there are some reports of a manual `ln -s` step being required.

Closes #3269