### PR TITLE
feat: Add CracContextProvider

### DIFF
--- a/crac/src/main/java/io/micronaut/crac/support/CracContextProvider.java
+++ b/crac/src/main/java/io/micronaut/crac/support/CracContextProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.crac.support;
+
+import io.micronaut.core.annotation.NonNull;
+import org.crac.Context;
+import org.crac.Resource;
+
+/**
+ * API to get the Context for checkpoint/restore notifications.
+ * @author Sergio del Amo
+ * @since 3.7.0
+ */
+@FunctionalInterface
+public interface CracContextProvider {
+
+    /**
+     *
+     * @return Gets the Context for checkpoint/restore notifications.
+     */
+    @NonNull
+    Context<Resource> provideContext();
+}

--- a/crac/src/main/java/io/micronaut/crac/support/GlobalCracContextFactory.java
+++ b/crac/src/main/java/io/micronaut/crac/support/GlobalCracContextFactory.java
@@ -19,7 +19,6 @@ import io.micronaut.context.annotation.Factory;
 import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.NonNull;
 import jakarta.inject.Singleton;
-import org.crac.Core;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,12 +37,13 @@ public class GlobalCracContextFactory {
     /**
      * Creates a delegating context class to allow CRaC to be used in Micronaut.
      *
+     * @param cracContextProvider API to get the Context for checkpoint/restore notifications.
      * @return The Global context for Coordinated Restore at Checkpoint.
      */
     @NonNull
     @Singleton
-    public CracContext createContext() {
-        CracContext cracContext = new DefaultCracContext(Core.getGlobalContext());
+    public CracContext createContext(@NonNull CracContextProvider cracContextProvider) {
+        CracContext cracContext = new DefaultCracContext(cracContextProvider.provideContext());
         if (LOG.isDebugEnabled()) {
             LOG.debug("Creating a Global CRaC context delegate {}", cracContext);
         }

--- a/crac/src/main/java/io/micronaut/crac/support/GlobalCracContextProvider.java
+++ b/crac/src/main/java/io/micronaut/crac/support/GlobalCracContextProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.crac.support;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.NonNull;
+import jakarta.inject.Singleton;
+import org.crac.Context;
+import org.crac.Core;
+import org.crac.Resource;
+
+/**
+ * Gets a Global Context through {@link Core#getGlobalContext()}.
+ * @author Sergio del Amo
+ * @since 3.7.0
+ */
+@Requires(classes = {Resource.class, Context.class})
+@Singleton
+public class GlobalCracContextProvider implements CracContextProvider {
+    @Override
+    @NonNull
+    public Context<Resource> provideContext() {
+        return Core.getGlobalContext();
+    }
+}

--- a/crac/src/main/java/io/micronaut/crac/support/GlobalCracContextProvider.java
+++ b/crac/src/main/java/io/micronaut/crac/support/GlobalCracContextProvider.java
@@ -15,7 +15,6 @@
  */
 package io.micronaut.crac.support;
 
-import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.NonNull;
 import jakarta.inject.Singleton;
 import org.crac.Context;
@@ -27,7 +26,6 @@ import org.crac.Resource;
  * @author Sergio del Amo
  * @since 3.7.0
  */
-@Requires(classes = {Resource.class, Context.class})
 @Singleton
 public class GlobalCracContextProvider implements CracContextProvider {
     @Override


### PR DESCRIPTION
This allows users to provide a Context without using `Core::getGlobalContext`