### PR TITLE
Clean up request even when using a customizable invoker

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/StreamTypeHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/StreamTypeHandler.java
@@ -21,6 +21,7 @@ import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.http.server.netty.types.NettyCustomizableResponseTypeHandler;
 import io.micronaut.http.server.netty.types.stream.NettyStreamedCustomizableResponseType;
 import io.micronaut.http.server.types.CustomizableResponseTypeException;
+import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 
 import java.io.InputStream;
@@ -38,7 +39,7 @@ class StreamTypeHandler implements NettyCustomizableResponseTypeHandler<Object> 
     private static final Class<?>[] SUPPORTED_TYPES = new Class[]{NettyStreamedCustomizableResponseType.class, InputStream.class};
 
     @Override
-    public void handle(Object object, HttpRequest<?> request, MutableHttpResponse<?> response, ChannelHandlerContext context) {
+    public ChannelFuture handle(Object object, HttpRequest<?> request, MutableHttpResponse<?> response, ChannelHandlerContext context) {
         NettyStreamedCustomizableResponseType type;
 
         if (object instanceof InputStream) {
@@ -50,8 +51,7 @@ class StreamTypeHandler implements NettyCustomizableResponseTypeHandler<Object> 
         }
 
         type.process(response);
-        type.write(request, response, context);
-        context.read();
+        return type.write(request, response, context);
     }
 
     @Override

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/types/NettyCustomizableResponseType.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/types/NettyCustomizableResponseType.java
@@ -19,6 +19,7 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.http.server.types.CustomizableResponseType;
+import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 
 /**
@@ -36,6 +37,7 @@ public interface NettyCustomizableResponseType extends CustomizableResponseType 
      * @param request  The request
      * @param response The response
      * @param context  The Netty {@link ChannelHandlerContext}
+     * @return The netty future that completes when the response is fully written.
      */
-    void write(HttpRequest<?> request, MutableHttpResponse<?> response, ChannelHandlerContext context);
+    ChannelFuture write(HttpRequest<?> request, MutableHttpResponse<?> response, ChannelHandlerContext context);
 }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/types/NettyCustomizableResponseTypeHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/types/NettyCustomizableResponseTypeHandler.java
@@ -20,6 +20,7 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.order.Ordered;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.MutableHttpResponse;
+import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 
 /**
@@ -40,8 +41,9 @@ public interface NettyCustomizableResponseTypeHandler<T> extends Ordered {
      * @param request  The native Netty request
      * @param response The mutable Micronaut response
      * @param context  The channel context
+     * @return The channel future that completes when the response is fully written.
      */
