### PR TITLE
build: Switch to using versions from boms, instead of custom versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,6 @@
 [versions]
 asm = "9.2"
 awaitility = "4.0.3"
-aws-java-sdk-lambda = "1.12.220"
 bcpkix = "1.69"
 blaze = "1.6.6"
 caffeine = "2.9.3"
@@ -23,10 +22,8 @@ jsr107 = "1.1.1"
 junit4 = "4.13.2"
 javax-el = "3.0.1-b12"
 javax-el-impl = "2.2.1-b05"
-kotest-junit5 = "4.6.4"
 logbook-netty = "2.4.1"
 log4j = "2.17.2"
-mysql-driver = "8.0.29"
 powermock = "2.0.9"
 selenium = "3.141.59"
 smallrye = "5.1.0"
@@ -362,7 +359,7 @@ asm-tree = { module = "org.ow2.asm:asm-tree", version.ref = "asm" }
 
 awaitility = { module = "org.awaitility:awaitility", version.ref = "awaitility" }
 
-aws-java-sdk-lambda = { module = "com.amazonaws:aws-java-sdk-lambda", version.ref = "aws-java-sdk-lambda" }
+aws-java-sdk-lambda = { module = "com.amazonaws:aws-java-sdk-lambda" }
 
 bcpkix = { module = "org.bouncycastle:bcpkix-jdk15on", version.ref = "bcpkix" }
 
@@ -405,7 +402,7 @@ jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "j
 
 kotlin-annotation-processing-embeddable = { module = "org.jetbrains.kotlin:kotlin-annotation-processing-embeddable", version.ref = "managed-kotlin" }
 kotlin-compiler-embeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "managed-kotlin" }
-kotlin-kotest-junit5 = { module = "io.kotest:kotest-runner-junit5-jvm", version.ref = "kotest-junit5"}
+kotlin-kotest-junit5 = { module = "io.kotest:kotest-runner-junit5-jvm" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "managed-kotlin" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "managed-kotlin" }
 kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "managed-kotlin" }
@@ -424,7 +421,7 @@ logbook-netty = { module = "org.zalando:logbook-netty", version.ref = "logbook-n
 
 micronaut-docs = { module = "io.micronaut.docs:micronaut-docs-asciidoc-config-props", version.ref = "micronaut-docs" }
 
-mysql-driver = { module = "mysql:mysql-connector-java", version.ref = "mysql-driver" }
+mysql-driver = { module = "mysql:mysql-connector-java" }
 
 netty-tcnative = { module = 'io.netty:netty-tcnative' }
 netty-tcnative-boringssl = { module = 'io.netty:netty-tcnative-boringssl-static' }
@@ -443,8 +440,8 @@ smallrye = { module = "io.smallrye:smallrye-fault-tolerance", version.ref = "sma
 
 systemlambda = { module = "com.github.stefanbirkner:system-lambda", version.ref = "systemlambda" }
 
-micronaut-tracing-jaeger = { module = "io.micronaut.tracing:micronaut-tracing-jaeger", version.ref = "managed-micronaut-tracing" }
-micronaut-tracing-zipkin = { module = "io.micronaut.tracing:micronaut-tracing-zipkin", version.ref = "managed-micronaut-tracing" }
+micronaut-tracing-jaeger = { module = "io.micronaut.tracing:micronaut-tracing-jaeger" }
+micronaut-tracing-zipkin = { module = "io.micronaut.tracing:micronaut-tracing-zipkin" }
 
 testcontainers-spock = { module = "org.testcontainers:spock", version.ref = "managed-testcontainers" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,12 +19,10 @@ jetbrains-annotations = "23.0.0"
 jetty = "9.4.46.v20220331"
 jmh = "1.29"
 jsr107 = "1.1.1"
-junit4 = "4.13.2"
 javax-el = "3.0.1-b12"
 javax-el-impl = "2.2.1-b05"
 logbook-netty = "2.4.1"
 log4j = "2.17.2"
-powermock = "2.0.9"
 selenium = "3.141.59"
 smallrye = "5.1.0"
 systemlambda = "1.2.1"
@@ -396,7 +394,6 @@ jsr107 = { module = "org.jsr107.ri:cache-ri-impl", version.ref = "jsr107" }
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "managed-junit5" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "managed-junit5" }
 junit-vintage = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "managed-junit5" }
-junit4 = { module = "junit:junit", version.ref = "junit4" }
 
 jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrains-annotations" }
 
@@ -425,9 +422,6 @@ mysql-driver = { module = "mysql:mysql-connector-java" }
 
 netty-tcnative = { module = 'io.netty:netty-tcnative' }
 netty-tcnative-boringssl = { module = 'io.netty:netty-tcnative-boringssl-static' }
-
-powermock-junit4 = { module = "org.powermock:powermock-module-junit4", version.ref = "powermock" }
-powermock-mockito2 = { module = "org.powermock:powermock-api-mockito2", version.ref = "powermock" }
 
 selenium-remote-driver = { module = "org.seleniumhq.selenium:selenium-remote-driver", version.ref = "selenium" }
 selenium-api = { module = "org.seleniumhq.selenium:selenium-api", version.ref = "selenium" }

--- a/http-server-netty/build.gradle
+++ b/http-server-netty/build.gradle
@@ -37,8 +37,6 @@ dependencies {
     testImplementation project(":inject-java-test")
     testImplementation project(":http-client")
     testImplementation libs.managed.spotbugs
-    testImplementation libs.powermock.junit4
-    testImplementation libs.powermock.mockito2
     if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_15)) {
         testImplementation libs.bcpkix
     }

