### PR TITLE
Release unwrapped body in NettyHttpRequest

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpRequest.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpRequest.java
@@ -148,6 +148,7 @@ public class NettyHttpRequest<T> extends AbstractNettyHttpRequest<T> implements 
     private List<ByteBufHolder> receivedContent = new ArrayList<>();
     private Map<IdentityWrapper, HttpData> receivedData = new LinkedHashMap<>();
 
+    private T bodyUnwrapped;
     private Supplier<Optional<T>> body;
     private RouteMatch<?> matchedRoute;
     private boolean bodyRequired;
@@ -176,7 +177,11 @@ public class NettyHttpRequest<T> extends AbstractNettyHttpRequest<T> implements 
         this.serverConfiguration = serverConfiguration;
         this.channelHandlerContext = ctx;
         this.headers = new NettyHttpHeaders(nettyRequest.headers(), conversionService);
-        this.body = SupplierUtil.memoizedNonEmpty(() -> Optional.ofNullable((T) buildBody()));
+        this.body = SupplierUtil.memoizedNonEmpty(() -> {
+            T built = (T) buildBody();
+            this.bodyUnwrapped = built;
+            return Optional.ofNullable(built);
+        });
     }
 
     /**
@@ -366,8 +371,8 @@ public class NettyHttpRequest<T> extends AbstractNettyHttpRequest<T> implements 
         getBody().ifPresent(releaseIfNecessary);
         receivedContent.forEach(releaseIfNecessary);
         receivedData.values().forEach(releaseIfNecessary);
-        if (this.body instanceof ReferenceCounted) {
-            ReferenceCounted referenceCounted = (ReferenceCounted) this.body;
+        if (bodyUnwrapped instanceof ReferenceCounted) {
+            ReferenceCounted referenceCounted = (ReferenceCounted) bodyUnwrapped;
             releaseIfNecessary(referenceCounted);
         }
         if (attributes != null) {

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpRequest.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpRequest.java
@@ -403,6 +403,7 @@ public class NettyHttpRequest<T> extends AbstractNettyHttpRequest<T> implements 
      */
     @Internal
     public void setBody(T body) {
+        this.bodyUnwrapped = body;
         this.body = () -> Optional.ofNullable(body);
         bodyConvertor.cleanup();
     }

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/HttpPipeliningSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/HttpPipeliningSpec.groovy
@@ -9,6 +9,7 @@ import io.micronaut.http.annotation.Post
 import io.micronaut.runtime.server.EmbeddedServer
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.netty.bootstrap.Bootstrap
+import io.netty.buffer.ByteBuf
 import io.netty.buffer.Unpooled
 import io.netty.channel.Channel
 import io.netty.channel.ChannelHandlerContext
@@ -96,6 +97,7 @@ class HttpPipeliningSpec extends Specification {
         responses[1].content().toString(StandardCharsets.UTF_8) == '[bar1,bar2]'
 
         cleanup:
+        responses*.content().forEach(ByteBuf::release)
         eventLoopGroup.shutdownGracefully()
     }
 