-    void handle(T object, HttpRequest<?> request, MutableHttpResponse<?> response, ChannelHandlerContext context);
+    ChannelFuture handle(T object, HttpRequest<?> request, MutableHttpResponse<?> response, ChannelHandlerContext context);
 
     /**
      * @param type The type to check

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/types/files/FileTypeHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/types/files/FileTypeHandler.java
@@ -29,6 +29,7 @@ import io.micronaut.http.server.netty.types.NettyFileCustomizableResponseType;
 import io.micronaut.http.server.types.CustomizableResponseTypeException;
 import io.micronaut.http.server.types.files.StreamedFile;
 import io.micronaut.http.server.types.files.SystemFile;
+import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.FullHttpResponse;
 
@@ -62,7 +63,7 @@ public class FileTypeHandler implements NettyCustomizableResponseTypeHandler<Obj
 
     @SuppressWarnings("MagicNumber")
     @Override
-    public void handle(Object obj, HttpRequest<?> request, MutableHttpResponse<?> response, ChannelHandlerContext context) {
+    public ChannelFuture handle(Object obj, HttpRequest<?> request, MutableHttpResponse<?> response, ChannelHandlerContext context) {
         NettyFileCustomizableResponseType type;
         if (obj instanceof File) {
             type = new NettySystemFileCustomizableResponseType((File) obj);
@@ -91,8 +92,7 @@ public class FileTypeHandler implements NettyCustomizableResponseTypeHandler<Obj
                 if (request instanceof NettyHttpRequest) {
                     ((NettyHttpRequest<?>) request).prepareHttp2ResponseIfNecessary(nettyResponse);
                 }
-                context.writeAndFlush(nettyResponse);
-                return;
+                return context.writeAndFlush(nettyResponse);
             }
         }
 
@@ -102,8 +102,7 @@ public class FileTypeHandler implements NettyCustomizableResponseTypeHandler<Obj
         setDateAndCacheHeaders(response, lastModified);
 
         type.process(response);
-        type.write(request, response, context);
-        context.read();
+        return type.write(request, response, context);
     }
 
     @Override

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/types/files/NettySystemFileCustomizableResponseType.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/types/files/NettySystemFileCustomizableResponseType.java
@@ -104,7 +104,7 @@ public class NettySystemFileCustomizableResponseType extends SystemFile implemen
     }
 
     @Override
-    public void write(HttpRequest<?> request, MutableHttpResponse<?> response, ChannelHandlerContext context) {
+    public ChannelFuture write(HttpRequest<?> request, MutableHttpResponse<?> response, ChannelHandlerContext context) {
 
         if (response instanceof NettyMutableHttpResponse) {
 
@@ -126,13 +126,13 @@ public class NettySystemFileCustomizableResponseType extends SystemFile implemen
                 // SSL not enabled - can use zero-copy file transfer.
                 context.write(new DefaultFileRegion(file.raf.getChannel(), 0, getLength()), context.newProgressivePromise())
                         .addListener(file);
-                context.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT);
+                return context.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT);
             } else {
                 // SSL enabled - cannot use zero-copy file transfer.
                 try {
                     // HttpChunkedInput will write the end marker (LastHttpContent) for us.
                     final HttpChunkedInput chunkedInput = new HttpChunkedInput(new ChunkedFile(file.raf, 0, getLength(), LENGTH_8K));
-                    context.writeAndFlush(chunkedInput, context.newProgressivePromise())
+                    return context.writeAndFlush(chunkedInput, context.newProgressivePromise())
                             .addListener(file);
                 } catch (IOException e) {
                     throw new CustomizableResponseTypeException("Could not read file", e);

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/types/stream/NettyStreamedCustomizableResponseType.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/types/stream/NettyStreamedCustomizableResponseType.java
@@ -21,6 +21,7 @@ import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.http.netty.NettyMutableHttpResponse;
 import io.micronaut.http.server.netty.NettyHttpRequest;
 import io.micronaut.http.server.netty.types.NettyCustomizableResponseType;
+import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.DefaultHttpResponse;
@@ -49,14 +50,13 @@ public interface NettyStreamedCustomizableResponseType extends NettyCustomizable
     InputStream getInputStream();
 
     @Override
-    default void write(HttpRequest<?> request, MutableHttpResponse<?> response, ChannelHandlerContext context) {
+    default ChannelFuture write(HttpRequest<?> request, MutableHttpResponse<?> response, ChannelHandlerContext context) {
         if (response instanceof NettyMutableHttpResponse) {
             NettyMutableHttpResponse nettyResponse = ((NettyMutableHttpResponse) response);
 
             // Write the request data
             final DefaultHttpResponse finalResponse = new DefaultHttpResponse(nettyResponse.getNettyHttpVersion(), nettyResponse.getNettyHttpStatus(), nettyResponse.getNettyHeaders());
             final io.micronaut.http.HttpVersion httpVersion = request.getHttpVersion();
-            final boolean isHttp2 = httpVersion == io.micronaut.http.HttpVersion.HTTP_2_0;
             if (request instanceof NettyHttpRequest) {
                 ((NettyHttpRequest<?>) request).prepareHttp2ResponseIfNecessary(finalResponse);
             }
@@ -73,9 +73,9 @@ public interface NettyStreamedCustomizableResponseType extends NettyCustomizable
                     }
                 };
                 final HttpChunkedInput chunkedInput = new HttpChunkedInput(new ChunkedStream(inputStream));
-                context.writeAndFlush(chunkedInput).addListener(closeListener);
+                return context.writeAndFlush(chunkedInput).addListener(closeListener);
             } else {
-                context.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT);
+                return context.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT);
             }
 
         } else {


### PR DESCRIPTION
When the response body is a `NettyCustomizableResponseTypeHandlerInvoker` (e.g. from an InputStream), `RoutingInBoundHandler` would never clean up the corresponding request.

This patch makes the `NettyCustomizableResponseType.write` and related classes return the `ChannelFuture` for the last response write operation they trigger. `RoutingInBoundHandler` then listens to that future and cleans up the associated request when the write completes.

Fixes #7704