### PR TITLE
Correct `JavaWildcardElement` native type

### DIFF
--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/AbstractJavaElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/AbstractJavaElement.java
@@ -403,6 +403,7 @@ public abstract class AbstractJavaElement implements io.micronaut.inject.ast.Ele
                 upperBounds = Stream.of(extendsBound);
             }
             return new JavaWildcardElement(
+                    wt,
                     upperBounds
                             .map(tm -> (JavaClassElement) mirrorToClassElement(tm, visitorContext, finalGenericsInfo, includeTypeAnnotations))
                             .collect(Collectors.toList()),

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaWildcardElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaWildcardElement.java
@@ -21,6 +21,7 @@ import io.micronaut.inject.ast.ArrayableClassElement;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.WildcardElement;
 
+import javax.lang.model.type.WildcardType;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -33,10 +34,11 @@ import java.util.stream.Collectors;
  */
 @Internal
 final class JavaWildcardElement extends JavaClassElement implements WildcardElement {
+    private final WildcardType wildcardType;
     private final List<JavaClassElement> upperBounds;
     private final List<JavaClassElement> lowerBounds;
 
-    JavaWildcardElement(@NonNull List<JavaClassElement> upperBounds, @NonNull List<JavaClassElement> lowerBounds) {
+    JavaWildcardElement(@NonNull WildcardType wildcardType, @NonNull List<JavaClassElement> upperBounds, @NonNull List<JavaClassElement> lowerBounds) {
         super(
                 upperBounds.get(0).classElement,
                 upperBounds.get(0).getAnnotationMetadata(),
@@ -44,8 +46,14 @@ final class JavaWildcardElement extends JavaClassElement implements WildcardElem
                 upperBounds.get(0).typeArguments,
                 upperBounds.get(0).getGenericTypeInfo()
         );
+        this.wildcardType = wildcardType;
         this.upperBounds = upperBounds;
         this.lowerBounds = lowerBounds;
+    }
+
+    @Override
+    public Object getNativeType() {
+        return wildcardType;
     }
 
     @NonNull
@@ -72,7 +80,7 @@ final class JavaWildcardElement extends JavaClassElement implements WildcardElem
     public ClassElement foldBoundGenericTypes(@NonNull Function<ClassElement, ClassElement> fold) {
         List<JavaClassElement> upperBounds = this.upperBounds.stream().map(ele -> toJavaClassElement(ele.foldBoundGenericTypes(fold))).collect(Collectors.toList());
         List<JavaClassElement> lowerBounds = this.lowerBounds.stream().map(ele -> toJavaClassElement(ele.foldBoundGenericTypes(fold))).collect(Collectors.toList());
-        return fold.apply(upperBounds.contains(null) || lowerBounds.contains(null) ? null : new JavaWildcardElement(upperBounds, lowerBounds));
+        return fold.apply(upperBounds.contains(null) || lowerBounds.contains(null) ? null : new JavaWildcardElement(wildcardType, upperBounds, lowerBounds));
     }
 
     private JavaClassElement toJavaClassElement(ClassElement element) {

--- a/inject-java/src/test/groovy/io/micronaut/annotation/processing/visitor/JavaReconstructionSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/annotation/processing/visitor/JavaReconstructionSpec.groovy
@@ -499,6 +499,7 @@ class Test {
 
         wildcardType.boundGenericTypes.size() == 1
         wildcardType.boundGenericTypes[0].isWildcard()
+        wildcardType.boundGenericTypes[0].getNativeType().class.name == 'com.sun.tools.javac.code.Type$WildcardType'
 
         objectType.boundGenericTypes.size() == 1
         !objectType.boundGenericTypes[0].isWildcard()


### PR DESCRIPTION
The native type of the wildcard element should be the actual one from the compiler