### PR TITLE
typeArgumentsForType should use resolved types

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/BeanElementBuilderSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/BeanElementBuilderSpec.groovy
@@ -281,6 +281,7 @@ class SomeBean {
         then:
         definition
         !definition.getTypeArguments(Supplier).isEmpty()
+        definition.getTypeArguments(Supplier).first().type.name == 'addbean.Test'
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/inject/writer/AbstractBeanDefinitionBuilder.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/AbstractBeanDefinitionBuilder.java
@@ -329,7 +329,7 @@ public abstract class AbstractBeanDefinitionBuilder implements BeanElementBuilde
                 if (this.typeArguments == null) {
                     this.typeArguments = new LinkedHashMap<>();
                 }
-                this.typeArguments.put(type.getName(), typeArguments);
+                this.typeArguments.put(type.getName(), resolvedTypes);
             }
         }
         return this;


### PR DESCRIPTION
Incorrect map is used to populated type arguments in bean builder. This fixes that.