### PR TITLE
feat: adds LocalizedMessageSource

### DIFF
--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/util/HttpLocalizedMessageSourceSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/util/HttpLocalizedMessageSourceSpec.groovy
@@ -66,16 +66,16 @@ class HttpLocalizedMessageSourceSpec extends Specification {
         @Produces(MediaType.TEXT_PLAIN)
         String message() {
             return localizedMessageSource.getMessage("hello").get() + " " +
-            localizedMessageSource.getMessage("welcome.name" , "Sergio").get() + " " +
-            localizedMessageSource.getMessageOrDefault("bye" , "Good Bye")
+                    localizedMessageSource.getMessage("welcome.name", "Sergio").get() + " " +
+                    localizedMessageSource.getMessageOrDefault("bye", "Good Bye")
         }
 
         @Get("/default")
         @Produces(MediaType.TEXT_PLAIN)
         String messageOrDefault() {
             return localizedMessageSource.getMessageOrDefault("hello", "Foo") + " " +
-                    localizedMessageSource.getMessageOrDefault("welcome.name" , "Foo", "Sergio") + " " +
-                    localizedMessageSource.getMessageOrDefault("bye" , "Good Bye", ["foo": "bar"])
+                    localizedMessageSource.getMessageOrDefault("welcome.name", "Foo", "Sergio") + " " +
+                    localizedMessageSource.getMessageOrDefault("bye", "Good Bye", ["foo": "bar"])
         }
     }
 }

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/util/HttpLocalizedMessageSourceSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/util/HttpLocalizedMessageSourceSpec.groovy
@@ -1,0 +1,81 @@
+package io.micronaut.http.server.netty.util
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.LocalizedMessageSource
+import io.micronaut.context.MessageSource
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.i18n.ResourceBundleMessageSource
+import io.micronaut.http.HttpHeaders
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Produces
+import io.micronaut.http.client.BlockingHttpClient
+import io.micronaut.http.client.HttpClient
+import io.micronaut.runtime.server.EmbeddedServer
+import jakarta.inject.Singleton
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class HttpLocalizedMessageSourceSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
+            'spec.name': 'HttpLocalizedMessageSourceSpec',
+    ])
+
+    @Shared
+    @AutoCleanup
+    HttpClient httpClient = embeddedServer.applicationContext.createBean(HttpClient, embeddedServer.URL)
+
+    @Shared
+    @AutoCleanup
+    BlockingHttpClient client = httpClient.toBlocking()
+
+    void "depending on the resolved locale default messages.properties or default messages_es.properties are used"() {
+        expect:
+        "Hello Welcome Sergio Good Bye" == client.retrieve(HttpRequest.GET('/i18n').header(HttpHeaders.ACCEPT_LANGUAGE, "en"))
+        "Hola Bienvenido Sergio Good Bye" == client.retrieve(HttpRequest.GET('/i18n').header(HttpHeaders.ACCEPT_LANGUAGE, "es"))
+        "Hello Welcome Sergio Good Bye" == client.retrieve(HttpRequest.GET('/i18n/default').header(HttpHeaders.ACCEPT_LANGUAGE, "en"))
+        "Hola Bienvenido Sergio Good Bye" == client.retrieve(HttpRequest.GET('/i18n/default').header(HttpHeaders.ACCEPT_LANGUAGE, "es"))
+    }
+
+    @Requires(property = "spec.name", value = "HttpLocalizedMessageSourceSpec")
+    @Factory
+    static class MessageSourceFactory {
+        @Singleton
+        MessageSource createMessageSource() {
+            return new ResourceBundleMessageSource("i18n.messages");
+        }
+    }
+
+    @Requires(property = "spec.name", value = "HttpLocalizedMessageSourceSpec")
+    @Controller("/i18n")
+    static class LocalizedMessageSourceController {
+        private final LocalizedMessageSource localizedMessageSource;
+
+        LocalizedMessageSourceController(LocalizedMessageSource localizedMessageSource) {
+            this.localizedMessageSource = localizedMessageSource
+        }
+
+        @Get
+        @Produces(MediaType.TEXT_PLAIN)
+        String message() {
+            return localizedMessageSource.getMessage("hello").get() + " " +
+            localizedMessageSource.getMessage("welcome.name" , "Sergio").get() + " " +
+            localizedMessageSource.getMessageOrDefault("bye" , "Good Bye")
+        }
+
+        @Get("/default")
+        @Produces(MediaType.TEXT_PLAIN)
+        String messageOrDefault() {
+            return localizedMessageSource.getMessageOrDefault("hello", "Foo") + " " +
+                    localizedMessageSource.getMessageOrDefault("welcome.name" , "Foo", "Sergio") + " " +
+                    localizedMessageSource.getMessageOrDefault("bye" , "Good Bye", ["foo": "bar"])
+        }
+    }
+}

--- a/http-server-netty/src/test/resources/i18n/messages.properties
+++ b/http-server-netty/src/test/resources/i18n/messages.properties
@@ -1,0 +1,2 @@
+hello=Hello
+welcome.name=Welcome {0}

