### PR TITLE
Referencing bean properties in annotations

### DIFF
--- a/aop/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
+++ b/aop/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
@@ -1265,19 +1265,6 @@ public class AopProxyWriter extends AbstractClassFileWriter implements ProxyingB
     }
 
     @Override
-    public void visitAnnotationMemberPropertyInjectionPoint(TypedElement annotationMemberBeanType,
-                                                            String annotationMemberProperty,
-                                                            String requiredValue,
-                                                            String notEqualsValue) {
-        deferredInjectionPoints.add(() ->
-                proxyBeanDefinitionWriter.visitAnnotationMemberPropertyInjectionPoint(
-                    annotationMemberBeanType,
-                    annotationMemberProperty,
-                    requiredValue,
-                    notEqualsValue));
-    }
-
-    @Override
     public void visitFieldValue(
             TypedElement declaringType,
             FieldElement fieldType,

--- a/context/src/main/java/io/micronaut/scheduling/annotation/Scheduled.java
+++ b/context/src/main/java/io/micronaut/scheduling/annotation/Scheduled.java
@@ -74,4 +74,55 @@ public @interface Scheduled {
      * {@link java.util.concurrent.ScheduledExecutorService} to use to schedule the task
      */
     String scheduler() default TaskExecutors.SCHEDULED;
+
+    /**
+     * The type of bean which properties can be referenced
+     * in other annotation members like {@link #cronProperty()}.
+     * The bean owning specified properties should be present within context for
+     * the property value to be resolved
+     *
+     * @since 3.4.0
+     * @return the bean to be used for property resolving
+     */
+    Class<?> bean() default void.class;
+
+    /**
+     * The property of {@link #bean()} containing CRON expression.
+     * Only to be used in conjunction with {@link #bean()}.
+     *
+     * @since 3.4.0
+     * @return name of bean property containing CRON expression
+     */
+    String cronProperty() default "";
+
+    /**
+     * The property of {@link #bean()} containing a {@link java.time.Duration} or a
+     * String representation of duration between the time of the last execution and the
+     * beginning of the next.
+     * Only to be used in conjunction with {@link #bean()}
+     *
+     * @since 3.4.0
+     * @return name of bean property containing fixed delay
+     */
+    String fixedDelayProperty() default "";
+
+    /**
+     * The property of {@link #bean()} containing a {@link java.time.Duration} or a
+     * String representation of duration before starting executions.
+     * Only to be used in conjunction with {@link #bean()}
+     *
+     * @since 3.4.0
+     * @return name of bean property containing initial delay
+     */
+    String initialDelayProperty() default "";
+
+    /**
+     * The property of {@link #bean()} containing a {@link java.time.Duration} or a
+     * String representation of duration between executions.
+     * Only to be used in conjunction with {@link #bean()}
+     *
+     * @since 3.4.0
+     * @return name of bean property containing fixed rate
+     */
+    String fixedRateProperty() default "";
 }

--- a/context/src/test/groovy/io/micronaut/scheduling/beanproperties/JavaPropertiesTask.java
+++ b/context/src/test/groovy/io/micronaut/scheduling/beanproperties/JavaPropertiesTask.java
@@ -1,0 +1,25 @@
+package io.micronaut.scheduling.beanproperties;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.scheduling.annotation.Scheduled;
+import jakarta.inject.Singleton;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * @author graemerocher
+ * @since 1.0
+ */
+@Singleton
+@Requires(property = "spec.name", value = "ScheduledBeanPropertiesSpec")
+@Requires(property = "scheduled-test.task.enabled", value = StringUtils.TRUE)
+public class JavaPropertiesTask {
+    AtomicInteger fixedRateEvents = new AtomicInteger(0);
+
+    @Scheduled(bean = TestConfig.class, fixedRateProperty = "stringFixedRate")
+    @Scheduled(bean = TestConfig.class, fixedRateProperty = "durationFixedRate")
+    void runFixed() {
+        fixedRateEvents.incrementAndGet();
+    }
+}

--- a/context/src/test/groovy/io/micronaut/scheduling/beanproperties/ScheduledBeanPropertiesSpec.groovy
+++ b/context/src/test/groovy/io/micronaut/scheduling/beanproperties/ScheduledBeanPropertiesSpec.groovy
@@ -1,0 +1,97 @@
+package io.micronaut.scheduling.beanproperties
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.scheduling.annotation.Scheduled
+import jakarta.inject.Singleton
+import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
+
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicInteger
+
+class ScheduledBeanPropertiesSpec extends Specification {
+
+    void 'test schedule task at fixed delay or rate '() {
+        given:
+        ApplicationContext beanContext = ApplicationContext.run(
+                'scheduled-test.task.enabled':true,
+                'spec.name': 'ScheduledBeanPropertiesSpec',
+                'scheduling.string-fixed-rate': '5s',
+                'scheduling.duration-fixed-rate': '6s'
+        )
+
+        PollingConditions conditions = new PollingConditions(timeout: 7)
+
+        when:
+        PropertiesTask propertiesTask = beanContext.getBean(PropertiesTask)
+        JavaPropertiesTask javaPropertiesTask = beanContext.getBean(JavaPropertiesTask)
+
+        then:
+        !propertiesTask.wasDelayedRun
+        conditions.eventually {
+            propertiesTask.wasRun
+            propertiesTask.fixedDelayWasRun
+            javaPropertiesTask.fixedRateEvents.get() == 2
+        }
+
+        and:
+        conditions.eventually {
+            propertiesTask.wasRun
+            propertiesTask.cronEvents.get() >= 2
+            propertiesTask.cronEventsNoSeconds.get() >= 0
+            propertiesTask.wasDelayedRun
+        }
+
+        cleanup:
+        beanContext.close()
+    }
+
+    @Singleton
+    static class SchedulingConfig {
+
+        String cron = '1/3 0/1 * 1/1 * ?';
+        String cronNoSeconds = '0/1 * 1/1 * ?';
+        Duration fixedRate = Duration.ofMillis(10);
+        Duration fixedDelay = Duration.ofMillis(10);
+        Duration initialDelay = Duration.ofSeconds(1)
+
+    }
+
+    @Singleton
+    @Requires(property = 'spec.name', value = 'ScheduledBeanPropertiesSpec')
+    @Requires(property = 'scheduled-test.task.enabled', value = 'true')
+    static class PropertiesTask {
+
+        boolean wasRun = false
+        boolean wasDelayedRun = false
+        boolean fixedDelayWasRun = false
+        AtomicInteger cronEvents = new AtomicInteger(0)
+        AtomicInteger cronEventsNoSeconds = new AtomicInteger(0)
+
+        @Scheduled(bean = SchedulingConfig.class, fixedRateProperty = 'fixedRate')
+        void runSomething() {
+            wasRun = true
+        }
+
+        @Scheduled(bean = SchedulingConfig.class, cronProperty = 'cron')
+        void runCron() {
+            cronEvents.incrementAndGet()
+        }
+
+        @Scheduled(bean = SchedulingConfig.class, cronProperty = 'cronNoSeconds')
+        void runCronNoSeconds() {
+            cronEventsNoSeconds.incrementAndGet()
+        }
+
+        @Scheduled(bean = SchedulingConfig.class, fixedDelayProperty = 'fixedDelay')
+        void runFixedDelay() {
+            fixedDelayWasRun = true
+        }
+
+        @Scheduled(bean = SchedulingConfig.class, fixedRateProperty = 'fixedRate', initialDelayProperty = 'initialDelay')
+        void runSomethingElse() {
+            wasDelayedRun = true
+        }
+    }
+}

--- a/context/src/test/groovy/io/micronaut/scheduling/beanproperties/TestConfig.java
+++ b/context/src/test/groovy/io/micronaut/scheduling/beanproperties/TestConfig.java
@@ -1,0 +1,34 @@
+package io.micronaut.scheduling.beanproperties;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.context.annotation.Requires;
+
+import java.time.Duration;
+
+@ConfigurationProperties("scheduling")
+@Requires(property = "spec.name", value = "ScheduledBeanPropertiesSpec")
+public class TestConfig
+{
+    private String stringFixedRate;
+    private Duration durationFixedRate;
+
+    public String getStringFixedRate()
+    {
+        return stringFixedRate;
+    }
+
+    public void setStringFixedRate(String stringFixedRate)
+    {
+        this.stringFixedRate = stringFixedRate;
+    }
+
+    public Duration getDurationFixedRate()
+    {
+        return durationFixedRate;
+    }
+
+    public void setDurationFixedRate(Duration durationFixedRate)
+    {
+        this.durationFixedRate = durationFixedRate;
+    }
+}

--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationMetadata.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationMetadata.java
@@ -27,15 +27,8 @@ import io.micronaut.core.value.OptionalValues;
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Repeatable;
 import java.lang.reflect.Array;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.OptionalDouble;
-import java.util.OptionalInt;
-import java.util.OptionalLong;
-import java.util.Set;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * <p>An interface implemented at compile time by Micronaut that allows the inspection of annotation metadata and
@@ -1555,4 +1548,15 @@ public interface AnnotationMetadata extends AnnotationSource {
         return this == AnnotationMetadata.EMPTY_METADATA;
     }
 
+    /**
+     * All the annotation values this metadata declares.
+     *
+     * @return All the annotation values this metadata declares
+     * @since 3.4.0
+     */
+    default List<AnnotationValue<?>> getAnnotationValues() {
+        return getAnnotationNames().stream()
+            .map(this::getAnnotation)
+            .collect(Collectors.toList());
+    }
 }

