### PR TITLE
Convert `TimeConverterRegistrar` to be loaded using the service loader

### DIFF
--- a/config/accepted-api-changes.json
+++ b/config/accepted-api-changes.json
@@ -189,7 +189,7 @@
     "member": "Method io.micronaut.core.type.TypeInformation.asType()",
     "reason": "Added a default method"
   },
-  {  
+  {
     "type": "io.micronaut.core.annotation.AnnotationMetadata",
     "member": "Method io.micronaut.core.annotation.AnnotationMetadata.getAnnotationValuesByStereotype(java.lang.String)",
     "reason": "New default method"
@@ -208,5 +208,35 @@
     "type": "io.micronaut.context.BeanDefinitionRegistry",
     "member": "Method io.micronaut.context.BeanDefinitionRegistry.registerBeanDefinition(io.micronaut.context.RuntimeBeanDefinition)",
     "reason": "new internal default method"
+  },
+  {
+    "type": "io.micronaut.runtime.converters.time.$TimeConverterRegistrar$Definition$Reference",
+    "member": "Class io.micronaut.runtime.converters.time.$TimeConverterRegistrar$Definition$Reference",
+    "reason": "Not a bean anymore"
+  },
+  {
+    "type": "io.micronaut.runtime.converters.time.$TimeConverterRegistrar$Definition$Reference",
+    "member": "Field $ANNOTATION_METADATA",
+    "reason": "Not a bean anymore"
+  },
+  {
+    "type": "io.micronaut.runtime.converters.time.$TimeConverterRegistrar$Definition$Reference",
+    "member": "Method io.micronaut.runtime.converters.time.$TimeConverterRegistrar$Definition$Reference.getBeanDefinitionType()",
+    "reason": "Not a bean anymore"
+  },
+  {
+    "type": "io.micronaut.runtime.converters.time.$TimeConverterRegistrar$Definition$Reference",
+    "member": "Method io.micronaut.runtime.converters.time.$TimeConverterRegistrar$Definition$Reference.getBeanType()",
+    "reason": "Not a bean anymore"
+  },
+  {
+    "type": "io.micronaut.runtime.converters.time.$TimeConverterRegistrar$Definition$Reference",
+    "member": "Method io.micronaut.runtime.converters.time.$TimeConverterRegistrar$Definition$Reference.load()",
+    "reason": "Not a bean anymore"
+  },
+  {
+    "type": "io.micronaut.runtime.converters.time.$TimeConverterRegistrar$Definition$Reference",
+    "member": "Constructor io.micronaut.runtime.converters.time.$TimeConverterRegistrar$Definition$Reference()",
+    "reason": "Not a bean anymore"
   }
 ]

--- a/context/src/main/java/io/micronaut/runtime/converters/time/TimeConverterRegistrar.java
+++ b/context/src/main/java/io/micronaut/runtime/converters/time/TimeConverterRegistrar.java
@@ -15,9 +15,7 @@
  */
 package io.micronaut.runtime.converters.time;
 
-import io.micronaut.context.annotation.BootstrapContextCompatible;
-import io.micronaut.context.annotation.Requires;
-import io.micronaut.context.env.Environment;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.TypeHint;
 import io.micronaut.core.convert.ConversionContext;
 import io.micronaut.core.convert.ConversionService;
@@ -25,9 +23,20 @@ import io.micronaut.core.convert.TypeConverter;
 import io.micronaut.core.convert.TypeConverterRegistrar;
 import io.micronaut.core.convert.format.Format;
 import io.micronaut.core.util.StringUtils;
-import jakarta.inject.Singleton;
 
-import java.time.*;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.MonthDay;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.Period;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
@@ -43,10 +52,6 @@ import java.util.regex.Pattern;
  * @author Graeme Rocher
  * @since 1.0
  */
-@Singleton
-// Android doesn't support java.time
-@Requires(notEnv = Environment.ANDROID)
-@BootstrapContextCompatible
 @TypeHint(
         value = {
                 Duration.class,
@@ -66,6 +71,7 @@ import java.util.regex.Pattern;
         },
         accessType = TypeHint.AccessType.ALL_PUBLIC
 )
+@Internal
 public class TimeConverterRegistrar implements TypeConverterRegistrar {
 
     private static final Pattern DURATION_MATCHER = Pattern.compile("^(-?\\d+)([unsmhd])(s?)$");

--- a/context/src/main/resources/META-INF/services/io.micronaut.core.convert.TypeConverterRegistrar
+++ b/context/src/main/resources/META-INF/services/io.micronaut.core.convert.TypeConverterRegistrar
@@ -1,0 +1,1 @@
+io.micronaut.runtime.converters.time.TimeConverterRegistrar


### PR DESCRIPTION
I see errors in logs:
`Invalid @Scheduled definition for method: void everyFiveMinutes$test_suite_kotlin() - Reason: Invalid fixed rate definition: 5m`
 that might indicate that scheduled logic was triggered before the time register. Anyway, I think it's better to register it with the newly added way of the service loader.