### PR TITLE
mapped mjs extension to application/javascript

### DIFF
--- a/http/src/main/resources/META-INF/http/mime.types
+++ b/http/src/main/resources/META-INF/http/mime.types
@@ -145,6 +145,7 @@ application/java-archive			jar
 application/java-serialized-object		ser
 application/java-vm				class
 application/javascript				js
+application/javascript				mjs
 # application/jose
 # application/jose+json
 # application/jrd+json


### PR DESCRIPTION
vue3/nuxt3 spa uses mjs (type module) so mapping static resource with micronaut gives exceptionand thinks to map mjs extenstion with text/plain. This change is to map .mjs with application/javascript.