--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationPropertyReference.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationPropertyReference.java
@@ -1,0 +1,66 @@
+package io.micronaut.core.annotation;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * A reference to a bean property in annotation metadata.
+ * Annotation property reference consists of bean property owning type, the property name (which is the original
+ * annotation member value) and a function which can be used to retrieve bean property value
+ *
+ * @param <T> The generic type of the bean property owning class
+ * @param <R> The generic type of bean property value
+ * @author Sergey Gavrilov
+ * @since 3.4.0
+ */
+public final class AnnotationPropertyReference<T, R> {
+
+    private final AnnotationClassValue<T> owningType;
+    private final String propertyName;
+    private final Function<T, R> propertyGetter;
+
+    /**
+     * Constructs annotation property property reference.
+     *
+     * @param owningType     the type owning referenced bean property
+     * @param propertyName   the name of reference bean property
+     * @param propertyGetter the function which can be used to access bean property
+     */
+    public AnnotationPropertyReference(AnnotationClassValue<T> owningType,
+                                       String propertyName,
+                                       Function<T, R> propertyGetter) {
+        this.owningType = owningType;
+        this.propertyName = propertyName;
+        this.propertyGetter = propertyGetter;
+    }
+
+    /**
+     * @return bean property name
+     */
+    public String getPropertyName() {
+        return propertyName;
+    }
+
+    /**
+     * @return bean property owning type
+     */
+    public AnnotationClassValue<T> getPropertyOwningType() {
+        return owningType;
+    }
+
+    /**
+     * Used to obtain bean property value when from the provided bean.
+     *
+     * @param bean object which property is obtained using respective property getter
+     * @return bean property value
+     */
+    @SuppressWarnings("unchecked")
+    public Optional<R> getPropertyValue(Object bean) {
+        try {
+            return Optional.ofNullable(propertyGetter.apply((T) bean));
+        } catch (Throwable ex) {
+            return Optional.empty();
+        }
+    }
+
+}

