### PR TITLE
bug: restarting netty in a named application throws error

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
@@ -556,7 +556,9 @@ public class NettyHttpServer implements NettyEmbeddedServer {
         applicationContext.getEventPublisher(ServerStartupEvent.class)
                 .publishEvent(new ServerStartupEvent(this));
         applicationName.ifPresent(id -> {
-            this.serviceInstance = applicationContext.createBean(NettyEmbeddedServerInstance.class, id, this);
+            if (serviceInstance == null) {
+                serviceInstance = applicationContext.createBean(NettyEmbeddedServerInstance.class, id, this);
+            }
             applicationContext
                     .getEventPublisher(ServiceReadyEvent.class)
                     .publishEvent(new ServiceReadyEvent(serviceInstance));

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/NettyStartStopSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/NettyStartStopSpec.groovy
@@ -1,0 +1,46 @@
+package io.micronaut.http.server.netty
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Context
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.event.ApplicationEventListener
+import io.micronaut.discovery.event.ServiceReadyEvent
+import io.micronaut.runtime.server.EmbeddedServer
+import jakarta.inject.Singleton
+import spock.lang.Specification
+
+import java.util.concurrent.atomic.AtomicInteger
+
+class NettyStartStopSpec extends Specification {
+
+    void "stopping and starting the netty server in a named application should work"() {
+        given:
+        EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
+                'spec.name': 'NettyStartStopSpec',
+                'micronaut.application.name': 'example'
+        ])
+        def listener = server.applicationContext.getBean(StartListener)
+
+        when:
+        server.stop()
+
+        and:
+        server.start()
+
+        then:
+        listener.eventCount.get() == 2
+    }
+
+    @Context
+    @Singleton
+    @Requires(property = "spec.name", value = "NettyStartStopSpec")
+    static class StartListener implements ApplicationEventListener<ServiceReadyEvent> {
+
+        AtomicInteger eventCount = new AtomicInteger(0)
+
+        @Override
+        void onApplicationEvent(ServiceReadyEvent event) {
+            eventCount.incrementAndGet()
+        }
+    }
+}


### PR DESCRIPTION
When restarting the NettyHttpServer, if the application has a name then it tries to recreate
`serviceInstance`, which fails with

```
io.micronaut.context.exceptions.BeanInstantiationException:
    Error instantiating bean of type [io.micronaut.http.server.netty.NettyEmbeddedServerInstance]:
         Bean of type [class io.micronaut.context.DefaultApplicationContext] is a manually registered
         singleton that was registered with the context via BeanContext.registerBean(..) and cannot
         be created directly
```

This PR fixes that, by using the known value if it is already set