### PR TITLE
HTTP client refactor

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/ConnectTTLHandler.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/ConnectTTLHandler.java
@@ -78,7 +78,7 @@ public class ConnectTTLHandler extends ChannelDuplexHandler {
     }
 
     /**
-     * Indicates whether the channels connection ttl has expired
+     * Indicates whether the channels connection ttl has expired.
      * @param channel The channel to check
      * @return true if the channels ttl has expired
      */

--- a/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
@@ -104,7 +104,7 @@ final class ConnectionManager {
     private final DefaultHttpClient httpClient; // TODO
     private final Logger log;
     EventLoopGroup group;
-    final Bootstrap bootstrap;
+    private final Bootstrap bootstrap;
     final ChannelPoolMap<DefaultHttpClient.RequestKey, ChannelPool> poolMap;
     private final HttpClientConfiguration configuration;
     final InvocationInstrumenter instrumenter;
@@ -194,6 +194,20 @@ final class ConnectionManager {
             }
         } else {
             this.poolMap = null;
+        }
+
+        Optional<Duration> connectTimeout = configuration.getConnectTimeout();
+        connectTimeout.ifPresent(duration -> bootstrap.option(
+            ChannelOption.CONNECT_TIMEOUT_MILLIS,
+            (int) duration.toMillis()
+        ));
+
+        for (Map.Entry<String, Object> entry : configuration.getChannelOptions().entrySet()) {
+            Object v = entry.getValue();
+            if (v != null) {
+                String channelOption = entry.getKey();
+                bootstrap.option(ChannelOption.valueOf(channelOption), v);
+            }
         }
     }
 

--- a/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
@@ -1,0 +1,122 @@
+package io.micronaut.http.client.netty;
+
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.http.HttpVersion;
+import io.micronaut.http.client.HttpClientConfiguration;
+import io.micronaut.http.netty.channel.ChannelPipelineListener;
+import io.micronaut.scheduling.instrument.InvocationInstrumenter;
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFactory;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.pool.AbstractChannelPoolHandler;
+import io.netty.channel.pool.AbstractChannelPoolMap;
+import io.netty.channel.pool.ChannelHealthChecker;
+import io.netty.channel.pool.ChannelPool;
+import io.netty.channel.pool.ChannelPoolMap;
+import io.netty.channel.pool.FixedChannelPool;
+import io.netty.channel.pool.SimpleChannelPool;
+import io.netty.handler.ssl.SslContext;
+import org.slf4j.Logger;
+
+import java.time.Duration;
+import java.util.Collection;
+
+final class ConnectionManager {
+    private final DefaultHttpClient httpClient; // TODO
+    private final Logger log;
+    EventLoopGroup group;
+    final Bootstrap bootstrap;
+    final ChannelPoolMap<DefaultHttpClient.RequestKey, ChannelPool> poolMap;
+    private final HttpClientConfiguration configuration;
+    final InvocationInstrumenter instrumenter;
+    @Nullable
+    final Long readTimeoutMillis;
+    @Nullable
+    final Long connectionTimeAliveMillis;
+    final HttpVersion httpVersion;
+    final SslContext sslContext;
+    final NettyClientCustomizer clientCustomizer;
+    final Collection<ChannelPipelineListener> pipelineListeners;
+    final String informationalServiceId;
+
+    ConnectionManager(
+        DefaultHttpClient httpClient,
+        Logger log, EventLoopGroup group,
+        HttpClientConfiguration configuration,
+        HttpVersion httpVersion,
+        InvocationInstrumenter instrumenter,
+        ChannelFactory<? extends Channel> socketChannelFactory,
+        @Nullable Long readTimeoutMillis,
+        @Nullable Long connectionTimeAliveMillis,
+        SslContext sslContext,
+        NettyClientCustomizer clientCustomizer,
+        Collection<ChannelPipelineListener> pipelineListeners, String informationalServiceId) {
+        this.httpClient = httpClient;
+        this.log = log;
+        this.httpVersion = httpVersion;
+        this.group = group;
+        this.sslContext = sslContext;
+        this.configuration = configuration;
+        this.instrumenter = instrumenter;
+        this.readTimeoutMillis = readTimeoutMillis;
+        this.connectionTimeAliveMillis = connectionTimeAliveMillis;
+        this.clientCustomizer = clientCustomizer;
+        this.pipelineListeners = pipelineListeners;
+        this.informationalServiceId = informationalServiceId;
+        this.bootstrap = new Bootstrap();
+        this.bootstrap.group(group)
+            .channelFactory(socketChannelFactory)
+            .option(ChannelOption.SO_KEEPALIVE, true);
+
+        final ChannelHealthChecker channelHealthChecker = channel -> channel.eventLoop().newSucceededFuture(channel.isActive() && !ConnectTTLHandler.isChannelExpired(channel));
+
+        HttpClientConfiguration.ConnectionPoolConfiguration connectionPoolConfiguration = configuration.getConnectionPoolConfiguration();
+        // HTTP/2 defaults to keep alive connections so should we should always use a pool
+        if (connectionPoolConfiguration.isEnabled() || httpVersion == io.micronaut.http.HttpVersion.HTTP_2_0) {
+            int maxConnections = connectionPoolConfiguration.getMaxConnections();
+            if (maxConnections > -1) {
+                poolMap = new AbstractChannelPoolMap<DefaultHttpClient.RequestKey, ChannelPool>() {
+                    @Override
+                    protected ChannelPool newPool(DefaultHttpClient.RequestKey key) {
+                        Bootstrap newBootstrap = bootstrap.clone(group);
+                        httpClient.initBootstrapForProxy(newBootstrap, key.isSecure(), key.getHost(), key.getPort());
+                        newBootstrap.remoteAddress(key.getRemoteAddress());
+
+                        AbstractChannelPoolHandler channelPoolHandler = httpClient.newPoolHandler(key);
+                        final long acquireTimeoutMillis = connectionPoolConfiguration.getAcquireTimeout().map(Duration::toMillis).orElse(-1L);
+                        return new FixedChannelPool(
+                            newBootstrap,
+                            channelPoolHandler,
+                            channelHealthChecker,
+                            acquireTimeoutMillis > -1 ? FixedChannelPool.AcquireTimeoutAction.FAIL : null,
+                            acquireTimeoutMillis,
+                            maxConnections,
+                            connectionPoolConfiguration.getMaxPendingAcquires()
+
+                        );
+                    }
+                };
+            } else {
+                poolMap = new AbstractChannelPoolMap<DefaultHttpClient.RequestKey, ChannelPool>() {
+                    @Override
+                    protected ChannelPool newPool(DefaultHttpClient.RequestKey key) {
+                        Bootstrap newBootstrap = bootstrap.clone(group);
+                        httpClient.initBootstrapForProxy(newBootstrap, key.isSecure(), key.getHost(), key.getPort());
+                        newBootstrap.remoteAddress(key.getRemoteAddress());
+
+                        AbstractChannelPoolHandler channelPoolHandler = httpClient.newPoolHandler(key);
+                        return new SimpleChannelPool(
+                            newBootstrap,
+                            channelPoolHandler,
+                            channelHealthChecker
+                        );
+                    }
+                };
+            }
+        } else {
+            this.poolMap = null;
+        }
+    }
+}

