### PR TITLE
Support JDK 18 in annotation processors

### DIFF
--- a/inject-java/src/main/java/io/micronaut/annotation/processing/AbstractInjectAnnotationProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/AbstractInjectAnnotationProcessor.java
@@ -79,14 +79,14 @@ abstract class AbstractInjectAnnotationProcessor extends AbstractProcessor {
     @Override
     public SourceVersion getSupportedSourceVersion() {
         SourceVersion sourceVersion = SourceVersion.latest();
-        if (sourceVersion.ordinal() <= 17) {
+        if (sourceVersion.ordinal() <= 18) {
             if (sourceVersion.ordinal() >= 8) {
                 return sourceVersion;
             } else {
                 return SourceVersion.RELEASE_8;
             }
         } else {
-            return (SourceVersion.values())[17];
+            return (SourceVersion.values())[18];
         }
     }
 


### PR DESCRIPTION

Given a Gradle project using JDK 18 and Micronaut 3.5.1:

```gradle
targetCompatibility = JavaVersion.VERSION_18
sourceCompatibility = JavaVersion.VERSION_18
```

The following warning(s) are currently raised during compilation:

```bash
warning: Supported source version 'RELEASE_17' from annotation processor 'org.gradle.api.internal.tasks.compile.processing.TimeTrackingProcessor' less than -source '18'
```