### PR TITLE
docs: Fix javadoc links to non-core projects

### DIFF
--- a/src/main/docs/guide/aop/caching.adoc
+++ b/src/main/docs/guide/aop/caching.adoc
@@ -1,18 +1,18 @@
-Like Spring and Grails, Micronaut provides caching annotations in the link:{micronautcacheapi}/package-summary.html[io.micronaut.cache] package.
+Like Spring and Grails, Micronaut provides caching annotations in the link:{micronautcacheapi}/io/micronaut/cache/package-summary.html[io.micronaut.cache] package.
 
-The link:{micronautcacheapi}/CacheManager.html[CacheManager] interface allows different cache implementations to be plugged in as necessary.
+The link:{micronautcacheapi}/io/micronaut/cache/CacheManager.html[CacheManager] interface allows different cache implementations to be plugged in as necessary.
 
-The link:{micronautcacheapi}/SyncCache.html[SyncCache] interface provides a synchronous API for caching, whilst the link:{micronautcacheapi}/AsyncCache.html[AsyncCache] API allows non-blocking operation.
+The link:{micronautcacheapi}io/micronaut/cache/SyncCache.html[SyncCache] interface provides a synchronous API for caching, whilst the link:{micronautcacheapi}/io/micronaut/cache/AsyncCache.html[AsyncCache] API allows non-blocking operation.
 
 == Cache Annotations
 
 The following cache annotations are supported:
 
-- link:{micronautcacheapi}/annotation/Cacheable.html[@Cacheable] - Indicates a method is cacheable in the specified cache
-- link:{micronautcacheapi}/annotation/CachePut.html[@CachePut] - Indicates that the return value of a method invocation should be cached. Unlike `@Cacheable` the original operation is never skipped.
-- link:{micronautcacheapi}/annotation/CacheInvalidate.html[@CacheInvalidate] - Indicates the invocation of a method should cause the invalidation of one or more caches.
+- link:{micronautcacheapi}/io/micronaut/cache/annotation/Cacheable.html[@Cacheable] - Indicates a method is cacheable in the specified cache
+- link:{micronautcacheapi}/io/micronaut/cache/annotation/CachePut.html[@CachePut] - Indicates that the return value of a method invocation should be cached. Unlike `@Cacheable` the original operation is never skipped.
+- link:{micronautcacheapi}/io/micronaut/cache/annotation/CacheInvalidate.html[@CacheInvalidate] - Indicates the invocation of a method should cause the invalidation of one or more caches.
 
-Using one of these annotations activates the link:{micronautcacheapi}/interceptor/CacheInterceptor[CacheInterceptor], which in the case of `@Cacheable` caches the return value of the method.
+Using one of these annotations activates the link:{micronautcacheapi}/io/micronaut/cache/interceptor/CacheInterceptor[CacheInterceptor], which in the case of `@Cacheable` caches the return value of the method.
 
 The emitted result is cached if the method return type is a non-blocking type (either link:{jdkapi}/java/util/concurrent/CompletableFuture.html[CompletableFuture] or an instance of rs:Publisher[]) .
 
@@ -36,7 +36,7 @@ The above example configures a cache called "my-cache" with a maximum size of 20
 [NOTE]
 .Naming Caches
 ====
-Define names of caches under `micronaut.caches` in kebab case (lowercase and hyphen separated); if you use camel case, the names are normalized to kebab case. For example `myCache` becomes `my-cache`. The kebab-case form must be used when referencing caches in the {micronautcacheapi}/annotation/Cacheable.html[@Cacheable] annotation.
+Define names of caches under `micronaut.caches` in kebab case (lowercase and hyphen separated); if you use camel case, the names are normalized to kebab case. For example `myCache` becomes `my-cache`. The kebab-case form must be used when referencing caches in the {micronautcacheapi}/io/micronaut/cache/annotation/Cacheable.html[@Cacheable] annotation.
 ====
 
 To configure a weigher to be used with the `maximumWeight` configuration, create a bean that implements `io.micronaut.caffeine.cache.Weigher`. To associate a given weigher with only a specific cache, annotate the bean with `@Named(<cache name>)`. Weighers without a named qualifier apply to all caches that don't have a named weigher. If no beans are found, a default implementation is used.
@@ -45,9 +45,9 @@ See the https://micronaut-projects.github.io/micronaut-cache/latest/guide/config
 
 == Dynamic Cache Creation
 
