### PR TITLE
Don't create stereotype for `@Nonnull(when=MAYBE)`

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/annotation/mapping/AnnotationMappingSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/annotation/mapping/AnnotationMappingSpec.groovy
@@ -84,4 +84,30 @@ class Key {
             idWithMapped.getDeclaredAnnotationNames() == idWithoutMapped.getDeclaredAnnotationNames()
     }
 
+    void "test @NonNull stereotype from @Nullable"() {
+        when:
+        def pojo = buildBeanIntrospection('test.Pojo', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.annotation.mapping.NonNullStereotyped;
+
+@Introspected
+public final class Pojo {
+    @NonNullStereotyped
+    private final String surname;
+
+    public Pojo(String surname) {
+        this.surname = surname;
+    }
+
+    public String getSurname() {
+        return this.surname;
+    }
+}
+''')
+        then:
+        !pojo.getProperty("surname").get().isNonNull()
+    }
+
 }

--- a/inject-java/src/test/groovy/io/micronaut/annotation/mapping/NonNullProducingMapper.java
+++ b/inject-java/src/test/groovy/io/micronaut/annotation/mapping/NonNullProducingMapper.java
@@ -1,0 +1,21 @@
+package io.micronaut.annotation.mapping;
+
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.inject.annotation.TypedAnnotationMapper;
+import io.micronaut.inject.visitor.VisitorContext;
+
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.List;
+
+public class NonNullProducingMapper implements TypedAnnotationMapper<NonNullStereotyped> {
+    @Override
+    public List<AnnotationValue<?>> map(AnnotationValue<NonNullStereotyped> annotation, VisitorContext visitorContext) {
+        return Collections.singletonList(AnnotationValue.builder(Nullable.class).build());
+    }
+
+    @Override
+    public Class<NonNullStereotyped> annotationType() {
+        return NonNullStereotyped.class;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/annotation/mapping/NonNullProducingMapper.java
+++ b/inject-java/src/test/groovy/io/micronaut/annotation/mapping/NonNullProducingMapper.java
@@ -4,14 +4,13 @@ import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.inject.annotation.TypedAnnotationMapper;
 import io.micronaut.inject.visitor.VisitorContext;
 
-import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 
 public class NonNullProducingMapper implements TypedAnnotationMapper<NonNullStereotyped> {
     @Override
     public List<AnnotationValue<?>> map(AnnotationValue<NonNullStereotyped> annotation, VisitorContext visitorContext) {
-        return Collections.singletonList(AnnotationValue.builder(Nullable.class).build());
+        return Collections.singletonList(AnnotationValue.builder("javax.annotation.Nullable").build());
     }
 
     @Override

--- a/inject-java/src/test/groovy/io/micronaut/annotation/mapping/NonNullStereotyped.java
+++ b/inject-java/src/test/groovy/io/micronaut/annotation/mapping/NonNullStereotyped.java
@@ -1,0 +1,11 @@
+package io.micronaut.annotation.mapping;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface NonNullStereotyped {
+}

--- a/inject-java/src/test/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationMapper
+++ b/inject-java/src/test/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationMapper
@@ -4,3 +4,4 @@ io.micronaut.inject.annotation.CustomHeaderMapper
 io.micronaut.aop.introduction.ListenerAdviceMarkerMapper
 io.micronaut.aop.compile.AroundCompileSpec$NamedTestAnnMapper
 io.micronaut.annotation.mapping.CustomEmbeddedIdMapper
+io.micronaut.annotation.mapping.NonNullProducingMapper

--- a/inject/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -1430,6 +1430,14 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
             interceptorBindings.getLast().members(data);
             return;
         }
+        // special case: don't add stereotype for @Nonnull when it's marked as UNKNOWN/MAYBE/NEVER.
+        // https://github.com/micronaut-projects/micronaut-core/issues/6795
+        if (annotationName.equals("javax.annotation.Nonnull")) {
+            String when = Objects.toString(data.get("when"));
+            if (when.equals("UNKNOWN") || when.equals("MAYBE") || when.equals("NEVER")) {
+                return;
+            }
+        }
         if (hasInterceptorBinding && Type.class.getName().equals(annotationName)) {
             final Object o = data.get(AnnotationMetadata.VALUE_MEMBER);
             AnnotationClassValue<?> interceptorType = null;


### PR DESCRIPTION
`javax.annotation.Nullable` is annotated with `@Nonnull(when = When.UNKNOWN)`. This annotation needs to be skipped during stereotype copying, or the property in a class introspection will incorrectly return true for `AnnotatedElement.isNonNull`.

As discussed in #6795 this is not usually an issue because `Nullable` isn't usually visited for stereotype copying, but it turns out this can also happen with a `AnnotationMapper` that returns a `Nullable` annotation (see test case).

Fixes #6795