### PR TITLE
CORS preflight request should return 404 when route doesn't exists

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
@@ -135,6 +135,8 @@ import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static io.micronaut.http.HttpAttributes.AVAILABLE_HTTP_METHODS;
+
 /**
  * Internal implementation of the {@link io.netty.channel.ChannelInboundHandler} for Micronaut.
  *
@@ -344,6 +346,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
                     .collect(Collectors.toList());
             if (!anyUriRoutes.isEmpty()) {
                 setRouteAttributes(request, anyUriRoutes.get(0));
+                request.setAttribute(AVAILABLE_HTTP_METHODS, anyUriRoutes.stream().map(UriRouteMatch::getHttpMethod).collect(Collectors.toList()));
             }
         }
 

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/OptionsRequestAttributesSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/OptionsRequestAttributesSpec.groovy
@@ -23,7 +23,7 @@ import spock.lang.Specification
 
 class OptionsRequestAttributesSpec extends Specification {
 
-    def 'test OPTIONS rquests attributes'() {
+    def 'test OPTIONS requests attributes'() {
         EmbeddedServer server = ApplicationContext.run(EmbeddedServer, ['spec.name': 'OptionsRequestAttributesSpec'])
         def ctx = server.applicationContext
         HttpClient client = ctx.createBean(HttpClient, server.getURL())

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/cors/CorsFilterSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/cors/CorsFilterSpec.groovy
@@ -408,7 +408,6 @@ class CorsFilterSpec extends Specification {
 
         then: "the request is successful"
         1 * headers.getFirst(ACCESS_CONTROL_REQUEST_METHOD, _) >> Optional.of(HttpMethod.POST)
-        2 * headers.get(ACCESS_CONTROL_REQUEST_HEADERS, _) >> Optional.of(['X-Header', 'Y-Header'])
         !result.isPresent()
     }
 

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/cors/NettyCorsSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/cors/NettyCorsSpec.groovy
@@ -316,8 +316,12 @@ class NettyCorsSpec extends AbstractMicronautSpec {
     static class TestController {
 
         @Get
-        @Post
         HttpResponse index() {
+            HttpResponse.noContent()
+        }
+
+        @Post
+        HttpResponse indexPost() {
             HttpResponse.noContent()
         }
 

--- a/http-server/src/main/java/io/micronaut/http/server/cors/CorsFilter.java
+++ b/http-server/src/main/java/io/micronaut/http/server/cors/CorsFilter.java
@@ -31,6 +31,8 @@ import io.micronaut.http.filter.HttpServerFilter;
 import io.micronaut.http.filter.ServerFilterChain;
 import io.micronaut.http.filter.ServerFilterPhase;
 import io.micronaut.http.server.HttpServerConfiguration;
+import io.micronaut.web.router.Router;
+import io.micronaut.web.router.UriRouteMatch;
 import org.reactivestreams.Publisher;
 
 import java.util.List;
@@ -56,11 +58,15 @@ public class CorsFilter implements HttpServerFilter {
 
     protected final HttpServerConfiguration.CorsConfiguration corsConfiguration;
 
+    private final Router router;
+
     /**
      * @param corsConfiguration The {@link CorsOriginConfiguration} instance
+     * @param router the {@link Router} instance
      */
-    public CorsFilter(HttpServerConfiguration.CorsConfiguration corsConfiguration) {
+    public CorsFilter(HttpServerConfiguration.CorsConfiguration corsConfiguration, Router router) {
         this.corsConfiguration = corsConfiguration;
+        this.router = router;
     }
 
     @Override
@@ -150,7 +156,11 @@ public class CorsFilter implements HttpServerFilter {
                     }
                 }
 
