### PR TITLE
Added lost slf4j and logback artifacts. Upgrade logback and slf4j. Added log4j bom dependency to final micronaut bom.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -138,6 +138,7 @@ managed-reactor = "3.4.23"
 managed-rxjava1 = "1.3.8"
 managed-rxjava1-interop = "0.13.7"
 managed-slf4j = "1.7.36"
+managed-log4j = "2.19.0"
 managed-spock = "2.2-groovy-4.0"
 managed-spotbugs = "4.7.1"
 managed-spring = "5.3.23"
@@ -192,6 +193,7 @@ boms-micronaut-test-resources = { module = "io.micronaut.testresources:micronaut
 
 boms-groovy = { module = "org.apache.groovy:groovy-bom", version.ref = "managed-groovy" }
 boms-jackson = { module = "com.fasterxml.jackson:jackson-bom", version.ref = "managed-jackson" }
+boms-log4j = { module = "org.apache.logging.log4j:log4j-bom", version.ref = "managed-log4j" }
 boms-junit5 = { module = "org.junit:junit-bom", version.ref = "managed-junit5" }
 boms-kotlin = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "managed-kotlin" }
 boms-kotlin-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-bom", version.ref = "managed-kotlin-coroutines" }
@@ -266,6 +268,10 @@ managed-jsr305 = { module = "com.google.code.findbugs:jsr305", version.ref = "ma
 managed-kafka212 = { module = "org.apache.kafka:kafka_2.12", version.ref = "managed-kafka" }
 
 managed-logback = { module = "ch.qos.logback:logback-classic", version.ref = "managed-logback" }
+managed-logback-core = { module = "ch.qos.logback:logback-core", version.ref = "managed-logback" }
+managed-logback-blackbox = { module = "ch.qos.logback:logback-classic-blackbox", version.ref = "managed-logback" }
+managed-logback-access = { module = "ch.qos.logback:logback-access", version.ref = "managed-logback" }
+managed-logback-core-blackbox = { module = "ch.qos.logback:logback-core-blackbox", version.ref = "managed-logback" }
 
 managed-lombok = { module = "org.projectlombok:lombok", version.ref = "managed-lombok" }
 
@@ -335,6 +341,14 @@ managed-rxjava1-interop = { module = "com.github.akarnokd:rxjava2-interop", vers
 
 managed-slf4j = { module = "org.slf4j:slf4j-api", version.ref = "managed-slf4j" }
 managed-slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "managed-slf4j" }
+managed-slf4j-nop = { module = "org.slf4j:slf4j-nop", version.ref = "managed-slf4j" }
+managed-slf4j-log4j12 = { module = "org.slf4j:slf4j-log4j12", version.ref = "managed-slf4j" }
+managed-slf4j-reload4j = { module = "org.slf4j:slf4j-reload4j", version.ref = "managed-slf4j" }
+managed-slf4j-ext = { module = "org.slf4j:slf4j-ext", version.ref = "managed-slf4j" }
+managed-slf4j-jcl-over-slf4j = { module = "org.slf4j:jcl-over-slf4j", version.ref = "managed-slf4j" }
+managed-slf4j-log4j-over-slf4j = { module = "org.slf4j:log4j-over-slf4j", version.ref = "managed-slf4j" }
+managed-slf4j-jul-to-slf4j = { module = "org.slf4j:jul-to-slf4j", version.ref = "managed-slf4j" }
+managed-slf4j-osgi-over-slf4 = { module = "org.slf4j:osgi-over-slf4", version.ref = "managed-slf4j" }
 
 managed-snakeyaml = { module = "org.yaml:snakeyaml", version.ref = "managed-snakeyaml" }
 
@@ -415,7 +429,7 @@ kotlinx-coroutines-rx2 = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-rx
 kotlinx-coroutines-slf4j = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-slf4j", version.ref = "managed-kotlin-coroutines" }
 kotlinx-coroutines-reactor = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-reactor", version.ref = "managed-kotlin-coroutines" }
 
-log4j = { module = "org.apache.logging.log4j:log4j-core", version.ref = "log4j" }
+log4j = { module = "org.apache.logging.log4j:log4j-core", version.ref = "managed-log4j" }
 
 logbook-netty = { module = "org.zalando:logbook-netty", version.ref = "logbook-netty" }
 

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/AbstractJavaElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/AbstractJavaElement.java
@@ -17,7 +17,6 @@ package io.micronaut.annotation.processing.visitor;
 
 import io.micronaut.annotation.processing.AnnotationUtils;
 import io.micronaut.core.annotation.AnnotationMetadata;
-import io.micronaut.core.annotation.AnnotationMetadataDelegate;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.AnnotationValueBuilder;
 import io.micronaut.core.annotation.NonNull;


### PR DESCRIPTION
Added lost slf4j and logback artifacts. Upgrade logback and slf4j. 

Added log4j bom dependency to final micronaut bom.

At the moment, it is not possible to fully use the micronaut bom file for the reason that sometimes additional slf4j artifacts are required (for example, the slf4j-nop artifact is needed in the micronaut-openapi library, and sometimes the jcl-over-slf4j or jul-to- artifacts are required in the project slf4j), and sometimes additional artifacts for log4j are required (for example, in micronaut-elasticsearch, it is more convenient for me to use logback and slf4j, this requires adding the log4j-to-slf4j artifact). And now, in order for everything to work, I have to duplicate the versions of these libraries in my gradle file, which is not very convenient.

In my opinion, you need to use the logic of the spring-boot command - they add all the artifacts of the family to the final bom file, even if they do not use all of them.

Actually, I don't understand why all the slf4j, logback and log4j artifacts were not added, but the same jackson-bom was added.

I think this change will make life easier not only for me :-)