### PR TITLE
Fix buildStaticServiceDefinitions for IOUtils changes

### DIFF
--- a/core/src/main/java/io/micronaut/core/graal/ServiceLoaderInitialization.java
+++ b/core/src/main/java/io/micronaut/core/graal/ServiceLoaderInitialization.java
@@ -103,6 +103,8 @@ final class ServiceLoaderFeature implements Feature {
                                     if (i > -1) {
                                         serviceName = serviceName.substring(i);
                                     }
+                                } else if (serviceName.startsWith("/")) {
+                                    serviceName = serviceName.substring(1);
                                 }
                                 if (serviceName.startsWith(path)) {
                                     servicePaths.add(serviceName);


### PR DESCRIPTION
Paths returned by eachFile now have a leading slash. This broke the service scanning.

Fixes #7671