### PR TITLE
Update contributor development setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,8 @@
 
 ## Finding Issues to Work on
 
-If you are interested in contributing to Micronaut and are looking for issues to work on, take a look at the issues tagged with [help wanted](https://github.com/micronaut-projects/micronaut-core/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22).
+If you are interested in contributing to Micronaut and are looking for issues to work on, take a look at the issues
+tagged with [help wanted](https://github.com/micronaut-projects/micronaut-core/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22).
 
 ## JDK Setup
 
@@ -15,12 +16,12 @@ Micronaut can be imported into IntelliJ IDEA by opening the `build.gradle` file.
 ## Docker Setup
 
 Micronaut tests currently require docker to be installed.
- 
+
 ## Running Tests
 
-To run the tests use `./gradlew check`. 
+To run the tests use `./gradlew check`.
 
-[Geb](http://gebish.org) functional tests are ignored unless you specify the geb environment via system property. 
+[Geb](http://gebish.org) functional tests are ignored unless you specify the geb environment via system property.
 
 To run with Chrome `./gradlew -Dgeb.env=chrome check`.
 
@@ -30,39 +31,18 @@ To run with Firefox `./gradlew -Dgeb.env=firefox check`.
 
 The documentation sources are located at `src/main/docs/guide`.
 
-To build the documentation run `./gradlew publishGuide` or `./gradlew pG` then open `build/docs/index.html`  
+To build the documentation run `./gradlew publishGuide` or `./gradlew pG` then open `build/docs/index.html`
 
 To also build the javadocs instead run `./gradlew docs`.
 
 ## Building the CLI
 
-- Clone [Micronaut Profiles](https://github.com/micronaut-projects/micronaut-profiles)
-- Install micronaut-profiles to Maven Local `micronaut-profiles$ ./gradlew clean publishToMavenLocal`
-- `micronaut-core$ ./gradlew cli:fatJar`
-- `micronaut-core$ cd cli/build/bin`
-- `micronaut-core/cli/build/bin$ ./mn`
-
+You can build the CLI from source by [following these instructions](https://micronaut-projects.github.io/micronaut-starter/latest/guide/index.html#installFromSource)
 
 ## Working on the code base
 
-If you are working with the IntelliJ IDEA development environment, you can import the project using the Intellij Gradle Tooling ( "File / Import Project" and select the "settings.gradle" file).
-
-To get a local development version of Micronaut working, first run the `cliZip` task.
-
-```
-./gradlew cliZip
-```
-
-Then install SDKman, which is the quickest way to set up a development environment.
-
-Once you have SDKman installed, point SDKman to your local development version of Micronaut.
-
-```
-sdk install micronaut dev /path/to/checkout/cli/build
-sdk use micronaut dev
-```
-
-Now the "mn" command will be using your development version!
+If you are working with the IntelliJ IDEA development environment, you can import the project using the Intellij Gradle
+Tooling ( "File / Import Project" and select the "settings.gradle" file).
 
 The most important command you will have to run before sending your changes is the check command.
 
@@ -80,29 +60,29 @@ Once you are satisfied with your changes:
 
 ## Checkstyle
 
-We want to keep the code clean, following good practices about organization, javadoc and style as much as possible. 
+We want to keep the code clean, following good practices about organization, javadoc and style as much as possible.
 
-Micronaut uses [Checkstyle](http://checkstyle.sourceforge.net/) to make sure that all the code follows those standards. The configuration file is defined in `config/checkstyle/checkstyle.xml` and to execute the Checkstyle you
+Micronaut uses [Checkstyle](http://checkstyle.sourceforge.net/) to make sure that all the code follows those standards. The configuration file is defined in `config/checkstyle/checkstyle.xml` and to execute Checkstyle you
 need to run:
- 
+
 ```
 ./gradlew <module-name>:checkstyleMain
 ```
 
-Before start contributing with new code it is recommended to install IntelliJ [CheckStyle-IDEA](https://plugins.jetbrains.com/plugin/1065-checkstyle-idea) plugin and configure it to use Micronaut's checkstyle configuration file.
-  
-IntelliJ will mark in red the issues Checkstyle finds. For example:
+Before you start contributing with new code it is recommended that you install the IntelliJ [CheckStyle-IDEA](https://plugins.jetbrains.com/plugin/1065-checkstyle-idea) plugin and configure it to use Micronaut's Checkstyle configuration file.
 
-![](https://github.com/micronaut-projects/micronaut-core/raw/master/src/main/docs/resources/img/checkstyle-issue.png)
+IntelliJ will mark the issues Checkstyle finds in red. For example:
+
+![](https://raw.githubusercontent.com/micronaut-projects/micronaut-core/5e4be034d92e5c3932967039eb6d665dccead1ab/src/main/docs/resources/img/checkstyle-issue.png)
 
 In this case, to fix the issues, we need to:
 
 - Add one empty line before `package` in line 16
 - Add the Javadoc for the constructor in line 27
-- Add an space after `if` in line 34
+- Add a space after `if` in line 34
 
-The plugin also adds a new tab in the bottom to run checkstyle report and see all the errors and warnings. It is recommended
-to run the report and fixing all the issues before submitting a pull request.
+The plugin also adds a new tab at the bottom to run the Checkstyle report and display all the errors and warnings. It is recommended
+that you run the report and fix any issues before submitting a pull request.
 
 ## Building on Windows 10
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Micronaut 
+# Micronaut
 
 [![Build Status](https://github.com/micronaut-projects/micronaut-core/workflows/Java%20CI/badge.svg)](https://github.com/micronaut-projects/micronaut-core/actions)
 [![Revved up by Gradle Enterprise](https://img.shields.io/badge/Revved%20up%20by-Gradle%20Enterprise-06A0CE?logo=Gradle&labelColor=02303A)](https://ge.micronaut.io/scans)
@@ -46,14 +46,9 @@ To build from source checkout the code and run:
 ./gradlew publishToMavenLocal
 ```
 
-This will publish the current version to your local Maven cache. To get the CLI operational you can do:
+This will publish the current version to your local Maven cache.
 
-```
-export MICRONAUT_HOME=/path/to/checkout
-export PATH="$PATH:$MICRONAUT_HOME/cli/build/bin"
-```
-
-You will also need to checkout the [Micronaut Profiles](https://github.com/micronaut-projects/micronaut-profiles/) and run `./gradlew publishToMavenLocal` there too.
+To get the CLI operational you can build and install it from source by [following these instructions](https://micronaut-projects.github.io/micronaut-starter/latest/guide/index.html#installFromSource)
 
 You should then be able to `mn create-app hello-world`.
 
@@ -69,7 +64,7 @@ Micronaut is using Semantic Versioning 2.0.0. To understand what that means, ple
 
 ## CI
 
-[Github Actions](https://github.com/micronaut-projects/micronaut-core/actions) are used to build Micronaut. If a build fails in `master`, check the [test reports](https://micronaut-projects.github.io/micronaut-core/index.html). 
+[Github Actions](https://github.com/micronaut-projects/micronaut-core/actions) are used to build Micronaut. If a build fails in `master`, check the [test reports](https://micronaut-projects.github.io/micronaut-core/index.html).
 
 
 


### PR DESCRIPTION
There were several outdated and redundant instructions in the README and CONTRIBUTING files, including references to the archived Micronaut Profiles repository and incorrect procedures for building and locally installing the CLI. Also, the image link in the Checkstyle section was broken, and there were some minor grammatical issues.

A pending concern I have is that the updated instructions do not address the caveats of the CLI being in a separate project from micronaut-core. In particular, following the instructions for building and installing the CLI will not pull in a locally built version of micronaut-core. An elegant and "idiomatic Gradle" way to incorporate such local builds would be a good addition to these instructions, but I've yet to find a nice way to do it that isn't a bit of a hack. 