### PR TITLE
Regression, do not check if bean is a singleton for a custom scope

### DIFF
--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -2895,10 +2895,6 @@ public class DefaultBeanContext implements InitializableBeanContext {
                                                @NonNull BeanDefinition<T> definition,
                                                boolean isProxy,
                                                boolean isScopedProxyDefinition) {
-        if (definition.isSingleton()) {
-            return null;
-        }
-
         Optional<Class<? extends Annotation>> scope = definition.getScope();
         if (scope.isPresent()) {
             Class<? extends Annotation> scopeAnnotation = scope.get();


### PR DESCRIPTION
The problem occurs for the pre 3.5 compiled beans that got the singleton scope inherited from the factory.