--- a/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
@@ -19,9 +19,7 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.reflect.InstantiationUtils;
 import io.micronaut.core.util.StringUtils;
-import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpVersion;
-import io.micronaut.http.MediaType;
 import io.micronaut.http.client.HttpClientConfiguration;
 import io.micronaut.http.client.exceptions.HttpClientException;
 import io.micronaut.http.client.netty.ssl.NettyClientSslBuilder;
@@ -392,11 +390,6 @@ final class ConnectionManager {
         if (proxy.type() != Proxy.Type.DIRECT) {
             localBootstrap.resolver(NoopAddressResolverGroup.INSTANCE);
         }
-    }
-
-    static boolean isAcceptEvents(HttpRequest<?> request) {
-        String acceptHeader = request.getHeaders().get(io.micronaut.http.HttpHeaders.ACCEPT);
-        return acceptHeader != null && acceptHeader.equalsIgnoreCase(MediaType.TEXT_EVENT_STREAM);
     }
 
     /**

--- a/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
@@ -115,7 +115,7 @@ final class ConnectionManager {
     @Nullable
     private final Long connectionTimeAliveMillis;
     final HttpVersion httpVersion;
-    final SslContext sslContext;
+    private final SslContext sslContext;
     private final NettyClientCustomizer clientCustomizer;
     private final Collection<ChannelPipelineListener> pipelineListeners;
     private final String informationalServiceId;

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -139,13 +139,11 @@ import io.netty.handler.codec.http.multipart.HttpPostRequestEncoder;
 import io.netty.handler.codec.http.multipart.InterfaceHttpData;
 import io.netty.handler.codec.http.websocketx.WebSocketClientHandshakerFactory;
 import io.netty.handler.codec.http.websocketx.WebSocketVersion;
-import io.netty.handler.codec.http2.Http2Stream;
 import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.util.AttributeKey;
 import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.DefaultThreadFactory;
-import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 import org.reactivestreams.Processor;
 import org.reactivestreams.Publisher;
@@ -207,16 +205,8 @@ public class DefaultHttpClient implements
      * Default logger, use {@link #log} where possible.
      */
     private static final Logger DEFAULT_LOG = LoggerFactory.getLogger(DefaultHttpClient.class);
-    static final AttributeKey<Http2Stream> STREAM_KEY = AttributeKey.valueOf("micronaut.http2.stream");
     static final AttributeKey<NettyClientCustomizer> CHANNEL_CUSTOMIZER_KEY =
         AttributeKey.valueOf("micronaut.http.customizer");
