### PR TITLE
Add @Inherited to @Version annotation

### DIFF
--- a/core/src/main/java/io/micronaut/core/version/annotation/Version.java
+++ b/core/src/main/java/io/micronaut/core/version/annotation/Version.java
@@ -16,6 +16,7 @@
 package io.micronaut.core.version.annotation;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -29,6 +30,7 @@ import java.lang.annotation.Target;
  */
 @Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
+@Inherited
 public @interface Version {
 
     /**

--- a/http-server-netty/src/test/groovy/io/micronaut/web/router/version/InheritedVersionControllerSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/web/router/version/InheritedVersionControllerSpec.groovy
@@ -1,0 +1,67 @@
+package io.micronaut.web.router.version
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.version.annotation.Version
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Produces
+import io.micronaut.http.client.BlockingHttpClient
+import io.micronaut.http.client.HttpClient
+import io.micronaut.runtime.server.EmbeddedServer
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class InheritedVersionControllerSpec extends Specification {
+    @AutoCleanup
+    @Shared
+    EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
+            'spec.name'                                 : 'AbstractVersionControllerSpec',
+            "micronaut.router.versioning.enabled"       : "true",
+            "micronaut.router.versioning.header.enabled": "true"
+    ])
+
+    @AutoCleanup
+    @Shared
+    HttpClient httpClient = embeddedServer.applicationContext.createBean(HttpClient, embeddedServer.URL)
+
+    BlockingHttpClient getClient() {
+        httpClient.toBlocking()
+    }
+
+    void "version defined on abstract controller works on child"() {
+        given:
+        HttpRequest request = HttpRequest.GET("/versioned/hello").header("X-API-VERSION", "1")
+
+        expect:
+        embeddedServer.applicationContext.containsBean(AbstractVersionedController)
+
+        when:
+        def r = client.exchange(request, String)
+
+        then:
+        noExceptionThrown()
+        r.status() == HttpStatus.OK
+        r.body() == "helloV1"
+    }
+
+    @Requires(property = "spec.name", value = "AbstractVersionControllerSpec")
+    @Controller("/versioned")
+    static class VersionedController extends AbstractVersionedController {
+
+    }
+
+    @Version("1")
+    static abstract class AbstractVersionedController {
+        @Produces(MediaType.TEXT_PLAIN)
+
+        @Get("/hello")
+        String helloV1() {
+            "helloV1"
+        }
+    }
+}


### PR DESCRIPTION
This adds the `@Inherited` to the `@Version` annotation. 
Without that the  `@Version` annotation had to be duplicated instead of using the one defined on an abstract Controller class.