### PR TITLE
Add option to keep request Host header in ProxyHttpClient

### DIFF
--- a/config/accepted-api-changes.json
+++ b/config/accepted-api-changes.json
@@ -93,5 +93,15 @@
         "type": "io.micronaut.context.scope.CustomScope",
         "member": "Method io.micronaut.context.scope.CustomScope.findBeanRegistration(io.micronaut.inject.BeanDefinition)",
         "reason": "New method added with a default implementation"
+    },
+    {
+        "type": "io.micronaut.http.client.ProxyHttpClient",
+        "member": "Class io.micronaut.http.client.ProxyHttpClient",
+        "reason": "New method added with a default implementation"
+    },
+    {
+        "type": "io.micronaut.http.client.ProxyHttpClient",
+        "member": "Method io.micronaut.http.client.ProxyHttpClient.proxy(io.micronaut.http.HttpRequest,boolean)",
+        "reason": "New method added with a default implementation"
     }
 ]

--- a/config/accepted-api-changes.json
+++ b/config/accepted-api-changes.json
@@ -101,7 +101,7 @@
     },
     {
         "type": "io.micronaut.http.client.ProxyHttpClient",
-        "member": "Method io.micronaut.http.client.ProxyHttpClient.proxy(io.micronaut.http.HttpRequest,boolean)",
+        "member": "Method io.micronaut.http.client.ProxyHttpClient.proxy(io.micronaut.http.HttpRequest,io.micronaut.http.client.ProxyRequestOptions)",
         "reason": "New method added with a default implementation"
     }
 ]

