### PR TITLE
Remove `bom-check` module

### DIFF
--- a/bom-check/README.md
+++ b/bom-check/README.md
@@ -1,4 +1,0 @@
-# Micronaut BOM Check
-
-This validates the Micronaut Bill of Materials (BOM). New Entries can be added in the root `build.gradle`.
-

--- a/bom-check/build.gradle
+++ b/bom-check/build.gradle
@@ -1,7 +1,0 @@
-plugins {
-    id 'io.micronaut.build.internal.bom-checker'
-}
-
-repositories {
-    mavenCentral()
-}

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,7 +21,6 @@ rootProject.name = 'micronaut'
 
 include "aop"
 include "bom"
-include "bom-check"
 include "parent"
 include "buffer-netty"
 include "core"


### PR DESCRIPTION
With the upgrade to build plugins 5.3.0, this module is redundant.