### PR TITLE
Remove redudant boxing in TimeConverterRegistrar

### DIFF
--- a/context/src/main/java/io/micronaut/runtime/converters/time/TimeConverterRegistrar.java
+++ b/context/src/main/java/io/micronaut/runtime/converters/time/TimeConverterRegistrar.java
@@ -91,23 +91,23 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
                     try {
                         switch (type) {
                             case 's':
-                                return Optional.of(Duration.ofSeconds(Integer.valueOf(amount)));
+                                return Optional.of(Duration.ofSeconds(Integer.parseInt(amount)));
                             case 'm':
                                 String ms = matcher.group(MILLIS);
                                 if (StringUtils.hasText(ms)) {
-                                    return Optional.of(Duration.ofMillis(Integer.valueOf(amount)));
+                                    return Optional.of(Duration.ofMillis(Integer.parseInt(amount)));
                                 } else {
-                                    return Optional.of(Duration.ofMinutes(Integer.valueOf(amount)));
+                                    return Optional.of(Duration.ofMinutes(Integer.parseInt(amount)));
                                 }
                             case 'h':
-                                return Optional.of(Duration.ofHours(Integer.valueOf(amount)));
+                                return Optional.of(Duration.ofHours(Integer.parseInt(amount)));
                             case 'd':
-                                return Optional.of(Duration.ofDays(Integer.valueOf(amount)));
+                                return Optional.of(Duration.ofDays(Integer.parseInt(amount)));
                             default:
                                 final String seq = g2 + matcher.group(3);
                                 switch (seq) {
                                     case "ns":
-                                        return Optional.of(Duration.ofNanos(Integer.valueOf(amount)));
+                                        return Optional.of(Duration.ofNanos(Integer.parseInt(amount)));
                                     default:
                                         context.reject(
                                                 value,


### PR DESCRIPTION
While modern hotspot will optimise this on the fly there is no reason for the integer boxing