### PR TITLE
Refactor DefaultHttpClient

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -1069,7 +1069,7 @@ public class DefaultHttpClient implements
     }
 
     /**
-     * Implementation of {@link #jsonStream}, {@link #dataStream}, {@link #exchangeStream}
+     * Implementation of {@link #jsonStream}, {@link #dataStream}, {@link #exchangeStream}.
      */
     @SuppressWarnings("MagicNumber")
     private  <I> Publisher<MutableHttpResponse<Object>> buildStreamExchange(
@@ -1594,17 +1594,7 @@ public class DefaultHttpClient implements
         }
     }
 
-    /**
-     * @param parentRequest     The parent request
-     * @param request           The request
-     * @param requestURI        The URI of the request
-     * @param requestWrapper    The request wrapper
-     * @param responsePublisher The response publisher
-     * @param <I>               The input type
-     * @param <O>               The output type
-     * @return The {@link Publisher} for the response
-     */
-    protected <I, O, R extends io.micronaut.http.HttpResponse<O>> Publisher<R> applyFilterToResponsePublisher(
+    private <I, O, R extends io.micronaut.http.HttpResponse<O>> Publisher<R> applyFilterToResponsePublisher(
             io.micronaut.http.HttpRequest<?> parentRequest,
             io.micronaut.http.HttpRequest<I> request,
             URI requestURI,

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -1069,15 +1069,10 @@ public class DefaultHttpClient implements
     }
 
     /**
-     * @param parentRequest The parent request
-     * @param request       The request
-     * @param requestURI    The request URI
-     * @param errorType     The error type
-     * @param <I>           The input type
-     * @return A {@link Flux}
+     * Implementation of {@link #jsonStream}, {@link #dataStream}, {@link #exchangeStream}
      */
     @SuppressWarnings("MagicNumber")
-    protected <I> Publisher<MutableHttpResponse<Object>> buildStreamExchange(
+    private  <I> Publisher<MutableHttpResponse<Object>> buildStreamExchange(
             @Nullable io.micronaut.http.HttpRequest<?> parentRequest,
             @NonNull io.micronaut.http.HttpRequest<I> request,
             @NonNull URI requestURI,

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -3284,7 +3284,6 @@ public class DefaultHttpClient implements
             }
         }
 
-
         /**
          * Create a {@link HttpClientResponseException} from a response with a failed HTTP status.
          */

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -3327,7 +3327,7 @@ public class DefaultHttpClient implements
         public FullHttpResponseHandler(
                 Channel channel,
                 ChannelPool channelPool, boolean secure, io.micronaut.http.HttpRequest<?> request, Argument<O> bodyType, Argument<?> errorType) {
-            super(combineFactories(), false);
+            super(combineFactories());
             this.responsePromise = channel.eventLoop().newPromise();
             this.secure = secure;
             this.request = request;
@@ -3411,15 +3411,6 @@ public class DefaultHttpClient implements
                     });
                 }
             } finally {
-                if (fullResponse.refCnt() > 0) {
-                    try {
-                        ReferenceCountUtil.release(fullResponse);
-                    } catch (Exception e) {
-                        if (log.isDebugEnabled()) {
-                            log.debug("Failed to release response: {}", fullResponse);
-                        }
-                    }
-                }
                 if (!HttpUtil.isKeepAlive(fullResponse)) {
                     keepAlive = false;
                 }

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -2652,34 +2652,18 @@ public class DefaultHttpClient implements
     }
 
     private void removeReadTimeoutHandler(ChannelPipeline pipeline) {
-        if (readTimeoutMillis != null) {
-            if (pipeline.context(ChannelPipelineCustomizer.HANDLER_READ_TIMEOUT) != null) {
-                pipeline.remove(ChannelPipelineCustomizer.HANDLER_READ_TIMEOUT);
-            }
-        }
-    }
-
-    private void setRedirectHeaders(@Nullable HttpRequest request, MutableHttpRequest<Object> redirectRequest) {
-        if (request != null) {
-            request.headers().forEach(header -> {
-                if (!REDIRECT_HEADER_BLOCKLIST.contains(header.getKey())) {
-                    redirectRequest.header(header.getKey(), header.getValue());
-                }
-            });
+        if (readTimeoutMillis != null && pipeline.context(ChannelPipelineCustomizer.HANDLER_READ_TIMEOUT) != null) {
+            pipeline.remove(ChannelPipelineCustomizer.HANDLER_READ_TIMEOUT);
         }
     }
 
     private void setRedirectHeaders(@Nullable io.micronaut.http.HttpRequest<?> request, MutableHttpRequest<Object> redirectRequest) {
         if (request != null) {
-            final Iterator<Map.Entry<String, List<String>>> headerIterator = request.getHeaders().iterator();
-            while (headerIterator.hasNext()) {
-                final Map.Entry<String, List<String>> originalHeader = headerIterator.next();
+            for (Map.Entry<String, List<String>> originalHeader : request.getHeaders()) {
                 if (!REDIRECT_HEADER_BLOCKLIST.contains(originalHeader.getKey())) {
                     final List<String> originalHeaderValue = originalHeader.getValue();
                     if (originalHeaderValue != null && !originalHeaderValue.isEmpty()) {
-                        final Iterator<String> headerValueIterator = originalHeaderValue.iterator();
-                        while (headerValueIterator.hasNext()) {
-                            final String value = headerValueIterator.next();
+                        for (String value : originalHeaderValue) {
                             if (value != null) {
                                 redirectRequest.header(originalHeader.getKey(), value);
                             }

--- a/http-client/src/main/java/io/micronaut/http/client/netty/ForwardingSubscriber.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/ForwardingSubscriber.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.client.netty;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import reactor.core.publisher.FluxSink;
+
+final class ForwardingSubscriber<T> implements Subscriber<T> {
+    private final FluxSink<T> sink;
+
+    ForwardingSubscriber(FluxSink<T> sink) {
+        this.sink = sink;
+    }
+
+    @Override
+    public void onSubscribe(Subscription s) {
+        sink.onRequest(s::request);
+    }
+
+    @Override
+    public void onNext(T t) {
+        sink.next(t);
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        sink.error(t);
+    }
+
+    @Override
+    public void onComplete() {
+        sink.complete();
+    }
+}

--- a/http-client/src/main/java/io/micronaut/http/client/netty/ForwardingSubscriber.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/ForwardingSubscriber.java
@@ -25,6 +25,7 @@ import reactor.core.publisher.FluxSink;
  *
  * @since 3.5.0
  * @author yawkat
+ * @param <T> The message type
  */
 @Internal
 final class ForwardingSubscriber<T> implements Subscriber<T> {

--- a/http-client/src/main/java/io/micronaut/http/client/netty/ForwardingSubscriber.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/ForwardingSubscriber.java
@@ -15,10 +15,18 @@
  */
 package io.micronaut.http.client.netty;
 
+import io.micronaut.core.annotation.Internal;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import reactor.core.publisher.FluxSink;
 
+/**
+ * {@link Subscriber} implementation that forwards items into a {@link FluxSink}.
+ *
+ * @since 3.5.0
+ * @author yawkat
+ */
+@Internal
 final class ForwardingSubscriber<T> implements Subscriber<T> {
     private final FluxSink<T> sink;
 

--- a/http-client/src/main/java/io/micronaut/http/client/netty/NettyFuturePublisher.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/NettyFuturePublisher.java
@@ -1,0 +1,46 @@
+package io.micronaut.http.client.netty;
+
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GenericFutureListener;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+final class NettyFuturePublisher<T> implements Publisher<T> {
+    private final Future<T> future;
+    private final boolean forwardCancel;
+
+    NettyFuturePublisher(Future<T> future, boolean forwardCancel) {
+        this.future = future;
+        this.forwardCancel = forwardCancel;
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super T> s) {
+        s.onSubscribe(new Subscription() {
+            boolean requested = false;
+
+            @Override
+            public void request(long n) {
+                if (!requested) {
+                    requested = true;
+                    future.addListener((Future<T> f) -> {
+                        if (f.isSuccess()) {
+                            s.onNext(f.getNow());
+                            s.onComplete();
+                        } else {
+                            s.onError(f.cause());
+                        }
+                    });
+                }
+            }
+
+            @Override
+            public void cancel() {
+                if (forwardCancel) {
+                    future.cancel(true);
+                }
+            }
+        });
+    }
+}

--- a/http-client/src/main/java/io/micronaut/http/client/netty/NettyFuturePublisher.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/NettyFuturePublisher.java
@@ -20,10 +20,20 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
+/**
+ * {@link Publisher} implementation that reads items from a netty {@link Future}.
+ *
+ * @since 3.5.0
+ * @author yawkat
+ */
 final class NettyFuturePublisher<T> implements Publisher<T> {
     private final Future<T> future;
     private final boolean forwardCancel;
 
+    /**
+     * @param future        The netty future to use as the source of this publisher
+     * @param forwardCancel Whether to forward calls to {@link Subscription#cancel()} to the future.
+     */
     NettyFuturePublisher(Future<T> future, boolean forwardCancel) {
         this.future = future;
         this.forwardCancel = forwardCancel;

--- a/http-client/src/main/java/io/micronaut/http/client/netty/NettyFuturePublisher.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/NettyFuturePublisher.java
@@ -25,6 +25,7 @@ import org.reactivestreams.Subscription;
  *
  * @since 3.5.0
  * @author yawkat
+ * @param <T> The message type
  */
 final class NettyFuturePublisher<T> implements Publisher<T> {
     private final Future<T> future;

--- a/http-client/src/main/java/io/micronaut/http/client/netty/NettyFuturePublisher.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/NettyFuturePublisher.java
@@ -1,7 +1,21 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.http.client.netty;
 
 import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.GenericFutureListener;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;

--- a/http-client/src/main/java/io/micronaut/http/client/netty/NettyPromiseSubscriber.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/NettyPromiseSubscriber.java
@@ -24,6 +24,7 @@ import org.reactivestreams.Subscription;
  *
  * @since 3.5.0
  * @author yawkat
+ * @param <T> The message type
  */
 final class NettyPromiseSubscriber<T> implements Subscriber<T> {
     private final Promise<? super T> promise;

--- a/http-client/src/main/java/io/micronaut/http/client/netty/NettyPromiseSubscriber.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/NettyPromiseSubscriber.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.http.client.netty;
 
 import io.netty.util.concurrent.Promise;

--- a/http-client/src/main/java/io/micronaut/http/client/netty/NettyPromiseSubscriber.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/NettyPromiseSubscriber.java
@@ -1,0 +1,34 @@
+package io.micronaut.http.client.netty;
+
+import io.netty.util.concurrent.Promise;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+final class NettyPromiseSubscriber<T> implements Subscriber<T> {
+    private final Promise<? super T> promise;
+    private T value;
+
+    public NettyPromiseSubscriber(Promise<? super T> promise) {
+        this.promise = promise;
+    }
+
+    @Override
+    public void onSubscribe(Subscription s) {
+        s.request(Long.MAX_VALUE);
+    }
+
+    @Override
+    public void onNext(T t) {
+        this.value = t;
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        promise.tryFailure(t);
+    }
+
+    @Override
+    public void onComplete() {
+        promise.trySuccess(value);
+    }
+}

--- a/http-client/src/main/java/io/micronaut/http/client/netty/NettyPromiseSubscriber.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/NettyPromiseSubscriber.java
@@ -19,11 +19,17 @@ import io.netty.util.concurrent.Promise;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
+/**
+ * {@link Subscriber} implementation that writes into a netty {@link Promise} on completion.
+ *
+ * @since 3.5.0
+ * @author yawkat
+ */
 final class NettyPromiseSubscriber<T> implements Subscriber<T> {
     private final Promise<? super T> promise;
     private T value;
 
-    public NettyPromiseSubscriber(Promise<? super T> promise) {
+    NettyPromiseSubscriber(Promise<? super T> promise) {
         this.promise = promise;
     }
 

--- a/http-client/src/main/java/io/micronaut/http/client/netty/SimpleChannelInboundHandlerInstrumented.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/SimpleChannelInboundHandlerInstrumented.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.client.netty;
+
+import io.micronaut.http.context.ServerRequestContext;
+import io.micronaut.scheduling.instrument.Instrumentation;
+import io.micronaut.scheduling.instrument.InvocationInstrumenter;
+import io.micronaut.scheduling.instrument.InvocationInstrumenterFactory;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+
+/**
+ * An extension of Netty {@link SimpleChannelInboundHandler} that instruments the channel read handler
+ * by using collection of available {@link InvocationInstrumenterFactory} (such as
+ * {@link ServerRequestContext#with(io.micronaut.http.HttpRequest, java.util.concurrent.Callable)}) if present during
+ * the constructor call of the http client.
+ * Thanks to that the {@link ServerRequestContext#currentRequest()} returns parent request.
+ *
+ * @param <I> the type of the inbound message
+ */
+abstract class SimpleChannelInboundHandlerInstrumented<I> extends SimpleChannelInboundHandler<I> {
+    private final InvocationInstrumenter instrumenter;
+
+    SimpleChannelInboundHandlerInstrumented(InvocationInstrumenter instrumenter) {
+        this.instrumenter = instrumenter;
+    }
+
+    SimpleChannelInboundHandlerInstrumented(InvocationInstrumenter instrumenter, boolean autoRelease) {
+        super(autoRelease);
+        this.instrumenter = instrumenter;
+    }
+
+    protected abstract void channelReadInstrumented(ChannelHandlerContext ctx, I msg) throws Exception;
+
+    @Override
+    protected final void channelRead0(ChannelHandlerContext ctx, I msg) throws Exception {
+        try (Instrumentation ignored = instrumenter.newInstrumentation()) {
+            channelReadInstrumented(ctx, msg);
+        }
+    }
+}

--- a/http-client/src/main/java/io/micronaut/http/client/netty/SimpleChannelInboundHandlerInstrumented.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/SimpleChannelInboundHandlerInstrumented.java
@@ -15,19 +15,17 @@
  */
 package io.micronaut.http.client.netty;
 
-import io.micronaut.http.context.ServerRequestContext;
 import io.micronaut.scheduling.instrument.Instrumentation;
 import io.micronaut.scheduling.instrument.InvocationInstrumenter;
-import io.micronaut.scheduling.instrument.InvocationInstrumenterFactory;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 
 /**
  * An extension of Netty {@link SimpleChannelInboundHandler} that instruments the channel read handler
- * by using collection of available {@link InvocationInstrumenterFactory} (such as
- * {@link ServerRequestContext#with(io.micronaut.http.HttpRequest, java.util.concurrent.Callable)}) if present during
+ * by using collection of available {@link io.micronaut.scheduling.instrument.InvocationInstrumenterFactory} (such as
+ * {@link io.micronaut.http.context.ServerRequestContext#with(io.micronaut.http.HttpRequest, java.util.concurrent.Callable)}) if present during
  * the constructor call of the http client.
- * Thanks to that the {@link ServerRequestContext#currentRequest()} returns parent request.
+ * Thanks to that the {@link io.micronaut.http.context.ServerRequestContext#currentRequest()} returns parent request.
  *
  * @param <I> the type of the inbound message
  */


### PR DESCRIPTION
This PR should have almost no functional changes. The main goal is reducing code duplication between different code paths in the HTTP client (streaming, proxying, normal exchange) in order to make implementation of new features easier.

The diff is quite big, but I tried to make many small commits that should be mostly mechanical (extracting a method, removing some duplication etc), so it may be easier to review the commits individually.

Targeted to 3.5.x because it's quite a big diff and fixes no bugs.