### PR TITLE
Fix incorrect getPropertiesFromGettersAndSetters groovy visitor for interfaces

### DIFF
--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyClassElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyClassElement.java
@@ -922,6 +922,7 @@ public class GroovyClassElement extends AbstractGroovyElement implements Arrayab
         ClassNode classNode = this.classNode;
         while (classNode != null && !classNode.equals(ClassHelper.OBJECT_TYPE) && !classNode.equals(ClassHelper.Enum_Type)) {
 
+            ClassNode finalClassNode = classNode;
             classNode.visitContents(
                     new PublicMethodVisitor(null) {
 
@@ -932,7 +933,7 @@ public class GroovyClassElement extends AbstractGroovyElement implements Arrayab
 
                         @Override
                         protected boolean isAcceptable(MethodNode node) {
-                            boolean validModifiers = node.isPublic() && !node.isStatic() && !node.isSynthetic() && !node.isAbstract();
+                            boolean validModifiers = node.isPublic() && !node.isStatic() && !node.isSynthetic() && (!node.isAbstract() || finalClassNode.isInterface());
                             if (validModifiers) {
                                 String methodName = node.getName();
                                 if (methodName.contains("$") || methodName.equals("getMetaClass")) {

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/ClassElementSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/ClassElementSpec.groovy
@@ -25,6 +25,7 @@ import io.micronaut.inject.ast.EnumElement
 import io.micronaut.inject.ast.FieldElement
 import io.micronaut.inject.ast.MethodElement
 import io.micronaut.inject.ast.PackageElement
+import io.micronaut.inject.ast.PropertyElement
 import spock.lang.Issue
 import spock.lang.Unroll
 import spock.util.environment.RestoreSystemProperties
@@ -41,6 +42,27 @@ class ClassElementSpec extends AbstractBeanDefinitionSpec {
 
     def cleanup() {
         AllElementsVisitor.clearVisited()
+    }
+
+    void "test interface bean properties"() {
+        given:
+        def element = buildClassElement("""
+package test
+
+interface HealthResult {
+
+    String getName();
+
+    Object getStatus();
+
+    Object getDetails();
+}
+""")
+
+        List<PropertyElement> properties = element.getBeanProperties()
+        expect:
+        properties
+        properties.size() == 3
     }
 
     @Unroll
@@ -162,24 +184,24 @@ abstract class Test extends SuperType implements AnotherInterface, SomeInt {
 
     protected boolean t1;
     private boolean t2;
-    
+
     private boolean privateMethod() {
         return true;
     }
-    
+
     boolean packagePrivateMethod() {
         return true;
     }
-    
+
     @java.lang.Override
     public boolean publicMethod() {
         return true;
     }
-    
+
     static boolean staticMethod() {
         return true;
     }
-    
+
     abstract boolean unimplementedMethod();
 }
 
@@ -189,15 +211,15 @@ abstract class SuperType {
     private boolean privateMethod() {
         return true;
     }
-    
+
     public boolean publicMethod() {
         return true;
     }
-    
+
     public boolean otherSuper() {
         return true;
     }
-    
+
     abstract boolean unimplementedSuperMethod();
 }
 
@@ -205,13 +227,13 @@ interface SomeInt {
     default boolean itfeMethod() {
         return true;
     }
-    
+
     boolean publicMethod();
 }
 
 interface AnotherInterface {
     boolean publicMethod();
-    
+
     boolean unimplementedItfeMethod();
 }
 ''')
@@ -244,19 +266,19 @@ class Test extends SuperType implements AnotherInterface, SomeInt {
 
     protected boolean t1;
     private boolean t2;
-    
+
     private boolean privateMethod() {
         return true;
     }
-    
+
     boolean packagePrivateMethod() {
         return true;
     }
-    
+
     public boolean publicMethod() {
         return true;
     }
-    
+
     static boolean staticMethod() {
         return true;
     }
@@ -268,11 +290,11 @@ class SuperType {
     private boolean privateMethod() {
         return true;
     }
-    
+
     public boolean publicMethod() {
         return true;
     }
-    
+
     public boolean otherSuper() {
         return true;
     }
@@ -282,7 +304,7 @@ interface SomeInt {
     default boolean itfeMethod() {
         return true;
     }
-    
+
     boolean publicMethod();
 }
 
@@ -344,12 +366,12 @@ import javax.inject.Inject;
 
 @Controller("/test")
 public class TestController implements java.util.function.Supplier<String> {
-    
+
     @Get("/getMethod")
     public String get() {
         return null;
     }
-    
+
 
 }
 
@@ -369,12 +391,12 @@ import javax.inject.Inject;
 
 @Controller("/test")
 public class TestController {
-    
+
     @Get("/getMethod")
     public String[] getMethod(int[] argument) {
         return null;
     }
-    
+
 
 }
 ''')
@@ -397,12 +419,12 @@ import javax.inject.Inject;
 
 @Controller("/test")
 public class TestController {
-    
+
     @Get("/getMethod")
     public HttpMethod getMethod(HttpMethod argument) {
         return null;
     }
-    
+
 
 }
 ''')
@@ -425,12 +447,12 @@ import javax.inject.Inject;
 
 @Controller("/test")
 public class TestController {
-    
+
     @Get("/getMethod")
     public int getMethod(long argument) {
         return 0;
     }
-    
+
 
 }
 ''')
@@ -451,12 +473,12 @@ import javax.inject.Inject;
 
 @Controller("/test")
 public class TestController<T extends Foo> {
-    
+
     @Get("/getMethod")
     public T getMethod(T argument) {
         return null;
     }
-    
+
 
 }
 
@@ -479,12 +501,12 @@ import javax.inject.Inject;
 
 @Controller("/test")
 public class TestController<T extends Foo> {
-    
+
     @Get("/getMethod")
     public T[] getMethod(T[] argument) {
         return null;
     }
-    
+
 
 }
 
@@ -509,12 +531,12 @@ import javax.inject.Inject;
 
 @Controller("/test")
 public class TestController {
-    
+
     @Get("/getMethod")
     public <T extends Foo> T getMethod(T argument) {
         return null;
     }
-    
+
 
 }
 
@@ -537,12 +559,12 @@ import javax.inject.Inject;
 
 @Controller("/test")
 public class TestController<T extends Foo> {
-    
+
     @Get("/getMethod")
     public java.util.List<T> getMethod(java.util.Set<T> argument) {
         return null;
     }
-    
+
 
 }
 


### PR DESCRIPTION
From micronaut openapi: found problem with standard endpoins instrospection. When visitor try to get bean properties for Interface `HealthResult` - it can't find any properties. Problem in GroovyClassElement.java:
![изображение](https://user-images.githubusercontent.com/48474279/190880636-f06106f6-e6d1-4998-ab55-ad8c58ad8961.png)
method isAcceptible return false, because method abstract.

With java all works correct.