### PR TITLE
Correct handling of properties starting with 'is' for Kotlin

### DIFF
--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
@@ -4165,6 +4165,25 @@ class AImpl implements A {
         property.isReadWrite()
     }
 
+    void "test targeting abstract class with @Introspected(classes = ) with getter matching field name"() {
+        ClassLoader classLoader = buildClassLoader("test.Test", """
+package test;
+import io.micronaut.core.annotation.Introspected;
+@Introspected(classes = {io.micronaut.inject.visitor.beans.TestMatchingGetterClass.class})
+class MyConfig {
+}
+""")
+
+        when:
+            BeanIntrospector beanIntrospector = BeanIntrospector.forClassLoader(classLoader)
+
+        then:
+            BeanIntrospection beanIntrospection = beanIntrospector.getIntrospection(TestMatchingGetterClass)
+            beanIntrospection != null
+            beanIntrospection.getBeanProperties().size() == 3
+            beanIntrospection.getPropertyNames() == ["deleted", "updated", "name"]
+    }
+
     @Override
     protected JavaParser newJavaParser() {
         return new JavaParser() {

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
@@ -4166,28 +4166,26 @@ class AImpl implements A {
     }
 
     void "test targeting abstract class with @Introspected(classes = ) with getter matching field name"() {
-        ClassLoader classLoader = buildClassLoader("test.Test", """
+        ClassLoader classLoader = buildClassLoader("test.MyConfig", '''\
 package test;
 import io.micronaut.core.annotation.Introspected;
 @Introspected(classes = {io.micronaut.inject.visitor.beans.TestMatchingGetterClass.class})
 class MyConfig {
-}
-""")
-
+}''')
         when:
-            BeanIntrospector beanIntrospector = BeanIntrospector.forClassLoader(classLoader)
+        BeanIntrospector beanIntrospector = BeanIntrospector.forClassLoader(classLoader)
+        BeanIntrospection beanIntrospection = beanIntrospector.getIntrospection(TestMatchingGetterClass)
 
         then:
-            BeanIntrospection beanIntrospection = beanIntrospector.getIntrospection(TestMatchingGetterClass)
-            beanIntrospection != null
-            beanIntrospection.getBeanProperties().size() == 3
-            beanIntrospection.getPropertyNames() == ["deleted", "updated", "name"]
+        beanIntrospection
+        beanIntrospection.beanProperties.size() == 3
+        beanIntrospection.propertyNames as List<String> == ["deleted", "updated", "name"]
     }
 
     @Requires({ jvm.isJava14Compatible() })
     void "test records with is in the property name"() {
         given:
-            BeanIntrospection introspection = buildBeanIntrospection('test.Foo', '''
+        BeanIntrospection introspection = buildBeanIntrospection('test.Foo', '''\
 package test;
 
 import io.micronaut.core.annotation.Creator;
@@ -4198,10 +4196,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 @io.micronaut.core.annotation.Introspected
 public record Foo(String name, String isSurname, boolean contains, Boolean purged, boolean isUpdated, Boolean isDeleted) {
-}
-''')
+}''')
         expect:
-            introspection.getPropertyNames() == ["name", "isSurname", "contains", "purged", "isUpdated", "isDeleted"]
+        introspection.propertyNames as List<String> == ["name", "isSurname", "contains", "purged", "isUpdated", "isDeleted"]
     }
 
     @Override

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
@@ -4184,6 +4184,26 @@ class MyConfig {
             beanIntrospection.getPropertyNames() == ["deleted", "updated", "name"]
     }
 
+    @Requires({ jvm.isJava14Compatible() })
+    void "test records with is in the property name"() {
+        given:
+            BeanIntrospection introspection = buildBeanIntrospection('test.Foo', '''
+package test;
+
+import io.micronaut.core.annotation.Creator;
+import java.util.List;
+import javax.validation.constraints.Min;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@io.micronaut.core.annotation.Introspected
+public record Foo(String name, String isSurname, boolean contains, Boolean purged, boolean isUpdated, Boolean isDeleted) {
+}
+''')
+        expect:
+            introspection.getPropertyNames() == ["name", "isSurname", "contains", "purged", "isUpdated", "isDeleted"]
+    }
+
     @Override
     protected JavaParser newJavaParser() {
         return new JavaParser() {

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/TestMatchingGetterClass.java
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/TestMatchingGetterClass.java
@@ -1,0 +1,33 @@
+package io.micronaut.inject.visitor.beans;
+
+
+public abstract class TestMatchingGetterClass {
+
+    private Boolean isDeleted;
+    private boolean updated;
+    private String name;
+
+    public Boolean isDeleted() {
+        return isDeleted;
+    }
+
+    public void setDeleted(Boolean isDeleted) {
+        this.isDeleted = isDeleted;
+    }
+
+    public boolean isUpdated() {
+        return updated;
+    }
+
+    public void setUpdated(Boolean updated) {
+        this.updated = updated;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
@@ -75,7 +75,8 @@ import java.util.stream.Collectors;
  */
 @Internal
 public class JavaClassElement extends AbstractJavaElement implements ArrayableClassElement {
-
+    private static final String KOTLIN_METADATA = "kotlin.Metadata";
+    private static final String PREFIX_IS = "is";
     protected final TypeElement classElement;
     protected final JavaVisitorContext visitorContext;
     final List<? extends TypeMirror> typeArguments;
@@ -373,12 +374,8 @@ public class JavaClassElement extends AbstractJavaElement implements ArrayableCl
                         final TypeElement declaringTypeElement = (TypeElement) executableElement.getEnclosingElement();
 
                         if (NameUtils.isReaderName(methodName, readPrefixes) && executableElement.getParameters().isEmpty()) {
-                            String propertyName;
-                            if (isKotlinClass(element.getEnclosingElement()) && methodName.startsWith("is")) {
-                                propertyName = methodName;
-                            } else {
-                                propertyName = NameUtils.getPropertyNameForGetter(methodName, readPrefixes);
-                            }
+                            String propertyName = isKotlinClass(element.getEnclosingElement()) && methodName.startsWith(PREFIX_IS) ?
+                                methodName : NameUtils.getPropertyNameForGetter(methodName, readPrefixes);
                             TypeMirror returnType = executableElement.getReturnType();
                             ClassElement getterReturnType;
                             if (returnType instanceof TypeVariable) {
@@ -529,7 +526,7 @@ public class JavaClassElement extends AbstractJavaElement implements ArrayableCl
     }
 
     private boolean isKotlinClass(Element element) {
-        return element.getAnnotationMirrors().stream().anyMatch(am -> am.getAnnotationType().asElement().toString().equals("kotlin.Metadata"));
+        return element.getAnnotationMirrors().stream().anyMatch(am -> am.getAnnotationType().asElement().toString().equals(KOTLIN_METADATA));
     }
 
     @Override

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
@@ -373,7 +373,12 @@ public class JavaClassElement extends AbstractJavaElement implements ArrayableCl
                         final TypeElement declaringTypeElement = (TypeElement) executableElement.getEnclosingElement();
 
                         if (NameUtils.isReaderName(methodName, readPrefixes) && executableElement.getParameters().isEmpty()) {
-                            String propertyName = NameUtils.getPropertyNameForGetter(methodName, readPrefixes);
+                            String propertyName;
+                            if (isKotlinClass(element.getEnclosingElement()) && methodName.startsWith("is")) {
+                                propertyName = methodName;
+                            } else {
+                                propertyName = NameUtils.getPropertyNameForGetter(methodName, readPrefixes);
+                            }
                             TypeMirror returnType = executableElement.getReturnType();
                             ClassElement getterReturnType;
                             if (returnType instanceof TypeVariable) {
@@ -521,6 +526,10 @@ public class JavaClassElement extends AbstractJavaElement implements ArrayableCl
             }
         }
         return Collections.unmodifiableList(beanProperties);
+    }
+
+    private boolean isKotlinClass(Element element) {
+        return element.getAnnotationMirrors().stream().anyMatch(am -> am.getAnnotationType().asElement().toString().equals("kotlin.Metadata"));
     }
 
     @Override

--- a/inject-kotlin-test/src/test/groovy/io/micronaut/annotation/processing/test/KotlinCompilerTest.groovy
+++ b/inject-kotlin-test/src/test/groovy/io/micronaut/annotation/processing/test/KotlinCompilerTest.groovy
@@ -1,5 +1,6 @@
 package io.micronaut.annotation.processing.test
 
+import io.micronaut.core.beans.BeanIntrospection
 import io.micronaut.core.version.SemanticVersion
 import spock.lang.Requires
 import spock.util.environment.Jvm
@@ -78,7 +79,7 @@ class Test {
 
     void "introspection with 'is' properties"() {
         given:
-            def introspection = buildBeanIntrospection('example.Test', '''
+        BeanIntrospection introspection = buildBeanIntrospection('example.Test', '''\
 package example
 
 import io.micronaut.core.annotation.Introspected
@@ -107,6 +108,6 @@ class Test(
 }
 ''')
         expect:
-            introspection.propertyNames.toList() == ['id', 'name', 'getSurname', 'isDeleted', 'isImportant', 'corrected', 'upgraded', 'isMyBool', 'isMyBool2', 'myBool3', 'myBool4', 'myBool5']
+        introspection.propertyNames.toList() == ['id', 'name', 'getSurname', 'isDeleted', 'isImportant', 'corrected', 'upgraded', 'isMyBool', 'isMyBool2', 'myBool3', 'myBool4', 'myBool5']
     }
 }

