### PR TITLE
print warning on insecure configuration

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/ssl/NettyClientSslBuilder.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/ssl/NettyClientSslBuilder.java
@@ -34,6 +34,8 @@ import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import jakarta.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLException;
@@ -52,6 +54,7 @@ import java.util.Optional;
 @Internal
 @BootstrapContextCompatible
 public class NettyClientSslBuilder extends SslBuilder<SslContext> {
+    private static final Logger LOG = LoggerFactory.getLogger(NettyClientSslBuilder.class);
 
     /**
      * @param resourceResolver The resource resolver
@@ -131,6 +134,9 @@ public class NettyClientSslBuilder extends SslBuilder<SslContext> {
                 return super.getTrustManagerFactory(ssl);
             } else {
                 if (ssl instanceof AbstractClientSslConfiguration && ((AbstractClientSslConfiguration) ssl).isInsecureTrustAllCertificates()) {
+                    if (LOG.isWarnEnabled()) {
+                        LOG.warn("HTTP Client is configured to trust all certificates ('insecure-trust-all-certificates' is set to true). Trusting all certificates is not secure and should not be used in production.");
+                    }
                     return InsecureTrustManagerFactory.INSTANCE;
                 } else {
                     // netty will use the JDK trust store

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/ssl/SelfSignedSslBuilder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/ssl/SelfSignedSslBuilder.java
@@ -34,6 +34,8 @@ import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import jakarta.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLException;
 import java.security.cert.CertificateException;
@@ -48,7 +50,7 @@ import java.util.Optional;
 @Singleton
 @Internal
 public class SelfSignedSslBuilder extends SslBuilder<SslContext> implements ServerSslBuilder {
-
+    private static final Logger LOG = LoggerFactory.getLogger(SelfSignedSslBuilder.class);
     private final ServerSslConfiguration ssl;
     private final HttpServerConfiguration serverConfiguration;
 
@@ -86,6 +88,9 @@ public class SelfSignedSslBuilder extends SslBuilder<SslContext> implements Serv
     @Override
     public Optional<SslContext> build(SslConfiguration ssl, HttpVersion httpVersion) {
         try {
+            if (LOG.isWarnEnabled()) {
+                LOG.warn("HTTP Server is configured to use a self-signed certificate ('build-self-signed' is set to true). This configuration should not be used in a production environment as self-signed certificates are inherently insecure.");
+            }
             SelfSignedCertificate ssc = new SelfSignedCertificate();
             final SslContextBuilder sslBuilder = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey());
             final boolean isHttp2 = httpVersion == HttpVersion.HTTP_2_0;


### PR DESCRIPTION
Currently if an insecure configuration is used the developer is not aware of that fact. This alters Micronaut to print a warning if an insecure arrangement not suitable for production is used.