-A {micronautcacheapi}/DynamicCacheManager.html[DynamicCacheManager] bean can be registered for use cases where caches cannot be configured ahead of time. When a cache is attempted to be retrieved that was not predefined, the dynamic cache manager is invoked to create and return a cache.
+A {micronautcacheapi}/io/micronaut/cache/DynamicCacheManager.html[DynamicCacheManager] bean can be registered for use cases where caches cannot be configured ahead of time. When a cache is attempted to be retrieved that was not predefined, the dynamic cache manager is invoked to create and return a cache.
 
-By default, if there is no other dynamic cache manager defined in the application, Micronaut registers an instance of {micronautcacheapi}/caffeine/DefaultDynamicCacheManager.html[DefaultDynamicCacheManager] that creates Caffeine caches with default values.
+By default, if there is no other dynamic cache manager defined in the application, Micronaut registers an instance of {micronautcacheapi}/io/micronaut/cache/caffeine/DefaultDynamicCacheManager.html[DefaultDynamicCacheManager] that creates Caffeine caches with default values.
 
 == Other Cache Implementations
 

--- a/src/main/docs/guide/aop/springAop.adoc
+++ b/src/main/docs/guide/aop/springAop.adoc
@@ -10,7 +10,7 @@ dependency:io.micronaut.spring:micronaut-spring[gradleScope="implementation"]
 
 NOTE: If you use Micronaut's <<hibernateSupport,Hibernate support>> you already get this dependency and a `HibernateTransactionManager` is configured for you.
 
-This is done by defining a Micronaut link:{micronautspringapi}/tx/annotation/Transactional.html[Transactional] annotation that uses ann:context.annotation.AliasFor[] in a manner that every time you set a value with link:{micronautspringapi}/tx/annotation/Transactional.html[Transactional] it aliases the value to the equivalent value in Spring's version of `@Transactional`.
+This is done by defining a Micronaut link:{micronautspringapi}/io/micronaut/spring/tx/annotation/Transactional.html[Transactional] annotation that uses ann:context.annotation.AliasFor[] in a manner that every time you set a value with link:{micronautspringapi}/io/micronaut/spring/tx/annotation/Transactional.html[Transactional] it aliases the value to the equivalent value in Spring's version of `@Transactional`.
 
 The benefit here is you can use Micronaut's compile-time, reflection-free AOP to declare programmatic Spring transactions. For example:
 
@@ -26,4 +26,4 @@ public Book saveBook(String title) {
 }
 ----
 
-NOTE: Micronaut's version of link:{micronautspringapi}/tx/annotation/Transactional.html[Transactional] is meta-annotated with ann:core.annotation.Blocking[], ensuring that all methods annotated with it use the I/O thread pool when executing within the HTTP server
+NOTE: Micronaut's version of link:{micronautspringapi}/io/micronaut/spring/tx/annotation/Transactional.html[Transactional] is meta-annotated with ann:core.annotation.Blocking[], ensuring that all methods annotated with it use the I/O thread pool when executing within the HTTP server

--- a/src/main/docs/guide/cloud/clientSideLoadBalancing/netflixRibbon.adoc
+++ b/src/main/docs/guide/cloud/clientSideLoadBalancing/netflixRibbon.adoc
@@ -15,7 +15,7 @@ To add Ribbon support to your application, add the `netflix-ribbon` configuratio
 
 dependency:io.micronaut.netflix:micronaut-netflix-ribbon[]
 
-The api:http.client.LoadBalancer[] implementations will now be link:{micronautribbonapi}/RibbonLoadBalancer.html[RibbonLoadBalancer] instances.
+The api:http.client.LoadBalancer[] implementations will now be link:{micronautribbonapi}/io/micronaut/configuration/ribbon/RibbonLoadBalancer.html[RibbonLoadBalancer] instances.
 
 Ribbon's http://netflix.github.io/ribbon/ribbon-core-javadoc/com/netflix/client/config/CommonClientConfigKey.html[Configuration options] can be set using the `ribbon` namespace in configuration. For example in `application.yml`:
 
@@ -39,4 +39,4 @@ ribbon:
       ServerListRefreshInterval: 2000
 ----
 
-By default Micronaut registers a link:{micronautribbonapi}/DiscoveryClientServerList.html[DiscoveryClientServerList] for each client that integrates Ribbon with Micronaut's api:discovery.DiscoveryClient[].
+By default Micronaut registers a link:{micronautribbonapi}/io/micronaut/configuration/ribbon/DiscoveryClientServerList.html[DiscoveryClientServerList] for each client that integrates Ribbon with Micronaut's api:discovery.DiscoveryClient[].

--- a/src/main/docs/guide/cloud/cloudConfiguration.adoc
+++ b/src/main/docs/guide/cloud/cloudConfiguration.adoc
@@ -76,7 +76,7 @@ Note that you can have multiple environments active, for example when running in
 
 In addition, using the value of the constants defined in the table above you can create environment-specific configuration files. For example if you create a `src/main/resources/application-gcp.yml` file, it is only loaded when running on Google Compute.
 
