### PR TITLE
micronaut-data issue 1378

### DIFF
--- a/core/src/main/java/io/micronaut/core/naming/NameUtils.java
+++ b/core/src/main/java/io/micronaut/core/naming/NameUtils.java
@@ -38,7 +38,7 @@ public class NameUtils {
     private static final Pattern SERVICE_ID_REGEX = Pattern.compile("[\\p{javaLowerCase}\\d-]+");
     private static final String PREFIX_GET = "get";
     private static final String PREFIX_SET = "set";
-    private static final String PREFIX_IS = "is";
+    public static final String PREFIX_IS = "is";
     private static final Pattern ENVIRONMENT_VAR_SEQUENCE = Pattern.compile("^[\\p{Lu}_{0-9}]+");
     private static final Pattern KEBAB_CASE_SEQUENCE = Pattern.compile("^(([a-z0-9])+([-.:])?)*([a-z0-9])+$");
     private static final Pattern KEBAB_REPLACEMENTS = Pattern.compile("[_ ]");

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
@@ -3763,15 +3763,12 @@ class MyConfig {
         then:
         BeanIntrospection beanIntrospection = beanIntrospector.getIntrospection(TestMatchingGetterClass)
         beanIntrospection != null
-        beanIntrospection.getBeanProperties().size() == 4
+        beanIntrospection.getBeanProperties().size() == 2
         String[] propertyNames = beanIntrospection.getPropertyNames()
-        propertyNames.contains("getName")
-        !propertyNames.contains("name")
+        propertyNames.contains("name")
+        !propertyNames.contains("getName")
         propertyNames.contains("isDeleted")
         !propertyNames.contains("deleted")
-        propertyNames.contains("author")
-        propertyNames.contains("getTest")
-        !propertyNames.contains("test")
     }
 
     void "test targeting abstract class with @Introspected(classes = ) with custom getter"() {

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
@@ -3763,13 +3763,15 @@ class MyConfig {
         then:
         BeanIntrospection beanIntrospection = beanIntrospector.getIntrospection(TestMatchingGetterClass)
         beanIntrospection != null
-        beanIntrospection.getBeanProperties().size() == 3
+        beanIntrospection.getBeanProperties().size() == 4
         String[] propertyNames = beanIntrospection.getPropertyNames()
         propertyNames.contains("getName")
         !propertyNames.contains("name")
         propertyNames.contains("isDeleted")
         !propertyNames.contains("deleted")
         propertyNames.contains("author")
+        propertyNames.contains("getTest")
+        !propertyNames.contains("test")
     }
 
     void "test targeting abstract class with @Introspected(classes = ) with custom getter"() {

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
@@ -3745,6 +3745,33 @@ class MyConfig {
         beanIntrospection.getBeanProperties().size() == 2
     }
 
+    void "test targeting abstract class with @Introspected(classes = ) with getter matching field name"() {
+        ClassLoader classLoader = buildClassLoader("test.Test", """
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected(classes = {io.micronaut.inject.visitor.beans.TestMatchingGetterClass.class})
+class MyConfig {
+
+}
+""")
+
+        when:
+        BeanIntrospector beanIntrospector = BeanIntrospector.forClassLoader(classLoader)
+
+        then:
+        BeanIntrospection beanIntrospection = beanIntrospector.getIntrospection(TestMatchingGetterClass)
+        beanIntrospection != null
+        beanIntrospection.getBeanProperties().size() == 3
+        String[] propertyNames = beanIntrospection.getPropertyNames()
+        propertyNames.contains("getName")
+        !propertyNames.contains("name")
+        propertyNames.contains("isDeleted")
+        !propertyNames.contains("deleted")
+        propertyNames.contains("author")
+    }
+
     void "test targeting abstract class with @Introspected(classes = ) with custom getter"() {
         ClassLoader classLoader = buildClassLoader("test.Test", """
 package test;

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/TestMatchingGetterClass.java
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/TestMatchingGetterClass.java
@@ -3,8 +3,7 @@ package io.micronaut.inject.visitor.beans;
 public abstract class TestMatchingGetterClass {
 
     private Boolean isDeleted;
-    private String getName;
-    private String author;
+    private String name;
 
     public Boolean isDeleted() {
         return isDeleted;
@@ -15,23 +14,10 @@ public abstract class TestMatchingGetterClass {
     }
 
     public String getName() {
-        return getName;
+        return name;
     }
 
-    public void setGetName(String getName) {
-        this.getName = getName;
+    public void setName(String name) {
+        this.name = name;
     }
-
-    public String getAuthor() {
-        return author;
-    }
-
-    public void setAuthor(String author) {
-        this.author = author;
-    }
-
-    // out of order test
-    public Integer getGetTest() { return getTest; }
-
-    private Integer getTest;
 }

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/TestMatchingGetterClass.java
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/TestMatchingGetterClass.java
@@ -29,4 +29,9 @@ public abstract class TestMatchingGetterClass {
     public void setAuthor(String author) {
         this.author = author;
     }
+
+    // out of order test
+    public Integer getGetTest() { return getTest; }
+
+    private Integer getTest;
 }

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/TestMatchingGetterClass.java
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/TestMatchingGetterClass.java
@@ -1,0 +1,32 @@
+package io.micronaut.inject.visitor.beans;
+
+public abstract class TestMatchingGetterClass {
+
+    private Boolean isDeleted;
+    private String getName;
+    private String author;
+
+    public Boolean isDeleted() {
+        return isDeleted;
+    }
+
+    public void setDeleted(Boolean isDeleted) {
+        this.isDeleted = isDeleted;
+    }
+
+    public String getName() {
+        return getName;
+    }
+
+    public void setGetName(String getName) {
+        this.getName = getName;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(String author) {
+        this.author = author;
+    }
+}

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
@@ -371,8 +371,8 @@ public class JavaClassElement extends AbstractJavaElement implements ArrayableCl
                         ExecutableElement executableElement = (ExecutableElement) element;
                         String methodName = executableElement.getSimpleName().toString();
                         final TypeElement declaringTypeElement = (TypeElement) executableElement.getEnclosingElement();
-                        if (NameUtils.isReaderName(methodName, readPrefixes) && executableElement.getParameters().isEmpty()) {
 
+                        if (NameUtils.isReaderName(methodName, readPrefixes) && executableElement.getParameters().isEmpty()) {
                             String propertyName;
                             if (fields.containsKey(methodName)) {
                                 propertyName = methodName;

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
@@ -371,9 +371,13 @@ public class JavaClassElement extends AbstractJavaElement implements ArrayableCl
                         ExecutableElement executableElement = (ExecutableElement) element;
                         String methodName = executableElement.getSimpleName().toString();
                         final TypeElement declaringTypeElement = (TypeElement) executableElement.getEnclosingElement();
-
                         if (NameUtils.isReaderName(methodName, readPrefixes) && executableElement.getParameters().isEmpty()) {
-                            String propertyName = NameUtils.getPropertyNameForGetter(methodName, readPrefixes);
+                            String propertyName;
+                            if (fields.containsKey(methodName)) {
+                                propertyName = methodName;
+                            } else {
+                                propertyName = NameUtils.getPropertyNameForGetter(methodName, readPrefixes);
+                            }
                             TypeMirror returnType = executableElement.getReturnType();
                             ClassElement getterReturnType;
                             if (returnType instanceof TypeVariable) {

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
@@ -374,7 +374,7 @@ public class JavaClassElement extends AbstractJavaElement implements ArrayableCl
 
                         if (NameUtils.isReaderName(methodName, readPrefixes) && executableElement.getParameters().isEmpty()) {
                             String propertyName;
-                            if (fields.containsKey(methodName)) {
+                            if (methodName.startsWith(NameUtils.PREFIX_IS) && fields.containsKey(methodName)) {
                                 propertyName = methodName;
                             } else {
                                 propertyName = NameUtils.getPropertyNameForGetter(methodName, readPrefixes);

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
@@ -372,6 +372,7 @@ public class JavaClassElement extends AbstractJavaElement implements ArrayableCl
                         String methodName = executableElement.getSimpleName().toString();
                         final TypeElement declaringTypeElement = (TypeElement) executableElement.getEnclosingElement();
                         if (NameUtils.isReaderName(methodName, readPrefixes) && executableElement.getParameters().isEmpty()) {
+
                             String propertyName;
                             if (fields.containsKey(methodName)) {
                                 propertyName = methodName;


### PR DESCRIPTION
With regards to this issue: https://github.com/micronaut-projects/micronaut-data/issues/1378

In cases where a field matches a getter exactly, a property should not be extracted but rather just passed through.

kotlin example:
```kotlin
class TestEntity(val isDeleted: Boolean)
```
turns into jvm byte code roughly representing this java code:
```java
class TestEntity {
    private Boolean isDeleted;
    public Boolean isDeleted() { return isDeleted; }
    // this part bums be out as it makes it seem difficult to correctly identify in the setter path
    // hence why I ignored it in this PR
    public void setDeleted(deleted: Boolean) {
        isDeleted = deleted;
    }
}
```