### PR TITLE
Allow querying enum constants as fields

### DIFF
--- a/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/ClassElementSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/ClassElementSpec.groovy
@@ -22,6 +22,7 @@ import io.micronaut.inject.ast.ClassElement
 import io.micronaut.inject.ast.ElementModifier
 import io.micronaut.inject.ast.ElementQuery
 import io.micronaut.inject.ast.EnumElement
+import io.micronaut.inject.ast.FieldElement
 import io.micronaut.inject.ast.MethodElement
 import io.micronaut.inject.ast.PackageElement
 import spock.lang.Issue
@@ -591,15 +592,46 @@ enum Test {
 }
 ''')
         when:
-            def allFields = classElement.getEnclosedElements(ElementQuery.ALL_FIELDS)
+        List<FieldElement> allFields = classElement.getEnclosedElements(ElementQuery.ALL_FIELDS)
+        List<String> expected = [
+                'A',
+                'B',
+                'C',
+                'publicStaticFinalField',
+                'publicStaticField',
+                'publicFinalField',
+                'publicField',
+                'protectedStaticFinalField',
+                'protectedStaticField',
+                'protectedFinalField',
+                'protectedField',
+                'packagePrivateStaticFinalField',
+                'packagePrivateStaticField',
+                'packagePrivateFinalField',
+                'packagePrivateField',
+                'privateStaticFinalField',
+                'privateStaticField',
+                'privateFinalField',
+                'privateField',
+                'MIN_VALUE',
+                'MAX_VALUE',
+                'name',
+                'ordinal',
+        ]
 
         then:
-            allFields.size() == 23 // + A, B, C, MIN_VALUE, MAX_VALUE, name, ordinal
+        for (String name : allFields*.name) {
+            assert expected.contains(name)
+        }
+        allFields.size() == expected.size()
 
         when:
-            def allFieldsWithEnums = classElement.getEnclosedElements(ElementQuery.ALL_FIELDS.includeEnumConstants())
+        allFields = classElement.getEnclosedElements(ElementQuery.ALL_FIELDS.includeEnumConstants())
 
         then:
-            allFieldsWithEnums.size() == 23
+        for (String name : allFields*.name) {
+            assert expected.contains(name)
+        }
+        allFields.size() == expected.size()
     }
 }

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/ClassElementSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/ClassElementSpec.groovy
@@ -559,4 +559,47 @@ class InvoicePO extends TransactionPO {
         expect:
         classElement.getBeanProperties().find { it.name == "discount" }.getType().hasAnnotation(SomeAnn)
     }
+
+    void "test find enum fields using ElementQuery"() {
+        given:
+            ClassElement classElement = buildClassElement('''
+package elementquery;
+
+enum Test {
+
+    A, B, C;
+
+    public static final String publicStaticFinalField = "";
+    public static String publicStaticField;
+    public final String publicFinalField = "";
+    public String publicField;
+
+    protected static final String protectedStaticFinalField = "";
+    protected static String protectedStaticField;
+    protected final String protectedFinalField = "";
+    protected String protectedField;
+
+    static final String packagePrivateStaticFinalField = "";
+    static String packagePrivateStaticField;
+    final String packagePrivateFinalField = "";
+    String packagePrivateField;
+
+    private static final String privateStaticFinalField = "";
+    private static String privateStaticField;
+    private final String privateFinalField = "";
+    private String privateField;
+}
+''')
+        when:
+            def allFields = classElement.getEnclosedElements(ElementQuery.ALL_FIELDS)
+
+        then:
+            allFields.size() == 23 // + A, B, C, MIN_VALUE, MAX_VALUE, name, ordinal
+
+        when:
+            def allFieldsWithEnums = classElement.getEnclosedElements(ElementQuery.ALL_FIELDS.includeEnumConstants())
+
+        then:
+            allFieldsWithEnums.size() == 23
+    }
 }

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
@@ -26,7 +26,6 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.reflect.ClassUtils;
-import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.ast.ArrayableClassElement;
 import io.micronaut.inject.ast.ClassElement;
@@ -536,6 +535,7 @@ public class JavaClassElement extends AbstractJavaElement implements ArrayableCl
         boolean onlyAbstract = result.isOnlyAbstract();
         boolean onlyConcrete = result.isOnlyConcrete();
         boolean onlyInstance = result.isOnlyInstance();
+        boolean includeEnumConstants = result.isIncludeEnumConstants();
 
         if (!onlyDeclared) {
             Elements elements = visitorContext.getElements();
@@ -681,7 +681,9 @@ public class JavaClassElement extends AbstractJavaElement implements ArrayableCl
         elementLoop:
         for (Element enclosedElement : enclosedElements) {
             ElementKind enclosedElementKind = enclosedElement.getKind();
-            if (enclosedElementKind == kind || (enclosedElementKind == ElementKind.ENUM && kind == ElementKind.CLASS)) {
+            if (enclosedElementKind == kind
+                    || includeEnumConstants && kind == ElementKind.FIELD && enclosedElementKind == ElementKind.ENUM_CONSTANT
+                    || (enclosedElementKind == ElementKind.ENUM && kind == ElementKind.CLASS)) {
                 String elementName = enclosedElement.getSimpleName().toString();
                 if (onlyAccessible) {
                     // exclude private members
@@ -750,6 +752,7 @@ public class JavaClassElement extends AbstractJavaElement implements ArrayableCl
                         );
                     break;
                     case FIELD:
+                    case ENUM_CONSTANT:
                         //noinspection unchecked
                         element = (T) elementFactory.newFieldElement(
                                 this,

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaGenericPlaceholderElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaGenericPlaceholderElement.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.annotation.processing.visitor;
 
+import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.inject.ast.ClassElement;
@@ -89,4 +90,8 @@ final class JavaGenericPlaceholderElement extends JavaClassElement implements Ge
         return fold.apply(this);
     }
 
+    @Override
+    public AnnotationMetadata getAnnotationMetadata() {
+        return super.getAnnotationMetadata();
+    }
 }

--- a/inject-java/src/test/groovy/io/micronaut/visitors/ClassElementSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/ClassElementSpec.groovy
@@ -1025,4 +1025,47 @@ class Person {
         !element.getBeanProperties()
     }
 
+    void "test find enum fields using ElementQuery"() {
+        given:
+            ClassElement classElement = buildClassElement('''
+package elementquery;
+
+enum Test {
+
+    A, B, C;
+
+    public static final String publicStaticFinalField = "";
+    public static String publicStaticField;
+    public final String publicFinalField = "";
+    public String publicField;
+
+    protected static final String protectedStaticFinalField = "";
+    protected static String protectedStaticField;
+    protected final String protectedFinalField = "";
+    protected String protectedField;
+
+    static final String packagePrivateStaticFinalField = "";
+    static String packagePrivateStaticField;
+    final String packagePrivateFinalField = "";
+    String packagePrivateField;
+
+    private static final String privateStaticFinalField = "";
+    private static String privateStaticField;
+    private final String privateFinalField = "";
+    private String privateField;
+}
+''')
+        when:
+            def allFields = classElement.getEnclosedElements(ElementQuery.ALL_FIELDS)
+
+        then:
+            allFields.size() == 16
+
+        when:
+            def allFieldsWithEnums = classElement.getEnclosedElements(ElementQuery.ALL_FIELDS.includeEnumConstants())
+
+        then:
+            allFieldsWithEnums.size() == 19
+    }
+
 }

--- a/inject-java/src/test/groovy/io/micronaut/visitors/ClassElementSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/ClassElementSpec.groovy
@@ -24,6 +24,7 @@ import io.micronaut.inject.ast.ConstructorElement
 import io.micronaut.inject.ast.ElementModifier
 import io.micronaut.inject.ast.ElementQuery
 import io.micronaut.inject.ast.EnumElement
+import io.micronaut.inject.ast.FieldElement
 import io.micronaut.inject.ast.MethodElement
 import io.micronaut.inject.ast.PackageElement
 import jakarta.inject.Singleton
@@ -1056,16 +1057,42 @@ enum Test {
 }
 ''')
         when:
-            def allFields = classElement.getEnclosedElements(ElementQuery.ALL_FIELDS)
+        List<FieldElement>  allFields = classElement.getEnclosedElements(ElementQuery.ALL_FIELDS)
+
+        List<String> expected = [
+                'publicStaticFinalField',
+                'publicStaticField',
+                'publicFinalField',
+                'publicField',
+                'protectedStaticFinalField',
+                'protectedStaticField',
+                'protectedFinalField',
+                'protectedField',
+                'packagePrivateStaticFinalField',
+                'packagePrivateStaticField',
+                'packagePrivateFinalField',
+                'packagePrivateField',
+                'privateStaticFinalField',
+                'privateStaticField',
+                'privateFinalField',
+                'privateField',
+        ]
 
         then:
-            allFields.size() == 16
+        for (String name : allFields*.name) {
+            assert expected.contains(name)
+        }
+        allFields.size() == expected.size()
 
         when:
-            def allFieldsWithEnums = classElement.getEnclosedElements(ElementQuery.ALL_FIELDS.includeEnumConstants())
+        allFields = classElement.getEnclosedElements(ElementQuery.ALL_FIELDS.includeEnumConstants())
+        expected = ['A', 'B', 'C'] + expected
 
         then:
-            allFieldsWithEnums.size() == 19
+        for (String name : allFields*.name) {
+            assert expected.contains(name)
+        }
+        allFields.size() == expected.size()
     }
 
 }

