### PR TITLE
Use ServiceCollector for SoftServiceLoader.iterator

### DIFF
--- a/config/accepted-api-changes.json
+++ b/config/accepted-api-changes.json
@@ -183,5 +183,15 @@
     "type": "io.micronaut.core.annotation.AnnotationMetadata",
     "member": "Method io.micronaut.core.annotation.AnnotationMetadata.getAnnotationValuesByStereotype(java.lang.String)",
     "reason": "New default method"
+  },
+  {
+    "type": "io.micronaut.core.io.service.SoftServiceLoader$ServiceCollector",
+    "member": "Class io.micronaut.core.io.service.SoftServiceLoader$ServiceCollector",
+    "reason": "New default method"
+  },
+  {
+    "type": "io.micronaut.core.io.service.SoftServiceLoader$ServiceCollector",
+    "member": "Method io.micronaut.core.io.service.SoftServiceLoader$ServiceCollector.collect(java.util.Collection,boolean)",
+    "reason": "New default method"
   }
 ]

--- a/core/src/main/java/io/micronaut/core/graal/ServiceLoaderInitialization.java
+++ b/core/src/main/java/io/micronaut/core/graal/ServiceLoaderInitialization.java
@@ -178,14 +178,14 @@ final class StaticServiceDefinitions {
 }
 
 @SuppressWarnings("unused")
