### PR TITLE
Allow matching `@Produces(ALL)` for ambiguous routes

### DIFF
--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/ContentNegotiationSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/ContentNegotiationSpec.groovy
@@ -6,7 +6,11 @@ import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus
 import io.micronaut.http.MediaType
-import io.micronaut.http.annotation.*
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Error
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Post
+import io.micronaut.http.annotation.Produces
 import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.http.client.exceptions.HttpClientResponseException
@@ -18,7 +22,9 @@ import reactor.core.publisher.Flux
 import spock.lang.Specification
 import spock.lang.Unroll
 
-import static io.micronaut.http.server.netty.ContentNegotiationSpec.NegotiatingController.*
+import static io.micronaut.http.server.netty.ContentNegotiationSpec.NegotiatingController.JSON
+import static io.micronaut.http.server.netty.ContentNegotiationSpec.NegotiatingController.TEXT
+import static io.micronaut.http.server.netty.ContentNegotiationSpec.NegotiatingController.XML
 
 @MicronautTest
 class ContentNegotiationSpec extends Specification {
@@ -137,6 +143,30 @@ class ContentNegotiationSpec extends Specification {
         MediaType.APPLICATION_JSON_TYPE | HttpStatus.BAD_REQUEST | MediaType.APPLICATION_JSON_TYPE | '{"message":"not a good request"}'
     }
 
+    @Unroll
+    void 'test produces any accepts #accept'() {
+        given:
+        def request = HttpRequest.GET('/negotiate/any/foo')
+        if (accept != null) {
+            request = request.accept(accept)
+        }
+
+        when:
+        HttpResponse<String> response = client.toBlocking().exchange(request, String)
+
+        then:
+        response.getContentType().get() == expectedContentType
+        response.body() == expectedBody
+
+        where:
+        accept                          | expectedContentType             | expectedBody
+        null                            | MediaType.TEXT_PLAIN_TYPE       | TEXT
+        MediaType.APPLICATION_XML_TYPE  | MediaType.APPLICATION_XML_TYPE  | XML
+        MediaType.APPLICATION_JSON_TYPE | MediaType.APPLICATION_JSON_TYPE | JSON
+        MediaType.TEXT_PLAIN_TYPE       | MediaType.TEXT_PLAIN_TYPE       | TEXT
+        MediaType.ALL_TYPE              | MediaType.TEXT_PLAIN_TYPE       | TEXT
+    }
+
     @Controller("/negotiate")
     static class NegotiatingController {
 
@@ -166,6 +196,25 @@ class ContentNegotiationSpec extends Specification {
         @Produces(MediaType.TEXT_PLAIN)
         String other() {
             return TEXT
+        }
+
+        @Get("/any/foo")
+        @Produces(MediaType.ALL)
+        HttpResponse<?> any(HttpRequest<?> req) {
+            def accept = req.accept()
+            if (accept.contains(MediaType.APPLICATION_JSON_TYPE)) {
+                return HttpResponse.ok(JSON).contentType(MediaType.APPLICATION_JSON_TYPE)
+            } else if (accept.contains(MediaType.APPLICATION_XML_TYPE)) {
+                return HttpResponse.ok(XML).contentType(MediaType.APPLICATION_XML_TYPE)
+            } else {
+                return HttpResponse.ok(TEXT).contentType(MediaType.TEXT_PLAIN_TYPE)
+            }
+        }
+
+        @Get("/any/{someVariable}")
+        @Produces(MediaType.ALL)
+        HttpResponse<?> anyWithVariable() {
+            throw new UnsupportedOperationException()
         }
 
         @Post(value = "/process",

--- a/router/src/main/java/io/micronaut/web/router/DefaultRouter.java
+++ b/router/src/main/java/io/micronaut/web/router/DefaultRouter.java
@@ -22,7 +22,11 @@ import io.micronaut.core.order.OrderUtil;
 import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.SupplierUtil;
-import io.micronaut.http.*;
+import io.micronaut.http.HttpAttributes;
+import io.micronaut.http.HttpMethod;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.Filter;
 import io.micronaut.http.annotation.FilterMatcher;
 import io.micronaut.http.filter.FilterPatternStyle;
@@ -34,7 +38,18 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
 import java.net.URI;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -66,7 +81,7 @@ public class DefaultRouter implements Router, HttpServerFilterResolver<RouteMatc
         httpFilters.sort(OrderUtil.COMPARATOR);
         return httpFilters;
     });
-    
+
     /**
      * Construct a new router for the given route builders.
      *
@@ -203,6 +218,7 @@ public class DefaultRouter implements Router, HttpServerFilterResolver<RouteMatc
         if (routeCount <= 1) {
             return uriRoutes;
         }
+        // if there are multiple routes, try to resolve the ambiguity
 
         if (CollectionUtils.isNotEmpty(acceptedProducedTypes)) {
             // take the highest priority accepted type
@@ -213,7 +229,7 @@ public class DefaultRouter implements Router, HttpServerFilterResolver<RouteMatc
                     mostSpecific.add(routeMatch);
                 }
             }
-            if (!mostSpecific.isEmpty() || !acceptedProducedTypes.contains(MediaType.ALL_TYPE)) {
+            if (!mostSpecific.isEmpty()) {
                 uriRoutes = mostSpecific;
             }
         }


### PR DESCRIPTION
If the client sends a specific content type, but the controller is annotated `@Produces(ALL)`, the matching logic for ambiguous routes would bail out and match no routes. This patch removes that logic, so that the ambiguity resolution can go on and match e.g. based on path variables. 
Fixes #7344