### PR TITLE
fix: String[] is convertible into String with comma delimiter

### DIFF
--- a/core/src/main/java/io/micronaut/core/convert/DefaultConversionService.java
+++ b/core/src/main/java/io/micronaut/core/convert/DefaultConversionService.java
@@ -334,7 +334,7 @@ public class DefaultConversionService implements ConversionService<DefaultConver
                 return Optional.empty();
             }
 
-            StringJoiner joiner = new StringJoiner("");
+            StringJoiner joiner = new StringJoiner(",");
             for (String string : object) {
                 joiner.add(string);
             }


### PR DESCRIPTION
Without this delimiter micronaut declarative client treats `Array<String>` query params in a buggy way. More specifically: it just concats all strings into single string without delimiter. This change fixes it by adding comma delimiter which is acceptable strategy for passing arrays in query params.