### PR TITLE
Duplicate Injectable Container Type definition

### DIFF
--- a/src/main/docs/guide/ioc/types.adoc
+++ b/src/main/docs/guide/ioc/types.adoc
@@ -24,10 +24,6 @@ In addition to being able to inject beans, Micronaut natively supports injecting
 |A `javax.inject.Provider` if a circular dependency requires it, or to instantiate a prototype for each `get` call.
 |`Provider<Engine>`
 
-|link:{jakartaapi}/jakarta/inject/Provider.html[Provider]
-|A `jakarta.inject.Provider` if a circular dependency requires it or to instantiate a prototype for each `get` call.
-|`Provider<Engine>`
-
 |api:context.BeanProvider[]
 |A `io.micronaut.context.BeanProvider` if a circular dependency requires it or to instantiate a prototype for each `get` call.
 |`BeanProvider<Engine>`


### PR DESCRIPTION
Removed duplicate injectable container type definition from the table.