### PR TITLE
Support JsonNaming and JsonProperty for BeanIntrospectionModule

### DIFF
--- a/jackson-databind/build.gradle
+++ b/jackson-databind/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 
     api project(":jackson-core")
 
+    compileOnly libs.managed.graal
     api libs.managed.jackson.databind
     api libs.managed.jackson.datatype.jdk8
     api libs.managed.jackson.datatype.jsr310

--- a/jackson-databind/src/main/java/io/micronaut/jackson/JacksonDatabindFeature.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/JacksonDatabindFeature.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.jackson;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.oracle.svm.core.annotate.AutomaticFeature;
+import io.micronaut.core.annotation.Internal;
+import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.nativeimage.hosted.RuntimeReflection;
+
+import java.util.stream.Stream;
+
+/**
+ * A native image feature that configures the jackson-databind library.
+ *
+ * @author Jonas Konrad
+ * @since 3.4.1
+ */
+@Internal
+@AutomaticFeature
+final class JacksonDatabindFeature implements Feature {
+    @SuppressWarnings("deprecation")
+    @Override
+    public void beforeAnalysis(BeforeAnalysisAccess access) {
+        Stream.of(
+                PropertyNamingStrategies.LowerCamelCaseStrategy.class,
+                PropertyNamingStrategies.UpperCamelCaseStrategy.class,
+                PropertyNamingStrategies.SnakeCaseStrategy.class,
+                PropertyNamingStrategies.UpperSnakeCaseStrategy.class,
+                PropertyNamingStrategies.LowerCaseStrategy.class,
+                PropertyNamingStrategies.KebabCaseStrategy.class,
+                PropertyNamingStrategies.LowerDotCaseStrategy.class,
+
+                PropertyNamingStrategy.UpperCamelCaseStrategy.class,
+                PropertyNamingStrategy.SnakeCaseStrategy.class,
+                PropertyNamingStrategy.LowerCaseStrategy.class,
+                PropertyNamingStrategy.KebabCaseStrategy.class,
+                PropertyNamingStrategy.LowerDotCaseStrategy.class
+        ).forEach(RuntimeReflection::registerForReflectiveInstantiation);
+    }
+}

