### PR TITLE
Fix inability to apply AOP advice to BeanElementBuilder created beans

### DIFF
--- a/aop/src/main/java/io/micronaut/aop/internal/intercepted/InterceptedMethodUtil.java
+++ b/aop/src/main/java/io/micronaut/aop/internal/intercepted/InterceptedMethodUtil.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.aop.internal.intercepted;
 
+import io.micronaut.aop.Around;
 import io.micronaut.aop.InterceptedMethod;
 import io.micronaut.aop.InterceptorBinding;
 import io.micronaut.aop.InterceptorKind;
@@ -91,5 +92,47 @@ public final class InterceptedMethodUtil {
                     .toArray(io.micronaut.core.annotation.AnnotationValue[]::new);
         }
         return AnnotationUtil.ZERO_ANNOTATION_VALUES;
+    }
+
+    /**
+     * Does the given metadata have AOP advice declared.
+     * @param annotationMetadata The annotation metadata
+     * @return True if it does
+     */
+    public static boolean hasAroundStereotype(AnnotationMetadata annotationMetadata) {
+        if (annotationMetadata == null) {
+            return false;
+        }
+        if (annotationMetadata.hasStereotype(Around.class)) {
+            return true;
+        } else if (annotationMetadata.hasStereotype(AnnotationUtil.ANN_INTERCEPTOR_BINDINGS)) {
+            return annotationMetadata.getAnnotationValuesByType(InterceptorBinding.class)
+                    .stream().anyMatch(av ->
+                            av.enumValue("kind", InterceptorKind.class).orElse(InterceptorKind.AROUND) == InterceptorKind.AROUND
+                    );
+        }
+
+        return false;
+    }
+
+    /**
+     * Does the given metadata have declared AOP advice.
+     * @param annotationMetadata The annotation metadata
+     * @return True if it does
+     */
+    public static boolean hasDeclaredAroundAdvice(AnnotationMetadata annotationMetadata) {
+        if (annotationMetadata == null) {
+            return false;
+        }
+        if (annotationMetadata.hasDeclaredStereotype(Around.class)) {
+            return true;
+        } else if (annotationMetadata.hasDeclaredStereotype(AnnotationUtil.ANN_INTERCEPTOR_BINDINGS)) {
+            return annotationMetadata.getDeclaredAnnotationValuesByType(InterceptorBinding.class)
+                    .stream().anyMatch(av ->
+                            av.enumValue("kind", InterceptorKind.class).orElse(InterceptorKind.AROUND) == InterceptorKind.AROUND
+                    );
+        }
+
+        return false;
     }
 }

