### PR TITLE
Allow fetching version props from included boms

### DIFF
--- a/buildSrc/src/main/groovy/io/micronaut/build/internal/WriteMicronautVersionInfoTask.java
+++ b/buildSrc/src/main/groovy/io/micronaut/build/internal/WriteMicronautVersionInfoTask.java
@@ -1,0 +1,102 @@
+package io.micronaut.build.internal;
+
+import groovy.lang.Closure;
+import groovy.xml.XmlSlurper;
+import groovy.xml.slurpersupport.GPathResult;
+import groovy.xml.slurpersupport.NodeChild;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.ResolvedArtifact;
+import org.gradle.api.artifacts.ResolvedDependency;
+import org.gradle.api.artifacts.result.ArtifactResolutionResult;
+import org.gradle.api.artifacts.result.ComponentArtifactsResult;
+import org.gradle.api.artifacts.result.ResolvedArtifactResult;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.maven.MavenModule;
+import org.gradle.maven.MavenPomArtifact;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.TreeMap;
+
+@CacheableTask
+public abstract class WriteMicronautVersionInfoTask extends DefaultTask {
+
+    public static final String MICRONAUT_VERSIONS_PROPERTIES_FILE_NAME = "micronaut-versions.properties";
+
+    @Input
+    public abstract Property<String> getVersion();
+
+    @Input
+    public abstract ListProperty<String> getExtraBomProperties();
+
+    @OutputDirectory
+    public abstract DirectoryProperty getOutputDirectory();
+
+    public WriteMicronautVersionInfoTask() {
+        getOutputs().doNotCacheIf("snapshot version", spec -> getVersion().get().endsWith("SNAPSHOT"));
+    }
+
+    @TaskAction
+    public void writeVersionInfo() throws IOException {
+        Map<String, String> props = new TreeMap<>();
+        for (Dependency dependency : getProject().getConfigurations().getByName("bomVersions").getAllDependencies()) {
+            getLogger().lifecycle("Scanning {}:{}:{}", dependency.getGroup(), dependency.getName(), dependency.getVersion());
+            Map<String, String> bomProperties = bomProperties(dependency.getGroup(), dependency.getName(), dependency.getVersion());
+            for (Map.Entry<String, String> entry : bomProperties.entrySet()) {
+                if (entry.getKey().startsWith("micronaut.")) {
+                    getLogger().lifecycle("Skipping {} from {}", entry.getKey(), dependency);
+                } else {
+                    if (props.containsKey(entry.getKey())) {
+                        getLogger().warn("Property {} from {} already exists ({}). Replacing with {}", entry.getKey(), dependency, props.get(entry.getKey()), entry.getValue());
+                    }
+                    props.put(entry.getKey(), entry.getValue());
+                }
+            }
+        }
+        try (OutputStream out = new FileOutputStream(getOutputDirectory().file(MICRONAUT_VERSIONS_PROPERTIES_FILE_NAME).get().getAsFile())) {
+            for (Map.Entry<String, String> entry : props.entrySet()) {
+                String line = entry.getKey() + "=" + entry.getValue() + "\n";
+                out.write(line.getBytes(StandardCharsets.ISO_8859_1));
+            }
+        }
+    }
+
+    private Map<String, String> bomProperties(String groupId, String artifactId, String version) {
+        ArtifactResolutionResult result = getProject().getDependencies().createArtifactResolutionQuery()
+                .forModule(groupId, artifactId, version)
+                .withArtifacts(MavenModule.class, MavenPomArtifact.class)
+                .execute();
+        Map<String, String> props = new TreeMap<>();
+        for (ComponentArtifactsResult component : result.getResolvedComponents()) {
+            component.getArtifacts(MavenPomArtifact.class).forEach(artifact -> {
+                if (artifact instanceof ResolvedArtifactResult) {
+                    ResolvedArtifactResult resolved = (ResolvedArtifactResult) artifact;
+                    GPathResult pom = null;
+                    try {
+                        pom = new XmlSlurper().parse(resolved.getFile());
+                    } catch (IOException | SAXException | ParserConfigurationException e) {
+                        // ignore
+                    }
+                    ((GPathResult) pom.getProperty("properties")).children().forEach(child -> {
+                        NodeChild node = (NodeChild) child;
+                        props.put(node.name(), node.text());
+                    });
+                }
+            });
+        }
+        return props;
+    }
+}

