### PR TITLE
feature: Allow stopping netty without stopping the application context

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyEmbeddedServer.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyEmbeddedServer.java
@@ -46,11 +46,13 @@ public interface NettyEmbeddedServer
     }
 
     @Override
+    @NonNull
     default NettyEmbeddedServer start() {
         return (NettyEmbeddedServer) EmbeddedServer.super.start();
     }
 
     @Override
+    @NonNull
     default NettyEmbeddedServer stop() {
         return (NettyEmbeddedServer) EmbeddedServer.super.stop();
     }
@@ -62,6 +64,7 @@ public interface NettyEmbeddedServer
      * @return The stopped NettyEmbeddedServer
      */
     @SuppressWarnings("unused") // Used by CRaC
+    @NonNull
     NettyEmbeddedServer stopServerOnly();
 
     @Override

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyEmbeddedServer.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyEmbeddedServer.java
@@ -55,6 +55,15 @@ public interface NettyEmbeddedServer
         return (NettyEmbeddedServer) EmbeddedServer.super.stop();
     }
 
+    /**
+     * Stops the Netty instance, but keeps the ApplicationContext running.
+     * This for CRaC checkpointing purposes.
+     *
+     * @return The stopped NettyEmbeddedServer
+     */
+    @SuppressWarnings("unused") // Used by CRaC
+    NettyEmbeddedServer stopServerOnly();
+
     @Override
     default void register(@NonNull NettyServerCustomizer customizer) {
         throw new UnsupportedOperationException();

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
@@ -259,6 +259,7 @@ public class NettyHttpServer implements NettyEmbeddedServer {
     }
 
     @Override
+    @NonNull
     public synchronized NettyEmbeddedServer start() {
         if (!isRunning()) {
             if (isDefault && !applicationContext.isRunning()) {
@@ -317,15 +318,18 @@ public class NettyHttpServer implements NettyEmbeddedServer {
     }
 
     @Override
+    @NonNull
     public synchronized NettyEmbeddedServer stop() {
         return stop(true);
     }
 
     @Override
+    @NonNull
     public NettyEmbeddedServer stopServerOnly() {
         return stop(false);
     }
 
+    @NonNull
     private NettyEmbeddedServer stop(boolean stopApplicationContext) {
         if (isRunning() && workerGroup != null) {
             if (running.compareAndSet(true, false)) {

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/NettyStopSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/NettyStopSpec.groovy
@@ -1,0 +1,33 @@
+package io.micronaut.http.server.netty
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.runtime.server.EmbeddedServer
+import spock.lang.Specification
+
+class NettyStopSpec extends Specification {
+
+    def 'can shutdown netty and application context'() {
+        NettyEmbeddedServer server = ApplicationContext.run(EmbeddedServer, ['spec.name': 'NettyStopSpec'])
+        def ctx = server.applicationContext
+
+        when:
+        server.stop()
+
+        then:
+        !ctx.running
+    }
+
+    def 'can shutdown netty and keep application context running'() {
+        NettyEmbeddedServer server = ApplicationContext.run(EmbeddedServer, ['spec.name': 'NettyStopSpec'])
+        def ctx = server.applicationContext
+
+        when:
+        server.stopServerOnly()
+
+        then:
+        ctx.running
+
+        cleanup:
+        ctx.stop()
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/ApplicationContextLifeCycle.java
+++ b/inject/src/main/java/io/micronaut/context/ApplicationContextLifeCycle.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.context;
 
+import io.micronaut.core.annotation.NonNull;
+
 /**
  * An interface for classes that manage the {@link ApplicationContext} life cycle and shut it down when the class is shutdown.
  *
@@ -24,12 +26,14 @@ public interface ApplicationContextLifeCycle<T extends ApplicationContextLifeCyc
 
     @SuppressWarnings("unchecked")
     @Override
+    @NonNull
     default T start() {
         return (T) this;
     }
 
     @SuppressWarnings("unchecked")
     @Override
+    @NonNull
     default T stop() {
         ApplicationContext applicationContext = getApplicationContext();
         if (applicationContext != null && applicationContext.isRunning()) {

--- a/messaging/src/main/java/io/micronaut/messaging/MessagingApplication.java
+++ b/messaging/src/main/java/io/micronaut/messaging/MessagingApplication.java
@@ -17,6 +17,7 @@ package io.micronaut.messaging;
 
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.naming.Described;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.qualifiers.Qualifiers;
@@ -76,6 +77,7 @@ public class MessagingApplication implements EmbeddedApplication<MessagingApplic
     }
 
     @Override
+    @NonNull
     public MessagingApplication start() {
         ApplicationContext applicationContext = getApplicationContext();
         if (applicationContext != null && !applicationContext.isRunning()) {
@@ -90,6 +92,7 @@ public class MessagingApplication implements EmbeddedApplication<MessagingApplic
     }
 
     @Override
+    @NonNull
     public MessagingApplication stop() {
         ApplicationContext applicationContext = getApplicationContext();
         if (applicationContext != null && applicationContext.isRunning()) {


### PR DESCRIPTION
For CRaC, we need to be able to stop the Netty server when a checkpoint is made, but keep the ApplicationContext alive.

This change adds a new method to NettyEmbeddedServer to allow this.

If we don't keep ApplicationContext running then we get

```
Caused by: io.micronaut.context.exceptions.NonUniqueBeanException: Multiple possible bean candidates found: [io.micronaut.aop.InterceptorRegistry, io.micronaut.aop.InterceptorRegistry]
	at io.micronaut.context.DefaultBeanContext.findConcreteCandidate(DefaultBeanContext.java:2472)
	at io.micronaut.context.DefaultApplicationContext.findConcreteCandidate(DefaultApplicationContext.java:484)
	at io.micronaut.context.DefaultBeanContext.lastChanceResolve(DefaultBeanContext.java:3249)
	at io.micronaut.context.DefaultBeanContext.findConcreteCandidateNoCache(DefaultBeanContext.java:3140)
	at io.micronaut.context.DefaultBeanContext.findConcreteCandidate(DefaultBeanContext.java:3058)
	at io.micronaut.context.DefaultBeanContext.findBeanDefinition(DefaultBeanContext.java:788)
	at io.micronaut.context.DefaultBeanContext.resolveBeanRegistration(DefaultBeanContext.java:2790)
	at io.micronaut.context.DefaultBeanContext.getBean(DefaultBeanContext.java:1617)
	at io.micronaut.context.DefaultBeanContext.getBean(DefaultBeanContext.java:867)
	at io.micronaut.context.DefaultBeanContext.getBean(DefaultBeanContext.java:859)
	at io.micronaut.aop.chain.InterceptorChain.resolveInterceptors(InterceptorChain.java:205)
	at io.micronaut.aop.chain.InterceptorChain.resolveAroundInterceptors(InterceptorChain.java:125)
	at com.bloidonia..<init>(Unknown Source)
	at com.bloidonia..build(Unknown Source)
	at io.micronaut.context.DefaultBeanContext.resolveByBeanFactory(DefaultBeanContext.java:2354)
```

When trying to inject a `BeanContext` or `Environment` into a bean (for example when using the `EnvironmentEndpoint`