### PR TITLE
Correct how proxies and its target beans are destroyed

### DIFF
--- a/aop/src/main/java/io/micronaut/aop/Intercepted.java
+++ b/aop/src/main/java/io/micronaut/aop/Intercepted.java
@@ -15,11 +15,13 @@
  */
 package io.micronaut.aop;
 
+import io.micronaut.inject.proxy.InterceptedBean;
+
 /**
  * An interface implemented by generated proxy classes.
  *
  * @author Graeme Rocher
  * @since 1.0
  */
-public interface Intercepted extends io.micronaut.inject.proxy.Intercepted {
+public interface Intercepted extends InterceptedBean {
 }

--- a/aop/src/main/java/io/micronaut/aop/InterceptedProxy.java
+++ b/aop/src/main/java/io/micronaut/aop/InterceptedProxy.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.aop;
 
+import io.micronaut.inject.proxy.InterceptedBeanProxy;
 import io.micronaut.inject.qualifiers.Qualified;
 
 /**
@@ -25,7 +26,7 @@ import io.micronaut.inject.qualifiers.Qualified;
  * @author Graeme Rocher
  * @since 1.0
  */
-public interface InterceptedProxy<T> extends Intercepted, Qualified<T>, io.micronaut.inject.proxy.InterceptedProxy<T> {
+public interface InterceptedProxy<T> extends Intercepted, Qualified<T>, InterceptedBeanProxy<T> {
 
     /**
      * This method will return the target object being proxied.
@@ -39,6 +40,7 @@ public interface InterceptedProxy<T> extends Intercepted, Qualified<T>, io.micro
      * Check if the proxy has the target cached before calling {@link #interceptedTarget()}.
      *
      * @return true if the target is cached
+     * @since 3.5.0
      */
     @Override
     default boolean hasCachedInterceptedTarget() {

--- a/config/accepted-api-changes.json
+++ b/config/accepted-api-changes.json
@@ -73,5 +73,25 @@
         "type": "io.micronaut.aop.InterceptedProxy",
         "member": "Method io.micronaut.aop.InterceptedProxy.hasCachedInterceptedTarget()",
         "reason": "New default method introduced to detect cached target, the interface is only implemented by the class generation"
+    },
+    {
+        "type": "io.micronaut.context.BeanDefinitionRegistry",
+        "member": "Class io.micronaut.context.BeanDefinitionRegistry",
+        "reason": "Added a new method"
+    },
+    {
+        "type": "io.micronaut.context.BeanDefinitionRegistry",
+        "member": "Method io.micronaut.context.BeanDefinitionRegistry.findProxyTargetBeanDefinition(io.micronaut.inject.BeanDefinition)",
+        "reason": "New method introduced"
+    },
+    {
+        "type": "io.micronaut.context.scope.CustomScope",
+        "member": "Class io.micronaut.context.scope.CustomScope",
+        "reason": "Added a new method"
+    },
+    {
+        "type": "io.micronaut.context.scope.CustomScope",
+        "member": "Method io.micronaut.context.scope.CustomScope.findBeanRegistration(io.micronaut.inject.BeanDefinition)",
+        "reason": "New method added with a default implementation"
     }
 ]

--- a/config/accepted-api-changes.json
+++ b/config/accepted-api-changes.json
@@ -63,5 +63,15 @@
         "type": "io.micronaut.graal.reflect.GraalTypeElementVisitor",
         "member": "Method io.micronaut.graal.reflect.GraalTypeElementVisitor.visitMethod(io.micronaut.inject.ast.MethodElement,io.micronaut.inject.visitor.VisitorContext)",
         "reason": "The Graal visitor is internal to the compiler and implementation detail not part of the public API"
+    },
+    {
+        "type": "io.micronaut.aop.InterceptedProxy",
+        "member": "Class io.micronaut.aop.InterceptedProxy",
+        "reason": "Class now extends similar interface from the Inject module allowing to detect intercepted proxies"
+    },
+    {
+        "type": "io.micronaut.aop.InterceptedProxy",
+        "member": "Method io.micronaut.aop.InterceptedProxy.hasCachedInterceptedTarget()",
+        "reason": "New default method introduced to detect cached target, the interface is only implemented by the class generation"
     }
 ]

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=3.5.0-VLV
+projectVersion=3.5.0-SNAPSHOT
 projectGroupId=io.micronaut
 title=Micronaut
 projectDesc=Natively Cloud Native

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=3.5.0-SNAPSHOT
+projectVersion=3.5.0-VLV
 projectGroupId=io.micronaut
 title=Micronaut
 projectDesc=Natively Cloud Native

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -1740,7 +1740,7 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
             if (!requiresReflection && modelUtils.isInheritedAndNotPublic(this.concreteClassElement, declaringClass, javaMethodElement)) {
                 requiresReflection = true;
             }
-
+            boolean lifecycleMethod = false;
             if (javaMethodElement.hasDeclaredAnnotation(AnnotationUtil.POST_CONSTRUCT)) {
                 BeanDefinitionVisitor writer = getOrCreateBeanDefinitionWriter(concreteClass, concreteClass.getQualifiedName());
                 addOriginatingElementIfNecessary(writer, declaringClass);
@@ -1750,7 +1750,9 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                         requiresReflection,
                         javaVisitorContext
                 );
