### PR TITLE
Add javadoc / groovydoc support to read any element documentation

### DIFF
--- a/config/accepted-api-changes.json
+++ b/config/accepted-api-changes.json
@@ -1,5 +1,15 @@
 [
   {
+    "type": "io.micronaut.ast.groovy.visitor.AbstractGroovyElement",
+    "member": "Class io.micronaut.ast.groovy.visitor.AbstractGroovyElement",
+    "reason": "Add support getDocumentation (groovydoc) for groovy"
+  },
+  {
+    "type": "io.micronaut.ast.groovy.visitor.AbstractGroovyElement",
+    "member": "Constructor io.micronaut.ast.groovy.visitor.AbstractGroovyElement(io.micronaut.ast.groovy.visitor.GroovyVisitorContext,org.codehaus.groovy.ast.AnnotatedNode,io.micronaut.core.annotation.AnnotationMetadata)",
+    "reason": "Add support getDocumentation (groovydoc) for groovy"
+  },
+  {
     "type": "io.micronaut.scheduling.TaskScheduler",
     "member": "Class io.micronaut.scheduling.TaskScheduler",
     "reason": "Added default methods"
@@ -189,7 +199,7 @@
     "member": "Method io.micronaut.core.type.TypeInformation.asType()",
     "reason": "Added a default method"
   },
-  {  
+  {
     "type": "io.micronaut.core.annotation.AnnotationMetadata",
     "member": "Method io.micronaut.core.annotation.AnnotationMetadata.getAnnotationValuesByStereotype(java.lang.String)",
     "reason": "New default method"

--- a/inject-groovy/build.gradle
+++ b/inject-groovy/build.gradle
@@ -41,6 +41,8 @@ dependencies {
 
 tasks.named("test") {
     exclude '**/*$_closure*'
+
+    systemProperty "groovy.attach.groovydoc", true
 }
 
 //compileTestGroovy.groovyOptions.forkOptions.jvmArgs = ['-Xdebug', '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005']

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/AbstractGroovyElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/AbstractGroovyElement.java
@@ -27,6 +27,7 @@ import io.micronaut.core.annotation.AnnotationValueBuilder;
 import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.annotation.AbstractAnnotationMetadataBuilder;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.Element;
@@ -46,6 +47,7 @@ import java.lang.reflect.Modifier;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 
 /**
  * Abstract Groovy element.
@@ -55,6 +57,8 @@ import java.util.function.Predicate;
  */
 
 public abstract class AbstractGroovyElement implements AnnotationMetadataDelegate, Element {
+
+    private static final Pattern JAVADOC_PATTERN = Pattern.compile("(/\\s*\\*\\*)|\\s*\\*|(\\s*[*/])");
 
     protected final SourceUnit sourceUnit;
     protected final CompilationUnit compilationUnit;
@@ -68,7 +72,7 @@ public abstract class AbstractGroovyElement implements AnnotationMetadataDelegat
      * @param annotatedNode      The annotated node
      * @param annotationMetadata The annotation metadata
      */
-    public AbstractGroovyElement(GroovyVisitorContext visitorContext, AnnotatedNode annotatedNode, AnnotationMetadata annotationMetadata) {
+    protected AbstractGroovyElement(GroovyVisitorContext visitorContext, AnnotatedNode annotatedNode, AnnotationMetadata annotationMetadata) {
         this.visitorContext = visitorContext;
         this.compilationUnit = visitorContext.getCompilationUnit();
         this.annotatedNode = annotatedNode;
@@ -333,6 +337,14 @@ public abstract class AbstractGroovyElement implements AnnotationMetadataDelegat
             }
         }
         return null;
+    }
+
+    @Override
+    public Optional<String> getDocumentation() {
+        if (annotatedNode.getGroovydoc() == null || annotatedNode.getGroovydoc().getContent() == null) {
+            return Optional.empty();
+        }
+        return Optional.of(JAVADOC_PATTERN.matcher(annotatedNode.getGroovydoc().getContent()).replaceAll(StringUtils.EMPTY_STRING).trim());
     }
 
     /**

--- a/inject-groovy/src/test/groovy/io/micronaut/ast/groovy/visitor/GroovyDocumentationSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/ast/groovy/visitor/GroovyDocumentationSpec.groovy
@@ -1,0 +1,50 @@
+package io.micronaut.ast.groovy.visitor
+
+import io.micronaut.ast.transform.test.AbstractBeanDefinitionSpec
+import io.micronaut.inject.ast.ElementQuery
+import io.micronaut.inject.ast.MethodElement
+
+class GroovyDocumentationSpec extends AbstractBeanDefinitionSpec {
+
+    void "test read class level documentation"() {
+        def classElement = buildClassElement("""
+package test
+
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.NotNull
+import io.micronaut.ast.groovy.visitor.SuperClass
+
+/**
+ * This is class level docs
+ */
+class Test extends SuperClass {
+    /**This is property level docs
+     */
+    @NotBlank
+    @NotNull
+    private String tenant
+
+    /**
+     * This is method level docs
+     */
+    String getTenant() {
+        return tenant
+    }
+
+    /**
+        This is method level docs
+
+     */
+    void setTenant(String tenant) {
+        this.tenant = tenant
+    }
+}
+""")
+
+        expect:
+        classElement.getDocumentation().get() == 'This is class level docs'
+        classElement.getFields().get(0).getDocumentation().get() == 'This is property level docs'
+        classElement.getEnclosedElements(ElementQuery.of(MethodElement.class).named("getTenant")).get(0).getDocumentation().get() == 'This is method level docs'
+        classElement.getEnclosedElements(ElementQuery.of(MethodElement.class).named("setTenant")).get(0).getDocumentation().get() == 'This is method level docs'
+    }
+}

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/AbstractJavaElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/AbstractJavaElement.java
@@ -48,6 +48,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -65,7 +66,7 @@ import static javax.lang.model.element.Modifier.PUBLIC;
  * @author graemerocher
  * @since 1.0
  */
-public abstract class AbstractJavaElement implements io.micronaut.inject.ast.Element, AnnotationMetadataDelegate {
+public abstract class AbstractJavaElement implements io.micronaut.inject.ast.Element {
 
     private final Element element;
     private final JavaVisitorContext visitorContext;
@@ -93,7 +94,7 @@ public abstract class AbstractJavaElement implements io.micronaut.inject.ast.Ele
         final AnnotationValue<T> av = builder.build();
         AnnotationUtils annotationUtils = visitorContext
                 .getAnnotationUtils();
-        this.annotationMetadata = annotationUtils
+        annotationMetadata = annotationUtils
                 .newAnnotationBuilder()
                 .annotate(annotationMetadata, av);
 
@@ -107,7 +108,7 @@ public abstract class AbstractJavaElement implements io.micronaut.inject.ast.Ele
 
         AnnotationUtils annotationUtils = visitorContext
                 .getAnnotationUtils();
-        this.annotationMetadata = annotationUtils
+        annotationMetadata = annotationUtils
                 .newAnnotationBuilder()
                 .annotate(annotationMetadata, annotationValue);
 
@@ -121,7 +122,7 @@ public abstract class AbstractJavaElement implements io.micronaut.inject.ast.Ele
         try {
             AnnotationUtils annotationUtils = visitorContext
                     .getAnnotationUtils();
-            this.annotationMetadata = annotationUtils
+            annotationMetadata = annotationUtils
                     .newAnnotationBuilder()
                     .removeAnnotation(annotationMetadata, annotationType);
             return this;
@@ -137,7 +138,7 @@ public abstract class AbstractJavaElement implements io.micronaut.inject.ast.Ele
             try {
                 AnnotationUtils annotationUtils = visitorContext
                         .getAnnotationUtils();
-                this.annotationMetadata = annotationUtils
+                annotationMetadata = annotationUtils
                         .newAnnotationBuilder()
                         .removeAnnotationIf(annotationMetadata, predicate);
                 return this;
@@ -154,7 +155,7 @@ public abstract class AbstractJavaElement implements io.micronaut.inject.ast.Ele
         try {
             AnnotationUtils annotationUtils = visitorContext
                     .getAnnotationUtils();
-            this.annotationMetadata = annotationUtils
+            annotationMetadata = annotationUtils
                     .newAnnotationBuilder()
                     .removeStereotype(annotationMetadata, annotationType);
             return this;
@@ -176,7 +177,7 @@ public abstract class AbstractJavaElement implements io.micronaut.inject.ast.Ele
             final Element nativeType = (Element) owningType.getNativeType();
             declaringTypeName = resolveCanonicalName(nativeType);
         } else {
-            final Object nativeType = this.getNativeType();
+            final Object nativeType = getNativeType();
             if (nativeType instanceof TypeVariable) {
                 declaringTypeName = resolveCanonicalName(((TypeVariable) nativeType).asElement());
             } else if (nativeType instanceof Element) {
@@ -214,10 +215,16 @@ public abstract class AbstractJavaElement implements io.micronaut.inject.ast.Ele
 
     @Override
     public Set<ElementModifier> getModifiers() {
-        return this.element
+        return element
                 .getModifiers().stream()
                 .map(m -> ElementModifier.valueOf(m.name()))
                 .collect(Collectors.toSet());
+    }
+
+    @Override
+    public Optional<String> getDocumentation() {
+        String doc = visitorContext.getElements().getDocComment(element);
+        return Optional.ofNullable(doc != null ? doc.trim() : null);
     }
 
     @Override

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaMethodElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaMethodElement.java
@@ -148,11 +148,6 @@ public class JavaMethodElement extends AbstractJavaElement implements MethodElem
     }
 
     @Override
-    public Optional<String> getDocumentation() {
-        return Optional.ofNullable(visitorContext.getElements().getDocComment(executableElement));
-    }
-
-    @Override
     public boolean isSuspend() {
         getParameters();
         return this.continuationParameter != null;

--- a/inject-java/src/test/groovy/io/micronaut/visitors/DocumentationSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/DocumentationSpec.groovy
@@ -1,0 +1,48 @@
+package io.micronaut.visitors
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.inject.ast.ElementQuery
+import io.micronaut.inject.ast.MethodElement
+
+class DocumentationSpec extends AbstractTypeElementSpec {
+
+    void "test read class level documentation"() {
+        def classElement = buildClassElement("""
+package test;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+/**
+ * This is class level docs
+ */
+class Test {
+    /**This is property level docs
+     */
+    @NotBlank
+    @NotNull
+    private String tenant;
+
+    /**
+     * This is method level docs*/
+    String getTenant() {
+        return tenant;
+    }
+
+    /**
+        This is method level docs
+
+     */
+    void setTenant(String tenant) {
+        this.tenant = tenant;
+    }
+}
+""")
+
+        expect:
+        classElement.getDocumentation().get() == 'This is class level docs'
+        classElement.getFields().get(0).getDocumentation().get() == 'This is property level docs'
+        classElement.getEnclosedElements(ElementQuery.of(MethodElement.class).named("getTenant")).get(0).getDocumentation().get() == 'This is method level docs'
+        classElement.getEnclosedElements(ElementQuery.of(MethodElement.class).named("setTenant")).get(0).getDocumentation().get() == 'This is method level docs'
+    }
+}


### PR DESCRIPTION
There is currently no way to read the documentation for the element class. The problem is that there are record classes that do not have attributes. This is done using class-level documentation with `@param` tags. Same problem with kotlin data classes.

Added support for Groovy Documentation when the `groovy.attach.groovydoc` property is enabled

Need it to generate openapi docs from javadocs. See this: https://github.com/micronaut-projects/micronaut-openapi/issues/134