-@TargetClass(SoftServiceLoader.class)
+@TargetClass(className = "io.micronaut.core.io.service.ServiceScanner")
 @Internal
 final class ServiceLoaderInitialization {
     private ServiceLoaderInitialization() {
     }
 
     @Substitute
-    private static Set<String> computeServiceTypeNames(URI uri, String path) {
+    private static Set<String> computeMicronautServiceTypeNames(URI uri, String path) {
         final StaticServiceDefinitions ssd = ImageSingletons.lookup(StaticServiceDefinitions.class);
         return ssd.serviceTypeMap.getOrDefault(
                 path,

--- a/core/src/main/java/io/micronaut/core/io/service/ServiceScanner.java
+++ b/core/src/main/java/io/micronaut/core/io/service/ServiceScanner.java
@@ -74,7 +74,7 @@ final class ServiceScanner<S> {
     }
 
     /**
-     * Note: referenced by io.micronaut.core.graal.ServiceLoaderInitialization
+     * Note: referenced by {@code io.micronaut.core.graal.ServiceLoaderInitialization}.
      */
     @SuppressWarnings("java:S3398")
     private static Set<String> computeMicronautServiceTypeNames(URI uri, String path) {

--- a/core/src/main/java/io/micronaut/core/io/service/ServiceScanner.java
+++ b/core/src/main/java/io/micronaut/core/io/service/ServiceScanner.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.core.io.service;
 
 import io.micronaut.core.annotation.Internal;
@@ -29,6 +44,8 @@ import java.util.function.Predicate;
 
 /**
  * Wrapper class for the tasks required to find services of a particular type.
+ *
+ * @param <S> service type
  */
 @Internal
 final class ServiceScanner<S> {

--- a/core/src/main/java/io/micronaut/core/io/service/ServiceScanner.java
+++ b/core/src/main/java/io/micronaut/core/io/service/ServiceScanner.java
@@ -1,0 +1,305 @@
+package io.micronaut.core.io.service;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.io.IOUtils;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.ServiceConfigurationError;
+import java.util.Set;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.RecursiveAction;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * Wrapper class for the tasks required to find services of a particular type.
+ */
+@Internal
+final class ServiceScanner<S> {
+    private final ClassLoader classLoader;
+    private final String serviceName;
+    private final Predicate<String> lineCondition;
+    private final Function<String, S> transformer;
+
+    public ServiceScanner(ClassLoader classLoader, String serviceName, Predicate<String> lineCondition, Function<String, S> transformer) {
+        this.classLoader = classLoader;
+        this.serviceName = serviceName;
+        this.lineCondition = lineCondition;
+        this.transformer = transformer;
+    }
+
+    private static URI normalizeFilePath(String path, URI uri) {
+        Path p = Paths.get(uri);
+        if (p.endsWith(path)) {
+            Path subpath = Paths.get(path);
+            for (int i = 0; i < subpath.getNameCount(); i++) {
+                p = p.getParent();
+            }
+            uri = p.toUri();
+        }
+        return uri;
+    }
+
+    @SuppressWarnings("java:S3398")
+    private static Set<String> computeMicronautServiceTypeNames(URI uri, String path) {
+        Set<String> typeNames = new HashSet<>();
+        IOUtils.eachFile(
+                uri, path, currentPath -> {
+                    if (Files.isRegularFile(currentPath)) {
+                        final String typeName = currentPath.getFileName().toString();
+                        typeNames.add(typeName);
+                    }
+                }
+        );
+        return typeNames;
+    }
+
+    @SuppressWarnings("java:S3398")
+    private Set<String> computeStandardServiceTypeNames(URL url) {
+        Set<String> typeNames = new HashSet<>();
+        try {
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(url.openStream()))) {
+                while (true) {
+                    String line = reader.readLine();
+                    if (line == null) {
+                        break;
+                    }
+                    if (line.length() == 0 || line.charAt(0) == '#') {
+                        continue;
+                    }
+                    if (!lineCondition.test(line)) {
+                        continue;
+                    }
+                    int i = line.indexOf('#');
+                    if (i > -1) {
+                        line = line.substring(0, i);
+                    }
+                    typeNames.add(line);
+                }
+            }
+        } catch (IOException | UncheckedIOException e) {
+            // ignore, can't do anything here and can't log because class used in compiler
+        }
+        return typeNames;
+    }
+
+    private Enumeration<URL> findStandardServiceConfigs() throws IOException {
+        return classLoader.getResources(SoftServiceLoader.META_INF_SERVICES + '/' + serviceName);
+    }
+
+    private void findMicronautMetaServiceConfigs(BiConsumer<URI, String> consumer) throws IOException, URISyntaxException {
+        final String path = "META-INF/micronaut/" + serviceName;
+        final Enumeration<URL> micronautResources = classLoader.getResources(path);
+        Set<URI> uniqueURIs = new LinkedHashSet<>();
+        while (micronautResources.hasMoreElements()) {
+            URL url = micronautResources.nextElement();
+            final URI uri = url.toURI();
+            uniqueURIs.add(uri);
+        }
+
+        for (URI uri : uniqueURIs) {
+            String scheme = uri.getScheme();
+            if ("file".equals(scheme)) {
+                uri = normalizeFilePath(path, uri);
+            }
+            // on GraalVM there are spurious extra resources that end with # and then a number
+            // we ignore this extra ones
+            if (!("resource".equals(scheme) && uri.toString().contains("#"))) {
+                consumer.accept(uri, path);
+            }
+        }
+    }
+
+    /**
+     * Fork-join recursive services loader.
+     */
+    @SuppressWarnings("java:S1948")
+    final class DefaultServiceCollector extends RecursiveActionValuesCollector<S> implements SoftServiceLoader.ServiceCollector<S> {
+
+        private final List<RecursiveActionValuesCollector<S>> tasks = new ArrayList<>();
+
+        @Override
+        protected void compute() {
+            try {
+                Enumeration<URL> serviceConfigs = findStandardServiceConfigs();
+                while (serviceConfigs.hasMoreElements()) {
+                    URL url = serviceConfigs.nextElement();
+                    UrlServicesLoader task = new UrlServicesLoader(url);
+                    tasks.add(task);
+                    task.fork();
+                }
+                findMicronautMetaServiceConfigs((uri, path) -> {
+                    final MicronautMetaServicesLoader task = new MicronautMetaServicesLoader(uri, path);
+                    tasks.add(task);
+                    task.fork();
+                });
+            } catch (IOException | URISyntaxException e) {
+                throw new ServiceConfigurationError("Failed to load resources for service: " + serviceName, e);
+            }
+        }
+
+        @Override
+        public void collect(Collection<S> values) {
+            ForkJoinPool.commonPool().invoke(this);
+            for (RecursiveActionValuesCollector<S> task : tasks) {
+                task.join();
+                task.collect(values);
+            }
+        }
+
+        @Override
+        public void collect(Collection<S> values, boolean allowFork) {
+            if (allowFork) {
+                ForkJoinPool.commonPool().invoke(this);
+                for (RecursiveActionValuesCollector<S> task : tasks) {
+                    task.join();
+                    task.collect(values);
+                }
+            } else {
+                try {
+                    Enumeration<URL> serviceConfigs = findStandardServiceConfigs();
+                    while (serviceConfigs.hasMoreElements()) {
+                        URL url = serviceConfigs.nextElement();
+                        for (String typeName : computeStandardServiceTypeNames(url)) {
+                            values.add(transformer.apply(typeName));
+                        }
+                    }
+                    findMicronautMetaServiceConfigs((uri, path) -> {
+                        for (String typeName : computeMicronautServiceTypeNames(uri, path)) {
+                            values.add(transformer.apply(typeName));
+                        }
+                    });
+                } catch (IOException | URISyntaxException e) {
+                    throw new ServiceConfigurationError("Failed to load resources for service: " + serviceName, e);
+                }
+            }
+        }
+    }
+
+    private final class MicronautMetaServicesLoader extends RecursiveActionValuesCollector<S> {
+        private final URI uri;
+        private final List<ServiceInstanceLoader> tasks = new ArrayList<>();
+        private final String path;
+
+        private MicronautMetaServicesLoader(URI uri, String path) {
+            this.uri = uri;
+            this.path = path;
+        }
+
+        @Override
+        public void collect(Collection<S> values) {
+            for (ServiceInstanceLoader task : tasks) {
+                task.join();
+                task.collect(values);
+            }
+        }
+
+        @Override
+        @SuppressWarnings("java:S2095")
+        protected void compute() {
+            Set<String> typeNames = computeMicronautServiceTypeNames(uri, path);
+            for (String typeName : typeNames) {
+                ServiceInstanceLoader task = new ServiceInstanceLoader(typeName);
+                tasks.add(task);
+                task.fork();
+            }
+        }
+    }
+
+    /**
+     * Reads URL, parses the file and produces sub tasks to initialize the entry.
+     */
+    @SuppressWarnings("java:S1948")
+    private final class UrlServicesLoader extends RecursiveActionValuesCollector<S> {
+
+        private final URL url;
+        private final List<ServiceInstanceLoader> tasks = new ArrayList<>();
+
+        public UrlServicesLoader(URL url) {
+            this.url = url;
+        }
+
+        @Override
+        @SuppressWarnings({"java:S3776", "java:S135"})
+        protected void compute() {
+            for (String typeName : computeStandardServiceTypeNames(url)) {
+                ServiceInstanceLoader task = new ServiceInstanceLoader(typeName);
+                tasks.add(task);
+                task.fork();
+            }
+        }
+
+        public void collect(Collection<S> values) {
+            for (ServiceInstanceLoader task : tasks) {
+                task.join();
+                task.collect(values);
+            }
+        }
+
+    }
+
+    /**
+     * Initializes and filters the entry.
+     */
+    @SuppressWarnings("java:S1948")
+    private final class ServiceInstanceLoader extends RecursiveActionValuesCollector<S> {
+
+        private final String className;
+        private S result;
+        private Throwable throwable;
+
+        public ServiceInstanceLoader(String className) {
+            this.className = className;
+        }
+
+        @Override
+        protected void compute() {
+            try {
+                result = transformer.apply(className);
+            } catch (Throwable e) {
+                throwable = e;
+            }
+        }
+
+        public void collect(Collection<S> values) {
+            if (throwable != null) {
+                throw new SoftServiceLoader.ServiceLoadingException("Failed to load a service: " + throwable.getMessage(), throwable);
+            }
+            if (result != null && !values.contains(result)) {
+                values.add(result);
+            }
+        }
+    }
+
+    /**
+     * Abstract recursive action class.
+     *
+     * @param <S> The type
+     */
+    private abstract static class RecursiveActionValuesCollector<S> extends RecursiveAction {
+
+        /**
+         * Collects loaded values.
+         *
+         * @param values The values
+         */
+        public abstract void collect(Collection<S> values);
+
+    }
+}

--- a/core/src/main/java/io/micronaut/core/io/service/ServiceScanner.java
+++ b/core/src/main/java/io/micronaut/core/io/service/ServiceScanner.java
@@ -73,6 +73,9 @@ final class ServiceScanner<S> {
         return uri;
     }
 
+    /**
+     * Note: referenced by io.micronaut.core.graal.ServiceLoaderInitialization
+     */
     @SuppressWarnings("java:S3398")
     private static Set<String> computeMicronautServiceTypeNames(URI uri, String path) {
         Set<String> typeNames = new HashSet<>();

--- a/core/src/main/java/io/micronaut/core/io/service/SoftServiceLoader.java
+++ b/core/src/main/java/io/micronaut/core/io/service/SoftServiceLoader.java
@@ -17,39 +17,18 @@ package io.micronaut.core.io.service;
 
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
-import io.micronaut.core.io.IOUtils;
 import io.micronaut.core.optim.StaticOptimizations;
 import io.micronaut.core.reflect.ClassUtils;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.UncheckedIOException;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Enumeration;
-import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Optional;
-import java.util.ServiceConfigurationError;
-import java.util.Set;
-import java.util.concurrent.ForkJoinPool;
-import java.util.concurrent.RecursiveAction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -75,9 +54,9 @@ public final class SoftServiceLoader<S> implements Iterable<ServiceDefinition<S>
 
     private final Class<S> serviceType;
     private final ClassLoader classLoader;
-    private final Map<String, ServiceDefinition<S>> loadedServices = new LinkedHashMap<>();
-    private final Iterator<ServiceDefinition<S>> unloadedServices;
+    private Collection<ServiceDefinition<S>> servicesForIterator;
     private final Predicate<String> condition;
+    private boolean allowFork = true;
 
     private SoftServiceLoader(Class<S> serviceType, ClassLoader classLoader) {
         this(serviceType, classLoader, (String name) -> true);
@@ -86,7 +65,6 @@ public final class SoftServiceLoader<S> implements Iterable<ServiceDefinition<S>
     private SoftServiceLoader(Class<S> serviceType, ClassLoader classLoader, Predicate<String> condition) {
         this.serviceType = serviceType;
         this.classLoader = classLoader == null ? ClassLoader.getSystemClassLoader() : classLoader;
-        this.unloadedServices = STATIC_SERVICES.containsKey(serviceType.getName()) ? new StaticServicesLoaderIterator() : new ServiceLoaderIterator();
         this.condition = condition == null ? (String name) -> true : condition;
     }
 
@@ -129,6 +107,11 @@ public final class SoftServiceLoader<S> implements Iterable<ServiceDefinition<S>
         return new SoftServiceLoader<>(service, loader, condition);
     }
 
+    public SoftServiceLoader<S> disableFork() {
+        allowFork = false;
+        return this;
+    }
+
     /**
      * @return Return the first such instance
      */
@@ -136,6 +119,22 @@ public final class SoftServiceLoader<S> implements Iterable<ServiceDefinition<S>
         Iterator<ServiceDefinition<S>> i = iterator();
         if (i.hasNext()) {
             return Optional.of(i.next());
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Find the first service definition that is {@link ServiceDefinition#isPresent() present}, and
+     * then {@link ServiceDefinition#load() load} it.
+     *
+     * @return Return the first such instance, or {@link Optional#empty()} if there is no definition
+     * or none of the definitions are present on the classpath.
+     */
+    public Optional<S> firstAvailable() {
+        for (ServiceDefinition<S> def : this) {
+            if (def.isPresent()) {
+                return Optional.of(def.load());
+            }
         }
         return Optional.empty();
     }
@@ -196,7 +195,7 @@ public final class SoftServiceLoader<S> implements Iterable<ServiceDefinition<S>
             }
             return null;
         });
-        collector.collect(values);
+        collector.collect(values, allowFork);
     }
 
     private void collectStaticServices(Collection<S> values, Predicate<S> predicate, StaticServiceLoader<S> loader) {
@@ -213,40 +212,54 @@ public final class SoftServiceLoader<S> implements Iterable<ServiceDefinition<S>
     }
 
     /**
+     * Collects all initialized instances.
+     *
+     * @return The instances of this service.
+     */
+    public List<S> collectAll() {
+        return collectAll((Predicate<S>) null);
+    }
+
+    /**
+     * Collects all initialized instances.
+     *
+     * @param predicate The predicated to filter the instances or null if not needed.
+     * @return The instances of this service.
+     */
+    public List<S> collectAll(Predicate<S> predicate) {
+        List<S> values = new ArrayList<>();
+        collectAll(values, predicate);
+        return values;
+    }
+
+    /**
      * @return The iterator
      */
     @Override
     @NonNull
     public Iterator<ServiceDefinition<S>> iterator() {
-        return new Iterator<ServiceDefinition<S>>() {
-            final Iterator<ServiceDefinition<S>> loaded = loadedServices.values().iterator();
-
-            @Override
-            public boolean hasNext() {
-                if (loaded.hasNext()) {
-                    return true;
-                }
-                return unloadedServices.hasNext();
+        if (servicesForIterator == null) {
+            if (STATIC_SERVICES.containsKey(serviceType.getName())) {
+                @SuppressWarnings("unchecked")
+                StaticServiceLoader<S> staticServiceLoader = (StaticServiceLoader<S>) STATIC_SERVICES.get(serviceType.getName());
+                this.servicesForIterator = staticServiceLoader.findAll(s -> condition == null || condition.test(s.getClass().getName()))
+                    .collect(Collectors.toList());
+            } else {
+                List<ServiceDefinition<S>> serviceDefinitions = new ArrayList<>();
+                newCollector(serviceType.getName(), condition, classLoader, name -> {
+                    try {
+                        @SuppressWarnings("unchecked")
+                        final Class<S> loadedClass = (Class<S>) Class.forName(name, false, classLoader);
+                        return createService(name, loadedClass);
+                    } catch (NoClassDefFoundError | ClassNotFoundException e) {
+                        return createService(name, null);
+                    }
+                }).collect(serviceDefinitions, false);
+                this.servicesForIterator = serviceDefinitions;
             }
+        }
 
-            @Override
-            public ServiceDefinition<S> next() {
-                if (!hasNext()) {
-                    throw new NoSuchElementException();
-                }
-
-                if (loaded.hasNext()) {
-                    return loaded.next();
-                }
-                if (unloadedServices.hasNext()) {
-                    ServiceDefinition<S> nextService = unloadedServices.next();
-                    loadedServices.put(nextService.getName(), nextService);
-                    return nextService;
-                }
-                // should not happen
-                throw new ServiceConfigurationError("Bug in iterator");
-            }
-        };
+        return servicesForIterator.iterator();
     }
 
     /**
@@ -271,25 +284,11 @@ public final class SoftServiceLoader<S> implements Iterable<ServiceDefinition<S>
         return new DefaultServiceDefinition<>(name, loadedClass);
     }
 
-    @SuppressWarnings("java:S3398")
-    private static Set<String> computeServiceTypeNames(URI uri, String path) {
-        Set<String> typeNames = new HashSet<>();
-        IOUtils.eachFile(
-                uri, path, currentPath -> {
-                    if (Files.isRegularFile(currentPath)) {
-                        final String typeName = currentPath.getFileName().toString();
-                        typeNames.add(typeName);
-                    }
-                }
-        );
-        return typeNames;
-    }
-
     public static <S> ServiceCollector<S> newCollector(String serviceName,
                                                        Predicate<String> lineCondition,
                                                        ClassLoader classLoader,
                                                        Function<String, S> transformer) {
-        return new DefaultServiceCollector<>(serviceName, lineCondition, classLoader, transformer);
+        return new ServiceScanner<>(classLoader, serviceName, lineCondition, transformer).new DefaultServiceCollector();
     }
 
     /**
@@ -342,105 +341,6 @@ public final class SoftServiceLoader<S> implements Iterable<ServiceDefinition<S>
         }
     }
 
-    private final class StaticServicesLoaderIterator implements Iterator<ServiceDefinition<S>> {
-
-        Iterator<StaticDefinition<S>> iterator;
-
-        @SuppressWarnings("unchecked")
-        private void ensureIterator() {
-            if (iterator == null) {
-                StaticServiceLoader<S> staticServiceLoader = (StaticServiceLoader<S>) STATIC_SERVICES.get(serviceType.getName());
-                iterator = staticServiceLoader.findAll(s -> condition == null || condition.test(s.getClass().getName()))
-                        .iterator();
-            }
-        }
-
-        @Override
-        public boolean hasNext() {
-            ensureIterator();
-            return iterator.hasNext();
-        }
-
-        @Override
-        public ServiceDefinition<S> next() {
-            ensureIterator();
-            if (!hasNext()) {
-                throw new NoSuchElementException();
-            }
-            return iterator.next();
-        }
-    }
-
-    /**
-     * A service loader iterator implementation.
-     */
-    private final class ServiceLoaderIterator implements Iterator<ServiceDefinition<S>> {
-        private Enumeration<URL> serviceConfigs = null;
-        private Iterator<String> unprocessed = null;
-
-        @Override
-        @SuppressWarnings({"java:S3776", "java:S135"})
-        public boolean hasNext() {
-
-            if (serviceConfigs == null) {
-                String name = serviceType.getName();
-                try {
-                    serviceConfigs = classLoader.getResources(META_INF_SERVICES + '/' + name);
-                } catch (IOException e) {
-                    throw new ServiceConfigurationError("Failed to load resources for service: " + name, e);
-                }
-            }
-            while (unprocessed == null || !unprocessed.hasNext()) {
-                if (!serviceConfigs.hasMoreElements()) {
-                    return false;
-                }
-                URL url = serviceConfigs.nextElement();
-                try {
-                    try (BufferedReader reader = new BufferedReader(new InputStreamReader(url.openStream()))) {
-                        List<String> lines = new LinkedList<>();
-                        while (true) {
-                            String line = reader.readLine();
-                            if (line == null) {
-                                break;
-                            }
-                            if (line.length() == 0 || line.charAt(0) == '#') {
-                                continue;
-                            }
-                            if (!condition.test(line)) {
-                                continue;
-                            }
-                            int i = line.indexOf('#');
-                            if (i > -1) {
-                                line = line.substring(0, i);
-                            }
-                            lines.add(line);
-                        }
-                        unprocessed = lines.iterator();
-                    }
-                } catch (IOException | UncheckedIOException e) {
-                    // ignore, can't do anything here and can't log because class used in compiler
-                }
-            }
-            return unprocessed.hasNext();
-        }
-
-        @Override
-        public ServiceDefinition<S> next() {
-            if (!hasNext()) {
-                throw new NoSuchElementException();
-            }
-
-            String nextName = unprocessed.next();
-            try {
-                @SuppressWarnings("unchecked")
-                final Class<S> loadedClass = (Class<S>) Class.forName(nextName, false, classLoader);
-                return createService(nextName, loadedClass);
-            } catch (NoClassDefFoundError | ClassNotFoundException e) {
-                return createService(nextName, null);
-            }
-        }
-    }
-
     /**
      * Service collector for loading services of the given type.
      *
@@ -448,6 +348,10 @@ public final class SoftServiceLoader<S> implements Iterable<ServiceDefinition<S>
      */
     public interface ServiceCollector<S> {
         void collect(Collection<S> values);
+
+        default void collect(Collection<S> values, boolean allowFork) {
+            collect(values);
+        }
 
         default void collect(Consumer<? super S> consumer) {
             List<S> values = new ArrayList<>();
@@ -458,228 +362,6 @@ public final class SoftServiceLoader<S> implements Iterable<ServiceDefinition<S>
                 }
             });
         }
-    }
-
-    /**
-     * Fork-join recursive services loader.
-     *
-     * @param <S> The type
-     */
-    @SuppressWarnings("java:S1948")
-    private static class DefaultServiceCollector<S> extends RecursiveActionValuesCollector<S> implements ServiceCollector<S> {
-
-        private final String serviceName;
-        private final Predicate<String> lineCondition;
-        private final ClassLoader classLoader;
-        private final Function<String, S> transformer;
-        private final List<RecursiveActionValuesCollector<S>> tasks = new LinkedList<>();
-
-        public DefaultServiceCollector(String serviceName, Predicate<String> lineCondition, ClassLoader classLoader, Function<String, S> transformer) {
-            this.serviceName = serviceName;
-            this.lineCondition = lineCondition;
-            this.classLoader = classLoader;
-            this.transformer = transformer;
-        }
-
-        private static URI normalizeFilePath(String path, URI uri) {
-            Path p = Paths.get(uri);
-            if (p.endsWith(path)) {
-                Path subpath = Paths.get(path);
-                for (int i = 0; i < subpath.getNameCount(); i++) {
-                     p = p.getParent();
-                }
-                uri = p.toUri();
-            }
-            return uri;
-        }
-
-        @Override
-        protected void compute() {
-            try {
-                Enumeration<URL> serviceConfigs = classLoader.getResources(META_INF_SERVICES + '/' + serviceName);
-                while (serviceConfigs.hasMoreElements()) {
-                    URL url = serviceConfigs.nextElement();
-                    UrlServicesLoader<S> task = new UrlServicesLoader<>(url, lineCondition, transformer);
-                    tasks.add(task);
-                    task.fork();
-                }
-                final String path = "META-INF/micronaut/" + serviceName;
-                final Enumeration<URL> micronautResources = classLoader.getResources(path);
-                Set<URI> uniqueURIs = new LinkedHashSet<>();
-                while (micronautResources.hasMoreElements()) {
-                    URL url = micronautResources.nextElement();
-                    final URI uri = url.toURI();
-                    uniqueURIs.add(uri);
-                }
-
-                for (URI uri : uniqueURIs) {
-                    String scheme = uri.getScheme();
-                    if ("file".equals(scheme)) {
-                        uri = normalizeFilePath(path, uri);
-                    }
-                    // on GraalVM there are spurious extra resources that end with # and then a number
-                    // we ignore this extra ones
-                    if (!("resource".equals(scheme) && uri.toString().contains("#"))) {
-                        final MicronautMetaServicesLoader<S> task = new MicronautMetaServicesLoader<>(uri, path, transformer);
-                        tasks.add(task);
-                        task.fork();
-                    }
-                }
-            } catch (IOException | URISyntaxException e) {
-                throw new ServiceConfigurationError("Failed to load resources for service: " + serviceName, e);
-            }
-        }
-
-        public void collect(Collection<S> values) {
-            ForkJoinPool.commonPool().invoke(this);
-            for (RecursiveActionValuesCollector<S> task : tasks) {
-                task.join();
-                task.collect(values);
-            }
-        }
-    }
-
-    private static final class MicronautMetaServicesLoader<S> extends RecursiveActionValuesCollector<S> {
-        private final URI uri;
-        private final transient Function<String, S> transformer;
-        private final List<ServiceInstanceLoader<S>> tasks = new LinkedList<>();
-        private final String path;
-
-        private MicronautMetaServicesLoader(URI uri, String path, Function<String, S> transformer) {
-            this.uri = uri;
-            this.path = path;
-            this.transformer = transformer;
-        }
-
-        @Override
-        public void collect(Collection<S> values) {
-            for (ServiceInstanceLoader<S> task : tasks) {
-                task.join();
-                task.collect(values);
-            }
-        }
-
-        @Override
-        @SuppressWarnings("java:S2095")
-        protected void compute() {
-            Set<String> typeNames = computeServiceTypeNames(uri, path);
-            for (String typeName : typeNames) {
-                ServiceInstanceLoader<S> task = new ServiceInstanceLoader<>(typeName, transformer);
-                tasks.add(task);
-                task.fork();
-            }
-        }
-    }
-
-    /**
-     * Reads URL, parses the file and produces sub tasks to initialize the entry.
-     *
-     * @param <S> The type
-     */
-    @SuppressWarnings("java:S1948")
-    private static final class UrlServicesLoader<S> extends RecursiveActionValuesCollector<S> {
-
-        private final URL url;
-        private final Predicate<String> lineCondition;
-        private final Function<String, S> transformer;
-        private final List<ServiceInstanceLoader<S>> tasks = new LinkedList<>();
-
-        public UrlServicesLoader(URL url, Predicate<String> lineCondition, Function<String, S> transformer) {
-            this.url = url;
-            this.lineCondition = lineCondition;
-            this.transformer = transformer;
-        }
-
-        @Override
-        @SuppressWarnings({"java:S3776", "java:S135"})
-        protected void compute() {
-            try {
-                try (BufferedReader reader = new BufferedReader(new InputStreamReader(url.openStream()))) {
-                    while (true) {
-                        String line = reader.readLine();
-                        if (line == null) {
-                            break;
-                        }
-                        if (line.length() == 0 || line.charAt(0) == '#') {
-                            continue;
-                        }
-                        if (!lineCondition.test(line)) {
-                            continue;
-                        }
-                        int i = line.indexOf('#');
-                        if (i > -1) {
-                            line = line.substring(0, i);
-                        }
-                        ServiceInstanceLoader<S> task = new ServiceInstanceLoader<>(line, transformer);
-                        tasks.add(task);
-                        task.fork();
-                    }
-                }
-            } catch (IOException | UncheckedIOException e) {
-                // ignore, can't do anything here and can't log because class used in compiler
-            }
-        }
-
-        public void collect(Collection<S> values) {
-            for (ServiceInstanceLoader<S> task : tasks) {
-                task.join();
-                task.collect(values);
-            }
-        }
-
-    }
-
-    /**
-     * Initializes and filters the entry.
-     *
-     * @param <S> The type
-     */
-    @SuppressWarnings("java:S1948")
-    private static final class ServiceInstanceLoader<S> extends RecursiveActionValuesCollector<S> {
-
-        private final String className;
-        private final Function<String, S> transformer;
-        private S result;
-        private Throwable throwable;
-
-        public ServiceInstanceLoader(String className, Function<String, S> transformer) {
-            this.className = className;
-            this.transformer = transformer;
-        }
-
-        @Override
-        protected void compute() {
-            try {
-                result = transformer.apply(className);
-            } catch (Throwable e) {
-                throwable = e;
-            }
-        }
-
-        public void collect(Collection<S> values) {
-            if (throwable != null) {
-                throw new ServiceLoadingException("Failed to load a service: " + throwable.getMessage(), throwable);
-            }
-            if (result != null && !values.contains(result)) {
-                values.add(result);
-            }
-        }
-    }
-
-    /**
-     * Abstract recursive action class.
-     *
-     * @param <S> The type
-     */
-    private abstract static class RecursiveActionValuesCollector<S> extends RecursiveAction {
-
-        /**
-         * Collects loaded values.
-         *
-         * @param values The values
-         */
-        public abstract void collect(Collection<S> values);
-
     }
 
     /**
@@ -721,7 +403,7 @@ public final class SoftServiceLoader<S> implements Iterable<ServiceDefinition<S>
     /**
      * Exception thrown when a service cannot be loaded.
      */
-    private static class ServiceLoadingException extends RuntimeException {
+    final static class ServiceLoadingException extends RuntimeException {
         public ServiceLoadingException(String message, Throwable cause) {
             super(message, cause);
         }

--- a/core/src/main/java/io/micronaut/core/io/service/SoftServiceLoader.java
+++ b/core/src/main/java/io/micronaut/core/io/service/SoftServiceLoader.java
@@ -403,7 +403,7 @@ public final class SoftServiceLoader<S> implements Iterable<ServiceDefinition<S>
     /**
      * Exception thrown when a service cannot be loaded.
      */
-    final static class ServiceLoadingException extends RuntimeException {
+    static final class ServiceLoadingException extends RuntimeException {
         public ServiceLoadingException(String message, Throwable cause) {
             super(message, cause);
         }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/AccessLogFormatParser.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/AccessLogFormatParser.java
@@ -15,7 +15,6 @@
  */
 package io.micronaut.http.server.netty.handler.accesslog.element;
 
-import io.micronaut.core.io.service.ServiceDefinition;
 import io.micronaut.core.io.service.SoftServiceLoader;
 import io.micronaut.core.order.OrderUtil;
 import io.netty.channel.ChannelHandlerContext;
@@ -95,13 +94,10 @@ public class AccessLogFormatParser {
     private String[] elements;
 
     static {
-        SoftServiceLoader<LogElementBuilder> builders = SoftServiceLoader.load(LogElementBuilder.class, LogElementBuilder.class.getClassLoader());
+        SoftServiceLoader<LogElementBuilder> builders = SoftServiceLoader.load(LogElementBuilder.class, LogElementBuilder.class.getClassLoader())
+            .disableFork();
         LOG_ELEMENT_BUILDERS = new ArrayList<>();
-        for (ServiceDefinition<LogElementBuilder> definition : builders) {
-            if (definition.isPresent()) {
-                LOG_ELEMENT_BUILDERS.add(definition.load());
-            }
-        }
+        builders.collectAll(LOG_ELEMENT_BUILDERS);
         OrderUtil.sort(LOG_ELEMENT_BUILDERS);
         trimToSize(LOG_ELEMENT_BUILDERS);
     }

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/annotation/GroovyAnnotationMetadataBuilder.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/annotation/GroovyAnnotationMetadataBuilder.java
@@ -26,7 +26,6 @@ import io.micronaut.ast.groovy.visitor.GroovyVisitorContext;
 import io.micronaut.core.annotation.AnnotationClassValue;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.convert.ConversionService;
-import io.micronaut.core.io.service.ServiceDefinition;
 import io.micronaut.core.io.service.SoftServiceLoader;
 import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.core.reflect.ReflectionUtils;
@@ -100,18 +99,8 @@ public class GroovyAnnotationMetadataBuilder extends AbstractAnnotationMetadataB
                 if (validator instanceof AnnotatedElementValidator) {
                     elementValidator = (AnnotatedElementValidator) validator;
                 } else {
-                    final SoftServiceLoader<AnnotatedElementValidator> validators = SoftServiceLoader.load(AnnotatedElementValidator.class);
-                    final Iterator<ServiceDefinition<AnnotatedElementValidator>> i = validators.iterator();
-                    AnnotatedElementValidator elementValidator = null;
-                    while (i.hasNext()) {
-                        final ServiceDefinition<AnnotatedElementValidator> v = i.next();
-                        if (v.isPresent()) {
-                            elementValidator = v.load();
-                            break;
-                        }
-                    }
-                    this.elementValidator = elementValidator;
-                    ast.putNodeMetaData(VALIDATOR_KEY, elementValidator);
+                    this.elementValidator = SoftServiceLoader.load(AnnotatedElementValidator.class).firstAvailable().orElse(null);
+                    ast.putNodeMetaData(VALIDATOR_KEY, this.elementValidator);
                 }
             } else {
                 this.elementValidator = null;

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/AnnotationUtils.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/AnnotationUtils.java
@@ -21,7 +21,6 @@ import io.micronaut.core.annotation.AnnotationUtil;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.convert.value.MutableConvertibleValues;
 import io.micronaut.core.convert.value.MutableConvertibleValuesMap;
-import io.micronaut.core.io.service.ServiceDefinition;
 import io.micronaut.core.io.service.SoftServiceLoader;
 import io.micronaut.core.util.clhm.ConcurrentLinkedHashMap;
 import io.micronaut.inject.annotation.AnnotatedElementValidator;
@@ -95,22 +94,8 @@ public class AnnotationUtils {
         this.filer = filer;
         this.visitorAttributes = visitorAttributes;
         this.processingEnv = processingEnv;
-        final SoftServiceLoader<AnnotatedElementValidator> validators = SoftServiceLoader.load(AnnotatedElementValidator.class);
-        final Iterator<ServiceDefinition<AnnotatedElementValidator>> i = validators.iterator();
-        AnnotatedElementValidator elementValidator = null;
-        while (i.hasNext()) {
-            final ServiceDefinition<AnnotatedElementValidator> validator = i.next();
-            if (validator.isPresent()) {
-                try {
-                    elementValidator = validator.load();
-                } catch (Throwable e) {
-                    // probably missing required dependencies to load the validator
-                }
-                break;
-            }
-        }
+        this.elementValidator = SoftServiceLoader.load(AnnotatedElementValidator.class).firstAvailable().orElse(null);
         this.javaAnnotationMetadataBuilder = newAnnotationBuilder();
-        this.elementValidator = elementValidator;
     }
 
     /**

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
@@ -22,7 +22,6 @@ import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Generated;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.Nullable;
-import io.micronaut.core.io.service.ServiceDefinition;
 import io.micronaut.core.io.service.SoftServiceLoader;
 import io.micronaut.core.order.OrderUtil;
 import io.micronaut.core.util.CollectionUtils;
@@ -68,7 +67,7 @@ import static javax.lang.model.element.ElementKind.FIELD;
         VisitorContext.MICRONAUT_PROCESSING_MODULE
 })
 public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcessor {
-    private static final SoftServiceLoader<TypeElementVisitor> SERVICE_LOADER = SoftServiceLoader.load(TypeElementVisitor.class, TypeElementVisitorProcessor.class.getClassLoader());
+    private static final SoftServiceLoader<TypeElementVisitor> SERVICE_LOADER = SoftServiceLoader.load(TypeElementVisitor.class, TypeElementVisitorProcessor.class.getClassLoader()).disableFork();
     private static final Set<String> VISITOR_WARNINGS;
     private static final Set<String> SUPPORTED_ANNOTATION_NAMES;
 
@@ -76,7 +75,7 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
 
         final HashSet<String> warnings = new HashSet<>();
         Set<String> names = new HashSet<>();
-        for (TypeElementVisitor<?, ?> typeElementVisitor : findCoreTypeElementVisitors(SERVICE_LOADER, warnings)) {
+        for (TypeElementVisitor<?, ?> typeElementVisitor : findCoreTypeElementVisitors(warnings)) {
             final Set<String> supportedAnnotationNames;
             try {
                 supportedAnnotationNames = typeElementVisitor.getSupportedAnnotationNames();
@@ -304,7 +303,7 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
         for (String visitorWarning : VISITOR_WARNINGS) {
             warning(visitorWarning);
         }
-        return findCoreTypeElementVisitors(SERVICE_LOADER, null);
+        return findCoreTypeElementVisitors(null);
     }
 
     /**
@@ -321,47 +320,31 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
 
     private static @NonNull
     Collection<TypeElementVisitor> findCoreTypeElementVisitors(
-            SoftServiceLoader<TypeElementVisitor> serviceLoader,
             @Nullable Set<String> warnings) {
-        Map<String, TypeElementVisitor> typeElementVisitors = new HashMap<>(10);
+        return SERVICE_LOADER.collectAll(visitor -> {
+            if (!visitor.isEnabled()) {
+                return false;
+            }
 
-        for (ServiceDefinition<TypeElementVisitor> definition : SERVICE_LOADER) {
-            if (definition.isPresent()) {
-                TypeElementVisitor visitor;
-                try {
-                    visitor = definition.load();
-                } catch (Throwable e) {
-                    if (warnings != null) {
-                        warnings.add("TypeElementVisitor [" + definition.getName() + "] will be ignored due to loading error: " + e.getMessage());
-                    }
-                    continue;
-                }
-                if (visitor == null || !visitor.isEnabled()) {
-                    continue;
-                }
-
-                final Requires requires = visitor.getClass().getAnnotation(Requires.class);
-                if (requires != null) {
-                    final Requires.Sdk sdk = requires.sdk();
-                    if (sdk == Requires.Sdk.MICRONAUT) {
-                        final String version = requires.version();
-                        if (StringUtils.isNotEmpty(version) && !VersionUtils.isAtLeastMicronautVersion(version)) {
-                            try {
-                                if (warnings != null) {
-                                    warnings.add("TypeElementVisitor [" + definition.getName() + "] will be ignored because Micronaut version [" + VersionUtils.MICRONAUT_VERSION + "] must be at least " + version);
-                                }
-                                continue;
-                            } catch (IllegalArgumentException e) {
-                                // shouldn't happen, thrown when invalid version encountered
+            final Requires requires = visitor.getClass().getAnnotation(Requires.class);
+            if (requires != null) {
+                final Requires.Sdk sdk = requires.sdk();
+                if (sdk == Requires.Sdk.MICRONAUT) {
+                    final String version = requires.version();
+                    if (StringUtils.isNotEmpty(version) && !VersionUtils.isAtLeastMicronautVersion(version)) {
+                        try {
+                            if (warnings != null) {
+                                warnings.add("TypeElementVisitor [" + visitor.getClass().getName() + "] will be ignored because Micronaut version [" + VersionUtils.MICRONAUT_VERSION + "] must be at least " + version);
                             }
+                            return false;
+                        } catch (IllegalArgumentException e) {
+                            // shouldn't happen, thrown when invalid version encountered
                         }
                     }
                 }
-
-                typeElementVisitors.put(definition.getName(), visitor);
             }
-        }
-        return typeElementVisitors.values();
+            return true;
+        });
     }
 
     /**

--- a/inject-java/src/test/groovy/io/micronaut/core/io/service/SoftServiceLoaderSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/core/io/service/SoftServiceLoaderSpec.groovy
@@ -1,0 +1,15 @@
+package io.micronaut.core.io.service
+
+import io.micronaut.core.beans.BeanIntrospectionReference
+import spock.lang.Specification
+
+class SoftServiceLoaderSpec extends Specification {
+    def 'bean references show up in iterator'() {
+        given:
+        def loader = SoftServiceLoader.load(BeanIntrospectionReference)
+        def iterator = loader.iterator()
+
+        expect:
+        iterator.hasNext()
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
+++ b/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
@@ -586,8 +586,7 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
     @SuppressWarnings("MagicNumber")
     private Collection<PropertySourceLoader> evaluatePropertySourceLoaders() {
         SoftServiceLoader<PropertySourceLoader> definitions = readPropertySourceLoaders();
-        Collection<PropertySourceLoader> allLoaders = new ArrayList<>(10);
-        definitions.collectAll(allLoaders);
+        Collection<PropertySourceLoader> allLoaders = definitions.collectAll();
         for (PropertySourceLoader propertySourceLoader : allLoaders) {
             Set<String> extensions = propertySourceLoader.getExtensions();
             for (String extension : extensions) {

--- a/inject/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -17,7 +17,6 @@ package io.micronaut.inject.annotation;
 
 import io.micronaut.context.annotation.*;
 import io.micronaut.core.annotation.*;
-import io.micronaut.core.io.service.ServiceDefinition;
 import io.micronaut.core.io.service.SoftServiceLoader;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.util.CollectionUtils;
@@ -63,61 +62,49 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
     private static final Map<String, Map<String, Object>> ANNOTATION_DEFAULTS = new HashMap<>(20);
 
     static {
-        SoftServiceLoader<AnnotationMapper> serviceLoader = SoftServiceLoader.load(AnnotationMapper.class,
-                                                                                   AbstractAnnotationMetadataBuilder.class.getClassLoader());
-        for (ServiceDefinition<AnnotationMapper> definition : serviceLoader) {
-            if (definition.isPresent()) {
-                AnnotationMapper mapper = definition.load();
-                try {
-                    String name = null;
-                    if (mapper instanceof TypedAnnotationMapper) {
-                        name = ((TypedAnnotationMapper) mapper).annotationType().getName();
-                    } else if (mapper instanceof NamedAnnotationMapper) {
-                        name = ((NamedAnnotationMapper) mapper).getName();
-                    }
-                    if (StringUtils.isNotEmpty(name)) {
-                        ANNOTATION_MAPPERS.computeIfAbsent(name, s -> new ArrayList<>(2)).add(mapper);
-                    }
-                } catch (Throwable e) {
-                    // mapper, missing dependencies, continue
+        for (AnnotationMapper mapper : SoftServiceLoader.load(AnnotationMapper.class, AbstractAnnotationMetadataBuilder.class.getClassLoader())
+            .disableFork().collectAll()) {
+            try {
+                String name = null;
+                if (mapper instanceof TypedAnnotationMapper) {
+                    name = ((TypedAnnotationMapper) mapper).annotationType().getName();
+                } else if (mapper instanceof NamedAnnotationMapper) {
+                    name = ((NamedAnnotationMapper) mapper).getName();
                 }
+                if (StringUtils.isNotEmpty(name)) {
+                    ANNOTATION_MAPPERS.computeIfAbsent(name, s -> new ArrayList<>(2)).add(mapper);
+                }
+            } catch (Throwable e) {
+                // mapper, missing dependencies, continue
             }
         }
 
-        SoftServiceLoader<AnnotationTransformer> transformerSoftServiceLoader =
-                SoftServiceLoader.load(AnnotationTransformer.class, AbstractAnnotationMetadataBuilder.class.getClassLoader());
-        for (ServiceDefinition<AnnotationTransformer> definition : transformerSoftServiceLoader) {
-            if (definition.isPresent()) {
-                AnnotationTransformer transformer = definition.load();
-                try {
-                    String name = null;
-                    if (transformer instanceof TypedAnnotationTransformer) {
-                        name = ((TypedAnnotationTransformer) transformer).annotationType().getName();
-                    } else if (transformer instanceof NamedAnnotationTransformer) {
-                        name = ((NamedAnnotationTransformer) transformer).getName();
-                    }
-                    if (StringUtils.isNotEmpty(name)) {
-                        ANNOTATION_TRANSFORMERS.computeIfAbsent(name, s -> new ArrayList<>(2)).add(transformer);
-                    }
-                } catch (Throwable e) {
-                    // mapper, missing dependencies, continue
+        for (AnnotationTransformer transformer : SoftServiceLoader.load(AnnotationTransformer.class, AbstractAnnotationMetadataBuilder.class.getClassLoader())
+            .disableFork().collectAll()) {
+            try {
+                String name = null;
+                if (transformer instanceof TypedAnnotationTransformer) {
+                    name = ((TypedAnnotationTransformer) transformer).annotationType().getName();
+                } else if (transformer instanceof NamedAnnotationTransformer) {
+                    name = ((NamedAnnotationTransformer) transformer).getName();
                 }
+                if (StringUtils.isNotEmpty(name)) {
+                    ANNOTATION_TRANSFORMERS.computeIfAbsent(name, s -> new ArrayList<>(2)).add(transformer);
+                }
+            } catch (Throwable e) {
+                // mapper, missing dependencies, continue
             }
         }
 
-        SoftServiceLoader<AnnotationRemapper> remapperLoader = SoftServiceLoader.load(AnnotationRemapper.class,
-                                                                                      AbstractAnnotationMetadataBuilder.class.getClassLoader());
-        for (ServiceDefinition<AnnotationRemapper> definition : remapperLoader) {
-            if (definition.isPresent()) {
-                AnnotationRemapper mapper = definition.load();
-                try {
-                    String name = mapper.getPackageName();
-                    if (StringUtils.isNotEmpty(name)) {
-                        ANNOTATION_REMAPPERS.computeIfAbsent(name, s -> new ArrayList<>(2)).add(mapper);
-                    }
-                } catch (Throwable e) {
-                    // mapper, missing dependencies, continue
+        for (AnnotationRemapper mapper : SoftServiceLoader.load(AnnotationRemapper.class, AbstractAnnotationMetadataBuilder.class.getClassLoader())
+            .disableFork().collectAll()) {
+            try {
+                String name = mapper.getPackageName();
+                if (StringUtils.isNotEmpty(name)) {
+                    ANNOTATION_REMAPPERS.computeIfAbsent(name, s -> new ArrayList<>(2)).add(mapper);
                 }
+            } catch (Throwable e) {
+                // mapper, missing dependencies, continue
             }
         }
     }

--- a/inject/src/main/java/io/micronaut/inject/visitor/BeanElementVisitorLoader.java
+++ b/inject/src/main/java/io/micronaut/inject/visitor/BeanElementVisitorLoader.java
@@ -15,12 +15,10 @@
  */
 package io.micronaut.inject.visitor;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.io.service.ServiceDefinition;
 import io.micronaut.core.io.service.SoftServiceLoader;
 import io.micronaut.core.order.OrderUtil;
 
@@ -34,21 +32,11 @@ final class BeanElementVisitorLoader {
     /**
      * @return The loaded visitors
      */
+    @SuppressWarnings("unchecked")
     static @NonNull List<BeanElementVisitor<?>> load() {
-        List<BeanElementVisitor<?>> visitors = new ArrayList<>(10);
-        final SoftServiceLoader<BeanElementVisitor> serviceLoader = SoftServiceLoader.load(BeanElementVisitor.class);
-        for (ServiceDefinition<BeanElementVisitor> definition : serviceLoader) {
-            if (definition.isPresent()) {
-                try {
-                    final BeanElementVisitor<?> visitor = definition.load();
-                    if (visitor.isEnabled()) {
-                        visitors.add(visitor);
-                    }
-                } catch (Exception e) {
-                    // ignore and skip
-                }
-            }
-        }
+        List<? extends BeanElementVisitor<?>> visitors = (List) SoftServiceLoader.load(BeanElementVisitor.class)
+            .disableFork()
+            .collectAll(BeanElementVisitor::isEnabled);
 
         if (visitors.isEmpty()) {
             return Collections.emptyList();


### PR DESCRIPTION
The new directory-based service discovery introduced by #7195 was implemented for ServiceCollector, but not for the old SoftServiceLoader.iterator method.

On a high level, this patch makes the iterator use the same collector logic as collectAll. Unfortunately, this revealed an issue with the fork-join approach: the service loader is often used in a static initializer, but multithreading is problematic there (can lead to class initialization deadlocks).

To avoid this issue, I made the multithreading opt-out, and refactored the RecursiveActions to facilitate optional single-threaded operation.

It may be better to make the multithreading opt-in instead, since using the service loader in a static initializer seems to be the norm, not the exception.

I also refactored various use sites of the SoftServiceLoader to use higher-level methods like collectAll and first.

Fixes #7594