### PR TITLE
Remove storing of return type annotations

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/CustomCrudRepo2.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/CustomCrudRepo2.java
@@ -1,0 +1,12 @@
+package io.micronaut.aop.introduction;
+
+import java.util.Optional;
+
+@RepoDef
+public interface CustomCrudRepo2 {
+
+    Optional<CustomEntity> custom1(Long aLong);
+
+    @Marker
+    Optional<CustomEntity> custom2(Long aLong);
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/CustomEntity.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/CustomEntity.java
@@ -1,0 +1,5 @@
+package io.micronaut.aop.introduction;
+
+@Marker
+public class CustomEntity {
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/MyRepoIntroductionSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/MyRepoIntroductionSpec.groovy
@@ -116,6 +116,18 @@ class MyRepoIntroductionSpec extends Specification {
             MyRepoIntroducer.EXECUTED_METHODS.clear()
     }
 
+    void "test return type annotations are method annotations"() {
+        when:
+            def beanDef = applicationContext.getBeanDefinition(CustomCrudRepo2)
+            def custom1Method = beanDef.getExecutableMethods().find(m -> m.getName() == "custom1")
+            def custom2Method = beanDef.getExecutableMethods().find(m -> m.getName() == "custom2")
+        then:
+            !custom1Method.hasAnnotation(Marker)
+            custom2Method.hasAnnotation(Marker)
+            !custom1Method.getReturnType().annotationMetadata.hasAnnotation(Marker)
+            custom2Method.getReturnType().annotationMetadata.hasAnnotation(Marker)
+    }
+
     void "test overridden void methods"() {
         when:
             def bean = applicationContext.getBean(MyRepo2)

--- a/inject/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
@@ -493,7 +493,7 @@ final class BeanIntrospectionWriter extends AbstractAnnotationMetadataWriter {
         staticInit.dup();
         // 1: return argument
         ClassElement genericReturnType = beanMethodData.methodElement.getGenericReturnType();
-        pushArgument(introspectionType, classWriter, staticInit, classElement.getName(), genericReturnType, defaults, loadTypeMethods);
+        pushReturnTypeArgument(introspectionType, classWriter, staticInit, classElement.getName(), genericReturnType, defaults, loadTypeMethods);
         // 2: name
         staticInit.push(beanMethodData.methodElement.getName());
         // 3: annotation metadata

--- a/inject/src/main/java/io/micronaut/inject/writer/AbstractClassFileWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/AbstractClassFileWriter.java
@@ -540,13 +540,13 @@ public abstract class AbstractClassFileWriter implements Opcodes, OriginatingEle
      * @param defaults             The annotation defaults
      * @param loadTypeMethods      The load type methods
      */
-    protected void pushArgument(Type owningType,
-                              ClassWriter classWriter,
-                              GeneratorAdapter generatorAdapter,
-                              String declaringTypeName,
-                              ClassElement argument,
-                              Map<String, Integer> defaults,
-                              Map<String, GeneratorAdapter> loadTypeMethods) {
+    protected void pushReturnTypeArgument(Type owningType,
+                                          ClassWriter classWriter,
+                                          GeneratorAdapter generatorAdapter,
+                                          String declaringTypeName,
+                                          ClassElement argument,
+                                          Map<String, Integer> defaults,
+                                          Map<String, GeneratorAdapter> loadTypeMethods) {
         Type type = Type.getType(Argument.class);
         if (argument.isPrimitive() && !argument.isArray()) {
             String constantName = argument.getName().toUpperCase(Locale.ENGLISH);
@@ -567,7 +567,7 @@ public abstract class AbstractClassFileWriter implements Opcodes, OriginatingEle
                     generatorAdapter,
                     argument.getName(),
                     argument,
-                    argument.getAnnotationMetadata(),
+                    AnnotationMetadata.EMPTY_METADATA, // Don't store return type annotations, method annotations are returned
                     argument.getTypeArguments(),
                     defaults,
                     loadTypeMethods


### PR DESCRIPTION
It wasn't used anyway, `ReturnType` is using method's metadata.
+ Deleted dead code.