### PR TITLE
Fix full response body logging

### DIFF
--- a/http-client/build.gradle
+++ b/http-client/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 
     testImplementation project(":http-server-netty")
     testImplementation libs.wiremock
+    testImplementation libs.managed.logback
 
     if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_15)) {
         testImplementation libs.bcpkix

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -3169,7 +3169,7 @@ public class DefaultHttpClient implements
 
             HttpHeaders headers = msg.headers();
             if (log.isTraceEnabled()) {
-                log.trace("HTTP Client Streaming Response Received ({}) for Request: {} {}", msg.status(), finalRequest.getMethodName(), finalRequest.getUri());
+                log.trace("HTTP Client Response Received ({}) for Request: {} {}", msg.status(), finalRequest.getMethodName(), finalRequest.getUri());
                 traceHeaders(headers);
             }
             buildResponse(responsePromise, msg, httpStatus);
@@ -3257,6 +3257,10 @@ public class DefaultHttpClient implements
         @Override
         protected void buildResponse(Promise<? super HttpResponse<O>> promise, FullHttpResponse msg, HttpStatus httpStatus) {
             try {
+                if (log.isTraceEnabled()) {
+                    traceBody("Response", msg.content());
+                }
+
                 if (httpStatus == HttpStatus.NO_CONTENT) {
                     // normalize the NO_CONTENT header, since http content aggregator adds it even if not present in the response
                     msg.headers().remove(HttpHeaderNames.CONTENT_LENGTH);

--- a/http-client/src/test/groovy/io/micronaut/http/client/HttpClientTraceLoggingSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/HttpClientTraceLoggingSpec.groovy
@@ -1,0 +1,66 @@
+package io.micronaut.http.client
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.AppenderBase
+import io.micronaut.context.ApplicationContext
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.runtime.server.EmbeddedServer
+import org.slf4j.LoggerFactory
+import spock.lang.Specification
+
+class HttpClientTraceLoggingSpec extends Specification {
+    def 'full response'() {
+        given:
+        String loggerName = 'io.micronaut.http.client.HttpClientTraceLoggingSpec.' + UUID.randomUUID()
+        MemoryAppender appender = new MemoryAppender()
+        Logger l = (Logger) LoggerFactory.getLogger(loggerName)
+        l.addAppender(appender)
+        l.setLevel(Level.ALL)
+        appender.start()
+
+        def configuration = new DefaultHttpClientConfiguration()
+        configuration.setLoggerName(loggerName)
+
+        def ctx = ApplicationContext.run()
+        def server = ctx.getBean(EmbeddedServer)
+        server.start()
+        def client = ctx.createBean(HttpClient, server.URI, configuration).toBlocking()
+
+        when:
+        client.exchange("/get-full")
+        then:
+        appender.events.any { it.contains('foo') }
+
+        cleanup:
+        client.close()
+        server.stop()
+        ctx.stop()
+    }
+
+
+    static class MemoryAppender extends AppenderBase<ILoggingEvent> {
+        private final List<String> events = new ArrayList<>()
+
+        @Override
+        protected void append(ILoggingEvent e) {
+            synchronized (events) {
+                events.add(e.toString())
+            }
+        }
+
+        List<String> getEvents() {
+            return events
+        }
+    }
+
+    @Controller
+    static class Ctrl {
+        @Get("/get-full")
+        def getFull() {
+            return 'foo'
+        }
+    }
+}

--- a/http-client/src/test/groovy/io/micronaut/http/client/HttpClientTraceLoggingSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/HttpClientTraceLoggingSpec.groovy
@@ -3,7 +3,7 @@ package io.micronaut.http.client
 import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.Logger
 import ch.qos.logback.classic.spi.ILoggingEvent
-import ch.qos.logback.core.AppenderBase
+import ch.qos.logback.core.read.ListAppender
 import io.micronaut.context.ApplicationContext
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
@@ -15,7 +15,7 @@ class HttpClientTraceLoggingSpec extends Specification {
     def 'full response'() {
         given:
         String loggerName = 'io.micronaut.http.client.HttpClientTraceLoggingSpec.' + UUID.randomUUID()
-        MemoryAppender appender = new MemoryAppender()
+        def appender = new ListAppender<ILoggingEvent>()
         Logger l = (Logger) LoggerFactory.getLogger(loggerName)
         l.addAppender(appender)
         l.setLevel(Level.ALL)
@@ -32,28 +32,13 @@ class HttpClientTraceLoggingSpec extends Specification {
         when:
         client.exchange("/get-full")
         then:
-        appender.events.any { it.contains('foo') }
+        appender.list.formattedMessage.any { it.contains('foo') }
 
         cleanup:
         client.close()
         server.stop()
         ctx.stop()
-    }
-
-
-    static class MemoryAppender extends AppenderBase<ILoggingEvent> {
-        private final List<String> events = new ArrayList<>()
-
-        @Override
-        protected void append(ILoggingEvent e) {
-            synchronized (events) {
-                events.add(e.toString())
-            }
-        }
-
-        List<String> getEvents() {
-            return events
-        }
+        appender.stop()
     }
 
     @Controller

--- a/http-client/src/test/groovy/io/micronaut/http/client/HttpGetSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/HttpGetSpec.groovy
@@ -52,8 +52,6 @@ import java.util.function.Consumer
  */
 @MicronautTest
 @Property(name = 'spec.name', value = 'HttpGetSpec')
-@Property(name = "micronaut.server.netty.log-level", value = 'trace')
-@Property(name = "micronaut.http.client.log-level", value = 'trace')
 class HttpGetSpec extends Specification {
 
     @Inject


### PR DESCRIPTION
In 18ef607c4c6ec276b2e0163f27cf4e28fce96b01, I merged the code paths of the full response and streaming response handlers. I included the chunk-level logging for the streaming response, but missed the full response logging.
Fixes #7572