-    /**
-     * Future on a pooled channel that will be completed when the channel has fully connected (e.g.
-     * TLS handshake has completed). If unset, then no handshake is needed or it has already
-     * completed.
-     */
-    static final AttributeKey<Future<?>> STREAM_CHANNEL_INITIALIZED =
-        AttributeKey.valueOf("micronaut.http.streamChannelInitialized");
     private static final int DEFAULT_HTTP_PORT = 80;
     private static final int DEFAULT_HTTPS_PORT = 443;
 

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -1982,13 +1982,17 @@ public class DefaultHttpClient implements
         return io.micronaut.http.HttpRequest.SCHEME_HTTPS.equalsIgnoreCase(scheme) || SCHEME_WSS.equalsIgnoreCase(scheme);
     }
 
-    <E extends HttpClientException> E customizeException(E exc) {
+    private <E extends HttpClientException> E customizeException(E exc) {
+        customizeException0(configuration, informationalServiceId, exc);
+        return exc;
+    }
+
+    static void customizeException0(HttpClientConfiguration configuration, String informationalServiceId, HttpClientException exc) {
         if (informationalServiceId != null) {
             exc.setServiceId(informationalServiceId);
         } else if (configuration instanceof ServiceHttpClientConfiguration) {
             exc.setServiceId(((ServiceHttpClientConfiguration) configuration).getServiceId());
         }
-        return exc;
     }
 
     @FunctionalInterface

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -115,7 +115,6 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFactory;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultithreadEventLoopGroup;
@@ -412,20 +411,6 @@ public class DefaultHttpClient implements
         this.informationalServiceId = informationalServiceId;
 
         this.connectionManager = new ConnectionManager(this, log, group, configuration, httpVersionN, combineFactories(), socketChannelFactory, readTimeoutMillis, connectionTimeAliveMillis, sslContext, clientCustomizer, pipelineListeners, informationalServiceId);
-
-        Optional<Duration> connectTimeout = configuration.getConnectTimeout();
-        connectTimeout.ifPresent(duration -> connectionManager.bootstrap.option(
-            ChannelOption.CONNECT_TIMEOUT_MILLIS,
-            (int) duration.toMillis()
-        ));
-
-        for (Map.Entry<String, Object> entry : configuration.getChannelOptions().entrySet()) {
-            Object v = entry.getValue();
-            if (v != null) {
-                String channelOption = entry.getKey();
-                connectionManager.bootstrap.option(ChannelOption.valueOf(channelOption), v);
-            }
-        }
     }
 
     /**

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -415,6 +415,11 @@ public class DefaultHttpClient implements
                 invocationInstrumenterFactories);
     }
 
+    static boolean isAcceptEvents(io.micronaut.http.HttpRequest<?> request) {
+        String acceptHeader = request.getHeaders().get(io.micronaut.http.HttpHeaders.ACCEPT);
+        return acceptHeader != null && acceptHeader.equalsIgnoreCase(MediaType.TEXT_EVENT_STREAM);
+    }
+
     /**
      * @return The configuration used by this client
      */
@@ -1014,7 +1019,7 @@ public class DefaultHttpClient implements
         } catch (Exception e) {
             return Flux.error(e);
         }
