### PR TITLE
Fix service loading on GraalVM 22.1

### DIFF
--- a/core/src/main/java/io/micronaut/core/io/service/SoftServiceLoader.java
+++ b/core/src/main/java/io/micronaut/core/io/service/SoftServiceLoader.java
@@ -499,9 +499,14 @@ public final class SoftServiceLoader<S> implements Iterable<ServiceDefinition<S>
                 }
 
                 for (URI uri : uniqueURIs) {
-                    final MicronautMetaServicesLoader<S> task = new MicronautMetaServicesLoader<>(uri, path, transformer);
-                    tasks.add(task);
-                    task.fork();
+                    String uriStr = uri.toString();
+                    // on GraalVM there are spurious extra resources that end with # and then a number
+                    // we ignore this extra ones
+                    if (!(uriStr.startsWith("resource:") && uriStr.contains("#"))) {
+                        final MicronautMetaServicesLoader<S> task = new MicronautMetaServicesLoader<>(uri, path, transformer);
+                        tasks.add(task);
+                        task.fork();
+                    }
                 }
             } catch (IOException | URISyntaxException e) {
                 throw new ServiceConfigurationError("Failed to load resources for service: " + serviceName, e);


### PR DESCRIPTION
GraalVM 22.1 creates a completely different view of static resources vs 22.0 and this causes beans to be scanned for multiple times resulting in exceptions at runtime. This change ignores those additional resources.

This will fix the `io.micronaut.context.exceptions.NonUniqueBeanException` errors happening in many builds like https://gitlab.com/micronaut-projects/micronaut-graal-tests/-/jobs/2445570377