### PR TITLE
Intercept suspend functions correctly

### DIFF
--- a/aop/src/main/java/io/micronaut/aop/internal/intercepted/KotlinInterceptedMethod.java
+++ b/aop/src/main/java/io/micronaut/aop/internal/intercepted/KotlinInterceptedMethod.java
@@ -19,6 +19,7 @@ import io.micronaut.aop.Interceptor;
 import io.micronaut.aop.MethodInvocationContext;
 import io.micronaut.aop.util.CompletableFutureContinuation;
 import io.micronaut.aop.util.DelegatingContextContinuation;
+import io.micronaut.aop.util.KotlinInterceptedMethodHelper;
 import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.type.Argument;
@@ -27,7 +28,6 @@ import kotlin.coroutines.Continuation;
 import kotlin.coroutines.CoroutineContext;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Consumer;
 
@@ -140,26 +140,12 @@ final class KotlinInterceptedMethod implements io.micronaut.aop.kotlin.KotlinInt
         } else {
             throw new IllegalStateException("Cannot convert " + result + "  to 'java.util.concurrent.CompletionStage'");
         }
-        completionStageResult.whenComplete((value, throwable) -> {
-            if (throwable == null) {
-                if (value == null && isUnitValueType) {
-                    value = kotlin.Unit.INSTANCE;
-                }
-                CompletableFutureContinuation.Companion.completeSuccess(continuation, value);
-            } else {
-                if (throwable instanceof CompletionException) {
-                    throwable = ((CompletionException) throwable).getCause();
-                }
-                CompletableFutureContinuation.Companion.completeExceptionally(continuation, (Throwable) throwable);
-            }
-        });
-        return KotlinUtils.COROUTINE_SUSPENDED;
+        return KotlinInterceptedMethodHelper.handleResult(completionStageResult, isUnitValueType, continuation);
     }
 
     @Override
     public <E extends Throwable> Object handleException(Exception exception) throws E {
-        CompletableFutureContinuation.Companion.completeExceptionally(continuation, exception);
-        return KotlinUtils.COROUTINE_SUSPENDED;
+        throw (E) exception;
     }
 
     @Override

--- a/aop/src/main/kotlin/io/micronaut/aop/util/KotlinInterceptedMethodHelper.kt
+++ b/aop/src/main/kotlin/io/micronaut/aop/util/KotlinInterceptedMethodHelper.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.util
+
+import io.micronaut.core.annotation.Experimental
+import io.micronaut.core.annotation.Internal
+import java.util.concurrent.CompletionException
+import java.util.concurrent.CompletionStage
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
+
+/**
+ * A helper utility class for intercepting Kotlin suspend methods as a value of [CompletionStage].
+ *
+ * @author Benedikt Hunger
+ * @since 3.5.0
+ */
+@Internal
+@Experimental
+internal object KotlinInterceptedMethodHelper {
+    @JvmStatic
+    suspend fun handleResult(result: CompletionStage<*>, isUnitValueType: Boolean): Any? = suspendCoroutine { continuation ->
+        result.whenComplete { value: Any?, throwable: Throwable? ->
+            if (throwable == null) {
+                val result = Result.success(value ?: if (isUnitValueType) Unit else null)
+                continuation.resumeWith(result)
+            } else {
+                val exception = if (throwable is CompletionException) { throwable.cause ?: throwable } else throwable
+                continuation.resumeWithException(exception)
+            }
+        }
+    }
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/annotation/processing/SuspendFunctionInterceptorSpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/annotation/processing/SuspendFunctionInterceptorSpec.kt
@@ -1,0 +1,90 @@
+package io.micronaut.annotation.processing
+
+import io.kotest.matchers.shouldBe
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Consumes
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.ContinuationInterceptor
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.startCoroutine
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@MicronautTest
+class SuspendFunctionInterceptorSpec {
+
+    @Inject
+    lateinit var demoClient: DemoClient
+
+    @Test
+    fun interceptSuspendMethod() {
+        val interceptor = TestCoroutineInterceptor()
+        val latch = CountDownLatch(1)
+        var answer: String? = null
+        demoClient::getSyncString.startCoroutine(Continuation(interceptor) { result ->
+            answer = result.getOrNull()
+            latch.countDown()
+        })
+        latch.await(1, TimeUnit.SECONDS) shouldBe true
+        assertTrue(interceptor.didIntercept())
+        answer shouldBe "sync string"
+    }
+
+    @Test
+    fun returnToCallerThreadWithSuspendClient() {
+        val singleThreadDispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+        runBlocking {
+            launch(singleThreadDispatcher) {
+                val threadId = Thread.currentThread().id
+                demoClient.getSyncString() shouldBe "sync string"
+                Thread.currentThread().id shouldBe threadId
+            }
+        }
+    }
+
+    @Client("/demo")
+    @Consumes(MediaType.TEXT_PLAIN)
+    interface DemoClient {
+        @Get("/sync/string")
+        suspend fun getSyncString(): String
+    }
+
+    class TestCoroutineInterceptor : ContinuationInterceptor {
+        private val didIntercept = AtomicBoolean(false)
+
+        fun didIntercept() = didIntercept.get()
+
+        override val key: CoroutineContext.Key<*>
+            get() = ContinuationInterceptor.Key
+
+        override fun <T> interceptContinuation(continuation: Continuation<T>): Continuation<T> {
+            return InterceptedContinuation(didIntercept, continuation)
+        }
+
+        class InterceptedContinuation<T>(
+            private val didIntercept: AtomicBoolean,
+            private val continuation: Continuation<T>
+        ) : Continuation<T> {
+            override val context: CoroutineContext
+                get() = continuation.context
+
+            override fun resumeWith(result: Result<T>) {
+                if (result as Any? !== Unit) { // startCoroutine directly calls resumeWith(Unit) after starting the coroutine
+                    didIntercept.set(true)
+                }
+                continuation.resumeWith(result)
+            }
+        }
+    }
+}


### PR DESCRIPTION
When a Kotlin suspend method is intercepted, the associated Continuation should be intercepted. Without this interception, some of the Kotlin coroutine mechanisms cease to work, for instance thread management.

For example:
```
@MicronautTest
class ClientDispatcherTest(
    private val testClient: TestClient
) : StringSpec() {

    init {
        "Execute client call and note the thread" {
            println("Thread before: ${Thread.currentThread().name}")
            testClient.test()
            println("Thread after: ${Thread.currentThread().name}")
        }
    }

    @Client("/test")
    interface TestClient {
        @Get
        suspend fun test(): String
    }

    @Controller("/test")
    class TestController {
        @Get
        fun test(): String = "Test"
    }
}
```

Expected behavior would be to switch back to the original thread:
```
Thread before: pool-3-thread-1
Thread after: pool-3-thread-1
```

Actual output (before the fix):
```
Thread before: pool-3-thread-1
Thread after: default-nioEventLoopGroup-1-2
```

Thus, we see that the code after the suspend call is executed in a Netty event loop thread. This is especially harmful if we have few processor cores (say, one) available, because in this case the Netty event loop thread pool size is only two. This can easily lead to the two threads blocking each other, for example by executing another client call after the first client call.

Also Kotlin tracing relies on intercepting the continuation, and probably there are even more issues.