### PR TITLE
Remove unused and deprecated import in documentation

### DIFF
--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/http/client/proxy/ProxyFilter.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/http/client/proxy/ProxyFilter.groovy
@@ -8,7 +8,6 @@ import io.micronaut.http.MutableHttpResponse
 import io.micronaut.http.annotation.Filter
 import io.micronaut.http.client.ProxyHttpClient
 import io.micronaut.http.filter.HttpServerFilter
-import io.micronaut.http.filter.OncePerRequestHttpServerFilter
 import io.micronaut.http.filter.ServerFilterChain
 import io.micronaut.http.uri.UriBuilder
 import io.micronaut.runtime.server.EmbeddedServer

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/http/client/proxy/ProxyFilter.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/http/client/proxy/ProxyFilter.kt
@@ -8,7 +8,6 @@ import io.micronaut.http.MutableHttpResponse
 import io.micronaut.http.annotation.Filter
 import io.micronaut.http.client.ProxyHttpClient
 import io.micronaut.http.filter.HttpServerFilter
-import io.micronaut.http.filter.OncePerRequestHttpServerFilter
 import io.micronaut.http.filter.ServerFilterChain
 import io.micronaut.http.uri.UriBuilder
 import io.micronaut.runtime.server.EmbeddedServer

--- a/test-suite/src/test/java/io/micronaut/docs/http/client/proxy/ProxyFilter.java
+++ b/test-suite/src/test/java/io/micronaut/docs/http/client/proxy/ProxyFilter.java
@@ -23,7 +23,6 @@ import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.http.annotation.Filter;
 import io.micronaut.http.client.ProxyHttpClient;
 import io.micronaut.http.filter.HttpServerFilter;
-import io.micronaut.http.filter.OncePerRequestHttpServerFilter;
 import io.micronaut.http.filter.ServerFilterChain;
 import io.micronaut.runtime.server.EmbeddedServer;
 import org.reactivestreams.Publisher;


### PR DESCRIPTION
`io.micronaut.http.filter.OncePerRequestHttpServerFilter` is deprecated therefore there shouldn't be any imports in the documentation samples.