### PR TITLE
Java time default formatters

### DIFF
--- a/context/src/main/java/io/micronaut/runtime/converters/time/TimeConverterRegistrar.java
+++ b/context/src/main/java/io/micronaut/runtime/converters/time/TimeConverterRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2022 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ import io.micronaut.core.convert.ConversionContext;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.TypeConverter;
 import io.micronaut.core.convert.TypeConverterRegistrar;
-import io.micronaut.core.convert.format.Format;
 import io.micronaut.core.util.StringUtils;
 import jakarta.inject.Singleton;
 
@@ -221,8 +220,8 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
     }
 
     private Optional<DateTimeFormatter> resolveFormatter(ConversionContext context) {
-        Optional<String> format = context.getAnnotationMetadata().stringValue(Format.class);
-        return format
-            .map(pattern -> DateTimeFormatter.ofPattern(pattern, context.getLocale()));
+        return context.getFormat().map(pattern -> ConversionContext.RFC_1123_FORMAT.equals(pattern) ?
+                DateTimeFormatter.RFC_1123_DATE_TIME :
+                DateTimeFormatter.ofPattern(pattern, context.getLocale()));
     }
 }

--- a/context/src/main/java/io/micronaut/runtime/converters/time/TimeConverterRegistrar.java
+++ b/context/src/main/java/io/micronaut/runtime/converters/time/TimeConverterRegistrar.java
@@ -145,7 +145,7 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
                 try {
                     return Optional.of(resolveFormatter(context)
                             .map(formatter -> LocalDateTime.parse(object, formatter))
-                            .orElse(LocalDateTime.parse(object)));
+                            .orElseGet(() -> LocalDateTime.parse(object)));
                 } catch (DateTimeParseException e) {
                     context.reject(object, e);
                     return Optional.empty();
@@ -158,7 +158,7 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
             try {
                 return Optional.of(resolveFormatter(context)
                         .map(formatter -> formatter.format(object))
-                        .orElse(object.toString()));
+                        .orElseGet(() -> object.toString()));
             } catch (DateTimeParseException e) {
                 context.reject(object, e);
                 return Optional.empty();
@@ -178,7 +178,7 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
                 try {
                     return Optional.of(resolveFormatter(context)
                             .map(formatter -> LocalDate.parse(object, formatter))
-                            .orElse(LocalDate.parse(object)));
+                            .orElseGet(() -> LocalDate.parse(object)));
                 } catch (DateTimeParseException e) {
                     context.reject(object, e);
                     return Optional.empty();
@@ -195,7 +195,7 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
                 try {
                     return Optional.of(resolveFormatter(context)
                             .map(formatter -> ZonedDateTime.parse(object, formatter))
-                            .orElse(ZonedDateTime.parse(object)));
+                            .orElseGet(() -> ZonedDateTime.parse(object)));
                 } catch (DateTimeParseException e) {
                     context.reject(object, e);
                     return Optional.empty();
@@ -211,7 +211,7 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
                     try {
                         return Optional.of(resolveFormatter(context)
                                 .map(formatter -> OffsetDateTime.parse(object, formatter))
-                                .orElse(OffsetDateTime.parse(object)));
+                                .orElseGet(() -> OffsetDateTime.parse(object)));
                     } catch (DateTimeParseException e) {
                         context.reject(object, e);
                         return Optional.empty();

--- a/context/src/main/java/io/micronaut/runtime/converters/time/TimeConverterRegistrar.java
+++ b/context/src/main/java/io/micronaut/runtime/converters/time/TimeConverterRegistrar.java
@@ -186,6 +186,22 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
                 temporalConverter
         );
 