--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationPropertyReference.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationPropertyReference.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.core.annotation;
 
 import java.util.Optional;

--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationValue.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationValue.java
@@ -629,6 +629,17 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
         return Optional.empty();
     }
 
+    @Override
+    public Optional<AnnotationPropertyReference<?, ?>> annotationPropertyReference(@NonNull String member) {
+        if (StringUtils.isNotEmpty(member)) {
+            Object o = values.get(member);
+            if (o instanceof AnnotationPropertyReference) {
+                return Optional.of((AnnotationPropertyReference<?, ?>) o);
+            }
+        }
+        return Optional.empty();
+    }
+
     /**
      * The integer value of the given member.
      *

--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationValueResolver.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationValueResolver.java
@@ -121,6 +121,15 @@ public interface AnnotationValueResolver extends ValueResolver<CharSequence> {
     Optional<AnnotationClassValue<?>> annotationClassValue(@NonNull String member);
 
     /**
+     * The {@link AnnotationPropertyReference} instance for the given member.
+     *
+     * @param member The annotation member
+     * @return An annotation property reference
+     * @since 3.4.0
+     */
+    Optional<AnnotationPropertyReference<?, ?>> annotationPropertyReference(@NonNull String member);
+
+    /**
      * The integer value of the given member.
      *
      * @param member The annotation member

--- a/http-client-core/src/main/java/io/micronaut/http/client/annotation/Client.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/annotation/Client.java
@@ -82,4 +82,24 @@ public @interface Client {
      * @return The HTTP version of the client.
      */
     HttpVersion httpVersion() default HttpVersion.HTTP_1_1;
