### PR TITLE
Fix producing beans from methods that return interfaces

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/BeanElementBuilderFactorySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/BeanElementBuilderFactorySpec.groovy
@@ -14,12 +14,13 @@ import io.micronaut.context.annotation.Prototype;
 
 @Prototype
 class Foo {
-    
+
 }
 ''')
         expect:
         context.getBean(TestBeanProducer.BeanB) instanceof TestBeanProducer.BeanB
         context.getBean(TestBeanProducer.BeanA) instanceof TestBeanProducer.BeanA
+        context.getBean(TestBeanProducer.InterfaceA) instanceof TestBeanProducer.InterfaceA
 
         cleanup:
         context.close()

--- a/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/TestBeanProducer.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beanbuilder/TestBeanProducer.java
@@ -12,6 +12,12 @@ public class TestBeanProducer {
         return new BeanB();
     }
 
+    @TestProduces
+    public InterfaceA interfaceA() {
+        return new InterfaceA() {
+        };
+    }
+
     public static class BeanA {
 
     }
@@ -19,4 +25,7 @@ public class TestBeanProducer {
     public static class BeanB {
 
     }
+
+    public interface InterfaceA {}
+
 }

--- a/inject/src/main/java/io/micronaut/inject/writer/AbstractBeanDefinitionBuilder.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/AbstractBeanDefinitionBuilder.java
@@ -503,14 +503,14 @@ public abstract class AbstractBeanDefinitionBuilder implements BeanElementBuilde
         methodsOrFields = methodsOrFields
                 .onlyConcrete()
                 .onlyInstance()
-                .modifiers((modifiers) -> modifiers.contains(ElementModifier.PUBLIC));
+                .modifiers(modifiers -> modifiers.contains(ElementModifier.PUBLIC));
         final List<E> enclosedElements = this.beanType.getEnclosedElements(methodsOrFields);
         for (E enclosedElement : enclosedElements) {
             if (enclosedElement instanceof FieldElement) {
                 FieldElement fe = (FieldElement) enclosedElement;
                 final ClassElement type = fe.getGenericField().getType();
                 if (type.isPublic() && !type.isPrimitive()) {
-                    return addChildBean(fe, childBeanBuilder);
+                    addChildBean(fe, childBeanBuilder);
                 }
             }
 
@@ -518,7 +518,7 @@ public abstract class AbstractBeanDefinitionBuilder implements BeanElementBuilde
                 MethodElement me = (MethodElement) enclosedElement;
                 final ClassElement type = me.getGenericReturnType().getType();
                 if (type.isPublic() && !type.isPrimitive()) {
-                    return addChildBean(me, childBeanBuilder);
+                    addChildBean(me, childBeanBuilder);
                 }
             }
         }
@@ -777,25 +777,29 @@ public abstract class AbstractBeanDefinitionBuilder implements BeanElementBuilde
         if (exposedTypes != null) {
             final AnnotationClassValue<?>[] annotationClassValues =
                     Arrays.stream(exposedTypes).map(ce -> new AnnotationClassValue<>(ce.getName())).toArray(AnnotationClassValue[]::new);
-            annotate(Bean.class, (builder) -> builder.member("typed", annotationClassValues));
+            annotate(Bean.class, builder -> builder.member("typed", annotationClassValues));
         }
         if (typeArguments != null) {
             beanDefinitionWriter.visitTypeArguments(AbstractBeanDefinitionBuilder.this.typeArguments);
         }
 
-        if (constructorElement == null) {
-            constructorElement = initConstructor(beanType);
-        }
+        Element producingElement = getProducingElement();
+        if (producingElement instanceof ClassElement) {
 
-        if (constructorElement == null) {
-            visitorContext.fail("Cannot create associated bean with no accessible primary constructor. Consider supply the constructor with createWith(..)", originatingElement);
-            return true;
-        } else {
-            beanDefinitionWriter.visitBeanDefinitionConstructor(
+            if (constructorElement == null) {
+                constructorElement = initConstructor(beanType);
+            }
+
+            if (constructorElement == null) {
+                visitorContext.fail("Cannot create associated bean with no accessible primary constructor. Consider supply the constructor with createWith(..)", originatingElement);
+                return true;
+            } else {
+                beanDefinitionWriter.visitBeanDefinitionConstructor(
                     constructorElement,
                     !constructorElement.isPublic(),
                     visitorContext
-            );
+                );
+            }
         }
         return false;
     }

--- a/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/inject/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -639,7 +639,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
             this.beanTypeElement = beanElementBuilder.getBeanType();
             this.packageName = this.beanTypeElement.getPackageName();
             this.isInterface = this.beanTypeElement.isInterface();
-            this.isAbstract = this.beanTypeElement.isAbstract();
+            this.isAbstract = beanElementBuilder.getProducingElement() instanceof ClassElement && this.beanTypeElement.isAbstract();
             this.beanFullClassName = this.beanTypeElement.getName();
             this.beanSimpleClassName = this.beanTypeElement.getSimpleName();
             if (uniqueIdentifier == null) {


### PR DESCRIPTION
Currently producing beans using the bean builder API from methods that return interfaces is broken. This fixes that.