### PR TITLE
Fix AnnotationValue#getAnnotation

### DIFF
--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationValue.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationValue.java
@@ -1169,7 +1169,7 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
         Object v = values.get(member);
         if (v instanceof AnnotationValue) {
             final AnnotationValue<T> av = (AnnotationValue<T>) v;
-            if (av.getAnnotationName().equals(type)) {
+            if (av.getAnnotationName().equals(typeName)) {
                 return Optional.of(av);
             }
             return Optional.empty();

--- a/core/src/test/groovy/io/micronaut/core/annotation/AnnotationValueSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/annotation/AnnotationValueSpec.groovy
@@ -154,4 +154,19 @@ class AnnotationValueSpec extends Specification {
         av.isFalse("five")
         av.isFalse("six")
     }
+
+    void "test getAnnotation()"() {
+        given:
+        def innerAv = AnnotationValue.builder(Bar.class).build()
+        def av = AnnotationValue.builder("test.Foo")
+                .member("bar", innerAv)
+                .member("bars", innerAv, innerAv)
+                .build()
+
+        expect:
+        av.getAnnotation("bar", Bar.class).get() == innerAv
+        av.getAnnotation("bars", Bar.class).get() == innerAv
+    }
 }
+
+@interface Bar {}


### PR DESCRIPTION
The comparison compared different types and thus always evaluates to "false"; as an effect, the `ErrorStrategy` from micronaut-kafka's `KafkaListener` ceased to work.