--- a/http-server-netty/src/test/resources/i18n/messages_es.properties
+++ b/http-server-netty/src/test/resources/i18n/messages_es.properties
@@ -1,0 +1,2 @@
+hello=Hola
+welcome.name=Bienvenido {0}

--- a/http-server/build.gradle
+++ b/http-server/build.gradle
@@ -1,7 +1,5 @@
-
-
 internalSanityChecks {
-    expectedServiceCount.put('io.micronaut.inject.BeanDefinitionReference', 30)
+    expectedServiceCount.put('io.micronaut.inject.BeanDefinitionReference', 32)
     expectedServiceCount.put('io.micronaut.inject.BeanConfiguration', 1)
 }           
 

--- a/http-server/src/main/java/io/micronaut/http/server/util/locale/HttpLocalizedMessageSource.java
+++ b/http-server/src/main/java/io/micronaut/http/server/util/locale/HttpLocalizedMessageSource.java
@@ -33,11 +33,15 @@ import java.util.Locale;
 public class HttpLocalizedMessageSource extends AbstractLocalizedMessageSource<HttpRequest<?>> implements RequestAware {
     private Locale locale;
     /**
+     * @param httpLocaleResolutionConfiguration The locale resolution configuration
      * @param localeResolver The locale resolver
      * @param messageSource  The message source
      */
-    public HttpLocalizedMessageSource(LocaleResolver<HttpRequest<?>> localeResolver, MessageSource messageSource) {
+    public HttpLocalizedMessageSource(HttpLocaleResolutionConfiguration httpLocaleResolutionConfiguration,
+                                      LocaleResolver<HttpRequest<?>> localeResolver,
+                                      MessageSource messageSource) {
         super(localeResolver, messageSource);
+        locale = httpLocaleResolutionConfiguration.getDefaultLocale();
     }
 
     @Override

--- a/http-server/src/main/java/io/micronaut/http/server/util/locale/HttpLocalizedMessageSource.java
+++ b/http-server/src/main/java/io/micronaut/http/server/util/locale/HttpLocalizedMessageSource.java
@@ -32,6 +32,7 @@ import java.util.Locale;
 @RequestScope
 public class HttpLocalizedMessageSource extends AbstractLocalizedMessageSource<HttpRequest<?>> implements RequestAware {
     private Locale locale;
+    
     /**
      * @param localeResolver The locale resolver
      * @param messageSource  The message source
@@ -43,6 +44,9 @@ public class HttpLocalizedMessageSource extends AbstractLocalizedMessageSource<H
     @Override
     @NonNull
     protected Locale getLocale() {
+        if (locale == null) {
+            throw new IllegalStateException("RequestAware::setRequest should have set the locale");
+        }
         return locale;
     }
 

--- a/http-server/src/main/java/io/micronaut/http/server/util/locale/HttpLocalizedMessageSource.java
+++ b/http-server/src/main/java/io/micronaut/http/server/util/locale/HttpLocalizedMessageSource.java
@@ -27,7 +27,7 @@ import java.util.Locale;
 /**
  * A {@link RequestScope} which uses the current {@link HttpRequest} to resolve the locale and hence return the localized messages.
  * @author Sergio del Amo
- * @since 3.4.x
+ * @since 3.4.0
  */
 @RequestScope
 public class HttpLocalizedMessageSource extends AbstractLocalizedMessageSource<HttpRequest<?>> implements RequestAware {

--- a/http-server/src/main/java/io/micronaut/http/server/util/locale/HttpLocalizedMessageSource.java
+++ b/http-server/src/main/java/io/micronaut/http/server/util/locale/HttpLocalizedMessageSource.java
@@ -33,15 +33,11 @@ import java.util.Locale;
 public class HttpLocalizedMessageSource extends AbstractLocalizedMessageSource<HttpRequest<?>> implements RequestAware {
     private Locale locale;
     /**
-     * @param httpLocaleResolutionConfiguration The locale resolution configuration
      * @param localeResolver The locale resolver
      * @param messageSource  The message source
      */
-    public HttpLocalizedMessageSource(HttpLocaleResolutionConfiguration httpLocaleResolutionConfiguration,
-                                      LocaleResolver<HttpRequest<?>> localeResolver,
-                                      MessageSource messageSource) {
+    public HttpLocalizedMessageSource(LocaleResolver<HttpRequest<?>> localeResolver, MessageSource messageSource) {
         super(localeResolver, messageSource);
-        locale = httpLocaleResolutionConfiguration.getDefaultLocale();
     }
 
     @Override

--- a/http-server/src/main/java/io/micronaut/http/server/util/locale/HttpLocalizedMessageSource.java
+++ b/http-server/src/main/java/io/micronaut/http/server/util/locale/HttpLocalizedMessageSource.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.util.locale;
+
+import io.micronaut.context.AbstractLocalizedMessageSource;
+import io.micronaut.context.MessageSource;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.util.LocaleResolver;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.runtime.http.scope.RequestAware;
+import io.micronaut.runtime.http.scope.RequestScope;
+import java.util.Locale;
+
+/**
+ * A {@link RequestScope} which uses the current {@link HttpRequest} to resolve the locale and hence return the localized messages.
+ * @author Sergio del Amo
+ * @since 3.4.x
+ */
+@RequestScope
+public class HttpLocalizedMessageSource extends AbstractLocalizedMessageSource<HttpRequest<?>> implements RequestAware {
+    private Locale locale;
+    /**
+     * @param localeResolver The locale resolver
+     * @param messageSource  The message source
+     */
+    public HttpLocalizedMessageSource(LocaleResolver<HttpRequest<?>> localeResolver, MessageSource messageSource) {
+        super(localeResolver, messageSource);
+    }
+
+    @Override
+    @NonNull
+    protected Locale getLocale() {
+        return locale;
+    }
+
+    @Override
+    public void setRequest(HttpRequest<?> request) {
+        this.locale = resolveLocale(request);
+    }
+}

--- a/http-server/src/test/groovy/io/micronaut/http/server/util/locale/HttpLocalizedMessageSourceIllegalStateExceptionSpec.groovy
+++ b/http-server/src/test/groovy/io/micronaut/http/server/util/locale/HttpLocalizedMessageSourceIllegalStateExceptionSpec.groovy
@@ -1,0 +1,15 @@
+package io.micronaut.http.server.util.locale
+
+import spock.lang.Specification
+
+class HttpLocalizedMessageSourceIllegalStateExceptionSpec extends Specification {
+
+    void "if locale is null an exception is thrown"() {
+        when:
+        new HttpLocalizedMessageSource(null, null).getLocale()
+
+        then:
+        thrown(IllegalStateException)
+
+    }
+}

--- a/http/build.gradle
+++ b/http/build.gradle
@@ -7,12 +7,6 @@ internalSanityChecks {
     expectedServiceCount.put('io.micronaut.inject.BeanDefinitionReference', 21)
 }
 
-
-internalSanityChecks {
-    expectedServiceCount.put('io.micronaut.inject.BeanDefinitionReference', 21)
-    expectedServiceCount.put('io.micronaut.core.beans.BeanIntrospectionReference', 4)
-}           
-
 dependencies {
     annotationProcessor project(":inject-java")
     annotationProcessor project(":graal")

--- a/inject/src/main/java/io/micronaut/context/AbstractLocalizedMessageSource.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractLocalizedMessageSource.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.util.LocaleResolver;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Abstract class which implements {@link LocalizedMessageSource} and leverages {@link LocaleResolver} API.
+ * @author Sergio del Amo
+ * @since 3.4.x
+ * @param <T> The context object which will be used to resolve the locale
+ */
+public abstract class AbstractLocalizedMessageSource<T> implements LocalizedMessageSource {
+    private final LocaleResolver<T> localeResolver;
+    private final MessageSource messageSource;
+
+    /**
+     *
+     * @param localeResolver The locale resolver
+     * @param messageSource The message source
+     */
+    public AbstractLocalizedMessageSource(LocaleResolver<T> localeResolver,
+                                          MessageSource messageSource) {
+        this.localeResolver = localeResolver;
+        this.messageSource = messageSource;
+    }
+
+    /**
+     *
+     * @return The resolved locale;
+     */
+    @NonNull
+    protected abstract Locale getLocale();
+
+    /**
+     * Resolve a message for the given code and variables for the messages.
+     * @param code The code
+     * @param variables to be used to interpolate the message
+     * @return A message if present
+     */
+    @Override
+    @NonNull
+    public Optional<String> getMessage(@NonNull String code, Object... variables) {
+        return messageSource.getMessage(code, getLocale(), variables);
+    }
+
+    /**
+     * Resolve a message for the given code and variables for the messages.
+     * @param code The code
+     * @param variables to be used to interpolate the message
+     * @return A message if present
+     */
+    @Override
+    @NonNull
+    public Optional<String> getMessage(@NonNull String code, Map<String, Object> variables) {
+        return messageSource.getMessage(code, getLocale(), variables);
+    }
+
+    @Override
+    @NonNull
+    public Optional<String> getMessage(@NonNull String code) {
+        return messageSource.getMessage(code, getLocale());
+    }
+
+    /**
+     * @param localeResolutionContext The context object which will be used to resolve the locale
+     * @return The resolved locale;
+     */
+    @NonNull
+    protected Locale resolveLocale(T localeResolutionContext) {
+        return localeResolver.resolveOrDefault(localeResolutionContext);
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/AbstractLocalizedMessageSource.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractLocalizedMessageSource.java
@@ -25,7 +25,7 @@ import java.util.Optional;
 /**
  * Abstract class which implements {@link LocalizedMessageSource} and leverages {@link LocaleResolver} API.
  * @author Sergio del Amo
- * @since 3.4.x
+ * @since 3.4.0
  * @param <T> The context object which will be used to resolve the locale
  */
 public abstract class AbstractLocalizedMessageSource<T> implements LocalizedMessageSource {

--- a/inject/src/main/java/io/micronaut/context/LocalizedMessageSource.java
+++ b/inject/src/main/java/io/micronaut/context/LocalizedMessageSource.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context;
+
+import io.micronaut.core.annotation.NonNull;
+
+import java.util.Map;
+import java.util.Optional;
+
+public interface LocalizedMessageSource {
+    /**
+     * Resolve a message for the given code.
+     * @param code The code
+     * @return A message if present
+     */
+    @NonNull Optional<String> getMessage(@NonNull String code);
+
+    /**
+     * Resolve a message for the given code and variables for the messages.
+     * @param code The code
+     * @param variables to be used to interpolate the message
+     * @return A message if present
+     */
+    @NonNull Optional<String> getMessage(@NonNull String code, Object... variables);
+
+    /**
+     * Resolve a message for the given code and variables for the messages.
+     * @param code The code
+     * @param variables to be used to interpolate the message
+     * @return A message if present
+     */
+    @NonNull Optional<String> getMessage(@NonNull String code, Map<String, Object> variables);
+
+    /**
+     * Resolve a message for the given code. If the message is not present then default message is returned.
+     * @param code The code
+     * @param defaultMessage The default message to use if no other message is found
+     * @return A message if present. If the message is not present then default message supplied is returned.
+     */
+    default @NonNull String getMessageOrDefault(@NonNull String code, @NonNull String defaultMessage) {
+        return getMessage(code).orElse(defaultMessage);
+    }
+
+    /**
+     * Resolve a message for the given code. If the message is not present then default message is returned.
+     * @param code The code
+     * @param defaultMessage The default message to use if no other message is found
+     * @param variables to be used to interpolate the message
+     * @return A message if present. If the message is not present then default message supplied is returned.
+     */
+    default @NonNull String getMessageOrDefault(@NonNull String code, @NonNull String defaultMessage, Object... variables) {
+        return getMessage(code, variables).orElse(defaultMessage);
+    }
+
+    /**
+     * Resolve a message for the given code. If the message is not present then default message is returned.
+     * @param code The code
+     * @param defaultMessage The default message to use if no other message is found
+     * @param variables to be used to interpolate the message
+     * @return A message if present. If the message is not present then default message supplied is returned.
+     */
+    default @NonNull String getMessageOrDefault(@NonNull String code, @NonNull String defaultMessage, Map<String, Object> variables) {
+        return getMessage(code, variables).orElse(defaultMessage);
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/LocalizedMessageSource.java
+++ b/inject/src/main/java/io/micronaut/context/LocalizedMessageSource.java
@@ -20,6 +20,11 @@ import io.micronaut.core.annotation.NonNull;
 import java.util.Map;
 import java.util.Optional;
 
+/**
+ * Retrieve messages for the resolved locale.
+ * @author Sergio del Amo
+ * @since 3.4.0
+ */
 public interface LocalizedMessageSource {
     /**
      * Resolve a message for the given code.

--- a/inject/src/main/java/io/micronaut/context/MessageSource.java
+++ b/inject/src/main/java/io/micronaut/context/MessageSource.java
@@ -19,6 +19,7 @@ import io.micronaut.context.exceptions.NoSuchMessageException;
 import io.micronaut.core.annotation.Indexed;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.order.Ordered;
 import io.micronaut.core.util.ArgumentUtils;
 import jakarta.inject.Singleton;
 
@@ -35,7 +36,7 @@ import java.util.Optional;
  */
 @Singleton
 @Indexed(MessageSource.class)
-public interface MessageSource {
+public interface MessageSource extends Ordered {
 
     /**
      * An empty message source.
@@ -57,12 +58,79 @@ public interface MessageSource {
     /**
      * Resolve a message for the given code and context.
      * @param code The code
+     * @param locale The locale to use to resolve messages.
+     * @return A message if present
+     */
+    default @NonNull Optional<String> getMessage(@NonNull String code, @NonNull Locale locale) {
+        return getMessage(code, MessageContext.of(locale));
+    }
+
+    /**
+     * Resolve a message for the given code and context.
+     * @param code The code
+     * @param locale The locale to use to resolve messages.
+     * @param variables The variables to use resolve message placeholders
+     * @return A message if present
+     */
+    default @NonNull Optional<String> getMessage(@NonNull String code, @NonNull Locale locale, @NonNull Object... variables) {
+        return getMessage(code, locale, MessageSourceUtils.variables(variables));
+    }
+
+    /**
+     * Resolve a message for the given code and context.
+     * @param code The code
+     * @param locale The locale to use to resolve messages.
+     * @param variables The variables to use resolve message placeholders
+     * @return A message if present
+     */
+    default @NonNull Optional<String> getMessage(@NonNull String code, @NonNull Locale locale, @NonNull Map<String, Object> variables) {
+        return getMessage(code, MessageContext.of(locale, variables));
+    }
+
+    /**
+     * Resolve a message for the given code and context.
+     * @param code The code
      * @param context The context
      * @return A message if present
      */
     default @NonNull Optional<String> getMessage(@NonNull String code, @NonNull MessageContext context) {
         Optional<String> rawMessage = getRawMessage(code, context);
         return rawMessage.map(message -> this.interpolate(message, context));
+    }
+
+    /**
+     * Resolve a message for the given code and context.
+     * @param code The code
+     * @param defaultMessage The default message to use if no other message is found
+     * @param locale The locale to use to resolve messages.
+     * @return A message if present
+     */
+    default @NonNull String getMessage(@NonNull String code, @NonNull String defaultMessage, @NonNull Locale locale) {
+        return getMessage(code, MessageContext.of(locale), defaultMessage);
+    }
+
+    /**
+     * Resolve a message for the given code and context.
+     * @param code The code
+     * @param defaultMessage The default message to use if no other message is found
+     * @param locale The locale to use to resolve messages.
+     * @param variables The variables to use resolve message placeholders
+     * @return A message if present
+     */
+    default @NonNull String getMessage(@NonNull String code, @NonNull String defaultMessage, @NonNull Locale locale, @NonNull Map<String, Object> variables) {
+        return getMessage(code, MessageContext.of(locale, variables), defaultMessage);
+    }
+
+    /**
+     * Resolve a message for the given code and context.
+     * @param code The code
+     * @param defaultMessage The default message to use if no other message is found
+     * @param locale The locale to use to resolve messages.
+     * @param variables The variables to use resolve message placeholders
+     * @return A message if present
+     */
+    default @NonNull String getMessage(@NonNull String code, @NonNull String defaultMessage, @NonNull Locale locale, @NonNull Object... variables) {
+        return getMessage(code, defaultMessage, locale, MessageSourceUtils.variables(variables));
     }
 
     /**
@@ -162,7 +230,7 @@ public interface MessageSource {
         }
 
         /**
-         * @return The variables to use resolve message place holders
+         * @return The variables to use resolve message placeholders
          */
         @NonNull default Map<String, Object> getVariables() {
             return Collections.emptyMap();

--- a/inject/src/main/java/io/micronaut/context/MessageSourceUtils.java
+++ b/inject/src/main/java/io/micronaut/context/MessageSourceUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context;
+
+import io.micronaut.core.annotation.NonNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Utility class used by {@link MessageSource} to create variables maps.
+ * @author Sergio del Amo
+ * @since 3.4.x
+ */
+public class MessageSourceUtils {
+    /**
+     * Returns a Map whose keys are the index of the varargs.
+     * E.g. for "Sergio", "John" the map ["0" => "Sergio", "1" => "John"] is returned
+     * @param args variables
+     * @return The variables map.
+     */
+    @NonNull
+    public static Map<String, Object> variables(@NonNull Object... args) {
+        Map<String, Object> variables = new HashMap<>();
+        int count = 0;
+        for (Object value : args) {
+            variables.put("" + count, value);
+            count++;
+        }
+        return variables;
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/MessageSourceUtils.java
+++ b/inject/src/main/java/io/micronaut/context/MessageSourceUtils.java
@@ -23,7 +23,7 @@ import java.util.Map;
 /**
  * Utility class used by {@link MessageSource} to create variables maps.
  * @author Sergio del Amo
- * @since 3.4.x
+ * @since 3.4.0
  */
 public class MessageSourceUtils {
     /**

--- a/inject/src/main/java/io/micronaut/context/MessageSourceUtils.java
+++ b/inject/src/main/java/io/micronaut/context/MessageSourceUtils.java
@@ -37,7 +37,7 @@ public class MessageSourceUtils {
         Map<String, Object> variables = new HashMap<>();
         int count = 0;
         for (Object value : args) {
-            variables.put("" + count, value);
+            variables.put(String.valueOf(count), value);
             count++;
         }
         return variables;

--- a/inject/src/test/groovy/io/micronaut/context/MessageSourceUtilsSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/MessageSourceUtilsSpec.groovy
@@ -1,0 +1,11 @@
+package io.micronaut.context
+
+import spock.lang.Specification
+
+class MessageSourceUtilsSpec extends Specification {
+    void "given a list MessageSourceUtils::variables returns a map whose key is a string with the numeric value of the item's position"() {
+        expect:
+        MessageSourceUtils.variables("Sergio", "John") == ["0": 'Sergio', "1": "John"]
+        MessageSourceUtils.variables("Sergio", "John") == ["0": 'Sergio', "1": "John"]
+    }
+}

--- a/src/main/docs/guide/i18n/bundle.adoc
+++ b/src/main/docs/guide/i18n/bundle.adoc
@@ -14,8 +14,16 @@ include::test-suite/src/test/resources/io/micronaut/docs/i18n/messages_en.proper
 include::test-suite/src/test/resources/io/micronaut/docs/i18n/messages_es.properties[]
 ----
 
-You can use api:context.i18n.ResourceBundleMessageSource[], an implementation of api:context.MessageSource[] which eases accessing link:{javase}/java/util/ResourceBundle.html[Resource Bundles] and provides cache functionality, to access the previous messages:
+You can use api:context.i18n.ResourceBundleMessageSource[], an implementation of api:context.MessageSource[] which eases accessing link:{javase}/java/util/ResourceBundle.html[Resource Bundles] and provides cache functionality, to access the previous messages.
+
+WARNING: Do not instantiate a new `ResourceBundleMessageSource` each time you retrieve a message. Instantiate it once, for example in a factory.
+
+snippet::io.micronaut.docs.i18n.MessageSourceFactory[tags="clazz",indent=0,title="MessageSource Factory Example"]
+
+Then you can retrieve the messages supplying the locale:
 
 snippet::io.micronaut.docs.i18n.I18nSpec[tags="test",indent=0,title="ResourceBundleMessageSource Example"]
 
-WARNING: Do not instantiate a new `ResourceBundleMessageSource` each time you retrieve a message. Instantiate it once, for example in a `javax.inject.Singleton`, and reuse it.
+
+
+

--- a/src/main/docs/guide/i18n/localizedMessageSource.adoc
+++ b/src/main/docs/guide/i18n/localizedMessageSource.adoc
@@ -1,0 +1,1 @@
+api:context.LocalizedMessageSource[] is a `@RequestScope` bean which you can inject in your Controllers and which uses <<localeResolution, Micronaut Locale Resolution>> to resolve the localized message for the current HTTP request.

--- a/src/main/docs/guide/ioc/beanValidation.adoc
+++ b/src/main/docs/guide/ioc/beanValidation.adoc
@@ -93,7 +93,7 @@ snippet::io.micronaut.docs.ioc.validation.custom.DurationPattern[tags="imports,c
 <2> A `message` template can be provided in a hard-coded manner as above. If none is specified, Micronaut tries to find a message using `ClassName.message` using the api:context.MessageSource[] interface (optional)
 <3> To support repeated annotations you can define an inner annotation (optional)
 
-TIP: You can add messages and message bundles using the api:context.MessageSource[] and api:context.i18n.ResourceBundleMessageSource[] classes.
+TIP: You can add messages and message bundles using the api:context.MessageSource[] and api:context.i18n.ResourceBundleMessageSource[] classes. See <<bundle, Resource Bundles>> documentation.
 
 Once you have defined the annotation, implement a api:validation.validator.constraints.ConstraintValidator[] that validates the annotation. You can either create a bean class that implements the interface directly or define a factory that returns one or more validators.
 

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -282,6 +282,7 @@ cli:
 i18n:
   title: Internationalization
   bundle: Resource Bundles
+  localizedMessageSource: Localized Message Source
 appendix:
   title: Appendices
   faq: Frequently Asked Questions (FAQ)

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/i18n/I18nSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/i18n/I18nSpec.groovy
@@ -15,22 +15,40 @@
  */
 package io.micronaut.docs.i18n
 
+import io.micronaut.context.MessageSource
 import io.micronaut.context.MessageSource.MessageContext
-import io.micronaut.context.i18n.ResourceBundleMessageSource
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
 import spock.lang.Specification
 
+@MicronautTest(startApplication = false)
 class I18nSpec extends Specification {
+
+    @Inject
+    MessageSource messageSource
 
     void "it is possible to create a MessageSource from resource bundle"() {
         //tag::test[]
-        given:
-        def ms = new ResourceBundleMessageSource("io.micronaut.docs.i18n.messages")
-
         expect:
-        ms.getMessage("hello", MessageContext.of(new Locale("es"))).get() == 'Hola'
+        messageSource.getMessage("hello", MessageContext.of(new Locale("es"))).get() == 'Hola'
 
         and:
-        ms.getMessage("hello", MessageContext.of(Locale.ENGLISH)).get() == 'Hello'
+        messageSource.getMessage("hello", MessageContext.of(Locale.ENGLISH)).get() == 'Hello'
         //end::test[]
+
+        messageSource.getMessage("hello", new Locale("es")).isPresent()
+        "Hola" == messageSource.getMessage("hello", new Locale("es")).get()
+        "Hello" == messageSource.getMessage("hello", Locale.ENGLISH).get()
+        messageSource.getMessage("hello", Locale.ENGLISH).isPresent()
+
+        messageSource.getMessage("hello.name", new Locale("es"), "Sergio").isPresent()
+        "Hola Sergio" == messageSource.getMessage("hello.name", new Locale("es"), "Sergio").get()
+        messageSource.getMessage("hello.name", Locale.ENGLISH, "Sergio").isPresent()
+        "Hello Sergio" == messageSource.getMessage("hello.name", Locale.ENGLISH, "Sergio").get()
+
+        messageSource.getMessage("hello.name", new Locale("es"), ["0": "Sergio"]).isPresent()
+        "Hola Sergio" == messageSource.getMessage("hello.name", new Locale("es"), ["0": "Sergio"]).get()
+        messageSource.getMessage("hello.name", Locale.ENGLISH, ["0": "Sergio"]).isPresent()
+        "Hello Sergio" == messageSource.getMessage("hello.name", Locale.ENGLISH, ["0": "Sergio"]).get()
     }
 }

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/i18n/MessageSourceFactory.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/i18n/MessageSourceFactory.groovy
@@ -1,0 +1,16 @@
+package io.micronaut.docs.i18n
+
+//tag::clazz[]
+import io.micronaut.context.MessageSource
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.i18n.ResourceBundleMessageSource
+import jakarta.inject.Singleton
+
+@Factory
+class MessageSourceFactory {
+    @Singleton
+    MessageSource createMessageSource() {
+        new ResourceBundleMessageSource("io.micronaut.docs.i18n.messages")
+    }
+}
+//end::clazz[]

--- a/test-suite-groovy/src/test/resources/io/micronaut/docs/i18n/messages_en.properties
+++ b/test-suite-groovy/src/test/resources/io/micronaut/docs/i18n/messages_en.properties
@@ -1,1 +1,2 @@
 hello=Hello
+hello.name=Hello {0}

--- a/test-suite-groovy/src/test/resources/io/micronaut/docs/i18n/messages_es.properties
+++ b/test-suite-groovy/src/test/resources/io/micronaut/docs/i18n/messages_es.properties
@@ -1,1 +1,2 @@
 hello=Hola
+hello.name=Hola {0}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/i18n/I18nSpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/i18n/I18nSpec.kt
@@ -17,17 +17,41 @@ package io.micronaut.docs.i18n
 
 import io.micronaut.context.MessageSource
 import io.micronaut.context.i18n.ResourceBundleMessageSource
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
-import java.util.Locale
+import java.util.*
 
+@MicronautTest(startApplication = false)
 class I18nTest {
+    @Inject
+    lateinit var messageSource: MessageSource
+
     @Test
     fun itIsPossibleToCreateAMessageSourceFromResourceBundle() {
         //tag::test[]
-        val ms = ResourceBundleMessageSource("io.micronaut.docs.i18n.messages")
-        Assertions.assertEquals("Hola", ms.getMessage("hello", MessageSource.MessageContext.of(Locale("es"))).get())
-        Assertions.assertEquals("Hello", ms.getMessage("hello", MessageSource.MessageContext.of(Locale.ENGLISH)).get())
+        Assertions.assertEquals("Hola", messageSource.getMessage("hello", MessageSource.MessageContext.of(Locale("es"))).get())
+        Assertions.assertEquals("Hello", messageSource.getMessage("hello", MessageSource.MessageContext.of(Locale.ENGLISH)).get())
         //end::test[]
+
+        Assertions.assertEquals("Hola", messageSource.getMessage("hello", Locale("es")).get())
+        Assertions.assertEquals("Hello", messageSource.getMessage("hello", Locale.ENGLISH).get())
+
+        Assertions.assertTrue(messageSource.getMessage("hello.name", Locale("es"), "Sergio").isPresent)
+        Assertions.assertEquals("Hola Sergio", messageSource.getMessage("hello.name", Locale("es"), "Sergio").get())
+        Assertions.assertTrue(messageSource.getMessage("hello.name", Locale.ENGLISH, "Sergio").isPresent)
+        Assertions.assertEquals("Hello Sergio", messageSource.getMessage("hello.name", Locale.ENGLISH, "Sergio").get())
+
+        Assertions.assertTrue(messageSource.getMessage("hello.name", Locale("es"), mapOf(Pair("0", "Sergio"))).isPresent)
+        Assertions.assertEquals(
+            "Hola Sergio",
+            messageSource.getMessage("hello.name", Locale("es"), mapOf(Pair("0", "Sergio"))).get()
+        )
+        Assertions.assertTrue(messageSource.getMessage("hello.name", Locale.ENGLISH, mapOf(Pair("0", "Sergio"))).isPresent)
+        Assertions.assertEquals(
+            "Hello Sergio",
+            messageSource.getMessage("hello.name", Locale.ENGLISH, mapOf(Pair("0", "Sergio"))).get()
+        )
     }
 }

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/i18n/MessageSourceFactory.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/i18n/MessageSourceFactory.kt
@@ -1,0 +1,14 @@
+package io.micronaut.docs.i18n
+
+//tag::clazz[]
+import io.micronaut.context.MessageSource
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.i18n.ResourceBundleMessageSource
+import jakarta.inject.Singleton
+
+@Factory
+internal class MessageSourceFactory {
+    @Singleton
+    fun createMessageSource(): MessageSource = ResourceBundleMessageSource("io.micronaut.docs.i18n.messages")
+}
+//end::clazz[]

--- a/test-suite-kotlin/src/test/resources/io/micronaut/docs/i18n/messages_en.properties
+++ b/test-suite-kotlin/src/test/resources/io/micronaut/docs/i18n/messages_en.properties
@@ -1,1 +1,2 @@
 hello=Hello
+hello.name=Hello {0}

--- a/test-suite-kotlin/src/test/resources/io/micronaut/docs/i18n/messages_es.properties
+++ b/test-suite-kotlin/src/test/resources/io/micronaut/docs/i18n/messages_es.properties
@@ -1,1 +1,2 @@
 hello=Hola
+hello.name=Hola {0}

--- a/test-suite/src/test/java/io/micronaut/docs/i18n/I18nSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/i18n/I18nSpec.java
@@ -15,21 +15,43 @@
  */
 package io.micronaut.docs.i18n;
 
+import io.micronaut.context.MessageSource;
 import io.micronaut.context.MessageSource.MessageContext;
-import io.micronaut.context.i18n.ResourceBundleMessageSource;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.Locale;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@MicronautTest(startApplication = false)
 class I18nSpec {
+
+    @Inject
+    MessageSource messageSource;
+
     @Test
     void itIsPossibleToCreateAMessageSourceFromResourceBundle() {
         //tag::test[]
-        ResourceBundleMessageSource ms = new ResourceBundleMessageSource("io.micronaut.docs.i18n.messages");
-        assertEquals("Hola", ms.getMessage("hello", MessageContext.of(new Locale("es"))).get());
-        assertEquals("Hello", ms.getMessage("hello", MessageContext.of(Locale.ENGLISH)).get());
+        assertEquals("Hola", messageSource.getMessage("hello", MessageContext.of(new Locale("es"))).get());
+        assertEquals("Hello", messageSource.getMessage("hello", MessageContext.of(Locale.ENGLISH)).get());
         //end::test[]
+
+        assertTrue(messageSource.getMessage("hello", new Locale("es")).isPresent());
+        assertEquals("Hola", messageSource.getMessage("hello", new Locale("es")).get());
+        assertEquals("Hello", messageSource.getMessage("hello", Locale.ENGLISH).get());
+        assertTrue(messageSource.getMessage("hello", Locale.ENGLISH).isPresent());
+
+        assertTrue(messageSource.getMessage("hello.name", new Locale("es"), "Sergio").isPresent());
+        assertEquals("Hola Sergio", messageSource.getMessage("hello.name", new Locale("es"), "Sergio").get());
+        assertTrue(messageSource.getMessage("hello.name", Locale.ENGLISH, "Sergio").isPresent());
+        assertEquals("Hello Sergio", messageSource.getMessage("hello.name", Locale.ENGLISH, "Sergio").get());
+
+        assertTrue(messageSource.getMessage("hello.name", new Locale("es"), Collections.singletonMap("0", "Sergio")).isPresent());
+        assertEquals("Hola Sergio", messageSource.getMessage("hello.name", new Locale("es"), Collections.singletonMap("0", "Sergio")).get());
+        assertTrue(messageSource.getMessage("hello.name", Locale.ENGLISH, Collections.singletonMap("0", "Sergio")).isPresent());
+        assertEquals("Hello Sergio", messageSource.getMessage("hello.name", Locale.ENGLISH, Collections.singletonMap("0", "Sergio")).get());
     }
 }

--- a/test-suite/src/test/java/io/micronaut/docs/i18n/MessageSourceFactory.java
+++ b/test-suite/src/test/java/io/micronaut/docs/i18n/MessageSourceFactory.java
@@ -1,0 +1,16 @@
+package io.micronaut.docs.i18n;
+
+//tag::clazz[]
+import io.micronaut.context.MessageSource;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.i18n.ResourceBundleMessageSource;
+import jakarta.inject.Singleton;
+
+@Factory
+class MessageSourceFactory {
+    @Singleton
+    MessageSource createMessageSource() {
+        return new ResourceBundleMessageSource("io.micronaut.docs.i18n.messages");
+    }
+}
+//end::clazz[]

--- a/test-suite/src/test/resources/io/micronaut/docs/i18n/messages_en.properties
+++ b/test-suite/src/test/resources/io/micronaut/docs/i18n/messages_en.properties
@@ -1,1 +1,2 @@
 hello=Hello
+hello.name=Hello {0}

--- a/test-suite/src/test/resources/io/micronaut/docs/i18n/messages_es.properties
+++ b/test-suite/src/test/resources/io/micronaut/docs/i18n/messages_es.properties
@@ -1,1 +1,2 @@
 hello=Hola
+hello.name=Hola {0}


### PR DESCRIPTION
- It makes MessageSource Ordered since CompositeMessageSource attempts to order the MessageSource beans.
- It shows the recommended approach of using a factory to create a MessageSource with a ResourceBundleMessageSource
- It adds extra default methods to MessageSource to make it easier to work with the API.