### PR TITLE
bug: Don't strip newlines proxying ServerSentEvents

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2022 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -898,6 +898,7 @@ public class DefaultHttpClient implements
                     requestKey.getPort(),
                     false,
                     false,
+                    false,
                     null
             ) {
                 @Override
@@ -1435,9 +1436,31 @@ public class DefaultHttpClient implements
             @Nullable SslContext sslCtx,
             boolean isStream,
             Consumer<ChannelHandlerContext> contextConsumer) throws HttpClientException {
+        return doConnect(request, uri, sslCtx, isStream, false, contextConsumer);
+    }
+
+    /**
+     * Creates an initial connection to the given remote host.
+     *
+     * @param request         The request
+     * @param uri             The URI to connect to
+     * @param sslCtx          The SslContext instance
+     * @param isStream        Is the connection a stream connection
+     * @param isProxy         Is this a streaming proxy
+     * @param contextConsumer The logic to run once the channel is configured correctly
+     * @return A ChannelFuture
+     * @throws HttpClientException If the URI is invalid
+     */
+    protected ChannelFuture doConnect(
+            io.micronaut.http.HttpRequest<?> request,
+            URI uri,
+            @Nullable SslContext sslCtx,
+            boolean isStream,
+            boolean isProxy,
+            Consumer<ChannelHandlerContext> contextConsumer) throws HttpClientException {
 
         RequestKey requestKey = new RequestKey(uri);
-        return doConnect(request, requestKey.getHost(), requestKey.getPort(), sslCtx, isStream, contextConsumer);
+        return doConnect(request, requestKey.getHost(), requestKey.getPort(), sslCtx, isStream, isProxy, contextConsumer);
     }
 
     /**
@@ -1458,6 +1481,29 @@ public class DefaultHttpClient implements
             @Nullable SslContext sslCtx,
             boolean isStream,
             Consumer<ChannelHandlerContext> contextConsumer) {
+        return doConnect(request, host, port, sslCtx, isStream, false, contextConsumer);
+    }
+
+    /**
+     * Creates an initial connection to the given remote host.
+     *
+     * @param request         The request
+     * @param host            The host
+     * @param port            The port
+     * @param sslCtx          The SslContext instance
+     * @param isStream        Is the connection a stream connection
+     * @param isProxy         Is this a streaming proxy
+     * @param contextConsumer The logic to run once the channel is configured correctly
+     * @return A ChannelFuture
+     */
+    protected ChannelFuture doConnect(
+            io.micronaut.http.HttpRequest<?> request,
+            String host,
+            int port,
+            @Nullable SslContext sslCtx,
+            boolean isStream,
+            boolean isProxy,
+            Consumer<ChannelHandlerContext> contextConsumer) {
         Bootstrap localBootstrap = this.bootstrap.clone();
         initBootstrapForProxy(localBootstrap, sslCtx != null, host, port);
         String acceptHeader = request.getHeaders().get(io.micronaut.http.HttpHeaders.ACCEPT);
@@ -1466,6 +1512,7 @@ public class DefaultHttpClient implements
                 host,
                 port,
                 isStream,
+                isProxy,
                 acceptHeader != null && acceptHeader.equalsIgnoreCase(MediaType.TEXT_EVENT_STREAM), contextConsumer)
         );
         return doConnect(localBootstrap, host, port);
@@ -2887,6 +2934,7 @@ public class DefaultHttpClient implements
                         key.getPort(),
                         false,
                         false,
