### PR TITLE
correctly propagate stereotypes from mutated annotations

### DIFF
--- a/config/accepted-api-changes.json
+++ b/config/accepted-api-changes.json
@@ -1,0 +1,17 @@
+[
+    {
+        "type": "io.micronaut.core.annotation.AnnotationMetadata",
+        "member": "Method io.micronaut.core.annotation.AnnotationMetadata.getStereotypeAnnotationNames()",
+        "reason": "AnnotationMetadata is an internally implemented data structure and not designed to be implemented by consumers of the framework."
+    },
+    {
+        "type": "io.micronaut.core.annotation.AnnotationMetadata",
+        "member": "Method io.micronaut.core.annotation.AnnotationMetadata.getDeclaredStereotypeAnnotationNames()",
+        "reason": "AnnotationMetadata is an internally implemented data structure and not designed to be implemented by consumers of the framework."
+    },
+    {
+        "type": "io.micronaut.core.annotation.AnnotationMetadata",
+        "member": "Class io.micronaut.core.annotation.AnnotationMetadata",
+        "reason": "AnnotationMetadata is an internally implemented data structure and not designed to be implemented by consumers of the framework."
+    }
+]

--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationMetadata.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationMetadata.java
@@ -111,6 +111,33 @@ public interface AnnotationMetadata extends AnnotationSource {
     }
 
     /**
+     * Returns the names of the annotations which are stereotypes.
+     *
+     * <p>A stereotype is a meta-annotation (an annotation declared on another annotation).</p>
+     * @return The names of the stereotype annotations
+     * @since 3.4.1
+     * @see #getDeclaredStereotypeAnnotationNames()
+     */
+    default @NonNull Set<String> getStereotypeAnnotationNames() {
+        return Collections.emptySet();
+    }
+
+    /**
+     * Returns the names of the annotations which are declared stereotypes.
+     *
+     * <p>A stereotype is a meta-annotation (an annotation declared on another annotation).</p>
+     *
+     * <p>A stereotype is considered declared when it it is a meta-annotation that is present on an annotation directly declared on the element and not inherited from a super class.</p>
+     * @return The names of the stereotype annotations
+     * @since 3.4.1
+     * @see #getStereotypeAnnotationNames()
+     * @see #getDeclaredAnnotationNames()
+     */
+    default @NonNull Set<String> getDeclaredStereotypeAnnotationNames() {
+        return Collections.emptySet();
+    }
+
+    /**
      * All the declared annotation names this metadata declares.
      *
      * @return All the declared annotation names this metadata declares

--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationMetadataDelegate.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationMetadataDelegate.java
@@ -29,6 +29,15 @@ import java.util.*;
  * @since 1.0
  */
 public interface AnnotationMetadataDelegate extends AnnotationMetadataProvider, AnnotationMetadata {
+    @Override
+    default Set<String> getStereotypeAnnotationNames() {
+        return getAnnotationMetadata().getStereotypeAnnotationNames();
+    }
+
+    @Override
+    default Set<String> getDeclaredStereotypeAnnotationNames() {
+        return getAnnotationMetadata().getDeclaredStereotypeAnnotationNames();
+    }
 
     @NonNull
     @Override

--- a/inject-java-test/src/main/groovy/io/micronaut/annotation/processing/test/AbstractTypeElementSpec.groovy
+++ b/inject-java-test/src/main/groovy/io/micronaut/annotation/processing/test/AbstractTypeElementSpec.groovy
@@ -192,6 +192,17 @@ class Test {
         context.getBean(context.classLoader.loadClass(className), qualifier)
     }
 
+
+    /**
+     * Gets a bean definition from the context for the given class name
+     * @param context The context
+     * @param className The class name
+     * @return The bean instance
+     */
+    BeanDefinition<?> getBeanDefinition(ApplicationContext context, String className, Qualifier qualifier = null) {
+        context.getBeanDefinition(context.classLoader.loadClass(className), qualifier)
+    }
+
     /**
      * Builds a {@link ApplicationContext} containing only the classes produced by the given source.
      *

--- a/inject-java/src/test/groovy/io/micronaut/inject/annotation/AddStereotypesFromVisitorSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/annotation/AddStereotypesFromVisitorSpec.groovy
@@ -27,6 +27,7 @@ import io.micronaut.aop.MethodInvocationContext;
 import io.micronaut.inject.annotation.MyQualifier;
 import io.micronaut.inject.annotation.MyScope;
 import io.micronaut.inject.annotation.MyAdvice;
+import io.micronaut.inject.annotation.MyAnnotation;
 import io.micronaut.aop.InterceptorBean;
 import java.util.Locale;
 
@@ -37,6 +38,9 @@ class TestBean {
 
 @MyQualifier
 class Other {}
+
+@MyAnnotation
+class StereotypeTest {}
 
 @MyScope
 class AdvisedBean {
@@ -56,8 +60,12 @@ class MyInterceptor implements MethodInterceptor<Object, Object> {
 }
 ''')
         expect:
+        getBean(context, 'addstereotype.StereotypeTest') != null
         getBean(context, 'addstereotype.TestBean').other != null
-        context.getBeanDefinition(context.classLoader.loadClass('addstereotype.TestBean'))
+        getBeanDefinition(context, 'addstereotype.StereotypeTest')
+            .getAnnotationNameByStereotype(AnnotationUtil.SCOPE)
+            .get() == MyScope.name
+        getBeanDefinition(context, 'addstereotype.TestBean')
                 .injectedFields.first().annotationMetadata.hasDeclaredStereotype(AnnotationUtil.QUALIFIER)
         getBean(context, 'addstereotype.AdvisedBean') instanceof Intercepted
         getBean(context, 'addstereotype.AdvisedBean').test("foo") == "FOO"
@@ -87,6 +95,9 @@ class MyInterceptor implements MethodInterceptor<Object, Object> {
             visitorContext.getClassElement(MyScope).ifPresent({ ClassElement ce ->
                 ce.annotate(Scope)
             })
+            visitorContext.getClassElement(MyAnnotation).ifPresent({ ClassElement ce ->
+                ce.annotate(MyScope)
+            })
         }
     }
 
@@ -109,3 +120,6 @@ class MyInterceptor implements MethodInterceptor<Object, Object> {
 
 @Retention(RetentionPolicy.RUNTIME)
 @interface MyAdvice {}
+
+@Retention(RetentionPolicy.RUNTIME)
+@interface MyAnnotation {}

--- a/inject/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -58,11 +58,13 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
     private static final Map<String, List<AnnotationRemapper>> ANNOTATION_REMAPPERS = new HashMap<>(5);
     private static final Map<MetadataKey, AnnotationMetadata> MUTATED_ANNOTATION_METADATA = new HashMap<>(100);
     private static final Map<String, Set<String>> NON_BINDING_CACHE = new HashMap<>(50);
-    private static final List<String> DEFAULT_ANNOTATE_EXCLUDES = Arrays.asList(Internal.class.getName(), Experimental.class.getName());
+    private static final List<String> DEFAULT_ANNOTATE_EXCLUDES = Arrays.asList(Internal.class.getName(),
+                                                                                Experimental.class.getName());
     private static final Map<String, Map<String, Object>> ANNOTATION_DEFAULTS = new HashMap<>(20);
 
     static {
-        SoftServiceLoader<AnnotationMapper> serviceLoader = SoftServiceLoader.load(AnnotationMapper.class, AbstractAnnotationMetadataBuilder.class.getClassLoader());
+        SoftServiceLoader<AnnotationMapper> serviceLoader = SoftServiceLoader.load(AnnotationMapper.class,
+                                                                                   AbstractAnnotationMetadataBuilder.class.getClassLoader());
         for (ServiceDefinition<AnnotationMapper> definition : serviceLoader) {
             if (definition.isPresent()) {
                 AnnotationMapper mapper = definition.load();
@@ -103,7 +105,8 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
             }
         }
 
-        SoftServiceLoader<AnnotationRemapper> remapperLoader = SoftServiceLoader.load(AnnotationRemapper.class, AbstractAnnotationMetadataBuilder.class.getClassLoader());
+        SoftServiceLoader<AnnotationRemapper> remapperLoader = SoftServiceLoader.load(AnnotationRemapper.class,
+                                                                                      AbstractAnnotationMetadataBuilder.class.getClassLoader());
         for (ServiceDefinition<AnnotationRemapper> definition : remapperLoader) {
             if (definition.isPresent()) {
                 AnnotationRemapper mapper = definition.load();
@@ -265,7 +268,8 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
      * @param element The element
      * @return The declaring type
      */
-    protected abstract @Nullable String getDeclaringType(@NonNull T element);
+    protected abstract @Nullable
+    String getDeclaringType(@NonNull T element);
 
     /**
      * Build the meta data for the given method element excluding any class metadata.
@@ -322,7 +326,9 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
      * @return The {@link AnnotationMetadata}
      */
     public AnnotationMetadata buildForParent(String declaringType, T parent, T element) {
-        return buildForParents(declaringType, parent == null ? Collections.emptyList() : Collections.singletonList(parent), element);
+        return buildForParents(declaringType,
+                               parent == null ? Collections.emptyList() : Collections.singletonList(parent),
+                               element);
     }
 
     /**
@@ -487,7 +493,11 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
      * @param memberName         The member name
      * @param resolvedValue      The resolved value
      */
-    protected void validateAnnotationValue(T originatingElement, String annotationName, T member, String memberName, Object resolvedValue) {
+    protected void validateAnnotationValue(T originatingElement,
+                                           String annotationName,
+                                           T member,
+                                           String memberName,
+                                           Object resolvedValue) {
         if (!validating) {
             return;
         }
@@ -660,10 +670,20 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                 Optional<?> aliasAnnotationName = aliasForValues.get("annotationName");
                 if (aliasMember.isPresent() && !(aliasAnnotation.isPresent() || aliasAnnotationName.isPresent())) {
                     String aliasedNamed = aliasMember.get().toString();
-                    readAnnotationRawValues(originatingElement, annotationTypeName, member, aliasedNamed, annotationValue, resolvedValues);
+                    readAnnotationRawValues(originatingElement,
+                                            annotationTypeName,
+                                            member,
+                                            aliasedNamed,
+                                            annotationValue,
+                                            resolvedValues);
                 }
                 String memberName = getAnnotationMemberName(member);
-                readAnnotationRawValues(originatingElement, annotationTypeName, member, memberName, annotationValue, resolvedValues);
+                readAnnotationRawValues(originatingElement,
+                                        annotationTypeName,
+                                        member,
+                                        memberName,
+                                        annotationValue,
+                                        resolvedValues);
             }
             av = new io.micronaut.core.annotation.AnnotationValue(annotationTypeName, resolvedValues);
         }
@@ -733,7 +753,10 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         String annotationName = getAnnotationTypeName(annotationMirror);
 
         if (retentionPolicy == RetentionPolicy.RUNTIME) {
-            processAnnotationDefaults(originatingElement, metadata, annotationName, () -> readAnnotationDefaultValues(annotationMirror));
+            processAnnotationDefaults(originatingElement,
+                                      metadata,
+                                      annotationName,
+                                      () -> readAnnotationDefaultValues(annotationMirror));
         }
 
         List<String> parentAnnotations = new ArrayList<>();
@@ -848,7 +871,6 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                                     );
                                 }
 