-TIP: Any configuration property in the api:context.env.Environment[] can also be set via an environment variable. For example, setting the `CONSUL_CLIENT_HOST` environment variable overrides the `host` property in link:{micronautdiscoveryapi}/consul/ConsulConfiguration.html[ConsulConfiguration].
+TIP: Any configuration property in the api:context.env.Environment[] can also be set via an environment variable. For example, setting the `CONSUL_CLIENT_HOST` environment variable overrides the `host` property in link:{micronautdiscoveryapi}/io/micronaut/discovery/consul/ConsulConfiguration.html[ConsulConfiguration].
 
 == Using Cloud Instance Metadata
 

--- a/src/main/docs/guide/cloud/cloudConfiguration/distributedConfigurationConsul.adoc
+++ b/src/main/docs/guide/cloud/cloudConfiguration/distributedConfigurationConsul.adoc
@@ -1,4 +1,4 @@
-https://www.consul.io[Consul] is a popular Service Discovery and Distributed Configuration server provided by HashiCorp. Micronaut features a native link:{micronautdiscoveryapi}/consul/client/v1/ConsulClient.html[ConsulClient] that uses Micronaut's support for <<clientAnnotation, Declarative HTTP Clients>>.
+https://www.consul.io[Consul] is a popular Service Discovery and Distributed Configuration server provided by HashiCorp. Micronaut features a native link:{micronautdiscoveryapi}/io/micronaut/discovery/consul/client/v1/ConsulClient.html[ConsulClient] that uses Micronaut's support for <<clientAnnotation, Declarative HTTP Clients>>.
 
 == Starting Consul
 

--- a/src/main/docs/guide/httpClient/clientAnnotation/netflixHystrix.adoc
+++ b/src/main/docs/guide/httpClient/clientAnnotation/netflixHystrix.adoc
@@ -15,7 +15,7 @@ dependency:io.micronaut.netflix:micronaut-netflix-hystrix[]
 
 == Using the @HystrixCommand Annotation
 
-With the above dependency declared you can annotate any method (including methods defined on `@Client` interfaces) with the link:{micronauthystrixapi}/annotation.HystrixCommand.html[HystrixCommand] annotation, and method's execution will be wrapped in a Hystrix command. For example:
+With the above dependency declared you can annotate any method (including methods defined on `@Client` interfaces) with the link:{micronauthystrixapi}/io/micronaut/configuration/hystrix/annotation/HystrixCommand.html[HystrixCommand] annotation, and method's execution will be wrapped in a Hystrix command. For example:
 
 .Using @HystrixCommand
 [source,groovy]
