### PR TITLE
Allow discovery of silent conversion errors for config and QueryValue

### DIFF
--- a/context/src/main/java/io/micronaut/runtime/Micronaut.java
+++ b/context/src/main/java/io/micronaut/runtime/Micronaut.java
@@ -180,6 +180,11 @@ public class Micronaut extends DefaultApplicationContextBuilder implements Appli
         return (Micronaut) super.banner(isEnabled);
     }
 
+    @Override
+    public @NonNull Micronaut failOnConfigConversionError(boolean fail) {
+        return (Micronaut) super.failOnConfigConversionError(fail);
+    }
+
     /**
      * Add classes to be included in the initialization of the application.
      *

--- a/core/src/main/java/io/micronaut/core/convert/ArgumentConversionContext.java
+++ b/core/src/main/java/io/micronaut/core/convert/ArgumentConversionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2022 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,9 @@ import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationMetadataProvider;
 import io.micronaut.core.type.Argument;
 
+import java.util.Iterator;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Extended version of the {@link ConversionContext} specifically for conversion {@link Argument} instances.
@@ -64,6 +66,31 @@ public interface ArgumentConversionContext<T> extends ConversionContext, Annotat
             @Override
             public AnnotationMetadata getAnnotationMetadata() {
                 return annotationMetadata;
+            }
+
+            @Override
+            public void reject(Exception exception) {
+                thisContext.reject(exception);
+            }
+
+            @Override
+            public void reject(Object value, Exception exception) {
+                thisContext.reject(value, exception);
+            }
+
+            @Override
+            public Iterator<ConversionError> iterator() {
+                return thisContext.iterator();
+            }
+
+            @Override
+            public boolean hasErrors() {
+                return thisContext.hasErrors();
+            }
+
+            @Override
+            public Optional<ConversionError> getLastError() {
+                return thisContext.getLastError();
             }
         };
     }

--- a/core/src/main/java/io/micronaut/core/convert/ConversionContext.java
+++ b/core/src/main/java/io/micronaut/core/convert/ConversionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2022 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -142,6 +142,11 @@ public interface ConversionContext extends AnnotationMetadataProvider, TypeVaria
             @Override
             public Iterator<ConversionError> iterator() {
                 return thisContext.iterator();
+            }
+
+            @Override
+            public boolean hasErrors() {
+                return thisContext.hasErrors();
             }
 
             @Override

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/DroppedQueryMappingDebugSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/DroppedQueryMappingDebugSpec.groovy
@@ -1,0 +1,110 @@
+package io.micronaut.http.server.netty.binding
+
+import ch.qos.logback.classic.Logger
+import io.micronaut.core.annotation.Nullable
+import io.micronaut.http.HttpMethod
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.QueryValue
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.http.server.binding.RequestArgumentSatisfier
+import io.micronaut.http.server.netty.AbstractMicronautSpec
+import io.micronaut.http.server.netty.configuration.MemoryAppender
+import org.slf4j.LoggerFactory
+import reactor.core.publisher.Flux
+import spock.util.concurrent.PollingConditions
+
+class DroppedQueryMappingDebugSpec extends AbstractMicronautSpec {
+
+    def conditions = new PollingConditions(timeout: 10, initialDelay: 0.1, factor: 1.25)
+    MemoryAppender appender
+
+    @Override
+    Map<String, Object> getConfiguration() {
+        ['logger.levels.io.micronaut.http.server.binding': 'DEBUG']
+    }
+
+    def setup() {
+        appender = new MemoryAppender()
+        ((Logger) LoggerFactory.getLogger(RequestArgumentSatisfier)).addAppender(appender)
+        appender.start()
+    }
+
+    def cleanup() {
+        appender.stop()
+        ((Logger) LoggerFactory.getLogger(RequestArgumentSatisfier)).detachAppender(appender)
+    }
+
+    def "test we get logging for failed #description #type conversion at #path"() {
+        when:
+        def response = get(path)
+
+        then:
+        response.body() == expected
+        conditions.eventually {
+            println appender.events
+            assert appender.events == ["[DEBUG] Failed to convert argument 'query' to $type at uri /dropped$path"]
+        }
+
+        where:
+        path                          | description                 | type                | expected
+        '/int?query=non-int'          | "nullable"                  | "Integer"           | "int null"
+        '/int-default?query=non-int'  | "non-nullable with default" | "Integer"           | "int-default 42"
+        '/int-optional?query=non-int' | "non-nullable optional"     | "Optional<Integer>" | "int-optional Optional.empty"
+        '/enum?query=baking'          | "nullable"                  | "State"             | "enum null"
+        '/enum-default?query=baking'  | "non-nullable with default" | "State"             | "enum-default WARM"
+        '/enum-optional?query=baking' | "non-nullable optional"     | "Optional<State>"   | "enum-optional Optional.empty"
+    }
+
+    private HttpResponse<?> get(uri) {
+        Flux.from(rxClient.exchange(HttpRequest.create(HttpMethod.GET, "/dropped$uri"), String)).onErrorResume(t -> {
+            if (t instanceof HttpClientResponseException) {
+                return Flux.just(((HttpClientResponseException) t).response)
+            }
+            throw t
+        }).blockFirst()
+    }
+
+    @Controller(value = "/dropped", produces = MediaType.TEXT_PLAIN)
+    static class FormattedController {
+
+        static enum State {
+            COOL,
+            WARM,
+            HOT
+        }
+
+        @Get("/int")
+        String asInt(@QueryValue @Nullable Integer query) {
+            "int $query"
+        }
+
+        @Get("/int-default")
+        String asIntDefault(@QueryValue(defaultValue = "42") Integer query) {
+            "int-default $query"
+        }
+
+        @Get("/int-optional")
+        String asInt(@QueryValue Optional<Integer> query) {
+            "int-optional $query"
+        }
+
+        @Get("/enum")
+        String asEnum(@QueryValue @Nullable State query) {
+            "enum $query"
+        }
+
+        @Get("/enum-default")
+        String asEnumDefault(@QueryValue(defaultValue = "warm") State query) {
+            "enum-default $query"
+        }
+
+        @Get("/enum-optional")
+        String asEnum(@QueryValue Optional<State> query) {
+            "enum-optional $query"
+        }
+    }
+}

--- a/http-server/src/main/java/io/micronaut/http/server/binding/RequestArgumentSatisfier.java
+++ b/http-server/src/main/java/io/micronaut/http/server/binding/RequestArgumentSatisfier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2022 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,8 @@ import io.micronaut.web.router.NullArgument;
 import io.micronaut.web.router.RouteMatch;
 import io.micronaut.web.router.UnresolvedArgument;
 import jakarta.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -47,6 +49,8 @@ import java.util.Optional;
 @Singleton
 @Internal
 public class RequestArgumentSatisfier {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RequestArgumentSatisfier.class);
 
     private final RequestBinderRegistry binderRegistry;
 
@@ -129,6 +133,9 @@ public class RequestArgumentSatisfier {
             } else {
                 ArgumentBinder.BindingResult bindingResult = argumentBinder.bind(conversionContext, request);
 
+                if (LOG.isDebugEnabled() && conversionContext.hasErrors()) {
+                    LOG.debug("Failed to convert argument '" + argument.getName() + "' to " + conversionContext.getArgument().getTypeString(true) + " at uri " + request.getUri());
+                }
                 if (argument.getType() == Optional.class) {
                     if (bindingResult.isSatisfied() || satisfyOptionals) {
                         Optional optionalValue = bindingResult.getValue();

--- a/inject/src/main/java/io/micronaut/context/ApplicationContextBuilder.java
+++ b/inject/src/main/java/io/micronaut/context/ApplicationContextBuilder.java
@@ -206,6 +206,14 @@ public interface ApplicationContextBuilder {
     @NonNull ApplicationContextBuilder banner(boolean isEnabled);
 
     /**
+     * Stop if there is an issue reading and converting the config at startup.
+     *
+     * @param fail Whether the app should stop if it fails to read or convert any of the configuration.
+     * @return This application
+     */
+    @NonNull ApplicationContextBuilder failOnConfigConversionError(boolean fail);
+
+    /**
      * Whether to error on an empty bean provider. Defaults to {@code false}.
      *
      * @param shouldAllow True if empty {@link jakarta.inject.Provider} instances are allowed

--- a/inject/src/main/java/io/micronaut/context/ApplicationContextConfiguration.java
+++ b/inject/src/main/java/io/micronaut/context/ApplicationContextConfiguration.java
@@ -111,6 +111,15 @@ public interface ApplicationContextConfiguration extends BeanContextConfiguratio
         return true;
     }
 
+    /**
+     * Should the app fail to start up if there are configuration conversion errors.
+     *
+     * @return Disabled by default.
+     */
+    default boolean isFailOnConfigConversionError() {
+        return false;
+    }
+
     @Nullable
     default Boolean isBootstrapEnvironmentEnabled() {
         return null;

--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContextBuilder.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContextBuilder.java
@@ -68,6 +68,7 @@ public class DefaultApplicationContextBuilder implements ApplicationContextBuild
     private ClassPathResourceLoader classPathResourceLoader;
     private boolean allowEmptyProviders = false;
     private Boolean bootstrapEnvironment = null;
+    private boolean failOnConfigConversionError = false;
 
     /**
      * Default constructor.
@@ -105,6 +106,11 @@ public class DefaultApplicationContextBuilder implements ApplicationContextBuild
     @Override
     public boolean isBannerEnabled() {
         return banner;
+    }
+
+    @Override
+    public boolean isFailOnConfigConversionError() {
+        return failOnConfigConversionError;
     }
 
     @Nullable
@@ -359,6 +365,12 @@ public class DefaultApplicationContextBuilder implements ApplicationContextBuild
     @Override
     public @NonNull ApplicationContextBuilder banner(boolean isEnabled) {
         this.banner = isEnabled;
+        return this;
+    }
+
+    @Override
+    public ApplicationContextBuilder failOnConfigConversionError(boolean fail) {
+        this.failOnConfigConversionError = fail;
         return this;
     }
 

--- a/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
+++ b/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
@@ -125,7 +125,7 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
      * @param configuration The configuration
      */
     public DefaultEnvironment(@NonNull ApplicationContextConfiguration configuration) {
-        super(configuration.getConversionService());
+        super(configuration.getConversionService(), configuration.isFailOnConfigConversionError());
         this.configuration = configuration;
         this.resourceLoader = configuration.getResourceLoader();
 

--- a/inject/src/test/groovy/io/micronaut/context/ApplicationContextBuilderSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/ApplicationContextBuilderSpec.groovy
@@ -1,5 +1,6 @@
 package io.micronaut.context
 
+import io.micronaut.core.convert.exceptions.ConversionErrorException
 import spock.lang.Specification
 
 class ApplicationContextBuilderSpec extends Specification {
@@ -21,5 +22,43 @@ class ApplicationContextBuilderSpec extends Specification {
         config.environments.contains('foo')
         config.deduceEnvironments.get() == false
 
+    }
+
+    void "test behaviour when failOnConfigConversionError is true"() {
+        given:
+        def server = ApplicationContext.builder()
+                .failOnConfigConversionError(true)
+                .properties('test.failing.value': 'not-an-int')
+                .start()
+
+        when:
+        server.environment.get('test.failing.value', Integer)
+
+        then:
+        def ex = thrown(ConversionErrorException)
+        ex.message.contains('Failed to convert argument [Integer] for value [not-an-int]')
+
+        cleanup:
+        server.close()
+    }
+
+    void "test behaviour when failOnConfigConversionError is false"() {
+        when:
+        def builder = ApplicationContext.builder()
+                .properties('test.failing.value': 'not-an-int')
+        def server = builder.start()
+
+        then: 'it defaults to false'
+        !server.contextConfiguration.isFailOnConfigConversionError()
+
+        when:
+        def result = server.environment.get('test.failing.value', Integer)
+
+        then:
+        noExceptionThrown()
+        !result.present
+
+        cleanup:
+        server.close()
     }
 }

--- a/inject/src/test/groovy/io/micronaut/context/env/Status.java
+++ b/inject/src/test/groovy/io/micronaut/context/env/Status.java
@@ -1,0 +1,8 @@
+package io.micronaut.context.env;
+
+public enum Status {
+
+    ONE,
+    TWO,
+    THREE
+}

--- a/src/main/docs/guide/config/environments.adoc
+++ b/src/main/docs/guide/config/environments.adoc
@@ -96,3 +96,22 @@ public class Application {
 }
 ----
 <1> Disable the banner
+
+== Fail on invalid configuration
+
+If you specify an invalid configuration value (such as a missing enum, or a badly formatted numeric), Micronaut will silently ignore this failure and the configuration will be set as null (or excluded from a list).
+
+Since Micronaut 3.3.0 it is possible to configure Micronaut to fail on startup if this conversion error is detected by modifying your `Application` class:
+
+[source,java]
+----
+public class Application {
+
+    public static void main(String[] args) {
+        Micronaut.build(args)
+                 .failOnConfigConversionError(true)  // <1>
+                 .start();
+    }
+}
+----
+<1> Throw an exception on startup for any property conversion errors.


### PR DESCRIPTION
previously if you had a list of values (especially enums) and one or more of them
were invalid, they were silently dropped, and the app started as per normal.

This change adds an ApplicationContextBuilder method failOnConfigConversionError which
if set to true when the app starts up will thrown an exception if one of these conversion
errors is seen.

This also adds a debug logger to request query resolution so calls with invalid data to @Nullable or Optional @QueryValues can be found by turning on the debug level logging for `io.micronaut.http.server.binding`