### PR TITLE
Don't destroy dependent custom scope beans

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxybeanwithpredestroy/ProxyBeanWithPreDestroySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxybeanwithpredestroy/ProxyBeanWithPreDestroySpec.groovy
@@ -19,6 +19,7 @@ import io.micronaut.context.BeanContext
 import io.micronaut.context.DefaultBeanContext
 import spock.lang.Specification
 
+// proxyTarget = false proxies are always destroyed
 class ProxyBeanWithPreDestroySpec extends Specification {
 
     def setup() {

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanwithpredestroy/CustomScopeScope.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanwithpredestroy/CustomScopeScope.java
@@ -25,7 +25,6 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.BeanIdentifier;
 import jakarta.inject.Singleton;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -68,7 +67,6 @@ public class CustomScopeScope implements CustomScope<io.micronaut.inject.lifecyc
         return findByBeanDefinition(beanDefinition);
     }
 
-    @NotNull
     private <T> Optional<BeanRegistration<T>> findByBeanDefinition(BeanDefinition<T> beanDefinition) {
         return beans.stream().filter(br -> br.getBeanDefinition().equals(beanDefinition)).map(br -> (BeanRegistration<T>) br).findFirst();
     }

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanwithpredestroy/ProxyTargetBeanWithPreDestroySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanwithpredestroy/ProxyTargetBeanWithPreDestroySpec.groovy
@@ -67,12 +67,12 @@ class ProxyTargetBeanWithPreDestroySpec extends Specification {
         when:
             context.destroyBean(root)
 
-        then:
-            B.interceptCalled == 2
-            B.noArgsDestroyCalled == 1
-            B.injectedDestroyCalled == 1
+        then: "Custom scope instance not destroyed"
+            B.interceptCalled == 1
+            B.noArgsDestroyCalled == 0
+            B.injectedDestroyCalled == 0
             D.created == 2 // Create proxy + target
-            D.destroyed == 2
+            D.destroyed == 1
 
         cleanup:
             context.close()
@@ -129,12 +129,12 @@ class ProxyTargetBeanWithPreDestroySpec extends Specification {
         when:
             context.destroyBean(registration)
 
-        then:
-            B.interceptCalled == 2
-            B.noArgsDestroyCalled == 1
-            B.injectedDestroyCalled == 1
+        then: "Custom scope instance not destroyed"
+            B.interceptCalled == 1
+            B.noArgsDestroyCalled == 0
+            B.injectedDestroyCalled == 0
             D.created == 2
-            D.destroyed == 2  // Destroy proxy + target
+            D.destroyed == 1  // Destroy proxy
 
         cleanup:
             context.close()

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -183,7 +183,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
 
     final Map<BeanIdentifier, BeanRegistration<?>> singlesInCreation = new ConcurrentHashMap<>(5);
 
-    private final SingletonScope singletonScope = new SingletonScope(this);
+    private final SingletonScope singletonScope = new SingletonScope();
 
     private final BeanContextConfiguration beanContextConfiguration;
     private final Collection<BeanDefinitionReference> beanDefinitionsClasses = new ConcurrentLinkedQueue<>();

--- a/inject/src/main/java/io/micronaut/context/SingletonScope.java
+++ b/inject/src/main/java/io/micronaut/context/SingletonScope.java
@@ -63,23 +63,15 @@ final class SingletonScope {
     /**
      * Register singleton.
      *
-     * @param beanDefinition The bean definition
-     * @param qualifier      The qualifier
-     * @param createdBean    The registered instance
-     * @param dependents     The dependents
-     * @param <T>            The singleton type
+     * @param registration The bean registration
+     * @param qualifier    The qualifier
+     * @param <T>          The singleton type
      * @return The new registration
      */
     @NonNull
-    <T> BeanRegistration<T> registerSingletonBean(@NonNull BeanDefinition<T> beanDefinition,
-                                                  @Nullable Qualifier<T> qualifier,
-                                                  @Nullable T createdBean,
-                                                  @NonNull List<BeanRegistration<?>> dependents) {
+    <T> BeanRegistration<T> registerSingletonBean(@NonNull BeanRegistration<T> registration, Qualifier qualifier) {
 
-
-        DefaultBeanContext.BeanKey<T> key = new DefaultBeanContext.BeanKey<>(beanDefinition.asArgument(), qualifier);
-        BeanRegistration<T> registration = BeanRegistration.of(beanContext, key, beanDefinition, createdBean, dependents);
-        
+        BeanDefinition<T> beanDefinition = registration.beanDefinition;
         singletonByBeanDefinition.put(BeanDefinitionIdentity.of(beanDefinition), registration);
         if (!beanDefinition.isSingleton()) {
             // In some cases you can register an instance of non-singleton bean and expect it act as a singleton
@@ -95,11 +87,11 @@ final class SingletonScope {
             DefaultBeanContext.BeanKey<T> beanKey = new DefaultBeanContext.BeanKey<>(beanDefinition, beanDefinition.getDeclaredQualifier());
             singletonByArgumentAndQualifier.put(beanKey, registration);
         }
-        if (createdBean != null && createdBean.getClass() != beanDefinition.getBeanType()) {
+        if (registration.bean != null && registration.bean.getClass() != beanDefinition.getBeanType()) {
             // If the actual type differs, allow to inject the actual implementation for cases like:
             // `MyInterface factoryBean() { new Impl.. }`
             // This might be something to remove in 4.0
-            DefaultBeanContext.BeanKey<T> concrete = new DefaultBeanContext.BeanKey<>((Class<T>) createdBean.getClass(), qualifier);
+            DefaultBeanContext.BeanKey<T> concrete = new DefaultBeanContext.BeanKey<>((Class<T>) registration.bean.getClass(), qualifier);
             singletonByArgumentAndQualifier.put(concrete, registration);
         }
         return registration;

--- a/inject/src/main/java/io/micronaut/context/SingletonScope.java
+++ b/inject/src/main/java/io/micronaut/context/SingletonScope.java
@@ -39,8 +39,6 @@ import java.util.stream.Stream;
 @Internal
 final class SingletonScope {
 
-    private final DefaultBeanContext beanContext;
-
     /**
      * The main collection storing registrations for {@link BeanDefinition}.
      */
@@ -50,15 +48,6 @@ final class SingletonScope {
      * Index collection to retrieve a the registration by {@link Argument} and {@link Qualifier}.
      */
     private final Map<DefaultBeanContext.BeanKey, BeanRegistration> singletonByArgumentAndQualifier = new ConcurrentHashMap<>(100);
-
-    /**
-     * The default constructor.
-     *
-     * @param beanContext The bean context.
-     */
-    SingletonScope(DefaultBeanContext beanContext) {
-        this.beanContext = beanContext;
-    }
 
     /**
      * Register singleton.


### PR DESCRIPTION
This reverts some of the changes done before. The custom scope bean shouldn't be removed when the parent-bean is discarded.