### PR TITLE
Deduplicate TypeElementVisitors

### DIFF
--- a/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
@@ -344,7 +344,9 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
                 }
             }
             return true;
-        });
+        }).stream()
+            // remove duplicate classes
+            .collect(Collectors.toMap(v -> v.getClass(), v -> v)).values();
     }
 
     /**


### PR DESCRIPTION
#7608 replaced the manual iteration in TypeElementVisitorProcessor with a collectAll call, which does not do deduplication of services. This introduced a regression in the maven plugin. This patch adds new logic for deduplication.