### PR TITLE
Correct recognizing a getter with a second character being a number

### DIFF
--- a/core/src/main/java/io/micronaut/core/naming/NameUtils.java
+++ b/core/src/main/java/io/micronaut/core/naming/NameUtils.java
@@ -537,7 +537,7 @@ public class NameUtils {
                 return Character.toString(Character.toLowerCase(name.charAt(0)));
             }
             for (int i = 1; i < Math.min(length, 3); i++) {
-                if (Character.isLowerCase(name.charAt(i))) {
+                if (!Character.isUpperCase(name.charAt(i))) {
                     char[] chars = name.toCharArray();
                     chars[0] = Character.toLowerCase(chars[0]);
                     return new String(chars);

--- a/core/src/test/groovy/io/micronaut/core/naming/NameUtilsSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/naming/NameUtilsSpec.groovy
@@ -143,6 +143,8 @@ class NameUtilsSpec extends Specification {
         "ABC"   | "ABC"
         "AB"    | "AB"
         "ABc"   | "aBc"
+        "S3abc" | "s3abc"
+        "S3a"   | "s3a"
     }
 
     void "test decapitalize returns same ref"() {

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/BeanIntrospectionSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/BeanIntrospectionSpec.groovy
@@ -2170,4 +2170,22 @@ class AImpl implements A {
         property.isReadWrite()
     }
 
+    def "property name with a number is not duplicated"() {
+        when:
+        def introspection = buildBeanIntrospection('test.Test', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected
+
+@Introspected
+class Test {
+    UUID id
+    String s3Name
+}
+''')
+
+        then:
+            introspection.properties.size() == 2
+    }
+
 }

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/BeanIntrospectionSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/BeanIntrospectionSpec.groovy
@@ -2185,7 +2185,7 @@ class Test {
 ''')
 
         then:
-            introspection.properties.size() == 2
+            introspection.beanProperties.size() == 2
     }
 
 }


### PR DESCRIPTION
Fixes https://github.com/micronaut-projects/micronaut-data/issues/1343 (Somehow transfer doesn't work)

Method `decapitalize` is corrected according to the JavaDoc.