-                if (preflight) {
+                final List<UriRouteMatch<?, ?>> anyMatchingRoutes = router
+                        .findAny(request.getUri().toString(), request)
+                        .collect(Collectors.toList());
+
+                if (preflight && !anyMatchingRoutes.isEmpty()) {
                     Optional<List<String>> accessControlHeaders = headers.get(ACCESS_CONTROL_REQUEST_HEADERS, ConversionContext.LIST_OF_STRING);
 
                     List<String> allowedHeaders = config.getAllowedHeaders();

--- a/http-server/src/main/java/io/micronaut/http/server/cors/CorsFilter.java
+++ b/http-server/src/main/java/io/micronaut/http/server/cors/CorsFilter.java
@@ -31,6 +31,8 @@ import io.micronaut.http.filter.HttpServerFilter;
 import io.micronaut.http.filter.ServerFilterChain;
 import io.micronaut.http.filter.ServerFilterPhase;
 import io.micronaut.http.server.HttpServerConfiguration;
+import io.micronaut.web.router.RouteMatch;
+import io.micronaut.web.router.RouteMatchUtils;
 import io.micronaut.web.router.Router;
 import io.micronaut.web.router.UriRouteMatch;
 import org.reactivestreams.Publisher;
@@ -58,15 +60,11 @@ public class CorsFilter implements HttpServerFilter {
 
     protected final HttpServerConfiguration.CorsConfiguration corsConfiguration;
 
-    private final Router router;
-
     /**
      * @param corsConfiguration The {@link CorsOriginConfiguration} instance
-     * @param router the {@link Router} instance
      */
-    public CorsFilter(HttpServerConfiguration.CorsConfiguration corsConfiguration, Router router) {
+    public CorsFilter(HttpServerConfiguration.CorsConfiguration corsConfiguration) {
         this.corsConfiguration = corsConfiguration;
-        this.router = router;
     }
 
     @Override
@@ -156,11 +154,7 @@ public class CorsFilter implements HttpServerFilter {
                     }
                 }
 
-                final List<UriRouteMatch<?, ?>> anyMatchingRoutes = router
-                        .findAny(request.getUri().toString(), request)
-                        .collect(Collectors.toList());
-
-                if (preflight && !anyMatchingRoutes.isEmpty()) {
+                if (preflight && RouteMatchUtils.findRouteMatch(request).isPresent()) {
                     Optional<List<String>> accessControlHeaders = headers.get(ACCESS_CONTROL_REQUEST_HEADERS, ConversionContext.LIST_OF_STRING);
 
                     List<String> allowedHeaders = config.getAllowedHeaders();

--- a/http-server/src/main/java/io/micronaut/http/server/cors/CorsFilter.java
+++ b/http-server/src/main/java/io/micronaut/http/server/cors/CorsFilter.java
@@ -31,10 +31,7 @@ import io.micronaut.http.filter.HttpServerFilter;
 import io.micronaut.http.filter.ServerFilterChain;
 import io.micronaut.http.filter.ServerFilterPhase;
 import io.micronaut.http.server.HttpServerConfiguration;
-import io.micronaut.web.router.RouteMatch;
 import io.micronaut.web.router.RouteMatchUtils;
-import io.micronaut.web.router.Router;
-import io.micronaut.web.router.UriRouteMatch;
 import org.reactivestreams.Publisher;
 
 import java.util.List;

--- a/http/src/main/java/io/micronaut/http/HttpAttributes.java
+++ b/http/src/main/java/io/micronaut/http/HttpAttributes.java
@@ -81,7 +81,12 @@ public enum HttpAttributes implements CharSequence {
     /**
      * Attribute used to store a client Certificate (mutual authentication).
      */
-    X509_CERTIFICATE("javax.servlet.request.X509Certificate");
+    X509_CERTIFICATE("javax.servlet.request.X509Certificate"),
+
+    /**
+     * Attribute used to store Available HTTP methods on the OPTIONS request.
+     */
+    AVAILABLE_HTTP_METHODS(Constants.PREFIX + ".route.availableHttpMethods");
 
     private final String name;
 


### PR DESCRIPTION
With this change the CORS preflight requests will return 200 only if there is an existing route and the HTTP method that can handle provided method that is specified inside the preflight request.

Added:
- AVAILABLE_HTTP_METHODS attribute on the request object which is populated only if http request method is `OPTIONS ` and contains all HTTP METHODS on provided route.
- new test that covers scenario