### PR TITLE
Do not request demand for completed HandlerPublisher

### DIFF
--- a/http-netty/src/main/java/io/micronaut/http/netty/reactive/HandlerPublisher.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/reactive/HandlerPublisher.java
@@ -160,9 +160,7 @@ public class HandlerPublisher<T> extends ChannelDuplexHandler implements HotObse
             LOG.trace("Demand received for next message (state = " + state + "). Calling context.read()");
         }
 
-        if (!completed.get()) {
-            ctx.read();
-        }
+        ctx.read();
     }
 
     /**
@@ -466,8 +464,10 @@ public class HandlerPublisher<T> extends ChannelDuplexHandler implements HotObse
             if (outstandingDemand > 0) {
                 if (state == BUFFERING) {
                     state = DEMANDING;
-                } // otherwise we're draining or done
-                requestDemand();
+                } // otherwise we're draining
+                if (!completed.get()) {
+                    requestDemand();
+                }
             } else if (state == BUFFERING) {
                 state = IDLE;
             }

--- a/http-netty/src/main/java/io/micronaut/http/netty/reactive/HandlerPublisher.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/reactive/HandlerPublisher.java
@@ -160,7 +160,9 @@ public class HandlerPublisher<T> extends ChannelDuplexHandler implements HotObse
             LOG.trace("Demand received for next message (state = " + state + "). Calling context.read()");
         }
 
-        ctx.read();
+        if (!completed.get()) {
+            ctx.read();
+        }
     }
 
     /**
@@ -464,10 +466,8 @@ public class HandlerPublisher<T> extends ChannelDuplexHandler implements HotObse
             if (outstandingDemand > 0) {
                 if (state == BUFFERING) {
                     state = DEMANDING;
-                } // otherwise we're draining
-                if (!completed.get()) {
-                    requestDemand();
-                }
+                } // otherwise we're draining or done
+                requestDemand();
             } else if (state == BUFFERING) {
                 state = IDLE;
             }

--- a/http-netty/src/main/java/io/micronaut/http/netty/reactive/HandlerPublisher.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/reactive/HandlerPublisher.java
@@ -465,7 +465,9 @@ public class HandlerPublisher<T> extends ChannelDuplexHandler implements HotObse
                 if (state == BUFFERING) {
                     state = DEMANDING;
                 } // otherwise we're draining
-                requestDemand();
+                if (!completed.get()) {
+                    requestDemand();
+                }
             } else if (state == BUFFERING) {
                 state = IDLE;
             }

--- a/http-netty/src/main/java/io/micronaut/http/netty/stream/HttpStreamsHandler.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/stream/HttpStreamsHandler.java
@@ -314,8 +314,8 @@ abstract class HttpStreamsHandler<In extends HttpMessage, Out extends HttpMessag
             if (bodyPublisher != null) {
                 ctx.fireChannelRead(content);
                 if (content instanceof LastHttpContent) {
-                    removeHandlerIfActive(ctx, HANDLER_BODY_PUBLISHER);
                     currentlyStreamedMessage = null;
+                    removeHandlerIfActive(ctx, HANDLER_BODY_PUBLISHER);
                     consumedInMessage(ctx);
                 }
             } else {

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/HttpPipelineBuilder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/HttpPipelineBuilder.java
@@ -193,6 +193,20 @@ final class HttpPipelineBuilder {
             return s;
         }
 
+        void initChannel() {
+            insertOuterTcpHandlers();
+
+            if (server.getServerConfiguration().getHttpVersion() != io.micronaut.http.HttpVersion.HTTP_2_0) {
+                configureForHttp1();
+            } else {
+                if (ssl) {
+                    configureForAlpn();
+                } else {
+                    configureForH2cSupport();
+                }
+            }
+        }
+
         /**
          * Insert handlers that wrap the outermost TCP stream. This is SSL and potentially packet capture.
          */

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/fuzzing/FuzzyInputSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/fuzzing/FuzzyInputSpec.groovy
@@ -1,8 +1,13 @@
 package io.micronaut.http.server.netty.fuzzing
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Post
 import io.micronaut.http.netty.channel.EventLoopGroupConfiguration
 import io.micronaut.http.netty.channel.EventLoopGroupRegistry
+import io.micronaut.http.server.netty.NettyHttpServer
 import io.micronaut.runtime.server.EmbeddedServer
 import io.netty.bootstrap.Bootstrap
 import io.netty.buffer.Unpooled
@@ -12,6 +17,9 @@ import io.netty.channel.ChannelOption
 import io.netty.channel.socket.nio.NioSocketChannel
 import io.netty.handler.timeout.ReadTimeoutHandler
 import io.netty.resolver.NoopAddressResolverGroup