+
+    /**
+     * The type of bean which properties can be referenced
+     * in other annotation members like {@link #urlProperty()}.
+     * The bean owning specified properties should be present within context for
+     * the property value to be resolved
+     *
+     * @since 3.4.0
+     * @return the bean to be used for property resolving
+     */
+    Class<?> bean() default void.class;
+
+    /**
+     * The property of {@link #bean()} containing URL
+     * of the remote service. Only to be used in conjunction with {@link #bean()}.
+     *
+     * @since 3.4.0
+     * @return name of bean property containing remote service URL
+     */
+    String urlProperty() default "";
 }

--- a/http-client/src/test/groovy/io/micronaut/http/client/beanprops/ClientBeanPropertiesSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/beanprops/ClientBeanPropertiesSpec.groovy
@@ -1,0 +1,86 @@
+package io.micronaut.http.client.beanprops
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Produces
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import reactor.core.publisher.Flux
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+
+@MicronautTest
+@Property(name = 'spec.name', value = 'ClientBeanPropertiesSpec')
+class ClientBeanPropertiesSpec extends Specification {
+
+    @Inject
+    @Client(bean = TestBean.class, urlProperty = "url")
+    @AutoCleanup
+    HttpClient client
+
+    @Inject
+    TestClient testClient
+
+    void "interface client URL property"() {
+        when:
+        Flux flowable = Flux.from(client.exchange(
+                HttpRequest.GET("/test").accept(MediaType.TEXT_PLAIN)
+        ))
+        Optional<String> body = flowable.map({ res ->
+            res.getBody(String)}
+        ).blockFirst()
+
+        then:
+        body.isPresent()
+        body.get() == 'success'
+    }
+
+    void "injected client URL property"() {
+        when:
+        HttpResponse<String> response = testClient.exchange()
+        Optional<String> body = response.getBody()
+
+        then:
+        response.status == HttpStatus.OK
+        body.isPresent()
+        body.get() == 'success'
+    }
+
+    @Requires(bean = TestBean.class, beanProperty = "url")
+    @Client(bean = TestBean.class, urlProperty = "url")
+    static interface TestClient {
+        @Get(uri = "/test", consumes = MediaType.TEXT_PLAIN)
+        HttpResponse exchange()
+    }
+
+    @Singleton
+    static class TestBean {
+
+        String url;
+
+        TestBean(EmbeddedServer embeddedServer) {
+            this.url = embeddedServer.getURL();
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'ClientBeanPropertiesSpec')
+    @Controller('/test')
+    static class TestController {
+
+        @Get
+        @Produces(MediaType.TEXT_PLAIN)
+        HttpResponse<String> test() {
+            return HttpResponse.ok("success")
+        }
+    }
+}

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -16,7 +16,6 @@
 package io.micronaut.annotation.processing;
 
 import io.micronaut.aop.internal.intercepted.InterceptedMethodUtil;
-import io.micronaut.context.RequiresCondition;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.annotation.processing.visitor.JavaElementFactory;
@@ -38,7 +37,6 @@ import io.micronaut.context.annotation.EachProperty;
 import io.micronaut.context.annotation.Executable;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Property;
-import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.annotation.Value;
 import io.micronaut.core.annotation.AnnotationClassValue;
 import io.micronaut.core.annotation.AnnotationMetadata;
@@ -502,7 +500,6 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                     aopProxyWriter.visitDefaultConstructor(concreteClassMetadata, javaVisitorContext);
                 }
                 beanDefinitionWriters.put(classElementQualifiedName, aopProxyWriter);
