### PR TITLE
Fix RandomAccessFile leak in NettySystemFileCustomizableResponseType

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/types/files/NettySystemFileCustomizableResponseType.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/types/files/NettySystemFileCustomizableResponseType.java
@@ -139,7 +139,7 @@ public class NettySystemFileCustomizableResponseType extends SystemFile implemen
      * Wrapper class around {@link RandomAccessFile} with two purposes: Leak detection, and implementation of
      * {@link ChannelFutureListener} that closes the file when called.
      */
-    private static class FileHolder implements ChannelFutureListener {
+    private static final class FileHolder implements ChannelFutureListener {
         private static final ResourceLeakDetector<RandomAccessFile> LEAK_DETECTOR =
                 ResourceLeakDetectorFactory.instance().newResourceLeakDetector(RandomAccessFile.class);
 

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/types/files/NettySystemFileCustomizableResponseType.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/types/files/NettySystemFileCustomizableResponseType.java
@@ -26,6 +26,7 @@ import io.micronaut.http.server.netty.types.NettyFileCustomizableResponseType;
 import io.micronaut.http.server.types.CustomizableResponseTypeException;
 import io.micronaut.http.server.types.files.FileCustomizableResponseType;
 import io.micronaut.http.server.types.files.SystemFile;
+import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.DefaultFileRegion;
@@ -34,6 +35,10 @@ import io.netty.handler.codec.http.HttpChunkedInput;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.stream.ChunkedFile;
+import io.netty.util.ResourceLeakDetector;
+import io.netty.util.ResourceLeakDetectorFactory;
+import io.netty.util.ResourceLeakTracker;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,8 +61,6 @@ public class NettySystemFileCustomizableResponseType extends SystemFile implemen
     private static final int LENGTH_8K = 8192;
     private static final Logger LOG = LoggerFactory.getLogger(NettySystemFileCustomizableResponseType.class);
 
-    protected final RandomAccessFile raf;
-    protected final long rafLength;
     protected Optional<FileCustomizableResponseType> delegate = Optional.empty();
 
     /**
@@ -65,16 +68,6 @@ public class NettySystemFileCustomizableResponseType extends SystemFile implemen
      */
     public NettySystemFileCustomizableResponseType(File file) {
         super(file);
-        try {
-            this.raf = new RandomAccessFile(file, "r");
-        } catch (FileNotFoundException e) {
-            throw new CustomizableResponseTypeException("Could not find file", e);
-        }
-        try {
-            this.rafLength = raf.length();
-        } catch (IOException e) {
-            throw new CustomizableResponseTypeException("Could not determine file length", e);
-        }
     }
 
     /**
@@ -83,11 +76,6 @@ public class NettySystemFileCustomizableResponseType extends SystemFile implemen
     public NettySystemFileCustomizableResponseType(SystemFile delegate) {
         this(delegate.getFile());
         this.delegate = Optional.of(delegate);
-    }
-
-    @Override
-    public long getLength() {
-        return rafLength;
     }
 
     @Override
@@ -123,27 +111,21 @@ public class NettySystemFileCustomizableResponseType extends SystemFile implemen
             }
             context.write(finalResponse, context.voidPromise());
 
-            ChannelFutureListener closeListener = (future) -> {
-                try {
-                    raf.close();
-                } catch (IOException e) {
-                    LOG.warn("An error occurred closing the file reference: " + getFile().getAbsolutePath(), e);
-                }
-            };
+            FileHolder file = new FileHolder(getFile());
 
             // Write the content.
             if (context.pipeline().get(SslHandler.class) == null && context.pipeline().get(SmartHttpContentCompressor.class).shouldSkip(finalResponse)) {
                 // SSL not enabled - can use zero-copy file transfer.
-                context.write(new DefaultFileRegion(raf.getChannel(), 0, getLength()), context.newProgressivePromise())
-                        .addListener(closeListener);
+                context.write(new DefaultFileRegion(file.raf.getChannel(), 0, getLength()), context.newProgressivePromise())
+                        .addListener(file);
                 context.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT);
             } else {
                 // SSL enabled - cannot use zero-copy file transfer.
                 try {
                     // HttpChunkedInput will write the end marker (LastHttpContent) for us.
-                    final HttpChunkedInput chunkedInput = new HttpChunkedInput(new ChunkedFile(raf, 0, getLength(), LENGTH_8K));
+                    final HttpChunkedInput chunkedInput = new HttpChunkedInput(new ChunkedFile(file.raf, 0, getLength(), LENGTH_8K));
                     context.writeAndFlush(chunkedInput, context.newProgressivePromise())
-                            .addListener(closeListener);
+                            .addListener(file);
                 } catch (IOException e) {
                     throw new CustomizableResponseTypeException("Could not read file", e);
                 }
@@ -153,4 +135,51 @@ public class NettySystemFileCustomizableResponseType extends SystemFile implemen
         }
     }
 
+    /**
+     * Wrapper class around {@link RandomAccessFile} with two purposes: Leak detection, and implementation of
+     * {@link ChannelFutureListener} that closes the file when called.
+     */
+    private static class FileHolder implements ChannelFutureListener {
+        private static final ResourceLeakDetector<RandomAccessFile> LEAK_DETECTOR =
+                ResourceLeakDetectorFactory.instance().newResourceLeakDetector(RandomAccessFile.class);
+
+        private final ResourceLeakTracker<RandomAccessFile> tracker;
+
+        private final File file;
+
+        final RandomAccessFile raf;
+        final long length;
+
+        FileHolder(File file) {
+            this.file = file;
+            try {
+                this.raf = new RandomAccessFile(file, "r");
+            } catch (FileNotFoundException e) {
+                throw new CustomizableResponseTypeException("Could not find file", e);
+            }
+            this.tracker = LEAK_DETECTOR.track(raf);
+            try {
+                this.length = raf.length();
+            } catch (IOException e) {
+                close();
+                throw new CustomizableResponseTypeException("Could not determine file length", e);
+            }
+        }
+
+        @Override
+        public void operationComplete(@NotNull ChannelFuture future) throws Exception {
+            close();
+        }
+
+        void close() {
+            try {
+                raf.close();
+            } catch (IOException e) {
+                LOG.warn("An error occurred closing the file reference: " + file.getAbsolutePath(), e);
+            }
+            if (tracker != null) {
+                tracker.close(raf);
+            }
+        }
+    }
 }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/types/files/NettySystemFileCustomizableResponseType.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/types/files/NettySystemFileCustomizableResponseType.java
@@ -146,12 +146,12 @@ public class NettySystemFileCustomizableResponseType extends SystemFile implemen
         private static final ResourceLeakDetector<RandomAccessFile> LEAK_DETECTOR =
                 ResourceLeakDetectorFactory.instance().newResourceLeakDetector(RandomAccessFile.class);
 
+        final RandomAccessFile raf;
+        final long length;
+
         private final ResourceLeakTracker<RandomAccessFile> tracker;
 
         private final File file;
-
-        final RandomAccessFile raf;
-        final long length;
 
         FileHolder(File file) {
             this.file = file;

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/types/files/NettySystemFileCustomizableResponseType.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/types/files/NettySystemFileCustomizableResponseType.java
@@ -68,6 +68,9 @@ public class NettySystemFileCustomizableResponseType extends SystemFile implemen
      */
     public NettySystemFileCustomizableResponseType(File file) {
         super(file);
+        if (!file.canRead()) {
+            throw new CustomizableResponseTypeException("Could not find file");
+        }
     }
 
     /**

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/resources/StaticResourceResolutionSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/resources/StaticResourceResolutionSpec.groovy
@@ -38,8 +38,8 @@ import static io.micronaut.http.HttpHeaders.*
 
 class StaticResourceResolutionSpec extends AbstractMicronautSpec {
 
-    private static File tempFile
-    private static File tempSubDir
+    static File tempFile
+    static File tempSubDir
 
     static {
         tempFile = File.createTempFile("staticResourceResolutionSpec", ".html")

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/resources/StaticResourceResolutionSpec2.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/resources/StaticResourceResolutionSpec2.groovy
@@ -1,0 +1,70 @@
+package io.micronaut.http.server.netty.resources
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.annotation.Filter
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.filter.FilterChain
+import io.micronaut.http.filter.HttpFilter
+import io.micronaut.http.server.netty.fuzzing.BufferLeakDetection
+import io.micronaut.runtime.server.EmbeddedServer
+import jakarta.inject.Singleton
+import org.reactivestreams.Publisher
+import reactor.core.publisher.Flux
+import spock.lang.Specification
+
+import static io.micronaut.http.HttpHeaders.CONTENT_TYPE
+
+class StaticResourceResolutionSpec2 extends Specification {
+
+    void 'filter does not cause resource leak when used for file system resource'() {
+        given:
+        BufferLeakDetection.startTracking()
+
+        def context = ApplicationContext.run(
+                [
+                        'micronaut.router.static-resources.default.paths': [
+                                'classpath:public',
+                                'file:' + StaticResourceResolutionSpec.tempFile.parent,
+                                'file:' + StaticResourceResolutionSpec.tempSubDir.absolutePath
+                        ],
+                        'spec.name': 'StaticResourceResolutionSpec2'
+                ]
+        )
+        def server = context.getBean(EmbeddedServer)
+        server.start()
+        def client = context.createBean(HttpClient, server.URI)
+
+        when:
+        HttpResponse<String> response = Flux.from(client.exchange(
+                HttpRequest.GET('/' + StaticResourceResolutionSpec.tempFile.getName()), String
+        )).blockFirst()
+
+        then:
+        response.status == HttpStatus.OK
+        response.header(CONTENT_TYPE) == "text/plain"
+        response.body() == "discarded"
+
+        BufferLeakDetection.stopTrackingAndReportLeaks()
+
+        cleanup:
+        client.close()
+        server.stop()
+    }
+
+    @Requires(property = 'spec.name', value = 'StaticResourceResolutionSpec2')
+    @Filter(Filter.MATCH_ALL_PATTERN)
+    @Singleton
+    static class DiscardingFilter implements HttpFilter {
+
+        @Override
+        Publisher<? extends HttpResponse<?>> doFilter(HttpRequest<?> request, FilterChain chain) {
+            return Flux.from(chain.proceed(request)).map(resp -> {
+                return HttpResponse.ok('discarded').contentType('text/plain')
+            })
+        }
+    }
+}


### PR DESCRIPTION
If `write` is never reached, the file is never closed. This patch does two things:
- Introduces netty leak detection for the `RandomAccessFile`. This is used for the test case.
- Delay the opening of the file until the write method. This fixes the leak itself. It's technically not allowed to do blocking IO on the netty event loop, and opening the file probably falls under that, but this approach isn't any worse than the old behavior because the constructor would also be called in the event loop.