### PR TITLE
feat: Decouple Micronaut banner from version banner

### DIFF
--- a/context/src/main/java/io/micronaut/runtime/Micronaut.java
+++ b/context/src/main/java/io/micronaut/runtime/Micronaut.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.runtime;
 
+import io.micronaut.context.banner.MicronautVersionBanner;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.context.ApplicationContext;
@@ -187,6 +188,11 @@ public class Micronaut extends DefaultApplicationContextBuilder implements Appli
         return (Micronaut) super.banner(isEnabled);
     }
 
+    @Override
+    public @NonNull Micronaut bannerMicronautVersion(boolean isEnabled) {
+        return (Micronaut) super.bannerMicronautVersion(isEnabled);
+    }
+
     /**
      * Add classes to be included in the initialization of the application.
      *
@@ -350,6 +356,10 @@ public class Micronaut extends DefaultApplicationContextBuilder implements Appli
             new ResourceBanner(resource.get(), out).print();
         } else {
             new MicronautBanner(out).print();
+        }
+
+        if (isBannerMicronautVersionEnabled()) {
+            new MicronautVersionBanner(out).print();
         }
     }
 

--- a/inject/src/main/java/io/micronaut/context/ApplicationContextBuilder.java
+++ b/inject/src/main/java/io/micronaut/context/ApplicationContextBuilder.java
@@ -206,6 +206,14 @@ public interface ApplicationContextBuilder {
     @NonNull ApplicationContextBuilder banner(boolean isEnabled);
 
     /**
+     * Whether the version of Micronaut is showed after main banner or not.
+     *
+     * @param isEnabled Whether the version of Micronaut is showed after main banner or not.
+     * @return This application
+     */
+    @NonNull ApplicationContextBuilder bannerMicronautVersion(boolean isEnabled);
+
+    /**
      * Whether to error on an empty bean provider. Defaults to {@code false}.
      *
      * @param shouldAllow True if empty {@link jakarta.inject.Provider} instances are allowed

--- a/inject/src/main/java/io/micronaut/context/ApplicationContextConfiguration.java
+++ b/inject/src/main/java/io/micronaut/context/ApplicationContextConfiguration.java
@@ -111,6 +111,15 @@ public interface ApplicationContextConfiguration extends BeanContextConfiguratio
         return true;
     }
 
+    /**
+     * The Micronaut version banner is enabled by default.
+     *
+     * @return The Micronaut version banner is enabled by default
+     */
+    default boolean isBannerMicronautVersionEnabled() {
+        return true;
+    }
+
     @Nullable
     default Boolean isBootstrapEnvironmentEnabled() {
         return null;

--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContextBuilder.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContextBuilder.java
@@ -63,6 +63,7 @@ public class DefaultApplicationContextBuilder implements ApplicationContextBuild
     private Set<Class<? extends Annotation>> eagerInitAnnotated = new HashSet<>(3);
     private String[] overrideConfigLocations;
     private boolean banner = true;
+    private boolean bannerMicronautVersion = true;
     private ClassPathResourceLoader classPathResourceLoader;
     private boolean allowEmptyProviders = false;
     private Boolean bootstrapEnvironment = null;
@@ -111,6 +112,11 @@ public class DefaultApplicationContextBuilder implements ApplicationContextBuild
     @Override
     public boolean isBannerEnabled() {
         return banner;
+    }
+
+    @Override
+    public boolean isBannerMicronautVersionEnabled() {
+        return bannerMicronautVersion;
     }
 
     @Nullable
@@ -365,6 +371,12 @@ public class DefaultApplicationContextBuilder implements ApplicationContextBuild
     @Override
     public @NonNull ApplicationContextBuilder banner(boolean isEnabled) {
         this.banner = isEnabled;
+        return this;
+    }
+
+    @Override
+    public @NonNull ApplicationContextBuilder bannerMicronautVersion(boolean isEnabled) {
+        this.bannerMicronautVersion = isEnabled;
         return this;
     }
 

--- a/inject/src/main/java/io/micronaut/context/banner/MicronautBanner.java
+++ b/inject/src/main/java/io/micronaut/context/banner/MicronautBanner.java
@@ -15,8 +15,6 @@
  */
 package io.micronaut.context.banner;
 
-import io.micronaut.core.version.VersionUtils;
-
 import java.io.PrintStream;
 
 /**
@@ -31,7 +29,6 @@ public class MicronautBanner implements Banner {
             "| |  | | | (__| | | (_) | | | | (_| | |_| | |_ ",
             "|_|  |_|_|\\___|_|  \\___/|_| |_|\\__,_|\\__,_|\\__|"
     };
-    private static final String MICRONAUT = "  Micronaut";
 
     private final PrintStream out;
 
@@ -49,8 +46,5 @@ public class MicronautBanner implements Banner {
         for (String line : MICRONAUT_BANNER) {
             out.println(line);
         }
-        String version = VersionUtils.getMicronautVersion();
-        version = (version != null) ? " (v" + version + ")" : "";
-        out.println(MICRONAUT + version + "\n");
     }
 }

--- a/inject/src/main/java/io/micronaut/context/banner/MicronautVersionBanner.java
+++ b/inject/src/main/java/io/micronaut/context/banner/MicronautVersionBanner.java
@@ -1,0 +1,31 @@
+package io.micronaut.context.banner;
+
+import java.io.PrintStream;
+
+import io.micronaut.core.version.VersionUtils;
+
+/**
+ * Implementation of {@link Banner} that prints the Micronaut version after main banner.
+ */
+public class MicronautVersionBanner implements Banner {
+    private static final String MICRONAUT = "  Micronaut";
+
+    private final PrintStream out;
+
+    /**
+     * Constructor.
+     *
+     * @param out The print stream
+     */
+    public MicronautVersionBanner(PrintStream out) {
+        this.out = out;
+    }
+
+
+    @Override
+    public void print() {
+        String version = VersionUtils.getMicronautVersion();
+        version = (version != null) ? " (v" + version + ")" : "";
+        out.println(MICRONAUT + version + "\n");
+    }
+}


### PR DESCRIPTION
Decouple Micronaut default banner and line that shows version of framework.

Usecase: 
I want to have my custom banner AND I still want to have line that shows the version of framework (usefull for searching when k8s pods restart in logs).

Adds more flexibility to customization of banner.

I'm not sure, whether this functionality should be covered with tests, because I didn't find any tests for MicronautBanner class.
Also, maybe it's not the best decision to implement Banner interface.
Maybe naming is not the best, I'm not sure either)