### PR TITLE
Fix introspection on beans with covariant return types

### DIFF
--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2022 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -383,7 +383,7 @@ public class JavaClassElement extends AbstractJavaElement implements ArrayableCl
                             if (beanPropertyData.setter != null) {
                                 TypeMirror typeMirror = beanPropertyData.setter.getParameters().get(0).asType();
                                 ClassElement setterParameterType = mirrorToClassElement(typeMirror, visitorContext, JavaClassElement.this.genericTypeInfo, true);
-                                if (!setterParameterType.getName().equals(getterReturnType.getName())) {
+                                if (!setterParameterType.isAssignable(getterReturnType)) {
                                     beanPropertyData.setter = null; // not a compatible setter
                                 }
                             }


### PR DESCRIPTION
Instead on comparing the name of the class returned by the overriden getter and passed
to the setter, compare the classes to see if they are assignable.

Added a test for Groovy as well, though Groovy didn't exhibit this issue so
didn't require a fix.