### PR TITLE
Fix bug with multiple factories of the same type with distinct qualifiers

### DIFF
--- a/inject-groovy/src/test/groovy/io/micronaut/inject/beanbuilder/BeanElementBuilderMultipleFactorySpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/beanbuilder/BeanElementBuilderMultipleFactorySpec.groovy
@@ -1,0 +1,39 @@
+package io.micronaut.inject.beanbuilder
+
+import io.micronaut.ast.groovy.TypeElementVisitorStart
+import io.micronaut.ast.transform.test.AbstractBeanDefinitionSpec
+import io.micronaut.inject.qualifiers.Qualifiers
+import io.micronaut.inject.visitor.AllElementsVisitor
+import io.micronaut.inject.visitor.TypeElementVisitor
+
+class BeanElementBuilderMultipleFactorySpec extends AbstractBeanDefinitionSpec {
+    def setup() {
+        System.setProperty(TypeElementVisitorStart.ELEMENT_VISITORS_PROPERTY, TestMultipleFactoryDefiningVisitor.name)
+    }
+
+    def cleanup() {
+        System.setProperty(TypeElementVisitorStart.ELEMENT_VISITORS_PROPERTY, "")
+        AllElementsVisitor.clearVisited()
+    }
+
+    void "test add associated factory bean"() {
+        given:
+        def context = buildContext('''
+package factorybuilder;
+
+import io.micronaut.context.annotation.Prototype;
+
+@Prototype
+class Foo {
+    
+}
+''')
+        expect:
+        context.getBean(OtherBeanProducer.BeanA).name == 'primary'
+        context.getBean(OtherBeanProducer.BeanA, Qualifiers.byName("other")).name == 'other'
+
+        cleanup:
+        context.close()
+    }
+
+}

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/beanbuilder/OtherBeanProducer.java
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/beanbuilder/OtherBeanProducer.java
@@ -1,0 +1,21 @@
+package io.micronaut.inject.beanbuilder;
+
+public class OtherBeanProducer {
+    @TestProduces
+    public BeanA beanB(String name) {
+        return new BeanA(name);
+    }
+
+    public static class BeanA {
+        private final String name;
+
+        public BeanA(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+}
+

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/beanbuilder/TestMultipleFactoryDefiningVisitor.java
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/beanbuilder/TestMultipleFactoryDefiningVisitor.java
@@ -1,0 +1,46 @@
+package io.micronaut.inject.beanbuilder;
+
+import io.micronaut.context.annotation.Primary;
+import io.micronaut.context.annotation.Prototype;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.ast.ElementQuery;
+import io.micronaut.inject.ast.MethodElement;
+import io.micronaut.inject.ast.beans.BeanElementBuilder;
+import io.micronaut.inject.visitor.TypeElementVisitor;
+import io.micronaut.inject.visitor.VisitorContext;
+
+public class TestMultipleFactoryDefiningVisitor implements TypeElementVisitor<Prototype, Object> {
+    @Override
+    public void visitClass(ClassElement element, VisitorContext context) {
+        if (element.hasAnnotation(Prototype.class)){
+
+            context.getClassElement(OtherBeanProducer.class)
+                    .ifPresent((producer) -> {
+                        final BeanElementBuilder beanElementBuilder = element.addAssociatedBean(producer)
+                                .qualifier(AnnotationValue.builder(Primary.class).build());
+                        final ElementQuery<MethodElement> query = ElementQuery.ALL_METHODS
+                                .annotated((am) -> am.hasAnnotation(TestProduces.class));
+                        beanElementBuilder.produceBeans(query, (builder) ->
+                                builder.withParameters(params ->
+                                    params[0].injectValue("primary")
+                                ).qualifier(AnnotationValue.builder(Primary.class).build())
+                        );
+
+                        final BeanElementBuilder beanElementBuilder2 = element.addAssociatedBean(producer)
+                                .qualifier("other");
+                        beanElementBuilder2.produceBeans(query, (builder) ->
+                            builder.withParameters(params ->
+                                    params[0].injectValue("other")
+                            ).qualifier("other")
+                        );
+                    });
+        }
+    }
+
+
+    @Override
+    public VisitorKind getVisitorKind() {
+        return VisitorKind.ISOLATING;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/BeanElementBuilderMultipleFactorySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/BeanElementBuilderMultipleFactorySpec.groovy
@@ -1,0 +1,32 @@
+package io.micronaut.inject.beanbuilder
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.inject.qualifiers.Qualifiers
+import io.micronaut.inject.visitor.TypeElementVisitor
+
+class BeanElementBuilderMultipleFactorySpec extends AbstractTypeElementSpec {
+    void "test add associated factory bean"() {
+        given:
+        def context = buildContext('''
+package factorybuilder;
+
+import io.micronaut.context.annotation.Prototype;
+
+@Prototype
+class Foo {
+    
+}
+''')
+        expect:
+        context.getBean(OtherBeanProducer.BeanA).name == 'primary'
+        context.getBean(OtherBeanProducer.BeanA, Qualifiers.byName("other")).name == 'other'
+
+        cleanup:
+        context.close()
+    }
+
+    @Override
+    protected Collection<TypeElementVisitor> getLocalTypeElementVisitors() {
+        return [new TestMultipleFactoryDefiningVisitor()]
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/OtherBeanProducer.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/OtherBeanProducer.java
@@ -1,0 +1,21 @@
+package io.micronaut.inject.beanbuilder;
+
+public class OtherBeanProducer {
+    @TestProduces
+    public BeanA beanB(String name) {
+        return new BeanA(name);
+    }
+
+    public static class BeanA {
+        private final String name;
+
+        public BeanA(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+}
+

--- a/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/TestMultipleFactoryDefiningVisitor.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/TestMultipleFactoryDefiningVisitor.java
@@ -1,0 +1,46 @@
+package io.micronaut.inject.beanbuilder;
+
+import io.micronaut.context.annotation.Primary;
+import io.micronaut.context.annotation.Prototype;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.ast.ElementQuery;
+import io.micronaut.inject.ast.MethodElement;
+import io.micronaut.inject.ast.beans.BeanElementBuilder;
+import io.micronaut.inject.visitor.TypeElementVisitor;
+import io.micronaut.inject.visitor.VisitorContext;
+
+public class TestMultipleFactoryDefiningVisitor implements TypeElementVisitor<Prototype, Object> {
+    @Override
+    public void visitClass(ClassElement element, VisitorContext context) {
+        if (element.hasAnnotation(Prototype.class)){
+
+            context.getClassElement(OtherBeanProducer.class)
+                    .ifPresent((producer) -> {
+                        final BeanElementBuilder beanElementBuilder = element.addAssociatedBean(producer)
+                                .qualifier(AnnotationValue.builder(Primary.class).build());
+                        final ElementQuery<MethodElement> query = ElementQuery.ALL_METHODS
+                                .annotated((am) -> am.hasAnnotation(TestProduces.class));
+                        beanElementBuilder.produceBeans(query, (builder) ->
+                                builder.withParameters(params ->
+                                    params[0].injectValue("primary")
+                                ).qualifier(AnnotationValue.builder(Primary.class).build())
+                        );
+
+                        final BeanElementBuilder beanElementBuilder2 = element.addAssociatedBean(producer)
+                                .qualifier("other");
+                        beanElementBuilder2.produceBeans(query, (builder) ->
+                            builder.withParameters(params ->
+                                    params[0].injectValue("other")
+                            ).qualifier("other")
+                        );
+                    });
+        }
+    }
+
+
+    @Override
+    public VisitorKind getVisitorKind() {
+        return VisitorKind.ISOLATING;
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/annotation/Primary.java
+++ b/inject/src/main/java/io/micronaut/context/annotation/Primary.java
@@ -36,6 +36,12 @@ import java.lang.annotation.Retention;
 @Retention(RUNTIME)
 public @interface Primary {
     /**
+     * Qualified name.
+     * @since 3.5.1
+     */
+    String NAME = Primary.class.getName();
+
+    /**
      * The simple name of this annotation.
      */
     String SIMPLE_NAME = Primary.class.getSimpleName();

--- a/inject/src/main/java/io/micronaut/inject/writer/AbstractBeanDefinitionBuilder.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/AbstractBeanDefinitionBuilder.java
@@ -260,7 +260,12 @@ public abstract class AbstractBeanDefinitionBuilder implements BeanElementBuilde
         return beanType;
     }
 
-    private BeanParameterElement[] initBeanParameters(ParameterElement[] constructorParameters) {
+    /**
+     * Initialize the bean parameters.
+     * @param constructorParameters The parameters to use.
+     * @return The initialized parameters
+     */
+    protected final BeanParameterElement[] initBeanParameters(@NonNull ParameterElement[] constructorParameters) {
         if (ArrayUtils.isNotEmpty(constructorParameters)) {
             return Arrays.stream(constructorParameters)
                     .map(InternalBeanParameter::new)
@@ -389,9 +394,17 @@ public abstract class AbstractBeanDefinitionBuilder implements BeanElementBuilde
     @Override
     public BeanElementBuilder withParameters(Consumer<BeanParameterElement[]> parameters) {
         if (parameters != null && this.constructorElement != null) {
-            parameters.accept(constructorElement.getParameters());
+            parameters.accept(getParameters());
         }
         return this;
+    }
+
+    /**
+     * @return The bean creation parameters.
+     */
+    @NonNull
+    protected BeanParameterElement[] getParameters() {
+        return constructorElement.getParameters();
     }
 
     @NonNull


### PR DESCRIPTION
A type element visitor can define multiple factories of the same type with different qualifiers. This leads to a NonUniqueBeanException since qualifiers are not factored in when looking up the factory. This fixes that.