### PR TITLE
Try to reduce the failures in tests

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/scope/custom/interceptors/InterceptorScopeTest.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/scope/custom/interceptors/InterceptorScopeTest.java
@@ -25,7 +25,6 @@ import io.micronaut.runtime.context.scope.ScopedProxy;
 import jakarta.annotation.PreDestroy;
 import jakarta.inject.Scope;
 import jakarta.inject.Singleton;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -34,6 +33,10 @@ public class InterceptorScopeTest {
 
     @Test
     void testInterceptorsWithCustomScopes() {
+        // Reset in case of retry
+        MyIntercepted1Interceptor.creationCount = 0;
+        MyIntercepted2Interceptor.creationCount = 0;
+
         try (ApplicationContext beanContext = ApplicationContext.run()) {
 
             MyCustomScope scope = beanContext.getBean(MyCustomScope.class);

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/multiple/InterceptorSpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/multiple/InterceptorSpec.kt
@@ -32,6 +32,7 @@ class InterceptorSpec : StringSpec() {
     init {
         "test correct interceptors calls" {
             runBlocking {
+                MyService.events.clear()
                 myService.someCall()
                 MyService.events.size shouldBeExactly 8
                 MyService.events[0] shouldBe "intercept1-start"


### PR DESCRIPTION
We have 2 tests that fail quite a lot, and seems to be caused by retries.

They both use static members, so this PR clears those down prior to running the test