### PR TITLE
Support @Scheduled cron timezones

### DIFF
--- a/context/src/main/java/io/micronaut/scheduling/NextFireTime.java
+++ b/context/src/main/java/io/micronaut/scheduling/NextFireTime.java
@@ -16,6 +16,7 @@
 package io.micronaut.scheduling;
 
 import java.time.Duration;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.function.Supplier;
 
@@ -42,6 +43,15 @@ final class NextFireTime implements Supplier<Duration> {
     NextFireTime(CronExpression cron) {
         this.cron = cron;
         nextFireTime = ZonedDateTime.now();
+    }
+
+    /**
+     * @param cron A cron expression
+     * @param zoneId The zoneId to base the cron expression on
+     */
+    NextFireTime(CronExpression cron, ZoneId zoneId) {
+        this.cron = cron;
+        nextFireTime = ZonedDateTime.now(zoneId);
     }
 
     @Override

--- a/context/src/main/java/io/micronaut/scheduling/TaskScheduler.java
+++ b/context/src/main/java/io/micronaut/scheduling/TaskScheduler.java
@@ -33,7 +33,6 @@ public interface TaskScheduler {
      * after the given delay.
      *
      * @param cron     The cron expression
-     * @param timezone The time zone to base the cron expression on. Defaults to system time zone
      * @param command  the task to execute
      * @return a ScheduledFuture representing pending completion of
      * the task and whose {@code get()} method will return
@@ -42,7 +41,39 @@ public interface TaskScheduler {
      *                                                         scheduled for execution
      * @throws NullPointerException                            if command or delay is null
      */
-    ScheduledFuture<?> schedule(String cron, String timezone, Runnable command);
+    ScheduledFuture<?> schedule(String cron, Runnable command);
+
+    /**
+     * Creates and executes a one-shot action that becomes enabled
+     * after the given delay.
+     *
+     * @param cron     The cron expression
+     * @param command  The task to execute
+     * @param <V>      The type of the callable's result
+     * @return a ScheduledFuture representing pending completion of
+     * the task and whose {@code get()} method will return
+     * {@code null} upon completion
+     * @throws java.util.concurrent.RejectedExecutionException if the task cannot be
+     *                                    scheduled for execution
+     * @throws NullPointerException       if command or delay is null
+     */
+    <V> ScheduledFuture<V> schedule(String cron, Callable<V> command);
+
+    /**
+     * Creates and executes a one-shot action that becomes enabled
+     * after the given delay.
+     *
+     * @param cron     The cron expression
+     * @param zoneId The zoneId to base the cron expression on. Defaults to system time zone
+     * @param command  the task to execute
+     * @return a ScheduledFuture representing pending completion of
+     * the task and whose {@code get()} method will return
+     * {@code null} upon completion
+     * @throws java.util.concurrent.RejectedExecutionException if the task cannot be
+     *                                                         scheduled for execution
+     * @throws NullPointerException                            if command or delay is null
+     */
+    ScheduledFuture<?> schedule(String cron, String zoneId, Runnable command);
 
     /**
      * Creates and executes a one-shot action that becomes enabled

--- a/context/src/main/java/io/micronaut/scheduling/TaskScheduler.java
+++ b/context/src/main/java/io/micronaut/scheduling/TaskScheduler.java
@@ -32,8 +32,9 @@ public interface TaskScheduler {
      * Creates and executes a one-shot action that becomes enabled
      * after the given delay.
      *
-     * @param cron    The cron expression
-     * @param command the task to execute
+     * @param cron     The cron expression
+     * @param timezone The time zone to base the cron expression on. Defaults to system time zone
+     * @param command  the task to execute
      * @return a ScheduledFuture representing pending completion of
      * the task and whose {@code get()} method will return
      * {@code null} upon completion
@@ -41,15 +42,16 @@ public interface TaskScheduler {
      *                                                         scheduled for execution
      * @throws NullPointerException                            if command or delay is null
      */
-    ScheduledFuture<?> schedule(String cron, Runnable command);
+    ScheduledFuture<?> schedule(String cron, String timezone, Runnable command);
 
     /**
      * Creates and executes a one-shot action that becomes enabled
      * after the given delay.
      *
-     * @param cron    The cron expression
-     * @param command The task to execute
-     * @param <V>     The type of the callable's result
+     * @param cron     The cron expression
+     * @param timezone The time zone to base the cron expression on. Defaults to system time zone
+     * @param command  The task to execute
+     * @param <V>      The type of the callable's result
      * @return a ScheduledFuture representing pending completion of
      * the task and whose {@code get()} method will return
      * {@code null} upon completion
@@ -57,7 +59,7 @@ public interface TaskScheduler {
      *                                    scheduled for execution
      * @throws NullPointerException       if command or delay is null
      */
-    <V> ScheduledFuture<V> schedule(String cron, Callable<V> command);
+    <V> ScheduledFuture<V> schedule(String cron, String timezone, Callable<V> command);
 
     /**
      * Creates and executes a one-shot action that becomes enabled

--- a/context/src/main/java/io/micronaut/scheduling/annotation/Scheduled.java
+++ b/context/src/main/java/io/micronaut/scheduling/annotation/Scheduled.java
@@ -47,6 +47,13 @@ public @interface Scheduled {
     String cron() default "";
 
     /**
+     * A String representation of the {@link java.time.ZoneId} to base our cron expression on.
+     * Defaults to {@link java.time.ZoneId#systemDefault}
+     * @return The timezone to base the cron expression on
+     */
+    String timezone() default "";
+
+    /**
      * A String representation of the {@link java.time.Duration} between the time of the last execution and the
      * beginning of the next. For example 10m == 10 minutes
      *

--- a/context/src/main/java/io/micronaut/scheduling/annotation/Scheduled.java
+++ b/context/src/main/java/io/micronaut/scheduling/annotation/Scheduled.java
@@ -49,9 +49,10 @@ public @interface Scheduled {
     /**
      * A String representation of the {@link java.time.ZoneId} to base our cron expression on.
      * Defaults to {@link java.time.ZoneId#systemDefault}
-     * @return The timezone to base the cron expression on
+     *
+     * @return The ZoneId to base the cron expression on
      */
-    String timezone() default "";
+    String zoneId() default "";
 
     /**
      * A String representation of the {@link java.time.Duration} between the time of the last execution and the

--- a/context/src/main/java/io/micronaut/scheduling/processor/ScheduledMethodProcessor.java
+++ b/context/src/main/java/io/micronaut/scheduling/processor/ScheduledMethodProcessor.java
@@ -60,6 +60,7 @@ public class ScheduledMethodProcessor implements ExecutableMethodProcessor<Sched
     private static final String MEMBER_FIXED_RATE = "fixedRate";
     private static final String MEMBER_INITIAL_DELAY = "initialDelay";
     private static final String MEMBER_CRON = "cron";
+    private static final String MEMBER_TIMEZONE = "timezone";
     private static final String MEMBER_FIXED_DELAY = "fixedDelay";
     private static final String MEMBER_SCHEDULER = "scheduler";
 
@@ -141,13 +142,16 @@ public class ScheduledMethodProcessor implements ExecutableMethodProcessor<Sched
             };
 
             String cronExpr = scheduledAnnotation.get(MEMBER_CRON, String.class, null);
+            String timezoneStr = scheduledAnnotation.get(MEMBER_TIMEZONE, String.class, null);
             String fixedDelay = scheduledAnnotation.get(MEMBER_FIXED_DELAY, String.class).orElse(null);
 
             if (StringUtils.isNotEmpty(cronExpr)) {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("Scheduling cron task [{}] for method: {}", cronExpr, method);
                 }
-                taskScheduler.schedule(cronExpr, task);
+
+                ScheduledFuture<?> scheduledFuture = taskScheduler.schedule(cronExpr, timezoneStr, task);
+                scheduledTasks.add(scheduledFuture);
             } else if (StringUtils.isNotEmpty(fixedRate)) {
                 Optional<Duration> converted = conversionService.convert(fixedRate, Duration.class);
                 Duration duration = converted.orElseThrow(() ->

--- a/context/src/main/java/io/micronaut/scheduling/processor/ScheduledMethodProcessor.java
+++ b/context/src/main/java/io/micronaut/scheduling/processor/ScheduledMethodProcessor.java
@@ -60,7 +60,7 @@ public class ScheduledMethodProcessor implements ExecutableMethodProcessor<Sched
     private static final String MEMBER_FIXED_RATE = "fixedRate";
     private static final String MEMBER_INITIAL_DELAY = "initialDelay";
     private static final String MEMBER_CRON = "cron";
-    private static final String MEMBER_TIMEZONE = "timezone";
+    private static final String MEMBER_ZONE_ID = "zoneId";
     private static final String MEMBER_FIXED_DELAY = "fixedDelay";
     private static final String MEMBER_SCHEDULER = "scheduler";
 
@@ -142,7 +142,7 @@ public class ScheduledMethodProcessor implements ExecutableMethodProcessor<Sched
             };
 
             String cronExpr = scheduledAnnotation.get(MEMBER_CRON, String.class, null);
-            String timezoneStr = scheduledAnnotation.get(MEMBER_TIMEZONE, String.class, null);
+            String zoneIdStr = scheduledAnnotation.get(MEMBER_ZONE_ID, String.class, null);
             String fixedDelay = scheduledAnnotation.get(MEMBER_FIXED_DELAY, String.class).orElse(null);
 
             if (StringUtils.isNotEmpty(cronExpr)) {
@@ -150,7 +150,7 @@ public class ScheduledMethodProcessor implements ExecutableMethodProcessor<Sched
                     LOG.debug("Scheduling cron task [{}] for method: {}", cronExpr, method);
                 }
 
-                ScheduledFuture<?> scheduledFuture = taskScheduler.schedule(cronExpr, timezoneStr, task);
+                ScheduledFuture<?> scheduledFuture = taskScheduler.schedule(cronExpr, zoneIdStr, task);
                 scheduledTasks.add(scheduledFuture);
             } else if (StringUtils.isNotEmpty(fixedRate)) {
                 Optional<Duration> converted = conversionService.convert(fixedRate, Duration.class);

--- a/context/src/test/groovy/io/micronaut/scheduling/ScheduledCustomExecutorSpec.groovy
+++ b/context/src/test/groovy/io/micronaut/scheduling/ScheduledCustomExecutorSpec.groovy
@@ -42,7 +42,7 @@ class ScheduledCustomExecutorSpec extends Specification {
 
         @Scheduled(cron = '1/3 0/1 * 1/1 * ?', scheduler = "dispatcher")
         @Scheduled(cron = '1/4 0/1 * 1/1 * ?', scheduler = "dispatcher")
-        @Scheduled(cron = '1/5 0/1 * 1/1 * ?', timezone = "America/Chicago", scheduler = "dispatcher")
+        @Scheduled(cron = '1/5 0/1 * 1/1 * ?', zoneId = "America/Chicago", scheduler = "dispatcher")
         void runCron() {
             cronEvents.incrementAndGet()
         }

--- a/context/src/test/groovy/io/micronaut/scheduling/ScheduledCustomExecutorSpec.groovy
+++ b/context/src/test/groovy/io/micronaut/scheduling/ScheduledCustomExecutorSpec.groovy
@@ -24,7 +24,7 @@ class ScheduledCustomExecutorSpec extends Specification {
         then:
         conditions.eventually {
             bean.ran
-            bean.cronEvents.get() >= 2
+            bean.cronEvents.get() >= 3
         }
     }
 
@@ -42,6 +42,7 @@ class ScheduledCustomExecutorSpec extends Specification {
 
         @Scheduled(cron = '1/3 0/1 * 1/1 * ?', scheduler = "dispatcher")
         @Scheduled(cron = '1/4 0/1 * 1/1 * ?', scheduler = "dispatcher")
+        @Scheduled(cron = '1/5 0/1 * 1/1 * ?', timezone = "America/Chicago", scheduler = "dispatcher")
         void runCron() {
             cronEvents.incrementAndGet()
         }

--- a/context/src/test/groovy/io/micronaut/scheduling/ScheduledFixedRateSpec.groovy
+++ b/context/src/test/groovy/io/micronaut/scheduling/ScheduledFixedRateSpec.groovy
@@ -138,7 +138,7 @@ class ScheduledFixedRateSpec extends Specification {
 
         @Scheduled(cron = '1/3 0/1 * 1/1 * ?')
         @Scheduled(cron = '1/4 0/1 * 1/1 * ?')
-        @Scheduled(cron = '1/5 0/1 * 1/1 * ?', zoneId = "America/Chicago", scheduler = "dispatcher")
+        @Scheduled(cron = '1/5 0/1 * 1/1 * ?', zoneId = "America/Chicago")
         void runCron() {
             cronEvents.incrementAndGet()
         }

--- a/context/src/test/groovy/io/micronaut/scheduling/ScheduledFixedRateSpec.groovy
+++ b/context/src/test/groovy/io/micronaut/scheduling/ScheduledFixedRateSpec.groovy
@@ -138,7 +138,7 @@ class ScheduledFixedRateSpec extends Specification {
 
         @Scheduled(cron = '1/3 0/1 * 1/1 * ?')
         @Scheduled(cron = '1/4 0/1 * 1/1 * ?')
-        @Scheduled(cron = '1/5 0/1 * 1/1 * ?', timezone = "America/Chicago", scheduler = "dispatcher")
+        @Scheduled(cron = '1/5 0/1 * 1/1 * ?', zoneId = "America/Chicago", scheduler = "dispatcher")
         void runCron() {
             cronEvents.incrementAndGet()
         }

--- a/context/src/test/groovy/io/micronaut/scheduling/ScheduledFixedRateSpec.groovy
+++ b/context/src/test/groovy/io/micronaut/scheduling/ScheduledFixedRateSpec.groovy
@@ -80,7 +80,7 @@ class ScheduledFixedRateSpec extends Specification {
 
         then:
         conditions.eventually {
-            myTask.cronEvents.get() == 2
+            myTask.cronEvents.get() == 3
         }
 
         cleanup:
@@ -138,6 +138,7 @@ class ScheduledFixedRateSpec extends Specification {
 
         @Scheduled(cron = '1/3 0/1 * 1/1 * ?')
         @Scheduled(cron = '1/4 0/1 * 1/1 * ?')
+        @Scheduled(cron = '1/5 0/1 * 1/1 * ?', timezone = "America/Chicago", scheduler = "dispatcher")
         void runCron() {
             cronEvents.incrementAndGet()
         }


### PR DESCRIPTION
Fills my need in https://github.com/micronaut-projects/micronaut-core/issues/6938.

Essentially - I want to (optionally) support using a non-default time zone for `@Scheduled(cron = ...)` tasks.

Is this enough testing? Can anyone think of a clean way to test that the time zone supplied is _actually_ being used over UTC?