### PR TITLE
Workaround for Netty MixedFileUpload bug

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,7 +44,7 @@ managed-google-function-invoker = "1.0.0"
 managed-gorm = "7.3.1"
 managed-gorm-hibernate = "7.2.2"
 # be sure to update graal version in gradle.properties as well
-# Intentionally pin to 22.0.0.2 see https://github.com/micronaut-projects/micronaut-kafka/pull/564 and https://github.com/micronaut-projects/micronaut-core/pull/7663 
+# Intentionally pin to 22.0.0.2 see https://github.com/micronaut-projects/micronaut-kafka/pull/564 and https://github.com/micronaut-projects/micronaut-core/pull/7663
 managed-graal-sdk = "22.0.0.2"
 managed-graal = "22.1.0"
 managed-graal-svm = "22.0.0.2"
@@ -429,6 +429,7 @@ testcontainers-spock = { module = "org.testcontainers:spock", version.ref = "man
 vertx = { module = "io.vertx:vertx-core", version.ref = "vertx" }
 vertx-webclient = { module = "io.vertx:vertx-web-client", version.ref = "vertx" }
 httpcomponents-client = { module = "org.apache.httpcomponents:httpclient", version.ref = "httpcomponents-client" }
+httpcomponents-mime = { module = "org.apache.httpcomponents:httpmime", version.ref = "httpcomponents-client" }
 
 wiremock = { module = "com.github.tomakehurst:wiremock-jre8", version.ref = "wiremock" }
 

--- a/http-netty/src/main/java/io/micronaut/http/netty/MicronautHttpDataFactory.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/MicronautHttpDataFactory.java
@@ -1,0 +1,336 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.netty;
+
+import io.micronaut.core.annotation.Internal;
+import io.netty.handler.codec.http.HttpConstants;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.multipart.Attribute;
+import io.netty.handler.codec.http.multipart.DiskAttribute;
+import io.netty.handler.codec.http.multipart.DiskFileUpload;
+import io.netty.handler.codec.http.multipart.FileUpload;
+import io.netty.handler.codec.http.multipart.HttpData;
+import io.netty.handler.codec.http.multipart.HttpDataFactory;
+import io.netty.handler.codec.http.multipart.InterfaceHttpData;
+import io.netty.handler.codec.http.multipart.MemoryAttribute;
+import io.netty.handler.codec.http.multipart.MemoryFileUpload;
+import io.netty.handler.codec.http.multipart.MixedAttribute;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Copied from {@link io.netty.handler.codec.http.multipart.DefaultHttpDataFactory}, but with
+ * {@link MixedFileUploadPatched}, pending fix for https://github.com/netty/netty/issues/12627.
+ */
+@Internal
+public class MicronautHttpDataFactory implements HttpDataFactory {
+
+    /**
+     * Proposed default MINSIZE as 16 KB.
+     */
+    public static final long MINSIZE = 0x4000;
+    /**
+     * Proposed default MAXSIZE = -1 as UNLIMITED.
+     */
+    public static final long MAXSIZE = -1;
+
+    private final boolean useDisk;
+
+    private final boolean checkSize;
+
+    private long minSize;
+
+    private long maxSize = MAXSIZE;
+
+    private Charset charset = HttpConstants.DEFAULT_CHARSET;
+
+    private String baseDir;
+
+    private boolean deleteOnExit; // false is a good default cause true leaks
+
+    /**
+     * Keep all {@link HttpData}s until cleaning methods are called.
+     * We need to use {@link IdentityHashMap} because different requests may be equal.
+     * See {@link io.netty.handler.codec.http.DefaultHttpRequest#hashCode} and
+     * {@link io.netty.handler.codec.http.DefaultHttpRequest#equals}.
+     * Similarly, when removing data items, we need to check their identities because
+     * different data items may be equal.
+     */
+    private final Map<HttpRequest, List<HttpData>> requestFileDeleteMap =
+        Collections.synchronizedMap(new IdentityHashMap<HttpRequest, List<HttpData>>());
+
+    /**
+     * HttpData will be in memory if less than default size (16KB).
+     * The type will be Mixed.
+     */
+    public MicronautHttpDataFactory() {
+        useDisk = false;
+        checkSize = true;
+        minSize = MINSIZE;
+    }
+
+    public MicronautHttpDataFactory(Charset charset) {
+        this();
+        this.charset = charset;
+    }
+
+    public MicronautHttpDataFactory(boolean useDisk) {
+        this.useDisk = useDisk;
+        checkSize = false;
+    }
+
+    public MicronautHttpDataFactory(boolean useDisk, Charset charset) {
+        this(useDisk);
+        this.charset = charset;
+    }
+
+    public MicronautHttpDataFactory(long minSize) {
+        useDisk = false;
+        checkSize = true;
+        this.minSize = minSize;
+    }
+
+    public MicronautHttpDataFactory(long minSize, Charset charset) {
+        this(minSize);
+        this.charset = charset;
+    }
+
+    /**
+     * Override global {@link DiskAttribute#baseDirectory} and {@link DiskFileUpload#baseDirectory} values.
+     *
+     * @param baseDir directory path where to store disk attributes and file uploads.
+     */
+    public void setBaseDir(String baseDir) {
+        this.baseDir = baseDir;
+    }
+
+    /**
+     * Override global {@link DiskAttribute#deleteOnExitTemporaryFile} and
+     * {@link DiskFileUpload#deleteOnExitTemporaryFile} values.
+     *
+     * @param deleteOnExit true if temporary files should be deleted with the JVM, false otherwise.
+     */
+    public void setDeleteOnExit(boolean deleteOnExit) {
+        this.deleteOnExit = deleteOnExit;
+    }
+
+    @Override
+    public void setMaxLimit(long maxSize) {
+        this.maxSize = maxSize;
+    }
+
+    /**
+     * @return the associated list of {@link HttpData} for the request
+     */
+    private List<HttpData> getList(HttpRequest request) {
+        List<HttpData> list = requestFileDeleteMap.get(request);
+        if (list == null) {
+            list = new ArrayList<HttpData>();
+            requestFileDeleteMap.put(request, list);
+        }
+        return list;
+    }
+
+    @Override
+    public Attribute createAttribute(HttpRequest request, String name) {
+        if (useDisk) {
+            Attribute attribute = new DiskAttribute(name, charset, baseDir, deleteOnExit);
+            attribute.setMaxSize(maxSize);
+            List<HttpData> list = getList(request);
+            list.add(attribute);
+            return attribute;
+        }
+        if (checkSize) {
+            Attribute attribute = new MixedAttribute(name, minSize, charset, baseDir, deleteOnExit);
+            attribute.setMaxSize(maxSize);
+            List<HttpData> list = getList(request);
+            list.add(attribute);
+            return attribute;
+        }
+        MemoryAttribute attribute = new MemoryAttribute(name);
+        attribute.setMaxSize(maxSize);
+        return attribute;
+    }
+
+    @Override
+    public Attribute createAttribute(HttpRequest request, String name, long definedSize) {
+        if (useDisk) {
+            Attribute attribute = new DiskAttribute(name, definedSize, charset, baseDir, deleteOnExit);
+            attribute.setMaxSize(maxSize);
+            List<HttpData> list = getList(request);
+            list.add(attribute);
+            return attribute;
+        }
+        if (checkSize) {
+            Attribute attribute = new MixedAttribute(name, definedSize, minSize, charset, baseDir, deleteOnExit);
+            attribute.setMaxSize(maxSize);
+            List<HttpData> list = getList(request);
+            list.add(attribute);
+            return attribute;
+        }
+        MemoryAttribute attribute = new MemoryAttribute(name, definedSize);
+        attribute.setMaxSize(maxSize);
+        return attribute;
+    }
+
+    private static void checkHttpDataSize(HttpData data) {
+        try {
+            data.checkSize(data.length());
+        } catch (IOException ignored) {
+            throw new IllegalArgumentException("Attribute bigger than maxSize allowed");
+        }
+    }
+
+    @Override
+    public Attribute createAttribute(HttpRequest request, String name, String value) {
+        if (useDisk) {
+            Attribute attribute;
+            try {
+                attribute = new DiskAttribute(name, value, charset, baseDir, deleteOnExit);
+                attribute.setMaxSize(maxSize);
+            } catch (IOException e) {
+                // revert to Mixed mode
+                attribute = new MixedAttribute(name, value, minSize, charset, baseDir, deleteOnExit);
+                attribute.setMaxSize(maxSize);
+            }
+            checkHttpDataSize(attribute);
+            List<HttpData> list = getList(request);
+            list.add(attribute);
+            return attribute;
+        }
+        if (checkSize) {
+            Attribute attribute = new MixedAttribute(name, value, minSize, charset, baseDir, deleteOnExit);
+            attribute.setMaxSize(maxSize);
+            checkHttpDataSize(attribute);
+            List<HttpData> list = getList(request);
+            list.add(attribute);
+            return attribute;
+        }
+        try {
+            MemoryAttribute attribute = new MemoryAttribute(name, value, charset);
+            attribute.setMaxSize(maxSize);
+            checkHttpDataSize(attribute);
+            return attribute;
+        } catch (IOException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    @Override
+    public FileUpload createFileUpload(HttpRequest request, String name, String filename,
+                                       String contentType, String contentTransferEncoding, Charset charset,
+                                       long size) {
+        if (useDisk) {
+            FileUpload fileUpload = new DiskFileUpload(name, filename, contentType,
+                contentTransferEncoding, charset, size, baseDir, deleteOnExit);
+            fileUpload.setMaxSize(maxSize);
+            checkHttpDataSize(fileUpload);
+            List<HttpData> list = getList(request);
+            list.add(fileUpload);
+            return fileUpload;
+        }
+        if (checkSize) {
+            FileUpload fileUpload = new MixedFileUploadPatched(name, filename, contentType,
+                contentTransferEncoding, charset, size, minSize, baseDir, deleteOnExit);
+            fileUpload.setMaxSize(maxSize);
+            checkHttpDataSize(fileUpload);
+            List<HttpData> list = getList(request);
+            list.add(fileUpload);
+            return fileUpload;
+        }
+        MemoryFileUpload fileUpload = new MemoryFileUpload(name, filename, contentType,
+            contentTransferEncoding, charset, size);
+        fileUpload.setMaxSize(maxSize);
+        checkHttpDataSize(fileUpload);
+        return fileUpload;
+    }
+
+    @Override
+    public void removeHttpDataFromClean(HttpRequest request, InterfaceHttpData data) {
+        if (!(data instanceof HttpData)) {
+            return;
+        }
+
+        // Do not use getList because it adds empty list to requestFileDeleteMap
+        // if request is not found
+        List<HttpData> list = requestFileDeleteMap.get(request);
+        if (list == null) {
+            return;
+        }
+
+        // Can't simply call list.remove(data), because different data items may be equal.
+        // Need to check identity.
+        Iterator<HttpData> i = list.iterator();
+        while (i.hasNext()) {
+            HttpData n = i.next();
+            if (n == data) {
+                i.remove();
+
+                // Remove empty list to avoid memory leak
+                if (list.isEmpty()) {
+                    requestFileDeleteMap.remove(request);
+                }
+
+                return;
+            }
+        }
+    }
+
+    @Override
+    public void cleanRequestHttpData(HttpRequest request) {
+        List<HttpData> list = requestFileDeleteMap.remove(request);
+        if (list != null) {
+            for (HttpData data : list) {
+                data.release();
+            }
+        }
+    }
+
+    @Override
+    public void cleanAllHttpData() {
+        Iterator<Map.Entry<HttpRequest, List<HttpData>>> i = requestFileDeleteMap.entrySet().iterator();
+        while (i.hasNext()) {
+            Map.Entry<HttpRequest, List<HttpData>> e = i.next();
+
+            // Calling i.remove() here will cause "java.lang.IllegalStateException: Entry was removed"
+            // at e.getValue() below
+
+            List<HttpData> list = e.getValue();
+            for (HttpData data : list) {
+                data.release();
+            }
+
+            i.remove();
+        }
+    }
+
+    @Override
+    public void cleanRequestHttpDatas(HttpRequest request) {
+        cleanRequestHttpData(request);
+    }
+
+    @Override
+    public void cleanAllHttpDatas() {
+        cleanAllHttpData();
+    }
+}

--- a/http-netty/src/main/java/io/micronaut/http/netty/MixedFileUploadPatched.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/MixedFileUploadPatched.java
@@ -1,0 +1,345 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.netty;
+
+import io.micronaut.core.util.SupplierUtil;
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.http.multipart.AbstractHttpData;
+import io.netty.handler.codec.http.multipart.DiskFileUpload;
+import io.netty.handler.codec.http.multipart.FileUpload;
+import io.netty.handler.codec.http.multipart.InterfaceHttpData;
+import io.netty.handler.codec.http.multipart.MemoryFileUpload;
+import io.netty.util.ResourceLeakDetector;
+import io.netty.util.ResourceLeakDetectorFactory;
+import io.netty.util.ResourceLeakTracker;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.util.function.Supplier;
+
+/**
+ * Copied and modified from {@link io.netty.handler.codec.http.multipart.MixedFileUpload}, pending
+ * fix for https://github.com/netty/netty/issues/12627.
+ */
+final class MixedFileUploadPatched extends AbstractHttpData implements FileUpload {
+    private static final Supplier<ResourceLeakDetector<MixedFileUploadPatched>> LEAK_DETECTOR = SupplierUtil.memoized(() ->
+        ResourceLeakDetectorFactory.instance().newResourceLeakDetector(MixedFileUploadPatched.class));
+
+    private final String baseDir;
+
+    private final boolean deleteOnExit;
+
+    private FileUpload fileUpload;
+
+    private final long limitSize;
+
+    private final long definedSize;
+
+    private final ResourceLeakTracker<MixedFileUploadPatched> tracker;
+
+    public MixedFileUploadPatched(String name, String filename, String contentType,
+                           String contentTransferEncoding, Charset charset, long size,
+                           long limitSize, String baseDir, boolean deleteOnExit) {
+        super(name, charset, size);
+        this.limitSize = limitSize;
+        if (size > this.limitSize) {
+            fileUpload = new DiskFileUpload(name, filename, contentType,
+                contentTransferEncoding, charset, size);
+        } else {
+            fileUpload = new MemoryFileUpload(name, filename, contentType,
+                contentTransferEncoding, charset, size);
+        }
+        tracker = LEAK_DETECTOR.get().track(this);
+        definedSize = size;
+        this.baseDir = baseDir;
+        this.deleteOnExit = deleteOnExit;
+    }
+
+    @Override
+    public void setMaxSize(long maxSize) {
+        super.setMaxSize(maxSize);
+        fileUpload.setMaxSize(maxSize);
+    }
+
+    @Override
+    public void addContent(ByteBuf buffer, boolean last)
+        throws IOException {
+        if (fileUpload instanceof MemoryFileUpload) {
+            try {
+                checkSize(fileUpload.length() + buffer.readableBytes());
+                if (fileUpload.length() + buffer.readableBytes() > limitSize) {
+                    DiskFileUpload diskFileUpload = new DiskFileUpload(fileUpload
+                        .getName(), fileUpload.getFilename(), fileUpload
+                        .getContentType(), fileUpload
+                        .getContentTransferEncoding(), fileUpload.getCharset(),
+                        definedSize, baseDir, deleteOnExit);
+                    diskFileUpload.setMaxSize(getMaxSize());
+                    ByteBuf data = fileUpload.getByteBuf();
+                    if (data != null && data.isReadable()) {
+                        diskFileUpload.addContent(data.retain(), false);
+                    }
+                    // release old upload
+                    fileUpload.release();
+
+                    fileUpload = diskFileUpload;
+                }
+            } catch (IOException e) {
+                buffer.release();
+                throw e;
+            }
+        }
+        fileUpload.addContent(buffer, last);
+    }
+
+    @Override
+    public void delete() {
+        fileUpload.delete();
+        if (tracker != null) {
+            tracker.close(this);
+        }
+    }
+
+    @Override
+    public byte[] get() throws IOException {
+        return fileUpload.get();
+    }
+
+    @Override
+    public ByteBuf getByteBuf() throws IOException {
+        return fileUpload.getByteBuf();
+    }
+
+    @Override
+    public String getContentType() {
+        return fileUpload.getContentType();
+    }
+
+    @Override
+    public String getContentTransferEncoding() {
+        return fileUpload.getContentTransferEncoding();
+    }
+
+    @Override
+    public String getFilename() {
+        return fileUpload.getFilename();
+    }
+
+    @Override
+    public String getString() throws IOException {
+        return fileUpload.getString();
+    }
+
+    @Override
+    public String getString(Charset encoding) throws IOException {
+        return fileUpload.getString(encoding);
+    }
+
+    @Override
+    public boolean isCompleted() {
+        return fileUpload.isCompleted();
+    }
+
+    @Override
+    public boolean isInMemory() {
+        return fileUpload.isInMemory();
+    }
+
+    @Override
+    public long length() {
+        return fileUpload.length();
+    }
+
+    @Override
+    public long definedLength() {
+        return fileUpload.definedLength();
+    }
+
+    @Override
+    public MixedFileUploadPatched touch() {
+        return touch(null);
+    }
+
+    @Override
+    public MixedFileUploadPatched touch(Object hint) {
+        if (tracker != null) {
+            tracker.record(hint);
+        }
+        return this;
+    }
+
+    @Override
+    public boolean renameTo(File dest) throws IOException {
+        return fileUpload.renameTo(dest);
+    }
+
+    @Override
+    public void setCharset(Charset charset) {
+        super.setCharset(charset);
+        // called from the super <init>, ugly workaround
+        if (fileUpload != null) {
+            fileUpload.setCharset(charset);
+        }
+    }
+
+    @Override
+    public void setContent(ByteBuf buffer) throws IOException {
+        try {
+            checkSize(buffer.readableBytes());
+        } catch (IOException e) {
+            buffer.release();
+            throw e;
+        }
+        if (buffer.readableBytes() > limitSize) {
+            if (fileUpload instanceof MemoryFileUpload) {
+                FileUpload memoryUpload = fileUpload;
+                // change to Disk
+                fileUpload = new DiskFileUpload(memoryUpload
+                    .getName(), memoryUpload.getFilename(), memoryUpload
+                    .getContentType(), memoryUpload
+                    .getContentTransferEncoding(), memoryUpload.getCharset(),
+                    definedSize, baseDir, deleteOnExit);
+                fileUpload.setMaxSize(getMaxSize());
+
+                // release old upload
+                memoryUpload.release();
+            }
+        }
+        fileUpload.setContent(buffer);
+    }
+
+    @Override
+    public void setContent(File file) throws IOException {
+        checkSize(file.length());
+        if (file.length() > limitSize) {
+            if (fileUpload instanceof MemoryFileUpload) {
+                FileUpload memoryUpload = fileUpload;
+
+                // change to Disk
+                fileUpload = new DiskFileUpload(memoryUpload
+                    .getName(), memoryUpload.getFilename(), memoryUpload
+                    .getContentType(), memoryUpload
+                    .getContentTransferEncoding(), memoryUpload.getCharset(),
+                    definedSize, baseDir, deleteOnExit);
+                fileUpload.setMaxSize(getMaxSize());
+
+                // release old upload
+                memoryUpload.release();
+            }
+        }
+        fileUpload.setContent(file);
+    }
+
+    @Override
+    public void setContent(InputStream inputStream) throws IOException {
+        if (fileUpload instanceof MemoryFileUpload) {
+            FileUpload memoryUpload = fileUpload;
+
+            // change to Disk
+            fileUpload = new DiskFileUpload(fileUpload
+                .getName(), fileUpload.getFilename(), fileUpload
+                .getContentType(), fileUpload
+                .getContentTransferEncoding(), fileUpload.getCharset(),
+                definedSize, baseDir, deleteOnExit);
+            fileUpload.setMaxSize(getMaxSize());
+
+            // release old upload
+            memoryUpload.release();
+        }
+        fileUpload.setContent(inputStream);
+    }
+
+    @Override
+    public void setContentType(String contentType) {
+        fileUpload.setContentType(contentType);
+    }
+
+    @Override
+    public void setContentTransferEncoding(String contentTransferEncoding) {
+        fileUpload.setContentTransferEncoding(contentTransferEncoding);
+    }
+
+    @Override
+    public void setFilename(String filename) {
+        fileUpload.setFilename(filename);
+    }
+
+    @Override
+    public InterfaceHttpData.HttpDataType getHttpDataType() {
+        return fileUpload.getHttpDataType();
+    }
+
+    @Override
+    public int hashCode() {
+        return fileUpload.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return fileUpload.equals(obj);
+    }
+
+    @Override
+    public int compareTo(InterfaceHttpData o) {
+        return fileUpload.compareTo(o);
+    }
+
+    @Override
+    public String toString() {
+        return "Mixed: " + fileUpload;
+    }
+
+    @Override
+    public ByteBuf getChunk(int length) throws IOException {
+        return fileUpload.getChunk(length);
+    }
+
+    @Override
+    public File getFile() throws IOException {
+        return fileUpload.getFile();
+    }
+
+    @Override
+    public FileUpload copy() {
+        return fileUpload.copy();
+    }
+
+    @Override
+    public FileUpload duplicate() {
+        return fileUpload.duplicate();
+    }
+
+    @Override
+    public FileUpload retainedDuplicate() {
+        return fileUpload.retainedDuplicate();
+    }
+
+    @Override
+    public FileUpload replace(ByteBuf content) {
+        return fileUpload.replace(content);
+    }
+
+    @Override
+    public MixedFileUploadPatched retain() {
+        return (MixedFileUploadPatched) super.retain();
+    }
+
+    @Override
+    public MixedFileUploadPatched retain(int increment) {
+        return (MixedFileUploadPatched) super.retain(increment);
+    }
+}

--- a/http-server-netty/build.gradle
+++ b/http-server-netty/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     testImplementation libs.vertx
     testImplementation libs.vertx.webclient
     testImplementation libs.httpcomponents.client
+    testImplementation libs.httpcomponents.mime
     testImplementation libs.jetty.alpn.openjdk8.client
 
     testImplementation libs.managed.groovy.json

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/FormDataHttpContentProcessor.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/FormDataHttpContentProcessor.java
@@ -18,6 +18,7 @@ package io.micronaut.http.server.netty;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.exceptions.ContentLengthExceededException;
+import io.micronaut.http.netty.MicronautHttpDataFactory;
 import io.micronaut.http.server.HttpServerConfiguration;
 import io.micronaut.http.server.netty.configuration.NettyHttpServerConfiguration;
 import io.netty.buffer.ByteBufHolder;
@@ -72,13 +73,13 @@ public class FormDataHttpContentProcessor extends AbstractHttpContentProcessor<H
         super(nettyHttpRequest, configuration);
         Charset characterEncoding = nettyHttpRequest.getCharacterEncoding();
         HttpServerConfiguration.MultipartConfiguration multipart = configuration.getMultipart();
-        DefaultHttpDataFactory factory;
+        HttpDataFactory factory;
         if (multipart.isDisk()) {
-            factory = new DefaultHttpDataFactory(true, characterEncoding);
+            factory = new MicronautHttpDataFactory(true, characterEncoding);
         } else if (multipart.isMixed()) {
-            factory = new DefaultHttpDataFactory(multipart.getThreshold(), characterEncoding);
+            factory = new MicronautHttpDataFactory(multipart.getThreshold(), characterEncoding);
         } else {
-            factory = new DefaultHttpDataFactory(false, characterEncoding);
+            factory = new MicronautHttpDataFactory(false, characterEncoding);
         }
         factory.setMaxLimit(multipart.getMaxFileSize());
         final HttpRequest nativeRequest = nettyHttpRequest.getNativeRequest();

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/MixedUploadLeakSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/MixedUploadLeakSpec.groovy
@@ -1,0 +1,84 @@
+package io.micronaut.http.server.netty
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Part
+import io.micronaut.http.annotation.Post
+import io.micronaut.http.multipart.CompletedFileUpload
+import io.micronaut.runtime.server.EmbeddedServer
+import org.apache.http.client.config.RequestConfig
+import org.apache.http.client.methods.HttpPost
+import org.apache.http.entity.ContentType
+import org.apache.http.entity.mime.MultipartEntityBuilder
+import org.apache.http.impl.client.HttpClients
+import org.apache.http.util.EntityUtils
+import spock.lang.Issue
+import spock.lang.Specification
+
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.TimeUnit
+import java.util.stream.Collectors
+import java.util.stream.IntStream
+
+class MixedUploadLeakSpec extends Specification {
+    @Issue('https://github.com/micronaut-projects/micronaut-core/issues/7699')
+    def 'leak test'() {
+        given:
+        def ctx = ApplicationContext.run([
+                'spec.name': 'MixedUploadLeakSpec',
+                'micronaut.server.max-request-size': '5000GB',
+                'micronaut.server.multipart.enabled': true,
+                'micronaut.server.multipart.max-file-size': '5000GB',
+                'micronaut.server.multipart.mixed': true,
+        ])
+        def embeddedServer = ctx.getBean(EmbeddedServer)
+        embeddedServer.start()
+
+        HttpPost request = new HttpPost(embeddedServer.URI.toString() + "/fdhcpLeak");
+
+        def httpClient = HttpClients.custom()
+                .setMaxConnPerRoute(50)
+                .setMaxConnTotal(200)
+                .setDefaultRequestConfig(RequestConfig.custom()
+                        .setConnectTimeout(60000)
+                        .build())
+                .evictIdleConnections(5, TimeUnit.MINUTES)
+                .evictExpiredConnections()
+                .build()
+
+        def bigFile = IntStream.range(0, 20000000).mapToObj(i -> "Data").collect(Collectors.joining()).getBytes(StandardCharsets.UTF_8)
+        final MultipartEntityBuilder multipartEntityBuilder = MultipartEntityBuilder.create()
+                .addTextBody("foo", "bar")
+                .addBinaryBody("file", bigFile, ContentType.TEXT_PLAIN, "any-path.txt")
+
+        request.setEntity(multipartEntityBuilder.build())
+
+        when:
+        def response = httpClient.execute(request)
+        def body = EntityUtils.toString(response.entity)
+        then:
+        body == 'bar ' + (20000000 * 4)
+
+        cleanup:
+        embeddedServer.stop()
+        httpClient.close()
+    }
+
+    @Controller('/fdhcpLeak')
+    @Requires(property = 'spec.name', value = 'MixedUploadLeakSpec')
+    static class Ctrl {
+        @Post(consumes = MediaType.MULTIPART_FORM_DATA)
+        def post(
+                @Part String foo,
+                @Part CompletedFileUpload file
+        ) {
+            try {
+                return foo + " " + file.size
+            } finally {
+                file.discard()
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is a fix for https://github.com/netty/netty/issues/12627 . This patch changes MixedFileUpload to use its own reference count independent of the underlying storage (memory or file), so that the ref count isn't lost when switching storage mode. I copied the DefaultHttpDataFactory and MixedFileUpload from netty to apply this change.

We can revert this change once a netty fix is available (though we should keep the test).

Fixes #7699