### PR TITLE
Clarify that `endpoints.all.path` configuration property needs to end with a '/' (it fails otherwise).

### DIFF
--- a/management/src/main/java/io/micronaut/management/endpoint/EndpointDefaultConfiguration.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/EndpointDefaultConfiguration.java
@@ -96,7 +96,7 @@ public class EndpointDefaultConfiguration {
     }
 
     /**
-     * The endpoints base path. It must include a trailing '/'. Default value ({@value #DEFAULT_ENDPOINT_BASE_PATH}).
+     * The endpoints base path. It must include a leading and trailing '/'. Default value ({@value #DEFAULT_ENDPOINT_BASE_PATH}).
      * @param path The path
      */
     public void setPath(String path) {

--- a/management/src/main/java/io/micronaut/management/endpoint/EndpointDefaultConfiguration.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/EndpointDefaultConfiguration.java
@@ -96,7 +96,7 @@ public class EndpointDefaultConfiguration {
     }
 
     /**
-     * The endpoints base path. Default value ({@value #DEFAULT_ENDPOINT_BASE_PATH}).
+     * The endpoints base path. It must include a trailing '/'. Default value ({@value #DEFAULT_ENDPOINT_BASE_PATH}).
      * @param path The path
      */
     public void setPath(String path) {

--- a/src/main/docs/guide/management/buildingEndpoints/endpointConfiguration.adoc
+++ b/src/main/docs/guide/management/buildingEndpoints/endpointConfiguration.adoc
@@ -25,4 +25,4 @@ endpoints:
     sensitive: Boolean
 ----
 
-NOTE: The base path for all endpoints is `/` by default. If you prefer the endpoints to be available under a different base path, configure `endpoints.all.path`. For example, if the value is set to `/endpoints`, the foo endpoint will be accessible at `/endpoints/foo`.
+NOTE: The base path for all endpoints is `/` by default. If you prefer the endpoints to be available under a different base path, configure `endpoints.all.path`. For example, if the value is set to `endpoints/`, the foo endpoint will be accessible at `endpoints/foo`, relative to the context path.

--- a/src/main/docs/guide/management/buildingEndpoints/endpointConfiguration.adoc
+++ b/src/main/docs/guide/management/buildingEndpoints/endpointConfiguration.adoc
@@ -25,4 +25,4 @@ endpoints:
     sensitive: Boolean
 ----
 
-NOTE: The base path for all endpoints is `/` by default. If you prefer the endpoints to be available under a different base path, configure `endpoints.all.path`. For example, if the value is set to `endpoints/`, the foo endpoint will be accessible at `endpoints/foo`, relative to the context path.
+NOTE: The base path for all endpoints is `/` by default. If you prefer the endpoints to be available under a different base path, configure `endpoints.all.path`. For example, if the value is set to `/endpoints/`, the foo endpoint will be accessible at `/endpoints/foo`, relative to the context path. Note that the leading and trailing `/` are required for `endpoints.all.path` unless `micronaut.server.context-path` is set, in which case the leading `/` isn't necessary.


### PR DESCRIPTION
closes #7605 