### PR TITLE
Support reading BeanDefinitionReference from nested JARS

### DIFF
--- a/core/src/main/java/io/micronaut/core/io/IOUtils.java
+++ b/core/src/main/java/io/micronaut/core/io/IOUtils.java
@@ -100,7 +100,7 @@ public class IOUtils {
                         }
                         Path currentJar = null;
                         if (jarFiles.length > 2) {
-                            for (int i = 1; i < (jarFiles.length -1); i++) {
+                            for (int i = 1; i < (jarFiles.length - 1); i++) {
                                 final Path nestedJar = fileSystem.getPath(jarFiles[i]);
                                 final Path extractedJar = Files.createTempFile("jar-" + i, ".jar");
                                 Files.copy(nestedJar, extractedJar, StandardCopyOption.REPLACE_EXISTING);

--- a/core/src/main/java/io/micronaut/core/io/IOUtils.java
+++ b/core/src/main/java/io/micronaut/core/io/IOUtils.java
@@ -77,7 +77,6 @@ public class IOUtils {
     @Blocking
     @SuppressWarnings({"java:S2095", "java:S1141", "java:S3776"})
     public static void eachFile(@NonNull URI uri, String path, @NonNull Consumer<Path> consumer) {
-        Path myPath;
         try {
             String scheme = uri.getScheme();
             FileSystem fileSystem = null;


### PR DESCRIPTION
Update `IOUtils.eachFile` method to read `META-INF/micronaut/io.micronaut.inject.BeanDefinitionReference` files from the nested JAR. For instance, `jar:file:/Users/pbehl/Downloads/foobar/build/libs/foobar-0.1.jar!/BOOT-INF/lib/micronaut-inject-3.5.3-SNAPSHOT.jar!/META-INF/micronaut/io.micronaut.inject.BeanDefinitionReference`.

Fixes https://github.com/grails/grails-core/issues/12589