--- a/inject/src/main/java/io/micronaut/inject/ast/DefaultElementQuery.java
+++ b/inject/src/main/java/io/micronaut/inject/ast/DefaultElementQuery.java
@@ -21,11 +21,15 @@ import io.micronaut.core.annotation.AnnotationUtil;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 
-import java.util.*;
-import java.util.function.Predicate;
-
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
 
 @Internal
 final class DefaultElementQuery<T extends Element> implements ElementQuery<T>, ElementQuery.Result<T> {
@@ -42,9 +46,10 @@ final class DefaultElementQuery<T extends Element> implements ElementQuery<T>, E
     private final List<Predicate<T>> elementPredicates;
     private final List<Predicate<ClassElement>> typePredicates;
     private final boolean onlyInstance;
+    private final boolean includeEnumConstants;
 
     DefaultElementQuery(Class<T> elementType) {
-        this(elementType, null, false, false, false, false, false, null, null, null, null, null);
+        this(elementType, null, false, false, false, false, false, false, null, null, null, null, null);
     }
 
     DefaultElementQuery(
@@ -55,6 +60,7 @@ final class DefaultElementQuery<T extends Element> implements ElementQuery<T>, E
             boolean onlyConcrete,
             boolean onlyInjected,
             boolean onlyInstance,
+            boolean includeEnumConstants,
             List<Predicate<AnnotationMetadata>> annotationPredicates,
             List<Predicate<Set<ElementModifier>>> modifiersPredicates,
             List<Predicate<T>> elementPredicates,
@@ -70,6 +76,7 @@ final class DefaultElementQuery<T extends Element> implements ElementQuery<T>, E
         this.modifiersPredicates = modifiersPredicates;
         this.elementPredicates = elementPredicates;
         this.onlyInstance = onlyInstance;
+        this.includeEnumConstants = includeEnumConstants;
         this.typePredicates = typePredicates;
     }
 
@@ -114,6 +121,11 @@ final class DefaultElementQuery<T extends Element> implements ElementQuery<T>, E
     @Override
     public boolean isOnlyInstance() {
         return onlyInstance;
+    }
+
+    @Override
+    public boolean isIncludeEnumConstants() {
+        return includeEnumConstants;
     }
 
     @Override
@@ -165,7 +177,9 @@ final class DefaultElementQuery<T extends Element> implements ElementQuery<T>, E
                 true,
                 onlyAbstract, onlyConcrete,
                 onlyInjected,
-                onlyInstance, annotationPredicates, modifiersPredicates, elementPredicates, namePredicates,
+                onlyInstance,
+                includeEnumConstants,
+                annotationPredicates, modifiersPredicates, elementPredicates, namePredicates,
                 typePredicates);
     }
 
@@ -180,9 +194,12 @@ final class DefaultElementQuery<T extends Element> implements ElementQuery<T>, E
         return new DefaultElementQuery<>(
                 elementType, onlyAccessibleType,
                 onlyDeclared,
-                onlyAbstract, onlyConcrete,
+                onlyAbstract,
+                onlyConcrete,
                 true,
-                onlyInstance, annotationPredicates, modifiersPredicates, elementPredicates, namePredicates,
+                onlyInstance,
+                includeEnumConstants,
+                annotationPredicates, modifiersPredicates, elementPredicates, namePredicates,
                 typePredicates);
     }
 
@@ -194,7 +211,9 @@ final class DefaultElementQuery<T extends Element> implements ElementQuery<T>, E
                 onlyDeclared,
                 onlyAbstract, true,
                 onlyInjected,
-                onlyInstance, annotationPredicates, modifiersPredicates, elementPredicates, namePredicates,
+                onlyInstance,
+                includeEnumConstants,
+                annotationPredicates, modifiersPredicates, elementPredicates, namePredicates,
                 typePredicates);
     }
 
@@ -206,7 +225,9 @@ final class DefaultElementQuery<T extends Element> implements ElementQuery<T>, E
                 onlyDeclared,
                 true, onlyConcrete,
                 onlyInjected,
-                onlyInstance, annotationPredicates, modifiersPredicates, elementPredicates, namePredicates,
+                onlyInstance,
+                includeEnumConstants,
+                annotationPredicates, modifiersPredicates, elementPredicates, namePredicates,
                 typePredicates);
     }
 
@@ -219,7 +240,9 @@ final class DefaultElementQuery<T extends Element> implements ElementQuery<T>, E
                 onlyDeclared,
                 onlyAbstract, onlyConcrete,
                 onlyInjected,
-                onlyInstance, annotationPredicates, modifiersPredicates, elementPredicates, namePredicates,
+                onlyInstance,
+                includeEnumConstants,
+                annotationPredicates, modifiersPredicates, elementPredicates, namePredicates,
                 typePredicates);
     }
 
