### PR TITLE
Cache JsonMapper in DefaultNettyHttpClientRegistry

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultNettyHttpClientRegistry.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultNettyHttpClientRegistry.java
@@ -126,7 +126,7 @@ class DefaultNettyHttpClientRegistry implements AutoCloseable,
      * @param eventLoopGroupFactory           The event loop group factory
      * @param beanContext                     The bean context
      * @param invocationInstrumenterFactories The invocation instrumenter factories
-     * @param jsonMapper
+     * @param jsonMapper                      JSON Mapper
      */
     public DefaultNettyHttpClientRegistry(
             HttpClientConfiguration defaultHttpClientConfiguration,

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultNettyHttpClientRegistry.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultNettyHttpClientRegistry.java
@@ -110,12 +110,12 @@ class DefaultNettyHttpClientRegistry implements AutoCloseable,
     private final List<InvocationInstrumenterFactory> invocationInstrumenterFactories;
     private final EventLoopGroupFactory eventLoopGroupFactory;
     private final HttpClientFilterResolver<ClientFilterResolutionContext> clientFilterResolver;
+    private final JsonMapper jsonMapper;
     private final Collection<ChannelPipelineListener> pipelineListeners = new CopyOnWriteArrayList<>();
 
     /**
      * Default constructor.
-     *
-     * @param defaultHttpClientConfiguration  The default HTTP client configuration
+     *  @param defaultHttpClientConfiguration  The default HTTP client configuration
      * @param httpClientFilterResolver        The HTTP client filter resolver
      * @param loadBalancerResolver            The load balancer resolver
      * @param nettyClientSslBuilder           The client SSL builder
@@ -125,6 +125,7 @@ class DefaultNettyHttpClientRegistry implements AutoCloseable,
      * @param eventLoopGroupFactory           The event loop group factory
      * @param beanContext                     The bean context
      * @param invocationInstrumenterFactories The invocation instrumenter factories
+     * @param jsonMapper
      */
     public DefaultNettyHttpClientRegistry(
             HttpClientConfiguration defaultHttpClientConfiguration,
@@ -136,8 +137,8 @@ class DefaultNettyHttpClientRegistry implements AutoCloseable,
             EventLoopGroupRegistry eventLoopGroupRegistry,
             EventLoopGroupFactory eventLoopGroupFactory,
             BeanContext beanContext,
-            List<InvocationInstrumenterFactory> invocationInstrumenterFactories
-    ) {
+            List<InvocationInstrumenterFactory> invocationInstrumenterFactories,
+            JsonMapper jsonMapper) {
         this.clientFilterResolver = httpClientFilterResolver;
         this.defaultHttpClientConfiguration = defaultHttpClientConfiguration;
         this.loadBalancerResolver = loadBalancerResolver;
@@ -148,6 +149,7 @@ class DefaultNettyHttpClientRegistry implements AutoCloseable,
         this.eventLoopGroupFactory = eventLoopGroupFactory;
         this.eventLoopGroupRegistry = eventLoopGroupRegistry;
         this.invocationInstrumenterFactories = invocationInstrumenterFactories;
+        this.jsonMapper = jsonMapper;
     }
 
     @NonNull
@@ -473,7 +475,7 @@ class DefaultNettyHttpClientRegistry implements AutoCloseable,
                 .getAnnotationNamesByStereotype(FilterMatcher.class);
         final Class configurationClass =
                 metadata.classValue(Client.class, "configuration").orElse(null);
-        JsonFeatures jsonFeatures = beanContext.getBean(JsonMapper.class).detectFeatures(metadata).orElse(null);
+        JsonFeatures jsonFeatures = jsonMapper.detectFeatures(metadata).orElse(null);
 
         return new ClientKey(httpVersion, clientId, filterAnnotation, path, configurationClass, jsonFeatures);
     }

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultNettyHttpClientRegistry.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultNettyHttpClientRegistry.java
@@ -115,7 +115,8 @@ class DefaultNettyHttpClientRegistry implements AutoCloseable,
 
     /**
      * Default constructor.
-     *  @param defaultHttpClientConfiguration  The default HTTP client configuration
+     *
+     * @param defaultHttpClientConfiguration  The default HTTP client configuration
      * @param httpClientFilterResolver        The HTTP client filter resolver
      * @param loadBalancerResolver            The load balancer resolver
      * @param nettyClientSslBuilder           The client SSL builder


### PR DESCRIPTION
This avoids a getBean call every time.
Fixes #7087