### PR TITLE
remove slf4j simple

### DIFF
--- a/inject-groovy/build.gradle
+++ b/inject-groovy/build.gradle
@@ -6,8 +6,6 @@ dependencies {
     api project(":inject")
     api project(':aop')
     api libs.managed.groovy
-    implementation(libs.managed.slf4j.simple)
-
 //    testImplementation 'javax.validation:validation-api:1.1.0.Final'
     testImplementation project(":context")
     testImplementation libs.javax.inject

--- a/inject-java/build.gradle
+++ b/inject-java/build.gradle
@@ -2,7 +2,6 @@ dependencies {
     api project(":inject")
     api project(':aop')
 
-    implementation(libs.managed.slf4j.simple)
     if (!JavaVersion.current().isJava9Compatible()) {
         compileOnly files(org.gradle.internal.jvm.Jvm.current().toolsJar)
     }


### PR DESCRIPTION
It is not longer required because the logging code has been removed from the core module