-
                             }
 
                             RetentionPolicy finalRetentionPolicy = retentionPolicy;
@@ -870,7 +892,10 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                                     }
                                 });
                                 if (finalRetentionPolicy == RetentionPolicy.RUNTIME) {
-                                    processAnnotationDefaults(originatingElement, metadata, mappedAnnotationName, () -> readAnnotationDefaultValues(mappedAnnotationName, annMirror));
+                                    processAnnotationDefaults(originatingElement,
+                                                              metadata,
+                                                              mappedAnnotationName,
+                                                              () -> readAnnotationDefaultValues(mappedAnnotationName, annMirror));
                                 }
                                 final ArrayList<String> parents = new ArrayList<>();
                                 processAnnotationStereotype(
@@ -890,7 +915,14 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         return annotationValues;
     }
 
-    private void handleAnnotationAlias(T originatingElement, DefaultAnnotationMetadata metadata, boolean isDeclared, String annotationName, List<String> parentAnnotations, Map<CharSequence, Object> annotationValues, T member, Object annotationValue) {
+    private void handleAnnotationAlias(T originatingElement,
+                                       DefaultAnnotationMetadata metadata,
+                                       boolean isDeclared,
+                                       String annotationName,
+                                       List<String> parentAnnotations,
+                                       Map<CharSequence, Object> annotationValues,
+                                       T member,
+                                       Object annotationValue) {
         Optional<?> aliases = getAnnotationValues(originatingElement, member, Aliases.class).get("value");
         if (aliases.isPresent()) {
             Object value = aliases.get();
@@ -910,7 +942,12 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                     );
                 }
             }
