### PR TITLE
Release streaming HTTP data when request is invalid

### DIFF
--- a/http-server-netty/build.gradle
+++ b/http-server-netty/build.gradle
@@ -2,7 +2,13 @@ import org.apache.tools.ant.taskdefs.condition.Os
 
 internalSanityChecks {
     expectedServiceCount.put('io.micronaut.inject.BeanDefinitionReference', 24)
-}           
+}
+
+test {
+    systemProperty("io.netty.leakDetection.level", "paranoid")
+    systemProperty("io.netty.customResourceLeakDetector", "io.micronaut.http.server.netty.fuzzing.BufferLeakDetection")
+    maxHeapSize("1G")
+}
 
 dependencies {
     annotationProcessor project(":inject-java")

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/decoders/HttpRequestDecoder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/decoders/HttpRequestDecoder.java
@@ -20,6 +20,7 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.order.Ordered;
 import io.micronaut.http.context.event.HttpRequestReceivedEvent;
+import io.micronaut.http.netty.stream.StreamedHttpRequest;
 import io.micronaut.http.server.HttpServerConfiguration;
 import io.micronaut.http.server.netty.NettyHttpRequest;
 import io.micronaut.http.server.netty.NettyHttpServer;
@@ -105,6 +106,10 @@ public class HttpRequestDecoder extends MessageToMessageDecoder<HttpRequest> imp
             );
             final Throwable cause = e.getCause();
             ctx.fireExceptionCaught(cause != null ? cause : e);
