### PR TITLE
Support custom HTTP status codes

### DIFF
--- a/http-client-core/src/main/java/io/micronaut/http/client/ServiceHttpClientFactory.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/ServiceHttpClientFactory.java
@@ -27,11 +27,11 @@ import io.micronaut.core.io.buffer.ByteBuffer;
 import io.micronaut.discovery.StaticServiceInstanceList;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
-import io.micronaut.http.HttpStatus;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import io.micronaut.runtime.server.event.ServerStartupEvent;
 import io.micronaut.scheduling.TaskScheduler;
 import reactor.core.publisher.Flux;
+
 import java.net.URI;
 import java.time.Duration;
 import java.util.Collection;
@@ -113,12 +113,12 @@ public class ServiceHttpClientFactory {
                                                 return Flux.just((HttpResponse<ByteBuffer>) responseException.getResponse());
                                             }
                                             return Flux.just(HttpResponse.serverError());
-                                        }).map(response -> Collections.singletonMap(originalURI, response.getStatus()));
+                                        }).map(response -> Collections.singletonMap(originalURI, response.code()));
                             }).subscribe(uriToStatusMap -> {
-                                Map.Entry<URI, HttpStatus> entry = uriToStatusMap.entrySet().iterator().next();
+                                Map.Entry<URI, Integer> entry = uriToStatusMap.entrySet().iterator().next();
                                 URI uri = entry.getKey();
-                                HttpStatus status = entry.getValue();
-                                if (status.getCode() >= 300) {
+                                int status = entry.getValue();
+                                if (status >= 300) {
                                     loadBalancedURIs.remove(uri);
                                 } else if (!loadBalancedURIs.contains(uri)) {
                                     loadBalancedURIs.add(uri);

--- a/http-client-core/src/main/java/io/micronaut/http/client/exceptions/HttpClientResponseException.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/exceptions/HttpClientResponseException.java
@@ -101,7 +101,7 @@ public class HttpClientResponseException extends HttpClientException implements 
     private Argument<?> getErrorType(HttpResponse<?> response) {
         Optional<MediaType> contentType = response.getContentType();
         Argument<?> errorType = null;
-        if (contentType.isPresent() && response.getStatus().getCode() > 399) {
+        if (contentType.isPresent() && response.code() > 399) {
             MediaType mediaType = contentType.get();
             if (errorDecoder != null) {
                 errorType = errorDecoder.getErrorType(mediaType);

--- a/http-client/src/main/java/io/micronaut/http/client/netty/FullNettyClientHttpResponse.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/FullNettyClientHttpResponse.java
@@ -61,7 +61,6 @@ public class FullNettyClientHttpResponse<B> implements HttpResponse<B>, Completa
 
     private static final Logger LOG = LoggerFactory.getLogger(DefaultHttpClient.class);
 
-    private final HttpStatus status;
     private final NettyHttpHeaders headers;
     private final NettyCookies nettyCookies;
     private final MutableConvertibleValues<Object> attributes;
@@ -75,7 +74,6 @@ public class FullNettyClientHttpResponse<B> implements HttpResponse<B>, Completa
 
     /**
      * @param fullHttpResponse       The full Http response
-     * @param httpStatus             The Http status
      * @param mediaTypeCodecRegistry The media type codec registry
      * @param byteBufferFactory      The byte buffer factory
      * @param bodyType               The body type
@@ -83,13 +81,11 @@ public class FullNettyClientHttpResponse<B> implements HttpResponse<B>, Completa
      */
     FullNettyClientHttpResponse(
             FullHttpResponse fullHttpResponse,
-            HttpStatus httpStatus,
             MediaTypeCodecRegistry mediaTypeCodecRegistry,
             ByteBufferFactory<ByteBufAllocator, ByteBuf> byteBufferFactory,
             Argument<B> bodyType,
             boolean convertBody) {
 
-        this.status = httpStatus;
         this.headers = new NettyHttpHeaders(fullHttpResponse.headers(), ConversionService.SHARED);
         this.attributes = new MutableConvertibleValuesMap<>();
         this.nettyHttpResponse = fullHttpResponse;
@@ -120,8 +116,8 @@ public class FullNettyClientHttpResponse<B> implements HttpResponse<B>, Completa
     }
 
     @Override
-    public HttpStatus getStatus() {
-        return status;
+    public int code() {
+        return this.nettyHttpResponse.status().code();
     }
 
     @Override
@@ -217,7 +213,7 @@ public class FullNettyClientHttpResponse<B> implements HttpResponse<B>, Completa
                     converted = convertByteBuf(content, finalArgument);
                 }
             } catch (RuntimeException e) {
-                if (status.getCode() < 400) {
+                if (code() < 400) {
                     throw e;
                 } else {
                     if (LOG.isDebugEnabled()) {

--- a/http-client/src/test/groovy/io/micronaut/http/client/netty/FullNettyClientHttpResponseSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/netty/FullNettyClientHttpResponseSpec.groovy
@@ -1,9 +1,15 @@
 package io.micronaut.http.client.netty
 
-import io.micronaut.http.HttpStatus
+
 import io.micronaut.http.cookie.Cookie
 import io.micronaut.http.cookie.Cookies
-import io.netty.handler.codec.http.*
+import io.netty.handler.codec.http.DefaultFullHttpResponse
+import io.netty.handler.codec.http.DefaultHttpHeaders
+import io.netty.handler.codec.http.FullHttpResponse
+import io.netty.handler.codec.http.HttpHeaderNames
+import io.netty.handler.codec.http.HttpHeaders
+import io.netty.handler.codec.http.HttpResponseStatus
+import io.netty.handler.codec.http.HttpVersion
 import spock.lang.Specification
 
 class FullNettyClientHttpResponseSpec extends Specification {
@@ -16,7 +22,7 @@ class FullNettyClientHttpResponseSpec extends Specification {
           fullHttpResponse.headers().set(httpHeaders)
 
         when:
-          FullNettyClientHttpResponse response = new FullNettyClientHttpResponse(fullHttpResponse, HttpStatus.OK, null, null, null, false)
+          FullNettyClientHttpResponse response = new FullNettyClientHttpResponse(fullHttpResponse, null, null, null, false)
 
         then:
             Cookies cookies = response.getCookies()
@@ -39,7 +45,7 @@ class FullNettyClientHttpResponseSpec extends Specification {
         fullHttpResponse.headers().set(httpHeaders)
 
         when:
-        FullNettyClientHttpResponse response = new FullNettyClientHttpResponse(fullHttpResponse, HttpStatus.OK, null, null, null, false)
+        FullNettyClientHttpResponse response = new FullNettyClientHttpResponse(fullHttpResponse, null, null, null, false)
 
         then:
         Cookies cookies = response.getCookies()

--- a/http-client/src/test/groovy/io/micronaut/http/client/netty/NettyStreamedHttpResponseSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/netty/NettyStreamedHttpResponseSpec.groovy
@@ -1,11 +1,14 @@
 package io.micronaut.http.client.netty
 
-import io.micronaut.http.HttpStatus
 import io.micronaut.http.cookie.Cookie
 import io.micronaut.http.cookie.Cookies
 import io.micronaut.http.netty.stream.DefaultStreamedHttpResponse
 import io.micronaut.http.netty.stream.StreamedHttpResponse
-import io.netty.handler.codec.http.*
+import io.netty.handler.codec.http.DefaultHttpHeaders
+import io.netty.handler.codec.http.HttpHeaderNames
+import io.netty.handler.codec.http.HttpHeaders
+import io.netty.handler.codec.http.HttpResponseStatus
+import io.netty.handler.codec.http.HttpVersion
 import spock.lang.Specification
 
 class NettyStreamedHttpResponseSpec extends Specification {
@@ -18,7 +21,7 @@ class NettyStreamedHttpResponseSpec extends Specification {
         streamedHttpResponse.headers().set(httpHeaders)
 
         when:
-        NettyStreamedHttpResponse response = new NettyStreamedHttpResponse(streamedHttpResponse, HttpStatus.OK)
+        NettyStreamedHttpResponse response = new NettyStreamedHttpResponse(streamedHttpResponse)
 
         then:
         Cookies cookies = response.getCookies()
@@ -41,7 +44,7 @@ class NettyStreamedHttpResponseSpec extends Specification {
         streamedHttpResponse.headers().set(httpHeaders)
 
         when:
-        NettyStreamedHttpResponse response = new NettyStreamedHttpResponse(streamedHttpResponse, HttpStatus.OK)
+        NettyStreamedHttpResponse response = new NettyStreamedHttpResponse(streamedHttpResponse)
 
         then:
         Cookies cookies = response.getCookies()
@@ -65,7 +68,7 @@ class NettyStreamedHttpResponseSpec extends Specification {
         streamedHttpResponse.headers().set(httpHeaders)
 
         when:
-        NettyStreamedHttpResponse response = new NettyStreamedHttpResponse(streamedHttpResponse, HttpStatus.OK)
+        NettyStreamedHttpResponse response = new NettyStreamedHttpResponse(streamedHttpResponse)
         response.cookie(Cookie.of("ADDED", "xyz").httpOnly(true).domain(".foo.com"))
 
         then:

--- a/http-netty/src/main/java/io/micronaut/http/netty/NettyMutableHttpResponse.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/NettyMutableHttpResponse.java
@@ -181,8 +181,7 @@ public class NettyMutableHttpResponse<B> implements MutableHttpResponse<B>, Nett
 
     @Override
     public String toString() {
-        HttpStatus status = getStatus();
-        return status.getCode() + " " + status.getReason();
+        return code() + " " + reason();
     }
 
     @Override
@@ -203,11 +202,6 @@ public class NettyMutableHttpResponse<B> implements MutableHttpResponse<B>, Nett
             }
         }
         return attributes;
-    }
-
-    @Override
-    public HttpStatus getStatus() {
-        return HttpStatus.valueOf(httpResponseStatus.code());
     }
 
     @Override
@@ -260,9 +254,11 @@ public class NettyMutableHttpResponse<B> implements MutableHttpResponse<B>, Nett
     }
 
     @Override
-    public MutableHttpResponse<B> status(HttpStatus status, CharSequence message) {
-        message = message == null ? status.getReason() : message;
-        httpResponseStatus = new HttpResponseStatus(status.getCode(), message.toString());
+    public MutableHttpResponse<B> status(int status, CharSequence message) {
+        if (message == null) {
+            message = HttpStatus.getDefaultReason(status);
+        }
+        httpResponseStatus = new HttpResponseStatus(status, message.toString());
         return this;
     }
 

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpResponseFactory.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpResponseFactory.java
@@ -57,7 +57,19 @@ public class NettyHttpResponseFactory implements HttpResponseFactory {
         if (reason == null) {
             nettyStatus = HttpResponseStatus.valueOf(status.getCode());
         } else {
-            nettyStatus = new HttpResponseStatus(status.getCode(), reason);
+            nettyStatus = HttpResponseStatus.valueOf(status.getCode(), reason);
+        }
+
+        return new NettyMutableHttpResponse(HttpVersion.HTTP_1_1, nettyStatus, ConversionService.SHARED);
+    }
+
+    @Override
+    public <T> MutableHttpResponse<T> status(int status, String reason) {
+        HttpResponseStatus nettyStatus;
+        if (reason == null) {
+            nettyStatus = HttpResponseStatus.valueOf(status);
+        } else {
+            nettyStatus = HttpResponseStatus.valueOf(status, reason);
         }
 
         return new NettyMutableHttpResponse(HttpVersion.HTTP_1_1, nettyStatus, ConversionService.SHARED);

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
@@ -1195,7 +1195,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
     }
 
     private void writeFinalNettyResponse(MutableHttpResponse<?> message, HttpRequest<?> request, ChannelHandlerContext context) {
-        HttpStatus httpStatus = message.status();
+        int httpStatus = message.code();
 
         final io.micronaut.http.HttpVersion httpVersion = request.getHttpVersion();
         final boolean isHttp2 = httpVersion == io.micronaut.http.HttpVersion.HTTP_2_0;
@@ -1233,7 +1233,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
             // default Connection header if not set explicitly
             if (!isHttp2) {
                 if (!message.getHeaders().contains(HttpHeaders.CONNECTION)) {
-                    if (!decodeError && (httpStatus.getCode() < 500 || serverConfiguration.isKeepAliveOnServerError())) {
+                    if (!decodeError && (httpStatus < 500 || serverConfiguration.isKeepAliveOnServerError())) {
                         message.getHeaders().set(HttpHeaders.CONNECTION, HttpHeaderValues.KEEP_ALIVE);
                     } else {
                         message.getHeaders().set(HttpHeaders.CONNECTION, HttpHeaderValues.CLOSE);
@@ -1251,7 +1251,7 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
             if (!isHttp2) {
                 if (!nettyHeaders.contains(HttpHeaderNames.CONNECTION)) {
                     boolean expectKeepAlive = nettyResponse.protocolVersion().isKeepAliveDefault() || request.getHeaders().isKeepAlive();
-                    if (!decodeError && (expectKeepAlive || httpStatus.getCode() < 500 || serverConfiguration.isKeepAliveOnServerError())) {
+                    if (!decodeError && (expectKeepAlive || httpStatus < 500 || serverConfiguration.isKeepAliveOnServerError())) {
                         nettyHeaders.set(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE);
                     } else {
                         nettyHeaders.set(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE);
@@ -1342,13 +1342,12 @@ class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.micronaut.htt
 
     @NonNull
     private NettyMutableHttpResponse<?> createNettyResponse(HttpResponse<?> message) {
-        HttpStatus httpStatus = message.status();
         Object body = message.body();
         io.netty.handler.codec.http.HttpHeaders nettyHeaders = new DefaultHttpHeaders(serverConfiguration.isValidateHeaders());
         message.getHeaders().forEach((BiConsumer<String, List<String>>) nettyHeaders::set);
         return new NettyMutableHttpResponse<>(
                 HttpVersion.HTTP_1_1,
-                HttpResponseStatus.valueOf(httpStatus.getCode(), httpStatus.getReason()),
+                HttpResponseStatus.valueOf(message.code(), message.reason()),
                 body instanceof ByteBuf ? body : null,
                 ConversionService.SHARED
         );

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/encoders/HttpResponseEncoder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/encoders/HttpResponseEncoder.java
@@ -121,7 +121,7 @@ public class HttpResponseEncoder extends MessageToMessageEncoder<MutableHttpResp
             ByteBuf body = b instanceof  ByteBuf ? (ByteBuf) b : Unpooled.buffer(0);
             FullHttpResponse nettyResponse = new DefaultFullHttpResponse(
                     HttpVersion.HTTP_1_1,
-                    HttpResponseStatus.valueOf(response.status().getCode(), response.status().getReason()),
+                    HttpResponseStatus.valueOf(response.code(), response.reason()),
                     body,
                     nettyHeaders,
                     EmptyHttpHeaders.INSTANCE

--- a/http-server/src/main/java/io/micronaut/http/server/RouteExecutor.java
+++ b/http-server/src/main/java/io/micronaut/http/server/RouteExecutor.java
@@ -516,11 +516,10 @@ public final class RouteExecutor {
 
     private Publisher<MutableHttpResponse<?>> handleStatusException(HttpRequest<?> request,
                                                                     MutableHttpResponse<?> response) {
-        HttpStatus status = response.status();
         RouteInfo<?> routeInfo = response.getAttribute(HttpAttributes.ROUTE_INFO, RouteInfo.class).orElse(null);
 
-        if (status.getCode() >= 400 && routeInfo != null && !routeInfo.isErrorRoute()) {
-            RouteMatch<Object> statusRoute = findStatusRoute(request, status, routeInfo);
+        if (response.code() >= 400 && routeInfo != null && !routeInfo.isErrorRoute()) {
+            RouteMatch<Object> statusRoute = findStatusRoute(request, response.status(), routeInfo);
 
             if (statusRoute != null) {
                 return executeRoute(
@@ -579,8 +578,7 @@ public final class RouteExecutor {
         if (message instanceof MutableHttpResponse) {
             mutableHttpResponse = (MutableHttpResponse<?>) message;
         } else {
-            HttpStatus httpStatus = message.status();
-            mutableHttpResponse = HttpResponse.status(httpStatus, httpStatus.getReason());
+            mutableHttpResponse = HttpResponse.status(message.code(), message.reason());
             mutableHttpResponse.body(message.body());
             message.getHeaders().forEach((name, value) -> {
                 for (String val : value) {

--- a/http-server/src/main/java/io/micronaut/http/server/exceptions/response/HateoasErrorResponseProcessor.java
+++ b/http-server/src/main/java/io/micronaut/http/server/exceptions/response/HateoasErrorResponseProcessor.java
@@ -64,13 +64,13 @@ public class HateoasErrorResponseProcessor implements ErrorResponseProcessor<Jso
         }
         JsonError error;
         if (!errorContext.hasErrors()) {
-            error = new JsonError(response.getStatus().getReason());
+            error = new JsonError(response.reason());
         } else if (errorContext.getErrors().size() == 1 && !alwaysSerializeErrorsAsList) {
             Error jsonError = errorContext.getErrors().get(0);
             error = new JsonError(jsonError.getMessage());
             jsonError.getPath().ifPresent(error::path);
         } else {
-            error = new JsonError(response.getStatus().getReason());
+            error = new JsonError(response.reason());
             List<Resource> errors = new ArrayList<>();
             for (Error jsonError : errorContext.getErrors()) {
                 errors.add(new JsonError(jsonError.getMessage()).path(jsonError.getPath().orElse(null)));

--- a/http/src/main/java/io/micronaut/http/HttpResponse.java
+++ b/http/src/main/java/io/micronaut/http/HttpResponse.java
@@ -15,11 +15,11 @@
  */
 package io.micronaut.http;
 
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.cookie.Cookie;
 import io.micronaut.http.cookie.Cookies;
 import io.micronaut.http.exceptions.UriSyntaxException;
 
-import io.micronaut.core.annotation.Nullable;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Optional;
@@ -37,7 +37,9 @@ public interface HttpResponse<B> extends HttpMessage<B> {
     /**
      * @return The current status
      */
-    HttpStatus getStatus();
+    default HttpStatus getStatus() {
+        return HttpStatus.valueOf(code());
+    }
 
     @Override
     default HttpResponse<B> setAttribute(CharSequence name, Object value) {
@@ -74,16 +76,12 @@ public interface HttpResponse<B> extends HttpMessage<B> {
     /**
      * @return The response status code
      */
-    default int code() {
-        return getStatus().getCode();
-    }
+    int code();
 
     /**
      * @return The HTTP status reason phrase
      */
-    default String reason() {
-        return getStatus().getReason();
-    }
+    String reason();
 
     /**
      * Return an {@link io.micronaut.http.HttpStatus#OK} response with an empty body.
@@ -385,6 +383,18 @@ public interface HttpResponse<B> extends HttpMessage<B> {
      * @return The response
      */
     static <T> MutableHttpResponse<T> status(HttpStatus status, String reason) {
+        return HttpResponseFactory.INSTANCE.status(status, reason);
+    }
+
+    /**
+     * Return a response for the given status.
+     *
+     * @param status The status
+     * @param reason An alternatively reason message
+     * @param <T>    The response type
+     * @return The response
+     */
+    static <T> MutableHttpResponse<T> status(int status, String reason) {
         return HttpResponseFactory.INSTANCE.status(status, reason);
     }
 

--- a/http/src/main/java/io/micronaut/http/HttpResponseFactory.java
+++ b/http/src/main/java/io/micronaut/http/HttpResponseFactory.java
@@ -51,6 +51,16 @@ public interface HttpResponseFactory {
      * Return a response for the given status.
      *
      * @param status The status
+     * @param reason An alternatively reason message
+     * @param <T>    The response type
+     * @return The response
+     */
+    <T> MutableHttpResponse<T> status(int status, String reason);
+
+    /**
+     * Return a response for the given status.
+     *
+     * @param status The status
      * @param body   The body
      * @param <T>    The body type
      * @return The response

--- a/http/src/main/java/io/micronaut/http/HttpResponseWrapper.java
+++ b/http/src/main/java/io/micronaut/http/HttpResponseWrapper.java
@@ -31,8 +31,13 @@ public class HttpResponseWrapper<B> extends HttpMessageWrapper<B> implements Htt
     }
 
     @Override
-    public HttpStatus getStatus() {
-        return getDelegate().getStatus();
+    public int code() {
+        return getDelegate().code();
+    }
+
+    @Override
+    public String reason() {
+        return getDelegate().reason();
     }
 
     @Override

--- a/http/src/main/java/io/micronaut/http/HttpStatus.java
+++ b/http/src/main/java/io/micronaut/http/HttpStatus.java
@@ -15,6 +15,9 @@
  */
 package io.micronaut.http;
 
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+
 import java.util.Objects;
 
 /**
@@ -264,6 +267,24 @@ public enum HttpStatus implements CharSequence {
             default:
                 throw new IllegalArgumentException("Invalid HTTP status code: " + code);
         }
+    }
+
+    /**
+     * Get the default reason phrase for the given status code, if it is a known status code.
+     *
+     * @param code The status code
+     * @return The default reason phrase, or {@code "CUSTOM"} if the code is unknown.
+     */
+    @Internal
+    @NonNull
+    public static String getDefaultReason(int code) {
+        HttpStatus httpStatus;
+        try {
+            httpStatus = valueOf(code);
+        } catch (IllegalArgumentException e) {
+            return "CUSTOM";
+        }
+        return httpStatus.getReason();
     }
 
     @Override

--- a/http/src/main/java/io/micronaut/http/MutableHttpResponse.java
+++ b/http/src/main/java/io/micronaut/http/MutableHttpResponse.java
@@ -15,9 +15,9 @@
  */
 package io.micronaut.http;
 
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.cookie.Cookie;
 
-import io.micronaut.core.annotation.Nullable;
 import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.Locale;
@@ -72,7 +72,12 @@ public interface MutableHttpResponse<B> extends HttpResponse<B>, MutableHttpMess
      * @param message The message
      * @return This response object
      */
-    MutableHttpResponse<B> status(HttpStatus status, CharSequence message);
+    default MutableHttpResponse<B> status(HttpStatus status, CharSequence message) {
+        if (message == null) {
+            message = status.getReason();
+        }
+        return status(status.getCode(), message);
+    }
 
     @Override
     default MutableHttpResponse<B> headers(Consumer<MutableHttpHeaders> headers) {
@@ -152,7 +157,7 @@ public interface MutableHttpResponse<B> extends HttpResponse<B>, MutableHttpMess
      * @return This response object
      */
     default MutableHttpResponse<B> status(int status) {
-        return status(HttpStatus.valueOf(status));
+        return status(status, null);
     }
 
     /**
@@ -162,9 +167,7 @@ public interface MutableHttpResponse<B> extends HttpResponse<B>, MutableHttpMess
      * @param message The message
      * @return This response object
      */
-    default MutableHttpResponse<B> status(int status, CharSequence message) {
-        return status(HttpStatus.valueOf(status), message);
-    }
+    MutableHttpResponse<B> status(int status, CharSequence message);
 
     /**
      * Sets the response status.

--- a/http/src/main/java/io/micronaut/http/simple/SimpleHttpResponse.java
+++ b/http/src/main/java/io/micronaut/http/simple/SimpleHttpResponse.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.http.simple;
 
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.annotation.TypeHint;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.value.MutableConvertibleValues;
@@ -26,7 +27,6 @@ import io.micronaut.http.cookie.Cookie;
 import io.micronaut.http.cookie.Cookies;
 import io.micronaut.http.simple.cookies.SimpleCookies;
 
-import io.micronaut.core.annotation.Nullable;
 import java.util.Optional;
 import java.util.Set;
 
@@ -45,7 +45,9 @@ class SimpleHttpResponse<B> implements MutableHttpResponse<B> {
     private final SimpleCookies cookies = new SimpleCookies(ConversionService.SHARED);
     private final MutableConvertibleValues<Object> attributes = new MutableConvertibleValuesMap<>();
 
-    private HttpStatus status = HttpStatus.OK;
+    private int status = HttpStatus.OK.getCode();
+    private String reason = HttpStatus.OK.getReason();
+
     private Object body;
 
     @Override
@@ -84,14 +86,24 @@ class SimpleHttpResponse<B> implements MutableHttpResponse<B> {
     }
 
     @Override
-    public MutableHttpResponse<B> status(HttpStatus status, CharSequence message) {
-        this.status = status;
-        return this;
+    public int code() {
+        return status;
     }
 
     @Override
-    public HttpStatus getStatus() {
-        return this.status;
+    public String reason() {
+        return reason;
+    }
+
+    @Override
+    public MutableHttpResponse<B> status(int status, CharSequence message) {
+        this.status = status;
+        if (message == null) {
+            this.reason = HttpStatus.getDefaultReason(status);
+        } else {
+            this.reason = message.toString();
+        }
+        return this;
     }
 
     /**

--- a/http/src/main/java/io/micronaut/http/simple/SimpleHttpResponseFactory.java
+++ b/http/src/main/java/io/micronaut/http/simple/SimpleHttpResponseFactory.java
@@ -40,6 +40,11 @@ public class SimpleHttpResponseFactory implements HttpResponseFactory {
     }
 
     @Override
+    public <T> MutableHttpResponse<T> status(int status, String reason) {
+        return new SimpleHttpResponse<T>().status(status, reason);
+    }
+
+    @Override
     public <T> MutableHttpResponse<T> status(HttpStatus status, T body) {
         return new SimpleHttpResponse<T>().status(status).body(body);
     }


### PR DESCRIPTION
This patch adds support for custom status codes to various HTTP server and client classes.

- On HttpResponse, the code()/reason() getters and the corresponding setter become the "primary" accessors for the HTTP status. Usages of status() and getStatus() are replaced where possible.
- HttpStatus instances are only computed lazily when the user calls status(), which will produce an error for unknown status codes. If the method is not called, there is no error.
- Various HttpResponse implementations are changed to not store HttpStatus.

Fixes #4791