### PR TITLE
Save service id alongside http client exceptions

### DIFF
--- a/http-client-core/src/main/java/io/micronaut/http/client/HttpClient.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/HttpClient.java
@@ -153,6 +153,7 @@ public interface HttpClient extends Closeable, LifeCycle<HttpClient> {
      * @return A {@link Publisher} that emits a result of the given type
      */
     default <I, O, E> Publisher<O> retrieve(@NonNull HttpRequest<I> request, @NonNull Argument<O> bodyType, @NonNull Argument<E> errorType) {
+        // note: this default impl isn't used by us anymore, it's overridden by DefaultHttpClient
         return Flux.from(exchange(request, bodyType, errorType)).map(response -> {
             if (bodyType.getType() == HttpStatus.class) {
                 return (O) response.getStatus();

--- a/http-client-core/src/main/java/io/micronaut/http/client/exceptions/HttpClientException.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/exceptions/HttpClientException.java
@@ -24,6 +24,8 @@ import io.micronaut.http.exceptions.HttpException;
  * @since 1.0
  */
 public class HttpClientException extends HttpException {
+    private String serviceId;
+    private boolean serviceIdLocked;
 
     /**
      * @param message The message
@@ -50,5 +52,26 @@ public class HttpClientException extends HttpException {
         if (!shared) {
             throw new IllegalArgumentException("shared must be true");
         }
+        serviceIdLocked = true;
+    }
+
+    public final String getServiceId() {
+        return serviceId;
+    }
+
+    public final void setServiceId(String serviceId) {
+        if (serviceIdLocked) {
+            throw new IllegalStateException("Service ID already set");
+        }
+        this.serviceId = serviceId;
+        serviceIdLocked = true;
+    }
+
+    @Override
+    public String getMessage() {
+        if (serviceId != null) {
+            return "Client '" + serviceId + "': " + super.getMessage();
+        }
+        return super.getMessage();
     }
 }

--- a/http-client-core/src/main/java/io/micronaut/http/client/exceptions/HttpClientException.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/exceptions/HttpClientException.java
@@ -16,6 +16,7 @@
 package io.micronaut.http.client.exceptions;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.exceptions.HttpException;
 
 /**
@@ -61,6 +62,7 @@ public class HttpClientException extends HttpException {
      *
      * @return The service ID of the client
      */
+    @Nullable
     public final String getServiceId() {
         return serviceId;
     }

--- a/http-client-core/src/main/java/io/micronaut/http/client/exceptions/HttpClientException.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/exceptions/HttpClientException.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.http.client.exceptions;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.http.exceptions.HttpException;
 
 /**
@@ -55,10 +56,23 @@ public class HttpClientException extends HttpException {
         serviceIdLocked = true;
     }
 
+    /**
+     * Get the service ID of the http client that produced this exception.
+     *
+     * @return The service ID of the client
+     */
     public final String getServiceId() {
         return serviceId;
     }
 
+    /**
+     * Set the service id that produced this exception.
+     *
+     * @param serviceId The service id
+     * @throws IllegalStateException If the service ID has already been set, or this is a shared
+     *                               exception (e.g. {@link ReadTimeoutException}).
+     */
+    @Internal
     public final void setServiceId(String serviceId) {
         if (serviceIdLocked) {
             throw new IllegalStateException("Service ID already set");

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -51,6 +51,7 @@ import io.micronaut.http.client.HttpClientConfiguration;
 import io.micronaut.http.client.LoadBalancer;
 import io.micronaut.http.client.ProxyHttpClient;
 import io.micronaut.http.client.ProxyRequestOptions;
+import io.micronaut.http.client.ServiceHttpClientConfiguration;
 import io.micronaut.http.client.StreamingHttpClient;
 import io.micronaut.http.client.exceptions.ContentLengthExceededException;
 import io.micronaut.http.client.exceptions.HttpClientErrorDecoder;
@@ -275,6 +276,7 @@ public class DefaultHttpClient implements
     private final RequestBinderRegistry requestBinderRegistry;
     private final Collection<ChannelPipelineListener> pipelineListeners;
     private final List<InvocationInstrumenterFactory> invocationInstrumenterFactories;
+    private final String informationalServiceId;
 
     /**
      * Construct a client for the given arguments.
@@ -298,7 +300,7 @@ public class DefaultHttpClient implements
             @Nullable AnnotationMetadataResolver annotationMetadataResolver,
             List<InvocationInstrumenterFactory> invocationInstrumenterFactories,
             HttpClientFilter... filters) {
-        this(loadBalancer, configuration.getHttpVersion(), configuration, contextPath, new DefaultHttpClientFilterResolver(annotationMetadataResolver, Arrays.asList(filters)), null, threadFactory, nettyClientSslBuilder, codecRegistry, WebSocketBeanRegistry.EMPTY, new DefaultRequestBinderRegistry(ConversionService.SHARED), null, NioSocketChannel::new, Collections.emptySet(), invocationInstrumenterFactories);
+        this(loadBalancer, configuration.getHttpVersion(), configuration, contextPath, new DefaultHttpClientFilterResolver(annotationMetadataResolver, Arrays.asList(filters)), null, threadFactory, nettyClientSslBuilder, codecRegistry, WebSocketBeanRegistry.EMPTY, new DefaultRequestBinderRegistry(ConversionService.SHARED), null, NioSocketChannel::new, Collections.emptySet(), invocationInstrumenterFactories, null);
     }
 
     /**
@@ -318,6 +320,7 @@ public class DefaultHttpClient implements
      * @param socketChannelFactory            The socket channel factory
      * @param pipelineListeners               The listeners to call for pipeline customization
      * @param invocationInstrumenterFactories The invocation instrumeter factories to instrument netty handlers execution with
+     * @param informationalServiceId          Optional service ID that will be passed to exceptions created by this client
      */
     public DefaultHttpClient(@Nullable LoadBalancer loadBalancer,
                              @Nullable io.micronaut.http.HttpVersion httpVersion,
@@ -333,7 +336,8 @@ public class DefaultHttpClient implements
                              @Nullable EventLoopGroup eventLoopGroup,
                              @NonNull ChannelFactory socketChannelFactory,
                              Collection<ChannelPipelineListener> pipelineListeners,
-                             List<InvocationInstrumenterFactory> invocationInstrumenterFactories
+                             List<InvocationInstrumenterFactory> invocationInstrumenterFactories,
+                             @Nullable String informationalServiceId
     ) {
         ArgumentUtils.requireNonNull("nettyClientSslBuilder", nettyClientSslBuilder);
         ArgumentUtils.requireNonNull("codecRegistry", codecRegistry);
@@ -451,6 +455,7 @@ public class DefaultHttpClient implements
         this.webSocketRegistry = webSocketBeanRegistry != null ? webSocketBeanRegistry : WebSocketBeanRegistry.EMPTY;
         this.requestBinderRegistry = requestBinderRegistry;
         this.pipelineListeners = pipelineListeners;
+        this.informationalServiceId = informationalServiceId;
     }
 
     /**
@@ -616,6 +621,29 @@ public class DefaultHttpClient implements
                     }
                 }).blockFirst();
             }
+
+            @Override
+            public <I, O, E> O retrieve(io.micronaut.http.HttpRequest<I> request, Argument<O> bodyType, Argument<E> errorType) {
+                // mostly copied from super method, but with customizeException
+
+                HttpResponse<O> response = exchange(request, bodyType, errorType);
+                if (HttpStatus.class.isAssignableFrom(bodyType.getType())) {
+                    return (O) response.getStatus();
+                } else {
+                    Optional<O> body = response.getBody();
+                    if (!body.isPresent() && response.getBody(Argument.of(byte[].class)).isPresent()) {
+                        throw customizeException(new HttpClientResponseException(
+                            String.format("Failed to decode the body for the given content type [%s]", response.getContentType().orElse(null)),
+                            response
+                        ));
+                    } else {
+                        return body.orElseThrow(() -> customizeException(new HttpClientResponseException(
+                            "Empty body",
+                            response
+                        )));
+                    }
+                }
+            }
         };
     }
 
@@ -740,7 +768,7 @@ public class DefaultHttpClient implements
                         if (t instanceof HttpClientException) {
                             emitter.error(t);
                         } else {
-                            emitter.error(new HttpClientException("Error consuming Server Sent Events: " + t.getMessage(), t));
+                            emitter.error(customizeException(new HttpClientException("Error consuming Server Sent Events: " + t.getMessage(), t)));
                         }
                     }
 
@@ -849,6 +877,29 @@ public class DefaultHttpClient implements
     }
 
     @Override
+    public <I, O, E> Publisher<O> retrieve(io.micronaut.http.HttpRequest<I> request, Argument<O> bodyType, Argument<E> errorType) {
+        // mostly same as default impl, but with exception customization
+        return Flux.from(exchange(request, bodyType, errorType)).map(response -> {
+            if (bodyType.getType() == HttpStatus.class) {
+                return (O) response.getStatus();
+            } else {
+                Optional<O> body = response.getBody();
+                if (!body.isPresent() && response.getBody(byte[].class).isPresent()) {
+                    throw customizeException(new HttpClientResponseException(
+                        String.format("Failed to decode the body for the given content type [%s]", response.getContentType().orElse(null)),
+                        response
+                    ));
+                } else {
+                    return body.orElseThrow(() -> customizeException(new HttpClientResponseException(
+                        "Empty body",
+                        response
+                    )));
+                }
+            }
+        });
+    }
+
+    @Override
     public <T extends AutoCloseable> Publisher<T> connect(Class<T> clientEndpointType, io.micronaut.http.MutableHttpRequest<?> request) {
         Publisher<URI> uriPublisher = resolveRequestURI(request);
         return Flux.from(uriPublisher)
@@ -890,7 +941,7 @@ public class DefaultHttpClient implements
 
             RequestKey requestKey;
             try {
-                requestKey = new RequestKey(uri);
+                requestKey = new RequestKey(this, uri);
             } catch (HttpClientException e) {
                 emitter.error(e);
                 return;
@@ -1169,9 +1220,7 @@ public class DefaultHttpClient implements
                                     ).subscribe(new ForwardingSubscriber<>(emitter));
                                 } else {
                                     Throwable cause = f.cause();
-                                    emitter.error(
-                                            new HttpClientException("Connect error:" + cause.getMessage(), cause)
-                                    );
+                                    emitter.error(customizeException(new HttpClientException("Connect error:" + cause.getMessage(), cause)));
                                 }
                             });
                 }
@@ -1202,7 +1251,7 @@ public class DefaultHttpClient implements
             boolean multipart = MediaType.MULTIPART_FORM_DATA_TYPE.equals(request.getContentType().orElse(null));
             if (poolMap != null && !multipart) {
                 try {
-                    RequestKey requestKey = new RequestKey(requestURI);
+                    RequestKey requestKey = new RequestKey(this, requestURI);
                     ChannelPool channelPool = poolMap.get(requestKey);
                     Future<Channel> channelFuture = channelPool.acquire();
                     addInstrumentedListener(channelFuture, future -> {
@@ -1223,9 +1272,7 @@ public class DefaultHttpClient implements
                             }
                         } else {
                             Throwable cause = future.cause();
-                            emitter.error(
-                                    new HttpClientException("Connect Error: " + cause.getMessage(), cause)
-                            );
+                            emitter.error(customizeException(new HttpClientException("Connect Error: " + cause.getMessage(), cause)));
                         }
                     });
                 } catch (HttpClientException e) {
@@ -1240,9 +1287,7 @@ public class DefaultHttpClient implements
                         if (emitter.isCancelled()) {
                             log.trace("Connection to {} failed, but emitter already cancelled.", requestURI, cause);
                         } else {
-                            emitter.error(
-                                    new HttpClientException("Connect Error: " + cause.getMessage(), cause)
-                            );
+                            emitter.error(customizeException(new HttpClientException("Connect Error: " + cause.getMessage(), cause)));
                         }
                     } else {
                         try {
@@ -1367,7 +1412,7 @@ public class DefaultHttpClient implements
             try {
                 return new URI(StringUtils.prependUri(contextPath, requestURI.toString()));
             } catch (URISyntaxException e) {
-                throw new HttpClientException("Failed to construct the request URI", e);
+                throw customizeException(new HttpClientException("Failed to construct the request URI", e));
             }
         }
         return requestURI;
@@ -1427,7 +1472,7 @@ public class DefaultHttpClient implements
             boolean isProxy,
             Consumer<ChannelHandlerContext> contextConsumer) throws HttpClientException {
 
-        RequestKey requestKey = new RequestKey(uri);
+        RequestKey requestKey = new RequestKey(this, uri);
         return doConnect(request, requestKey.getHost(), requestKey.getPort(), sslCtx, isStream, isProxy, contextConsumer);
     }
 
@@ -1542,7 +1587,7 @@ public class DefaultHttpClient implements
             sslCtx = sslContext;
             //Allow https requests to be sent if SSL is disabled but a proxy is present
             if (sslCtx == null && !configuration.getProxyAddress().isPresent()) {
-                throw new HttpClientException("Cannot send HTTPS request. SSL is disabled");
+                throw customizeException(new HttpClientException("Cannot send HTTPS request. SSL is disabled"));
             }
         } else {
             sslCtx = null;
@@ -1774,7 +1819,7 @@ public class DefaultHttpClient implements
                     }
                     if (bodyContent == null) {
                         bodyContent = ConversionService.SHARED.convert(bodyValue, ByteBuf.class).orElseThrow(() ->
-                                new HttpClientException("Body [" + bodyValue + "] cannot be encoded to content type [" + requestContentType + "]. No possible codecs or converters found.")
+                                customizeException(new HttpClientException("Body [" + bodyValue + "] cannot be encoded to content type [" + requestContentType + "]. No possible codecs or converters found."))
                         );
                     }
                 }
@@ -1858,7 +1903,7 @@ public class DefaultHttpClient implements
                     httpClientInitializer.addHttp1Handlers(p);
                 } else {
                     ctx.close();
-                    throw new HttpClientException("Unknown Protocol: " + protocol);
+                    throw customizeException(new HttpClientException("Unknown Protocol: " + protocol));
                 }
             }
         });
@@ -1968,17 +2013,17 @@ public class DefaultHttpClient implements
                                         FullHttpResponse fullHttpResponse = new DefaultFullHttpResponse(nettyResponse.protocolVersion(), nettyResponse.status(), buffer, nettyResponse.headers(), new DefaultHttpHeaders(true));
                                         final FullNettyClientHttpResponse<Object> fullNettyClientHttpResponse = new FullNettyClientHttpResponse<>(fullHttpResponse, response.status(), mediaTypeCodecRegistry, byteBufferFactory, (Argument<Object>) errorType, true);
                                         fullNettyClientHttpResponse.onComplete();
-                                        emitter.error(new HttpClientResponseException(
-                                                fullHttpResponse.status().reasonPhrase(),
-                                                null,
-                                                fullNettyClientHttpResponse,
-                                                new HttpClientErrorDecoder() {
-                                                    @Override
-                                                    public Argument<?> getErrorType(MediaType mediaType) {
-                                                        return errorType;
-                                                    }
+                                        emitter.error(customizeException(new HttpClientResponseException(
+                                            fullHttpResponse.status().reasonPhrase(),
+                                            null,
+                                            fullNettyClientHttpResponse,
+                                            new HttpClientErrorDecoder() {
+                                                @Override
+                                                public Argument<?> getErrorType(MediaType mediaType) {
+                                                    return errorType;
                                                 }
-                                        ));
+                                            }
+                                        )));
                                     } finally {
                                         buffer.release();
                                     }
@@ -1996,7 +2041,7 @@ public class DefaultHttpClient implements
     private <I> Publisher<URI> resolveURI(io.micronaut.http.HttpRequest<I> request, boolean includeContextPath) {
         URI requestURI = request.getUri();
         if (loadBalancer == null) {
-            return Flux.error(new NoHostException("Request URI specifies no host to connect to"));
+            return Flux.error(customizeException(new NoHostException("Request URI specifies no host to connect to")));
         }
 
         return Flux.from(loadBalancer.select(getLoadBalancerDiscriminator())).map(server -> {
@@ -2089,7 +2134,7 @@ public class DefaultHttpClient implements
     ) {
         boolean errorStatus = response.code() >= 400;
         if (errorStatus && failOnError) {
-            return Flux.error(new HttpClientResponseException(response.getStatus().getReason(), response));
+            return Flux.error(customizeException(new HttpClientResponseException(response.getStatus().getReason(), response)));
         } else {
             return Flux.just(response);
         }
@@ -2141,7 +2186,7 @@ public class DefaultHttpClient implements
     }
 
     private String getHostHeader(URI requestURI) {
-        RequestKey requestKey = new RequestKey(requestURI);
+        RequestKey requestKey = new RequestKey(this, requestURI);
         StringBuilder host = new StringBuilder(requestKey.getHost());
         int port = requestKey.getPort();
         if (port > -1 && port != 80 && port != 443) {
@@ -2572,6 +2617,15 @@ public class DefaultHttpClient implements
         return io.micronaut.http.HttpRequest.SCHEME_HTTPS.equalsIgnoreCase(scheme) || SCHEME_WSS.equalsIgnoreCase(scheme);
     }
 
+    private <E extends HttpClientException> E customizeException(E exc) {
+        if (informationalServiceId != null) {
+            exc.setServiceId(informationalServiceId);
+        } else if (configuration instanceof ServiceHttpClientConfiguration) {
+            exc.setServiceId(((ServiceHttpClientConfiguration) configuration).getServiceId());
+        }
+        return exc;
+    }
+
     @FunctionalInterface
     interface ThrowingBiConsumer<T1, T2> {
         void accept(T1 t1, T2 t2) throws Exception;
@@ -2641,7 +2695,7 @@ public class DefaultHttpClient implements
                         );
                         builder.frameLogger(new Http2FrameLogger(nettyLevel, DefaultHttpClient.class));
                     } catch (IllegalArgumentException e) {
-                        throw new HttpClientException("Unsupported log level: " + logLevel);
+                        throw customizeException(new HttpClientException("Unsupported log level: " + logLevel));
                     }
                 });
                 HttpToHttp2ConnectionHandler connectionHandler = builder
@@ -2665,7 +2719,7 @@ public class DefaultHttpClient implements
                         );
                         p.addLast(new LoggingHandler(DefaultHttpClient.class, nettyLevel));
                     } catch (IllegalArgumentException e) {
-                        throw new HttpClientException("Unsupported log level: " + logLevel);
+                        throw customizeException(new HttpClientException("Unsupported log level: " + logLevel));
                     }
                 });
 
@@ -2893,14 +2947,19 @@ public class DefaultHttpClient implements
         private final int port;
         private final boolean secure;
 
-        public RequestKey(URI requestURI) {
+        /**
+         * @param ctx The HTTP client that created this request key. Only used for exception
+         *            context, not stored
+         * @param requestURI The request URI
+         */
+        public RequestKey(DefaultHttpClient ctx, URI requestURI) {
             this.secure = isSecureScheme(requestURI.getScheme());
             String host = requestURI.getHost();
             int port;
             if (host == null) {
                 host = requestURI.getAuthority();
                 if (host == null) {
-                    throw new NoHostException("URI specifies no host to connect to");
+                    throw ctx.customizeException(new NoHostException("URI specifies no host to connect to"));
                 }
 
                 final int i = host.indexOf(':');
@@ -2910,7 +2969,7 @@ public class DefaultHttpClient implements
                     try {
                         port = Integer.parseInt(portStr);
                     } catch (NumberFormatException e) {
-                        throw new HttpClientException("URI specifies an invalid port: " + portStr);
+                        throw ctx.customizeException(new HttpClientException("URI specifies an invalid port: " + portStr));
                     }
                 } else {
                     port = requestURI.getPort() > -1 ? requestURI.getPort() : secure ? DEFAULT_HTTPS_PORT : DEFAULT_HTTP_PORT;
@@ -3018,7 +3077,7 @@ public class DefaultHttpClient implements
                         if (future.isSuccess()) {
                             processRequestWrite(channel, channelPool, emitter, pipeline);
                         } else {
-                            throw new HttpClientException("HTTP/2 clear text upgrade failed to complete", future.cause());
+                            throw customizeException(new HttpClientException("HTTP/2 clear text upgrade failed to complete", future.cause()));
                         }
                     });
                     return;
@@ -3118,11 +3177,11 @@ public class DefaultHttpClient implements
 
             HttpClientException result;
             if (cause instanceof TooLongFrameException) {
-                result = (new ContentLengthExceededException(configuration.getMaxContentLength()));
+                result = customizeException(new ContentLengthExceededException(configuration.getMaxContentLength()));
             } else if (cause instanceof io.netty.handler.timeout.ReadTimeoutException) {
                 result = ReadTimeoutException.TIMEOUT_EXCEPTION;
             } else {
-                result = new HttpClientException("Error occurred reading HTTP response: " + message, cause);
+                result = customizeException(new HttpClientException("Error occurred reading HTTP response: " + message, cause));
             }
             responsePromise.tryFailure(result);
         }
@@ -3302,19 +3361,19 @@ public class DefaultHttpClient implements
          */
         private HttpClientResponseException makeErrorFromRequestBody(HttpResponseStatus status, FullNettyClientHttpResponse<?> response) {
             if (errorType != null && errorType != HttpClient.DEFAULT_ERROR_TYPE) {
-                return new HttpClientResponseException(
-                        status.reasonPhrase(),
-                        null,
-                        response,
-                        new HttpClientErrorDecoder() {
-                            @Override
-                            public Argument<?> getErrorType(MediaType mediaType) {
-                                return errorType;
-                            }
+                return customizeException(new HttpClientResponseException(
+                    status.reasonPhrase(),
+                    null,
+                    response,
+                    new HttpClientErrorDecoder() {
+                        @Override
+                        public Argument<?> getErrorType(MediaType mediaType) {
+                            return errorType;
                         }
-                );
+                    }
+                ));
             } else {
-                return new HttpClientResponseException(status.reasonPhrase(), response);
+                return customizeException(new HttpClientResponseException(status.reasonPhrase(), response));
             }
         }
 
@@ -3332,12 +3391,12 @@ public class DefaultHttpClient implements
             );
             // this onComplete call disables further parsing by HttpClientResponseException
             errorResponse.onComplete();
-            return new HttpClientResponseException(
-                    "Error decoding HTTP error response body: " + t.getMessage(),
-                    t,
-                    errorResponse,
-                    null
-            );
+            return customizeException(new HttpClientResponseException(
+                "Error decoding HTTP error response body: " + t.getMessage(),
+                t,
+                errorResponse,
+                null
+            ));
         }
 
         private void makeNormalBodyParseError(FullHttpResponse fullResponse, HttpStatus httpStatus, Throwable t, Consumer<HttpClientResponseException> forward) {
@@ -3349,17 +3408,17 @@ public class DefaultHttpClient implements
                     null,
                     false
             );
-            HttpClientResponseException clientResponseError = new HttpClientResponseException(
-                    "Error decoding HTTP response body: " + t.getMessage(),
-                    t,
-                    response,
-                    new HttpClientErrorDecoder() {
-                        @Override
-                        public Argument<?> getErrorType(MediaType mediaType) {
-                            return errorType;
-                        }
+            HttpClientResponseException clientResponseError = customizeException(new HttpClientResponseException(
+                "Error decoding HTTP response body: " + t.getMessage(),
+                t,
+                response,
+                new HttpClientErrorDecoder() {
+                    @Override
+                    public Argument<?> getErrorType(MediaType mediaType) {
+                        return errorType;
                     }
-            );
+                }
+            ));
             try {
                 forward.accept(clientResponseError);
             } finally {

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultNettyHttpClientRegistry.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultNettyHttpClientRegistry.java
@@ -321,7 +321,6 @@ class DefaultNettyHttpClientRegistry implements AutoCloseable,
             }
 
             LoadBalancer loadBalancer = null;
-            List<String> clientIdentifiers = null;
             final HttpClientConfiguration configuration;
             if (configurationClass != null) {
                 configuration = (HttpClientConfiguration) this.beanContext.getBean(configurationClass);
@@ -339,7 +338,6 @@ class DefaultNettyHttpClientRegistry implements AutoCloseable,
                 loadBalancer = loadBalancerResolver.resolve(clientId)
                         .orElseThrow(() ->
                                 new HttpClientException("Invalid service reference [" + clientId + "] specified to @Client"));
-                clientIdentifiers = Collections.singletonList(clientId);
             }
 
             String contextPath = null;
@@ -358,7 +356,7 @@ class DefaultNettyHttpClientRegistry implements AutoCloseable,
                     loadBalancer,
                     clientKey.httpVersion,
                     configuration,
-                    clientIdentifiers,
+                    clientId,
                     contextPath,
                     beanContext,
                     annotationMetadata
@@ -387,7 +385,7 @@ class DefaultNettyHttpClientRegistry implements AutoCloseable,
             LoadBalancer loadBalancer,
             HttpVersion httpVersion,
             HttpClientConfiguration configuration,
-            List<String> clientIdentifiers,
+            String clientId,
             String contextPath,
             BeanContext beanContext,
             AnnotationMetadata annotationMetadata) {
@@ -400,7 +398,7 @@ class DefaultNettyHttpClientRegistry implements AutoCloseable,
                 contextPath,
                 clientFilterResolver,
                 clientFilterResolver.resolveFilterEntries(new ClientFilterResolutionContext(
-                        clientIdentifiers,
+                        clientId == null ? null : Collections.singletonList(clientId),
                         annotationMetadata
                 )),
                 threadFactory,
@@ -413,7 +411,8 @@ class DefaultNettyHttpClientRegistry implements AutoCloseable,
                 eventLoopGroup,
                 resolveSocketChannelFactory(configuration, beanContext),
                 pipelineListeners,
-                invocationInstrumenterFactories
+                invocationInstrumenterFactories,
+                clientId
         );
     }
 

--- a/http-client/src/test/groovy/io/micronaut/http/client/ClientIntroductionAdviceSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/ClientIntroductionAdviceSpec.groovy
@@ -55,7 +55,7 @@ class ClientIntroductionAdviceSpec extends Specification {
         then:
         def e = thrown(HttpClientResponseException)
         e.serviceId == 'test-service'
-        e.message == 'Client \'test-service\': Bad Request'
+        e.message == "Client 'test-service': Bad Request"
 
         cleanup:
         embeddedServer.close()

--- a/http-client/src/test/groovy/io/micronaut/http/client/ClientIntroductionAdviceSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/ClientIntroductionAdviceSpec.groovy
@@ -21,9 +21,11 @@ import io.micronaut.core.annotation.Introspected
 import io.micronaut.discovery.ServiceInstance
 import io.micronaut.discovery.ServiceInstanceList
 import io.micronaut.http.BasicAuth
+import io.micronaut.http.HttpResponse
 import io.micronaut.http.MediaType
 import io.micronaut.http.annotation.*
 import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.runtime.server.EmbeddedServer
 import spock.lang.Specification
 
@@ -36,6 +38,24 @@ class ClientIntroductionAdviceSpec extends Specification {
 
         expect:
         myService.index() == 'success'
+
+        cleanup:
+        embeddedServer.close()
+    }
+
+    void "service id appears in exceptions"() {
+        given:
+        EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, ['spec.name': 'ClientIntroductionAdviceSpec'])
+        embeddedServer.applicationContext.registerSingleton(new TestServiceInstanceList(embeddedServer.getURI()))
+
+        PolicyClient myService = embeddedServer.applicationContext.getBean(PolicyClient)
+
+        when:
+        myService.failure()
+        then:
+        def e = thrown(HttpClientResponseException)
+        e.serviceId == 'test-service'
+        e.message == 'Client \'test-service\': Bad Request'
 
         cleanup:
         embeddedServer.close()
@@ -170,6 +190,11 @@ class ClientIntroductionAdviceSpec extends Specification {
         String index() {
             "policy"
         }
+
+        @Get('/failure')
+        HttpResponse<?> failure() {
+            return HttpResponse.badRequest()
+        }
     }
 
     @Requires(property = 'spec.name', value = 'ClientIntroductionAdviceSpec')
@@ -225,6 +250,9 @@ class ClientIntroductionAdviceSpec extends Specification {
     static interface PolicyClient {
         @Get
         String index()
+
+        @Get('/failure')
+        String failure()
     }
 
     @Requires(property = 'spec.name', value = 'ClientIntroductionAdviceSpec')

--- a/http-client/src/test/groovy/io/micronaut/http/client/HttpGetSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/HttpGetSpec.groovy
@@ -572,7 +572,7 @@ class HttpGetSpec extends Specification {
 
         then:
         def ex = thrown(HttpClientResponseException)
-        ex.message == "Failed to decode the body for the given content type [does/notexist]"
+        ex.message == "Client '/get': Failed to decode the body for the given content type [does/notexist]"
     }
 
     @Issue("https://github.com/micronaut-projects/micronaut-core/issues/5223")
@@ -592,7 +592,7 @@ class HttpGetSpec extends Specification {
 
         then:
         HttpClientResponseException ex = thrown()
-        ex.message == "Failed to decode the body for the given content type [does/notexist]"
+        ex.message == "Client '/get': Failed to decode the body for the given content type [does/notexist]"
     }
 
     void "test deserializing map wrapped by Reactive type"() {

--- a/http-client/src/test/groovy/io/micronaut/http/client/HttpHeadSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/HttpHeadSpec.groovy
@@ -77,7 +77,7 @@ class HttpHeadSpec extends Specification {
 
         then:
         def e = thrown(HttpClientResponseException)
-        e.message == "Not Found"
+        e.message == "Client '/': Not Found"
         e.status == HttpStatus.NOT_FOUND
     }
 
@@ -91,7 +91,7 @@ class HttpHeadSpec extends Specification {
 
         then:
         def e = thrown(HttpClientResponseException)
-        e.message == "Internal Server Error"
+        e.message == "Client '/': Internal Server Error"
         e.status == HttpStatus.INTERNAL_SERVER_ERROR
         !e.response.getBody(String).isPresent()
     }
@@ -106,7 +106,7 @@ class HttpHeadSpec extends Specification {
 
         then:
         def e = thrown(HttpClientResponseException)
-        e.message == "Internal Server Error"
+        e.message == "Client '/': Internal Server Error"
         e.status == HttpStatus.INTERNAL_SERVER_ERROR
     }
 
@@ -184,7 +184,7 @@ class HttpHeadSpec extends Specification {
 
         then:
         def ex = thrown(HttpClientResponseException)
-        ex.message == "Empty body"
+        ex.message == "Client '/': Empty body"
     }
 
     void "test simple get request with POJO list"() {
@@ -224,21 +224,21 @@ class HttpHeadSpec extends Specification {
 
         then:
         def ex = thrown(HttpClientResponseException)
-        ex.message == "Empty body"
+        ex.message == "Client '/head': Empty body"
 
         when:
         client.queryParam('foo', 'bar')
 
         then:
         ex = thrown(HttpClientResponseException)
-        ex.message == "Empty body"
+        ex.message == "Client '/head': Empty body"
 
         when:
         client.queryParam('foo%', 'bar')
 
         then:
         ex = thrown(HttpClientResponseException)
-        ex.message == "Empty body"
+        ex.message == "Client '/head': Empty body"
     }
 
     void "test body availability"() {
@@ -269,7 +269,7 @@ class HttpHeadSpec extends Specification {
 
         then:
         def e = thrown(HttpClientResponseException)
-        e.message == "Not Found"
+        e.message == "Client '/': Not Found"
         e.status == HttpStatus.NOT_FOUND
     }
 
@@ -281,7 +281,7 @@ class HttpHeadSpec extends Specification {
 
         then:
         def ex = thrown(HttpClientResponseException)
-        ex.message == "Empty body"
+        ex.message == "Client '/': Empty body"
     }
 
     void 'test format dates with @Format'() {
@@ -295,28 +295,28 @@ class HttpHeadSpec extends Specification {
 
         then:
         def ex = thrown(HttpClientResponseException)
-        ex.message == "Empty body"
+        ex.message == "Client '/head': Empty body"
 
         when:
         client.formatDateQuery(d)
 
         then:
         ex = thrown(HttpClientResponseException)
-        ex.message == "Empty body"
+        ex.message == "Client '/head': Empty body"
 
         when:
         client.formatDateTime(dt)
 
         then:
         ex = thrown(HttpClientResponseException)
-        ex.message == "Empty body"
+        ex.message == "Client '/head': Empty body"
 
         when:
         client.formatDateTimeQuery(dt)
 
         then:
         ex = thrown(HttpClientResponseException)
-        ex.message == "Empty body"
+        ex.message == "Client '/head': Empty body"
     }
 
     void "test no body returned"() {
@@ -325,7 +325,7 @@ class HttpHeadSpec extends Specification {
 
         then:
         def ex = thrown(HttpClientResponseException)
-        ex.message == "Empty body"
+        ex.message == "Client '/head': Empty body"
     }
 
     void "test a request with a custom host header"() {
@@ -336,7 +336,7 @@ class HttpHeadSpec extends Specification {
 
         then:
         def ex = thrown(HttpClientResponseException)
-        ex.message == "Empty body"
+        ex.message == "Client '/': Empty body"
 
     }
 
@@ -349,7 +349,7 @@ class HttpHeadSpec extends Specification {
 
         then:
         def ex = thrown(HttpClientResponseException)
-        ex.message == "Method Not Allowed"
+        ex.message == "Client '/head': Method Not Allowed"
 
         when:
         String body = client.toBlocking().retrieve(HttpRequest.GET("/head/no-head"), String)

--- a/http-client/src/test/groovy/io/micronaut/http/client/MaxResponseSizeSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/MaxResponseSizeSpec.groovy
@@ -46,7 +46,7 @@ class MaxResponseSizeSpec extends Specification {
 
         then:
         def e = thrown(ContentLengthExceededException)
-        e.message == 'Client \'/\': The received length exceeds the maximum allowed content length [1024]'
+        e.message == "Client '/': The received length exceeds the maximum allowed content length [1024]"
     }
 
     @Requires(property = "spec.name", value = 'MaxResponseSizeSpec' )

--- a/http-client/src/test/groovy/io/micronaut/http/client/MaxResponseSizeSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/MaxResponseSizeSpec.groovy
@@ -46,7 +46,7 @@ class MaxResponseSizeSpec extends Specification {
 
         then:
         def e = thrown(ContentLengthExceededException)
-        e.message == 'The received length exceeds the maximum allowed content length [1024]'
+        e.message == 'Client \'/\': The received length exceeds the maximum allowed content length [1024]'
     }
 
     @Requires(property = "spec.name", value = 'MaxResponseSizeSpec' )

--- a/http-client/src/test/groovy/io/micronaut/http/client/ServerErrorSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/ServerErrorSpec.groovy
@@ -104,7 +104,7 @@ class ServerErrorSpec extends Specification {
 
         then:
         response.body.isPresent()
-        response.body.get() == "Internal Server Error"
+        response.body.get() == "Client '/server-errors': Internal Server Error"
     }
 
     @Requires(property = 'spec.name', value = 'ServerErrorSpec')

--- a/http-client/src/test/groovy/io/micronaut/http/client/bind/ClientBindSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/bind/ClientBindSpec.groovy
@@ -38,7 +38,7 @@ class ClientBindSpec extends Specification {
 
         then:
         HttpClientException ex = thrown()
-        ex.message == "Failed to construct the request URI"
+        ex.message == "Client '/': Failed to construct the request URI"
     }
 
     void "test bind to method"() {

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/sse/ServerSentEventSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/sse/ServerSentEventSpec.groovy
@@ -85,7 +85,7 @@ class ServerSentEventSpec extends Specification {
         then:
         def ex = thrown(HttpClientResponseException)
         ex.status == HttpStatus.INTERNAL_SERVER_ERROR
-        ex.message == "Internal Server Error"
+        ex.message == "Client '/sse': Internal Server Error"
     }
 
     @Client('/sse')

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/stream/ErrorResponseSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/stream/ErrorResponseSpec.groovy
@@ -29,7 +29,7 @@ class ErrorResponseSpec extends Specification {
         def e = thrown(HttpClientResponseException)
         verifyAll {
             e.status == HttpStatus.BAD_REQUEST
-            e.message == 'Client \'/flowable\': expected flowable error'
+            e.message == "Client '/flowable': expected flowable error"
         }
     }
 

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/stream/ErrorResponseSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/stream/ErrorResponseSpec.groovy
@@ -29,7 +29,7 @@ class ErrorResponseSpec extends Specification {
         def e = thrown(HttpClientResponseException)
         verifyAll {
             e.status == HttpStatus.BAD_REQUEST
-            e.message == 'expected flowable error'
+            e.message == 'Client \'/flowable\': expected flowable error'
         }
     }
 


### PR DESCRIPTION
This patch adds a serviceId field to HttpClientException, and sets that field with information from the client where possible.

The service ID is prepended to the message of the exception (does not apply when there is a special JsonError message in the body as in HttpResponseException), and it's accessible with a getter.

Resolves https://github.com/micronaut-projects/micronaut-core/issues/7421