### PR TITLE
Deduplicate TypeElementVisitors (without an error)

### DIFF
--- a/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
@@ -346,7 +346,7 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
             return true;
         }).stream()
             // remove duplicate classes
-            .collect(Collectors.toMap(v -> v.getClass(), v -> v)).values();
+            .collect(Collectors.toMap(v -> v.getClass(), v -> v, (a, b) -> a)).values();
     }
 
     /**

--- a/inject-java/src/test/resources/META-INF/micronaut/io.micronaut.inject.visitor.TypeElementVisitor/io.micronaut.visitors.InjectVisitor
+++ b/inject-java/src/test/resources/META-INF/micronaut/io.micronaut.inject.visitor.TypeElementVisitor/io.micronaut.visitors.InjectVisitor
@@ -1,0 +1,1 @@
+# duplicated in the normal service config to test deduplication in TypeElementVisitorProcessor


### PR DESCRIPTION
Fix of #7651. The PR threw an exception on duplicate elements (but somehow still resolved the maven plugin issue? go figure).

On top of the fix, this PR actually triggers the failure in `TypeElementVisitorProcessorSpec` by adding a duplicate service to the test resources.

Fixes #7652