@@ -135,7 +137,9 @@ class HttpPipeliningSpec extends Specification {
             responses.size() == 10
         }
         for (def r : responses) {
-            r.content().toString(StandardCharsets.UTF_8) == 'foo'
+            def content = r.content()
+            assert content.toString(StandardCharsets.UTF_8) == 'foo'
+            content.release()
         }
 
         cleanup:

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/fuzzing/FuzzyInputSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/fuzzing/FuzzyInputSpec.groovy
@@ -18,6 +18,7 @@ import spock.lang.Specification
  * HTTP inputs generated from fuzzing.
  */
 class FuzzyInputSpec extends Specification {
+
     def 'http1 cleartext buffer leaks'() {
         given:
         BufferLeakDetection.startTracking()

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/handler/accesslog/AccessLogSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/handler/accesslog/AccessLogSpec.groovy
@@ -13,6 +13,7 @@ import io.micronaut.http.annotation.Post
 import io.micronaut.http.netty.channel.ChannelPipelineCustomizer
 import io.micronaut.runtime.server.EmbeddedServer
 import io.netty.bootstrap.Bootstrap
+import io.netty.buffer.ByteBuf
 import io.netty.buffer.Unpooled
 import io.netty.channel.Channel
 import io.netty.channel.ChannelHandlerContext
@@ -120,6 +121,7 @@ class AccessLogSpec extends Specification {
         listAppender.list[1].message.contains('/interleave/finish')
 
         cleanup:
+        responses*.content().forEach(ByteBuf::release)
         server.close()
         channel.close()
         bootstrap.config().group().shutdownGracefully()
@@ -185,6 +187,7 @@ class AccessLogSpec extends Specification {
         listAppender.list[0].message.contains('/interleave/finish')
 
         cleanup:
+        responses*.content().forEach(ByteBuf::release)
         server.close()
         channel.close()
         bootstrap.config().group().shutdownGracefully()
@@ -254,6 +257,7 @@ class AccessLogSpec extends Specification {
         listAppender.list[1].message.contains('/interleave/simple')
 
         cleanup:
+        responses*.content().forEach(ByteBuf::release)
         server.close()
         channel.close()
         bootstrap.config().group().shutdownGracefully()
@@ -365,6 +369,7 @@ class AccessLogSpec extends Specification {
         listAppender.list[2].message.contains('/interleave/finish')
 
         cleanup:
+        responses*.content().forEach(ByteBuf::release)
         server.close()
         channel.close()
         bootstrap.config().group().shutdownGracefully()
@@ -462,6 +467,7 @@ class AccessLogSpec extends Specification {
         listAppender.list[3].message.contains('/interleave/finish')
 
         cleanup:
+        responses*.content().forEach(ByteBuf::release)
         server.close()
         channel.close()
         bootstrap.config().group().shutdownGracefully()
@@ -557,6 +563,7 @@ class AccessLogSpec extends Specification {
         listAppender.list[0].message.contains('/interleave/open')
 
         cleanup:
+        responses*.content().forEach(ByteBuf::release)
         server.close()
         channel.close()
         bootstrap.config().group().shutdownGracefully()

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/http2/H2cSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/http2/H2cSpec.groovy
@@ -206,8 +206,14 @@ class H2cSpec extends Specification {
 
         CompletableFuture responseFuture = requestUpgrade(request)
 
-        expect:
-        ((FullHttpResponse) responseFuture.get(10, TimeUnit.SECONDS)).content().toString(StandardCharsets.UTF_8) == 'Example response: foo'
+        when:
+        def content = ((FullHttpResponse) responseFuture.get(10, TimeUnit.SECONDS)).content()
+
+        then:
+        content.toString(StandardCharsets.UTF_8) == 'Example response: foo'
+
+        cleanup:
+        content.release()
     }
 
     @Issue('https://github.com/micronaut-projects/micronaut-core/issues/6299')
@@ -219,8 +225,14 @@ class H2cSpec extends Specification {
 
         CompletableFuture responseFuture = requestUpgrade(request)
 
-        expect:
-        ((FullHttpResponse) responseFuture.get(10, TimeUnit.SECONDS)).content().toString(StandardCharsets.UTF_8) == 'Example response: foo'
+        when:
+        def content = ((FullHttpResponse) responseFuture.get(10, TimeUnit.SECONDS)).content()
+
+        then:
+        content.toString(StandardCharsets.UTF_8) == 'Example response: foo'
+
+        cleanup:
+        content.release()
     }
 
     @Controller("/h2c")

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/http2/Http2ServerPushSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/http2/Http2ServerPushSpec.groovy
@@ -10,6 +10,7 @@ import io.micronaut.http.annotation.Get
 import io.micronaut.runtime.server.EmbeddedServer
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.netty.bootstrap.Bootstrap
+import io.netty.buffer.ByteBuf
 import io.netty.buffer.Unpooled
 import io.netty.channel.ChannelHandlerContext
 import io.netty.channel.ChannelInitializer
@@ -77,6 +78,9 @@ class Http2ServerPushSpec extends Specification {
 
         runner.pushPromiseHeaders.any { it.scheme() == 'https' && it.path() == '/serverPush/resource2' }
         runner.responses.any { it.content().toString(StandardCharsets.UTF_8) == 'baz' }
+
+        cleanup:
+        runner.responses*.content().forEach(ByteBuf::release)
     }
 
     def 'check headers'() {
@@ -117,8 +121,10 @@ class Http2ServerPushSpec extends Specification {
 
         expect:
         runner.responses.size() == 1
-
         runner.responses[0].content().toString(StandardCharsets.UTF_8) == 'push supported: false'
+
+        cleanup:
+        runner.responses*.content().forEach(ByteBuf::release)
     }
 
     private class Runner {


### PR DESCRIPTION
This is an attempt at a fix for the flaky FuzzyInputSpec. Can't reproduce that locally, but this code is obviously buggy, so this might help.

`body` is a memoized supplier, but `NettyHttpRequest.release` checks whether it's a reference counted object. The supplier is never reference counted, but the object it supplies might be. This patch stores the unwrapped value as a separate field so that it can be released properly.

The test for #6712 still passes, so this doesn't seem to regress the issue that the patch that caused this leak fixed.