### PR TITLE
Use the version of projectreactor from micronaut-reactor

### DIFF
--- a/function-client/build.gradle
+++ b/function-client/build.gradle
@@ -7,5 +7,6 @@ dependencies {
     api project(":function")
     api project(":http-client")
 
-    implementation libs.managed.reactor
+    implementation(platform(libs.boms.micronaut.reactor))
+    implementation libs.project.reactor
 }

--- a/function-web/build.gradle
+++ b/function-web/build.gradle
@@ -8,7 +8,8 @@ dependencies {
     api project(":router")
     api project(":http-server")
 
-    testImplementation libs.managed.reactor
+    testImplementation(platform(libs.boms.micronaut.reactor))
+    testImplementation libs.project.reactor
 
     testImplementation project(":http-client")
     testImplementation project(":inject")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -103,7 +103,7 @@ managed-micronaut-picocli = "4.2.1"
 managed-micronaut-problem = "2.3.1"
 managed-micronaut-rabbitmq = "3.1.0"
 managed-micronaut-r2dbc = "3.0.0"
-managed-micronaut-reactor = "2.2.2"
+managed-micronaut-reactor = "2.3.0"
 managed-micronaut-redis = "5.2.0"
 managed-micronaut-rss = "3.0.0"
 managed-micronaut-rxjava1 = "1.0.0"
@@ -126,8 +126,6 @@ managed-neo4j-java-driver = "4.2.7"
 managed-netty = "4.1.77.Final"
 managed-reactive-pg-client = "0.11.4"
 managed-reactive-streams = "1.0.4"
-# This should be kept aligned with https://github.com/micronaut-projects/micronaut-reactor/blob/master/gradle.properties from the BOM
-managed-reactor = "3.4.18"
 managed-rxjava1 = "1.3.8"
 managed-rxjava1-interop = "0.13.7"
 managed-slf4j = "1.7.36"
@@ -322,8 +320,6 @@ managed-micronaut-xml = { module = "io.micronaut.xml:micronaut-jackson-xml", ver
 managed-reactive-pg-client = { module = "io.reactiverse:reactive-pg-client", version.ref = "managed-reactive-pg-client" }
 managed-reactive-streams = { module = "org.reactivestreams:reactive-streams", version.ref = "managed-reactive-streams" }
 
-managed-reactor = { module = "io.projectreactor:reactor-core", version.ref = "managed-reactor" }
-
 managed-rxjava1 = { module = "io.reactivex:rxjava", version.ref = "managed-rxjava1" }
 managed-rxjava1-interop = { module = "com.github.akarnokd:rxjava2-interop", version.ref = "managed-rxjava1-interop" }
 
@@ -423,6 +419,8 @@ mysql-driver = { module = "mysql:mysql-connector-java" }
 
 netty-tcnative = { module = 'io.netty:netty-tcnative' }
 netty-tcnative-boringssl = { module = 'io.netty:netty-tcnative-boringssl-static' }
+
+project-reactor = { module = "io.projectreactor:reactor-core" }
 
 selenium-remote-driver = { module = "org.seleniumhq.selenium:selenium-remote-driver", version.ref = "selenium" }
 selenium-api = { module = "org.seleniumhq.selenium:selenium-api", version.ref = "selenium" }

--- a/http-client-core/build.gradle
+++ b/http-client-core/build.gradle
@@ -5,7 +5,8 @@ plugins {
 dependencies {
     annotationProcessor project(":inject-java")
 
-    implementation libs.managed.reactor
+    implementation(platform(libs.boms.micronaut.reactor))
+    implementation libs.project.reactor
 
     api project(":runtime")
 

--- a/http-client/build.gradle
+++ b/http-client/build.gradle
@@ -24,7 +24,8 @@ dependencies {
     testImplementation project(":validation")
     testImplementation project(":inject")
 
-    implementation libs.managed.reactor
+    implementation(platform(libs.boms.micronaut.reactor))
+    implementation libs.project.reactor
 
     testImplementation project(":http-server-netty")
     testImplementation libs.wiremock

--- a/http-netty/build.gradle
+++ b/http-netty/build.gradle
@@ -17,7 +17,8 @@ dependencies {
     api libs.managed.netty.codec.http2
     api libs.managed.netty.handler
 
-    implementation libs.managed.reactor
+    implementation(platform(libs.boms.micronaut.reactor))
+    implementation libs.project.reactor
 
     testImplementation project(":runtime")
 }

--- a/http-server-netty/build.gradle
+++ b/http-server-netty/build.gradle
@@ -26,7 +26,8 @@ dependencies {
     api project(":http-netty")
     api libs.managed.netty.codec.http
 
-    implementation libs.managed.reactor
+    implementation(platform(libs.boms.micronaut.reactor))
+    implementation libs.project.reactor
 
     compileOnly libs.kotlin.stdlib
     compileOnly libs.managed.netty.transport.native.unix.common

--- a/http-server/build.gradle
+++ b/http-server/build.gradle
@@ -8,7 +8,8 @@ dependencies {
     api project(":router")
     compileOnly libs.kotlinx.coroutines.core
     compileOnly libs.kotlinx.coroutines.reactor
-    implementation libs.managed.reactor
+    implementation(platform(libs.boms.micronaut.reactor))
+    implementation libs.project.reactor
     annotationProcessor project(":inject-java")
 
     testImplementation libs.managed.netty.codec.http

--- a/http/build.gradle
+++ b/http/build.gradle
@@ -8,7 +8,10 @@ dependencies {
     annotationProcessor project(":graal")
     api project(":inject")
     api project(":core-reactive")
-    implementation libs.managed.reactor
+
+    implementation(platform(libs.boms.micronaut.reactor))
+    implementation libs.project.reactor
+
     compileOnly libs.kotlinx.coroutines.core
     compileOnly libs.kotlinx.coroutines.reactor
 

--- a/inject-groovy/build.gradle
+++ b/inject-groovy/build.gradle
@@ -34,7 +34,8 @@ dependencies {
     testImplementation libs.managed.groovy.json
     testImplementation libs.blaze.persistence.core
 
-    testImplementation libs.managed.reactor
+    testImplementation(platform(libs.boms.micronaut.reactor))
+    testImplementation libs.project.reactor
 
     functionalTestImplementation(testFixtures(project(":test-suite")))
 }

--- a/inject-java/build.gradle
+++ b/inject-java/build.gradle
@@ -24,7 +24,8 @@ dependencies {
     testImplementation project(":inject-test-utils")
     testImplementation project(":runtime")
 
-    testImplementation libs.managed.reactor
+    testImplementation(platform(libs.boms.micronaut.reactor))
+    testImplementation libs.project.reactor
 
     testImplementation libs.managed.spotbugs
     testImplementation libs.hibernate

--- a/management/build.gradle
+++ b/management/build.gradle
@@ -13,7 +13,8 @@ dependencies {
         exclude module:'micronaut-bom'
     }
 
-    implementation libs.managed.reactor
+    implementation(platform(libs.boms.micronaut.reactor))
+    implementation libs.project.reactor
 
     testImplementation project(":http-client")
     testImplementation project(":inject-groovy")

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -13,7 +13,8 @@ dependencies {
     api project(":jackson-databind")
     api libs.managed.validation
 
-    implementation libs.managed.reactor
+    implementation(platform(libs.boms.micronaut.reactor))
+    implementation libs.project.reactor
 
     compileOnly libs.managed.graal
     compileOnly libs.managed.jcache

--- a/session/build.gradle
+++ b/session/build.gradle
@@ -10,7 +10,8 @@ dependencies {
     compileOnly project(":http-server")
     compileOnly project(":http-server-netty")
 
-    implementation libs.managed.reactor
+    implementation(platform(libs.boms.micronaut.reactor))
+    implementation libs.project.reactor
 
     testAnnotationProcessor project(":inject-java")
     testCompileOnly project(":inject-groovy")

--- a/test-suite-groovy/build.gradle
+++ b/test-suite-groovy/build.gradle
@@ -29,7 +29,8 @@ dependencies {
     testRuntimeOnly(platform(libs.boms.micronaut.aws))
     testRuntimeOnly libs.aws.java.sdk.lambda
 
-    testImplementation libs.managed.reactor
+    testImplementation(platform(libs.boms.micronaut.reactor))
+    testImplementation libs.project.reactor
 }
 
 //tasks.withType(Test).configureEach {

--- a/test-suite-kotlin/build.gradle
+++ b/test-suite-kotlin/build.gradle
@@ -64,7 +64,8 @@ dependencies {
         testImplementation libs.bcpkix
     }
 
-    testImplementation libs.managed.reactor
+    testImplementation(platform(libs.boms.micronaut.reactor))
+    testImplementation libs.project.reactor
 }
 
 tasks.named("compileTestKotlin") {

--- a/test-suite/build.gradle
+++ b/test-suite/build.gradle
@@ -87,7 +87,8 @@ dependencies {
         testImplementation libs.bcpkix
     }
 
-    testImplementation libs.managed.reactor
+    testImplementation(platform(libs.boms.micronaut.reactor))
+    testImplementation libs.project.reactor
 
     testFixturesApi libs.managed.spock
     testFixturesApi libs.managed.groovy

--- a/validation/build.gradle
+++ b/validation/build.gradle
@@ -18,7 +18,8 @@ dependencies {
     compileOnly libs.managed.gorm
     compileOnly project(":http-server")
 
-    implementation libs.managed.reactor
+    implementation(platform(libs.boms.micronaut.reactor))
+    implementation libs.project.reactor
 
     testImplementation libs.managed.spotbugs
     testAnnotationProcessor project(":inject-java")

--- a/websocket/build.gradle
+++ b/websocket/build.gradle
@@ -12,7 +12,8 @@ dependencies {
     api project(":inject")
     api project(':aop')
 
-    implementation libs.managed.reactor
+    implementation(platform(libs.boms.micronaut.reactor))
+    implementation libs.project.reactor
 
     testImplementation project(":inject-groovy")
 }


### PR DESCRIPTION
Instead of having to keep it aligned.

@melix is this right?  Project reactor no longer appears in the bom-pom

### micronaut-bom Pom changes

```diff
82d81
<     <reactor.version>3.4.18</reactor.version>
119c118
<     <micronaut.reactor.version>2.2.2</micronaut.reactor.version>
---
>     <micronaut.reactor.version>2.3.0</micronaut.reactor.version>
637,641d635
<         <groupId>io.projectreactor</groupId>
<         <artifactId>reactor-core</artifactId>
<         <version>${reactor.version}</version>
<       </dependency>
<       <dependency>
```

### micronaut-bom toml changes

```diff
78c78
< micronaut-reactor = "2.2.2"
---
> micronaut-reactor = "2.3.0"
101d100
< reactor = "3.4.18"
553c552,553
< reactor = {group = "io.projectreactor", name = "reactor-core", version.ref = "reactor" }
---
> reactor = {group = "io.projectreactor", name = "reactor-core", version = "" }
> reactor-core = {group = "io.projectreactor", name = "reactor-core", version = "" }
```

I suspect not, so creating this as a draft

Closes #7638