### PR TITLE
Lazily create the singleton stream-pipeline attribute to fix native image

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/HttpPipelineBuilder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/HttpPipelineBuilder.java
@@ -521,19 +521,20 @@ final class HttpPipelineBuilder {
 
     // We need the AttributeKey to be static, as it's used in NettyHttpRequest, but we can't eagerly initialize it
     // as it would fail in Graal
-    static class StreamPipelineAttributeKeyHolder {
+    static final class StreamPipelineAttributeKeyHolder {
 
-        private static final AtomicReference<AttributeKey<StreamPipeline>> instance = new AtomicReference<>();
+        private static final AtomicReference<AttributeKey<StreamPipeline>> INSTANCE = new AtomicReference<>();
 
         private StreamPipelineAttributeKeyHolder() {
         }
 
         static AttributeKey<StreamPipeline> getInstance() {
-            return instance.updateAndGet(key -> {
+            return INSTANCE.updateAndGet(key -> {
                 if (key == null) {
                     return AttributeKey.newInstance("micronaut-stream-pipeline");
                 }
                 return key;
             });
         }
-    }}
+    }
+}

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/HttpPipelineBuilder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/HttpPipelineBuilder.java
@@ -74,6 +74,7 @@ import java.nio.channels.ClosedChannelException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 /**
@@ -528,15 +529,17 @@ final class HttpPipelineBuilder {
     // as it would fail in Graal
     static class StreamPipelineAttributeKeyHolder {
 
+        private static final AtomicReference<AttributeKey<StreamPipeline>> instance = new AtomicReference<>();
+
         private StreamPipelineAttributeKeyHolder() {
         }
 
-        private static class InstanceHolder {
-            private static final AttributeKey<StreamPipeline> INSTANCE = AttributeKey.newInstance("stream-pipeline");
-        }
-
         static AttributeKey<StreamPipeline> getInstance() {
-            return InstanceHolder.INSTANCE;
+            return instance.updateAndGet(key -> {
+                if (key == null) {
+                    return AttributeKey.newInstance("micronaut-stream-pipeline");
+                }
+                return key;
+            });
         }
-    }
-}
+    }}

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/HttpPipelineBuilder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/HttpPipelineBuilder.java
@@ -75,7 +75,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Supplier;
 
 /**
  * Helper class that manages the {@link ChannelPipeline} of incoming HTTP connections.
@@ -136,11 +135,6 @@ final class HttpPipelineBuilder {
 
     boolean supportsSsl() {
         return sslContext != null;
-    }
-
-    static Supplier<AttributeKey<StreamPipeline>> getStreamPipelineAttribute() {
-        AttributeKey<StreamPipeline> attributeKey = AttributeKey.newInstance("stream-pipeline");
-        return () -> attributeKey;
     }
 
     final class ConnectionPipeline {

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpRequest.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpRequest.java
@@ -527,7 +527,7 @@ public class NettyHttpRequest<T> extends AbstractNettyHttpRequest<T> implements 
             );
 
             int ourStream = ((Http2StreamChannel) channelHandlerContext.channel()).stream().id();
-            HttpPipelineBuilder.StreamPipeline originalStreamPipeline = channelHandlerContext.channel().attr(HttpPipelineBuilder.STREAM_PIPELINE_ATTRIBUTE).get();
+            HttpPipelineBuilder.StreamPipeline originalStreamPipeline = channelHandlerContext.channel().attr(HttpPipelineBuilder.getStreamPipelineAttribute().get()).get();
 
             new Http2StreamChannelBootstrap(channelHandlerContext.channel().parent())
                     .handler(new ChannelInitializer<Http2StreamChannel>() {

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpRequest.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpRequest.java
@@ -527,7 +527,7 @@ public class NettyHttpRequest<T> extends AbstractNettyHttpRequest<T> implements 
             );
 
             int ourStream = ((Http2StreamChannel) channelHandlerContext.channel()).stream().id();
-            HttpPipelineBuilder.StreamPipeline originalStreamPipeline = channelHandlerContext.channel().attr(HttpPipelineBuilder.getStreamPipelineAttribute().get()).get();
+            HttpPipelineBuilder.StreamPipeline originalStreamPipeline = channelHandlerContext.channel().attr(HttpPipelineBuilder.StreamPipelineAttributeKeyHolder.getInstance()).get();
 
             new Http2StreamChannelBootstrap(channelHandlerContext.channel().parent())
                     .handler(new ChannelInitializer<Http2StreamChannel>() {


### PR DESCRIPTION
We cannot have static AttributeKey fields as Graal doesn't allow them to be generated at build time

This PR switches the one in HttpPipelineBuilder to be a memoized supplier

Fixes #8115