### PR TITLE
Do not add `Named` to factory bean fields

### DIFF
--- a/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -869,7 +869,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
         } else {
             constructor = factoryField;
 
-            autoApplyNamed(factoryField);
+            autoApplyNamedIfPresent(factoryField, factoryField.getAnnotationMetadata());
             // now prepare the implementation of the build method. See BeanFactory interface
             visitBuildFactoryMethodDefinition(factoryClass, factoryField);
             // now override the injectBean method


### PR DESCRIPTION
I have spent a long time but can only reproduce it on ODI project where the qualifier is resolved as something strange: `@Named("Named")` and then doesn't work when called `getBean(Argument, Qualifier)`.
 
It's a bit confusing as to how this possible can work, added `Named` cannot be recognized as `Qualifier` to adjust `annotationsByStereotype` etc