### PR TITLE
Add excludeServiceId to client filter definitions

### DIFF
--- a/http-client-core/src/main/java/io/micronaut/http/client/filter/DefaultHttpClientFilterResolver.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/filter/DefaultHttpClientFilterResolver.java
@@ -98,10 +98,15 @@ public class DefaultHttpClientFilterResolver implements HttpClientFilterResolver
                     }
 
                     if (matches) {
-                        String[] clients = annotationMetadata.stringValues(Filter.class, "serviceId");
-                        boolean hasClients = ArrayUtils.isNotEmpty(clients);
-                        if (hasClients) {
-                            matches = containsIdentifier(context.getClientIds(), clients);
+                        String[] serviceIds = annotationMetadata.stringValues(Filter.class, "serviceId");
+                        if (ArrayUtils.isNotEmpty(serviceIds)) {
+                            matches = containsIdentifier(context.getClientIds(), serviceIds);
+                        }
+                    }
+                    if (matches) {
+                        String[] serviceIdsExclude = annotationMetadata.stringValues(Filter.class, "excludeServiceId");
+                        if (ArrayUtils.isNotEmpty(serviceIdsExclude)) {
+                            matches = !containsIdentifier(context.getClientIds(), serviceIdsExclude);
                         }
                     }
                     return matches;

--- a/http-client/src/test/groovy/io/micronaut/http/client/aop/ClientFilterSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/aop/ClientFilterSpec.groovy
@@ -18,6 +18,7 @@ package io.micronaut.http.client.aop
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Requires
 import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpVersion
 import io.micronaut.http.MediaType
 import io.micronaut.http.MutableHttpRequest
 import io.micronaut.http.annotation.Controller
@@ -25,6 +26,7 @@ import io.micronaut.http.annotation.Filter
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Header
 import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.HttpClientRegistry
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.http.filter.ClientFilterChain
 import io.micronaut.http.filter.HttpClientFilter
@@ -71,6 +73,24 @@ class ClientFilterSpec extends Specification{
         client.close()
     }
 
+    void "test a client doesn't match a filter with an excluded service id"() {
+        given:
+        ApplicationContext ctx = ApplicationContext.builder([
+                'spec.name': 'ClientFilterSpec',
+                'micronaut.http.services.my-service.url': embeddedServer.getURL().toString()
+        ]).start()
+        HttpClient client = ctx.getBean(HttpClientRegistry).getClient(HttpVersion.HTTP_1_1, "my-service", null)
+
+        when:
+        HttpResponse<String> response = client.toBlocking().exchange("/excluded-filters/name", String.class)
+
+        then:
+        response.body() == 'Flintstone'
+
+        cleanup:
+        ctx.close()
+    }
+
     void "test a client filter that throws an exception"() {
         given:
         HttpClient client = context.createBean(HttpClient, embeddedServer.getURL())
@@ -110,12 +130,17 @@ class ClientFilterSpec extends Specification{
     }
 
     @Requires(property = 'spec.name', value = "ClientFilterSpec")
-    @Controller('/filters')
+    @Controller
     static class TestController {
 
-        @Get(value = '/name', produces = MediaType.TEXT_PLAIN)
+        @Get(value = '/filters/name', produces = MediaType.TEXT_PLAIN)
         String name(@Header('X-Auth-Username') String username, @Header('X-Auth-Lastname') Optional<String> lastname) {
             return username + lastname.orElse('')
+        }
+
+        @Get(value = '/excluded-filters/name', produces = MediaType.TEXT_PLAIN)
+        String nameExcluded(@Header('X-Auth-Lastname') Optional<String> lastname) {
+            return lastname.orElse('')
         }
     }
 
@@ -184,6 +209,30 @@ class ClientFilterSpec extends Specification{
         @Override
         Publisher<? extends HttpResponse<?>> doFilter(MutableHttpRequest<?> request, ClientFilterChain chain) {
             request.header("X-Auth-Lastname", "Flintstone")
+            return chain.proceed(request)
+        }
+    }
+
+    // this filter should match the test
+    @Requires(property = 'spec.name', value = "ClientFilterSpec")
+    @Filter(patterns = '/excluded-filters/**', excludeServiceId = 'otherClient')
+    static class Filter2 implements HttpClientFilter {
+
+        @Override
+        Publisher<? extends HttpResponse<?>> doFilter(MutableHttpRequest<?> request, ClientFilterChain chain) {
+            request.header("X-Auth-Lastname", "Flintstone")
+            return chain.proceed(request)
+        }
+    }
+
+    // this filter should not match the test
+    @Requires(property = 'spec.name', value = "ClientFilterSpec")
+    @Filter(patterns = '/excluded-filters/**', excludeServiceId = 'my-service')
+    static class Filter3 implements HttpClientFilter {
+
+        @Override
+        Publisher<? extends HttpResponse<?>> doFilter(MutableHttpRequest<?> request, ClientFilterChain chain) {
+            request.header("X-Auth-Lastname", "Fred")
             return chain.proceed(request)
         }
     }

--- a/http/src/main/java/io/micronaut/http/annotation/Filter.java
+++ b/http/src/main/java/io/micronaut/http/annotation/Filter.java
@@ -72,9 +72,15 @@ public @interface Filter {
 
     /**
      * The service identifiers this filter applies to. Currently, applies only to {@link io.micronaut.http.filter.HttpClientFilter} instances.
-     * Equivalent to the {@code id()} of {@code io.micronaut.http.client.Client}.
      *
      * @return The service identifiers
      */
     String[] serviceId() default {};
+
+    /**
+     * The service identifiers this filter does not apply to. Currently, applies only to {@link io.micronaut.http.filter.HttpClientFilter} instances.
+     *
+     * @return The service identifiers
+     */
+    String[] excludeServiceId() default {};
 }


### PR DESCRIPTION
Same as serviceId, except inverted.

Resolves #3924