+import io.netty.util.ReferenceCountUtil
+import jakarta.inject.Singleton
+import org.reactivestreams.Publisher
 import spock.lang.Specification
 
 /**
@@ -24,6 +32,7 @@ class FuzzyInputSpec extends Specification {
         BufferLeakDetection.startTracking()
 
         ApplicationContext ctx = ApplicationContext.run([
+                'spec.name': 'FuzzyInputSpec',
                 "micronaut.server.port": "-1",
                 "micronaut.netty.event-loops.default.num-threads": "1"
         ])
@@ -58,7 +67,59 @@ class FuzzyInputSpec extends Specification {
 
         where:
         input << [
-                Base64.decoder.decode("T1BUSU9OUyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKiBIVFRQLzEuMQpUcmFuc2Zlci1FbmNvZGluZzpjaHVua2VkCgo0CgoNSU9OUyAqIEhUVFAvMS4xClRyYW5zZmVyLUVuY29kaW5nOmNodW5rZWSKCg")
+                Base64.decoder.decode("T1BUSU9OUyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKiBIVFRQLzEuMQpUcmFuc2Zlci1FbmNvZGluZzpjaHVua2VkCgo0CgoNSU9OUyAqIEhUVFAvMS4xClRyYW5zZmVyLUVuY29kaW5nOmNodW5rZWSKCg"),
+                Base64.decoder.decode("T0dUSU9OUyAqIEhgVFRQLzEuMQpjb250ZW50LWxlbmd2aDo0Cgqfn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fnw1JT05TIC8gSFRUUC8xLjEKVHJhbnNmZXItYG5jb2Rpbmc6Y2h1T1BUSU9OUyAqIEhUVFDU1C8xLjEKY29udGVudC1sZXZoZ246NAoKDUlPTlMgLyBIVFRQLzEuMQpUcmFuc2Zlci1gbmNvZGluZzpjaHVPUFRJT05TICogSFRUUNTU////////////////////////////////////////Z2dnZ2dnZ1RU/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////y8xLjEKY29udGVudC1sZW5ndGg6NAoKDUlPTlMgLyBIVFRQLzEuMQpUcmFuc2Zlci1FbmNvZGluZzpjaHVua2X/////T1NUIC8gSFRUUC8xLjEKQ29udGVudC1UeXBlOm47Kj04Cgr//////////////////////////////////////////////////////////2phY2tzb24uYmVhbi3//////////2phY2tzb24uYmVhbi1pbnRyb3NwZWN0aVRJT05TICogSGBUVFAvMS4xCmNvbnRlbnQtbGVuZ3RoOjQKCg1JT05TIC8gSFRUUC8xLjEKVHJhbnNmZXItYG5jb2Rpbmc6Y2h1T1BUSU9OUyAqIEhUVFDU1P///////////////////////////////////////2dnZ2dnZ2dUVP///////////////////////////////////////////////////////////////3Ryb3NwZWN0aVRJT05TICogSGBUVFAvMC4xCmNvbnRlbnQtbGVuZ3RoOjQKCg1JT05TIC8gSFRUUC8xLjEKVHJhbnNmZXItYG5jb2Rpbmc6Y2h1T1BUSU9OUyAqIEhUVFDU1P///////////////////////////////////////2dnZ2dnZ2dUVP////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////8vMS4xCmNvbnRlbnQtbGVuZ3RoOjQKCg1JT05TIC8gSFRUUC8xLjEKVHJhbnNmZXItRW5jb2Rpbmc6Y2h1bmtl/////09TVP///////////////////////////////////////2dnZ2dnZ2dUVP////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////9nZ2dnZ2dnVFT/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////LzEuMQpjb250ZW50LWxlbmd0aDo0CgoNSU9OUyAvIEhUVFAvMS4xClRyYW5zZmVyLUVuY29kaW5nOmNodW5rZf////9PU1QgLyBIVFRQLzEuMQpDb250ZW50LVR5cGU6bjsqPTgKCv//////////////////////////////////////////////////////////amFja3Nvbi5iZWFuLf//////////amFja3Nvbi5iZWFuLWludHJvc3BlY3RpVElPTlMgKiBIYFRUUC8xLjEKY29udGVudC1sZW5ndGg6NAoKDUlPTlMgLyBIVFRQLzEuMQpUcmFuc2Zlci1gbmNvZGluZzpjaHVPUFRJT05TICogSFRUUNTU////////////////////////////////////////Z2dnZ2dnZ1RU////////////////////////////////////////////////////////////////dHJvc3BlY3RpVElPTlMgKiBIYFRUUC8wLjEKY29udGVudC1sZW5ndGg6NAoKDUlPTlMgLyBIVFRQLzEuMQpUcmFuc2Zlci1gbmNvZGluZzpjaHVPUFRJT05TICogSFRUUNTU////////////////////////////////////////Z2dnZ2dnZ1RU/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////y8xLjEKY29udGVudC1sZW5ndGg609PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09P//////2phY2tzb24uYmVhbi3//////////2phY2tzb24uYmVhbi1pbnRyb3JhbnNmZXItRW5jb2Rpbmc6Y2h1bmtl/////09TVCAvIEhUVFAvbjFDCi5vMXRlbnQtVHlwZTpuOyo9OAoK//////////////////////////////////////////////////////////9qYWNrc29uLmJlYW4t//////////9qYWNrc29uLmJlYW4taW50cm9zcGVjdGlvbi1tb2R1bG9uLW1vZCAvIEhUVFAvMS4xCkNvbnRlbnQtVHl1bGUu//9kCgo="),
         ]
+    }
+
+    def 'http1 cleartext embedded channel'() {
+        given:
+        BufferLeakDetection.startTracking()
+
+        ApplicationContext ctx = ApplicationContext.run([
+                'spec.name': 'FuzzyInputSpec',
+        ])
+        def embeddedServer = (NettyHttpServer) ctx.getBean(EmbeddedServer)
+
+        when:
+        def embeddedChannel = embeddedServer.buildEmbeddedChannel(false)
+
+        embeddedChannel.writeOneInbound(Unpooled.wrappedBuffer(input));
+        embeddedChannel.runPendingTasks();
+
+        embeddedChannel.releaseOutbound()
+        // don't release inbound, that doesn't happen normally either
+        for (Object inboundMessage : embeddedChannel.inboundMessages()) {
+            ReferenceCountUtil.touch(inboundMessage)
+        }
+        embeddedChannel.finish()
+
+        then:
+        embeddedChannel.checkException()
+
+        BufferLeakDetection.stopTrackingAndReportLeaks()
+
+        cleanup:
+        embeddedServer.stop()
+
+        where:
+        input << [
+                Base64.decoder.decode("RyAqIFAvMS4xCmNvbnRlbnQtbGVuZ3RoOjQKCg1JT05TIC8gUC8xLjEKClMgLyBQLzEuMQpjb250ZW50LWxlbmd0aDo0CgoNZ3BJUyAvIFQvMS43CgpQT1NUIC8gUC8xLjEKY29udGVudC1sZW5ndGg6NAoKDUlPTlMgLyBILzEuMQpjb250ZW50LWxlbmd0aDo0Cgo="),
+        ]
+    }
+
+    @Singleton
+    @Controller
+    @Requires(property = 'spec.name', value = 'FuzzyInputSpec')
+    public static class SimpleController {
+        @Get
+        public String index() {
+            return "index"
+        }
+
+        @Post
+        public Publisher<String> index(Publisher<String> foo) {
+            return foo
+        }
     }
 }

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/fuzzing/FuzzyInputSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/fuzzing/FuzzyInputSpec.groovy
@@ -5,6 +5,7 @@ import io.micronaut.context.annotation.Requires
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Post
+import io.micronaut.http.context.ServerRequestContext
 import io.micronaut.http.netty.channel.EventLoopGroupConfiguration
 import io.micronaut.http.netty.channel.EventLoopGroupRegistry
 import io.micronaut.http.server.netty.NettyHttpServer
@@ -100,7 +101,8 @@ class FuzzyInputSpec extends Specification {
         BufferLeakDetection.stopTrackingAndReportLeaks()
 
         cleanup:
-        embeddedServer.stop()
+        // normally this is set on the event loop and so doesn't persist across tests, but with EmbeddedChannel we don't make a new thread
+        ServerRequestContext.set(null)
 
         where:
         input << [


### PR DESCRIPTION
When a HandlerPublisher is removed, it is completed. If at that point it is in DEMANDING state, this will trigger a `flushBuffer()`, which in turn can trigger a `requestDemand()` and a `context.read()`. This read will happen before the removal of the HandlerPublisher has finished, which can lead to a race condition upstream in HttpStreamsHandler: currentlyStreamedMessage will be set to null *after* the removal of the publisher, at which point a new publisher has already been created from the `context.read()`.

This patch fixes this issue in two ways: the HandlerPublisher won't trigger a read anymore if it's already completed, and the HttpStreamsHandler will unset the currentlyStreamedMessage *before* triggering downstream handler removal.

The test case for this also includes a new `EmbeddedChannel` approach to testing the server, which removes the need for a dedicated event loop, and thus removes any race conditions (as long as the IO pool isn't used). The basic `EmbeddedChannel` factory method is placed in `NettyHttpServer` so that I can use it in fuzzing.