### PR TITLE
Correct dependent beans destruction

### DIFF
--- a/context/src/main/java/io/micronaut/runtime/context/scope/refresh/RefreshScope.java
+++ b/context/src/main/java/io/micronaut/runtime/context/scope/refresh/RefreshScope.java
@@ -161,7 +161,8 @@ public class RefreshScope implements CustomScope<Refreshable>, LifeCycle<Refresh
         for (CreatedBean<?> created : refreshableBeans.values()) {
             if (created.bean() == bean) {
                 //noinspection unchecked
-                return Optional.of(new BeanRegistration<>(
+                return Optional.of(BeanRegistration.of(
+                        beanContext,
                         created.id(),
                         (BeanDefinition<T>) created.definition(),
                         (T) created.bean()

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/DestroyDependentBeansSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/DestroyDependentBeansSpec.groovy
@@ -16,8 +16,8 @@ class DestroyDependentBeansSpec extends Specification {
         TestData.DESTRUCTION_ORDER.clear()
 
         when:
-        def context = ApplicationContext.run()
-        def bean = context.getBean(SingletonBeanA)
+        ApplicationContext context = ApplicationContext.run()
+        SingletonBeanA bean = context.getBean(SingletonBeanA)
 
         then:
         !bean.beanBField.destroyed
@@ -50,9 +50,9 @@ class DestroyDependentBeansSpec extends Specification {
         TestData.DESTRUCTION_ORDER.clear()
         
         when:
-        def context = ApplicationContext.run()
-        def bean = context.getBean(ScopedBeanA)
-        def refreshScope = context.getBean(CustomScope, Qualifiers.byExactTypeArgumentName(Refreshable.class.name))
+        ApplicationContext context = ApplicationContext.run()
+        ScopedBeanA bean = context.getBean(ScopedBeanA)
+        CustomScope refreshScope = context.getBean(CustomScope, Qualifiers.byExactTypeArgumentName(Refreshable.class.name))
 
         then:
         TestData.DESTRUCTION_ORDER.isEmpty()
@@ -64,7 +64,7 @@ class DestroyDependentBeansSpec extends Specification {
 
 
         when:"When the context is stopped"
-        def target = bean.interceptedTarget()
+        ScopedBeanA target = ((InterceptedProxy<ScopedBeanA>) bean).interceptedTarget()
         context.stop()
 
         then:"Dependent objects stored"
@@ -86,8 +86,8 @@ class DestroyDependentBeansSpec extends Specification {
             TestData.DESTRUCTION_ORDER.clear()
 
         when:
-            def context = ApplicationContext.run()
-            def bean = context.getBean(SingletonBeanANoCallback)
+            ApplicationContext context = ApplicationContext.run()
+            SingletonBeanANoCallback bean = context.getBean(SingletonBeanANoCallback)
 
         then:
             !bean.beanBField.destroyed
@@ -137,10 +137,10 @@ class DestroyDependentBeansSpec extends Specification {
             TestData.DESTRUCTION_ORDER.clear()
 
         when:
-            def context = ApplicationContext.run()
-            def beanDefinition = context.getBeanDefinition(PrototypeBeanA)
-            def registration = context.getBeanRegistration(beanDefinition)
-            def bean = registration.bean
+            ApplicationContext context = ApplicationContext.run()
+            BeanDefinition<PrototypeBeanA> beanDefinition = context.getBeanDefinition(PrototypeBeanA)
+            BeanRegistration<PrototypeBeanA> registration = context.getBeanRegistration(beanDefinition)
+            PrototypeBeanA bean = registration.bean
 
         then:
             !bean.beanBField.destroyed
@@ -186,8 +186,8 @@ class DestroyDependentBeansSpec extends Specification {
             TestData.DESTRUCTION_ORDER.clear()
 
         when:
-            def context = ApplicationContext.run()
-            def bean = context.getBean(AnotherSingletonBeanA)
+            ApplicationContext context = ApplicationContext.run()
+            AnotherSingletonBeanA bean = context.getBean(AnotherSingletonBeanA)
 
         then:
             !bean.beanBField.destroyed

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/PrototypeBeanA.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/PrototypeBeanA.java
@@ -1,0 +1,23 @@
+package io.micronaut.inject.dependent;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import java.util.List;
+
+@Singleton
+public class PrototypeBeanA {
+    @Inject public BeanB beanBField;
+    public final BeanB beanBConstructor;
+    public BeanB beanBMethod;
+    @Inject public List<InterfaceA> collection;
+
+    public PrototypeBeanA(BeanB beanBConstructor) {
+        this.beanBConstructor = beanBConstructor;
+    }
+
+    @Inject
+    public void setBeanBMethod(BeanB beanBMethod) {
+        this.beanBMethod = beanBMethod;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/SingletonBeanANoCallback.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/SingletonBeanANoCallback.java
@@ -1,0 +1,24 @@
+package io.micronaut.inject.dependent;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import java.util.List;
+
+@Singleton
+public class SingletonBeanANoCallback {
+    @Inject public BeanB beanBField;
+    public final BeanB beanBConstructor;
+    public BeanB beanBMethod;
+    @Inject public List<InterfaceA> collection;
+
+    public SingletonBeanANoCallback(BeanB beanBConstructor) {
+        this.beanBConstructor = beanBConstructor;
+    }
+
+    @Inject
+    public void setBeanBMethod(BeanB beanBMethod) {
+        this.beanBMethod = beanBMethod;
+    }
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/factory/DestroyFactorySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/factory/DestroyFactorySpec.groovy
@@ -10,7 +10,6 @@ class DestroyFactorySpec extends Specification {
 
     void "test destroy dependent objects from singleton using listeners"() {
         when:
-            def bean = registration.bean
             ApplicationContext context = ApplicationContext.run()
             BeanDefinition<MyBean1> beanDefinition = context.getBeanDefinition(MyBean1)
             BeanRegistration<MyBean1> registration = context.getBeanRegistration(beanDefinition)

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/factory/DestroyFactorySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/factory/DestroyFactorySpec.groovy
@@ -9,9 +9,6 @@ import spock.lang.Specification
 class DestroyFactorySpec extends Specification {
 
     void "test destroy dependent objects from singleton using listeners"() {
-        given:
-            TestData.DESTRUCTION_ORDER.clear()
-
         when:
             def bean = registration.bean
             ApplicationContext context = ApplicationContext.run()
@@ -57,5 +54,8 @@ class DestroyFactorySpec extends Specification {
 
             TestData.DESTRUCTION_ORDER.count("MyBean3") == 1
             TestData.DESTRUCTION_ORDER.count("MyBean3Factory") == 1
+
+        cleanup:
+            TestData.DESTRUCTION_ORDER.clear()
     }
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/factory/DestroyFactorySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/factory/DestroyFactorySpec.groovy
@@ -1,6 +1,8 @@
 package io.micronaut.inject.dependent.factory
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.BeanRegistration
+import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.dependent.TestData
 import spock.lang.Specification
 
@@ -11,10 +13,10 @@ class DestroyFactorySpec extends Specification {
             TestData.DESTRUCTION_ORDER.clear()
 
         when:
-            def context = ApplicationContext.run()
-            def beanDefinition = context.getBeanDefinition(MyBean1)
-            def registration = context.getBeanRegistration(beanDefinition)
             def bean = registration.bean
+            ApplicationContext context = ApplicationContext.run()
+            BeanDefinition<MyBean1> beanDefinition = context.getBeanDefinition(MyBean1)
+            BeanRegistration<MyBean1> registration = context.getBeanRegistration(beanDefinition)
 
         then:
             MyBean1Factory.destroyed == 1 // prototype

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/factory/DestroyFactorySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/factory/DestroyFactorySpec.groovy
@@ -1,0 +1,59 @@
+package io.micronaut.inject.dependent.factory
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.inject.dependent.TestData
+import spock.lang.Specification
+
+class DestroyFactorySpec extends Specification {
+
+    void "test destroy dependent objects from singleton using listeners"() {
+        given:
+            TestData.DESTRUCTION_ORDER.clear()
+
+        when:
+            def context = ApplicationContext.run()
+            def beanDefinition = context.getBeanDefinition(MyBean1)
+            def registration = context.getBeanRegistration(beanDefinition)
+            def bean = registration.bean
+
+        then:
+            MyBean1Factory.destroyed == 1 // prototype
+            MyBean1Factory.beanCreated == 1
+            MyBean2Factory.destroyed == 1 // prototype
+            MyBean2Factory.beanCreated == 1
+            MyBean2Factory.beanDestroyed == 0
+            MyBean3Factory.destroyed == 0 // singleton
+            MyBean3Factory.beanDestroyed == 0
+
+        when:
+            context.destroyBean(registration)
+        then:
+            MyBean1Factory.destroyed == 1
+            MyBean1Factory.beanCreated == 1
+            MyBean2Factory.destroyed == 1
+            MyBean2Factory.beanCreated == 1
+            MyBean2Factory.beanDestroyed == 1  // prototype
+            MyBean3Factory.destroyed == 0
+            MyBean3Factory.beanDestroyed == 0 // singleton
+
+        when:
+            context.stop()
+
+        then:
+            MyBean1Factory.destroyed == 1
+            MyBean1Factory.beanCreated == 1
+            MyBean2Factory.destroyed == 1
+            MyBean2Factory.beanCreated == 1
+            MyBean2Factory.beanDestroyed == 1
+            MyBean3Factory.destroyed == 1 // singleton
+            MyBean3Factory.beanDestroyed == 1 // singleton
+
+            TestData.DESTRUCTION_ORDER.size() == 5
+            TestData.DESTRUCTION_ORDER.get(0) == 'MyBean1Factory'
+            TestData.DESTRUCTION_ORDER.get(1) == 'MyBean2Factory'
+            TestData.DESTRUCTION_ORDER.get(2) == 'MyBean2'
+
+            TestData.DESTRUCTION_ORDER.count("MyBean3") == 1
+            TestData.DESTRUCTION_ORDER.count("MyBean3Factory") == 1
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/factory/MyBean1.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/factory/MyBean1.java
@@ -1,0 +1,10 @@
+package io.micronaut.inject.dependent.factory;
+
+public class MyBean1 {
+
+    private final MyBean2 myBean2;
+
+    public MyBean1(MyBean2 myBean2) {
+        this.myBean2 = myBean2;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/factory/MyBean1Factory.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/factory/MyBean1Factory.java
@@ -1,0 +1,20 @@
+package io.micronaut.inject.dependent.factory;
+
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Prototype;
+
+@Prototype
+@Factory
+public class MyBean1Factory {
+
+    public static int beanCreated;
+    public static int destroyed;
+
+    @Bean
+    MyBean1 myBean1(MyBean2 myBean2) {
+        beanCreated++;
+        return new MyBean1(myBean2);
+    }
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/factory/MyBean2.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/factory/MyBean2.java
@@ -1,0 +1,11 @@
+package io.micronaut.inject.dependent.factory;
+
+public class MyBean2 {
+
+    private final MyBean3 myBean3;
+
+    public MyBean2(MyBean3 myBean3) {
+        this.myBean3 = myBean3;
+    }
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/factory/MyBean2Factory.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/factory/MyBean2Factory.java
@@ -1,0 +1,29 @@
+package io.micronaut.inject.dependent.factory;
+
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Prototype;
+import io.micronaut.inject.dependent.TestData;
+import jakarta.annotation.PreDestroy;
+
+@Prototype
+@Factory
+public class MyBean2Factory {
+
+    public static int beanCreated;
+    public static int beanDestroyed;
+    public static int destroyed;
+
+    @Bean
+    MyBean2 myBean2(MyBean3 myBean3) {
+        beanCreated++;
+        return new MyBean2(myBean3);
+    }
+
+    @PreDestroy
+    public void destroyMyFactory() {
+        TestData.DESTRUCTION_ORDER.add(MyBean2Factory.class.getSimpleName());
+        destroyed++;
+    }
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/factory/MyBean3.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/factory/MyBean3.java
@@ -1,0 +1,4 @@
+package io.micronaut.inject.dependent.factory;
+
+public class MyBean3 {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/factory/MyBean3Factory.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/factory/MyBean3Factory.java
@@ -1,0 +1,26 @@
+package io.micronaut.inject.dependent.factory;
+
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.inject.dependent.TestData;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+
+//@Singleton
+@Factory
+public class MyBean3Factory {
+
+    public static int beanDestroyed;
+    public static int destroyed;
+
+    @Singleton
+    @Bean
+    MyBean3 myBean3 = new MyBean3();
+
+    @PreDestroy
+    public void destroyMyFactory() {
+        TestData.DESTRUCTION_ORDER.add(MyBean3Factory.class.getSimpleName());
+        destroyed++;
+    }
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/factory/MyBean3Factory.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/factory/MyBean3Factory.java
@@ -6,7 +6,6 @@ import io.micronaut.inject.dependent.TestData;
 import jakarta.annotation.PreDestroy;
 import jakarta.inject.Singleton;
 
-//@Singleton
 @Factory
 public class MyBean3Factory {
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/factory/PreDestroyMyBean1Factory.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/factory/PreDestroyMyBean1Factory.java
@@ -1,0 +1,16 @@
+package io.micronaut.inject.dependent.factory;
+
+import io.micronaut.context.annotation.Prototype;
+import io.micronaut.context.event.BeanPreDestroyEvent;
+import io.micronaut.context.event.BeanPreDestroyEventListener;
+import io.micronaut.inject.dependent.TestData;
+
+@Prototype
+public class PreDestroyMyBean1Factory implements BeanPreDestroyEventListener<MyBean1Factory> {
+    @Override
+    public MyBean1Factory onPreDestroy(BeanPreDestroyEvent<MyBean1Factory> event) {
+        TestData.DESTRUCTION_ORDER.add(MyBean1Factory.class.getSimpleName());
+        MyBean1Factory.destroyed++;
+        return event.getBean();
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/factory/PreDestroyMyBean2.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/factory/PreDestroyMyBean2.java
@@ -1,0 +1,16 @@
+package io.micronaut.inject.dependent.factory;
+
+import io.micronaut.context.event.BeanPreDestroyEvent;
+import io.micronaut.context.event.BeanPreDestroyEventListener;
+import io.micronaut.inject.dependent.TestData;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class PreDestroyMyBean2 implements BeanPreDestroyEventListener<MyBean2> {
+    @Override
+    public MyBean2 onPreDestroy(BeanPreDestroyEvent<MyBean2> event) {
+        TestData.DESTRUCTION_ORDER.add(MyBean2.class.getSimpleName());
+        MyBean2Factory.beanDestroyed++;
+        return event.getBean();
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/factory/PreDestroyMyBean3.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/factory/PreDestroyMyBean3.java
@@ -1,0 +1,16 @@
+package io.micronaut.inject.dependent.factory;
+
+import io.micronaut.context.annotation.Prototype;
+import io.micronaut.context.event.BeanPreDestroyEvent;
+import io.micronaut.context.event.BeanPreDestroyEventListener;
+import io.micronaut.inject.dependent.TestData;
+
+@Prototype
+public class PreDestroyMyBean3 implements BeanPreDestroyEventListener<MyBean3> {
+    @Override
+    public MyBean3 onPreDestroy(BeanPreDestroyEvent<MyBean3> event) {
+        TestData.DESTRUCTION_ORDER.add(MyBean3.class.getSimpleName());
+        MyBean3Factory.beanDestroyed++;
+        return event.getBean();
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/listeners/AnotherBeanB.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/listeners/AnotherBeanB.java
@@ -1,0 +1,19 @@
+package io.micronaut.inject.dependent.listeners;
+
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.inject.dependent.TestAnn;
+import jakarta.inject.Inject;
+
+@Bean
+public class AnotherBeanB {
+    @Inject
+    public AnotherBeanC beanC;
+    public boolean destroyed = false;
+
+    @TestAnn
+        // dependent interceptor
+    void test() {
+
+    }
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/listeners/AnotherBeanC.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/listeners/AnotherBeanC.java
@@ -1,0 +1,8 @@
+package io.micronaut.inject.dependent.listeners;
+
+import io.micronaut.context.annotation.Bean;
+
+@Bean
+public class AnotherBeanC {
+    public boolean destroyed = false;
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/listeners/AnotherBeanD.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/listeners/AnotherBeanD.java
@@ -1,0 +1,8 @@
+package io.micronaut.inject.dependent.listeners;
+
+import io.micronaut.context.annotation.Bean;
+
+@Bean
+public class AnotherBeanD implements AnotherInterfaceA {
+    public boolean destroyed = false;
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/listeners/AnotherBeanE.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/listeners/AnotherBeanE.java
@@ -1,0 +1,8 @@
+package io.micronaut.inject.dependent.listeners;
+
+import io.micronaut.context.annotation.Bean;
+
+@Bean
+public class AnotherBeanE implements AnotherInterfaceA {
+    public boolean destroyed = false;
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/listeners/AnotherInterfaceA.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/listeners/AnotherInterfaceA.java
@@ -1,0 +1,4 @@
+package io.micronaut.inject.dependent.listeners;
+
+public interface AnotherInterfaceA {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/listeners/AnotherSingletonBeanA.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/listeners/AnotherSingletonBeanA.java
@@ -1,0 +1,25 @@
+package io.micronaut.inject.dependent.listeners;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import java.util.List;
+
+@Singleton
+public class AnotherSingletonBeanA {
+    @Inject public AnotherBeanB beanBField;
+    public final AnotherBeanB beanBConstructor;
+    public AnotherBeanB beanBMethod;
+    public boolean destroyed;
+    @Inject public List<AnotherInterfaceA> collection;
+
+    public AnotherSingletonBeanA(AnotherBeanB beanBConstructor) {
+        this.beanBConstructor = beanBConstructor;
+    }
+
+    @Inject
+    public void setBeanBMethod(AnotherBeanB beanBMethod) {
+        this.beanBMethod = beanBMethod;
+    }
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/listeners/PreDestroyAnotherBeanA.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/listeners/PreDestroyAnotherBeanA.java
@@ -1,0 +1,17 @@
+package io.micronaut.inject.dependent.listeners;
+
+import io.micronaut.context.annotation.Prototype;
+import io.micronaut.context.event.BeanPreDestroyEvent;
+import io.micronaut.context.event.BeanPreDestroyEventListener;
+import io.micronaut.inject.dependent.TestData;
+
+@Prototype
+public class PreDestroyAnotherBeanA implements BeanPreDestroyEventListener<AnotherSingletonBeanA> {
+    @Override
+    public AnotherSingletonBeanA onPreDestroy(BeanPreDestroyEvent<AnotherSingletonBeanA> event) {
+        TestData.DESTRUCTION_ORDER.add(AnotherSingletonBeanA.class.getSimpleName());
+        AnotherSingletonBeanA bean = event.getBean();
+        bean.destroyed = true;
+        return bean;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/listeners/PreDestroyAnotherBeanB.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/listeners/PreDestroyAnotherBeanB.java
@@ -1,0 +1,17 @@
+package io.micronaut.inject.dependent.listeners;
+
+import io.micronaut.context.annotation.Prototype;
+import io.micronaut.context.event.BeanPreDestroyEvent;
+import io.micronaut.context.event.BeanPreDestroyEventListener;
+import io.micronaut.inject.dependent.TestData;
+
+@Prototype
+public class PreDestroyAnotherBeanB implements BeanPreDestroyEventListener<AnotherBeanB> {
+    @Override
+    public AnotherBeanB onPreDestroy(BeanPreDestroyEvent<AnotherBeanB> event) {
+        TestData.DESTRUCTION_ORDER.add(AnotherBeanB.class.getSimpleName());
+        AnotherBeanB bean = event.getBean();
+        bean.destroyed = true;
+        return bean;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/listeners/PreDestroyAnotherBeanC.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/listeners/PreDestroyAnotherBeanC.java
@@ -1,0 +1,17 @@
+package io.micronaut.inject.dependent.listeners;
+
+import io.micronaut.context.annotation.Prototype;
+import io.micronaut.context.event.BeanPreDestroyEvent;
+import io.micronaut.context.event.BeanPreDestroyEventListener;
+import io.micronaut.inject.dependent.TestData;
+
+@Prototype
+public class PreDestroyAnotherBeanC implements BeanPreDestroyEventListener<AnotherBeanC> {
+    @Override
+    public AnotherBeanC onPreDestroy(BeanPreDestroyEvent<AnotherBeanC> event) {
+        TestData.DESTRUCTION_ORDER.add(AnotherBeanC.class.getSimpleName());
+        AnotherBeanC bean = event.getBean();
+        bean.destroyed = true;
+        return bean;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/listeners/PreDestroyAnotherBeanD.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/listeners/PreDestroyAnotherBeanD.java
@@ -1,0 +1,17 @@
+package io.micronaut.inject.dependent.listeners;
+
+import io.micronaut.context.annotation.Prototype;
+import io.micronaut.context.event.BeanPreDestroyEvent;
+import io.micronaut.context.event.BeanPreDestroyEventListener;
+import io.micronaut.inject.dependent.TestData;
+
+@Prototype
+public class PreDestroyAnotherBeanD implements BeanPreDestroyEventListener<AnotherBeanD> {
+    @Override
+    public AnotherBeanD onPreDestroy(BeanPreDestroyEvent<AnotherBeanD> event) {
+        TestData.DESTRUCTION_ORDER.add(AnotherBeanD.class.getSimpleName());
+        AnotherBeanD bean = event.getBean();
+        bean.destroyed = true;
+        return bean;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/listeners/PreDestroyAnotherBeanE.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/listeners/PreDestroyAnotherBeanE.java
@@ -1,0 +1,17 @@
+package io.micronaut.inject.dependent.listeners;
+
+import io.micronaut.context.annotation.Prototype;
+import io.micronaut.context.event.BeanPreDestroyEvent;
+import io.micronaut.context.event.BeanPreDestroyEventListener;
+import io.micronaut.inject.dependent.TestData;
+
+@Prototype
+public class PreDestroyAnotherBeanE implements BeanPreDestroyEventListener<AnotherBeanE> {
+    @Override
+    public AnotherBeanE onPreDestroy(BeanPreDestroyEvent<AnotherBeanE> event) {
+        TestData.DESTRUCTION_ORDER.add(AnotherBeanE.class.getSimpleName());
+        AnotherBeanE bean = event.getBean();
+        bean.destroyed = true;
+        return bean;
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/AbstractBeanResolutionContext.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractBeanResolutionContext.java
@@ -157,9 +157,9 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
 
     @Override
     public BeanRegistration<?> getAndResetDependentFactoryBean() {
-        BeanRegistration<?> dependentFactory = this.dependentFactory;
+        BeanRegistration<?> result = this.dependentFactory;
         this.dependentFactory = null;
-        return dependentFactory;
+        return result;
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/context/AbstractBeanResolutionContext.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractBeanResolutionContext.java
@@ -164,9 +164,9 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
 
     @Override
     public List<BeanRegistration<?>> popDependentBeans() {
-        List<BeanRegistration<?>> dependentBeans = this.dependentBeans;
+        List<BeanRegistration<?>> result = this.dependentBeans;
         this.dependentBeans = null;
-        return dependentBeans;
+        return result;
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/context/AbstractBeanResolutionContext.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractBeanResolutionContext.java
@@ -47,6 +47,7 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
     private Map<CharSequence, Object> attributes;
     private Qualifier<?> qualifier;
     private List<BeanRegistration<?>> dependentBeans;
+    private BeanRegistration<?> dependentFactory;
 
     /**
      * @param context        The bean context
@@ -110,6 +111,10 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
 
     @Override
     public <T> void addDependentBean(BeanRegistration<T> beanRegistration) {
+        if (beanRegistration.getBeanDefinition() == rootDefinition) {
+            // Don't add self
+            return;
+        }
         if (dependentBeans == null) {
             dependentBeans = new ArrayList<>(3);
         }
@@ -132,9 +137,44 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
         if (dependentBeans == null) {
             return Collections.emptyList();
         }
-        final List<BeanRegistration<?>> registrations = Collections.unmodifiableList(new ArrayList<>(dependentBeans));
-        dependentBeans.clear();
+        final List<BeanRegistration<?>> registrations = Collections.unmodifiableList(dependentBeans);
+        dependentBeans = null;
         return registrations;
+    }
+
+    @Override
+    public void markDependentAsFactory() {
+        if (dependentBeans != null) {
+            if (dependentBeans.isEmpty()) {
+                return;
+            }
+            if (dependentBeans.size() != 1) {
+                throw new IllegalStateException("Expected only one bean dependent!");
+            }
+            dependentFactory = dependentBeans.remove(0);
+        }
+    }
+
+    @Override
+    public BeanRegistration<?> getAndResetDependentFactoryBean() {
+        BeanRegistration<?> dependentFactory = this.dependentFactory;
+        this.dependentFactory = null;
+        return dependentFactory;
+    }
+
+    @Override
+    public List<BeanRegistration<?>> popDependentBeans() {
+        List<BeanRegistration<?>> dependentBeans = this.dependentBeans;
+        this.dependentBeans = null;
+        return dependentBeans;
+    }
+
+    @Override
+    public void pushDependentBeans(List<BeanRegistration<?>> dependentBeans) {
+        if (this.dependentBeans != null && !this.dependentBeans.isEmpty()) {
+            throw new IllegalStateException("Found existing dependent beans!");
+        }
+        this.dependentBeans = dependentBeans;
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/context/BeanDefinitionRegistry.java
+++ b/inject/src/main/java/io/micronaut/context/BeanDefinitionRegistry.java
@@ -332,6 +332,18 @@ public interface BeanDefinitionRegistry {
     }
 
     /**
+     * Find a bean registration for the given bean definition.
+     *
+     * @param beanDefinition The bean definition
+     * @param <T>            The concrete type
+     * @return The bean registration
+     * @throws NoSuchBeanException if the bean doesn't exist
+     * @since 3.5.0
+     */
+    @NonNull
+    <T> BeanRegistration<T> getBeanRegistration(@NonNull BeanDefinition<T> beanDefinition);
+
+    /**
      * Obtain the original {@link BeanDefinition} for a {@link io.micronaut.inject.ProxyBeanDefinition}.
      *
      * @param beanType  The type

--- a/inject/src/main/java/io/micronaut/context/BeanRegistration.java
+++ b/inject/src/main/java/io/micronaut/context/BeanRegistration.java
@@ -20,6 +20,7 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.order.OrderUtil;
 import io.micronaut.core.order.Ordered;
+import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.BeanIdentifier;
 import io.micronaut.inject.BeanType;
@@ -90,7 +91,7 @@ public class BeanRegistration<T> implements Ordered, CreatedBean<T>, BeanType<T>
                                              @NonNull K bean,
                                              @Nullable
                                              List<BeanRegistration<?>> dependents) {
-        boolean hasDependents = dependents != null && !dependents.isEmpty();
+        boolean hasDependents = CollectionUtils.isNotEmpty(dependents);
         if (beanDefinition instanceof DisposableBeanDefinition || bean instanceof LifeCycle || hasDependents) {
             if (hasDependents) {
                 return new BeanDisposingRegistration<>(beanContext, identifier, beanDefinition, bean, dependents);

--- a/inject/src/main/java/io/micronaut/context/BeanRegistration.java
+++ b/inject/src/main/java/io/micronaut/context/BeanRegistration.java
@@ -93,10 +93,9 @@ public class BeanRegistration<T> implements Ordered, CreatedBean<T>, BeanType<T>
                                              List<BeanRegistration<?>> dependents) {
         boolean hasDependents = CollectionUtils.isNotEmpty(dependents);
         if (beanDefinition instanceof DisposableBeanDefinition || bean instanceof LifeCycle || hasDependents) {
-            if (hasDependents) {
-                return new BeanDisposingRegistration<>(beanContext, identifier, beanDefinition, bean, dependents);
-            }
-            return new BeanDisposingRegistration<>(beanContext, identifier, beanDefinition, bean);
+            return hasDependents ?
+                new BeanDisposingRegistration<>(beanContext, identifier, beanDefinition, bean, dependents) :
+                new BeanDisposingRegistration<>(beanContext, identifier, beanDefinition, bean);
         }
         return new BeanRegistration<>(identifier, beanDefinition, bean);
     }

--- a/inject/src/main/java/io/micronaut/context/BeanRegistration.java
+++ b/inject/src/main/java/io/micronaut/context/BeanRegistration.java
@@ -17,12 +17,15 @@ package io.micronaut.context;
 
 import io.micronaut.context.scope.CreatedBean;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.order.OrderUtil;
 import io.micronaut.core.order.Ordered;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.BeanIdentifier;
 import io.micronaut.inject.BeanType;
+import io.micronaut.inject.DisposableBeanDefinition;
 
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -47,6 +50,54 @@ public class BeanRegistration<T> implements Ordered, CreatedBean<T>, BeanType<T>
         this.identifier = identifier;
         this.beanDefinition = beanDefinition;
         this.bean = bean;
+    }
+
+    /**
+     * Creates new bean registration. Possibly disposing registration can be returned.
+     *
+     * @param beanContext    The bean context
+     * @param identifier     The bean identifier
+     * @param beanDefinition The bean definition
+     * @param bean           The bean instance
+     * @param <K>            The bean registration type
+     * @return new bean registration
+     * @since 3.5.0
+     */
+    @NonNull
+    public static <K> BeanRegistration<K> of(@NonNull BeanContext beanContext,
+                                             @NonNull BeanIdentifier identifier,
+                                             @NonNull BeanDefinition<K> beanDefinition,
+                                             @NonNull K bean) {
+        return of(beanContext, identifier, beanDefinition, bean, null);
+    }
+
+    /**
+     * Creates new bean registration. Possibly disposing registration can be returned.
+     *
+     * @param beanContext    The bean context
+     * @param identifier     The bean identifier
+     * @param beanDefinition The bean definition
+     * @param bean           The bean instance
+     * @param dependents     The dependents
+     * @param <K>            The bean registration type
+     * @return new bean registration
+     * @since 3.5.0
+     */
+    @NonNull
+    public static <K> BeanRegistration<K> of(@NonNull BeanContext beanContext,
+                                             @NonNull BeanIdentifier identifier,
+                                             @NonNull BeanDefinition<K> beanDefinition,
+                                             @NonNull K bean,
+                                             @Nullable
+                                             List<BeanRegistration<?>> dependents) {
+        boolean hasDependents = dependents != null && !dependents.isEmpty();
+        if (beanDefinition instanceof DisposableBeanDefinition || bean instanceof LifeCycle || hasDependents) {
+            if (hasDependents) {
+                return new BeanDisposingRegistration<>(beanContext, identifier, beanDefinition, bean, dependents);
+            }
+            return new BeanDisposingRegistration<>(beanContext, identifier, beanDefinition, bean);
+        }
+        return new BeanRegistration<>(identifier, beanDefinition, bean);
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/context/BeanResolutionContext.java
+++ b/inject/src/main/java/io/micronaut/context/BeanResolutionContext.java
@@ -224,6 +224,41 @@ public interface BeanResolutionContext extends ValueResolver<CharSequence>, Auto
     }
 
     /**
+     * @return The current dependent beans that must be destroyed by an upstream bean
+     *
+     * @since 3.5.0
+     */
+    default @Nullable List<BeanRegistration<?>> popDependentBeans() {
+        return null;
+    }
+
+    /**
+     * The push the current dependent beans that must be destroyed by an upstream bean.
+     *
+     * @param dependentBeans Dependent beans collection that can be used to add more dependents
+     * @since 3.5.0
+     */
+    default void pushDependentBeans(@Nullable List<BeanRegistration<?>> dependentBeans) {
+    }
+
+    /**
+     * Marks first dependent as factory.
+     * Dependent can be missing which means it's a singleton or scoped bean.
+     *
+     * @since 3.5.0
+     */
+    default void markDependentAsFactory() {
+    }
+
+    /**
+     * @return The dependent factory beans that was used to create the bean in context
+     * @since 3.5.0
+     */
+    default @Nullable BeanRegistration<?> getAndResetDependentFactoryBean() {
+        return null;
+    }
+
+    /**
      * Represents a path taken to resolve a bean definitions dependencies.
      */
     interface Path extends Deque<Segment<?>>, AutoCloseable {

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1075,7 +1075,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
             if (beanDefinition.isPresent()) {
                 BeanDefinition<T> definition = beanDefinition.get();
                 BeanKey<T> key = new BeanKey<>(definition, definition.getDeclaredQualifier());
-                destroyBean(BeanDisposingRegistration.of(this, key, definition, bean));
+                destroyBean(BeanRegistration.of(this, key, definition, bean));
             }
         }
         return bean;

--- a/inject/src/main/java/io/micronaut/context/SingletonScope.java
+++ b/inject/src/main/java/io/micronaut/context/SingletonScope.java
@@ -78,9 +78,7 @@ final class SingletonScope {
 
 
         DefaultBeanContext.BeanKey<T> key = new DefaultBeanContext.BeanKey<>(beanDefinition.asArgument(), qualifier);
-        BeanRegistration<T> registration = dependents.isEmpty() ?
-            new BeanDisposingRegistration<>(beanContext, key, beanDefinition, createdBean) :
-            new BeanDisposingRegistration<>(beanContext, key, beanDefinition, createdBean, dependents);
+        BeanRegistration<T> registration = BeanRegistration.of(beanContext, key, beanDefinition, createdBean, dependents);
         
         singletonByBeanDefinition.put(BeanDefinitionIdentity.of(beanDefinition), registration);
         if (!beanDefinition.isSingleton()) {

--- a/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -1820,7 +1820,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
                     ElementQuery.ALL_METHODS
                             .onlyAccessible(beanTypeElement)
                             .onlyInstance()
-                            .named((name) -> annotationMemberProperty.equals(NameUtils.getPropertyNameForGetter(name, readPrefixes)))
+                            .named(name -> annotationMemberProperty.equals(NameUtils.getPropertyNameForGetter(name, readPrefixes)))
                             .filter((e) -> !e.hasParameters())
             ).orElse(null);
         }

--- a/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -472,6 +472,10 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
     private static final org.objectweb.asm.commons.Method METHOD_QUALIFIER_BY_TYPE = org.objectweb.asm.commons.Method.getMethod(
             ReflectionUtils.getRequiredMethod(Qualifiers.class, "byType", Class[].class)
     );
+
+    private static final org.objectweb.asm.commons.Method METHOD_BEAN_RESOLUTION_CONTEXT_MARK_FACTORY = org.objectweb.asm.commons.Method.getMethod(
+            ReflectionUtils.getRequiredMethod(BeanResolutionContext.class, "markDependentAsFactory")
+    );
     private static final Type TYPE_QUALIFIERS = Type.getType(Qualifiers.class);
     private static final Type TYPE_QUALIFIER = Type.getType(Qualifier.class);
 
@@ -3092,9 +3096,14 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
                     org.objectweb.asm.commons.Method.getMethod(METHOD_GET_BEAN)
             );
 
-            // store a reference to the bean being built at index 3
-            int factoryVar = buildMethodVisitor.newLocal(JavaModelUtils.getTypeReference(factoryClass));
-            buildMethodVisitor.storeLocal(factoryVar);
+            int factoryVar = buildMethodVisitor.newLocal(factoryType);
+            buildMethodVisitor.storeLocal(factoryVar, factoryType);
+
+            // BeanResolutionContext
+            buildMethodVisitor.loadArg(0);
+            // .markDependentAsFactory()
+            buildMethodVisitor.invokeInterface(TYPE_RESOLUTION_CONTEXT, METHOD_BEAN_RESOLUTION_CONTEXT_MARK_FACTORY);
+
             buildMethodVisitor.loadLocal(factoryVar);
             pushCastToType(buildMethodVisitor, factoryClass);
             String methodDescriptor = getMethodDescriptorForReturnType(beanType, parameterList);

--- a/src/main/docs/guide/ioc/factories.adoc
+++ b/src/main/docs/guide/ioc/factories.adoc
@@ -2,6 +2,8 @@ In many cases, you may want to make available as a bean a class that is not part
 
 A factory is a class annotated with the link:{api}/io/micronaut/context/annotation/Factory.html[Factory] annotation that provides one or more methods annotated with a bean scope annotation. Which annotation you use depends on what scope you want the bean to be in. See the section on <<scopes, bean scopes>> for more information.
 
+NOTE: The factory has the default scope singleton and will be destroyed with the context. If you want to dispose the factory after it produces a bean, use @Prototype scope.
+
 The return types of methods annotated with a bean scope annotation are the bean types. This is best illustrated by an example:
 
 snippet::io.micronaut.docs.factories.CrankShaft,io.micronaut.docs.factories.V8Engine,io.micronaut.docs.factories.EngineFactory[tags="class",indent=0]

--- a/src/main/docs/guide/ioc/lifecycle.adoc
+++ b/src/main/docs/guide/ioc/lifecycle.adoc
@@ -31,3 +31,8 @@ snippet::io.micronaut.docs.lifecycle.Connection[tags="class", indent=0]
 <2> The annotation value matches the method name
 
 NOTE: Simply implementing the `Closeable` or `AutoCloseable` interface is not enough for a bean to be closed with the context. One of the above methods must be used.
+
+== Dependent Beans
+
+Dependent beans are the beans used in the construction of your bean.
+If the dependent bean's scope is `@Prototype` or unknown, it will be destroyed along with your instance.

--- a/src/main/docs/guide/ioc/lifecycle.adoc
+++ b/src/main/docs/guide/ioc/lifecycle.adoc
@@ -1,6 +1,6 @@
-== When The Context Starts
+== When The Bean Is Constructed
 
-To invoke a method when a bean is constructed, use the `jakarta.annotation.PostConstruct` annotation:
+To invoke a method when the bean is constructed, use the `jakarta.annotation.PostConstruct` annotation:
 
 snippet::io.micronaut.docs.lifecycle.V8Engine[tags="imports, class", indent=0]
 
@@ -10,9 +10,9 @@ snippet::io.micronaut.docs.lifecycle.V8Engine[tags="imports, class", indent=0]
 
 To manage when a bean is constructed, see the section on <<scopes, bean scopes>>.
 
-== When The Context Closes
+== When The Bean Is Destroyed
 
-To invoke a method when the context is closed, use the `javax.annotation.PreDestroy` annotation:
+To invoke a method when the bean is destroyed, use the `javax.annotation.PreDestroy` annotation:
 
 snippet::io.micronaut.docs.lifecycle.PreDestroyBean[tags="class", indent=0]
 

--- a/src/main/docs/guide/ioc/lifecycle.adoc
+++ b/src/main/docs/guide/ioc/lifecycle.adoc
@@ -12,7 +12,7 @@ To manage when a bean is constructed, see the section on <<scopes, bean scopes>>
 
 == When The Bean Is Destroyed
 
-To invoke a method when the bean is destroyed, use the `javax.annotation.PreDestroy` annotation:
+To invoke a method when the bean is destroyed, use the `jakarta.annotation.PreDestroy` annotation:
 
 snippet::io.micronaut.docs.lifecycle.PreDestroyBean[tags="class", indent=0]
 


### PR DESCRIPTION
Now pre-destroy listeners are invoked for all dependent beans. Corrected how they are attached to the bean registration.
Factories with a prototype scope are now destroyed after the bean has been produced.