### PR TITLE
Move some netty converters to SPI

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/converters/NettyConverters.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/converters/NettyConverters.java
@@ -32,7 +32,6 @@ import io.netty.buffer.ByteBufInputStream;
 import io.netty.channel.ChannelOption;
 import io.netty.handler.codec.http.multipart.Attribute;
 import io.netty.handler.codec.http.multipart.FileUpload;
-import io.netty.handler.codec.http.multipart.HttpData;
 import jakarta.inject.Singleton;
 
 import java.io.IOException;

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/converters/NettyConverters.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/converters/NettyConverters.java
@@ -25,19 +25,11 @@ import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.codec.MediaTypeCodec;
 import io.micronaut.http.codec.MediaTypeCodecRegistry;
-import io.micronaut.http.multipart.CompletedFileUpload;
-import io.micronaut.http.multipart.CompletedPart;
 import io.micronaut.http.netty.channel.converters.ChannelOptionFactory;
-import io.micronaut.http.server.netty.multipart.NettyCompletedAttribute;
-import io.micronaut.http.server.netty.multipart.NettyCompletedFileUpload;
 import io.micronaut.http.server.netty.multipart.NettyPartData;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
-import io.netty.buffer.ByteBufUtil;
-import io.netty.buffer.CompositeByteBuf;
-import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelOption;
-import io.netty.channel.WriteBufferWaterMark;
 import io.netty.handler.codec.http.multipart.Attribute;
 import io.netty.handler.codec.http.multipart.FileUpload;
 import io.netty.handler.codec.http.multipart.HttpData;
@@ -47,7 +39,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -90,46 +81,11 @@ public class NettyConverters implements TypeConverterRegistrar {
                     return Optional.of(channelOptionFactory.channelOption(name));
                 }
         );
