### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/central-sync.yml
+++ b/.github/workflows/central-sync.yml
@@ -10,6 +10,9 @@ on:
       release_version:
         description: 'Release version (eg: 1.2.3)'
         required: true
+permissions:
+  contents: read
+
 jobs:
   central-sync:
     runs-on: ubuntu-latest

--- a/.github/workflows/corretto.yml
+++ b/.github/workflows/corretto.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - master
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -5,6 +5,9 @@
 # and edit them there. Note that it will be sync'ed to all the Micronaut repos
 name: Publish snapshot release
 on: [workflow_dispatch]
+permissions:
+  contents: read
+
 jobs:
   build:
     if: github.repository != 'micronaut-projects/micronaut-project-template'


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