--- a/inject-kotlin-test/src/test/groovy/io/micronaut/annotation/processing/test/KotlinCompilerTest.groovy
+++ b/inject-kotlin-test/src/test/groovy/io/micronaut/annotation/processing/test/KotlinCompilerTest.groovy
@@ -75,4 +75,38 @@ class Test {
         expect:
         definition != null
     }
+
+    void "introspection with 'is' properties"() {
+        given:
+            def introspection = buildBeanIntrospection('example.Test', '''
+package example
+
+import io.micronaut.core.annotation.Introspected
+
+@Introspected
+class Test(
+        var id: Long,
+        var name: String,
+        var getSurname: String,
+        var isDeleted: Boolean,
+        val isImportant: Boolean,
+        var corrected: Boolean,
+        val upgraded: Boolean,
+) {
+    val isMyBool: Boolean
+        get() = false
+    var isMyBool2: Boolean
+        get() = false
+        set(v) {}
+    var myBool3: Boolean
+        get() = false
+        set(v) {}
+   val myBool4: Boolean
+        get() = false
+   var myBool5: Boolean = false
+}
+''')
+        expect:
+            introspection.propertyNames.toList() == ['id', 'name', 'getSurname', 'isDeleted', 'isImportant', 'corrected', 'upgraded', 'isMyBool', 'isMyBool2', 'myBool3', 'myBool4', 'myBool5']
+    }
 }

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/core/beans/AbstractTestEntity.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/core/beans/AbstractTestEntity.kt
@@ -1,0 +1,23 @@
+package io.micronaut.core.beans
+
+abstract class AbstractTestEntity(
+        var id: Long,
+        var name: String,
+        var getSurname: String,
+        var isDeleted: Boolean,
+        val isImportant: Boolean,
+        var corrected: Boolean,
+        val upgraded: Boolean,
+) {
+    val isMyBool: Boolean
+        get() = false
+    var isMyBool2: Boolean
+        get() = false
+        set(v) {}
+    var myBool3: Boolean
+        get() = false
+        set(v) {}
+    val myBool4: Boolean
+        get() = false
+    var myBool5: Boolean = false
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/core/beans/KotlinBeanIntrospectionSpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/core/beans/KotlinBeanIntrospectionSpec.kt
@@ -25,4 +25,15 @@ class KotlinBeanIntrospectionSpec {
         }
 
     }
