### PR TITLE
Fix duplicate beans when kapt is used in Java project

### DIFF
--- a/core/src/main/java/io/micronaut/core/io/service/SoftServiceLoader.java
+++ b/core/src/main/java/io/micronaut/core/io/service/SoftServiceLoader.java
@@ -443,6 +443,8 @@ public final class SoftServiceLoader<S> implements Iterable<ServiceDefinition<S>
                 Enumeration<URL> serviceConfigs = classLoader.getResources(META_INF_SERVICES + '/' + serviceName);
                 while (serviceConfigs.hasMoreElements()) {
                     URL url = serviceConfigs.nextElement();
+                    if (url.getPath().contains("/build/temp/kapt3"))
+                        continue;
                     UrlServicesLoader<S> task = new UrlServicesLoader<>(url, lineCondition, transformer);
                     tasks.add(task);
                     task.fork();


### PR DESCRIPTION
I recently added Kotlin to an existing Micronaut codebase and was having issues in tests where Micronaut was giving me this error:
```
More than 1 route matched the incoming request. The following routes matched /api/v1/test: POST - /api/v1/test, POST - /api/v1/test
```
After a few hours of debugging I discovered the recently added kapt dependency for Kotlin was generating duplicate class files and META-INF in 
`build/tmp/kapt3/classes`, 
the exact same classes as are generated in 
`build/classes/java`. 
This was causing the class loader used by Micronaut to load every class twice and adding them to the bean definitions list.

The proposed fix isn't ideal and rather patch-y but it does work for my use case. I would like if the maintainer(s) could add a better fix or merge this one if it's acceptable.

Edit: commit seems to break Kotlin stuff, nevermind it. Issue still stands.