-            } else if (javaMethodElement.hasDeclaredAnnotation(AnnotationUtil.PRE_DESTROY)) {
+                lifecycleMethod = true;
+            }
+            if (javaMethodElement.hasDeclaredAnnotation(AnnotationUtil.PRE_DESTROY)) {
                 BeanDefinitionVisitor writer = getOrCreateBeanDefinitionWriter(concreteClass, concreteClass.getQualifiedName());
                 addOriginatingElementIfNecessary(writer, declaringClass);
                 writer.visitPreDestroyMethod(
@@ -1759,7 +1761,12 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                         requiresReflection,
                         javaVisitorContext
                 );
-            } else if (javaMethodElement.hasDeclaredStereotype(AnnotationUtil.INJECT) ||
+                lifecycleMethod = true;
+            }
+            if (lifecycleMethod) {
+                return;
+            }
+            if (javaMethodElement.hasDeclaredStereotype(AnnotationUtil.INJECT) ||
                     javaMethodElement.hasDeclaredStereotype(ConfigurationInject.class)) {
                 BeanDefinitionVisitor writer = getOrCreateBeanDefinitionWriter(concreteClass, concreteClass.getQualifiedName());
                 addOriginatingElementIfNecessary(writer, declaringClass);

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/beanwithpredestroy/CDestroyedListener.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/beanwithpredestroy/CDestroyedListener.java
@@ -8,10 +8,10 @@ import jakarta.inject.Singleton;
 
 @Singleton
 public class CDestroyedListener implements BeanDestroyedEventListener<C> {
-    private boolean called = true;
+    private boolean called = false;
     @Override
     public void onDestroyed(BeanDestroyedEvent<C> event) {
-        this.called = called;
+        this.called = true;
         Assertions.assertTrue(event.getBean().isClosed());
     }
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/beanwithprivatepredestroy/CDestroyedListener.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/beanwithprivatepredestroy/CDestroyedListener.java
@@ -7,10 +7,10 @@ import org.junit.jupiter.api.Assertions;
 
 @Singleton
 public class CDestroyedListener implements BeanDestroyedEventListener<C> {
-    private boolean called = true;
+    private boolean called = false;
     @Override
     public void onDestroyed(BeanDestroyedEvent<C> event) {
-        this.called = called;
+        this.called = true;
         Assertions.assertTrue(event.getBean().isClosed());
     }
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxybeanwithpredestroy/A.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxybeanwithpredestroy/A.java
@@ -13,13 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.aop;
+package io.micronaut.inject.lifecycle.proxybeanwithpredestroy;
 
-/**
- * An interface implemented by generated proxy classes.
- *
- * @author Graeme Rocher
- * @since 1.0
- */
-public interface Intercepted extends io.micronaut.inject.proxy.Intercepted {
+import jakarta.inject.Singleton;
+
+@Singleton
+public class A {
+
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxybeanwithpredestroy/B.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxybeanwithpredestroy/B.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.lifecycle.proxybeanwithpredestroy;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Inject;
+
+import java.io.Closeable;
+
+@CustomScope
+public class B implements Closeable {
+
+    static int interceptCalled = 0;
+    static int noArgsDestroyCalled = 0;
+    static int injectedDestroyCalled = 0;
+
+    private final D prototypeD;
+
+    @Inject
+    protected A another;
+    private A a;
+
+    public B(D prototypeD) {
+        this.prototypeD = prototypeD;
+    }
+
+    @PostConstruct
+    @PreDestroy
+    public void intercept() {
+        interceptCalled++;
+    }
+
+    @Inject
+    void setA(A a ) {
+        this.a = a;
+    }
+
+    A getA() {
+        return a;
+    }
+
+    @Override
+    @PreDestroy
+    public void close() {
+        noArgsDestroyCalled++;
+    }
+
+    @PreDestroy
+    void another(C c) {
+        if(c != null) {
+            injectedDestroyCalled++;
+        }
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxybeanwithpredestroy/C.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxybeanwithpredestroy/C.java
@@ -13,13 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.aop;
+package io.micronaut.inject.lifecycle.proxybeanwithpredestroy;
 
-/**
- * An interface implemented by generated proxy classes.
- *
- * @author Graeme Rocher
- * @since 1.0
- */
-public interface Intercepted extends io.micronaut.inject.proxy.Intercepted {
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class C implements AutoCloseable {
+
+    static int closed;
+
+    @Override
+    @PreDestroy
+    public void close() throws Exception {
+        closed++;
+    }
+
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxybeanwithpredestroy/CDestroyedListener.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxybeanwithpredestroy/CDestroyedListener.java
@@ -11,7 +11,7 @@ public class CDestroyedListener implements BeanDestroyedEventListener<C> {
     @Override
     public void onDestroyed(BeanDestroyedEvent<C> event) {
         this.called++;
-        Assertions.assertEquals(C.closed, 1);
+        Assertions.assertEquals(1, C.closed);
     }
 
     public int getCalled() {

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxybeanwithpredestroy/CDestroyedListener.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxybeanwithpredestroy/CDestroyedListener.java
@@ -1,0 +1,20 @@
+package io.micronaut.inject.lifecycle.proxybeanwithpredestroy;
+
+import io.micronaut.context.event.BeanDestroyedEvent;
+import io.micronaut.context.event.BeanDestroyedEventListener;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.Assertions;
+
+@Singleton
+public class CDestroyedListener implements BeanDestroyedEventListener<C> {
+    private int called = 0;
+    @Override
+    public void onDestroyed(BeanDestroyedEvent<C> event) {
+        this.called++;
+        Assertions.assertEquals(C.closed, 1);
+    }
+
+    public int getCalled() {
+        return called;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxybeanwithpredestroy/CPreDestroyEventListener.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxybeanwithpredestroy/CPreDestroyEventListener.java
@@ -1,0 +1,22 @@
+package io.micronaut.inject.lifecycle.proxybeanwithpredestroy;
+
+import io.micronaut.context.event.BeanPreDestroyEvent;
+import io.micronaut.context.event.BeanPreDestroyEventListener;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.Assertions;
+
+@Singleton
+public class CPreDestroyEventListener implements BeanPreDestroyEventListener<C> {
+    private int called = 0;
+    @Override
+    public C onPreDestroy(BeanPreDestroyEvent<C> event) {
+        this.called++;
+        Assertions.assertEquals(C.closed, 0);
+        return event.getBean();
+    }
+
+    public int getCalled() {
+        return called;
+    }
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxybeanwithpredestroy/CPreDestroyEventListener.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxybeanwithpredestroy/CPreDestroyEventListener.java
@@ -11,7 +11,7 @@ public class CPreDestroyEventListener implements BeanPreDestroyEventListener<C> 
     @Override
     public C onPreDestroy(BeanPreDestroyEvent<C> event) {
         this.called++;
-        Assertions.assertEquals(C.closed, 0);
+        Assertions.assertEquals(0, C.closed);
         return event.getBean();
     }
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxybeanwithpredestroy/CustomScope.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxybeanwithpredestroy/CustomScope.java
@@ -13,13 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.aop;
+package io.micronaut.inject.lifecycle.proxybeanwithpredestroy;
 
-/**
- * An interface implemented by generated proxy classes.
- *
- * @author Graeme Rocher
- * @since 1.0
- */
-public interface Intercepted extends io.micronaut.inject.proxy.Intercepted {
+import io.micronaut.aop.Around;
+import io.micronaut.runtime.context.scope.ScopedProxy;
+import jakarta.inject.Scope;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@ScopedProxy
+@Around(proxyTarget = false, lazy = true)
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Scope
+public @interface CustomScope {
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxybeanwithpredestroy/CustomScopeScope.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxybeanwithpredestroy/CustomScopeScope.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.lifecycle.proxybeanwithpredestroy;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.BeanRegistration;
+import io.micronaut.context.LifeCycle;
+import io.micronaut.context.scope.BeanCreationContext;
+import io.micronaut.context.scope.CreatedBean;
+import io.micronaut.context.scope.CustomScope;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.inject.BeanDefinition;
+import io.micronaut.inject.BeanIdentifier;
+import jakarta.inject.Singleton;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Singleton
+public class CustomScopeScope implements CustomScope<io.micronaut.inject.lifecycle.proxybeanwithpredestroy.CustomScope>, LifeCycle<CustomScopeScope> {
+
+    private final BeanContext beanContext;
+    private List<BeanRegistration> beans = new ArrayList<>();
+
+    public CustomScopeScope(BeanContext beanContext) {
+        this.beanContext = beanContext;
+    }
+
+    @Override
+    public Class<io.micronaut.inject.lifecycle.proxybeanwithpredestroy.CustomScope> annotationType() {
+        return io.micronaut.inject.lifecycle.proxybeanwithpredestroy.CustomScope.class;
+    }
+
+    @Override
+    public <T> T getOrCreate(BeanCreationContext<T> creationContext) {
+        return this.<T>findById(creationContext.id()).orElseGet(() -> {
+            CreatedBean<T> createdBean = creationContext.create();
+            BeanRegistration<T> br = (BeanRegistration<T>) createdBean;
+            beans.add(br);
+            return br;
+        }).getBean();
+    }
+
+    @Override
+    public <T> Optional<T> remove(BeanIdentifier identifier) {
+        Optional<BeanRegistration<T>> found = findById(identifier);
+        found.ifPresent(tBeanRegistration -> beans.remove(tBeanRegistration));
+        return found.map(BeanRegistration::getBean);
+    }
+
+    @Override
+    public <T> Optional<BeanRegistration<T>> findBeanRegistration(BeanDefinition<T> beanDefinition) {
+        return findByBeanDefinition(beanDefinition);
+    }
+
+    @NotNull
+    private <T> Optional<BeanRegistration<T>> findByBeanDefinition(BeanDefinition<T> beanDefinition) {
+        return beans.stream().filter(br -> br.getBeanDefinition().equals(beanDefinition)).map(br -> (BeanRegistration<T>) br).findFirst();
+    }
+
+    @NonNull
+    private <T> Optional<BeanRegistration<T>> findById(BeanIdentifier identifier) {
+        return beans.stream().filter(br -> br.getIdentifier().equals(identifier)).map(br -> (BeanRegistration<T>) br).findFirst();
+    }
+
+    @Override
+    public boolean isRunning() {
+        return true;
+    }
+
+    @Override
+    public CustomScopeScope stop() {
+        beans.forEach(beanContext::destroyBean);
+        beans.clear();
+        return this;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxybeanwithpredestroy/D.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxybeanwithpredestroy/D.java
@@ -13,13 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.aop;
+package io.micronaut.inject.lifecycle.proxybeanwithpredestroy;
 
-/**
- * An interface implemented by generated proxy classes.
- *
- * @author Graeme Rocher
- * @since 1.0
- */
-public interface Intercepted extends io.micronaut.inject.proxy.Intercepted {
+import io.micronaut.context.annotation.Prototype;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+
+@Prototype
+public class D {
+
+    static int created;
+    static int destroyed;
+
+    @PostConstruct
+    public void create() {
+        created++;
+    }
+
+    @PreDestroy
+    public void destroy() {
+        destroyed++;
+    }
+
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxybeanwithpredestroy/ProxyBeanWithPreDestroySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxybeanwithpredestroy/ProxyBeanWithPreDestroySpec.groovy
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.lifecycle.proxybeanwithpredestroy
+
+import io.micronaut.context.BeanContext
+import io.micronaut.context.DefaultBeanContext
+import spock.lang.Specification
+
+class ProxyBeanWithPreDestroySpec extends Specification {
+
+    def setup() {
+        B.interceptCalled = 0
+        B.injectedDestroyCalled = 0
+        B.noArgsDestroyCalled = 0
+        C.closed = 0
+        D.destroyed = 0
+        D.created = 0
+    }
+
+    void "test cannot destroyed a proxy bean by the class name"() {
+        given:
+            BeanContext context = new DefaultBeanContext()
+            context.start()
+
+        when:
+            context.getBean(B)
+            context.destroyBean(B)
+        then:
+            thrown(IllegalArgumentException)
+            B.noArgsDestroyCalled == 0
+            B.injectedDestroyCalled == 0
+            D.destroyed == 0
+
+        cleanup:
+            context.close()
+    }
+
+    void "test that a pre-destroy hook works"() {
+        given:
+            BeanContext context = new DefaultBeanContext()
+            context.start()
+
+        when:
+            Root root = context.getBean(Root)
+
+        then:
+            root.b.a != null
+            B.interceptCalled == 1
+            B.noArgsDestroyCalled == 0
+            B.injectedDestroyCalled == 0
+            D.destroyed == 0
+
+        when:
+            context.destroyBean(root)
+
+        then:
+            B.interceptCalled == 2
+            B.noArgsDestroyCalled == 1
+            B.injectedDestroyCalled == 1
+            D.created == 1
+            D.destroyed == 1
+
+        cleanup:
+            context.close()
+    }
+
+    void "test that a pre-destroy hook works when destroyed by registration"() {
+        given:
+            BeanContext context = new DefaultBeanContext()
+            context.start()
+
+        when:
+            def beanDefinition = context.findBeanDefinition(B).get()
+            def registration = context.getBeanRegistration(beanDefinition)
+            B b = registration.bean
+
+        then:
+            B.interceptCalled == 1
+            b.a != null
+            B.noArgsDestroyCalled == 0
+            B.injectedDestroyCalled == 0
+            D.created == 1
+            D.destroyed == 0
+
+        when:
+            context.destroyBean(registration)
+
+        then:
+            B.interceptCalled == 2
+            B.noArgsDestroyCalled == 1
+            B.injectedDestroyCalled == 1
+            D.created == 1
+            D.destroyed == 1
+
+        cleanup:
+            context.close()
+    }
+
+    void "test that a bean with a pre-destroy hook works closed on close"() {
+        given:
+            BeanContext context = new DefaultBeanContext()
+            context.start()
+
+        when:
+            Root root = context.getBean(Root)
+        then:
+            root.b.a != null
+            B.interceptCalled == 1
+            B.noArgsDestroyCalled == 0
+            B.injectedDestroyCalled == 0
+            D.created == 1
+            D.destroyed == 0
+
+        when:
+            context.close()
+
+        then:
+            B.interceptCalled == 2
+            B.noArgsDestroyCalled == 1
+            B.injectedDestroyCalled == 1
+            D.created == 1
+            D.destroyed == 1
+    }
+
+    void "test that destroy events run in the right phase"() {
+        given:
+            BeanContext context = new DefaultBeanContext()
+            context.start()
+
+
+        when:
+            def pre = context.getBean(CPreDestroyEventListener)
+            def post = context.getBean(CDestroyedListener)
+            def c = context.getBean(C)
+
+        then:
+            C.closed == 0
+
+        when:
+            context.close()
+
+        then:
+            pre.called == 1
+            post.called == 1
+            C.closed == 1
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxybeanwithpredestroy/Root.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxybeanwithpredestroy/Root.java
@@ -13,13 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.aop;
+package io.micronaut.inject.lifecycle.proxybeanwithpredestroy;
 
-/**
- * An interface implemented by generated proxy classes.
- *
- * @author Graeme Rocher
- * @since 1.0
- */
-public interface Intercepted extends io.micronaut.inject.proxy.Intercepted {
+import jakarta.inject.Singleton;
+
+@Singleton
+public class Root {
+
+    public final B b;
+
+    public Root(B b) {
+        this.b = b;
+    }
+
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanprototypewithpredestroy/A.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanprototypewithpredestroy/A.java
@@ -13,13 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.aop;
+package io.micronaut.inject.lifecycle.proxytargetbeanprototypewithpredestroy;
 
-/**
- * An interface implemented by generated proxy classes.
- *
- * @author Graeme Rocher
- * @since 1.0
- */
-public interface Intercepted extends io.micronaut.inject.proxy.Intercepted {
+import jakarta.inject.Singleton;
+
+@Singleton
+public class A {
+
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanprototypewithpredestroy/B.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanprototypewithpredestroy/B.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.lifecycle.proxytargetbeanprototypewithpredestroy;
+
+import io.micronaut.context.annotation.Prototype;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Inject;
+
+import java.io.Closeable;
+
+@CustomScope
+@Prototype
+public class B implements Closeable {
+
+    static int interceptCalled = 0;
+    static int noArgsDestroyCalled = 0;
+    static int injectedDestroyCalled = 0;
+
+    private final D prototypeD;
+
+    @Inject
+    protected A another;
+    private A a;
+
+    public B(D prototypeD) {
+        this.prototypeD = prototypeD;
+    }
+
+    @Inject
+    void setA(A a ) {
+        this.a = a;
+    }
+
+    A getA() {
+        return a;
+    }
+
+    @PostConstruct
+    @PreDestroy
+    public void intercept() {
+        interceptCalled++;
+    }
+
+    @Override
+    @PreDestroy
+    public void close() {
+        noArgsDestroyCalled++;
+    }
+
+    @PreDestroy
+    void another(C c) {
+        if(c != null) {
+            injectedDestroyCalled++;
+        }
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanprototypewithpredestroy/C.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanprototypewithpredestroy/C.java
@@ -13,13 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.aop;
+package io.micronaut.inject.lifecycle.proxytargetbeanprototypewithpredestroy;
 
-/**
- * An interface implemented by generated proxy classes.
- *
- * @author Graeme Rocher
- * @since 1.0
- */
-public interface Intercepted extends io.micronaut.inject.proxy.Intercepted {
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class C implements AutoCloseable {
+
+    static int closed;
+
+    @Override
+    @PreDestroy
+    public void close() throws Exception {
+        closed++;
+    }
+
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanprototypewithpredestroy/CDestroyedListener.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanprototypewithpredestroy/CDestroyedListener.java
@@ -1,0 +1,20 @@
+package io.micronaut.inject.lifecycle.proxytargetbeanprototypewithpredestroy;
+
+import io.micronaut.context.event.BeanDestroyedEvent;
+import io.micronaut.context.event.BeanDestroyedEventListener;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.Assertions;
+
+@Singleton
+public class CDestroyedListener implements BeanDestroyedEventListener<C> {
+    private int called = 0;
+    @Override
+    public void onDestroyed(BeanDestroyedEvent<C> event) {
+        this.called++;
+        Assertions.assertEquals(C.closed, 1);
+    }
+
+    public int getCalled() {
+        return called;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanprototypewithpredestroy/CDestroyedListener.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanprototypewithpredestroy/CDestroyedListener.java
@@ -11,7 +11,7 @@ public class CDestroyedListener implements BeanDestroyedEventListener<C> {
     @Override
     public void onDestroyed(BeanDestroyedEvent<C> event) {
         this.called++;
-        Assertions.assertEquals(C.closed, 1);
+        Assertions.assertEquals(1, C.closed);
     }
 
     public int getCalled() {

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanprototypewithpredestroy/CPreDestroyEventListener.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanprototypewithpredestroy/CPreDestroyEventListener.java
@@ -11,7 +11,7 @@ public class CPreDestroyEventListener implements BeanPreDestroyEventListener<C> 
     @Override
     public C onPreDestroy(BeanPreDestroyEvent<C> event) {
         this.called++;
-        Assertions.assertEquals(C.closed, 0);
+        Assertions.assertEquals(0, C.closed);
         return event.getBean();
     }
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanprototypewithpredestroy/CPreDestroyEventListener.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanprototypewithpredestroy/CPreDestroyEventListener.java
@@ -1,0 +1,22 @@
+package io.micronaut.inject.lifecycle.proxytargetbeanprototypewithpredestroy;
+
+import io.micronaut.context.event.BeanPreDestroyEvent;
+import io.micronaut.context.event.BeanPreDestroyEventListener;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.Assertions;
+
+@Singleton
+public class CPreDestroyEventListener implements BeanPreDestroyEventListener<C> {
+    private int called = 0;
+    @Override
+    public C onPreDestroy(BeanPreDestroyEvent<C> event) {
+        this.called++;
+        Assertions.assertEquals(C.closed, 0);
+        return event.getBean();
+    }
+
+    public int getCalled() {
+        return called;
+    }
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanprototypewithpredestroy/CustomScope.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanprototypewithpredestroy/CustomScope.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.lifecycle.proxytargetbeanprototypewithpredestroy;
+
+import io.micronaut.aop.Around;
+import io.micronaut.runtime.context.scope.ScopedProxy;
+import jakarta.inject.Scope;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Around(
+        lazy = true,
+        proxyTarget = true,
+        cacheableLazyTarget = true
+)
+@ScopedProxy
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Scope
+public @interface CustomScope {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanprototypewithpredestroy/D.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanprototypewithpredestroy/D.java
@@ -13,13 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.aop;
+package io.micronaut.inject.lifecycle.proxytargetbeanprototypewithpredestroy;
 
-/**
- * An interface implemented by generated proxy classes.
- *
- * @author Graeme Rocher
- * @since 1.0
- */
-public interface Intercepted extends io.micronaut.inject.proxy.Intercepted {
+import io.micronaut.context.annotation.Prototype;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+
+@Prototype
+public class D {
+
+    static int created;
+    static int destroyed;
+
+    @PostConstruct
+    public void create() {
+        created++;
+    }
+
+    @PreDestroy
+    public void destroy() {
+        destroyed++;
+    }
+
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanprototypewithpredestroy/ProxyLazyCachedTargetPrototypeBeanWithPreDestroySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanprototypewithpredestroy/ProxyLazyCachedTargetPrototypeBeanWithPreDestroySpec.groovy
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.lifecycle.proxytargetbeanprototypewithpredestroy
+
+import io.micronaut.context.BeanContext
+import io.micronaut.context.DefaultBeanContext
+import spock.lang.Specification
+
+class ProxyLazyCachedTargetPrototypeBeanWithPreDestroySpec extends Specification {
+
+    def setup() {
+        B.interceptCalled = 0
+        B.injectedDestroyCalled = 0
+        B.noArgsDestroyCalled = 0
+        C.closed = 0
+        D.destroyed = 0
+        D.created = 0
+    }
+
+    void "test that a lazy target bean with a pre-destroy hook works"() {
+        given:
+            BeanContext context = new DefaultBeanContext()
+            context.start()
+
+        when:
+            Root root = context.getBean(Root)
+            root.triggerProxyInitializeForB()
+
+        then:
+            root.b.a != null
+            B.interceptCalled == 1
+            B.noArgsDestroyCalled == 0
+            B.injectedDestroyCalled == 0
+            D.destroyed == 0
+
+        when:
+            context.destroyBean(root)
+
+        then:
+            B.interceptCalled == 2
+            B.noArgsDestroyCalled == 1
+            B.injectedDestroyCalled == 1
+            D.created == 2 // Create proxy + target
+            D.destroyed == 2
+
+        cleanup:
+            context.close()
+    }
+
+    void "test that a proxy pre-destroy is not called on not-initialized target"() {
+        given:
+            BeanContext context = new DefaultBeanContext()
+            context.start()
+
+        when:
+            Root root = context.getBean(Root)
+
+        then:
+            B.interceptCalled == 0
+            B.noArgsDestroyCalled == 0
+            B.injectedDestroyCalled == 0
+            D.created == 1 // Create proxy
+            D.destroyed == 0
+
+        when:
+            context.destroyBean(root)
+
+        then: "Lazy target or proxy is not destroyed"
+            B.interceptCalled == 0
+            B.noArgsDestroyCalled == 0
+            B.injectedDestroyCalled == 0
+            D.created == 1
+            D.destroyed == 1
+
+        cleanup:
+            context.close()
+    }
+
+    void "test that a lazy proxy bean with a pre-destroy hook works when destroyed by registration"() {
+        given:
+            BeanContext context = new DefaultBeanContext()
+            context.start()
+
+        when:
+            def beanDefinition = context.findBeanDefinition(B).get()
+            def registration = context.getBeanRegistration(beanDefinition)
+            B b = registration.bean
+            b.getA() // B is lazy
+
+        then:
+            b.a != null
+            B.interceptCalled == 1
+            B.noArgsDestroyCalled == 0
+            B.injectedDestroyCalled == 0
+            D.created == 2  // Create proxy + target
+            D.destroyed == 0
+
+        when:
+            context.destroyBean(registration)
+
+        then:
+            B.interceptCalled == 2
+            B.noArgsDestroyCalled == 1
+            B.injectedDestroyCalled == 1
+            D.created == 2
+            D.destroyed == 2  // Destroy proxy + target
+
+        cleanup:
+            context.close()
+    }
+
+    void "test that a lazy proxy bean with a pre-destroy hook is not called on not-initialized target"() {
+        given:
+            BeanContext context = new DefaultBeanContext()
+            context.start()
+
+        when:
+            def beanDefinition = context.findBeanDefinition(B).get()
+            def registration = context.getBeanRegistration(beanDefinition)
+            registration.bean
+
+        then:
+            B.interceptCalled == 0
+            B.noArgsDestroyCalled == 0
+            B.injectedDestroyCalled == 0
+            D.created == 1 // Create proxy
+            D.destroyed == 0
+
+        when:
+            context.destroyBean(registration)
+
+        then:
+            B.interceptCalled == 0
+            B.noArgsDestroyCalled == 0
+            B.injectedDestroyCalled == 0
+            D.created == 1
+            D.destroyed == 1 // Destroy proxy
+
+        cleanup:
+            context.close()
+    }
+
+    void "test that a bean with a pre-destroy hook works closed on close"() {
+        given:
+            BeanContext context = new DefaultBeanContext()
+            context.start()
+
+        when:
+            Root root = context.getBean(Root)
+            root.triggerProxyInitializeForB()
+
+        then:
+            root.b.a != null
+            B.interceptCalled == 1
+            B.noArgsDestroyCalled == 0
+            B.injectedDestroyCalled == 0
+            D.created == 2
+            D.destroyed == 0
+
+        when:
+            context.close()
+
+        then:
+            B.interceptCalled == 2
+            B.noArgsDestroyCalled == 1
+            B.injectedDestroyCalled == 1
+            D.created == 2
+            D.destroyed == 2
+    }
+
+    void "test proxies are prototypes and dependent beans not destroyed when created by `getBean(<ProxyClass>)`"() {
+        given:
+            BeanContext context = new DefaultBeanContext()
+            context.start()
+
+        when:
+            B b = context.getBean(B)
+            b.getA() // B is lazy
+
+        then:
+            b.a != null
+            B.interceptCalled == 1
+            B.noArgsDestroyCalled == 0
+            B.injectedDestroyCalled == 0
+            D.created == 2
+            D.destroyed == 0
+
+        when:
+            context.close()
+
+        then:
+            // Prototype target is not destroyed
+            B.interceptCalled == 1
+            B.noArgsDestroyCalled == 0
+            B.injectedDestroyCalled == 0
+            D.created == 2
+            D.destroyed == 0
+    }
+
+    void "test that destroy events run in the right phase"() {
+        given:
+            BeanContext context = new DefaultBeanContext()
+            context.start()
+
+
+        when:
+            def pre = context.getBean(CPreDestroyEventListener)
+            def post = context.getBean(CDestroyedListener)
+            def c = context.getBean(C)
+
+        then:
+            C.closed == 0
+
+        when:
+            context.close()
+
+        then:
+            pre.called == 1
+            post.called == 1
+            C.closed == 1
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanprototypewithpredestroy/Root.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanprototypewithpredestroy/Root.java
@@ -13,13 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.aop;
+package io.micronaut.inject.lifecycle.proxytargetbeanprototypewithpredestroy;
 
-/**
- * An interface implemented by generated proxy classes.
- *
- * @author Graeme Rocher
- * @since 1.0
- */
-public interface Intercepted extends io.micronaut.inject.proxy.Intercepted {
+import jakarta.inject.Singleton;
+
+@Singleton
+public class Root {
+
+    public final B b;
+
+    public Root(B b) {
+        this.b = b;
+    }
+
+    void triggerProxyInitializeForB() {
+        b.getA();
+    }
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanwithpredestroy/A.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanwithpredestroy/A.java
@@ -13,13 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.aop;
+package io.micronaut.inject.lifecycle.proxytargetbeanwithpredestroy;
 
-/**
- * An interface implemented by generated proxy classes.
- *
- * @author Graeme Rocher
- * @since 1.0
- */
-public interface Intercepted extends io.micronaut.inject.proxy.Intercepted {
+import jakarta.inject.Singleton;
+
+@Singleton
+public class A {
+
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanwithpredestroy/B.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanwithpredestroy/B.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.lifecycle.proxytargetbeanwithpredestroy;
+
+import io.micronaut.aop.Intercepted;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Inject;
+
+import java.io.Closeable;
+
+@CustomScope
+public class B implements Closeable {
+
+    static int interceptCalled = 0;
+    static int noArgsDestroyCalled = 0;
+    static int injectedDestroyCalled = 0;
+
+    private final D prototypeD;
+
+    @Inject
+    protected A another;
+    private A a;
+
+    public B(D prototypeD) {
+        this.prototypeD = prototypeD;
+    }
+
+    @PostConstruct
+    @PreDestroy
+    public void intercept() {
+        interceptCalled++;
+    }
+
+    @Inject
+    void setA(A a ) {
+        this.a = a;
+    }
+
+    A getA() {
+        return a;
+    }
+
+    @Override
+    @PreDestroy
+    public void close() {
+        if (this instanceof Intercepted) {
+            throw new IllegalStateException("Intercepted should not have hooks invoked!");
+        }
+        noArgsDestroyCalled++;
+    }
+
+    @PreDestroy
+    void another(C c) {
+        if (this instanceof Intercepted) {
+            throw new IllegalStateException("Intercepted should not have hooks invoked!");
+        }
+        if(c != null) {
+            injectedDestroyCalled++;
+        }
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanwithpredestroy/C.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanwithpredestroy/C.java
@@ -13,13 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.aop;
+package io.micronaut.inject.lifecycle.proxytargetbeanwithpredestroy;
 
-/**
- * An interface implemented by generated proxy classes.
- *
- * @author Graeme Rocher
- * @since 1.0
- */
-public interface Intercepted extends io.micronaut.inject.proxy.Intercepted {
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class C implements AutoCloseable {
+
+    static int closed;
+
+    @Override
+    @PreDestroy
+    public void close() throws Exception {
+        closed++;
+    }
+
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanwithpredestroy/CDestroyedListener.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanwithpredestroy/CDestroyedListener.java
@@ -1,0 +1,20 @@
+package io.micronaut.inject.lifecycle.proxytargetbeanwithpredestroy;
+
+import io.micronaut.context.event.BeanDestroyedEvent;
+import io.micronaut.context.event.BeanDestroyedEventListener;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.Assertions;
+
+@Singleton
+public class CDestroyedListener implements BeanDestroyedEventListener<C> {
+    private int called = 0;
+    @Override
+    public void onDestroyed(BeanDestroyedEvent<C> event) {
+        this.called++;
+        Assertions.assertEquals(C.closed, 1);
+    }
+
+    public int getCalled() {
+        return called;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanwithpredestroy/CDestroyedListener.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanwithpredestroy/CDestroyedListener.java
@@ -11,7 +11,7 @@ public class CDestroyedListener implements BeanDestroyedEventListener<C> {
     @Override
     public void onDestroyed(BeanDestroyedEvent<C> event) {
         this.called++;
-        Assertions.assertEquals(C.closed, 1);
+        Assertions.assertEquals(1, C.closed);
     }
 
     public int getCalled() {

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanwithpredestroy/CPreDestroyEventListener.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanwithpredestroy/CPreDestroyEventListener.java
@@ -1,0 +1,22 @@
+package io.micronaut.inject.lifecycle.proxytargetbeanwithpredestroy;
+
+import io.micronaut.context.event.BeanPreDestroyEvent;
+import io.micronaut.context.event.BeanPreDestroyEventListener;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.Assertions;
+
+@Singleton
+public class CPreDestroyEventListener implements BeanPreDestroyEventListener<C> {
+    private int called = 0;
+    @Override
+    public C onPreDestroy(BeanPreDestroyEvent<C> event) {
+        this.called++;
+        Assertions.assertEquals(C.closed, 0);
+        return event.getBean();
+    }
+
+    public int getCalled() {
+        return called;
+    }
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanwithpredestroy/CPreDestroyEventListener.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanwithpredestroy/CPreDestroyEventListener.java
@@ -11,7 +11,7 @@ public class CPreDestroyEventListener implements BeanPreDestroyEventListener<C> 
     @Override
     public C onPreDestroy(BeanPreDestroyEvent<C> event) {
         this.called++;
-        Assertions.assertEquals(C.closed, 0);
+        Assertions.assertEquals(0, C.closed);
         return event.getBean();
     }
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanwithpredestroy/CustomScope.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanwithpredestroy/CustomScope.java
@@ -13,13 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.aop;
+package io.micronaut.inject.lifecycle.proxytargetbeanwithpredestroy;
 
-/**
- * An interface implemented by generated proxy classes.
- *
- * @author Graeme Rocher
- * @since 1.0
- */
-public interface Intercepted extends io.micronaut.inject.proxy.Intercepted {
+import io.micronaut.runtime.context.scope.ScopedProxy;
+import jakarta.inject.Scope;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@ScopedProxy
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Scope
+public @interface CustomScope {
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanwithpredestroy/CustomScopeScope.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanwithpredestroy/CustomScopeScope.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.lifecycle.proxytargetbeanwithpredestroy;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.BeanRegistration;
+import io.micronaut.context.LifeCycle;
+import io.micronaut.context.scope.BeanCreationContext;
+import io.micronaut.context.scope.CreatedBean;
+import io.micronaut.context.scope.CustomScope;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.inject.BeanDefinition;
+import io.micronaut.inject.BeanIdentifier;
+import jakarta.inject.Singleton;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Singleton
+public class CustomScopeScope implements CustomScope<io.micronaut.inject.lifecycle.proxytargetbeanwithpredestroy.CustomScope>, LifeCycle<CustomScopeScope> {
+
+    private final BeanContext beanContext;
+    private List<BeanRegistration> beans = new ArrayList<>();
+
+    public CustomScopeScope(BeanContext beanContext) {
+        this.beanContext = beanContext;
+    }
+
+    @Override
+    public Class<io.micronaut.inject.lifecycle.proxytargetbeanwithpredestroy.CustomScope> annotationType() {
+        return io.micronaut.inject.lifecycle.proxytargetbeanwithpredestroy.CustomScope.class;
+    }
+
+    @Override
+    public <T> T getOrCreate(BeanCreationContext<T> creationContext) {
+        return this.<T>findById(creationContext.id()).orElseGet(() -> {
+            CreatedBean<T> createdBean = creationContext.create();
+            BeanRegistration<T> br = (BeanRegistration<T>) createdBean;
+            beans.add(br);
+            return br;
+        }).getBean();
+    }
+
+    @Override
+    public <T> Optional<T> remove(BeanIdentifier identifier) {
+        Optional<BeanRegistration<T>> found = findById(identifier);
+        found.ifPresent(tBeanRegistration -> beans.remove(tBeanRegistration));
+        return found.map(BeanRegistration::getBean);
+    }
+
+    @Override
+    public <T> Optional<BeanRegistration<T>> findBeanRegistration(BeanDefinition<T> beanDefinition) {
+        return findByBeanDefinition(beanDefinition);
+    }
+
+    @NotNull
+    private <T> Optional<BeanRegistration<T>> findByBeanDefinition(BeanDefinition<T> beanDefinition) {
+        return beans.stream().filter(br -> br.getBeanDefinition().equals(beanDefinition)).map(br -> (BeanRegistration<T>) br).findFirst();
+    }
+
+    @NonNull
+    private <T> Optional<BeanRegistration<T>> findById(BeanIdentifier identifier) {
+        return beans.stream().filter(br -> br.getIdentifier().equals(identifier)).map(br -> (BeanRegistration<T>) br).findFirst();
+    }
+
+    @Override
+    public boolean isRunning() {
+        return true;
+    }
+
+    @Override
+    public CustomScopeScope stop() {
+        beans.forEach(beanContext::destroyBean);
+        beans.clear();
+        return this;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanwithpredestroy/D.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanwithpredestroy/D.java
@@ -13,13 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.aop;
+package io.micronaut.inject.lifecycle.proxytargetbeanwithpredestroy;
 
-/**
- * An interface implemented by generated proxy classes.
- *
- * @author Graeme Rocher
- * @since 1.0
- */
-public interface Intercepted extends io.micronaut.inject.proxy.Intercepted {
+import io.micronaut.context.annotation.Prototype;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+
+@Prototype
+public class D {
+
+    static int created;
+    static int destroyed;
+
+    @PostConstruct
+    public void create() {
+        created++;
+    }
+
+    @PreDestroy
+    public void destroy() {
+        destroyed++;
+    }
+
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanwithpredestroy/ProxyTargetBeanWithPreDestroySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanwithpredestroy/ProxyTargetBeanWithPreDestroySpec.groovy
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.lifecycle.proxytargetbeanwithpredestroy
+
+import io.micronaut.context.BeanContext
+import io.micronaut.context.DefaultBeanContext
+import spock.lang.Specification
+
+class ProxyTargetBeanWithPreDestroySpec extends Specification {
+
+    def setup() {
+        B.interceptCalled = 0
+        B.injectedDestroyCalled = 0
+        B.noArgsDestroyCalled = 0
+        C.closed = 0
+        D.destroyed = 0
+        D.created = 0
+    }
+
+    void "test cannot destroyed a proxy bean by the class name"() {
+        given:
+            BeanContext context = new DefaultBeanContext()
+            context.start()
+
+        when:
+            context.getBean(B)
+            context.destroyBean(B)
+        then:
+            thrown(IllegalArgumentException)
+            B.noArgsDestroyCalled == 0
+            B.injectedDestroyCalled == 0
+            D.destroyed == 0
+
+        cleanup:
+            context.close()
+    }
+
+    void "test that a lazy target bean with a pre-destroy hook works"() {
+        given:
+            BeanContext context = new DefaultBeanContext()
+            context.start()
+
+        when:
+            Root root = context.getBean(Root)
+            root.triggerProxyInitializeForB()
+
+        then:
+            root.b.a != null
+            B.interceptCalled == 1
+            B.noArgsDestroyCalled == 0
+            B.injectedDestroyCalled == 0
+            D.destroyed == 0
+
+        when:
+            context.destroyBean(root)
+
+        then:
+            B.interceptCalled == 2
+            B.noArgsDestroyCalled == 1
+            B.injectedDestroyCalled == 1
+            D.created == 2 // Create proxy + target
+            D.destroyed == 2
+
+        cleanup:
+            context.close()
+    }
+
+    void "test that a proxy pre-destroy is not called on not-initialized target"() {
+        given:
+            BeanContext context = new DefaultBeanContext()
+            context.start()
+
+        when:
+            Root root = context.getBean(Root)
+
+        then:
+            B.interceptCalled == 0
+            B.noArgsDestroyCalled == 0
+            B.injectedDestroyCalled == 0
+            D.created == 1 // Create proxy
+            D.destroyed == 0
+
+        when:
+            context.destroyBean(root)
+
+        then: "Lazy target or proxy is not destroyed"
+            B.interceptCalled == 0
+            B.noArgsDestroyCalled == 0
+            B.injectedDestroyCalled == 0
+            D.created == 1
+            D.destroyed == 1
+
+        cleanup:
+            context.close()
+    }
+
+    void "test that a lazy proxy bean with a pre-destroy hook works when destroyed by registration"() {
+        given:
+            BeanContext context = new DefaultBeanContext()
+            context.start()
+
+        when:
+            def beanDefinition = context.findBeanDefinition(B).get()
+            def registration = context.getBeanRegistration(beanDefinition)
+            B b = registration.bean
+            b.getA() // B is lazy
+
+        then:
+            b.a != null
+            B.interceptCalled == 1
+            B.noArgsDestroyCalled == 0
+            B.injectedDestroyCalled == 0
+            D.created == 2  // Create proxy + target
+            D.destroyed == 0
+
+        when:
+            context.destroyBean(registration)
+
+        then:
+            B.interceptCalled == 2
+            B.noArgsDestroyCalled == 1
+            B.injectedDestroyCalled == 1
+            D.created == 2
+            D.destroyed == 2  // Destroy proxy + target
+
+        cleanup:
+            context.close()
+    }
+
+    void "test that a lazy proxy bean with a pre-destroy hook is not called on not-initialized target"() {
+        given:
+            BeanContext context = new DefaultBeanContext()
+            context.start()
+
+        when:
+            def beanDefinition = context.findBeanDefinition(B).get()
+            def registration = context.getBeanRegistration(beanDefinition)
+            registration.bean
+
+        then:
+            B.interceptCalled == 0
+            B.noArgsDestroyCalled == 0
+            B.injectedDestroyCalled == 0
+            D.created == 1 // Create proxy
+            D.destroyed == 0
+
+        when:
+            context.destroyBean(registration)
+
+        then:
+            B.interceptCalled == 0
+            B.noArgsDestroyCalled == 0
+            B.injectedDestroyCalled == 0
+            D.created == 1
+            D.destroyed == 1 // Destroy proxy
+
+        cleanup:
+            context.close()
+    }
+
+    void "test that a bean with a pre-destroy hook works closed on close"() {
+        given:
+            BeanContext context = new DefaultBeanContext()
+            context.start()
+
+        when:
+            Root root = context.getBean(Root)
+            root.triggerProxyInitializeForB()
+
+        then:
+            root.b.a != null
+            B.interceptCalled == 1
+            B.noArgsDestroyCalled == 0
+            B.injectedDestroyCalled == 0
+            D.created == 2
+            D.destroyed == 0
+
+        when:
+            context.close()
+
+        then:
+            B.interceptCalled == 2
+            B.noArgsDestroyCalled == 1
+            B.injectedDestroyCalled == 1
+            D.created == 2
+            D.destroyed == 2
+    }
+
+    void "test proxies are prototypes and dependent beans not destroyed when created by `getBean(<ProxyClass>)`"() {
+        given:
+            BeanContext context = new DefaultBeanContext()
+            context.start()
+
+        when:
+            B b = context.getBean(B)
+            b.getA() // B is lazy
+
+        then:
+            b.a != null
+            B.interceptCalled == 1
+            B.noArgsDestroyCalled == 0
+            B.injectedDestroyCalled == 0
+            D.created == 2
+            D.destroyed == 0
+
+        when:
+            context.close()
+
+        then:
+            B.interceptCalled == 2
+            B.noArgsDestroyCalled == 1
+            B.injectedDestroyCalled == 1
+            D.created == 2
+            D.destroyed == 1 // Proxies are always prototypes
+    }
+
+    void "test that destroy events run in the right phase"() {
+        given:
+            BeanContext context = new DefaultBeanContext()
+            context.start()
+
+
+        when:
+            def pre = context.getBean(CPreDestroyEventListener)
+            def post = context.getBean(CDestroyedListener)
+            def c = context.getBean(C)
+
+        then:
+            C.closed == 0
+
+        when:
+            context.close()
+
+        then:
+            pre.called == 1
+            post.called == 1
+            C.closed == 1
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanwithpredestroy/Root.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanwithpredestroy/Root.java
@@ -13,13 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.aop;
+package io.micronaut.inject.lifecycle.proxytargetbeanwithpredestroy;
 
-/**
- * An interface implemented by generated proxy classes.
- *
- * @author Graeme Rocher
- * @since 1.0
- */
-public interface Intercepted extends io.micronaut.inject.proxy.Intercepted {
+import jakarta.inject.Singleton;
+
+@Singleton
+public class Root {
+
+    public final B b;
+
+    public Root(B b) {
+        this.b = b;
+    }
+
+    void triggerProxyInitializeForB() {
+        b.getA();
+    }
 }

--- a/inject/src/main/java/io/micronaut/context/AbstractBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractBeanDefinition.java
@@ -683,10 +683,10 @@ public class AbstractBeanDefinition<T> extends AbstractBeanContextConditional im
             resolutionContext.addInFlightBean(key, new BeanRegistration(key, this, bean));
         }
 
-        final Set<Map.Entry<Class, List<BeanInitializedEventListener>>> beanInitializedEventListeners
+        final Set<Map.Entry<Class<?>, List<BeanInitializedEventListener>>> beanInitializedEventListeners
                 = ((DefaultBeanContext) context).beanInitializedEventListeners;
         if (CollectionUtils.isNotEmpty(beanInitializedEventListeners)) {
-            for (Map.Entry<Class, List<BeanInitializedEventListener>> entry : beanInitializedEventListeners) {
+            for (Map.Entry<Class<?>, List<BeanInitializedEventListener>> entry : beanInitializedEventListeners) {
                 if (entry.getKey().isAssignableFrom(getBeanType())) {
                     for (BeanInitializedEventListener listener : entry.getValue()) {
                         bean = listener.onInitialized(new BeanInitializingEvent(context, this, bean));

--- a/inject/src/main/java/io/micronaut/context/AbstractInitializableBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractInitializableBeanDefinition.java
@@ -816,10 +816,10 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
     @Internal
     @UsedByGeneratedCode
     protected Object postConstruct(BeanResolutionContext resolutionContext, BeanContext context, Object bean) {
-        final Set<Map.Entry<Class, List<BeanInitializedEventListener>>> beanInitializedEventListeners
+        final Set<Map.Entry<Class<?>, List<BeanInitializedEventListener>>> beanInitializedEventListeners
                 = ((DefaultBeanContext) context).beanInitializedEventListeners;
         if (CollectionUtils.isNotEmpty(beanInitializedEventListeners)) {
-            for (Map.Entry<Class, List<BeanInitializedEventListener>> entry : beanInitializedEventListeners) {
+            for (Map.Entry<Class<?>, List<BeanInitializedEventListener>> entry : beanInitializedEventListeners) {
                 if (entry.getKey().isAssignableFrom(getBeanType())) {
                     for (BeanInitializedEventListener listener : entry.getValue()) {
                         bean = listener.onInitialized(new BeanInitializingEvent(context, this, bean));

--- a/inject/src/main/java/io/micronaut/context/BeanDefinitionRegistry.java
+++ b/inject/src/main/java/io/micronaut/context/BeanDefinitionRegistry.java
@@ -24,6 +24,8 @@ import io.micronaut.inject.BeanDefinitionReference;
 
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.inject.ProxyBeanDefinition;
+
 import java.util.Collection;
 import java.util.Objects;
 import java.util.Optional;
@@ -376,6 +378,25 @@ public interface BeanDefinitionRegistry {
     /**
      * Obtain the original {@link BeanDefinition} for a {@link io.micronaut.inject.ProxyBeanDefinition}.
      *
+     * @param proxyBeanDefinition  The proxy bean definition
+     * @param <T>       The concrete type
+     * @return An {@link Optional} of the bean definition
+     * @throws io.micronaut.context.exceptions.NonUniqueBeanException When multiple possible bean definitions exist for the given type
+     * @since 3.5.0
+     */
+    default @NonNull <T> Optional<BeanDefinition<T>> findProxyTargetBeanDefinition(@NonNull BeanDefinition<T> proxyBeanDefinition) {
+        Objects.requireNonNull(proxyBeanDefinition, "Proxy bean definition cannot be null");
+        if (proxyBeanDefinition instanceof ProxyBeanDefinition) {
+            Class<T> targetType = ((ProxyBeanDefinition<T>) proxyBeanDefinition).getTargetType();
+            Qualifier<T> targetQualifier = proxyBeanDefinition.getDeclaredQualifier();
+            return findProxyTargetBeanDefinition(targetType, targetQualifier);
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Obtain the proxy {@link BeanDefinition} for the bean of type and qualifier.
+     *
      * @param beanType  The type
      * @param qualifier The qualifier
      * @param <T>       The concrete type
@@ -386,7 +407,7 @@ public interface BeanDefinitionRegistry {
     @NonNull <T> Optional<BeanDefinition<T>> findProxyBeanDefinition(@NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier);
 
     /**
-     * Obtain the original {@link BeanDefinition} for a {@link io.micronaut.inject.ProxyBeanDefinition}.
+     * Obtain the proxy {@link BeanDefinition} for the bean of type and qualifier.
      *
      * @param beanType  The type
      * @param qualifier The qualifier

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1111,11 +1111,9 @@ public class DefaultBeanContext implements InitializableBeanContext {
         if (LOG_LIFECYCLE.isDebugEnabled()) {
             LOG_LIFECYCLE.debug("Destroying bean [{}] with identifier [{}]", registration.bean, registration.identifier);
         }
-        if (registration.beanDefinition instanceof ProxyBeanDefinition) {
-            if (registration.bean instanceof InterceptedBeanProxy) {
-                // Ignore the proxy and destroy the target
-                destroyProxyTargetBean(registration);
-            }
+        if (registration.beanDefinition instanceof ProxyBeanDefinition && registration.bean instanceof InterceptedBeanProxy) {
+            // Ignore the proxy and destroy the target
+            destroyProxyTargetBean(registration);
             return;
         }
         T beanToDestroy = registration.getBean();

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1111,7 +1111,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
         if (LOG_LIFECYCLE.isDebugEnabled()) {
             LOG_LIFECYCLE.debug("Destroying bean [{}] with identifier [{}]", registration.bean, registration.identifier);
         }
-        if (registration.bean instanceof InterceptedBeanProxy) {
+        if (registration.beanDefinition instanceof ProxyBeanDefinition) {
             // Ignore the proxy and destroy the target
             destroyProxyTargetBean(registration);
             return;

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -99,7 +99,7 @@ import io.micronaut.inject.MethodExecutionHandle;
 import io.micronaut.inject.ParametrizedBeanFactory;
 import io.micronaut.inject.ProxyBeanDefinition;
 import io.micronaut.inject.ValidatedBeanDefinition;
-import io.micronaut.inject.proxy.InterceptedProxy;
+import io.micronaut.inject.proxy.InterceptedBeanProxy;
 import io.micronaut.inject.qualifiers.AnyQualifier;
 import io.micronaut.inject.qualifiers.Qualified;
 import io.micronaut.inject.qualifiers.Qualifiers;
@@ -1111,7 +1111,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
         if (LOG_LIFECYCLE.isDebugEnabled()) {
             LOG_LIFECYCLE.debug("Destroying bean [{}] with identifier [{}]", registration.bean, registration.identifier);
         }
-        if (registration.bean instanceof InterceptedProxy) {
+        if (registration.bean instanceof InterceptedBeanProxy) {
             // Ignore the proxy and destroy the target
             destroyProxyTargetBean(registration);
             return;
@@ -1200,8 +1200,8 @@ public class DefaultBeanContext implements InitializableBeanContext {
         if (!declaredScope.isPresent()) {
             LOG.debug("Cannot find a scope for a bean definition: {}", proxyTargetBeanDefinition);
             if (!proxyTargetBeanDefinition.isSingleton()
-                    && registration.bean instanceof InterceptedProxy) {
-                InterceptedProxy<T> interceptedProxy = (InterceptedProxy<T>) registration.bean;
+                    && registration.bean instanceof InterceptedBeanProxy) {
+                InterceptedBeanProxy<T> interceptedProxy = (InterceptedBeanProxy<T>) registration.bean;
                 if (interceptedProxy.hasCachedInterceptedTarget()) {
                     T interceptedTarget = interceptedProxy.interceptedTarget();
                     if (destroyed.contains(interceptedTarget)) {

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -99,6 +99,7 @@ import io.micronaut.inject.MethodExecutionHandle;
 import io.micronaut.inject.ParametrizedBeanFactory;
 import io.micronaut.inject.ProxyBeanDefinition;
 import io.micronaut.inject.ValidatedBeanDefinition;
+import io.micronaut.inject.proxy.InterceptedProxy;
 import io.micronaut.inject.qualifiers.AnyQualifier;
 import io.micronaut.inject.qualifiers.Qualified;
 import io.micronaut.inject.qualifiers.Qualifiers;
@@ -111,13 +112,13 @@ import org.slf4j.LoggerFactory;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.EventListener;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -180,7 +181,6 @@ public class DefaultBeanContext implements InitializableBeanContext {
     protected final AtomicBoolean terminating = new AtomicBoolean(false);
 
     final Map<BeanIdentifier, BeanRegistration<?>> singlesInCreation = new ConcurrentHashMap<>(5);
-    Set<Map.Entry<Class, List<BeanInitializedEventListener>>> beanInitializedEventListeners;
 
     private final SingletonScope singletonScope = new SingletonScope(this);
 
@@ -223,10 +223,15 @@ public class DefaultBeanContext implements InitializableBeanContext {
     private final String[] eagerInitStereotypes;
     private final boolean eagerInitStereotypesPresent;
     private final boolean eagerInitSingletons;
-    private Set<Map.Entry<Class, List<BeanCreatedEventListener>>> beanCreationEventListeners;
+
     private BeanDefinitionValidator beanValidator;
     private List<BeanDefinitionReference> beanDefinitionReferences;
     private List<BeanConfiguration> beanConfigurationsList;
+
+    private Set<Map.Entry<Class<?>, List<BeanCreatedEventListener>>> beanCreationEventListeners;
+    Set<Map.Entry<Class<?>, List<BeanInitializedEventListener>>> beanInitializedEventListeners;
+    private Set<Map.Entry<Class<?>, List<BeanPreDestroyEventListener>>> beanPreDestroyEventListeners;
+    private Set<Map.Entry<Class<?>, List<BeanDestroyedEventListener>>> beanDestroyedEventListeners;
 
     /**
      * Construct a new bean context using the same classloader that loaded this DefaultBeanContext class.
@@ -407,6 +412,8 @@ public class DefaultBeanContext implements InitializableBeanContext {
             singletonScope.clear();
             beanInitializedEventListeners = null;
             beanCreationEventListeners = null;
+            beanPreDestroyEventListeners = null;
+            beanDestroyedEventListeners = null;
 
             terminating.set(false);
             running.set(false);
@@ -446,7 +453,6 @@ public class DefaultBeanContext implements InitializableBeanContext {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public Collection<BeanRegistration<?>> getActiveBeanRegistrations(Qualifier<?> qualifier) {
         if (qualifier == null) {
@@ -455,7 +461,6 @@ public class DefaultBeanContext implements InitializableBeanContext {
         return singletonScope.getBeanRegistrations(qualifier);
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public <T> Collection<BeanRegistration<T>> getActiveBeanRegistrations(Class<T> beanType) {
         if (beanType == null) {
@@ -1097,7 +1102,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
                 return beanRegistration.bean;
             }
         }
-        return null;
+        throw new IllegalArgumentException("Cannot destroy non-singleton bean using bean definition! Use 'destroyBean(BeanRegistration)` or `destroyBean(<BeanInstance>)`.");
     }
 
     @Nullable
@@ -1106,34 +1111,20 @@ public class DefaultBeanContext implements InitializableBeanContext {
         if (LOG_LIFECYCLE.isDebugEnabled()) {
             LOG_LIFECYCLE.debug("Destroying bean [{}] with identifier [{}]", registration.bean, registration.identifier);
         }
-        if (registration.bean != null) {
-            purgeCacheForBeanInstance(registration.bean);
-            if (registration.beanDefinition.isSingleton()) {
-                singletonScope.purgeCacheForBeanInstance(registration.beanDefinition, registration.bean);
-            }
+        if (registration.bean instanceof InterceptedProxy) {
+            // Ignore the proxy and destroy the target
+            destroyProxyTargetBean(registration);
+            return;
         }
-        BeanDefinition<T> definition = registration.getBeanDefinition();
-        Argument<T> beanType;
-        if (definition instanceof ProxyBeanDefinition) {
-            beanType = Argument.of(((ProxyBeanDefinition<T>) definition).getTargetType());
-        } else {
-            beanType = definition.asArgument();
-        }
-        final List<BeanPreDestroyEventListener> preDestroyEventListeners = resolveListeners(BeanPreDestroyEventListener.class, beanType);
         T beanToDestroy = registration.getBean();
-        if (CollectionUtils.isNotEmpty(preDestroyEventListeners)) {
-            for (BeanPreDestroyEventListener<T> listener : preDestroyEventListeners) {
-                try {
-                    final BeanPreDestroyEvent<T> event = new BeanPreDestroyEvent<>(this, definition, beanToDestroy);
-                    beanToDestroy = Objects.requireNonNull(
-                            listener.onPreDestroy(event),
-                            "PreDestroy event listener illegally returned null: " + listener.getClass()
-                    );
-                } catch (Exception e) {
-                    throw new BeanDestructionException(definition, e);
-                }
+        BeanDefinition<T> definition = registration.getBeanDefinition();
+        if (beanToDestroy != null) {
+            purgeCacheForBeanInstance(beanToDestroy);
+            if (definition.isSingleton()) {
+                singletonScope.purgeCacheForBeanInstance(definition, beanToDestroy);
             }
         }
+        beanToDestroy = triggerPreDestroyListeners(definition, beanToDestroy);
 
         if (definition instanceof DisposableBeanDefinition) {
             ((DisposableBeanDefinition<T>) definition).dispose(this, beanToDestroy);
@@ -1161,24 +1152,108 @@ public class DefaultBeanContext implements InitializableBeanContext {
             }
         }
 
-        final List<BeanDestroyedEventListener> postDestroyListeners = resolveListeners(BeanDestroyedEventListener.class, beanType);
-        if (CollectionUtils.isNotEmpty(postDestroyListeners)) {
-            for (BeanDestroyedEventListener<T> listener : postDestroyListeners) {
-                try {
-                    final BeanDestroyedEvent<T> event = new BeanDestroyedEvent<>(this, definition, beanToDestroy);
-                    listener.onDestroyed(event);
-                } catch (Exception e) {
-                    throw new BeanDestructionException(definition, e);
+        triggerBeanDestroyedListeners(definition, beanToDestroy);
+    }
+
+    @NonNull
+    private <T> T triggerPreDestroyListeners(@NonNull BeanDefinition<T> beanDefinition, @NonNull T bean) {
+        if (beanPreDestroyEventListeners == null) {
+            beanPreDestroyEventListeners = loadListeners(BeanPreDestroyEventListener.class).entrySet();
+        }
+        if (!beanPreDestroyEventListeners.isEmpty()) {
+            Class<T> beanType = getBeanType(beanDefinition);
+            for (Map.Entry<Class<?>, List<BeanPreDestroyEventListener>> entry : beanPreDestroyEventListeners) {
+                if (entry.getKey().isAssignableFrom(beanType)) {
+                    final BeanPreDestroyEvent<T> event = new BeanPreDestroyEvent<>(this, beanDefinition, bean);
+                    for (BeanPreDestroyEventListener<T> listener : entry.getValue()) {
+                        try {
+                            bean = Objects.requireNonNull(
+                                    listener.onPreDestroy(event),
+                                    "PreDestroy event listener illegally returned null: " + listener.getClass()
+                            );
+                        } catch (Exception e) {
+                            throw new BeanDestructionException(beanDefinition, e);
+                        }
+                    }
+
+                }
+            }
+        }
+        return bean;
+    }
+
+    private <T> void destroyProxyTargetBean(@NonNull BeanRegistration<T> registration) {
+        Set<Object> destroyed = Collections.emptySet();
+        if (registration instanceof BeanDisposingRegistration) {
+            BeanDisposingRegistration<?> disposingRegistration = (BeanDisposingRegistration<?>) registration;
+            if (disposingRegistration.getDependents() != null) {
+                destroyed = Collections.newSetFromMap(new IdentityHashMap<>());
+                for (BeanRegistration<?> beanRegistration : disposingRegistration.getDependents()) {
+                    destroyBean(beanRegistration);
+                    destroyed.add(beanRegistration.bean);
+                }
+            }
+        }
+        BeanDefinition<T> proxyTargetBeanDefinition = findProxyTargetBeanDefinition(registration.beanDefinition)
+                .orElseThrow(() -> new IllegalStateException("Cannot find a proxy target bean definition for: " + registration.beanDefinition));
+        Optional<CustomScope<?>> declaredScope = customScopeRegistry.findDeclaredScope(proxyTargetBeanDefinition);
+        if (!declaredScope.isPresent()) {
+            LOG.debug("Cannot find a scope for a bean definition: {}", proxyTargetBeanDefinition);
+            if (!proxyTargetBeanDefinition.isSingleton()
+                    && registration.bean instanceof InterceptedProxy) {
+                InterceptedProxy<T> interceptedProxy = (InterceptedProxy<T>) registration.bean;
+                if (interceptedProxy.hasCachedInterceptedTarget()) {
+                    T interceptedTarget = interceptedProxy.interceptedTarget();
+                    if (destroyed.contains(interceptedTarget)) {
+                        return;
+                    }
+                    destroyBean(BeanRegistration.of(this,
+                            new BeanKey<>(proxyTargetBeanDefinition, proxyTargetBeanDefinition.getDeclaredQualifier()),
+                            proxyTargetBeanDefinition,
+                            interceptedTarget,
+                            registration instanceof BeanDisposingRegistration ? ((BeanDisposingRegistration<T>) registration).getDependents() : null
+                    ));
+                }
+            }
+            return;
+        }
+        CustomScope<?> customScope = declaredScope.get();
+        Optional<BeanRegistration<T>> targetBeanRegistration = customScope.findBeanRegistration(proxyTargetBeanDefinition);
+        if (targetBeanRegistration.isPresent()) {
+            BeanRegistration<T> targetRegistration = targetBeanRegistration.get();
+            customScope.remove(targetRegistration.identifier);
+            destroyBean(targetRegistration);
+        }
+    }
+
+    @NonNull
+    private <T> void triggerBeanDestroyedListeners(@NonNull BeanDefinition<T> beanDefinition, @NonNull T bean) {
+        if (beanDestroyedEventListeners == null) {
+            beanDestroyedEventListeners = loadListeners(BeanDestroyedEventListener.class).entrySet();
+        }
+        if (!beanDestroyedEventListeners.isEmpty()) {
+            Class<T> beanType = getBeanType(beanDefinition);
+            for (Map.Entry<Class<?>, List<BeanDestroyedEventListener>> entry : beanDestroyedEventListeners) {
+                if (entry.getKey().isAssignableFrom(beanType)) {
+                    final BeanDestroyedEvent<T> event = new BeanDestroyedEvent<>(this, beanDefinition, bean);
+                    for (BeanDestroyedEventListener<T> listener : entry.getValue()) {
+                        try {
+                            listener.onDestroyed(event);
+                        } catch (Exception e) {
+                            throw new BeanDestructionException(beanDefinition, e);
+                        }
+                    }
                 }
             }
         }
     }
 
     @NonNull
-    private <T extends EventListener> List<T> resolveListeners(Class<T> type, Argument<?> genericType) {
-        return streamOfType(Argument.of(type, genericType))
-                .sorted(OrderUtil.COMPARATOR)
-                .collect(Collectors.toList());
+    private <T> Class<T> getBeanType(@NonNull BeanDefinition<T> beanDefinition) {
+        if (beanDefinition instanceof ProxyBeanDefinition) {
+            return ((ProxyBeanDefinition<T>) beanDefinition).getTargetType();
+        }
+        return beanDefinition.getBeanType();
     }
 
     /**
@@ -1681,47 +1756,33 @@ public class DefaultBeanContext implements InitializableBeanContext {
      * Initialize the event listeners.
      */
     protected void initializeEventListeners() {
-        final Collection<BeanDefinition<BeanCreatedEventListener>> beanCreatedDefinitions = getBeanDefinitions(BeanCreatedEventListener.class);
-        final HashMap<Class, List<BeanCreatedEventListener>> beanCreatedListeners = new HashMap<>(beanCreatedDefinitions.size());
-
-        //noinspection ArraysAsListWithZeroOrOneArgument
-        beanCreatedListeners.put(AnnotationProcessor.class, Arrays.asList(new AnnotationProcessorListener()));
-        for (BeanDefinition<BeanCreatedEventListener> beanCreatedDefinition : beanCreatedDefinitions) {
-            try (BeanResolutionContext context = newResolutionContext(beanCreatedDefinition, null)) {
-                BeanCreatedEventListener<?> listener = resolveBeanRegistration(context, beanCreatedDefinition).bean;
-                List<Argument<?>> typeArguments = beanCreatedDefinition.getTypeArguments(BeanCreatedEventListener.class);
-                Argument<?> argument = CollectionUtils.last(typeArguments);
-                if (argument == null) {
-                    argument = Argument.OBJECT_ARGUMENT;
-                }
-                beanCreatedListeners.computeIfAbsent(argument.getType(), aClass -> new ArrayList<>(10))
-                        .add(listener);
-            }
-        }
-        for (List<BeanCreatedEventListener> listenerList : beanCreatedListeners.values()) {
-            OrderUtil.sort(listenerList);
-        }
-
-        final HashMap<Class, List<BeanInitializedEventListener>> beanInitializedListeners = new HashMap<>(beanCreatedDefinitions.size());
-        final Collection<BeanDefinition<BeanInitializedEventListener>> beanInitializedDefinitions = getBeanDefinitions(BeanInitializedEventListener.class);
-        for (BeanDefinition<BeanInitializedEventListener> definition : beanInitializedDefinitions) {
-            try (BeanResolutionContext context = newResolutionContext(definition, null)) {
-                BeanInitializedEventListener<?> listener = resolveBeanRegistration(context, definition).bean;
-                List<Argument<?>> typeArguments = definition.getTypeArguments(BeanInitializedEventListener.class);
-                Argument<?> argument = CollectionUtils.last(typeArguments);
-                if (argument == null) {
-                    argument = Argument.OBJECT_ARGUMENT;
-                }
-                beanInitializedListeners.computeIfAbsent(argument.getType(), aClass -> new ArrayList<>(10))
-                        .add(listener);
-            }
-        }
-        for (List<BeanInitializedEventListener> listenerList : beanInitializedListeners.values()) {
-            OrderUtil.sort(listenerList);
-        }
-
+        final Map<Class<?>, List<BeanCreatedEventListener>> beanCreatedListeners = loadListeners(BeanCreatedEventListener.class);
+        beanCreatedListeners.put(AnnotationProcessor.class, Collections.singletonList(new AnnotationProcessorListener()));
+        final Map<Class<?>, List<BeanInitializedEventListener>> beanInitializedListeners = loadListeners(BeanInitializedEventListener.class);
         this.beanCreationEventListeners = beanCreatedListeners.entrySet();
         this.beanInitializedEventListeners = beanInitializedListeners.entrySet();
+    }
+
+    @NotNull
+    private <T extends EventListener> Map<Class<?>, List<T>> loadListeners(@NotNull Class<T> listenerType) {
+        final Collection<BeanDefinition<T>> beanDefinitions = getBeanDefinitions(listenerType);
+        final HashMap<Class<?>, List<T>> typeToListener = new HashMap<>(beanDefinitions.size(), 1);
+        for (BeanDefinition<T> beanCreatedDefinition : beanDefinitions) {
+            try (BeanResolutionContext context = newResolutionContext(beanCreatedDefinition, null)) {
+                T listener = resolveBeanRegistration(context, beanCreatedDefinition).bean;
+                List<Argument<?>> typeArguments = beanCreatedDefinition.getTypeArguments(listenerType);
+                Argument<?> argument = CollectionUtils.last(typeArguments);
+                if (argument == null) {
+                    argument = Argument.OBJECT_ARGUMENT;
+                }
+                typeToListener.computeIfAbsent(argument.getType(), aClass -> new ArrayList<>(10))
+                        .add(listener);
+            }
+        }
+        for (List<T> listenerList : typeToListener.values()) {
+            OrderUtil.sort(listenerList);
+        }
+        return typeToListener;
     }
 
     /**
@@ -2218,10 +2279,27 @@ public class DefaultBeanContext implements InitializableBeanContext {
                                   @NonNull BeanDefinition<T> beanDefinition,
                                   @Nullable Qualifier<T> qualifier,
                                   @NonNull T bean) {
-        Class<T> beanType = beanDefinition.getBeanType();
         Qualifier<T> finalQualifier = qualifier != null ? qualifier : beanDefinition.getDeclaredQualifier();
+
+        bean = triggerBeanCreatedEventListener(resolutionContext, beanDefinition, bean, finalQualifier);
+
+        if (beanDefinition instanceof ValidatedBeanDefinition) {
+            bean = ((ValidatedBeanDefinition<T>) beanDefinition).validate(resolutionContext, bean);
+        }
+        if (LOG_LIFECYCLE.isDebugEnabled()) {
+            LOG_LIFECYCLE.debug("Created bean [{}] from definition [{}] with qualifier [{}]", bean, beanDefinition, finalQualifier);
+        }
+        return bean;
+    }
+
+    @NonNull
+    private <T> T triggerBeanCreatedEventListener(@NonNull BeanResolutionContext resolutionContext,
+                                                  @NonNull BeanDefinition<T> beanDefinition,
+                                                  @NonNull T bean,
+                                                  @Nullable Qualifier<T> finalQualifier) {
+        Class<T> beanType = beanDefinition.getBeanType();
         if (!(bean instanceof BeanCreatedEventListener) && CollectionUtils.isNotEmpty(beanCreationEventListeners)) {
-            for (Map.Entry<Class, List<BeanCreatedEventListener>> entry : beanCreationEventListeners) {
+            for (Map.Entry<Class<?>, List<BeanCreatedEventListener>> entry : beanCreationEventListeners) {
                 if (entry.getKey().isAssignableFrom(beanType)) {
                     BeanKey<T> beanKey = new BeanKey<>(beanDefinition, finalQualifier);
                     for (BeanCreatedEventListener<?> listener : entry.getValue()) {
@@ -2233,18 +2311,12 @@ public class DefaultBeanContext implements InitializableBeanContext {
                 }
             }
         }
-        if (beanDefinition instanceof ValidatedBeanDefinition) {
-            bean = ((ValidatedBeanDefinition<T>) beanDefinition).validate(resolutionContext, bean);
-        }
-        if (LOG_LIFECYCLE.isDebugEnabled()) {
-            LOG_LIFECYCLE.debug("Created bean [{}] from definition [{}] with qualifier [{}]", bean, beanDefinition, finalQualifier);
-        }
         return bean;
     }
 
     @NotNull
     private <T> Map<String, Object> getRequiredArgumentValues(@NonNull BeanResolutionContext resolutionContext,
-                                                              @NonNull  Argument<?>[] requiredArguments,
+                                                              @NonNull Argument<?>[] requiredArguments,
                                                               @Nullable Map<String, Object> argumentValues,
                                                               @NonNull BeanDefinition<T> beanDefinition) {
         Map<String, Object> convertedValues;
@@ -2713,14 +2785,21 @@ public class DefaultBeanContext implements InitializableBeanContext {
         final boolean isProxy = definition.isProxy();
         final boolean isScopedProxyDefinition = definition.hasStereotype(SCOPED_PROXY_ANN);
 
-        T bean;
         if (isProxy && isScopedProxyDefinition && qualifier != PROXY_TARGET_QUALIFIER
                 && (definition.getDeclaredQualifier() == null)) {
             // With scopes proxies we have to inject a reference into the injection point
-            return getScopedBeanInterceptorForDefinition(resolutionContext, beanType, qualifier, definition);
+            Qualifier<T> q = qualifier;
+            if (q == null) {
+                q = definition.getDeclaredQualifier();
+            }
+            BeanRegistration<T> registration = createPrototypeRegistration(resolutionContext, beanType, q, definition);
+            T bean = registration.bean;
+            if (bean instanceof Qualified) {
+                ((Qualified<T>) bean).$withBeanQualifier(q);
+            }
+            return registration;
         }
 
-        BeanKey<T> beanKey = new BeanKey<>(beanType, qualifier);
         BeanResolutionContext.Segment<?> currentSegment = resolutionContext
                 .getPath()
                 .currentSegment()
@@ -2742,50 +2821,48 @@ public class DefaultBeanContext implements InitializableBeanContext {
                         qualifier
                 );
             }
-            BeanDefinition<T> finalDefinition = definition;
-
-            bean = registeredScope.getOrCreate(
-                    new BeanCreationContext<T>() {
-                        @NonNull
-                        @Override
-                        public BeanDefinition<T> definition() {
-                            return finalDefinition;
-                        }
-
-                        @NonNull
-                        @Override
-                        public BeanIdentifier id() {
-                            return beanKey;
-                        }
-
-                        @NonNull
-                        @Override
-                        public CreatedBean<T> create() throws BeanCreationException {
-                            List<BeanRegistration<?>> dependentBeans = resolutionContext.popDependentBeans();
-                            final T bean = doCreateBean(resolutionContext, finalDefinition, beanType, qualifier);
-                            BeanRegistration<T> registration = BeanRegistration.of(
-                                    DefaultBeanContext.this,
-                                    beanKey,
-                                    finalDefinition,
-                                    bean,
-                                    resolutionContext.getAndResetDependentBeans()
-                            );
-                            resolutionContext.pushDependentBeans(dependentBeans);
-                            return registration;
-                        }
-                    }
-            );
-            return BeanRegistration.of(this, beanKey, finalDefinition, bean);
+            return getOrCreateScopedRegistration(resolutionContext, registeredScope, qualifier, beanType, definition);
         }
-        return getUnknownScopeBean(resolutionContext, beanType, qualifier, definition);
+        // Unknown scope, prototype scope etc
+        return createPrototypeRegistration(resolutionContext, beanType, qualifier, definition);
+    }
+
+    @NonNull
+    private <T> BeanRegistration<T> getOrCreateScopedRegistration(@NonNull BeanResolutionContext resolutionContext,
+                                                                  @NonNull CustomScope<?> registeredScope,
+                                                                  @Nullable Qualifier<T> qualifier,
+                                                                  @NonNull Argument<T> beanType,
+                                                                  @NonNull BeanDefinition<T> definition) {
+        BeanKey<T> beanKey = new BeanKey<>(beanType, qualifier);
+        T bean = registeredScope.getOrCreate(
+                new BeanCreationContext<T>() {
+                    @NonNull
+                    @Override
+                    public BeanDefinition<T> definition() {
+                        return definition;
+                    }
+
+                    @NonNull
+                    @Override
+                    public BeanIdentifier id() {
+                        return beanKey;
+                    }
+
+                    @NonNull
+                    @Override
+                    public CreatedBean<T> create() throws BeanCreationException {
+                        return createPrototypeRegistration(resolutionContext, beanType, qualifier, definition);
+                    }
+                }
+        );
+        return BeanRegistration.of(this, beanKey, definition, bean);
     }
 
     @NotNull
-    private <T> BeanRegistration<T> getUnknownScopeBean(@NonNull BeanResolutionContext resolutionContext,
-                                                        @NonNull Argument<T> beanType,
-                                                        @Nullable Qualifier<T> qualifier,
-                                                        @NonNull BeanDefinition<T> definition) {
-        // Unknown scope, prototype scope etc
+    private <T> BeanRegistration<T> createPrototypeRegistration(@NonNull BeanResolutionContext resolutionContext,
+                                                                @NonNull Argument<T> beanType,
+                                                                @Nullable Qualifier<T> qualifier,
+                                                                @NonNull BeanDefinition<T> definition) {
         List<BeanRegistration<?>> parentDependentBeans = resolutionContext.popDependentBeans();
         T bean = doCreateBean(resolutionContext, definition, qualifier);
         BeanRegistration<?> dependentFactoryBean = resolutionContext.getAndResetDependentFactoryBean();
@@ -2799,22 +2876,6 @@ public class DefaultBeanContext implements InitializableBeanContext {
         // Unknown scope and prototype beans are treated as beans dependent
         resolutionContext.addDependentBean(beanRegistration);
         return beanRegistration;
-    }
-
-    @NotNull
-    private <T> BeanRegistration<T> getScopedBeanInterceptorForDefinition(@NonNull BeanResolutionContext resolutionContext,
-                                                                          @NonNull Argument<T> beanType,
-                                                                          @Nullable Qualifier<T> qualifier,
-                                                                          @NonNull BeanDefinition<T> definition) {
-        Qualifier<T> q = qualifier;
-        if (q == null) {
-            q = definition.getDeclaredQualifier();
-        }
-        T bean = doCreateBean(resolutionContext, definition, q);
-        if (bean instanceof Qualified) {
-            ((Qualified<T>) bean).$withBeanQualifier(q);
-        }
-        return BeanRegistration.of(this, new BeanKey<>(beanType, qualifier), definition, bean);
     }
 
     /**
@@ -3699,6 +3760,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
 
     /**
      * Class used as a bean candidate key.
+     *
      * @param <T> The bean candidate type
      */
     static final class BeanCandidateKey<T> {

--- a/inject/src/main/java/io/micronaut/context/scope/AbstractConcurrentCustomScope.java
+++ b/inject/src/main/java/io/micronaut/context/scope/AbstractConcurrentCustomScope.java
@@ -223,6 +223,9 @@ public abstract class AbstractConcurrentCustomScope<A extends Annotation> implem
             }
             for (CreatedBean<?> createdBean : scopeMap.values()) {
                 if (createdBean.bean() == bean) {
+                    if (createdBean instanceof BeanRegistration) {
+                        return Optional.of((BeanRegistration<T>) createdBean);
+                    }
                     return Optional.of(
                             new BeanRegistration<>(
                                     createdBean.id(),

--- a/inject/src/main/java/io/micronaut/context/scope/CustomScope.java
+++ b/inject/src/main/java/io/micronaut/context/scope/CustomScope.java
@@ -17,6 +17,7 @@ package io.micronaut.context.scope;
 
 import io.micronaut.context.BeanRegistration;
 import io.micronaut.core.annotation.Indexed;
+import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.BeanIdentifier;
 
 import java.lang.annotation.Annotation;
@@ -64,6 +65,18 @@ public interface CustomScope<A extends Annotation> {
      * @return The bean definition if it can be resolved
      */
     default <T> Optional<BeanRegistration<T>> findBeanRegistration(T bean) {
+        return Optional.empty();
+    }
+
+    /**
+     * Get the {@link io.micronaut.inject.BeanDefinition} for the given bean.
+     *
+     * @param beanDefinition The bean definition
+     * @param <T> The bean generic type
+     * @return The bean definition if it can be resolved
+     * @since 3.5.0
+     */
+    default <T> Optional<BeanRegistration<T>> findBeanRegistration(BeanDefinition<T> beanDefinition) {
         return Optional.empty();
     }
 }

--- a/inject/src/main/java/io/micronaut/inject/ast/DefaultElementQuery.java
+++ b/inject/src/main/java/io/micronaut/inject/ast/DefaultElementQuery.java
@@ -21,8 +21,6 @@ import io.micronaut.core.annotation.AnnotationUtil;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -208,8 +206,8 @@ final class DefaultElementQuery<T extends Element> implements ElementQuery<T>, E
         annotationPredicates.add((metadata) ->
                 metadata.hasDeclaredAnnotation(AnnotationUtil.INJECT) ||
                 (metadata.hasDeclaredStereotype(AnnotationUtil.QUALIFIER) && !metadata.hasDeclaredAnnotation(Bean.class)) ||
-                metadata.hasDeclaredAnnotation(PreDestroy.class) ||
-                metadata.hasDeclaredAnnotation(PostConstruct.class));
+                metadata.hasDeclaredAnnotation(AnnotationUtil.PRE_DESTROY) ||
+                metadata.hasDeclaredAnnotation(AnnotationUtil.POST_CONSTRUCT));
         return new DefaultElementQuery<>(
                 elementType, onlyAccessibleType,
                 onlyDeclared,

--- a/inject/src/main/java/io/micronaut/inject/proxy/Intercepted.java
+++ b/inject/src/main/java/io/micronaut/inject/proxy/Intercepted.java
@@ -13,13 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.aop;
+package io.micronaut.inject.proxy;
+
+import io.micronaut.core.annotation.Internal;
 
 /**
- * An interface implemented by generated proxy classes.
- *
- * @author Graeme Rocher
- * @since 1.0
+ * An internal interface implemented by generated proxy classes.
+ * Inject aware version of AOP interface.
+
+ * @author Denis Stepanov
+ * @since 3.5.0
  */
-public interface Intercepted extends io.micronaut.inject.proxy.Intercepted {
+@Internal
+public interface Intercepted {
 }

--- a/inject/src/main/java/io/micronaut/inject/proxy/InterceptedBean.java
+++ b/inject/src/main/java/io/micronaut/inject/proxy/InterceptedBean.java
@@ -25,5 +25,5 @@ import io.micronaut.core.annotation.Internal;
  * @since 3.5.0
  */
 @Internal
-public interface Intercepted {
+public interface InterceptedBean {
 }

--- a/inject/src/main/java/io/micronaut/inject/proxy/InterceptedBeanProxy.java
+++ b/inject/src/main/java/io/micronaut/inject/proxy/InterceptedBeanProxy.java
@@ -19,7 +19,7 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.inject.qualifiers.Qualified;
 
 /**
- * An internal {@link Intercepted} that proxies another instance.
+ * An internal {@link InterceptedBean} that proxies another instance.
  * Inject aware version of AOP interface.
  *
  * @param <T> The declaring type
@@ -28,7 +28,7 @@ import io.micronaut.inject.qualifiers.Qualified;
  * @since 3.5.0
  */
 @Internal
-public interface InterceptedProxy<T> extends Intercepted, Qualified<T> {
+public interface InterceptedBeanProxy<T> extends InterceptedBean, Qualified<T> {
 
     /**
      * This method will return the target object being proxied.

--- a/inject/src/main/java/io/micronaut/inject/proxy/InterceptedProxy.java
+++ b/inject/src/main/java/io/micronaut/inject/proxy/InterceptedProxy.java
@@ -13,26 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.aop;
+package io.micronaut.inject.proxy;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.inject.qualifiers.Qualified;
 
 /**
- * A {@link Intercepted} that proxies another instance.
+ * An internal {@link Intercepted} that proxies another instance.
+ * Inject aware version of AOP interface.
  *
  * @param <T> The declaring type
  *
- * @author Graeme Rocher
- * @since 1.0
+ * @author Denis Stepanov
+ * @since 3.5.0
  */
-public interface InterceptedProxy<T> extends Intercepted, Qualified<T>, io.micronaut.inject.proxy.InterceptedProxy<T> {
+@Internal
+public interface InterceptedProxy<T> extends Intercepted, Qualified<T> {
 
     /**
      * This method will return the target object being proxied.
      *
      * @return The proxy target
      */
-    @Override
     T interceptedTarget();
 
     /**
@@ -40,8 +42,8 @@ public interface InterceptedProxy<T> extends Intercepted, Qualified<T>, io.micro
      *
      * @return true if the target is cached
      */
-    @Override
     default boolean hasCachedInterceptedTarget() {
         return false;
     }
+
 }


### PR DESCRIPTION
This corrects how proxies are destroyed. For target bean proxies we need to ignore the actual proxy and just destroy the target. I had to introduce the same interfaces from AOP for the Inject module to be able to recognize which bean is an introspected proxy and added a new method to check if the target is initialized for the cases when it's lazy.

I had to add a new method to find the bean registration by bean definition in `CustomScope` to properly implement destroying the scoped instance.

This PR also changes to allow `PostCreate` and `PreDestroy` to be on the same method to have the same behavior as CDI.