### PR TITLE
Do not wait for request data after decode failure

### DIFF
--- a/http-netty/src/main/java/io/micronaut/http/netty/stream/HttpStreamsServerHandler.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/stream/HttpStreamsServerHandler.java
@@ -91,6 +91,10 @@ public class HttpStreamsServerHandler extends HttpStreamsHandler<HttpRequest, Ht
 
     @Override
     protected boolean hasBody(HttpRequest request) {
+        // if there's a decoder failure (e.g. invalid header), don't expect the body to come in
+        if (request.decoderResult().isFailure()) {
+            return false;
+        }
         // Http requests don't have a body if they define 0 content length, or no content length and no transfer
         // encoding
         return HttpUtil.getContentLength(request, 0) != 0 || HttpUtil.isTransferEncodingChunked(request);

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
@@ -1145,12 +1145,15 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
         final io.micronaut.http.HttpVersion httpVersion = request.getHttpVersion();
         final boolean isHttp2 = httpVersion == io.micronaut.http.HttpVersion.HTTP_2_0;
 
+        boolean decodeError = request instanceof NettyHttpRequest &&
+                ((NettyHttpRequest<?>) request).getNativeRequest().decoderResult().isFailure();
+
         final Object body = message.body();
         if (body instanceof NettyCustomizableResponseTypeHandlerInvoker) {
             // default Connection header if not set explicitly
             if (!isHttp2) {
                 if (!message.getHeaders().contains(HttpHeaders.CONNECTION)) {
-                    if (httpStatus.getCode() < 500 || serverConfiguration.isKeepAliveOnServerError()) {
+                    if (!decodeError && (httpStatus.getCode() < 500 || serverConfiguration.isKeepAliveOnServerError())) {
                         message.getHeaders().set(HttpHeaders.CONNECTION, HttpHeaderValues.KEEP_ALIVE);
                     } else {
                         message.getHeaders().set(HttpHeaders.CONNECTION, HttpHeaderValues.CLOSE);
@@ -1168,7 +1171,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
             if (!isHttp2) {
                 if (!nettyHeaders.contains(HttpHeaderNames.CONNECTION)) {
                     boolean expectKeepAlive = nettyResponse.protocolVersion().isKeepAliveDefault() || request.getHeaders().isKeepAlive();
-                    if (expectKeepAlive || httpStatus.getCode() < 500 || serverConfiguration.isKeepAliveOnServerError()) {
+                    if (!decodeError && (expectKeepAlive || httpStatus.getCode() < 500 || serverConfiguration.isKeepAliveOnServerError())) {
                         nettyHeaders.set(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE);
                     } else {
                         nettyHeaders.set(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE);


### PR DESCRIPTION
When there is a failure during decoding of header values, netty will consume the entire input and not forward it. However, if we expect content data e.g. due to a Content-Length header, RoutingInBoundHandler would wait indefinitely for that data before sending the error response.

This patch changes HttpStreamsServerHandler to treat a decode failure request as if it had no body. This way a StreamedHttpRequest is never created. I also considered just bypassing the StreamedHttpRequest wait in RoutingInBoundHandler, but that risks unexpected behavior from the StreamedHttpRequest publisher never finishing (see #6935), so I tried to avoid StreamedHttpRequest entirely.

There is also a change to force the connection to close, to prevent possible downstream errors from connection reuse.

Fixes #6925