### PR TITLE
Correct Java implementation if `PackageElement#getName` method

### DIFF
--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyPackageElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyPackageElement.java
@@ -15,9 +15,9 @@
  */
 package io.micronaut.ast.groovy.visitor;
 
-import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.inject.ast.PackageElement;
 import org.codehaus.groovy.ast.PackageNode;
 
@@ -51,6 +51,16 @@ public class GroovyPackageElement extends AbstractGroovyElement implements Packa
             return n.substring(0, n.length() - 1);
         }
         return n;
+    }
+
+    @Override
+    public String getSimpleName() {
+        String name = getName();
+        int index = name.lastIndexOf(".");
+        if (index > -1) {
+            return name.substring(index + 1);
+        }
+        return name;
     }
 
     @Override

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/ClassElementSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/ClassElementSpec.groovy
@@ -132,6 +132,24 @@ class PckElementTest {
 
         expect:
         pe.name == 'pkgeltest'
+        pe.simpleName == 'pkgeltest'
+        pe.getClass().name.contains("GroovyPackageElement")
+    }
+
+    void "test get full package element"() {
+        given:
+        def element = buildClassElement('''
+package abc.my.pkgeltest;
+
+class PckElementTest {
+
+}
+''')
+        PackageElement pe = element.getPackage()
+
+        expect:
+        pe.name == 'abc.my.pkgeltest'
+        pe.simpleName == 'pkgeltest'
         pe.getClass().name.contains("GroovyPackageElement")
     }
 

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaPackageElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaPackageElement.java
@@ -28,6 +28,9 @@ import javax.lang.model.element.PackageElement;
  */
 @Internal
 public class JavaPackageElement extends AbstractJavaElement implements io.micronaut.inject.ast.PackageElement {
+
+    private final PackageElement element;
+
     /**
      * @param element            The {@link PackageElement}
      * @param annotationMetadata The Annotation metadata
@@ -38,5 +41,16 @@ public class JavaPackageElement extends AbstractJavaElement implements io.micron
             AnnotationMetadata annotationMetadata,
             JavaVisitorContext visitorContext) {
         super(element, annotationMetadata, visitorContext);
+        this.element = element;
+    }
+
+    @Override
+    public String getName() {
+        return element.getQualifiedName().toString();
+    }
+
+    @Override
+    public String getSimpleName() {
+        return element.getSimpleName().toString();
     }
 }

--- a/inject-java/src/test/groovy/io/micronaut/visitors/ClassElementSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/ClassElementSpec.groovy
@@ -197,6 +197,23 @@ class PckElementTest {
         pe.getClass().name.contains("JavaPackageElement")
     }
 
+    void "test get full package element"() {
+        given:
+        def element = buildClassElement('''
+package abc.my.pkgeltest;
+
+class PckElementTest {
+
+}
+''')
+        PackageElement pe = element.getPackage()
+
+        expect:
+        pe.name == 'abc.my.pkgeltest'
+        pe.simpleName == 'pkgeltest'
+        pe.getClass().name.contains("JavaPackageElement")
+    }
+
     @Issue('https://github.com/micronaut-projects/micronaut-core/issues/5611')
     void 'test visit enum with custom annotation'() {
         when: "An enum has an annotation that is visited by CustomAnnVisitor"


### PR DESCRIPTION
It needs to return the full path like the Groovy impl not just the last name.