### PR TITLE
Set an identifier on collections of BeanRegistrations

### DIFF
--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2022 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -3739,7 +3739,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
                     ));
                 }
             } else {
-                beansOfTypeList.add(new BeanRegistration(null, candidate, bean));
+                beansOfTypeList.add(new BeanRegistration(new BeanKey(beanType, candidate.getDeclaredQualifier()), candidate, bean));
             }
         }
     }

--- a/inject/src/test/groovy/io/micronaut/context/BeanRegistrationCollectionSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/BeanRegistrationCollectionSpec.groovy
@@ -1,0 +1,46 @@
+package io.micronaut.context
+
+import io.micronaut.context.annotation.Requires
+import jakarta.inject.Named
+import jakarta.inject.Singleton
+import spock.lang.Specification
+
+class BeanRegistrationCollectionSpec extends Specification {
+
+    void "test beanregistration identifiers are returned"() {
+        given:
+        ApplicationContext ctx = ApplicationContext.run(["spec.name": getClass().simpleName])
+
+        when:
+        def service = ctx.getBean(MyService)
+
+        then:
+        service.beans*.identifier*.name.sort() == ['first-bean', 'second-bean']
+    }
+
+    static interface BaseBean {
+    }
+
+    @Singleton
+    @Named("first-bean")
+    @Requires(property = "spec.name", value = "BeanRegistrationCollectionSpec")
+    static class FirstBean implements BaseBean {
+    }
+
+    @Singleton
+    @Named("second-bean")
+    @Requires(property = "spec.name", value = "BeanRegistrationCollectionSpec")
+    static class SecondBean implements BaseBean {
+    }
+
+    @Singleton
+    @Requires(property = "spec.name", value = "BeanRegistrationCollectionSpec")
+    static class MyService {
+
+        final Collection<BeanRegistration<BaseBean>> beans
+
+        MyService(Collection<BeanRegistration<BaseBean>> beans) {
+            this.beans = beans
+        }
+    }
+}


### PR DESCRIPTION
Closes #6878 

This does not fix the case where someone is injecting a single `BeanRegistration<MyClass>`, but I'm not sure what the use case of doing that would be.

All the tests pass locally, but I am not sure of the wider damage that this change might inflict.

I've targeted 3.3.x as it's not an API change