### PR TITLE
Fix ClientFilterSpec

### DIFF
--- a/http-client/src/test/groovy/io/micronaut/http/client/aop/ClientFilterSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/aop/ClientFilterSpec.groovy
@@ -42,13 +42,11 @@ import spock.lang.Specification
  */
 class ClientFilterSpec extends Specification{
 
-    @Shared
     @AutoCleanup
     ApplicationContext context = ApplicationContext.run([
             'spec.name': 'ClientFilterSpec',
     ])
 
-    @Shared
     EmbeddedServer embeddedServer = context.getBean(EmbeddedServer).start()
 
     void "test client filter includes header"() {


### PR DESCRIPTION
It doesn't like the shared context for some reason.