-        return connectionManager.connectForStream(requestKey, isProxy, ConnectionManager.isAcceptEvents(request)).flatMapMany(poolHandle -> {
+        return connectionManager.connectForStream(requestKey, isProxy, isAcceptEvents(request)).flatMapMany(poolHandle -> {
             request.setAttribute(NettyClientHttpRequest.CHANNEL, poolHandle.channel);
             return this.streamRequestThroughChannel(
                 parentRequest,
@@ -1044,7 +1049,7 @@ public class DefaultHttpClient implements
             return Flux.error(e);
         }
 
-        Mono<ConnectionManager.PoolHandle> handlePublisher = connectionManager.connectForExchange(requestKey, MediaType.MULTIPART_FORM_DATA_TYPE.equals(request.getContentType().orElse(null)), ConnectionManager.isAcceptEvents(request));
+        Mono<ConnectionManager.PoolHandle> handlePublisher = connectionManager.connectForExchange(requestKey, MediaType.MULTIPART_FORM_DATA_TYPE.equals(request.getContentType().orElse(null)), isAcceptEvents(request));
 
         Flux<io.micronaut.http.HttpResponse<O>> responsePublisher = handlePublisher.flatMapMany(poolHandle -> {
             return Flux.create(emitter -> {

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -150,8 +150,6 @@ import io.netty.handler.codec.http.websocketx.WebSocketClientHandshakerFactory;
 import io.netty.handler.codec.http.websocketx.WebSocketVersion;
 import io.netty.handler.codec.http2.Http2Stream;
 import io.netty.handler.codec.http2.HttpConversionUtil;
-import io.netty.handler.proxy.HttpProxyHandler;
-import io.netty.handler.proxy.Socks5ProxyHandler;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.handler.timeout.ReadTimeoutHandler;
@@ -181,9 +179,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
-import java.net.Proxy;
-import java.net.Proxy.Type;
-import java.net.SocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
@@ -1336,59 +1331,6 @@ public class DefaultHttpClient implements
             sslCtx = null;
         }
         return sslCtx;
-    }
-
-    /**
-     * Configures the HTTP proxy for the pipeline.
-     *
-     * @param pipeline The pipeline
-     * @param proxy    The proxy
-     */
-    protected void configureProxy(ChannelPipeline pipeline, Proxy proxy) {
-        configureProxy(pipeline, proxy.type(), proxy.address());
-    }
-
-    /**
-     * Configures the HTTP proxy for the pipeline.
-     *
-     * @param pipeline     The pipeline
-     * @param proxyType    The proxy type
-     * @param proxyAddress The proxy address
-     */
-    protected void configureProxy(ChannelPipeline pipeline, Type proxyType, SocketAddress proxyAddress) {
-        String username = configuration.getProxyUsername().orElse(null);
-        String password = configuration.getProxyPassword().orElse(null);
-
-        if (proxyAddress instanceof InetSocketAddress) {
-            InetSocketAddress isa = (InetSocketAddress) proxyAddress;
-            if (isa.isUnresolved()) {
-                proxyAddress = new InetSocketAddress(isa.getHostString(), isa.getPort());
-            }
-        }
-
-        if (StringUtils.isNotEmpty(username) && StringUtils.isNotEmpty(password)) {
-            switch (proxyType) {
-                case HTTP:
-                    pipeline.addLast(ChannelPipelineCustomizer.HANDLER_HTTP_PROXY, new HttpProxyHandler(proxyAddress, username, password));
-                    break;
-                case SOCKS:
-                    pipeline.addLast(ChannelPipelineCustomizer.HANDLER_SOCKS_5_PROXY, new Socks5ProxyHandler(proxyAddress, username, password));
-                    break;
-                default:
-                    // no-op
-            }
-        } else {
-            switch (proxyType) {
-                case HTTP:
-                    pipeline.addLast(ChannelPipelineCustomizer.HANDLER_HTTP_PROXY, new HttpProxyHandler(proxyAddress));
-                    break;
-                case SOCKS:
-                    pipeline.addLast(ChannelPipelineCustomizer.HANDLER_SOCKS_5_PROXY, new Socks5ProxyHandler(proxyAddress));
-                    break;
-                default:
-                    // no-op
-            }
-        }
     }
 
     private <I, O, R extends io.micronaut.http.HttpResponse<O>> Publisher<R> applyFilterToResponsePublisher(

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -83,10 +83,7 @@ import io.micronaut.http.netty.NettyHttpResponseBuilder;
 import io.micronaut.http.netty.channel.ChannelPipelineCustomizer;
 import io.micronaut.http.netty.channel.ChannelPipelineListener;
 import io.micronaut.http.netty.channel.NettyThreadFactory;
-import io.micronaut.http.netty.stream.DefaultHttp2Content;
 import io.micronaut.http.netty.stream.DefaultStreamedHttpResponse;
-import io.micronaut.http.netty.stream.Http2Content;
-import io.micronaut.http.netty.stream.HttpStreamsClientHandler;
 import io.micronaut.http.netty.stream.JsonSubscriber;
 import io.micronaut.http.netty.stream.StreamedHttpRequest;
 import io.micronaut.http.netty.stream.StreamedHttpResponse;
@@ -120,7 +117,6 @@ import io.netty.channel.ChannelFactory;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
-import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
@@ -132,7 +128,6 @@ import io.netty.channel.pool.ChannelPool;
 import io.netty.channel.pool.SimpleChannelPool;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
-import io.netty.handler.codec.LineBasedFrameDecoder;
 import io.netty.handler.codec.TooLongFrameException;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
@@ -140,25 +135,21 @@ import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.EmptyHttpHeaders;
-import io.netty.handler.codec.http.FullHttpMessage;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpClientCodec;
 import io.netty.handler.codec.http.HttpClientUpgradeHandler;
 import io.netty.handler.codec.http.HttpContent;
-import io.netty.handler.codec.http.HttpContentDecompressor;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMessage;
 import io.netty.handler.codec.http.HttpMethod;
-import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpScheme;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
-import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.codec.http.multipart.DefaultHttpDataFactory;
 import io.netty.handler.codec.http.multipart.FileUpload;
 import io.netty.handler.codec.http.multipart.HttpDataFactory;
@@ -166,30 +157,23 @@ import io.netty.handler.codec.http.multipart.HttpPostRequestEncoder;
 import io.netty.handler.codec.http.multipart.InterfaceHttpData;
 import io.netty.handler.codec.http.websocketx.WebSocketClientHandshakerFactory;
 import io.netty.handler.codec.http.websocketx.WebSocketVersion;
-import io.netty.handler.codec.http2.DefaultHttp2Connection;
 import io.netty.handler.codec.http2.DelegatingDecompressorFrameListener;
 import io.netty.handler.codec.http2.Http2ClientUpgradeCodec;
 import io.netty.handler.codec.http2.Http2Connection;
 import io.netty.handler.codec.http2.Http2FrameListener;
-import io.netty.handler.codec.http2.Http2FrameLogger;
 import io.netty.handler.codec.http2.Http2Settings;
 import io.netty.handler.codec.http2.Http2Stream;
 import io.netty.handler.codec.http2.HttpConversionUtil;
 import io.netty.handler.codec.http2.HttpToHttp2ConnectionHandler;
 import io.netty.handler.codec.http2.HttpToHttp2ConnectionHandlerBuilder;
 import io.netty.handler.codec.http2.InboundHttp2ToHttpAdapterBuilder;
-import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.proxy.HttpProxyHandler;
 import io.netty.handler.proxy.Socks5ProxyHandler;
 import io.netty.handler.ssl.ApplicationProtocolNames;
 import io.netty.handler.ssl.ApplicationProtocolNegotiationHandler;
 import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.stream.ChunkedWriteHandler;
-import io.netty.handler.timeout.IdleStateEvent;
-import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.handler.timeout.ReadTimeoutHandler;
-import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
 import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
@@ -267,8 +251,8 @@ public class DefaultHttpClient implements
      * Default logger, use {@link #log} where possible.
      */
     private static final Logger DEFAULT_LOG = LoggerFactory.getLogger(DefaultHttpClient.class);
-    private static final AttributeKey<Http2Stream> STREAM_KEY = AttributeKey.valueOf("micronaut.http2.stream");
-    private static final AttributeKey<NettyClientCustomizer> CHANNEL_CUSTOMIZER_KEY =
+    static final AttributeKey<Http2Stream> STREAM_KEY = AttributeKey.valueOf("micronaut.http2.stream");
+    static final AttributeKey<NettyClientCustomizer> CHANNEL_CUSTOMIZER_KEY =
         AttributeKey.valueOf("micronaut.http.customizer");
     /**
      * Future on a pooled channel that will be completed when the channel has fully connected (e.g.
@@ -1632,7 +1616,7 @@ public class DefaultHttpClient implements
      * @param connectionHandler     The connection handler
      */
     protected void configureHttp2Ssl(
-            HttpClientInitializer httpClientInitializer,
+            ConnectionManager.HttpClientInitializer httpClientInitializer,
             @NonNull SocketChannel ch,
             @NonNull SslContext sslCtx,
             String host,
@@ -1699,7 +1683,7 @@ public class DefaultHttpClient implements
      * @param connectionHandler     The connection handler
      */
     protected void configureHttp2ClearText(
-            HttpClientInitializer httpClientInitializer,
+            ConnectionManager.HttpClientInitializer httpClientInitializer,
             @NonNull SocketChannel ch,
             @NonNull HttpToHttp2ConnectionHandler connectionHandler) {
         HttpClientCodec sourceCodec = new HttpClientCodec();
@@ -2055,7 +2039,7 @@ public class DefaultHttpClient implements
     /**
      * Note: caller must ensure this is only called for plaintext HTTP, not TLS HTTP2.
      */
-    private boolean discardH2cStream(HttpMessage message) {
+    boolean discardH2cStream(HttpMessage message) {
         // only applies to h2c
         if (connectionManager.httpVersion == io.micronaut.http.HttpVersion.HTTP_2_0) {
             int streamId = message.headers().getInt(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), -1);
@@ -2355,257 +2339,9 @@ public class DefaultHttpClient implements
     }
 
     /**
-     * Initializes the HTTP client channel.
-     */
-    protected class HttpClientInitializer extends ChannelInitializer<SocketChannel> {
-
-        final SslContext sslContext;
-        final String host;
-        final int port;
-        final boolean stream;
-        final boolean proxy;
-        final boolean acceptsEvents;
-        Http2SettingsHandler settingsHandler;
-        private final Consumer<ChannelHandlerContext> contextConsumer;
-        private NettyClientCustomizer channelCustomizer;
-
-        /**
-         * @param sslContext      The ssl context
-         * @param host            The host
-         * @param port            The port
-         * @param stream          Whether is stream
-         * @param proxy           Is this a streaming proxy
-         * @param acceptsEvents   Whether an event stream is accepted
-         * @param contextConsumer The context consumer
-         */
-        protected HttpClientInitializer(
-                SslContext sslContext,
-                String host,
-                int port,
-                boolean stream,
-                boolean proxy,
-                boolean acceptsEvents,
-                Consumer<ChannelHandlerContext> contextConsumer) {
-            this.sslContext = sslContext;
-            this.stream = stream;
-            this.host = host;
-            this.port = port;
-            this.proxy = proxy;
-            this.acceptsEvents = acceptsEvents;
-            this.contextConsumer = contextConsumer;
-        }
-
-        /**
-         * @param ch The channel
-         */
-        @Override
-        protected void initChannel(SocketChannel ch) {
-            channelCustomizer = connectionManager.clientCustomizer.specializeForChannel(ch, NettyClientCustomizer.ChannelRole.CONNECTION);
-            ch.attr(CHANNEL_CUSTOMIZER_KEY).set(channelCustomizer);
-
-            ChannelPipeline p = ch.pipeline();
-
-            Proxy proxy = configuration.resolveProxy(sslContext != null, host, port);
-            if (!Proxy.NO_PROXY.equals(proxy)) {
-                configureProxy(p, proxy);
-            }
-
-            if (connectionManager.httpVersion == io.micronaut.http.HttpVersion.HTTP_2_0) {
-                final Http2Connection connection = new DefaultHttp2Connection(false);
-                final HttpToHttp2ConnectionHandlerBuilder builder =
-                        newHttp2ConnectionHandlerBuilder(connection, configuration, stream);
-
-                configuration.getLogLevel().ifPresent(logLevel -> {
-                    try {
-                        final io.netty.handler.logging.LogLevel nettyLevel = io.netty.handler.logging.LogLevel.valueOf(
-                                logLevel.name()
-                        );
-                        builder.frameLogger(new Http2FrameLogger(nettyLevel, DefaultHttpClient.class));
-                    } catch (IllegalArgumentException e) {
-                        throw customizeException(new HttpClientException("Unsupported log level: " + logLevel));
-                    }
-                });
-                HttpToHttp2ConnectionHandler connectionHandler = builder
-                        .build();
-                if (sslContext != null) {
-                    configureHttp2Ssl(this, ch, sslContext, host, port, connectionHandler);
-                } else {
-                    configureHttp2ClearText(this, ch, connectionHandler);
-                }
-                channelCustomizer.onInitialPipelineBuilt();
-            } else {
-                if (stream) {
-                    // for streaming responses we disable auto read
-                    // so that the consumer is in charge of back pressure
-                    ch.config().setAutoRead(false);
-                }
-
-                configuration.getLogLevel().ifPresent(logLevel -> {
-                    try {
-                        final io.netty.handler.logging.LogLevel nettyLevel = io.netty.handler.logging.LogLevel.valueOf(
-                                logLevel.name()
-                        );
-                        p.addLast(new LoggingHandler(DefaultHttpClient.class, nettyLevel));
-                    } catch (IllegalArgumentException e) {
-                        throw customizeException(new HttpClientException("Unsupported log level: " + logLevel));
-                    }
-                });
-
-                if (sslContext != null) {
-                    SslHandler sslHandler = sslContext.newHandler(ch.alloc(), host, port);
-                    sslHandler.setHandshakeTimeoutMillis(configuration.getSslConfiguration().getHandshakeTimeout().toMillis());
-                    p.addLast(ChannelPipelineCustomizer.HANDLER_SSL, sslHandler);
-                }
-
-                // Pool connections require alternative timeout handling
-                if (connectionManager.poolMap == null) {
-                    // read timeout settings are not applied to streamed requests.
-                    // instead idle timeout settings are applied.
-                    if (stream) {
-                        Optional<Duration> readIdleTime = configuration.getReadIdleTimeout();
-                        if (readIdleTime.isPresent()) {
-                            Duration duration = readIdleTime.get();
-                            if (!duration.isNegative()) {
-                                p.addLast(ChannelPipelineCustomizer.HANDLER_IDLE_STATE, new IdleStateHandler(
-                                        duration.toMillis(),
-                                        duration.toMillis(),
-                                        duration.toMillis(),
-                                        TimeUnit.MILLISECONDS
-                                ));
-                            }
-                        }
-                    }
-                }
-
-                addHttp1Handlers(p);
-                channelCustomizer.onInitialPipelineBuilt();
-                onStreamPipelineBuilt();
-            }
-        }
-
-        /**
-         * Called when the stream pipeline is fully set up (all handshakes completed) and we can
-         * start processing requests.
-         */
-        void onStreamPipelineBuilt() {
-            channelCustomizer.onStreamPipelineBuilt();
-        }
-
-        private void addHttp1Handlers(ChannelPipeline p) {
-            p.addLast(ChannelPipelineCustomizer.HANDLER_HTTP_CLIENT_CODEC, new HttpClientCodec());
-
-            p.addLast(ChannelPipelineCustomizer.HANDLER_HTTP_DECODER, new HttpContentDecompressor());
-
-            int maxContentLength = configuration.getMaxContentLength();
-
-            if (!stream) {
-                p.addLast(ChannelPipelineCustomizer.HANDLER_HTTP_AGGREGATOR, new HttpObjectAggregator(maxContentLength) {
-                    @Override
-                    protected void finishAggregation(FullHttpMessage aggregated) throws Exception {
-                        if (!HttpUtil.isContentLengthSet(aggregated)) {
-                            if (aggregated.content().readableBytes() > 0) {
-                                super.finishAggregation(aggregated);
-                            }
-                        }
-                    }
-                });
-            }
-            addEventStreamHandlerIfNecessary(p);
-            addFinalHandler(p);
-            for (ChannelPipelineListener pipelineListener : connectionManager.pipelineListeners) {
-                pipelineListener.onConnect(p);
-            }
-        }
-
-        private void addEventStreamHandlerIfNecessary(ChannelPipeline p) {
-            // if the content type is a SSE event stream we add a decoder
-            // to delimit the content by lines (unless we are proxying the stream)
-            if (acceptsEventStream() && !proxy) {
-                p.addLast(ChannelPipelineCustomizer.HANDLER_MICRONAUT_SSE_EVENT_STREAM, new LineBasedFrameDecoder(configuration.getMaxContentLength(), true, true) {
-
-                    @Override
-                    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-                        if (msg instanceof HttpContent) {
-                            if (msg instanceof LastHttpContent) {
-                                super.channelRead(ctx, msg);
-                            } else {
-                                Attribute<Http2Stream> streamKey = ctx.channel().attr(STREAM_KEY);
-                                if (msg instanceof Http2Content) {
-                                    streamKey.set(((Http2Content) msg).stream());
-                                }
-                                try {
-                                    super.channelRead(ctx, ((HttpContent) msg).content());
-                                } finally {
-                                    streamKey.set(null);
-                                }
-                            }
-                        } else {
-                            super.channelRead(ctx, msg);
-                        }
-                    }
-                });
-
-                p.addLast(ChannelPipelineCustomizer.HANDLER_MICRONAUT_SSE_CONTENT, new SimpleChannelInboundHandlerInstrumented<ByteBuf>(connectionManager.instrumenter, false) {
-
-                    @Override
-                    public boolean acceptInboundMessage(Object msg) {
-                        return msg instanceof ByteBuf;
-                    }
-
-                    @Override
-                    protected void channelReadInstrumented(ChannelHandlerContext ctx, ByteBuf msg) {
-                        try {
-                            Attribute<Http2Stream> streamKey = ctx.channel().attr(STREAM_KEY);
-                            Http2Stream http2Stream = streamKey.get();
-                            if (http2Stream != null) {
-                                ctx.fireChannelRead(new DefaultHttp2Content(msg.copy(), http2Stream));
-                            } else {
-                                ctx.fireChannelRead(new DefaultHttpContent(msg.copy()));
-                            }
-                        } finally {
-                            msg.release();
-                        }
-                    }
-                });
-
-            }
-        }
-
-        /**
-         * Allows overriding the final handler added to the pipeline.
-         *
-         * @param pipeline The pipeline
-         */
-        protected void addFinalHandler(ChannelPipeline pipeline) {
-            pipeline.addLast(
-                    ChannelPipelineCustomizer.HANDLER_HTTP_STREAM,
-                    new HttpStreamsClientHandler() {
-                @Override
-                public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
-                    if (evt instanceof IdleStateEvent) {
-                        // close the connection if it is idle for too long
-                        ctx.close();
-                    }
-                    super.userEventTriggered(ctx, evt);
-                }
-
-                @Override
-                protected boolean isValidInMessage(Object msg) {
-                    // ignore data on stream 1, that is the response to our initial upgrade request
-                    return super.isValidInMessage(msg) && (sslContext != null || !discardH2cStream((HttpMessage) msg));
-                }
-            });
-        }
-
-        private boolean acceptsEventStream() {
-            return this.acceptsEvents;
-        }
-    }
-
-    /**
      * Reads the first {@link Http2Settings} object and notifies a {@link io.netty.channel.ChannelPromise}.
      */
-    private final class Http2SettingsHandler extends
+    final class Http2SettingsHandler extends
             SimpleChannelInboundHandlerInstrumented<Http2Settings> {
         private final ChannelPromise promise;
 
@@ -2633,7 +2369,7 @@ public class DefaultHttpClient implements
      */
     private class UpgradeRequestHandler extends ChannelInboundHandlerAdapter {
 
-        private final HttpClientInitializer initializer;
+        private final ConnectionManager.HttpClientInitializer initializer;
         private final Http2SettingsHandler settingsHandler;
 
         /**
@@ -2641,7 +2377,7 @@ public class DefaultHttpClient implements
          *
          * @param initializer The initializer
          */
-        public UpgradeRequestHandler(HttpClientInitializer initializer) {
+        public UpgradeRequestHandler(ConnectionManager.HttpClientInitializer initializer) {
             this.initializer = initializer;
             this.settingsHandler = initializer.settingsHandler;
         }

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -491,12 +491,6 @@ public class DefaultHttpClient implements
                         shutdownTimeout.toMillis(),
                         TimeUnit.MILLISECONDS
                 );
-                connectionManager.addInstrumentedListener(future, f -> {
-                    if (!f.isSuccess() && log.isErrorEnabled()) {
-                        Throwable cause = f.cause();
-                        log.error("Error shutting down HTTP client: " + cause.getMessage(), cause);
-                    }
-                });
                 try {
                     future.await(shutdownTimeout.toMillis());
                 } catch (InterruptedException e) {

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -232,15 +232,16 @@ public class DefaultHttpClient implements
     protected MediaTypeCodecRegistry mediaTypeCodecRegistry;
     protected ByteBufferFactory<ByteBufAllocator, ByteBuf> byteBufferFactory = new NettyByteBufferFactory();
 
+    final ConnectionManager connectionManager;
+
     private final List<HttpFilterResolver.FilterEntry<HttpClientFilter>> clientFilterEntries;
     private final LoadBalancer loadBalancer;
     private final HttpClientConfiguration configuration;
     private final String contextPath;
     private final Charset defaultCharset;
-    final ConnectionManager connectionManager;
     private final Logger log;
     private final HttpClientFilterResolver<ClientFilterResolutionContext> filterResolver;
-    final WebSocketBeanRegistry webSocketRegistry;
+    private final WebSocketBeanRegistry webSocketRegistry;
     private final RequestBinderRegistry requestBinderRegistry;
     private final List<InvocationInstrumenterFactory> invocationInstrumenterFactories;
     private final String informationalServiceId;

--- a/http-client/src/main/java/io/micronaut/http/client/netty/websocket/NettyWebSocketClientHandler.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/websocket/NettyWebSocketClientHandler.java
@@ -293,7 +293,7 @@ public class NettyWebSocketClientHandler<T> extends AbstractNettyWebSocketHandle
         super.exceptionCaught(ctx, cause);
     }
 
-    public Mono<T> getHandshakeCompletedMono() {
+    public final Mono<T> getHandshakeCompletedMono() {
         return completion.asMono();
     }
 }

--- a/http-client/src/test/groovy/io/micronaut/http/client/ClientEventLoopGroupSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/ClientEventLoopGroupSpec.groovy
@@ -34,7 +34,7 @@ class ClientEventLoopGroupSpec extends Specification {
         HttpClient client = context.getBean(HttpClient)
 
         then:
-        client.group == context.getBean(EventLoopGroup, Qualifiers.byName("other"))
+        client.connectionManager.group == context.getBean(EventLoopGroup, Qualifiers.byName("other"))
 
         cleanup:
         context.close()

--- a/http-client/src/test/groovy/io/micronaut/http/client/ConnectionTTLSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/ConnectionTTLSpec.groovy
@@ -1,4 +1,4 @@
-package io.micronaut.http.client;
+package io.micronaut.http.client
 
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Requires
@@ -9,7 +9,6 @@ import io.micronaut.http.annotation.Get
 import io.micronaut.runtime.server.EmbeddedServer
 import io.netty.channel.Channel
 import io.netty.channel.pool.AbstractChannelPoolMap
-import reactor.core.publisher.Flux
 import spock.lang.AutoCleanup
 import spock.lang.Retry
 import spock.lang.Shared
@@ -151,7 +150,7 @@ class ConnectionTTLSpec extends Specification {
   }
 
   Deque getQueuedChannels(HttpClient client) {
-    AbstractChannelPoolMap poolMap = client.poolMap
+    AbstractChannelPoolMap poolMap = client.connectionManager.poolMap
     Field mapField = AbstractChannelPoolMap.getDeclaredField("map")
     mapField.setAccessible(true)
     Map innerMap = mapField.get(poolMap)

--- a/http-client/src/test/groovy/io/micronaut/http/client/IdleTimeoutSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/IdleTimeoutSpec.groovy
@@ -9,10 +9,10 @@ import io.micronaut.http.annotation.Get
 import io.micronaut.runtime.server.EmbeddedServer
 import io.netty.channel.Channel
 import io.netty.channel.pool.AbstractChannelPoolMap
-import spock.lang.Retry
-import spock.lang.Specification
 import spock.lang.AutoCleanup
+import spock.lang.Retry
 import spock.lang.Shared
+import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
 
 import java.lang.reflect.Field
@@ -112,7 +112,7 @@ class IdleTimeoutSpec extends Specification {
     }
 
     Deque getQueuedChannels(HttpClient client) {
-        AbstractChannelPoolMap poolMap = client.poolMap
+        AbstractChannelPoolMap poolMap = client.connectionManager.poolMap
         Field mapField = AbstractChannelPoolMap.getDeclaredField("map")
         mapField.setAccessible(true)
         Map innerMap = mapField.get(poolMap)

--- a/http-client/src/test/groovy/io/micronaut/http/client/ReadTimeoutSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/ReadTimeoutSpec.groovy
@@ -310,7 +310,7 @@ class ReadTimeoutSpec extends Specification {
     }
 
     FixedChannelPool getPool(HttpClient client) {
-        AbstractChannelPoolMap poolMap = client.poolMap
+        AbstractChannelPoolMap poolMap = client.connectionManager.poolMap
         Field mapField = AbstractChannelPoolMap.getDeclaredField("map")
         mapField.setAccessible(true)
         Map innerMap = mapField.get(poolMap)


### PR DESCRIPTION
Note: making the PR against 3.7.x, but this can go into 3.8.x once there is a branch for that, if the review isn't done in time for 3.7.0.

This is a first PR for my HTTP client refactor. The goal of these changes is to move the connection / channel management code out of DefaultHttpClient, with minimal functional changes. Request/response mapping (basically anything that happens downstream of HTTP parsing) remains in DefaultHttpClient.

This encapsulation will allow me to make functional changes to pooling (pooling for streaming requests, http2 single-connection pooling) with lower risk of breaking changes. I am making this PR so that my changes don't diverge too much.

To make review doable, I've split up these changes into many individual commits. Each commit contains changes that work standalone, and most commits are mechanical (e.g. moving a method from DefaultHttpClient to ConnectionManager) so should be easy to review. There are a few more interesting changes mixed in, such as removal of closeChannelAsync which turned out to do nothing.