### PR TITLE
Don't use .* to match whitespace in IGNORABLE_ERROR_MESSAGE

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
@@ -148,7 +148,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
      * Also present in {@link RouteExecutor}.
      */
     private static final Pattern IGNORABLE_ERROR_MESSAGE = Pattern.compile(
-            "^.*(?:connection.*(?:reset|closed|abort|broken)|broken.*pipe).*$", Pattern.CASE_INSENSITIVE);
+            "^.*(?:connection (?:reset|closed|abort|broken)|broken pipe).*$", Pattern.CASE_INSENSITIVE);
     private static final Argument ARGUMENT_PART_DATA = Argument.of(PartData.class);
     private final Router router;
     private final StaticResourceResolver staticResourceResolver;

--- a/http-server/src/main/java/io/micronaut/http/server/RouteExecutor.java
+++ b/http-server/src/main/java/io/micronaut/http/server/RouteExecutor.java
@@ -96,7 +96,7 @@ public final class RouteExecutor {
      * Also present in netty RoutingInBoundHandler.
      */
     private static final Pattern IGNORABLE_ERROR_MESSAGE = Pattern.compile(
-            "^.*(?:connection.*(?:reset|closed|abort|broken)|broken.*pipe).*$", Pattern.CASE_INSENSITIVE);
+            "^.*(?:connection (?:reset|closed|abort|broken)|broken pipe).*$", Pattern.CASE_INSENSITIVE);
 
     private final Router router;
     private final BeanContext beanContext;


### PR DESCRIPTION
Sonar flagged this because it can lead to regex backtracking. I don't think the error messages we want to match contain longer strings in between the words anyway.