### PR TITLE
Fix double-checked locking

### DIFF
--- a/http-client-core/src/main/java/io/micronaut/http/client/HttpClientFactoryResolver.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/HttpClientFactoryResolver.java
@@ -29,7 +29,7 @@ import java.util.ServiceLoader;
 @Internal
 final class HttpClientFactoryResolver {
 
-    private static HttpClientFactory factory;
+    private static volatile HttpClientFactory factory;
 
     static HttpClientFactory getFactory() {
         if (factory == null) {

--- a/http-client-core/src/main/java/io/micronaut/http/client/ProxyHttpClientFactoryResolver.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/ProxyHttpClientFactoryResolver.java
@@ -29,7 +29,7 @@ import java.util.ServiceLoader;
 @Internal
 final class ProxyHttpClientFactoryResolver {
 
-    private volatile static ProxyHttpClientFactory factory;
+    private static volatile ProxyHttpClientFactory factory;
 
     static ProxyHttpClientFactory getFactory() {
         if (factory == null) {

--- a/http-client-core/src/main/java/io/micronaut/http/client/ProxyHttpClientFactoryResolver.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/ProxyHttpClientFactoryResolver.java
@@ -29,7 +29,7 @@ import java.util.ServiceLoader;
 @Internal
 final class ProxyHttpClientFactoryResolver {
 
-    private static ProxyHttpClientFactory factory;
+    private volatile static ProxyHttpClientFactory factory;
 
     static ProxyHttpClientFactory getFactory() {
         if (factory == null) {

--- a/http-client-core/src/main/java/io/micronaut/http/client/StreamingHttpClientFactoryResolver.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/StreamingHttpClientFactoryResolver.java
@@ -29,7 +29,7 @@ import java.util.ServiceLoader;
 @Internal
 final class StreamingHttpClientFactoryResolver {
 
-    private volatile static StreamingHttpClientFactory factory;
+    private static volatile StreamingHttpClientFactory factory;
 
     static StreamingHttpClientFactory getFactory() {
         if (factory == null) {

--- a/http-client-core/src/main/java/io/micronaut/http/client/StreamingHttpClientFactoryResolver.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/StreamingHttpClientFactoryResolver.java
@@ -29,7 +29,7 @@ import java.util.ServiceLoader;
 @Internal
 final class StreamingHttpClientFactoryResolver {
 
-    private static StreamingHttpClientFactory factory;
+    private volatile static StreamingHttpClientFactory factory;
 
     static StreamingHttpClientFactory getFactory() {
         if (factory == null) {

--- a/http-client-core/src/main/java/io/micronaut/http/client/sse/SseClientFactoryResolver.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/sse/SseClientFactoryResolver.java
@@ -29,7 +29,7 @@ import java.util.ServiceLoader;
 @Internal
 final class SseClientFactoryResolver {
 
-    private static SseClientFactory factory;
+    private static volatile SseClientFactory factory;
 
     static SseClientFactory getFactory() {
         if (factory == null) {

--- a/inject/src/main/java/io/micronaut/context/condition/OperatingSystem.java
+++ b/inject/src/main/java/io/micronaut/context/condition/OperatingSystem.java
@@ -25,7 +25,7 @@ import java.util.Locale;
  */
 public final class OperatingSystem {
 
-    private static OperatingSystem instance;
+    private static volatile OperatingSystem instance;
     private final Family family;
 
     private OperatingSystem(Family family) {

--- a/websocket/src/main/java/io/micronaut/websocket/WebSocketClientFactoryResolver.java
+++ b/websocket/src/main/java/io/micronaut/websocket/WebSocketClientFactoryResolver.java
@@ -29,7 +29,7 @@ import java.util.ServiceLoader;
 @Internal
 final class WebSocketClientFactoryResolver {
 
-    private static WebSocketClientFactory factory;
+    private static volatile WebSocketClientFactory factory;
 
     static WebSocketClientFactory getFactory() {
         if (factory == null) {


### PR DESCRIPTION
Double-checked locking needs safe publication. See https://shipilev.net/blog/2014/safe-public-construction/

This fixes four sonar issues.