### PR TITLE
fix runtime beans using interfaces or abstract classes

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/beans/RuntimeBeanDefinitionSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beans/RuntimeBeanDefinitionSpec.groovy
@@ -101,6 +101,7 @@ import io.micronaut.inject.annotation.MutableAnnotationMetadata;
 
 @Singleton
 class Foo {
+    @Inject @Named("test2") public Bazz bazz;
     @Inject public Bar bar;
     @Inject @Named("another") public Bar another;
 }
@@ -164,6 +165,18 @@ class RegistrarC {
                   new Stuff()
           )
         );
+        registry.registerBeanDefinition(
+          RuntimeBeanDefinition.builder(
+                  Bazz.class,
+                  () -> new BazzImpl(1)
+          ).named("test").build()
+        );
+        registry.registerBeanDefinition(
+          RuntimeBeanDefinition.builder(
+                  Bazz.class,
+                  () -> new BazzImpl(2)
+          ).named("test2").build()
+        );
     }
 }
 
@@ -178,10 +191,20 @@ class Bar {
 class Baz {}
 
 class Stuff {}
+
+interface Bazz {}
+class BazzImpl implements Bazz  {
+    public final int num;
+    BazzImpl(int num) {
+        this.num = num;
+    }
+}
 ''')
         def foo = getBean(context, 'registerref.Foo')
         expect:
         foo.bar != null
+        foo.bazz != null
+        foo.bazz.num == 2
         foo.bar.name == 'primary'
         foo.another.name == 'another'
 

--- a/inject/src/main/java/io/micronaut/context/DefaultRuntimeBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultRuntimeBeanDefinition.java
@@ -76,6 +76,11 @@ final class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextCondition
     }
 
     @Override
+    public boolean isAbstract() {
+        return false;
+    }
+
+    @Override
     @NonNull
     public Set<Class<?>> getExposedTypes() {
         return ArrayUtils.isNotEmpty(exposedTypes) ?

--- a/inject/src/main/java/io/micronaut/context/RuntimeBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/RuntimeBeanDefinition.java
@@ -25,6 +25,7 @@ import io.micronaut.inject.BeanContextConditional;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.BeanDefinitionReference;
 import io.micronaut.inject.BeanFactory;
+import io.micronaut.inject.qualifiers.Qualifiers;
 
 import java.lang.annotation.Annotation;
 import java.util.Objects;
@@ -180,6 +181,21 @@ public interface RuntimeBeanDefinition<T> extends BeanDefinitionReference<T>, Be
          * @return This builder
          */
         Builder<B> qualifier(@Nullable Qualifier<B> qualifier);
+
+        /**
+         * The qualifier to use.
+         * @param name The named qualifier to use.
+         * @return This builder
+         * @since 3.7.0
+         */
+        default Builder<B> named(@Nullable String name) {
+            if (name == null) {
+                qualifier(null);
+            } else {
+                qualifier(Qualifiers.byName(name));
+            }
+            return this;
+        }
 
         /**
          * The scope to use.


### PR DESCRIPTION
currently it is not possible to register beans at runtime that specify an interface or abstract class as a bean type. This fixes that, adds a test and adds a convenience method for specifying named qualifiers