### PR TITLE
Temporarially stop running japiCmp

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.convention-library.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.convention-library.gradle
@@ -21,3 +21,9 @@ tasks.named("shadowJar") {
     relocate "com.github.benmanes.caffeine", "io.micronaut.caffeine"
     relocate "org.objectweb.asm", "io.micronaut.asm"
 }
+
+micronautBuild {
+    binaryCompatibility {
+        enabled = false
+    }
+}


### PR DESCRIPTION
Finding the baseline version is causing issues as we believe we are getting rate limited

Turn it off for now as we need to get a snapshot released because the lack of it is causing
errors downstream.

Related:

https://github.com/micronaut-projects/micronaut-build/pull/366
https://github.com/micronaut-projects/micronaut-build/pull/367