### PR TITLE
Close the NettyCompletedFileUpload release tracker when getInputStream is called

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/multipart/NettyCompletedFileUpload.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/multipart/NettyCompletedFileUpload.java
@@ -90,12 +90,14 @@ public class NettyCompletedFileUpload implements CompletedFileUpload {
             if (byteBuf == null) {
                 throw new IOException("The input stream has already been released");
             }
+            closeTracker();
             return new ByteBufInputStream(byteBuf, controlRelease);
         } else {
             File file = fileUpload.getFile();
             if (file == null) {
                 throw new IOException("The input stream has already been released");
             }
+            closeTracker();
             return new NettyFileUploadInputStream(fileUpload, controlRelease);
         }
     }
@@ -179,6 +181,10 @@ public class NettyCompletedFileUpload implements CompletedFileUpload {
         if (controlRelease) {
             fileUpload.release();
         }
+        closeTracker();
+    }
+
+    private void closeTracker() {
         if (tracker != null) {
             tracker.close(this);
         }

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/FileUploadSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/FileUploadSpec.groovy
@@ -1,0 +1,47 @@
+package io.micronaut.http.server.netty
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Post
+import io.micronaut.http.annotation.Produces
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.multipart.MultipartBody
+import io.micronaut.http.multipart.CompletedFileUpload
+import io.micronaut.runtime.server.EmbeddedServer
+import spock.lang.Specification
+
+class FileUploadSpec extends Specification {
+    def 'leak with inputstream getter'() {
+        given:
+        def ctx = ApplicationContext.run(['spec.name': 'FileUploadSpec'])
+        def server = ctx.getBean(EmbeddedServer)
+        server.start()
+        def client = ctx.createBean(HttpClient, server.URI).toBlocking()
+
+        when:
+        def response = client.exchange(HttpRequest.POST(
+                '/multipart/complete-file-upload',
+                MultipartBody.builder().addPart('data', 'name', 'foo'.bytes).build())
+                .contentType(MediaType.MULTIPART_FORM_DATA_TYPE), String)
+        then:
+        response.body() == 'Uploaded 3 bytes'
+
+        cleanup:
+        client.close()
+        server.stop()
+    }
+
+    @Controller('/multipart')
+    @Requires(property = 'spec.name', value = 'FileUploadSpec')
+    @Produces(MediaType.TEXT_PLAIN)
+    static class MultipartController {
+        @Post(value = '/complete-file-upload', consumes = MediaType.MULTIPART_FORM_DATA)
+        String completeFileUpload(CompletedFileUpload data) {
+            def bytes = data.inputStream.bytes
+            return "Uploaded ${bytes.length} bytes"
+        }
+    }
+}


### PR DESCRIPTION
getInputStream delegates control of the release of the buffer to the stream it returns. discard is never called. This patch releases the resource tracker on NettyCompletedFileUpload so that it doesn't erroneously report a leak in that case.

Testing is a bit messy because it's another resource leak, but the test case *should* trigger the leak detection sometimes.