-            readAnnotationRawValues(originatingElement, annotationName, member, getAnnotationMemberName(member), annotationValue, annotationValues);
+            readAnnotationRawValues(originatingElement,
+                                    annotationName,
+                                    member,
+                                    getAnnotationMemberName(member),
+                                    annotationValue,
+                                    annotationValues);
         } else {
             OptionalValues<?> aliasForValues = getAnnotationValues(
                     originatingElement,
@@ -928,7 +965,12 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                     annotationValue,
                     aliasForValues
             );
-            readAnnotationRawValues(originatingElement, annotationName, member, getAnnotationMemberName(member), annotationValue, annotationValues);
+            readAnnotationRawValues(originatingElement,
+                                    annotationName,
+                                    member,
+                                    getAnnotationMemberName(member),
+                                    annotationValue,
+                                    annotationValues);
         }
     }
 
@@ -938,14 +980,16 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
      * @param member The member
      * @return The annotation member
      */
-    protected abstract @Nullable T getAnnotationMember(T originatingElement, CharSequence member);
+    protected abstract @Nullable
+    T getAnnotationMember(T originatingElement, CharSequence member);
 
     /**
      * Obtain the annotation mappers for the given annotation name.
      * @param annotationName The annotation name
      * @return The mappers
      */
-    protected @NonNull List<AnnotationMapper<? extends Annotation>> getAnnotationMappers(@NonNull String annotationName) {
+    protected @NonNull
+    List<AnnotationMapper<? extends Annotation>> getAnnotationMappers(@NonNull String annotationName) {
         return ANNOTATION_MAPPERS.get(annotationName);
     }
 
@@ -954,7 +998,8 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
      * @param annotationName The annotation name
      * @return The transformers
      */
-    protected @NonNull List<AnnotationTransformer<Annotation>> getAnnotationTransformers(@NonNull String annotationName) {
+    protected @NonNull
+    List<AnnotationTransformer<Annotation>> getAnnotationTransformers(@NonNull String annotationName) {
         return ANNOTATION_TRANSFORMERS.get(annotationName);
     }
 
@@ -965,7 +1010,10 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
      */
     protected abstract VisitorContext createVisitorContext();
 
-    private void processAnnotationDefaults(T originatingElement, DefaultAnnotationMetadata metadata, String annotationName, Supplier<Map<? extends T, ?>> elementDefaultValues) {
+    private void processAnnotationDefaults(T originatingElement,
+                                           DefaultAnnotationMetadata metadata,
+                                           String annotationName,
+                                           Supplier<Map<? extends T, ?>> elementDefaultValues) {
         Map<CharSequence, Object> defaultValues;
         final Map<String, Object> defaults = ANNOTATION_DEFAULTS.get(annotationName);
         if (defaults != null) {
@@ -984,7 +1032,9 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         metadata.addDefaultAnnotationValues(annotationName, defaultValues);
     }
 
-    private Map<CharSequence, Object> getAnnotationDefaults(T originatingElement, String annotationName, Map<? extends T, ?> elementDefaultValues) {
+    private Map<CharSequence, Object> getAnnotationDefaults(T originatingElement,
+                                                            String annotationName,
+                                                            Map<? extends T, ?> elementDefaultValues) {
         if (elementDefaultValues != null) {
             Map<CharSequence, Object> defaultValues = new LinkedHashMap<>();
             for (Map.Entry<? extends T, ?> entry : elementDefaultValues.entrySet()) {
@@ -992,7 +1042,12 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                 String memberName = getAnnotationMemberName(member);
                 if (!defaultValues.containsKey(memberName)) {
                     Object annotationValue = entry.getValue();
-                    readAnnotationRawValues(originatingElement, annotationName, member, memberName, annotationValue, defaultValues);
+                    readAnnotationRawValues(originatingElement,
+                                            annotationName,
+                                            member,
+                                            memberName,
+                                            annotationValue,
+                                            defaultValues);
                 }
             }
             return defaultValues;
@@ -1032,14 +1087,18 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
 
                 if (v != null) {
                     final List<AnnotationValue<?>> remappedValues = remapAnnotation(aliasedAnnotation);
-                    for (AnnotationValue<?> remappedAnnotation: remappedValues) {
+                    for (AnnotationValue<?> remappedAnnotation : remappedValues) {
                         String aliasedAnnotationName = remappedAnnotation.getAnnotationName();
                         Optional<T> annotationMirror = getAnnotationMirror(aliasedAnnotationName);
                         RetentionPolicy retentionPolicy = RetentionPolicy.RUNTIME;
                         String repeatableName = null;
                         if (annotationMirror.isPresent()) {
                             final T annotationTypeMirror = annotationMirror.get();
-                            processAnnotationDefaults(originatingElement, metadata, aliasedAnnotationName, () -> readAnnotationDefaultValues(aliasedAnnotationName, annotationTypeMirror));
+                            processAnnotationDefaults(originatingElement,
+                                                      metadata,
+                                                      aliasedAnnotationName,
+                                                      () -> readAnnotationDefaultValues(aliasedAnnotationName,
+                                                                                        annotationTypeMirror));
                             retentionPolicy = getRetentionPolicy(annotationTypeMirror);
                             repeatableName = getRepeatableNameForType(annotationTypeMirror);
                         }
@@ -1171,7 +1230,8 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
             );
 
         }
-        if (!annotationMetadata.hasDeclaredStereotype(AnnotationUtil.SCOPE) && annotationMetadata.hasDeclaredStereotype(DefaultScope.class)) {
+        if (!annotationMetadata.hasDeclaredStereotype(AnnotationUtil.SCOPE) && annotationMetadata.hasDeclaredStereotype(
+                DefaultScope.class)) {
             Optional<String> value = annotationMetadata.stringValue(DefaultScope.class);
             value.ifPresent(name -> annotationMetadata.addDeclaredAnnotation(name, Collections.emptyMap()));
         }
@@ -1193,7 +1253,9 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                 continue;
             }
             if (DEPRECATED_ANNOTATION_NAMES.containsKey(annotationName)) {
-                addWarning(element, "Usages of deprecated annotation " + annotationName + " found. You should use " + DEPRECATED_ANNOTATION_NAMES.get(annotationName) + " instead.");
+                addWarning(element,
+                           "Usages of deprecated annotation " + annotationName + " found. You should use " + DEPRECATED_ANNOTATION_NAMES.get(
+                                   annotationName) + " instead.");
             }
 
             final T annotationType = getTypeForAnnotation(annotationMirror);
@@ -1240,7 +1302,11 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
             String annotationTypeName = getAnnotationTypeName(annotationMirror);
             String packageName = NameUtils.getPackageName(annotationTypeName);
             if (!AnnotationUtil.STEREOTYPE_EXCLUDES.contains(packageName)) {
-                processAnnotationStereotype(element, originatingElementIsSameParent, annotationMirror, annotationMetadata, isDeclared);
+                processAnnotationStereotype(element,
+                                            originatingElementIsSameParent,
+                                            annotationMirror,
+                                            annotationMetadata,
+                                            isDeclared);
             }
         }
     }
@@ -1345,11 +1411,21 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
             AnnotationMetadata modifiedStereotypes = MUTATED_ANNOTATION_METADATA.get(new MetadataKey(lastParent, element));
             if (modifiedStereotypes != null) {
                 Set<String> annotationNames = modifiedStereotypes.getAnnotationNames();
+                handleModifiedStereotypes(parents,
+                          metadata,
+                          isDeclared,
+                          isInherited,
+                          excludes,
+                          interceptorBindings,
+                          lastParent,
+                          modifiedStereotypes);
+
                 for (String annotationName : annotationNames) {
                     AnnotationValue<Annotation> a = modifiedStereotypes.getAnnotation(annotationName);
                     if (a != null) {
                         String stereotypeName = a.getAnnotationName();
-                        if (!AnnotationUtil.INTERNAL_ANNOTATION_NAMES.contains(stereotypeName) && !excludes.contains(stereotypeName)) {
+                        if (!AnnotationUtil.INTERNAL_ANNOTATION_NAMES.contains(stereotypeName) && !excludes.contains(
+                                stereotypeName)) {
                             final T annotationType = getAnnotationMirror(stereotypeName).orElse(null);
                             if (annotationType != null) {
                                 Map<CharSequence, Object> values = a.getValues();
@@ -1408,6 +1484,51 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         }
     }
 
+    private void handleModifiedStereotypes(List<String> parents,
+                           DefaultAnnotationMetadata metadata,
+                           boolean isDeclared,
+                           boolean isInherited,
+                           List<String> excludes,
+                           LinkedList<AnnotationValueBuilder<?>> interceptorBindings,
+                           String lastParent,
+                           AnnotationMetadata modifiedStereotypes) {
+        final Set<String> stereotypeAnnotationNames = modifiedStereotypes.getStereotypeAnnotationNames();
+        for (String stereotypeName : stereotypeAnnotationNames) {
+            final AnnotationValue<Annotation> a = modifiedStereotypes.getAnnotation(stereotypeName);
+            if (a != null && !AnnotationUtil.INTERNAL_ANNOTATION_NAMES.contains(stereotypeName) && !excludes.contains(
+                    stereotypeName)) {
+                final T annotationType = getAnnotationMirror(stereotypeName).orElse(null);
+                final List<String> stereotypeParents = modifiedStereotypes.getAnnotationNamesByStereotype(
+                        stereotypeName);
+                List<String> resolvedParents = new ArrayList<>(parents);
+                resolvedParents.addAll(stereotypeParents);
+                Map<CharSequence, Object> values = a.getValues();
+                if (annotationType != null) {
+
+                    handleAnnotationStereotype(
+                            resolvedParents,
+                            metadata,
+                            isDeclared,
+                            isInherited,
+                            interceptorBindings,
+                            lastParent,
+                            null,
+                            annotationType,
+                            stereotypeName,
+                            values
+                    );
+                } else {
+                    metadata.addStereotype(
+                            resolvedParents,
+                            stereotypeName,
+                            values,
+                            RetentionPolicy.RUNTIME
+                    );
+                }
+            }
+        }
+    }
+
     private void handleAnnotationStereotype(
             List<String> parents,
             DefaultAnnotationMetadata metadata,
@@ -1455,12 +1576,12 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
 
         if (isDeclared) {
             applyTransformations(listIterator, metadata, true, annotationType, data, parents, interceptorBindings,
-                    (string, av) -> metadata.addDeclaredRepeatableStereotype(parents, string, av),
-                    (string, values, rp) -> metadata.addDeclaredStereotype(parents, string, values, rp));
+                                 (string, av) -> metadata.addDeclaredRepeatableStereotype(parents, string, av),
+                                 (string, values, rp) -> metadata.addDeclaredStereotype(parents, string, values, rp));
         } else if (isInherited) {
             applyTransformations(listIterator, metadata, false, annotationType, data, parents, interceptorBindings,
-                    (string, av) -> metadata.addRepeatableStereotype(parents, string, av),
-                    (string, values, rp) -> metadata.addStereotype(parents, string, values, rp));
+                                 (string, av) -> metadata.addRepeatableStereotype(parents, string, av),
+                                 (string, values, rp) -> metadata.addStereotype(parents, string, values, rp));
         } else {
             if (listIterator != null) {
                 listIterator.remove();
@@ -1493,8 +1614,8 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                     }
                     final AnnotationValueBuilder<Annotation> builder =
                             AnnotationValue
-                                .builder(lastParent)
-                                .members(values);
+                                    .builder(lastParent)
+                                    .members(values);
                     data.put(
                             InterceptorBindingQualifier.META_MEMBER_MEMBERS,
                             builder.build()
@@ -1511,7 +1632,8 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
      * @return The members
      * @since 3.3.0
      */
-    protected abstract @NonNull Map<String, ? extends T> getAnnotationMembers(@NonNull String annotationType);
+    protected abstract @NonNull
+    Map<String, ? extends T> getAnnotationMembers(@NonNull String annotationType);
 
     /**
      * Returns true if a simple meta annotation is present for the given element and annotation type.
@@ -1522,7 +1644,9 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
      */
     protected abstract boolean hasSimpleAnnotation(T element, String simpleName);
 
-    private void addToInterceptorBindingsIfNecessary(LinkedList<AnnotationValueBuilder<?>> interceptorBindings, String lastParent, String annotationName) {
+    private void addToInterceptorBindingsIfNecessary(LinkedList<AnnotationValueBuilder<?>> interceptorBindings,
+                                                     String lastParent,
+                                                     String annotationName) {
         if (lastParent != null) {
             AnnotationValueBuilder<?> interceptorBinding = null;
             if (AnnotationUtil.ANN_AROUND.equals(annotationName) || AnnotationUtil.ANN_INTERCEPTOR_BINDING.equals(annotationName)) {
@@ -1709,7 +1833,13 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
             boolean isInherited) {
         List<String> stereoTypeParents = new ArrayList<>(parents);
         stereoTypeParents.add(annotationTypeName);
-        buildStereotypeHierarchy(stereoTypeParents, annotationType, metadata, isDeclared, isInherited, true, Collections.emptyList());
+        buildStereotypeHierarchy(stereoTypeParents,
+                                 annotationType,
+                                 metadata,
+                                 isDeclared,
+                                 isInherited,
+                                 true,
+                                 Collections.emptyList());
     }
 
     private void processAnnotationStereotype(
@@ -1745,15 +1875,15 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
     }
 
     private void applyTransformationsForAnnotationType(
-                                      @Nullable ListIterator<? extends A> hierarchyIterator,
-                                      DefaultAnnotationMetadata annotationMetadata,
-                                      boolean isDeclared,
-                                      @NonNull T annotationType,
-                                      Map<CharSequence, Object> data,
-                                      List<String> parents,
-                                      @Nullable LinkedList<AnnotationValueBuilder<?>> interceptorBindings,
-                                      BiConsumer<String, AnnotationValue> addRepeatableAnnotation,
-                                      TriConsumer<String, Map<CharSequence, Object>, RetentionPolicy> addAnnotation) {
+            @Nullable ListIterator<? extends A> hierarchyIterator,
+            DefaultAnnotationMetadata annotationMetadata,
+            boolean isDeclared,
+            @NonNull T annotationType,
+            Map<CharSequence, Object> data,
+            List<String> parents,
+            @Nullable LinkedList<AnnotationValueBuilder<?>> interceptorBindings,
+            BiConsumer<String, AnnotationValue> addRepeatableAnnotation,
+            TriConsumer<String, Map<CharSequence, Object>, RetentionPolicy> addAnnotation) {
         String annotationName = getElementName(annotationType);
         String packageName = NameUtils.getPackageName(annotationName);
         String repeatableName = getRepeatableNameForType(annotationType);
@@ -1766,7 +1896,8 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
 
         if (repeatableName != null) {
             if (!remapped && !transformed) {
-                io.micronaut.core.annotation.AnnotationValue av = new io.micronaut.core.annotation.AnnotationValue(annotationName, data);
+                io.micronaut.core.annotation.AnnotationValue av = new io.micronaut.core.annotation.AnnotationValue(annotationName,
+                                                                                                                   data);
                 addRepeatableAnnotation.accept(repeatableName, av);
             } else if (remapped) {
 
@@ -1809,7 +1940,8 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                 }
                 if (CollectionUtils.isNotEmpty(repeatableTransformers)) {
                     for (AnnotationTransformer<Annotation> repeatableTransformer : repeatableTransformers) {
-                        final List<AnnotationValue<?>> transformedRepeatable = repeatableTransformer.transform(repeatableAnn, visitorContext);
+                        final List<AnnotationValue<?>> transformedRepeatable = repeatableTransformer.transform(repeatableAnn,
+                                                                                                               visitorContext);
                         for (AnnotationValue<?> annotationValue : transformedRepeatable) {
                             for (AnnotationTransformer<Annotation> transformer : annotationTransformers) {
                                 final List<AnnotationValue<?>> tav = transformer.transform(av, visitorContext);
@@ -1818,7 +1950,10 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                                     if (CollectionUtils.isNotEmpty(value.getStereotypes())) {
                                         addTransformedStereotypes(annotationMetadata, isDeclared, value, parents);
                                     } else {
-                                        addTransformedStereotypes(annotationMetadata, isDeclared, value.getAnnotationName(), parents);
+                                        addTransformedStereotypes(annotationMetadata,
+                                                                  isDeclared,
+                                                                  value.getAnnotationName(),
+                                                                  parents);
                                     }
                                 }
                             }
@@ -1843,7 +1978,9 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
             if (!remapped && !transformed) {
                 addAnnotation.accept(annotationName, data, retentionPolicy);
             } else if (remapped) {
-                io.micronaut.core.annotation.AnnotationValue<?> av = new io.micronaut.core.annotation.AnnotationValue(annotationName, data);
+                io.micronaut.core.annotation.AnnotationValue<?> av = new io.micronaut.core.annotation.AnnotationValue(
+                        annotationName,
+                        data);
                 VisitorContext visitorContext = createVisitorContext();
 
                 boolean wasRemapped = false;
@@ -2107,9 +2244,10 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
     @Internal
     public static boolean isAnnotationMapped(@Nullable String annotationName) {
         return annotationName != null &&
-                (ANNOTATION_MAPPERS.containsKey(annotationName) ||
-                        ANNOTATION_TRANSFORMERS.containsKey(annotationName) ||
-                        ANNOTATION_TRANSFORMERS.keySet().stream().anyMatch(annotationName::startsWith));
+                (
+                        ANNOTATION_MAPPERS.containsKey(annotationName) ||
+                                ANNOTATION_TRANSFORMERS.containsKey(annotationName) ||
+                                ANNOTATION_TRANSFORMERS.keySet().stream().anyMatch(annotationName::startsWith));
     }
 
     /**
@@ -2145,7 +2283,9 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         final boolean isReference = annotationMetadata instanceof AnnotationMetadataReference;
         boolean isReferenceOrEmpty = annotationMetadata == AnnotationMetadata.EMPTY_METADATA || isReference;
         if (annotationMetadata instanceof DefaultAnnotationMetadata || isReferenceOrEmpty) {
-            final DefaultAnnotationMetadata defaultMetadata = isReferenceOrEmpty ? new MutableAnnotationMetadata() : (DefaultAnnotationMetadata) annotationMetadata;
+            final DefaultAnnotationMetadata defaultMetadata = isReferenceOrEmpty
+                    ? new MutableAnnotationMetadata()
+                    : (DefaultAnnotationMetadata) annotationMetadata;
             T annotationMirror = getAnnotationMirror(annotationName).orElse(null);
             if (annotationMirror != null) {
                 applyTransformationsForAnnotationType(
@@ -2285,7 +2425,8 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
      * @param <T1> The annotation type
      * @return The potentially modified metadata
      */
-    public @NonNull <T1 extends Annotation> AnnotationMetadata removeAnnotationIf(
+    public @NonNull
+    <T1 extends Annotation> AnnotationMetadata removeAnnotationIf(
             @NonNull AnnotationMetadata annotationMetadata,
             @NonNull Predicate<AnnotationValue<T1>> predicate) {
         // we only care if the metadata is an hierarchy or default mutable

--- a/inject/src/main/java/io/micronaut/inject/annotation/DefaultAnnotationMetadata.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/DefaultAnnotationMetadata.java
@@ -1217,6 +1217,22 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     }
 
     @Override
+    public Set<String> getStereotypeAnnotationNames() {
+        if (allStereotypes != null) {
+            return Collections.unmodifiableSet(allStereotypes.keySet());
+        }
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Set<String> getDeclaredStereotypeAnnotationNames() {
+        if (declaredStereotypes != null) {
+            return Collections.unmodifiableSet(declaredStereotypes.keySet());
+        }
+        return Collections.emptySet();
+    }
+
+    @Override
     public @NonNull
     Set<String> getDeclaredAnnotationNames() {
         if (declaredAnnotations != null) {


### PR DESCRIPTION
Currently when an annotation is annotated, the stereotypes are not applied to any consumers of the annotation. This resolved that by copying the stereotypes from a mutated annotation to the metadata where the annotation is used.