@@ -28,9 +28,9 @@ String hello(String name) {
 
 NOTE: This works for reactive return types such as reactor:Flux[], and the reactive type will be wrapped in a `HystrixObservableCommand`.
 
-The link:{micronauthystrixapi}/annotation.HystrixCommand.html[HystrixCommand] annotation also integrates with Micronaut's support for <<retry, Retry Advice>> and <<clientFallback, Fallbacks>>
+The link:{micronauthystrixapi}/io/micronaut/configuration/hystrix/annotation/HystrixCommand.html[HystrixCommand] annotation also integrates with Micronaut's support for <<retry, Retry Advice>> and <<clientFallback, Fallbacks>>
 
-TIP: For information on how to customize the Hystrix thread pool, group, and properties, see the Javadoc for link:{micronauthystrixapi}/annotation.HystrixCommand.html[HystrixCommand].
+TIP: For information on how to customize the Hystrix thread pool, group, and properties, see the Javadoc for link:{micronauthystrixapi}/io/micronaut/configuration/hystrix/annotation/HystrixCommand.html[HystrixCommand].
 
 == Enabling Hystrix Stream and Dashboard
 

--- a/src/main/docs/guide/httpClient/clientFilter.adoc
+++ b/src/main/docs/guide/httpClient/clientFilter.adoc
@@ -9,7 +9,7 @@ To resolve this you can define a filter. The following is an example `BintraySer
 snippet::io.micronaut.docs.client.ThirdPartyClientFilterSpec[tags="bintrayApiConstants, bintrayService", indent=0]
 
 
-<1> An link:{micronautreactorapi}/client/ReactorHttpClient[ReactorHttpClient] is injected for the Bintray API
+<1> An link:{micronautreactorapi}/io/micronaut/reactor/client/ReactorHttpClient[ReactorHttpClient] is injected for the Bintray API
 <2> The organization is configurable via configuration
 
 The Bintray API is secured. To authenticate you add an `Authorization` header for every request. You can modify `fetchRepositories` and `fetchPackages` methods to include the necessary HTTP Header for each request, but using a filter is much simpler:
@@ -24,9 +24,9 @@ Now when you invoke the `bintrayService.fetchRepositories()` method, the `Author
 
 === Injecting Another Client into a HttpClientFilter
 
-To create an link:{micronautreactorapi}/client/ReactorHttpClient[ReactorHttpClient], Micronaut needs to resolve all `HttpClientFilter` instances, which creates a circular dependency when injecting another link:{micronautreactorapi}/client.ReactorHttpClient[] or a `@Client` bean into an instance of a `HttpClientFilter`.
+To create an link:{micronautreactorapi}/io/micronaut/reactor/client/ReactorHttpClient[ReactorHttpClient], Micronaut needs to resolve all `HttpClientFilter` instances, which creates a circular dependency when injecting another link:{micronautreactorapi}/io/micronaut/reactor/client/ReactorHttpClient[] or a `@Client` bean into an instance of a `HttpClientFilter`.
 
-To resolve this issue, use the api:context.BeanProvider[] interface to inject another link:{micronautreactorapi}/client/ReactorHttpClient[ReactorHttpClient] or a `@Client` bean into an instance of `HttpClientFilter`.
+To resolve this issue, use the api:context.BeanProvider[] interface to inject another link:{micronautreactorapi}/io/micronaut/reactor/client/ReactorHttpClient[ReactorHttpClient] or a `@Client` bean into an instance of `HttpClientFilter`.
 
 The following example which implements a filter allowing https://cloud.google.com/run/docs/authenticating/service-to-service[authentication between services on Google Cloud Run] demonstrates how to use api:context.BeanProvider[] to inject another client:
 

--- a/src/main/docs/guide/httpClient/lowLevelHttpClient.adoc
+++ b/src/main/docs/guide/httpClient/lowLevelHttpClient.adoc
@@ -2,4 +2,4 @@ The api:http.client.HttpClient[] interface forms the basis for the low-level API
 
 The majority of the methods in the api:http.client.HttpClient[] interface return Reactive Streams rs:Publisher[] instances, which is not always the most useful interface to work against.
 
-Micronaut's Reactor HTTP Client dependency ships with a sub-interface named link:{micronautreactorapi}/client/ReactorHttpClient[ReactorHttpClient]. It provides a variation of the api:http.client.HttpClient[] interface that returns https://projectreactor.io[Project Reactor] reactor:Flux[] types.
+Micronaut's Reactor HTTP Client dependency ships with a sub-interface named link:{micronautreactorapi}/io/micronaut/reactor/http/client/ReactorHttpClient.html[ReactorHttpClient]. It provides a variation of the api:http.client.HttpClient[] interface that returns https://projectreactor.io[Project Reactor] reactor:Flux[] types.

--- a/src/main/docs/guide/httpClient/lowLevelHttpClient/clientStreaming.adoc
+++ b/src/main/docs/guide/httpClient/lowLevelHttpClient/clientStreaming.adoc
@@ -1,4 +1,4 @@
-Micronaut's HTTP client includes support for streaming data over HTTP via the link:{micronautreactorapi}/client/ReactorStreamingHttpClient[ReactorStreamingHttpClient] interface which includes methods specific to streaming including:
+Micronaut's HTTP client includes support for streaming data over HTTP via the link:{micronautreactorapi}/io/micronaut/reactor/http/client/ReactorStreamingHttpClient.html[ReactorStreamingHttpClient] interface which includes methods specific to streaming including:
 
 .HTTP Streaming Methods
 |===


### PR DESCRIPTION
In this commit:

https://github.com/micronaut-projects/micronaut-core/commit/61dde1ca2298557de4cc26c68905fe073419607b#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19

We removed the path to the Javadoc for the external modules, and just have a path to /api

This means the links to these javadoc pages are giving 404s.  Eg: `@Cacheable` here:

https://docs.micronaut.io/latest/guide/index.html#caching

If we put the path back into the `gradle.properties`, then we get a warning

```
[javadocs] gradle.properties file declares entry https://micronaut-projects.github.io/micronaut-discovery-client/latest/api/io/micronaut/discovery should stop at /api. Automatically truncated to https://micronaut-projects.github.io/micronaut-discovery-client/latest/api/
```

This change goes through all the uses of those properties in the asciidocs, and adds the
correct path back in.

We should consider automated testing to make sure links to m-p.github.io in the generated
docs don't result in a 404 to catch this in the future