### PR TITLE
Add unsupported config option for logging HTTP data to pcap file

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
@@ -97,6 +97,7 @@ import io.netty.handler.codec.http2.HttpToHttp2ConnectionHandler;
 import io.netty.handler.codec.http2.HttpToHttp2ConnectionHandlerBuilder;
 import io.netty.handler.flow.FlowControlHandler;
 import io.netty.handler.logging.LoggingHandler;
+import io.netty.handler.pcap.PcapWriteHandler;
 import io.netty.handler.ssl.ApplicationProtocolNames;
 import io.netty.handler.ssl.ApplicationProtocolNegotiationHandler;
 import io.netty.handler.ssl.SslContext;
@@ -113,14 +114,18 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.net.BindException;
 import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
+import java.net.SocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.channels.ClosedChannelException;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -133,6 +138,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
@@ -680,6 +686,53 @@ public class NettyHttpServer implements NettyEmbeddedServer {
         }
     }
 
+    private void insertPcapLoggingHandler(ChannelPipeline pipeline, String qualifier) {
+        String pattern = serverConfiguration.getPcapLoggingPathPattern();
+        if (pattern == null) {
+            return;
+        }
+
+        String path = pattern;
+        path = path.replace("{qualifier}", qualifier);
+        path = path.replace("{localAddress}", resolveIfNecessary(pipeline.channel().localAddress()));
+        path = path.replace("{remoteAddress}", resolveIfNecessary(pipeline.channel().remoteAddress()));
+        path = path.replace("{random}", Long.toHexString(ThreadLocalRandom.current().nextLong()));
+        path = path.replace("{timestamp}", Instant.now().toString());
+
+        path = path.replace(':', '_'); // for windows
+
+        LOG.warn("Logging *full* request data, as configured. This will contain sensitive information! Path: '{}'", path);
+
+        try {
+            pipeline.addLast(new PcapWriteHandler(new FileOutputStream(path)));
+        } catch (FileNotFoundException e) {
+            LOG.warn("Failed to create target pcap at '{}', not logging.", path, e);
+        }
+    }
+
+    /**
+     * Force resolution of the given address, and then transform it to string. This prevents any potential user data
+     * appearing in the file path
+     */
+    private static String resolveIfNecessary(SocketAddress address) {
+        if (address instanceof InetSocketAddress) {
+            if (((InetSocketAddress) address).isUnresolved()) {
+                // try resolution
+                address = new InetSocketAddress(((InetSocketAddress) address).getHostString(), ((InetSocketAddress) address).getPort());
+                if (((InetSocketAddress) address).isUnresolved()) {
+                    // resolution failed, bail
+                    return "unresolved";
+                }
+            }
+            return ((InetSocketAddress) address).getAddress().getHostAddress() + ':' + ((InetSocketAddress) address).getPort();
+        }
+        String s = address.toString();
+        if (s.contains("/")) {
+            return "weird";
+        }
+        return s;
+    }
+
     /**
      * Negotiates with the browser if HTTP2 or HTTP is going to be used. Once decided, the Netty
      * pipeline is setup with the correct handlers for the selected protocol.
@@ -880,12 +933,16 @@ public class NettyHttpServer implements NettyEmbeddedServer {
         protected void initChannel(SocketChannel ch) {
             ChannelPipeline pipeline = ch.pipeline();
 
+            insertPcapLoggingHandler(pipeline, "encapsulated");
+
             int port = ch.localAddress().getPort();
             boolean ssl = sslContext != null && sslConfiguration != null && port == serverPort;
             if (ssl) {
                 SslHandler sslHandler = sslContext.newHandler(ch.alloc());
                 sslHandler.setHandshakeTimeoutMillis(sslConfiguration.getHandshakeTimeout().toMillis());
                 pipeline.addLast(ChannelPipelineCustomizer.HANDLER_SSL, sslHandler);
+
+                insertPcapLoggingHandler(pipeline, "ssl-decapsulated");
             }
 
             if (loggingHandler != null) {

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/configuration/NettyHttpServerConfiguration.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/configuration/NettyHttpServerConfiguration.java
@@ -19,6 +19,7 @@ import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Replaces;
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.convert.format.ReadableBytes;
@@ -135,6 +136,7 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
     private Http2Settings http2Settings = new Http2Settings();
     private boolean keepAliveOnServerError = DEFAULT_KEEP_ALIVE_ON_SERVER_ERROR;
     private boolean bindToRouterExposedPorts = true;
+    private String pcapLoggingPathPattern = null;
 
     /**
      * Default empty constructor.
@@ -519,6 +521,28 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
      */
     public void setKeepAliveOnServerError(boolean keepAliveOnServerError) {
         this.keepAliveOnServerError = keepAliveOnServerError;
+    }
+
+    /**
+     * The path pattern to use for logging incoming connections to pcap. This is an unsupported option: Behavior may
+     * change, or it may disappear entirely, without notice!
+     *
+     * @return The path pattern, or {@code null} if logging is disabled.
+     */
+    @Internal
+    public String getPcapLoggingPathPattern() {
+        return pcapLoggingPathPattern;
+    }
+
+    /**
+     * The path pattern to use for logging incoming connections to pcap. This is an unsupported option: Behavior may
+     * change, or it may disappear entirely, without notice!
+     *
+     * @param pcapLoggingPathPattern The path pattern, or {@code null} to disable logging.
+     */
+    @Internal
+    public void setPcapLoggingPathPattern(String pcapLoggingPathPattern) {
+        this.pcapLoggingPathPattern = pcapLoggingPathPattern;
     }
 
     /**

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/PcapLoggingSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/PcapLoggingSpec.groovy
@@ -1,0 +1,63 @@
+package io.micronaut.http.server.netty
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.http.client.HttpClient
+import io.micronaut.runtime.server.EmbeddedServer
+import reactor.core.publisher.Flux
+import spock.lang.Specification
+
+import java.nio.file.FileVisitResult
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.attribute.BasicFileAttributes
+import java.util.stream.Collectors
+
+class PcapLoggingSpec extends Specification {
+    def 'pcap logging'() {
+        given:
+        def tmp = Files.createTempDirectory("micronaut-http-server-netty-test-pcap-logging-spec")
+        def ctx = ApplicationContext.run([
+                'micronaut.server.netty.pcap-logging-path-pattern': tmp.toString() + '/{localAddress}-{remoteAddress}-{random}-{qualifier}-{timestamp}.pcap',
+                'micronaut.ssl.enabled': true,
+                'micronaut.ssl.buildSelfSigned': true,
+                'micronaut.ssl.port': -1,
+                'micronaut.http.client.ssl.insecure-trust-all-certificates': true,
+        ])
+        def server = ctx.getBean(EmbeddedServer)
+        server.start()
+        def client = ctx.createBean(HttpClient, server.URI)
+
+        expect:
+        Files.list(tmp).collect(Collectors.toList()).isEmpty()
+
+        when:
+        try {
+            Flux.from(client.exchange('/')).blockLast()
+        } catch (ignored) {
+            // don't actually care about the response
+        }
+        def names = Files.list(tmp).map(p -> p.fileName.toString()).sorted().collect(Collectors.toList())
+        then:
+        names.size() == 2
+        names[0].matches('127\\.0\\.0\\.1_\\d+-127\\.0\\.0\\.1_\\d+-\\w+-encapsulated-\\d+-\\d+-\\d+T\\d+_\\d+_\\d+\\.\\d+Z\\.pcap')
+        names[1].matches('127\\.0\\.0\\.1_\\d+-127\\.0\\.0\\.1_\\d+-\\w+-ssl-decapsulated-\\d+-\\d+-\\d+T\\d+_\\d+_\\d+\\.\\d+Z\\.pcap')
+
+        cleanup:
+        server.close()
+        client.close()
+        Files.walkFileTree(tmp, new SimpleFileVisitor<Path>() {
+            @Override
+            FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                Files.delete(file)
+                return FileVisitResult.CONTINUE
+            }
+
+            @Override
+            FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                Files.delete(dir)
+                return FileVisitResult.CONTINUE
+            }
+        })
+    }
+}

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/PcapLoggingSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/PcapLoggingSpec.groovy
@@ -18,7 +18,7 @@ class PcapLoggingSpec extends Specification {
         given:
         def tmp = Files.createTempDirectory("micronaut-http-server-netty-test-pcap-logging-spec")
         def ctx = ApplicationContext.run([
-                'micronaut.server.netty.pcap-logging-path-pattern': tmp.toString() + '/{localAddress}-{remoteAddress}-{random}-{qualifier}-{timestamp}.pcap',
+                'micronaut.server.netty.pcap-logging-path-pattern': tmp.toString() + '/{localAddress}-{remoteAddress}-{qualifier}-{random}-{timestamp}.pcap',
                 'micronaut.ssl.enabled': true,
                 'micronaut.ssl.buildSelfSigned': true,
                 'micronaut.ssl.port': -1,
@@ -40,8 +40,8 @@ class PcapLoggingSpec extends Specification {
         def names = Files.list(tmp).map(p -> p.fileName.toString()).sorted().collect(Collectors.toList())
         then:
         names.size() == 2
-        names[0].matches('127\\.0\\.0\\.1_\\d+-127\\.0\\.0\\.1_\\d+-\\w+-encapsulated-\\d+-\\d+-\\d+T\\d+_\\d+_\\d+\\.\\d+Z\\.pcap')
-        names[1].matches('127\\.0\\.0\\.1_\\d+-127\\.0\\.0\\.1_\\d+-\\w+-ssl-decapsulated-\\d+-\\d+-\\d+T\\d+_\\d+_\\d+\\.\\d+Z\\.pcap')
+        names[0].matches('127\\.0\\.0\\.1_\\d+-127\\.0\\.0\\.1_\\d+-encapsulated-\\w+-\\d+-\\d+-\\d+T\\d+_\\d+_\\d+\\.\\d+Z\\.pcap')
+        names[1].matches('127\\.0\\.0\\.1_\\d+-127\\.0\\.0\\.1_\\d+-ssl-decapsulated-\\w+-\\d+-\\d+-\\d+T\\d+_\\d+_\\d+\\.\\d+Z\\.pcap')
 
         cleanup:
         server.close()


### PR DESCRIPTION
This patch adds an option to the netty config to set a file path pattern where pcap dumps are written to. For every connection, two files are created, one for the "full" stream (qualifier: 'encapsulated'), and one with the ssl removed (qualifier: 'ssl-decapsulated').
I've been using similar code for debugging HTTP issues for a while, especially the decapsulated approach. Adding this to core behind a config option allows us to use this logging for hard-to-reproduce issues as well.

Because the config option is marked as `@Internal`, and the code path does nothing if the option is not set, there should be little risk to this change.
To prevent users shooting themselves in the foot by forgetting to turn off this option, there is a log warning on every request.