### PR TITLE
UTF-8 support for Content-Disposition headers for file downloads

### DIFF
--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/types/FileTypeHandlerSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/types/FileTypeHandlerSpec.groovy
@@ -198,7 +198,7 @@ class FileTypeHandlerSpec extends AbstractMicronautSpec {
         then: "the content type is still based on the file extension"
         response.code() == HttpStatus.OK.code
         response.header(CONTENT_TYPE) == "text/html"
-        response.header(CONTENT_DISPOSITION) == "attachment; filename=\"abc.xyz\""
+        response.header(CONTENT_DISPOSITION).startsWith("attachment; filename=\"abc.xyz\"")
         Integer.parseInt(response.header(CONTENT_LENGTH)) > 0
         response.headers.getDate(DATE) < response.headers.getDate(EXPIRES)
         response.header(CACHE_CONTROL) == "private, max-age=60"
@@ -213,7 +213,7 @@ class FileTypeHandlerSpec extends AbstractMicronautSpec {
         then: "the content type is still based on the file extension"
         response.code() == HttpStatus.OK.code
         response.header(CONTENT_TYPE) == "text/html"
-        response.header(CONTENT_DISPOSITION) == "attachment; filename=\"abc.xyz\""
+        response.header(CONTENT_DISPOSITION).startsWith("attachment; filename=\"abc.xyz\"")
         Integer.parseInt(response.header(CONTENT_LENGTH)) > 0
         response.headers.getDate(DATE) < response.headers.getDate(EXPIRES)
         response.header(CACHE_CONTROL) == "private, max-age=60"
@@ -228,7 +228,7 @@ class FileTypeHandlerSpec extends AbstractMicronautSpec {
         then:
         response.code() == HttpStatus.OK.code
         response.header(CONTENT_TYPE) == "text/plain"
-        response.header(CONTENT_DISPOSITION) == "attachment; filename=\"temp.html\""
+        response.header(CONTENT_DISPOSITION).startsWith("attachment; filename=\"temp.html\"")
         Integer.parseInt(response.header(CONTENT_LENGTH)) > 0
         response.headers.getDate(DATE) < response.headers.getDate(EXPIRES)
         response.header(CACHE_CONTROL) == "private, max-age=60"
@@ -243,7 +243,7 @@ class FileTypeHandlerSpec extends AbstractMicronautSpec {
         then:
         response.code() == HttpStatus.OK.code
         response.header(CONTENT_TYPE) == "text/plain"
-        response.header(CONTENT_DISPOSITION) == "attachment; filename=\"temp.html\""
+        response.header(CONTENT_DISPOSITION).startsWith("attachment; filename=\"temp.html\"")
         Integer.parseInt(response.header(CONTENT_LENGTH)) > 0
         response.headers.getDate(DATE) < response.headers.getDate(EXPIRES)
         response.header(CACHE_CONTROL) == "private, max-age=60"
@@ -258,7 +258,7 @@ class FileTypeHandlerSpec extends AbstractMicronautSpec {
         then:
         response.code() == HttpStatus.OK.code
         response.header(CONTENT_TYPE) == "text/plain"
-        response.header(CONTENT_DISPOSITION) == "attachment; filename=\"temp.html\""
+        response.header(CONTENT_DISPOSITION).startsWith("attachment; filename=\"temp.html\"")
         Integer.parseInt(response.header(CONTENT_LENGTH)) > 0
         response.headers.getDate(DATE) < response.headers.getDate(EXPIRES)
         response.header(CACHE_CONTROL) == "private, max-age=60"

--- a/http-server/build.gradle
+++ b/http-server/build.gradle
@@ -10,6 +10,8 @@ dependencies {
     compileOnly libs.kotlinx.coroutines.reactor
     implementation libs.managed.reactor
     annotationProcessor project(":inject-java")
+
+    testImplementation libs.managed.netty.codec.http
 }
 
 //compileTestGroovy.groovyOptions.forkOptions.jvmArgs = ['-Xdebug', '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005']

--- a/http-server/src/main/java/io/micronaut/http/server/types/files/FileCustomizableResponseType.java
+++ b/http-server/src/main/java/io/micronaut/http/server/types/files/FileCustomizableResponseType.java
@@ -26,6 +26,9 @@ import io.micronaut.http.server.types.CustomizableResponseType;
  */
 public interface FileCustomizableResponseType extends CustomizableResponseType {
 
+    /**
+     * @deprecated Unused now, please follow <a href="https://httpwg.org/specs/rfc6266.html">RFC 6266</a>
+     */
     @Deprecated
     String ATTACHMENT_HEADER = "attachment; filename=\"%s\"";
 

--- a/http-server/src/main/java/io/micronaut/http/server/types/files/FileCustomizableResponseType.java
+++ b/http-server/src/main/java/io/micronaut/http/server/types/files/FileCustomizableResponseType.java
@@ -26,6 +26,7 @@ import io.micronaut.http.server.types.CustomizableResponseType;
  */
 public interface FileCustomizableResponseType extends CustomizableResponseType {
 
+    @Deprecated
     String ATTACHMENT_HEADER = "attachment; filename=\"%s\"";
 
     /**

--- a/http-server/src/main/java/io/micronaut/http/server/types/files/StreamedFile.java
+++ b/http-server/src/main/java/io/micronaut/http/server/types/files/StreamedFile.java
@@ -156,7 +156,7 @@ public class StreamedFile implements FileCustomizableResponseType {
 
     // this is mostly copied from netty QueryStringEncoder
 
-    @SuppressWarnings({"S3776", "S135", "S127"}) // stay close to netty impl
+    @SuppressWarnings({"java:S3776", "java:S135", "java:S127"}) // stay close to netty impl
     static String encodeRfc6987(String s) {
         StringBuilder uriBuilder = new StringBuilder();
         for (int i = 0; i < s.length(); i++) {

--- a/http-server/src/main/java/io/micronaut/http/server/types/files/StreamedFile.java
+++ b/http-server/src/main/java/io/micronaut/http/server/types/files/StreamedFile.java
@@ -34,6 +34,7 @@ import java.time.Instant;
  * @since 1.0
  */
 public class StreamedFile implements FileCustomizableResponseType {
+    private static final char[] HEX_DIGITS = "0123456789ABCDEF".toCharArray();
 
     private final MediaType mediaType;
     private final String name;
@@ -131,8 +132,85 @@ public class StreamedFile implements FileCustomizableResponseType {
     @Override
     public void process(MutableHttpResponse<?> response) {
         if (attachmentName != null) {
-            response.header(HttpHeaders.CONTENT_DISPOSITION, String.format(ATTACHMENT_HEADER, attachmentName));
+            response.header(HttpHeaders.CONTENT_DISPOSITION, buildAttachmentHeader(attachmentName));
         }
     }
 
+    static String buildAttachmentHeader(String attachmentName) {
+        // https://httpwg.org/specs/rfc6266.html#advice.generating
+        // 'filename' parameter is the fallback for legacy browsers, 'filename*' is the supported approach.
+        return "attachment; filename=\"" + sanitizeAscii(attachmentName) + "\"; filename*=utf-8''" + encodeRfc6987(attachmentName);
+    }
+
+    private static String sanitizeAscii(String s) {
+        StringBuilder builder = new StringBuilder(s.length());
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            // " ends the string
+            if (c >= 32 && c < 127 && c != '"') {
+                builder.append(c);
+            }
+        }
+        return builder.toString();
+    }
+
+    // this is mostly copied from netty QueryStringEncoder
+
+    @SuppressWarnings({"S3776", "S135", "S127"}) // stay close to netty impl
+    static String encodeRfc6987(String s) {
+        StringBuilder uriBuilder = new StringBuilder();
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (c < 0x80) {
+                if (dontNeedEncoding(c)) {
+                    uriBuilder.append(c);
+                } else {
+                    appendEncoded(uriBuilder, c);
+                }
+            } else if (c < 0x800) {
+                appendEncoded(uriBuilder, 0xc0 | (c >> 6));
+                appendEncoded(uriBuilder, 0x80 | (c & 0x3f));
+            } else if (Character.isSurrogate(c)) {
+                if (!Character.isHighSurrogate(c)) {
+                    appendEncoded(uriBuilder, '?');
+                    continue;
+                }
+                // Surrogate Pair consumes 2 characters.
+                if (++i == s.length()) {
+                    appendEncoded(uriBuilder, '?');
+                    break;
+                }
+                // Extra method to allow inlining the rest of writeUtf8 which is the most likely code path.
+                writeUtf8Surrogate(uriBuilder, c, s.charAt(i));
+            } else {
+                appendEncoded(uriBuilder, 0xe0 | (c >> 12));
+                appendEncoded(uriBuilder, 0x80 | ((c >> 6) & 0x3f));
+                appendEncoded(uriBuilder, 0x80 | (c & 0x3f));
+            }
+        }
+        return uriBuilder.toString();
+    }
+
+    private static boolean dontNeedEncoding(char ch) {
+        return ch >= 'a' && ch <= 'z' || ch >= 'A' && ch <= 'Z' || ch >= '0' && ch <= '9'
+                || ch == '-' || ch == '_' || ch == '.' || ch == '*' || ch == '~';
+    }
+
+    private static void appendEncoded(StringBuilder uriBuilder, int b) {
+        uriBuilder.append('%').append(HEX_DIGITS[(b >> 4) & 0xf]).append(HEX_DIGITS[b & 0xf]);
+    }
+
+    private static void writeUtf8Surrogate(StringBuilder uriBuilder, char c, char c2) {
+        if (!Character.isLowSurrogate(c2)) {
+            appendEncoded(uriBuilder, '?');
+            appendEncoded(uriBuilder, Character.isHighSurrogate(c2) ? '?' : c2);
+            return;
+        }
+        int codePoint = Character.toCodePoint(c, c2);
+        // See https://www.unicode.org/versions/Unicode7.0.0/ch03.pdf#G2630.
+        appendEncoded(uriBuilder, 0xf0 | (codePoint >> 18));
+        appendEncoded(uriBuilder, 0x80 | ((codePoint >> 12) & 0x3f));
+        appendEncoded(uriBuilder, 0x80 | ((codePoint >> 6) & 0x3f));
+        appendEncoded(uriBuilder, 0x80 | (codePoint & 0x3f));
+    }
 }

--- a/http-server/src/main/java/io/micronaut/http/server/types/files/SystemFile.java
+++ b/http-server/src/main/java/io/micronaut/http/server/types/files/SystemFile.java
@@ -99,7 +99,7 @@ public class SystemFile implements FileCustomizableResponseType {
     @Override
     public void process(MutableHttpResponse response) {
         if (attachmentName != null) {
-            response.header(HttpHeaders.CONTENT_DISPOSITION, String.format(ATTACHMENT_HEADER, attachmentName));
+            response.header(HttpHeaders.CONTENT_DISPOSITION, StreamedFile.buildAttachmentHeader(attachmentName));
         }
     }
 }

--- a/http-server/src/test/groovy/io/micronaut/http/server/types/files/StreamedFileSpec.groovy
+++ b/http-server/src/test/groovy/io/micronaut/http/server/types/files/StreamedFileSpec.groovy
@@ -1,0 +1,27 @@
+package io.micronaut.http.server.types.files
+
+import io.netty.handler.codec.http.QueryStringEncoder
+import spock.lang.Specification
+
+class StreamedFileSpec extends Specification {
+    def 'encode RFC 6987'() {
+        expect:
+        for (int codePoint = 0; codePoint < 0x10000; codePoint++) {
+            StringBuilder sb = new StringBuilder(2);
+            sb.appendCodePoint(codePoint)
+            String s = sb.toString()
+
+            def encoder = new QueryStringEncoder('')
+            encoder.addParam("foo", s)
+            def encoded = encoder.toString().substring("?foo=".length())
+
+            assert StreamedFile.encodeRfc6987(s) == encoded
+        }
+    }
+
+    def 'buildAttachmentHeader'() {
+        expect:
+        StreamedFile.buildAttachmentHeader('foo') == 'attachment; filename="foo"; filename*=utf-8\'\'foo'
+        StreamedFile.buildAttachmentHeader('€ rates') == 'attachment; filename=" rates"; filename*=utf-8\'\'%E2%82%AC%20rates'
+    }
+}


### PR DESCRIPTION
This patch implements the file name encoding logic from RFC 6266 for unicode file names.
RFC 6987 encoding logic is copied from netty. It's unfortunately not quite the same encoding as URLEncoder, and these classes are in http-server, so can't use the netty code.

Fixes #7401