### PR TITLE
fix: attempts to encode paths

### DIFF
--- a/http/src/main/java/io/micronaut/http/uri/DefaultUriBuilder.java
+++ b/http/src/main/java/io/micronaut/http/uri/DefaultUriBuilder.java
@@ -331,13 +331,11 @@ class DefaultUriBuilder implements UriBuilder {
             String pathStr = path.toString();
             if (isTemplate(pathStr, values)) {
                 pathStr = UriTemplate.of(pathStr).expand(values);
-            } else {
+            } else if (pathStr.chars().filter(ch -> ch == '/').count() <= 1) {
                 final String templateVariable = "pathString";
-                if (pathStr.chars().filter(ch -> ch == '/').count() <= 1) {
-                    pathStr = (pathStr.charAt(0) == '/') ?
-                            UriTemplate.of("/{" + templateVariable + "}").expand(Collections.singletonMap(templateVariable, pathStr.substring(1))) :
-                            UriTemplate.of("{" + templateVariable + "}").expand(Collections.singletonMap(templateVariable, pathStr));
-                }
+                pathStr = (pathStr.charAt(0) == '/') ?
+                        UriTemplate.of("/{" + templateVariable + "}").expand(Collections.singletonMap(templateVariable, pathStr.substring(1))) :
+                        UriTemplate.of("{" + templateVariable + "}").expand(Collections.singletonMap(templateVariable, pathStr));
             }
 
             builder.append(pathStr);

--- a/http/src/main/java/io/micronaut/http/uri/DefaultUriBuilder.java
+++ b/http/src/main/java/io/micronaut/http/uri/DefaultUriBuilder.java
@@ -331,6 +331,13 @@ class DefaultUriBuilder implements UriBuilder {
             String pathStr = path.toString();
             if (isTemplate(pathStr, values)) {
                 pathStr = UriTemplate.of(pathStr).expand(values);
+            } else {
+                final String templateVariable = "pathString";
+                if (pathStr.chars().filter(ch -> ch == '/').count() <= 1) {
+                    pathStr = (pathStr.charAt(0) == '/') ?
+                            UriTemplate.of("/{" + templateVariable + "}").expand(Collections.singletonMap(templateVariable, pathStr.substring(1))) :
+                            UriTemplate.of("{" + templateVariable + "}").expand(Collections.singletonMap(templateVariable, pathStr));
+                }
             }
 
             builder.append(pathStr);
@@ -343,6 +350,9 @@ class DefaultUriBuilder implements UriBuilder {
 
         String fragment = this.fragment;
         if (StringUtils.isNotEmpty(fragment)) {
+            if (builder.length() == 0) {
+                builder.append('/');
+            }
             fragment = expandOrEncode(fragment, values);
             if (fragment.charAt(0) != '#') {
                 builder.append('#');

--- a/http/src/main/java/io/micronaut/http/uri/DefaultUriBuilder.java
+++ b/http/src/main/java/io/micronaut/http/uri/DefaultUriBuilder.java
@@ -331,11 +331,9 @@ class DefaultUriBuilder implements UriBuilder {
             String pathStr = path.toString();
             if (isTemplate(pathStr, values)) {
                 pathStr = UriTemplate.of(pathStr).expand(values);
-            } else if (pathStr.chars().filter(ch -> ch == '/').count() <= 1) {
+            } else if (pathStr.chars().filter(ch -> ch == '/').count() == 1 && pathStr.charAt(0) == '/') { // encode only if the path has a single leading slash
                 final String templateVariable = "pathString";
-                pathStr = (pathStr.charAt(0) == '/') ?
-                        UriTemplate.of("/{" + templateVariable + "}").expand(Collections.singletonMap(templateVariable, pathStr.substring(1))) :
-                        UriTemplate.of("{" + templateVariable + "}").expand(Collections.singletonMap(templateVariable, pathStr));
+                pathStr = UriTemplate.of("/{" + templateVariable + "}").expand(Collections.singletonMap(templateVariable, pathStr.substring(1)));
             }
 
             builder.append(pathStr);

--- a/http/src/test/groovy/io/micronaut/http/uri/UriBuilderSpec.groovy
+++ b/http/src/test/groovy/io/micronaut/http/uri/UriBuilderSpec.groovy
@@ -15,9 +15,13 @@
  */
 package io.micronaut.http.uri
 
+import io.micronaut.core.util.CollectionUtils
 import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.Unroll
+import spock.lang.PendingFeature
+import spock.lang.See
+
 class UriBuilderSpec extends Specification {
 
     @Issue("https://github.com/micronaut-projects/micronaut-core/issues/7288")
@@ -191,4 +195,15 @@ class UriBuilderSpec extends Specification {
                 .build()
                 .toString()
     }
+
+    @PendingFeature(reason = "not sure if its worth the effort to implement this corner case")
+    @See("https://datatracker.ietf.org/doc/html/rfc3986#section-3.4")
+    void "fragments with adjacent, reserved/unsafe chars"() {
+        expect:
+        '/#the%20date%20%272022-12-31%27/events' == UriBuilder.of("/")
+                .fragment("the date '{year}-{month}-{day}'/events")
+                .expand(CollectionUtils.mapOf("year", "2022", "month", "12", "day", "31"))
+                .toString()
+    }
+
 }

--- a/http/src/test/groovy/io/micronaut/http/uri/UriBuilderSpec.groovy
+++ b/http/src/test/groovy/io/micronaut/http/uri/UriBuilderSpec.groovy
@@ -18,8 +18,20 @@ package io.micronaut.http.uri
 import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.Unroll
-
 class UriBuilderSpec extends Specification {
+
+    @Issue("https://github.com/micronaut-projects/micronaut-core/issues/7288")
+    void "path encodes"() {
+        given:
+        String path = "this has a space in it"
+        String expected = "/this%20has%20a%20space%20in%20it";
+
+        expect:
+        expected == UriBuilder.of("")
+                .path(path)
+                .build()
+                .toString()
+    }
 
     void "test uri builder expand"() {
         given:
@@ -72,7 +84,6 @@ class UriBuilderSpec extends Specification {
 
         UriBuilder uriBuilder = UriBuilder.of("/api").path("v1").path("secretendpoint");
         for (String paramKey : params.keySet()) {
-            System.out.println(paramKey)
             uriBuilder = uriBuilder.queryParam(paramKey, params.get(paramKey));
         }
 
@@ -156,5 +167,28 @@ class UriBuilderSpec extends Specification {
 
         expect:
         uri == 'myurl?%24top=10&%24filter=xyz'
+    }
+
+    void "fragments in URIs"() {
+        expect:
+        '/#foo' ==  UriBuilder.of("/").fragment("foo").build().toString()
+        '/#foo' ==  UriBuilder.of("").fragment("foo").build().toString()
+    }
+
+    void "query params in URIs"() {
+        expect:
+        '/foo?foo=bar' == UriBuilder.of("/foo")
+                .queryParam("foo", "bar")
+                .build()
+                .toString()
+    }
+
+    void "query params and fragments in URIs"() {
+        expect:
+        '/foo?foo=bar#baz' == UriBuilder.of("/foo")
+                .queryParam("foo", "bar")
+                .fragment("baz")
+                .build()
+                .toString()
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/micronaut-projects/micronaut-core/issues/7288

Currently this works: 

```java
    @Test ✅
    void pathVariableWithSpacesAndPathWithExpand() {
        String path = "this has a space in it";
        String expected = "/this%20has%20a%20space%20in%20it";
        assertEquals(expected,
                UriBuilder.of("").path("{pathwithspaces}")
                    .expand(CollectionUtils.mapOf("pathwithspaces", path)).toString());
    }
```

this fails: 

```java
@Test ❌
    void pathVariableWithSpacesAndPath() {
        String path = "this has a space in it";
        String expected = "/this%20has%20a%20space%20in%20it";
        assertEquals(expected, UriBuilder.of("")
                .path(path)
                .build().toString());
    }
```

@hollingsworthd has a [work in progress with bigger refactor of UriBuilder](https://github.com/micronaut-projects/micronaut-core/pull/7283) to support the handling of fragments and strings with parts of them as templates and parts of them not as templates. I don't think it is worth it to go that rabbit whole for now and I think this PR will fix the most common issue which users use `path` and they expected it to be Url encoded but it is not unless they use a template. 