--- a/buildSrc/src/main/groovy/io/micronaut/build/internal/WriteMicronautVersionInfoTask.java
+++ b/buildSrc/src/main/groovy/io/micronaut/build/internal/WriteMicronautVersionInfoTask.java
@@ -13,7 +13,10 @@ import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.maven.MavenModule;
 import org.gradle.maven.MavenPomArtifact;
@@ -35,8 +38,9 @@ public abstract class WriteMicronautVersionInfoTask extends DefaultTask {
     @Input
     public abstract Property<String> getVersion();
 
-    @Input
-    public abstract Property<Configuration> getConfiguration();
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
+    public Configuration configuration;
 
     @OutputDirectory
     public abstract DirectoryProperty getOutputDirectory();
@@ -44,7 +48,7 @@ public abstract class WriteMicronautVersionInfoTask extends DefaultTask {
     @TaskAction
     public void writeVersionInfo() throws IOException {
         Map<String, String> props = new TreeMap<>();
-        for (Dependency dependency : getConfiguration().get().getAllDependencies()) {
+        for (Dependency dependency : configuration.getAllDependencies()) {
             getLogger().lifecycle("Scanning {}:{}:{}", dependency.getGroup(), dependency.getName(), dependency.getVersion());
             Map<String, String> bomProperties = bomProperties(dependency.getGroup(), dependency.getName(), dependency.getVersion());
             for (Map.Entry<String, String> entry : bomProperties.entrySet()) {
@@ -90,5 +94,9 @@ public abstract class WriteMicronautVersionInfoTask extends DefaultTask {
             });
         }
         return props;
+    }
+
+    public Configuration getConfiguration() {
+        return configuration;
     }
 }

--- a/buildSrc/src/main/groovy/io/micronaut/build/internal/WriteMicronautVersionInfoTask.java
+++ b/buildSrc/src/main/groovy/io/micronaut/build/internal/WriteMicronautVersionInfoTask.java
@@ -10,7 +10,6 @@ import org.gradle.api.artifacts.result.ArtifactResolutionResult;
 import org.gradle.api.artifacts.result.ComponentArtifactsResult;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.file.DirectoryProperty;
-import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Input;
@@ -21,7 +20,6 @@ import org.gradle.maven.MavenPomArtifact;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
@@ -39,9 +37,6 @@ public abstract class WriteMicronautVersionInfoTask extends DefaultTask {
 
     @Input
     public abstract Property<Configuration> getConfiguration();
-
-    @Input
-    public abstract ListProperty<String> getExtraBomProperties();
 
     @OutputDirectory
     public abstract DirectoryProperty getOutputDirectory();

--- a/parent/build.gradle
+++ b/parent/build.gradle
@@ -17,9 +17,7 @@ dependencies {
 
 def micronautVersionInfo = tasks.register("micronautVersionInfo", WriteMicronautVersionInfoTask) {
     it.version = projectVersion
-    it.extraBomProperties = [
-            'io.micronaut.grpc:micronaut-grpc'
-    ]
+    it.configuration.set(configurations.bomVersions)
     it.outputDirectory = layout.buildDirectory.dir("version-info")
 }
 

--- a/parent/build.gradle
+++ b/parent/build.gradle
@@ -1,3 +1,22 @@
+import io.micronaut.build.internal.WriteMicronautVersionInfoTask
+
+apply plugin:'base'
+
+configurations {
+    bomVersions
+}
+
+repositories {
+    mavenCentral()
+}
+
+// Include any of our boms that hava required properties
+dependencies {
+    bomVersions(libs.boms.micronaut.grpc)
+}
+
+def directory = layout.buildDirectory.dir("version-info")
+
 group projectGroupId
 version projectVersion
 
@@ -32,6 +51,10 @@ ext.extraPomInfo = {
         'maven-shade-plugin.version'('3.2.4')
         'maven-surefire-plugin.version'('2.22.2') // Override actual Maven surefire and failsafe version (2.12) to get native support for executing tests on the JUnit Platform (JUnit 5)
         'protoc-jar-maven-plugin.version'('3.11.4')
+        // inject the properties from the required boms
+        directory.get().file(WriteMicronautVersionInfoTask.MICRONAUT_VERSIONS_PROPERTIES_FILE_NAME).asFile.text.readLines()*.split('=', 2).each {
+            "${it[0]}"(it[1])
+        }
     }
     delegate.profiles {
         delegate.profile {
@@ -247,4 +270,18 @@ ext.extraPomInfo = {
     }
 }
 
+def micronautVersionInfo = tasks.register("micronautVersionInfo", WriteMicronautVersionInfoTask) {
+    it.version = projectVersion
+    it.extraBomProperties = [
+            'io.micronaut.grpc:micronaut-grpc'
+    ]
+    it.outputDirectory = directory
+}
+
 apply plugin: "io.micronaut.build.internal.publishing"
+
+afterEvaluate {
+    tasks.named("generatePomFileForMavenPublication", GenerateMavenPom).configure {
+        dependsOn micronautVersionInfo
+    }
+}

--- a/parent/build.gradle
+++ b/parent/build.gradle
@@ -15,7 +15,13 @@ dependencies {
     bomVersions(libs.boms.micronaut.grpc)
 }
 
-def directory = layout.buildDirectory.dir("version-info")
+def micronautVersionInfo = tasks.register("micronautVersionInfo", WriteMicronautVersionInfoTask) {
+    it.version = projectVersion
+    it.extraBomProperties = [
+            'io.micronaut.grpc:micronaut-grpc'
+    ]
+    it.outputDirectory = layout.buildDirectory.dir("version-info")
+}
 
 group projectGroupId
 version projectVersion
@@ -52,7 +58,11 @@ ext.extraPomInfo = {
         'maven-surefire-plugin.version'('2.22.2') // Override actual Maven surefire and failsafe version (2.12) to get native support for executing tests on the JUnit Platform (JUnit 5)
         'protoc-jar-maven-plugin.version'('3.11.4')
         // inject the properties from the required boms
-        directory.get().file(WriteMicronautVersionInfoTask.MICRONAUT_VERSIONS_PROPERTIES_FILE_NAME).asFile.text.readLines()*.split('=', 2).each {
+        micronautVersionInfo.flatMap { it.outputDirectory.file(WriteMicronautVersionInfoTask.MICRONAUT_VERSIONS_PROPERTIES_FILE_NAME) }
+                .get()
+                .asFile
+                .text
+                .readLines()*.split('=', 2).each {
             "${it[0]}"(it[1])
         }
     }
@@ -268,14 +278,6 @@ ext.extraPomInfo = {
             }
         }
     }
-}
-
-def micronautVersionInfo = tasks.register("micronautVersionInfo", WriteMicronautVersionInfoTask) {
-    it.version = projectVersion
-    it.extraBomProperties = [
-            'io.micronaut.grpc:micronaut-grpc'
-    ]
-    it.outputDirectory = directory
 }
 
 apply plugin: "io.micronaut.build.internal.publishing"

--- a/parent/build.gradle
+++ b/parent/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
 def micronautVersionInfo = tasks.register("micronautVersionInfo", WriteMicronautVersionInfoTask) {
     it.version = projectVersion
-    it.configuration.set(configurations.bomVersions)
+    it.configuration = configurations.bomVersions
     it.outputDirectory = layout.buildDirectory.dir("version-info")
 }
 


### PR DESCRIPTION
We require the grpc.version from the grpc bom.  This is no longer managed by the core bom.

This change allows setting a list of projects to fetch the bom form, and these properties are
added to those extracted from the core bom