### PR TITLE
Fix the missing graalVersion in the docs

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -48,6 +48,9 @@ webdriverBinariesVersion=1.4
 kotlinVersion=1.6.10
 kotlin.stdlib.default.dependency=false
 
+# For the docs
+graalVersion=21.3.0
+
 org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx1g


### PR DESCRIPTION
Added the 3.2.x version to gradle.properties