### PR TITLE
Fix Test Resources property in the BOM

### DIFF
--- a/bom/build.gradle
+++ b/bom/build.gradle
@@ -18,6 +18,7 @@ micronautBom {
             'paho.v5': 'pahov5',
             'graal.sdk': 'graalSdk',
             'neo4j.java.driver': 'neo4j.bolt',
+            'micronaut.test.resources': 'micronaut.test-resources'
     ]
     propertyName = 'core'
     suppressions {


### PR DESCRIPTION
Currently is being generated as `<micronaut.test.resources.version>`.

This changes it to be `<micronaut.test-resources.version>`