### PR TITLE
Switch to string based dependencies for version lookup

### DIFF
--- a/buildSrc/src/main/groovy/io/micronaut/build/internal/WriteMicronautVersionInfoTask.java
+++ b/buildSrc/src/main/groovy/io/micronaut/build/internal/WriteMicronautVersionInfoTask.java
@@ -4,13 +4,18 @@ import groovy.xml.XmlSlurper;
 import groovy.xml.slurpersupport.GPathResult;
 import groovy.xml.slurpersupport.NodeChild;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.DependencySet;
 import org.gradle.api.artifacts.result.ArtifactResolutionResult;
 import org.gradle.api.artifacts.result.ComponentArtifactsResult;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
@@ -22,12 +27,14 @@ import org.gradle.maven.MavenModule;
 import org.gradle.maven.MavenPomArtifact;
 import org.xml.sax.SAXException;
 
+import javax.inject.Inject;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 
 @CacheableTask
@@ -38,19 +45,24 @@ public abstract class WriteMicronautVersionInfoTask extends DefaultTask {
     @Input
     public abstract Property<String> getVersion();
 
-    @InputFiles
-    @PathSensitive(PathSensitivity.RELATIVE)
-    public Configuration configuration;
+    @Input
+    public ListProperty<String> dependencies;
 
     @OutputDirectory
     public abstract DirectoryProperty getOutputDirectory();
 
+    @Inject
+    public WriteMicronautVersionInfoTask(Project project) {
+        dependencies = project.getObjects().listProperty(String.class);
+    }
+
     @TaskAction
     public void writeVersionInfo() throws IOException {
         Map<String, String> props = new TreeMap<>();
-        for (Dependency dependency : configuration.getAllDependencies()) {
-            getLogger().lifecycle("Scanning {}:{}:{}", dependency.getGroup(), dependency.getName(), dependency.getVersion());
-            Map<String, String> bomProperties = bomProperties(dependency.getGroup(), dependency.getName(), dependency.getVersion());
+        for (String dependency : dependencies.get()) {
+            String[] groups = dependency.split(":", 3);
+            getLogger().lifecycle("Scanning {}:{}:{}", groups[0], groups[1], groups[2]);
+            Map<String, String> bomProperties = bomProperties(groups[0], groups[1], groups[2]);
             for (Map.Entry<String, String> entry : bomProperties.entrySet()) {
                 if (entry.getKey().startsWith("micronaut.")) {
                     getLogger().lifecycle("Skipping {} from {}", entry.getKey(), dependency);
@@ -96,7 +108,7 @@ public abstract class WriteMicronautVersionInfoTask extends DefaultTask {
         return props;
     }
 
-    public Configuration getConfiguration() {
-        return configuration;
+    public ListProperty<String> getDependencies() {
+        return dependencies;
     }
 }

--- a/parent/build.gradle
+++ b/parent/build.gradle
@@ -18,10 +18,8 @@ dependencies {
 
 def micronautVersionInfo = tasks.register("micronautVersionInfo", WriteMicronautVersionInfoTask) {
     version = projectVersion
-    configuration = configurations.bomVersions
+    dependencies.set(configurations.bomVersions.getAllDependencies().collect { "$it.group:$it.name:$it.version" })
     outputDirectory = layout.buildDirectory.dir("version-info")
-    // TODO: Fix the caching for this task
-    outputs.upToDateWhen { false }
 }
 
 group projectGroupId

--- a/parent/build.gradle
+++ b/parent/build.gradle
@@ -17,9 +17,11 @@ dependencies {
 }
 
 def micronautVersionInfo = tasks.register("micronautVersionInfo", WriteMicronautVersionInfoTask) {
-    it.version = projectVersion
-    it.configuration = configurations.bomVersions
-    it.outputDirectory = layout.buildDirectory.dir("version-info")
+    version = projectVersion
+    configuration = configurations.bomVersions
+    outputDirectory = layout.buildDirectory.dir("version-info")
+    // TODO: Fix the caching for this task
+    outputs.upToDateWhen { false }
 }
 
 group projectGroupId


### PR DESCRIPTION
Caching isn't working for this task, so adding a new bomVersions library still uses
the old one from the cache.

We have switched to using string coordinates, and caching works again