### PR TITLE
Newly introduced annotation should not break inherited qualifier/scope

### DIFF
--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -1125,6 +1125,11 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                     );
                     AnnotationMetadata producedTypeAnnotationMetadata = annotationUtils.getAnnotationMetadata(producedTypeElement);
                     AnnotationMetadata elementAnnotationMetadata = annotationUtils.getAnnotationMetadata(element);
+                    if (elementAnnotationMetadata instanceof AnnotationMetadataHierarchy) {
+                        // If the element has added annotation from a type visitor, annotation metadata is a hierarchy
+                        // We only need actual element metadata
+                        elementAnnotationMetadata = elementAnnotationMetadata.getDeclaredMetadata();
+                    }
                     cleanupScopeAndQualifierAnnotations((MutableAnnotationMetadata) producedAnnotationMetadata, producedTypeAnnotationMetadata, elementAnnotationMetadata);
                     producedTypeName = producedTypeElement.getQualifiedName().toString();
                 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/factory/BasicVisitor.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/factory/BasicVisitor.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.factory;
+
+import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.ast.Element;
+import io.micronaut.inject.ast.FieldElement;
+import io.micronaut.inject.ast.MethodElement;
+import io.micronaut.inject.visitor.TypeElementVisitor;
+import io.micronaut.inject.visitor.VisitorContext;
+
+public class BasicVisitor implements TypeElementVisitor<Object, Object> {
+
+    @Override
+    public void visitMethod(MethodElement element, VisitorContext context) {
+        visitElement(element);
+    }
+
+    @Override
+    public void visitField(FieldElement element, VisitorContext context) {
+        visitElement(element);
+
+    }
+
+    @Override
+    public void visitClass(ClassElement element, VisitorContext context) {
+        visitElement(element);
+    }
+
+    private void visitElement(Element element) {
+        if (element.hasAnnotation(RemappedAnnotation.class)) {
+            element.annotate(NewAnnotation.class);
+        }
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/factory/NewAnnotation.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/factory/NewAnnotation.java
@@ -1,0 +1,14 @@
+package io.micronaut.inject.factory;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE, ElementType.TYPE, ElementType.FIELD})
+public @interface NewAnnotation {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/factory/RemappedAnnotation.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/factory/RemappedAnnotation.java
@@ -1,0 +1,14 @@
+package io.micronaut.inject.factory;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE, ElementType.TYPE, ElementType.FIELD})
+public @interface RemappedAnnotation {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/factory/beanmethod/FactoryBeanMethodSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/factory/beanmethod/FactoryBeanMethodSpec.groovy
@@ -61,6 +61,21 @@ class TestFactory$TestMethod {
     Bar6 bar6() {
         return new Bar6();    
     }
+    
+    @io.micronaut.inject.factory.RemappedAnnotation
+    @Bean
+    @Xyz
+    @Prototype
+    Bar7 bar7() {
+        return new Bar7();    
+    }
+    
+    @Bean
+    @Xyz
+    @Prototype
+    Bar8 bar8() {
+        return new Bar8();    
+    }
 }
 
 @Abc
@@ -89,6 +104,17 @@ class Bar5 {
 @Abc
 @Singleton
 class Bar6 {
+}
+
+@Abc
+@Singleton
+class Bar7 {
+}
+
+@Abc
+@Singleton
+@io.micronaut.inject.factory.RemappedAnnotation
+class Bar8 {
 }
 
 @Retention(RUNTIME)
@@ -127,6 +153,12 @@ class Bar6 {
             def bar6BeanDefinition = context.getBeanDefinitions(context.classLoader.loadClass('test.Bar6'))
                     .find {it.getDeclaringType().get().simpleName.contains("TestFactory")}
 
+            def bar7BeanDefinition = context.getBeanDefinitions(context.classLoader.loadClass('test.Bar7'))
+                    .find {it.getDeclaringType().get().simpleName.contains("TestFactory")}
+
+            def bar8BeanDefinition = context.getBeanDefinitions(context.classLoader.loadClass('test.Bar8'))
+                    .find {it.getDeclaringType().get().simpleName.contains("TestFactory")}
+
         then:
             bar1BeanDefinition.getScope().get() == Prototype.class
             bar1BeanDefinition.declaredQualifier == null
@@ -155,6 +187,16 @@ class Bar6 {
             bar6BeanDefinition.getScope().get() == Prototype.class
             bar6BeanDefinition.declaredQualifier.toString() == "@Named('test.Xyz')"
             bar6BeanDefinition.getAnnotationNamesByStereotype(AnnotationUtil.SCOPE).size() == 1
+        and:
+            bar7BeanDefinition.getScope().get() == Prototype.class
+            bar7BeanDefinition.declaredQualifier.toString() == "@Named('test.Xyz')"
+            bar7BeanDefinition.getAnnotationNamesByStereotype(AnnotationUtil.SCOPE).size() == 1
+            bar7BeanDefinition.hasAnnotation(io.micronaut.inject.factory.RemappedAnnotation)
+        and:
+            bar8BeanDefinition.getScope().get() == Prototype.class
+            bar8BeanDefinition.declaredQualifier.toString() == "@Named('test.Xyz')"
+            bar8BeanDefinition.getAnnotationNamesByStereotype(AnnotationUtil.SCOPE).size() == 1
+            bar8BeanDefinition.hasAnnotation(io.micronaut.inject.factory.RemappedAnnotation)
 
         cleanup:
             context.close()

--- a/inject-java/src/test/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
+++ b/inject-java/src/test/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
@@ -3,3 +3,4 @@ io.micronaut.visitors.IntroductionVisitor
 io.micronaut.visitors.AllElementsVisitor
 io.micronaut.visitors.AllClassesVisitor
 io.micronaut.visitors.InjectVisitor
+io.micronaut.inject.factory.BasicVisitor

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -2686,13 +2686,16 @@ public class DefaultBeanContext implements InitializableBeanContext {
                     path.pushBeanCreate(definition, beanType);
                 }
                 try {
+                    List<BeanRegistration<?>> dependentBeans = context.popDependentBeans();
                     T createdBean = doCreateBean(context, definition, qualifier);
-                    return singletonScope.registerSingletonBean(
+                    BeanRegistration<T> registration = singletonScope.registerSingletonBean(
                             definition,
                             qualifier,
                             createdBean,
                             context.getAndResetDependentBeans()
                     );
+                    context.pushDependentBeans(dependentBeans);
+                    return registration;
                 } finally {
                     if (isNewPath) {
                         path.pop();
@@ -2758,14 +2761,17 @@ public class DefaultBeanContext implements InitializableBeanContext {
                         @NonNull
                         @Override
                         public CreatedBean<T> create() throws BeanCreationException {
+                            List<BeanRegistration<?>> dependentBeans = resolutionContext.popDependentBeans();
                             final T bean = doCreateBean(resolutionContext, finalDefinition, beanType, qualifier);
-                            return BeanRegistration.of(
+                            BeanRegistration<T> registration = BeanRegistration.of(
                                     DefaultBeanContext.this,
                                     beanKey,
                                     finalDefinition,
                                     bean,
                                     resolutionContext.getAndResetDependentBeans()
                             );
+                            resolutionContext.pushDependentBeans(dependentBeans);
+                            return registration;
                         }
                     }
             );

--- a/inject/src/main/java/io/micronaut/inject/BeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/inject/BeanDefinition.java
@@ -15,22 +15,23 @@
  */
 package io.micronaut.inject;
 
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.BeanResolutionContext;
+import io.micronaut.context.Qualifier;
 import io.micronaut.context.annotation.DefaultScope;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.EachProperty;
 import io.micronaut.context.annotation.Provided;
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.AnnotationMetadataDelegate;
 import io.micronaut.core.annotation.AnnotationUtil;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
-import io.micronaut.context.BeanContext;
-import io.micronaut.context.BeanResolutionContext;
-import io.micronaut.context.Qualifier;
-import io.micronaut.core.annotation.AnnotationMetadataDelegate;
 import io.micronaut.core.naming.Named;
 import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.type.ArgumentCoercible;
-import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
 import io.micronaut.inject.qualifiers.Qualifiers;
 import jakarta.inject.Singleton;
 
@@ -421,29 +422,34 @@ public interface BeanDefinition<T> extends AnnotationMetadataDelegate, Named, Be
      * @return The qualifier or null if this isn't one
      */
     default @Nullable Qualifier<T> getDeclaredQualifier() {
+        AnnotationMetadata annotationMetadata = getAnnotationMetadata();
+        if (annotationMetadata instanceof AnnotationMetadataHierarchy) {
+            // Beans created by a factory will have AnnotationMetadataHierarchy = producing element + factory class
+            // All qualifiers are removed from the factory class anyway, so we can skip the hierarchy
+            annotationMetadata = annotationMetadata.getDeclaredMetadata();
+        }
         final List<String> annotations = getAnnotationNamesByStereotype(AnnotationUtil.QUALIFIER);
-        if (CollectionUtils.isNotEmpty(annotations)) {
+        if (!annotations.isEmpty()) {
             if (annotations.size() == 1) {
                 final String annotation = annotations.iterator().next();
                 if (annotation.equals(Qualifier.PRIMARY)) {
                     // primary is the same as null
                     return null;
                 }
-                return Qualifiers.byAnnotation(this, annotation);
+                return Qualifiers.byAnnotation(annotationMetadata, annotation);
             } else {
-                @SuppressWarnings("rawtypes") final Qualifier[] qualifiers = annotations.stream()
-                        .map((name) -> Qualifiers.byAnnotation(this, name))
-                        .toArray(Qualifier[]::new);
-                //noinspection unchecked
-                return Qualifiers.byQualifiers(
-                        qualifiers
-                );
+                Qualifier<T>[] qualifiers = new Qualifier[annotations.size()];
+                int i = 0;
+                for (String annotationName : annotations) {
+                    qualifiers[i++] = Qualifiers.byAnnotation(annotationMetadata, annotationName);
+                }
+                return Qualifiers.byQualifiers(qualifiers);
             }
         } else {
             Qualifier<T> qualifier = resolveDynamicQualifier();
             if (qualifier == null) {
-                String name = getAnnotationMetadata().stringValue(AnnotationUtil.NAMED).orElse(null);
-                qualifier = name != null ? Qualifiers.byAnnotation(this, name) : null;
+                String name = annotationMetadata.stringValue(AnnotationUtil.NAMED).orElse(null);
+                qualifier = name != null ? Qualifiers.byAnnotation(annotationMetadata, name) : null;
             }
             return qualifier;
         }

--- a/inject/src/main/java/io/micronaut/inject/BeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/inject/BeanDefinition.java
@@ -428,7 +428,7 @@ public interface BeanDefinition<T> extends AnnotationMetadataDelegate, Named, Be
             // All qualifiers are removed from the factory class anyway, so we can skip the hierarchy
             annotationMetadata = annotationMetadata.getDeclaredMetadata();
         }
-        final List<String> annotations = getAnnotationNamesByStereotype(AnnotationUtil.QUALIFIER);
+        final List<String> annotations = annotationMetadata.getAnnotationNamesByStereotype(AnnotationUtil.QUALIFIER);
         if (!annotations.isEmpty()) {
             if (annotations.size() == 1) {
                 final String annotation = annotations.iterator().next();


### PR DESCRIPTION
Somehow if the method has been processed by a type visitor and metadata altered, the cached metadata will be the hierarchy (method + type), for cleaning scope/qualifier annotations we only need the method annotations.