--- a/jackson-databind/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
@@ -249,12 +249,9 @@ public class BeanIntrospectionModule extends SimpleModule {
     }
 
     private String getName(MapperConfig<?> mapperConfig, @Nullable PropertyNamingStrategy namingStrategy, AnnotatedElement property) {
-        AnnotationValue<JsonProperty> explicitAnnotation = property.getAnnotation(JsonProperty.class);
-        if (explicitAnnotation != null) {
-            String explicitName = explicitAnnotation.stringValue().orElse(JsonProperty.USE_DEFAULT_NAME);
-            if (!explicitName.equals(JsonProperty.USE_DEFAULT_NAME)) {
-                return explicitName;
-            }
+        String explicitName = property.getAnnotationMetadata().stringValue(JsonProperty.class).orElse(JsonProperty.USE_DEFAULT_NAME);
+        if (!explicitName.equals(JsonProperty.USE_DEFAULT_NAME)) {
+            return explicitName;
         }
         String implicitName = property.getName();
         if (namingStrategy != null) {

--- a/jackson-databind/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
@@ -240,6 +240,7 @@ public class BeanIntrospectionModule extends SimpleModule {
                     Constructor<?> emptyConstructor = clazz.get().getConstructor();
                     return (PropertyNamingStrategy) emptyConstructor.newInstance();
                 } catch (NoSuchMethodException ignored) {
+                    return mapperConfig.getPropertyNamingStrategy();
                 } catch (ReflectiveOperationException e) {
                     throw new RuntimeException("Failed to construct configured PropertyNamingStrategy", e);
                 }

--- a/jackson-databind/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.core.SerializableString;
 import com.fasterxml.jackson.core.io.SerializedString;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.cfg.MapperConfig;
 import com.fasterxml.jackson.databind.deser.BeanDeserializerBuilder;
@@ -56,6 +57,7 @@ import com.fasterxml.jackson.databind.ser.impl.PropertySerializerMap;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.fasterxml.jackson.databind.util.SimpleBeanPropertyDefinition;
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.AnnotatedElement;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Experimental;
@@ -69,7 +71,6 @@ import io.micronaut.core.reflect.exception.InstantiationException;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
-import io.micronaut.http.hateoas.Resource;
 import io.micronaut.jackson.JacksonConfiguration;
 import jakarta.inject.Singleton;
 import org.slf4j.Logger;
@@ -77,6 +78,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -228,6 +230,40 @@ public class BeanIntrospectionModule extends SimpleModule {
         );
     }
 
+    @Nullable
+    private PropertyNamingStrategy findNamingStrategy(MapperConfig<?> mapperConfig, BeanIntrospection<?> introspection) {
+        AnnotationValue<JsonNaming> namingAnnotation = introspection.getAnnotation(JsonNaming.class);
+        if (namingAnnotation != null) {
+            Optional<Class<?>> clazz = namingAnnotation.classValue();
+            if (clazz.isPresent()) {
+                try {
+                    Constructor<?> emptyConstructor = clazz.get().getConstructor();
+                    return (PropertyNamingStrategy) emptyConstructor.newInstance();
+                } catch (NoSuchMethodException ignored) {
+                } catch (ReflectiveOperationException e) {
+                    throw new RuntimeException("Failed to construct configured PropertyNamingStrategy", e);
+                }
+            }
+        }
+        return mapperConfig.getPropertyNamingStrategy();
+    }
+
+    private String getName(MapperConfig<?> mapperConfig, @Nullable PropertyNamingStrategy namingStrategy, AnnotatedElement property) {
+        AnnotationValue<JsonProperty> explicitAnnotation = property.getAnnotation(JsonProperty.class);
+        if (explicitAnnotation != null) {
+            String explicitName = explicitAnnotation.stringValue().orElse(JsonProperty.USE_DEFAULT_NAME);
+            if (!explicitName.equals(JsonProperty.USE_DEFAULT_NAME)) {
+                return explicitName;
+            }
+        }
+        String implicitName = property.getName();
+        if (namingStrategy != null) {
+            return namingStrategy.nameForGetterMethod(mapperConfig, null, implicitName);
+        } else {
+            return implicitName;
+        }
+    }
+
     /**
      * Modifies bean serialization.
      */
@@ -235,13 +271,14 @@ public class BeanIntrospectionModule extends SimpleModule {
         @Override
         public BeanSerializerBuilder updateBuilder(SerializationConfig config, BeanDescription beanDesc, BeanSerializerBuilder builder) {
             final Class<?> beanClass = beanDesc.getBeanClass();
-            final boolean isResource = Resource.class.isAssignableFrom(beanDesc.getBeanClass());
             final BeanIntrospection<Object> introspection =
                     findIntrospection(beanClass);
 
             if (introspection == null) {
                 return super.updateBuilder(config, beanDesc, builder);
             } else {
+                PropertyNamingStrategy namingStrategy = findNamingStrategy(config, introspection);
+
                 final BeanSerializerBuilder newBuilder = new BeanSerializerBuilder(beanDesc) {
                     @Override
                     public JsonSerializer<?> build() {
@@ -270,19 +307,7 @@ public class BeanIntrospectionModule extends SimpleModule {
                         if (beanProperty.hasAnnotation(JsonIgnore.class)) {
                             continue;
                         }
-                        final String propertyName;
-                        if (isResource) {
-                            final String n = beanProperty.getName();
-                            if ("embedded".equals(n)) {
-                                propertyName = Resource.EMBEDDED;
-                            } else if ("links".equals(n)) {
-                                propertyName = Resource.LINKS;
-                            } else {
-                                propertyName = beanProperty.stringValue(JsonProperty.class).orElse(beanProperty.getName());
-                            }
-                        } else {
-                            propertyName = beanProperty.stringValue(JsonProperty.class).orElse(beanProperty.getName());
-                        }
+                        final String propertyName = getName(config, namingStrategy, beanProperty);
                         BeanPropertyWriter writer = new BeanIntrospectionPropertyWriter(
                                 createVirtualMember(
                                         typeResolutionContext,
@@ -310,50 +335,18 @@ public class BeanIntrospectionModule extends SimpleModule {
                     }
 
                     final List<BeanPropertyWriter> newProperties = new ArrayList<>(properties);
-                    Map<String, BeanProperty> named = new LinkedHashMap<>(properties.size());
+                    Map<String, BeanProperty<Object, Object>> named = new LinkedHashMap<>();
                     for (BeanProperty<Object, Object> beanProperty : beanProperties) {
-                        final Optional<String> n = beanProperty.stringValue(JsonProperty.class);
-                        n.ifPresent(s -> named.put(s, beanProperty));
+                        named.put(getName(config, namingStrategy, beanProperty), beanProperty);
                     }
                     for (int i = 0; i < properties.size(); i++) {
                         final BeanPropertyWriter existing = properties.get(i);
 
-                        final Optional<BeanProperty<Object, Object>> property;
-                        final String existingName = existing.getName();
-                        if (named.containsKey(existingName)) {
-                            property = Optional.of(named.get(existingName));
-                        } else {
-                            property = introspection.getProperty(existingName);
-                        }
+                        final Optional<BeanProperty<Object, Object>> property = Optional.ofNullable(named.get(existing.getName()));
                         // ignore properties that are @JsonIgnore, so that we don't replace other properties of the
                         // same name
                         if (property.isPresent() && !property.get().isAnnotationPresent(JsonIgnore.class)) {
                             final BeanProperty<Object, Object> beanProperty = property.get();
-                            if (isResource) {
-                                if ("embedded".equals(beanProperty.getName())) {
-                                    newProperties.set(i, new BeanIntrospectionPropertyWriter(
-                                                    new SerializedString(Resource.EMBEDDED),
-                                                    existing,
-                                                    beanProperty,
-                                                    existing.getSerializer(),
-                                                    config.getTypeFactory(),
-                                                    existing.getViews()
-                                            )
-                                    );
-                                    continue;
-                                } else if ("links".equals(beanProperty.getName())) {
-                                    newProperties.set(i, new BeanIntrospectionPropertyWriter(
-                                                    new SerializedString(Resource.LINKS),
-                                                    existing,
-                                                    beanProperty,
-                                                    existing.getSerializer(),
-                                                    config.getTypeFactory(),
-                                                    existing.getViews()
-                                            )
-                                    );
-                                    continue;
-                                }
-                            }
                             newProperties.set(i, new BeanIntrospectionPropertyWriter(
                                         existing,
                                         beanProperty,
@@ -394,6 +387,8 @@ public class BeanIntrospectionModule extends SimpleModule {
             if (introspection == null) {
                 return builder;
             } else {
+                PropertyNamingStrategy propertyNamingStrategy = findNamingStrategy(config, introspection);
+
                 final Iterator<SettableBeanProperty> properties = builder.getProperties();
                 if ((ignoreReflectiveProperties || !properties.hasNext()) && introspection.getPropertyNames().length > 0) {
                     // mismatch, probably GraalVM reflection not enabled for bean. Try recreate
@@ -403,6 +398,7 @@ public class BeanIntrospectionModule extends SimpleModule {
                                             beanDesc.getClassInfo(),
                                             config.getTypeFactory(),
                                             beanProperty,
+                                            getName(config, propertyNamingStrategy, beanProperty),
                                             findSerializerFromAnnotation(beanProperty, JsonDeserialize.class)),
                                     true);
                         }
@@ -416,7 +412,7 @@ public class BeanIntrospectionModule extends SimpleModule {
                             continue;
                         }
 
-                        remainingProperties.put(beanProperty.getName(), beanProperty);
+                        remainingProperties.put(getName(config, propertyNamingStrategy, beanProperty), beanProperty);
                     }
                     while (properties.hasNext()) {
                         final SettableBeanProperty settableBeanProperty = properties.next();
@@ -444,6 +440,7 @@ public class BeanIntrospectionModule extends SimpleModule {
                                                 beanDesc.getClassInfo(),
                                                 config.getTypeFactory(),
                                                 entry.getValue(),
+                                                entry.getKey(),
                                                 findSerializerFromAnnotation(entry.getValue(), JsonDeserialize.class)),
                                         true);
                             }
@@ -468,7 +465,7 @@ public class BeanIntrospectionModule extends SimpleModule {
                                 final JavaType javaType = existingProperty != null ? existingProperty.getType() : newType(argument, typeFactory);
                                 final AnnotationMetadata annotationMetadata = argument.getAnnotationMetadata();
                                 PropertyMetadata propertyMetadata = newPropertyMetadata(argument, annotationMetadata);
-                                final String simpleName = existingProperty != null ? existingProperty.getName() : annotationMetadata.stringValue(JsonProperty.class).orElse(argument.getName());
+                                final String simpleName = existingProperty != null ? existingProperty.getName() : getName(config, propertyNamingStrategy, argument);
                                 TypeDeserializer typeDeserializer;
                                 try {
                                     typeDeserializer = config.findTypeDeserializer(javaType);
@@ -673,9 +670,9 @@ public class BeanIntrospectionModule extends SimpleModule {
         final BeanProperty beanProperty;
         final TypeResolutionContext typeResolutionContext;
 
-        VirtualSetter(TypeResolutionContext typeResolutionContext, TypeFactory typeFactory, BeanProperty beanProperty, JsonDeserializer<Object> valueDeser) {
+        VirtualSetter(TypeResolutionContext typeResolutionContext, TypeFactory typeFactory, BeanProperty beanProperty, String propertyName, JsonDeserializer<Object> valueDeser) {
             super(
-                    new PropertyName(beanProperty.getName()),
+                    new PropertyName(propertyName),
                     newType(beanProperty.asArgument(), typeFactory),
                     newPropertyMetadata(beanProperty.asArgument(), beanProperty.getAnnotationMetadata()), valueDeser);
             this.beanProperty = beanProperty;

--- a/jackson-databind/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
@@ -668,7 +668,7 @@ public class BeanIntrospectionModule extends SimpleModule {
         final BeanProperty beanProperty;
         final TypeResolutionContext typeResolutionContext;
 
-        VirtualSetter(TypeResolutionContext typeResolutionContext, TypeFactory typeFactory, BeanProperty beanProperty, String propertyName, JsonDeserializer<Object> valueDeser) {
+        VirtualSetter(TypeResolutionContext typeResolutionContext, TypeFactory typeFactory, BeanProperty<?,?> beanProperty, String propertyName, JsonDeserializer<Object> valueDeser) {
             super(
                     new PropertyName(propertyName),
                     newType(beanProperty.asArgument(), typeFactory),

--- a/jackson-databind/src/test/groovy/io/micronaut/jackson/modules/BeanIntrospectionModuleSpec.groovy
+++ b/jackson-databind/src/test/groovy/io/micronaut/jackson/modules/BeanIntrospectionModuleSpec.groovy
@@ -32,6 +32,7 @@ import io.micronaut.jackson.modules.testcase.EmailTemplate
 import io.micronaut.jackson.modules.testcase.Notification
 import io.micronaut.jackson.modules.wrappers.*
 import spock.lang.Issue
+import spock.lang.Unroll
 import spock.lang.Specification
 
 import java.beans.ConstructorProperties
@@ -915,7 +916,8 @@ class BeanIntrospectionModuleSpec extends Specification {
         }
     }
 
-    void "JsonIgnore on one accessor"() {
+    @Unroll("JsonIgnore is supported with ignoreReflectiveProperties: #ignoreReflectiveProperties")
+    void "JsonIgnore on one accessor"(boolean ignoreReflectiveProperties) {
         given:
         ApplicationContext ctx = ApplicationContext.run()
         ctx.getBean(BeanIntrospectionModule).ignoreReflectiveProperties = ignoreReflectiveProperties
@@ -963,7 +965,8 @@ class BeanIntrospectionModuleSpec extends Specification {
         }
     }
 
-    void "JsonProperty support"() {
+    @Unroll("JsonProperty annotation is supported with ignoreReflectiveProperties: #ignoreReflectiveProperties")
+    void "JsonProperty support"(boolean ignoreReflectiveProperties) {
         given:
         ApplicationContext ctx = ApplicationContext.run()
         ctx.getBean(BeanIntrospectionModule).ignoreReflectiveProperties = ignoreReflectiveProperties

--- a/jackson-databind/src/test/groovy/io/micronaut/jackson/modules/BeanIntrospectionModuleSpec.groovy
+++ b/jackson-databind/src/test/groovy/io/micronaut/jackson/modules/BeanIntrospectionModuleSpec.groovy
@@ -27,7 +27,6 @@ import io.micronaut.context.ApplicationContext
 import io.micronaut.core.annotation.Creator
 import io.micronaut.core.annotation.Introspected
 import io.micronaut.http.hateoas.JsonError
-import io.micronaut.http.hateoas.Link
 import io.micronaut.jackson.JacksonConfiguration
 import io.micronaut.jackson.modules.testcase.EmailTemplate
 import io.micronaut.jackson.modules.testcase.Notification
@@ -961,6 +960,104 @@ class BeanIntrospectionModuleSpec extends Specification {
         @JsonIgnore
         public void setBar(String s) {
             this.bar = s
+        }
+    }
+
+    void "JsonProperty support"() {
+        given:
+        ApplicationContext ctx = ApplicationContext.run()
+        ctx.getBean(BeanIntrospectionModule).ignoreReflectiveProperties = ignoreReflectiveProperties
+        ObjectMapper objectMapper = ctx.getBean(ObjectMapper)
+
+        expect:
+        objectMapper.writeValueAsString(new JsonPropertyBean(foo: 'x')) == '{"bar":"x"}'
+        objectMapper.readValue('{"bar":"x"}', JsonPropertyBean).foo == 'x'
+
+        cleanup:
+        ctx.close()
+
+        where:
+        // without reflection we only see JsonIgnore on the whole property
+        ignoreReflectiveProperties << [true, false]
+    }
+
+    @Introspected
+    static class JsonPropertyBean {
+
+        private String foo
+
+        @JsonProperty('bar')
+        public String getFoo() {
+            return foo
+        }
+
+        public void setFoo(String s) {
+            this.foo = s
+        }
+    }
+
+    void "JsonNaming support"() {
+        given:
+        ApplicationContext ctx = ApplicationContext.run()
+        ctx.getBean(BeanIntrospectionModule).ignoreReflectiveProperties = ignoreReflectiveProperties
+        ObjectMapper objectMapper = ctx.getBean(ObjectMapper)
+
+        expect:
+        objectMapper.writeValueAsString(new JsonNamingBean(fooBar: 'x')) == '{"foo_bar":"x"}'
+        objectMapper.readValue('{"foo_bar":"x"}', JsonNamingBean).fooBar == 'x'
+
+        cleanup:
+        ctx.close()
+
+        where:
+        // without reflection we only see JsonIgnore on the whole property
+        ignoreReflectiveProperties << [true, false]
+    }
+
+    @Introspected
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy)
+    static class JsonNamingBean {
+
+        private String fooBar
+
+        public String getFooBar() {
+            return fooBar
+        }
+
+        public void setFooBar(String s) {
+            this.fooBar = s
+        }
+    }
+
+    void "JsonNaming support in config"() {
+        given:
+        ApplicationContext ctx = ApplicationContext.run(["jackson.property-naming-strategy": "SNAKE_CASE"])
+        ctx.getBean(BeanIntrospectionModule).ignoreReflectiveProperties = ignoreReflectiveProperties
+        ObjectMapper objectMapper = ctx.getBean(ObjectMapper)
+
+        expect:
+        objectMapper.writeValueAsString(new JsonNamingBeanConfig(fooBar: 'x')) == '{"foo_bar":"x"}'
+        objectMapper.readValue('{"foo_bar":"x"}', JsonNamingBeanConfig).fooBar == 'x'
+
+        cleanup:
+        ctx.close()
+
+        where:
+        // without reflection we only see JsonIgnore on the whole property
+        ignoreReflectiveProperties << [true, false]
+    }
+
+    @Introspected
+    static class JsonNamingBeanConfig {
+
+        private String fooBar
+
+        public String getFooBar() {
+            return fooBar
+        }
+
+        public void setFooBar(String s) {
+            this.fooBar = s
         }
     }
 }


### PR DESCRIPTION
Support for JsonNaming was missing (same for the `property-naming-strategy` config property), and support for JsonProperty was spotty. This implements both.
Also removed some old code that special-cased the property names for `Resource`. Not needed anymore since #6254

Fixes #6904
Fixes #6665
Fixes #7129
Fixes micronaut-security/#946