### PR TITLE
Ignore unrecoverable ClosedChannelException errors

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/HttpPipelineBuilder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/HttpPipelineBuilder.java
@@ -354,6 +354,16 @@ final class HttpPipelineBuilder {
         void configureForAlpn() {
             pipeline.addLast(new ApplicationProtocolNegotiationHandler(server.getServerConfiguration().getFallbackProtocol()) {
                 @Override
+                public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                    if (routingInBoundHandler.isIgnorable(cause)) {
+                        // just abandon ship, nothing can be done here to recover
+                        ctx.close();
+                    } else {
+                        super.exceptionCaught(ctx, cause);
+                    }
+                }
+
+                @Override
                 public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
                     if (evt instanceof SslHandshakeCompletionEvent) {
                         SslHandshakeCompletionEvent event = (SslHandshakeCompletionEvent) evt;

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
@@ -1419,7 +1419,15 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
         return byteBuf;
     }
 
-    private boolean isIgnorable(Throwable cause) {
+    /**
+     * Is the exception ignorable by Micronaut.
+     * @param cause The cause
+     * @return True if it can be ignored.
+     */
+    protected boolean isIgnorable(Throwable cause) {
+        if (cause instanceof ClosedChannelException || cause.getCause() instanceof ClosedChannelException) {
+            return true;
+        }
         String message = cause.getMessage();
         return cause instanceof IOException && message != null && IGNORABLE_ERROR_MESSAGE.matcher(message).matches();
     }


### PR DESCRIPTION
Spurious log entries exist when an HTTP/2 browser drops the connection as a ClosedChannelException exception is thrown and propagated down the pipeline. Since it is not possible to recover from these exceptions this change just alters the behavior to swallow them the same as connection reset IO exceptions.

Fixes #7244