+                        false,
                         null
                 ) {
                     @Override
@@ -2965,7 +3013,7 @@ public class DefaultHttpClient implements
                         try {
                             if (httpVersion == io.micronaut.http.HttpVersion.HTTP_2_0) {
 
-                                channelFuture = doConnect(request, requestURI, sslContext, true, channelHandlerContext -> {
+                                channelFuture = doConnect(request, requestURI, sslContext, true, true, channelHandlerContext -> {
                                     try {
                                         final Channel channel = channelHandlerContext.channel();
                                         request.setAttribute(NettyClientHttpRequest.CHANNEL, channel);
@@ -2981,7 +3029,7 @@ public class DefaultHttpClient implements
                                     }
                                 });
                             } else {
-                                channelFuture = doConnect(request, requestURI, sslContext, true, null);
+                                channelFuture = doConnect(request, requestURI, sslContext, true, true, null);
                                 addInstrumentedListener(channelFuture,
                                         (ChannelFutureListener) f -> {
                                             if (f.isSuccess()) {
@@ -3109,6 +3157,7 @@ public class DefaultHttpClient implements
         final String host;
         final int port;
         final boolean stream;
+        final boolean proxy;
         final boolean acceptsEvents;
         Http2SettingsHandler settingsHandler;
         private final Consumer<ChannelHandlerContext> contextConsumer;
@@ -3118,6 +3167,7 @@ public class DefaultHttpClient implements
          * @param host            The host
          * @param port            The port
          * @param stream          Whether is stream
+         * @param proxy           Is this a streaming proxy
          * @param acceptsEvents   Whether an event stream is accepted
          * @param contextConsumer The context consumer
          */
@@ -3126,12 +3176,14 @@ public class DefaultHttpClient implements
                 String host,
                 int port,
                 boolean stream,
+                boolean proxy,
                 boolean acceptsEvents,
                 Consumer<ChannelHandlerContext> contextConsumer) {
             this.sslContext = sslContext;
             this.stream = stream;
             this.host = host;
             this.port = port;
+            this.proxy = proxy;
             this.acceptsEvents = acceptsEvents;
             this.contextConsumer = contextConsumer;
         }
@@ -3248,7 +3300,8 @@ public class DefaultHttpClient implements
             // if the content type is a SSE event stream we add a decoder
             // to delimit the content by lines
             if (acceptsEventStream()) {
-                p.addLast(ChannelPipelineCustomizer.HANDLER_MICRONAUT_SSE_EVENT_STREAM, new LineBasedFrameDecoder(configuration.getMaxContentLength(), true, true) {
+                // If we are proxying, we should not strip the delimiter (see #6985)
+                p.addLast(ChannelPipelineCustomizer.HANDLER_MICRONAUT_SSE_EVENT_STREAM, new LineBasedFrameDecoder(configuration.getMaxContentLength(), !proxy, true) {
 
                     @Override
                     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {

--- a/http-client/src/test/groovy/io/micronaut/http/client/sse/ServerSentEventProxyingSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/sse/ServerSentEventProxyingSpec.groovy
@@ -1,0 +1,91 @@
+package io.micronaut.http.client.sse
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.util.StringUtils
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.MediaType
+import io.micronaut.http.MutableHttpResponse
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Filter
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.client.ProxyHttpClient
+import io.micronaut.http.filter.HttpServerFilter
+import io.micronaut.http.filter.ServerFilterChain
+import io.micronaut.http.sse.Event
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.annotation.ExecuteOn
+import jakarta.inject.Inject
+import org.reactivestreams.Publisher
+import reactor.core.publisher.Flux
+import spock.lang.AutoCleanup
+import spock.lang.Issue
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.time.Duration
+
+@Issue("https://github.com/micronaut-projects/micronaut-core/issues/6985")
+class ServerSentEventProxyingSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    ApplicationContext context = ApplicationContext.run(
+            'spec.name': 'ServerSentEventProxyingSpec'
+    )
+
+    @Shared
+    EmbeddedServer embeddedServer = context.getBean(EmbeddedServer).start()
+
+    @Shared
+    @AutoCleanup
+    SseClient sseClient = context.createBean(SseClient, embeddedServer.getURL())
+
+    void "test a request expecting a full response intercepted by a proxy providing a streaming response"() {
+        given:
+        def result = Flux.from(sseClient.eventStream("/proxy/events", String.class)).collectList().block()
+
+        expect:
+        result.data == ['EventNo: 1', 'EventNo: 2']
+    }
+
+    @Requires(property = "spec.name", value = "ServerSentEventProxyingSpec")
+    @Controller
+    @ExecuteOn(TaskExecutors.IO)
+    static class TestController {
+
+        @Get(value = "/real/events", produces = MediaType.TEXT_EVENT_STREAM)
+        public Flux<Event<String>> events() {
+            return Flux.range(1, 2)
+                    .delayElements(Duration.ofSeconds(1))
+                    .map(i -> Event.of("EventNo: " + i).name("TYPE1"));
+        }
+    }
+
+    @Requires(property = "spec.name", value = "ServerSentEventProxyingSpec")
+    @Filter("/proxy/**")
+    static class TestFilter implements HttpServerFilter {
+
+        @Inject
+        ProxyHttpClient client
+        @Inject
+        EmbeddedServer server
+
+        @Override
+        Publisher<MutableHttpResponse<?>> doFilter(HttpRequest<?> request, ServerFilterChain chain) {
+            return client.proxy( //
+                    request.mutate() //
+                            .uri(b -> b //
+                                    .scheme("http")
+                                    .host(server.getHost())
+                                    .port(server.getPort())
+                                    .replacePath(StringUtils.prependUri(
+                                            "/real",
+                                            request.getPath().substring("/proxy".length())
+                                    ))
+                            )
+            )
+        }
+    }
+}


### PR DESCRIPTION
When the HttpClient.proxy is used to proxy an SSE stream, we were stripping
delimiters from the data, which caused consumers of this that were sending;

```
Accept: text/event-stream
```

To get a single stripped event at the end of the stream, instead of the events
arriving individually as expected.

This change passes that we are proxying down to the `HttpClientInitializer`
so we can stop stripping delimiters if this is the case.

Fixes: #6985

Huge thanks to @yawkat for helping triage this