### PR TITLE
Fix wrong declairingType in groovy properties when get genericReturnType

### DIFF
--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyClassElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyClassElement.java
@@ -851,11 +851,22 @@ public class GroovyClassElement extends AbstractGroovyElement implements Arrayab
             if (propertyNode.isPublic() && !propertyNode.isStatic()) {
                 final String propertyName = propertyNode.getName();
                 boolean readOnly = propertyNode.getField().isFinal();
+
+                ClassNode propDeclaringClass = propertyNode.getDeclaringClass();
+                GroovyClassElement declaringEl = this;
+                if (!propDeclaringClass.getName().equals(getName())) {
+                    declaringEl = new GroovyClassElement(
+                        visitorContext,
+                        propDeclaringClass,
+                        AstAnnotationUtils.getAnnotationMetadata(sourceUnit, compilationUnit, propDeclaringClass)
+                    );
+                }
+
                 final AnnotationMetadata annotationMetadata =
                         AstAnnotationUtils.getAnnotationMetadata(sourceUnit, compilationUnit, propertyNode.getField());
                 GroovyPropertyElement groovyPropertyElement = new GroovyPropertyElement(
                         visitorContext,
-                        this,
+                        declaringEl,
                         propertyNode.getField(),
                         annotationMetadata,
                         propertyName,

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyMethodElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyMethodElement.java
@@ -130,7 +130,7 @@ public class GroovyMethodElement extends AbstractGroovyElement implements Method
     @NonNull
     @Override
     public ClassElement getGenericReturnType() {
-        ClassNode returnType = methodNode.getReturnType();
+        ClassNode returnType = methodNode.getReturnType().redirect();
         ClassElement rawElement = getReturnType();
         return getGenericElement(returnType, rawElement);
     }
@@ -176,7 +176,7 @@ public class GroovyMethodElement extends AbstractGroovyElement implements Method
     @Override
     @NonNull
     public ClassElement getReturnType() {
-        return visitorContext.getElementFactory().newClassElement(methodNode.getReturnType(), AstAnnotationUtils.getAnnotationMetadata(sourceUnit, compilationUnit, methodNode.getReturnType()));
+        return visitorContext.getElementFactory().newClassElement(methodNode.getReturnType().redirect(), AstAnnotationUtils.getAnnotationMetadata(sourceUnit, compilationUnit, methodNode.getReturnType()));
     }
 
     @Override


### PR DESCRIPTION
Fix wrong declairingType in groovy properties when get genericReturnType.

See https://github.com/micronaut-projects/micronaut-openapi/issues/670