### PR TITLE
Make the CLI optional to use Micronaut in quick start documentation

### DIFF
--- a/src/main/docs/guide/quickStart.adoc
+++ b/src/main/docs/guide/quickStart.adoc
@@ -1,5 +1,4 @@
 The following sections walk you through a Quick Start on how to use Micronaut to setup a basic "Hello World" application.
 
-Before getting started ensure you have a Java 8 or higher JDK installed, and it is recommended that you use a suitable IDE such as IntelliJ IDEA.
+Before getting started ensure you have a Java 8 or higher JDK installed, and it is recommended that you use a <<ideSetup,suitable IDE>> such as IntelliJ IDEA.
 
-To follow the Quick Start it is also recommended that you have the Micronaut CLI installed.

--- a/src/main/docs/guide/quickStart/buildCLI.adoc
+++ b/src/main/docs/guide/quickStart/buildCLI.adoc
@@ -1,3 +1,3 @@
-The best way to install Micronaut on Unix systems is with https://sdkman.io/[SDKMAN] which greatly simplifies installing and managing multiple Micronaut versions.
+The Micronaut CLI is an optional but convenient way to create Micronaut applications. The best way to install Micronaut CLI on Unix systems is with https://sdkman.io/[SDKMAN] which greatly simplifies installing and managing multiple Micronaut versions.
 
 To see all available installation methods, check the https://micronaut-projects.github.io/micronaut-starter/latest/guide/#installation[Micronaut Starter documentation].

--- a/src/main/docs/guide/quickStart/creatingServer.adoc
+++ b/src/main/docs/guide/quickStart/creatingServer.adoc
@@ -1,6 +1,4 @@
-Although not required to use Micronaut, the Micronaut CLI is the quickest way to create a new server application.
-
-Using the CLI you can create a new Micronaut application in either Groovy, Java, or Kotlin (the default is Java).
+Using the Micronaut CLI you can create a new Micronaut application in either Groovy, Java, or Kotlin (the default is Java).
 
 The following command creates a new "Hello World" server application in Java with a Gradle build:
 
@@ -13,13 +11,24 @@ $ mn create-app hello-world
 
 TIP: Supply `--build maven` to create a Maven-based build instead
 
-The previous command creates a new Java application in a directory called `hello-world` featuring a Gradle build. You can run the application with `./gradlew run`:
+If you don't have the CLI installed then you can also create the same application by visiting https://launch.micronaut.io[Micronaut Launch] and clicking the "Generate Project" button or by using the following `curl` command on Unix systems:
+
+[source,bash]
+----
+curl https://launch.micronaut.io/hello-world.zip -o hello-world.zip
+unzip hello-world.zip
+cd hello-world
+----
+
+TIP: Add `?build=maven` to the URL passed to `curl` to generate a Maven project.
+
+The previous steps created a new Java application in a directory called `hello-world` featuring a Gradle build. You can run the application with `./gradlew run`:
 
 [source,bash]
 ----
 $ ./gradlew run
 > Task :run
-[main] INFO  io.micronaut.runtime.Micronaut - Startup completed in 972ms. Server Running: http://localhost:28933
+[main] INFO  io.micronaut.runtime.Micronaut - Startup completed in 540ms. Server Running: http://localhost:28933
 ----
 
 If you have created a Maven-based project, use `./mvnw mn:run` instead.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -4,7 +4,7 @@ introduction:
   upgrading: Upgrading to Micronaut 3.x
 quickStart:
   title: Quick Start
-  buildCLI: Build/Install the CLI
+  buildCLI: Install the CLI
   creatingServer: Creating a Server Application
   ideSetup:
     title: Setting up an IDE


### PR DESCRIPTION
The quick start as written implies that the CLI is a requirement to create a Micronaut application. This PR addresses that.