### PR TITLE
Allow defining additional beans with processed methods

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/BuildElementBuilderProcessedMethodsSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/BuildElementBuilderProcessedMethodsSpec.groovy
@@ -1,18 +1,15 @@
 package io.micronaut.inject.beanbuilder
 
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
-import io.micronaut.context.annotation.Prototype
 import io.micronaut.core.annotation.AnnotationUtil
 import io.micronaut.inject.ast.ClassElement
 import io.micronaut.inject.ast.ElementQuery
-import io.micronaut.inject.ast.FieldElement
 import io.micronaut.inject.ast.MethodElement
 import io.micronaut.inject.ast.beans.BeanElementBuilder
 import io.micronaut.inject.visitor.TypeElementVisitor
 import io.micronaut.inject.visitor.VisitorContext
-import jakarta.inject.Singleton
 
-class BuildElementBuilderScheduledSpec extends AbstractTypeElementSpec {
+class BuildElementBuilderProcessedMethodsSpec extends AbstractTypeElementSpec {
 
     void "test that bean definitions can be processed on startup"() {
         given:
@@ -26,8 +23,21 @@ class Foo {
     
 }
 ''')
-        expect:
-        context.getBeanDefinition(TestBeanScheduled).requiresMethodProcessing()
+
+        when:
+        def definition = context.getBeanDefinition(TestBeanScheduled)
+        def method = definition.getRequiredMethod("scheduleMe")
+
+        then:
+        definition.requiresMethodProcessing()
+        method != null
+
+        when:
+        def testBean = context.getBean(TestBeanScheduled)
+        def result = method.invoke(testBean)
+
+        then:
+        result == 'good'
 
         cleanup:
         context.close()
@@ -63,8 +73,8 @@ class Foo {
     }
 
     static class TestBeanScheduled {
-        void scheduleMe() {
-            println "running"
+        String scheduleMe() {
+            "good"
         }
     }
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/BuildElementBuilderScheduledSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/BuildElementBuilderScheduledSpec.groovy
@@ -1,0 +1,70 @@
+package io.micronaut.inject.beanbuilder
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.annotation.Prototype
+import io.micronaut.core.annotation.AnnotationUtil
+import io.micronaut.inject.ast.ClassElement
+import io.micronaut.inject.ast.ElementQuery
+import io.micronaut.inject.ast.FieldElement
+import io.micronaut.inject.ast.MethodElement
+import io.micronaut.inject.ast.beans.BeanElementBuilder
+import io.micronaut.inject.visitor.TypeElementVisitor
+import io.micronaut.inject.visitor.VisitorContext
+import jakarta.inject.Singleton
+
+class BuildElementBuilderScheduledSpec extends AbstractTypeElementSpec {
+
+    void "test that bean definitions can be processed on startup"() {
+        given:
+        def context = buildContext('''
+package factorybuilder;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+class Foo {
+    
+}
+''')
+        expect:
+        context.getBeanDefinition(TestBeanScheduled).requiresMethodProcessing()
+
+        cleanup:
+        context.close()
+    }
+
+    @Override
+    protected Collection<TypeElementVisitor> getLocalTypeElementVisitors() {
+        [new TestAddAssociatedScheduledVisitor()]
+    }
+
+    static class TestAddAssociatedScheduledVisitor implements TypeElementVisitor {
+        @Override
+        VisitorKind getVisitorKind() {
+            return VisitorKind.ISOLATING
+        }
+
+        @Override
+        void visitClass(ClassElement element, VisitorContext context) {
+            if (element.hasAnnotation(AnnotationUtil.SINGLETON)){
+
+                context.getClassElement(TestBeanScheduled.class)
+                        .ifPresent((scheduled) -> {
+                            final BeanElementBuilder beanElementBuilder = element.addAssociatedBean(scheduled);
+                            final ElementQuery<MethodElement> query = ElementQuery.ALL_METHODS
+                                    .onlyInstance()
+                                    .onlyDeclared()
+                            beanElementBuilder.withMethods(query, { method ->
+                                method.executable(true)
+                            })
+                        });
+            }
+        }
+    }
+
+    static class TestBeanScheduled {
+        void scheduleMe() {
+            println "running"
+        }
+    }
+}

--- a/inject/src/main/java/io/micronaut/inject/ast/beans/BeanMethodElement.java
+++ b/inject/src/main/java/io/micronaut/inject/ast/beans/BeanMethodElement.java
@@ -42,6 +42,21 @@ public interface BeanMethodElement extends MethodElement {
     }
 
     /**
+     * Make the method executable.
+     *
+     * @param processOnStartup Whether to process on startup
+     * @return This bean method
+     * @since 3.4.0
+     */
+    default @NonNull
+    BeanMethodElement executable(boolean processOnStartup) {
+        annotate(Executable.class, (builder) ->
+            builder.member("processOnStartup", processOnStartup)
+        );
+        return this;
+    }
+
+    /**
      * Make the method injected.
      *
      * @return This bean method

--- a/inject/src/main/java/io/micronaut/inject/ast/beans/BeanMethodElement.java
+++ b/inject/src/main/java/io/micronaut/inject/ast/beans/BeanMethodElement.java
@@ -50,9 +50,7 @@ public interface BeanMethodElement extends MethodElement {
      */
     default @NonNull
     BeanMethodElement executable(boolean processOnStartup) {
-        annotate(Executable.class, (builder) ->
-            builder.member("processOnStartup", processOnStartup)
-        );
+        annotate(Executable.class, builder -> builder.member("processOnStartup", processOnStartup));
         return this;
     }
 

--- a/inject/src/main/java/io/micronaut/inject/writer/AbstractBeanDefinitionBuilder.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/AbstractBeanDefinitionBuilder.java
@@ -16,6 +16,7 @@
 package io.micronaut.inject.writer;
 
 import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Executable;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Value;
 import io.micronaut.core.annotation.AnnotationClassValue;
@@ -583,6 +584,9 @@ public abstract class AbstractBeanDefinitionBuilder implements BeanElementBuilde
                     executableMethod,
                     visitorContext
             );
+            if (executableMethod.getAnnotationMetadata().isTrue(Executable.class, "processOnStartup")) {
+                beanDefinitionWriter.setRequiresMethodProcessing(true);
+            }
         }
 
         for (BeanMethodElement postConstructMethod : postConstructMethods) {
@@ -848,6 +852,14 @@ public abstract class AbstractBeanDefinitionBuilder implements BeanElementBuilde
                 AbstractBeanDefinitionBuilder.this.executableMethods.add(this);
             }
             return BeanMethodElement.super.executable();
+        }
+
+        @Override
+        public BeanMethodElement executable(boolean processOnStartup) {
+            if (!AbstractBeanDefinitionBuilder.this.executableMethods.contains(this)) {
+                AbstractBeanDefinitionBuilder.this.executableMethods.add(this);
+            }
+            return BeanMethodElement.super.executable(processOnStartup);
         }
 
         @NonNull


### PR DESCRIPTION
Currently it is not possible to define an additional bean that has a processed method. Trying to fix issues with the CDI TCK.