### PR TITLE
Add ctor overload to HttpStatusException to allow a cause to be provided

### DIFF
--- a/http/src/main/java/io/micronaut/http/exceptions/HttpException.java
+++ b/http/src/main/java/io/micronaut/http/exceptions/HttpException.java
@@ -37,6 +37,13 @@ public abstract class HttpException extends RuntimeException {
     }
 
     /**
+     * @param cause   The throwable
+     */
+    public HttpException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
      * @param message The message
      * @param cause   The throwable
      */

--- a/http/src/main/java/io/micronaut/http/exceptions/HttpStatusException.java
+++ b/http/src/main/java/io/micronaut/http/exceptions/HttpStatusException.java
@@ -20,7 +20,7 @@ import io.micronaut.http.HttpStatus;
 import java.util.Optional;
 
 /**
- * Exception thrown to return an specific HttpStatus and an error message.
+ * Exception thrown to return a specific HttpStatus and an error message.
  *
  * @author Iván López
  * @since 1.0
@@ -44,6 +44,27 @@ public class HttpStatusException extends HttpException {
      * @param body   The arbitrary object to return
      */
     public HttpStatusException(HttpStatus status, Object body) {
+        this.status = status;
+        this.body = body;
+    }
+
+    /**
+     * @param status  The {@link io.micronaut.http.HttpStatus}
+     * @param message The message
+     * @param cause   The throwable
+     */
+    public HttpStatusException(HttpStatus status, String message, Throwable cause) {
+        super(message, cause);
+        this.status = status;
+    }
+
+    /**
+     * @param status The {@link io.micronaut.http.HttpStatus}
+     * @param body   The arbitrary object to return
+     * @param cause   The throwable
+     */
+    public HttpStatusException(HttpStatus status, Object body, Throwable cause) {
+        super(cause);
         this.status = status;
         this.body = body;
     }


### PR DESCRIPTION
The main use case it to be able to catch another kind of exception and provide a specific status code.  For example, without this change, this is how causes are set:


```java
try {
  customer = customerTable.lookupById(request.getId());
} catch (IllegalArgumentException e) {
  var failure = new HttpStatusException(HttpStatus.BAD_REQUEST, "bad customer id");
  failure.initCause(e);
  throw failure;
}
```