-                visitAnnotationMetadata(aopProxyWriter, this.currentClassMetadata);
                 visitIntroductionAdviceInterface(classElement, typeAnnotationMetadata, aopProxyWriter);
 
                 if (!isInterface) {
@@ -528,7 +525,6 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                                 return null;
                             }
                             BeanDefinitionVisitor beanDefinitionWriter = getOrCreateBeanDefinitionWriter(classElement, qualifiedName);
-                            visitAnnotationMetadata(beanDefinitionWriter, this.currentClassMetadata);
 
                             if (isAopProxyType) {
 
@@ -666,22 +662,6 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                 }
             }
             return beanDefinitionWriter;
-        }
-
-        private void visitAnnotationMetadata(BeanDefinitionVisitor writer, AnnotationMetadata annotationMetadata) {
-            for (io.micronaut.core.annotation.AnnotationValue<Requires> annotation: annotationMetadata.getAnnotationValuesByType(Requires.class)) {
-                annotation.stringValue(RequiresCondition.MEMBER_BEAN_PROPERTY)
-                    .ifPresent(beanProperty -> {
-                        annotation.stringValue(RequiresCondition.MEMBER_BEAN)
-                            .map(className -> elementUtils.getTypeElement(className.replace('$', '.')))
-                            .map(element -> elementFactory.newClassElement(element, annotationUtils.getAnnotationMetadata(element)))
-                            .ifPresent(classElement -> {
-                                String requiredValue = annotation.stringValue().orElse(null);
-                                String notEqualsValue = annotation.stringValue(RequiresCondition.MEMBER_NOT_EQUALS).orElse(null);
-                                writer.visitAnnotationMemberPropertyInjectionPoint(classElement, beanProperty, requiredValue, notEqualsValue);
-                            });
-                    });
-            }
         }
 
         private void visitIntroductionAdviceInterface(TypeElement classElement, AnnotationMetadata typeAnnotationMetadata, AopProxyWriter aopProxyWriter) {
@@ -1129,7 +1109,6 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
 
             BeanDefinitionWriter beanMethodWriter = createFactoryBeanMethodWriterFor(element, producedTypeElement);
             Map<String, Map<String, ClassElement>> allTypeArguments = producedClassElement.getAllTypeArguments();
-            visitAnnotationMetadata(beanMethodWriter, methodAnnotationMetadata);
             beanMethodWriter.visitTypeArguments(allTypeArguments);
 
             beanDefinitionWriters.put(new DynamicName(beanProducingElement.getDescription(false)), beanMethodWriter);

--- a/inject/src/main/java/io/micronaut/inject/annotation/AnnotationPropertyElement.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AnnotationPropertyElement.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.inject.annotation;
 
 import io.micronaut.core.annotation.AnnotationClassValue;

--- a/inject/src/main/java/io/micronaut/inject/annotation/AnnotationPropertyElement.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AnnotationPropertyElement.java
@@ -1,0 +1,81 @@
+package io.micronaut.inject.annotation;
+
+import io.micronaut.core.annotation.AnnotationClassValue;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.inject.ast.MethodElement;
+
+import java.util.Objects;
+
+/**
+ * Used to represent bean properties referenced in annotations at
+ * compilation time.
+ *
+ * @author Sergey Gavrilov
+ * @since 3.4.0
+ */
+@Internal
+public final class AnnotationPropertyElement {
+    private final AnnotationClassValue<?> owningType;
+    private final String propertyName;
+    private final MethodElement propertyGetter;
+
+    /**
+     * Constructs annotation property element.
+     *
+     * @param owningType the type owning referenced bean property
+     * @param propertyName the name of bean property
+     * @param propertyGetter the method used to access bean property
+     */
+    public AnnotationPropertyElement(AnnotationClassValue<?> owningType,
+                                     String propertyName,
+                                     MethodElement propertyGetter) {
+        this.owningType = owningType;
+        this.propertyName = propertyName;
+        this.propertyGetter = propertyGetter;
+    }
+
+    /**
+     * @return bean property name.
+     */
+    public String getPropertyName() {
+        return propertyName;
+    }
+
+    /**
+     * @return method used to access bean property.
+     */
+    public MethodElement getPropertyGetter() {
+        return propertyGetter;
+    }
+
+    /**
+     * @return the type of bean owning the property.
+     */
+    public AnnotationClassValue<?> getOwningType() {
+        return owningType;
+    }
+
+    @Override
+    public String toString() {
+        return propertyName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AnnotationPropertyElement that = (AnnotationPropertyElement) o;
+        return Objects.equals(owningType, that.owningType) &&
+                   Objects.equals(propertyName, that.propertyName) &&
+                   Objects.equals(propertyGetter, that.propertyGetter);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(owningType, propertyName, propertyGetter);
+    }
+}

--- a/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionVisitor.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionVisitor.java
@@ -252,20 +252,6 @@ public interface BeanDefinitionVisitor extends OriginatingElements, Toggleable {
                                   boolean requiresReflection);
 
     /**
-     * Visits an annotation injection point.
-     *
-     * @param annotationMemberBeanType     The type of the injected bean
-     * @param annotationMemberProperty       Required property of the injected bean
-     * @param requiredValue      Required value of the bean property for the bean to be loaded
-     * @param notEqualsValue      The bean property value which should not be equal to present value for the bean to
-     *                           be loaded
-     */
-    void visitAnnotationMemberPropertyInjectionPoint(TypedElement annotationMemberBeanType,
-                                                     String annotationMemberProperty,
-                                                     @Nullable String requiredValue,
-                                                     @Nullable String notEqualsValue);
-
-    /**
      * Visits a field injection point.
      *
      * @param declaringType      The declaring type. Either a Class or a string representing the name of the type


### PR DESCRIPTION
This PR develops the ideas described in #5350 and partly implemented in #6173
Since the original issue #5350 was not only about using bean properties in `@Requires` annotation but mostly about allowing to reference bean properties in any annotations where this can be considered useful, this PR does the following:
- Provides a universal mechanism for referencing bean properties in annotations 
- Adds support for this feature in `@Scheduled` and `@Client ` annotations (these are places where out team would like to use this feature)
- Slightly refactors the usage of bean properties in `@Requires` to make it based on the new mechanism (I've been working on this while waiting for #6173 to be merged)

The basic idea of this PR is to introduce a concept of `AnnotationPropertyReference` which is built as part of annotation metadata at compilation time and contains a method reference to bean property getter, which can be supplied with bean of specified type to obtain bean property value at runtime without using reflection

Would be grateful for review and feedback