+        // ZonedDateTime -> CharSequence
+        conversionService.addConverter(
+                ZonedDateTime.class,
+                CharSequence.class,
+                (object, targetType, context) -> {
+                    try {
+                        return Optional.of(resolveFormatter(context)
+                                .map(object::format)
+                                .orElseGet(object::toString));
+                    } catch (DateTimeParseException e) {
+                        context.reject(object, e);
+                        return Optional.empty();
+                    }
+                }
+        );
+
         // CharSequence -> LocalDate
         conversionService.addConverter(
             CharSequence.class,

--- a/context/src/main/java/io/micronaut/runtime/converters/time/TimeConverterRegistrar.java
+++ b/context/src/main/java/io/micronaut/runtime/converters/time/TimeConverterRegistrar.java
@@ -143,9 +143,9 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
             LocalDateTime.class,
             (object, targetType, context) -> {
                 try {
-                    DateTimeFormatter formatter = resolveFormatter(context);
-                    LocalDateTime result = LocalDateTime.parse(object, formatter);
-                    return Optional.of(result);
+                    return Optional.of(resolveFormatter(context)
+                            .map(formatter -> LocalDateTime.parse(object, formatter))
+                            .orElse(LocalDateTime.parse(object)));
                 } catch (DateTimeParseException e) {
                     context.reject(object, e);
                     return Optional.empty();
@@ -156,8 +156,9 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
         // TemporalAccessor - CharSequence
         final TypeConverter<TemporalAccessor, CharSequence> temporalConverter = (object, targetType, context) -> {
             try {
-                DateTimeFormatter formatter = resolveFormatter(context);
-                return Optional.of(formatter.format(object));
+                return Optional.of(resolveFormatter(context)
+                        .map(formatter -> formatter.format(object))
+                        .orElse(object.toString()));
             } catch (DateTimeParseException e) {
                 context.reject(object, e);
                 return Optional.empty();
@@ -175,9 +176,9 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
             LocalDate.class,
             (object, targetType, context) -> {
                 try {
-                    DateTimeFormatter formatter = resolveFormatter(context);
-                    LocalDate result = LocalDate.parse(object, formatter);
-                    return Optional.of(result);
+                    return Optional.of(resolveFormatter(context)
+                            .map(formatter -> LocalDate.parse(object, formatter))
+                            .orElse(LocalDate.parse(object)));
                 } catch (DateTimeParseException e) {
                     context.reject(object, e);
                     return Optional.empty();
@@ -192,9 +193,9 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
             ZonedDateTime.class,
             (object, targetType, context) -> {
                 try {
-                    DateTimeFormatter formatter = resolveFormatter(context);
-                    ZonedDateTime result = ZonedDateTime.parse(object, formatter);
-                    return Optional.of(result);
+                    return Optional.of(resolveFormatter(context)
+                            .map(formatter -> ZonedDateTime.parse(object, formatter))
+                            .orElse(ZonedDateTime.parse(object)));
                 } catch (DateTimeParseException e) {
                     context.reject(object, e);
                     return Optional.empty();
@@ -208,9 +209,9 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
                 OffsetDateTime.class,
                 (object, targetType, context) -> {
                     try {
-                        DateTimeFormatter formatter = resolveFormatter(context);
-                        OffsetDateTime result = OffsetDateTime.parse(object, formatter);
-                        return Optional.of(result);
+                        return Optional.of(resolveFormatter(context)
+                                .map(formatter -> OffsetDateTime.parse(object, formatter))
+                                .orElse(OffsetDateTime.parse(object)));
                     } catch (DateTimeParseException e) {
                         context.reject(object, e);
                         return Optional.empty();
@@ -219,10 +220,9 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
         );
     }
 
-    private DateTimeFormatter resolveFormatter(ConversionContext context) {
+    private Optional<DateTimeFormatter> resolveFormatter(ConversionContext context) {
         Optional<String> format = context.getAnnotationMetadata().stringValue(Format.class);
         return format
-            .map(pattern -> DateTimeFormatter.ofPattern(pattern, context.getLocale()))
-            .orElse(DateTimeFormatter.RFC_1123_DATE_TIME);
+            .map(pattern -> DateTimeFormatter.ofPattern(pattern, context.getLocale()));
     }
 }

--- a/context/src/main/java/io/micronaut/runtime/converters/time/TimeConverterRegistrar.java
+++ b/context/src/main/java/io/micronaut/runtime/converters/time/TimeConverterRegistrar.java
@@ -52,6 +52,7 @@ import java.util.regex.Pattern;
                 TemporalAmount.class,
                 Instant.class,
                 LocalDate.class,
+                LocalTime.class,
                 LocalDateTime.class,
                 MonthDay.class,
                 OffsetDateTime.class,
@@ -152,6 +153,22 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
             }
         );
 
+        // CharSequence -> Instant
+        conversionService.addConverter(
+                CharSequence.class,
+                Instant.class,
+                (object, targetType, context) -> {
+                    try {
+                        return Optional.of(resolveFormatter(context)
+                                .map(formatter -> ZonedDateTime.parse(object, formatter).toInstant())
+                                .orElseGet(() -> Instant.parse(object)));
+                    } catch (DateTimeParseException e) {
+                        context.reject(object, e);
+                        return Optional.empty();
+                    }
+                }
+        );
+
         // TemporalAccessor - CharSequence
         final TypeConverter<TemporalAccessor, CharSequence> temporalConverter = (object, targetType, context) -> {
             try {
@@ -185,6 +202,21 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
             }
         );
 
+        // CharSequence -> LocalTime
+        conversionService.addConverter(
+                CharSequence.class,
+                LocalTime.class,
+                (object, targetType, context) -> {
+                    try {
+                        return Optional.of(resolveFormatter(context)
+                                .map(formatter -> LocalTime.parse(object, formatter))
+                                .orElseGet(() -> LocalTime.parse(object)));
+                    } catch (DateTimeParseException e) {
+                        context.reject(object, e);
+                        return Optional.empty();
+                    }
+                }
+        );
 
         // CharSequence -> ZonedDateTime
         conversionService.addConverter(
@@ -211,6 +243,22 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
                         return Optional.of(resolveFormatter(context)
                                 .map(formatter -> OffsetDateTime.parse(object, formatter))
                                 .orElseGet(() -> OffsetDateTime.parse(object)));
+                    } catch (DateTimeParseException e) {
+                        context.reject(object, e);
+                        return Optional.empty();
+                    }
+                }
+        );
+
+        // CharSequence -> OffsetTime
+        conversionService.addConverter(
+                CharSequence.class,
+                OffsetTime.class,
+                (object, targetType, context) -> {
+                    try {
+                        return Optional.of(resolveFormatter(context)
+                                .map(formatter -> OffsetTime.parse(object, formatter))
+                                .orElseGet(() -> OffsetTime.parse(object)));
                     } catch (DateTimeParseException e) {
                         context.reject(object, e);
                         return Optional.empty();

--- a/core/src/main/java/io/micronaut/core/convert/ArgumentConversionContext.java
+++ b/core/src/main/java/io/micronaut/core/convert/ArgumentConversionContext.java
@@ -60,14 +60,8 @@ public interface ArgumentConversionContext<T> extends ConversionContext, Annotat
      */
     @SuppressWarnings("unchecked")
     default ArgumentConversionContext<T> with(AnnotationMetadata annotationMetadata) {
-
         ConversionContext thisContext = this;
-        return new DefaultArgumentConversionContext(getArgument(), thisContext.getLocale(), thisContext.getCharset()) {
-            @Override
-            public AnnotationMetadata getAnnotationMetadata() {
-                return annotationMetadata;
-            }
-        };
+        return new DefaultArgumentConversionContext(getArgument(), thisContext.getLocale(), thisContext.getCharset(), annotationMetadata, getDefaultFormat().orElse(null));
     }
 
     /**
@@ -78,13 +72,7 @@ public interface ArgumentConversionContext<T> extends ConversionContext, Annotat
      */
     @SuppressWarnings("unchecked")
     default ArgumentConversionContext<T> withDefaultFormat(@Nullable String format) {
-
         ArgumentConversionContext<T> thisContext = this;
-        return new DefaultArgumentConversionContext(getArgument(), thisContext.getLocale(), thisContext.getCharset()) {
-            @Override
-            public Optional<String> getDefaultFormat() {
-                return Optional.ofNullable(format);
-            }
-        };
+        return new DefaultArgumentConversionContext(getArgument(), thisContext.getLocale(), thisContext.getCharset(), getAnnotationMetadata(), format);
     }
 }

--- a/core/src/main/java/io/micronaut/core/convert/ArgumentConversionContext.java
+++ b/core/src/main/java/io/micronaut/core/convert/ArgumentConversionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2022 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,11 @@ package io.micronaut.core.convert;
 
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationMetadataProvider;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.type.Argument;
 
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Extended version of the {@link ConversionContext} specifically for conversion {@link Argument} instances.
@@ -64,6 +66,24 @@ public interface ArgumentConversionContext<T> extends ConversionContext, Annotat
             @Override
             public AnnotationMetadata getAnnotationMetadata() {
                 return annotationMetadata;
+            }
+        };
+    }
+
+    /**
+     * Augment this context with a default format string.
+     *
+     * @param format The format
+     * @return The conversion context
+     */
+    @SuppressWarnings("unchecked")
+    default ArgumentConversionContext<T> withDefaultFormat(@Nullable String format) {
+
+        ArgumentConversionContext<T> thisContext = this;
+        return new DefaultArgumentConversionContext(getArgument(), thisContext.getLocale(), thisContext.getCharset()) {
+            @Override
+            public Optional<String> defaultFormat() {
+                return Optional.ofNullable(format);
             }
         };
     }

--- a/core/src/main/java/io/micronaut/core/convert/ArgumentConversionContext.java
+++ b/core/src/main/java/io/micronaut/core/convert/ArgumentConversionContext.java
@@ -82,7 +82,7 @@ public interface ArgumentConversionContext<T> extends ConversionContext, Annotat
         ArgumentConversionContext<T> thisContext = this;
         return new DefaultArgumentConversionContext(getArgument(), thisContext.getLocale(), thisContext.getCharset()) {
             @Override
-            public Optional<String> defaultFormat() {
+            public Optional<String> getDefaultFormat() {
                 return Optional.ofNullable(format);
             }
         };

--- a/core/src/main/java/io/micronaut/core/convert/ConversionContext.java
+++ b/core/src/main/java/io/micronaut/core/convert/ConversionContext.java
@@ -115,7 +115,7 @@ public interface ConversionContext extends AnnotationMetadataProvider, TypeVaria
 
         ConversionContext childContext = ConversionContext.of(argument);
         ConversionContext thisContext = this;
-        return new DefaultArgumentConversionContext(argument, thisContext.getLocale(), thisContext.getCharset()) {
+        return new DefaultArgumentConversionContext(argument, thisContext.getLocale(), thisContext.getCharset(), argument.getAnnotationMetadata(), thisContext.getDefaultFormat().orElse(null)) {
             @Override
             public <T extends Annotation> T synthesize(Class<T> annotationClass) {
                 T annotation = childContext.synthesize(annotationClass);

--- a/core/src/main/java/io/micronaut/core/convert/ConversionContext.java
+++ b/core/src/main/java/io/micronaut/core/convert/ConversionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2022 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package io.micronaut.core.convert;
 
 import io.micronaut.core.annotation.AnnotationMetadataProvider;
+import io.micronaut.core.convert.format.Format;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.type.TypeVariableResolver;
 import io.micronaut.core.util.ArgumentUtils;
@@ -34,6 +35,11 @@ import java.util.*;
  * @since 1.0
  */
 public interface ConversionContext extends AnnotationMetadataProvider, TypeVariableResolver, ErrorsContext {
+
+    /**
+     * A constant to define a {@link java.time.format.DateTimeFormatter#RFC_1123_DATE_TIME} formatter.
+     */
+    String RFC_1123_FORMAT = "RFC_1123_FORMAT";
 
     /**
      * The default conversion context.
@@ -228,5 +234,25 @@ public interface ConversionContext extends AnnotationMetadataProvider, TypeVaria
         Charset finalCharset = charset != null ? charset : StandardCharsets.UTF_8;
         Locale finalLocale = locale != null ? locale : Locale.getDefault();
         return new DefaultArgumentConversionContext<>(argument, finalLocale, finalCharset);
+    }
+
+    /**
+     * Gets the default format for the current conversion.  Can be overridden if required (for example Headers have a specific
+     * timestamp format no matter what the attribute type).
+     *
+     * @return the default format for this context
+     */
+    default Optional<String> defaultFormat() {
+        return Optional.empty();
+    }
+
+    /**
+     * Gets the current format (if any) from the annotation metadata. Falls back to {@link #defaultFormat()} if there is none.
+     *
+     * @return The current format
+     */
+    default Optional<String> getFormat() {
+        Optional<String> format = getAnnotationMetadata().stringValue(Format.class);
+        return format.isPresent() ? format : defaultFormat();
     }
 }

--- a/core/src/main/java/io/micronaut/core/convert/ConversionContext.java
+++ b/core/src/main/java/io/micronaut/core/convert/ConversionContext.java
@@ -242,17 +242,17 @@ public interface ConversionContext extends AnnotationMetadataProvider, TypeVaria
      *
      * @return the default format for this context
      */
-    default Optional<String> defaultFormat() {
+    default Optional<String> getDefaultFormat() {
         return Optional.empty();
     }
 
     /**
-     * Gets the current format (if any) from the annotation metadata. Falls back to {@link #defaultFormat()} if there is none.
+     * Gets the current format (if any) from the annotation metadata. Falls back to {@link #getDefaultFormat()} if there is none.
      *
      * @return The current format
      */
     default Optional<String> getFormat() {
         Optional<String> format = getAnnotationMetadata().stringValue(Format.class);
-        return format.isPresent() ? format : defaultFormat();
+        return format.isPresent() ? format : getDefaultFormat();
     }
 }

--- a/core/src/main/java/io/micronaut/core/convert/DefaultArgumentConversionContext.java
+++ b/core/src/main/java/io/micronaut/core/convert/DefaultArgumentConversionContext.java
@@ -15,7 +15,9 @@
  */
 package io.micronaut.core.convert;
 
+import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.type.Argument;
 
 import java.nio.charset.Charset;
@@ -34,6 +36,9 @@ class DefaultArgumentConversionContext<T> implements ArgumentConversionContext<T
     private final Argument<T> argument;
     private final Locale finalLocale;
     private final Charset finalCharset;
+    private final AnnotationMetadata annotationMetadata;
+    @Nullable
+    private final String defaultFormat;
     private final List<ConversionError> conversionErrors = new ArrayList<>(3);
 
     /**
@@ -42,9 +47,15 @@ class DefaultArgumentConversionContext<T> implements ArgumentConversionContext<T
      * @param finalCharset The final charset
      */
     DefaultArgumentConversionContext(Argument<T> argument, Locale finalLocale, Charset finalCharset) {
+        this(argument, finalLocale, finalCharset, argument.getAnnotationMetadata(), null);
+    }
+
+    DefaultArgumentConversionContext(Argument<T> argument, Locale finalLocale, Charset finalCharset, AnnotationMetadata annotationMetadata, @Nullable String defaultFormat) {
         this.argument = argument;
         this.finalLocale = finalLocale;
         this.finalCharset = finalCharset;
+        this.annotationMetadata = annotationMetadata;
+        this.defaultFormat = defaultFormat;
     }
 
     @Override
@@ -55,6 +66,16 @@ class DefaultArgumentConversionContext<T> implements ArgumentConversionContext<T
     @Override
     public Charset getCharset() {
         return finalCharset;
+    }
+
+    @Override
+    public Optional<String> getDefaultFormat() {
+        return Optional.ofNullable(defaultFormat);
+    }
+
+    @Override
+    public AnnotationMetadata getAnnotationMetadata() {
+        return annotationMetadata;
     }
 
     @Override

--- a/core/src/main/java/io/micronaut/core/convert/DefaultConversionService.java
+++ b/core/src/main/java/io/micronaut/core/convert/DefaultConversionService.java
@@ -68,11 +68,18 @@ import java.util.function.Function;
  */
 public class DefaultConversionService implements ConversionService<DefaultConversionService> {
 
+    /**
+     * SimpleDateFormat instance to parseHeader timestamps into Dates
+     */
     public static final SimpleDateFormat RFC_1123_SIMPLE_DATE_FORMAT = new SimpleDateFormat("EEE, d MMM yyyy HH:mm:ss 'GMT'");
+
+    /**
+     * The pattern for parsing standard java.util.Dates from their toString representation
+     */
+    public static final String DEFAULT_DATE_TO_STRING_FORMAT = "EEE MMM d HH:mm:ss zzz yyyy";
 
     private static final int CACHE_MAX = 150;
     private static final TypeConverter UNCONVERTIBLE = (object, targetType, context) -> Optional.empty();
-    private static final String DEFAULT_DATE_TO_STRING_FORMAT = "EEE MMM d HH:mm:ss zzz yyyy";
 
     private final Map<ConvertiblePair, TypeConverter> typeConverters = new ConcurrentHashMap<>();
     private final Map<ConvertiblePair, TypeConverter> converterCache = new ConcurrentLinkedHashMap.Builder<ConvertiblePair, TypeConverter>()

--- a/core/src/main/java/io/micronaut/core/convert/DefaultConversionService.java
+++ b/core/src/main/java/io/micronaut/core/convert/DefaultConversionService.java
@@ -68,8 +68,11 @@ import java.util.function.Function;
  */
 public class DefaultConversionService implements ConversionService<DefaultConversionService> {
 
+    public static final SimpleDateFormat RFC_1123_SIMPLE_DATE_FORMAT = new SimpleDateFormat("EEE, d MMM yyyy HH:mm:ss 'GMT'");
+
     private static final int CACHE_MAX = 150;
     private static final TypeConverter UNCONVERTIBLE = (object, targetType, context) -> Optional.empty();
+    private static final String DEFAULT_DATE_TO_STRING_FORMAT = "EEE MMM d HH:mm:ss zzz yyyy";
 
     private final Map<ConvertiblePair, TypeConverter> typeConverters = new ConcurrentHashMap<>();
     private final Map<ConvertiblePair, TypeConverter> converterCache = new ConcurrentLinkedHashMap.Builder<ConvertiblePair, TypeConverter>()
@@ -967,11 +970,10 @@ public class DefaultConversionService implements ConversionService<DefaultConver
     }
 
     private SimpleDateFormat resolveFormat(ConversionContext context) {
-        AnnotationMetadata annotationMetadata = context.getAnnotationMetadata();
         Optional<String> format = context.getFormat();
         return format
-            .map(pattern -> new SimpleDateFormat(pattern, context.getLocale()))
-            .orElseGet(() -> new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z", context.getLocale()));
+            .map(pattern -> ConversionContext.RFC_1123_FORMAT.equals(pattern) ? RFC_1123_SIMPLE_DATE_FORMAT : new SimpleDateFormat(pattern, context.getLocale()))
+            .orElseGet(() -> new SimpleDateFormat(DEFAULT_DATE_TO_STRING_FORMAT, context.getLocale()));
     }
 
     private <S, T> ConvertiblePair newPair(Class<S> sourceType, Class<T> targetType, TypeConverter<S, T> typeConverter) {

--- a/core/src/main/java/io/micronaut/core/convert/DefaultConversionService.java
+++ b/core/src/main/java/io/micronaut/core/convert/DefaultConversionService.java
@@ -69,12 +69,12 @@ import java.util.function.Function;
 public class DefaultConversionService implements ConversionService<DefaultConversionService> {
 
     /**
-     * SimpleDateFormat instance to parseHeader timestamps into Dates
+     * The pattern for parsing Header standard timestamps into Dates.
      */
-    public static final SimpleDateFormat RFC_1123_SIMPLE_DATE_FORMAT = new SimpleDateFormat("EEE, d MMM yyyy HH:mm:ss 'GMT'");
+    public static final String RFC_1123_FORMAT = "EEE, d MMM yyyy HH:mm:ss z";
 
     /**
-     * The pattern for parsing standard java.util.Dates from their toString representation
+     * The pattern for parsing standard java.util.Dates from their toString representation.
      */
     public static final String DEFAULT_DATE_TO_STRING_FORMAT = "EEE MMM d HH:mm:ss zzz yyyy";
 
@@ -979,7 +979,15 @@ public class DefaultConversionService implements ConversionService<DefaultConver
     private SimpleDateFormat resolveFormat(ConversionContext context) {
         Optional<String> format = context.getFormat();
         return format
-            .map(pattern -> ConversionContext.RFC_1123_FORMAT.equals(pattern) ? RFC_1123_SIMPLE_DATE_FORMAT : new SimpleDateFormat(pattern, context.getLocale()))
+            .map(pattern -> {
+                if (ConversionContext.RFC_1123_FORMAT.equals(pattern)) {
+                    SimpleDateFormat dateFormat = new SimpleDateFormat(RFC_1123_FORMAT);
+                    dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
+                    return dateFormat;
+                } else {
+                    return new SimpleDateFormat(pattern, context.getLocale());
+                }
+            })
             .orElseGet(() -> new SimpleDateFormat(DEFAULT_DATE_TO_STRING_FORMAT, context.getLocale()));
     }
 

--- a/core/src/main/java/io/micronaut/core/convert/DefaultConversionService.java
+++ b/core/src/main/java/io/micronaut/core/convert/DefaultConversionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2022 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -968,7 +968,7 @@ public class DefaultConversionService implements ConversionService<DefaultConver
 
     private SimpleDateFormat resolveFormat(ConversionContext context) {
         AnnotationMetadata annotationMetadata = context.getAnnotationMetadata();
-        Optional<String> format = annotationMetadata.stringValue(Format.class);
+        Optional<String> format = context.getFormat();
         return format
             .map(pattern -> new SimpleDateFormat(pattern, context.getLocale()))
             .orElseGet(() -> new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z", context.getLocale()));

--- a/core/src/main/java/io/micronaut/core/convert/converters/MultiValuesConverterFactory.java
+++ b/core/src/main/java/io/micronaut/core/convert/converters/MultiValuesConverterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 original authors
+ * Copyright 2017-2022 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -254,8 +254,7 @@ public class MultiValuesConverterFactory {
             ConvertibleMultiValues<String> parameters = (ConvertibleMultiValues<String>) object;
             ArgumentConversionContext<T> context = (ArgumentConversionContext<T>) conversionContext;
 
-            String format = conversionContext.getAnnotationMetadata()
-                    .getValue(Format.class, String.class).orElse(null);
+            String format = conversionContext.getFormat().orElse(null);
             if (format == null) {
                 return Optional.empty();
             }
@@ -306,7 +305,6 @@ public class MultiValuesConverterFactory {
          *                          (including type and annotations)
          * @param name the name of the parameter
          * @param parameters all the parameters from which the parameter of given name needs to be retrieved
-         * @param defaultValue default value
          * @return the converted value if conversion was successful
          */
         protected abstract Optional<T> retrieveMultiValue(ArgumentConversionContext<T> conversionContext,
@@ -574,7 +572,7 @@ public class MultiValuesConverterFactory {
             // noinspection unchecked
             ArgumentConversionContext<Object> context = (ArgumentConversionContext<Object>) conversionContext;
 
-            String format = conversionContext.getAnnotationMetadata().getValue(Format.class, String.class).orElse(null);
+            String format = conversionContext.getFormat().orElse(null);
             if (format == null) {
                 return Optional.empty();
             }

--- a/http-client-core/src/main/java/io/micronaut/http/client/bind/DefaultHttpClientBinderRegistry.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/bind/DefaultHttpClientBinderRegistry.java
@@ -48,11 +48,6 @@ import jakarta.inject.Singleton;
 import kotlin.coroutines.Continuation;
 
 import java.lang.annotation.Annotation;
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.time.temporal.TemporalAccessor;
 import java.util.Date;
 import java.util.LinkedHashMap;

--- a/http-client-core/src/main/java/io/micronaut/http/client/bind/DefaultHttpClientBinderRegistry.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/bind/DefaultHttpClientBinderRegistry.java
@@ -53,6 +53,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.temporal.TemporalAccessor;
 import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -126,46 +127,11 @@ public class DefaultHttpClientBinderRegistry implements HttpClientBinderRegistry
                     .orElse(NameUtils.hyphenate(context.getArgument().getName()));
 
             // Header dates must be in GMT
-            if (value instanceof Date) {
-                conversionService.convert(
-                                ((Date) value).toInstant().atZone(ZoneId.of("GMT")),
-                                String.class,
-                                context.withDefaultFormat(ConversionContext.RFC_1123_FORMAT)
-                        )
-                        .ifPresent(header -> request.getHeaders().set(headerName, header));
-            } else if (value instanceof ZonedDateTime) {
-                conversionService.convert(
-                                ((ZonedDateTime) value).withZoneSameInstant(ZoneId.of("GMT")),
-                                String.class,
-                                context.withDefaultFormat(ConversionContext.RFC_1123_FORMAT)
-                        )
-                        .ifPresent(header -> request.getHeaders().set(headerName, header));
-            } else if (value instanceof OffsetDateTime) {
-                conversionService.convert(
-                                ((OffsetDateTime) value).atZoneSameInstant(ZoneId.of("GMT")),
-                                String.class,
-                                context.withDefaultFormat(ConversionContext.RFC_1123_FORMAT)
-                        )
-                        .ifPresent(header -> request.getHeaders().set(headerName, header));
-            } else if (value instanceof LocalDateTime) {
-                conversionService.convert(
-                                ((LocalDateTime) value).atZone(ZoneId.of("GMT")),
-                                String.class,
-                                context.withDefaultFormat(ConversionContext.RFC_1123_FORMAT)
-                        )
-                        .ifPresent(header -> request.getHeaders().set(headerName, header));
-            } else if (value instanceof Instant) {
-                conversionService.convert(
-                                ((Instant) value).atZone(ZoneId.of("GMT")),
-                                String.class,
-                                context.withDefaultFormat(ConversionContext.RFC_1123_FORMAT)
-                        )
-                        .ifPresent(header -> request.getHeaders().set(headerName, header));
-            } else {
-                // Not a timestamp header
-                conversionService.convert(value, String.class, context)
-                        .ifPresent(header -> request.getHeaders().set(headerName, header));
+            if (value instanceof Date || value instanceof TemporalAccessor) {
+                context = context.withDefaultFormat(ConversionContext.RFC_1123_FORMAT);
             }
+            conversionService.convert(value, String.class, context)
+                    .ifPresent(header -> request.getHeaders().set(headerName, header));
         });
         byAnnotation.put(RequestAttribute.class, (context, uriContext, value, request) -> {
             AnnotationMetadata annotationMetadata = context.getAnnotationMetadata();

--- a/http-client-core/src/main/java/io/micronaut/http/client/bind/DefaultHttpClientBinderRegistry.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/bind/DefaultHttpClientBinderRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2022 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,12 @@ import jakarta.inject.Singleton;
 import kotlin.coroutines.Continuation;
 
 import java.lang.annotation.Annotation;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -119,8 +125,47 @@ public class DefaultHttpClientBinderRegistry implements HttpClientBinderRegistry
                     .filter(StringUtils::isNotEmpty)
                     .orElse(NameUtils.hyphenate(context.getArgument().getName()));
 
-            conversionService.convert(value, String.class)
-                    .ifPresent(header -> request.getHeaders().set(headerName, header));
+            // Header dates must be in GMT
+            if (value instanceof Date) {
+                conversionService.convert(
+                                ((Date) value).toInstant().atZone(ZoneId.of("GMT")),
+                                String.class,
+                                context.withDefaultFormat(ConversionContext.RFC_1123_FORMAT)
+                        )
+                        .ifPresent(header -> request.getHeaders().set(headerName, header));
+            } else if (value instanceof ZonedDateTime) {
+                conversionService.convert(
+                                ((ZonedDateTime) value).withZoneSameInstant(ZoneId.of("GMT")),
+                                String.class,
+                                context.withDefaultFormat(ConversionContext.RFC_1123_FORMAT)
+                        )
+                        .ifPresent(header -> request.getHeaders().set(headerName, header));
+            } else if (value instanceof OffsetDateTime) {
+                conversionService.convert(
+                                ((OffsetDateTime) value).atZoneSameInstant(ZoneId.of("GMT")),
+                                String.class,
+                                context.withDefaultFormat(ConversionContext.RFC_1123_FORMAT)
+                        )
+                        .ifPresent(header -> request.getHeaders().set(headerName, header));
+            } else if (value instanceof LocalDateTime) {
+                conversionService.convert(
+                                ((LocalDateTime) value).atZone(ZoneId.of("GMT")),
+                                String.class,
+                                context.withDefaultFormat(ConversionContext.RFC_1123_FORMAT)
+                        )
+                        .ifPresent(header -> request.getHeaders().set(headerName, header));
+            } else if (value instanceof Instant) {
+                conversionService.convert(
+                                ((Instant) value).atZone(ZoneId.of("GMT")),
+                                String.class,
+                                context.withDefaultFormat(ConversionContext.RFC_1123_FORMAT)
+                        )
+                        .ifPresent(header -> request.getHeaders().set(headerName, header));
+            } else {
+                // Not a timestamp header
+                conversionService.convert(value, String.class, context)
+                        .ifPresent(header -> request.getHeaders().set(headerName, header));
+            }
         });
         byAnnotation.put(RequestAttribute.class, (context, uriContext, value, request) -> {
             AnnotationMetadata annotationMetadata = context.getAnnotationMetadata();
@@ -160,11 +205,12 @@ public class DefaultHttpClientBinderRegistry implements HttpClientBinderRegistry
 
         if (KOTLIN_COROUTINES_SUPPORTED) {
             //Clients should do nothing with the continuation
-            byType.put(Argument.of(Continuation.class).typeHashCode(),  (context, uriContext, value, request) -> { });
+            byType.put(Argument.of(Continuation.class).typeHashCode(), (context, uriContext, value, request) -> {
+            });
         }
 
         if (CollectionUtils.isNotEmpty(binders)) {
-            for (ClientRequestBinder binder: binders) {
+            for (ClientRequestBinder binder : binders) {
                 addBinder(binder);
             }
         }

--- a/http/src/main/java/io/micronaut/http/bind/binders/HeaderAnnotationBinder.java
+++ b/http/src/main/java/io/micronaut/http/bind/binders/HeaderAnnotationBinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2022 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.micronaut.http.bind.binders;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.bind.annotation.AbstractAnnotatedArgumentBinder;
 import io.micronaut.core.convert.ArgumentConversionContext;
+import io.micronaut.core.convert.ConversionContext;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.value.ConvertibleMultiValues;
 import io.micronaut.core.naming.NameUtils;
@@ -48,7 +49,8 @@ public class HeaderAnnotationBinder<T> extends AbstractAnnotatedArgumentBinder<H
         ConvertibleMultiValues<String> parameters = source.getHeaders();
         AnnotationMetadata annotationMetadata = argument.getAnnotationMetadata();
         String parameterName = annotationMetadata.stringValue(Header.class).orElse(argument.getArgument().getName());
-        return doBind(argument, parameters, parameterName);
+        // We use this as "EEE, d MMM yyyy HH:mm:ss zzz" as a pattern returns a different result (with a timezone)
+        return doBind(argument.withDefaultFormat(ConversionContext.RFC_1123_FORMAT), parameters, parameterName);
     }
 
     @Override

--- a/http/src/main/java/io/micronaut/http/bind/binders/HeaderAnnotationBinder.java
+++ b/http/src/main/java/io/micronaut/http/bind/binders/HeaderAnnotationBinder.java
@@ -53,7 +53,11 @@ public class HeaderAnnotationBinder<T> extends AbstractAnnotatedArgumentBinder<H
         AnnotationMetadata annotationMetadata = context.getAnnotationMetadata();
         Argument<T> argument = context.getArgument();
         String parameterName = annotationMetadata.stringValue(Header.class).orElse(argument.getName());
-        if (TemporalAccessor.class.isAssignableFrom(argument.getType()) || argument.getType() == Date.class) {
+        Argument<?> type = argument;
+        if (argument.isWrapperType()) {
+            type = argument.getWrappedType();
+        }
+        if (TemporalAccessor.class.isAssignableFrom(type.getType()) || type.getType() == Date.class) {
             context = context.withDefaultFormat(ConversionContext.RFC_1123_FORMAT);
         }
         return doBind(context, parameters, parameterName);

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
@@ -26,7 +26,6 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.reflect.ClassUtils;
-import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.ast.ArrayableClassElement;
 import io.micronaut.inject.ast.ClassElement;

--- a/runtime/src/test/groovy/io/micronaut/runtime/converters/time/TimeConverterRegistrarSpec.groovy
+++ b/runtime/src/test/groovy/io/micronaut/runtime/converters/time/TimeConverterRegistrarSpec.groovy
@@ -21,10 +21,15 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 import java.time.Duration
+import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
 import java.time.OffsetDateTime
+import java.time.OffsetTime
+import java.time.ZoneId
 import java.time.ZoneOffset
+import java.time.ZonedDateTime
 
 class TimeConverterRegistrarSpec extends Specification {
 
@@ -46,45 +51,41 @@ class TimeConverterRegistrarSpec extends Specification {
         '10d'  | Duration.ofDays(10)
         '10h'  | Duration.ofHours(10)
         '10ns' | Duration.ofNanos(10)
-
     }
 
-    void "test convert offsetdatetime"() {
+    @Unroll
+    void "test convert #input to #typeName"() {
         given:
         ConversionService conversionService = new DefaultConversionService()
         new TimeConverterRegistrar().register(conversionService)
 
         when:
-        OffsetDateTime result = conversionService.convert('2021-11-26T21:19+01:00', OffsetDateTime).get();
+        def result = conversionService.convert(input, type).get();
 
         then:
-        result == OffsetDateTime.of(LocalDateTime.of(2021, 11, 26, 21, 19), ZoneOffset.ofHours(1))
+        result == expected
 
-    }
+        and:
+        result.toString() == input
 
-    void "test convert localdatetime"() {
-        given:
-        ConversionService conversionService = new DefaultConversionService()
-        new TimeConverterRegistrar().register(conversionService)
+        where:
+        input                                      | type           | expected
+        '2021-11-26T21:19+01:00'                   | OffsetDateTime | OffsetDateTime.of(LocalDateTime.of(2021, 11, 26, 21, 19), ZoneOffset.ofHours(1))
+        '21:19:32+01:00'                           | OffsetTime     | OffsetTime.of(LocalTime.of(21, 19, 32), ZoneOffset.ofHours(1))
+        '21:19+01:00'                              | OffsetTime     | OffsetTime.of(LocalTime.of(21, 19), ZoneOffset.ofHours(1))
+        '2021-11-26T21:19'                         | LocalDateTime  | LocalDateTime.of(2021, 11, 26, 21, 19)
+        '2021-11-26'                               | LocalDate      | LocalDate.of(2021, 11, 26)
+        '10:15:34'                                 | LocalTime      | LocalTime.of(10, 15, 34)
+        '10:15'                                    | LocalTime      | LocalTime.of(10, 15)
+        '2022-02-03T12:15:30+02:00[Europe/Athens]' | ZonedDateTime  | LocalDateTime.of(2022, 2, 3, 10, 15, 30).atZone(ZoneId.of("UTC")).withZoneSameInstant(ZoneId.of("Europe/Athens"))
+        '2021-11-26T20:19:00Z'                     | Instant        | Instant.from(OffsetDateTime.of(LocalDateTime.of(2021, 11, 26, 21, 19), ZoneOffset.ofHours(1)))
+        'PT0.01S'                                  | Duration       | Duration.ofMillis(10)
+        'PT10S'                                    | Duration       | Duration.ofSeconds(10)
+        'PT10M'                                    | Duration       | Duration.ofMinutes(10)
+        'PT240H'                                   | Duration       | Duration.ofDays(10)
+        'PT10H'                                    | Duration       | Duration.ofHours(10)
+        'PT0.00000001S'                            | Duration       | Duration.ofNanos(10)
 
-        when:
-        LocalDateTime result = conversionService.convert('2021-11-26T21:19', LocalDateTime).get();
-
-        then:
-        result == LocalDateTime.of(2021, 11, 26, 21, 19)
-
-    }
-
-    void "test convert localdate"() {
-        given:
-        ConversionService conversionService = new DefaultConversionService()
-        new TimeConverterRegistrar().register(conversionService)
-
-        when:
-        LocalDate result = conversionService.convert('2021-11-26', LocalDate).get();
-
-        then:
-        result == LocalDate.of(2021, 11, 26)
-
+        typeName = type.simpleName
     }
 }

--- a/runtime/src/test/groovy/io/micronaut/runtime/converters/time/TimeConverterRegistrarSpec.groovy
+++ b/runtime/src/test/groovy/io/micronaut/runtime/converters/time/TimeConverterRegistrarSpec.groovy
@@ -21,6 +21,10 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 import java.time.Duration
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 
 class TimeConverterRegistrarSpec extends Specification {
 
@@ -42,6 +46,45 @@ class TimeConverterRegistrarSpec extends Specification {
         '10d'  | Duration.ofDays(10)
         '10h'  | Duration.ofHours(10)
         '10ns' | Duration.ofNanos(10)
+
+    }
+
+    void "test convert offsetdatetime"() {
+        given:
+        ConversionService conversionService = new DefaultConversionService()
+        new TimeConverterRegistrar().register(conversionService)
+
+        when:
+        OffsetDateTime result = conversionService.convert('2021-11-26T21:19+01:00', OffsetDateTime).get();
+
+        then:
+        result == OffsetDateTime.of(LocalDateTime.of(2021, 11, 26, 21, 19), ZoneOffset.ofHours(1))
+
+    }
+
+    void "test convert localdatetime"() {
+        given:
+        ConversionService conversionService = new DefaultConversionService()
+        new TimeConverterRegistrar().register(conversionService)
+
+        when:
+        LocalDateTime result = conversionService.convert('2021-11-26T21:19', LocalDateTime).get();
+
+        then:
+        result == LocalDateTime.of(2021, 11, 26, 21, 19)
+
+    }
+
+    void "test convert localdate"() {
+        given:
+        ConversionService conversionService = new DefaultConversionService()
+        new TimeConverterRegistrar().register(conversionService)
+
+        when:
+        LocalDate result = conversionService.convert('2021-11-26', LocalDate).get();
+
+        then:
+        result == LocalDate.of(2021, 11, 26)
 
     }
 }

--- a/src/main/docs/guide/appendix/breaks.adoc
+++ b/src/main/docs/guide/appendix/breaks.adoc
@@ -1,5 +1,9 @@
 This section documents breaking changes between Micronaut versions
 
+== 4.0.0
+
+- Previously, all date-time parameters used the `RFC_1123_DATE_TIME` format as the default.  This has now changed to use the default format of the specified type.
+
 == 3.2.4
 
 - The link:{api}/io/micronaut/http/client/ProxyHttpClient.html[ProxyHttpClient] now sends the Host header of the proxied service https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.23[as per the RFC], instead of the originating service.

--- a/src/main/docs/guide/httpServer/binding.adoc
+++ b/src/main/docs/guide/httpServer/binding.adoc
@@ -92,6 +92,8 @@ Generally any type that can be converted from a String representation to a Java 
 
 This includes most common Java types, however additional link:{api}/io/micronaut/core/convert/TypeConverter.html[TypeConverter] instances can be registered by creating `@Singleton` beans of type `TypeConverter`.
 
+=== Nullability
+
 The handling of nullability deserves special mention. Consider for example the following example:
 
 snippet::io.micronaut.docs.server.binding.BindingController[tags="header2",indent=0]
@@ -106,7 +108,11 @@ A `null` string is passed if the header is absent from the request.
 
 NOTE: `java.util.Optional` can also be used, but that is discouraged for method parameters.
 
-Additionally, any `DateTime` that conforms to link:{jdkapi}/java/time/format/DateTimeFormatter.html#RFC_1123_DATE_TIME[RFC-1123] can be bound to a parameter. Alternatively the format can be customized with the link:{api}/io/micronaut/core/convert/format/Format.html[Format] annotation:
+=== Header HTTP-date values
+
+As https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3.1[per the RFC], header dates are expected to be in link:{jdkapi}/java/time/format/DateTimeFormatter.html#RFC_1123_DATE_TIME[RFC-1123] format.
+
+Alternatively the format can be customized with the link:{api}/io/micronaut/core/convert/format/Format.html[Format] annotation:
 
 snippet::io.micronaut.docs.server.binding.BindingController[tags="format1,format2",indent=0]
 

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/binding/BindingController.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/binding/BindingController.groovy
@@ -90,7 +90,7 @@ class BindingController {
 
     // tag::format1[]
     @Get("/date")
-    String date(@Header ZonedDateTime date) {
+    String rfcDate(@Header ZonedDateTime date) {
         // ...
         // end::format1[]
         date.toString()
@@ -100,7 +100,7 @@ class BindingController {
 
     // tag::format2[]
     @Get("/dateFormat")
-    String dateFormat(@Format("dd/MM/yyyy hh:mm:ss a z") @Header ZonedDateTime date) {
+    String customDateFormat(@Format("dd/MM/yyyy hh:mm:ss a z") @Header ZonedDateTime date) {
         // ...
         // end::format2[]
         date.toString()

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/binding/BindingController.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/binding/BindingController.kt
@@ -89,7 +89,7 @@ class BindingController {
 
     // tag::format1[]
     @Get("/date")
-    fun date(@Header date: ZonedDateTime): String {
+    fun rfcDate(@Header date: ZonedDateTime): String {
         // ...
         // end::format1[]
         return date.toString()
@@ -99,7 +99,7 @@ class BindingController {
 
     // tag::format2[]
     @Get("/dateFormat")
-    fun dateFormat(@Format("dd/MM/yyyy hh:mm:ss a z") @Header date: ZonedDateTime): String {
+    fun customDateFormat(@Format("dd/MM/yyyy hh:mm:ss a z") @Header date: ZonedDateTime): String {
         // ...
         // end::format2[]
         return date.toString()

--- a/test-suite/src/test/groovy/io/micronaut/http/DateTimeConversionSpec.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/http/DateTimeConversionSpec.groovy
@@ -90,6 +90,8 @@ class DateTimeConversionSpec extends Specification {
         where:
         desc                       | endpoint               | formatter                       | converter
         'java.util.Date'           | 'header-date'          | DateTimeFormatter.ISO_DATE_TIME | null
+        'java.util.Date'           | 'optional-date'        | DateTimeFormatter.ISO_DATE_TIME | null
+        'java.time.ZonedDateTime'  | 'optional-temporal'    | DateTimeFormatter.ISO_DATE_TIME | null
         'java.time.OffsetDateTime' | 'header-offset'        | DateTimeFormatter.ISO_DATE_TIME | null
         'java.time.OffsetTime'     | 'header-offsettime'    | DateTimeFormatter.ISO_TIME      | null
         'java.time.ZonedDateTime'  | 'header-zoned'         | DateTimeFormatter.ISO_DATE_TIME | null
@@ -340,6 +342,16 @@ class DateTimeConversionSpec extends Specification {
         @Post('/zoned')
         String zonedPost(@Body ZonedDateTimeBody value) {
             response(value.body)
+        }
+
+        @Get('/optional-date')
+        def optionalDate(@Header('X-Test') Optional<Date> date) {
+            response(date.get())
+        }
+
+        @Get('/optional-temporal')
+        def optionalTemporal(@Header('X-Test') Optional<ZonedDateTime> date) {
+            response(date.get())
         }
     }
 

--- a/test-suite/src/test/groovy/io/micronaut/http/DateTimeConversionSpec.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/http/DateTimeConversionSpec.groovy
@@ -1,0 +1,283 @@
+package io.micronaut.http
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.convert.format.Format
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Header
+import io.micronaut.http.client.BlockingHttpClient
+import io.micronaut.http.client.HttpClient
+import io.micronaut.runtime.server.EmbeddedServer
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.OffsetDateTime
+import java.time.OffsetTime
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+
+class DateTimeConversionSpec extends Specification {
+
+    private static final String FORMAT = "'TS':yyyyMMdd:HHmmss:X"
+
+    @AutoCleanup
+    EmbeddedServer server
+
+    @AutoCleanup
+    BlockingHttpClient client
+
+    def setup() {
+        server = ApplicationContext.run(EmbeddedServer, ['spec.name': getClass().simpleName, "micronaut.http.client.readTimeout": '300s'])
+        client = server.applicationContext.getBean(HttpClient).toBlocking()
+    }
+
+    def "timestamped headers can be converted to a #desc"() {
+        given:
+        def now = ZonedDateTime.now(ZoneOffset.UTC)
+
+        // Timestamps in headers are always in GMT in this format https://httpwg.org/specs/rfc7231.html#http.date
+        def header = now.format(DateTimeFormatter.RFC_1123_DATE_TIME)
+        def expected = now.truncatedTo(ChronoUnit.SECONDS).with {
+            (converter ? converter(it) : it).format(formatter)
+        }
+
+        when:
+        def response = client.exchange(
+                HttpRequest.GET("$server.URL/dates/$endpoint")
+                        .header('X-Test', header),
+                String
+        )
+
+        then:
+        response.body() == expected
+
+        where:
+        desc                       | endpoint               | formatter                       | converter
+        'java.util.Date'           | 'header-date'          | DateTimeFormatter.ISO_DATE_TIME | null
+        'java.time.OffsetDateTime' | 'header-offset'        | DateTimeFormatter.ISO_DATE_TIME | null
+        'java.time.OffsetTime'     | 'header-offsettime'    | DateTimeFormatter.ISO_TIME      | null
+        'java.time.ZonedDateTime'  | 'header-zoned'         | DateTimeFormatter.ISO_DATE_TIME | null
+        'java.time.LocalDate'      | 'header-localdate'     | DateTimeFormatter.ISO_DATE      | { ZonedDateTime it -> it.toLocalDate() }
+        'java.time.LocalTime'      | 'header-localtime'     | DateTimeFormatter.ISO_TIME      | { ZonedDateTime it -> it.toLocalTime() }
+        'java.time.LocalDateTime'  | 'header-localdatetime' | DateTimeFormatter.ISO_DATE_TIME | { ZonedDateTime it -> it.toLocalDateTime() }
+        'java.time.Instant'        | 'header-instant'       | DateTimeFormatter.ISO_DATE_TIME | null
+    }
+
+    def "timestamped can parse the default format for #desc"() {
+        when:
+        def response = client.exchange(
+                HttpRequest.GET("$server.URL/dates/$endpoint?date=${URLEncoder.encode(value.toString(), 'UTF-8')}"),
+                String
+        )
+
+        then:
+        response.body() == value.toString()
+
+        where:
+        desc                       | endpoint        | value
+        'java.util.Date'           | 'date'          | new Date()
+        'java.time.OffsetDateTime' | 'offset'        | OffsetDateTime.now()
+        'java.time.OffsetTime'     | 'offset-time'   | OffsetTime.now()
+        'java.time.ZonedDateTime'  | 'zoned'         | ZonedDateTime.now()
+        'java.time.LocalDate'      | 'localdate'     | LocalDate.now()
+        'java.time.LocalTime'      | 'localtime'     | LocalTime.now()
+        'java.time.LocalDateTime'  | 'localdatetime' | LocalDateTime.now()
+        'java.time.Instant'        | 'instant'       | Instant.now()
+    }
+
+    def "timestamp custom format works for #desc"() {
+        given:
+        def now = ZonedDateTime.now(ZoneOffset.UTC)
+
+        def sent = now.format(DateTimeFormatter.ofPattern(FORMAT))
+
+        def expected = now.truncatedTo(ChronoUnit.SECONDS).with {
+            (converter ? converter(it) : it).format(formatter)
+        }
+
+        when:
+        def response = client.exchange(
+                HttpRequest.GET("$server.URL/dates/$endpoint?date=$sent"),
+                String
+        )
+
+        then:
+        response.body() == expected
+
+        where:
+        desc                       | endpoint                  | formatter                       | converter
+        'java.util.Date'           | 'formatted-date'          | DateTimeFormatter.ISO_DATE_TIME | null
+        'java.time.OffsetDateTime' | 'formatted-offset'        | DateTimeFormatter.ISO_DATE_TIME | null
+        'java.time.OffsetTime'     | 'formatted-offset-time'   | DateTimeFormatter.ISO_TIME      | null
+        'java.time.ZonedDateTime'  | 'formatted-zoned'         | DateTimeFormatter.ISO_DATE_TIME | null
+        'java.time.LocalDate'      | 'formatted-localdate'     | DateTimeFormatter.ISO_DATE      | { ZonedDateTime it -> it.toLocalDate() }
+        'java.time.LocalTime'      | 'formatted-localtime'     | DateTimeFormatter.ISO_TIME      | { ZonedDateTime it -> it.toLocalTime() }
+        'java.time.LocalDateTime'  | 'formatted-localdatetime' | DateTimeFormatter.ISO_DATE_TIME | { ZonedDateTime it -> it.toLocalDateTime() }
+        'java.time.Instant'        | 'formatted-instant'       | DateTimeFormatter.ISO_DATE_TIME | null
+    }
+
+    @Controller("/dates")
+    @Requires(property = 'spec.name', value = 'DateTimeConversionSpec')
+    @SuppressWarnings('GrMethodMayBeStatic')
+    static class DateFormattingController {
+        @Get('/header-date')
+        def headerDate(@Header('X-Test') Date date) {
+            response(date)
+        }
+
+        @Get('/header-offset')
+        def headerOffset(@Header('X-Test') OffsetDateTime date) {
+            response(date)
+        }
+
+        @Get('/header-offsettime')
+        def headerOffset(@Header('X-Test') OffsetTime date) {
+            response(date)
+        }
+
+        @Get('/header-zoned')
+        def headerZoned(@Header('X-Test') ZonedDateTime date) {
+            response(date)
+        }
+
+        @Get('/header-localdate')
+        def headerLocalDate(@Header('X-Test') LocalDate date) {
+            response(date)
+        }
+
+        @Get('/header-localtime')
+        def headerLocalTime(@Header('X-Test') LocalTime date) {
+            response(date)
+        }
+
+        @Get('/header-localdatetime')
+        def headerLocalDateTime(@Header('X-Test') LocalDateTime date) {
+            response(date)
+        }
+
+        @Get('/header-instant')
+        def headerInstant(@Header('X-Test') Instant date) {
+            response(date);
+        }
+
+        @Get('/date')
+        def date(Date date) {
+            date.toString()
+        }
+
+        @Get('/offset')
+        def offset(OffsetDateTime date) {
+            date.toString()
+        }
+
+        @Get('/offset-time')
+        def offsetTime(OffsetTime date) {
+            date.toString()
+        }
+
+        @Get('/zoned')
+        def zoned(ZonedDateTime date) {
+            date.toString()
+        }
+
+        @Get('/localdate')
+        def localDate(LocalDate date) {
+            date.toString()
+        }
+
+        @Get('/localtime')
+        def localTime(LocalTime date) {
+            date.toString()
+        }
+
+        @Get('/localdatetime')
+        def localDateTime(LocalDateTime date) {
+            date.toString()
+        }
+
+
+        @Get('/instant')
+        def instant(Instant date) {
+            date.toString()
+        }
+
+        @Get('/formatted-date')
+        def formatDate(@Format(FORMAT) Date date) {
+            response(date)
+        }
+
+        @Get('/formatted-offset')
+        def formatOffset(@Format(FORMAT) OffsetDateTime date) {
+            response(date)
+        }
+
+        @Get('/formatted-offset-time')
+        def formatOffsetTime(@Format(FORMAT) OffsetTime date) {
+            response(date)
+        }
+
+        @Get('/formatted-zoned')
+        def formatZoned(@Format(FORMAT) ZonedDateTime date) {
+            response(date)
+        }
+
+        @Get('/formatted-localdate')
+        def formatLocalDate(@Format(FORMAT) LocalDate date) {
+            response(date)
+        }
+
+        @Get('/formatted-localtime')
+        def formatLocalTime(@Format(FORMAT) LocalTime date) {
+            response(date)
+        }
+
+        @Get('/formatted-localdatetime')
+        def formatLocalDateTime(@Format(FORMAT) LocalDateTime date) {
+            response(date)
+        }
+
+        @Get('/formatted-instant')
+        def formatInstant(@Format(FORMAT) Instant date) {
+            response(date)
+        }
+
+        private String response(Date date) {
+            date.toInstant().atZone(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS).format(DateTimeFormatter.ISO_DATE_TIME)
+        }
+
+        private String response(OffsetDateTime date) {
+            date.toZonedDateTime().truncatedTo(ChronoUnit.SECONDS).format(DateTimeFormatter.ISO_DATE_TIME)
+        }
+
+        private String response(OffsetTime date) {
+            date.truncatedTo(ChronoUnit.SECONDS).format(DateTimeFormatter.ISO_TIME)
+        }
+
+        private String response(ZonedDateTime date) {
+            date.truncatedTo(ChronoUnit.SECONDS).format(DateTimeFormatter.ISO_DATE_TIME)
+        }
+
+        private String response(LocalDate date) {
+            date.format(DateTimeFormatter.ISO_DATE)
+        }
+
+        private String response(LocalTime date) {
+            date.truncatedTo(ChronoUnit.SECONDS).format(DateTimeFormatter.ISO_TIME)
+        }
+
+        private String response(LocalDateTime date) {
+            date.truncatedTo(ChronoUnit.SECONDS).format(DateTimeFormatter.ISO_DATE_TIME)
+        }
+
+        private String response(Instant date) {
+            date.atZone(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS).format(DateTimeFormatter.ISO_DATE_TIME)
+        }
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/docs/server/binding/BindingController.java
+++ b/test-suite/src/test/java/io/micronaut/docs/server/binding/BindingController.java
@@ -92,7 +92,7 @@ public class BindingController {
 
     // tag::format1[]
     @Get("/date")
-    public String date(@Header ZonedDateTime date) {
+    public String rfcDate(@Header ZonedDateTime date) {
         // ...
         // end::format1[]
         return date.toString();
@@ -102,7 +102,7 @@ public class BindingController {
 
     // tag::format2[]
     @Get("/dateFormat")
-    public String dateFormat(@Format("dd/MM/yyyy hh:mm:ss a z") @Header ZonedDateTime date) {
+    public String customDateFormat(@Format("dd/MM/yyyy hh:mm:ss a z") @Header ZonedDateTime date) {
         // ...
         // end::format2[]
         return date.toString();


### PR DESCRIPTION
Originally https://github.com/micronaut-projects/micronaut-core/pull/6576

> The Java Time classes have default formatters built in which use the ISO formats. So if in micronaut somewhere a string is to be converted to one of those classes we expect the default format to be the default format of the classes.
>
> Up to now micronaut used RFC_1123_DATE_TIME as the default format for converting but this is a rather human readable format and does not use the defaults that are already there.
>
> Another advantage of the built in defaults is, that they the classes do use the same format in .toString(). So i.e. OffsetDateTime.toString() is compatible with OffsetDateTime.parse() without thinking about the format.