+            if (msg instanceof StreamedHttpRequest) {
+                // discard any data that may come in
+                ((StreamedHttpRequest) msg).closeIfNoSubscriber();
+            }
         }
     }
 }

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/fuzzing/BufferLeakDetection.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/fuzzing/BufferLeakDetection.groovy
@@ -1,0 +1,98 @@
+package io.micronaut.http.server.netty.fuzzing
+
+import io.netty.util.ResourceLeakDetector
+import io.netty.util.ResourceLeakDetectorFactory
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Hook into netty resource leak detection that allows test cases to check for resource leaks.
+ */
+class BufferLeakDetection<T> extends ResourceLeakDetector<T> {
+    private static final Logger LOG = LoggerFactory.getLogger(BufferLeakDetection)
+
+    private static final List<ResourceLeakDetector<?>> allDetectors = new CopyOnWriteArrayList<>()
+
+    private static volatile boolean leakDetected = false
+    private static volatile boolean canaryDetected = false
+
+    static void startTracking() {
+        leakDetected = false
+        canaryDetected = false
+
+        LOG.debug("Starting resource leak tracking")
+        if (level != Level.PARANOID) {
+            LOG.warn("Resource leaks can't be detected properly below leak detection level 'paranoid'")
+        }
+        Canary.CANARY_LEAK_DETECTOR.track(new Canary())
+    }
+
+    static void stopTrackingAndReportLeaks() {
+        // this seems to be reasonably reliable to trigger collection of remaining buffers
+        System.gc()
+        try {
+            //noinspection GroovyUnusedAssignment
+            byte[] unused = new byte[(int) Runtime.getRuntime().freeMemory()]
+        } catch (OutOfMemoryError ignored) {}
+
+        // trigger detectors – ref queue collection is only done on track()
+        for (ResourceLeakDetector<?> detector : allDetectors) {
+            def obj = new Object()
+            detector.track(obj).close(obj)
+        }
+
+        if (leakDetected) {
+            throw new RuntimeException("Detected a resource leak. Please check logs")
+        } else {
+            LOG.debug("No resource leak detected")
+            if (!canaryDetected) {
+                LOG.warn("Canary resource leak wasn't detected. Leak detection not functional")
+            }
+        }
+    }
+
+    @SuppressWarnings('unused')
+    BufferLeakDetection(Class<?> resourceType, int samplingInterval) {
+        super(resourceType, samplingInterval)
+        allDetectors.add(this)
+    }
+
+    @SuppressWarnings('unused')
+    BufferLeakDetection(Class<?> resourceType, int samplingInterval, long maxActive) {
+        // maxActive ignored by superclass
+        this(resourceType, samplingInterval)
+    }
+
+    @Override
+    protected boolean needReport() {
+        return true
+    }
+
+    @Override
+    protected void reportTracedLeak(String resourceType, String records) {
+        if (resourceType.contains(Canary.class.getSimpleName())) {
+            canaryDetected = true
+            return
+        }
+
+        leakDetected = true
+        super.reportTracedLeak(resourceType, records)
+    }
+
+    @Override
+    protected void reportUntracedLeak(String resourceType) {
+        if (resourceType.contains(Canary.class.getSimpleName())) {
+            canaryDetected = true
+            return
+        }
+
+        leakDetected = true
+        super.reportUntracedLeak(resourceType)
+    }
+
+    private static class Canary {
+        private static final ResourceLeakDetector<Canary> CANARY_LEAK_DETECTOR = ResourceLeakDetectorFactory.instance().newResourceLeakDetector(Canary)
+    }
+}

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/fuzzing/FuzzyInputSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/fuzzing/FuzzyInputSpec.groovy
@@ -1,0 +1,63 @@
+package io.micronaut.http.server.netty.fuzzing
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.http.netty.channel.EventLoopGroupConfiguration
+import io.micronaut.http.netty.channel.EventLoopGroupRegistry
+import io.micronaut.runtime.server.EmbeddedServer
+import io.netty.bootstrap.Bootstrap
+import io.netty.buffer.Unpooled
+import io.netty.channel.Channel
+import io.netty.channel.ChannelInitializer
+import io.netty.channel.ChannelOption
+import io.netty.channel.socket.nio.NioSocketChannel
+import io.netty.handler.timeout.ReadTimeoutHandler
+import io.netty.resolver.NoopAddressResolverGroup
+import spock.lang.Specification
+
+/**
+ * HTTP inputs generated from fuzzing.
+ */
+class FuzzyInputSpec extends Specification {
+    def 'http1 cleartext buffer leaks'() {
+        given:
+        BufferLeakDetection.startTracking()
+
+        ApplicationContext ctx = ApplicationContext.run([
+                "micronaut.server.port": "-1",
+                "micronaut.netty.event-loops.default.num-threads": "1"
+        ])
+        def embeddedServer = ctx.getBean(EmbeddedServer)
+        embeddedServer.start()
+
+        def clientBootstrap = new Bootstrap()
+                .remoteAddress(new InetSocketAddress(embeddedServer.getHost(),
+                        embeddedServer.getPort()))
+                .resolver(NoopAddressResolverGroup.INSTANCE)
+                .group(ctx.getBean(EventLoopGroupRegistry.class).getEventLoopGroup(EventLoopGroupConfiguration.DEFAULT).get())
+                .channel(NioSocketChannel.class)
+                .option(ChannelOption.AUTO_READ, true)
+                .handler(new ChannelInitializer<Channel>() {
+                    @Override
+                    protected void initChannel(Channel ch) throws Exception {
+                        ch.pipeline()
+                                .addLast(new ReadTimeoutHandler(1))
+                    }
+                })
+
+        when:
+        def channel = clientBootstrap.connect().sync().channel()
+        channel.writeAndFlush(Unpooled.wrappedBuffer(input))
+        channel.closeFuture().sync()
+
+        then:
+        BufferLeakDetection.stopTrackingAndReportLeaks()
+
+        cleanup:
+        embeddedServer.stop()
+
+        where:
+        input << [
+                Base64.decoder.decode("T1BUSU9OUyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKiBIVFRQLzEuMQpUcmFuc2Zlci1FbmNvZGluZzpjaHVua2VkCgo0CgoNSU9OUyAqIEhUVFAvMS4xClRyYW5zZmVyLUVuY29kaW5nOmNodW5rZWSKCg")
+        ]
+    }
+}


### PR DESCRIPTION
Buffer leak discovered by fuzzing. This patch also adds infrastructure to http-server-netty that can be used to test for buffer leaks.

The IllegalArgumentException in this particular test case is caused by an invalid URI passed to the server.