### PR TITLE
Allow JDK serialization of `null`

### DIFF
--- a/core/src/main/java/io/micronaut/core/serialize/ObjectSerializer.java
+++ b/core/src/main/java/io/micronaut/core/serialize/ObjectSerializer.java
@@ -82,10 +82,6 @@ public interface ObjectSerializer {
      * @throws SerializationException if there is a serialization problem
      */
     default Optional<byte[]> serialize(@Nullable Object object) throws SerializationException {
-        if (object == null) {
-            return Optional.empty();
-        }
-
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         serialize(object, outputStream);
         return Optional.of(outputStream.toByteArray());

--- a/core/src/test/groovy/io/micronaut/core/serialize/JdkSerializerSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/serialize/JdkSerializerSpec.groovy
@@ -32,6 +32,15 @@ class JdkSerializerSpec extends Specification {
         foo.name == "test"
     }
 
+    void 'test serialize null'() {
+        when:
+        def bytes = ObjectSerializer.JDK.serialize(null).get()
+        Optional<Foo> foo = ObjectSerializer.JDK.deserialize(bytes, Foo)
+
+        then:
+        !foo.isPresent()
+    }
+
     static class Foo implements Serializable {
         String name
     }


### PR DESCRIPTION
This adjusts the default behavior of `serialize(Object)` to match that of `serialize(Object, OutputStream)`.
Fixes #6153