--- a/aop/src/main/java/io/micronaut/aop/internal/intercepted/InterceptedMethodUtil.java
+++ b/aop/src/main/java/io/micronaut/aop/internal/intercepted/InterceptedMethodUtil.java
@@ -114,7 +114,7 @@ public final class InterceptedMethodUtil {
      * @param annotationMetadata The annotation metadata
      * @return True if it does
      */
-    public static boolean hasDeclaredAroundAdvice(AnnotationMetadata annotationMetadata) {
+    public static boolean hasDeclaredAroundAdvice(@Nullable AnnotationMetadata annotationMetadata) {
         return hasAround(annotationMetadata,
                 annMetadata -> annMetadata.hasDeclaredStereotype(Around.class),
                 annMetdata -> annMetdata.getDeclaredAnnotationValuesByType(InterceptorBinding.class));

--- a/aop/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
+++ b/aop/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
@@ -394,6 +394,21 @@ public class AopProxyWriter extends AbstractClassFileWriter implements ProxyingB
     }
 
     @Override
+    public void visitBeanFactoryMethod(ClassElement factoryClass, MethodElement factoryMethod) {
+        proxyBeanDefinitionWriter.visitBeanFactoryMethod(factoryClass, factoryMethod);
+    }
+
+    @Override
+    public void visitBeanFactoryMethod(ClassElement factoryClass, MethodElement factoryMethod, ParameterElement[] parameters) {
+        proxyBeanDefinitionWriter.visitBeanFactoryMethod(factoryClass, factoryMethod, parameters);
+    }
+
+    @Override
+    public void visitBeanFactoryField(ClassElement factoryClass, FieldElement factoryField) {
+        proxyBeanDefinitionWriter.visitBeanFactoryField(factoryClass, factoryField);
+    }
+
+    @Override
     public boolean isSingleton() {
         return proxyBeanDefinitionWriter.isSingleton();
     }

--- a/config/accepted-api-changes.json
+++ b/config/accepted-api-changes.json
@@ -1,152 +1,182 @@
 [
-    {
-        "type": "io.micronaut.scheduling.TaskScheduler",
-        "member": "Class io.micronaut.scheduling.TaskScheduler",
-        "reason": "Added default methods"
-    },
-    {
-        "type": "io.micronaut.scheduling.TaskScheduler",
-        "member": "Method io.micronaut.scheduling.TaskScheduler.schedule(java.lang.String,java.lang.String,java.lang.Runnable)",
-        "reason": "Added default methods"
-    },
-    {
-        "type": "io.micronaut.scheduling.TaskScheduler",
-        "member": "Method io.micronaut.scheduling.TaskScheduler.schedule(java.lang.String,java.lang.String,java.util.concurrent.Callable)",
-        "reason": "Added default methods"
-    },
-    {
-        "type": "io.micronaut.core.annotation.AnnotationMetadata",
-        "member": "Method io.micronaut.core.annotation.AnnotationMetadata.getStereotypeAnnotationNames()",
-        "reason": "AnnotationMetadata is an internally implemented data structure and not designed to be implemented by consumers of the framework."
-    },
-    {
-        "type": "io.micronaut.core.annotation.AnnotationMetadata",
-        "member": "Method io.micronaut.core.annotation.AnnotationMetadata.getDeclaredStereotypeAnnotationNames()",
-        "reason": "AnnotationMetadata is an internally implemented data structure and not designed to be implemented by consumers of the framework."
-    },
-    {
-        "type": "io.micronaut.core.annotation.AnnotationMetadata",
-        "member": "Class io.micronaut.core.annotation.AnnotationMetadata",
-        "reason": "AnnotationMetadata is an internally implemented data structure and not designed to be implemented by consumers of the framework."
-    },
-    {
-        "type": "io.micronaut.inject.writer.ClassWriterOutputVisitor",
-        "member": "Class io.micronaut.inject.writer.ClassWriterOutputVisitor",
-        "reason": "Classes in the io.micronaut.inject.writer package are considered non-public implementation detail"
-    },
-    {
-        "type": "io.micronaut.inject.writer.ClassWriterOutputVisitor",
-        "member": "Method io.micronaut.inject.writer.ClassWriterOutputVisitor.visitServiceDescriptor(java.lang.Class,java.lang.String,io.micronaut.inject.ast.Element)",
-        "reason": "Classes in the io.micronaut.inject.writer package are considered non-public implementation detail"
-    },
-    {
-        "type": "io.micronaut.graal.reflect.GraalTypeElementVisitor",
-        "member": "Class io.micronaut.graal.reflect.GraalTypeElementVisitor",
-        "reason": "The Graal visitor is internal to the compiler and implementation detail not part of the public API"
-    },
-    {
-        "type": "io.micronaut.graal.reflect.GraalTypeElementVisitor",
-        "member": "Field originatingElements",
-        "reason": "The Graal visitor is internal to the compiler and implementation detail not part of the public API"
-    },
-    {
-        "type": "io.micronaut.graal.reflect.GraalTypeElementVisitor",
-        "member": "Field classes",
-        "reason": "The Graal visitor is internal to the compiler and implementation detail not part of the public API"
-    },
-    {
-        "type": "io.micronaut.graal.reflect.GraalTypeElementVisitor",
-        "member": "Field packages",
-        "reason": "The Graal visitor is internal to the compiler and implementation detail not part of the public API"
-    },
-    {
-        "type": "io.micronaut.graal.reflect.GraalTypeElementVisitor",
-        "member": "Field arrays",
-        "reason": "The Graal visitor is internal to the compiler and implementation detail not part of the public API"
-    },
-    {
-        "type": "io.micronaut.graal.reflect.GraalTypeElementVisitor",
-        "member": "Method io.micronaut.graal.reflect.GraalTypeElementVisitor.visitConstructor(io.micronaut.inject.ast.ConstructorElement,io.micronaut.inject.visitor.VisitorContext)",
-        "reason": "The Graal visitor is internal to the compiler and implementation detail not part of the public API"
-    },
-    {
-        "type": "io.micronaut.graal.reflect.GraalTypeElementVisitor",
-        "member": "Method io.micronaut.graal.reflect.GraalTypeElementVisitor.visitField(io.micronaut.inject.ast.FieldElement,io.micronaut.inject.visitor.VisitorContext)",
-        "reason": "The Graal visitor is internal to the compiler and implementation detail not part of the public API"
-    },
-    {
-        "type": "io.micronaut.graal.reflect.GraalTypeElementVisitor",
-        "member": "Method io.micronaut.graal.reflect.GraalTypeElementVisitor.visitMethod(io.micronaut.inject.ast.MethodElement,io.micronaut.inject.visitor.VisitorContext)",
-        "reason": "The Graal visitor is internal to the compiler and implementation detail not part of the public API"
-    },
-    {
-        "type": "io.micronaut.http.netty.channel.EventLoopGroupFactory",
-        "member": "Class io.micronaut.http.netty.channel.EventLoopGroupFactory",
-        "reason": "Added default methods"
-    },
-    {
-        "type": "io.micronaut.http.netty.channel.EventLoopGroupFactory",
-        "member": "Method io.micronaut.http.netty.channel.EventLoopGroupFactory.domainServerSocketChannelClass()",
-        "reason": "Added default methods"
-    },
-    {
-        "type": "io.micronaut.http.netty.channel.EventLoopGroupFactory",
-        "member": "Method io.micronaut.http.netty.channel.EventLoopGroupFactory.domainServerSocketChannelClass(io.micronaut.http.netty.channel.EventLoopGroupConfiguration)",
-        "reason": "Added default methods"
-    },
-    {
-        "type": "io.micronaut.http.netty.channel.EventLoopGroupFactory",
-        "member": "Method io.micronaut.http.netty.channel.EventLoopGroupFactory.domainServerSocketChannelInstance(io.micronaut.http.netty.channel.EventLoopGroupConfiguration)",
-        "reason": "Added default methods"
-    },
-    {
-        "type": "io.micronaut.aop.InterceptedProxy",
-        "member": "Class io.micronaut.aop.InterceptedProxy",
-        "reason": "Class now extends similar interface from the Inject module allowing to detect intercepted proxies"
-    },
-    {
-        "type": "io.micronaut.aop.InterceptedProxy",
-        "member": "Method io.micronaut.aop.InterceptedProxy.hasCachedInterceptedTarget()",
-        "reason": "New default method introduced to detect cached target, the interface is only implemented by the class generation"
-    },
-    {
-        "type": "io.micronaut.context.BeanDefinitionRegistry",
-        "member": "Class io.micronaut.context.BeanDefinitionRegistry",
-        "reason": "Added a new method"
-    },
-    {
-        "type": "io.micronaut.context.BeanDefinitionRegistry",
-        "member": "Method io.micronaut.context.BeanDefinitionRegistry.findProxyTargetBeanDefinition(io.micronaut.inject.BeanDefinition)",
-        "reason": "New method introduced"
-    },
-    {
-        "type": "io.micronaut.context.scope.CustomScope",
-        "member": "Class io.micronaut.context.scope.CustomScope",
-        "reason": "Added a new method"
-    },
-    {
-        "type": "io.micronaut.context.scope.CustomScope",
-        "member": "Method io.micronaut.context.scope.CustomScope.findBeanRegistration(io.micronaut.inject.BeanDefinition)",
-        "reason": "New method added with a default implementation"
-    },
-    {
-        "type": "io.micronaut.http.client.ProxyHttpClient",
-        "member": "Class io.micronaut.http.client.ProxyHttpClient",
-        "reason": "New method added with a default implementation"
-    },
-    {
-        "type": "io.micronaut.http.client.ProxyHttpClient",
-        "member": "Method io.micronaut.http.client.ProxyHttpClient.proxy(io.micronaut.http.HttpRequest,io.micronaut.http.client.ProxyRequestOptions)",
-        "reason": "New method added with a default implementation"
-    },
-    {
-        "type": "io.micronaut.context.annotation.Replaces",
-        "member": "Class io.micronaut.context.annotation.Replaces",
-        "reason": "Improvement of the API"
-    },
-    {
-        "type": "io.micronaut.context.annotation.Replaces",
-        "member": "Method io.micronaut.context.annotation.Replaces.qualifier()",
-        "reason": "Improvement of the API"
-    }
+  {
+    "type": "io.micronaut.scheduling.TaskScheduler",
+    "member": "Class io.micronaut.scheduling.TaskScheduler",
+    "reason": "Added default methods"
+  },
+  {
+    "type": "io.micronaut.scheduling.TaskScheduler",
+    "member": "Method io.micronaut.scheduling.TaskScheduler.schedule(java.lang.String,java.lang.String,java.lang.Runnable)",
+    "reason": "Added default methods"
+  },
+  {
+    "type": "io.micronaut.scheduling.TaskScheduler",
+    "member": "Method io.micronaut.scheduling.TaskScheduler.schedule(java.lang.String,java.lang.String,java.util.concurrent.Callable)",
+    "reason": "Added default methods"
+  },
+  {
+    "type": "io.micronaut.core.annotation.AnnotationMetadata",
+    "member": "Method io.micronaut.core.annotation.AnnotationMetadata.getStereotypeAnnotationNames()",
+    "reason": "AnnotationMetadata is an internally implemented data structure and not designed to be implemented by consumers of the framework."
+  },
+  {
+    "type": "io.micronaut.core.annotation.AnnotationMetadata",
+    "member": "Method io.micronaut.core.annotation.AnnotationMetadata.getDeclaredStereotypeAnnotationNames()",
+    "reason": "AnnotationMetadata is an internally implemented data structure and not designed to be implemented by consumers of the framework."
+  },
+  {
+    "type": "io.micronaut.core.annotation.AnnotationMetadata",
+    "member": "Class io.micronaut.core.annotation.AnnotationMetadata",
+    "reason": "AnnotationMetadata is an internally implemented data structure and not designed to be implemented by consumers of the framework."
+  },
+  {
+    "type": "io.micronaut.inject.writer.ClassWriterOutputVisitor",
+    "member": "Class io.micronaut.inject.writer.ClassWriterOutputVisitor",
+    "reason": "Classes in the io.micronaut.inject.writer package are considered non-public implementation detail"
+  },
+  {
+    "type": "io.micronaut.inject.writer.ClassWriterOutputVisitor",
+    "member": "Method io.micronaut.inject.writer.ClassWriterOutputVisitor.visitServiceDescriptor(java.lang.Class,java.lang.String,io.micronaut.inject.ast.Element)",
+    "reason": "Classes in the io.micronaut.inject.writer package are considered non-public implementation detail"
+  },
+  {
+    "type": "io.micronaut.graal.reflect.GraalTypeElementVisitor",
+    "member": "Class io.micronaut.graal.reflect.GraalTypeElementVisitor",
+    "reason": "The Graal visitor is internal to the compiler and implementation detail not part of the public API"
+  },
+  {
+    "type": "io.micronaut.graal.reflect.GraalTypeElementVisitor",
+    "member": "Field originatingElements",
+    "reason": "The Graal visitor is internal to the compiler and implementation detail not part of the public API"
+  },
+  {
+    "type": "io.micronaut.graal.reflect.GraalTypeElementVisitor",
+    "member": "Field classes",
+    "reason": "The Graal visitor is internal to the compiler and implementation detail not part of the public API"
+  },
+  {
+    "type": "io.micronaut.graal.reflect.GraalTypeElementVisitor",
+    "member": "Field packages",
+    "reason": "The Graal visitor is internal to the compiler and implementation detail not part of the public API"
+  },
+  {
+    "type": "io.micronaut.graal.reflect.GraalTypeElementVisitor",
+    "member": "Field arrays",
+    "reason": "The Graal visitor is internal to the compiler and implementation detail not part of the public API"
+  },
+  {
+    "type": "io.micronaut.graal.reflect.GraalTypeElementVisitor",
+    "member": "Method io.micronaut.graal.reflect.GraalTypeElementVisitor.visitConstructor(io.micronaut.inject.ast.ConstructorElement,io.micronaut.inject.visitor.VisitorContext)",
+    "reason": "The Graal visitor is internal to the compiler and implementation detail not part of the public API"
+  },
+  {
+    "type": "io.micronaut.graal.reflect.GraalTypeElementVisitor",
+    "member": "Method io.micronaut.graal.reflect.GraalTypeElementVisitor.visitField(io.micronaut.inject.ast.FieldElement,io.micronaut.inject.visitor.VisitorContext)",
+    "reason": "The Graal visitor is internal to the compiler and implementation detail not part of the public API"
+  },
+  {
+    "type": "io.micronaut.graal.reflect.GraalTypeElementVisitor",
+    "member": "Method io.micronaut.graal.reflect.GraalTypeElementVisitor.visitMethod(io.micronaut.inject.ast.MethodElement,io.micronaut.inject.visitor.VisitorContext)",
+    "reason": "The Graal visitor is internal to the compiler and implementation detail not part of the public API"
+  },
+  {
+    "type": "io.micronaut.http.netty.channel.EventLoopGroupFactory",
+    "member": "Class io.micronaut.http.netty.channel.EventLoopGroupFactory",
+    "reason": "Added default methods"
+  },
+  {
+    "type": "io.micronaut.http.netty.channel.EventLoopGroupFactory",
+    "member": "Method io.micronaut.http.netty.channel.EventLoopGroupFactory.domainServerSocketChannelClass()",
+    "reason": "Added default methods"
+  },
+  {
+    "type": "io.micronaut.http.netty.channel.EventLoopGroupFactory",
+    "member": "Method io.micronaut.http.netty.channel.EventLoopGroupFactory.domainServerSocketChannelClass(io.micronaut.http.netty.channel.EventLoopGroupConfiguration)",
+    "reason": "Added default methods"
+  },
+  {
+    "type": "io.micronaut.http.netty.channel.EventLoopGroupFactory",
+    "member": "Method io.micronaut.http.netty.channel.EventLoopGroupFactory.domainServerSocketChannelInstance(io.micronaut.http.netty.channel.EventLoopGroupConfiguration)",
+    "reason": "Added default methods"
+  },
+  {
+    "type": "io.micronaut.aop.InterceptedProxy",
+    "member": "Class io.micronaut.aop.InterceptedProxy",
+    "reason": "Class now extends similar interface from the Inject module allowing to detect intercepted proxies"
+  },
+  {
+    "type": "io.micronaut.aop.InterceptedProxy",
+    "member": "Method io.micronaut.aop.InterceptedProxy.hasCachedInterceptedTarget()",
+    "reason": "New default method introduced to detect cached target, the interface is only implemented by the class generation"
+  },
+  {
+    "type": "io.micronaut.context.BeanDefinitionRegistry",
+    "member": "Class io.micronaut.context.BeanDefinitionRegistry",
+    "reason": "Added a new method"
+  },
+  {
+    "type": "io.micronaut.context.BeanDefinitionRegistry",
+    "member": "Method io.micronaut.context.BeanDefinitionRegistry.findProxyTargetBeanDefinition(io.micronaut.inject.BeanDefinition)",
+    "reason": "New method introduced"
+  },
+  {
+    "type": "io.micronaut.context.scope.CustomScope",
+    "member": "Class io.micronaut.context.scope.CustomScope",
+    "reason": "Added a new method"
+  },
+  {
+    "type": "io.micronaut.context.scope.CustomScope",
+    "member": "Method io.micronaut.context.scope.CustomScope.findBeanRegistration(io.micronaut.inject.BeanDefinition)",
+    "reason": "New method added with a default implementation"
+  },
+  {
+    "type": "io.micronaut.http.client.ProxyHttpClient",
+    "member": "Class io.micronaut.http.client.ProxyHttpClient",
+    "reason": "New method added with a default implementation"
+  },
+  {
+    "type": "io.micronaut.http.client.ProxyHttpClient",
+    "member": "Method io.micronaut.http.client.ProxyHttpClient.proxy(io.micronaut.http.HttpRequest,io.micronaut.http.client.ProxyRequestOptions)",
+    "reason": "New method added with a default implementation"
+  },
+  {
+    "type": "io.micronaut.context.annotation.Replaces",
+    "member": "Class io.micronaut.context.annotation.Replaces",
+    "reason": "Improvement of the API"
+  },
+  {
+    "type": "io.micronaut.context.annotation.Replaces",
+    "member": "Method io.micronaut.context.annotation.Replaces.qualifier()",
+    "reason": "Improvement of the API"
+  },
+  {
+    "type": "io.micronaut.inject.ast.ElementQuery",
+    "member": "Method io.micronaut.inject.ast.ElementQuery.named(java.lang.String)",
+    "reason": "New internally implemented default method"
+  },
+  {
+    "type": "io.micronaut.inject.ast.ElementQuery",
+    "member": "Class io.micronaut.inject.ast.ElementQuery",
+    "reason": "New internally implemented default method"
+  },
+  {
+    "type": "io.micronaut.inject.ast.beans.BeanMethodElement",
+    "member": "Class io.micronaut.inject.ast.beans.BeanMethodElement",
+    "reason": "New New internal default method default method"
+  },
+  {
+    "type": "io.micronaut.inject.ast.beans.BeanMethodElement",
+    "member": "Method io.micronaut.inject.ast.beans.BeanMethodElement.intercept(io.micronaut.core.annotation.AnnotationValue[])",
+    "reason": "New New internal default method default method"
+  },
+  {
+    "type": "io.micronaut.inject.ast.beans.BeanElementBuilder",
+    "member": "Class io.micronaut.inject.ast.beans.BeanElementBuilder",
+    "reason": "New New internal default method default method"
+  },
+  {
+    "type": "io.micronaut.inject.ast.beans.BeanElementBuilder",
+    "member": "Method io.micronaut.inject.ast.beans.BeanElementBuilder.intercept(io.micronaut.core.annotation.AnnotationValue[])",
+    "reason": "New New internal default method default method"
+  }
 ]

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyBeanDefinitionBuilder.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyBeanDefinitionBuilder.java
@@ -30,19 +30,18 @@ import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.Element;
 import io.micronaut.inject.ast.FieldElement;
 import io.micronaut.inject.ast.MethodElement;
+import io.micronaut.inject.ast.TypedElement;
 import io.micronaut.inject.ast.beans.BeanParameterElement;
 import io.micronaut.inject.configuration.ConfigurationMetadataBuilder;
 import io.micronaut.inject.writer.AbstractBeanDefinitionBuilder;
-import io.micronaut.inject.writer.BeanClassWriter;
 import io.micronaut.inject.writer.BeanDefinitionVisitor;
 import io.micronaut.inject.writer.BeanDefinitionWriter;
-import io.micronaut.inject.writer.ClassWriterOutputVisitor;
 import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.FieldNode;
 import org.codehaus.groovy.ast.MethodNode;
 
-import java.io.IOException;
 import java.lang.annotation.Annotation;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -243,55 +242,29 @@ class GroovyBeanDefinitionBuilder extends AbstractBeanDefinitionBuilder {
     }
 
     @Override
-    public BeanClassWriter build() {
-        BeanClassWriter beanWriter = super.build();
-        if (beanWriter == null) {
-            return null;
-        }
-        BeanDefinitionVisitor parentVisitor = beanWriter.getBeanDefinitionVisitor();
-        AnnotationMetadata annotationMetadata = getAnnotationMetadata();
-        if (isIntercepted() && parentVisitor instanceof BeanDefinitionWriter) {
-            return new BeanClassWriter() {
-                @Override
-                public BeanDefinitionVisitor getBeanDefinitionVisitor() {
-                    return parentVisitor;
-                }
+    protected BeanDefinitionVisitor createAopWriter(BeanDefinitionWriter beanDefinitionWriter, AnnotationMetadata annotationMetadata) {
+        AnnotationValue<?>[] interceptorTypes =
+                InterceptedMethodUtil.resolveInterceptorBinding(annotationMetadata, InterceptorKind.AROUND);
+        BeanDefinitionVisitor aopProxyWriter = new AopProxyWriter(
+                beanDefinitionWriter,
+                annotationMetadata.getValues(Around.class, Boolean.class),
+                ConfigurationMetadataBuilder.getConfigurationMetadataBuilder().orElse(null),
+                visitorContext,
+                interceptorTypes
+        );
+        return aopProxyWriter;
+    }
 
-                @Override
-                public void accept(ClassWriterOutputVisitor classWriterOutputVisitor) throws IOException {
-                    io.micronaut.core.annotation.AnnotationValue<?>[] interceptorTypes =
-                            InterceptedMethodUtil.resolveInterceptorBinding(annotationMetadata, InterceptorKind.AROUND);
-
-                    BeanDefinitionWriter beanDefinitionWriter = (BeanDefinitionWriter) parentVisitor;
-                    AopProxyWriter aopProxyWriter = new AopProxyWriter(
-                            beanDefinitionWriter,
-                            annotationMetadata.getValues(Around.class, Boolean.class),
-                            ConfigurationMetadataBuilder.getConfigurationMetadataBuilder().orElse(null),
-                            visitorContext,
-                            interceptorTypes
-                    );
-
-                    if (configureBeanVisitor(aopProxyWriter)) {
-                        return;
-                    }
-
-                    visitInterceptedMethods(
-                            (bean, method) -> {
-                                io.micronaut.core.annotation.AnnotationValue<?>[] newTypes =
-                                        InterceptedMethodUtil.resolveInterceptorBinding(method.getAnnotationMetadata(), InterceptorKind.AROUND);
-                                aopProxyWriter.visitInterceptorBinding(newTypes);
-                                aopProxyWriter.visitAroundMethod(
-                                        bean, method
-                                );
-                            }
-                    );
-
-                    finalizeAndWriteBean(classWriterOutputVisitor, aopProxyWriter);
-                    beanWriter.accept(classWriterOutputVisitor);
-                }
-            };
-        } else {
-            return beanWriter;
-        }
+    @Override
+    protected BiConsumer<TypedElement, MethodElement> createAroundMethodVisitor(BeanDefinitionVisitor aopWriter) {
+        AopProxyWriter aopProxyWriter = (AopProxyWriter) aopWriter;
+        return (bean, method) -> {
+            AnnotationValue<?>[] newTypes =
+                    InterceptedMethodUtil.resolveInterceptorBinding(method.getAnnotationMetadata(), InterceptorKind.AROUND);
+            aopProxyWriter.visitInterceptorBinding(newTypes);
+            aopProxyWriter.visitAroundMethod(
+                    bean, method
+            );
+        };
     }
 }

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyBeanDefinitionBuilder.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyBeanDefinitionBuilder.java
@@ -15,6 +15,10 @@
  */
 package io.micronaut.ast.groovy.visitor;
 
+import io.micronaut.aop.Around;
+import io.micronaut.aop.InterceptorKind;
+import io.micronaut.aop.internal.intercepted.InterceptedMethodUtil;
+import io.micronaut.aop.writer.AopProxyWriter;
 import io.micronaut.ast.groovy.annotation.GroovyAnnotationMetadataBuilder;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationValue;
@@ -29,11 +33,15 @@ import io.micronaut.inject.ast.MethodElement;
 import io.micronaut.inject.ast.beans.BeanParameterElement;
 import io.micronaut.inject.configuration.ConfigurationMetadataBuilder;
 import io.micronaut.inject.writer.AbstractBeanDefinitionBuilder;
+import io.micronaut.inject.writer.BeanClassWriter;
+import io.micronaut.inject.writer.BeanDefinitionVisitor;
 import io.micronaut.inject.writer.BeanDefinitionWriter;
+import io.micronaut.inject.writer.ClassWriterOutputVisitor;
 import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.FieldNode;
 import org.codehaus.groovy.ast.MethodNode;
 
+import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -88,8 +96,8 @@ class GroovyBeanDefinitionBuilder extends AbstractBeanDefinitionBuilder {
             }
 
             @Override
-            protected BeanDefinitionWriter createBeanDefinitionWriter() {
-                final BeanDefinitionWriter writer = super.createBeanDefinitionWriter();
+            protected BeanDefinitionVisitor createBeanDefinitionWriter() {
+                final BeanDefinitionVisitor writer = super.createBeanDefinitionWriter();
                 final GroovyElementFactory elementFactory = ((GroovyVisitorContext) visitorContext).getElementFactory();
                 final FieldNode fieldNode = (FieldNode) producerField.getNativeType();
                 ClassElement resolvedParent = resolveParent(parentType, elementFactory);
@@ -137,8 +145,8 @@ class GroovyBeanDefinitionBuilder extends AbstractBeanDefinitionBuilder {
             }
 
             @Override
-            protected BeanDefinitionWriter createBeanDefinitionWriter() {
-                final BeanDefinitionWriter writer = super.createBeanDefinitionWriter();
+            protected BeanDefinitionVisitor createBeanDefinitionWriter() {
+                final BeanDefinitionVisitor writer = super.createBeanDefinitionWriter();
                 final GroovyElementFactory elementFactory = ((GroovyVisitorContext) visitorContext).getElementFactory();
                 ClassElement resolvedParent = resolveParent(parentType, elementFactory);
                 final MethodNode methodNode = (MethodNode) producerMethod.getNativeType();
@@ -232,5 +240,58 @@ class GroovyBeanDefinitionBuilder extends AbstractBeanDefinitionBuilder {
             resolvedParent = elementFactory.newClassElement((ClassNode) nativeType, this.getAnnotationMetadata());
         }
         return resolvedParent;
+    }
+
+    @Override
+    public BeanClassWriter build() {
+        BeanClassWriter beanWriter = super.build();
+        if (beanWriter == null) {
+            return null;
+        }
+        BeanDefinitionVisitor parentVisitor = beanWriter.getBeanDefinitionVisitor();
+        AnnotationMetadata annotationMetadata = getAnnotationMetadata();
+        if (isIntercepted() && parentVisitor instanceof BeanDefinitionWriter) {
+            return new BeanClassWriter() {
+                @Override
+                public BeanDefinitionVisitor getBeanDefinitionVisitor() {
+                    return parentVisitor;
+                }
+
+                @Override
+                public void accept(ClassWriterOutputVisitor classWriterOutputVisitor) throws IOException {
+                    io.micronaut.core.annotation.AnnotationValue<?>[] interceptorTypes =
+                            InterceptedMethodUtil.resolveInterceptorBinding(annotationMetadata, InterceptorKind.AROUND);
+
+                    BeanDefinitionWriter beanDefinitionWriter = (BeanDefinitionWriter) parentVisitor;
+                    AopProxyWriter aopProxyWriter = new AopProxyWriter(
+                            beanDefinitionWriter,
+                            annotationMetadata.getValues(Around.class, Boolean.class),
+                            ConfigurationMetadataBuilder.getConfigurationMetadataBuilder().orElse(null),
+                            visitorContext,
+                            interceptorTypes
+                    );
+
+                    if (configureBeanVisitor(aopProxyWriter)) {
+                        return;
+                    }
+
+                    visitInterceptedMethods(
+                            (bean, method) -> {
+                                io.micronaut.core.annotation.AnnotationValue<?>[] newTypes =
+                                        InterceptedMethodUtil.resolveInterceptorBinding(method.getAnnotationMetadata(), InterceptorKind.AROUND);
+                                aopProxyWriter.visitInterceptorBinding(newTypes);
+                                aopProxyWriter.visitAroundMethod(
+                                        bean, method
+                                );
+                            }
+                    );
+
+                    finalizeAndWriteBean(classWriterOutputVisitor, aopProxyWriter);
+                    beanWriter.accept(classWriterOutputVisitor);
+                }
+            };
+        } else {
+            return beanWriter;
+        }
     }
 }

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyBeanDefinitionBuilder.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyBeanDefinitionBuilder.java
@@ -245,14 +245,13 @@ class GroovyBeanDefinitionBuilder extends AbstractBeanDefinitionBuilder {
     protected BeanDefinitionVisitor createAopWriter(BeanDefinitionWriter beanDefinitionWriter, AnnotationMetadata annotationMetadata) {
         AnnotationValue<?>[] interceptorTypes =
                 InterceptedMethodUtil.resolveInterceptorBinding(annotationMetadata, InterceptorKind.AROUND);
-        BeanDefinitionVisitor aopProxyWriter = new AopProxyWriter(
+        return new AopProxyWriter(
                 beanDefinitionWriter,
                 annotationMetadata.getValues(Around.class, Boolean.class),
                 ConfigurationMetadataBuilder.getConfigurationMetadataBuilder().orElse(null),
                 visitorContext,
                 interceptorTypes
         );
-        return aopProxyWriter;
     }
 
     @Override

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -690,7 +690,7 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
         private void visitIntroductionAdviceInterface(TypeElement classElement, AnnotationMetadata typeAnnotationMetadata, AopProxyWriter aopProxyWriter) {
             ClassElement introductionType = elementFactory.newClassElement(classElement, typeAnnotationMetadata);
             final AnnotationMetadata resolvedTypeMetadata = annotationUtils.getAnnotationMetadata(classElement);
-            final boolean isAopProxyType = InterceptedMethodUtil.hasDeclaredAroundAdvice(resolvedTypeMetadata);
+            final boolean resolvedTypeMetadataIsAopProxyType = InterceptedMethodUtil.hasDeclaredAroundAdvice(resolvedTypeMetadata);
             final boolean isConfigProps = typeAnnotationMetadata.hasAnnotation(ANN_CONFIGURATION_ADVICE);
             if (isConfigProps) {
                 metadataBuilder.visitProperties(
@@ -703,7 +703,7 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                 @Override
                 protected boolean isAcceptableMethod(ExecutableElement executableElement) {
                     return super.isAcceptableMethod(executableElement)
-                            || isAopProxyType
+                            || resolvedTypeMetadataIsAopProxyType
                             || hasMethodLevelAdvice(executableElement);
                 }
 

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaBeanDefinitionBuilder.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaBeanDefinitionBuilder.java
@@ -116,14 +116,13 @@ class JavaBeanDefinitionBuilder extends AbstractBeanDefinitionBuilder {
     protected BeanDefinitionVisitor createAopWriter(BeanDefinitionWriter beanDefinitionWriter, AnnotationMetadata annotationMetadata) {
         AnnotationValue<?>[] interceptorTypes =
                 InterceptedMethodUtil.resolveInterceptorBinding(annotationMetadata, InterceptorKind.AROUND);
-        BeanDefinitionVisitor aopProxyWriter = new AopProxyWriter(
+        return new AopProxyWriter(
                 beanDefinitionWriter,
                 annotationMetadata.getValues(Around.class, Boolean.class),
                 ConfigurationMetadataBuilder.getConfigurationMetadataBuilder().orElse(null),
                 visitorContext,
                 interceptorTypes
         );
-        return aopProxyWriter;
     }
 
     @Override

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaBeanDefinitionBuilder.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaBeanDefinitionBuilder.java
@@ -16,6 +16,10 @@
 package io.micronaut.annotation.processing.visitor;
 
 import io.micronaut.annotation.processing.AnnotationUtils;
+import io.micronaut.aop.Around;
+import io.micronaut.aop.InterceptorKind;
+import io.micronaut.aop.internal.intercepted.InterceptedMethodUtil;
+import io.micronaut.aop.writer.AopProxyWriter;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.AnnotationValueBuilder;
@@ -29,8 +33,12 @@ import io.micronaut.inject.ast.beans.BeanParameterElement;
 import io.micronaut.inject.configuration.ConfigurationMetadataBuilder;
 import io.micronaut.inject.visitor.TypeElementVisitor;
 import io.micronaut.inject.writer.AbstractBeanDefinitionBuilder;
+import io.micronaut.inject.writer.BeanClassWriter;
+import io.micronaut.inject.writer.BeanDefinitionVisitor;
 import io.micronaut.inject.writer.BeanDefinitionWriter;
+import io.micronaut.inject.writer.ClassWriterOutputVisitor;
 
+import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -88,8 +96,8 @@ class JavaBeanDefinitionBuilder extends AbstractBeanDefinitionBuilder {
             }
 
             @Override
-            protected BeanDefinitionWriter createBeanDefinitionWriter() {
-                final BeanDefinitionWriter writer = super.createBeanDefinitionWriter();
+            protected BeanDefinitionVisitor createBeanDefinitionWriter() {
+                final BeanDefinitionVisitor writer = super.createBeanDefinitionWriter();
                 final JavaElementFactory elementFactory = ((JavaVisitorContext) visitorContext).getElementFactory();
                 final VariableElement variableElement = (VariableElement) producerField.getNativeType();
                 ClassElement resolvedParent = resolveParentType(parentType, elementFactory);
@@ -107,8 +115,56 @@ class JavaBeanDefinitionBuilder extends AbstractBeanDefinitionBuilder {
     }
 
     @Override
-    protected BeanDefinitionWriter createBeanDefinitionWriter() {
-        return super.createBeanDefinitionWriter();
+    public BeanClassWriter build() {
+        BeanClassWriter beanWriter = super.build();
+        if (beanWriter == null) {
+            return null;
+        }
+        BeanDefinitionVisitor parentVisitor = beanWriter.getBeanDefinitionVisitor();
+        AnnotationMetadata annotationMetadata = getAnnotationMetadata();
+        if (isIntercepted() && parentVisitor instanceof BeanDefinitionWriter) {
+            return new BeanClassWriter() {
+                @Override
+                public BeanDefinitionVisitor getBeanDefinitionVisitor() {
+                    return parentVisitor;
+                }
+
+                @Override
+                public void accept(ClassWriterOutputVisitor classWriterOutputVisitor) throws IOException {
+                    io.micronaut.core.annotation.AnnotationValue<?>[] interceptorTypes =
+                            InterceptedMethodUtil.resolveInterceptorBinding(annotationMetadata, InterceptorKind.AROUND);
+
+                    BeanDefinitionWriter beanDefinitionWriter = (BeanDefinitionWriter) parentVisitor;
+                    AopProxyWriter aopProxyWriter = new AopProxyWriter(
+                            beanDefinitionWriter,
+                            annotationMetadata.getValues(Around.class, Boolean.class),
+                            ConfigurationMetadataBuilder.getConfigurationMetadataBuilder().orElse(null),
+                            visitorContext,
+                            interceptorTypes
+                    );
+
+                    if (configureBeanVisitor(aopProxyWriter)) {
+                        return;
+                    }
+
+                    visitInterceptedMethods(
+                            (bean, method) -> {
+                                io.micronaut.core.annotation.AnnotationValue<?>[] newTypes =
+                                        InterceptedMethodUtil.resolveInterceptorBinding(method.getAnnotationMetadata(), InterceptorKind.AROUND);
+                                aopProxyWriter.visitInterceptorBinding(newTypes);
+                                aopProxyWriter.visitAroundMethod(
+                                        bean, method
+                                );
+                            }
+                    );
+
+                    finalizeAndWriteBean(classWriterOutputVisitor, aopProxyWriter);
+                    beanWriter.accept(classWriterOutputVisitor);
+                }
+            };
+        } else {
+            return beanWriter;
+        }
     }
 
     @Override
@@ -140,8 +196,8 @@ class JavaBeanDefinitionBuilder extends AbstractBeanDefinitionBuilder {
             }
 
             @Override
-            protected BeanDefinitionWriter createBeanDefinitionWriter() {
-                final BeanDefinitionWriter writer = super.createBeanDefinitionWriter();
+            protected BeanDefinitionVisitor createBeanDefinitionWriter() {
+                final BeanDefinitionVisitor writer = super.createBeanDefinitionWriter();
                 final JavaElementFactory elementFactory = ((JavaVisitorContext) visitorContext).getElementFactory();
                 final ExecutableElement variableElement = (ExecutableElement) producerMethod.getNativeType();
                 ClassElement resolvedParent = resolveParentType(parentType, elementFactory);

--- a/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/ApplyAopToMe.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/ApplyAopToMe.java
@@ -1,11 +1,20 @@
 package io.micronaut.inject.beanbuilder;
 
+import io.micronaut.context.env.Environment;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Assertions;
+
 public class ApplyAopToMe {
+    @Inject
+    Environment environment;
+
     public String hello(String name) {
+        Assertions.assertNotNull(environment);
         return "Hello " + name;
     }
 
     public String plain(String name) {
+        Assertions.assertNotNull(environment);
         return "Hello " + name;
     }
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/ApplyAopToMe.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/ApplyAopToMe.java
@@ -1,0 +1,11 @@
+package io.micronaut.inject.beanbuilder;
+
+public class ApplyAopToMe {
+    public String hello(String name) {
+        return "Hello " + name;
+    }
+
+    public String plain(String name) {
+        return "Hello " + name;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/ApplyAopToMethodVisitor.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/ApplyAopToMethodVisitor.java
@@ -23,6 +23,7 @@ public class ApplyAopToMethodVisitor implements TypeElementVisitor<Object, Objec
             context.getClassElement(ApplyAopToMe.class)
                     .ifPresent((applyAopToMe) -> element
                             .addAssociatedBean(applyAopToMe)
+                            .inject()
                             .withMethods(ElementQuery.ALL_METHODS.named(n -> n.equals("hello")), method ->
                                 method.intercept(av)
                             ));

--- a/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/ApplyAopToMethodVisitor.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/ApplyAopToMethodVisitor.java
@@ -1,0 +1,37 @@
+package io.micronaut.inject.beanbuilder;
+
+import io.micronaut.core.annotation.AnnotationUtil;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.AnnotationValueBuilder;
+import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.ast.ElementQuery;
+import io.micronaut.inject.visitor.TypeElementVisitor;
+import io.micronaut.inject.visitor.VisitorContext;
+
+import java.lang.annotation.Annotation;
+
+public class ApplyAopToMethodVisitor implements TypeElementVisitor<Object, Object> {
+
+    @Override
+    public void visitClass(ClassElement element, VisitorContext context) {
+        if (element.hasAnnotation(AnnotationUtil.SINGLETON)){
+
+            AnnotationValue<Annotation> av = AnnotationValue
+                    .builder("aopbuilder.Mutating")
+                    .value("name")
+                    .build();
+            context.getClassElement(ApplyAopToMe.class)
+                    .ifPresent((applyAopToMe) -> element
+                            .addAssociatedBean(applyAopToMe)
+                            .withMethods(ElementQuery.ALL_METHODS.named(n -> n.equals("hello")), method ->
+                                method.intercept(av)
+                            ));
+        }
+    }
+
+    @Override
+    public VisitorKind getVisitorKind() {
+        return VisitorKind.ISOLATING;
+    }
+}
+

--- a/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/ApplyAopToTypeVisitor.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/ApplyAopToTypeVisitor.java
@@ -20,7 +20,9 @@ public class ApplyAopToTypeVisitor implements TypeElementVisitor<Object, Object>
             context.getClassElement(ApplyAopToMe.class)
                     .ifPresent((applyAopToMe) -> element
                             .addAssociatedBean(applyAopToMe)
-                            .intercept(av));
+                            .intercept(av)
+                            .inject()
+                    );
         }
     }
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/ApplyAopToTypeVisitor.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/ApplyAopToTypeVisitor.java
@@ -1,0 +1,31 @@
+package io.micronaut.inject.beanbuilder;
+
+import io.micronaut.core.annotation.AnnotationUtil;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.visitor.TypeElementVisitor;
+import io.micronaut.inject.visitor.VisitorContext;
+
+import java.lang.annotation.Annotation;
+
+public class ApplyAopToTypeVisitor implements TypeElementVisitor<Object, Object> {
+
+    @Override
+    public void visitClass(ClassElement element, VisitorContext context) {
+        if (element.hasAnnotation(AnnotationUtil.SINGLETON)){
+            AnnotationValue<Annotation> av = AnnotationValue
+                    .builder("aopbuilder.Mutating")
+                    .value("name")
+                    .build();
+            context.getClassElement(ApplyAopToMe.class)
+                    .ifPresent((applyAopToMe) -> element
+                            .addAssociatedBean(applyAopToMe)
+                            .intercept(av));
+        }
+    }
+
+    @Override
+    public VisitorKind getVisitorKind() {
+        return VisitorKind.ISOLATING;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/BuildElementBuilderAopOnMethodSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/BuildElementBuilderAopOnMethodSpec.groovy
@@ -1,0 +1,82 @@
+package io.micronaut.inject.beanbuilder
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.inject.visitor.TypeElementVisitor
+
+class BuildElementBuilderAopOnMethodSpec extends AbstractTypeElementSpec {
+
+    void "test AOP applied to a type registered via the builder"() {
+        given:
+        def context = buildContext('''
+package aopbuilder;
+
+import io.micronaut.aop.Around;
+import io.micronaut.aop.InterceptorBean;
+import io.micronaut.aop.MethodInterceptor;
+import io.micronaut.aop.MethodInvocationContext;
+import io.micronaut.core.type.MutableArgumentValue;
+import jakarta.inject.Singleton;
+import io.micronaut.inject.beanbuilder.ApplyAopToMe;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Singleton
+class Test {
+    private final ApplyAopToMe applyAopToMe;
+    
+    Test(ApplyAopToMe applyAopToMe) {
+        this.applyAopToMe = applyAopToMe;
+    }
+    
+    public String hello(String name) {
+        return applyAopToMe.hello(name);
+    }
+    
+    public String plain(String name) {
+        return applyAopToMe.plain(name);
+    }
+}
+
+@InterceptorBean(Mutating.class)
+class MutatingInterceptor implements MethodInterceptor<Object, Object> {
+    @Override public Object intercept(MethodInvocationContext<Object,Object> context) {
+        String m = context.stringValue(Mutating.class).orElse(null);
+        MutableArgumentValue arg = context.getParameters().get(m);
+        if(arg != null) {
+            arg.setValue("changed");
+        }
+        return context.proceed();
+    }
+}
+
+@Around
+@Retention(RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE, ElementType.FIELD})
+@Inherited
+@interface Mutating {
+    String value();
+}
+
+''')
+        def test = getBean(context, "aopbuilder.Test")
+
+        expect:
+        test.hello("john") == "Hello changed"
+        test.plain("john") == "Hello john"
+
+        cleanup:
+        context.close()
+    }
+
+    @Override
+    protected Collection<TypeElementVisitor> getLocalTypeElementVisitors() {
+        [new ApplyAopToMethodVisitor()]
+    }
+
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/BuildElementBuilderAopOnTypeSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/BuildElementBuilderAopOnTypeSpec.groovy
@@ -1,0 +1,77 @@
+package io.micronaut.inject.beanbuilder
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.inject.visitor.TypeElementVisitor
+
+class BuildElementBuilderAopOnTypeSpec extends AbstractTypeElementSpec {
+
+    void "test AOP applied to a type registered via the builder"() {
+        given:
+        def context = buildContext('''
+package aopbuilder;
+
+import io.micronaut.aop.Around;
+import io.micronaut.aop.InterceptorBean;
+import io.micronaut.aop.MethodInterceptor;
+import io.micronaut.aop.MethodInvocationContext;
+import io.micronaut.core.type.MutableArgumentValue;
+import jakarta.inject.Singleton;
+import io.micronaut.inject.beanbuilder.ApplyAopToMe;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Singleton
+class Test {
+    private final ApplyAopToMe applyAopToMe;
+    
+    Test(ApplyAopToMe applyAopToMe) {
+        this.applyAopToMe = applyAopToMe;
+    }
+    
+    public String hello(String name) {
+        return applyAopToMe.hello(name);
+    }
+}
+
+@InterceptorBean(Mutating.class)
+class MutatingInterceptor implements MethodInterceptor<Object, Object> {
+    @Override public Object intercept(MethodInvocationContext<Object,Object> context) {
+        String m = context.stringValue(Mutating.class).orElse(null);
+        MutableArgumentValue arg = context.getParameters().get(m);
+        if(arg != null) {
+            arg.setValue("changed");
+        }
+        return context.proceed();
+    }
+}
+
+@Around
+@Retention(RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE, ElementType.FIELD})
+@Inherited
+@interface Mutating {
+    String value();
+}
+
+''')
+        def test = getBean(context, "aopbuilder.Test")
+
+        expect:
+        test.hello("john") == "Hello changed"
+
+        cleanup:
+        context.close()
+    }
+
+    @Override
+    protected Collection<TypeElementVisitor> getLocalTypeElementVisitors() {
+        [new ApplyAopToTypeVisitor()]
+    }
+
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/BuildElementBuilderAopOnTypeSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/BuildElementBuilderAopOnTypeSpec.groovy
@@ -36,6 +36,10 @@ class Test {
     public String hello(String name) {
         return applyAopToMe.hello(name);
     }
+    
+   public String plain(String name) {
+        return applyAopToMe.plain(name);
+    }
 }
 
 @InterceptorBean(Mutating.class)
@@ -63,6 +67,7 @@ class MutatingInterceptor implements MethodInterceptor<Object, Object> {
 
         expect:
         test.hello("john") == "Hello changed"
+        test.plain("john") == "Hello changed"
 
         cleanup:
         context.close()

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -185,6 +185,8 @@ public class DefaultBeanContext implements InitializableBeanContext {
 
     final Map<BeanIdentifier, BeanRegistration<?>> singlesInCreation = new ConcurrentHashMap<>(5);
 
+    Set<Map.Entry<Class<?>, List<BeanInitializedEventListener>>> beanInitializedEventListeners;
+
     private final SingletonScope singletonScope = new SingletonScope();
 
     private final BeanContextConfiguration beanContextConfiguration;
@@ -232,7 +234,6 @@ public class DefaultBeanContext implements InitializableBeanContext {
     private List<BeanConfiguration> beanConfigurationsList;
 
     private Set<Map.Entry<Class<?>, List<BeanCreatedEventListener<?>>>> beanCreationEventListeners;
-    Set<Map.Entry<Class<?>, List<BeanInitializedEventListener>>> beanInitializedEventListeners;
     private Set<Map.Entry<Class<?>, List<BeanPreDestroyEventListener>>> beanPreDestroyEventListeners;
     private Set<Map.Entry<Class<?>, List<BeanDestroyedEventListener>>> beanDestroyedEventListeners;
 

--- a/inject/src/main/java/io/micronaut/inject/ast/ElementQuery.java
+++ b/inject/src/main/java/io/micronaut/inject/ast/ElementQuery.java
@@ -145,6 +145,16 @@ public interface ElementQuery<T extends Element> {
     @NonNull ElementQuery<T> named(@NonNull Predicate<String> predicate);
 
     /**
+     * Allows filtering elements by name.
+     * @param name The name to filter by
+     * @return This query
+     * @since 3.5.2
+     */
+    default @NonNull ElementQuery<T> named(@NonNull String name) {
+        return named(n -> n.equals(name));
+    }
+
+    /**
      * Allows filtering elements by type. For {@link MethodElement} instances this is based on the return type.
      * @param predicate The predicate to use. Should return true to include the element.
      * @return This query

--- a/inject/src/main/java/io/micronaut/inject/ast/beans/BeanElementBuilder.java
+++ b/inject/src/main/java/io/micronaut/inject/ast/beans/BeanElementBuilder.java
@@ -42,6 +42,21 @@ import java.util.function.Predicate;
 public interface BeanElementBuilder extends ConfigurableElement {
 
     /**
+     * Intercept the bean.
+     * @param annotationValue The annotation to intercept
+     * @return This bean method
+     * @since 3.5.2
+     */
+    default @NonNull BeanElementBuilder intercept(AnnotationValue<?>... annotationValue) {
+        if (annotationValue != null) {
+            for (AnnotationValue<?> value : annotationValue) {
+                annotate(value);
+            }
+        }
+        return this;
+    }
+
+    /**
      * @return The originating element
      */
     @NonNull

--- a/inject/src/main/java/io/micronaut/inject/ast/beans/BeanMethodElement.java
+++ b/inject/src/main/java/io/micronaut/inject/ast/beans/BeanMethodElement.java
@@ -17,6 +17,7 @@ package io.micronaut.inject.ast.beans;
 
 import io.micronaut.context.annotation.Executable;
 import io.micronaut.core.annotation.AnnotationUtil;
+import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.inject.ast.MethodElement;
 
@@ -30,6 +31,22 @@ import java.util.function.Consumer;
  * @since 3.0.0
  */
 public interface BeanMethodElement extends MethodElement {
+
+    /**
+     * Intercept the method.
+     * @param annotationValue The annotation to intercept
+     * @return This bean method
+     * @since 3.5.2
+     */
+    default @NonNull BeanMethodElement intercept(AnnotationValue<?>... annotationValue) {
+        if (annotationValue != null) {
+            for (AnnotationValue<?> value : annotationValue) {
+                annotate(value);
+            }
+        }
+        return this;
+    }
+
     /**
      * Make the method executable.
      *

--- a/inject/src/main/java/io/micronaut/inject/writer/AbstractBeanDefinitionBuilder.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/AbstractBeanDefinitionBuilder.java
@@ -28,6 +28,8 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.util.ArrayUtils;
+import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
 import io.micronaut.inject.annotation.MutableAnnotationMetadata;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.ConstructorElement;
@@ -39,6 +41,7 @@ import io.micronaut.inject.ast.FieldElement;
 import io.micronaut.inject.ast.MemberElement;
 import io.micronaut.inject.ast.MethodElement;
 import io.micronaut.inject.ast.ParameterElement;
+import io.micronaut.inject.ast.TypedElement;
 import io.micronaut.inject.ast.beans.BeanConstructorElement;
 import io.micronaut.inject.ast.beans.BeanElementBuilder;
 import io.micronaut.inject.ast.beans.BeanFieldElement;
@@ -47,6 +50,8 @@ import io.micronaut.inject.ast.beans.BeanParameterElement;
 import io.micronaut.inject.configuration.ConfigurationMetadataBuilder;
 import io.micronaut.inject.visitor.VisitorContext;
 
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
@@ -59,8 +64,10 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -100,6 +107,7 @@ public abstract class AbstractBeanDefinitionBuilder implements BeanElementBuilde
     private final int identifier;
     private final MutableAnnotationMetadata annotationMetadata;
     private final List<BeanMethodElement> executableMethods = new ArrayList<>(5);
+    private final List<BeanMethodElement> interceptedMethods = new ArrayList<>(5);
     private final List<AbstractBeanDefinitionBuilder> childBeans = new ArrayList<>(5);
     private final List<BeanMethodElement> injectedMethods = new ArrayList<>(5);
     private final List<BeanMethodElement> preDestroyMethods = new ArrayList<>(5);
@@ -108,6 +116,7 @@ public abstract class AbstractBeanDefinitionBuilder implements BeanElementBuilde
     private BeanConstructorElement constructorElement;
     private Map<String, Map<String, ClassElement>> typeArguments;
     private ClassElement[] exposedTypes;
+    private boolean intercepted;
 
     /**
      * Default constructor.
@@ -144,6 +153,15 @@ public abstract class AbstractBeanDefinitionBuilder implements BeanElementBuilde
         this.constructorElement = initConstructor(beanType);
     }
 
+    @Override
+    public BeanElementBuilder intercept(AnnotationValue<?>... annotationValue) {
+        for (AnnotationValue<?> value : annotationValue) {
+            annotate(value);
+        }
+        this.intercepted = true;
+        return this;
+    }
+
     @Internal
     public static void writeBeanDefinitionBuilders(ClassWriterOutputVisitor classWriterOutputVisitor,
                                                    List<AbstractBeanDefinitionBuilder> beanDefinitionBuilders)
@@ -159,14 +177,9 @@ public abstract class AbstractBeanDefinitionBuilder implements BeanElementBuilde
 
     private static void writeBeanDefinition(ClassWriterOutputVisitor classWriterOutputVisitor, AbstractBeanDefinitionBuilder beanDefinitionBuilder)
             throws IOException {
-        final BeanDefinitionWriter beanDefinitionWriter = beanDefinitionBuilder.build();
+        final ClassOutputWriter beanDefinitionWriter = beanDefinitionBuilder.build();
         if (beanDefinitionWriter != null) {
             beanDefinitionWriter.accept(classWriterOutputVisitor);
-            BeanDefinitionReferenceWriter beanDefinitionReferenceWriter =
-                    new BeanDefinitionReferenceWriter(beanDefinitionWriter);
-            beanDefinitionReferenceWriter
-                    .setRequiresMethodProcessing(beanDefinitionWriter.requiresMethodProcessing());
-            beanDefinitionReferenceWriter.accept(classWriterOutputVisitor);
         }
     }
 
@@ -176,6 +189,14 @@ public abstract class AbstractBeanDefinitionBuilder implements BeanElementBuilde
                 !m.isPublic(),
                 initBeanParameters(m.getParameters())
         )).orElse(null);
+    }
+
+    /**
+     * Is the bean to be built intercepted?
+     * @return True if it is
+     */
+    protected boolean isIntercepted() {
+        return this.intercepted || !this.interceptedMethods.isEmpty();
     }
 
     @Override
@@ -514,6 +535,50 @@ public abstract class AbstractBeanDefinitionBuilder implements BeanElementBuilde
     protected abstract @NonNull AbstractBeanDefinitionBuilder createChildBean(FieldElement producerField);
 
     /**
+     * Visit the intercepted methods of this type.
+     * @param consumer A consumer to handle the method
+     */
+    protected void visitInterceptedMethods(BiConsumer<TypedElement, MethodElement> consumer) {
+        if (consumer != null) {
+
+            ClassElement beanClass = getBeanType();
+            if (CollectionUtils.isNotEmpty(interceptedMethods)) {
+                for (BeanMethodElement interceptedMethod : interceptedMethods) {
+                    handleMethod(beanClass, interceptedMethod, consumer);
+                }
+            }
+
+            if (this.intercepted) {
+                beanClass.getEnclosedElements(
+                        ElementQuery.ALL_METHODS
+                                .onlyInstance()
+                                .modifiers(mods -> !mods.contains(ElementModifier.FINAL) && mods.contains(ElementModifier.PUBLIC))
+                ).forEach(method -> {
+                    InternalBeanElementMethod ibem = new InternalBeanElementMethod(
+                            method,
+                            true
+                    );
+                    if (!interceptedMethods.contains(ibem)) {
+                        handleMethod(beanClass, ibem, consumer);
+                    }
+                });
+            }
+        }
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private void handleMethod(ClassElement beanClass, MethodElement method, BiConsumer<TypedElement, MethodElement> consumer) {
+        ElementFactory elementFactory = visitorContext.getElementFactory();
+        AnnotationMetadataHierarchy fusedMetadata = new AnnotationMetadataHierarchy(getAnnotationMetadata(), method.getAnnotationMetadata());
+        MethodElement finalMethod = elementFactory.newMethodElement(
+                beanClass,
+                method.getNativeType(),
+                fusedMetadata
+        );
+        consumer.accept(beanClass, finalMethod);
+    }
+
+    /**
      * Creates a child bean for the given producer method.
      * @param producerMethod The producer method
      * @return The child bean builder
@@ -525,15 +590,136 @@ public abstract class AbstractBeanDefinitionBuilder implements BeanElementBuilde
      * @return The writer, possibly null if it wasn't possible to build it
      */
     @Nullable
-    public BeanDefinitionWriter build() {
+    public BeanClassWriter build() {
+        final BeanDefinitionVisitor beanDefinitionWriter = createBeanDefinitionWriter();
+        return new BeanClassWriter() {
+            @Override
+            public BeanDefinitionVisitor getBeanDefinitionVisitor() {
+                return beanDefinitionWriter;
+            }
+
+            @Override
+            public void accept(ClassWriterOutputVisitor classWriterOutputVisitor) throws IOException {
+                if (configureBeanVisitor(beanDefinitionWriter)) {
+                    return;
+                }
+
+                Map<ClassElement, List<MemberElement>> sortedInjections = new LinkedHashMap<>();
+                List<MemberElement> allInjected = new ArrayList<>();
+                allInjected.addAll(injectedFields);
+                allInjected.addAll(injectedMethods);
+                allInjected.sort(SORTER);
+                for (MemberElement memberElement : allInjected) {
+                    final List<MemberElement> list = sortedInjections
+                            .computeIfAbsent(memberElement.getDeclaringType(),
+                                    classElement -> new ArrayList<>()
+                            );
+                    list.add(memberElement);
+                }
+                for (List<MemberElement> members : sortedInjections.values()) {
+                    members.sort((o1, o2) -> {
+                        if (o1 instanceof FieldElement && o2 instanceof MethodElement) {
+                            return 1;
+                        } else if (o1 instanceof MethodElement && o1 instanceof FieldElement) {
+                            return -1;
+                        }
+                        return 0;
+                    });
+                }
+
+                for (List<MemberElement> list : sortedInjections.values()) {
+                    for (MemberElement memberElement : list) {
+                        if (memberElement instanceof FieldElement) {
+                            InternalBeanElementField ibf = (InternalBeanElementField) memberElement;
+                            ibf.<InternalBeanElementField>with((element) ->
+                                    visitField(beanDefinitionWriter, element, element)
+                            );
+
+                        } else {
+                            InternalBeanElementMethod ibm = (InternalBeanElementMethod) memberElement;
+                            ibm.<InternalBeanElementMethod>with((element) ->
+                                    beanDefinitionWriter.visitMethodInjectionPoint(
+                                            ibm.getDeclaringType(),
+                                            ibm,
+                                            ibm.isReflectionRequired(),
+                                            visitorContext
+                                    )
+                            );
+
+                        }
+                    }
+                }
+
+
+                for (BeanMethodElement executableMethod : executableMethods) {
+                    beanDefinitionWriter.visitExecutableMethod(
+                            beanType,
+                            executableMethod,
+                            visitorContext
+                    );
+                    if (executableMethod.getAnnotationMetadata().isTrue(Executable.class, "processOnStartup")) {
+                        beanDefinitionWriter.setRequiresMethodProcessing(true);
+                    }
+                }
+
+                for (BeanMethodElement postConstructMethod : postConstructMethods) {
+                    if (postConstructMethod.getDeclaringType().equals(beanType)) {
+                        beanDefinitionWriter.visitPostConstructMethod(
+                                beanType,
+                                postConstructMethod,
+                                postConstructMethod.isReflectionRequired(),
+                                visitorContext
+                        );
+                    }
+                }
+
+                for (BeanMethodElement preDestroyMethod : preDestroyMethods) {
+                    if (preDestroyMethod.getDeclaringType().equals(beanType)) {
+                        beanDefinitionWriter.visitPreDestroyMethod(
+                                beanType,
+                                preDestroyMethod,
+                                preDestroyMethod.isReflectionRequired(),
+                                visitorContext
+                        );
+                    }
+                }
+
+                finalizeAndWriteBean(classWriterOutputVisitor, beanDefinitionWriter);
+            }
+        };
+    }
+
+    /**
+     * Finish the given bean and write it to the output.
+     * @param classWriterOutputVisitor The output
+     * @param beanDefinitionWriter The writer
+     * @throws IOException If an error occurred
+     */
+    protected void finalizeAndWriteBean(
+            ClassWriterOutputVisitor classWriterOutputVisitor,
+            BeanDefinitionVisitor beanDefinitionWriter) throws IOException {
+        beanDefinitionWriter.visitBeanDefinitionEnd();
+        BeanDefinitionReferenceWriter beanDefinitionReferenceWriter =
+                new BeanDefinitionReferenceWriter(beanDefinitionWriter);
+        beanDefinitionReferenceWriter
+                .setRequiresMethodProcessing(beanDefinitionWriter.requiresMethodProcessing());
+        beanDefinitionReferenceWriter.accept(classWriterOutputVisitor);
+        beanDefinitionWriter.accept(classWriterOutputVisitor);
+    }
+
+    /**
+     * Configure the bean visitor for this builder.
+     * @param beanDefinitionWriter The bean visitor
+     * @return True if an error occurred
+     */
+    protected boolean configureBeanVisitor(BeanDefinitionVisitor beanDefinitionWriter) {
         if (exposedTypes != null) {
-            final AnnotationClassValue[] annotationClassValues =
+            final AnnotationClassValue<?>[] annotationClassValues =
                     Arrays.stream(exposedTypes).map(ce -> new AnnotationClassValue<>(ce.getName())).toArray(AnnotationClassValue[]::new);
             annotate(Bean.class, (builder) -> builder.member("typed", annotationClassValues));
         }
-        final BeanDefinitionWriter beanDefinitionWriter = createBeanDefinitionWriter();
         if (typeArguments != null) {
-            beanDefinitionWriter.visitTypeArguments(this.typeArguments);
+            beanDefinitionWriter.visitTypeArguments(AbstractBeanDefinitionBuilder.this.typeArguments);
         }
 
         if (constructorElement == null) {
@@ -542,7 +728,7 @@ public abstract class AbstractBeanDefinitionBuilder implements BeanElementBuilde
 
         if (constructorElement == null) {
             visitorContext.fail("Cannot create associated bean with no accessible primary constructor. Consider supply the constructor with createWith(..)", originatingElement);
-            return null;
+            return true;
         } else {
             beanDefinitionWriter.visitBeanDefinitionConstructor(
                     constructorElement,
@@ -550,96 +736,13 @@ public abstract class AbstractBeanDefinitionBuilder implements BeanElementBuilde
                     visitorContext
             );
         }
-
-        Map<ClassElement, List<MemberElement>> sortedInjections = new LinkedHashMap<>();
-        List<MemberElement> allInjected = new ArrayList<>();
-        allInjected.addAll(injectedFields);
-        allInjected.addAll(injectedMethods);
-        allInjected.sort(SORTER);
-        for (MemberElement memberElement : allInjected) {
-            final List<MemberElement> list = sortedInjections
-                    .computeIfAbsent(memberElement.getDeclaringType(),
-                                     classElement -> new ArrayList<>()
-                    );
-            list.add(memberElement);
-        }
-        for (List<MemberElement> members : sortedInjections.values()) {
-            members.sort((o1, o2) -> {
-                if (o1 instanceof FieldElement && o2 instanceof MethodElement) {
-                    return 1;
-                } else if (o1 instanceof MethodElement && o1 instanceof FieldElement) {
-                    return -1;
-                }
-                return 0;
-            });
-        }
-
-        for (List<MemberElement> list : sortedInjections.values()) {
-            for (MemberElement memberElement : list) {
-                if (memberElement instanceof FieldElement) {
-                    InternalBeanElementField ibf = (InternalBeanElementField) memberElement;
-                    ibf.<InternalBeanElementField>with((element) ->
-                         visitField(beanDefinitionWriter, element, element)
-                    );
-
-                } else {
-                    InternalBeanElementMethod ibm = (InternalBeanElementMethod) memberElement;
-                    ibm.<InternalBeanElementMethod>with((element) ->
-                         beanDefinitionWriter.visitMethodInjectionPoint(
-                                 ibm.getDeclaringType(),
-                                 ibm,
-                                 ibm.isReflectionRequired(),
-                                 visitorContext
-                         )
-                    );
-
-                }
-            }
-        }
-
-
-        for (BeanMethodElement executableMethod : executableMethods) {
-            beanDefinitionWriter.visitExecutableMethod(
-                    beanType,
-                    executableMethod,
-                    visitorContext
-            );
-            if (executableMethod.getAnnotationMetadata().isTrue(Executable.class, "processOnStartup")) {
-                beanDefinitionWriter.setRequiresMethodProcessing(true);
-            }
-        }
-
-        for (BeanMethodElement postConstructMethod : postConstructMethods) {
-            if (postConstructMethod.getDeclaringType().equals(beanType)) {
-                beanDefinitionWriter.visitPostConstructMethod(
-                        beanType,
-                        postConstructMethod,
-                        ((InternalBeanElementMethod) postConstructMethod).isReflectionRequired(),
-                        visitorContext
-                );
-            }
-        }
-
-        for (BeanMethodElement preDestroyMethod : preDestroyMethods) {
-            if (preDestroyMethod.getDeclaringType().equals(beanType)) {
-                beanDefinitionWriter.visitPreDestroyMethod(
-                        beanType,
-                        preDestroyMethod,
-                        ((InternalBeanElementMethod) preDestroyMethod).isReflectionRequired(),
-                        visitorContext
-                );
-            }
-        }
-
-        beanDefinitionWriter.visitBeanDefinitionEnd();
-
-        return beanDefinitionWriter;
+        return false;
     }
 
     /**
      * @return Creates the bean definition writer.
      */
-    protected BeanDefinitionWriter createBeanDefinitionWriter() {
+    protected BeanDefinitionVisitor createBeanDefinitionWriter() {
         return new BeanDefinitionWriter(
                 this,
                 OriginatingElements.of(originatingElement),
@@ -649,7 +752,7 @@ public abstract class AbstractBeanDefinitionBuilder implements BeanElementBuilde
         );
     }
 
-    private void visitField(BeanDefinitionWriter beanDefinitionWriter,
+    private void visitField(BeanDefinitionVisitor beanDefinitionWriter,
                            BeanFieldElement injectedField,
                            InternalBeanElementField ibf) {
         if (injectedField.hasAnnotation(Value.class) || injectedField.hasAnnotation(Property.class)) {
@@ -727,6 +830,23 @@ public abstract class AbstractBeanDefinitionBuilder implements BeanElementBuilde
             }
         }
 
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            InternalBeanElement<?> that = (InternalBeanElement<?>) o;
+            return element.equals(that.element);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(element);
+        }
+
         @NonNull
         @Override
         public AnnotationMetadata getAnnotationMetadata() {
@@ -762,6 +882,12 @@ public abstract class AbstractBeanDefinitionBuilder implements BeanElementBuilde
         @Override
         public <T extends Annotation> Element annotate(@NonNull String annotationType, @NonNull Consumer<AnnotationValueBuilder<T>> consumer) {
             AbstractBeanDefinitionBuilder.this.annotate(elementMetadata, annotationType, consumer);
+            return this;
+        }
+
+        @Override
+        public <T extends Annotation> Element annotate(AnnotationValue<T> annotationValue) {
+            AbstractBeanDefinitionBuilder.this.annotate(elementMetadata, annotationValue);
             return this;
         }
 
@@ -873,6 +999,14 @@ public abstract class AbstractBeanDefinitionBuilder implements BeanElementBuilde
                 AbstractBeanDefinitionBuilder.this.executableMethods.add(this);
             }
             return BeanMethodElement.super.executable();
+        }
+
+        @Override
+        public BeanMethodElement intercept(AnnotationValue<?>... annotationValue) {
+            if (!AbstractBeanDefinitionBuilder.this.interceptedMethods.contains(this)) {
+                AbstractBeanDefinitionBuilder.this.interceptedMethods.add(this);
+            }
+            return BeanMethodElement.super.intercept(annotationValue);
         }
 
         @Override

--- a/inject/src/main/java/io/micronaut/inject/writer/AbstractBeanDefinitionBuilder.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/AbstractBeanDefinitionBuilder.java
@@ -588,6 +588,7 @@ public abstract class AbstractBeanDefinitionBuilder implements BeanElementBuilde
      * Build the bean definition writer.
      * @return The writer, possibly null if it wasn't possible to build it
      */
+    @SuppressWarnings({"ConstantConditions", "java:S2583"})
     @Nullable
     public BeanClassWriter build() {
         BeanClassWriter beanWriter = buildBeanClassWriter();

--- a/inject/src/main/java/io/micronaut/inject/writer/AbstractBeanDefinitionBuilder.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/AbstractBeanDefinitionBuilder.java
@@ -49,7 +49,6 @@ import io.micronaut.inject.ast.beans.BeanMethodElement;
 import io.micronaut.inject.ast.beans.BeanParameterElement;
 import io.micronaut.inject.configuration.ConfigurationMetadataBuilder;
 import io.micronaut.inject.visitor.VisitorContext;
-import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.lang.annotation.Annotation;

--- a/inject/src/main/java/io/micronaut/inject/writer/AbstractBeanDefinitionBuilder.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/AbstractBeanDefinitionBuilder.java
@@ -50,8 +50,6 @@ import io.micronaut.inject.ast.beans.BeanParameterElement;
 import io.micronaut.inject.configuration.ConfigurationMetadataBuilder;
 import io.micronaut.inject.visitor.VisitorContext;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;

--- a/inject/src/main/java/io/micronaut/inject/writer/AbstractClassFileWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/AbstractClassFileWriter.java
@@ -76,7 +76,7 @@ import java.util.stream.Collectors;
  * @since 1.0
  */
 @Internal
-public abstract class AbstractClassFileWriter implements Opcodes, OriginatingElements {
+public abstract class AbstractClassFileWriter implements Opcodes, OriginatingElements, ClassOutputWriter {
 
     protected static final Type TYPE_ARGUMENT = Type.getType(Argument.class);
     protected static final Type TYPE_ARGUMENT_ARRAY = Type.getType(Argument[].class);
@@ -720,14 +720,6 @@ public abstract class AbstractClassFileWriter implements Opcodes, OriginatingEle
             return null;
         }
     }
-
-    /**
-     * Accept a ClassWriterOutputVisitor to write this writer to disk.
-     *
-     * @param classWriterOutputVisitor The {@link ClassWriterOutputVisitor}
-     * @throws IOException if there is an error writing to disk
-     */
-    public abstract void accept(ClassWriterOutputVisitor classWriterOutputVisitor) throws IOException;
 
     /**
      * Implements a method called "getInterceptedType" for the given type and class writer.

--- a/inject/src/main/java/io/micronaut/inject/writer/BeanClassWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/BeanClassWriter.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.writer;
+
+import io.micronaut.core.annotation.NonNull;
+
+/**
+ * Extended version of {@link ClassWriterOutputVisitor} for types that write beans.
+ *
+ * @since 3.5.2
+ */
+public interface BeanClassWriter extends ClassOutputWriter {
+    /**
+     * @return The bean definition visitor
+     */
+    @NonNull
+    BeanDefinitionVisitor getBeanDefinitionVisitor();
+}

--- a/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionVisitor.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionVisitor.java
@@ -15,7 +15,6 @@
  */
 package io.micronaut.inject.writer;
 
-import io.micronaut.context.annotation.Bean;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.util.Toggleable;
 import io.micronaut.inject.BeanDefinition;
@@ -64,7 +63,7 @@ public interface BeanDefinitionVisitor extends OriginatingElements, Toggleable {
 
     /**
      * <p>In the case where the produced class is produced by a factory method annotated with
-     * {@link Bean} this method should be called.</p>
+     * {@link io.micronaut.context.annotation.Bean} this method should be called.</p>
      *
      * @param factoryClass  The factory class
      * @param factoryMethod The factory method

--- a/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionVisitor.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionVisitor.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.inject.writer;
 
+import io.micronaut.context.annotation.Bean;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.util.Toggleable;
 import io.micronaut.inject.BeanDefinition;
@@ -50,6 +51,37 @@ public interface BeanDefinitionVisitor extends OriginatingElements, Toggleable {
     @Nullable
     Element getOriginatingElement();
 
+
+    /**
+     * <p>In the case where the produced class is produced by a factory method annotated with
+     * {@link io.micronaut.context.annotation.Bean} this method should be called.</p>
+     *
+     * @param factoryClass  The factory class
+     * @param factoryMethod The factory method
+     */
+    void visitBeanFactoryMethod(ClassElement factoryClass,
+                                MethodElement factoryMethod);
+
+    /**
+     * <p>In the case where the produced class is produced by a factory method annotated with
+     * {@link Bean} this method should be called.</p>
+     *
+     * @param factoryClass  The factory class
+     * @param factoryMethod The factory method
+     * @param parameters    The parameters
+     */
+    void visitBeanFactoryMethod(ClassElement factoryClass,
+                                MethodElement factoryMethod,
+                                ParameterElement[] parameters);
+
+    /**
+     * <p>In the case where the produced class is produced by a factory field annotated with
+     * {@link io.micronaut.context.annotation.Bean} this method should be called.</p>
+     *
+     * @param factoryClass The factory class
+     * @param factoryField The factory field
+     */
+    void visitBeanFactoryField(ClassElement factoryClass, FieldElement factoryField);
 
     /**
      * Visits the constructor used to create the bean definition.

--- a/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -737,9 +737,11 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
     @NonNull
     @Override
     public ClassElement[] getTypeArguments() {
-        final Map<String, ClassElement> args = this.typeArguments.get(this.getBeanTypeName());
-        if (CollectionUtils.isNotEmpty(args)) {
-            return args.values().toArray(new ClassElement[0]);
+        if (hasTypeArguments()) {
+            final Map<String, ClassElement> args = this.typeArguments.get(this.getBeanTypeName());
+            if (CollectionUtils.isNotEmpty(args)) {
+                return args.values().toArray(ClassElement.ZERO_CLASS_ELEMENTS);
+            }
         }
         return BeanDefinitionVisitor.super.getTypeArguments();
     }

--- a/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -845,6 +845,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
      * @param factoryClass  The factory class
      * @param factoryMethod The factory method
      */
+    @Override
     public void visitBeanFactoryMethod(ClassElement factoryClass,
                                        MethodElement factoryMethod) {
         if (constructor != null) {
@@ -866,6 +867,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
      * @param factoryMethod The factory method
      * @param parameters    The parameters
      */
+    @Override
     public void visitBeanFactoryMethod(ClassElement factoryClass,
                                        MethodElement factoryMethod,
                                        ParameterElement[] parameters) {
@@ -887,6 +889,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
      * @param factoryClass The factory class
      * @param factoryField The factory field
      */
+    @Override
     public void visitBeanFactoryField(ClassElement factoryClass, FieldElement factoryField) {
         if (constructor != null) {
             throw new IllegalStateException("Only a single call to visitBeanFactoryMethod(..) is permitted");

--- a/inject/src/main/java/io/micronaut/inject/writer/ClassOutputWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/ClassOutputWriter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.writer;
+
+import java.io.IOException;
+
+/**
+ * A component that accepts a {@link ClassWriterOutputVisitor} and writes classes to it.
+ *
+ * @since 3.5.2
+ */
+public interface ClassOutputWriter {
+    /**
+     * Accept a ClassWriterOutputVisitor to write this writer to disk.
+     *
+     * @param classWriterOutputVisitor The {@link ClassWriterOutputVisitor}
+     * @throws IOException if there is an error writing to disk
+     */
+    void accept(ClassWriterOutputVisitor classWriterOutputVisitor) throws IOException;
+}


### PR DESCRIPTION
For CDI we need to be able import beans that have AOP advice applied to them, turns out that doesn't work with the current `BeanElementBuilder` API. This PR fixes that.