### PR TITLE
More java.time support for yaml and converters

### DIFF
--- a/context/src/main/java/io/micronaut/runtime/converters/time/TimeConverterRegistrar.java
+++ b/context/src/main/java/io/micronaut/runtime/converters/time/TimeConverterRegistrar.java
@@ -41,8 +41,11 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalAmount;
+import java.time.temporal.TemporalQuery;
+import java.util.Date;
 import java.util.Optional;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -143,23 +146,7 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
             (object, targetType, context) -> durationConverter.apply(object, context).map(TemporalAmount.class::cast)
         );
 
-        // CharSequence -> LocalDateTime
-        conversionService.addConverter(
-            CharSequence.class,
-            LocalDateTime.class,
-            (object, targetType, context) -> {
-                try {
-                    DateTimeFormatter formatter = resolveFormatter(context);
-                    LocalDateTime result = LocalDateTime.parse(object, formatter);
-                    return Optional.of(result);
-                } catch (DateTimeParseException e) {
-                    context.reject(object, e);
-                    return Optional.empty();
-                }
-            }
-        );
-
-        // TemporalAccessor - CharSequence
+        // TemporalAccessor -> CharSequence
         final TypeConverter<TemporalAccessor, CharSequence> temporalConverter = (object, targetType, context) -> {
             try {
                 DateTimeFormatter formatter = resolveFormatter(context);
@@ -175,54 +162,58 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
                 temporalConverter
         );
 
-        // CharSequence -> LocalDate
-        conversionService.addConverter(
-            CharSequence.class,
-            LocalDate.class,
-            (object, targetType, context) -> {
+        addTemporalStringConverter(conversionService, Instant.class, DateTimeFormatter.ISO_INSTANT, Instant::from);
+        addTemporalStringConverter(conversionService, LocalDate.class, DateTimeFormatter.ISO_LOCAL_DATE, LocalDate::from);
+        addTemporalStringConverter(conversionService, LocalDateTime.class, DateTimeFormatter.ISO_LOCAL_DATE_TIME, LocalDateTime::from);
+        addTemporalStringConverter(conversionService, OffsetTime.class, DateTimeFormatter.ISO_OFFSET_TIME, OffsetTime::from);
+        addTemporalStringConverter(conversionService, OffsetDateTime.class, DateTimeFormatter.ISO_OFFSET_DATE_TIME, OffsetDateTime::from);
+        addTemporalStringConverter(conversionService, ZonedDateTime.class, DateTimeFormatter.ISO_ZONED_DATE_TIME, ZonedDateTime::from);
+
+        // java.time -> Date
+        addTemporalToDateConverter(conversionService, Instant.class, Function.identity());
+        addTemporalToDateConverter(conversionService, OffsetDateTime.class, OffsetDateTime::toInstant);
+        addTemporalToDateConverter(conversionService, ZonedDateTime.class, ZonedDateTime::toInstant);
+        // these two are a bit icky, but required for yaml parsing compatibility
+        addTemporalToDateConverter(conversionService, LocalDate.class, ld -> ld.atTime(0, 0).toInstant(ZoneOffset.UTC));
+        addTemporalToDateConverter(conversionService, LocalDateTime.class, ldt -> ldt.toInstant(ZoneOffset.UTC));
+    }
+
+    private <T extends TemporalAccessor> void addTemporalStringConverter(ConversionService<?> conversionService, Class<T> temporalType, DateTimeFormatter isoFormatter, TemporalQuery<T> query) {
+        conversionService.addConverter(CharSequence.class, temporalType, (CharSequence object, Class<T> targetType, ConversionContext context) -> {
+            if (StringUtils.isEmpty(object)) {
+                return Optional.empty();
+            }
+            // try explicit format first
+            Optional<String> format = context.getAnnotationMetadata().stringValue(Format.class);
+            if (format.isPresent()) {
+                DateTimeFormatter formatter = DateTimeFormatter.ofPattern(format.get(), context.getLocale());
                 try {
-                    DateTimeFormatter formatter = resolveFormatter(context);
-                    LocalDate result = LocalDate.parse(object, formatter);
+                    T converted = formatter.parse(object, query);
+                    return Optional.of(converted);
+                } catch (DateTimeParseException e) {
+                    context.reject(object, e);
+                    return Optional.empty();
+                }
+            } else {
+                try {
+                    T converted = isoFormatter.parse(object, query);
+                    return Optional.of(converted);
+                } catch (DateTimeParseException ignored) {
+                }
+                // fall back to RFC 1123 date time for compatibility
+                try {
+                    T result = DateTimeFormatter.RFC_1123_DATE_TIME.parse(object, query);
                     return Optional.of(result);
                 } catch (DateTimeParseException e) {
                     context.reject(object, e);
                     return Optional.empty();
                 }
             }
-        );
+        });
+    }
 
-
-        // CharSequence -> ZonedDateTime
-        conversionService.addConverter(
-            CharSequence.class,
-            ZonedDateTime.class,
-            (object, targetType, context) -> {
-                try {
-                    DateTimeFormatter formatter = resolveFormatter(context);
-                    ZonedDateTime result = ZonedDateTime.parse(object, formatter);
-                    return Optional.of(result);
-                } catch (DateTimeParseException e) {
-                    context.reject(object, e);
-                    return Optional.empty();
-                }
-            }
-        );
-
-        // CharSequence -> OffsetDateTime
-        conversionService.addConverter(
-                CharSequence.class,
-                OffsetDateTime.class,
-                (object, targetType, context) -> {
-                    try {
-                        DateTimeFormatter formatter = resolveFormatter(context);
-                        OffsetDateTime result = OffsetDateTime.parse(object, formatter);
-                        return Optional.of(result);
-                    } catch (DateTimeParseException e) {
-                        context.reject(object, e);
-                        return Optional.empty();
-                    }
-                }
-        );
+    private <T extends TemporalAccessor> void addTemporalToDateConverter(ConversionService<?> conversionService, Class<T> temporalType, Function<T, Instant> toInstant) {
+        conversionService.addConverter(temporalType, Date.class, (T object, Class<Date> targetType, ConversionContext context) -> Optional.of(Date.from(toInstant.apply(object))));
     }
 
     private DateTimeFormatter resolveFormatter(ConversionContext context) {

--- a/context/src/main/java/io/micronaut/runtime/converters/time/TimeConverterRegistrar.java
+++ b/context/src/main/java/io/micronaut/runtime/converters/time/TimeConverterRegistrar.java
@@ -174,6 +174,7 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
         addTemporalToDateConverter(conversionService, OffsetDateTime.class, OffsetDateTime::toInstant);
         addTemporalToDateConverter(conversionService, ZonedDateTime.class, ZonedDateTime::toInstant);
         // these two are a bit icky, but required for yaml parsing compatibility
+        // TODO Micronaut 4 Consider deletion
         addTemporalToDateConverter(conversionService, LocalDate.class, ld -> ld.atTime(0, 0).toInstant(ZoneOffset.UTC));
         addTemporalToDateConverter(conversionService, LocalDateTime.class, ldt -> ldt.toInstant(ZoneOffset.UTC));
     }

--- a/inject/src/main/java/io/micronaut/context/env/yaml/ConstructIsoTimestampString.java
+++ b/inject/src/main/java/io/micronaut/context/env/yaml/ConstructIsoTimestampString.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context.env.yaml;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import org.yaml.snakeyaml.constructor.AbstractConstruct;
+import org.yaml.snakeyaml.error.YAMLException;
+import org.yaml.snakeyaml.nodes.Node;
+import org.yaml.snakeyaml.nodes.ScalarNode;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.Temporal;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Adapted from {@link org.yaml.snakeyaml.constructor.SafeConstructor.ConstructYamlTimestamp} but
+ * with java 8 time.
+ */
+@Internal
+final class ConstructIsoTimestampString extends AbstractConstruct {
+    private static final Pattern TIMESTAMP_REGEXP = Pattern.compile(
+        "^([0-9][0-9][0-9][0-9])-([0-9][0-9]?)-([0-9][0-9]?)(?:(?:[Tt]|[ \t]+)([0-9][0-9]?):([0-9][0-9]):([0-9][0-9])(?:\\.([0-9]*))?(?:[ \t]*(?:(Z)|([-+][0-9][0-9]?)(?::([0-9][0-9])?)?))?)?$");
+    private static final Pattern YMD_REGEXP = Pattern
+        .compile("^([0-9][0-9][0-9][0-9])-([0-9][0-9]?)-([0-9][0-9]?)$");
+
+    @Override
+    public Object construct(Node node) {
+        ScalarNode scalar = (ScalarNode) node;
+        String nodeValue = scalar.getValue();
+        return parse(nodeValue);
+    }
+
+    @NonNull
+    static Temporal parse(String nodeValue) {
+        Matcher match = YMD_REGEXP.matcher(nodeValue);
+        if (match.matches()) {
+            String yearS = match.group(1);
+            String monthS = match.group(2);
+            String dayS = match.group(3);
+            return LocalDate.of(
+                Integer.parseInt(yearS),
+                Integer.parseInt(monthS),
+                Integer.parseInt(dayS)
+            );
+        } else {
+            match = TIMESTAMP_REGEXP.matcher(nodeValue);
+            if (!match.matches()) {
+                throw new YAMLException("Unexpected timestamp: " + nodeValue);
+            }
+            String yearS = match.group(1);
+            String monthS = match.group(2);
+            String dayS = match.group(3);
+            String hourS = match.group(4);
+            String minS = match.group(5);
+            // seconds and milliseconds
+            String seconds = match.group(6);
+            String millis = match.group(7);
+            if (millis != null) {
+                seconds = seconds + "." + millis;
+            }
+            double fractions = Double.parseDouble(seconds);
+            int secS = (int) Math.round(Math.floor(fractions));
+            int nsec = (int) Math.round((fractions - secS) * 1_000_000_000);
+
+            LocalDateTime ldt = LocalDateTime.of(
+                Integer.parseInt(yearS),
+                Integer.parseInt(monthS),
+                Integer.parseInt(dayS),
+                Integer.parseInt(hourS),
+                Integer.parseInt(minS),
+                secS,
+                nsec
+            );
+
+            // timezone
+            String timezonehS = match.group(9);
+            String timezonemS = match.group(10);
+            if (timezonehS != null) {
+                ZoneOffset offset;
+                if (timezonemS == null) {
+                    offset = ZoneOffset.ofHours(Integer.parseInt(timezonehS));
+                } else {
+                    offset = ZoneOffset.ofHoursMinutes(Integer.parseInt(timezonehS), Integer.parseInt(timezonemS));
+                }
+                return ldt.atOffset(offset);
+            } else {
+                if (match.group(8) != null) {
+                    // Z
+                    return ldt.atOffset(ZoneOffset.UTC);
+                } else {
+                    // no time zone provided
+                    return ldt;
+                }
+            }
+        }
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/env/yaml/CustomSafeConstructor.java
+++ b/inject/src/main/java/io/micronaut/context/env/yaml/CustomSafeConstructor.java
@@ -19,6 +19,7 @@ import io.micronaut.core.annotation.Internal;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
 import org.yaml.snakeyaml.nodes.MappingNode;
 import org.yaml.snakeyaml.nodes.SequenceNode;
+import org.yaml.snakeyaml.nodes.Tag;
 
 import java.util.List;
 import java.util.Map;
@@ -32,6 +33,9 @@ import java.util.Map;
  */
 @Internal
 class CustomSafeConstructor extends SafeConstructor {
+    CustomSafeConstructor() {
+        yamlConstructors.put(Tag.TIMESTAMP, new ConstructIsoTimestampString());
+    }
 
     @Override
     protected Map<Object, Object> newMap(MappingNode node) {

--- a/inject/src/test/groovy/io/micronaut/context/env/yaml/ConstructIsoTimestampStringSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/env/yaml/ConstructIsoTimestampStringSpec.groovy
@@ -1,0 +1,25 @@
+package io.micronaut.context.env.yaml
+
+import spock.lang.Specification
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.temporal.Temporal
+
+class ConstructIsoTimestampStringSpec extends Specification {
+    def parse(String literal, Temporal expected) {
+        when:
+        Temporal parsed = ConstructIsoTimestampString.parse(literal)
+        then:
+        parsed == expected
+
+        where:
+        literal                         | expected
+        '2022-08-12'                    | LocalDate.of(2022, 8, 12)
+        '2022-08-12T10:01:02.345'       | LocalDateTime.of(2022, 8, 12, 10, 1, 2, 345_000_000)
+        '2022-08-12T10:01:02.345Z'      | LocalDateTime.of(2022, 8, 12, 10, 1, 2, 345_000_000).atOffset(ZoneOffset.UTC)
+        '2022-08-12T10:01:02.345+05'    | LocalDateTime.of(2022, 8, 12, 10, 1, 2, 345_000_000).atOffset(ZoneOffset.ofHours(5))
+        '2022-08-12T10:01:02.345+05:06' | LocalDateTime.of(2022, 8, 12, 10, 1, 2, 345_000_000).atOffset(ZoneOffset.ofHoursMinutes(5, 6))
+    }
+}

--- a/inject/src/test/groovy/io/micronaut/context/env/yaml/YamlPropertySourceLoaderSpec2.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/env/yaml/YamlPropertySourceLoaderSpec2.groovy
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context.env.yaml
+
+import io.micronaut.context.ApplicationContextConfiguration
+import io.micronaut.context.env.DefaultEnvironment
+import io.micronaut.context.env.Environment
+import io.micronaut.context.env.PropertySourceLoader
+import io.micronaut.core.io.service.ServiceDefinition
+import io.micronaut.core.io.service.SoftServiceLoader
+import spock.lang.Specification
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+/**
+ * not limited by groovy version
+ */
+class YamlPropertySourceLoaderSpec2 extends Specification {
+
+    void "test yaml value conversion"(String literal, Class<?> type, Object expected) {
+        given:
+        def serviceDefinition = Mock(ServiceDefinition)
+        serviceDefinition.isPresent() >> true
+        serviceDefinition.load() >> new YamlPropertySourceLoader()
+
+        Environment env = new DefaultEnvironment(new ApplicationContextConfiguration() {
+            @Override
+            List<String> getEnvironments() {
+                return ['test']
+            }
+        }) {
+            @Override
+            protected SoftServiceLoader<PropertySourceLoader> readPropertySourceLoaders() {
+                GroovyClassLoader gcl = new GroovyClassLoader()
+                gcl.addClass(YamlPropertySourceLoader)
+                gcl.addURL(YamlPropertySourceLoader.getResource("/META-INF/services/io.micronaut.context.env.PropertySourceLoader"))
+                return new SoftServiceLoader<PropertySourceLoader>(PropertySourceLoader, gcl)
+            }
+
+            @Override
+            Optional<InputStream> getResourceAsStream(String path) {
+                if (path.endsWith("application.yml")) {
+                    return Optional.of(new ByteArrayInputStream("""\
+foo: $literal
+""".bytes))
+                }
+
+                return Optional.empty()
+            }
+
+        }
+
+
+        when:
+        env.start()
+
+        then:
+        env.get("foo", type).get() == expected
+
+        where:
+        // note: string->Date is not supported
+
+        literal                       | type           | expected
+        // YMD
+        '2022-08-12'                  | LocalDate      | LocalDate.of(2022, 8, 12)
+        '"2022-08-12"'                | LocalDate      | LocalDate.of(2022, 8, 12)
+        '2022-08-12'                  | Date           | Date.from(LocalDate.of(2022, 8, 12).atTime(0, 0).atOffset(ZoneOffset.UTC).toInstant())
+        // YMD HMS
+        '2022-08-12T10:12:34'         | LocalDateTime  | LocalDateTime.of(2022, 8, 12, 10, 12, 34)
+        '"2022-08-12T10:12:34"'       | LocalDateTime  | LocalDateTime.of(2022, 8, 12, 10, 12, 34)
+        '2022-08-12T10:12:34'         | Date           | Date.from(LocalDateTime.of(2022, 8, 12, 10, 12, 34).atOffset(ZoneOffset.UTC).toInstant())
+        // YMD HMS Z
+        '2022-08-12T10:12:34+05:00'   | OffsetDateTime | LocalDateTime.of(2022, 8, 12, 10, 12, 34).atOffset(ZoneOffset.ofHours(5))
+        '"2022-08-12T10:12:34+05:00"' | OffsetDateTime | LocalDateTime.of(2022, 8, 12, 10, 12, 34).atOffset(ZoneOffset.ofHours(5))
+        '2022-08-12T10:12:34+05:00'   | Date           | Date.from(LocalDateTime.of(2022, 8, 12, 10, 12, 34).atOffset(ZoneOffset.ofHours(5)).toInstant())
+    }
+}

--- a/runtime/src/test/groovy/io/micronaut/runtime/converters/time/TimeConverterRegistrarSpec.groovy
+++ b/runtime/src/test/groovy/io/micronaut/runtime/converters/time/TimeConverterRegistrarSpec.groovy
@@ -21,6 +21,14 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.OffsetTime
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
 
 class TimeConverterRegistrarSpec extends Specification {
 
@@ -43,5 +51,30 @@ class TimeConverterRegistrarSpec extends Specification {
         '10h'  | Duration.ofHours(10)
         '10ns' | Duration.ofNanos(10)
 
+    }
+    @Unroll
+    void "test converts a #sourceObject.class.name to a #targetType.name"() {
+        given:
+        ConversionService conversionService = new DefaultConversionService()
+        new TimeConverterRegistrar().register(conversionService)
+
+        expect:
+        conversionService.convert(sourceObject, targetType).get() == result
+
+        where:
+        sourceObject            | targetType  | result
+        Instant.ofEpochMilli(123)                                            | Date | new Date(123)
+        Instant.ofEpochMilli(123).atOffset(ZoneOffset.ofHours(5))            | Date | new Date(123)
+        Instant.ofEpochMilli(123).atZone(ZoneId.of("Europe/Berlin"))         | Date | new Date(123)
+        Instant.ofEpochMilli(123).atOffset(ZoneOffset.UTC).toLocalDateTime() | Date | new Date(123)
+        Instant.ofEpochMilli(123).atOffset(ZoneOffset.UTC).toLocalDate()     | Date | new Date(0)
+
+        "2022-08-12"                               | LocalDate      | LocalDate.of(2022, 8, 12)
+        "2022-08-12T12:19:00"                      | LocalDateTime  | LocalDateTime.of(2022, 8, 12, 12, 19)
+        "12:19:00+05:00"                           | OffsetTime     | OffsetTime.of(12, 19, 0, 0, ZoneOffset.ofHours(5))
+        "2022-08-12T12:19:00+05:00"                | OffsetDateTime | OffsetDateTime.of(2022, 8, 12, 12, 19, 0, 0, ZoneOffset.ofHours(5))
+        "2022-08-12T12:19:00+05:00"                | ZonedDateTime  | ZonedDateTime.of(2022, 8, 12, 12, 19, 0, 0, ZoneOffset.ofHours(5))
+        "2022-08-12T12:19:00+02:00[Europe/Berlin]" | ZonedDateTime  | ZonedDateTime.of(2022, 8, 12, 12, 19, 0, 0, ZoneId.of("Europe/Berlin"))
+        "2022-08-12T12:19:00Z"                     | Instant        | LocalDateTime.of(2022, 8, 12, 12, 19).toInstant(ZoneOffset.UTC)
     }
 }


### PR DESCRIPTION
YAML has a defined timestamp type that is used when iso8601-like values are encountered, e.g. 2022-08-12. Unfortunately, snakeyaml parses them as java.util.Date by default (at UTC timezone).
This patch adds a snakeyaml constructor that parses timestamps as the appropriate java.time type instead – LocalDate, LocalDateTime, or OffsetDateTime, depending on the actual input.
To maintain compatibility, I added conversions from these types to Date. For ODT this is straight-forward, but for LD and LDT, it uses UTC as the offset to match the old snakeyaml behavior. This is a bit arbitrary, but required for compatibility. We could remove these conversions for Micronaut 4.
I've also altered the existing time conversions to be able to handle ISO 8601 strings as inputs for conversion to the java.time types. This means that when a configuration property is defined with java.time, you can use the same ISO 8601 string for the yaml and e.g. properties or toml definition.
Fixes #7863