--- a/inject-java/build.gradle
+++ b/inject-java/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     testImplementation libs.managed.micrometer.core
     testImplementation project(":validation")
     testImplementation libs.junit.jupiter.api
+    testImplementation(platform(libs.boms.micronaut.tracing))
     testImplementation(libs.micronaut.tracing.zipkin) {
         exclude module: 'micronaut-bom'
         exclude module: 'micronaut-http-client'

--- a/inject-java/build.gradle
+++ b/inject-java/build.gradle
@@ -28,7 +28,6 @@ dependencies {
 
     testImplementation libs.managed.spotbugs
     testImplementation libs.hibernate
-    testImplementation libs.junit4
     testImplementation libs.compile.testing
     testImplementation(libs.managed.neo4j.bolt) {
         version {

--- a/inject-java/src/test/groovy/io/micronaut/inject/dependent/factory/DestroyFactorySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/dependent/factory/DestroyFactorySpec.groovy
@@ -9,6 +9,15 @@ import spock.lang.Specification
 class DestroyFactorySpec extends Specification {
 
     void "test destroy dependent objects from singleton using listeners"() {
+        given:
+            MyBean1Factory.beanCreated = 0
+            MyBean1Factory.destroyed = 0
+            MyBean2Factory.beanCreated = 0
+            MyBean2Factory.destroyed = 0
+            MyBean3Factory.beanDestroyed = 0
+            MyBean3Factory.destroyed = 0
+            TestData.DESTRUCTION_ORDER.clear()
+
         when:
             ApplicationContext context = ApplicationContext.run()
             BeanDefinition<MyBean1> beanDefinition = context.getBeanDefinition(MyBean1)
@@ -53,8 +62,5 @@ class DestroyFactorySpec extends Specification {
 
             TestData.DESTRUCTION_ORDER.count("MyBean3") == 1
             TestData.DESTRUCTION_ORDER.count("MyBean3Factory") == 1
-
-        cleanup:
-            TestData.DESTRUCTION_ORDER.clear()
     }
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/factory/nullreturn/NullReturnFactorySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/factory/nullreturn/NullReturnFactorySpec.groovy
@@ -141,6 +141,9 @@ class Test2 {}
 
     void "test each bean on a class with null factory"() {
         given:
+        DProcessor.constructed.set(0)
+        ParameterDProcessor.constructed.set(0)
+        NullableDProcessor.constructed.set(0)
         BeanContext beanContext = ApplicationContext.run(["spec.name": getClass().simpleName])
 
         expect:

--- a/management/build.gradle
+++ b/management/build.gradle
@@ -23,7 +23,8 @@ dependencies {
         exclude module:'micronaut-bom'
     }
     testImplementation libs.managed.groovy.json
-    testRuntimeOnly(platform(libs.boms.micronaut.data))
+
+    testRuntimeOnly(platform(libs.boms.micronaut.sql))
     testRuntimeOnly libs.managed.h2
     testRuntimeOnly libs.mysql.driver
 

--- a/management/build.gradle
+++ b/management/build.gradle
@@ -23,8 +23,9 @@ dependencies {
         exclude module:'micronaut-bom'
     }
     testImplementation libs.managed.groovy.json
-    testImplementation libs.managed.h2
-    testImplementation libs.mysql.driver
+    testRuntimeOnly(platform(libs.boms.micronaut.data))
+    testRuntimeOnly libs.managed.h2
+    testRuntimeOnly libs.mysql.driver
 
     compileOnly libs.managed.logback
     compileOnly libs.log4j

--- a/test-suite-groovy/build.gradle
+++ b/test-suite-groovy/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     testImplementation libs.logbook.netty
     testImplementation project(":function-client")
     testImplementation project(":function-web")
+    testRuntimeOnly(platform(libs.boms.micronaut.aws))
     testRuntimeOnly libs.aws.java.sdk.lambda
 
     testImplementation libs.managed.reactor

--- a/test-suite-kotlin/build.gradle
+++ b/test-suite-kotlin/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     kaptTest project(':inject-java')
     kaptTest project(':validation')
     testImplementation libs.javax.inject
+    testImplementation(platform(libs.boms.micronaut.tracing))
     testImplementation(libs.micronaut.tracing.zipkin) {
         exclude module: 'micronaut-bom'
         exclude module: 'micronaut-http-client'
@@ -57,6 +58,7 @@ dependencies {
     }
 
     testRuntimeOnly libs.junit.jupiter.engine
+    testRuntimeOnly(platform(libs.boms.micronaut.aws))
     testRuntimeOnly libs.aws.java.sdk.lambda
     if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_15)) {
         testImplementation libs.bcpkix

--- a/test-suite/build.gradle
+++ b/test-suite/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     testImplementation libs.junit.jupiter.api
 
     testImplementation libs.managed.jcache
+    testImplementation(platform(libs.boms.micronaut.tracing))
     testImplementation(libs.micronaut.tracing.jaeger) {
         exclude module: 'micronaut-bom'
         exclude module: 'micronaut-http-client'
@@ -64,6 +65,7 @@ dependencies {
     testAnnotationProcessor project(":inject-java")
     testAnnotationProcessor project(":test-suite")
 
+    testRuntimeOnly(platform(libs.boms.micronaut.aws))
     testRuntimeOnly libs.managed.h2
     testRuntimeOnly libs.junit.vintage
     testRuntimeOnly libs.managed.logback


### PR DESCRIPTION
These versions are used in tests, but can be provided by declaring a platform
dependency on the upstream bom that also pulls them in.

The reasoning for doing this is that renovate-bot should spam us less with
dependency updates as these will be handled by the modules themselves.

All the tests still passed without junit4 or powermock, so I removed these entirely.

This also includes a couple of test fixes where static counters were not being reset in case of a retry