@@ -232,7 +255,9 @@ final class DefaultElementQuery<T extends Element> implements ElementQuery<T>, E
                 onlyDeclared,
                 onlyAbstract, onlyConcrete,
                 onlyInjected,
-                onlyInstance, annotationPredicates, modifiersPredicates, elementPredicates, namePredicates,
+                onlyInstance,
+                includeEnumConstants,
+                annotationPredicates, modifiersPredicates, elementPredicates, namePredicates,
                 typePredicates);
     }
 
@@ -243,7 +268,22 @@ final class DefaultElementQuery<T extends Element> implements ElementQuery<T>, E
                 onlyDeclared,
                 onlyAbstract, onlyConcrete,
                 onlyInjected,
-                true, annotationPredicates, modifiersPredicates, elementPredicates, namePredicates,
+                true,
+                includeEnumConstants,
+                annotationPredicates, modifiersPredicates, elementPredicates, namePredicates,
+                typePredicates);
+    }
+
+    @Override
+    public ElementQuery<T> includeEnumConstants() {
+        return new DefaultElementQuery<>(
+                elementType, onlyAccessibleType,
+                onlyDeclared,
+                onlyAbstract, onlyConcrete,
+                onlyInjected,
+                onlyInstance,
+                true,
+                annotationPredicates, modifiersPredicates, elementPredicates, namePredicates,
                 typePredicates);
     }
 
@@ -264,7 +304,7 @@ final class DefaultElementQuery<T extends Element> implements ElementQuery<T>, E
                 onlyDeclared,
                 onlyAbstract,
                 onlyConcrete,
-                onlyInjected, onlyInstance,
+                onlyInjected, onlyInstance, includeEnumConstants,
                 annotationPredicates,
                 modifiersPredicates,
                 elementPredicates,
@@ -289,7 +329,7 @@ final class DefaultElementQuery<T extends Element> implements ElementQuery<T>, E
                 onlyDeclared,
                 onlyAbstract,
                 onlyConcrete,
-                onlyInjected, onlyInstance,
+                onlyInjected, onlyInstance, includeEnumConstants,
                 annotationPredicates,
                 modifiersPredicates,
                 elementPredicates,
@@ -313,7 +353,8 @@ final class DefaultElementQuery<T extends Element> implements ElementQuery<T>, E
                 onlyDeclared,
                 onlyAbstract, onlyConcrete,
                 onlyInjected,
-                onlyInstance, annotationPredicates, modifiersPredicates, elementPredicates, namePredicates,
+                onlyInstance, includeEnumConstants,
+                annotationPredicates, modifiersPredicates, elementPredicates, namePredicates,
                 typePredicates);
     }
 
@@ -332,7 +373,8 @@ final class DefaultElementQuery<T extends Element> implements ElementQuery<T>, E
                 elementType, onlyAccessibleType,
                 onlyDeclared, onlyAbstract, onlyConcrete,
                 onlyInjected,
-                onlyInstance, annotationPredicates, modifierPredicates, elementPredicates, namePredicates,
+                onlyInstance, includeEnumConstants,
+                annotationPredicates, modifierPredicates, elementPredicates, namePredicates,
                 typePredicates);
     }
 
@@ -351,7 +393,8 @@ final class DefaultElementQuery<T extends Element> implements ElementQuery<T>, E
                 elementType, onlyAccessibleType,
                 onlyDeclared, onlyAbstract, onlyConcrete,
                 onlyInjected,
-                onlyInstance, annotationPredicates, modifiersPredicates, elementPredicates, namePredicates,
+                onlyInstance, includeEnumConstants,
+                annotationPredicates, modifiersPredicates, elementPredicates, namePredicates,
                 typePredicates);
     }
 

--- a/inject/src/main/java/io/micronaut/inject/ast/ElementQuery.java
+++ b/inject/src/main/java/io/micronaut/inject/ast/ElementQuery.java
@@ -117,6 +117,13 @@ public interface ElementQuery<T extends Element> {
     ElementQuery<T> onlyInstance();
 
     /**
+     * Indicates to include enum constants, only applicable for fields query.
+     * @since 3.4.0
+     * @return The query
+     */
+    ElementQuery<T> includeEnumConstants();
+
+    /**
      * Allows filtering elements by name.
      * @param predicate The predicate to use. Should return true to include the element.
      * @return This query
@@ -216,6 +223,12 @@ public interface ElementQuery<T extends Element> {
          * @return Whether to return only instance methods
          */
         boolean isOnlyInstance();
+
+        /**
+         * @return Whether to include enum constants
+         * @since 3.4.0
+         */
+        boolean isIncludeEnumConstants();
 
         /**
          * @return The name predicates


### PR DESCRIPTION
CDI land model spec is checking for enum fields.

Groovy does already returns them with some other extra fields.