-        conversionService.addConverter(
-                ByteBuf.class,
-                CharSequence.class,
-                byteBufCharSequenceTypeConverter()
-        );
-
-        conversionService.addConverter(
-                CompositeByteBuf.class,
-                CharSequence.class,
-                compositeByteBufCharSequenceTypeConverter()
-        );
-
-        conversionService.addConverter(
-                ByteBuf.class,
-                byte[].class,
-                byteBufToArrayTypeConverter()
-        );
-
-        conversionService.addConverter(
-                byte[].class,
-                ByteBuf.class,
-                byteArrayToByteBuffTypeConverter()
-        );
 
         conversionService.addConverter(
                 ByteBuf.class,
                 Object.class,
                 byteBufToObjectConverter()
-        );
-
-        conversionService.addConverter(
-                FileUpload.class,
-                CompletedFileUpload.class,
-                fileUploadToCompletedFileUploadConverter()
-        );
-
-        conversionService.addConverter(
-                Attribute.class,
-                CompletedPart.class,
-                attributeToCompletedPartConverter()
         );
 
         conversionService.addConverter(
@@ -152,12 +108,6 @@ public class NettyConverters implements TypeConverterRegistrar {
 
         conversionService.addConverter(
                 NettyPartData.class,
-                byte[].class,
-                nettyPartDataToByteArrayConverter()
-        );
-
-        conversionService.addConverter(
-                NettyPartData.class,
                 Object.class,
                 nettyPartDataToObjectConverter()
         );
@@ -173,26 +123,6 @@ public class NettyConverters implements TypeConverterRegistrar {
                 ChannelOption.class,
                 s -> channelOptionFactory.channelOption(NameUtils.environmentName(s))
         );
-
-        conversionService.addConverter(
-                Map.class,
-                WriteBufferWaterMark.class,
-                (map, targetType, context) -> {
-                    Object h = map.get("high");
-                    Object l = map.get("low");
-                    if (h != null && l != null) {
-                        try {
-                            int high = Integer.parseInt(h.toString());
-                            int low = Integer.parseInt(l.toString());
-                            return Optional.of(new WriteBufferWaterMark(low, high));
-                        } catch (NumberFormatException e) {
-                            context.reject(e);
-                            return Optional.empty();
-                        }
-                    }
-                    return Optional.empty();
-                }
-        );
     }
 
     private TypeConverter<Attribute, Object> nettyAttributeToObjectConverter() {
@@ -204,17 +134,6 @@ public class NettyConverters implements TypeConverterRegistrar {
                 } else {
                     return conversionService.convert(value, targetType, context);
                 }
-            } catch (IOException e) {
-                context.reject(e);
-                return Optional.empty();
-            }
-        };
-    }
-
-    private TypeConverter<NettyPartData, byte[]> nettyPartDataToByteArrayConverter() {
-        return (upload, targetType, context) -> {
-            try {
-                return Optional.of(upload.getBytes());
             } catch (IOException e) {
                 context.reject(e);
                 return Optional.empty();
@@ -283,42 +202,6 @@ public class NettyConverters implements TypeConverterRegistrar {
     /**
      * @return A FileUpload to CompletedFileUpload converter
      */
-    protected TypeConverter<FileUpload, CompletedFileUpload> fileUploadToCompletedFileUploadConverter() {
-        return (object, targetType, context) -> {
-            try {
-                if (!object.isCompleted()) {
-                    return Optional.empty();
-                }
-
-                return Optional.of(new NettyCompletedFileUpload(object));
-            } catch (Exception e) {
-                context.reject(e);
-                return Optional.empty();
-            }
-        };
-    }
-
-    /**
-     * @return An Attribute to CompletedPart converter
-     */
-    protected TypeConverter<Attribute, CompletedPart> attributeToCompletedPartConverter() {
-        return (object, targetType, context) -> {
-            try {
-                if (!object.isCompleted()) {
-                    return Optional.empty();
-                }
-
-                return Optional.of(new NettyCompletedAttribute(object));
-            } catch (Exception e) {
-                context.reject(e);
-                return Optional.empty();
-            }
-        };
-    }
-
-    /**
-     * @return A FileUpload to CompletedFileUpload converter
-     */
     protected TypeConverter<FileUpload, Object> fileUploadToObjectConverter() {
         return (object, targetType, context) -> {
             try {
@@ -352,33 +235,5 @@ public class NettyConverters implements TypeConverterRegistrar {
      */
     protected TypeConverter<ByteBuf, Object> byteBufToObjectConverter() {
         return (object, targetType, context) -> conversionService.convert(object.toString(context.getCharset()), targetType, context);
-    }
-
-    /**
-     * @return A converter that converts bytebufs to strings
-     */
-    protected TypeConverter<ByteBuf, CharSequence> byteBufCharSequenceTypeConverter() {
-        return (object, targetType, context) -> Optional.of(object.toString(context.getCharset()));
-    }
-
-    /**
-     * @return A converter that converts composite bytebufs to strings
-     */
-    protected TypeConverter<CompositeByteBuf, CharSequence> compositeByteBufCharSequenceTypeConverter() {
-        return (object, targetType, context) -> Optional.of(object.toString(context.getCharset()));
-    }
-
-    /**
-     * @return A converter that converts bytebufs to byte arrays
-     */
-    protected TypeConverter<ByteBuf, byte[]> byteBufToArrayTypeConverter() {
-        return (object, targetType, context) -> Optional.of(ByteBufUtil.getBytes(object));
-    }
-
-    /**
-     * @return A converter that converts bytebufs to byte arrays
-     */
-    protected TypeConverter<byte[], ByteBuf> byteArrayToByteBuffTypeConverter() {
-        return (object, targetType, context) -> Optional.of(Unpooled.wrappedBuffer(object));
     }
 }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/converters/NettyConverters.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/converters/NettyConverters.java
@@ -95,18 +95,6 @@ public class NettyConverters implements TypeConverterRegistrar {
         );
 
         conversionService.addConverter(
-                HttpData.class,
-                byte[].class,
-                httpDataToByteArrayConverter()
-        );
-
-        conversionService.addConverter(
-                HttpData.class,
-                CharSequence.class,
-                httpDataToStringConverter()
-        );
-
-        conversionService.addConverter(
                 NettyPartData.class,
                 Object.class,
                 nettyPartDataToObjectConverter()
@@ -157,42 +145,6 @@ public class NettyConverters implements TypeConverterRegistrar {
                     }
                 }
             } catch (IOException e) {
-                context.reject(e);
-                return Optional.empty();
-            }
-        };
-    }
-
-    /**
-     * @return The HTTP data to string converter.
-     */
-    protected TypeConverter<HttpData, CharSequence> httpDataToStringConverter() {
-        return (upload, targetType, context) -> {
-            try {
-                if (!upload.isCompleted()) {
-                    return Optional.empty();
-                }
-                ByteBuf byteBuf = upload.getByteBuf();
-                return conversionService.convert(byteBuf, targetType, context);
-            } catch (Exception e) {
-                context.reject(e);
-                return Optional.empty();
-            }
-        };
-    }
-
-    /**
-     * @return The HTTP data to byte array converter
-     */
-    protected TypeConverter<HttpData, byte[]> httpDataToByteArrayConverter() {
-        return (upload, targetType, context) -> {
-            try {
-                if (!upload.isCompleted()) {
-                    return Optional.empty();
-                }
-                ByteBuf byteBuf = upload.getByteBuf();
-                return conversionService.convert(byteBuf, targetType, context);
-            } catch (Exception e) {
                 context.reject(e);
                 return Optional.empty();
             }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/converters/NettyConvertersSpi.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/converters/NettyConvertersSpi.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.netty.converters;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.convert.TypeConverter;
+import io.micronaut.core.convert.TypeConverterRegistrar;
+import io.micronaut.http.multipart.CompletedFileUpload;
+import io.micronaut.http.multipart.CompletedPart;
+import io.micronaut.http.server.netty.multipart.NettyCompletedAttribute;
+import io.micronaut.http.server.netty.multipart.NettyCompletedFileUpload;
+import io.micronaut.http.server.netty.multipart.NettyPartData;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.WriteBufferWaterMark;
+import io.netty.handler.codec.http.multipart.Attribute;
+import io.netty.handler.codec.http.multipart.FileUpload;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Factory for bytebuf related converters that do not need the application context (can be
+ * registered with SPI).
+ *
+ * @author Jonas Konrad
+ * @since 3.6.3
+ */
+@Internal
+public class NettyConvertersSpi implements TypeConverterRegistrar {
+    @Override
+    public void register(ConversionService<?> conversionService) {
+        conversionService.addConverter(
+            ByteBuf.class,
+            CharSequence.class,
+            byteBufCharSequenceTypeConverter()
+        );
+
+        conversionService.addConverter(
+            CompositeByteBuf.class,
+            CharSequence.class,
+            compositeByteBufCharSequenceTypeConverter()
+        );
+
+        conversionService.addConverter(
+            ByteBuf.class,
+            byte[].class,
+            byteBufToArrayTypeConverter()
+        );
+
+        conversionService.addConverter(
+            byte[].class,
+            ByteBuf.class,
+            byteArrayToByteBuffTypeConverter()
+        );
+
+        conversionService.addConverter(
+            FileUpload.class,
+            CompletedFileUpload.class,
+            fileUploadToCompletedFileUploadConverter()
+        );
+
+        conversionService.addConverter(
+            Attribute.class,
+            CompletedPart.class,
+            attributeToCompletedPartConverter()
+        );
+
+        conversionService.addConverter(
+            NettyPartData.class,
+            byte[].class,
+            nettyPartDataToByteArrayConverter()
+        );
+
+        conversionService.addConverter(
+            Map.class,
+            WriteBufferWaterMark.class,
+            (map, targetType, context) -> {
+                Object h = map.get("high");
+                Object l = map.get("low");
+                if (h != null && l != null) {
+                    try {
+                        int high = Integer.parseInt(h.toString());
+                        int low = Integer.parseInt(l.toString());
+                        return Optional.of(new WriteBufferWaterMark(low, high));
+                    } catch (NumberFormatException e) {
+                        context.reject(e);
+                        return Optional.empty();
+                    }
+                }
+                return Optional.empty();
+            }
+        );
+    }
+
+    private TypeConverter<NettyPartData, byte[]> nettyPartDataToByteArrayConverter() {
+        return (upload, targetType, context) -> {
+            try {
+                return Optional.of(upload.getBytes());
+            } catch (IOException e) {
+                context.reject(e);
+                return Optional.empty();
+            }
+        };
+    }
+
+    /**
+     * @return A FileUpload to CompletedFileUpload converter
+     */
+    protected TypeConverter<FileUpload, CompletedFileUpload> fileUploadToCompletedFileUploadConverter() {
+        return (object, targetType, context) -> {
+            try {
+                if (!object.isCompleted()) {
+                    return Optional.empty();
+                }
+
+                return Optional.of(new NettyCompletedFileUpload(object));
+            } catch (Exception e) {
+                context.reject(e);
+                return Optional.empty();
+            }
+        };
+    }
+
+    /**
+     * @return An Attribute to CompletedPart converter
+     */
+    protected TypeConverter<Attribute, CompletedPart> attributeToCompletedPartConverter() {
+        return (object, targetType, context) -> {
+            try {
+                if (!object.isCompleted()) {
+                    return Optional.empty();
+                }
+
+                return Optional.of(new NettyCompletedAttribute(object));
+            } catch (Exception e) {
+                context.reject(e);
+                return Optional.empty();
+            }
+        };
+    }
+
+    /**
+     * @return A converter that converts bytebufs to strings
+     */
+    protected TypeConverter<ByteBuf, CharSequence> byteBufCharSequenceTypeConverter() {
+        return (object, targetType, context) -> Optional.of(object.toString(context.getCharset()));
+    }
+
+    /**
+     * @return A converter that converts composite bytebufs to strings
+     */
+    protected TypeConverter<CompositeByteBuf, CharSequence> compositeByteBufCharSequenceTypeConverter() {
+        return (object, targetType, context) -> Optional.of(object.toString(context.getCharset()));
+    }
+
+    /**
+     * @return A converter that converts bytebufs to byte arrays
+     */
+    protected TypeConverter<ByteBuf, byte[]> byteBufToArrayTypeConverter() {
+        return (object, targetType, context) -> Optional.of(ByteBufUtil.getBytes(object));
+    }
+
+    /**
+     * @return A converter that converts bytebufs to byte arrays
+     */
+    protected TypeConverter<byte[], ByteBuf> byteArrayToByteBuffTypeConverter() {
+        return (object, targetType, context) -> Optional.of(Unpooled.wrappedBuffer(object));
+    }
+}

--- a/http-server-netty/src/main/resources/META-INF/services/io.micronaut.core.convert.TypeConverterRegistrar
+++ b/http-server-netty/src/main/resources/META-INF/services/io.micronaut.core.convert.TypeConverterRegistrar
@@ -1,0 +1,1 @@
+io.micronaut.http.server.netty.converters.NettyConvertersSpi

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/converters/ConverterRegistrySpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/converters/ConverterRegistrySpec.groovy
@@ -17,8 +17,11 @@ package io.micronaut.http.server.netty.converters
 
 import io.micronaut.context.ApplicationContext
 import io.micronaut.core.convert.ConversionService
+import io.netty.buffer.ByteBuf
 import io.netty.buffer.CompositeByteBuf
 import io.netty.buffer.Unpooled
+import io.netty.channel.ChannelOption
+import spock.lang.PendingFeature
 import spock.lang.Specification
 
 import java.nio.charset.StandardCharsets
@@ -41,5 +44,48 @@ class ConverterRegistrySpec extends Specification {
         cleanup:
         compositeByteBuf.release()
         ctx.close()
+    }
+
+    def "test convert bytebuf to string after context reset"() {
+        given:
+        ApplicationContext ctx1 = ApplicationContext.run()
+        ApplicationContext ctx2 = ApplicationContext.run()
+        ByteBuf buf = Unpooled.wrappedBuffer("foo".bytes)
+
+        expect:
+        ctx1.getBean(ConversionService).convert(buf, String).get() == 'foo'
+        ctx2.getBean(ConversionService).convert(buf, String).get() == 'foo'
+
+        when:
+        ctx2.stop()
+
+        then:
+        ctx1.getBean(ConversionService).convert(buf, String).get() == 'foo'
+
+        cleanup:
+        buf.release()
+        ctx1.close()
+    }
+
+    @PendingFeature
+    def "test convert string to channel option after context reset"() {
+        given:
+        ApplicationContext ctx1 = ApplicationContext.run()
+        ApplicationContext ctx2 = ApplicationContext.run()
+
+        expect:
+        // works as expected
+        ctx1.getBean(ConversionService).convert("AUTO_READ", ChannelOption).get() == ChannelOption.AUTO_READ
+        ctx2.getBean(ConversionService).convert("AUTO_READ", ChannelOption).get() == ChannelOption.AUTO_READ
+
+        when:
+        ctx2.stop()
+
+        then:
+        // this fails, the converter has been removed by ctx2.stop()
+        ctx1.getBean(ConversionService).convert("AUTO_READ", ChannelOption).get() == ChannelOption.AUTO_READ
+
+        cleanup:
+        ctx1.close()
     }
 }


### PR DESCRIPTION
Move some converters from NettyConverters into a new converter registrar that does not require further dependencies from the application context. This allows the registrar to be loaded into the default conversion service with no app context present.

This is a workaround for #7948, and fixes https://github.com/micronaut-projects/micronaut-aws/pull/1452 .