### PR TITLE
Properties annotated with JPA transient should not be excluded from introspections by default

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/EntityIntrospectedAnnotationMapper.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/EntityIntrospectedAnnotationMapper.java
@@ -45,9 +45,7 @@ public class EntityIntrospectedAnnotationMapper implements NamedAnnotationMapper
 
     @Override
     public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) { // <1>
-        final AnnotationValueBuilder<Introspected> builder = AnnotationValue.builder(Introspected.class)
-                // don't bother with transients properties
-                .member("excludedAnnotations", "javax.persistence.Transient"); // <2>
+        final AnnotationValueBuilder<Introspected> builder = AnnotationValue.builder(Introspected.class); // <2>
         return Arrays.asList(
                 builder.build(),
                 AnnotationValue.builder(ReflectiveAccess.class).build()

--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/persistence/JakartaEntityIntrospectedAnnotationMapper.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/persistence/JakartaEntityIntrospectedAnnotationMapper.java
@@ -44,9 +44,7 @@ public class JakartaEntityIntrospectedAnnotationMapper implements NamedAnnotatio
 
     @Override
     public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
-        final AnnotationValueBuilder<Introspected> builder = AnnotationValue.builder(Introspected.class)
-                // don't bother with transients properties
-                .member("excludedAnnotations", "jakarta.persistence.Transient");
+        final AnnotationValueBuilder<Introspected> builder = AnnotationValue.builder(Introspected.class);
         return Arrays.asList(
                 builder.build(),
                 AnnotationValue.builder(ReflectiveAccess.class).build()

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/TestEntityAnnotationMapper.java
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/TestEntityAnnotationMapper.java
@@ -36,8 +36,6 @@ public class TestEntityAnnotationMapper implements NamedAnnotationMapper {
     @Override
     public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
         final AnnotationValueBuilder<Introspected> builder = AnnotationValue.builder(Introspected.class)
-                // don't bother with transients properties
-                .member("excludedAnnotations", "javax.persistence.Transient")
                 // following are indexed for fast lookups
                 .member("indexed",
                         AnnotationValue.builder(Introspected.IndexedAnnotation.class)


### PR DESCRIPTION
…ronaut-core/discussions/8052

Don't remove the fields marked as @Transient from the introspection.

The PR micronaut-data to ignore these properties since they will now be part of the introspection:https://github.com/micronaut-projects/micronaut-data/pull/1758