### PR TITLE
build: Add OpenAPI BOM

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -133,7 +133,6 @@ managed-rxjava1-interop = "0.13.7"
 managed-slf4j = "1.7.36"
 managed-spock = "2.0-groovy-3.0"
 managed-spotbugs = "4.7.0"
-managed-swagger = "2.2.0"
 managed-validation = "2.0.1.Final"
 managed-testcontainers = "1.17.2"
 managed-snakeyaml = "1.30"
@@ -159,6 +158,7 @@ boms-micronaut-microstream = { module = "io.micronaut.microstream:micronaut-micr
 boms-micronaut-mongo = { module = "io.micronaut.mongodb:micronaut-mongo-bom", version.ref = "managed-micronaut-mongo" }
 boms-micronaut-mqtt = { module = "io.micronaut.mqtt:micronaut-mqtt-bom", version.ref = "managed-micronaut-mqtt" }
 boms-micronaut-oraclecloud = { module = "io.micronaut.oraclecloud:micronaut-oraclecloud-bom", version.ref = "managed-micronaut-oraclecloud" }
+boms-micronaut-openapi = { module = "io.micronaut.openapi:micronaut-openapi-bom", version.ref = "managed-micronaut-openapi" }
 boms-micronaut-picocli = { module = "io.micronaut.picocli:micronaut-picocli-bom", version.ref = "managed-micronaut-picocli" }
 boms-micronaut-problem-json = { module = "io.micronaut.problem:micronaut-problem-json-bom", version.ref = "managed-micronaut-problem" }
 boms-micronaut-redis = { module = "io.micronaut.redis:micronaut-redis-bom", version.ref = "managed-micronaut-redis" }
@@ -326,10 +326,6 @@ managed-snakeyaml = { module = "org.yaml:snakeyaml", version.ref = "managed-snak
 
 managed-spock = { module = "org.spockframework:spock-core", version.ref = "managed-spock" }
 managed-spotbugs = { module = "com.github.spotbugs:spotbugs-annotations", version.ref = "managed-spotbugs" }
-
-managed-swagger = { module = "io.swagger.core.v3:swagger-core", version.ref = "managed-swagger" }
-managed-swagger-models = { module = "io.swagger.core.v3:swagger-models", version.ref = "managed-swagger" }
-managed-swagger-annotations = { module = "io.swagger.core.v3:swagger-annotations", version.ref = "managed-swagger" }
 
 managed-validation = { module = "javax.validation:validation-api", version.ref = "managed-validation" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -134,6 +134,7 @@ managed-rxjava1-interop = "0.13.7"
 managed-slf4j = "1.7.36"
 managed-spock = "2.0-groovy-3.0"
 managed-spotbugs = "4.7.0"
+managed-swagger = "2.2.1"
 managed-validation = "2.0.1.Final"
 managed-testcontainers = "1.17.2"
 managed-snakeyaml = "1.30"
@@ -328,6 +329,10 @@ managed-snakeyaml = { module = "org.yaml:snakeyaml", version.ref = "managed-snak
 
 managed-spock = { module = "org.spockframework:spock-core", version.ref = "managed-spock" }
 managed-spotbugs = { module = "com.github.spotbugs:spotbugs-annotations", version.ref = "managed-spotbugs" }
+
+managed-swagger = { module = "io.swagger.core.v3:swagger-core", version.ref = "managed-swagger" }
+managed-swagger-models = { module = "io.swagger.core.v3:swagger-models", version.ref = "managed-swagger" }
+managed-swagger-annotations = { module = "io.swagger.core.v3:swagger-annotations", version.ref = "managed-swagger" }
 
 managed-validation = { module = "javax.validation:validation-api", version.ref = "managed-validation" }
 


### PR DESCRIPTION
This results in the following diff in the published catalog:

```diff
108d107
< swagger = "2.2.0"
401a401
> micronaut-openapi-bom = {group = "io.micronaut.openapi", name = "micronaut-openapi-bom", version = "" }
560,562c560,562
< swagger = {group = "io.swagger.core.v3", name = "swagger-core", version.ref = "swagger" }
< swagger-annotations = {group = "io.swagger.core.v3", name = "swagger-annotations", version.ref = "swagger" }
< swagger-models = {group = "io.swagger.core.v3", name = "swagger-models", version.ref = "swagger" }
---
> swagger-annotations = {group = "io.swagger.core.v3", name = "swagger-annotations", version = "" }
> swagger-core = {group = "io.swagger.core.v3", name = "swagger-core", version = "" }
> swagger-models = {group = "io.swagger.core.v3", name = "swagger-models", version = "" }
```

The main difference being that instead of `swagger`, we now have `swagger-core`

Is this ok for a minor release?  Or do we need to rename the managed swagger dependency in the openapi module?

Closes #7490 