+
+    @Test
+    fun testIsProperties() {
+        val introspection = BeanIntrospection.getIntrospection(TestEntity::class.java)
+
+        assertEquals(listOf("id", "name", "getSurname", "isDeleted", "isImportant", "corrected", "upgraded", "isMyBool", "isMyBool2", "myBool3", "myBool4", "myBool5"), introspection.propertyNames.asList())
+
+        val introspection2 = BeanIntrospection.getIntrospection(TestEntity2::class.java)
+
+        assertEquals(listOf("id", "name", "getSurname", "isDeleted", "isImportant", "corrected", "upgraded", "isMyBool", "isMyBool2", "myBool3", "myBool4", "myBool5"), introspection2.propertyNames.asList())
+    }
 }

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/core/beans/TestEntity.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/core/beans/TestEntity.kt
@@ -1,0 +1,26 @@
+package io.micronaut.core.beans
+
+import io.micronaut.core.annotation.Introspected
+
+@Introspected
+class TestEntity(
+        var id: Long,
+        var name: String,
+        var getSurname: String,
+        var isDeleted: Boolean,
+        val isImportant: Boolean,
+        var corrected: Boolean,
+        val upgraded: Boolean,
+) {
+    val isMyBool: Boolean
+        get() = false
+    var isMyBool2: Boolean
+        get() = false
+        set(v) {}
+    var myBool3: Boolean
+        get() = false
+        set(v) {}
+    val myBool4: Boolean
+        get() = false
+    var myBool5: Boolean = false
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/core/beans/TestEntity2.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/core/beans/TestEntity2.kt
@@ -1,0 +1,7 @@
+package io.micronaut.core.beans
+
+import io.micronaut.core.annotation.Introspected
+
+@Introspected
+class TestEntity2(id: Long, name: String, getSurname: String, isDeleted: Boolean, isImportant: Boolean, corrected: Boolean, upgraded: Boolean) : AbstractTestEntity(id, name, getSurname, isDeleted, isImportant, corrected, upgraded) {
+}


### PR DESCRIPTION
It looks like Kotlin will generate `isProp` getter only when the property is prefixed `is` otherwise `Boolean` property will have `getProp` getter.

Fixes https://github.com/micronaut-projects/micronaut-data/issues/1378
Fixes https://github.com/micronaut-projects/micronaut-data/issues/942#issuecomment-1071112210
Fixes https://github.com/micronaut-projects/micronaut-openapi/issues/616