### PR TITLE
doc: change scope from runtime to runtimeOnly

### DIFF
--- a/src/main/docs/guide/configurations/dataAccess/sqlSupport.adoc
+++ b/src/main/docs/guide/configurations/dataAccess/sqlSupport.adoc
@@ -13,16 +13,16 @@ $ mn create-app my-app --features jdbc-tomcat
 
 To get started, add a dependency for one of the JDBC configurations that corresponds to the implementation you will use. Choose one of the following:
 
-dependency:micronaut-jdbc-tomcat[groupId="io.micronaut.sql", scope="runtime"]
+dependency:micronaut-jdbc-tomcat[groupId="io.micronaut.sql", scope="runtimeOnly"]
 
-dependency:micronaut-jdbc-hikari[groupId="io.micronaut.sql",scope="runtime"]
+dependency:micronaut-jdbc-hikari[groupId="io.micronaut.sql",scope="runtimeOnly"]
 
-dependency:micronaut-jdbc-dbcp[groupId="io.micronaut.sql",scope="runtime"]
+dependency:micronaut-jdbc-dbcp[groupId="io.micronaut.sql",scope="runtimeOnly"]
 
-dependency:micronaut-jdbc-ucp[groupId="io.micronaut.sql",scope="runtime"]
+dependency:micronaut-jdbc-ucp[groupId="io.micronaut.sql",scope="runtimeOnly"]
 
 Also, add a JDBC driver dependency to your build. For example to add the https://www.h2database.com[H2 In-Memory Database]:
 
-dependency:h2[groupId="com.h2database",scope="runtime"]
+dependency:h2[groupId="com.h2database",scope="runtimeOnly"]
 
 For more information see the https://micronaut-projects.github.io/micronaut-sql/latest/guide/#jdbc[Configuring JDBC] section of the https://github.com/micronaut-projects/micronaut-sql[Micronaut SQL libraries] project.

--- a/src/main/docs/guide/httpServer/serverConfiguration.adoc
+++ b/src/main/docs/guide/httpServer/serverConfiguration.adoc
@@ -31,19 +31,19 @@ To enable native transports, first add a dependency:
 
 For macOS on x86:
 
-dependency:netty-transport-native-kqueue[groupId="io.netty",scope="runtime",classifier="osx-x86_64"]
+dependency:netty-transport-native-kqueue[groupId="io.netty",scope="runtimeOnly",classifier="osx-x86_64"]
 
 For macOS on M1:
 
-dependency:netty-transport-native-kqueue[groupId="io.netty",scope="runtime",classifier="osx-aarch_64"]
+dependency:netty-transport-native-kqueue[groupId="io.netty",scope="runtimeOnly",classifier="osx-aarch_64"]
 
 For Linux on x86:
 
-dependency:netty-transport-native-epoll[groupId="io.netty",scope="runtime",classifier="linux-x86_64"]
+dependency:netty-transport-native-epoll[groupId="io.netty",scope="runtimeOnly",classifier="linux-x86_64"]
 
 For Linux on ARM64:
 
-dependency:netty-transport-native-epoll[groupId="io.netty",scope="runtime",classifier="linux-aarch_64"]
+dependency:netty-transport-native-epoll[groupId="io.netty",scope="runtimeOnly",classifier="linux-aarch_64"]
 
 Then configure the default event loop group to prefer native transports:
 

--- a/src/main/docs/guide/ioc/introspection.adoc
+++ b/src/main/docs/guide/ioc/introspection.adoc
@@ -10,7 +10,7 @@ dependency::micronaut-inject-java[scope="annotationProcessor", version="{version
 
 NOTE: For Kotlin, add the `micronaut-inject-java` dependency in `kapt` scope, and for Groovy add `micronaut-inject-groovy` in `compileOnly` scope.
 
-dependency::micronaut-core[scope="runtime", version="{version}"]
+dependency::micronaut-core[scope="runtimeOnly", version="{version}"]
 
 Once your build is configured you have a few ways to generate introspection data.
 


### PR DESCRIPTION
see: https://docs.gradle.org/current/userguide/upgrading_version_6.html#sec:configuration_removal

maven handles it https://github.com/micronaut-projects/micronaut-build/blob/master/src/main/groovy/io/micronaut/docs/BuildDependencyMacro.groovy#L126