--- a/http-client-core/src/main/java/io/micronaut/http/client/ProxyHttpClient.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/ProxyHttpClient.java
@@ -45,12 +45,12 @@ public interface ProxyHttpClient {
      * If a relative URL is specified then the method will try to resolve the URI for the current server otherwise an exception will be thrown.
      *
      * @param request The request
-     * @param retainHostHeader If {@code true}, retain the host header from the given request. If {@code false}, it will be recomputed based on the request URI (same behavior as {@link #proxy(HttpRequest)})
+     * @param options Further options for the proxy request
      * @return A publisher that emits the response.
      * @since 3.5.0
      */
-    default Publisher<MutableHttpResponse<?>> proxy(@NonNull HttpRequest<?> request, boolean retainHostHeader) {
-        if (!retainHostHeader) {
+    default Publisher<MutableHttpResponse<?>> proxy(@NonNull HttpRequest<?> request, @NonNull ProxyRequestOptions options) {
+        if (options.equals(ProxyRequestOptions.getDefault())) {
             return proxy(request);
         } else {
             throw new UnsupportedOperationException("Not implemented");

--- a/http-client-core/src/main/java/io/micronaut/http/client/ProxyHttpClient.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/ProxyHttpClient.java
@@ -41,6 +41,23 @@ public interface ProxyHttpClient {
     Publisher<MutableHttpResponse<?>> proxy(@NonNull HttpRequest<?> request);
 
     /**
+     * Proxy the given request and emit the response. This method expects the full absolute URL to be included in the request.
+     * If a relative URL is specified then the method will try to resolve the URI for the current server otherwise an exception will be thrown.
+     *
+     * @param request The request
+     * @param retainHostHeader If {@code true}, retain the host header from the given request. If {@code false}, it will be recomputed based on the request URI (same behavior as {@link #proxy(HttpRequest)})
+     * @return A publisher that emits the response.
+     * @since 3.5.0
+     */
+    default Publisher<MutableHttpResponse<?>> proxy(@NonNull HttpRequest<?> request, boolean retainHostHeader) {
+        if (!retainHostHeader) {
+            return proxy(request);
+        } else {
+            throw new UnsupportedOperationException("Not implemented");
+        }
+    }
+
+    /**
      * Create a new {@link ProxyHttpClient}.
      * Note that this method should only be used outside of the context of a Micronaut application.
      * The returned {@link ProxyHttpClient} is not subject to dependency injection.

--- a/http-client-core/src/main/java/io/micronaut/http/client/ProxyRequestOptions.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/ProxyRequestOptions.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.client;
+
+import java.util.Objects;
+
+/**
+ * Further options for {@link ProxyHttpClient} when handling proxy requests.
+ */
+public final class ProxyRequestOptions {
+    private static final ProxyRequestOptions DEFAULT = builder().build();
+
+    private final boolean retainHostHeader;
+
+    private ProxyRequestOptions(Builder builder) {
+        this.retainHostHeader = builder.retainHostHeader;
+    }
+
+    /**
+     * @return A new options builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * @return A default {@link ProxyRequestOptions} that will behave the same way as
+     * {@link ProxyHttpClient#proxy(io.micronaut.http.HttpRequest)}
+     */
+    public static ProxyRequestOptions getDefault() {
+        return DEFAULT;
+    }
+
+    /**
+     * If {@code true}, retain the host header from the given request. If {@code false}, it will be recomputed
+     * based on the request URI (same behavior as {@link ProxyHttpClient#proxy(io.micronaut.http.HttpRequest)}).
+     *
+     * @return Whether to retain the host header from the proxy request instead of recomputing it based on URL.
+     */
+    public boolean isRetainHostHeader() {
+        return retainHostHeader;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof ProxyRequestOptions &&
+                isRetainHostHeader() == ((ProxyRequestOptions) o).isRetainHostHeader();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(isRetainHostHeader());
+    }
+
+    /**
+     * Builder class.
+     */
+    public static final class Builder {
+        private boolean retainHostHeader = false;
+
+        private Builder() {
+        }
+
+        /**
+         * Build an immutable {@link ProxyRequestOptions} with the options configured in this builder.
+         *
+         * @return The options
+         */
+        public ProxyRequestOptions build() {
+            return new ProxyRequestOptions(this);
+        }
+
+        /**
+         * If {@code true}, retain the host header from the given request. If {@code false}, it will be recomputed
+         * based on the request URI (same behavior as {@link ProxyHttpClient#proxy(io.micronaut.http.HttpRequest)}).
+         *
+         * @param retainHostHeader Whether to retain the host header from the proxy request instead of recomputing it
+         *                         based on URL.
+         * @return This builder.
+         */
+        public Builder retainHostHeader(boolean retainHostHeader) {
+            this.retainHostHeader = retainHostHeader;
+            return this;
+        }
+
+        /**
+         * Equivalent to {@link #retainHostHeader(boolean)}.
+         *
+         * @return This builder.
+         */
+        public Builder retainHostHeader() {
+            return retainHostHeader(true);
+        }
+    }
+}

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -1093,12 +1093,19 @@ public class DefaultHttpClient implements
 
     @Override
     public Publisher<MutableHttpResponse<?>> proxy(@NonNull io.micronaut.http.HttpRequest<?> request) {
+        return proxy(request, false);
+    }
+
+    @Override
+    public Publisher<MutableHttpResponse<?>> proxy(@NonNull io.micronaut.http.HttpRequest<?> request, boolean retainHostHeader) {
         return Flux.from(resolveRequestURI(request))
                 .flatMap(requestURI -> {
                     io.micronaut.http.MutableHttpRequest<?> httpRequest = request instanceof MutableHttpRequest
                             ? (io.micronaut.http.MutableHttpRequest<?>) request
                             : request.mutate();
-                    httpRequest.headers(headers -> headers.remove(HttpHeaderNames.HOST));
+                    if (!retainHostHeader) {
+                        httpRequest.headers(headers -> headers.remove(HttpHeaderNames.HOST));
+                    }
 
                     AtomicReference<io.micronaut.http.HttpRequest<?>> requestWrapper = new AtomicReference<>(httpRequest);
                     Flux<MutableHttpResponse<Object>> proxyResponsePublisher = connectAndStream(request, request, requestURI, buildSslContext(requestURI), requestWrapper, true, false);

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -50,6 +50,7 @@ import io.micronaut.http.client.HttpClient;
 import io.micronaut.http.client.HttpClientConfiguration;
 import io.micronaut.http.client.LoadBalancer;
 import io.micronaut.http.client.ProxyHttpClient;
+import io.micronaut.http.client.ProxyRequestOptions;
 import io.micronaut.http.client.StreamingHttpClient;
 import io.micronaut.http.client.exceptions.ContentLengthExceededException;
 import io.micronaut.http.client.exceptions.HttpClientErrorDecoder;
@@ -1093,17 +1094,18 @@ public class DefaultHttpClient implements
 
     @Override
     public Publisher<MutableHttpResponse<?>> proxy(@NonNull io.micronaut.http.HttpRequest<?> request) {
-        return proxy(request, false);
+        return proxy(request, ProxyRequestOptions.getDefault());
     }
 
     @Override
-    public Publisher<MutableHttpResponse<?>> proxy(@NonNull io.micronaut.http.HttpRequest<?> request, boolean retainHostHeader) {
+    public Publisher<MutableHttpResponse<?>> proxy(@NonNull io.micronaut.http.HttpRequest<?> request, @NonNull ProxyRequestOptions options) {
+        Objects.requireNonNull(options, "options");
         return Flux.from(resolveRequestURI(request))
                 .flatMap(requestURI -> {
                     io.micronaut.http.MutableHttpRequest<?> httpRequest = request instanceof MutableHttpRequest
                             ? (io.micronaut.http.MutableHttpRequest<?>) request
                             : request.mutate();
-                    if (!retainHostHeader) {
+                    if (!options.isRetainHostHeader()) {
                         httpRequest.headers(headers -> headers.remove(HttpHeaderNames.HOST));
                     }
 

--- a/http-client/src/test/groovy/io/micronaut/http/client/ProxyHttpClientMutableRequestSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/ProxyHttpClientMutableRequestSpec.groovy
@@ -106,7 +106,7 @@ class ProxyHttpClientMutableRequestSpec extends Specification {
                 def mutableReq = request.mutate()
                         .uri(UriBuilder.of(request.uri).replacePath("/hello/host").build())
                 mutableReq.getHeaders().set("Host", "foo")
-                return proxyHttpClient.proxy(mutableReq, true)
+                return proxyHttpClient.proxy(mutableReq, ProxyRequestOptions.builder().retainHostHeader().build())
             } else {
                 return proxyHttpClient.proxy(request)
             }


### PR DESCRIPTION
Without this patch, the Host header was always cleared and then recomputed from the request URI. This PR adds an overload with an additional boolean flag that if set to true, does not clear the Host header.

Normally I'm not a big fan of such magic flags from a design pov, but I don't see a better solution.

Adds #7158