### PR TITLE
Update broken links in the guide

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -199,7 +199,7 @@ allprojects {
 }
 
 htmlSanityCheck {
-    sourceDir = new File("${rootProject.buildDir}/docs/")
+    sourceDir = new File("${rootProject.buildDir}/docs/guide/")
     sourceDocuments = fileTree(sourceDir) {
         include "index.html"
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -50,6 +50,7 @@ kotlin.stdlib.default.dependency=false
 
 # For the docs
 graalVersion=22.0.0.2
+micronautSecurityVersion=3.3.0
 
 org.gradle.caching=true
 org.gradle.parallel=true

--- a/src/main/docs/guide/aop/caching.adoc
+++ b/src/main/docs/guide/aop/caching.adoc
@@ -2,7 +2,7 @@ Like Spring and Grails, Micronaut provides caching annotations in the link:{micr
 
 The link:{micronautcacheapi}/io/micronaut/cache/CacheManager.html[CacheManager] interface allows different cache implementations to be plugged in as necessary.
 
-The link:{micronautcacheapi}io/micronaut/cache/SyncCache.html[SyncCache] interface provides a synchronous API for caching, whilst the link:{micronautcacheapi}/io/micronaut/cache/AsyncCache.html[AsyncCache] API allows non-blocking operation.
+The link:{micronautcacheapi}/io/micronaut/cache/SyncCache.html[SyncCache] interface provides a synchronous API for caching, whilst the link:{micronautcacheapi}/io/micronaut/cache/AsyncCache.html[AsyncCache] API allows non-blocking operation.
 
 == Cache Annotations
 

--- a/src/main/docs/guide/aop/introductionAdvice.adoc
+++ b/src/main/docs/guide/aop/introductionAdvice.adoc
@@ -1,6 +1,6 @@
 Introduction advice is distinct from Around advice in that it involves providing an implementation instead of decorating.
 
-Examples of introduction advice include http://gorm.grails.org[GORM] and http://projects.spring.io/spring-data[Spring Data] which implement persistence logic for you.
+Examples of introduction advice include https://gorm.grails.org[GORM] and https://projects.spring.io/spring-data[Spring Data] which implement persistence logic for you.
 
 Micronaut's api:http.client.annotation.Client[] annotation is another example of introduction advice where Micronaut implements HTTP client interfaces for you at compile time.
 

--- a/src/main/docs/guide/cli/commands.adoc
+++ b/src/main/docs/guide/cli/commands.adoc
@@ -230,7 +230,7 @@ $ mn create-websocket-client MyChat
 |===
 
 The `create-command` command generates a standalone application that can be executed as a
-http://picocli.info[picocli] link:http://picocli.info/apidocs/picocli/CommandLine.Command.html[Command]. It follows a `*Command` convention for generating the class name. It creates an associated test that runs the application and verifies that a command line option was set.
+https://picocli.info[picocli] link:https://picocli.info/apidocs/picocli/CommandLine.Command.html[Command]. It follows a `*Command` convention for generating the class name. It creates an associated test that runs the application and verifies that a command line option was set.
 
 [source,bash]
 ----

--- a/src/main/docs/guide/cli/features.adoc
+++ b/src/main/docs/guide/cli/features.adoc
@@ -5,7 +5,7 @@ Features consist of additional dependencies and configuration to enable specific
 $ mn create-app my-demo-app --features mongo-reactive
 ----
 
-This adds the necessary dependencies and configuration for the http://mongodb.github.io/mongo-java-driver-reactivestreams[MongoDB Reactive Driver] in your application. You can view the available features using the `--list-features` flag for whichever create command you use.
+This adds the necessary dependencies and configuration for the https://mongodb.github.io/mongo-java-driver-reactivestreams[MongoDB Reactive Driver] in your application. You can view the available features using the `--list-features` flag for whichever create command you use.
 
 [source,bash]
 ----

--- a/src/main/docs/guide/cloud/clientSideLoadBalancing/netflixRibbon.adoc
+++ b/src/main/docs/guide/cloud/clientSideLoadBalancing/netflixRibbon.adoc
@@ -17,7 +17,7 @@ dependency:io.micronaut.netflix:micronaut-netflix-ribbon[]
 
 The api:http.client.LoadBalancer[] implementations will now be link:{micronautribbonapi}/io/micronaut/configuration/ribbon/RibbonLoadBalancer.html[RibbonLoadBalancer] instances.
 
-Ribbon's http://netflix.github.io/ribbon/ribbon-core-javadoc/com/netflix/client/config/CommonClientConfigKey.html[Configuration options] can be set using the `ribbon` namespace in configuration. For example in `application.yml`:
+Ribbon's https://netflix.github.io/ribbon/ribbon-core-javadoc/com/netflix/client/config/CommonClientConfigKey.html[Configuration options] can be set using the `ribbon` namespace in configuration. For example in `application.yml`:
 
 .Configuring Ribbon
 [source,yaml]

--- a/src/main/docs/guide/configurations/dataAccess.adoc
+++ b/src/main/docs/guide/configurations/dataAccess.adoc
@@ -8,7 +8,7 @@ This table summarizes the configuration modules and dependencies to add to your 
 |Configures SQL jdk:javax.sql.DataSource[]s using https://commons.apache.org/proper/commons-dbcp/[Commons DBCP]
 
 |`io.micronaut.sql:micronaut-jdbc-hikari`
-|Configures SQL jdk:javax.sql.DataSource[]s using https://brettwooldridge.github.io/HikariCP/[Hikari Connection Pool]
+|Configures SQL jdk:javax.sql.DataSource[]s using https://github.com/brettwooldridge/HikariCP[Hikari Connection Pool]
 
 |`io.micronaut.sql:micronaut-jdbc-tomcat`
 |Configures SQL jdk:javax.sql.DataSource[]s using https://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html[Tomcat Connection Pool]
@@ -17,19 +17,19 @@ This table summarizes the configuration modules and dependencies to add to your 
 |Configures Hibernate/JPA `EntityManagerFactory` beans
 
 |`io.micronaut.groovy:micronaut-hibernate-gorm`
-|Configures http://gorm.grails.org/latest/hibernate/manual[GORM for Hibernate] for Groovy applications
+|Configures https://gorm.grails.org/latest/hibernate/manual[GORM for Hibernate] for Groovy applications
 
 |`io.micronaut.mongodb:micronaut-mongo-reactive`
-|Configures the http://mongodb.github.io/mongo-java-driver-reactivestreams[MongoDB Reactive Driver]
+|Configures the https://mongodb.github.io/mongo-java-driver-reactivestreams[MongoDB Reactive Driver]
 
 |`io.micronaut.groovy:micronaut-mongo-gorm`
-|Configures http://gorm.grails.org/latest/mongodb/manual[GORM for MongoDB] for Groovy applications
+|Configures https://gorm.grails.org/latest/mongodb/manual[GORM for MongoDB] for Groovy applications
 
 |`io.micronaut.neo4j:micronaut-neo4j-bolt`
 |Configures the https://github.com/neo4j/neo4j-java-driver[Bolt Java Driver] for https://neo4j.com[Neo4j]
 
 |`io.micronaut.groovy:micronaut-neo4j-gorm`
-|Configures http://gorm.grails.org/latest/neo4j/manual[GORM for Neo4j] for Groovy applications
+|Configures https://gorm.grails.org/latest/neo4j/manual[GORM for Neo4j] for Groovy applications
 
 |`io.micronaut.sql:micronaut-vertx-mysql-client`
 |Configures the https://github.com/eclipse-vertx/vertx-sql-client/tree/master/vertx-mysql-client[Reactive MySQL Client]
@@ -41,7 +41,7 @@ This table summarizes the configuration modules and dependencies to add to your 
 |Configures the https://lettuce.io[Lettuce] driver for https://redis.io[Redis]
 
 |`io.micronaut.cassandra:micronaut-cassandra`
-|Configures the https://github.com/datastax/java-driver[Datastax Java Driver] for http://cassandra.apache.org[Cassandra]
+|Configures the https://github.com/datastax/java-driver[Datastax Java Driver] for https://cassandra.apache.org[Cassandra]
 
 |===
 
@@ -53,7 +53,7 @@ For example, to add support for MongoDB, add the following dependency:
 compile "io.micronaut.mongodb:micronaut-mongo-reactive"
 ----
 
-For Groovy users, Micronaut provides special support for http://gorm.grails.org[GORM].
+For Groovy users, Micronaut provides special support for https://gorm.grails.org[GORM].
 
 WARNING: With GORM for Hibernate you cannot have both the `hibernate-jpa` and `hibernate-gorm` dependencies.
 

--- a/src/main/docs/guide/configurations/dataAccess/hibernateSupport.adoc
+++ b/src/main/docs/guide/configurations/dataAccess/hibernateSupport.adoc
@@ -9,7 +9,7 @@ $ mn create-app my-app --features hibernate-jpa
 ----
 ====
 
-Micronaut includes support for configuring a http://hibernate.org[Hibernate] / JPA `EntityManager` that builds on the <<sqlSupport, SQL DataSource support>>.
+Micronaut includes support for configuring a https://hibernate.org[Hibernate] / JPA `EntityManager` that builds on the <<sqlSupport, SQL DataSource support>>.
 
 Once you have <<sqlSupport, configured one or more DataSources>> to use Hibernate, add the `hibernate-jpa` dependency to your build:
 
@@ -19,7 +19,7 @@ For more information see the https://micronaut-projects.github.io/micronaut-sql/
 
 ==== Using GORM for Hibernate
 
-For Groovy users and users familiar with the Grails framework, special support for http://gorm.grails.org[GORM for Hibernate] is available. To use GORM for Hibernate *do not* include Micronaut's built-in <<sqlSupport, SQL Support>> or the `hibernate-jpa` dependency since GORM itself takes responsibility for creating the `DataSource`, `SessionFactory`, etc.
+For Groovy users and users familiar with the Grails framework, special support for https://gorm.grails.org[GORM for Hibernate] is available. To use GORM for Hibernate *do not* include Micronaut's built-in <<sqlSupport, SQL Support>> or the `hibernate-jpa` dependency since GORM itself takes responsibility for creating the `DataSource`, `SessionFactory`, etc.
 
 [TIP]
 .Using the CLI

--- a/src/main/docs/guide/configurations/dataAccess/liquibaseSupport.adoc
+++ b/src/main/docs/guide/configurations/dataAccess/liquibaseSupport.adoc
@@ -1,2 +1,2 @@
-To configure Micronaut integration with http://www.liquibase.org[Liquibase], please follow
+To configure Micronaut integration with https://www.liquibase.org[Liquibase], please follow
 https://micronaut-projects.github.io/micronaut-liquibase/latest/guide/index.html[these instructions].

--- a/src/main/docs/guide/configurations/dataAccess/mongoSupport.adoc
+++ b/src/main/docs/guide/configurations/dataAccess/mongoSupport.adoc
@@ -22,9 +22,9 @@ mongodb:
   uri: mongodb://username:password@localhost:27017/databaseName
 ----
 
-TIP: The `mongodb.uri` follows the https://docs.mongodb.com/manual/reference/connection-string[MongoDB Connection String] format.
+TIP: The `mongodb.uri` follows the https://docs.mongodb.com/manual/reference/connection-string/[MongoDB Connection String] format.
 
-A non-blocking Reactive Streams http://mongodb.github.io/mongo-java-driver-reactivestreams/1.8/javadoc/com/mongodb/reactivestreams/client/MongoClient.html[MongoClient] is then available for dependency injection.
+A non-blocking Reactive Streams https://mongodb.github.io/mongo-java-driver-reactivestreams/1.8/javadoc/com/mongodb/reactivestreams/client/MongoClient.html[MongoClient] is then available for dependency injection.
 
 To use the blocking driver, add a dependency to your build on the mongo-java-driver:
 
@@ -33,6 +33,6 @@ To use the blocking driver, add a dependency to your build on the mongo-java-dri
 compile "org.mongodb:mongo-java-driver"
 ----
 
-Then the blocking http://mongodb.github.io/mongo-java-driver/3.7/javadoc/com/mongodb/MongoClient.html[MongoClient] will be available for injection.
+Then the blocking https://mongodb.github.io/mongo-java-driver/3.7/javadoc/com/mongodb/MongoClient.html[MongoClient] will be available for injection.
 
 See the https://micronaut-projects.github.io/micronaut-mongodb/latest/guide/[Micronaut MongoDB] documentation for further information on configuring and using MongoDB within Micronaut.

--- a/src/main/docs/guide/configurations/dataAccess/sqlSupport.adoc
+++ b/src/main/docs/guide/configurations/dataAccess/sqlSupport.adoc
@@ -21,7 +21,7 @@ dependency:micronaut-jdbc-dbcp[groupId="io.micronaut.sql",scope="runtime"]
 
 dependency:micronaut-jdbc-ucp[groupId="io.micronaut.sql",scope="runtime"]
 
-Also, add a JDBC driver dependency to your build. For example to add the http://www.h2database.com[H2 In-Memory Database]:
+Also, add a JDBC driver dependency to your build. For example to add the https://www.h2database.com[H2 In-Memory Database]:
 
 dependency:h2[groupId="com.h2database",scope="runtime"]
 

--- a/src/main/docs/guide/configurations/reactiveConfigs/reactor.adoc
+++ b/src/main/docs/guide/configurations/reactiveConfigs/reactor.adoc
@@ -1,9 +1,9 @@
 To add support for Reactor, add the following module:
 
-dependency:io.micronaut.reactor:micronaut-reactor[scope="compile"]
+dependency:micronaut-reactor[scope="compile", groupId="io.micronaut.reactor"]
 
 To use the Reactor HTTP client, add the following dependency:
 
-dependency:io.micronaut.reactor:micronaut-reactor-http-client[scope="compile"]
+dependency:micronaut-reactor-http-client[scope="compile", groupId="io.micronaut.reactor"]
 
 For more information see the documentation for https://micronaut-projects.github.io/micronaut-reactor/latest/guide/[Micronaut Reactor].

--- a/src/main/docs/guide/httpClient/clientFilter.adoc
+++ b/src/main/docs/guide/httpClient/clientFilter.adoc
@@ -9,7 +9,7 @@ To resolve this you can define a filter. The following is an example `BintraySer
 snippet::io.micronaut.docs.client.ThirdPartyClientFilterSpec[tags="bintrayApiConstants, bintrayService", indent=0]
 
 
-<1> An link:{micronautreactorapi}/io/micronaut/reactor/client/ReactorHttpClient[ReactorHttpClient] is injected for the Bintray API
+<1> An link:{micronautreactorapi}/io/micronaut/reactor/http/client/ReactorHttpClient.html[ReactorHttpClient] is injected for the Bintray API
 <2> The organization is configurable via configuration
 
 The Bintray API is secured. To authenticate you add an `Authorization` header for every request. You can modify `fetchRepositories` and `fetchPackages` methods to include the necessary HTTP Header for each request, but using a filter is much simpler:
@@ -24,9 +24,9 @@ Now when you invoke the `bintrayService.fetchRepositories()` method, the `Author
 
 === Injecting Another Client into a HttpClientFilter
 
-To create an link:{micronautreactorapi}/io/micronaut/reactor/client/ReactorHttpClient[ReactorHttpClient], Micronaut needs to resolve all `HttpClientFilter` instances, which creates a circular dependency when injecting another link:{micronautreactorapi}/io/micronaut/reactor/client/ReactorHttpClient[] or a `@Client` bean into an instance of a `HttpClientFilter`.
+To create an link:{micronautreactorapi}/io/micronaut/reactor/http/client/ReactorHttpClient.html[ReactorHttpClient], Micronaut needs to resolve all `HttpClientFilter` instances, which creates a circular dependency when injecting another link:{micronautreactorapi}/io/micronaut/reactor/http/client/ReactorHttpClient.html[ReactorHttpClient] or a `@Client` bean into an instance of a `HttpClientFilter`.
 
-To resolve this issue, use the api:context.BeanProvider[] interface to inject another link:{micronautreactorapi}/io/micronaut/reactor/client/ReactorHttpClient[ReactorHttpClient] or a `@Client` bean into an instance of `HttpClientFilter`.
+To resolve this issue, use the api:context.BeanProvider[] interface to inject another link:{micronautreactorapi}/io/micronaut/reactor/http/client/ReactorHttpClient.html[ReactorHttpClient] or a `@Client` bean into an instance of `HttpClientFilter`.
 
 The following example which implements a filter allowing https://cloud.google.com/run/docs/authenticating/service-to-service[authentication between services on Google Cloud Run] demonstrates how to use api:context.BeanProvider[] to inject another client:
 

--- a/src/main/docs/guide/httpClient/clientSample.adoc
+++ b/src/main/docs/guide/httpClient/clientSample.adoc
@@ -1,3 +1,3 @@
-TIP: Read the HTTP Client Guide (http://guides.micronaut.io/micronaut-http-client/guide/index.html[Java],
-http://guides.micronaut.io/micronaut-http-client-groovy/guide/index.html[Groovy],
-http://guides.micronaut.io/micronaut-http-client-kotlin/guide/index.html[Kotlin]), a step-by-step tutorial, to learn more.
+TIP: Read the HTTP Client Guide (https://guides.micronaut.io/micronaut-http-client/guide/index.html[Java],
+https://guides.micronaut.io/micronaut-http-client-groovy/guide/index.html[Groovy],
+https://guides.micronaut.io/micronaut-http-client-kotlin/guide/index.html[Kotlin]), a step-by-step tutorial, to learn more.

--- a/src/main/docs/guide/httpServer/http2Server.adoc
+++ b/src/main/docs/guide/httpServer/http2Server.adoc
@@ -12,9 +12,9 @@ micronaut:
     http-version: 2.0
 ----
 
-With this configuration, Micronaut enables support for the `h2c` protocol (see https://http2.github.io/http2-spec/#discover-http[HTTP/2 over cleartext]) which is fine for development.
+With this configuration, Micronaut enables support for the `h2c` protocol (see https://httpwg.org/specs/rfc7540.html#discover-http[HTTP/2 over cleartext]) which is fine for development.
 
-Since browsers don't support `h2c` and in general https://http2.github.io/http2-spec/#discover-https[HTTP/2 over TLS] (the `h2` protocol), it is recommended for production that you enable <<https, HTTPS support>>. For development this can be done with:
+Since browsers don't support `h2c` and in general https://httpwg.org/specs/rfc7540.html#discover-https[HTTP/2 over TLS] (the `h2` protocol), it is recommended for production that you enable <<https, HTTPS support>>. For development this can be done with:
 
 .Enabling `h2` Protocol Support
 [source,yaml]

--- a/src/main/docs/guide/httpServer/jsonBinding.adoc
+++ b/src/main/docs/guide/httpServer/jsonBinding.adoc
@@ -1,6 +1,6 @@
-:jackson-annotations: http://fasterxml.github.io/jackson-annotations/javadoc/2.9/
-:jackson-databind: http://fasterxml.github.io/jackson-databind/javadoc/2.9/
-:jackson-core: http://fasterxml.github.io/jackson-core/javadoc/2.9/
+:jackson-annotations: https://fasterxml.github.io/jackson-annotations/javadoc/2.9/
+:jackson-databind: https://fasterxml.github.io/jackson-databind/javadoc/2.9/
+:jackson-core: https://fasterxml.github.io/jackson-core/javadoc/2.9/
 
 The most common data interchange format nowadays is JSON.
 

--- a/src/main/docs/guide/httpServer/serverConfiguration/accessLogger.adoc
+++ b/src/main/docs/guide/httpServer/serverConfiguration/accessLogger.adoc
@@ -1,4 +1,4 @@
-In the spirit of http://httpd.apache.org/docs/current/mod/mod_log_config.html[apache mod_log_config] and https://tomcat.apache.org/tomcat-10.0-doc/config/valve.html#Access_Logging[Tomcat Access Log Valve], it is possible to enable an access logger for the HTTP server (this works for both HTTP/1 and HTTP/2).
+In the spirit of https://httpd.apache.org/docs/current/mod/mod_log_config.html[apache mod_log_config] and https://tomcat.apache.org/tomcat-10.0-doc/config/valve.html#Access_Logging[Tomcat Access Log Valve], it is possible to enable an access logger for the HTTP server (this works for both HTTP/1 and HTTP/2).
 
 To enable and configure the access logger, in `application.yml` set:
 
@@ -67,7 +67,7 @@ The pattern should only have the message marker, as other elements will be proce
 
 ==== Log Format
 
-The syntax is based on http://httpd.apache.org/docs/current/mod/mod_log_config.html[Apache httpd log format].
+The syntax is based on https://httpd.apache.org/docs/current/mod/mod_log_config.html[Apache httpd log format].
 
 These are the supported markers:
 
@@ -98,5 +98,5 @@ These are the supported markers:
 
 In addition, you can use the following aliases for common patterns:
 
-* *common* - `%h %l %u %t "%r" %s %b` for https://httpd.apache.org/docs/1.3/logs.html#common[Common Log Format] (CLF)
-* *combined* - `%h %l %u %t "%r" %s %b "%{Referer}i" "%{User-Agent}i"` for https://httpd.apache.org/docs/1.3/logs.html#combined[Combined Log Format]
+* *common* - `%h %l %u %t "%r" %s %b` for https://httpd.apache.org/docs/2.4/logs.html#common[Common Log Format] (CLF)
+* *combined* - `%h %l %u %t "%r" %s %b "%{Referer}i" "%{User-Agent}i"` for https://httpd.apache.org/docs/2.4/logs.html#combined[Combined Log Format]

--- a/src/main/docs/guide/httpServer/serverConfiguration/threadPools.adoc
+++ b/src/main/docs/guide/httpServer/serverConfiguration/threadPools.adoc
@@ -1,4 +1,4 @@
-The HTTP server is built on http://netty.io[Netty] which is designed as a non-blocking I/O toolkit in an event loop model.
+The HTTP server is built on https://netty.io[Netty] which is designed as a non-blocking I/O toolkit in an event loop model.
 
 The Netty worker event loop uses the "default" named event loop group. This can be configured through `micronaut.netty.event-loops.default`.
 

--- a/src/main/docs/guide/httpServer/sse.adoc
+++ b/src/main/docs/guide/httpServer/sse.adoc
@@ -14,7 +14,7 @@ snippet::io.micronaut.docs.server.sse.HeadlineController[tags="imports,class", i
 
 <1> The controller method returns a rs:Publisher[] of api:http.sse.Event[]
 <2> A headline is emitted for each version of Micronaut
-<3> The reactor:Flux[] type's `generate` method generates a rs:Publisher[]. The `generate` method accepts an initial value and a lambda that accepts the value and a rx:Emitter[]. Note that this example executes on the same thread as the controller action, but you could use `subscribeOn` or map an existing "hot" rx:Flux[].
+<3> The reactor:Flux[] type's `generate` method generates a rs:Publisher[]. The `generate` method accepts an initial value and a lambda that accepts the value and a rx:Emitter[]. Note that this example executes on the same thread as the controller action, but you could use `subscribeOn` or map an existing "hot" reactor:Flux[].
 <4> The rx:Emitter[] interface `onNext` method emits objects of type api:http.sse.Event[]. The api:http.sse.Event.of(ET)[] factory method constructs the event.
 <5> The rx:Emitter[] interface `onComplete` method indicates when to finish sending server sent events.
 

--- a/src/main/docs/guide/introduction/whatsNew.adoc
+++ b/src/main/docs/guide/introduction/whatsNew.adoc
@@ -375,7 +375,7 @@ Micronaut 3 to simplify instrumentation, thanks to https://projectreactor.io/doc
 
 ==== Micronaut Micrometer 4.0.0
 
-The https://micronaut-projects.github.io/micronaut-micrometer/latest/guide/[Micrometer module] has been upgraded and now supports repeated definitions of the https://micrometer.io/docs/concepts#_the_timed_annotation[@Timed] annotation as well as also supporting the `@Counted` annotation for counters when you add the `micronaut-micrometer-annotation` dependency to your annotation processor classpath.
+The https://micronaut-projects.github.io/micronaut-micrometer/latest/guide/[Micrometer module] has been upgraded and now supports repeated definitions of the https://micrometer.io/?/docs/concepts#_the_timed_annotation[@Timed] annotation as well as also supporting the `@Counted` annotation for counters when you add the `micronaut-micrometer-annotation` dependency to your annotation processor classpath.
 
 ==== Micronaut Oracle Cloud 2.0.0
 

--- a/src/main/docs/guide/ioc/beans.adoc
+++ b/src/main/docs/guide/ioc/beans.adoc
@@ -1,4 +1,4 @@
-A bean is an object whose lifecycle is managed by the Micronaut IoC container. That lifecycle may include creation, execution, and destruction. Micronaut implements the http://javax-inject.github.io/javax-inject/[JSR-330 (javax.inject) - Dependency Injection for Java] specification, hence to use Micronaut you simply use the link:{jeeapi}/javax/inject/package-summary.html[annotations provided by javax.inject].
+A bean is an object whose lifecycle is managed by the Micronaut IoC container. That lifecycle may include creation, execution, and destruction. Micronaut implements the https://javax-inject.github.io/javax-inject/[JSR-330 (javax.inject) - Dependency Injection for Java] specification, hence to use Micronaut you simply use the link:{jeeapi}/javax/inject/package-summary.html[annotations provided by javax.inject].
 
 The following is a simple example:
 

--- a/src/main/docs/guide/ioc/types.adoc
+++ b/src/main/docs/guide/ioc/types.adoc
@@ -8,7 +8,7 @@ In addition to being able to inject beans, Micronaut natively supports injecting
 |An `Optional` of a bean. `empty()` is injected if the bean doesn't exist
 |`Optional<Engine>`
 
-|link:{jdkapi}/java/lang/Collection.html[java.lang.Collection]
+|link:{jdkapi}/java/util/Collection.html[java.lang.Collection]
 |An `Collection` or subtype of `Collection` (e.g. `List`, `Set`, etc.)
 |`Collection<Engine>`
 

--- a/src/main/docs/guide/languageSupport/graal/graalFAQ.adoc
+++ b/src/main/docs/guide/languageSupport/graal/graalFAQ.adoc
@@ -1,6 +1,6 @@
 ==== How does Micronaut manage to run on GraalVM?
 
-Micronaut features a Dependency Injection and Aspect-Oriented Programming runtime that uses no reflection. This makes it easier for Micronaut applications to run on GraalVM since there are https://github.com/oracle/graal/blob/master/substratevm/LIMITATIONS.md[limitations] particularly around https://github.com/oracle/graal/blob/master/substratevm/REFLECTION.md[reflection] on SubstrateVM.
+Micronaut features a Dependency Injection and Aspect-Oriented Programming runtime that uses no reflection. This makes it easier for Micronaut applications to run on GraalVM since there are https://github.com/oracle/graal/blob/master/docs/reference-manual/native-image/Limitations.md[limitations] particularly around https://github.com/oracle/graal/blob/master/docs/reference-manual/native-image/Reflection.md[reflection] in Native Images.
 
 ==== How can I make a Micronaut application that uses picocli run on GraalVM?
 

--- a/src/main/docs/guide/languageSupport/groovy.adoc
+++ b/src/main/docs/guide/languageSupport/groovy.adoc
@@ -1,4 +1,4 @@
-http://groovy-lang.org[Groovy] has first-class support in Micronaut.
+https://groovy-lang.org[Groovy] has first-class support in Micronaut.
 
 == Groovy-Specific Modules
 
@@ -123,7 +123,7 @@ class HelloController {
 }
 ----
 
-As you can see from the output from the CLI, a http://spockframework.org[Spock] test was also generated for you which demonstrates how to test the controller:
+As you can see from the output from the CLI, a https://spockframework.org[Spock] test was also generated for you which demonstrates how to test the controller:
 
 [source,groovy]
 .HelloControllerSpec.groovy
@@ -165,26 +165,26 @@ The above example results in the following routes:
 
 == Using GORM in a Groovy application
 
-http://gorm.grails.org[GORM] is a data access toolkit originally created as part of Grails. It supports multiple database types. The following table summarizes the modules needed to use GORM, and links to documentation.
+https://gorm.grails.org[GORM] is a data access toolkit originally created as part of Grails. It supports multiple database types. The following table summarizes the modules needed to use GORM, and links to documentation.
 
 .GORM Modules
 |===
 |Dependency|Description
 
 |`io.micronaut.groovy:micronaut-hibernate-gorm`
-|Configures http://gorm.grails.org/latest/hibernate/manual[GORM for Hibernate] for Groovy applications. See the <<hibernateSupport, Hibernate Support>> docs
+|Configures https://gorm.grails.org/latest/hibernate/manual[GORM for Hibernate] for Groovy applications. See the <<hibernateSupport, Hibernate Support>> docs
 
 |`io.micronaut.groovy:micronaut-mongo-gorm`
-|Configures http://gorm.grails.org/latest/mongodb/manual[GORM for MongoDB] for Groovy applications. See the <<mongoSupport, Mongo Support>> docs.
+|Configures https://gorm.grails.org/latest/mongodb/manual[GORM for MongoDB] for Groovy applications. See the <<mongoSupport, Mongo Support>> docs.
 
 |`io.micronaut.groovy:micronaut-neo4j-gorm`
-|Configures http://gorm.grails.org/latest/neo4j/manual[GORM for Neo4j] for Groovy applications. See the <<neo4jSupport, Neo4j Support>> docs.
+|Configures https://gorm.grails.org/latest/neo4j/manual[GORM for Neo4j] for Groovy applications. See the <<neo4jSupport, Neo4j Support>> docs.
 
 |===
 
 Once you have configured a GORM implementation per the instructions linked in the table above you can use all features of GORM.
 
-http://gorm.grails.org/latest/hibernate/manual/index.html#dataServices[GORM Data Services] can also participate in dependency injection and life cycle methods:
+https://gorm.grails.org/latest/hibernate/manual/index.html#dataServices[GORM Data Services] can also participate in dependency injection and life cycle methods:
 
 [source,groovy]
 .GORM Data Service VehicleService.groovy

--- a/src/main/docs/guide/languageSupport/java/ide.adoc
+++ b/src/main/docs/guide/languageSupport/java/ide.adoc
@@ -1,5 +1,5 @@
 You can use any IDE to develop Micronaut applications, if you depend on your configured build tool (Gradle or Maven) to build the application.
 
-However, running tests within the IDE is currently possible with http://jetbrains.com/idea[IntelliJ IDEA] or Eclipse 4.9 or higher.
+However, running tests within the IDE is currently possible with https://jetbrains.com/idea[IntelliJ IDEA] or Eclipse 4.9 or higher.
 
 See the section on <<ideSetup, IDE Setup>> in the Quick start for more information on how to configure IntelliJ and Eclipse.

--- a/src/main/docs/guide/logging.adoc
+++ b/src/main/docs/guide/logging.adoc
@@ -1,1 +1,1 @@
-Micronaut uses http://www.slf4j.org/[Slf4j] to log messages. The default implementation for applications created via Micronaut Launch is http://logback.qos.ch/[Logback]. Any other Slf4j implementation is supported however.
+Micronaut uses https://www.slf4j.org/[Slf4j] to log messages. The default implementation for applications created via Micronaut Launch is https://logback.qos.ch/[Logback]. Any other Slf4j implementation is supported however.

--- a/src/main/docs/guide/logging/logback.adoc
+++ b/src/main/docs/guide/logging/logback.adoc
@@ -2,7 +2,7 @@ To use the logback library, add the following dependency to your build.
 
 dependency:ch.qos.logback:logback-classic[gradleScope="implementation"]
 
-If it does not exist yet, place a link:http://logback.qos.ch/manual/configuration.html[logback.xml] file in the resources folder and modify the content for your needs. For example:
+If it does not exist yet, place a link:https://logback.qos.ch/manual/configuration.html[logback.xml] file in the resources folder and modify the content for your needs. For example:
 
 .src/main/resources/logback.xml
 [source,xml]

--- a/src/main/docs/guide/management/providedEndpoints/infoEndpoint.adoc
+++ b/src/main/docs/guide/management/providedEndpoints/infoEndpoint.adoc
@@ -69,7 +69,7 @@ The git info source can be disabled using the `endpoints.info.git.enabled` prope
 
 === Build Info Source
 
-If a `META-INF/build-info.properties` file is available on the classpath, the link:{api}/io/micronaut/management/endpoint/info/source/BuildInfoSource.html[BuildInfoSource] exposes the values in that file under the `build` key. Generating a `build-info.properties` file must be configured as part of your build. One easy option for Gradle users is the https://plugins.gradle.org/plugin/com.pasam.gradle.buildinfo[Gradle Build Info Plugin]. An option for Maven users is the https://docs.spring.io/spring-boot/docs/current/maven-plugin/examples/build-info.html[Spring Boot Maven Plugin]
+If a `META-INF/build-info.properties` file is available on the classpath, the link:{api}/io/micronaut/management/endpoint/info/source/BuildInfoSource.html[BuildInfoSource] exposes the values in that file under the `build` key. Generating a `build-info.properties` file must be configured as part of your build. One easy option for Gradle users is the https://plugins.gradle.org/plugin/com.pasam.gradle.buildinfo[Gradle Build Info Plugin]. An option for Maven users is the https://docs.spring.io/spring-boot/docs/current/maven-plugin/reference/htmlsingle/#goals-build-info[Spring Boot Maven Plugin]
 
 ==== Configuration
 

--- a/src/main/docs/guide/management/providedEndpoints/metricsEndpoint.adoc
+++ b/src/main/docs/guide/management/providedEndpoints/metricsEndpoint.adoc
@@ -1,4 +1,4 @@
-Micronaut can expose application metrics via integration with http://micrometer.io[Micrometer].
+Micronaut can expose application metrics via integration with https://micrometer.io[Micrometer].
 
 [TIP]
 .Using the CLI

--- a/src/main/docs/guide/quickStart/buildCLI.adoc
+++ b/src/main/docs/guide/quickStart/buildCLI.adoc
@@ -1,3 +1,3 @@
-The best way to install Micronaut on Unix systems is with http://sdkman.io/[SDKMAN] which greatly simplifies installing and managing multiple Micronaut versions.
+The best way to install Micronaut on Unix systems is with https://sdkman.io/[SDKMAN] which greatly simplifies installing and managing multiple Micronaut versions.
 
 To see all available installation methods, check the https://micronaut-projects.github.io/micronaut-starter/latest/guide/#installation[Micronaut Starter documentation].

--- a/src/main/docs/guide/quickStart/ideSetup/eclipseSetup.adoc
+++ b/src/main/docs/guide/quickStart/ideSetup/eclipseSetup.adoc
@@ -1,4 +1,4 @@
-To use Eclipse IDE, it is recommended you import your Micronaut project into Eclipse using either https://projects.eclipse.org/projects/tools.buildship[Gradle BuildShip] for Gradle or http://www.eclipse.org/m2e/[M2Eclipse] for Maven.
+To use Eclipse IDE, it is recommended you import your Micronaut project into Eclipse using either https://projects.eclipse.org/projects/tools.buildship[Gradle BuildShip] for Gradle or https://www.eclipse.org/m2e/[M2Eclipse] for Maven.
 
 NOTE: Micronaut requires Eclipse IDE 4.9 or higher
 
@@ -10,7 +10,7 @@ Once you have set up Eclipse 4.9 or higher with https://projects.eclipse.org/pro
 
 For Eclipse 4.9 and above with Maven you need the following Eclipse plugins:
 
-* http://www.eclipse.org/m2e/[M2Eclipse for Maven]
+* https://www.eclipse.org/m2e/[M2Eclipse for Maven]
 * https://github.com/jbosstools/m2e-apt[Maven integration with Eclipse JDT Annotation Processor Toolkit]
 
 Once these are installed, import the project by selecting `File -> Import` and choosing `Maven -> Existing Maven Project` and navigating to the root directory of your project (where the `pom.xml` file is located).


### PR DESCRIPTION
A lot of these changes are moving from http: links to https: and some were
resources that had either moved, or had gone away (sensible replacements
were found where possible)

The only remaining issues of consequence are:

1. `Warning: http://micronaut.io returned statuscode 301, new location: https://micronaut.io/`
2. `Error: https://www.baeldung.com/jackson-json-view-annotation returned statuscode 403.`
3. `Error: https://http2.github.io/http2-spec/#discover-https returned statuscode 404.`
4. `Error: https://http2.github.io/http2-spec/#discover-http returned statuscode 404.`

Of these,

1. is fixed in a PR to the micronaut-docs project (merged in https://github.com/micronaut-projects/micronaut-docs/pull/63)
2. is unknown.  baeldung.com seems to reject curl requests for some reason

I require some direction on 3 and 4.

They are used here

https://github.com/micronaut-projects/micronaut-core/blame/3.3.x/src/main/docs/guide/httpServer/http2Server.adoc#L15-L17

But no longer exist (indeed I believe h2c may be deprecated as a protocol)