### PR TITLE
Define Maven plugin versions (#7231)

### DIFF
--- a/parent/build.gradle
+++ b/parent/build.gradle
@@ -27,7 +27,10 @@ ext.extraPomInfo = {
         'function-maven-plugin.version'('0.9.8')
         'jib-maven-plugin.version'('3.1.4')
         'maven-compiler-plugin.version'('3.10.1') // Override actual Maven compiler version (3.1) because some bugs cause annotation processors doesn't work well
+        'maven-deploy-plugin.version'('3.0.0-M2')
         'maven-failsafe-plugin.version'('2.22.2') // Override actual Maven surefire and failsafe version (2.12) to get native support for executing tests on the JUnit Platform (JUnit 5)
+        'maven-install-plugin.version'('3.0.0-M1')
+        'maven-jar-plugin.version'('3.2.2')
         'maven-resources-plugin.version'('3.2.0')
         'maven-shade-plugin.version'('3.2.4')
         'maven-surefire-plugin.version'('2.22.2') // Override actual Maven surefire and failsafe version (2.12) to get native support for executing tests on the JUnit Platform (JUnit 5)
@@ -146,6 +149,21 @@ ext.extraPomInfo = {
                     delegate.version '${azure-functions-maven-plugin.version}'
                 }
 
+                delegate.plugin {
+                    groupId "org.apache.maven.plugins"
+                    artifactId "maven-deploy-plugin"
+                    delegate.version '${maven-deploy-plugin.version}'
+                }
+                delegate.plugin {
+                    groupId "org.apache.maven.plugins"
+                    artifactId "maven-install-plugin"
+                    delegate.version '${maven-install-plugin.version}'
+                }
+                delegate.plugin {
+                    groupId "org.apache.maven.plugins"
+                    artifactId "maven-jar-plugin"
+                    delegate.version '${maven-jar-plugin.version}'
+                }
                 delegate.plugin {
                     groupId "org.apache.maven.plugins"
                     artifactId "maven-resources-plugin"


### PR DESCRIPTION
Due to the fact that some Maven plugin versions aren't defined in the
Micronaut BOM the metadata for those plugins are downloaded, even when
the latest plugins are already available locally.

By defining the versions for those plugins we prevent the extra
downloads.