### PR TITLE
Bean context improvements and refactoring

### DIFF
--- a/context/src/main/java/io/micronaut/runtime/context/scope/refresh/RefreshScope.java
+++ b/context/src/main/java/io/micronaut/runtime/context/scope/refresh/RefreshScope.java
@@ -192,7 +192,7 @@ public class RefreshScope implements CustomScope<Refreshable>, LifeCycle<Refresh
             if (value.isPresent()) {
                 String configPrefix = value.get();
                 if (keySet.stream().anyMatch(key -> key.startsWith(configPrefix))) {
-                    beanContext.refreshBean(registration.getIdentifier());
+                    beanContext.refreshBean(registration);
                 }
             }
         }
@@ -202,7 +202,7 @@ public class RefreshScope implements CustomScope<Refreshable>, LifeCycle<Refresh
         Collection<BeanRegistration<?>> registrations =
             beanContext.getActiveBeanRegistrations(Qualifiers.byStereotype(ConfigurationProperties.class));
         for (BeanRegistration<?> registration : registrations) {
-            beanContext.refreshBean(registration.getIdentifier());
+            beanContext.refreshBean(registration);
         }
     }
 

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/ImmediateCloseSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/ImmediateCloseSpec.groovy
@@ -32,6 +32,7 @@ class ImmediateCloseSpec extends Specification {
         embeddedServer.start()
 
         when:
+        def holder = ctx.getBean(Holder) // Get holder before the close is called and instance is destroyed
         HttpGet get = new HttpGet(embeddedServer.URI.toString() + '/empty')
         CloseableHttpClient httpClient = HttpClients.createDefault()
         def response = httpClient.execute(get)
@@ -40,7 +41,7 @@ class ImmediateCloseSpec extends Specification {
 
         then:
         response.getStatusLine().statusCode == 401
-        ctx.getBean(Holder).handleCount == 1
+        holder.handleCount == 1
         // can't check for log messages :(
 
         cleanup:

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/ImmediateCloseSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/ImmediateCloseSpec.groovy
@@ -13,6 +13,7 @@ import io.micronaut.http.filter.ServerFilterChain
 import io.micronaut.runtime.server.EmbeddedServer
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
+import org.apache.http.client.methods.CloseableHttpResponse
 import org.apache.http.client.methods.HttpGet
 import org.apache.http.impl.client.CloseableHttpClient
 import org.apache.http.impl.client.HttpClients
@@ -24,18 +25,15 @@ class ImmediateCloseSpec extends Specification {
     @Issue('https://github.com/micronaut-projects/micronaut-core/issues/6723')
     def 'immediate close of client connection should not lead to log message'() {
         given:
-        def ctx = ApplicationContext.run([
+        EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
                 'spec.name': 'ImmediateCloseSpec',
-                //'micronaut.server.port': 8080
         ])
-        def embeddedServer = ctx.getBean(EmbeddedServer)
-        embeddedServer.start()
 
         when:
-        def holder = ctx.getBean(Holder) // Get holder before the close is called and instance is destroyed
+        Holder holder = embeddedServer.applicationContext.getBean(Holder) // Get holder before the close is called and instance is destroyed
         HttpGet get = new HttpGet(embeddedServer.URI.toString() + '/empty')
         CloseableHttpClient httpClient = HttpClients.createDefault()
-        def response = httpClient.execute(get)
+        CloseableHttpResponse response = httpClient.execute(get)
         httpClient.close()
         embeddedServer.close() // wait for connection handling to finish
 

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/scope/ContextScopeSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/scope/ContextScopeSpec.groovy
@@ -32,7 +32,7 @@ class ContextScopeSpec extends Specification {
         beanContext.start()
 
         then:"So is the bean"
-        beanContext.@singletonObjects.values().find() { it.bean instanceof A }
+        beanContext.@singletonScope.@singletonByBeanDefinition.values().find() { it.bean instanceof A }
     }
 
     @Context

--- a/inject-java/src/test/groovy/io/micronaut/inject/records/RecordBeansSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/records/RecordBeansSpec.groovy
@@ -27,7 +27,7 @@ import io.micronaut.context.BeanContext;
 record Test(
     @Min(20) int num, 
     String name, 
-    @Primary ConversionService conversionService,
+    @Inject ConversionService conversionService,
     @Inject BeanContext beanContext) {
 }
 ''')

--- a/inject-java/src/test/groovy/io/micronaut/inject/scope/ContextScopeSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/scope/ContextScopeSpec.groovy
@@ -28,6 +28,6 @@ class ContextScopeSpec extends Specification {
         beanContext.start()
 
         then:"So is the bean"
-        beanContext.@singletonObjects.values().find() { it.bean instanceof A }
+        beanContext.@singletonScope.@singletonByBeanDefinition.values().find() { it.bean instanceof A }
     }
 }

--- a/inject/src/main/java/io/micronaut/context/AbstractBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractBeanDefinition.java
@@ -680,7 +680,7 @@ public class AbstractBeanDefinition<T> extends AbstractBeanContextConditional im
             // this is to ensure that if the post construct method does anything funky to
             // cause recreation of this bean then we don't have a circular problem
             key = new DefaultBeanContext.BeanKey(this, resolutionContext.getCurrentQualifier());
-            resolutionContext.addInFlightBean(key, bean);
+            resolutionContext.addInFlightBean(key, new BeanRegistration(key, this, bean));
         }
 
         final Set<Map.Entry<Class, List<BeanInitializedEventListener>>> beanInitializedEventListeners

--- a/inject/src/main/java/io/micronaut/context/AbstractBeanResolutionContext.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractBeanResolutionContext.java
@@ -109,11 +109,11 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
     }
 
     @Override
-    public <T> void addDependentBean(BeanIdentifier identifier, BeanDefinition<T> definition, T bean) {
+    public <T> void addDependentBean(BeanRegistration<T> beanRegistration) {
         if (dependentBeans == null) {
             dependentBeans = new ArrayList<>(3);
         }
-        dependentBeans.add(new BeanRegistration<>(identifier, definition, bean));
+        dependentBeans.add(beanRegistration);
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/context/AbstractInitializableBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractInitializableBeanDefinition.java
@@ -1125,17 +1125,18 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
      * @param methodIndex       The method index
      * @param argIndex          The argument index
      * @param qualifier         The qualifier
+     * @param <K>               The bean type
      * @return The resolved bean
      */
     @Internal
     @SuppressWarnings("WeakerAccess")
     @UsedByGeneratedCode
-    protected final Object getBeanForMethodArgument(BeanResolutionContext resolutionContext, BeanContext context, int methodIndex, int argIndex, Qualifier qualifier) {
+    protected final <K> K getBeanForMethodArgument(BeanResolutionContext resolutionContext, BeanContext context, int methodIndex, int argIndex, Qualifier<K> qualifier) {
         MethodReference methodRef = methodInjection[methodIndex];
-        Argument argument = resolveArgument(context, argIndex, methodRef.arguments);
+        Argument<K> argument = resolveArgument(context, argIndex, methodRef.arguments);
         try (BeanResolutionContext.Path ignored = resolutionContext.getPath()
                 .pushMethodArgumentResolve(this, methodRef.methodName, argument, methodRef.arguments, methodRef.requiresReflection)) {
-            return resolveBean(resolutionContext, context, argument, qualifier, true);
+            return resolveBean(resolutionContext, argument, qualifier, true);
         }
     }
 
@@ -1149,13 +1150,15 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
      * @param argumentIndex     The argument index
      * @param genericType       The generic type
      * @param qualifier         The qualifier
+     * @param <K>               The bean type
+     * @param <R>               The result collection type
      * @return The resolved bean
      */
     @Internal
     @UsedByGeneratedCode
-    protected final Collection<Object> getBeansOfTypeForMethodArgument(BeanResolutionContext resolutionContext, BeanContext context, int methodIndex, int argumentIndex, Argument genericType, Qualifier qualifier) {
+    protected final <K, R extends Collection<K>> R getBeansOfTypeForMethodArgument(BeanResolutionContext resolutionContext, BeanContext context, int methodIndex, int argumentIndex, Argument<K> genericType, Qualifier<K> qualifier) {
         MethodReference methodRef = methodInjection[methodIndex];
-        Argument argument = resolveArgument(context, argumentIndex, methodRef.arguments);
+        Argument<R> argument = resolveArgument(context, argumentIndex, methodRef.arguments);
         try (BeanResolutionContext.Path ignored =
                      resolutionContext.getPath().pushMethodArgumentResolve(this, methodRef.methodName, argument, methodRef.arguments, methodRef.requiresReflection)) {
             return resolveBeansOfType(resolutionContext, context, argument, resolveEnvironmentArgument(context, genericType), qualifier);
@@ -1180,7 +1183,7 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
     protected final Object getBeanForSetter(BeanResolutionContext resolutionContext, BeanContext context, String setterName, Argument argument, Qualifier qualifier) {
         try (BeanResolutionContext.Path ignored = resolutionContext.getPath()
                 .pushMethodArgumentResolve(this, setterName, argument, new Argument[] {argument}, false)) {
-            return resolveBean(resolutionContext, context, argument, qualifier, true);
+            return resolveBean(resolutionContext, argument, qualifier, true);
         }
     }
 
@@ -1216,13 +1219,14 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
      * @param argIndex          The argument index
      * @param genericType       The generic type
      * @param qualifier         The qualifier
+     * @param <K>               The bean type
      * @return The resolved bean
      */
     @Internal
     @UsedByGeneratedCode
-    protected final Optional findBeanForMethodArgument(BeanResolutionContext resolutionContext, BeanContext context, int methodIndex, int argIndex, Argument genericType, Qualifier qualifier) {
+    protected final <K> Optional<K> findBeanForMethodArgument(BeanResolutionContext resolutionContext, BeanContext context, int methodIndex, int argIndex, Argument<K> genericType, Qualifier<K> qualifier) {
         MethodReference methodRef = methodInjection[methodIndex];
-        Argument<?> argument = resolveArgument(context, argIndex, methodRef.arguments);
+        Argument<K> argument = resolveArgument(context, argIndex, methodRef.arguments);
         try (BeanResolutionContext.Path ignored =
                      resolutionContext.getPath().pushMethodArgumentResolve(this, methodRef.methodName, argument, methodRef.arguments, methodRef.requiresReflection)) {
             return resolveOptionalBean(resolutionContext, argument, resolveEnvironmentArgument(context, genericType), qualifier);
@@ -1249,7 +1253,7 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
         Argument<?> argument = resolveArgument(context, argIndex, methodRef.arguments);
         try (BeanResolutionContext.Path ignored =
                      resolutionContext.getPath().pushMethodArgumentResolve(this, methodRef.methodName, argument, methodRef.arguments, methodRef.requiresReflection)) {
-            return resolveStreamOfType(resolutionContext, context, argument, resolveEnvironmentArgument(context, genericType), qualifier);
+            return resolveStreamOfType(resolutionContext, argument, resolveEnvironmentArgument(context, genericType), qualifier);
         }
     }
 
@@ -1277,7 +1281,7 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
         }
         try (BeanResolutionContext.Path ignored = resolutionContext.getPath()
                 .pushConstructorResolve(this, argument)) {
-            return resolveBean(resolutionContext, context, argument, qualifier, true);
+            return resolveBean(resolutionContext, argument, qualifier, true);
         }
     }
 
@@ -1432,13 +1436,15 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
      * @param argumentIndex     The argument index
      * @param genericType       The generic type
      * @param qualifier         The qualifier
+     * @param <K>               The bean type
+     * @param <R>               The result collection type
      * @return The resolved bean
      */
     @Internal
     @UsedByGeneratedCode
-    protected final Collection<BeanRegistration<Object>> getBeanRegistrationsForConstructorArgument(BeanResolutionContext resolutionContext, BeanContext context, int argumentIndex, Argument genericType, Qualifier qualifier) {
+    protected final <K, R extends Collection<BeanRegistration<K>>> R getBeanRegistrationsForConstructorArgument(BeanResolutionContext resolutionContext, BeanContext context, int argumentIndex, Argument<K> genericType, Qualifier<K> qualifier) {
         MethodReference constructorMethodRef = (MethodReference) constructor;
-        Argument<?> argument = resolveArgument(context, argumentIndex, constructorMethodRef.arguments);
+        Argument<R> argument = resolveArgument(context, argumentIndex, constructorMethodRef.arguments);
         try (BeanResolutionContext.Path ignored = resolutionContext.getPath().pushConstructorResolve(this, argument)) {
             return resolveBeanRegistrations(resolutionContext, argument, resolveEnvironmentArgument(context, genericType), qualifier);
         }
@@ -1454,13 +1460,14 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
      * @param argumentIndex     The arg index
      * @param genericType       The generic type
      * @param qualifier         The qualifier
+     * @param <K>               The bean type
      * @return The resolved bean registration
      */
     @Internal
     @UsedByGeneratedCode
-    protected final BeanRegistration<?> getBeanRegistrationForConstructorArgument(BeanResolutionContext resolutionContext, BeanContext context, int argumentIndex, Argument genericType, Qualifier qualifier) {
+    protected final <K> BeanRegistration<K> getBeanRegistrationForConstructorArgument(BeanResolutionContext resolutionContext, BeanContext context, int argumentIndex, Argument<K> genericType, Qualifier<K> qualifier) {
         MethodReference constructorMethodRef = (MethodReference) constructor;
-        Argument<?> argument = resolveArgument(context, argumentIndex, constructorMethodRef.arguments);
+        Argument<K> argument = resolveArgument(context, argumentIndex, constructorMethodRef.arguments);
         try (BeanResolutionContext.Path ignored = resolutionContext.getPath().pushConstructorResolve(this, argument)) {
             return resolveBeanRegistration(resolutionContext, context, argument, resolveEnvironmentArgument(context, genericType), qualifier);
         }
@@ -1477,13 +1484,15 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
      * @param argIndex          The arg index
      * @param genericType       The generic type
      * @param qualifier         The qualifier
+     * @param <K>               The bean type
+     * @param <R>               The result collection type
      * @return The resolved bean
      */
     @Internal
     @UsedByGeneratedCode
-    protected final Collection<BeanRegistration<Object>> getBeanRegistrationsForMethodArgument(BeanResolutionContext resolutionContext, BeanContext context, int methodIndex, int argIndex, Argument genericType, Qualifier qualifier) {
+    protected final <K, R extends Collection<BeanRegistration<K>>> R getBeanRegistrationsForMethodArgument(BeanResolutionContext resolutionContext, BeanContext context, int methodIndex, int argIndex, Argument<K> genericType, Qualifier<K> qualifier) {
         MethodReference methodReference = methodInjection[methodIndex];
-        Argument<?> argument = resolveArgument(context, argIndex, methodReference.arguments);
+        Argument<R> argument = resolveArgument(context, argIndex, methodReference.arguments);
         try (BeanResolutionContext.Path ignored = resolutionContext.getPath()
                 .pushMethodArgumentResolve(this, methodReference.methodName, argument, methodReference.arguments, methodReference.requiresReflection)) {
             return resolveBeanRegistrations(resolutionContext, argument, resolveEnvironmentArgument(context, genericType), qualifier);
@@ -1501,13 +1510,14 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
      * @param argIndex          The arg index
      * @param genericType       The generic type
      * @param qualifier         The qualifier
+     * @param <K>               The bean type
      * @return The resolved bean registration
      */
     @Internal
     @UsedByGeneratedCode
-    protected final BeanRegistration<?> getBeanRegistrationForMethodArgument(BeanResolutionContext resolutionContext, BeanContext context, int methodIndex, int argIndex, Argument genericType, Qualifier qualifier) {
+    protected final <K> BeanRegistration<K> getBeanRegistrationForMethodArgument(BeanResolutionContext resolutionContext, BeanContext context, int methodIndex, int argIndex, Argument<K> genericType, Qualifier<K> qualifier) {
         MethodReference methodRef = methodInjection[methodIndex];
-        Argument<?> argument = resolveArgument(context, argIndex, methodRef.arguments);
+        Argument<K> argument = resolveArgument(context, argIndex, methodRef.arguments);
         try (BeanResolutionContext.Path ignored = resolutionContext.getPath()
                 .pushMethodArgumentResolve(this, methodRef.methodName, argument, methodRef.arguments, methodRef.requiresReflection)) {
             return resolveBeanRegistration(resolutionContext, context, argument, resolveEnvironmentArgument(context, genericType), qualifier);
@@ -1524,15 +1534,16 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
      * @param argIndex          The argument index
      * @param genericType       The generic type
      * @param qualifier         The qualifier
+     * @param <K>               The bean type
      * @return The resolved bean
      */
     @Internal
     @UsedByGeneratedCode
-    protected final Stream<?> getStreamOfTypeForConstructorArgument(BeanResolutionContext resolutionContext, BeanContext context, int argIndex, Argument genericType, Qualifier qualifier) {
+    protected final <K> Stream<K> getStreamOfTypeForConstructorArgument(BeanResolutionContext resolutionContext, BeanContext context, int argIndex, Argument<K> genericType, Qualifier<K> qualifier) {
         MethodReference constructorMethodRef = (MethodReference) constructor;
-        Argument<?> argument = resolveArgument(context, argIndex, constructorMethodRef.arguments);
+        Argument<K> argument = resolveArgument(context, argIndex, constructorMethodRef.arguments);
         try (BeanResolutionContext.Path ignored = resolutionContext.getPath().pushConstructorResolve(this, argument)) {
-            return resolveStreamOfType(resolutionContext, context, argument, resolveEnvironmentArgument(context, genericType), qualifier);
+            return resolveStreamOfType(resolutionContext, argument, resolveEnvironmentArgument(context, genericType), qualifier);
         }
     }
 
@@ -1546,13 +1557,14 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
      * @param argIndex          The argument index
      * @param genericType       The generic type
      * @param qualifier         The qualifier
+     * @param <K>               The bean type
      * @return The resolved bean
      */
     @Internal
     @UsedByGeneratedCode
-    protected final Optional<?> findBeanForConstructorArgument(BeanResolutionContext resolutionContext, BeanContext context, int argIndex, Argument genericType, Qualifier qualifier) {
+    protected final <K> Optional<K> findBeanForConstructorArgument(BeanResolutionContext resolutionContext, BeanContext context, int argIndex, Argument<K> genericType, Qualifier<K> qualifier) {
         MethodReference constructorMethodRef = (MethodReference) constructor;
-        Argument<?> argument = resolveArgument(context, argIndex, constructorMethodRef.arguments);
+        Argument<K> argument = resolveArgument(context, argIndex, constructorMethodRef.arguments);
         try (BeanResolutionContext.Path ignored = resolutionContext.getPath().pushConstructorResolve(this, argument)) {
             return resolveOptionalBean(resolutionContext, argument, resolveEnvironmentArgument(context, genericType), qualifier);
         }
@@ -1567,25 +1579,26 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
      * @param context           The context
      * @param fieldIndex        The field index
      * @param qualifier         The qualifier
+     * @param <K>               The bean type
      * @return The resolved bean
      */
     @Internal
     @UsedByGeneratedCode
-    protected final Object getBeanForField(BeanResolutionContext resolutionContext, BeanContext context, int fieldIndex, Qualifier qualifier) {
-        final Argument argument = resolveEnvironmentArgument(context, fieldInjection[fieldIndex].argument);
+    protected final <K> K getBeanForField(BeanResolutionContext resolutionContext, BeanContext context, int fieldIndex, Qualifier<K> qualifier) {
+        final Argument<K> argument = resolveEnvironmentArgument(context, fieldInjection[fieldIndex].argument);
         try (BeanResolutionContext.Path ignored = resolutionContext.getPath()
                 .pushFieldResolve(this, argument, fieldInjection[fieldIndex].requiresReflection)) {
-            return resolveBean(resolutionContext, context, argument, qualifier, true);
+            return resolveBean(resolutionContext, argument, qualifier, true);
         }
     }
 
     @Internal
     @UsedByGeneratedCode
-    protected final Object getBeanForAnnotation(BeanResolutionContext resolutionContext, BeanContext context, int annotationBeanIndex, Qualifier qualifier) {
-        final Argument argument = resolveEnvironmentArgument(context, annotationInjection[annotationBeanIndex].argument);
+    protected final <K> K getBeanForAnnotation(BeanResolutionContext resolutionContext, BeanContext context, int annotationBeanIndex, Qualifier<K> qualifier) {
+        final Argument<K> argument = resolveEnvironmentArgument(context, annotationInjection[annotationBeanIndex].argument);
         try (BeanResolutionContext.Path ignored = resolutionContext.getPath()
                 .pushAnnotationResolve(this, argument)) {
-            return resolveBean(resolutionContext, context, argument, qualifier);
+            return resolveBean(resolutionContext, argument, qualifier);
         }
     }
 
@@ -1732,13 +1745,15 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
      * @param fieldIndex        The field index
      * @param genericType       The generic type
      * @param qualifier         The qualifier
+     * @param <K>               The bean type
+     * @param <R>               The result collection type
      * @return The resolved bean
      */
     @Internal
     @UsedByGeneratedCode
-    protected final Object getBeansOfTypeForField(BeanResolutionContext resolutionContext, BeanContext context, int fieldIndex, Argument genericType, Qualifier qualifier) {
+    protected final <K, R extends Collection<K>> R getBeansOfTypeForField(BeanResolutionContext resolutionContext, BeanContext context, int fieldIndex, Argument<K> genericType, Qualifier<K> qualifier) {
         final FieldReference fieldRef = fieldInjection[fieldIndex];
-        final Argument<?> argument = resolveEnvironmentArgument(context, fieldRef.argument);
+        final Argument<R> argument = resolveEnvironmentArgument(context, fieldRef.argument);
         try (BeanResolutionContext.Path ignored = resolutionContext.getPath().pushFieldResolve(this, argument, fieldRef.requiresReflection)) {
             return resolveBeansOfType(resolutionContext, context, argument, resolveEnvironmentArgument(context, genericType), qualifier);
         }
@@ -1754,13 +1769,15 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
      * @param fieldIndex        The field index
      * @param genericType       The generic type
      * @param qualifier         The qualifier
+     * @param <K>               The bean type
+     * @param <R>               The result collection type
      * @return The resolved bean
      */
     @Internal
     @UsedByGeneratedCode
-    protected final Object getBeanRegistrationsForField(BeanResolutionContext resolutionContext, BeanContext context, int fieldIndex, Argument genericType, Qualifier qualifier) {
+    protected final <K, R extends Collection<BeanRegistration<K>>> R getBeanRegistrationsForField(BeanResolutionContext resolutionContext, BeanContext context, int fieldIndex, Argument<K> genericType, Qualifier<K> qualifier) {
         FieldReference fieldRef = fieldInjection[fieldIndex];
-        Argument argument = resolveEnvironmentArgument(context, fieldRef.argument);
+        Argument<R> argument = resolveEnvironmentArgument(context, fieldRef.argument);
         try (BeanResolutionContext.Path ignored = resolutionContext.getPath()
                 .pushFieldResolve(this, argument, fieldRef.requiresReflection)) {
             return resolveBeanRegistrations(resolutionContext, argument, resolveEnvironmentArgument(context, genericType), qualifier);
@@ -1781,9 +1798,9 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
      */
     @Internal
     @UsedByGeneratedCode
-    protected final BeanRegistration<?> getBeanRegistrationForField(BeanResolutionContext resolutionContext, BeanContext context, int fieldIndex, Argument genericType, Qualifier qualifier) {
+    protected final <K> BeanRegistration<K> getBeanRegistrationForField(BeanResolutionContext resolutionContext, BeanContext context, int fieldIndex, Argument<K> genericType, Qualifier<K> qualifier) {
         FieldReference fieldRef = fieldInjection[fieldIndex];
-        Argument argument = resolveEnvironmentArgument(context, fieldRef.argument);
+        Argument<K> argument = resolveEnvironmentArgument(context, fieldRef.argument);
         try (BeanResolutionContext.Path ignored = resolutionContext.getPath()
                 .pushFieldResolve(this, argument, fieldRef.requiresReflection)) {
             return resolveBeanRegistration(resolutionContext, context, argument, resolveEnvironmentArgument(context, genericType), qualifier);
@@ -1800,13 +1817,14 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
      * @param fieldIndex        The field index
      * @param genericType       The generic type
      * @param qualifier         The qualifier
+     * @param <K>               The bean type
      * @return The resolved bean
      */
     @Internal
     @UsedByGeneratedCode
-    protected final Optional findBeanForField(BeanResolutionContext resolutionContext, BeanContext context, int fieldIndex, Argument genericType, Qualifier qualifier) {
+    protected final <K> Optional<K> findBeanForField(BeanResolutionContext resolutionContext, BeanContext context, int fieldIndex, Argument<K> genericType, Qualifier<K> qualifier) {
         FieldReference fieldRef = fieldInjection[fieldIndex];
-        Argument argument = resolveEnvironmentArgument(context, fieldRef.argument);
+        Argument<K> argument = resolveEnvironmentArgument(context, fieldRef.argument);
         try (BeanResolutionContext.Path ignored = resolutionContext.getPath()
                 .pushFieldResolve(this, argument, fieldRef.requiresReflection)) {
             return resolveOptionalBean(resolutionContext, argument, resolveEnvironmentArgument(context, genericType), qualifier);
@@ -1823,16 +1841,17 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
      * @param fieldIndex        The field index
      * @param genericType       The generic type
      * @param qualifier         The qualifier
+     * @param <K>               The bean type
      * @return The resolved bean
      */
     @Internal
     @UsedByGeneratedCode
-    protected final Stream getStreamOfTypeForField(BeanResolutionContext resolutionContext, BeanContext context, int fieldIndex, Argument genericType, Qualifier qualifier) {
+    protected final <K> Stream<K> getStreamOfTypeForField(BeanResolutionContext resolutionContext, BeanContext context, int fieldIndex, Argument<K> genericType, Qualifier<K> qualifier) {
         FieldReference fieldRef = fieldInjection[fieldIndex];
-        Argument argument = resolveEnvironmentArgument(context, fieldRef.argument);
+        Argument<K> argument = resolveEnvironmentArgument(context, fieldRef.argument);
         try (BeanResolutionContext.Path ignored = resolutionContext.getPath()
                 .pushFieldResolve(this, argument, fieldRef.requiresReflection)) {
-            return resolveStreamOfType(resolutionContext, context, argument, resolveEnvironmentArgument(context, genericType), qualifier);
+            return resolveStreamOfType(resolutionContext, argument, resolveEnvironmentArgument(context, genericType), qualifier);
         }
     }
 
@@ -1897,7 +1916,7 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
         if (isInnerConfiguration(argumentType.getType())) {
             qualifier = qualifier == null ? resolveQualifierWithInnerConfiguration(resolutionContext, argument, true) : qualifier;
             if (isCollection) {
-                Collection beans = resolutionContext.getBeansOfType(argumentType, qualifier);
+                Collection<?> beans = resolutionContext.getBeansOfType(argumentType, qualifier);
                 return coerceCollectionToCorrectType((Class) argumentJavaType, beans, resolutionContext, argument);
             } else {
                 return resolutionContext.getBean(argumentType, qualifier);
@@ -2013,19 +2032,18 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
         }
     }
 
-    private Object resolveBean(BeanResolutionContext resolutionContext, BeanContext context, Argument argument, @Nullable Qualifier qualifier) {
-        return resolveBean(resolutionContext, context, argument, qualifier, false);
+    private <K> K resolveBean(BeanResolutionContext resolutionContext, Argument<K> argument, @Nullable Qualifier<K> qualifier) {
+        return resolveBean(resolutionContext, argument, qualifier, false);
     }
 
-    private Object resolveBean(
+    private <K> K resolveBean(
             BeanResolutionContext resolutionContext,
-            BeanContext context,
-            Argument argument,
-            @Nullable Qualifier qualifier,
+            Argument<K> argument,
+            @Nullable Qualifier<K> qualifier,
             boolean resolveIsInnerConfiguration) {
         qualifier = qualifier == null ? resolveQualifier(resolutionContext, argument, resolveIsInnerConfiguration) : qualifier;
         if (Qualifier.class.isAssignableFrom(argument.getType())) {
-            return qualifier;
+            return (K) qualifier;
         }
         try {
             Object previous = !argument.isAnnotationPresent(Parameter.class) ? resolutionContext.removeAttribute(NAMED_ATTRIBUTE) : null;
@@ -2057,16 +2075,16 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
         }
     }
 
-    private Optional resolveValue(
+    private <K> Optional<K> resolveValue(
             ApplicationContext context,
-            ArgumentConversionContext<?> argument,
+            ArgumentConversionContext<K> argument,
             boolean hasValueAnnotation,
             String valString) {
 
         if (hasValueAnnotation) {
             return context.resolvePlaceholders(valString).flatMap(v -> context.getConversionService().convert(v, argument));
         } else {
-            Optional<?> value = context.getProperty(valString, argument);
+            Optional<K> value = context.getProperty(valString, argument);
             if (!value.isPresent() && isConfigurationProperties) {
                 String cliOption = resolveCliOption(argument.getArgument().getName());
                 if (cliOption != null) {
@@ -2122,16 +2140,16 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
         return null;
     }
 
-    private Collection<Object> resolveBeansOfType(BeanResolutionContext resolutionContext, BeanContext context, Argument argument, Argument resultGenericType, Qualifier qualifier) {
+    private <K, R extends Collection<K>> R resolveBeansOfType(BeanResolutionContext resolutionContext, BeanContext context, Argument<R> argument, Argument<K> resultGenericType, Qualifier<K> qualifier) {
         if (resultGenericType == null) {
             throw new DependencyInjectionException(resolutionContext, "Type " + argument.getType() + " has no generic argument");
         }
-        qualifier = qualifier == null ? resolveQualifier(resolutionContext, argument, true) : qualifier;
-        Collection beansOfType = resolutionContext.getBeansOfType(resolveEnvironmentArgument(context, resultGenericType), qualifier);
+        qualifier = qualifier == null ? resolveQualifier(resolutionContext, (Argument<K>) argument, true) : qualifier;
+        Collection<K> beansOfType = resolutionContext.getBeansOfType(resolveEnvironmentArgument(context, resultGenericType), qualifier);
         return coerceCollectionToCorrectType(argument.getType(), beansOfType, resolutionContext, argument);
     }
 
-    private Stream<?> resolveStreamOfType(BeanResolutionContext resolutionContext, BeanContext context, Argument<?> argument, Argument<?> resultGenericType, Qualifier qualifier) {
+    private <K> Stream<K> resolveStreamOfType(BeanResolutionContext resolutionContext, Argument<K> argument, Argument<K> resultGenericType, Qualifier<K> qualifier) {
         if (resultGenericType == null) {
             throw new DependencyInjectionException(resolutionContext, "Type " + argument.getType() + " has no generic argument");
         }
@@ -2139,7 +2157,7 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
         return resolutionContext.streamOfType(resultGenericType, qualifier);
     }
 
-    private Optional<?> resolveOptionalBean(BeanResolutionContext resolutionContext, Argument<?> argument, Argument<?> resultGenericType, Qualifier qualifier) {
+    private <K> Optional<K> resolveOptionalBean(BeanResolutionContext resolutionContext, Argument<K> argument, Argument<K> resultGenericType, Qualifier<K> qualifier) {
         if (resultGenericType == null) {
             throw new DependencyInjectionException(resolutionContext, "Type " + argument.getType() + " has no generic argument");
         }
@@ -2147,13 +2165,16 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
         return resolutionContext.findBean(resultGenericType, qualifier);
     }
 
-    private <B> Collection<BeanRegistration<B>> resolveBeanRegistrations(BeanResolutionContext resolutionContext, Argument argument, Argument genericArgument, Qualifier qualifier) {
+    private <I, K extends Collection<BeanRegistration<I>>> K resolveBeanRegistrations(BeanResolutionContext resolutionContext,
+                                                                                      Argument<K> argument,
+                                                                                      Argument<I> genericArgument,
+                                                                                      Qualifier<I> qualifier) {
         try {
             if (genericArgument == null) {
                 throw new DependencyInjectionException(resolutionContext, "Cannot resolve bean registrations. Argument [" + argument + "] missing generic type information.");
             }
-            qualifier = qualifier == null ? resolveQualifier(resolutionContext, argument) : qualifier;
-            Collection beanRegistrations = resolutionContext.getBeanRegistrations(genericArgument, qualifier);
+            qualifier = qualifier == null ? resolveQualifier(resolutionContext, (Argument) argument) : qualifier;
+            Collection<BeanRegistration<I>> beanRegistrations = resolutionContext.getBeanRegistrations(genericArgument, qualifier);
             return coerceCollectionToCorrectType(argument.getType(), beanRegistrations, resolutionContext, argument);
         } catch (NoSuchBeanException e) {
             if (argument.isNullable()) {
@@ -2163,17 +2184,17 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
         }
     }
 
-    private Argument<?> resolveArgument(BeanContext context, int argIndex, Argument<?>[] arguments) {
+    private <K> Argument<K> resolveArgument(BeanContext context, int argIndex, Argument<?>[] arguments) {
         if (arguments == null) {
             return null;
         }
-        return resolveEnvironmentArgument(context, arguments[argIndex]);
+        return resolveEnvironmentArgument(context, (Argument<K>) arguments[argIndex]);
     }
 
-    private Argument<?> resolveEnvironmentArgument(BeanContext context, Argument<?> argument) {
+    private <K> Argument<K> resolveEnvironmentArgument(BeanContext context, Argument<K> argument) {
         if (argument instanceof DefaultArgument) {
             if (argument.getAnnotationMetadata().hasPropertyExpressions()) {
-                argument = new EnvironmentAwareArgument<>((DefaultArgument) argument);
+                argument = new EnvironmentAwareArgument<>((DefaultArgument<K>) argument);
                 instrumentAnnotationMetadata(context, argument);
             }
         }
@@ -2181,7 +2202,7 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
     }
 
     private <B> BeanRegistration<B> resolveBeanRegistration(BeanResolutionContext resolutionContext, BeanContext context,
-                                                            Argument<?> argument, Argument<?> genericArgument, Qualifier qualifier) {
+                                                            Argument<B> argument, Argument<B> genericArgument, Qualifier<B> qualifier) {
         try {
             if (genericArgument == null) {
                 throw new DependencyInjectionException(resolutionContext, "Cannot resolve bean registration. Argument [" + argument + "] missing generic type information.");
@@ -2196,36 +2217,36 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
         }
     }
 
-    private Qualifier resolveQualifier(BeanResolutionContext resolutionContext, Argument argument) {
+    private <K> Qualifier<K> resolveQualifier(BeanResolutionContext resolutionContext, Argument<K> argument) {
         return resolveQualifier(resolutionContext, argument, false);
     }
 
-    private Qualifier resolveQualifier(BeanResolutionContext resolutionContext, Argument argument, boolean resolveIsInnerConfiguration) {
+    private <K> Qualifier<K> resolveQualifier(BeanResolutionContext resolutionContext, Argument<K> argument, boolean resolveIsInnerConfiguration) {
         boolean innerConfiguration = resolveIsInnerConfiguration && isInnerConfiguration(argument.getType());
         return resolveQualifierWithInnerConfiguration(resolutionContext, argument, innerConfiguration);
     }
 
-    private Qualifier resolveQualifierWithInnerConfiguration(BeanResolutionContext resolutionContext, Argument argument, boolean innerConfiguration) {
+    private <K> Qualifier<K> resolveQualifierWithInnerConfiguration(BeanResolutionContext resolutionContext, Argument<K> argument, boolean innerConfiguration) {
         boolean hasMetadata = argument.getAnnotationMetadata() != AnnotationMetadata.EMPTY_METADATA;
-        Qualifier<?> qualifier = null;
+        Qualifier<K> qualifier = null;
         boolean isIterable = isIterable() || resolutionContext.get(EachProperty.class.getName(), Class.class).map(getBeanType()::equals).orElse(false);
         if (isIterable) {
             qualifier = resolutionContext.get(AnnotationUtil.QUALIFIER, Map.class)
-                    .map(map -> (Qualifier<?>) map.get(argument))
+                    .map(map -> (Qualifier<K>) map.get(argument))
                     .orElse(null);
         }
         if (qualifier == null) {
             if ((hasMetadata && argument.isAnnotationPresent(Parameter.class)) ||
                     (innerConfiguration && isIterable) ||
                     Qualifier.class == argument.getType()) {
-                final Qualifier<?> currentQualifier = resolutionContext.getCurrentQualifier();
+                final Qualifier<K> currentQualifier = (Qualifier<K>) resolutionContext.getCurrentQualifier();
                 if (currentQualifier != null &&
                         currentQualifier.getClass() != InterceptorBindingQualifier.class &&
                         currentQualifier.getClass() != TypeAnnotationQualifier.class) {
                     qualifier = currentQualifier;
                 } else {
                     final Optional<String> n = resolutionContext.get(NAMED_ATTRIBUTE, ConversionContext.STRING);
-                    qualifier = n.map(Qualifiers::byName).orElse(null);
+                    qualifier = n.map(Qualifiers::<K>byName).orElse(null);
                 }
             }
         }
@@ -2233,12 +2254,12 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
     }
 
     @SuppressWarnings("unchecked")
-    private <I, K extends Collection<I>> Collection coerceCollectionToCorrectType(Class<K> collectionType, Collection<I> beansOfType, BeanResolutionContext resolutionContext, Argument argument) {
+    private <I, K extends Collection<I>> K coerceCollectionToCorrectType(Class<K> collectionType, Collection<I> beansOfType, BeanResolutionContext resolutionContext, Argument<?> argument) {
         if (argument.isArray() || collectionType.isInstance(beansOfType)) {
             // Arrays are converted by compile-time code
-            return beansOfType;
+            return (K) beansOfType;
         } else {
-            return (Collection) CollectionUtils.convertCollection(collectionType, beansOfType)
+            return (K) CollectionUtils.convertCollection(collectionType, beansOfType)
                     .orElseThrow(() -> new DependencyInjectionException(resolutionContext, "Cannot create a collection of type: " + collectionType.getName()));
         }
     }

--- a/inject/src/main/java/io/micronaut/context/AbstractInitializableBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractInitializableBeanDefinition.java
@@ -214,20 +214,20 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
             boolean isContainerType,
             boolean requiresMethodProcessing) {
         this(beanType,
-            constructor,
-            annotationMetadata,
-            methodInjection,
-            fieldInjection,
-            executableMethodsDefinition,
-            typeArgumentsMap,
-            scope, isAbstract,
-            isProvided,
-            isIterable,
-            isSingleton,
-            isPrimary,
-            isConfigurationProperties,
-            isContainerType,
-            requiresMethodProcessing);
+                constructor,
+                annotationMetadata,
+                methodInjection,
+                fieldInjection,
+                executableMethodsDefinition,
+                typeArgumentsMap,
+                scope, isAbstract,
+                isProvided,
+                isIterable,
+                isSingleton,
+                isPrimary,
+                isConfigurationProperties,
+                isContainerType,
+                requiresMethodProcessing);
         this.annotationInjection = annotationInjection;
     }
 
@@ -469,7 +469,7 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
             }
         }
         if (annotationInjection != null) {
-            for (AnnotationReference annotationReference: annotationInjection) {
+            for (AnnotationReference annotationReference : annotationInjection) {
                 if (annotationReference.argument != null) {
                     argumentConsumer.accept(annotationReference.argument);
                 }
@@ -869,8 +869,9 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
 
     /**
      * Checks whether the bean should be loaded.
+     *
      * @param resolutionContext - the resolution context
-     * @param context - the bean context
+     * @param context           - the bean context
      */
     @Internal
     @UsedByGeneratedCode
@@ -882,9 +883,9 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
      * bean should be loaded.
      *
      * @param injectedBeanPropertyName the name of the injected bean property
-     * @param beanPropertyValue the value of injected bean property
-     * @param requiredValue the value which is required for the bean to be loaded
-     * @param notEqualsValue the value which bean property should not be equal to for the bean to be loaded
+     * @param beanPropertyValue        the value of injected bean property
+     * @param requiredValue            the value which is required for the bean to be loaded
+     * @param notEqualsValue           the value which bean property should not be equal to for the bean to be loaded
      */
     @Internal
     @UsedByGeneratedCode
@@ -902,10 +903,10 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
         } else if (convertedValue != null) {
             if (requiredValue != null && !convertedValue.equals(requiredValue)) {
                 throw new DisabledBeanException("Bean [" + getBeanType() + "] is disabled since bean property [" + injectedBeanPropertyName + "] " +
-                                                        "value is not equal to [" + requiredValue + "]");
+                        "value is not equal to [" + requiredValue + "]");
             } else if (requiredValue == null && convertedValue.equals(notEqualsValue)) {
                 throw new DisabledBeanException("Bean [" + getBeanType() + "] is disabled since bean property [" + injectedBeanPropertyName + "] " +
-                                                    "value is equal to [" + notEqualsValue + "]");
+                        "value is equal to [" + notEqualsValue + "]");
             }
         }
     }
@@ -1067,7 +1068,7 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
                                                      String propertyValue,
                                                      String cliProperty) {
         try (BeanResolutionContext.Path ignored = resolutionContext.getPath()
-                .pushMethodArgumentResolve(this, setterName, argument, new Argument[] {argument}, false)) {
+                .pushMethodArgumentResolve(this, setterName, argument, new Argument[]{argument}, false)) {
             return resolvePropertyValue(resolutionContext, context, argument, propertyValue, cliProperty, false);
         }
     }
@@ -1090,7 +1091,7 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
                                                                 Argument<?> argument,
                                                                 String value) {
         try (BeanResolutionContext.Path ignored = resolutionContext.getPath()
-                .pushMethodArgumentResolve(this, setterName, argument, new Argument[] {argument}, false)) {
+                .pushMethodArgumentResolve(this, setterName, argument, new Argument[]{argument}, false)) {
             return resolvePropertyValue(resolutionContext, context, argument, value, null, true);
         }
     }
@@ -1182,7 +1183,7 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
     @UsedByGeneratedCode
     protected final Object getBeanForSetter(BeanResolutionContext resolutionContext, BeanContext context, String setterName, Argument argument, Qualifier qualifier) {
         try (BeanResolutionContext.Path ignored = resolutionContext.getPath()
-                .pushMethodArgumentResolve(this, setterName, argument, new Argument[] {argument}, false)) {
+                .pushMethodArgumentResolve(this, setterName, argument, new Argument[]{argument}, false)) {
             return resolveBean(resolutionContext, argument, qualifier, true);
         }
     }
@@ -1203,7 +1204,7 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
     @UsedByGeneratedCode
     protected final Collection<Object> getBeansOfTypeForSetter(BeanResolutionContext resolutionContext, BeanContext context, String setterName, Argument argument, Argument genericType, Qualifier qualifier) {
         try (BeanResolutionContext.Path ignored =
-                     resolutionContext.getPath().pushMethodArgumentResolve(this, setterName, argument, new Argument[] {argument}, false)) {
+                     resolutionContext.getPath().pushMethodArgumentResolve(this, setterName, argument, new Argument[]{argument}, false)) {
             return resolveBeansOfType(resolutionContext, context, argument, resolveEnvironmentArgument(context, genericType), qualifier);
         }
     }
@@ -1751,7 +1752,8 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
      */
     @Internal
     @UsedByGeneratedCode
-    protected final <K, R extends Collection<K>> R getBeansOfTypeForField(BeanResolutionContext resolutionContext, BeanContext context, int fieldIndex, Argument<K> genericType, Qualifier<K> qualifier) {
+    protected final <K, R extends Collection<K>> Object getBeansOfTypeForField(BeanResolutionContext resolutionContext, BeanContext context, int fieldIndex, Argument<K> genericType, Qualifier<K> qualifier) {
+        // Keep Object type for backwards compatibility
         final FieldReference fieldRef = fieldInjection[fieldIndex];
         final Argument<R> argument = resolveEnvironmentArgument(context, fieldRef.argument);
         try (BeanResolutionContext.Path ignored = resolutionContext.getPath().pushFieldResolve(this, argument, fieldRef.requiresReflection)) {
@@ -1794,6 +1796,7 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
      * @param fieldIndex        The field index
      * @param genericType       The generic type
      * @param qualifier         The qualifier
+     * @param <K>               The bean type
      * @return The resolved bean registration
      */
     @Internal

--- a/inject/src/main/java/io/micronaut/context/BeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/BeanContext.java
@@ -248,6 +248,16 @@ public interface BeanContext extends
     <T> T destroyBean(@NonNull T bean);
 
     /**
+     * Destroys the given bean.
+     *
+     * @param beanRegistration The bean registration
+     * @param <T>  The bean type
+     * @since 3.5.0
+     */
+    @NonNull
+    <T> void destroyBean(@NonNull BeanRegistration<T> beanRegistration);
+
+    /**
      * <p>Refresh the state of the given registered bean applying dependency injection and configuration wiring again.</p>
      * <p>
      * <p>Note that if the bean was produced by a {@link io.micronaut.context.annotation.Factory} then this method will

--- a/inject/src/main/java/io/micronaut/context/BeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/BeanContext.java
@@ -261,6 +261,21 @@ public interface BeanContext extends
     <T> Optional<T> refreshBean(@Nullable BeanIdentifier identifier);
 
     /**
+     * <p>Refresh the state of the given registered bean applying dependency injection and configuration wiring again.</p>
+     * <p>
+     * <p>Note that if the bean was produced by a {@link io.micronaut.context.annotation.Factory} then this method will
+     * refresh the factory too</p>
+     * <p>
+     * This methods skips an additional resolution of the {@link BeanRegistration}.
+     *
+     * @param beanRegistration The {@link BeanRegistration}
+     * @param <T>              The concrete class
+     * @since 3.5.0
+     */
+    @NonNull
+    <T> void refreshBean(@NonNull BeanRegistration<T> beanRegistration);
+
+    /**
      * @return The class loader used by this context
      */
     @NonNull

--- a/inject/src/main/java/io/micronaut/context/BeanDefinitionDelegate.java
+++ b/inject/src/main/java/io/micronaut/context/BeanDefinitionDelegate.java
@@ -50,6 +50,13 @@ class BeanDefinitionDelegate<T> extends AbstractBeanContextConditional implement
         this.definition = definition;
     }
 
+    /**
+     * @return the attributes
+     */
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
     @Nullable
     @Override
     public Qualifier<T> resolveDynamicQualifier() {

--- a/inject/src/main/java/io/micronaut/context/BeanDisposingRegistration.java
+++ b/inject/src/main/java/io/micronaut/context/BeanDisposingRegistration.java
@@ -16,6 +16,7 @@
 package io.micronaut.context;
 
 import io.micronaut.context.exceptions.BeanDestructionException;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.DisposableBeanDefinition;
 
@@ -26,8 +27,10 @@ import java.util.ListIterator;
  * The disposing bean registration.
  *
  * @param <BT> The bean type
+ * @author Denis Stepanov
  * @since 3.5.0
  */
+@Internal
 final class BeanDisposingRegistration<BT> extends BeanRegistration<BT> {
     private final BeanContext beanContext;
     private final List<BeanRegistration<?>> dependents;

--- a/inject/src/main/java/io/micronaut/context/BeanDisposingRegistration.java
+++ b/inject/src/main/java/io/micronaut/context/BeanDisposingRegistration.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context;
+
+import io.micronaut.context.exceptions.BeanDestructionException;
+import io.micronaut.inject.BeanDefinition;
+import io.micronaut.inject.DisposableBeanDefinition;
+
+import java.util.List;
+import java.util.ListIterator;
+
+/**
+ * The disposing bean registration.
+ *
+ * @param <BT> The bean type
+ * @since 3.5.0
+ */
+final class BeanDisposingRegistration<BT> extends BeanRegistration<BT> {
+    private final BeanContext beanContext;
+    private final List<BeanRegistration<?>> dependents;
+    private final boolean hasDependents;
+
+    BeanDisposingRegistration(BeanContext beanContext, DefaultBeanContext.BeanKey<BT> key, BeanDefinition<BT> beanDefinition, BT createdBean, List<BeanRegistration<?>> dependents) {
+        super(key, beanDefinition, createdBean);
+        this.beanContext = beanContext;
+        this.dependents = dependents;
+        this.hasDependents = true;
+    }
+
+    BeanDisposingRegistration(BeanContext beanContext, DefaultBeanContext.BeanKey<BT> key, BeanDefinition<BT> beanDefinition, BT createdBean) {
+        super(key, beanDefinition, createdBean);
+        this.beanContext = beanContext;
+        this.hasDependents = false;
+        this.dependents = null;
+    }
+
+    @Override
+    public void close() {
+        final BeanDefinition<BT> definition = definition();
+        final BT beanToDestroy = getBean();
+        if (definition instanceof DisposableBeanDefinition) {
+            ((DisposableBeanDefinition<BT>) definition).dispose(beanContext, beanToDestroy);
+        }
+        if (beanToDestroy instanceof LifeCycle) {
+            try {
+                ((LifeCycle) beanToDestroy).stop();
+            } catch (Exception e) {
+                throw new BeanDestructionException(definition, e);
+            }
+        }
+        if (hasDependents) {
+            final ListIterator<BeanRegistration<?>> i = dependents.listIterator(dependents.size());
+            while (i.hasPrevious()) {
+                final BeanRegistration<?> dependent = i.previous();
+                final Object bean = dependent.getBean();
+                final BeanDefinition<?> beanDefinition = dependent.getBeanDefinition();
+                if (beanDefinition instanceof DisposableBeanDefinition) {
+                    try {
+                        //noinspection unchecked
+                        ((DisposableBeanDefinition) beanDefinition).dispose(beanContext, bean);
+                    } catch (Exception e) {
+                        if (DefaultBeanContext.LOG.isErrorEnabled()) {
+                            DefaultBeanContext.LOG.error("Error disposing dependent bean of type " + beanDefinition.getBeanType().getName() + ": " + e.getMessage(), e);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/BeanResolutionContext.java
+++ b/inject/src/main/java/io/micronaut/context/BeanResolutionContext.java
@@ -58,9 +58,7 @@ public interface BeanResolutionContext extends ValueResolver<CharSequence>, Auto
      * @since 3.5.0
      */
     @NonNull
-    default <T> T getBean(@NonNull Argument<T> beanType, @Nullable Qualifier<T> qualifier) {
-        return ((DefaultBeanContext) getContext()).getBean(this, beanType, qualifier);
-    }
+    <T> T getBean(@NonNull Argument<T> beanType, @Nullable Qualifier<T> qualifier);
 
     /**
      * Get all beans of the given type and qualifier.
@@ -72,9 +70,7 @@ public interface BeanResolutionContext extends ValueResolver<CharSequence>, Auto
      * @since 3.5.0
      */
     @NonNull
-    default <T> Collection<T> getBeansOfType(@NonNull Argument<T> beanType, @Nullable Qualifier<T> qualifier) {
-        return ((DefaultBeanContext) getContext()).getBeansOfType(this, beanType, qualifier);
-    }
+    <T> Collection<T> getBeansOfType(@NonNull Argument<T> beanType, @Nullable Qualifier<T> qualifier);
 
     /**
      * Obtains a stream of beans of the given type and qualifier.
@@ -86,9 +82,7 @@ public interface BeanResolutionContext extends ValueResolver<CharSequence>, Auto
      * @since 3.5.0
      */
     @NonNull
-    default <T> Stream<T> streamOfType(@NonNull  Argument<T> beanType, @Nullable  Qualifier<T> qualifier) {
-        return ((DefaultBeanContext) getContext()).streamOfType(this, beanType, qualifier);
-    }
+    <T> Stream<T> streamOfType(@NonNull  Argument<T> beanType, @Nullable  Qualifier<T> qualifier);
 
     /**
      * Find an optional bean of the given type and qualifier.
@@ -100,9 +94,7 @@ public interface BeanResolutionContext extends ValueResolver<CharSequence>, Auto
      * @since 3.5.0
      */
     @NonNull
-    default <T> Optional<T> findBean(@NonNull Argument<T> beanType, @Nullable Qualifier<T> qualifier) {
-        return ((DefaultBeanContext) getContext()).findBean(this, beanType, qualifier);
-    }
+    <T> Optional<T> findBean(@NonNull Argument<T> beanType, @Nullable Qualifier<T> qualifier);
 
     /**
      * Injects a bean.
@@ -114,9 +106,7 @@ public interface BeanResolutionContext extends ValueResolver<CharSequence>, Auto
      * @since 3.5.0
      */
     @NonNull
-    default <T> T inject(@Nullable BeanDefinition<?> beanDefinition, @NonNull T instance) {
-        return ((DefaultBeanContext) getContext()).inject(this, beanDefinition, instance);
-    }
+    <T> T inject(@Nullable BeanDefinition<?> beanDefinition, @NonNull T instance);
 
     /**
      * Obtains the bean registrations for the given type and qualifier.
@@ -128,9 +118,7 @@ public interface BeanResolutionContext extends ValueResolver<CharSequence>, Auto
      * @since 3.5.0
      */
     @NonNull
-    default <T> Collection<BeanRegistration<T>> getBeanRegistrations(@NonNull Argument<T> beanType, @Nullable Qualifier<T> qualifier) {
-        return ((DefaultBeanContext) getContext()).getBeanRegistrations(this, beanType, qualifier);
-    }
+    <T> Collection<BeanRegistration<T>> getBeanRegistrations(@NonNull Argument<T> beanType, @Nullable Qualifier<T> qualifier);
 
     /**
      * Call back to destroy any {@link io.micronaut.context.annotation.InjectScope} beans.

--- a/inject/src/main/java/io/micronaut/context/BeanResolutionContext.java
+++ b/inject/src/main/java/io/micronaut/context/BeanResolutionContext.java
@@ -211,12 +211,10 @@ public interface BeanResolutionContext extends ValueResolver<CharSequence>, Auto
 
     /**
      * Adds a dependent bean to the resolution context.
-     * @param identifier The identifier
-     * @param definition The bean definition
-     * @param bean The bean
+     * @param beanRegistration The bean registration
      * @param <T> The generic type
      */
-    <T> void addDependentBean(BeanIdentifier identifier, BeanDefinition<T> definition, T bean);
+    <T> void addDependentBean(BeanRegistration<T> beanRegistration);
 
     /**
      * @return The dependent beans that must be destroyed by an upstream bean

--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
@@ -79,8 +79,8 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
     /**
      * Construct a new ApplicationContext for the given environment name and classloader.
      *
-     * @param environmentNames   The environment names
-     * @param resourceLoader     The class loader
+     * @param environmentNames The environment names
+     * @param resourceLoader   The class loader
      */
     public DefaultApplicationContext(@NonNull ClassPathResourceLoader resourceLoader, @NonNull String... environmentNames) {
         this(new ApplicationContextConfiguration() {
@@ -92,7 +92,8 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
             }
 
             @Override
-            public @NonNull ClassPathResourceLoader getResourceLoader() {
+            public @NonNull
+            ClassPathResourceLoader getResourceLoader() {
                 ArgumentUtils.requireNonNull("resourceLoader", resourceLoader);
                 return resourceLoader;
             }
@@ -109,7 +110,7 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
     /**
      * Construct a new ApplicationContext for the given environment name and classloader.
      *
-     * @param configuration    The application context configuration
+     * @param configuration The application context configuration
      */
     public DefaultApplicationContext(@NonNull ApplicationContextConfiguration configuration) {
         super(configuration);
@@ -120,7 +121,8 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
     }
 
     @Override
-    public @NonNull <T> ApplicationContext registerSingleton(@NonNull Class<T> type, @NonNull T singleton, @Nullable Qualifier<T> qualifier, boolean inject) {
+    public @NonNull
+    <T> ApplicationContext registerSingleton(@NonNull Class<T> type, @NonNull T singleton, @Nullable Qualifier<T> qualifier, boolean inject) {
         return (ApplicationContext) super.registerSingleton(type, singleton, qualifier, inject);
     }
 
@@ -130,7 +132,8 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
      * @param configuration The application context configuration
      * @return The environment instance
      */
-    protected @NonNull Environment createEnvironment(@NonNull ApplicationContextConfiguration configuration) {
+    protected @NonNull
+    Environment createEnvironment(@NonNull ApplicationContextConfiguration configuration) {
         return new RuntimeConfiguredEnvironment(configuration, isBootstrapEnabled(configuration));
     }
 
@@ -160,17 +163,20 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
      *
      * @return The conversion service
      */
-    protected @NonNull ConversionService createConversionService() {
+    protected @NonNull
+    ConversionService createConversionService() {
         return ConversionService.SHARED;
     }
 
     @Override
-    public @NonNull ConversionService<?> getConversionService() {
+    public @NonNull
+    ConversionService<?> getConversionService() {
         return conversionService;
     }
 
     @Override
-    public @NonNull Environment getEnvironment() {
+    public @NonNull
+    Environment getEnvironment() {
         if (environment == null) {
             environment = createEnvironment(configuration);
         }
@@ -178,13 +184,15 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
     }
 
     @Override
-    public synchronized @NonNull ApplicationContext start() {
+    public synchronized @NonNull
+    ApplicationContext start() {
         startEnvironment();
         return (ApplicationContext) super.start();
     }
 
     @Override
-    public synchronized @NonNull ApplicationContext stop() {
+    public synchronized @NonNull
+    ApplicationContext stop() {
         return (ApplicationContext) super.stop();
     }
 
@@ -228,7 +236,7 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
     protected void startEnvironment() {
         Environment defaultEnvironment = getEnvironment();
         defaultEnvironment.start();
-        registerSingleton(Environment.class, defaultEnvironment);
+        registerSingleton(Environment.class, defaultEnvironment, null, false);
     }
 
     @Override
@@ -257,201 +265,245 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
             for (BeanDefinition candidate : candidates) {
                 if (candidate.isIterable()) {
                     if (candidate.hasDeclaredStereotype(EachProperty.class)) {
-                        boolean isList = candidate.booleanValue(EachProperty.class, "list").orElse(false);
-                        String property = candidate.stringValue(ConfigurationReader.class, "prefix")
-                                .map(prefix ->
-                                        //strip the .* or [*]
-                                        prefix.substring(0, prefix.length() - (isList ? 3 : 2)))
-                                .orElseGet(() -> candidate.stringValue(EachProperty.class).orElse(null));
-                        String primaryPrefix = candidate.stringValue(EachProperty.class, "primary").orElse(null);
-                        if (StringUtils.isNotEmpty(property)) {
-                            if (isList) {
-                                List entries = getEnvironment().getProperty(property, List.class, Collections.emptyList());
-                                if (!entries.isEmpty()) {
-                                    for (int i = 0; i < entries.size(); i++) {
-                                        if (entries.get(i) != null) {
-                                            BeanDefinitionDelegate delegate = BeanDefinitionDelegate.create(candidate);
-                                            String index = String.valueOf(i);
-                                            if (primaryPrefix != null && primaryPrefix.equals(index)) {
-                                                delegate.put(BeanDefinitionDelegate.PRIMARY_ATTRIBUTE, true);
-                                            }
-                                            delegate.put("Array", index);
-                                            delegate.put(Named.class.getName(), index);
-
-                                            if (delegate.isEnabled(this, resolutionContext)) {
-                                                transformedCandidates.add(delegate);
-                                            }
-                                        }
-                                    }
-                                }
-                            } else {
-                                Collection<String> propertyEntries = getEnvironment().getPropertyEntries(property);
-                                if (!propertyEntries.isEmpty()) {
-                                    for (String key : propertyEntries) {
-                                        BeanDefinitionDelegate delegate = BeanDefinitionDelegate.create(candidate);
-                                        if (primaryPrefix != null && primaryPrefix.equals(key)) {
-                                            delegate.put(BeanDefinitionDelegate.PRIMARY_ATTRIBUTE, true);
-                                        }
-                                        delegate.put(EachProperty.class.getName(), delegate.getBeanType());
-                                        delegate.put(Named.class.getName(), key);
-
-                                        if (delegate.isEnabled(this, resolutionContext)) {
-                                            transformedCandidates.add(delegate);
-                                        }
-                                    }
-                                }
-                            }
-                        } else {
-                            throw new IllegalArgumentException("Blank value specified to @Each property for bean: " + candidate);
-                        }
+                        transformEachPropertyBeanDefinition(resolutionContext, candidate, transformedCandidates);
                     } else if (candidate.hasDeclaredStereotype(EachBean.class)) {
-                        Class dependentType = candidate.classValue(EachBean.class).orElse(null);
-                        if (dependentType == null) {
-                            transformedCandidates.add(candidate);
-                            continue;
-                        }
-
-                        Collection<BeanDefinition> dependentCandidates = findBeanCandidates(resolutionContext, Argument.of(dependentType), filterProxied, null);
-
-                        if (!dependentCandidates.isEmpty()) {
-                            for (BeanDefinition dependentCandidate : dependentCandidates) {
-
-                                BeanDefinitionDelegate<?> delegate = BeanDefinitionDelegate.create(candidate);
-                                Optional<Qualifier> optional;
-                                if (dependentCandidate instanceof BeanDefinitionDelegate) {
-                                    BeanDefinitionDelegate<?> parentDelegate = (BeanDefinitionDelegate) dependentCandidate;
-                                    optional = parentDelegate.get(Named.class.getName(), String.class).map(Qualifiers::byName);
-                                } else {
-                                    Optional<String> qualifierName = dependentCandidate.getAnnotationNameByStereotype(AnnotationUtil.QUALIFIER);
-                                    optional = qualifierName.map(name -> Qualifiers.byAnnotation(dependentCandidate, name));
-                                }
-
-                                if (dependentCandidate.isPrimary()) {
-                                    delegate.put(BeanDefinitionDelegate.PRIMARY_ATTRIBUTE, true);
-                                }
-
-                                optional.ifPresent(qualifier -> {
-                                            String qualifierKey = AnnotationUtil.QUALIFIER;
-                                            Argument<?>[] arguments = candidate.getConstructor().getArguments();
-                                            for (Argument<?> argument : arguments) {
-                                                Class<?> argumentType = argument.getType();
-                                                if (argumentType.equals(dependentType)) {
-                                                    Map<? extends Argument<?>, Qualifier> qualifedArg = Collections.singletonMap(argument, qualifier);
-                                                    delegate.put(qualifierKey, qualifedArg);
-                                                    break;
-                                                }
-                                            }
-
-                                            if (qualifier instanceof Named) {
-                                                delegate.put(Named.class.getName(), ((Named) qualifier).getName());
-                                            }
-                                            if (delegate.isEnabled(this, resolutionContext)) {
-                                                transformedCandidates.add((BeanDefinition<T>) delegate);
-                                            }
-                                        }
-                                );
-                            }
-                        }
+                        transformEachBeanBeanDefinition(resolutionContext, candidate, transformedCandidates, filterProxied);
                     }
+                } else if (candidate.hasStereotype(ConfigurationReader.class)) {
+                    transformConfigurationReaderBeanDefinition(resolutionContext, candidate, transformedCandidates);
                 } else {
-                    if (candidate.hasStereotype(ConfigurationReader.class)) {
-                        final String prefix = candidate.stringValue(ConfigurationReader.class, "prefix").orElse(null);
-                        if (prefix != null) {
-                            int mapIndex = prefix.indexOf("*");
-                            int arrIndex = prefix.indexOf("[*]");
-                            boolean isList = arrIndex > -1;
-                            boolean isMap = mapIndex > -1;
-                            if (isList || isMap) {
-                                int startIndex = isList ? arrIndex : mapIndex;
-                                String eachProperty = prefix.substring(0, startIndex);
-                                if (eachProperty.endsWith(".")) {
-                                    eachProperty = eachProperty.substring(0, eachProperty.length() - 1);
-                                }
-
-                                if (StringUtils.isNotEmpty(eachProperty)) {
-
-                                    if (isList) {
-                                        List entries = getProperty(eachProperty, List.class, Collections.emptyList());
-                                        if (!entries.isEmpty()) {
-                                            for (int i = 0; i < entries.size(); i++) {
-                                                if (entries.get(i) != null) {
-                                                    BeanDefinitionDelegate delegate = BeanDefinitionDelegate.create(candidate);
-                                                    String index = String.valueOf(i);
-                                                    delegate.put("Array", index);
-                                                    delegate.put(Named.class.getName(), index);
-
-                                                    if (delegate.isEnabled(this, resolutionContext) &&
-                                                            containsProperties(prefix.replace("*", index))) {
-                                                        transformedCandidates.add(delegate);
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    } else {
-                                        Map entries = getProperty(eachProperty, Map.class, Collections.emptyMap());
-                                        if (!entries.isEmpty()) {
-                                            for (Object key : entries.keySet()) {
-
-                                                BeanDefinitionDelegate delegate = BeanDefinitionDelegate.create(candidate);
-                                                delegate.put(EachProperty.class.getName(), delegate.getBeanType());
-                                                delegate.put(Named.class.getName(), key.toString());
-
-                                                if (delegate.isEnabled(this, resolutionContext) &&
-                                                        containsProperties(prefix.replace("*", key.toString()))) {
-                                                    transformedCandidates.add(delegate);
-                                                }
-                                            }
-                                        }
-                                    }
-
-                                } else {
-                                    throw new IllegalArgumentException("Blank value specified to @Each property for bean: " + candidate);
-                                }
-                            } else {
-                                transformedCandidates.add(candidate);
-                            }
-                        } else {
-                            transformedCandidates.add(candidate);
-                        }
-                    } else {
-                        transformedCandidates.add(candidate);
-                    }
+                    transformedCandidates.add(candidate);
                 }
             }
             if (LOG.isDebugEnabled()) {
-                LOG.debug("Finalized bean definitions candidates: {}", transformedCandidates);
+                LOG.debug("Finalized bean definitions candidates: {}", candidates);
+                for (BeanDefinition<?> definition : transformedCandidates) {
+                    LOG.debug("  {} {} {}", definition.getBeanType(), definition.getDeclaredQualifier(), definition);
+                }
             }
             return transformedCandidates;
         }
         return candidates;
     }
 
-    @Override
-    protected <T> BeanDefinition<T> findConcreteCandidate(Class<T> beanType, Qualifier<T> qualifier, Collection<BeanDefinition<T>> candidates) {
-        if (candidates.stream().allMatch(BeanDefinition::isIterable)) {
-            if (qualifier instanceof Named) {
-                Named named = (Named) qualifier;
-                String name = named.getName();
-                for (BeanDefinition<T> candidate : candidates) {
-                    if (candidate instanceof BeanDefinitionDelegate) {
+    private <T> void transformConfigurationReaderBeanDefinition(BeanResolutionContext resolutionContext, BeanDefinition candidate, List<BeanDefinition<T>> transformedCandidates) {
+        final String prefix = candidate.stringValue(ConfigurationReader.class, "prefix").orElse(null);
+        if (prefix != null) {
+            int mapIndex = prefix.indexOf("*");
+            int arrIndex = prefix.indexOf("[*]");
 
-                        BeanDefinitionDelegate<T> delegate = (BeanDefinitionDelegate) candidate;
-                        Optional<String> value = delegate.get(Named.class.getName(), String.class);
-                        if (value.isPresent()) {
-                            if (name.equals(value.get())) {
-                                return delegate;
-                            }
-                        } else {
-                            Optional<Qualifier> resolvedQualifier = delegate.get(AnnotationUtil.QUALIFIER, Qualifier.class);
-                            if (resolvedQualifier.isPresent() && resolvedQualifier.get().equals(qualifier)) {
-                                return delegate;
-                            }
-                        }
+            boolean isList = arrIndex > -1;
+            boolean isMap = mapIndex > -1;
+            if (isList || isMap) {
+                int startIndex = isList ? arrIndex : mapIndex;
+                String eachProperty = prefix.substring(0, startIndex);
+                if (eachProperty.endsWith(".")) {
+                    eachProperty = eachProperty.substring(0, eachProperty.length() - 1);
+                }
+
+                if (StringUtils.isEmpty(eachProperty)) {
+                    throw new IllegalArgumentException("Blank value specified to @Each property for bean: " + candidate);
+                }
+                if (isList) {
+                    transformConfigurationReaderList(resolutionContext, candidate, prefix, eachProperty, transformedCandidates);
+                } else {
+                    transformConfigurationReaderMap(resolutionContext, candidate, prefix, eachProperty, transformedCandidates);
+                }
+                return;
+            }
+        }
+        transformedCandidates.add(candidate);
+    }
+
+    private <T> void transformConfigurationReaderMap(BeanResolutionContext resolutionContext,
+                                                     BeanDefinition candidate,
+                                                     String prefix,
+                                                     String eachProperty,
+                                                     List<BeanDefinition<T>> transformedCandidates) {
+        Map entries = getProperty(eachProperty, Map.class, Collections.emptyMap());
+        if (!entries.isEmpty()) {
+            for (Object key : entries.keySet()) {
+                BeanDefinitionDelegate delegate = BeanDefinitionDelegate.create(candidate);
+                delegate.put(EachProperty.class.getName(), delegate.getBeanType());
+                delegate.put(Named.class.getName(), key.toString());
+
+                if (delegate.isEnabled(this, resolutionContext) &&
+                        containsProperties(prefix.replace("*", key.toString()))) {
+                    transformedCandidates.add(delegate);
+                }
+            }
+        }
+    }
+
+    private <T> void transformConfigurationReaderList(BeanResolutionContext resolutionContext,
+                                                      BeanDefinition candidate,
+                                                      String prefix,
+                                                      String eachProperty,
+                                                      List<BeanDefinition<T>> transformedCandidates) {
+        List entries = getProperty(eachProperty, List.class, Collections.emptyList());
+        if (!entries.isEmpty()) {
+            for (int i = 0; i < entries.size(); i++) {
+                if (entries.get(i) != null) {
+                    BeanDefinitionDelegate delegate = BeanDefinitionDelegate.create(candidate);
+                    String index = String.valueOf(i);
+                    delegate.put("Array", index);
+                    delegate.put(Named.class.getName(), index);
+
+                    if (delegate.isEnabled(this, resolutionContext) &&
+                            containsProperties(prefix.replace("*", index))) {
+                        transformedCandidates.add(delegate);
                     }
                 }
             }
         }
+    }
 
+    private <T> void transformEachBeanBeanDefinition(BeanResolutionContext resolutionContext,
+                                                     BeanDefinition candidate,
+                                                     List<BeanDefinition<T>> transformedCandidates,
+                                                     boolean filterProxied) {
+        Class dependentType = candidate.classValue(EachBean.class).orElse(null);
+        if (dependentType == null) {
+            transformedCandidates.add(candidate);
+            return;
+        }
+
+        Collection<BeanDefinition> dependentCandidates = findBeanCandidates(resolutionContext, Argument.of(dependentType), filterProxied, null);
+
+        if (!dependentCandidates.isEmpty()) {
+            for (BeanDefinition dependentCandidate : dependentCandidates) {
+
+                BeanDefinitionDelegate<?> delegate = BeanDefinitionDelegate.create(candidate);
+                Optional<Qualifier> optional;
+                if (dependentCandidate instanceof BeanDefinitionDelegate) {
+                    BeanDefinitionDelegate<?> parentDelegate = (BeanDefinitionDelegate) dependentCandidate;
+                    optional = parentDelegate.get(Named.class.getName(), String.class).map(Qualifiers::byName);
+                } else {
+                    Optional<String> qualifierName = dependentCandidate.getAnnotationNameByStereotype(AnnotationUtil.QUALIFIER);
+                    optional = qualifierName.map(name -> Qualifiers.byAnnotation(dependentCandidate, name));
+                }
+
+                if (dependentCandidate.isPrimary()) {
+                    delegate.put(BeanDefinitionDelegate.PRIMARY_ATTRIBUTE, true);
+                }
+
+                optional.ifPresent(qualifier -> {
+                            String qualifierKey = AnnotationUtil.QUALIFIER;
+                            Argument<?>[] arguments = candidate.getConstructor().getArguments();
+                            for (Argument<?> argument : arguments) {
+                                Class<?> argumentType = argument.getType();
+                                if (argumentType.equals(dependentType)) {
+                                    Map<? extends Argument<?>, Qualifier> qualifedArg = Collections.singletonMap(argument, qualifier);
+                                    delegate.put(qualifierKey, qualifedArg);
+                                    break;
+                                }
+                            }
+
+                            if (qualifier instanceof Named) {
+                                delegate.put(Named.class.getName(), ((Named) qualifier).getName());
+                            }
+                            if (delegate.isEnabled(this, resolutionContext)) {
+                                transformedCandidates.add((BeanDefinition<T>) delegate);
+                            }
+                        }
+                );
+            }
+        }
+    }
+
+    private <T> void transformEachPropertyBeanDefinition(BeanResolutionContext resolutionContext,
+                                                         BeanDefinition candidate,
+                                                         List<BeanDefinition<T>> transformedCandidates) {
+        boolean isList = candidate.booleanValue(EachProperty.class, "list").orElse(false);
+        String property = candidate.stringValue(ConfigurationReader.class, "prefix")
+                .map(prefix ->
+                        //strip the .* or [*]
+                        prefix.substring(0, prefix.length() - (isList ? 3 : 2)))
+                .orElseGet(() -> candidate.stringValue(EachProperty.class).orElse(null));
+        String primaryPrefix = candidate.stringValue(EachProperty.class, "primary").orElse(null);
+        if (StringUtils.isEmpty(property)) {
+            throw new IllegalArgumentException("Blank value specified to @Each property for bean: " + candidate);
+        }
+        if (isList) {
+            transformEachPropertyOfList(resolutionContext, candidate, primaryPrefix, property, transformedCandidates);
+        } else {
+            transformEachPropertyOfMap(resolutionContext, candidate, primaryPrefix, property, transformedCandidates);
+        }
+    }
+
+    private <T> void transformEachPropertyOfMap(BeanResolutionContext resolutionContext,
+                                                BeanDefinition candidate,
+                                                String primaryPrefix,
+                                                String property,
+                                                List<BeanDefinition<T>> transformedCandidates) {
+        for (String key : getEnvironment().getPropertyEntries(property)) {
+            BeanDefinitionDelegate delegate = BeanDefinitionDelegate.create(candidate);
+            if (primaryPrefix != null && primaryPrefix.equals(key)) {
+                delegate.put(BeanDefinitionDelegate.PRIMARY_ATTRIBUTE, true);
+            }
+            delegate.put(EachProperty.class.getName(), delegate.getBeanType());
+            delegate.put(Named.class.getName(), key);
+
+            if (delegate.isEnabled(this, resolutionContext)) {
+                transformedCandidates.add(delegate);
+            }
+        }
+    }
+
+    private <T> void transformEachPropertyOfList(BeanResolutionContext resolutionContext,
+                                                 BeanDefinition candidate,
+                                                 String primaryPrefix,
+                                                 String property,
+                                                 List<BeanDefinition<T>> transformedCandidates) {
+        List<?> entries = getEnvironment().getProperty(property, List.class, Collections.emptyList());
+        int i = 0;
+        for (Object entry : entries) {
+            if (entry != null) {
+                BeanDefinitionDelegate delegate = BeanDefinitionDelegate.create(candidate);
+                String index = String.valueOf(i);
+                if (primaryPrefix != null && primaryPrefix.equals(index)) {
+                    delegate.put(BeanDefinitionDelegate.PRIMARY_ATTRIBUTE, true);
+                }
+                delegate.put("Array", index);
+                delegate.put(Named.class.getName(), index);
+
+                if (delegate.isEnabled(this, resolutionContext)) {
+                    transformedCandidates.add(delegate);
+                }
+            }
+            i++;
+        }
+    }
+
+    @Override
+    protected <T> BeanDefinition<T> findConcreteCandidate(Class<T> beanType, Qualifier<T> qualifier, Collection<BeanDefinition<T>> candidates) {
+        if (!(qualifier instanceof Named)) {
+            return super.findConcreteCandidate(beanType, qualifier, candidates);
+        }
+        for (BeanDefinition<T> candidate : candidates) {
+            if (!candidate.isIterable()) {
+                return super.findConcreteCandidate(beanType, qualifier, candidates);
+            }
+        }
+        Named named = (Named) qualifier;
+        String name = named.getName();
+        for (BeanDefinition<T> candidate : candidates) {
+            if (candidate instanceof BeanDefinitionDelegate) {
+
+                BeanDefinitionDelegate<T> delegate = (BeanDefinitionDelegate) candidate;
+                Optional<String> value = delegate.get(Named.class.getName(), String.class);
+                if (value.isPresent()) {
+                    if (name.equals(value.get())) {
+                        return delegate;
+                    }
+                } else {
+                    Optional<Qualifier> resolvedQualifier = delegate.get(AnnotationUtil.QUALIFIER, Qualifier.class);
+                    if (resolvedQualifier.isPresent() && resolvedQualifier.get().equals(qualifier)) {
+                        return delegate;
+                    }
+                }
+            }
+        }
         return super.findConcreteCandidate(beanType, qualifier, candidates);
     }
 
@@ -469,20 +521,18 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
      * @param beanContext The bean context
      */
     protected void initializeTypeConverters(BeanContext beanContext) {
-        Collection<BeanRegistration<TypeConverter>> typeConverters = beanContext.getBeanRegistrations(TypeConverter.class);
-        for (BeanRegistration<TypeConverter> typeConverterRegistration : typeConverters) {
+        for (BeanRegistration<TypeConverter> typeConverterRegistration : beanContext.getBeanRegistrations(TypeConverter.class)) {
             TypeConverter typeConverter = typeConverterRegistration.getBean();
             List<Argument<?>> typeArguments = typeConverterRegistration.getBeanDefinition().getTypeArguments(TypeConverter.class);
             if (typeArguments.size() == 2) {
-                Class source = typeArguments.get(0).getType();
-                Class target = typeArguments.get(1).getType();
-                if (source != null && target != null && !(source == Object.class && target == Object.class)) {
+                Class<?> source = typeArguments.get(0).getType();
+                Class<?> target = typeArguments.get(1).getType();
+                if (!(source == Object.class && target == Object.class)) {
                     getConversionService().addConverter(source, target, typeConverter);
                 }
             }
         }
-        Collection<TypeConverterRegistrar> registrars = beanContext.getBeansOfType(TypeConverterRegistrar.class);
-        for (TypeConverterRegistrar registrar : registrars) {
+        for (TypeConverterRegistrar registrar : beanContext.getBeansOfType(TypeConverterRegistrar.class)) {
             registrar.register(conversionService);
         }
     }
@@ -629,7 +679,8 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
         }
 
         @Override
-        public @NonNull Environment getEnvironment() {
+        public @NonNull
+        Environment getEnvironment() {
             return bootstrapEnvironment;
         }
 
@@ -640,7 +691,8 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
         }
 
         @Override
-        protected @NonNull List<BeanDefinitionReference> resolveBeanDefinitionReferences() {
+        protected @NonNull
+        List<BeanDefinitionReference> resolveBeanDefinitionReferences() {
             List<BeanDefinitionReference> refs = DefaultApplicationContext.this.resolveBeanDefinitionReferences();
             List<BeanDefinitionReference> beanDefinitionReferences = new ArrayList<>(100);
             for (BeanDefinitionReference reference : refs) {
@@ -652,13 +704,14 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
         }
 
         @Override
-        protected @NonNull Iterable<BeanConfiguration> resolveBeanConfigurations() {
+        protected @NonNull
+        Iterable<BeanConfiguration> resolveBeanConfigurations() {
             return DefaultApplicationContext.this.resolveBeanConfigurations();
         }
 
         @Override
         protected void startEnvironment() {
-            registerSingleton(Environment.class, bootstrapEnvironment);
+            registerSingleton(Environment.class, bootstrapEnvironment, null, false);
         }
 
         @Override

--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
@@ -262,7 +262,7 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
         if (!candidates.isEmpty()) {
 
             List<BeanDefinition<T>> transformedCandidates = new ArrayList<>();
-            for (BeanDefinition candidate : candidates) {
+            for (BeanDefinition<T> candidate : candidates) {
                 if (candidate.isIterable()) {
                     if (candidate.hasDeclaredStereotype(EachProperty.class)) {
                         transformEachPropertyBeanDefinition(resolutionContext, candidate, transformedCandidates);
@@ -286,7 +286,9 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
         return candidates;
     }
 
-    private <T> void transformConfigurationReaderBeanDefinition(BeanResolutionContext resolutionContext, BeanDefinition candidate, List<BeanDefinition<T>> transformedCandidates) {
+    private <T> void transformConfigurationReaderBeanDefinition(BeanResolutionContext resolutionContext,
+                                                                BeanDefinition<T> candidate,
+                                                                List<BeanDefinition<T>> transformedCandidates) {
         final String prefix = candidate.stringValue(ConfigurationReader.class, "prefix").orElse(null);
         if (prefix != null) {
             int mapIndex = prefix.indexOf("*");
@@ -316,14 +318,14 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
     }
 
     private <T> void transformConfigurationReaderMap(BeanResolutionContext resolutionContext,
-                                                     BeanDefinition candidate,
+                                                     BeanDefinition<T> candidate,
                                                      String prefix,
                                                      String eachProperty,
                                                      List<BeanDefinition<T>> transformedCandidates) {
         Map entries = getProperty(eachProperty, Map.class, Collections.emptyMap());
         if (!entries.isEmpty()) {
             for (Object key : entries.keySet()) {
-                BeanDefinitionDelegate delegate = BeanDefinitionDelegate.create(candidate);
+                BeanDefinitionDelegate<T> delegate = BeanDefinitionDelegate.create(candidate);
                 delegate.put(EachProperty.class.getName(), delegate.getBeanType());
                 delegate.put(Named.class.getName(), key.toString());
 
@@ -336,7 +338,7 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
     }
 
     private <T> void transformConfigurationReaderList(BeanResolutionContext resolutionContext,
-                                                      BeanDefinition candidate,
+                                                      BeanDefinition<T> candidate,
                                                       String prefix,
                                                       String eachProperty,
                                                       List<BeanDefinition<T>> transformedCandidates) {
@@ -344,7 +346,7 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
         if (!entries.isEmpty()) {
             for (int i = 0; i < entries.size(); i++) {
                 if (entries.get(i) != null) {
-                    BeanDefinitionDelegate delegate = BeanDefinitionDelegate.create(candidate);
+                    BeanDefinitionDelegate<T> delegate = BeanDefinitionDelegate.create(candidate);
                     String index = String.valueOf(i);
                     delegate.put("Array", index);
                     delegate.put(Named.class.getName(), index);
@@ -359,7 +361,7 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
     }
 
     private <T> void transformEachBeanBeanDefinition(BeanResolutionContext resolutionContext,
-                                                     BeanDefinition candidate,
+                                                     BeanDefinition<T> candidate,
                                                      List<BeanDefinition<T>> transformedCandidates,
                                                      boolean filterProxied) {
         Class dependentType = candidate.classValue(EachBean.class).orElse(null);
@@ -412,7 +414,7 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
     }
 
     private <T> void transformEachPropertyBeanDefinition(BeanResolutionContext resolutionContext,
-                                                         BeanDefinition candidate,
+                                                         BeanDefinition<T> candidate,
                                                          List<BeanDefinition<T>> transformedCandidates) {
         boolean isList = candidate.booleanValue(EachProperty.class, "list").orElse(false);
         String property = candidate.stringValue(ConfigurationReader.class, "prefix")
@@ -432,12 +434,12 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
     }
 
     private <T> void transformEachPropertyOfMap(BeanResolutionContext resolutionContext,
-                                                BeanDefinition candidate,
+                                                BeanDefinition<T> candidate,
                                                 String primaryPrefix,
                                                 String property,
                                                 List<BeanDefinition<T>> transformedCandidates) {
         for (String key : getEnvironment().getPropertyEntries(property)) {
-            BeanDefinitionDelegate delegate = BeanDefinitionDelegate.create(candidate);
+            BeanDefinitionDelegate<T> delegate = BeanDefinitionDelegate.create(candidate);
             if (primaryPrefix != null && primaryPrefix.equals(key)) {
                 delegate.put(BeanDefinitionDelegate.PRIMARY_ATTRIBUTE, true);
             }
@@ -451,7 +453,7 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
     }
 
     private <T> void transformEachPropertyOfList(BeanResolutionContext resolutionContext,
-                                                 BeanDefinition candidate,
+                                                 BeanDefinition<T> candidate,
                                                  String primaryPrefix,
                                                  String property,
                                                  List<BeanDefinition<T>> transformedCandidates) {
@@ -459,7 +461,7 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
         int i = 0;
         for (Object entry : entries) {
             if (entry != null) {
-                BeanDefinitionDelegate delegate = BeanDefinitionDelegate.create(candidate);
+                BeanDefinitionDelegate<T> delegate = BeanDefinitionDelegate.create(candidate);
                 String index = String.valueOf(i);
                 if (primaryPrefix != null && primaryPrefix.equals(index)) {
                     delegate.put(BeanDefinitionDelegate.PRIMARY_ATTRIBUTE, true);

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -73,7 +73,6 @@ import io.micronaut.core.naming.Named;
 import io.micronaut.core.order.OrderUtil;
 import io.micronaut.core.order.Ordered;
 import io.micronaut.core.reflect.ClassUtils;
-import io.micronaut.core.reflect.GenericTypeUtils;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.type.ReturnType;
 import io.micronaut.core.util.ArgumentUtils;
@@ -95,11 +94,9 @@ import io.micronaut.inject.BeanType;
 import io.micronaut.inject.ConstructorInjectionPoint;
 import io.micronaut.inject.DisposableBeanDefinition;
 import io.micronaut.inject.ExecutableMethod;
-import io.micronaut.inject.FieldInjectionPoint;
 import io.micronaut.inject.InitializingBeanDefinition;
 import io.micronaut.inject.InjectionPoint;
 import io.micronaut.inject.MethodExecutionHandle;
-import io.micronaut.inject.MethodInjectionPoint;
 import io.micronaut.inject.ParametrizedBeanFactory;
 import io.micronaut.inject.ProxyBeanDefinition;
 import io.micronaut.inject.ValidatedBeanDefinition;
@@ -125,7 +122,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -183,9 +179,10 @@ public class DefaultBeanContext implements InitializableBeanContext {
     protected final AtomicBoolean initializing = new AtomicBoolean(false);
     protected final AtomicBoolean terminating = new AtomicBoolean(false);
 
-    final Map<BeanKey, BeanRegistration> singletonObjects = new ConcurrentHashMap<>(100);
     final Map<BeanIdentifier, BeanRegistration<?>> singlesInCreation = new ConcurrentHashMap<>(5);
     Set<Map.Entry<Class, List<BeanInitializedEventListener>>> beanInitializedEventListeners;
+
+    private final SingletonScope singletonScope = new SingletonScope(this);
 
     private final BeanContextConfiguration beanContextConfiguration;
     private final Collection<BeanDefinitionReference> beanDefinitionsClasses = new ConcurrentLinkedQueue<>();
@@ -193,10 +190,13 @@ public class DefaultBeanContext implements InitializableBeanContext {
     private final Map<BeanKey, Boolean> containsBeanCache = new ConcurrentHashMap<>(30);
     private final Map<CharSequence, Object> attributes = Collections.synchronizedMap(new HashMap<>(5));
 
-    private final Map<BeanKey, Collection> initializedObjectsByType = new ConcurrentHashMap<>(50);
-    private final Map<BeanKey, Optional<BeanDefinition>> beanConcreteCandidateCache =
-            new ConcurrentLinkedHashMap.Builder<BeanKey, Optional<BeanDefinition>>().maximumWeightedCapacity(30).build();
+    private final Map<BeanKey, Collection> singletonBeanRegistrations = new ConcurrentHashMap<>(50);
+
+    private final Map<BeanCandidateKey, Optional<BeanDefinition>> beanConcreteCandidateCache =
+            new ConcurrentLinkedHashMap.Builder<BeanCandidateKey, Optional<BeanDefinition>>().maximumWeightedCapacity(30).build();
+
     private final Map<Argument, Collection<BeanDefinition>> beanCandidateCache = new ConcurrentLinkedHashMap.Builder<Argument, Collection<BeanDefinition>>().maximumWeightedCapacity(30).build();
+
     private final Map<Class, Collection<BeanDefinitionReference>> beanIndex = new ConcurrentHashMap<>(12);
 
     private final ClassLoader classLoader;
@@ -280,7 +280,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
         this.customScopeRegistry = Objects.requireNonNull(createCustomScopeRegistry(), "Scope registry cannot be null");
         Set<Class<? extends Annotation>> eagerInitAnnotated = contextConfiguration.getEagerInitAnnotated();
         List<String> eagerInitStereotypes = new ArrayList<>(eagerInitAnnotated.size());
-        for (Class<? extends Annotation> ann: eagerInitAnnotated) {
+        for (Class<? extends Annotation> ann : eagerInitAnnotated) {
             eagerInitStereotypes.add(ann.getName());
         }
         this.eagerInitStereotypes = eagerInitStereotypes.toArray(new String[0]);
@@ -291,6 +291,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
 
     /**
      * Allows customizing the custom scope registry.
+     *
      * @return The custom scope registry to use.
      * @since 3.0.0
      */
@@ -363,11 +364,21 @@ public class DefaultBeanContext implements InitializableBeanContext {
             attributes.clear();
 
             // need to sort registered singletons so that beans with that require other beans appear first
-            List<BeanRegistration> objects = topologicalSort(singletonObjects.values());
+            List<BeanRegistration> objects = topologicalSort(singletonScope.getBeanRegistrations());
+
+            Map<Boolean, List<BeanRegistration>> result = objects.stream().collect(Collectors.groupingBy(br -> br.bean != null
+                    && (br.bean instanceof BeanPreDestroyEventListener || br.bean instanceof BeanDestroyedEventListener)));
+
+            List<BeanRegistration> listeners = result.get(true);
+            if (listeners != null) {
+                // destroy all bean destroy listeners at the end
+                objects.clear();
+                objects.addAll(result.get(false));
+                objects.addAll(listeners);
+            }
 
             Set<Integer> processed = new HashSet<>();
             for (BeanRegistration beanRegistration : objects) {
-                BeanDefinition def = beanRegistration.beanDefinition;
                 Object bean = beanRegistration.bean;
                 int sysId = System.identityHashCode(bean);
                 if (processed.contains(sysId)) {
@@ -380,13 +391,22 @@ public class DefaultBeanContext implements InitializableBeanContext {
 
                 processed.add(sysId);
                 try {
-                    disposeBean(beanRegistration, def.asArgument(), bean, def);
+                    destroyBean(beanRegistration);
                 } catch (BeanDestructionException e) {
                     if (LOG.isErrorEnabled()) {
                         LOG.error(e.getMessage(), e);
                     }
                 }
             }
+
+            singletonBeanRegistrations.clear();
+            beanConcreteCandidateCache.clear();
+            beanCandidateCache.clear();
+            containsBeanCache.clear();
+            beanConfigurations.clear();
+            singletonScope.clear();
+            beanInitializedEventListeners = null;
+            beanCreationEventListeners = null;
 
             terminating.set(false);
             running.set(false);
@@ -399,28 +419,31 @@ public class DefaultBeanContext implements InitializableBeanContext {
     public AnnotationMetadata resolveMetadata(Class<?> type) {
         if (type == null) {
             return AnnotationMetadata.EMPTY_METADATA;
-        } else {
-            Optional<? extends BeanDefinition<?>> candidate = findConcreteCandidate(
-                    null,
-                    Argument.of(type),
-                    null,
-                    false
-            );
-            return candidate.map(AnnotationMetadataProvider::getAnnotationMetadata).orElse(AnnotationMetadata.EMPTY_METADATA);
         }
+        return findBeanDefinition(Argument.of(type), null, false)
+                .map(AnnotationMetadataProvider::getAnnotationMetadata)
+                .orElse(AnnotationMetadata.EMPTY_METADATA);
     }
 
-    @SuppressWarnings({"SuspiciousMethodCalls", "unchecked"})
     @Override
-    public <T> Optional<T> refreshBean(BeanIdentifier identifier) {
-        if (identifier != null) {
-            BeanRegistration beanRegistration = singletonObjects.get(identifier);
-            if (beanRegistration != null) {
-                BeanDefinition definition = beanRegistration.getBeanDefinition();
-                return Optional.of((T) definition.inject(this, beanRegistration.getBean()));
-            }
+    public <T> Optional<T> refreshBean(@Nullable BeanIdentifier identifier) {
+        if (identifier == null) {
+            return Optional.empty();
+        }
+        BeanRegistration<T> beanRegistration = singletonScope.findBeanRegistration(identifier);
+        if (beanRegistration != null) {
+            refreshBean(beanRegistration);
+            return Optional.of(beanRegistration.bean);
         }
         return Optional.empty();
+    }
+
+    @Override
+    public <T> void refreshBean(@NonNull BeanRegistration<T> beanRegistration) {
+        Objects.requireNonNull(beanRegistration, "BeanRegistration cannot be null");
+        if (beanRegistration.bean != null) {
+            beanRegistration.definition().inject(this, beanRegistration.bean);
+        }
     }
 
     @SuppressWarnings("unchecked")
@@ -429,15 +452,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
         if (qualifier == null) {
             return Collections.emptyList();
         }
-        List result = singletonObjects
-                .values()
-                .stream()
-                .filter(registration -> {
-                    BeanDefinition beanDefinition = registration.beanDefinition;
-                    return qualifier.reduce(beanDefinition.getBeanType(), Stream.of(beanDefinition)).findFirst().isPresent();
-                })
-                .collect(Collectors.toList());
-        return result;
+        return singletonScope.getBeanRegistrations(qualifier);
     }
 
     @SuppressWarnings("unchecked")
@@ -446,15 +461,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
         if (beanType == null) {
             return Collections.emptyList();
         }
-        List result = singletonObjects
-                .values()
-                .stream()
-                .filter(registration -> {
-                    BeanDefinition beanDefinition = registration.beanDefinition;
-                    return beanType.isAssignableFrom(beanDefinition.getBeanType());
-                })
-                .collect(Collectors.toList());
-        return result;
+        return singletonScope.getBeanRegistrations(beanType);
     }
 
     @Override
@@ -501,10 +508,9 @@ public class DefaultBeanContext implements InitializableBeanContext {
         if (bean == null) {
             return Optional.empty();
         }
-        for (BeanRegistration beanRegistration : singletonObjects.values()) {
-            if (bean == beanRegistration.getBean()) {
-                return Optional.of(beanRegistration);
-            }
+        BeanRegistration<T> beanRegistration = singletonScope.findBeanRegistration(bean);
+        if (beanRegistration != null) {
+            return Optional.of(beanRegistration);
         }
         return customScopeRegistry.findBeanRegistration(bean);
     }
@@ -526,7 +532,6 @@ public class DefaultBeanContext implements InitializableBeanContext {
                 return method.getAnnotationMetadata();
             }
 
-            @SuppressWarnings("rawtypes")
             @Override
             public Object getTarget() {
                 Object target = this.target;
@@ -534,17 +539,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
                     synchronized (this) { // double check
                         target = this.target;
                         if (target == null) {
-                            try (BeanResolutionContext context = newResolutionContext(beanDefinition, null)) {
-                                BeanDefinition rawDefinition = beanDefinition;
-                                target = getBeanForDefinition(
-                                        context,
-                                        Argument.of(rawDefinition.getBeanType()),
-                                        rawDefinition.getDeclaredQualifier(),
-                                        true,
-                                        rawDefinition
-                                ).bean;
-                            }
-
+                            target = getBean(beanDefinition);
                             this.target = target;
                         }
                     }
@@ -662,77 +657,73 @@ public class DefaultBeanContext implements InitializableBeanContext {
 
     @Override
     public <T> BeanContext registerSingleton(@NonNull Class<T> type, @NonNull T singleton, Qualifier<T> qualifier, boolean inject) {
-        ArgumentUtils.requireNonNull("type", type);
-        ArgumentUtils.requireNonNull("singleton", singleton);
-        BeanKey<T> beanKey = new BeanKey<>(type, qualifier);
-        synchronized (singletonObjects) {
+        purgeCacheForBeanInstance(singleton);
 
-            initializedObjectsByType.clear();
-            beanCandidateCache.remove(Argument.of(type));
-            BeanDefinition<T> beanDefinition = inject ? findConcreteCandidate(
-                    null,
-                    beanKey.beanType,
-                    qualifier,
-                    false
-            ).orElse(null) : null;
-            if (beanDefinition != null && beanDefinition.getBeanType().isInstance(singleton)) {
-                try (BeanResolutionContext context = newResolutionContext(beanDefinition, null)) {
-                    doInject(context, singleton, beanDefinition);
-                    final List<BeanRegistration<?>> dependentBeans = context.getAndResetDependentBeans();
-                    if (dependentBeans.isEmpty()) {
-                        singletonObjects.put(beanKey, new BeanDisposingRegistration(beanKey, beanDefinition, singleton));
-
-                    } else {
-                        singletonObjects.put(beanKey, new BeanDisposingRegistration(beanKey, beanDefinition, singleton, dependentBeans));
-                    }
-                    BeanKey concreteKey = new BeanKey(singleton.getClass(), qualifier);
-                    singletonObjects.put(concreteKey, new BeanRegistration<>(concreteKey, beanDefinition, singleton));
-                }
+        BeanDefinition<T> beanDefinition;
+        if (inject && running.get()) {
+            // Bean cannot be injected before the start of the context
+            beanDefinition = findBeanDefinition(type, qualifier).orElse(null);
+            if (beanDefinition == null) {
+                // Purge cache miss
+                beanCandidateCache.entrySet().removeIf(entry -> entry.getKey().isInstance(singleton));
+                beanConcreteCandidateCache.entrySet().removeIf(entry -> entry.getKey().beanType.isInstance(singleton));
+            }
+        } else {
+            beanDefinition = null;
+        }
+        if (beanDefinition != null && beanDefinition.getBeanType().isInstance(singleton)) {
+            try (BeanResolutionContext context = newResolutionContext(beanDefinition, null)) {
+                doInject(context, singleton, beanDefinition);
+                singletonScope.registerSingletonBean(beanDefinition, qualifier, singleton, Collections.emptyList());
+            }
+        } else {
+            NoInjectionBeanDefinition<T> dynamicRegistration = new NoInjectionBeanDefinition<>(singleton.getClass(), qualifier);
+            if (qualifier instanceof Named) {
+                final BeanDefinitionDelegate<T> delegate = BeanDefinitionDelegate.create(dynamicRegistration);
+                delegate.put(BeanDefinition.NAMED_ATTRIBUTE, ((Named) qualifier).getName());
+                beanDefinition = delegate;
             } else {
-                NoInjectionBeanDefinition<T> dynamicRegistration = new NoInjectionBeanDefinition<>(singleton.getClass(), qualifier);
-                if (qualifier instanceof Named) {
-                    final BeanDefinitionDelegate<T> delegate = BeanDefinitionDelegate.create(dynamicRegistration);
-                    delegate.put(BeanDefinition.NAMED_ATTRIBUTE, ((Named) qualifier).getName());
-                    beanDefinition = delegate;
-                } else {
-                    beanDefinition = dynamicRegistration;
-                }
-                beanDefinitionsClasses.add(dynamicRegistration);
-                singletonObjects.put(beanKey, new BeanRegistration<>(beanKey, dynamicRegistration, singleton));
-                BeanKey concreteKey = new BeanKey(singleton.getClass(), qualifier);
-                singletonObjects.put(concreteKey, new BeanRegistration<>(concreteKey, dynamicRegistration, singleton));
+                beanDefinition = dynamicRegistration;
+            }
+            beanDefinitionsClasses.add(dynamicRegistration);
+            singletonScope.registerSingletonBean(dynamicRegistration, qualifier, singleton, Collections.emptyList());
 
-                for (Class indexedType : indexedTypes) {
-                    if (indexedType == type || indexedType.isAssignableFrom(type)) {
-                        final Collection<BeanDefinitionReference> indexed = resolveTypeIndex(indexedType);
-                        BeanDefinition<T> finalBeanDefinition = beanDefinition;
-                        indexed.add(new AbstractBeanDefinitionReference(type.getName(), type.getName()) {
-                            @Override
-                            protected Class<? extends BeanDefinition<?>> getBeanDefinitionType() {
-                                return (Class<? extends BeanDefinition<?>>) finalBeanDefinition.getClass();
-                            }
+            for (Class indexedType : indexedTypes) {
+                if (indexedType == type || indexedType.isAssignableFrom(type)) {
+                    final Collection<BeanDefinitionReference> indexed = resolveTypeIndex(indexedType);
+                    BeanDefinition<T> finalBeanDefinition = beanDefinition;
+                    indexed.add(new AbstractBeanDefinitionReference(type.getName(), type.getName()) {
+                        @Override
+                        protected Class<? extends BeanDefinition<?>> getBeanDefinitionType() {
+                            return (Class<? extends BeanDefinition<?>>) finalBeanDefinition.getClass();
+                        }
 
-                            @Override
-                            public BeanDefinition load() {
-                                return finalBeanDefinition;
-                            }
+                        @Override
+                        public BeanDefinition load() {
+                            return finalBeanDefinition;
+                        }
 
-                            @Override
-                            public Class getBeanType() {
-                                return type;
-                            }
-                        });
-                        break;
-                    }
+                        @Override
+                        public Class getBeanType() {
+                            return type;
+                        }
+                    });
+                    break;
                 }
             }
-
         }
         return this;
     }
 
+    private <T> void purgeCacheForBeanInstance(T singleton) {
+        beanCandidateCache.entrySet().removeIf(entry -> entry.getKey().isInstance(singleton));
+        beanConcreteCandidateCache.entrySet().removeIf(entry -> entry.getKey().beanType.isInstance(singleton));
+        singletonBeanRegistrations.entrySet().removeIf(entry -> entry.getKey().beanType.isInstance(singleton));
+        containsBeanCache.entrySet().removeIf(entry -> entry.getKey().beanType.isInstance(singleton));
+    }
+
     @NonNull
-    private BeanResolutionContext newResolutionContext(BeanDefinition<?> beanDefinition, @Nullable BeanResolutionContext currentContext) {
+    final BeanResolutionContext newResolutionContext(BeanDefinition<?> beanDefinition, @Nullable BeanResolutionContext currentContext) {
         if (currentContext == null) {
             return new SingletonBeanResolutionContext(beanDefinition);
         } else {
@@ -765,44 +756,26 @@ public class DefaultBeanContext implements InitializableBeanContext {
 
     @Override
     public <T> BeanDefinition<T> getBeanDefinition(Argument<T> beanType, Qualifier<T> qualifier) {
-        return findConcreteCandidate(null, beanType, qualifier, true)
+        return findBeanDefinition(beanType, qualifier)
                 .orElseThrow(() -> new NoSuchBeanException(beanType, qualifier));
     }
 
     @Override
     public <T> Optional<BeanDefinition<T>> findBeanDefinition(Argument<T> beanType, Qualifier<T> qualifier) {
-        if (Objects.requireNonNull(beanType, "Bean type cannot be null").equalsType(Argument.OBJECT_ARGUMENT)) {
-            // optimization for object resolve
-            return Optional.empty();
+        BeanDefinition<T> beanDefinition = singletonScope.findCachedSingletonBeanDefinition(beanType, qualifier);
+        if (beanDefinition != null) {
+            return Optional.of(beanDefinition);
         }
+        return findConcreteCandidate(null, beanType, qualifier, true);
+    }
 
-        BeanKey<T> beanKey = new BeanKey<>(beanType, qualifier);
-        @SuppressWarnings("unchecked") BeanRegistration<T> reg = singletonObjects.get(beanKey);
-        if (reg != null) {
-            return Optional.of(reg.getBeanDefinition());
-        }
-        Collection<BeanDefinition<T>> beanCandidates = new ArrayList<>(findBeanCandidatesInternal(null, beanKey.beanType));
-        if (qualifier != null) {
-            beanCandidates = qualifier.reduce(beanType.getType(), beanCandidates.stream()).collect(Collectors.toList());
-        }
-        filterProxiedTypes(beanCandidates, true, true, null);
-        if (beanCandidates.isEmpty()) {
-            return Optional.empty();
-        } else {
-            if (beanCandidates.size() == 1) {
-                return Optional.of(beanCandidates.iterator().next());
-            } else {
-                return findConcreteCandidate(null, beanKey.beanType, qualifier, false);
-            }
-        }
+    private <T> Optional<BeanDefinition<T>> findBeanDefinition(Argument<T> beanType, Qualifier<T> qualifier, boolean throwNonUnique) {
+        return findConcreteCandidate(null, beanType, qualifier, throwNonUnique);
     }
 
     @Override
     public <T> Optional<BeanDefinition<T>> findBeanDefinition(Class<T> beanType, Qualifier<T> qualifier) {
-        return findBeanDefinition(
-                Argument.of(beanType),
-                qualifier
-        );
+        return findBeanDefinition(Argument.of(beanType), qualifier);
     }
 
     @Override
@@ -812,19 +785,15 @@ public class DefaultBeanContext implements InitializableBeanContext {
 
     @Override
     public <T> Collection<BeanDefinition<T>> getBeanDefinitions(Argument<T> beanType) {
-        Collection<BeanDefinition<T>> candidates = findBeanCandidatesInternal(
-                null,
-                Objects.requireNonNull(beanType, "Bean type cannot be null")
-        );
+        Objects.requireNonNull(beanType, "Bean type cannot be null");
+        Collection<BeanDefinition<T>> candidates = findBeanCandidatesInternal(null, beanType);
         return Collections.unmodifiableCollection(candidates);
     }
 
     @Override
     public <T> Collection<BeanDefinition<T>> getBeanDefinitions(Class<T> beanType, Qualifier<T> qualifier) {
-        return getBeanDefinitions(
-                Argument.of(Objects.requireNonNull(beanType, "Bean type cannot be null")),
-                qualifier
-        );
+        Objects.requireNonNull(beanType, "Bean type cannot be null");
+        return getBeanDefinitions(Argument.of(beanType), qualifier);
     }
 
     @Override
@@ -849,7 +818,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
         if (containsBeanCache.containsKey(beanKey)) {
             return containsBeanCache.get(beanKey);
         } else {
-            boolean result = singletonObjects.containsKey(beanKey) ||
+            boolean result = singletonScope.containsBean(beanType, qualifier) ||
                     isCandidatePresent(beanKey.beanType, qualifier);
 
             containsBeanCache.put(beanKey, result);
@@ -857,45 +826,31 @@ public class DefaultBeanContext implements InitializableBeanContext {
         }
     }
 
+    @NonNull
     @Override
-    public @NonNull
-    <T> T getBean(@NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier) {
+    public <T> T getBean(@NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier) {
+        Objects.requireNonNull(beanType, "Bean type cannot be null");
+        return getBean(Argument.of(beanType), qualifier);
+    }
+
+    @NonNull
+    @Override
+    public <T> T getBean(@NonNull Class<T> beanType) {
+        Objects.requireNonNull(beanType, "Bean type cannot be null");
+        return getBean(Argument.of(beanType), null);
+    }
+
+    @NonNull
+    @Override
+    public <T> T getBean(@NonNull Argument<T> beanType, @Nullable Qualifier<T> qualifier) {
         Objects.requireNonNull(beanType, "Bean type cannot be null");
         try {
-            //noinspection ConstantConditions
-            return getBeanInternal(
-                    null,
-                    Argument.of(beanType),
-                    qualifier,
-                    true,
-                    true
-            ).bean;
+            return getBean(null, beanType, qualifier);
         } catch (DisabledBeanException e) {
             if (AbstractBeanContextConditional.LOG.isDebugEnabled()) {
                 AbstractBeanContextConditional.LOG.debug("Bean of type [{}] disabled for reason: {}", beanType.getSimpleName(), e.getMessage());
             }
             throw new NoSuchBeanException(beanType, qualifier);
-        }
-    }
-
-    @Override
-    public @NonNull
-    <T> T getBean(@NonNull Class<T> beanType) {
-        Objects.requireNonNull(beanType, "Bean type cannot be null");
-        try {
-            //noinspection ConstantConditions
-            return getBeanInternal(
-                    null,
-                    Argument.of(beanType),
-                    null,
-                    true,
-                    true
-            ).bean;
-        } catch (DisabledBeanException e) {
-            if (AbstractBeanContextConditional.LOG.isDebugEnabled()) {
-                AbstractBeanContextConditional.LOG.debug("Bean of type [{}] disabled for reason: {}", beanType.getSimpleName(), e.getMessage());
-            }
-            throw new NoSuchBeanException(beanType, null);
         }
     }
 
@@ -916,10 +871,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
 
     @Override
     public <T> Collection<T> getBeansOfType(Class<T> beanType, Qualifier<T> qualifier) {
-        return getBeanRegistrations(null, Argument.of(beanType), qualifier)
-                .stream()
-                .map(BeanRegistration::getBean)
-                .collect(Collectors.toList());
+        return getBeansOfType(Argument.of(beanType), qualifier);
     }
 
     @Override
@@ -971,14 +923,14 @@ public class DefaultBeanContext implements InitializableBeanContext {
                 .map(BeanRegistration::getBean);
     }
 
+    @NonNull
     @Override
-    public @NonNull
-    <T> T inject(@NonNull T instance) {
+    public <T> T inject(@NonNull T instance) {
         Objects.requireNonNull(instance, "Instance cannot be null");
 
         Collection<BeanDefinition> candidates = findBeanCandidatesForInstance(instance);
         if (candidates.size() == 1) {
-            BeanDefinition<T> beanDefinition = candidates.stream().findFirst().get();
+            BeanDefinition<T> beanDefinition = candidates.iterator().next();
             try (BeanResolutionContext resolutionContext = newResolutionContext(beanDefinition, null)) {
                 final BeanKey<T> beanKey = new BeanKey<>(beanDefinition.getBeanType(), null);
                 resolutionContext.addInFlightBean(
@@ -999,34 +951,22 @@ public class DefaultBeanContext implements InitializableBeanContext {
         return instance;
     }
 
+    @NonNull
     @Override
-    public @NonNull
-    <T> T createBean(@NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier) {
+    public <T> T createBean(@NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier) {
         return createBean(null, beanType, qualifier);
     }
 
+    @NonNull
     @Override
-    public @NonNull
-    <T> T createBean(@NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier, @Nullable Map<String, Object> argumentValues) {
+    public <T> T createBean(@NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier, @Nullable Map<String, Object> argumentValues) {
         ArgumentUtils.requireNonNull("beanType", beanType);
 
         final Argument<T> beanArg = Argument.of(beanType);
-        Optional<BeanDefinition<T>> candidate = findConcreteCandidate(
-                null,
-                beanArg,
-                qualifier,
-                true
-        );
+        Optional<BeanDefinition<T>> candidate = findBeanDefinition(beanArg, qualifier);
         if (candidate.isPresent()) {
             try (BeanResolutionContext resolutionContext = newResolutionContext(candidate.get(), null)) {
-                T createdBean = doCreateBean(
-                        resolutionContext,
-                        candidate.get(),
-                        qualifier,
-                        beanArg,
-                        false,
-                        argumentValues
-                );
+                T createdBean = doCreateBean(resolutionContext, candidate.get(), qualifier, argumentValues);
                 if (createdBean == null) {
                     throw new NoSuchBeanException(beanType);
                 }
@@ -1036,27 +976,16 @@ public class DefaultBeanContext implements InitializableBeanContext {
         throw new NoSuchBeanException(beanType);
     }
 
+    @NonNull
     @Override
-    public @NonNull
-    <T> T createBean(@NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier, @Nullable Object... args) {
+    public <T> T createBean(@NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier, @Nullable Object... args) {
         ArgumentUtils.requireNonNull("beanType", beanType);
         final Argument<T> beanArg = Argument.of(beanType);
-        Optional<BeanDefinition<T>> candidate = findConcreteCandidate(
-                null,
-                beanArg,
-                qualifier,
-                true
-        );
+        Optional<BeanDefinition<T>> candidate = findBeanDefinition(beanArg, qualifier);
         if (candidate.isPresent()) {
             BeanDefinition<T> definition = candidate.get();
             try (BeanResolutionContext resolutionContext = newResolutionContext(definition, null)) {
-                return doCreateBean(
-                        resolutionContext,
-                        definition,
-                        Argument.of(beanType),
-                        qualifier,
-                        args
-                );
+                return doCreateBean(resolutionContext, definition, beanArg, qualifier, args);
             }
         }
         throw new NoSuchBeanException(beanType);
@@ -1071,17 +1000,17 @@ public class DefaultBeanContext implements InitializableBeanContext {
      * @param <T>               the bean generic type
      * @return The instance
      */
-    protected @NonNull
-    <T> T doCreateBean(@NonNull BeanResolutionContext resolutionContext,
-                       @NonNull BeanDefinition<T> definition,
-                       @NonNull Argument<T> beanType,
-                       @Nullable Qualifier<T> qualifier,
-                       @Nullable Object... args) {
+    @NonNull
+    protected <T> T doCreateBean(@NonNull BeanResolutionContext resolutionContext,
+                                 @NonNull BeanDefinition<T> definition,
+                                 @NonNull Argument<T> beanType,
+                                 @Nullable Qualifier<T> qualifier,
+                                 @Nullable Object... args) {
         Map<String, Object> argumentValues = resolveArgumentValues(resolutionContext, definition, args);
         if (LOG.isTraceEnabled()) {
             LOG.trace("Computed bean argument values: {}", argumentValues);
         }
-        T createdBean = doCreateBean(resolutionContext, definition, qualifier, beanType, false, argumentValues);
+        T createdBean = doCreateBean(resolutionContext, definition, qualifier, argumentValues);
         if (createdBean == null) {
             throw new NoSuchBeanException(beanType);
         }
@@ -1130,91 +1059,71 @@ public class DefaultBeanContext implements InitializableBeanContext {
         return argumentValues;
     }
 
+    @Nullable
     @Override
-    public <T> T destroyBean(Argument<T> beanType, Qualifier<T> qualifier) {
+    public <T> T destroyBean(@NonNull Argument<T> beanType, Qualifier<T> qualifier) {
         ArgumentUtils.requireNonNull("beanType", beanType);
-        T bean = null;
-        BeanKey<T> beanKey = new BeanKey<>(beanType, qualifier);
+        return findBeanDefinition(beanType, qualifier)
+                .map(this::destroyBean)
+                .orElse(null);
+    }
 
-        synchronized (singletonObjects) {
-            if (singletonObjects.containsKey(beanKey)) {
-                @SuppressWarnings("unchecked") BeanRegistration<T> beanRegistration = singletonObjects.get(beanKey);
-                bean = beanRegistration.bean;
-                if (bean != null) {
-                    if (LOG_LIFECYCLE.isDebugEnabled()) {
-                        LOG_LIFECYCLE.debug("Destroying bean [{}] with identifier [{}]", bean, beanKey);
-                    }
-
-                    purgeBeanRegistrations(bean);
-                    disposeBean(beanRegistration, beanType, bean, beanRegistration.beanDefinition);
-                }
-            } else {
-                final BeanDefinition<T> candidate = findConcreteCandidate(
-                        null,
-                        beanKey.beanType,
-                        qualifier,
-                        false
-                ).orElse(null);
-                if (candidate != null) {
-                    BeanRegistration<T> registration = findExistingCompatibleSingleton(beanType, null, qualifier, candidate);
-                    if (registration != null) {
-                        bean = registration.getBean();
-                        disposeBean(registration, beanType, bean, candidate);
-                        purgeBeanRegistrations(bean);
-                    }
-                }
+    @Override
+    @NonNull
+    public <T> T destroyBean(@NonNull T bean) {
+        ArgumentUtils.requireNonNull("bean", bean);
+        Optional<BeanRegistration<T>> beanRegistration = findBeanRegistration(bean);
+        if (beanRegistration.isPresent()) {
+            destroyBean(beanRegistration.get());
+        } else {
+            Optional<BeanDefinition<T>> beanDefinition = findBeanDefinition((Class<T>) bean.getClass());
+            if (beanDefinition.isPresent()) {
+                BeanDefinition<T> definition = beanDefinition.get();
+                BeanKey<T> key = new BeanKey<>(definition, definition.getDeclaredQualifier());
+                destroyBean(new BeanDisposingRegistration<>(this, key, definition, bean));
             }
         }
         return bean;
     }
 
-    private <T> void purgeBeanRegistrations(T bean) {
-        singletonObjects.entrySet().removeIf(entry -> entry.getValue().bean == bean);
-    }
-
-    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
-    @NonNull
-    public <T> T destroyBean(T bean) {
-        Objects.requireNonNull(bean, "Bean cannot be null");
-        final Argument arg = Argument.of(bean.getClass());
-        final BeanDefinition concreteCandidate = (BeanDefinition) findConcreteCandidate(
-                null,
-                arg,
-                null,
-                false
-        ).orElse(null);
-        if (concreteCandidate != null) {
-            disposeBean(new BeanDisposingRegistration<>(
-                    new BeanKey<>(concreteCandidate, concreteCandidate.getDeclaredQualifier()),
-                    concreteCandidate,
-                    bean
-            ), arg, bean, concreteCandidate);
-        }
-        return bean;
-    }
-
-    @Override
-    public @Nullable
-    <T> T destroyBean(@NonNull Class<T> beanType) {
+    @Nullable
+    public <T> T destroyBean(@NonNull Class<T> beanType) {
+        ArgumentUtils.requireNonNull("beanType", beanType);
         return destroyBean(Argument.of(beanType), null);
     }
 
-    private <T> void disposeBean(
-            BeanRegistration<T> registration,
-            Argument<T> beanType,
-            T finalBean,
-            BeanDefinition<T> definition) {
-        final List<BeanPreDestroyEventListener> preDestroyEventListeners = resolveListeners(
-                BeanPreDestroyEventListener.class, beanType
-        );
+    @Nullable
+    private <T> T destroyBean(@NonNull BeanDefinition<T> beanDefinition) {
+        if (beanDefinition.isSingleton()) {
+            BeanRegistration<T> beanRegistration = singletonScope.findBeanRegistration(beanDefinition);
+            if (beanRegistration != null) {
+                destroyBean(beanRegistration);
+                return beanRegistration.bean;
+            }
+        }
+        return null;
+    }
 
-        T beanToDestroy = finalBean;
+    @Nullable
+    private <T> void destroyBean(@NonNull BeanRegistration<T> registration) {
+        if (LOG_LIFECYCLE.isDebugEnabled()) {
+            LOG_LIFECYCLE.debug("Destroying bean [{}] with identifier [{}]", registration.bean, registration.identifier);
+        }
+        if (registration.bean != null) {
+            purgeCacheForBeanInstance(registration.bean);
+            if (registration.beanDefinition.isSingleton()) {
+                singletonScope.purgeCacheForBeanInstance(registration.beanDefinition, registration.bean);
+            }
+        }
+        BeanDefinition<T> definition = registration.getBeanDefinition();
+        Argument<T> beanType = definition.asArgument();
+        final List<BeanPreDestroyEventListener> preDestroyEventListeners = resolveListeners(BeanPreDestroyEventListener.class, beanType);
+        T beanToDestroy = registration.getBean();
         if (CollectionUtils.isNotEmpty(preDestroyEventListeners)) {
             for (BeanPreDestroyEventListener<T> listener : preDestroyEventListeners) {
                 try {
-                    final BeanPreDestroyEvent<T> event =
-                            new BeanPreDestroyEvent<>(this, definition, beanToDestroy);
+                    final BeanPreDestroyEvent<T> event = new BeanPreDestroyEvent<>(this, definition, beanToDestroy);
                     beanToDestroy = Objects.requireNonNull(
                             listener.onPreDestroy(event),
                             "PreDestroy event listener illegally returned null: " + listener.getClass()
@@ -1225,29 +1134,23 @@ public class DefaultBeanContext implements InitializableBeanContext {
             }
         }
 
-
         try {
-
             registration.close();
         } catch (Exception e) {
             throw new BeanDestructionException(definition, e);
         }
 
-        final List<BeanDestroyedEventListener> postDestroyListeners = resolveListeners(
-                BeanDestroyedEventListener.class, beanType
-        );
+        final List<BeanDestroyedEventListener> postDestroyListeners = resolveListeners(BeanDestroyedEventListener.class, beanType);
         if (CollectionUtils.isNotEmpty(postDestroyListeners)) {
             for (BeanDestroyedEventListener<T> listener : postDestroyListeners) {
                 try {
-                    final BeanDestroyedEvent<T> event =
-                            new BeanDestroyedEvent<>(this, definition, beanToDestroy);
+                    final BeanDestroyedEvent<T> event = new BeanDestroyedEvent<>(this, definition, beanToDestroy);
                     listener.onDestroyed(event);
                 } catch (Exception e) {
                     throw new BeanDestructionException(definition, e);
                 }
             }
         }
-
     }
 
     @NonNull
@@ -1270,7 +1173,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
         if (beanDefinition == null) {
             return null;
         }
-        return singletonObjects.get(new BeanKey(beanDefinition, qualifier));
+        return singletonScope.findBeanRegistration(beanDefinition, qualifier);
     }
 
     /**
@@ -1282,31 +1185,20 @@ public class DefaultBeanContext implements InitializableBeanContext {
      * @param <T>               The bean generic type
      * @return The instance
      */
-    protected @NonNull
-    <T> T createBean(@Nullable BeanResolutionContext resolutionContext, @NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier) {
+    @NonNull
+    protected <T> T createBean(@Nullable BeanResolutionContext resolutionContext,
+                               @NonNull Class<T> beanType,
+                               @Nullable Qualifier<T> qualifier) {
         ArgumentUtils.requireNonNull("beanType", beanType);
 
-        final Argument<T> beanArgument = Argument.of(beanType);
-        Optional<BeanDefinition<T>> concreteCandidate = findConcreteCandidate(
-                resolutionContext,
-                beanArgument,
-                qualifier,
-                true
-        );
+        Optional<BeanDefinition<T>> concreteCandidate = findBeanDefinition(beanType, qualifier);
         if (concreteCandidate.isPresent()) {
             BeanDefinition<T> candidate = concreteCandidate.get();
             try (BeanResolutionContext context = newResolutionContext(candidate, resolutionContext)) {
-                T createBean = doCreateBean(
-                        context,
-                        candidate,
-                        qualifier,
-                        beanArgument,
-                        false, null
-                );
-                if (createBean == null) {
-                    throw new NoSuchBeanException(beanType);
+                T createBean = doCreateBean(context, candidate, qualifier);
+                if (createBean != null) {
+                    return createBean;
                 }
-                return createBean;
             }
         }
         throw new NoSuchBeanException(beanType);
@@ -1322,15 +1214,12 @@ public class DefaultBeanContext implements InitializableBeanContext {
      * @return The instance
      */
     @Internal
-    protected @NonNull
-    <T> T inject(@NonNull BeanResolutionContext resolutionContext, @Nullable BeanDefinition<?> requestingBeanDefinition, @NonNull T instance) {
+    @NonNull
+    protected <T> T inject(@NonNull BeanResolutionContext resolutionContext,
+                           @Nullable BeanDefinition<?> requestingBeanDefinition,
+                           @NonNull T instance) {
         @SuppressWarnings("unchecked") Class<T> beanType = (Class<T>) instance.getClass();
-        Optional<BeanDefinition<T>> concreteCandidate = findConcreteCandidate(
-                resolutionContext,
-                Argument.of(beanType),
-                null,
-                false
-        );
+        Optional<BeanDefinition<T>> concreteCandidate = findBeanDefinition(beanType, null);
         if (concreteCandidate.isPresent()) {
             BeanDefinition definition = concreteCandidate.get();
             if (requestingBeanDefinition != null && requestingBeanDefinition.equals(definition)) {
@@ -1350,11 +1239,9 @@ public class DefaultBeanContext implements InitializableBeanContext {
      * @param <T>               The bean type parameter
      * @return The found beans
      */
-    protected @NonNull
-    <T> Collection<T> getBeansOfType(@Nullable BeanResolutionContext resolutionContext, @NonNull Argument<T> beanType) {
-        return getBeanRegistrations(resolutionContext, beanType, null)
-                .stream().map(BeanRegistration::getBean)
-                .collect(Collectors.toList());
+    @NonNull
+    protected <T> Collection<T> getBeansOfType(@Nullable BeanResolutionContext resolutionContext, @NonNull Argument<T> beanType) {
+        return getBeansOfType(resolutionContext, beanType, null);
     }
 
     /**
@@ -1367,20 +1254,22 @@ public class DefaultBeanContext implements InitializableBeanContext {
      * @return The found beans
      */
     @Internal
-    public @NonNull
-    <T> Collection<T> getBeansOfType(
-            @Nullable BeanResolutionContext resolutionContext,
-            @NonNull Argument<T> beanType,
-            @Nullable Qualifier<T> qualifier) {
-        return getBeanRegistrations(resolutionContext, beanType, qualifier)
-                .stream().map(BeanRegistration::getBean)
-                .collect(Collectors.toList());
+    @NonNull
+    public <T> Collection<T> getBeansOfType(@Nullable BeanResolutionContext resolutionContext,
+                                            @NonNull Argument<T> beanType,
+                                            @Nullable Qualifier<T> qualifier) {
+        Collection<BeanRegistration<T>> beanRegistrations = getBeanRegistrations(resolutionContext, beanType, qualifier);
+        List<T> list = new ArrayList<>(beanRegistrations.size());
+        for (BeanRegistration<T> beanRegistration : beanRegistrations) {
+            list.add(beanRegistration.getBean());
+        }
+        return list;
     }
 
     @SuppressWarnings("unchecked")
     @Override
-    public @NonNull
-    <T> T getProxyTargetBean(@NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier) {
+    @NonNull
+    public <T> T getProxyTargetBean(@NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier) {
         ArgumentUtils.requireNonNull("beanType", beanType);
         return getProxyTargetBean(Argument.of(beanType), qualifier);
     }
@@ -1391,16 +1280,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
         BeanDefinition<T> definition = getProxyTargetBeanDefinition(beanType, qualifier);
         @SuppressWarnings("unchecked")
         Qualifier<T> proxyQualifier = qualifier != null ? Qualifiers.byQualifiers(qualifier, PROXY_TARGET_QUALIFIER) : PROXY_TARGET_QUALIFIER;
-        try (BeanResolutionContext resolutionContext = newResolutionContext(definition, null)) {
-
-            return getBeanForDefinition(
-                    resolutionContext,
-                    beanType,
-                    proxyQualifier,
-                    true,
-                    definition
-            ).bean;
-        }
+        return resolveBeanRegistration(null, definition, beanType, proxyQualifier, true).bean;
     }
 
     /**
@@ -1415,30 +1295,30 @@ public class DefaultBeanContext implements InitializableBeanContext {
      */
     @NonNull
     @UsedByGeneratedCode
-    public <T> T getProxyTargetBean(BeanResolutionContext resolutionContext, @NonNull Argument<T> beanType, @Nullable Qualifier<T> qualifier) {
+    public <T> T getProxyTargetBean(@Nullable BeanResolutionContext resolutionContext,
+                                    @NonNull Argument<T> beanType,
+                                    @Nullable Qualifier<T> qualifier) {
         BeanDefinition<T> definition = getProxyTargetBeanDefinition(beanType, qualifier);
         @SuppressWarnings("unchecked")
         Qualifier<T> proxyQualifier = qualifier != null ? Qualifiers.byQualifiers(qualifier, PROXY_TARGET_QUALIFIER) : PROXY_TARGET_QUALIFIER;
-        return getBeanForDefinition(
+        return resolveBeanRegistration(
                 resolutionContext,
-                beanType,
-                proxyQualifier,
-                true,
-                definition
+                definition, beanType, proxyQualifier, true
         ).bean;
     }
 
+    @NonNull
     @Override
-    public @NonNull
-    <T, R> Optional<ExecutableMethod<T, R>> findProxyTargetMethod(@NonNull Class<T> beanType, @NonNull String method, @NonNull Class[] arguments) {
+    public <T, R> Optional<ExecutableMethod<T, R>> findProxyTargetMethod(@NonNull Class<T> beanType, @NonNull String method, @NonNull Class[] arguments) {
         ArgumentUtils.requireNonNull("beanType", beanType);
         ArgumentUtils.requireNonNull("method", method);
         BeanDefinition<T> definition = getProxyTargetBeanDefinition(beanType, null);
         return definition.findMethod(method, arguments);
     }
 
+    @NonNull
     @Override
-    public <T, R> Optional<ExecutableMethod<T, R>> findProxyTargetMethod(Class<T> beanType, Qualifier<T> qualifier, String method, Class... arguments) {
+    public <T, R> Optional<ExecutableMethod<T, R>> findProxyTargetMethod(@NonNull Class<T> beanType, Qualifier<T> qualifier, @NonNull String method, Class... arguments) {
         ArgumentUtils.requireNonNull("beanType", beanType);
         ArgumentUtils.requireNonNull("method", method);
         BeanDefinition<T> definition = getProxyTargetBeanDefinition(beanType, qualifier);
@@ -1446,47 +1326,37 @@ public class DefaultBeanContext implements InitializableBeanContext {
     }
 
     @Override
-    public <T, R> Optional<ExecutableMethod<T, R>> findProxyTargetMethod(Argument<T> beanType, Qualifier<T> qualifier, String method, Class... arguments) {
+    public <T, R> Optional<ExecutableMethod<T, R>> findProxyTargetMethod(@NonNull Argument<T> beanType, Qualifier<T> qualifier, @NonNull String method, Class... arguments) {
         ArgumentUtils.requireNonNull("beanType", beanType);
         ArgumentUtils.requireNonNull("method", method);
         BeanDefinition<T> definition = getProxyTargetBeanDefinition(beanType, qualifier);
         return definition.findMethod(method, arguments);
     }
 
+    @NonNull
     @Override
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    public @NonNull
-    <T> Optional<BeanDefinition<T>> findProxyTargetBeanDefinition(@NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier) {
-        return findProxyTargetBeanDefinition(
-                Argument.of(beanType),
-                qualifier
-        );
+    public <T> Optional<BeanDefinition<T>> findProxyTargetBeanDefinition(@NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier) {
+        return findProxyTargetBeanDefinition(Argument.of(beanType), qualifier);
     }
 
     @Override
-    public <T> Optional<BeanDefinition<T>> findProxyTargetBeanDefinition(Argument<T> beanType, Qualifier<T> qualifier) {
+    public <T> Optional<BeanDefinition<T>> findProxyTargetBeanDefinition(@NonNull Argument<T> beanType, @Nullable Qualifier<T> qualifier) {
         ArgumentUtils.requireNonNull("beanType", beanType);
         @SuppressWarnings("unchecked")
         Qualifier<T> proxyQualifier = qualifier != null ? Qualifiers.byQualifiers(qualifier, PROXY_TARGET_QUALIFIER) : PROXY_TARGET_QUALIFIER;
-        BeanKey<T> key = new BeanKey<>(beanType, proxyQualifier);
+        BeanCandidateKey<T> key = new BeanCandidateKey<>(beanType, proxyQualifier, true);
 
         Optional beanDefinition = beanConcreteCandidateCache.get(key);
         //noinspection OptionalAssignedToNull
         if (beanDefinition == null) {
-            BeanRegistration<T> beanRegistration = singletonObjects.get(key);
+            BeanRegistration<T> beanRegistration = singletonScope.findCachedSingletonBeanRegistration(beanType, qualifier);
             if (beanRegistration != null) {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("Resolved existing bean [{}] for type [{}] and qualifier [{}]", beanRegistration.bean, beanType, qualifier);
                 }
                 beanDefinition = Optional.of(beanRegistration.beanDefinition);
             } else {
-                beanDefinition = findConcreteCandidateNoCache(
-                        null,
-                        beanType,
-                        proxyQualifier,
-                        true,
-                        false
-                );
+                beanDefinition = findConcreteCandidateNoCache(null, beanType, proxyQualifier, true, false);
             }
 
             beanConcreteCandidateCache.put(key, beanDefinition);
@@ -1495,9 +1365,9 @@ public class DefaultBeanContext implements InitializableBeanContext {
     }
 
     @SuppressWarnings("unchecked")
+    @NonNull
     @Override
-    public @NonNull
-    Collection<BeanDefinition<?>> getBeanDefinitions(@Nullable Qualifier<Object> qualifier) {
+    public Collection<BeanDefinition<?>> getBeanDefinitions(@Nullable Qualifier<Object> qualifier) {
         if (qualifier == null) {
             return Collections.emptyList();
         }
@@ -1526,9 +1396,9 @@ public class DefaultBeanContext implements InitializableBeanContext {
     }
 
     @SuppressWarnings("unchecked")
+    @NonNull
     @Override
-    public @NonNull
-    Collection<BeanDefinition<?>> getAllBeanDefinitions() {
+    public Collection<BeanDefinition<?>> getAllBeanDefinitions() {
         if (LOG.isDebugEnabled()) {
             LOG.debug("Finding all bean definitions");
         }
@@ -1546,9 +1416,9 @@ public class DefaultBeanContext implements InitializableBeanContext {
     }
 
     @SuppressWarnings("unchecked")
+    @NonNull
     @Override
-    public @NonNull
-    Collection<BeanDefinitionReference<?>> getBeanDefinitionReferences() {
+    public Collection<BeanDefinitionReference<?>> getBeanDefinitionReferences() {
         if (!beanDefinitionsClasses.isEmpty()) {
             final List refs = beanDefinitionsClasses.stream().filter(ref -> ref.isEnabled(this))
                     .collect(Collectors.toList());
@@ -1567,40 +1437,17 @@ public class DefaultBeanContext implements InitializableBeanContext {
      * @return The found bean
      */
     @UsedByGeneratedCode
-    public @NonNull
-    <T> T getBean(@Nullable BeanResolutionContext resolutionContext, @NonNull Class<T> beanType) {
+    @NonNull
+    public <T> T getBean(@Nullable BeanResolutionContext resolutionContext, @NonNull Class<T> beanType) {
         ArgumentUtils.requireNonNull("beanType", beanType);
-        //noinspection ConstantConditions
-        return getBeanInternal(
-                resolutionContext,
-                Argument.of(beanType),
-                null,
-                true,
-                true
-        ).bean;
+        return getBean(resolutionContext, Argument.of(beanType), null);
     }
 
     @NonNull
     @Override
     public <T> T getBean(@NonNull BeanDefinition<T> definition) {
         ArgumentUtils.requireNonNull("definition", definition);
-        Qualifier<T> declaredQualifier = definition.getDeclaredQualifier();
-        BeanKey<T> key = new BeanKey<>(definition, declaredQualifier);
-        if (definition.isSingleton()) {
-            BeanRegistration beanRegistration = singletonObjects.get(key);
-            if (beanRegistration != null) {
-                return (T) beanRegistration.bean;
-            }
-        }
-        try (BeanResolutionContext context = newResolutionContext(definition, null)) {
-            return getBeanForDefinition(
-                    context,
-                    key.beanType,
-                    declaredQualifier,
-                    true,
-                    definition
-            ).bean;
-        }
+        return resolveBeanRegistration(null, definition).bean;
     }
 
     /**
@@ -1612,13 +1459,11 @@ public class DefaultBeanContext implements InitializableBeanContext {
      * @param <T>               The bean type parameter
      * @return The found bean
      */
-    public @NonNull
-    <T> T getBean(@Nullable BeanResolutionContext resolutionContext, @NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier) {
-        return getBean(
-                resolutionContext,
-                Argument.of(beanType),
-                qualifier
-        );
+    @NonNull
+    public <T> T getBean(@Nullable BeanResolutionContext resolutionContext,
+                         @NonNull Class<T> beanType,
+                         @Nullable Qualifier<T> qualifier) {
+        return getBean(resolutionContext, Argument.of(beanType), qualifier);
     }
 
     /**
@@ -1631,16 +1476,12 @@ public class DefaultBeanContext implements InitializableBeanContext {
      * @return The found bean
      * @since 3.0.0
      */
-    public @NonNull
-    <T> T getBean(@Nullable BeanResolutionContext resolutionContext, @NonNull Argument<T> beanType, @Nullable Qualifier<T> qualifier) {
+    @NonNull
+    public <T> T getBean(@Nullable BeanResolutionContext resolutionContext,
+                         @NonNull Argument<T> beanType,
+                         @Nullable Qualifier<T> qualifier) {
         ArgumentUtils.requireNonNull("beanType", beanType);
-        return getBeanInternal(
-                resolutionContext,
-                beanType,
-                qualifier,
-                true,
-                true
-        ).bean;
+        return resolveBeanRegistration(resolutionContext, beanType, qualifier, true).bean;
     }
 
     /**
@@ -1662,25 +1503,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
                          @Nullable Qualifier<T> qualifier) {
         ArgumentUtils.requireNonNull("beanDefinition", beanDefinition);
         ArgumentUtils.requireNonNull("beanType", beanType);
-        return getBeanForDefinition(
-                resolutionContext,
-                beanType,
-                qualifier,
-                true,
-                beanDefinition
-        ).bean;
-    }
-
-    @Override
-    public <T> T getBean(Argument<T> beanType, Qualifier<T> qualifier) {
-        ArgumentUtils.requireNonNull("beanType", beanType);
-        return getBeanInternal(
-                null,
-                beanType,
-                qualifier,
-                true,
-                true
-        ).bean;
+        return resolveBeanRegistration(resolutionContext, beanDefinition, beanType, qualifier, true).bean;
     }
 
     /**
@@ -1692,13 +1515,11 @@ public class DefaultBeanContext implements InitializableBeanContext {
      * @param <T>               The bean type parameter
      * @return The found bean wrapped as an {@link Optional}
      */
-    public @NonNull
-    <T> Optional<T> findBean(@Nullable BeanResolutionContext resolutionContext, @NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier) {
-        return findBean(
-                resolutionContext,
-                Argument.of(beanType),
-                qualifier
-        );
+    @NonNull
+    public <T> Optional<T> findBean(@Nullable BeanResolutionContext resolutionContext,
+                                    @NonNull Class<T> beanType,
+                                    @Nullable Qualifier<T> qualifier) {
+        return findBean(resolutionContext, Argument.of(beanType), qualifier);
     }
 
     /**
@@ -1712,8 +1533,10 @@ public class DefaultBeanContext implements InitializableBeanContext {
      * @since 3.0.0
      */
     @Internal
-    public @NonNull
-    <T> Optional<T> findBean(@Nullable BeanResolutionContext resolutionContext, @NonNull Argument<T> beanType, @Nullable Qualifier<T> qualifier) {
+    @NonNull
+    public <T> Optional<T> findBean(@Nullable BeanResolutionContext resolutionContext,
+                                    @NonNull Argument<T> beanType,
+                                    @Nullable Qualifier<T> qualifier) {
         ArgumentUtils.requireNonNull("beanType", beanType);
         // allow injection the bean context
         if (thisInterfaces.contains(beanType.getType())) {
@@ -1721,13 +1544,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
         }
 
         try {
-            BeanRegistration<T> beanRegistration = getBeanInternal(
-                    resolutionContext,
-                    beanType,
-                    qualifier,
-                    true,
-                    false
-            );
+            BeanRegistration<T> beanRegistration = resolveBeanRegistration(resolutionContext, beanType, qualifier, false);
             if (beanRegistration == null || beanRegistration.bean == null) {
                 return Optional.empty();
             } else {
@@ -1761,32 +1578,33 @@ public class DefaultBeanContext implements InitializableBeanContext {
         return getBean(Argument.of(ApplicationEventPublisher.class, event.getClass())).publishEventAsync(event);
     }
 
+    @NonNull
     @Override
-    public @NonNull
-    <T> Optional<BeanDefinition<T>> findProxyBeanDefinition(@NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier) {
+    public <T> Optional<BeanDefinition<T>> findProxyBeanDefinition(@NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier) {
         ArgumentUtils.requireNonNull("beanType", beanType);
-        return getBeanDefinitions(beanType, qualifier)
-                .stream()
-                .filter(BeanDefinition::isProxy)
-                .findFirst();
+        return findProxyBeanDefinition(Argument.of(beanType), qualifier);
     }
 
     @NonNull
     @Override
     public <T> Optional<BeanDefinition<T>> findProxyBeanDefinition(@NonNull Argument<T> beanType, @Nullable Qualifier<T> qualifier) {
         ArgumentUtils.requireNonNull("beanType", beanType);
-        return getBeanDefinitions(beanType, qualifier)
-                .stream()
-                .filter(BeanDefinition::isProxy)
-                .findFirst();
+        for (BeanDefinition<T> beanDefinition : getBeanDefinitions(beanType, qualifier)) {
+            if (beanDefinition.isProxy()) {
+                return Optional.of(beanDefinition);
+            }
+        }
+        return Optional.empty();
     }
 
     /**
-     * Invalidates the bean caches.
+     * Invalidates the bean caches. For testing only.
      */
+    @Internal
     protected void invalidateCaches() {
         beanCandidateCache.clear();
-        initializedObjectsByType.clear();
+        beanConcreteCandidateCache.clear();
+        singletonBeanRegistrations.clear();
     }
 
     /**
@@ -1794,8 +1612,8 @@ public class DefaultBeanContext implements InitializableBeanContext {
      *
      * @return The bean definition classes
      */
-    protected @NonNull
-    List<BeanDefinitionReference> resolveBeanDefinitionReferences() {
+    @NonNull
+    protected List<BeanDefinitionReference> resolveBeanDefinitionReferences() {
         if (beanDefinitionReferences == null) {
             final SoftServiceLoader<BeanDefinitionReference> definitions = SoftServiceLoader.load(BeanDefinitionReference.class, classLoader);
             beanDefinitionReferences = new ArrayList<>(300);
@@ -1810,9 +1628,9 @@ public class DefaultBeanContext implements InitializableBeanContext {
      * @param predicate The filter predicate, can be null
      * @return The bean definition classes
      */
+    @NonNull
     @Deprecated
-    protected @NonNull
-    List<BeanDefinitionReference> resolveBeanDefinitionReferences(@Nullable Predicate<BeanDefinitionReference> predicate) {
+    protected List<BeanDefinitionReference> resolveBeanDefinitionReferences(@Nullable Predicate<BeanDefinitionReference> predicate) {
         if (predicate != null) {
             List<BeanDefinitionReference> allRefs = resolveBeanDefinitionReferences();
             List<BeanDefinitionReference> newRefs = new ArrayList<>(allRefs.size());
@@ -1831,8 +1649,8 @@ public class DefaultBeanContext implements InitializableBeanContext {
      *
      * @return The bean definition classes
      */
-    protected @NonNull
-    Iterable<BeanConfiguration> resolveBeanConfigurations() {
+    @NonNull
+    protected Iterable<BeanConfiguration> resolveBeanConfigurations() {
         if (beanConfigurationsList == null) {
             final SoftServiceLoader<BeanConfiguration> definitions = SoftServiceLoader.load(BeanConfiguration.class, classLoader);
             beanConfigurationsList = new ArrayList<>(300);
@@ -1852,23 +1670,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
         beanCreatedListeners.put(AnnotationProcessor.class, Arrays.asList(new AnnotationProcessorListener()));
         for (BeanDefinition<BeanCreatedEventListener> beanCreatedDefinition : beanCreatedDefinitions) {
             try (BeanResolutionContext context = newResolutionContext(beanCreatedDefinition, null)) {
-                final BeanCreatedEventListener listener;
-                final Qualifier qualifier = beanCreatedDefinition.getDeclaredQualifier();
-                if (beanCreatedDefinition.isSingleton()) {
-                    listener = (BeanCreatedEventListener) createAndRegisterSingleton(
-                            context,
-                            beanCreatedDefinition,
-                            beanCreatedDefinition.getBeanType(),
-                            qualifier
-                    ).bean;
-                } else {
-                    listener = doCreateBean(
-                            context,
-                            beanCreatedDefinition,
-                            Argument.of(BeanCreatedEventListener.class),
-                            qualifier
-                    );
-                }
+                BeanCreatedEventListener<?> listener = resolveBeanRegistration(context, beanCreatedDefinition).bean;
                 List<Argument<?>> typeArguments = beanCreatedDefinition.getTypeArguments(BeanCreatedEventListener.class);
                 Argument<?> argument = CollectionUtils.last(typeArguments);
                 if (argument == null) {
@@ -1876,7 +1678,6 @@ public class DefaultBeanContext implements InitializableBeanContext {
                 }
                 beanCreatedListeners.computeIfAbsent(argument.getType(), aClass -> new ArrayList<>(10))
                         .add(listener);
-
             }
         }
         for (List<BeanCreatedEventListener> listenerList : beanCreatedListeners.values()) {
@@ -1887,23 +1688,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
         final Collection<BeanDefinition<BeanInitializedEventListener>> beanInitializedDefinitions = getBeanDefinitions(BeanInitializedEventListener.class);
         for (BeanDefinition<BeanInitializedEventListener> definition : beanInitializedDefinitions) {
             try (BeanResolutionContext context = newResolutionContext(definition, null)) {
-                final Qualifier qualifier = definition.getDeclaredQualifier();
-                final BeanInitializedEventListener listener;
-                if (definition.isSingleton()) {
-                    listener = (BeanInitializedEventListener) createAndRegisterSingleton(
-                            context,
-                            definition,
-                            definition.getBeanType(),
-                            qualifier
-                    ).bean;
-                } else {
-                    listener = doCreateBean(
-                            context,
-                            definition,
-                            Argument.of(BeanInitializedEventListener.class),
-                            qualifier
-                    );
-                }
+                BeanInitializedEventListener<?> listener = resolveBeanRegistration(context, definition).bean;
                 List<Argument<?>> typeArguments = definition.getTypeArguments(BeanInitializedEventListener.class);
                 Argument<?> argument = CollectionUtils.last(typeArguments);
                 if (argument == null) {
@@ -1911,7 +1696,6 @@ public class DefaultBeanContext implements InitializableBeanContext {
                 }
                 beanInitializedListeners.computeIfAbsent(argument.getType(), aClass -> new ArrayList<>(10))
                         .add(listener);
-
             }
         }
         for (List<BeanInitializedEventListener> listenerList : beanInitializedListeners.values()) {
@@ -2049,7 +1833,6 @@ public class DefaultBeanContext implements InitializableBeanContext {
                 beanDefinitionsClasses.removeIf((BeanDefinitionReference beanDefinitionReference) ->
                         !beanDefinitionReference.isEnabled(this));
         ForkJoinPool.commonPool().execute(runnable);
-
     }
 
     /**
@@ -2060,8 +1843,8 @@ public class DefaultBeanContext implements InitializableBeanContext {
      * @param filter   A bean definition to filter out
      * @return The candidates
      */
-    protected @NonNull
-    <T> Collection<BeanDefinition<T>> findBeanCandidates(@NonNull Class<T> beanType, @Nullable BeanDefinition<?> filter) {
+    @NonNull
+    protected <T> Collection<BeanDefinition<T>> findBeanCandidates(@NonNull Class<T> beanType, @Nullable BeanDefinition<?> filter) {
         return findBeanCandidates(null, Argument.of(beanType), filter, true);
     }
 
@@ -2076,12 +1859,11 @@ public class DefaultBeanContext implements InitializableBeanContext {
      * @return The candidates
      */
     @SuppressWarnings("unchecked")
-    protected @NonNull
-    <T> Collection<BeanDefinition<T>> findBeanCandidates(
-            @Nullable BeanResolutionContext resolutionContext,
-            @NonNull Argument<T> beanType,
-            @Nullable BeanDefinition<?> filter,
-            boolean filterProxied) {
+    @NonNull
+    protected <T> Collection<BeanDefinition<T>> findBeanCandidates(@Nullable BeanResolutionContext resolutionContext,
+                                                                   @NonNull Argument<T> beanType,
+                                                                   @Nullable BeanDefinition<?> filter,
+                                                                   boolean filterProxied) {
         Predicate<BeanDefinition<T>> predicate = filter == null ? null : definition -> !definition.equals(filter);
         return findBeanCandidates(resolutionContext, beanType, filterProxied, predicate);
     }
@@ -2097,12 +1879,11 @@ public class DefaultBeanContext implements InitializableBeanContext {
      * @return The candidates
      */
     @SuppressWarnings("unchecked")
-    protected @NonNull
-    <T> Collection<BeanDefinition<T>> findBeanCandidates(
-            @Nullable BeanResolutionContext resolutionContext,
-            @NonNull Argument<T> beanType,
-            boolean filterProxied,
-            Predicate<BeanDefinition<T>> predicate) {
+    @NonNull
+    protected <T> Collection<BeanDefinition<T>> findBeanCandidates(@Nullable BeanResolutionContext resolutionContext,
+                                                                   @NonNull Argument<T> beanType,
+                                                                   boolean filterProxied,
+                                                                   Predicate<BeanDefinition<T>> predicate) {
         ArgumentUtils.requireNonNull("beanType", beanType);
         final Class<T> beanClass = beanType.getType();
         if (LOG.isDebugEnabled()) {
@@ -2121,9 +1902,10 @@ public class DefaultBeanContext implements InitializableBeanContext {
             beanDefinitionsClasses = this.beanDefinitionsClasses;
         }
 
+        Set<BeanDefinition<T>> candidates;
         if (!beanDefinitionsClasses.isEmpty()) {
 
-            Set<BeanDefinition<T>> candidates = new HashSet<>();
+            candidates = new HashSet<>();
             for (BeanDefinitionReference reference : beanDefinitionsClasses) {
                 if (!reference.isCandidateBean(beanType) || !reference.isEnabled(this, resolutionContext)) {
                     continue;
@@ -2152,17 +1934,20 @@ public class DefaultBeanContext implements InitializableBeanContext {
                 }
                 filterReplacedBeans(resolutionContext, candidates);
             }
-
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Resolved bean candidates {} for type: {}", candidates, beanType);
-            }
-            return candidates;
         } else {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("No bean candidates found for type: {}", beanType);
-            }
-            return Collections.emptySet();
+            candidates = Collections.emptySet();
         }
+
+        if (LOG.isDebugEnabled()) {
+            if (candidates.isEmpty()) {
+                LOG.debug("No bean candidates found for type: {}", beanType);
+            } else {
+                for (BeanDefinition<?> candidate : candidates) {
+                    LOG.debug("  {} {} {}", candidate.getBeanType(), candidate.getDeclaredQualifier(), candidate);
+                }
+            }
+        }
+        return candidates;
     }
 
     /**
@@ -2185,8 +1970,8 @@ public class DefaultBeanContext implements InitializableBeanContext {
      * @param <T>      The bean generic type
      * @return The candidates
      */
-    protected @NonNull
-    <T> Collection<BeanDefinition> findBeanCandidatesForInstance(@NonNull T instance) {
+    @NonNull
+    protected <T> Collection<BeanDefinition> findBeanCandidatesForInstance(@NonNull T instance) {
         ArgumentUtils.requireNonNull("instance", instance);
         if (LOG.isDebugEnabled()) {
             LOG.debug("Finding candidate beans for instance: {}", instance);
@@ -2198,21 +1983,21 @@ public class DefaultBeanContext implements InitializableBeanContext {
         if (beanDefinitions == null) {
             // first traverse component definition classes and load candidates
             if (!beanDefinitionsClasses.isEmpty()) {
-
-                List<BeanDefinition> candidates = beanDefinitionsClasses
-                        .stream()
-                        .filter(reference -> {
-                            if (reference.isEnabled(this)) {
-                                Class<?> candidateType = reference.getBeanType();
-
-                                return candidateType != null && candidateType.isInstance(instance);
-                            } else {
-                                return false;
-                            }
-                        })
-                        .map(ref -> ref.load(this))
-                        .filter(candidate -> candidate.isEnabled(this))
-                        .collect(Collectors.toList());
+                List<BeanDefinition> candidates = new ArrayList<>();
+                for (BeanDefinitionReference<?> reference : beanDefinitionsClasses) {
+                    if (!reference.isEnabled(this)) {
+                        continue;
+                    }
+                    Class<?> candidateType = reference.getBeanType();
+                    if (candidateType == null || !candidateType.isInstance(instance)) {
+                        continue;
+                    }
+                    BeanDefinition<?> candidate = reference.load(this);
+                    if (!candidate.isEnabled(this)) {
+                        continue;
+                    }
+                    candidates.add(candidate);
+                }
 
                 if (candidates.size() > 1) {
                     // try narrow to exact type
@@ -2223,7 +2008,6 @@ public class DefaultBeanContext implements InitializableBeanContext {
                                             candidate.getBeanType() == beanClass
                             )
                             .collect(Collectors.toList());
-                    beanDefinitions = candidates;
                 }
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("Resolved bean candidates {} for instance: {}", candidates, instance);
@@ -2257,12 +2041,51 @@ public class DefaultBeanContext implements InitializableBeanContext {
      * @param resolutionContext The {@link BeanResolutionContext}
      * @param beanDefinition    The {@link BeanDefinition}
      * @param qualifier         The {@link Qualifier}
+     * @param argumentValues    Any argument values passed to create the bean
+     * @param <T>               The bean generic type
+     * @return The created bean
+     */
+    @Internal
+    @Nullable
+    private <T> T doCreateBean(@NonNull BeanResolutionContext resolutionContext,
+                               @NonNull BeanDefinition<T> beanDefinition,
+                               @Nullable Qualifier<T> qualifier,
+                               @Nullable Map<String, Object> argumentValues) {
+        return doCreateBean(resolutionContext, beanDefinition, qualifier, Argument.of(beanDefinition.getBeanType()), false, argumentValues);
+    }
+
+    /**
+     * Execution the creation of a bean. The returned value can be null if a
+     * factory method returned null.
+     *
+     * @param resolutionContext The {@link BeanResolutionContext}
+     * @param beanDefinition    The {@link BeanDefinition}
+     * @param qualifier         The {@link Qualifier}
+     * @param <T>               The bean generic type
+     * @return The created bean
+     */
+    @Internal
+    @Nullable
+    final <T> T doCreateBean(@NonNull BeanResolutionContext resolutionContext,
+                             @NonNull BeanDefinition<T> beanDefinition,
+                             @Nullable Qualifier<T> qualifier) {
+        return doCreateBean(resolutionContext, beanDefinition, qualifier, Argument.of(beanDefinition.getBeanType()), false, null);
+    }
+
+    /**
+     * Execution the creation of a bean. The returned value can be null if a
+     * factory method returned null.
+     *
+     * @param resolutionContext The {@link BeanResolutionContext}
+     * @param beanDefinition    The {@link BeanDefinition}
+     * @param qualifier         The {@link Qualifier}
      * @param isSingleton       Whether the bean is a singleton
      * @param argumentValues    Any argument values passed to create the bean
      * @param <T>               The bean generic type
      * @return The created bean
-     * @deprecated Use {@link #doCreateBean(BeanResolutionContext, BeanDefinition, Qualifier, Argument, boolean, Map)} instead.
+     * @deprecated Use {@link #doCreateBean(BeanResolutionContext, BeanDefinition, Qualifier, Map)} instead.
      */
+    @Internal
     @Nullable
     @Deprecated
     protected <T> T doCreateBean(@NonNull BeanResolutionContext resolutionContext,
@@ -2276,6 +2099,8 @@ public class DefaultBeanContext implements InitializableBeanContext {
     /**
      * Execution the creation of a bean. The returned value can be null if a
      * factory method returned null.
+     * <p>
+     * Method is deprecated since it doesn't do anything related to the singleton.
      *
      * @param resolutionContext The {@link BeanResolutionContext}
      * @param beanDefinition    The {@link BeanDefinition}
@@ -2285,48 +2110,35 @@ public class DefaultBeanContext implements InitializableBeanContext {
      * @param argumentValues    Any argument values passed to create the bean
      * @param <T>               The bean generic type
      * @return The created bean
+     * @deprecated Use {@link #doCreateBean(BeanResolutionContext, BeanDefinition, Qualifier, Map)} instead.
      */
+    @Internal
     @Nullable
+    @Deprecated
     protected <T> T doCreateBean(@NonNull BeanResolutionContext resolutionContext,
                                  @NonNull BeanDefinition<T> beanDefinition,
                                  @Nullable Qualifier<T> qualifier,
                                  @Nullable Argument<T> qualifierBeanType,
                                  boolean isSingleton,
                                  @Nullable Map<String, Object> argumentValues) {
-        if (isSingleton) {
-            BeanRegistration<T> beanRegistration = singletonObjects.get(new BeanKey<>(beanDefinition, beanDefinition.getDeclaredQualifier()));
-            final Class<T> beanClass = qualifierBeanType.getType();
-            if (beanRegistration != null) {
-                if (qualifier == null || qualifier.reduce(beanClass, Stream.of(beanRegistration.beanDefinition)).findFirst().isPresent()) {
-                    return beanRegistration.bean;
-                }
-            } else if (qualifier != null) {
-                beanRegistration = singletonObjects.get(new BeanKey<>(beanDefinition, null));
-                if (beanRegistration != null && qualifier.reduce(beanClass, Stream.of(beanRegistration.beanDefinition)).findFirst().isPresent()) {
-                    return beanRegistration.bean;
-                }
-            }
-        }
-
         T bean;
         if (beanDefinition instanceof BeanFactory) {
-            bean = resolveByBeanFactory(resolutionContext, beanDefinition, qualifier, argumentValues == null ? Collections.emptyMap() : argumentValues);
+            bean = resolveByBeanFactory(resolutionContext, beanDefinition, qualifier, argumentValues);
         } else {
             bean = resolveByBeanDefinition(resolutionContext, beanDefinition);
         }
-
         if (bean != null) {
             bean = postBeanCreated(resolutionContext, beanDefinition, qualifier, bean);
         }
-
         return bean;
     }
 
     @NotNull
-    private <T> T resolveByBeanDefinition(BeanResolutionContext resolutionContext, BeanDefinition<T> beanDefinition) {
-        T bean;
+    private <T> T resolveByBeanDefinition(@NonNull BeanResolutionContext resolutionContext,
+                                          @NonNull BeanDefinition<T> beanDefinition) {
         ConstructorInjectionPoint<T> constructor = beanDefinition.getConstructor();
         Argument<?>[] requiredConstructorArguments = constructor.getArguments();
+        T bean;
         if (requiredConstructorArguments.length == 0) {
             bean = constructor.invoke();
         } else {
@@ -2342,18 +2154,17 @@ public class DefaultBeanContext implements InitializableBeanContext {
         return bean;
     }
 
-    private <T> T resolveByBeanFactory(BeanResolutionContext resolutionContext,
-                                       BeanDefinition<T> beanDefinition,
-                                       Qualifier<T> qualifier,
-                                       Map<String, Object> argumentValues) {
-        T bean;
-        BeanFactory<T> beanFactory = (BeanFactory<T>) beanDefinition;
+    @Nullable
+    private <T> T resolveByBeanFactory(@NonNull BeanResolutionContext resolutionContext,
+                                       @NonNull BeanDefinition<T> beanDefinition,
+                                       @Nullable Qualifier<T> qualifier,
+                                       @Nullable Map<String, Object> argumentValues) {
         try {
-            if (beanFactory instanceof ParametrizedBeanFactory) {
-                bean = resolveByParametrizedBeanFactory(resolutionContext, beanDefinition, argumentValues, (ParametrizedBeanFactory<T>) beanFactory);
-            } else {
-                bean = resolveByBeanFactory(resolutionContext, beanDefinition, qualifier, beanFactory);
+            if (beanDefinition instanceof ParametrizedBeanFactory) {
+                return resolveByParametrizedBeanFactory(resolutionContext, beanDefinition, argumentValues, (ParametrizedBeanFactory<T>) beanDefinition);
             }
+            BeanFactory<T> beanFactory = (BeanFactory<T>) beanDefinition;
+            return resolveByBeanFactory(resolutionContext, beanDefinition, qualifier, beanFactory);
         } catch (Throwable e) {
             if (e instanceof DependencyInjectionException) {
                 throw e;
@@ -2371,12 +2182,13 @@ public class DefaultBeanContext implements InitializableBeanContext {
                 }
             }
         }
-        return bean;
     }
 
     @NotNull
-    private <T> T resolveByBeanFactory(BeanResolutionContext resolutionContext, BeanDefinition<T> beanDefinition, Qualifier<T> qualifier, BeanFactory<T> beanFactory) {
-        T bean;
+    private <T> T resolveByBeanFactory(@NonNull BeanResolutionContext resolutionContext,
+                                       @NonNull BeanDefinition<T> beanDefinition,
+                                       @Nullable  Qualifier<T> qualifier,
+                                       @NonNull BeanFactory<T> beanFactory) {
         Qualifier<T> declaredQualifier = beanDefinition.getDeclaredQualifier();
         boolean propagateQualifier = beanDefinition.isProxy() && declaredQualifier instanceof Named;
         if (propagateQualifier) {
@@ -2384,25 +2196,27 @@ public class DefaultBeanContext implements InitializableBeanContext {
         }
         resolutionContext.setCurrentQualifier(declaredQualifier != null ? declaredQualifier : qualifier);
         try {
-            bean = beanFactory.build(resolutionContext, this, beanDefinition);
+            T bean = beanFactory.build(resolutionContext, this, beanDefinition);
+            if (bean == null) {
+                throw new BeanInstantiationException(resolutionContext, "Bean Factory [" + beanFactory + "] returned null");
+            }
+            if (bean instanceof Qualified) {
+                ((Qualified) bean).$withBeanQualifier(declaredQualifier);
+            }
+            return bean;
         } finally {
             resolutionContext.setCurrentQualifier(null);
             if (propagateQualifier) {
                 resolutionContext.removeAttribute(BeanDefinition.NAMED_ATTRIBUTE);
             }
         }
-
-        if (bean == null) {
-            throw new BeanInstantiationException(resolutionContext, "Bean Factory [" + beanFactory + "] returned null");
-        } else {
-            if (bean instanceof Qualified) {
-                ((Qualified) bean).$withBeanQualifier(declaredQualifier);
-            }
-        }
-        return bean;
     }
 
-    private <T> T postBeanCreated(BeanResolutionContext resolutionContext, BeanDefinition<T> beanDefinition, Qualifier<T> qualifier, T bean) {
+    @NonNull
+    private <T> T postBeanCreated(@NonNull BeanResolutionContext resolutionContext,
+                                  @NonNull BeanDefinition<T> beanDefinition,
+                                  @Nullable Qualifier<T> qualifier,
+                                  @NonNull T bean) {
         Class<T> beanType = beanDefinition.getBeanType();
         Qualifier<T> finalQualifier = qualifier != null ? qualifier : beanDefinition.getDeclaredQualifier();
         if (!(bean instanceof BeanCreatedEventListener) && CollectionUtils.isNotEmpty(beanCreationEventListeners)) {
@@ -2427,20 +2241,28 @@ public class DefaultBeanContext implements InitializableBeanContext {
         return bean;
     }
 
-    private <T> T resolveByParametrizedBeanFactory(BeanResolutionContext resolutionContext,
-                                                   BeanDefinition<T> beanDefinition,
-                                                   Map<String, Object> argumentValues,
-                                                   ParametrizedBeanFactory<T> parametrizedBeanFactory) {
+    @Nullable
+    private <T> T resolveByParametrizedBeanFactory(@NonNull BeanResolutionContext resolutionContext,
+                                                   @NonNull BeanDefinition<T> beanDefinition,
+                                                   @Nullable Map<String, Object> argumentValues,
+                                                   @NonNull ParametrizedBeanFactory<T> parametrizedBeanFactory) {
         Argument<?>[] requiredArguments = parametrizedBeanFactory.getRequiredArguments();
-        Map<String, Object> convertedValues = new LinkedHashMap<>(argumentValues);
+        Map<String, Object> convertedValues;
+        if (argumentValues == null) {
+            convertedValues = Collections.emptyMap();
+            argumentValues = Collections.emptyMap();
+        } else {
+            convertedValues = new LinkedHashMap<>();
+        }
         for (Argument<?> requiredArgument : requiredArguments) {
             String argumentName = requiredArgument.getName();
             Object val = argumentValues.get(argumentName);
-            if (val == null && !requiredArgument.isDeclaredNullable()) {
-                throw new BeanInstantiationException(resolutionContext, "Missing bean argument [" + requiredArgument + "] for type: " + beanDefinition.getBeanType().getName() + ". Required arguments: " + ArrayUtils.toString(requiredArguments));
-            }
-            Object convertedValue = null;
-            if (val != null) {
+            if (val == null) {
+                if (!requiredArgument.isDeclaredNullable()) {
+                    throw new BeanInstantiationException(resolutionContext, "Missing bean argument [" + requiredArgument + "] for type: " + beanDefinition.getBeanType().getName() + ". Required arguments: " + ArrayUtils.toString(requiredArguments));
+                }
+            } else {
+                Object convertedValue;
                 if (requiredArgument.getType().isInstance(val)) {
                     convertedValue = val;
                 } else {
@@ -2448,16 +2270,10 @@ public class DefaultBeanContext implements InitializableBeanContext {
                             new BeanInstantiationException(resolutionContext, "Invalid bean argument [" + requiredArgument + "]. Cannot convert object [" + val + "] to required type: " + requiredArgument.getType())
                     );
                 }
+                convertedValues.put(argumentName, convertedValue);
             }
-            convertedValues.put(argumentName, convertedValue);
         }
-
-        return parametrizedBeanFactory.build(
-                resolutionContext,
-                this,
-                beanDefinition,
-                convertedValues
-        );
+        return parametrizedBeanFactory.build(resolutionContext, this, beanDefinition, convertedValues);
     }
 
     /**
@@ -2469,11 +2285,10 @@ public class DefaultBeanContext implements InitializableBeanContext {
      * @param <T>        The generic time
      * @return The concrete bean definition
      */
-    protected @NonNull
-    <T> BeanDefinition<T> findConcreteCandidate(
-            @NonNull Class<T> beanType,
-            @Nullable Qualifier<T> qualifier,
-            @NonNull Collection<BeanDefinition<T>> candidates) {
+    @NonNull
+    protected <T> BeanDefinition<T> findConcreteCandidate(@NonNull Class<T> beanType,
+                                                          @Nullable Qualifier<T> qualifier,
+                                                          @NonNull Collection<BeanDefinition<T>> candidates) {
         if (qualifier instanceof AnyQualifier) {
             return candidates.iterator().next();
         } else {
@@ -2494,9 +2309,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
                     Collection<BeanDefinition> parallelDefinitions = new ArrayList<>();
                     finalParallelBeans.forEach(beanDefinitionReference -> {
                         try {
-                            synchronized (singletonObjects) {
-                                loadContextScopeBean(beanDefinitionReference, parallelDefinitions::add);
-                            }
+                            loadContextScopeBean(beanDefinitionReference, parallelDefinitions::add);
                         } catch (Throwable e) {
                             LOG.error("Parallel Bean definition [" + beanDefinitionReference.getName() + "] could not be loaded: " + e.getMessage(), e);
                             Boolean shutdownOnError = beanDefinitionReference.getAnnotationMetadata().booleanValue(Parallel.class, "shutdownOnError").orElse(true);
@@ -2511,9 +2324,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
 
                     parallelDefinitions.forEach(beanDefinition -> ForkJoinPool.commonPool().execute(() -> {
                         try {
-                            synchronized (singletonObjects) {
-                                loadContextScopeBean(beanDefinition);
-                            }
+                            loadContextScopeBean(beanDefinition);
                         } catch (Throwable e) {
                             LOG.error("Parallel Bean definition [" + beanDefinition.getName() + "] could not be loaded: " + e.getMessage(), e);
                             Boolean shutdownOnError = beanDefinition.getAnnotationMetadata().booleanValue(Parallel.class, "shutdownOnError").orElse(true);
@@ -2700,30 +2511,34 @@ public class DefaultBeanContext implements InitializableBeanContext {
         if (beanDefinition.isIterable() || beanDefinition.hasStereotype(ConfigurationReader.class.getName())) {
             Collection<BeanDefinition> beanCandidates = (Collection<BeanDefinition>) transformIterables(null, Collections.singleton(beanDefinition), true);
             for (BeanDefinition beanCandidate : beanCandidates) {
-                try (BeanResolutionContext resolutionContext = newResolutionContext(beanDefinition, null)) {
-                    createAndRegisterSingleton(
-                            resolutionContext,
-                            beanCandidate,
-                            beanCandidate.getBeanType(),
-                            beanCandidate.hasAnnotation(Context.class) ? null : beanDefinition.getDeclaredQualifier()
-                    );
-                }
+                findOrCreateSingletonBeanRegistration(
+                        null,
+                        beanCandidate,
+                        beanCandidate.asArgument(),
+                        beanCandidate.hasAnnotation(Context.class) ? null : beanDefinition.getDeclaredQualifier()
+                );
             }
 
         } else {
-            try (BeanResolutionContext resolutionContext = newResolutionContext(beanDefinition, null)) {
-                createAndRegisterSingletonInternal(resolutionContext, beanDefinition, beanDefinition.asArgument(), null);
-            }
+            findOrCreateSingletonBeanRegistration(null, beanDefinition, beanDefinition.asArgument(), null);
         }
     }
 
+    /**
+     * Resolve the {@link BeanRegistration} by an argument and a qualifier.
+     *
+     * @param resolutionContext The resolution context
+     * @param beanType          The bean type
+     * @param qualifier         The qualifier
+     * @param throwNoSuchBean   Throw if it doesn't exist
+     * @param <T>               The type
+     * @return The bean registration
+     */
     @Nullable
-    private <T> BeanRegistration<T> getBeanInternal(
-            @Nullable BeanResolutionContext resolutionContext,
-            @NonNull Argument<T> beanType,
-            Qualifier<T> qualifier,
-            boolean throwNonUnique,
-            boolean throwNoSuchBean) {
+    private <T> BeanRegistration<T> resolveBeanRegistration(@Nullable BeanResolutionContext resolutionContext,
+                                                            @NonNull Argument<T> beanType,
+                                                            @Nullable Qualifier<T> qualifier,
+                                                            boolean throwNoSuchBean) {
         // allow injection the bean context
         final Class<T> beanClass = beanType.getType();
         if (thisInterfaces.contains(beanClass)) {
@@ -2743,58 +2558,30 @@ public class DefaultBeanContext implements InitializableBeanContext {
             return inFlightBeanRegistration;
         }
 
-        BeanRegistration<T> beanRegistration = singletonObjects.get(beanKey);
+        // Fast singleton lookup
+        BeanRegistration<T> beanRegistration = singletonScope.findCachedSingletonBeanRegistration(beanType, qualifier);
         if (beanRegistration != null) {
-            if (beanRegistration.bean == null && throwNoSuchBean) {
-                throw new NoSuchBeanException(beanType, qualifier);
-            } else {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Resolved existing bean [{}] for type [{}] and qualifier [{}]", beanRegistration.bean, beanType, qualifier);
-                }
-                return beanRegistration;
-            }
-        } else if (LOG.isTraceEnabled()) {
-            LOG.trace("No existing bean found for bean key: {}", beanKey);
+            return beanRegistration;
         }
 
-        synchronized (singletonObjects) {
+        Optional<BeanDefinition<T>> concreteCandidate = findBeanDefinition(beanType, qualifier);
 
-            Optional<BeanDefinition<T>> concreteCandidate = findConcreteCandidate(
-                    resolutionContext,
-                    beanType,
-                    qualifier,
-                    throwNonUnique
-            );
+        BeanRegistration<T> registration;
 
-            BeanRegistration<T> registration = null;
+        if (concreteCandidate.isPresent()) {
+            BeanDefinition<T> definition = concreteCandidate.get();
 
-            if (concreteCandidate.isPresent()) {
-                BeanDefinition<T> definition = concreteCandidate.get();
-
-                if (definition.isContainerType() && beanClass != definition.getBeanType()) {
-                    throw new NonUniqueBeanException(beanClass, Collections.singletonList(definition).iterator());
-                }
-
-                if (definition.isSingleton()) {
-                    registration = findExistingCompatibleSingleton(
-                            definition.asArgument(),
-                            beanType,
-                            qualifier,
-                            definition
-                    );
-                }
-                if (registration == null || registration.bean == null) {
-                    registration = getBeanForDefinition(resolutionContext, beanType, qualifier, throwNoSuchBean, definition);
-                }
-            } else {
-                registration = findExistingCompatibleSingleton(beanType, null, qualifier, null);
+            if (definition.isContainerType() && beanClass != definition.getBeanType()) {
+                throw new NonUniqueBeanException(beanClass, Collections.singletonList(definition).iterator());
             }
-            if ((registration == null || registration.bean == null) && throwNoSuchBean) {
-                throw new NoSuchBeanException(beanType, qualifier);
-            } else {
-                return registration;
-            }
+            registration = resolveBeanRegistration(resolutionContext, definition, beanType, qualifier, throwNoSuchBean);
+        } else {
+            registration = null;
         }
+        if ((registration == null || registration.bean == null) && throwNoSuchBean) {
+            throw new NoSuchBeanException(beanType, qualifier);
+        }
+        return registration;
     }
 
     @Nullable
@@ -2829,27 +2616,48 @@ public class DefaultBeanContext implements InitializableBeanContext {
         return null;
     }
 
-    private <T> BeanRegistration<T> getBeanForDefinition(
-            BeanResolutionContext resolutionContext,
-            Argument<T> beanType,
-            Qualifier<T> qualifier,
-            boolean throwNoSuchBean,
-            BeanDefinition<T> definition) {
+    /**
+     * Resolve the {@link BeanRegistration} by a {@link BeanDefinition}.
+     *
+     * @param resolutionContext The resolution context
+     * @param definition        The bean type
+     * @param <T>               The type
+     * @return The bean registration or {@link NoSuchBeanException}
+     */
+    @NonNull
+    private <T> BeanRegistration<T> resolveBeanRegistration(@Nullable BeanResolutionContext resolutionContext,
+                                                            @NonNull BeanDefinition<T> definition) {
+        return resolveBeanRegistration(resolutionContext, definition, definition.asArgument(), definition.getDeclaredQualifier(), true);
+    }
+
+    /**
+     * Resolve the {@link BeanRegistration} by a {@link BeanDefinition}.
+     *
+     * @param resolutionContext The resolution context
+     * @param definition        The bean type
+     * @param beanType          The bean type
+     * @param qualifier         The qualifier
+     * @param throwNoSuchBean   Throw if it doesn't exist
+     * @param <T>               The type
+     * @return The bean registration
+     */
+    @Nullable
+    private <T> BeanRegistration<T> resolveBeanRegistration(@Nullable BeanResolutionContext resolutionContext,
+                                                            @NonNull BeanDefinition<T> definition,
+                                                            @NonNull Argument<T> beanType,
+                                                            @Nullable Qualifier<T> qualifier,
+                                                            boolean throwNoSuchBean) {
+        if (definition.isSingleton() && !definition.hasStereotype(SCOPED_PROXY_ANN)) {
+            return findOrCreateSingletonBeanRegistration(resolutionContext, definition, beanType, qualifier);
+        }
         try (BeanResolutionContext context = newResolutionContext(definition, resolutionContext)) {
             final BeanResolutionContext.Path path = context.getPath();
             final boolean isNewPath = path.isEmpty();
             if (isNewPath) {
-                path.pushBeanCreate(
-                        definition,
-                        beanType
-                );
+                path.pushBeanCreate(definition, beanType);
             }
             try {
-                if (definition.isSingleton() && !definition.hasStereotype(SCOPED_PROXY_ANN)) {
-                    return createAndRegisterSingleton(context, definition, beanType.getType(), qualifier);
-                } else {
-                    return getNotSingletonBeanForDefinition(context, beanType, qualifier, throwNoSuchBean, definition);
-                }
+                return getNotSingletonBeanForDefinition(context, beanType, qualifier, throwNoSuchBean, definition);
             } finally {
                 if (isNewPath) {
                     path.pop();
@@ -2858,13 +2666,50 @@ public class DefaultBeanContext implements InitializableBeanContext {
         }
     }
 
-    @SuppressWarnings("unchecked")
-    private <T> BeanRegistration<T> getNotSingletonBeanForDefinition(
-            final @NonNull BeanResolutionContext resolutionContext,
-            Argument<T> beanType,
-            Qualifier<T> qualifier,
-            boolean throwNoSuchBean,
-            BeanDefinition<T> definition) {
+    @Nullable
+    private <T> BeanRegistration<T> findOrCreateSingletonBeanRegistration(@Nullable BeanResolutionContext resolutionContext,
+                                                                          @NonNull BeanDefinition<T> definition,
+                                                                          @NonNull Argument<T> beanType,
+                                                                          @Nullable Qualifier<T> qualifier) {
+        BeanRegistration<T> beanRegistration = singletonScope.findBeanRegistration(definition, beanType, qualifier);
+        if (beanRegistration != null) {
+            return beanRegistration;
+        }
+        synchronized (singletonScope) {
+            // Check if have been added
+            beanRegistration = singletonScope.findBeanRegistration(definition, beanType, qualifier);
+            if (beanRegistration != null) {
+                return beanRegistration;
+            }
+            try (BeanResolutionContext context = newResolutionContext(definition, resolutionContext)) {
+                final BeanResolutionContext.Path path = context.getPath();
+                final boolean isNewPath = path.isEmpty();
+                if (isNewPath) {
+                    path.pushBeanCreate(definition, beanType);
+                }
+                try {
+                    T createdBean = doCreateBean(context, definition, qualifier);
+                    return singletonScope.registerSingletonBean(
+                            definition,
+                            qualifier,
+                            createdBean,
+                            context.getAndResetDependentBeans()
+                    );
+                } finally {
+                    if (isNewPath) {
+                        path.pop();
+                    }
+                }
+            }
+        }
+    }
+
+    @NonNull
+    private <T> BeanRegistration<T> getNotSingletonBeanForDefinition(@NonNull BeanResolutionContext resolutionContext,
+                                                                     @NonNull Argument<T> beanType,
+                                                                     @Nullable Qualifier<T> qualifier,
+                                                                     boolean throwNoSuchBean,
+                                                                     @NonNull BeanDefinition<T> definition) {
         final boolean isProxy = definition.isProxy();
         final boolean isScopedProxyDefinition = definition.hasStereotype(SCOPED_PROXY_ANN);
 
@@ -2884,7 +2729,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
 
         if (currentSegment != null) {
             Argument<?> argument = currentSegment.getArgument();
-            registeredScope =  customScopeRegistry.findDeclaredScope(argument).orElse(null);
+            registeredScope = customScopeRegistry.findDeclaredScope(argument).orElse(null);
         }
 
         if (registeredScope == null && (!isScopedProxyDefinition || !isProxy)) {
@@ -2919,9 +2764,10 @@ public class DefaultBeanContext implements InitializableBeanContext {
                             final T bean = doCreateBean(resolutionContext, finalDefinition, beanType, qualifier);
                             final List<BeanRegistration<?>> dependentBeans = resolutionContext.getAndResetDependentBeans();
                             if (dependentBeans.isEmpty()) {
-                                return new BeanDisposingRegistration<>(beanKey, finalDefinition, bean);
+                                return new BeanDisposingRegistration<>(DefaultBeanContext.this, beanKey, finalDefinition, bean);
                             } else {
                                 return new BeanDisposingRegistration<>(
+                                        DefaultBeanContext.this,
                                         beanKey,
                                         finalDefinition,
                                         bean,
@@ -2937,19 +2783,13 @@ public class DefaultBeanContext implements InitializableBeanContext {
     }
 
     @NotNull
-    private <T> BeanRegistration<T> getUnknownScopeBean(BeanResolutionContext resolutionContext,
-                                                        Argument<T> beanType, Qualifier<T> qualifier,
+    private <T> BeanRegistration<T> getUnknownScopeBean(@NonNull BeanResolutionContext resolutionContext,
+                                                        @NonNull Argument<T> beanType,
+                                                        @Nullable Qualifier<T> qualifier,
                                                         boolean throwNoSuchBean,
-                                                        BeanDefinition<T> definition) {
+                                                        @NonNull BeanDefinition<T> definition) {
         BeanKey<T> beanKey = new BeanKey<>(beanType, qualifier);
-        T bean = doCreateBean(
-                resolutionContext,
-                definition,
-                qualifier,
-                beanType,
-                false,
-                null
-        );
+        T bean = doCreateBean(resolutionContext, definition, qualifier);
         if (bean == null && throwNoSuchBean) {
             throw new NoSuchBeanException(definition.getBeanType(), qualifier);
         } else if (definition instanceof DisposableBeanDefinition) {
@@ -2962,24 +2802,17 @@ public class DefaultBeanContext implements InitializableBeanContext {
     }
 
     @NotNull
-    private <T> BeanRegistration<T> getScopedBeanInterceptorForDefinition(BeanResolutionContext resolutionContext,
-                                                                          Argument<T> beanType,
-                                                                          Qualifier<T> qualifier,
+    private <T> BeanRegistration<T> getScopedBeanInterceptorForDefinition(@NonNull BeanResolutionContext resolutionContext,
+                                                                          @NonNull Argument<T> beanType,
+                                                                          @Nullable Qualifier<T> qualifier,
                                                                           boolean throwNoSuchBean,
-                                                                          BeanDefinition<T> definition) {
+                                                                          @NonNull BeanDefinition<T> definition) {
         Qualifier<T> q = qualifier;
         if (q == null) {
             q = definition.getDeclaredQualifier();
         }
 
-        T bean = doCreateBean(
-                resolutionContext,
-                definition,
-                q,
-                beanType,
-                false,
-                null
-        );
+        T bean = doCreateBean(resolutionContext, definition, q);
         if (bean instanceof Qualified) {
             ((Qualified<T>) bean).$withBeanQualifier(q);
         }
@@ -2989,94 +2822,24 @@ public class DefaultBeanContext implements InitializableBeanContext {
         return new BeanRegistration<>(new BeanKey<>(beanType, qualifier), definition, bean);
     }
 
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    private <T> BeanRegistration<T> findExistingCompatibleSingleton(
-            @NonNull Argument<T> beanType,
-            @Nullable Argument<?> requestedType,
-            @Nullable Qualifier<T> qualifier,
-            @Nullable BeanDefinition<T> definition) {
-        BeanRegistration<T> bean = null;
-        final Argument resolvedBeanType = requestedType != null ? requestedType : beanType;
-        final Class<?> beanClass = resolvedBeanType.getType();
-        for (Map.Entry<BeanKey, BeanRegistration> entry : singletonObjects.entrySet()) {
-            BeanKey<?> key = entry.getKey();
-            if (qualifier == null || qualifier.equals(key.qualifier)) {
-                BeanRegistration reg = entry.getValue();
-                if (beanClass.isInstance(reg.bean)) {
-                    final Set exposedTypes = reg.getBeanDefinition().getExposedTypes();
-                    if (!exposedTypes.isEmpty() && !exposedTypes.contains(beanClass)) {
-                        continue;
-                    }
-
-                    if (qualifier == null && definition != null && !reg.beanDefinition.equals(definition)) {
-                        // different definition, so ignore
-                        continue;
-                    }
-
-                    if (!reg.beanDefinition.isCandidateBean(resolvedBeanType)) {
-                        continue;
-                    }
-                    synchronized (singletonObjects) {
-                        bean = reg;
-                        registerSingletonBean(
-                                reg.beanDefinition,
-                                resolvedBeanType,
-                                (T) reg.bean,
-                                qualifier,
-                                true,
-                                Collections.emptyList()
-                        );
-                        break;
-                    }
-                }
-            } else if (key.qualifier == null) {
-                BeanRegistration registration = entry.getValue();
-                if (beanType.getType().isInstance(registration.bean)) {
-                    Optional<BeanDefinition<T>> candidate = ((Qualifier) qualifier).qualify(beanClass, Stream.of(registration.beanDefinition));
-                    if (candidate.isPresent()) {
-                        synchronized (singletonObjects) {
-                            final BeanDefinition<T> beanDefinition = candidate.get();
-                            final Set<Class<?>> exposedTypes = beanDefinition.getExposedTypes();
-                            if (!exposedTypes.isEmpty() && !exposedTypes.contains(beanClass)) {
-                                continue;
-                            }
-                            if (!beanDefinition.isCandidateBean(resolvedBeanType)) {
-                                continue;
-                            }
-                            bean = (BeanRegistration<T>) registration;
-                            registerSingletonBean(
-                                    beanDefinition,
-                                    resolvedBeanType,
-                                    bean.getBean(),
-                                    qualifier,
-                                    true,
-                                    Collections.emptyList()
-                            );
-                            break;
-                        }
-                    }
-                }
-            }
-        }
-        return bean;
-    }
-
     /**
      * Find a concrete candidate for the given qualifier.
      *
-     * @param beanType        The bean type
-     * @param qualifier       The qualifier
-     * @param throwNonUnique  Whether to throw an exception if the bean is not found
-     * @param <T>             The bean generic type
+     * @param beanType       The bean type
+     * @param qualifier      The qualifier
+     * @param throwNonUnique Whether to throw an exception if the bean is not found
+     * @param <T>            The bean generic type
      * @return The concrete bean definition candidate
      */
     @SuppressWarnings({"unchecked", "rawtypes"})
-    private <T> Optional<BeanDefinition<T>> findConcreteCandidate(
-            BeanResolutionContext resolutionContext,
-            Argument<T> beanType,
-            Qualifier<T> qualifier,
-            boolean throwNonUnique) {
-        BeanKey bk = new BeanKey(beanType, qualifier);
+    private <T> Optional<BeanDefinition<T>> findConcreteCandidate(@Nullable BeanResolutionContext resolutionContext,
+                                                                  @NonNull Argument<T> beanType,
+                                                                  @Nullable Qualifier<T> qualifier,
+                                                                  boolean throwNonUnique) {
+        if (beanType.getType() == Object.class && qualifier == null) {
+            return Optional.empty();
+        }
+        BeanCandidateKey bk = new BeanCandidateKey(beanType, qualifier, throwNonUnique);
         Optional beanDefinition = beanConcreteCandidateCache.get(bk);
         //noinspection OptionalAssignedToNull
         if (beanDefinition == null) {
@@ -3092,12 +2855,11 @@ public class DefaultBeanContext implements InitializableBeanContext {
         return beanDefinition;
     }
 
-    private <T> Optional<BeanDefinition<T>> findConcreteCandidateNoCache(
-            BeanResolutionContext resolutionContext,
-            Argument<T> beanType,
-            Qualifier<T> qualifier,
-            boolean throwNonUnique,
-            boolean filterProxied) {
+    private <T> Optional<BeanDefinition<T>> findConcreteCandidateNoCache(@Nullable BeanResolutionContext resolutionContext,
+                                                                         @NonNull Argument<T> beanType,
+                                                                         @Nullable Qualifier<T> qualifier,
+                                                                         boolean throwNonUnique,
+                                                                         boolean filterProxied) {
 
         Predicate<BeanDefinition<T>> predicate = new Predicate<BeanDefinition<T>>() {
             @Override
@@ -3108,7 +2870,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
                 if (qualifier != null) {
                     if (candidate instanceof NoInjectionBeanDefinition) {
                         NoInjectionBeanDefinition noInjectionBeanDefinition = (NoInjectionBeanDefinition) candidate;
-                        return qualifier.contains(noInjectionBeanDefinition.qualifier);
+                        return qualifier.contains(noInjectionBeanDefinition.getQualifier());
                     }
                 }
                 return true;
@@ -3134,7 +2896,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
                     if (!c.isAbstract()) {
                         if (c instanceof NoInjectionBeanDefinition) {
                             NoInjectionBeanDefinition noInjectionBeanDefinition = (NoInjectionBeanDefinition) c;
-                            return qualifier.contains(noInjectionBeanDefinition.qualifier);
+                            return qualifier.contains(noInjectionBeanDefinition.getQualifier());
                         }
                         return true;
                     }
@@ -3222,11 +2984,10 @@ public class DefaultBeanContext implements InitializableBeanContext {
         }
     }
 
-    private <T> BeanDefinition<T> lastChanceResolve(
-            Argument<T> beanType,
-            Qualifier<T> qualifier,
-            boolean throwNonUnique,
-            Collection<BeanDefinition<T>> candidates) {
+    private <T> BeanDefinition<T> lastChanceResolve(Argument<T> beanType,
+                                                    Qualifier<T> qualifier,
+                                                    boolean throwNonUnique,
+                                                    Collection<BeanDefinition<T>> candidates) {
         final Class<T> beanClass = beanType.getType();
 
         if (candidates.size() > 1) {
@@ -3283,37 +3044,6 @@ public class DefaultBeanContext implements InitializableBeanContext {
         }
     }
 
-    private <T> BeanRegistration<T> createAndRegisterSingleton(
-            BeanResolutionContext resolutionContext,
-            BeanDefinition<T> definition,
-            Class<T> beanType,
-            Qualifier<T> qualifier) {
-        synchronized (singletonObjects) {
-            return createAndRegisterSingletonInternal(resolutionContext, definition, Argument.of(beanType), qualifier);
-        }
-    }
-
-    private <T> BeanRegistration<T> createAndRegisterSingletonInternal(BeanResolutionContext resolutionContext, BeanDefinition<T> definition, Argument<T> beanType, Qualifier<T> qualifier) {
-        if (definition instanceof NoInjectionBeanDefinition) {
-            NoInjectionBeanDefinition<T> manuallyRegistered = (NoInjectionBeanDefinition) definition;
-            BeanRegistration<T> reg = singletonObjects.get(new BeanKey(manuallyRegistered.getBeanType(), manuallyRegistered.getQualifier()));
-            if (reg == null) {
-                throw new IllegalStateException("Manually registered singleton no longer present in bean context");
-            }
-            return registerSingletonBean(definition, beanType, reg.bean, qualifier, true, Collections.emptyList());
-        } else {
-            T createdBean = doCreateBean(resolutionContext, definition, qualifier, beanType, true, null);
-            return registerSingletonBean(
-                    definition,
-                    beanType,
-                    createdBean,
-                    qualifier,
-                    true,
-                    resolutionContext.getAndResetDependentBeans()
-            );
-        }
-    }
-
     private void readAllBeanConfigurations() {
         Iterable<BeanConfiguration> beanConfigurations = resolveBeanConfigurations();
         for (BeanConfiguration beanConfiguration : beanConfigurations) {
@@ -3322,99 +3052,13 @@ public class DefaultBeanContext implements InitializableBeanContext {
     }
 
     private <T> Collection<BeanDefinition<T>> filterExactMatch(final Class<T> beanType, Collection<BeanDefinition<T>> candidates) {
-        Stream<BeanDefinition<T>> filteredResults = candidates
-                .stream()
-                .filter((BeanDefinition<T> candidate) -> candidate.getBeanType() == beanType);
-        return filteredResults.collect(Collectors.toList());
-    }
-
-    @NonNull
-    private <T> BeanRegistration<T> registerSingletonBean(
-            BeanDefinition<T> beanDefinition,
-            Argument<T> beanType,
-            T createdBean,
-            Qualifier<T> qualifier,
-            boolean singleCandidate,
-            List<BeanRegistration<?>> dependents) {
-        // for only one candidate create link to bean type as singleton
-        if (qualifier == null) {
-            qualifier = beanDefinition.getDeclaredQualifier();
+        List<BeanDefinition<T>> list = new ArrayList<>(candidates.size());
+        for (BeanDefinition<T> candidate : candidates) {
+            if (candidate.getBeanType() == beanType) {
+                list.add(candidate);
+            }
         }
-
-        final Set<Class<?>> exposedTypes = beanDefinition.getExposedTypes();
-        final boolean hasNoExposedTypes = CollectionUtils.isEmpty(exposedTypes);
-        if (hasNoExposedTypes) {
-            BeanKey<T> key = new BeanKey<>(beanDefinition, qualifier);
-            if (LOG.isDebugEnabled()) {
-                if (qualifier != null) {
-                    LOG.debug("Registering singleton bean {} for type [{} {}] using bean key {}", createdBean, qualifier, beanType.getName(), key);
-                } else {
-                    LOG.debug("Registering singleton bean {} for type [{}] using bean key {}", createdBean, beanType.getName(), key);
-                }
-            }
-            BeanRegistration<T> registration;
-
-            if (dependents.isEmpty()) {
-                registration = new BeanDisposingRegistration<>(key, beanDefinition, createdBean);
-            } else {
-                registration = new BeanDisposingRegistration<>(key, beanDefinition, createdBean, dependents);
-            }
-
-            if (singleCandidate || key.beanType.getTypeParameters().length > 0) {
-                singletonObjects.put(key, registration);
-            }
-
-            final Class<T> beanClass = beanType.getType();
-
-            boolean isNotProxyTarget = qualifier != PROXY_TARGET_QUALIFIER;
-            if (isNotProxyTarget) {
-                Class<?> createdType = createdBean != null ? createdBean.getClass() : beanClass;
-                boolean createdTypeDiffers = !createdType.equals(beanClass);
-
-                BeanKey<?> createdBeanKey = new BeanKey(createdType, qualifier);
-                Qualifier<T> declaredQualifier = beanDefinition.getDeclaredQualifier();
-                if (declaredQualifier != null) {
-                    BeanKey qualifierKey = new BeanKey(createdType, declaredQualifier);
-                    if (!qualifierKey.equals(createdBeanKey)) {
-                        singletonObjects.put(qualifierKey, registration);
-                    }
-                } else if (!beanDefinition.isIterable()) {
-                    BeanKey primaryBeanKey = new BeanKey<>(createdType, null);
-                    singletonObjects.put(primaryBeanKey, registration);
-                    if (qualifier != null) {
-                        BeanKey qualifiedKey = new BeanKey<>(beanType, qualifier);
-                        singletonObjects.put(qualifiedKey, registration);
-                    }
-                } else if (beanDefinition.isPrimary()) {
-                    BeanKey primaryBeanKey = new BeanKey<>(beanType, null);
-                    singletonObjects.put(primaryBeanKey, registration);
-                    if (createdTypeDiffers) {
-                        singletonObjects.put(new BeanKey<>(createdType, null), registration);
-                    }
-                }
-                singletonObjects.put(createdBeanKey, registration);
-            }
-
-            return registration;
-        } else {
-            for (Class<?> exposedType : exposedTypes) {
-                BeanKey<T> key = new BeanKey(exposedType, qualifier);
-                if (LOG.isDebugEnabled()) {
-                    if (qualifier != null) {
-                        LOG.debug("Registering singleton bean {} for type [{} {}] using bean key {}", createdBean, qualifier, exposedType.getName(), key);
-                    } else {
-                        LOG.debug("Registering singleton bean {} for type [{}] using bean key {}", createdBean, exposedType.getName(), key);
-                    }
-                }
-                BeanDisposingRegistration<T> exposedRegistration = new BeanDisposingRegistration<>(key, beanDefinition, createdBean, dependents);
-                singletonObjects.put(key, exposedRegistration);
-                if (qualifier != null && beanDefinition.isPrimary()) {
-                    BeanKey<?> primaryKey = new BeanKey<>(exposedType, null);
-                    singletonObjects.put(primaryKey, exposedRegistration);
-                }
-            }
-            return new BeanDisposingRegistration<>(new BeanKey<>(beanType, qualifier), beanDefinition, createdBean, dependents);
-        }
+        return list;
     }
 
     private void readAllBeanDefinitionClasses() {
@@ -3510,8 +3154,10 @@ public class DefaultBeanContext implements InitializableBeanContext {
      * @return A {@link BeanRegistration}
      */
     @Internal
-    public <T> BeanRegistration<T> getBeanRegistration(@Nullable BeanResolutionContext resolutionContext, @NonNull Argument<T> beanType, @Nullable Qualifier<T> qualifier) {
-        return getBeanInternal(resolutionContext, beanType, qualifier, true, true);
+    public <T> BeanRegistration<T> getBeanRegistration(@Nullable BeanResolutionContext resolutionContext,
+                                                       @NonNull Argument<T> beanType,
+                                                       @Nullable Qualifier<T> qualifier) {
+        return resolveBeanRegistration(resolutionContext, beanType, qualifier, true);
     }
 
     /**
@@ -3525,10 +3171,9 @@ public class DefaultBeanContext implements InitializableBeanContext {
      */
     @SuppressWarnings("unchecked")
     @Internal
-    public <T> Collection<BeanRegistration<T>> getBeanRegistrations(
-            @Nullable BeanResolutionContext resolutionContext,
-            @NonNull Argument<T> beanType,
-            @Nullable Qualifier<T> qualifier) {
+    public <T> Collection<BeanRegistration<T>> getBeanRegistrations(@Nullable BeanResolutionContext resolutionContext,
+                                                                    @NonNull Argument<T> beanType,
+                                                                    @Nullable Qualifier<T> qualifier) {
         boolean hasQualifier = qualifier != null;
         if (LOG.isDebugEnabled()) {
             if (hasQualifier) {
@@ -3537,133 +3182,101 @@ public class DefaultBeanContext implements InitializableBeanContext {
                 LOG.debug("Resolving beans for type: {}", beanType.getTypeName());
             }
         }
-        final Class<T> beanClass = beanType.getType();
-        BeanKey<T> key = new BeanKey<>(beanType, qualifier);
 
+        BeanKey<T> key = new BeanKey<>(beanType, qualifier);
         if (LOG.isTraceEnabled()) {
             LOG.trace("Looking up existing beans for key: {}", key);
         }
-        @SuppressWarnings("unchecked") Collection<BeanRegistration<T>> existing =
-                (Collection<BeanRegistration<T>>) initializedObjectsByType.get(key);
+        Collection<BeanRegistration<T>> existing = singletonBeanRegistrations.get(key);
         if (existing != null) {
-            logResolvedExisting(beanType, qualifier, hasQualifier, existing);
+            logResolvedExistingBeanRegistrations(beanType, qualifier, existing);
             return existing;
         }
 
-        if (LOG.isTraceEnabled()) {
-            LOG.trace("No beans found for key: {}", key);
+        Collection<BeanDefinition<T>> beanDefinitions = findBeanCandidatesInternal(resolutionContext, beanType);
+        Stream<BeanDefinition<T>> candidateStream = applyBeanResolutionFilters(resolutionContext, beanDefinitions.stream());
+        if (qualifier != null) {
+            candidateStream = qualifier.reduce(beanType.getType(), candidateStream);
         }
+        beanDefinitions = candidateStream.collect(Collectors.toList());
 
-        synchronized (singletonObjects) {
-            existing = (Collection<BeanRegistration<T>>) initializedObjectsByType.get(key);
-            if (existing != null) {
-                logResolvedExisting(beanType, qualifier, hasQualifier, existing);
-                return existing;
-            }
-
-            HashSet<BeanRegistration<T>> beansOfTypeList;
+        Collection<BeanRegistration<T>> beanRegistrations;
+        if (beanDefinitions.isEmpty()) {
+            beanRegistrations = Collections.emptySet();
+        } else {
             boolean allCandidatesAreSingleton = true;
-            boolean hasOrderAnnotation = false;
-            Collection<BeanRegistration<T>> beanRegistrations;
-            Collection<BeanDefinition<T>> candidates = findBeanCandidatesInternal(resolutionContext, beanType);
-            filterProxiedTypes(candidates, true, false, null);
-            boolean hasCandidates = !candidates.isEmpty();
-            if (hasQualifier && hasCandidates) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Qualifying bean [{}] from candidates {} for qualifier: {} ", beanType.getName(), candidates, qualifier);
-                }
-                Stream<BeanDefinition<T>> candidateStream = candidates.stream();
-                candidateStream = applyBeanResolutionFilters(resolutionContext, candidateStream);
-
-                List<BeanDefinition<T>> reduced = qualifier.reduce(beanClass, candidateStream)
-                        .collect(Collectors.toList());
-                if (!reduced.isEmpty()) {
-                    beansOfTypeList = new HashSet<>(reduced.size());
-                    for (BeanDefinition<T> definition : reduced) {
-                        if (!definition.isSingleton()) {
-                            allCandidatesAreSingleton = false;
-                        }
-                        if (definition.hasAnnotation(Order.class)) {
-                            hasOrderAnnotation = true;
-                        }
-                        addCandidateToList(resolutionContext, beanType, definition, beansOfTypeList, qualifier, reduced.size() == 1);
-                    }
-                    beanRegistrations = beansOfTypeList;
-                } else {
-
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Found no matching beans of type [{}] for qualifier: {} ", beanType.getName(), qualifier);
-                    }
-                    beanRegistrations = Collections.emptySet();
-                }
-            } else if (hasCandidates) {
-                int candidateCount = candidates.size();
-                Stream<BeanDefinition<T>> candidateStream = candidates.stream();
-                candidateStream = applyBeanResolutionFilters(resolutionContext, candidateStream);
-
-                List<BeanDefinition<T>> candidateList = candidateStream.collect(Collectors.toList());
-                beansOfTypeList = new HashSet<>(candidateCount);
-                for (BeanDefinition<T> candidate : candidateList) {
-                    if (!candidate.isSingleton()) {
-                        allCandidatesAreSingleton = false;
-                    }
-                    if (candidate.hasAnnotation(Order.class)) {
-                        hasOrderAnnotation = true;
-                    }
-                    addCandidateToList(resolutionContext, beanType, candidate, beansOfTypeList, qualifier, candidateCount == 1);
-                }
-                beanRegistrations = beansOfTypeList;
-            } else {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Found no possible candidate beans of type [{}] for qualifier: {} ", beanType.getName(), qualifier);
-                }
-                beanRegistrations = Collections.emptySet();
-            }
-
-            Collection<BeanRegistration<T>> beans = Collections.emptyList();
-            if (beanRegistrations != Collections.EMPTY_SET) {
-                Stream<BeanRegistration<T>> stream = beanRegistrations.stream();
-                if (Ordered.class.isAssignableFrom(beanClass)) {
-                    beans = stream
-                            .sorted(OrderUtil.COMPARATOR)
-                            .collect(StreamUtils.toImmutableCollection());
-                } else {
-                    if (hasOrderAnnotation) {
-                        stream = stream.sorted(BEAN_REGISTRATION_COMPARATOR);
-                    }
-                    beans = stream
-                            .collect(StreamUtils.toImmutableCollection());
+            for (BeanDefinition<T> definition : beanDefinitions) {
+                if (!definition.isSingleton()) {
+                    allCandidatesAreSingleton = false;
                 }
             }
-
             if (allCandidatesAreSingleton) {
-                initializedObjectsByType.put(key, beans);
-            }
-            if (LOG.isDebugEnabled() && !beans.isEmpty()) {
-                if (hasQualifier) {
-                    LOG.debug("Found {} beans for type [{} {}]: {} ", beanRegistrations.size(), qualifier, beanType.getName(), beanRegistrations);
-                } else {
-                    LOG.debug("Found {} beans for type [{}]: {} ", beanRegistrations.size(), beanType.getName(), beanRegistrations);
+                synchronized (singletonScope) {
+                    existing = singletonBeanRegistrations.get(key);
+                    if (existing != null) {
+                        logResolvedExistingBeanRegistrations(beanType, qualifier, existing);
+                        return existing;
+                    }
+                    beanRegistrations = resolveBeanRegistrations(resolutionContext, beanDefinitions, beanType, qualifier);
+                    singletonBeanRegistrations.put(key, beanRegistrations);
                 }
+            } else {
+                beanRegistrations = resolveBeanRegistrations(resolutionContext, beanDefinitions, beanType, qualifier);
             }
-
-            return beans;
         }
+        if (LOG.isDebugEnabled() && !beanRegistrations.isEmpty()) {
+            if (hasQualifier) {
+                LOG.debug("Found {} bean registrations for type [{} {}]", beanRegistrations.size(), qualifier, beanType.getName());
+            } else {
+                LOG.debug("Found {} bean registrations for type [{}]", beanRegistrations.size(), beanType.getName());
+            }
+            for (BeanRegistration<?> beanRegistration : beanRegistrations) {
+                LOG.debug("  {} {}", beanRegistration.definition(), beanRegistration.definition().getDeclaredQualifier());
+            }
+        }
+        return beanRegistrations;
     }
 
-    private <T> void logResolvedExisting(Argument<T> beanType, Qualifier<T> qualifier, boolean hasQualifier, Collection<BeanRegistration<T>> existing) {
-        if (LOG.isTraceEnabled()) {
-            if (hasQualifier) {
-                LOG.trace("Found {} existing beans for type [{} {}]: {} ", existing.size(), qualifier, beanType.getName(), existing);
+    private <T> Collection<BeanRegistration<T>> resolveBeanRegistrations(BeanResolutionContext resolutionContext,
+                                                                         Collection<BeanDefinition<T>> beanDefinitions,
+                                                                         Argument<T> beanType,
+                                                                         Qualifier<T> qualifier) {
+        boolean hasOrderAnnotation = false;
+        Set<BeanRegistration<T>> beansOfTypeList = new HashSet<>();
+        for (BeanDefinition<T> definition : beanDefinitions) {
+            if (!hasOrderAnnotation && definition.hasAnnotation(Order.class)) {
+                hasOrderAnnotation = true;
+            }
+            addCandidateToList(resolutionContext, definition, beanType, qualifier, beansOfTypeList);
+        }
+        Collection<BeanRegistration<T>> result = beansOfTypeList;
+        if (beansOfTypeList != Collections.EMPTY_SET) {
+            Stream<BeanRegistration<T>> stream = beansOfTypeList.stream();
+            if (Ordered.class.isAssignableFrom(beanType.getType())) {
+                result = stream
+                        .sorted(OrderUtil.COMPARATOR)
+                        .collect(StreamUtils.toImmutableCollection());
             } else {
-                LOG.trace("Found {} existing beans for type [{}]: {} ", existing.size(), beanType.getName(), existing);
+                if (hasOrderAnnotation) {
+                    stream = stream.sorted(BEAN_REGISTRATION_COMPARATOR);
+                }
+                result = stream.collect(StreamUtils.toImmutableCollection());
+            }
+        }
+        return result;
+    }
+
+    private <T> void logResolvedExistingBeanRegistrations(Argument<T> beanType, Qualifier<T> qualifier, Collection<BeanRegistration<T>> existing) {
+        if (LOG.isDebugEnabled()) {
+            if (qualifier == null) {
+                LOG.debug("Found {} existing beans for type [{}]: {} ", existing.size(), beanType.getName(), existing);
+            } else {
+                LOG.debug("Found {} existing beans for type [{} {}]: {} ", existing.size(), qualifier, beanType.getName(), existing);
             }
         }
     }
 
     private <T> Stream<BeanDefinition<T>> applyBeanResolutionFilters(@Nullable BeanResolutionContext resolutionContext, Stream<BeanDefinition<T>> candidateStream) {
-        candidateStream = candidateStream.filter(c -> !c.isAbstract());
-
         BeanResolutionContext.Segment<?> segment = resolutionContext != null ? resolutionContext.getPath().peek() : null;
         if (segment instanceof AbstractBeanResolutionContext.ConstructorSegment || segment instanceof AbstractBeanResolutionContext.MethodSegment) {
             BeanDefinition<?> declaringBean = segment.getDeclaringType();
@@ -3681,62 +3294,16 @@ public class DefaultBeanContext implements InitializableBeanContext {
         return candidateStream;
     }
 
-    private <T> void addCandidateToList(
-            @Nullable BeanResolutionContext resolutionContext,
-            Argument<T> beanType,
-            BeanDefinition<T> candidate,
-            Collection<BeanRegistration<T>> beansOfTypeList,
-            Qualifier<T> qualifier,
-            boolean singleCandidate) {
-        T bean = null;
-        final boolean isContainerType = candidate.isContainerType();
+    private <T> void addCandidateToList(@Nullable BeanResolutionContext resolutionContext,
+                                        @NonNull BeanDefinition<T> candidate,
+                                        @NonNull Argument<T> beanType,
+                                        @Nullable Qualifier<T> qualifier,
+                                        @NonNull Collection<BeanRegistration<T>> beansOfTypeList) {
+        BeanRegistration<T> beanRegistration = null;
         try {
-            try (BeanResolutionContext context = newResolutionContext(candidate, resolutionContext)) {
-                if (candidate.isSingleton()) {
-                    synchronized (singletonObjects) {
-                        if (candidate instanceof NoInjectionBeanDefinition) {
-                            NoInjectionBeanDefinition noibd = (NoInjectionBeanDefinition) candidate;
-                            final BeanKey key = new BeanKey(noibd.singletonClass, noibd.qualifier);
-                            final BeanRegistration beanRegistration = singletonObjects.get(key);
-                            if (beanRegistration != null) {
-                                bean = (T) beanRegistration.bean;
-                            } else {
-                                throw new IllegalStateException("Singleton not present for key: " + key);
-                            }
-                        } else {
-                            bean = doCreateBean(
-                                    context,
-                                    candidate,
-                                    qualifier,
-                                    beanType,
-                                    true,
-                                    null
-                            );
-
-                            if (candidate.getBeanType() != beanType.getType() && isContainerType) {
-                                registerSingletonBean(
-                                        candidate,
-                                        candidate.asArgument(),
-                                        bean,
-                                        qualifier,
-                                        singleCandidate,
-                                        context.getAndResetDependentBeans()
-                                );
-                            } else {
-                                registerSingletonBean(
-                                        candidate,
-                                        beanType,
-                                        bean,
-                                        qualifier,
-                                        singleCandidate,
-                                        context.getAndResetDependentBeans()
-                                );
-                            }
-                        }
-                    }
-                } else {
-                    bean = getNotSingletonBeanForDefinition(context, candidate.asArgument(), qualifier, true, candidate).bean;
-                }
+            beanRegistration = resolveBeanRegistration(resolutionContext, candidate);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Found a registration {} for candidate: {} with qualifier: {}", beanRegistration, candidate, qualifier);
             }
         } catch (DisabledBeanException e) {
             if (AbstractBeanContextConditional.LOG.isDebugEnabled()) {
@@ -3744,9 +3311,9 @@ public class DefaultBeanContext implements InitializableBeanContext {
             }
         }
 
-        if (bean != null) {
-            if (isContainerType && bean instanceof Iterable) {
-                Iterable<Object> iterable = (Iterable<Object>) bean;
+        if (beanRegistration != null) {
+            if (candidate.isContainerType() && beanRegistration.bean instanceof Iterable) {
+                Iterable<Object> iterable = (Iterable<Object>) beanRegistration.bean;
                 int i = 0;
                 for (Object o : iterable) {
                     if (o == null || !beanType.isInstance(o)) {
@@ -3759,7 +3326,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
                     ));
                 }
             } else {
-                beansOfTypeList.add(new BeanRegistration(new BeanKey(beanType, candidate.getDeclaredQualifier()), candidate, bean));
+                beansOfTypeList.add(beanRegistration);
             }
         }
     }
@@ -3772,7 +3339,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
             if (qualifier != null && !(qualifier instanceof AnyQualifier)) {
                 stream = qualifier.reduce(beanType.getType(), stream);
             }
-            return stream.count() > 0;
+            return stream.findAny().isPresent();
         }
         return false;
     }
@@ -4057,7 +3624,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
      * @param <T> The bean type
      */
     static final class BeanKey<T> implements BeanIdentifier {
-        private final Argument<T> beanType;
+        final Argument<T> beanType;
         private final Qualifier<T> qualifier;
         private final int hashCode;
 
@@ -4139,151 +3706,28 @@ public class DefaultBeanContext implements InitializableBeanContext {
         }
     }
 
-
     /**
-     * @param <T> The bean type
+     * Class used as a bean candidate key.
+     * @param <T> The bean candidate type
      */
-    private static final class NoInjectionBeanDefinition<T> implements BeanDefinition<T>, BeanDefinitionReference<T> {
-        private final Class<?> singletonClass;
-        private final Map<Class<?>, List<Argument<?>>> typeArguments = new HashMap<>();
-
+    static final class BeanCandidateKey<T> {
+        private final Argument<T> beanType;
         private final Qualifier<T> qualifier;
+        private final boolean throwNonUnique;
+        private final int hashCode;
 
         /**
-         * @param singletonClass The singleton class
+         * A bean key for the given bean definition.
+         *
+         * @param argument       The argument
+         * @param qualifier      The qualifier
+         * @param throwNonUnique The throwNonUnique
          */
-        NoInjectionBeanDefinition(Class singletonClass, Qualifier<T> qualifier) {
-            this.singletonClass = singletonClass;
+        BeanCandidateKey(Argument<T> argument, Qualifier<T> qualifier, boolean throwNonUnique) {
+            this.beanType = argument;
             this.qualifier = qualifier;
-        }
-
-        @Nullable
-        public Qualifier<T> getQualifier() {
-            return qualifier;
-        }
-
-        @Override
-        public Optional<Class<? extends Annotation>> getScope() {
-            return Optional.of(javax.inject.Singleton.class);
-        }
-
-        @Override
-        public Optional<String> getScopeName() {
-            return Optional.of(AnnotationUtil.SINGLETON);
-        }
-
-        @NonNull
-        @Override
-        public List<Argument<?>> getTypeArguments(Class<?> type) {
-            List<Argument<?>> result = typeArguments.get(type);
-            if (result == null) {
-                Class[] classes = type.isInterface() ? GenericTypeUtils.resolveInterfaceTypeArguments(singletonClass, type) : GenericTypeUtils.resolveSuperTypeGenericArguments(singletonClass, type);
-                result = Arrays.stream(classes).map((Function<Class, Argument<?>>) Argument::of).collect(Collectors.toList());
-                typeArguments.put(type, result);
-            }
-
-            return result;
-        }
-
-        @Override
-        public boolean isSingleton() {
-            return true;
-        }
-
-        @Override
-        public boolean isProvided() {
-            return false;
-        }
-
-        @Override
-        public boolean isIterable() {
-            return false;
-        }
-
-        @Override
-        public boolean isPrimary() {
-            return true;
-        }
-
-        @Override
-        public Class getBeanType() {
-            return singletonClass;
-        }
-
-        @Override
-        public Optional<Class<?>> getDeclaringType() {
-            return Optional.empty();
-        }
-
-        @Override
-        public ConstructorInjectionPoint getConstructor() {
-            throw new UnsupportedOperationException("Bean of type [" + getBeanType() + "] is a manually registered singleton that was registered with the context via BeanContext.registerBean(..) and cannot be created directly");
-        }
-
-        @Override
-        public Collection<Class<?>> getRequiredComponents() {
-            return Collections.emptyList();
-        }
-
-        @Override
-        public Collection<MethodInjectionPoint<T, ?>> getInjectedMethods() {
-            return Collections.emptyList();
-        }
-
-        @Override
-        public Collection<FieldInjectionPoint<T, ?>> getInjectedFields() {
-            return Collections.emptyList();
-        }
-
-        @Override
-        public Collection<MethodInjectionPoint<T, ?>> getPostConstructMethods() {
-            return Collections.emptyList();
-        }
-
-        @Override
-        public Collection<MethodInjectionPoint<T, ?>> getPreDestroyMethods() {
-            return Collections.emptyList();
-        }
-
-        @Override
-        @NonNull
-        public String getName() {
-            return singletonClass.getName();
-        }
-
-        @Override
-        public boolean isEnabled(BeanContext beanContext) {
-            return true;
-        }
-
-        @Override
-        public boolean isEnabled(@NonNull BeanContext context, @Nullable BeanResolutionContext resolutionContext) {
-            return true;
-        }
-
-        @Override
-        public <R> Optional<ExecutableMethod<T, R>> findMethod(String name, Class<?>[] argumentTypes) {
-            return Optional.empty();
-        }
-
-        @Override
-        public T inject(BeanContext context, T bean) {
-            return bean;
-        }
-
-        @Override
-        public T inject(BeanResolutionContext resolutionContext, BeanContext context, T bean) {
-            return bean;
-        }
-
-        @Override
-        public Collection<ExecutableMethod<T, ?>> getExecutableMethods() {
-            return Collections.emptyList();
-        }
-
-        @Override
-        public Stream<ExecutableMethod<T, ?>> findPossibleMethods(String name) {
-            return Stream.empty();
+            this.hashCode = argument.typeHashCode();
+            this.throwNonUnique = throwNonUnique;
         }
 
         @Override
@@ -4294,91 +3738,16 @@ public class DefaultBeanContext implements InitializableBeanContext {
             if (o == null || getClass() != o.getClass()) {
                 return false;
             }
-
-            NoInjectionBeanDefinition that = (NoInjectionBeanDefinition) o;
-            return singletonClass.equals(that.singletonClass);
+            BeanCandidateKey<?> beanKey = (BeanCandidateKey<?>) o;
+            return beanType.equalsType(beanKey.beanType) &&
+                    Objects.equals(qualifier, beanKey.qualifier) && throwNonUnique == beanKey.throwNonUnique;
         }
 
         @Override
         public int hashCode() {
-            return singletonClass.hashCode();
+            return hashCode;
         }
 
-        @Override
-        public String getBeanDefinitionName() {
-            return singletonClass.getName();
-        }
-
-        @Override
-        public BeanDefinition<T> load() {
-            return this;
-        }
-
-        @Override
-        public BeanDefinition<T> load(BeanContext context) {
-            return this;
-        }
-
-        @Override
-        public boolean isContextScope() {
-            return false;
-        }
-
-        @Override
-        public boolean isPresent() {
-            return true;
-        }
-    }
-
-    private final class BeanDisposingRegistration<BT> extends BeanRegistration<BT> {
-        private final List<BeanRegistration<?>> dependents;
-        private final boolean hasDependents;
-
-        BeanDisposingRegistration(BeanKey<BT> key, BeanDefinition<BT> beanDefinition, BT createdBean, List<BeanRegistration<?>> dependents) {
-            super(key, beanDefinition, createdBean);
-            this.dependents = dependents;
-            this.hasDependents = true;
-        }
-
-        BeanDisposingRegistration(BeanKey<BT> key, BeanDefinition<BT> beanDefinition, BT createdBean) {
-            super(key, beanDefinition, createdBean);
-            this.hasDependents = false;
-            this.dependents = null;
-        }
-
-        @Override
-        public void close() {
-            final BeanDefinition<BT> definition = definition();
-            final BT beanToDestroy = getBean();
-            if (definition instanceof DisposableBeanDefinition) {
-                ((DisposableBeanDefinition<BT>) definition).dispose(DefaultBeanContext.this, beanToDestroy);
-            }
-            if (beanToDestroy instanceof LifeCycle) {
-                try {
-                    ((LifeCycle) beanToDestroy).stop();
-                } catch (Exception e) {
-                    throw new BeanDestructionException(definition, e);
-                }
-            }
-            if (hasDependents) {
-                final ListIterator<BeanRegistration<?>> i = dependents.listIterator(dependents.size());
-                while (i.hasPrevious()) {
-                    final BeanRegistration<?> dependent = i.previous();
-                    final Object bean = dependent.getBean();
-                    final BeanDefinition<?> beanDefinition = dependent.getBeanDefinition();
-                    if (beanDefinition instanceof DisposableBeanDefinition) {
-                        try {
-                            //noinspection unchecked
-                            ((DisposableBeanDefinition) beanDefinition).dispose(DefaultBeanContext.this, bean);
-                        } catch (Exception e) {
-                            if (LOG.isErrorEnabled()) {
-                                LOG.error("Error disposing dependent bean of type " + beanDefinition.getBeanType().getName() + ": " + e.getMessage(), e);
-                            }
-                        }
-                    }
-                }
-            }
-        }
     }
 
     private class SingletonBeanResolutionContext extends AbstractBeanResolutionContext {

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1106,7 +1106,8 @@ public class DefaultBeanContext implements InitializableBeanContext {
     }
 
     @Nullable
-    private <T> void destroyBean(@NonNull BeanRegistration<T> registration) {
+    @Override
+    public <T> void destroyBean(@NonNull BeanRegistration<T> registration) {
         if (LOG_LIFECYCLE.isDebugEnabled()) {
             LOG_LIFECYCLE.debug("Destroying bean [{}] with identifier [{}]", registration.bean, registration.identifier);
         }

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanResolutionContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanResolutionContext.java
@@ -31,7 +31,7 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 @Internal
 public final class DefaultBeanResolutionContext extends AbstractBeanResolutionContext {
-    private final Map<BeanIdentifier, Object> beansInCreation = new ConcurrentHashMap<>(5);
+    private final Map<BeanIdentifier, BeanRegistration> beansInCreation = new ConcurrentHashMap<>(5);
 
     /**
      * @param context        The bean context
@@ -46,7 +46,7 @@ public final class DefaultBeanResolutionContext extends AbstractBeanResolutionCo
      * @param rootDefinition The bean root definition
      * @param beansInCreation the beans in creation
      */
-    public DefaultBeanResolutionContext(BeanContext context, BeanDefinition rootDefinition, Map<BeanIdentifier, Object> beansInCreation) {
+    public DefaultBeanResolutionContext(BeanContext context, BeanDefinition rootDefinition, Map<BeanIdentifier, BeanRegistration> beansInCreation) {
         super(context, rootDefinition);
         if (beansInCreation != null) {
             this.beansInCreation.putAll(beansInCreation);
@@ -66,8 +66,8 @@ public final class DefaultBeanResolutionContext extends AbstractBeanResolutionCo
     }
 
     @Override
-    public <T> void addInFlightBean(BeanIdentifier beanIdentifier, T instance) {
-        beansInCreation.put(beanIdentifier, instance);
+    public <T> void addInFlightBean(BeanIdentifier beanIdentifier, BeanRegistration<T> beanRegistration) {
+        beansInCreation.put(beanIdentifier, beanRegistration);
     }
 
     @Override
@@ -77,8 +77,8 @@ public final class DefaultBeanResolutionContext extends AbstractBeanResolutionCo
 
     @Nullable
     @Override
-    public <T> T getInFlightBean(BeanIdentifier beanIdentifier) {
+    public <T> BeanRegistration<T> getInFlightBean(BeanIdentifier beanIdentifier) {
         //noinspection unchecked
-        return (T) beansInCreation.get(beanIdentifier);
+        return (BeanRegistration<T>) beansInCreation.get(beanIdentifier);
     }
 }

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanResolutionContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanResolutionContext.java
@@ -31,26 +31,14 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 @Internal
 public final class DefaultBeanResolutionContext extends AbstractBeanResolutionContext {
-    private final Map<BeanIdentifier, BeanRegistration> beansInCreation = new ConcurrentHashMap<>(5);
+    private final Map<BeanIdentifier, BeanRegistration<?>> beansInCreation = new ConcurrentHashMap<>(5);
 
     /**
      * @param context        The bean context
      * @param rootDefinition The bean root definition
      */
-    public DefaultBeanResolutionContext(BeanContext context, BeanDefinition rootDefinition) {
-        super(context, rootDefinition);
-    }
-
-    /**
-     * @param context        The bean context
-     * @param rootDefinition The bean root definition
-     * @param beansInCreation the beans in creation
-     */
-    public DefaultBeanResolutionContext(BeanContext context, BeanDefinition rootDefinition, Map<BeanIdentifier, BeanRegistration> beansInCreation) {
-        super(context, rootDefinition);
-        if (beansInCreation != null) {
-            this.beansInCreation.putAll(beansInCreation);
-        }
+    public DefaultBeanResolutionContext(BeanContext context, BeanDefinition<?> rootDefinition) {
+        super((DefaultBeanContext) context, rootDefinition);
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/context/NoInjectionBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/NoInjectionBeanDefinition.java
@@ -16,6 +16,7 @@
 package io.micronaut.context;
 
 import io.micronaut.core.annotation.AnnotationUtil;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.reflect.GenericTypeUtils;
@@ -45,6 +46,7 @@ import java.util.stream.Stream;
  * @param <T> The bean type
  * @since 3.5.0
  */
+@Internal
 final class NoInjectionBeanDefinition<T> implements BeanDefinition<T>, BeanDefinitionReference<T> {
     private final Class<?> singletonClass;
     private final Map<Class<?>, List<Argument<?>>> typeArguments = new HashMap<>();

--- a/inject/src/main/java/io/micronaut/context/NoInjectionBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/NoInjectionBeanDefinition.java
@@ -55,7 +55,7 @@ final class NoInjectionBeanDefinition<T> implements BeanDefinition<T>, BeanDefin
      * @param singletonClass The singleton class
      * @param qualifier      The qualifier
      */
-    NoInjectionBeanDefinition(Class singletonClass, Qualifier<T> qualifier) {
+    NoInjectionBeanDefinition(Class<?> singletonClass, Qualifier<T> qualifier) {
         this.singletonClass = singletonClass;
         this.qualifier = qualifier;
     }
@@ -203,7 +203,7 @@ final class NoInjectionBeanDefinition<T> implements BeanDefinition<T>, BeanDefin
             return false;
         }
 
-        NoInjectionBeanDefinition that = (NoInjectionBeanDefinition) o;
+        NoInjectionBeanDefinition<?> that = (NoInjectionBeanDefinition) o;
         return singletonClass.equals(that.singletonClass);
     }
 

--- a/inject/src/main/java/io/micronaut/context/NoInjectionBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/NoInjectionBeanDefinition.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context;
+
+import io.micronaut.core.annotation.AnnotationUtil;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.reflect.GenericTypeUtils;
+import io.micronaut.core.type.Argument;
+import io.micronaut.inject.BeanDefinition;
+import io.micronaut.inject.BeanDefinitionReference;
+import io.micronaut.inject.ConstructorInjectionPoint;
+import io.micronaut.inject.ExecutableMethod;
+import io.micronaut.inject.FieldInjectionPoint;
+import io.micronaut.inject.MethodInjectionPoint;
+
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Manual injection bean definition.
+ *
+ * @param <T> The bean type
+ * @since 3.5.0
+ */
+final class NoInjectionBeanDefinition<T> implements BeanDefinition<T>, BeanDefinitionReference<T> {
+    private final Class<?> singletonClass;
+    private final Map<Class<?>, List<Argument<?>>> typeArguments = new HashMap<>();
+
+    private final Qualifier<T> qualifier;
+
+    /**
+     * @param singletonClass The singleton class
+     * @param qualifier      The qualifier
+     */
+    NoInjectionBeanDefinition(Class singletonClass, Qualifier<T> qualifier) {
+        this.singletonClass = singletonClass;
+        this.qualifier = qualifier;
+    }
+
+    @Nullable
+    public Qualifier<T> getQualifier() {
+        return qualifier;
+    }
+
+    @Override
+    public Qualifier<T> getDeclaredQualifier() {
+        return getQualifier();
+    }
+
+    @Override
+    public Optional<Class<? extends Annotation>> getScope() {
+        return Optional.of(javax.inject.Singleton.class);
+    }
+
+    @Override
+    public Optional<String> getScopeName() {
+        return Optional.of(AnnotationUtil.SINGLETON);
+    }
+
+    @NonNull
+    @Override
+    public List<Argument<?>> getTypeArguments(Class<?> type) {
+        List<Argument<?>> result = typeArguments.get(type);
+        if (result == null) {
+            Class[] classes = type.isInterface() ? GenericTypeUtils.resolveInterfaceTypeArguments(singletonClass, type) : GenericTypeUtils.resolveSuperTypeGenericArguments(singletonClass, type);
+            result = Arrays.stream(classes).map((Function<Class, Argument<?>>) Argument::of).collect(Collectors.toList());
+            typeArguments.put(type, result);
+        }
+
+        return result;
+    }
+
+    @Override
+    public boolean isSingleton() {
+        return true;
+    }
+
+    @Override
+    public boolean isProvided() {
+        return false;
+    }
+
+    @Override
+    public boolean isIterable() {
+        return false;
+    }
+
+    @Override
+    public boolean isPrimary() {
+        return true;
+    }
+
+    @Override
+    public Class getBeanType() {
+        return singletonClass;
+    }
+
+    @Override
+    public Optional<Class<?>> getDeclaringType() {
+        return Optional.empty();
+    }
+
+    @Override
+    public ConstructorInjectionPoint getConstructor() {
+        throw new UnsupportedOperationException("Bean of type [" + getBeanType() + "] is a manually registered singleton that was registered with the context via BeanContext.registerBean(..) and cannot be created directly");
+    }
+
+    @Override
+    public Collection<Class<?>> getRequiredComponents() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Collection<MethodInjectionPoint<T, ?>> getInjectedMethods() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Collection<FieldInjectionPoint<T, ?>> getInjectedFields() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Collection<MethodInjectionPoint<T, ?>> getPostConstructMethods() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Collection<MethodInjectionPoint<T, ?>> getPreDestroyMethods() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    @NonNull
+    public String getName() {
+        return singletonClass.getName();
+    }
+
+    @Override
+    public boolean isEnabled(BeanContext beanContext) {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled(@NonNull BeanContext context, @Nullable BeanResolutionContext resolutionContext) {
+        return true;
+    }
+
+    @Override
+    public <R> Optional<ExecutableMethod<T, R>> findMethod(String name, Class<?>[] argumentTypes) {
+        return Optional.empty();
+    }
+
+    @Override
+    public T inject(BeanContext context, T bean) {
+        return bean;
+    }
+
+    @Override
+    public T inject(BeanResolutionContext resolutionContext, BeanContext context, T bean) {
+        return bean;
+    }
+
+    @Override
+    public Collection<ExecutableMethod<T, ?>> getExecutableMethods() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Stream<ExecutableMethod<T, ?>> findPossibleMethods(String name) {
+        return Stream.empty();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        NoInjectionBeanDefinition that = (NoInjectionBeanDefinition) o;
+        return singletonClass.equals(that.singletonClass);
+    }
+
+    @Override
+    public int hashCode() {
+        return singletonClass.hashCode();
+    }
+
+    @Override
+    public String getBeanDefinitionName() {
+        return singletonClass.getName();
+    }
+
+    @Override
+    public BeanDefinition<T> load() {
+        return this;
+    }
+
+    @Override
+    public BeanDefinition<T> load(BeanContext context) {
+        return this;
+    }
+
+    @Override
+    public boolean isContextScope() {
+        return false;
+    }
+
+    @Override
+    public boolean isPresent() {
+        return true;
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/SingletonScope.java
+++ b/inject/src/main/java/io/micronaut/context/SingletonScope.java
@@ -76,13 +76,12 @@ final class SingletonScope {
                                                   @Nullable T createdBean,
                                                   @NonNull List<BeanRegistration<?>> dependents) {
 
-        BeanRegistration<T> registration;
+
         DefaultBeanContext.BeanKey<T> key = new DefaultBeanContext.BeanKey<>(beanDefinition.asArgument(), qualifier);
-        if (dependents.isEmpty()) {
-            registration = new BeanDisposingRegistration<>(beanContext, key, beanDefinition, createdBean);
-        } else {
-            registration = new BeanDisposingRegistration<>(beanContext, key, beanDefinition, createdBean, dependents);
-        }
+        BeanRegistration<T> registration = dependents.isEmpty() ?
+            new BeanDisposingRegistration<>(beanContext, key, beanDefinition, createdBean) :
+            new BeanDisposingRegistration<>(beanContext, key, beanDefinition, createdBean, dependents);
+        
         singletonByBeanDefinition.put(BeanDefinitionIdentity.of(beanDefinition), registration);
         if (!beanDefinition.isSingleton()) {
             // In some cases you can register an instance of non-singleton bean and expect it act as a singleton

--- a/inject/src/main/java/io/micronaut/context/SingletonScope.java
+++ b/inject/src/main/java/io/micronaut/context/SingletonScope.java
@@ -1,0 +1,431 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.type.Argument;
+import io.micronaut.core.util.ArgumentUtils;
+import io.micronaut.inject.BeanDefinition;
+import io.micronaut.inject.BeanIdentifier;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
+
+/**
+ * The singleton scope implementation.
+ *
+ * @author Denis Stepanov
+ * @since 3.5.0
+ */
+final class SingletonScope {
+
+    private final DefaultBeanContext beanContext;
+
+    /**
+     * The main collection storing registrations for {@link BeanDefinition}.
+     */
+    private final Map<BeanDefinitionIdentity, BeanRegistration> singletonByBeanDefinition = new ConcurrentHashMap<>(100);
+
+    /**
+     * Index collection to retrieve a the registration by {@link Argument} and {@link Qualifier}.
+     */
+    private final Map<DefaultBeanContext.BeanKey, BeanRegistration> singletonByArgumentAndQualifier = new ConcurrentHashMap<>(100);
+
+    /**
+     * The default constructor.
+     *
+     * @param beanContext The bean context.
+     */
+    SingletonScope(DefaultBeanContext beanContext) {
+        this.beanContext = beanContext;
+    }
+
+    /**
+     * Register singleton.
+     *
+     * @param beanDefinition The bean definition
+     * @param qualifier      The qualifier
+     * @param createdBean    The registered instance
+     * @param dependents     The dependents
+     * @param <T>            The singleton type
+     * @return The new registration
+     */
+    @NonNull
+    <T> BeanRegistration<T> registerSingletonBean(@NonNull BeanDefinition<T> beanDefinition,
+                                                  @Nullable Qualifier<T> qualifier,
+                                                  @Nullable T createdBean,
+                                                  @NonNull List<BeanRegistration<?>> dependents) {
+
+        BeanRegistration<T> registration;
+        DefaultBeanContext.BeanKey<T> key = new DefaultBeanContext.BeanKey<>(beanDefinition.asArgument(), qualifier);
+        if (dependents.isEmpty()) {
+            registration = new BeanDisposingRegistration<>(beanContext, key, beanDefinition, createdBean);
+        } else {
+            registration = new BeanDisposingRegistration<>(beanContext, key, beanDefinition, createdBean, dependents);
+        }
+        singletonByBeanDefinition.put(BeanDefinitionIdentity.of(beanDefinition), registration);
+        if (!beanDefinition.isSingleton()) {
+            // In some cases you can register an instance of non-singleton bean and expect it act as a singleton
+            // Current test `RegisterSingletonSpec "test register singleton method"` does it because of the present @Inject annotation
+            // This might be something to remove in 4.0
+            DefaultBeanContext.BeanKey<T> beanKey = new DefaultBeanContext.BeanKey(beanDefinition, qualifier);
+            singletonByArgumentAndQualifier.put(beanKey, registration);
+        }
+        if (beanDefinition instanceof BeanDefinitionDelegate || beanDefinition instanceof NoInjectionBeanDefinition) {
+            // Special cases when custom bean definitions need to be indexed:
+            // BeanDefinitionDelegate - doesn't really exist with a custom qualifier
+            // NoInjectionBeanDefinition - cannot be properly selected from 'beanDefinitionsClasses' when is used with a custom qualifier
+            DefaultBeanContext.BeanKey<T> beanKey = new DefaultBeanContext.BeanKey(beanDefinition, beanDefinition.getDeclaredQualifier());
+            singletonByArgumentAndQualifier.put(beanKey, registration);
+        }
+        if (createdBean != null && createdBean.getClass() != beanDefinition.getBeanType()) {
+            // If the actual type differs, allow to inject the actual implementation for cases like:
+            // `MyInterface factoryBean() { new Impl.. }`
+            // This might be something to remove in 4.0
+            DefaultBeanContext.BeanKey<T> concrete = new DefaultBeanContext.BeanKey(createdBean.getClass(), qualifier);
+            singletonByArgumentAndQualifier.put(concrete, registration);
+        }
+        return registration;
+    }
+
+    /**
+     * Fast check if singleton is present.
+     *
+     * @param beanType  The bean type
+     * @param qualifier The qualifier
+     * @param <T>       The singleton type
+     * @return true if contains, false doesn't mean the singleton is not present.
+     */
+    <T> boolean containsBean(Argument<T> beanType, Qualifier<T> qualifier) {
+        ArgumentUtils.requireNonNull("beanType", beanType);
+        DefaultBeanContext.BeanKey<T> beanKey = new DefaultBeanContext.BeanKey<>(beanType, qualifier);
+        return singletonByArgumentAndQualifier.containsKey(beanKey);
+    }
+
+    /**
+     * @return Active singleton registrations
+     */
+    @NonNull
+    Collection<BeanRegistration> getBeanRegistrations() {
+        return singletonByBeanDefinition.values();
+    }
+
+    /**
+     * @param qualifier The qualifier
+     * @return Active singleton registrations by qualifier
+     */
+    @NonNull
+    Collection<BeanRegistration<?>> getBeanRegistrations(@NonNull Qualifier<?> qualifier) {
+        List<BeanRegistration<?>> beanRegistrations = new ArrayList<>();
+        for (BeanRegistration<?> beanRegistration : singletonByBeanDefinition.values()) {
+            BeanDefinition beanDefinition = beanRegistration.beanDefinition;
+            if (qualifier.reduce(beanDefinition.getBeanType(), Stream.of(beanDefinition)).findFirst().isPresent()) {
+                beanRegistrations.add(beanRegistration);
+            }
+        }
+        return beanRegistrations;
+    }
+
+    /**
+     * @param beanType The beanType
+     * @param <T> The bean type
+     * @return Active singleton registrations by beanType
+     */
+    @SuppressWarnings("unchecked")
+    @NonNull
+    <T> Collection<BeanRegistration<T>> getBeanRegistrations(@NonNull Class<T> beanType) {
+        List<BeanRegistration<T>> beanRegistrations = new ArrayList<>();
+        for (BeanRegistration<?> beanRegistration : singletonByBeanDefinition.values()) {
+            BeanDefinition beanDefinition = beanRegistration.beanDefinition;
+            if (beanType.isAssignableFrom(beanDefinition.getBeanType())) {
+                beanRegistrations.add((BeanRegistration<T>) beanRegistration);
+            }
+        }
+        return beanRegistrations;
+    }
+
+    /**
+     * Find active bean registration by provided bean definition and qualifier.
+     *
+     * @param beanDefinition The beanDefinition
+     * @param qualifier      The qualifier
+     * @param <T> The bean type
+     * @return found registration or null
+     */
+    @Nullable
+    <T> BeanRegistration<T> findBeanRegistration(@NonNull BeanDefinition<T> beanDefinition, @Nullable Qualifier<T> qualifier) {
+        return findBeanRegistration(beanDefinition, beanDefinition.asArgument(), qualifier);
+    }
+
+    /**
+     * Find active bean registration by provided identifier.
+     *
+     * @param identifier The identifier
+     * @param <T> The bean type
+     * @return found registration or null
+     */
+    @Nullable
+    <T> BeanRegistration<T> findBeanRegistration(@NonNull BeanIdentifier identifier) {
+        for (BeanRegistration registration : singletonByBeanDefinition.values()) {
+            if (registration.identifier.equals(identifier)) {
+                return registration;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Find active bean registration by provided bean instance.
+     *
+     * @param bean The bean
+     * @param <T> The bean type
+     * @return found registration or null
+     */
+    @Nullable
+    <T> BeanRegistration<T> findBeanRegistration(@Nullable T bean) {
+        if (bean == null) {
+            return null;
+        }
+        for (BeanRegistration beanRegistration : singletonByBeanDefinition.values()) {
+            if (bean == beanRegistration.getBean()) {
+                return beanRegistration;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Find active bean registration by provided bean definition.
+     *
+     * @param definition The
+     * @param <T> The bean type
+     * @return found registration or null
+     */
+    @Nullable
+    <T> BeanRegistration<T> findBeanRegistration(@NonNull BeanDefinition<T> definition) {
+        return singletonByBeanDefinition.get(BeanDefinitionIdentity.of(definition));
+    }
+
+    /**
+     * Find active bean registration by provided bean definition, beanType and qualifier.
+     *
+     * @param beanDefinition The beanDefinition
+     * @param beanType       The beanType
+     * @param qualifier      The qualifier
+     * @param <T> The bean type
+     * @return found registration or null
+     */
+    @Nullable
+    <T> BeanRegistration<T> findBeanRegistration(@NonNull BeanDefinition<T> beanDefinition,
+                                                 @NonNull Argument<T> beanType,
+                                                 @Nullable Qualifier<T> qualifier) {
+        BeanRegistration<T> beanRegistration = singletonByBeanDefinition.get(BeanDefinitionIdentity.of(beanDefinition));
+        if (beanRegistration == null) {
+            return findCachedSingletonBeanRegistration(beanType, qualifier);
+        }
+        return beanRegistration;
+    }
+
+    /**
+     * Find cached singleton registration by beanType and qualifier.
+     * <p>
+     * If the result is null it doesn't mean singleton is not present.
+     *
+     * @param beanType  The bean type
+     * @param qualifier The qualifier
+     * @param <T>       The type
+     * @return found registration.
+     */
+    @Nullable
+    <T> BeanRegistration<T> findCachedSingletonBeanRegistration(@NonNull Argument<T> beanType, @Nullable Qualifier<T> qualifier) {
+        DefaultBeanContext.BeanKey<T> beanKey = new DefaultBeanContext.BeanKey<>(beanType, qualifier);
+        BeanRegistration<T> beanRegistration = singletonByArgumentAndQualifier.get(beanKey);
+        if (beanRegistration != null && beanRegistration.bean != null) {
+            return beanRegistration;
+        }
+        return null;
+    }
+
+    /**
+     * Find cached singleton registration's bean definition by beanType and qualifier.
+     * <p>
+     * If the result is null it doesn't mean singleton is not present.
+     *
+     * @param beanType  The bean type
+     * @param qualifier The qualifier
+     * @param <T>       The type
+     * @return found registration's bean definition.
+     */
+    @Nullable
+    <T> BeanDefinition<T> findCachedSingletonBeanDefinition(@NonNull Argument<T> beanType, @Nullable Qualifier<T> qualifier) {
+        BeanRegistration<T> reg = findCachedSingletonBeanRegistration(beanType, qualifier);
+        if (reg != null) {
+            return reg.getBeanDefinition();
+        }
+        return null;
+    }
+
+    /**
+     * Purge cached instances by {@link BeanDefinition} and an instance.
+     *
+     * @param beanDefinition The bean definition
+     * @param bean           The bean
+     * @param <T>            The bean type
+     */
+    synchronized <T> void purgeCacheForBeanInstance(BeanDefinition<T> beanDefinition, T bean) {
+        singletonByBeanDefinition.remove(BeanDefinitionIdentity.of(beanDefinition));
+        singletonByArgumentAndQualifier.entrySet().removeIf(entry -> entry.getKey().beanType.isInstance(bean));
+    }
+
+    /**
+     * Cleanup the scope.
+     */
+    void clear() {
+        singletonByBeanDefinition.clear();
+        singletonByArgumentAndQualifier.clear();
+    }
+
+    /**
+     * The bean definition identity implementation.
+     *
+     * @author Denis Stepanov
+     * @since 3.5.0
+     */
+    interface BeanDefinitionIdentity {
+
+        static BeanDefinitionIdentity of(BeanDefinition<?> beanDefinition) {
+            if (beanDefinition instanceof BeanDefinitionDelegate) {
+                return new BeanDefinitionDelegatedIdentity((BeanDefinitionDelegate) beanDefinition);
+            }
+            if (beanDefinition instanceof NoInjectionBeanDefinition) {
+                return new NoInjectionBeanDefinitionIdentity((NoInjectionBeanDefinition) beanDefinition);
+            }
+            return new SimpleBeanDefinitionIdentity(beanDefinition);
+        }
+
+    }
+
+    /**
+     * Simple key object that compares {@link BeanDefinitionDelegate}s by its class name and attributes.
+     *
+     * @since 3.5.0
+     */
+    static final class BeanDefinitionDelegatedIdentity implements BeanDefinitionIdentity {
+
+        private final BeanDefinitionDelegate beanDefinitionDelegate;
+
+        BeanDefinitionDelegatedIdentity(BeanDefinitionDelegate beanDefinitionDelegate) {
+            this.beanDefinitionDelegate = beanDefinitionDelegate;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            BeanDefinitionDelegatedIdentity that = (BeanDefinitionDelegatedIdentity) o;
+            if (beanDefinitionDelegate.definition.getClass() != that.beanDefinitionDelegate.definition.getClass()) {
+                return false;
+            }
+            return beanDefinitionDelegate.getAttributes().equals(that.beanDefinitionDelegate.getAttributes());
+        }
+
+        @Override
+        public int hashCode() {
+            return beanDefinitionDelegate.definition.hashCode();
+        }
+    }
+
+    /**
+     * Simple key object that compares {@link BeanDefinitionDelegate}s by its class name and attributes.
+     *
+     * @since 3.5.0
+     */
+    static final class NoInjectionBeanDefinitionIdentity implements BeanDefinitionIdentity {
+
+        private final NoInjectionBeanDefinition beanDefinition;
+
+        NoInjectionBeanDefinitionIdentity(NoInjectionBeanDefinition beanDefinition) {
+            this.beanDefinition = beanDefinition;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            NoInjectionBeanDefinitionIdentity that = (NoInjectionBeanDefinitionIdentity) o;
+            if (beanDefinition.getBeanType() != that.beanDefinition.getBeanType()) {
+                return false;
+            }
+            Qualifier qualifier = beanDefinition.getQualifier();
+            Qualifier thatQualifier = that.beanDefinition.getQualifier();
+            if (qualifier == thatQualifier) {
+                return true;
+            }
+            return qualifier != null && qualifier.equals(thatQualifier);
+        }
+
+        @Override
+        public int hashCode() {
+            return beanDefinition.getBeanType().hashCode();
+        }
+    }
+
+    /**
+     * Simple key object that compares {@link BeanDefinition}s by its class name.
+     * It's possible we have multiple instances of the same bean definition.
+     *
+     * @since 3.5.0
+     */
+    static final class SimpleBeanDefinitionIdentity implements BeanDefinitionIdentity {
+
+        private final Class<?> beanDefinitionClass;
+
+        SimpleBeanDefinitionIdentity(BeanDefinition<?> beanDefinition) {
+            this.beanDefinitionClass = beanDefinition.getClass();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            SimpleBeanDefinitionIdentity that = (SimpleBeanDefinitionIdentity) o;
+            return beanDefinitionClass == that.beanDefinitionClass;
+        }
+
+        @Override
+        public int hashCode() {
+            return beanDefinitionClass.hashCode();
+        }
+    }
+
+}

--- a/inject/src/main/java/io/micronaut/context/SingletonScope.java
+++ b/inject/src/main/java/io/micronaut/context/SingletonScope.java
@@ -86,21 +86,21 @@ final class SingletonScope {
             // In some cases you can register an instance of non-singleton bean and expect it act as a singleton
             // Current test `RegisterSingletonSpec "test register singleton method"` does it because of the present @Inject annotation
             // This might be something to remove in 4.0
-            DefaultBeanContext.BeanKey<T> beanKey = new DefaultBeanContext.BeanKey(beanDefinition, qualifier);
+            DefaultBeanContext.BeanKey<T> beanKey = new DefaultBeanContext.BeanKey<>(beanDefinition, qualifier);
             singletonByArgumentAndQualifier.put(beanKey, registration);
         }
         if (beanDefinition instanceof BeanDefinitionDelegate || beanDefinition instanceof NoInjectionBeanDefinition) {
             // Special cases when custom bean definitions need to be indexed:
             // BeanDefinitionDelegate - doesn't really exist with a custom qualifier
             // NoInjectionBeanDefinition - cannot be properly selected from 'beanDefinitionsClasses' when is used with a custom qualifier
-            DefaultBeanContext.BeanKey<T> beanKey = new DefaultBeanContext.BeanKey(beanDefinition, beanDefinition.getDeclaredQualifier());
+            DefaultBeanContext.BeanKey<T> beanKey = new DefaultBeanContext.BeanKey<>(beanDefinition, beanDefinition.getDeclaredQualifier());
             singletonByArgumentAndQualifier.put(beanKey, registration);
         }
         if (createdBean != null && createdBean.getClass() != beanDefinition.getBeanType()) {
             // If the actual type differs, allow to inject the actual implementation for cases like:
             // `MyInterface factoryBean() { new Impl.. }`
             // This might be something to remove in 4.0
-            DefaultBeanContext.BeanKey<T> concrete = new DefaultBeanContext.BeanKey(createdBean.getClass(), qualifier);
+            DefaultBeanContext.BeanKey<T> concrete = new DefaultBeanContext.BeanKey<>((Class<T>) createdBean.getClass(), qualifier);
             singletonByArgumentAndQualifier.put(concrete, registration);
         }
         return registration;
@@ -313,10 +313,10 @@ final class SingletonScope {
 
         static BeanDefinitionIdentity of(BeanDefinition<?> beanDefinition) {
             if (beanDefinition instanceof BeanDefinitionDelegate) {
-                return new BeanDefinitionDelegatedIdentity((BeanDefinitionDelegate) beanDefinition);
+                return new BeanDefinitionDelegatedIdentity((BeanDefinitionDelegate<?>) beanDefinition);
             }
             if (beanDefinition instanceof NoInjectionBeanDefinition) {
-                return new NoInjectionBeanDefinitionIdentity((NoInjectionBeanDefinition) beanDefinition);
+                return new NoInjectionBeanDefinitionIdentity((NoInjectionBeanDefinition<?>) beanDefinition);
             }
             return new SimpleBeanDefinitionIdentity(beanDefinition);
         }
@@ -330,9 +330,9 @@ final class SingletonScope {
      */
     static final class BeanDefinitionDelegatedIdentity implements BeanDefinitionIdentity {
 
-        private final BeanDefinitionDelegate beanDefinitionDelegate;
+        private final BeanDefinitionDelegate<?> beanDefinitionDelegate;
 
-        BeanDefinitionDelegatedIdentity(BeanDefinitionDelegate beanDefinitionDelegate) {
+        BeanDefinitionDelegatedIdentity(BeanDefinitionDelegate<?> beanDefinitionDelegate) {
             this.beanDefinitionDelegate = beanDefinitionDelegate;
         }
 
@@ -364,9 +364,9 @@ final class SingletonScope {
      */
     static final class NoInjectionBeanDefinitionIdentity implements BeanDefinitionIdentity {
 
-        private final NoInjectionBeanDefinition beanDefinition;
+        private final NoInjectionBeanDefinition<?> beanDefinition;
 
-        NoInjectionBeanDefinitionIdentity(NoInjectionBeanDefinition beanDefinition) {
+        NoInjectionBeanDefinitionIdentity(NoInjectionBeanDefinition<?> beanDefinition) {
             this.beanDefinition = beanDefinition;
         }
 
@@ -382,8 +382,8 @@ final class SingletonScope {
             if (beanDefinition.getBeanType() != that.beanDefinition.getBeanType()) {
                 return false;
             }
-            Qualifier qualifier = beanDefinition.getQualifier();
-            Qualifier thatQualifier = that.beanDefinition.getQualifier();
+            Qualifier<?> qualifier = beanDefinition.getQualifier();
+            Qualifier<?> thatQualifier = that.beanDefinition.getQualifier();
             if (qualifier == thatQualifier) {
                 return true;
             }

--- a/inject/src/main/java/io/micronaut/context/SingletonScope.java
+++ b/inject/src/main/java/io/micronaut/context/SingletonScope.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.context;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.type.Argument;
@@ -35,6 +36,7 @@ import java.util.stream.Stream;
  * @author Denis Stepanov
  * @since 3.5.0
  */
+@Internal
 final class SingletonScope {
 
     private final DefaultBeanContext beanContext;

--- a/inject/src/test/groovy/io/micronaut/context/DefaultBeanContextSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/DefaultBeanContextSpec.groovy
@@ -1,0 +1,70 @@
+package io.micronaut.context
+
+
+import io.micronaut.core.type.Argument
+import spock.lang.Specification
+
+class DefaultBeanContextSpec extends Specification {
+
+    def "test null safe methods and special cases"() {
+        given:
+            DefaultBeanContext beanContext = new DefaultBeanContext()
+            beanContext.start()
+
+        expect:
+            beanContext.resolveMetadata(null).isEmpty()
+            !beanContext.refreshBean(null).isPresent()
+            beanContext.getActiveBeanRegistrations((Qualifier) null).isEmpty()
+            beanContext.getBeanRegistrations(null).isEmpty()
+            beanContext.getBeanRegistrations((Class) null, null).isEmpty()
+            !beanContext.findBeanRegistration(null).isPresent()
+            !beanContext.findExecutionHandle(System, "xyz").isPresent()
+            !beanContext.findExecutableMethod(null, "xyz", null).isPresent()
+            !beanContext.findExecutionHandle(null, "xyz", null).isPresent()
+            !beanContext.findBeanDefinition(Argument.OBJECT_ARGUMENT, null).isPresent()
+            !beanContext.findBeanDefinition(Argument.OBJECT_ARGUMENT, null).isPresent()
+            beanContext.getActiveBeanRegistration(null, null) == null
+            beanContext.getBeanDefinitions((Qualifier) null).isEmpty()
+
+
+        cleanup:
+            beanContext.close()
+    }
+
+    def "test attributes"() {
+        given:
+            DefaultBeanContext beanContext = new DefaultBeanContext()
+            beanContext.start()
+
+        when:
+            def attributes = beanContext.getAttributes()
+        then:
+            attributes.isEmpty()
+            !beanContext.getAttribute("xyz").isPresent()
+            !beanContext.getAttribute("xyz", String).isPresent()
+            !beanContext.getAttribute("xyz", Integer).isPresent()
+
+        when:
+            beanContext.setAttribute("xyz", 123)
+            beanContext.setAttribute(null, 222)
+
+        then:
+            !attributes.isEmpty()
+            beanContext.getAttribute("xyz").get() == 123
+            beanContext.getAttribute("xyz", String).get() == "123"
+            beanContext.getAttribute("xyz", Integer).get() == 123
+
+        when:
+            beanContext.removeAttribute("xyz", Integer)
+            beanContext.removeAttribute("fff", Integer)
+        then:
+            attributes.isEmpty()
+            !beanContext.getAttribute("xyz").isPresent()
+            !beanContext.getAttribute("xyz", String).isPresent()
+            !beanContext.getAttribute("xyz", Integer).isPresent()
+
+        cleanup:
+            beanContext.close()
+    }
+
+}

--- a/test-suite-jakarta-inject-bean-import/src/test/groovy/io/micronaut/jakartainject/tck/beanimport/BeanImportSpec.groovy
+++ b/test-suite-jakarta-inject-bean-import/src/test/groovy/io/micronaut/jakartainject/tck/beanimport/BeanImportSpec.groovy
@@ -13,7 +13,7 @@ class BeanImportSpec extends AbstractTypeElementSpec {
 
     void "test parse bean import"() {
         given:
-        def context = buildContext('''
+        ApplicationContext context = buildContext('''
 package beanimporttest;
 
 import io.micronaut.context.annotation.Import;
@@ -27,9 +27,9 @@ class BeanImportTest {
 ''')
         when:
         Car car = getBean(context, 'org.atinject.tck.auto.Car')
-        def test = Tck.testsFor(car, false, true)
+        Test test = Tck.testsFor(car, false, true)
 
-        def result = new TestResult()
+        TestResult result = new TestResult()
         test.run(result)
 
         then:

--- a/test-suite-jakarta-inject-bean-import/src/test/java/io/micronaut/jakartainject/tck/beanimport/BeanImportTck.java
+++ b/test-suite-jakarta-inject-bean-import/src/test/java/io/micronaut/jakartainject/tck/beanimport/BeanImportTck.java
@@ -2,18 +2,26 @@ package io.micronaut.jakartainject.tck.beanimport;
 
 import io.micronaut.context.BeanContext;
 import io.micronaut.context.annotation.Import;
-import junit.framework.Test;
+import junit.framework.TestResult;
 import org.atinject.tck.Tck;
 import org.atinject.tck.auto.Car;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Import(
         packages = {"org.atinject.tck.auto", "org.atinject.tck.auto.accessories"},
         annotated = "*")
-public class BeanImportTck {
+class BeanImportTck {
 
-    public static Test suite() {
+    @Test
+    void suite() {
         BeanContext beanContext = BeanContext.run();
-        // Tests are running after this method, keep the bean context open
-        return Tck.testsFor(beanContext.getBean(Car.class), false, true);
+        junit.framework.Test test = Tck.testsFor(beanContext.getBean(Car.class), false, true);
+        TestResult result = new TestResult();
+        test.run(result);
+        assertTrue(result.runCount() > 0);
+        assertTrue(result.wasSuccessful());
+        beanContext.close();
     }
 }

--- a/test-suite-jakarta-inject-bean-import/src/test/java/io/micronaut/jakartainject/tck/beanimport/BeanImportTck.java
+++ b/test-suite-jakarta-inject-bean-import/src/test/java/io/micronaut/jakartainject/tck/beanimport/BeanImportTck.java
@@ -12,8 +12,8 @@ import org.atinject.tck.auto.Car;
 public class BeanImportTck {
 
     public static Test suite() {
-        try (BeanContext beanContext = BeanContext.run()) {
-            return Tck.testsFor(beanContext.getBean(Car.class), false, true);
-        }
+        BeanContext beanContext = BeanContext.run();
+        // Tests are running after this method, keep the bean context open
+        return Tck.testsFor(beanContext.getBean(Car.class), false, true);
     }
 }


### PR DESCRIPTION
Multiple improvements for CDI implementation:

- Delegate AbstractInitializableBeanDefinition bean context interaction thru BeanResolutionContext, allowing to inject of custom implementations and aggregate dependable beans
- Refactor of DefaultBeanContext to have main getBean methods return the bean definition which CDI impl. might need to determine the scope of the bean. New methods to get bean registration by the bean definition.

Big refactoring of bean context:
- Extract everything related to the singleton into one class to reduce the size of `DefaultBeanContext`
- Changed how singletons are stored, instead of multiple entries of argument-qualifier keys now there is one representation of `BeanDefinition -> BeanRegistration` plus the fast lookup by argument-qualifier
- Removed duplicate logic
- Added correct `stop` context cleanup, which also spotted a few tests that were using the context after it's been closed
- Extracted some methods to make code more readable

Sonar fixes to introduce generics and simplify methods