### PR TITLE
fix: UriBuilder queryParam and replaceQueryParam should ignore null values

### DIFF
--- a/http/src/main/java/io/micronaut/http/uri/DefaultUriBuilder.java
+++ b/http/src/main/java/io/micronaut/http/uri/DefaultUriBuilder.java
@@ -18,6 +18,7 @@ package io.micronaut.http.uri;
 import io.micronaut.core.convert.value.MutableConvertibleMultiValues;
 import io.micronaut.core.convert.value.MutableConvertibleMultiValuesMap;
 import io.micronaut.core.util.ArrayUtils;
+import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.exceptions.UriSyntaxException;
 
@@ -235,7 +236,9 @@ class DefaultUriBuilder implements UriBuilder {
                     strings.add(value.toString());
                 }
             }
-            queryParams.put(name, strings);
+            if (CollectionUtils.isNotEmpty(strings)) {
+                queryParams.put(name, strings);
+            }
         }
         return this;
     }
@@ -250,7 +253,9 @@ class DefaultUriBuilder implements UriBuilder {
                     strings.add(value.toString());
                 }
             }
-            queryParams.put(name, strings);
+            if (CollectionUtils.isNotEmpty(strings)) {
+                queryParams.put(name, strings);
+            }
         }
         return this;
     }

--- a/http/src/test/groovy/io/micronaut/http/uri/UriBuilderSpec.groovy
+++ b/http/src/test/groovy/io/micronaut/http/uri/UriBuilderSpec.groovy
@@ -138,12 +138,38 @@ class UriBuilderSpec extends Specification {
         builder.toString() == expected
 
         where:
-        uri                  | params                  | expected
-        '/foo?existing=true' | ['foo': 'bar']          | '/foo?existing=true&foo=bar'
-        '/foo'               | ['foo': 'bar']          | '/foo?foo=bar'
-        '/foo'               | ['foo': 'hello world']  | '/foo?foo=hello+world'
-        '/foo'               | ['foo': ['bar', 'baz']] | '/foo?foo=bar&foo=baz'
-        '/foo'               | ['foo': ['bar', 'baz']] | '/foo?foo=bar&foo=baz'
+        uri                  | params                              | expected
+        '/foo?existing=true' | ['foo': 'bar']                      | '/foo?existing=true&foo=bar'
+        '/foo'               | ['foo': 'bar']                      | '/foo?foo=bar'
+        '/foo'               | ['foo': 'hello world']              | '/foo?foo=hello+world'
+        '/foo'               | ['foo': ['bar', 'baz']]             | '/foo?foo=bar&foo=baz'
+        '/foo'               | ['foo': null, 'bar': 'baz']         | '/foo?bar=baz'
+        '/foo'               | ['foo': [null, null], 'bar': 'baz'] | '/foo?bar=baz'
+    }
+
+    @Unroll
+    void "test replaceQueryParam method for uri #uri"() {
+        given:
+        def builder = UriBuilder.of(uri)
+        for (p in params) {
+            if (p.value instanceof List) {
+                builder.replaceQueryParam(p.key, *p.value)
+            } else {
+                builder.replaceQueryParam(p.key, p.value)
+            }
+        }
+
+        expect:
+        builder.toString() == expected
+
+        where:
+        uri             | params                              | expected
+        '/foo?foo=old'  | ['foo': 'bar']                      | '/foo?foo=bar'
+        '/foo?old=keep' | ['foo': 'bar']                      | '/foo?old=keep&foo=bar'
+        '/foo?foo=old'  | ['foo': 'hello world']              | '/foo?foo=hello+world'
+        '/foo?foo=old'  | ['foo': ['bar', 'baz']]             | '/foo?foo=bar&foo=baz'
+        '/foo?foo=old'  | ['foo': null, 'bar': 'baz']         | '/foo?foo=old&bar=baz'
+        '/foo?foo=old'  | ['foo': [null, null], 'bar': 'baz'] | '/foo?foo=old&bar=baz'
     }
 
     @Issue("https://github.com/micronaut-projects/micronaut-core/issues/2823")


### PR DESCRIPTION
Fix `UriBuilder::queryParam` and `UriBuilder::replaceQueryParam` to hold its promise on null values.

According to the javadoc of [`UriBuilder::queryParam`](https://github.com/micronaut-projects/micronaut-core/blob/3.6.x/http/src/main/java/io/micronaut/http/uri/UriBuilder.java#L89) and `UriBuilder::replaceQueryParam`:
> If either name or values are null the value will be ignored.

In Java (at least), passing `null` to `UriBuilder::queryParam` among other valid query parameters will produce dangling `&` in the final URI. This is because when calling `builder.queryParam('foo', null)`, the resulting parameter `Object... values` will be an array of size 1 containing `null`.

Also fixes the case where values is an array of mutliple `null`.

Example:
```
UriBuilder.of('/foo')
    .queryParam("foo", "ok")
    .queryParam("bar", null)
    .queryParam("bar", anArrayOfNull)
    .queryParam("fizz", "fine")
    .build()
    .toString();
```

Expected result: `/foo?foo=ok&fizz=fine`

Actual result: `/foo?foo=ok&&&fizz=fine`

I only tested the `[null, null]` case since it seems Groovy doesn't have the same behaviour than Java when passing only`null`: `Object... values` is `null` and correctly ignored.

Testing the whole issue would require a Java test, I can add one if you want.