### PR TITLE
Use v6.0.1 of the internal build tools

### DIFF
--- a/.github/workflows/central-sync.yml
+++ b/.github/workflows/central-sync.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
-          java-version: '11'
+          java-version: '17'
       - name: Publish to Sonatype OSSRH
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/.github/workflows/corretto.yml
+++ b/.github/workflows/corretto.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['8', '11']
+        java: ['17']
     container: amazoncorretto:${{ matrix.java }}
     steps:
     - name: Display Java and Linux version

--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['11', '17']
+        java: ['17']
         graalvm: ['latest', 'dev']
     steps:
        # https://github.com/actions/virtual-environments/issues/709

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['8', '11', '17']
+        java: ['17']
     steps:
        # https://github.com/actions/virtual-environments/issues/709
       - name: Free disk space
@@ -72,7 +72,7 @@ jobs:
           name: binary-compatibility-reports
           path: "**/build/reports/binary-compatibility-*.html"
       - name: Publish to Sonatype Snapshots
-        if: success() && github.event_name == 'push' && matrix.java == '11'
+        if: success() && github.event_name == 'push' && matrix.java == '17'
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
@@ -88,7 +88,7 @@ jobs:
           if_true: "micronaut-projects/micronaut-docs"
           if_false: ${{ github.repository }}
       - name: Publish to Github Pages
-        if: success() && github.event_name == 'push' && matrix.java == '11'
+        if: success() && github.event_name == 'push' && matrix.java == '17'
         uses: micronaut-projects/github-pages-deploy-action@master
         env:
           TARGET_REPOSITORY: ${{ steps.docs_target.outputs.value }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
-          java-version: '11'
+          java-version: '17'
       - name: Publish to Sonatype Snapshots
         if: success()
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
-          java-version: '11'
+          java-version: '17'
       - name: Set the current release version
         id: release_version
         run: echo ::set-output name=release_version::${GITHUB_REF:11}

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
-          java-version: 11
+          java-version: 17
       - name: Optional setup step
         env:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.convention-base.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.convention-base.gradle
@@ -47,11 +47,8 @@ tasks.withType(Jar).configureEach {
 }
 
 configurations.all {
-    resolutionStrategy.eachDependency { DependencyResolveDetails details ->
-        if (details.requested.group == 'org.codehaus.groovy') {
-            details.useTarget("org.apache.groovy:${details.requested.name}:${details.requested.version}")
-            details.because "Plugin 'io.micronaut.build.internal.common' isn't Groovy 4 yet and it's pulling in old versions"
-        }
+    resolutionStrategy.dependencySubstitution {
+        substitute module("io.micronaut:micronaut-inject-groovy") using project(":inject-groovy") because "we want to test with what we're building"
     }
 }
 

--- a/inject-java-test/build.gradle
+++ b/inject-java-test/build.gradle
@@ -29,6 +29,14 @@ dependencies {
     testImplementation libs.smallrye
 }
 
+tasks.withType(JavaCompile).configureEach {
+    options.compilerArgs += [
+            '--add-exports', 'jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED'
+    ]
+    // https://github.com/gradle/gradle/issues/18824
+    sourceCompatibility = 17
+}
+
 tasks.named("sourcesJar") {
     from "$projectDir/src/main/groovy"
 }

--- a/inject-java-test/build.gradle
+++ b/inject-java-test/build.gradle
@@ -29,14 +29,6 @@ dependencies {
     testImplementation libs.smallrye
 }
 
-tasks.withType(JavaCompile).configureEach {
-    options.compilerArgs += [
-            '--add-exports', 'jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED'
-    ]
-    // https://github.com/gradle/gradle/issues/18824
-    sourceCompatibility = 17
-}
-
 tasks.named("sourcesJar") {
     from "$projectDir/src/main/groovy"
 }

--- a/inject-java-test/src/main/java/io/micronaut/annotation/processing/test/JavaParser.java
+++ b/inject-java-test/src/main/java/io/micronaut/annotation/processing/test/JavaParser.java
@@ -336,16 +336,6 @@ public class JavaParser implements Closeable {
 
     @Override
     public void close() {
-        if (compiler != null) {
-            try {
-                // avoid illegal access
-                if (!Jvm.getCurrent().isJava15Compatible()) {
-                    ((com.sun.tools.javac.main.JavaCompiler) compiler).close();
-                }
-            } catch (Exception e) {
-                // ignore
-            }
-        }
         if (fileManager != null) {
             try {
                 fileManager.close();

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'io.micronaut.build.shared.settings' version '5.3.14'
+    id 'io.micronaut.build.shared.settings' version '6.0.0'
 }
 
 rootProject.name = 'micronaut'

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'io.micronaut.build.shared.settings' version '6.0.0'
+    id 'io.micronaut.build.shared.settings' version '6.0.1'
 }
 
 rootProject.name = 'micronaut'


### PR DESCRIPTION
The plugin pulls in io.micronaut:micronaut-inject-groovy which can't be resolved versionless.

So I added a resolution to switch this with the :inject-groovy module, which I think is more sensible here