### PR TITLE
Properly proceed in filter processing when request is replaced

### DIFF
--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/filters/FilterReplaceRequestSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/filters/FilterReplaceRequestSpec.groovy
@@ -34,8 +34,7 @@ class FilterReplaceRequestSpec extends Specification {
         server.stop()
         client.stop()
     }
-
-
+    
     @Filter(Filter.MATCH_ALL_PATTERN)
     @Requires(property = 'spec.name', value = 'FilterReplaceRequestSpec')
     static class Filter1 implements HttpServerFilter {

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/filters/FilterReplaceRequestSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/filters/FilterReplaceRequestSpec.groovy
@@ -1,0 +1,87 @@
+package io.micronaut.http.server.netty.filters
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.MutableHttpResponse
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Filter
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.filter.HttpServerFilter
+import io.micronaut.http.filter.ServerFilterChain
+import io.micronaut.runtime.server.EmbeddedServer
+import org.reactivestreams.Publisher
+import spock.lang.Specification
+
+class FilterReplaceRequestSpec extends Specification {
+    def 'test replaced http request is handled by next filter'() {
+        given:
+        def ctx = ApplicationContext.run(['spec.name': 'FilterReplaceRequestSpec'])
+        def server = ctx.getBean(EmbeddedServer)
+        server.start()
+        def client = ctx.createBean(HttpClient, server.URI)
+        def filter1 = ctx.getBean(Filter1)
+        def filter2 = ctx.getBean(Filter2)
+
+        when:
+        def resp = client.toBlocking().exchange("/initial", String)
+        then:
+        resp.body() == "initial"
+        filter1.filteredRequest.path == "/initial"
+        filter2.filteredRequest.path == "/filter1"
+
+        cleanup:
+        server.stop()
+        client.stop()
+    }
+
+
+    @Filter(Filter.MATCH_ALL_PATTERN)
+    @Requires(property = 'spec.name', value = 'FilterReplaceRequestSpec')
+    static class Filter1 implements HttpServerFilter {
+        HttpRequest<?> filteredRequest = null
+
+        @Override
+        int getOrder() {
+            1
+        }
+
+        @Override
+        Publisher<MutableHttpResponse<?>> doFilter(HttpRequest<?> request, ServerFilterChain chain) {
+            filteredRequest = request
+            return chain.proceed(HttpRequest.GET("/filter1"))
+        }
+    }
+
+    @Filter(Filter.MATCH_ALL_PATTERN)
+    @Requires(property = 'spec.name', value = 'FilterReplaceRequestSpec')
+    static class Filter2 implements HttpServerFilter {
+        HttpRequest<?> filteredRequest = null
+
+        @Override
+        int getOrder() {
+            2
+        }
+
+        @Override
+        Publisher<MutableHttpResponse<?>> doFilter(HttpRequest<?> request, ServerFilterChain chain) {
+            filteredRequest = request
+            return chain.proceed(HttpRequest.GET("/filter2"))
+        }
+    }
+
+    @Controller
+    @Requires(property = 'spec.name', value = 'FilterReplaceRequestSpec')
+    static class Ctrl {
+        @Get("/filter2")
+        def filter2() {
+            return "filter2"
+        }
+
+        @Get("/initial")
+        def initial() {
+            return "initial"
+        }
+    }
+}

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/filters/FilterReplaceRequestSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/filters/FilterReplaceRequestSpec.groovy
@@ -18,12 +18,10 @@ import spock.lang.Specification
 class FilterReplaceRequestSpec extends Specification {
     def 'test replaced http request is handled by next filter'() {
         given:
-        ApplicationContext ctx = ApplicationContext.run(['spec.name': 'FilterReplaceRequestSpec'])
-        EmbeddedServer server = ctx.getBean(EmbeddedServer)
-        server.start()
-        HttpClient client = ctx.createBean(HttpClient, server.URI)
-        Filter1 filter1 = ctx.getBean(Filter1)
-        Filter2 filter2 = ctx.getBean(Filter2)
+        EmbeddedServer server = ApplicationContext.run(EmbeddedServer, ['spec.name': 'FilterReplaceRequestSpec'])
+        HttpClient client = server.applicationContext.createBean(HttpClient, server.URI)
+        Filter1 filter1 = server.applicationContext.getBean(Filter1)
+        Filter2 filter2 = server.applicationContext.getBean(Filter2)
 
         when:
         HttpResponse<String> resp = client.toBlocking().exchange("/initial", String)

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/filters/FilterReplaceRequestSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/filters/FilterReplaceRequestSpec.groovy
@@ -51,7 +51,7 @@ class FilterReplaceRequestSpec extends Specification {
         @Override
         Publisher<MutableHttpResponse<?>> doFilter(HttpRequest<?> request, ServerFilterChain chain) {
             filteredRequest = request
-            return chain.proceed(HttpRequest.GET("/filter1"))
+            chain.proceed(HttpRequest.GET("/filter1"))
         }
     }
 
@@ -68,7 +68,7 @@ class FilterReplaceRequestSpec extends Specification {
         @Override
         Publisher<MutableHttpResponse<?>> doFilter(HttpRequest<?> request, ServerFilterChain chain) {
             filteredRequest = request
-            return chain.proceed(HttpRequest.GET("/filter2"))
+            chain.proceed(HttpRequest.GET("/filter2"))
         }
     }
 
@@ -77,12 +77,12 @@ class FilterReplaceRequestSpec extends Specification {
     static class Ctrl {
         @Get("/filter2")
         String filter2() {
-            return "filter2"
+            "filter2"
         }
 
         @Get("/initial")
         String initial() {
-            return "initial"
+            "initial"
         }
     }
 }

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/filters/FilterReplaceRequestSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/filters/FilterReplaceRequestSpec.groovy
@@ -14,6 +14,7 @@ import io.micronaut.http.filter.ServerFilterChain
 import io.micronaut.runtime.server.EmbeddedServer
 import org.reactivestreams.Publisher
 import spock.lang.AutoCleanup
+import spock.lang.PendingFeature
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -26,17 +27,25 @@ class FilterReplaceRequestSpec extends Specification {
     @Shared
     @AutoCleanup
     HttpClient client = server.applicationContext.createBean(HttpClient, server.URI)
-    
+
     def 'test replaced http request is handled by next filter'() {
         when:
-        HttpResponse<String> resp = client.toBlocking().exchange("/initial", String)
+        client.toBlocking().exchange("/initial", String)
         Filter1 filter1 = server.applicationContext.getBean(Filter1)
         Filter2 filter2 = server.applicationContext.getBean(Filter2)
 
         then:
-        resp.body() == "initial"
         filter1.filteredRequest.path == "/initial"
         filter2.filteredRequest.path == "/filter1"
+    }
+
+    @PendingFeature
+    def 'last filter http request is used to match route'() {
+        when:
+        HttpResponse<String> resp = client.toBlocking().retrieve("/initial", String)
+
+        then:
+        resp.body() == "filter2"
     }
     
     @Filter(Filter.MATCH_ALL_PATTERN)

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/filters/FilterReplaceRequestSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/filters/FilterReplaceRequestSpec.groovy
@@ -3,6 +3,7 @@ package io.micronaut.http.server.netty.filters
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Requires
 import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
 import io.micronaut.http.MutableHttpResponse
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Filter
@@ -17,15 +18,15 @@ import spock.lang.Specification
 class FilterReplaceRequestSpec extends Specification {
     def 'test replaced http request is handled by next filter'() {
         given:
-        def ctx = ApplicationContext.run(['spec.name': 'FilterReplaceRequestSpec'])
-        def server = ctx.getBean(EmbeddedServer)
+        ApplicationContext ctx = ApplicationContext.run(['spec.name': 'FilterReplaceRequestSpec'])
+        EmbeddedServer server = ctx.getBean(EmbeddedServer)
         server.start()
-        def client = ctx.createBean(HttpClient, server.URI)
-        def filter1 = ctx.getBean(Filter1)
-        def filter2 = ctx.getBean(Filter2)
+        HttpClient client = ctx.createBean(HttpClient, server.URI)
+        Filter1 filter1 = ctx.getBean(Filter1)
+        Filter2 filter2 = ctx.getBean(Filter2)
 
         when:
-        def resp = client.toBlocking().exchange("/initial", String)
+        HttpResponse<String> resp = client.toBlocking().exchange("/initial", String)
         then:
         resp.body() == "initial"
         filter1.filteredRequest.path == "/initial"
@@ -75,12 +76,12 @@ class FilterReplaceRequestSpec extends Specification {
     @Requires(property = 'spec.name', value = 'FilterReplaceRequestSpec')
     static class Ctrl {
         @Get("/filter2")
-        def filter2() {
+        String filter2() {
             return "filter2"
         }
 
         @Get("/initial")
-        def initial() {
+        String initial() {
             return "initial"
         }
     }

--- a/http-server/src/main/java/io/micronaut/http/server/RouteExecutor.java
+++ b/http-server/src/main/java/io/micronaut/http/server/RouteExecutor.java
@@ -393,9 +393,9 @@ public final class RouteExecutor {
                 }
                 HttpFilter httpFilter = filters.get(pos);
 
-                HttpRequest<?> requestForFilter = requestReference.getAndSet(request);
+                requestReference.set(request);
                 try {
-                    return Flux.from((Publisher<MutableHttpResponse<?>>) httpFilter.doFilter(requestForFilter, this))
+                    return Flux.from((Publisher<MutableHttpResponse<?>>) httpFilter.doFilter(request, this))
                             .flatMap(handleStatusException)
                             .onErrorResume(onError);
                 } catch (Throwable t) {


### PR DESCRIPTION
When a filter calls chain.proceed with a new request, that request should be used for further processing.
Replacing the request is still not fully working even with this change, so #5491 is not fully fixed. RoutingInBoundHandler still does not consider the new request, because most of the request processing happens before the filter is applied. In the test case of this patch, this manifests as the response text still being "initial" even though the request has been replaced.