### PR TITLE
fix: kaptKoltin exception with micronaut-inject processor

### DIFF
--- a/inject/src/main/java/io/micronaut/inject/annotation/DefaultAnnotationMetadata.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/DefaultAnnotationMetadata.java
@@ -1962,7 +1962,7 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
             }
         } else {
             if (!hasValues) {
-                existing = existing == null ? new LinkedHashMap<>() : existing;
+                existing = existing == null ? new LinkedHashMap<>(3) : existing;
             } else {
                 existing = new LinkedHashMap<>(values.size());
                 existing.putAll(values);

--- a/inject/src/main/java/io/micronaut/inject/annotation/DefaultAnnotationMetadata.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/DefaultAnnotationMetadata.java
@@ -1962,7 +1962,7 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
             }
         } else {
             if (!hasValues) {
-                existing = existing == null ? Collections.emptyMap() : existing;
+                existing = existing == null ? new LinkedHashMap<>() : existing;
             } else {
                 existing = new LinkedHashMap<>(values.size());
                 existing.putAll(values);

--- a/inject/src/test/groovy/io/micronaut/inject/annotation/AnnotationMetadataSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/inject/annotation/AnnotationMetadataSpec.groovy
@@ -7,6 +7,8 @@ import io.micronaut.core.annotation.AnnotationValueBuilder
 import io.micronaut.core.annotation.TypeHint
 import spock.lang.Specification
 
+import java.lang.annotation.RetentionPolicy
+
 class AnnotationMetadataSpec extends Specification {
 
     void "test class values with string"() {
@@ -33,7 +35,19 @@ class AnnotationMetadataSpec extends Specification {
         metadata.stringValues(TypeHint).size() == 2
     }
 
-    AnnotationMetadata newMetadata(AnnotationValueBuilder...builders) {
+    void "test empty values then append"() {
+        given:
+        DefaultAnnotationMetadata metadata = new DefaultAnnotationMetadata([:], null, null, [:], null)
+        metadata.addAnnotation("foo.Bar", [:])
+
+        when:
+        metadata.addRepeatable("foo.Bar", new AnnotationValue("foo.Bar"), RetentionPolicy.RUNTIME)
+
+        then:
+        noExceptionThrown()
+    }
+
+    AnnotationMetadata newMetadata(AnnotationValueBuilder... builders) {
 
         def values = builders.collect({ it.build() })
 


### PR DESCRIPTION
Fixes: #7961

Replace `Collections.emptyMap()` to `new LinkedHashMap<>()` to allow add annotation values