### PR TITLE
Refactor `ConversionService` to remove mutable operations from `ConversionService.SHARED`

### DIFF
--- a/aop/src/main/java/io/micronaut/aop/InterceptedMethod.java
+++ b/aop/src/main/java/io/micronaut/aop/InterceptedMethod.java
@@ -18,6 +18,7 @@ package io.micronaut.aop;
 import io.micronaut.aop.internal.intercepted.InterceptedMethodUtil;
 import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.type.Argument;
 import org.reactivestreams.Publisher;
 
@@ -40,7 +41,18 @@ public interface InterceptedMethod {
      * @return The {@link InterceptedMethod}
      */
     static InterceptedMethod of(MethodInvocationContext<?, ?> context) {
-        return InterceptedMethodUtil.of(context);
+        return of(context, ConversionService.SHARED);
+    }
+
+    /**
+     * Creates a new instance of intercept method supporting intercepting different reactive invocations.
+     *
+     * @param context           The {@link MethodInvocationContext}
+     * @param conversionService The conversion service
+     * @return The {@link InterceptedMethod}
+     */
+    static InterceptedMethod of(MethodInvocationContext<?, ?> context, ConversionService conversionService) {
+        return InterceptedMethodUtil.of(context, conversionService);
     }
 
     /**

--- a/aop/src/main/java/io/micronaut/aop/internal/intercepted/CompletionStageInterceptedMethod.java
+++ b/aop/src/main/java/io/micronaut/aop/internal/intercepted/CompletionStageInterceptedMethod.java
@@ -37,13 +37,13 @@ import java.util.concurrent.Future;
 @Internal
 @Experimental
 class CompletionStageInterceptedMethod implements InterceptedMethod {
-    private final ConversionService<?> conversionService = ConversionService.SHARED;
-
     private final MethodInvocationContext<?, ?> context;
+    private final ConversionService conversionService;
     private final Argument<?> returnTypeValue;
 
-    CompletionStageInterceptedMethod(MethodInvocationContext<?, ?> context) {
+    CompletionStageInterceptedMethod(MethodInvocationContext<?, ?> context, ConversionService conversionService) {
         this.context = context;
+        this.conversionService = conversionService;
         this.returnTypeValue = context.getReturnType().asArgument().getFirstTypeVariable().orElse(Argument.OBJECT_ARGUMENT);
     }
 

--- a/aop/src/main/java/io/micronaut/aop/internal/intercepted/InterceptedMethodUtil.java
+++ b/aop/src/main/java/io/micronaut/aop/internal/intercepted/InterceptedMethodUtil.java
@@ -26,6 +26,7 @@ import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.type.ReturnType;
 
 import java.util.List;
@@ -48,10 +49,11 @@ public final class InterceptedMethodUtil {
     /**
      * Find possible {@link InterceptedMethod} implementation.
      *
-     * @param context The {@link MethodInvocationContext}
+     * @param context           The {@link MethodInvocationContext}
+     * @param conversionService The {@link ConversionService}
      * @return The {@link InterceptedMethod}
      */
-    public static InterceptedMethod of(MethodInvocationContext<?, ?> context) {
+    public static InterceptedMethod of(MethodInvocationContext<?, ?> context, ConversionService conversionService) {
         if (context.isSuspend()) {
             KotlinInterceptedMethod kotlinInterceptedMethod = KotlinInterceptedMethod.of(context);
             if (kotlinInterceptedMethod != null) {
@@ -65,9 +67,9 @@ public final class InterceptedMethodUtil {
                 // Micro Optimization
                 return new SynchronousInterceptedMethod(context);
             } else if (CompletionStage.class.isAssignableFrom(returnTypeClass) || Future.class.isAssignableFrom(returnTypeClass)) {
-                return new CompletionStageInterceptedMethod(context);
+                return new CompletionStageInterceptedMethod(context, conversionService);
             } else if (PublisherInterceptedMethod.isConvertibleToPublisher(returnTypeClass)) {
-                return new PublisherInterceptedMethod(context);
+                return new PublisherInterceptedMethod(context, conversionService);
             } else {
                 return new SynchronousInterceptedMethod(context);
             }

--- a/aop/src/main/java/io/micronaut/aop/internal/intercepted/InterceptedMethodUtil.java
+++ b/aop/src/main/java/io/micronaut/aop/internal/intercepted/InterceptedMethodUtil.java
@@ -52,8 +52,10 @@ public final class InterceptedMethodUtil {
      * @param context           The {@link MethodInvocationContext}
      * @param conversionService The {@link ConversionService}
      * @return The {@link InterceptedMethod}
+     * @since 4.0.0
      */
-    public static InterceptedMethod of(MethodInvocationContext<?, ?> context, ConversionService conversionService) {
+    @NonNull
+    public static InterceptedMethod of(@NonNull MethodInvocationContext<?, ?> context, @NonNull ConversionService conversionService) {
         if (context.isSuspend()) {
             KotlinInterceptedMethod kotlinInterceptedMethod = KotlinInterceptedMethod.of(context);
             if (kotlinInterceptedMethod != null) {

--- a/aop/src/main/java/io/micronaut/aop/internal/intercepted/PublisherInterceptedMethod.java
+++ b/aop/src/main/java/io/micronaut/aop/internal/intercepted/PublisherInterceptedMethod.java
@@ -40,13 +40,13 @@ import java.util.concurrent.ExecutorService;
 @Experimental
 class PublisherInterceptedMethod implements InterceptedMethod {
     private static final boolean AVAILABLE = ClassUtils.isPresent("io.micronaut.core.async.publisher.Publishers", PublisherInterceptedMethod.class.getClassLoader());
-    private final ConversionService<?> conversionService = ConversionService.SHARED;
-
     private final MethodInvocationContext<?, ?> context;
+    private final ConversionService conversionService;
     private final Argument<?> returnTypeValue;
 
-    PublisherInterceptedMethod(MethodInvocationContext<?, ?> context) {
+    PublisherInterceptedMethod(MethodInvocationContext<?, ?> context, ConversionService conversionService) {
         this.context = context;
+        this.conversionService = conversionService;
         this.returnTypeValue = context.getReturnType().asArgument().getFirstTypeVariable().orElse(Argument.OBJECT_ARGUMENT);
     }
 

--- a/buffer-netty/src/main/java/io/micronaut/buffer/netty/NettyByteBufferFactory.java
+++ b/buffer-netty/src/main/java/io/micronaut/buffer/netty/NettyByteBufferFactory.java
@@ -17,7 +17,7 @@ package io.micronaut.buffer.netty;
 
 import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.convert.MutableConversionService;
 import io.micronaut.core.io.buffer.ByteBuffer;
 import io.micronaut.core.io.buffer.ByteBufferFactory;
 import io.netty.buffer.ByteBuf;
@@ -59,7 +59,7 @@ public class NettyByteBufferFactory implements ByteBufferFactory<ByteBufAllocato
     }
 
     @PostConstruct
-    final void register(ConversionService<?> conversionService) {
+    final void register(MutableConversionService conversionService) {
         conversionService.addConverter(ByteBuf.class, ByteBuffer.class, DEFAULT::wrap);
         conversionService.addConverter(ByteBuffer.class, ByteBuf.class, byteBuffer -> {
             if (byteBuffer instanceof NettyByteBuffer) {

--- a/context/src/main/java/io/micronaut/runtime/converters/time/TimeConverterRegistrar.java
+++ b/context/src/main/java/io/micronaut/runtime/converters/time/TimeConverterRegistrar.java
@@ -18,7 +18,7 @@ package io.micronaut.runtime.converters.time;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.TypeHint;
 import io.micronaut.core.convert.ConversionContext;
-import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.convert.MutableConversionService;
 import io.micronaut.core.convert.TypeConverter;
 import io.micronaut.core.convert.TypeConverterRegistrar;
 import io.micronaut.core.convert.format.Format;
@@ -81,7 +81,7 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
     private static final int MILLIS = 3;
 
     @Override
-    public void register(ConversionService<?> conversionService) {
+    public void register(MutableConversionService conversionService) {
         final BiFunction<CharSequence, ConversionContext, Optional<Duration>> durationConverter = (object, context) -> {
             String value = object.toString().trim();
             if (value.startsWith("P")) {
@@ -179,7 +179,7 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
         addTemporalToDateConverter(conversionService, LocalDateTime.class, ldt -> ldt.toInstant(ZoneOffset.UTC));
     }
 
-    private <T extends TemporalAccessor> void addTemporalStringConverter(ConversionService<?> conversionService, Class<T> temporalType, DateTimeFormatter isoFormatter, TemporalQuery<T> query) {
+    private <T extends TemporalAccessor> void addTemporalStringConverter(MutableConversionService conversionService, Class<T> temporalType, DateTimeFormatter isoFormatter, TemporalQuery<T> query) {
         conversionService.addConverter(CharSequence.class, temporalType, (CharSequence object, Class<T> targetType, ConversionContext context) -> {
             if (StringUtils.isEmpty(object)) {
                 return Optional.empty();
@@ -213,7 +213,7 @@ public class TimeConverterRegistrar implements TypeConverterRegistrar {
         });
     }
 
-    private <T extends TemporalAccessor> void addTemporalToDateConverter(ConversionService<?> conversionService, Class<T> temporalType, Function<T, Instant> toInstant) {
+    private <T extends TemporalAccessor> void addTemporalToDateConverter(MutableConversionService conversionService, Class<T> temporalType, Function<T, Instant> toInstant) {
         conversionService.addConverter(temporalType, Date.class, (T object, Class<Date> targetType, ConversionContext context) -> Optional.of(Date.from(toInstant.apply(object))));
     }
 

--- a/context/src/main/java/io/micronaut/scheduling/processor/ScheduledMethodProcessor.java
+++ b/context/src/main/java/io/micronaut/scheduling/processor/ScheduledMethodProcessor.java
@@ -66,7 +66,7 @@ public class ScheduledMethodProcessor implements ExecutableMethodProcessor<Sched
     private static final String MEMBER_SCHEDULER = "scheduler";
 
     private final BeanContext beanContext;
-    private final ConversionService<?> conversionService;
+    private final ConversionService conversionService;
     private final Queue<ScheduledFuture<?>> scheduledTasks = new ConcurrentLinkedDeque<>();
     private final TaskExceptionHandler<?, ?> taskExceptionHandler;
 
@@ -76,7 +76,7 @@ public class ScheduledMethodProcessor implements ExecutableMethodProcessor<Sched
      * @param taskExceptionHandler The default task exception handler
      */
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-    public ScheduledMethodProcessor(BeanContext beanContext, Optional<ConversionService<?>> conversionService, TaskExceptionHandler<?, ?> taskExceptionHandler) {
+    public ScheduledMethodProcessor(BeanContext beanContext, Optional<ConversionService> conversionService, TaskExceptionHandler<?, ?> taskExceptionHandler) {
         this.beanContext = beanContext;
         this.conversionService = conversionService.orElse(ConversionService.SHARED);
         this.taskExceptionHandler = taskExceptionHandler;

--- a/core-reactive/src/main/java/io/micronaut/core/async/converters/ReactiveTypeConverterRegistrar.java
+++ b/core-reactive/src/main/java/io/micronaut/core/async/converters/ReactiveTypeConverterRegistrar.java
@@ -13,14 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.runtime.converters.reactive;
+package io.micronaut.core.async.converters;
 
-import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.async.publisher.Publishers;
-import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.convert.MutableConversionService;
 import io.micronaut.core.convert.TypeConverterRegistrar;
 import org.reactivestreams.Publisher;
-import jakarta.inject.Singleton;
 
 /**
  * Registers converters for Reactive types such as {@link Publisher}.
@@ -28,12 +27,11 @@ import jakarta.inject.Singleton;
  * @author Sergio del Amo
  * @since 3.0.0
  */
-@Singleton
-@Requires(classes = Publishers.class)
+@Internal
 public class ReactiveTypeConverterRegistrar implements TypeConverterRegistrar {
 
     @Override
-    public void register(ConversionService<?> conversionService) {
+    public void register(MutableConversionService conversionService) {
         conversionService.addConverter(Object.class, Publisher.class, obj -> {
             if (obj instanceof Publisher) {
                 return (Publisher) obj;

--- a/core-reactive/src/main/resources/META-INF/services/io.micronaut.core.convert.TypeConverterRegistrar
+++ b/core-reactive/src/main/resources/META-INF/services/io.micronaut.core.convert.TypeConverterRegistrar
@@ -1,0 +1,1 @@
+io.micronaut.core.async.converters.ReactiveTypeConverterRegistrar

--- a/core/src/main/java/io/micronaut/core/bind/annotation/AbstractAnnotatedArgumentBinder.java
+++ b/core/src/main/java/io/micronaut/core/bind/annotation/AbstractAnnotatedArgumentBinder.java
@@ -39,14 +39,14 @@ import java.util.Optional;
 public abstract class AbstractAnnotatedArgumentBinder<A extends Annotation, T, S> implements AnnotatedArgumentBinder<A, T, S> {
 
     private static final String DEFAULT_VALUE_MEMBER = "defaultValue";
-    private final ConversionService<?> conversionService;
+    protected final ConversionService conversionService;
 
     /**
      * Constructor.
      *
      * @param conversionService conversionService
      */
-    protected AbstractAnnotatedArgumentBinder(ConversionService<?> conversionService) {
+    protected AbstractAnnotatedArgumentBinder(ConversionService conversionService) {
         this.conversionService = conversionService;
     }
 

--- a/core/src/main/java/io/micronaut/core/convert/ConversionService.java
+++ b/core/src/main/java/io/micronaut/core/convert/ConversionService.java
@@ -15,49 +15,24 @@
  */
 package io.micronaut.core.convert;
 
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.convert.exceptions.ConversionErrorException;
 import io.micronaut.core.type.Argument;
-import io.micronaut.core.annotation.Nullable;
+
 import java.util.Optional;
-import java.util.function.Function;
 
 /**
  * A service for allowing conversion from one type to another.
  *
- * @param <Impl> The type
  * @author Graeme Rocher
  * @since 1.0
  */
-public interface ConversionService<Impl extends ConversionService> {
+public interface ConversionService {
 
     /**
      * The default shared conversion service.
      */
-    ConversionService<?> SHARED = new DefaultConversionService();
-
-    /**
-     * Adds a type converter.
-     *
-     * @param sourceType    The source type
-     * @param targetType    The target type
-     * @param typeConverter The type converter
-     * @param <S>           The source generic type
-     * @param <T>           The target generic type
-     * @return This conversion service
-     */
-    <S, T> Impl addConverter(Class<S> sourceType, Class<T> targetType, Function<S, T> typeConverter);
-
-    /**
-     * Adds a type converter.
-     *
-     * @param sourceType    The source type
-     * @param targetType    The target type
-     * @param typeConverter The type converter
-     * @param <S>           The source generic type
-     * @param <T>           The target generic type
-     * @return This conversion service
-     */
-    <S, T> Impl addConverter(Class<S> sourceType, Class<T> targetType, TypeConverter<S, T> typeConverter);
+    ConversionService SHARED = new DefaultMutableConversionService();
 
     /**
      * Attempts to convert the given object to the given target type. If conversion fails or is not possible an empty {@link Optional} is returned.

--- a/core/src/main/java/io/micronaut/core/convert/ConversionServiceAware.java
+++ b/core/src/main/java/io/micronaut/core/convert/ConversionServiceAware.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.core.convert;
+
+import io.micronaut.core.annotation.NonNull;
+
+/**
+ * Interface used when the component requires to set up bean context's {@link ConversionService}.
+ *
+ * @author Denis Stepanov
+ * @since 4.0.0
+ */
+public interface ConversionServiceAware {
+
+    /**
+     * Sets the conversion service.
+     *
+     * @param conversionService The conversion service
+     */
+    void setConversionService(@NonNull ConversionService conversionService);
+
+}

--- a/core/src/main/java/io/micronaut/core/convert/ConversionServiceProvider.java
+++ b/core/src/main/java/io/micronaut/core/convert/ConversionServiceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2022 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,10 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package io.micronaut.core.convert;
+
+import io.micronaut.core.annotation.NonNull;
+
 /**
- * Contains classes for reactive streams conversion.
+ * Interface for a component to provide the access to its {@link ConversionService}.
  *
- * @author Sergio del Amo
- * @since 3.0.0
+ * @author Denis Stepanov
+ * @since 4.0.0
  */
-package io.micronaut.runtime.converters.reactive;
+public interface ConversionServiceProvider {
+
+    /**
+     * Provides the conversion service.
+     *
+     * @return the conversion service
+     */
+    @NonNull
+    ConversionService getConversionService();
+
+}

--- a/core/src/main/java/io/micronaut/core/convert/DefaultMutableConversionService.java
+++ b/core/src/main/java/io/micronaut/core/convert/DefaultMutableConversionService.java
@@ -85,7 +85,7 @@ import java.util.function.Function;
  * @author Graeme Rocher
  * @since 1.0
  */
-public class DefaultMutableConversionService implements MutableConversionService<DefaultMutableConversionService> {
+public class DefaultMutableConversionService implements MutableConversionService {
 
     private static final int CACHE_MAX = 150;
     private static final TypeConverter UNCONVERTIBLE = (object, targetType, context) -> Optional.empty();
@@ -179,20 +179,18 @@ public class DefaultMutableConversionService implements MutableConversionService
     }
 
     @Override
-    public <S, T> DefaultMutableConversionService addConverter(Class<S> sourceType, Class<T> targetType, TypeConverter<S, T> typeConverter) {
+    public <S, T> void addConverter(Class<S> sourceType, Class<T> targetType, TypeConverter<S, T> typeConverter) {
         ConvertiblePair pair = newPair(sourceType, targetType, typeConverter);
         typeConverters.put(pair, typeConverter);
         converterCache.put(pair, typeConverter);
-        return this;
     }
 
     @Override
-    public <S, T> DefaultMutableConversionService addConverter(Class<S> sourceType, Class<T> targetType, Function<S, T> function) {
+    public <S, T> void addConverter(Class<S> sourceType, Class<T> targetType, Function<S, T> function) {
         ConvertiblePair pair = new ConvertiblePair(sourceType, targetType);
         TypeConverter<S, T> typeConverter = TypeConverter.of(sourceType, targetType, function);
         typeConverters.put(pair, typeConverter);
         converterCache.put(pair, typeConverter);
-        return this;
     }
 
     /**

--- a/core/src/main/java/io/micronaut/core/convert/DefaultMutableConversionService.java
+++ b/core/src/main/java/io/micronaut/core/convert/DefaultMutableConversionService.java
@@ -85,7 +85,7 @@ import java.util.function.Function;
  * @author Graeme Rocher
  * @since 1.0
  */
-public class DefaultMutableConversionService implements MutableConversionService {
+public class DefaultMutableConversionService implements MutableConversionService<DefaultMutableConversionService> {
 
     private static final int CACHE_MAX = 150;
     private static final TypeConverter UNCONVERTIBLE = (object, targetType, context) -> Optional.empty();
@@ -179,18 +179,20 @@ public class DefaultMutableConversionService implements MutableConversionService
     }
 
     @Override
-    public <S, T> void addConverter(Class<S> sourceType, Class<T> targetType, TypeConverter<S, T> typeConverter) {
+    public <S, T> DefaultMutableConversionService addConverter(Class<S> sourceType, Class<T> targetType, TypeConverter<S, T> typeConverter) {
         ConvertiblePair pair = newPair(sourceType, targetType, typeConverter);
         typeConverters.put(pair, typeConverter);
         converterCache.put(pair, typeConverter);
+        return this;
     }
 
     @Override
-    public <S, T> void addConverter(Class<S> sourceType, Class<T> targetType, Function<S, T> function) {
+    public <S, T> DefaultMutableConversionService addConverter(Class<S> sourceType, Class<T> targetType, Function<S, T> function) {
         ConvertiblePair pair = new ConvertiblePair(sourceType, targetType);
         TypeConverter<S, T> typeConverter = TypeConverter.of(sourceType, targetType, function);
         typeConverters.put(pair, typeConverter);
         converterCache.put(pair, typeConverter);
+        return this;
     }
 
     /**

--- a/core/src/main/java/io/micronaut/core/convert/MutableConversionService.java
+++ b/core/src/main/java/io/micronaut/core/convert/MutableConversionService.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.core.convert;
+
+import java.util.function.Function;
+
+/**
+ * A version of {@link ConversionService} that supports adding new converters.
+ *
+ * @author Denis Stepanov
+ * @since 4.0.0
+ */
+public interface MutableConversionService extends ConversionService {
+
+    /**
+     * Creates a new mutable conversion service that extends the shared conversion service.
+     * In most cases the mutable service from the bean context should be used.
+     *
+     * @return A new mutable conversion service.
+     */
+    static MutableConversionService create() {
+        return new DefaultMutableConversionService();
+    }
+
+    /**
+     * Adds a type converter.
+     *
+     * @param sourceType    The source type
+     * @param targetType    The target type
+     * @param typeConverter The type converter
+     * @param <S>           The source generic type
+     * @param <T>           The target generic type
+     */
+    <S, T> void addConverter(Class<S> sourceType, Class<T> targetType, Function<S, T> typeConverter);
+
+    /**
+     * Adds a type converter.
+     *
+     * @param sourceType    The source type
+     * @param targetType    The target type
+     * @param typeConverter The type converter
+     * @param <S>           The source generic type
+     * @param <T>           The target generic type
+     */
+    <S, T> void addConverter(Class<S> sourceType, Class<T> targetType, TypeConverter<S, T> typeConverter);
+
+}

--- a/core/src/main/java/io/micronaut/core/convert/MutableConversionService.java
+++ b/core/src/main/java/io/micronaut/core/convert/MutableConversionService.java
@@ -25,7 +25,7 @@ import java.util.function.Function;
  * @author Denis Stepanov
  * @since 4.0.0
  */
-public interface MutableConversionService extends ConversionService {
+public interface MutableConversionService<Impl extends ConversionService> extends ConversionService {
 
     /**
      * Creates a new mutable conversion service that extends the shared conversion service.
@@ -34,7 +34,7 @@ public interface MutableConversionService extends ConversionService {
      * @return A new mutable conversion service.
      */
     @NonNull
-    static MutableConversionService create() {
+    static MutableConversionService<?> create() {
         return new DefaultMutableConversionService();
     }
 
@@ -47,7 +47,7 @@ public interface MutableConversionService extends ConversionService {
      * @param <S>           The source generic type
      * @param <T>           The target generic type
      */
-    <S, T> void addConverter(@NonNull Class<S> sourceType, @NonNull Class<T> targetType, @NonNull Function<S, T> typeConverter);
+    <S, T> Impl addConverter(@NonNull Class<S> sourceType, @NonNull Class<T> targetType, @NonNull Function<S, T> typeConverter);
 
     /**
      * Adds a type converter.
@@ -58,6 +58,6 @@ public interface MutableConversionService extends ConversionService {
      * @param <S>           The source generic type
      * @param <T>           The target generic type
      */
-    <S, T> void addConverter(@NonNull Class<S> sourceType, @NonNull Class<T> targetType, @NonNull TypeConverter<S, T> typeConverter);
+    <S, T> Impl addConverter(@NonNull Class<S> sourceType, @NonNull Class<T> targetType, @NonNull TypeConverter<S, T> typeConverter);
 
 }

--- a/core/src/main/java/io/micronaut/core/convert/MutableConversionService.java
+++ b/core/src/main/java/io/micronaut/core/convert/MutableConversionService.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.core.convert;
 
+import io.micronaut.core.annotation.NonNull;
+
 import java.util.function.Function;
 
 /**
@@ -31,6 +33,7 @@ public interface MutableConversionService extends ConversionService {
      *
      * @return A new mutable conversion service.
      */
+    @NonNull
     static MutableConversionService create() {
         return new DefaultMutableConversionService();
     }
@@ -44,7 +47,7 @@ public interface MutableConversionService extends ConversionService {
      * @param <S>           The source generic type
      * @param <T>           The target generic type
      */
-    <S, T> void addConverter(Class<S> sourceType, Class<T> targetType, Function<S, T> typeConverter);
+    <S, T> void addConverter(@NonNull Class<S> sourceType, @NonNull Class<T> targetType, @NonNull Function<S, T> typeConverter);
 
     /**
      * Adds a type converter.
@@ -55,6 +58,6 @@ public interface MutableConversionService extends ConversionService {
      * @param <S>           The source generic type
      * @param <T>           The target generic type
      */
-    <S, T> void addConverter(Class<S> sourceType, Class<T> targetType, TypeConverter<S, T> typeConverter);
+    <S, T> void addConverter(@NonNull Class<S> sourceType, @NonNull Class<T> targetType, @NonNull TypeConverter<S, T> typeConverter);
 
 }

--- a/core/src/main/java/io/micronaut/core/convert/MutableConversionService.java
+++ b/core/src/main/java/io/micronaut/core/convert/MutableConversionService.java
@@ -25,7 +25,7 @@ import java.util.function.Function;
  * @author Denis Stepanov
  * @since 4.0.0
  */
-public interface MutableConversionService<Impl extends ConversionService> extends ConversionService {
+public interface MutableConversionService extends ConversionService {
 
     /**
      * Creates a new mutable conversion service that extends the shared conversion service.
@@ -34,7 +34,7 @@ public interface MutableConversionService<Impl extends ConversionService> extend
      * @return A new mutable conversion service.
      */
     @NonNull
-    static MutableConversionService<?> create() {
+    static MutableConversionService create() {
         return new DefaultMutableConversionService();
     }
 
@@ -47,7 +47,7 @@ public interface MutableConversionService<Impl extends ConversionService> extend
      * @param <S>           The source generic type
      * @param <T>           The target generic type
      */
-    <S, T> Impl addConverter(@NonNull Class<S> sourceType, @NonNull Class<T> targetType, @NonNull Function<S, T> typeConverter);
+    <S, T> void addConverter(@NonNull Class<S> sourceType, @NonNull Class<T> targetType, @NonNull Function<S, T> typeConverter);
 
     /**
      * Adds a type converter.
@@ -58,6 +58,6 @@ public interface MutableConversionService<Impl extends ConversionService> extend
      * @param <S>           The source generic type
      * @param <T>           The target generic type
      */
-    <S, T> Impl addConverter(@NonNull Class<S> sourceType, @NonNull Class<T> targetType, @NonNull TypeConverter<S, T> typeConverter);
+    <S, T> void addConverter(@NonNull Class<S> sourceType, @NonNull Class<T> targetType, @NonNull TypeConverter<S, T> typeConverter);
 
 }

--- a/core/src/main/java/io/micronaut/core/convert/TypeConverterRegistrar.java
+++ b/core/src/main/java/io/micronaut/core/convert/TypeConverterRegistrar.java
@@ -31,5 +31,5 @@ public interface TypeConverterRegistrar {
      *
      * @param conversionService The {@link ConversionService}
      */
-    void register(ConversionService<?> conversionService);
+    void register(MutableConversionService conversionService);
 }

--- a/core/src/main/java/io/micronaut/core/convert/converters/MultiValuesConverterFactory.java
+++ b/core/src/main/java/io/micronaut/core/convert/converters/MultiValuesConverterFactory.java
@@ -236,9 +236,9 @@ public class MultiValuesConverterFactory {
      */
     private abstract static class AbstractConverterFromMultiValues<T>
             implements FormattingTypeConverter<ConvertibleMultiValues, T, Format> {
-        protected ConversionService<?> conversionService;
+        protected ConversionService conversionService;
 
-        AbstractConverterFromMultiValues(ConversionService<?> conversionService) {
+        AbstractConverterFromMultiValues(ConversionService conversionService) {
             this.conversionService = conversionService;
         }
 
@@ -336,7 +336,7 @@ public class MultiValuesConverterFactory {
      * A converter to convert from {@link ConvertibleMultiValues} to an {@link Iterable}.
      */
     public static class MultiValuesToIterableConverter extends AbstractConverterFromMultiValues<Iterable> {
-        public MultiValuesToIterableConverter(ConversionService<?> conversionService) {
+        public MultiValuesToIterableConverter(ConversionService conversionService) {
             super(conversionService);
         }
 
@@ -407,7 +407,7 @@ public class MultiValuesConverterFactory {
      * A converter to convert from {@link ConvertibleMultiValues} to an {@link Map}.
      */
     public static class MultiValuesToMapConverter extends AbstractConverterFromMultiValues<Map> {
-        public MultiValuesToMapConverter(ConversionService<?> conversionService) {
+        public MultiValuesToMapConverter(ConversionService conversionService) {
             super(conversionService);
         }
 
@@ -484,7 +484,7 @@ public class MultiValuesConverterFactory {
      */
     public static class MultiValuesToObjectConverter extends AbstractConverterFromMultiValues<Object> {
 
-        public MultiValuesToObjectConverter(ConversionService<?> conversionService) {
+        public MultiValuesToObjectConverter(ConversionService conversionService) {
             super(conversionService);
         }
 
@@ -556,9 +556,9 @@ public class MultiValuesConverterFactory {
      */
     public abstract static class AbstractConverterToMultiValues<T>
             implements FormattingTypeConverter<T, ConvertibleMultiValues, Format> {
-        protected ConversionService<?> conversionService;
+        protected ConversionService conversionService;
 
-        public AbstractConverterToMultiValues(ConversionService<?> conversionService) {
+        public AbstractConverterToMultiValues(ConversionService conversionService) {
             this.conversionService = conversionService;
         }
 
@@ -655,7 +655,7 @@ public class MultiValuesConverterFactory {
      * A converter from {@link Iterable} to {@link ConvertibleMultiValues}.
      */
     public static class IterableToMultiValuesConverter extends AbstractConverterToMultiValues<Iterable> {
-        public IterableToMultiValuesConverter(ConversionService<?> conversionService) {
+        public IterableToMultiValuesConverter(ConversionService conversionService) {
             super(conversionService);
         }
 
@@ -704,7 +704,7 @@ public class MultiValuesConverterFactory {
      * A converter from {@link Map} to {@link ConvertibleMultiValues}.
      */
     public static class MapToMultiValuesConverter extends AbstractConverterToMultiValues<Map> {
-        public MapToMultiValuesConverter(ConversionService<?> conversionService) {
+        public MapToMultiValuesConverter(ConversionService conversionService) {
             super(conversionService);
         }
 
@@ -759,7 +759,7 @@ public class MultiValuesConverterFactory {
      * A converter from generic {@link Object} to {@link ConvertibleMultiValues}.
      */
     public static class ObjectToMultiValuesConverter extends AbstractConverterToMultiValues<Object> {
-        public ObjectToMultiValuesConverter(ConversionService<?> conversionService) {
+        public ObjectToMultiValuesConverter(ConversionService conversionService) {
             super(conversionService);
         }
 

--- a/core/src/main/java/io/micronaut/core/convert/value/ConvertibleMultiValuesMap.java
+++ b/core/src/main/java/io/micronaut/core/convert/value/ConvertibleMultiValuesMap.java
@@ -17,6 +17,7 @@ package io.micronaut.core.convert.value;
 
 import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.convert.ConversionServiceAware;
 import io.micronaut.core.type.Argument;
 
 import java.util.Collection;
@@ -36,11 +37,15 @@ import java.util.stream.Collectors;
  * @author Graeme Rocher
  * @since 1.0
  */
-public class ConvertibleMultiValuesMap<V> implements ConvertibleMultiValues<V> {
-    public static final ConvertibleMultiValues EMPTY = new ConvertibleMultiValuesMap<>(Collections.emptyMap());
+public class ConvertibleMultiValuesMap<V> implements ConvertibleMultiValues<V>, ConversionServiceAware {
+    public static final ConvertibleMultiValues EMPTY = new ConvertibleMultiValuesMap(Collections.emptyMap()) {
+        @Override
+        public void setConversionService(ConversionService conversionService) {
+        }
+    };
 
     protected final Map<CharSequence, List<V>> values;
-    private final ConversionService<?> conversionService;
+    private ConversionService conversionService;
 
     /**
      * Construct an empty {@link ConvertibleValuesMap}.
@@ -64,7 +69,7 @@ public class ConvertibleMultiValuesMap<V> implements ConvertibleMultiValues<V> {
      * @param values            The map
      * @param conversionService The conversion service
      */
-    public ConvertibleMultiValuesMap(Map<CharSequence, List<V>> values, ConversionService<?> conversionService) {
+    public ConvertibleMultiValuesMap(Map<CharSequence, List<V>> values, ConversionService conversionService) {
         this.values = wrapValues(values);
         this.conversionService = conversionService;
     }
@@ -137,4 +142,13 @@ public class ConvertibleMultiValuesMap<V> implements ConvertibleMultiValues<V> {
         return Collections.unmodifiableMap(values);
     }
 
+    @Override
+    public ConversionService getConversionService() {
+        return conversionService;
+    }
+
+    @Override
+    public void setConversionService(ConversionService conversionService) {
+        this.conversionService = conversionService;
+    }
 }

--- a/core/src/main/java/io/micronaut/core/convert/value/ConvertibleValues.java
+++ b/core/src/main/java/io/micronaut/core/convert/value/ConvertibleValues.java
@@ -19,11 +19,21 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.ConversionContext;
 import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.convert.ConversionServiceProvider;
 import io.micronaut.core.reflect.GenericTypeUtils;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.value.ValueResolver;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
@@ -34,7 +44,7 @@ import java.util.stream.Collectors;
  * @author Graeme Rocher
  * @since 1.0
  */
-public interface ConvertibleValues<V> extends ValueResolver<CharSequence>, Iterable<Map.Entry<String, V>> {
+public interface ConvertibleValues<V> extends ValueResolver<CharSequence>, Iterable<Map.Entry<String, V>>, ConversionServiceProvider {
 
     ConvertibleValues EMPTY = new ConvertibleValuesMap<>(Collections.emptyMap());
 
@@ -133,9 +143,9 @@ public interface ConvertibleValues<V> extends ValueResolver<CharSequence>, Itera
         Map<KT, VT> newMap = new LinkedHashMap<>();
         for (Map.Entry<String, V> entry : this) {
             String key = entry.getKey();
-            Optional<KT> convertedKey = ConversionService.SHARED.convert(key, keyType);
+            Optional<KT> convertedKey = getConversionService().convert(key, keyType);
             if (convertedKey.isPresent()) {
-                Optional<VT> convertedValue = ConversionService.SHARED.convert(entry.getValue(), valueType);
+                Optional<VT> convertedValue = getConversionService().convert(entry.getValue(), valueType);
                 convertedValue.ifPresent(vt -> newMap.put(convertedKey.get(), vt));
             }
         }
@@ -247,10 +257,23 @@ public interface ConvertibleValues<V> extends ValueResolver<CharSequence>, Itera
      * @return The values
      */
     static <T> ConvertibleValues<T> of(Map<? extends CharSequence, T> values) {
+        return of(values, ConversionService.SHARED);
+    }
+
+    /**
+     * Creates a new {@link ConvertibleValues} for the values.
+     *
+     * @param values A map of values
+     * @param conversionService The conversion service
+     * @param <T>    The target generic type
+     * @return The values
+     * @since 4.0.0
+     */
+    static <T> ConvertibleValues<T> of(Map<? extends CharSequence, T> values, ConversionService conversionService) {
         if (values == null) {
             return ConvertibleValuesMap.empty();
         } else {
-            return new ConvertibleValuesMap<>(values);
+            return new ConvertibleValuesMap<>(values, conversionService);
         }
     }
 
@@ -263,5 +286,10 @@ public interface ConvertibleValues<V> extends ValueResolver<CharSequence>, Itera
     @SuppressWarnings("unchecked")
     static <V> ConvertibleValues<V> empty() {
         return ConvertibleValues.EMPTY;
+    }
+
+    @Override
+    default ConversionService getConversionService() {
+        return ConversionService.SHARED;
     }
 }

--- a/core/src/main/java/io/micronaut/core/convert/value/ConvertibleValuesMap.java
+++ b/core/src/main/java/io/micronaut/core/convert/value/ConvertibleValuesMap.java
@@ -18,6 +18,7 @@ package io.micronaut.core.convert.value;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.convert.ConversionServiceAware;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -34,10 +35,10 @@ import java.util.stream.Collectors;
  * @param <V> generic value
  * @since 1.0
  */
-public class ConvertibleValuesMap<V> implements ConvertibleValues<V> {
+public class ConvertibleValuesMap<V> implements ConvertibleValues<V>, ConversionServiceAware {
 
     protected final Map<? extends CharSequence, V> map;
-    private final ConversionService<?> conversionService;
+    private ConversionService conversionService;
 
     /**
      * Constructor.
@@ -59,7 +60,7 @@ public class ConvertibleValuesMap<V> implements ConvertibleValues<V> {
      * @param map map of values.
      * @param conversionService conversionService
      */
-    public ConvertibleValuesMap(Map<? extends CharSequence, V> map, ConversionService<?> conversionService) {
+    public ConvertibleValuesMap(Map<? extends CharSequence, V> map, ConversionService conversionService) {
         this.map = map;
         this.conversionService = conversionService;
     }
@@ -103,5 +104,10 @@ public class ConvertibleValuesMap<V> implements ConvertibleValues<V> {
     @SuppressWarnings("unchecked")
     public static <V> ConvertibleValues<V> empty() {
         return EMPTY;
+    }
+
+    @Override
+    public void setConversionService(ConversionService conversionService) {
+        this.conversionService = conversionService;
     }
 }

--- a/core/src/main/java/io/micronaut/core/convert/value/MutableConvertibleMultiValuesMap.java
+++ b/core/src/main/java/io/micronaut/core/convert/value/MutableConvertibleMultiValuesMap.java
@@ -47,7 +47,7 @@ public class MutableConvertibleMultiValuesMap<V> extends ConvertibleMultiValuesM
      * @param values            The values
      * @param conversionService The conversion service
      */
-    public MutableConvertibleMultiValuesMap(Map<CharSequence, List<V>> values, ConversionService<?> conversionService) {
+    public MutableConvertibleMultiValuesMap(Map<CharSequence, List<V>> values, ConversionService conversionService) {
         super(values, conversionService);
     }
 

--- a/core/src/main/java/io/micronaut/core/convert/value/MutableConvertibleValuesMap.java
+++ b/core/src/main/java/io/micronaut/core/convert/value/MutableConvertibleValuesMap.java
@@ -45,7 +45,7 @@ public class MutableConvertibleValuesMap<V> extends ConvertibleValuesMap<V> impl
      * @param map               The map
      * @param conversionService The conversion service
      */
-    public MutableConvertibleValuesMap(Map<? extends CharSequence, V> map, ConversionService<?> conversionService) {
+    public MutableConvertibleValuesMap(Map<? extends CharSequence, V> map, ConversionService conversionService) {
         super(map, conversionService);
     }
 

--- a/core/src/main/java/io/micronaut/core/serialize/JdkSerializer.java
+++ b/core/src/main/java/io/micronaut/core/serialize/JdkSerializer.java
@@ -36,12 +36,12 @@ import java.util.Optional;
  */
 public class JdkSerializer implements ObjectSerializer {
 
-    private final ConversionService<?> conversionService;
+    private final ConversionService conversionService;
 
     /**
      * @param conversionService The conversion service
      */
-    public JdkSerializer(ConversionService<?> conversionService) {
+    public JdkSerializer(ConversionService conversionService) {
         this.conversionService = conversionService;
     }
 

--- a/core/src/main/java/io/micronaut/core/value/MapPropertyResolver.java
+++ b/core/src/main/java/io/micronaut/core/value/MapPropertyResolver.java
@@ -34,7 +34,7 @@ import java.util.stream.Collectors;
  */
 public class MapPropertyResolver implements PropertyResolver {
     private final Map<String, Object> map;
-    private final ConversionService<?> conversionService;
+    private final ConversionService conversionService;
 
     /**
      * @param map The map to resolves the properties from

--- a/core/src/test/groovy/io/micronaut/core/convert/DefaultConversionServiceSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/convert/DefaultConversionServiceSpec.groovy
@@ -31,7 +31,7 @@ class DefaultConversionServiceSpec extends Specification {
     @Unroll
     void "test default conversion service converts a #sourceObject.class.name to a #targetType.name"() {
         given:
-        ConversionService conversionService = new DefaultConversionService()
+        ConversionService conversionService = new DefaultMutableConversionService()
 
         expect:
         conversionService.convert(sourceObject, targetType).get() == result
@@ -70,7 +70,7 @@ class DefaultConversionServiceSpec extends Specification {
 
     void "test empty string conversion"() {
         given:
-        ConversionService conversionService = new DefaultConversionService()
+        ConversionService conversionService = new DefaultMutableConversionService()
 
         expect:
         !conversionService.convert("", targetType).isPresent()
@@ -81,7 +81,7 @@ class DefaultConversionServiceSpec extends Specification {
 
     void "test convert required"() {
         given:
-        ConversionService conversionService = new DefaultConversionService()
+        ConversionService conversionService = new DefaultMutableConversionService()
 
         when:
         conversionService.convertRequired("junk", Integer)
@@ -94,7 +94,7 @@ class DefaultConversionServiceSpec extends Specification {
 
     void "test conversion service with type arguments"() {
         given:
-        ConversionService conversionService = new DefaultConversionService()
+        ConversionService conversionService = new DefaultMutableConversionService()
 
         expect:
         conversionService.convert(sourceObject, targetType, ConversionContext.of(typeArguments)).get() == result

--- a/core/src/test/groovy/io/micronaut/core/convert/value/ConvertibleValuesSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/convert/value/ConvertibleValuesSpec.groovy
@@ -15,6 +15,7 @@
  */
 package io.micronaut.core.convert.value
 
+
 import spock.lang.Specification
 
 class ConvertibleValuesSpec extends Specification {

--- a/function-web/src/main/java/io/micronaut/function/web/AnnotatedFunctionRouteBuilder.java
+++ b/function-web/src/main/java/io/micronaut/function/web/AnnotatedFunctionRouteBuilder.java
@@ -77,7 +77,7 @@ public class AnnotatedFunctionRouteBuilder
     public AnnotatedFunctionRouteBuilder(
         ExecutionHandleLocator executionHandleLocator,
         UriNamingStrategy uriNamingStrategy,
-        ConversionService<?> conversionService,
+        ConversionService conversionService,
         MediaTypeCodecRegistry codecRegistry,
         @Value("${micronaut.function.context-path:/}") String contextPath) {
         super(executionHandleLocator, uriNamingStrategy, conversionService);

--- a/function/src/main/java/io/micronaut/function/executor/StreamFunctionExecutor.java
+++ b/function/src/main/java/io/micronaut/function/executor/StreamFunctionExecutor.java
@@ -178,7 +178,7 @@ public class StreamFunctionExecutor<C> extends AbstractExecutor<C> {
     }
 
     private Object decodeInputArgument(
-        ConversionService<?> conversionService,
+        ConversionService conversionService,
         LocalFunctionRegistry localFunctionRegistry,
         Argument<?> arg,
         InputStream input) {
@@ -204,7 +204,7 @@ public class StreamFunctionExecutor<C> extends AbstractExecutor<C> {
     }
 
     private Object decodeContext(
-        ConversionService<?> conversionService,
+        ConversionService conversionService,
         Argument<?> arg,
         Object context) {
         if (ClassUtils.isJavaLangType(arg.getType())) {
@@ -216,7 +216,7 @@ public class StreamFunctionExecutor<C> extends AbstractExecutor<C> {
         throw new CodecException("Unable to decode argument from stream: " + arg);
     }
 
-    private Object doConvertInput(ConversionService<?> conversionService, Argument<?> arg, Object object) {
+    private Object doConvertInput(ConversionService conversionService, Argument<?> arg, Object object) {
         ArgumentConversionContext conversionContext = ConversionContext.of(arg);
         Optional<?> convert = conversionService.convert(object, conversionContext);
         if (convert.isPresent()) {

--- a/http-client-core/src/main/java/io/micronaut/http/client/bind/DefaultHttpClientBinderRegistry.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/bind/DefaultHttpClientBinderRegistry.java
@@ -80,7 +80,7 @@ public class DefaultHttpClientBinderRegistry implements HttpClientBinderRegistry
      * @param binders           The request binders
      * @param beanContext       The context to resolve beans
      */
-    protected DefaultHttpClientBinderRegistry(ConversionService<?> conversionService,
+    protected DefaultHttpClientBinderRegistry(ConversionService conversionService,
                                               List<ClientRequestBinder> binders,
                                               BeanContext beanContext) {
         byType.put(Argument.of(HttpHeaders.class).typeHashCode(), (ClientArgumentRequestBinder<HttpHeaders>) (context, uriContext, value, request) -> value.forEachValue(request::header));

--- a/http-client-core/src/main/java/io/micronaut/http/client/bind/binders/QueryValueClientArgumentRequestBinder.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/bind/binders/QueryValueClientArgumentRequestBinder.java
@@ -42,9 +42,9 @@ import java.util.Optional;
  */
 public class QueryValueClientArgumentRequestBinder implements AnnotatedClientArgumentRequestBinder<QueryValue> {
 
-    private final ConversionService<?> conversionService;
+    private final ConversionService conversionService;
 
-    public QueryValueClientArgumentRequestBinder(ConversionService<?> conversionService) {
+    public QueryValueClientArgumentRequestBinder(ConversionService conversionService) {
         this.conversionService = conversionService;
     }
 

--- a/http-client-core/src/main/java/io/micronaut/http/client/interceptor/HttpClientIntroductionAdvice.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/interceptor/HttpClientIntroductionAdvice.java
@@ -114,7 +114,7 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
     private final HttpClientBinderRegistry binderRegistry;
     private final JsonMediaTypeCodec jsonMediaTypeCodec;
     private final HttpClientRegistry<?> clientFactory;
-    private final ConversionService<?> conversionService;
+    private final ConversionService conversionService;
 
     /**
      * Constructor for advice class to setup things like Headers, Cookies, Parameters for Clients.
@@ -130,7 +130,7 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
             JsonMediaTypeCodec jsonMediaTypeCodec,
             List<ReactiveClientResultTransformer> transformers,
             HttpClientBinderRegistry binderRegistry,
-            ConversionService<?> conversionService) {
+            ConversionService conversionService) {
         this.clientFactory = clientFactory;
         this.jsonMediaTypeCodec = jsonMediaTypeCodec;
         this.transformers = transformers != null ? transformers : Collections.emptyList();
@@ -194,7 +194,7 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
                             .orElse(argument.getName());
                     // Convert and put as path param
                     if (argument.getAnnotationMetadata().hasStereotype(Format.class)) {
-                        ConversionService.SHARED.convert(value,
+                        conversionService.convert(value,
                                 ConversionContext.STRING.with(argument.getAnnotationMetadata()))
                                 .ifPresent(v -> pathParams.put(name, v));
                     } else {
@@ -461,9 +461,9 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
                 if (reactiveValueType == ByteBuffer.class) {
                     return byteBufferPublisher;
                 } else {
-                    if (ConversionService.SHARED.canConvert(ByteBuffer.class, reactiveValueType)) {
+                    if (conversionService.canConvert(ByteBuffer.class, reactiveValueType)) {
                         // It would be nice if we could capture the TypeConverter here
-                        return Publishers.map(byteBufferPublisher, value -> ConversionService.SHARED.convert(value, reactiveValueType).get());
+                        return Publishers.map(byteBufferPublisher, value -> conversionService.convert(value, reactiveValueType).get());
                     } else {
                         throw new ConfigurationException("Cannot create the generated HTTP client's " +
                                 "required return type, since no TypeConverter from ByteBuffer to " +

--- a/http-client-core/src/main/java/io/micronaut/http/client/loadbalance/LoadBalancerConverters.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/loadbalance/LoadBalancerConverters.java
@@ -15,10 +15,9 @@
  */
 package io.micronaut.http.client.loadbalance;
 
-import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.convert.MutableConversionService;
 import io.micronaut.core.convert.TypeConverterRegistrar;
 import io.micronaut.http.client.LoadBalancer;
-import jakarta.inject.Singleton;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -30,11 +29,10 @@ import java.net.URL;
  * @author graemerocher
  * @since 1.0
  */
-@Singleton
 public class LoadBalancerConverters implements TypeConverterRegistrar {
-    @SuppressWarnings("deprecation")
+
     @Override
-    public void register(ConversionService<?> conversionService) {
+    public void register(MutableConversionService conversionService) {
         conversionService.addConverter(URI.class, LoadBalancer.class, LoadBalancer::fixed);
         conversionService.addConverter(URL.class, LoadBalancer.class, LoadBalancer::fixed);
         conversionService.addConverter(String.class, LoadBalancer.class, url -> {

--- a/http-client-core/src/main/resources/META-INF/services/io.micronaut.core.convert.TypeConverterRegistrar
+++ b/http-client-core/src/main/resources/META-INF/services/io.micronaut.core.convert.TypeConverterRegistrar
@@ -1,0 +1,1 @@
+io.micronaut.http.client.loadbalance.LoadBalancerConverters

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -2399,7 +2399,7 @@ public class DefaultHttpClient implements
         }
 
         @Override
-        protected void buildResponse(Promise<? super HttpResponse<?>> promise, StreamedHttpResponse msg) {
+        protected void buildResponse(Promise<? super MutableHttpResponse<?>> promise, StreamedHttpResponse msg) {
             promise.trySuccess(new NettyStreamedHttpResponse<>(msg, conversionService));
         }
 

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -24,6 +24,7 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.core.beans.BeanMap;
 import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.convert.ConversionServiceAware;
 import io.micronaut.core.io.ResourceResolver;
 import io.micronaut.core.io.buffer.ByteBuffer;
 import io.micronaut.core.io.buffer.ByteBufferFactory;
@@ -252,7 +253,7 @@ public class DefaultHttpClient implements
     private final RequestBinderRegistry requestBinderRegistry;
     private final List<InvocationInstrumenterFactory> invocationInstrumenterFactories;
     private final String informationalServiceId;
-    private final ConversionService<?> conversionService;
+    private final ConversionService conversionService;
 
     /**
      * Construct a client for the given arguments.
@@ -265,6 +266,7 @@ public class DefaultHttpClient implements
      * @param codecRegistry                   The {@link MediaTypeCodecRegistry} to use for encoding and decoding objects
      * @param annotationMetadataResolver      The annotation metadata resolver
      * @param invocationInstrumenterFactories The invocation instrumeter factories to instrument netty handlers execution with
+     * @param conversionService               The conversion service
      * @param filters                         The filters to use
      */
     public DefaultHttpClient(@Nullable LoadBalancer loadBalancer,
@@ -275,6 +277,7 @@ public class DefaultHttpClient implements
             MediaTypeCodecRegistry codecRegistry,
             @Nullable AnnotationMetadataResolver annotationMetadataResolver,
             List<InvocationInstrumenterFactory> invocationInstrumenterFactories,
+            ConversionService conversionService,
             HttpClientFilter... filters) {
         this(loadBalancer,
             null,
@@ -286,13 +289,13 @@ public class DefaultHttpClient implements
             nettyClientSslBuilder,
             codecRegistry,
             WebSocketBeanRegistry.EMPTY,
-            new DefaultRequestBinderRegistry(ConversionService.SHARED),
+            new DefaultRequestBinderRegistry(conversionService),
             null,
             NioSocketChannel::new,
             CompositeNettyClientCustomizer.EMPTY,
             invocationInstrumenterFactories,
             null,
-            ConversionService.SHARED);
+            conversionService);
     }
 
     /**
@@ -313,6 +316,7 @@ public class DefaultHttpClient implements
      * @param clientCustomizer                The pipeline customizer
      * @param invocationInstrumenterFactories The invocation instrumeter factories to instrument netty handlers execution with
      * @param informationalServiceId          Optional service ID that will be passed to exceptions created by this client
+     * @param conversionService               The conversionService
      */
     public DefaultHttpClient(@Nullable LoadBalancer loadBalancer,
                              @Nullable HttpVersionSelection explicitHttpVersion,
@@ -330,7 +334,7 @@ public class DefaultHttpClient implements
                              NettyClientCustomizer clientCustomizer,
                              List<InvocationInstrumenterFactory> invocationInstrumenterFactories,
                              @Nullable String informationalServiceId,
-                             @NonNull ConversionService<?> conversionService
+                             ConversionService conversionService
     ) {
         ArgumentUtils.requireNonNull("nettyClientSslBuilder", nettyClientSslBuilder);
         ArgumentUtils.requireNonNull("codecRegistry", codecRegistry);
@@ -406,7 +410,7 @@ public class DefaultHttpClient implements
                 new NettyClientSslBuilder(new ResourceResolver()),
                 createDefaultMediaTypeRegistry(),
                 AnnotationMetadataResolver.DEFAULT,
-                Collections.emptyList());
+                Collections.emptyList(), ConversionService.SHARED);
     }
 
     /**
@@ -420,7 +424,7 @@ public class DefaultHttpClient implements
                 new NettyClientSslBuilder(new ResourceResolver()),
                 createDefaultMediaTypeRegistry(),
                 AnnotationMetadataResolver.DEFAULT,
-                invocationInstrumenterFactories);
+                invocationInstrumenterFactories, ConversionService.SHARED);
     }
 
     static boolean isAcceptEvents(io.micronaut.http.HttpRequest<?> request) {
@@ -539,6 +543,7 @@ public class DefaultHttpClient implements
     @SuppressWarnings("SubscriberImplementation")
     @Override
     public <I> Publisher<Event<ByteBuffer<?>>> eventStream(@NonNull io.micronaut.http.HttpRequest<I> request) {
+        setupConversionService(request);
         return eventStreamOrError(request, null);
     }
 
@@ -671,11 +676,13 @@ public class DefaultHttpClient implements
     @Override
     public <I, B> Publisher<Event<B>> eventStream(@NonNull io.micronaut.http.HttpRequest<I> request,
                                                   @NonNull Argument<B> eventType) {
+        setupConversionService(request);
         return eventStream(request, eventType, DEFAULT_ERROR_TYPE);
     }
 
     @Override
     public <I, B> Publisher<Event<B>> eventStream(@NonNull io.micronaut.http.HttpRequest<I> request, @NonNull Argument<B> eventType, @NonNull Argument<?> errorType) {
+        setupConversionService(request);
         return Flux.from(eventStreamOrError(request, errorType)).map(byteBufferEvent -> {
             ByteBuffer<?> data = byteBufferEvent.getData();
             Optional<MediaTypeCodec> registeredCodec;
@@ -697,11 +704,13 @@ public class DefaultHttpClient implements
 
     @Override
     public <I> Publisher<ByteBuffer<?>> dataStream(@NonNull io.micronaut.http.HttpRequest<I> request) {
+        setupConversionService(request);
         return dataStream(request, DEFAULT_ERROR_TYPE);
     }
 
     @Override
     public <I> Publisher<ByteBuffer<?>> dataStream(@NonNull io.micronaut.http.HttpRequest<I> request, @NonNull Argument<?> errorType) {
+        setupConversionService(request);
         final io.micronaut.http.HttpRequest<Object> parentRequest = ServerRequestContext.currentRequest().orElse(null);
         return new MicronautFlux<>(Flux.from(resolveRequestURI(request))
                 .flatMap(requestURI -> dataStreamImpl(toMutableRequest(request), errorType, parentRequest, requestURI)))
@@ -723,6 +732,7 @@ public class DefaultHttpClient implements
 
     @Override
     public <I> Publisher<io.micronaut.http.HttpResponse<ByteBuffer<?>>> exchangeStream(@NonNull io.micronaut.http.HttpRequest<I> request, @NonNull Argument<?> errorType) {
+        setupConversionService(request);
         io.micronaut.http.HttpRequest<Object> parentRequest = ServerRequestContext.currentRequest().orElse(null);
         return new MicronautFlux<>(Flux.from(resolveRequestURI(request))
                 .flatMap(uri -> exchangeStreamImpl(parentRequest, toMutableRequest(request), errorType, uri)))
@@ -741,7 +751,9 @@ public class DefaultHttpClient implements
 
     @Override
     public <I, O> Publisher<O> jsonStream(@NonNull io.micronaut.http.HttpRequest<I> request, @NonNull Argument<O> type, @NonNull Argument<?> errorType) {
+        setupConversionService(request);
         final io.micronaut.http.HttpRequest<Object> parentRequest = ServerRequestContext.currentRequest().orElse(null);
+        setupConversionService(parentRequest);
         return Flux.from(resolveRequestURI(request))
                 .flatMap(requestURI -> jsonStreamImpl(parentRequest, toMutableRequest(request), type, errorType, requestURI));
     }
@@ -754,11 +766,13 @@ public class DefaultHttpClient implements
 
     @Override
     public <I, O> Publisher<O> jsonStream(@NonNull io.micronaut.http.HttpRequest<I> request, @NonNull Class<O> type) {
+        setupConversionService(request);
         return jsonStream(request, io.micronaut.core.type.Argument.of(type));
     }
 
     @Override
     public <I, O, E> Publisher<io.micronaut.http.HttpResponse<O>> exchange(@NonNull io.micronaut.http.HttpRequest<I> request, @NonNull Argument<O> bodyType, @NonNull Argument<E> errorType) {
+        setupConversionService(request);
         final io.micronaut.http.HttpRequest<Object> parentRequest = ServerRequestContext.currentRequest().orElse(null);
         Publisher<URI> uriPublisher = resolveRequestURI(request);
         return Flux.from(uriPublisher)
@@ -767,6 +781,7 @@ public class DefaultHttpClient implements
 
     @Override
     public <I, O, E> Publisher<O> retrieve(io.micronaut.http.HttpRequest<I> request, Argument<O> bodyType, Argument<E> errorType) {
+        setupConversionService(request);
         // mostly same as default impl, but with exception customization
         return Flux.from(exchange(request, bodyType, errorType)).map(response -> {
             if (bodyType.getType() == HttpStatus.class) {
@@ -790,6 +805,7 @@ public class DefaultHttpClient implements
 
     @Override
     public <T extends AutoCloseable> Publisher<T> connect(Class<T> clientEndpointType, io.micronaut.http.MutableHttpRequest<?> request) {
+        setupConversionService(request);
         Publisher<URI> uriPublisher = resolveRequestURI(request);
         return Flux.from(uriPublisher)
                 .switchMap(resolvedURI -> connectWebSocket(resolvedURI, request, clientEndpointType, null));
@@ -851,7 +867,8 @@ public class DefaultHttpClient implements
             WebSocketClientHandshakerFactory.newHandshaker(
                 webSocketURL, protocolVersion, subprotocol, true, customHeaders, maxFramePayloadLength),
             requestBinderRegistry,
-            mediaTypeCodecRegistry);
+            mediaTypeCodecRegistry,
+            conversionService);
 
         return connectionManager.connectForWebsocket(requestKey, handler)
             .then(handler.getHandshakeCompletedMono());
@@ -872,7 +889,7 @@ public class DefaultHttpClient implements
                             traceBody("Response", byteBuf);
                         }
                         ByteBuffer<?> byteBuffer = byteBufferFactory.wrap(byteBuf);
-                        NettyStreamedHttpResponse<ByteBuffer<?>> thisResponse = new NettyStreamedHttpResponse<>(streamedHttpResponse);
+                        NettyStreamedHttpResponse<ByteBuffer<?>> thisResponse = new NettyStreamedHttpResponse<>(streamedHttpResponse, conversionService);
                         thisResponse.setBody(byteBuffer);
                         return (HttpResponse<ByteBuffer<?>>) new HttpResponseWrapper<>(thisResponse);
                     });
@@ -964,6 +981,7 @@ public class DefaultHttpClient implements
     @Override
     public Publisher<MutableHttpResponse<?>> proxy(@NonNull io.micronaut.http.HttpRequest<?> request, @NonNull ProxyRequestOptions options) {
         Objects.requireNonNull(options, "options");
+        setupConversionService(request);
         return Flux.from(resolveRequestURI(request))
                 .flatMap(requestURI -> {
                     io.micronaut.http.MutableHttpRequest<?> httpRequest = toMutableRequest(request);
@@ -986,6 +1004,12 @@ public class DefaultHttpClient implements
                     );
                     return proxyResponsePublisher;
                 });
+    }
+
+    private void setupConversionService(io.micronaut.http.HttpRequest<?> httpRequest) {
+        if (httpRequest instanceof ConversionServiceAware) {
+            ((ConversionServiceAware) httpRequest).setConversionService(conversionService);
+        }
     }
 
     private <I> Flux<MutableHttpResponse<?>> connectAndStream(
@@ -1425,7 +1449,7 @@ public class DefaultHttpClient implements
                                 public void onComplete() {
                                     try {
                                         FullHttpResponse fullHttpResponse = new DefaultFullHttpResponse(nettyResponse.protocolVersion(), nettyResponse.status(), buffer, nettyResponse.headers(), new DefaultHttpHeaders(true));
-                                        final FullNettyClientHttpResponse<Object> fullNettyClientHttpResponse = new FullNettyClientHttpResponse<>(fullHttpResponse, mediaTypeCodecRegistry, byteBufferFactory, (Argument<Object>) errorType, true);
+                                        final FullNettyClientHttpResponse<Object> fullNettyClientHttpResponse = new FullNettyClientHttpResponse<>(fullHttpResponse, mediaTypeCodecRegistry, byteBufferFactory, (Argument<Object>) errorType, true, conversionService);
                                         fullNettyClientHttpResponse.onComplete();
                                         emitter.error(customizeException(new HttpClientResponseException(
                                             fullHttpResponse.status().reasonPhrase(),
@@ -2195,7 +2219,7 @@ public class DefaultHttpClient implements
                 boolean convertBodyWithBodyType = msg.status().code() < 400 ||
                         (!DefaultHttpClient.this.configuration.isExceptionOnErrorStatus() && bodyType.equalsType(errorType));
                 FullNettyClientHttpResponse<O> response
-                        = new FullNettyClientHttpResponse<>(msg, mediaTypeCodecRegistry, byteBufferFactory, bodyType, convertBodyWithBodyType);
+                        = new FullNettyClientHttpResponse<>(msg, mediaTypeCodecRegistry, byteBufferFactory, bodyType, convertBodyWithBodyType, conversionService);
 
                 if (convertBodyWithBodyType) {
                     promise.trySuccess(response);
@@ -2253,7 +2277,8 @@ public class DefaultHttpClient implements
                     mediaTypeCodecRegistry,
                     byteBufferFactory,
                     null,
-                    false
+                    false,
+                    conversionService
             );
             // this onComplete call disables further parsing by HttpClientResponseException
             errorResponse.onComplete();
@@ -2271,7 +2296,8 @@ public class DefaultHttpClient implements
                     mediaTypeCodecRegistry,
                     byteBufferFactory,
                     null,
-                    false
+                    false,
+                    conversionService
             );
             HttpClientResponseException clientResponseError = customizeException(new HttpClientResponseException(
                 "Error decoding HTTP response body: " + t.getMessage(),
@@ -2344,7 +2370,7 @@ public class DefaultHttpClient implements
                     msg.headers(),
                     bodyPublisher
             );
-            promise.trySuccess(new NettyStreamedHttpResponse<>(nettyResponse));
+            promise.trySuccess(new NettyStreamedHttpResponse<>(nettyResponse, conversionService));
         }
 
         @Override
@@ -2367,15 +2393,14 @@ public class DefaultHttpClient implements
             return msg instanceof StreamedHttpResponse;
         }
 
-        @Override
         protected void removeHandler(ChannelHandlerContext ctx) {
             ctx.pipeline().remove(ChannelPipelineCustomizer.HANDLER_MICRONAUT_HTTP_RESPONSE_FULL);
             ctx.pipeline().remove(ChannelPipelineCustomizer.HANDLER_MICRONAUT_HTTP_RESPONSE_STREAM);
         }
 
         @Override
-        protected void buildResponse(Promise<? super MutableHttpResponse<?>> promise, StreamedHttpResponse msg) {
-            promise.trySuccess(new NettyStreamedHttpResponse<>(msg));
+        protected void buildResponse(Promise<? super HttpResponse<?>> promise, StreamedHttpResponse msg) {
+            promise.trySuccess(new NettyStreamedHttpResponse<>(msg, conversionService));
         }
 
         @Override

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultNettyHttpClientRegistry.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultNettyHttpClientRegistry.java
@@ -421,7 +421,6 @@ class DefaultNettyHttpClientRegistry implements AutoCloseable,
                 resolveSocketChannelFactory(configuration, beanContext),
                 clientCustomizer,
                 invocationInstrumenterFactories,
-                clientId
                 clientId,
                 conversionService
         );

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultNettyHttpClientRegistry.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultNettyHttpClientRegistry.java
@@ -421,6 +421,7 @@ class DefaultNettyHttpClientRegistry implements AutoCloseable,
                 resolveSocketChannelFactory(configuration, beanContext),
                 clientCustomizer,
                 invocationInstrumenterFactories,
+                clientId
                 clientId,
                 conversionService
         );

--- a/http-client/src/main/java/io/micronaut/http/client/netty/MutableHttpRequestWrapper.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/MutableHttpRequestWrapper.java
@@ -39,19 +39,19 @@ import java.util.Optional;
  */
 @Internal
 final class MutableHttpRequestWrapper<B> extends HttpRequestWrapper<B> implements MutableHttpRequest<B> {
-    private final ConversionService<?> conversionService;
+    private ConversionService conversionService;
 
     @Nullable
     private B body;
     @Nullable
     private URI uri;
 
-    MutableHttpRequestWrapper(ConversionService<?> conversionService, HttpRequest<B> delegate) {
+    MutableHttpRequestWrapper(ConversionService conversionService, HttpRequest<B> delegate) {
         super(delegate);
         this.conversionService = conversionService;
     }
 
-    static MutableHttpRequest<?> wrapIfNecessary(ConversionService<?> conversionService, HttpRequest<?> request) {
+    static MutableHttpRequest<?> wrapIfNecessary(ConversionService conversionService, HttpRequest<?> request) {
         if (request instanceof MutableHttpRequest<?>) {
             return (MutableHttpRequest<?>) request;
         } else {
@@ -127,5 +127,10 @@ final class MutableHttpRequestWrapper<B> extends HttpRequestWrapper<B> implement
     public <T> MutableHttpRequest<T> body(T body) {
         this.body = (B) body;
         return (MutableHttpRequest<T>) this;
+    }
+
+    @Override
+    public void setConversionService(ConversionService conversionService) {
+        this.conversionService = conversionService;
     }
 }

--- a/http-client/src/main/java/io/micronaut/http/client/netty/NettyClientHttpRequest.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/NettyClientHttpRequest.java
@@ -76,6 +76,7 @@ class NettyClientHttpRequest<B> implements MutableHttpRequest<B>, NettyHttpReque
     private URI uri;
     private Object body;
     private NettyHttpParameters httpParameters;
+    private ConversionService conversionService = ConversionService.SHARED;
 
     /**
      * This constructor is actually required for the case of non-standard http methods.
@@ -175,7 +176,7 @@ class NettyClientHttpRequest<B> implements MutableHttpRequest<B>, NettyHttpReque
 
     @Override
     public <T> Optional<T> getBody(Argument<T> type) {
-        return getBody().flatMap(b -> ConversionService.SHARED.convert(b, ConversionContext.of(type)));
+        return getBody().flatMap(b -> conversionService.convert(b, ConversionContext.of(type)));
     }
 
     @Override
@@ -217,7 +218,7 @@ class NettyClientHttpRequest<B> implements MutableHttpRequest<B>, NettyHttpReque
     private NettyHttpParameters decodeParameters(URI uri) {
         QueryStringDecoder queryStringDecoder = createDecoder(uri);
         return new NettyHttpParameters(queryStringDecoder.parameters(),
-                ConversionService.SHARED,
+                conversionService,
                 (name, value) -> {
                     UriBuilder newUri = UriBuilder.of(getUri());
                     newUri.replaceQueryParam(name.toString(), value.toArray());
@@ -326,5 +327,10 @@ class NettyClientHttpRequest<B> implements MutableHttpRequest<B>, NettyHttpReque
     @Override
     public boolean isStream() {
         return body instanceof Publisher;
+    }
+
+    @Override
+    public void setConversionService(ConversionService conversionService) {
+        this.conversionService = conversionService;
     }
 }

--- a/http-client/src/main/java/io/micronaut/http/client/netty/NettyStreamedHttpResponse.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/NettyStreamedHttpResponse.java
@@ -57,10 +57,11 @@ class NettyStreamedHttpResponse<B> implements MutableHttpResponse<B>, NettyHttpR
 
     /**
      * @param response The streamed Http response
+     * @param conversionService The conversion service
      */
-    NettyStreamedHttpResponse(StreamedHttpResponse response) {
+    NettyStreamedHttpResponse(StreamedHttpResponse response, ConversionService conversionService) {
         this.nettyResponse = response;
-        this.headers = new NettyHttpHeaders(response.headers(), ConversionService.SHARED);
+        this.headers = new NettyHttpHeaders(response.headers(), conversionService);
     }
 
     /**

--- a/http-client/src/main/java/io/micronaut/http/client/netty/websocket/NettyWebSocketClientHandler.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/websocket/NettyWebSocketClientHandler.java
@@ -87,23 +87,26 @@ public class NettyWebSocketClientHandler<T> extends AbstractNettyWebSocketHandle
 
     /**
      * Default constructor.
-     *  @param request The originating request that created the WebSocket.
-     * @param webSocketBean The WebSocket client bean.
-     * @param handshaker The handshaker
-     * @param requestBinderRegistry The request binder registry
+     *
+     * @param request                The originating request that created the WebSocket.
+     * @param webSocketBean          The WebSocket client bean.
+     * @param handshaker             The handshaker
+     * @param requestBinderRegistry  The request binder registry
      * @param mediaTypeCodecRegistry The media type codec registry
+     * @param conversionService      The conversionService
      */
     public NettyWebSocketClientHandler(
             MutableHttpRequest<?> request,
             WebSocketBean<T> webSocketBean,
             final WebSocketClientHandshaker handshaker,
             RequestBinderRegistry requestBinderRegistry,
-            MediaTypeCodecRegistry mediaTypeCodecRegistry) {
-        super(null, requestBinderRegistry, mediaTypeCodecRegistry, webSocketBean, request, Collections.emptyMap(), handshaker.version(), handshaker.actualSubprotocol(), null);
+            MediaTypeCodecRegistry mediaTypeCodecRegistry,
+            ConversionService conversionService) {
+        super(null, requestBinderRegistry, mediaTypeCodecRegistry, webSocketBean, request, Collections.emptyMap(), handshaker.version(), handshaker.actualSubprotocol(), null, conversionService);
         this.codecRegistry = mediaTypeCodecRegistry;
         this.handshaker = handshaker;
         this.genericWebSocketBean = webSocketBean;
-        this.webSocketStateBinderRegistry = new WebSocketStateBinderRegistry(requestBinderRegistry != null ? requestBinderRegistry : new DefaultRequestBinderRegistry(ConversionService.SHARED));
+        this.webSocketStateBinderRegistry = new WebSocketStateBinderRegistry(requestBinderRegistry != null ? requestBinderRegistry : new DefaultRequestBinderRegistry(conversionService), conversionService);
         String clientPath = webSocketBean.getBeanDefinition().stringValue(ClientWebSocket.class).orElse("");
         UriMatchTemplate matchTemplate = UriMatchTemplate.of(clientPath);
         this.matchInfo = matchTemplate.match(request.getPath()).orElse(null);
@@ -282,7 +285,7 @@ public class NettyWebSocketClientHandler<T> extends AbstractNettyWebSocketHandle
                 @Override
                 public ConvertibleValues<Object> getUriVariables() {
                     if (matchInfo != null) {
-                        return ConvertibleValues.of(matchInfo.getVariableValues());
+                        return ConvertibleValues.of(matchInfo.getVariableValues(), conversionService);
                     }
                     return ConvertibleValues.empty();
                 }

--- a/http-client/src/test/groovy/io/micronaut/http/client/HttpPostSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/HttpPostSpec.groovy
@@ -19,6 +19,7 @@ import groovy.transform.EqualsAndHashCode
 import io.micronaut.context.annotation.Property
 import io.micronaut.context.annotation.Requires
 import io.micronaut.core.annotation.Introspected
+import io.micronaut.core.convert.ConversionService
 import io.micronaut.core.type.Argument
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponse
@@ -50,6 +51,9 @@ class HttpPostSpec extends Specification {
 
     @Inject
     PostClient postClient
+
+    @Inject
+    ConversionService conversionService
 
     void "test send invalid http method"() {
         given:
@@ -382,6 +386,12 @@ class HttpPostSpec extends Specification {
     void "test http post getBody should return right type"() {
         when:
         def request = HttpRequest.POST('/', JsonObject.createObjectNode([:]))
+
+        then:
+        request.getBody(String).get() != '{}'
+
+        when:
+        request.setConversionService(conversionService)
 
         then:
         request.getBody(String).get() == '{}'

--- a/http-client/src/test/groovy/io/micronaut/http/client/netty/FullNettyClientHttpResponseSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/netty/FullNettyClientHttpResponseSpec.groovy
@@ -1,6 +1,6 @@
 package io.micronaut.http.client.netty
 
-
+import io.micronaut.core.convert.ConversionService
 import io.micronaut.http.cookie.Cookie
 import io.micronaut.http.cookie.Cookies
 import io.netty.handler.codec.http.DefaultFullHttpResponse
@@ -22,7 +22,7 @@ class FullNettyClientHttpResponseSpec extends Specification {
           fullHttpResponse.headers().set(httpHeaders)
 
         when:
-          FullNettyClientHttpResponse response = new FullNettyClientHttpResponse(fullHttpResponse, null, null, null, false)
+          FullNettyClientHttpResponse response = new FullNettyClientHttpResponse(fullHttpResponse, null, null, null, false, ConversionService.SHARED)
 
         then:
             Cookies cookies = response.getCookies()
@@ -45,7 +45,7 @@ class FullNettyClientHttpResponseSpec extends Specification {
         fullHttpResponse.headers().set(httpHeaders)
 
         when:
-        FullNettyClientHttpResponse response = new FullNettyClientHttpResponse(fullHttpResponse, null, null, null, false)
+        FullNettyClientHttpResponse response = new FullNettyClientHttpResponse(fullHttpResponse, null, null, null, false, ConversionService.SHARED)
 
         then:
         Cookies cookies = response.getCookies()

--- a/http-client/src/test/groovy/io/micronaut/http/client/netty/NettyStreamedHttpResponseSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/netty/NettyStreamedHttpResponseSpec.groovy
@@ -1,5 +1,6 @@
 package io.micronaut.http.client.netty
 
+import io.micronaut.core.convert.ConversionService
 import io.micronaut.http.cookie.Cookie
 import io.micronaut.http.cookie.Cookies
 import io.micronaut.http.netty.stream.DefaultStreamedHttpResponse
@@ -21,7 +22,7 @@ class NettyStreamedHttpResponseSpec extends Specification {
         streamedHttpResponse.headers().set(httpHeaders)
 
         when:
-        NettyStreamedHttpResponse response = new NettyStreamedHttpResponse(streamedHttpResponse)
+        NettyStreamedHttpResponse response = new NettyStreamedHttpResponse(streamedHttpResponse, ConversionService.SHARED)
 
         then:
         Cookies cookies = response.getCookies()
@@ -44,7 +45,7 @@ class NettyStreamedHttpResponseSpec extends Specification {
         streamedHttpResponse.headers().set(httpHeaders)
 
         when:
-        NettyStreamedHttpResponse response = new NettyStreamedHttpResponse(streamedHttpResponse)
+        NettyStreamedHttpResponse response = new NettyStreamedHttpResponse(streamedHttpResponse, ConversionService.SHARED)
 
         then:
         Cookies cookies = response.getCookies()
@@ -68,7 +69,7 @@ class NettyStreamedHttpResponseSpec extends Specification {
         streamedHttpResponse.headers().set(httpHeaders)
 
         when:
-        NettyStreamedHttpResponse response = new NettyStreamedHttpResponse(streamedHttpResponse)
+        NettyStreamedHttpResponse response = new NettyStreamedHttpResponse(streamedHttpResponse, ConversionService.SHARED)
         response.cookie(Cookie.of("ADDED", "xyz").httpOnly(true).domain(".foo.com"))
 
         then:

--- a/http-netty/src/main/java/io/micronaut/http/netty/AbstractNettyHttpRequest.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/AbstractNettyHttpRequest.java
@@ -54,7 +54,7 @@ public abstract class AbstractNettyHttpRequest<B> extends DefaultAttributeMap im
     public static final AsciiString STREAM_ID = HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text();
     public static final AsciiString HTTP2_SCHEME = HttpConversionUtil.ExtensionHeaderNames.SCHEME.text();
     protected final io.netty.handler.codec.http.HttpRequest nettyRequest;
-    protected final ConversionService<?> conversionService;
+    protected final ConversionService conversionService;
     protected final HttpMethod httpMethod;
     protected final URI uri;
     protected final String httpMethodName;

--- a/http-netty/src/main/java/io/micronaut/http/netty/NettyHttpHeaders.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/NettyHttpHeaders.java
@@ -50,7 +50,7 @@ import java.util.stream.Collectors;
 public class NettyHttpHeaders implements MutableHttpHeaders {
 
     io.netty.handler.codec.http.HttpHeaders nettyHeaders;
-    final ConversionService<?> conversionService;
+    ConversionService conversionService;
 
     /**
      * @param nettyHeaders      The Netty Http headers
@@ -233,4 +233,13 @@ public class NettyHttpHeaders implements MutableHttpHeaders {
         return add(HttpHeaderNames.CONTENT_TYPE, mediaType);
     }
 
+    @Override
+    public ConversionService getConversionService() {
+        return conversionService;
+    }
+
+    @Override
+    public void setConversionService(ConversionService conversionService) {
+        this.conversionService = conversionService;
+    }
 }

--- a/http-netty/src/main/java/io/micronaut/http/netty/NettyHttpParameters.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/NettyHttpParameters.java
@@ -19,7 +19,6 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.ConversionService;
-import io.micronaut.core.convert.value.ConvertibleMultiValues;
 import io.micronaut.core.convert.value.ConvertibleMultiValuesMap;
 import io.micronaut.http.MutableHttpParameters;
 
@@ -44,7 +43,7 @@ import java.util.stream.Collectors;
 public class NettyHttpParameters implements MutableHttpParameters {
 
     private final LinkedHashMap<CharSequence, List<String>> valuesMap;
-    private final ConvertibleMultiValues<String> values;
+    private final ConvertibleMultiValuesMap<String> values;
     private final BiConsumer<CharSequence, List<String>> onChange;
 
     /**
@@ -53,7 +52,7 @@ public class NettyHttpParameters implements MutableHttpParameters {
      * @param onChange A callback for changes
      */
     public NettyHttpParameters(Map<String, List<String>> parameters,
-                               ConversionService<?> conversionService,
+                               ConversionService conversionService,
                                @Nullable BiConsumer<CharSequence, List<String>> onChange) {
         this.valuesMap = new LinkedHashMap<>(parameters.size());
         this.values = new ConvertibleMultiValuesMap<>(valuesMap, conversionService);
@@ -107,5 +106,15 @@ public class NettyHttpParameters implements MutableHttpParameters {
             onChange.accept(name, valueList);
         }
         return this;
+    }
+
+    @Override
+    public ConversionService getConversionService() {
+        return values.getConversionService();
+    }
+
+    @Override
+    public void setConversionService(ConversionService conversionService) {
+        values.setConversionService(conversionService);
     }
 }

--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/converters/KQueueChannelOptionFactory.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/converters/KQueueChannelOptionFactory.java
@@ -18,7 +18,7 @@ package io.micronaut.http.netty.channel.converters;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.env.Environment;
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.convert.MutableConversionService;
 import io.micronaut.core.convert.TypeConverterRegistrar;
 import io.micronaut.http.netty.channel.KQueueAvailabilityCondition;
 import io.netty.channel.ChannelOption;
@@ -56,7 +56,7 @@ public class KQueueChannelOptionFactory implements ChannelOptionFactory, TypeCon
     }
 
     @Override
-    public void register(ConversionService<?> conversionService) {
+    public void register(MutableConversionService conversionService) {
         conversionService.addConverter(
                 Map.class,
                 AcceptFilter.class,

--- a/http-netty/src/main/java/io/micronaut/http/netty/cookies/NettyCookies.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/cookies/NettyCookies.java
@@ -45,7 +45,7 @@ public class NettyCookies implements Cookies {
 
     private static final Logger LOG = LoggerFactory.getLogger(NettyCookies.class);
 
-    private final ConversionService<?> conversionService;
+    private final ConversionService conversionService;
     private final Map<CharSequence, Cookie> cookies;
 
     /**
@@ -131,5 +131,10 @@ public class NettyCookies implements Cookies {
     @Override
     public Collection<Cookie> values() {
         return Collections.unmodifiableCollection(cookies.values());
+    }
+
+    @Override
+    public ConversionService getConversionService() {
+        return conversionService;
     }
 }

--- a/http-server-netty/build.gradle
+++ b/http-server-netty/build.gradle
@@ -42,11 +42,12 @@ dependencies {
         testImplementation libs.bcpkix
     }
 
-    testImplementation(libs.managed.micronaut.xml) {
-        exclude module:'micronaut-inject'
-        exclude module:'micronaut-http'
-        exclude module:'micronaut-bom'
-    }
+// Add Micronaut Jackson XML after v4 Migration
+//    testImplementation(libs.managed.micronaut.xml) {
+//        exclude module:'micronaut-inject'
+//        exclude module:'micronaut-http'
+//        exclude module:'micronaut-bom'
+//    }
     testImplementation libs.managed.jackson.databind
 
     // http impls for tests

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/HttpPipelineBuilder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/HttpPipelineBuilder.java
@@ -132,8 +132,8 @@ final class HttpPipelineBuilder {
                 embeddedServices.getEventPublisher(HttpRequestReceivedEvent.class));
         responseEncoder = new HttpResponseEncoder(
                 embeddedServices.getMediaTypeCodecRegistry(),
-                server.getServerConfiguration()
-        );
+                server.getServerConfiguration(),
+                embeddedServices.getApplicationContext().getConversionService());
     }
 
     boolean supportsSsl() {

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyEmbeddedServerInstance.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyEmbeddedServerInstance.java
@@ -20,6 +20,7 @@ import io.micronaut.context.annotation.Parameter;
 import io.micronaut.context.annotation.Prototype;
 import io.micronaut.context.env.Environment;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.value.ConvertibleValues;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.discovery.EmbeddedServerInstance;
@@ -48,6 +49,7 @@ class NettyEmbeddedServerInstance implements EmbeddedServerInstance {
     private final Environment environment;
     private final List<ServiceInstanceMetadataContributor> metadataContributors;
     private final BeanLocator beanLocator;
+    private final ConversionService conversionService;
 
     private ConvertibleValues<String> instanceMetadata;
 
@@ -57,19 +59,21 @@ class NettyEmbeddedServerInstance implements EmbeddedServerInstance {
      * @param environment          The Environment
      * @param beanLocator          The bean locator
      * @param metadataContributors The {@link ServiceInstanceMetadataContributor}
+     * @param conversionService    The conversion service
      */
     NettyEmbeddedServerInstance(
-            @Parameter String id,
-            @Parameter NettyHttpServer nettyHttpServer,
-            Environment environment,
-            BeanLocator beanLocator,
-            List<ServiceInstanceMetadataContributor> metadataContributors) {
+        @Parameter String id,
+        @Parameter NettyHttpServer nettyHttpServer,
+        Environment environment,
+        BeanLocator beanLocator,
+        List<ServiceInstanceMetadataContributor> metadataContributors, ConversionService conversionService) {
 
         this.id = id;
         this.nettyHttpServer = nettyHttpServer;
         this.environment = environment;
         this.beanLocator = beanLocator;
         this.metadataContributors = metadataContributors;
+        this.conversionService = conversionService;
     }
 
     @Override
@@ -108,7 +112,7 @@ class NettyEmbeddedServerInstance implements EmbeddedServerInstance {
             if (cloudMetadata != null) {
                 cloudMetadata.putAll(metadata);
             }
-            instanceMetadata = ConvertibleValues.of(cloudMetadata);
+            instanceMetadata = ConvertibleValues.of(cloudMetadata, conversionService);
         }
         return instanceMetadata;
     }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpRequest.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpRequest.java
@@ -627,8 +627,17 @@ public class NettyHttpRequest<T> extends AbstractNettyHttpRequest<T> implements 
     private class NettyMutableHttpRequest implements MutableHttpRequest<T>, NettyHttpRequestBuilder {
 
         private URI uri = NettyHttpRequest.this.uri;
+        @Nullable
         private MutableHttpParameters httpParameters;
+        @Nullable
         private Object body;
+
+        @Override
+        public void setConversionService(ConversionService conversionService) {
+            if (httpParameters != null) {
+                httpParameters.setConversionService(conversionService);
+            }
+        }
 
         @Override
         public MutableHttpRequest<T> cookie(Cookie cookie) {

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
@@ -176,7 +176,8 @@ public class NettyHttpServer implements NettyEmbeddedServer {
                 nettyEmbeddedServices,
                 ioExecutor,
                 httpContentProcessorResolver,
-                httpRequestTerminatedEventPublisher
+                httpRequestTerminatedEventPublisher,
+                applicationContext.getConversionService()
         );
         this.hostResolver = new DefaultHttpHostResolver(serverConfiguration, () -> NettyHttpServer.this);
 

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/NettyBinderRegistrar.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/NettyBinderRegistrar.java
@@ -20,7 +20,6 @@ import io.micronaut.context.BeanProvider;
 import io.micronaut.context.event.BeanCreatedEvent;
 import io.micronaut.context.event.BeanCreatedEventListener;
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.http.bind.RequestBinderRegistry;
 import io.micronaut.http.server.HttpServerConfiguration;
@@ -42,7 +41,7 @@ import java.util.concurrent.ExecutorService;
 @Internal
 class NettyBinderRegistrar implements BeanCreatedEventListener<RequestBinderRegistry> {
 
-    private final ConversionService<?> conversionService;
+    private final ConversionService conversionService;
     private final HttpContentProcessorResolver httpContentProcessorResolver;
     private final BeanLocator beanLocator;
     private final BeanProvider<HttpServerConfiguration> httpServerConfiguration;
@@ -57,13 +56,12 @@ class NettyBinderRegistrar implements BeanCreatedEventListener<RequestBinderRegi
      * @param httpServerConfiguration      The server config
      * @param executorService              The executor to offload blocking operations
      */
-    NettyBinderRegistrar(
-            @Nullable ConversionService<?> conversionService,
-            HttpContentProcessorResolver httpContentProcessorResolver,
-            BeanLocator beanLocator,
-            BeanProvider<HttpServerConfiguration> httpServerConfiguration,
-            @Named(TaskExecutors.IO) BeanProvider<ExecutorService> executorService) {
-        this.conversionService = conversionService == null ? ConversionService.SHARED : conversionService;
+    NettyBinderRegistrar(ConversionService conversionService,
+                         HttpContentProcessorResolver httpContentProcessorResolver,
+                         BeanLocator beanLocator,
+                         BeanProvider<HttpServerConfiguration> httpServerConfiguration,
+                         @Named(TaskExecutors.IO) BeanProvider<ExecutorService> executorService) {
+        this.conversionService = conversionService;
         this.httpContentProcessorResolver = httpContentProcessorResolver;
         this.beanLocator = beanLocator;
         this.httpServerConfiguration = httpServerConfiguration;

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/converters/NettyConverters.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/converters/NettyConverters.java
@@ -18,6 +18,7 @@ package io.micronaut.http.server.netty.converters;
 import io.micronaut.context.BeanProvider;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.convert.MutableConversionService;
 import io.micronaut.core.convert.TypeConverter;
 import io.micronaut.core.convert.TypeConverterRegistrar;
 import io.micronaut.core.naming.NameUtils;
@@ -50,7 +51,7 @@ import java.util.Optional;
 @Internal
 public class NettyConverters implements TypeConverterRegistrar {
 
-    private final ConversionService<?> conversionService;
+    private final ConversionService conversionService;
     private final BeanProvider<MediaTypeCodecRegistry> decoderRegistryProvider;
     private final ChannelOptionFactory channelOptionFactory;
 
@@ -60,7 +61,7 @@ public class NettyConverters implements TypeConverterRegistrar {
      * @param decoderRegistryProvider The decoder registry provider
      * @param channelOptionFactory The decoder channel option factory
      */
-    public NettyConverters(ConversionService<?> conversionService,
+    public NettyConverters(ConversionService conversionService,
                            //Prevent early initialization of the codecs
                            BeanProvider<MediaTypeCodecRegistry> decoderRegistryProvider,
                            ChannelOptionFactory channelOptionFactory) {
@@ -70,7 +71,7 @@ public class NettyConverters implements TypeConverterRegistrar {
     }
 
     @Override
-    public void register(ConversionService<?> conversionService) {
+    public void register(MutableConversionService conversionService) {
         conversionService.addConverter(
                 CharSequence.class,
                 ChannelOption.class,

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/converters/NettyConvertersSpi.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/converters/NettyConvertersSpi.java
@@ -16,7 +16,7 @@
 package io.micronaut.http.server.netty.converters;
 
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.convert.MutableConversionService;
 import io.micronaut.core.convert.TypeConverter;
 import io.micronaut.core.convert.TypeConverterRegistrar;
 import io.micronaut.http.multipart.CompletedFileUpload;
@@ -47,7 +47,7 @@ import java.util.Optional;
 @Internal
 public final class NettyConvertersSpi implements TypeConverterRegistrar {
     @Override
-    public void register(ConversionService<?> conversionService) {
+    public void register(MutableConversionService conversionService) {
         conversionService.addConverter(
             ByteBuf.class,
             CharSequence.class,

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/decoders/HttpRequestDecoder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/decoders/HttpRequestDecoder.java
@@ -54,7 +54,7 @@ public class HttpRequestDecoder extends MessageToMessageDecoder<HttpRequest> imp
     private static final Logger LOG = LoggerFactory.getLogger(NettyHttpServer.class);
 
     private final EmbeddedServer embeddedServer;
-    private final ConversionService<?> conversionService;
+    private final ConversionService conversionService;
     private final HttpServerConfiguration configuration;
     private final ApplicationEventPublisher<HttpRequestReceivedEvent> httpRequestReceivedEventPublisher;
 
@@ -64,7 +64,7 @@ public class HttpRequestDecoder extends MessageToMessageDecoder<HttpRequest> imp
      * @param configuration     The Http server configuration
      * @param httpRequestReceivedEventPublisher The publisher of {@link HttpRequestReceivedEvent}
      */
-    public HttpRequestDecoder(EmbeddedServer embeddedServer, ConversionService<?> conversionService, HttpServerConfiguration configuration, ApplicationEventPublisher<HttpRequestReceivedEvent> httpRequestReceivedEventPublisher) {
+    public HttpRequestDecoder(EmbeddedServer embeddedServer, ConversionService conversionService, HttpServerConfiguration configuration, ApplicationEventPublisher<HttpRequestReceivedEvent> httpRequestReceivedEventPublisher) {
         this.embeddedServer = embeddedServer;
         this.conversionService = conversionService;
         this.configuration = configuration;

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/encoders/HttpResponseEncoder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/encoders/HttpResponseEncoder.java
@@ -17,6 +17,7 @@ package io.micronaut.http.server.netty.encoders;
 
 import io.micronaut.buffer.netty.NettyByteBufferFactory;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.io.Writable;
 import io.micronaut.core.io.buffer.ByteBuffer;
 import io.micronaut.http.HttpHeaders;
@@ -64,16 +65,19 @@ public class HttpResponseEncoder extends MessageToMessageEncoder<MutableHttpResp
 
     private final MediaTypeCodecRegistry mediaTypeCodecRegistry;
     private final HttpServerConfiguration serverConfiguration;
+    private final ConversionService conversionService;
 
     /**
      * Default constructor.
      *
      * @param mediaTypeCodecRegistry The media type registry
-     * @param serverConfiguration The server config
+     * @param serverConfiguration    The server config
+     * @param conversionService      The conversion service
      */
-    public HttpResponseEncoder(MediaTypeCodecRegistry mediaTypeCodecRegistry, HttpServerConfiguration serverConfiguration) {
+    public HttpResponseEncoder(MediaTypeCodecRegistry mediaTypeCodecRegistry, HttpServerConfiguration serverConfiguration, ConversionService conversionService) {
         this.mediaTypeCodecRegistry = mediaTypeCodecRegistry;
         this.serverConfiguration = serverConfiguration;
+        this.conversionService = conversionService;
     }
 
     @Override
@@ -105,7 +109,7 @@ public class HttpResponseEncoder extends MessageToMessageEncoder<MutableHttpResp
                 response = encodeBodyWithCodec(response, body, codec, responseMediaType, context);
             }
 
-            MediaTypeCodec defaultCodec = new TextPlainCodec(serverConfiguration.getDefaultCharset());
+            MediaTypeCodec defaultCodec = new TextPlainCodec(serverConfiguration.getDefaultCharset(), conversionService);
 
             response = encodeBodyWithCodec(response, body, defaultCodec, responseMediaType, context);
         }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/websocket/NettyServerWebSocketHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/websocket/NettyServerWebSocketHandler.java
@@ -111,7 +111,8 @@ public class NettyServerWebSocketHandler extends AbstractNettyWebSocketHandler {
                 routeMatch.getVariableValues(),
                 handshaker.version(),
                 handshaker.selectedSubprotocol(),
-                webSocketSessionRepository);
+                webSocketSessionRepository,
+                nettyEmbeddedServices.getApplicationContext().getConversionService());
 
         this.nettyEmbeddedServices = nettyEmbeddedServices;
         this.coroutineHelper = coroutineHelper;

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/ContentNegotiationSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/ContentNegotiationSpec.groovy
@@ -45,8 +45,9 @@ class ContentNegotiationSpec extends Specification {
         [new MediaType("application/json;q=0.5"), new MediaType("application/xml;q=0.9")] | XML
         [MediaType.APPLICATION_JSON_TYPE]                                                 | JSON
         [MediaType.APPLICATION_JSON_TYPE, MediaType.APPLICATION_XML_TYPE]                 | JSON
-        [MediaType.APPLICATION_XML_TYPE, MediaType.APPLICATION_JSON_TYPE]                 | XML
-        [MediaType.APPLICATION_XML_TYPE]                                                  | XML
+// Add Micronaut Jackson XML after v4 Migration
+//        [MediaType.APPLICATION_XML_TYPE, MediaType.APPLICATION_JSON_TYPE]                 | XML
+//        [MediaType.APPLICATION_XML_TYPE]                                                  | XML
         [MediaType.TEXT_PLAIN_TYPE]                                                       | TEXT
         [MediaType.ALL_TYPE]                                                              | JSON
 
@@ -72,7 +73,8 @@ class ContentNegotiationSpec extends Specification {
         contentType                     | expectedContentType             | expectedBody
         null                            | MediaType.APPLICATION_JSON_TYPE | '{"name":"Fred","age":10}'
         MediaType.APPLICATION_JSON_TYPE | MediaType.APPLICATION_JSON_TYPE | '{"name":"Fred","age":10}'
-        MediaType.APPLICATION_XML_TYPE  | MediaType.APPLICATION_XML_TYPE  | '<Person><name>Fred</name><age>10</age></Person>'
+// Add Micronaut Jackson XML after v4 Migration
+//        MediaType.APPLICATION_XML_TYPE  | MediaType.APPLICATION_XML_TYPE  | '<Person><name>Fred</name><age>10</age></Person>'
     }
 
     void "test send unacceptable type"() {

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/NettyHttpRequestSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/NettyHttpRequestSpec.groovy
@@ -15,7 +15,7 @@
  */
 package io.micronaut.http.server.netty.binding
 
-import io.micronaut.core.convert.DefaultConversionService
+import io.micronaut.core.convert.DefaultMutableConversionService
 import io.micronaut.http.HttpHeaders
 import io.micronaut.http.HttpMethod
 import io.micronaut.http.MutableHttpRequest
@@ -37,7 +37,7 @@ class NettyHttpRequestSpec extends Specification {
     void "test mutate request"() {
         given:
         DefaultFullHttpRequest nettyRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, GET, "/foo/bar")
-        NettyHttpRequest request = new NettyHttpRequest(nettyRequest, Mock(ChannelHandlerContext), new DefaultConversionService(), new HttpServerConfiguration())
+        NettyHttpRequest request = new NettyHttpRequest(nettyRequest, Mock(ChannelHandlerContext), new DefaultMutableConversionService(), new HttpServerConfiguration())
 
         when:
         def altered = request.mutate()
@@ -52,7 +52,7 @@ class NettyHttpRequestSpec extends Specification {
     void "test mutating a mutable request"() {
         given:
         DefaultFullHttpRequest nettyRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, GET, "/foo/bar")
-        def request = new NettyHttpRequest(nettyRequest, Mock(ChannelHandlerContext), new DefaultConversionService(), new HttpServerConfiguration())
+        def request = new NettyHttpRequest(nettyRequest, Mock(ChannelHandlerContext), new DefaultMutableConversionService(), new HttpServerConfiguration())
 
         when:
         request = request.mutate()
@@ -70,7 +70,7 @@ class NettyHttpRequestSpec extends Specification {
     void "test netty http request parameters"() {
         given:
         DefaultFullHttpRequest nettyRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, method, uri)
-        NettyHttpRequest request = new NettyHttpRequest(nettyRequest, Mock(ChannelHandlerContext), new DefaultConversionService(), new HttpServerConfiguration())
+        NettyHttpRequest request = new NettyHttpRequest(nettyRequest, Mock(ChannelHandlerContext), new DefaultMutableConversionService(), new HttpServerConfiguration())
         String fullURI = request.uri.toString()
         String expectedPath = fullURI.indexOf('?') > -1 ? fullURI.substring(0, fullURI.indexOf('?')) : fullURI
 
@@ -93,7 +93,7 @@ class NettyHttpRequestSpec extends Specification {
             nettyRequest.headers().add(header.key.toString(), header.value)
         }
 
-        NettyHttpRequest request = new NettyHttpRequest(nettyRequest, Mock(ChannelHandlerContext), new DefaultConversionService(), new HttpServerConfiguration())
+        NettyHttpRequest request = new NettyHttpRequest(nettyRequest, Mock(ChannelHandlerContext), new DefaultMutableConversionService(), new HttpServerConfiguration())
         String fullURI = request.uri.toString()
         String expectedPath = fullURI.indexOf('?') > -1 ? fullURI.substring(0, fullURI.indexOf('?')) : fullURI
 
@@ -115,7 +115,7 @@ class NettyHttpRequestSpec extends Specification {
             nettyRequest.headers().add(header.key.toString(), header.value)
         }
 
-        NettyHttpRequest request = new NettyHttpRequest(nettyRequest, Mock(ChannelHandlerContext), new DefaultConversionService(), new HttpServerConfiguration())
+        NettyHttpRequest request = new NettyHttpRequest(nettyRequest, Mock(ChannelHandlerContext), new DefaultMutableConversionService(), new HttpServerConfiguration())
         String fullURI = request.uri.toString()
         String expectedPath = fullURI.indexOf('?') > -1 ? fullURI.substring(0, fullURI.indexOf('?')) : fullURI
 
@@ -140,7 +140,7 @@ class NettyHttpRequestSpec extends Specification {
             nettyRequest.headers().add(header.key.toString(), header.value)
         }
 
-        NettyHttpRequest request = new NettyHttpRequest(nettyRequest, Mock(ChannelHandlerContext), new DefaultConversionService(), new HttpServerConfiguration())
+        NettyHttpRequest request = new NettyHttpRequest(nettyRequest, Mock(ChannelHandlerContext), new DefaultMutableConversionService(), new HttpServerConfiguration())
         String fullURI = request.uri.toString()
         String expectedPath = fullURI.indexOf('?') > -1 ? fullURI.substring(0, fullURI.indexOf('?')) : fullURI
 

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/NettyHttpResponseSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/NettyHttpResponseSpec.groovy
@@ -15,7 +15,7 @@
  */
 package io.micronaut.http.server.netty.binding
 
-import io.micronaut.core.convert.DefaultConversionService
+import io.micronaut.core.convert.DefaultMutableConversionService
 import io.micronaut.http.HttpHeaders
 import io.micronaut.http.HttpStatus
 import io.micronaut.http.MutableHttpResponse
@@ -37,7 +37,7 @@ class NettyHttpResponseSpec extends Specification {
     void "test add headers"() {
         given:
         DefaultFullHttpResponse nettyResponse = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK)
-        NettyMutableHttpResponse response = new NettyMutableHttpResponse(nettyResponse, new DefaultConversionService())
+        NettyMutableHttpResponse response = new NettyMutableHttpResponse(nettyResponse, new DefaultMutableConversionService())
 
         response.status(HttpStatus."$status")
         response.headers.add(header, value)
@@ -54,7 +54,7 @@ class NettyHttpResponseSpec extends Specification {
     void "test add simple cookie"() {
         given:
         DefaultFullHttpResponse nettyResponse = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK)
-        MutableHttpResponse response = new NettyMutableHttpResponse(nettyResponse, new DefaultConversionService())
+        MutableHttpResponse response = new NettyMutableHttpResponse(nettyResponse, new DefaultMutableConversionService())
 
         response.status(HttpStatus."$status")
         response.cookie(Cookie.of("foo", "bar"))
@@ -71,7 +71,7 @@ class NettyHttpResponseSpec extends Specification {
     void "test add cookie with max age"() {
         given:
         DefaultFullHttpResponse nettyResponse = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK)
-        MutableHttpResponse response = new NettyMutableHttpResponse(nettyResponse, new DefaultConversionService())
+        MutableHttpResponse response = new NettyMutableHttpResponse(nettyResponse, new DefaultMutableConversionService())
 
         response.status(HttpStatus."$status")
         response.cookie(Cookie.of("foo", "bar").maxAge(Duration.ofHours(2)))
@@ -89,7 +89,7 @@ class NettyHttpResponseSpec extends Specification {
     void "test multiple cookies"() {
         given:
         DefaultFullHttpResponse nettyResponse = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK)
-        MutableHttpResponse response = new NettyMutableHttpResponse(nettyResponse, new DefaultConversionService())
+        MutableHttpResponse response = new NettyMutableHttpResponse(nettyResponse, new DefaultMutableConversionService())
 
         response.cookies([Cookie.of("a", "b"), Cookie.of("c", "d")] as Set)
 

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/converters/ConverterRegistrySpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/converters/ConverterRegistrySpec.groovy
@@ -21,7 +21,6 @@ import io.netty.buffer.ByteBuf
 import io.netty.buffer.CompositeByteBuf
 import io.netty.buffer.Unpooled
 import io.netty.channel.ChannelOption
-import spock.lang.PendingFeature
 import spock.lang.Specification
 
 import java.nio.charset.StandardCharsets
@@ -67,7 +66,6 @@ class ConverterRegistrySpec extends Specification {
         ctx1.close()
     }
 
-    @PendingFeature
     def "test convert string to channel option after context reset"() {
         given:
         ApplicationContext ctx1 = ApplicationContext.run()
@@ -82,7 +80,6 @@ class ConverterRegistrySpec extends Specification {
         ctx2.stop()
 
         then:
-        // this fails, the converter has been removed by ctx2.stop()
         ctx1.getBean(ConversionService).convert("AUTO_READ", ChannelOption).get() == ChannelOption.AUTO_READ
 
         cleanup:

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/util/MockHttpHeaders.java
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/util/MockHttpHeaders.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 public class MockHttpHeaders implements MutableHttpHeaders {
 
     private final Map<CharSequence, List<String>> headers;
+    private ConversionService conversionService = ConversionService.SHARED;
 
     public MockHttpHeaders(Map<CharSequence, List<String>> headers) {
         this.headers = headers;
@@ -88,6 +89,11 @@ public class MockHttpHeaders implements MutableHttpHeaders {
 
     @Override
     public <T> Optional<T> get(CharSequence name, ArgumentConversionContext<T> conversionContext) {
-        return ConversionService.SHARED.convert(get(name), conversionContext);
+        return conversionService.convert(get(name), conversionContext);
+    }
+
+    @Override
+    public void setConversionService(ConversionService conversionService) {
+        this.conversionService = conversionService;
     }
 }

--- a/http-server/src/main/java/io/micronaut/http/server/websocket/ServerWebSocketProcessor.java
+++ b/http-server/src/main/java/io/micronaut/http/server/websocket/ServerWebSocketProcessor.java
@@ -50,7 +50,7 @@ public class ServerWebSocketProcessor extends DefaultRouteBuilder implements Exe
      * @param uriNamingStrategy The {@link io.micronaut.web.router.RouteBuilder.UriNamingStrategy}
      * @param conversionService The {@link ConversionService}
      */
-    ServerWebSocketProcessor(ExecutionHandleLocator executionHandleLocator, UriNamingStrategy uriNamingStrategy, ConversionService<?> conversionService) {
+    ServerWebSocketProcessor(ExecutionHandleLocator executionHandleLocator, UriNamingStrategy uriNamingStrategy, ConversionService conversionService) {
         super(executionHandleLocator, uriNamingStrategy, conversionService);
     }
 

--- a/http-server/src/test/groovy/io/micronaut/http/server/util/MockHttpHeaders.java
+++ b/http-server/src/test/groovy/io/micronaut/http/server/util/MockHttpHeaders.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 public class MockHttpHeaders implements MutableHttpHeaders {
 
     private final Map<CharSequence, List<String>> headers;
+    private ConversionService conversionService = ConversionService.SHARED;
 
     public MockHttpHeaders(Map<CharSequence, List<String>> headers) {
         this.headers = headers;
@@ -89,5 +90,10 @@ public class MockHttpHeaders implements MutableHttpHeaders {
     @Override
     public <T> Optional<T> get(CharSequence name, ArgumentConversionContext<T> conversionContext) {
         return ConversionService.SHARED.convert(get(name), conversionContext);
+    }
+
+    @Override
+    public void setConversionService(ConversionService conversionService) {
+        this.conversionService = conversionService;
     }
 }

--- a/http-validation/src/main/java/io/micronaut/validation/routes/RouteValidationVisitor.java
+++ b/http-validation/src/main/java/io/micronaut/validation/routes/RouteValidationVisitor.java
@@ -21,13 +21,17 @@ import io.micronaut.context.env.DefaultPropertyPlaceholderResolver.RawSegment;
 import io.micronaut.context.env.DefaultPropertyPlaceholderResolver.Segment;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.convert.DefaultConversionService;
+import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.http.uri.UriMatchTemplate;
 import io.micronaut.inject.ast.MethodElement;
 import io.micronaut.inject.visitor.TypeElementVisitor;
 import io.micronaut.inject.visitor.VisitorContext;
-import io.micronaut.validation.routes.rules.*;
+import io.micronaut.validation.routes.rules.ClientTypesRule;
+import io.micronaut.validation.routes.rules.MissingParameterRule;
+import io.micronaut.validation.routes.rules.NullableParameterRule;
+import io.micronaut.validation.routes.rules.RequestBeanParameterRule;
+import io.micronaut.validation.routes.rules.RouteValidationRule;
 
 import javax.annotation.processing.SupportedOptions;
 import java.util.ArrayList;
@@ -51,7 +55,7 @@ public class RouteValidationVisitor implements TypeElementVisitor<Object, Object
     private static final String METHOD_MAPPING_ANN = "io.micronaut.http.annotation.HttpMethodMapping";
     private List<RouteValidationRule> rules = new ArrayList<>();
     private boolean skipValidation = false;
-    private final DefaultPropertyPlaceholderResolver resolver = new DefaultPropertyPlaceholderResolver(null, new DefaultConversionService());
+    private final DefaultPropertyPlaceholderResolver resolver = new DefaultPropertyPlaceholderResolver(null, ConversionService.SHARED);
 
     @NonNull
     @Override

--- a/http/src/main/java/io/micronaut/http/MediaTypeConvertersRegistrar.java
+++ b/http/src/main/java/io/micronaut/http/MediaTypeConvertersRegistrar.java
@@ -16,9 +16,11 @@
 package io.micronaut.http;
 
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.convert.MutableConversionService;
 import io.micronaut.core.convert.TypeConverterRegistrar;
 import io.micronaut.core.util.StringUtils;
+
+import java.util.Optional;
 
 /**
  * The media type converters registrar.
@@ -30,13 +32,18 @@ import io.micronaut.core.util.StringUtils;
 public final class MediaTypeConvertersRegistrar implements TypeConverterRegistrar {
 
     @Override
-    public void register(ConversionService<?> conversionService) {
-        conversionService.addConverter(CharSequence.class, MediaType.class, charSequence -> {
-                if (StringUtils.isNotEmpty(charSequence)) {
-                    return MediaType.of(charSequence.toString());
+    public void register(MutableConversionService conversionService) {
+        conversionService.addConverter(CharSequence.class, MediaType.class, (object, targetType, context) -> {
+            if (StringUtils.isEmpty(object)) {
+                return Optional.empty();
+            } else {
+                try {
+                    return Optional.of(MediaType.of(object.toString()));
+                } catch (IllegalArgumentException e) {
+                    context.reject(e);
+                    return Optional.empty();
                 }
-                return null;
             }
-        );
+        });
     }
 }

--- a/http/src/main/java/io/micronaut/http/MutableHttpHeaders.java
+++ b/http/src/main/java/io/micronaut/http/MutableHttpHeaders.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.http;
 
+import io.micronaut.core.convert.ConversionServiceAware;
 import io.micronaut.core.type.MutableHeaders;
 
 import java.net.URI;
@@ -35,7 +36,7 @@ import java.util.stream.Collectors;
  * @author Graeme Rocher
  * @since 1.0
  */
-public interface MutableHttpHeaders extends MutableHeaders, HttpHeaders  {
+public interface MutableHttpHeaders extends MutableHeaders, HttpHeaders, ConversionServiceAware {
 
     /**
      * The default GMT zone for date values.

--- a/http/src/main/java/io/micronaut/http/MutableHttpParameters.java
+++ b/http/src/main/java/io/micronaut/http/MutableHttpParameters.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.http;
 
+import io.micronaut.core.convert.ConversionServiceAware;
+
 import java.util.Collections;
 import java.util.List;
 
@@ -24,7 +26,7 @@ import java.util.List;
  * @author Vladimir Orany
  * @since 1.0
  */
-public interface MutableHttpParameters extends HttpParameters {
+public interface MutableHttpParameters extends HttpParameters, ConversionServiceAware {
 
     /**
      * Adds a new http parameter.

--- a/http/src/main/java/io/micronaut/http/MutableHttpRequest.java
+++ b/http/src/main/java/io/micronaut/http/MutableHttpRequest.java
@@ -16,6 +16,7 @@
 package io.micronaut.http;
 
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.convert.ConversionServiceAware;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.http.cookie.Cookie;
 import io.micronaut.http.uri.UriBuilder;
@@ -33,7 +34,7 @@ import java.util.function.Consumer;
  * @author Graeme Rocher
  * @since 1.0
  */
-public interface MutableHttpRequest<B> extends HttpRequest<B>, MutableHttpMessage<B> {
+public interface MutableHttpRequest<B> extends HttpRequest<B>, MutableHttpMessage<B>, ConversionServiceAware {
 
     /**
      * Sets the specified cookie on the request.

--- a/http/src/main/java/io/micronaut/http/bind/DefaultRequestBinderRegistry.java
+++ b/http/src/main/java/io/micronaut/http/bind/DefaultRequestBinderRegistry.java
@@ -23,16 +23,36 @@ import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.clhm.ConcurrentLinkedHashMap;
-import io.micronaut.core.util.StringUtils;
-import io.micronaut.http.*;
+import io.micronaut.http.FullHttpRequest;
+import io.micronaut.http.HttpHeaders;
+import io.micronaut.http.HttpMethod;
+import io.micronaut.http.HttpParameters;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.PushCapableHttpRequest;
 import io.micronaut.http.annotation.Body;
-import io.micronaut.http.bind.binders.*;
+import io.micronaut.http.bind.binders.AnnotatedRequestArgumentBinder;
+import io.micronaut.http.bind.binders.ContinuationArgumentBinder;
+import io.micronaut.http.bind.binders.CookieAnnotationBinder;
+import io.micronaut.http.bind.binders.DefaultBodyAnnotationBinder;
+import io.micronaut.http.bind.binders.HeaderAnnotationBinder;
+import io.micronaut.http.bind.binders.ParameterAnnotationBinder;
+import io.micronaut.http.bind.binders.PartAnnotationBinder;
+import io.micronaut.http.bind.binders.PathVariableAnnotationBinder;
+import io.micronaut.http.bind.binders.RequestArgumentBinder;
+import io.micronaut.http.bind.binders.RequestAttributeAnnotationBinder;
+import io.micronaut.http.bind.binders.RequestBeanAnnotationBinder;
+import io.micronaut.http.bind.binders.TypedRequestArgumentBinder;
 import io.micronaut.http.cookie.Cookie;
 import io.micronaut.http.cookie.Cookies;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+
 import java.lang.annotation.Annotation;
-import java.util.*;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import static io.micronaut.core.util.KotlinUtils.KOTLIN_COROUTINES_SUPPORTED;
 
@@ -50,7 +70,7 @@ public class DefaultRequestBinderRegistry implements RequestBinderRegistry {
     private final Map<Class<? extends Annotation>, RequestArgumentBinder> byAnnotation = new LinkedHashMap<>();
     private final Map<TypeAndAnnotation, RequestArgumentBinder> byTypeAndAnnotation = new LinkedHashMap<>();
     private final Map<Integer, RequestArgumentBinder> byType = new LinkedHashMap<>();
-    private final ConversionService<?> conversionService;
+    private final ConversionService conversionService;
     private final Map<TypeAndAnnotation, Optional<RequestArgumentBinder>> argumentBinderCache =
         new ConcurrentLinkedHashMap.Builder<TypeAndAnnotation, Optional<RequestArgumentBinder>>().maximumWeightedCapacity(CACHE_MAX_SIZE).build();
 
@@ -66,7 +86,8 @@ public class DefaultRequestBinderRegistry implements RequestBinderRegistry {
      * @param conversionService The conversion service
      * @param binders           The request argument binders
      */
-    @Inject public DefaultRequestBinderRegistry(ConversionService conversionService, List<RequestArgumentBinder> binders) {
+    @Inject
+    public DefaultRequestBinderRegistry(ConversionService conversionService, List<RequestArgumentBinder> binders) {
         this.conversionService = conversionService;
 
         if (CollectionUtils.isNotEmpty(binders)) {
@@ -75,7 +96,6 @@ public class DefaultRequestBinderRegistry implements RequestBinderRegistry {
             }
         }
 
-        registerDefaultConverters(conversionService);
         registerDefaultAnnotationBinders(byAnnotation);
 
         byType.put(Argument.of(HttpHeaders.class).typeHashCode(), (RequestArgumentBinder<HttpHeaders>) (argument, source) -> () -> Optional.of(source.getHeaders()));
@@ -210,30 +230,6 @@ public class DefaultRequestBinderRegistry implements RequestBinderRegistry {
             }
             return Optional.ofNullable(requestArgumentBinder);
         }).orElse(null);
-
-    }
-
-    /**
-     * Registers a default converter.
-     *
-     * @param conversionService The conversion service
-     */
-    protected void registerDefaultConverters(ConversionService<?> conversionService) {
-        conversionService.addConverter(
-            CharSequence.class,
-            MediaType.class, (object, targetType, context) -> {
-                    if (StringUtils.isEmpty(object)) {
-                        return Optional.empty();
-                    } else {
-                        final String str = object.toString();
-                        try {
-                            return Optional.of(MediaType.of(str));
-                        } catch (IllegalArgumentException e) {
-                            context.reject(e);
-                            return Optional.empty();
-                        }
-                    }
-                });
 
     }
 

--- a/http/src/main/java/io/micronaut/http/bind/binders/CookieAnnotationBinder.java
+++ b/http/src/main/java/io/micronaut/http/bind/binders/CookieAnnotationBinder.java
@@ -38,7 +38,7 @@ public class CookieAnnotationBinder<T> extends AbstractAnnotatedArgumentBinder<C
     /**
      * @param conversionService The conversion service
      */
-    public CookieAnnotationBinder(ConversionService<?> conversionService) {
+    public CookieAnnotationBinder(ConversionService conversionService) {
         super(conversionService);
     }
 

--- a/http/src/main/java/io/micronaut/http/bind/binders/DefaultBodyAnnotationBinder.java
+++ b/http/src/main/java/io/micronaut/http/bind/binders/DefaultBodyAnnotationBinder.java
@@ -36,7 +36,7 @@ import java.util.Optional;
  */
 public class DefaultBodyAnnotationBinder<T> implements BodyArgumentBinder<T> {
 
-    protected final ConversionService<?> conversionService;
+    protected final ConversionService conversionService;
 
     /**
      * @param conversionService The conversion service

--- a/http/src/main/java/io/micronaut/http/bind/binders/HeaderAnnotationBinder.java
+++ b/http/src/main/java/io/micronaut/http/bind/binders/HeaderAnnotationBinder.java
@@ -39,7 +39,7 @@ public class HeaderAnnotationBinder<T> extends AbstractAnnotatedArgumentBinder<H
     /**
      * @param conversionService The conversion service
      */
-    public HeaderAnnotationBinder(ConversionService<?> conversionService) {
+    public HeaderAnnotationBinder(ConversionService conversionService) {
         super(conversionService);
     }
 

--- a/http/src/main/java/io/micronaut/http/bind/binders/ParameterAnnotationBinder.java
+++ b/http/src/main/java/io/micronaut/http/bind/binders/ParameterAnnotationBinder.java
@@ -43,7 +43,7 @@ public class ParameterAnnotationBinder<T> extends AbstractAnnotatedArgumentBinde
     /**
      * @param conversionService The conversion service
      */
-    public ParameterAnnotationBinder(ConversionService<?> conversionService) {
+    public ParameterAnnotationBinder(ConversionService conversionService) {
         super(conversionService);
         this.queryValueArgumentBinder = new QueryValueArgumentBinder<>(conversionService);
     }

--- a/http/src/main/java/io/micronaut/http/bind/binders/PartAnnotationBinder.java
+++ b/http/src/main/java/io/micronaut/http/bind/binders/PartAnnotationBinder.java
@@ -30,7 +30,7 @@ import io.micronaut.http.annotation.Part;
  */
 public class PartAnnotationBinder<T> extends AbstractAnnotatedArgumentBinder<Part, T, HttpRequest<?>> implements AnnotatedRequestArgumentBinder<Part, T> {
 
-    public PartAnnotationBinder(ConversionService<?> conversionService) {
+    public PartAnnotationBinder(ConversionService conversionService) {
         super(conversionService);
     }
 

--- a/http/src/main/java/io/micronaut/http/bind/binders/PathVariableAnnotationBinder.java
+++ b/http/src/main/java/io/micronaut/http/bind/binders/PathVariableAnnotationBinder.java
@@ -44,7 +44,7 @@ public class PathVariableAnnotationBinder<T> extends AbstractAnnotatedArgumentBi
     /**
      * @param conversionService The conversion service
      */
-    public PathVariableAnnotationBinder(ConversionService<?> conversionService) {
+    public PathVariableAnnotationBinder(ConversionService conversionService) {
         super(conversionService);
     }
 
@@ -78,7 +78,7 @@ public class PathVariableAnnotationBinder<T> extends AbstractAnnotatedArgumentBi
         // attempt to bind from request parameters. This avoids allowing the request URI to
         // be manipulated to override POST or JSON variables
         if (hasAnnotation && matchInfo.isPresent()) {
-            final ConvertibleValues<Object> variableValues = ConvertibleValues.of(matchInfo.get().getVariableValues());
+            final ConvertibleValues<Object> variableValues = ConvertibleValues.of(matchInfo.get().getVariableValues(), conversionService);
             if (bindAll) {
                 Object value;
                 // Only maps and POJOs will "bindAll", lists work like normal

--- a/http/src/main/java/io/micronaut/http/bind/binders/QueryValueArgumentBinder.java
+++ b/http/src/main/java/io/micronaut/http/bind/binders/QueryValueArgumentBinder.java
@@ -44,16 +44,13 @@ public class QueryValueArgumentBinder<T>
         extends AbstractAnnotatedArgumentBinder<QueryValue, T, HttpRequest<?>>
         implements AnnotatedRequestArgumentBinder<QueryValue, T> {
 
-    private final ConversionService<?> conversionService;
-
     /**
      * Constructor.
      *
      * @param conversionService conversion service
      */
-    public QueryValueArgumentBinder(ConversionService<?> conversionService) {
+    public QueryValueArgumentBinder(ConversionService conversionService) {
         super(conversionService);
-        this.conversionService = conversionService;
     }
 
     @Override

--- a/http/src/main/java/io/micronaut/http/bind/binders/RequestAttributeAnnotationBinder.java
+++ b/http/src/main/java/io/micronaut/http/bind/binders/RequestAttributeAnnotationBinder.java
@@ -38,7 +38,7 @@ public class RequestAttributeAnnotationBinder<T> extends AbstractAnnotatedArgume
     /**
      * @param conversionService conversionService
      */
-    public RequestAttributeAnnotationBinder(ConversionService<?> conversionService) {
+    public RequestAttributeAnnotationBinder(ConversionService conversionService) {
         super(conversionService);
     }
 

--- a/http/src/main/java/io/micronaut/http/bind/binders/RequestBeanAnnotationBinder.java
+++ b/http/src/main/java/io/micronaut/http/bind/binders/RequestBeanAnnotationBinder.java
@@ -53,7 +53,7 @@ public class RequestBeanAnnotationBinder<T> extends AbstractAnnotatedArgumentBin
      * @param requestBinderRegistry Original request binder registry
      * @param conversionService The conversion service
      */
-    public RequestBeanAnnotationBinder(RequestBinderRegistry requestBinderRegistry, ConversionService<?> conversionService) {
+    public RequestBeanAnnotationBinder(RequestBinderRegistry requestBinderRegistry, ConversionService conversionService) {
         super(conversionService);
         this.requestBinderRegistry = requestBinderRegistry;
     }

--- a/http/src/main/java/io/micronaut/http/converters/HttpConverterRegistrar.java
+++ b/http/src/main/java/io/micronaut/http/converters/HttpConverterRegistrar.java
@@ -16,20 +16,13 @@
 package io.micronaut.http.converters;
 
 import io.micronaut.context.exceptions.ConfigurationException;
-import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.convert.MutableConversionService;
 import io.micronaut.core.convert.TypeConverterRegistrar;
 import io.micronaut.core.io.Readable;
 import io.micronaut.core.io.ResourceLoader;
 import io.micronaut.core.io.ResourceResolver;
-import io.micronaut.http.HttpStatus;
-import io.micronaut.http.HttpVersion;
-import io.micronaut.http.MediaType;
 import jakarta.inject.Singleton;
 
-import java.net.InetSocketAddress;
-import java.net.MalformedURLException;
-import java.net.ProxySelector;
-import java.net.SocketAddress;
 import java.net.URL;
 import java.util.Optional;
 
@@ -54,15 +47,7 @@ public class HttpConverterRegistrar implements TypeConverterRegistrar {
     }
 
     @Override
-    public void register(ConversionService<?> conversionService) {
-        conversionService.addConverter(String.class, HttpVersion.class, s -> {
-            try {
-                return HttpVersion.valueOf(Double.parseDouble(s));
-            } catch (NumberFormatException e) {
-                return HttpVersion.valueOf(s);
-            }
-        });
-        conversionService.addConverter(Number.class, HttpVersion.class, s -> HttpVersion.valueOf(s.doubleValue()));
+    public void register(MutableConversionService conversionService) {
         conversionService.addConverter(
                 CharSequence.class,
                 Readable.class,
@@ -84,75 +69,6 @@ public class HttpConverterRegistrar implements TypeConverterRegistrar {
                         }
                     }
 
-                }
-        );
-        conversionService.addConverter(
-                CharSequence.class,
-                MediaType.class,
-                (object, targetType, context) -> {
-                    try {
-                        return Optional.of(MediaType.of(object));
-                    } catch (IllegalArgumentException e) {
-                        context.reject(e);
-                        return Optional.empty();
-                    }
-                }
-        );
-        conversionService.addConverter(
-                Number.class,
-                HttpStatus.class,
-                (object, targetType, context) -> {
-                    try {
-                        HttpStatus status = HttpStatus.valueOf(object.shortValue());
-                        return Optional.of(status);
-                    } catch (IllegalArgumentException e) {
-                        context.reject(object, e);
-                        return Optional.empty();
-                    }
-                }
-        );
-        conversionService.addConverter(
-                CharSequence.class,
-                SocketAddress.class,
-                (object, targetType, context) -> {
-                    String address = object.toString();
-                    try {
-                        URL url = new URL(address);
-                        int port = url.getPort();
-                        if (port == -1) {
-                            port = url.getDefaultPort();
-                        }
-                        if (port == -1) {
-                            context.reject(object, new ConfigurationException("Failed to find a port in the given value"));
-                            return Optional.empty();
-                        }
-                        return Optional.of(InetSocketAddress.createUnresolved(url.getHost(), port));
-                    } catch (MalformedURLException malformedURLException) {
-                        String[] parts = object.toString().split(":");
-                        if (parts.length == 2) {
-                            try {
-                                int port = Integer.parseInt(parts[1]);
-                                return Optional.of(InetSocketAddress.createUnresolved(parts[0], port));
-                            } catch (IllegalArgumentException illegalArgumentException) {
-                                context.reject(object, illegalArgumentException);
-                                return Optional.empty();
-                            }
-                        } else {
-                            context.reject(object, new ConfigurationException("The address is not in a proper format of IP:PORT or a standard URL"));
-                            return Optional.empty();
-                        }
-                    }
-                }
-        );
-        conversionService.addConverter(
-                CharSequence.class,
-                ProxySelector.class,
-                (object, targetType, context) -> {
-                    if (object.toString().equals("default")) {
-                        return Optional.of(ProxySelector.getDefault());
-                    } else {
-                        return Optional.empty();
-                    }
                 }
         );
     }

--- a/http/src/main/java/io/micronaut/http/converters/SharedHttpConvertersRegistrar.java
+++ b/http/src/main/java/io/micronaut/http/converters/SharedHttpConvertersRegistrar.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.converters;
+
+import io.micronaut.context.exceptions.ConfigurationException;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.convert.MutableConversionService;
+import io.micronaut.core.convert.TypeConverterRegistrar;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.HttpVersion;
+
+import java.net.InetSocketAddress;
+import java.net.MalformedURLException;
+import java.net.ProxySelector;
+import java.net.SocketAddress;
+import java.net.URL;
+import java.util.Optional;
+
+/**
+ * Converter registrar for HTTP classes.
+ *
+ * @author Denis Stepanov
+ * @since 4.0.0
+ */
+@Internal
+public class SharedHttpConvertersRegistrar implements TypeConverterRegistrar {
+
+    @Override
+    public void register(MutableConversionService conversionService) {
+        conversionService.addConverter(String.class, HttpVersion.class, s -> {
+            try {
+                return HttpVersion.valueOf(Double.parseDouble(s));
+            } catch (NumberFormatException e) {
+                return HttpVersion.valueOf(s);
+            }
+        });
+        conversionService.addConverter(Number.class, HttpVersion.class, s -> HttpVersion.valueOf(s.doubleValue()));
+        conversionService.addConverter(
+                Number.class,
+                HttpStatus.class,
+                (object, targetType, context) -> {
+                    try {
+                        HttpStatus status = HttpStatus.valueOf(object.shortValue());
+                        return Optional.of(status);
+                    } catch (IllegalArgumentException e) {
+                        context.reject(object, e);
+                        return Optional.empty();
+                    }
+                }
+        );
+        conversionService.addConverter(
+                CharSequence.class,
+                SocketAddress.class,
+                (object, targetType, context) -> {
+                    String address = object.toString();
+                    try {
+                        URL url = new URL(address);
+                        int port = url.getPort();
+                        if (port == -1) {
+                            port = url.getDefaultPort();
+                        }
+                        if (port == -1) {
+                            context.reject(object, new ConfigurationException("Failed to find a port in the given value"));
+                            return Optional.empty();
+                        }
+                        return Optional.of(InetSocketAddress.createUnresolved(url.getHost(), port));
+                    } catch (MalformedURLException malformedURLException) {
+                        String[] parts = object.toString().split(":");
+                        if (parts.length == 2) {
+                            try {
+                                int port = Integer.parseInt(parts[1]);
+                                return Optional.of(InetSocketAddress.createUnresolved(parts[0], port));
+                            } catch (IllegalArgumentException illegalArgumentException) {
+                                context.reject(object, illegalArgumentException);
+                                return Optional.empty();
+                            }
+                        } else {
+                            context.reject(object, new ConfigurationException("The address is not in a proper format of IP:PORT or a standard URL"));
+                            return Optional.empty();
+                        }
+                    }
+                }
+        );
+        conversionService.addConverter(
+                CharSequence.class,
+                ProxySelector.class,
+                (object, targetType, context) -> {
+                    if (object.toString().equals("default")) {
+                        return Optional.of(ProxySelector.getDefault());
+                    } else {
+                        return Optional.empty();
+                    }
+                }
+        );
+    }
+}

--- a/http/src/main/java/io/micronaut/http/simple/SimpleHttpHeaders.java
+++ b/http/src/main/java/io/micronaut/http/simple/SimpleHttpHeaders.java
@@ -31,7 +31,7 @@ import java.util.*;
 public class SimpleHttpHeaders implements MutableHttpHeaders {
 
     private final MutableConvertibleMultiValuesMap<String> headers = new MutableConvertibleMultiValuesMap<>();
-    private final ConversionService conversionService;
+    private ConversionService conversionService;
 
     /**
      * Map-based implementation of {@link MutableHttpHeaders}.
@@ -92,5 +92,10 @@ public class SimpleHttpHeaders implements MutableHttpHeaders {
     public MutableHttpHeaders remove(CharSequence header) {
         headers.remove(header.toString());
         return this;
+    }
+
+    @Override
+    public void setConversionService(ConversionService conversionService) {
+        this.conversionService = conversionService;
     }
 }

--- a/http/src/main/java/io/micronaut/http/simple/SimpleHttpParameters.java
+++ b/http/src/main/java/io/micronaut/http/simple/SimpleHttpParameters.java
@@ -17,11 +17,15 @@ package io.micronaut.http.simple;
 
 import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.ConversionService;
-import io.micronaut.core.convert.value.ConvertibleMultiValues;
 import io.micronaut.core.convert.value.ConvertibleMultiValuesMap;
 import io.micronaut.http.MutableHttpParameters;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -35,7 +39,7 @@ import java.util.stream.Collectors;
 public class SimpleHttpParameters implements MutableHttpParameters {
 
     private final Map<CharSequence, List<String>> valuesMap;
-    private final ConvertibleMultiValues<String> values;
+    private final ConvertibleMultiValuesMap<String> values;
 
     /**
      * @param values The parameter values
@@ -82,5 +86,10 @@ public class SimpleHttpParameters implements MutableHttpParameters {
     public MutableHttpParameters add(CharSequence name, List<CharSequence> values) {
         valuesMap.put(name, values.stream().map(v -> v == null ? null : v.toString()).collect(Collectors.toList()));
         return this;
+    }
+
+    @Override
+    public void setConversionService(ConversionService conversionService) {
+        values.setConversionService(conversionService);
     }
 }

--- a/http/src/main/java/io/micronaut/http/simple/SimpleHttpRequest.java
+++ b/http/src/main/java/io/micronaut/http/simple/SimpleHttpRequest.java
@@ -40,7 +40,7 @@ import java.util.Set;
  */
 public class SimpleHttpRequest<B> implements MutableHttpRequest<B> {
 
-    private final MutableConvertibleValues<Object> attributes = new MutableConvertibleValuesMap<>();
+    private final MutableConvertibleValuesMap<Object> attributes = new MutableConvertibleValuesMap<>();
     private final SimpleCookies cookies = new SimpleCookies(ConversionService.SHARED);
     private final SimpleHttpHeaders headers = new SimpleHttpHeaders(ConversionService.SHARED);
     private final SimpleHttpParameters parameters = new SimpleHttpParameters(ConversionService.SHARED);
@@ -125,5 +125,13 @@ public class SimpleHttpRequest<B> implements MutableHttpRequest<B> {
     @Override
     public Optional<B> getBody() {
         return (Optional<B>) Optional.ofNullable(this.body);
+    }
+
+    @Override
+    public void setConversionService(ConversionService conversionService) {
+        attributes.setConversionService(conversionService);
+        cookies.setConversionService(conversionService);
+        headers.setConversionService(conversionService);
+        parameters.setConversionService(conversionService);
     }
 }

--- a/http/src/main/java/io/micronaut/http/simple/cookies/SimpleCookies.java
+++ b/http/src/main/java/io/micronaut/http/simple/cookies/SimpleCookies.java
@@ -17,6 +17,7 @@ package io.micronaut.http.simple.cookies;
 
 import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.convert.ConversionServiceAware;
 import io.micronaut.http.cookie.Cookie;
 import io.micronaut.http.cookie.Cookies;
 
@@ -29,9 +30,9 @@ import java.util.*;
  * @author Vladimir Orany
  * @since 1.0
  */
-public class SimpleCookies implements Cookies {
+public class SimpleCookies implements Cookies, ConversionServiceAware {
 
-    private final ConversionService<?> conversionService;
+    private ConversionService conversionService;
     private final Map<CharSequence, Cookie> cookies;
 
     /**
@@ -89,5 +90,10 @@ public class SimpleCookies implements Cookies {
      */
     public void putAll(Map<CharSequence, Cookie> cookies) {
         this.cookies.putAll(cookies);
+    }
+
+    @Override
+    public void setConversionService(ConversionService conversionService) {
+        this.conversionService = conversionService;
     }
 }

--- a/http/src/main/resources/META-INF/services/io.micronaut.core.convert.TypeConverterRegistrar
+++ b/http/src/main/resources/META-INF/services/io.micronaut.core.convert.TypeConverterRegistrar
@@ -1,1 +1,2 @@
 io.micronaut.http.MediaTypeConvertersRegistrar
+io.micronaut.http.converters.SharedHttpConvertersRegistrar

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/generics/InjectWithWildcardSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/generics/InjectWithWildcardSpec.groovy
@@ -43,15 +43,15 @@ class InjectWithWildcardSpec extends Specification {
     static class WildCardInject {
         // tests injecting field
         @Inject
-        protected ConversionService<?> conversionService
+        protected ConversionService conversionService
 
         // tests injecting constructor
-        WildCardInject(ConversionService<?> conversionService) {
+        WildCardInject(ConversionService conversionService) {
         }
 
         // tests injection method
         @Inject
-        void setConversionService(ConversionService<?> conversionService) {
+        void setConversionService(ConversionService conversionService) {
             this.conversionService = conversionService
         }
     }

--- a/inject-java/src/test/groovy/io/micronaut/inject/ast/beans/BeanElementVisitorSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/ast/beans/BeanElementVisitorSpec.groovy
@@ -16,12 +16,11 @@ import io.micronaut.context.env.Environment;
 import io.micronaut.core.convert.ConversionService;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
-import jakarta.inject.Singleton;
 
 @Prototype
 @Named("blah")
 class Test implements Runnable {
-    @Inject ConversionService<?> conversionService;
+    @Inject ConversionService conversionService;
 
     @Inject
     void setEnvironment(Environment environment) {
@@ -59,12 +58,11 @@ import io.micronaut.context.env.Environment;
 import io.micronaut.core.convert.ConversionService;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
-import jakarta.inject.Singleton;
 
 @Prototype
 @Named("blah")
 class Test implements Runnable {
-    @Inject ConversionService<?> conversionService;
+    @Inject ConversionService conversionService;
 
     @Inject
     void setEnvironment(Environment environment) {
@@ -103,13 +101,11 @@ import io.micronaut.context.annotation.Prototype;
 import io.micronaut.context.env.Environment;
 import io.micronaut.core.convert.ConversionService;
 import jakarta.inject.Inject;
-import jakarta.inject.Named;
-import jakarta.inject.Singleton;
 
 @Prototype
 @Factory
 class TestFactory implements Runnable {
-    @Inject ConversionService<?> conversionService;
+    @Inject ConversionService conversionService;
 
     @Inject
     void setEnvironment(Environment environment) {

--- a/inject-java/src/test/groovy/io/micronaut/inject/generics/WildCardInject.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/generics/WildCardInject.java
@@ -22,15 +22,15 @@ import jakarta.inject.Inject;
 public class WildCardInject {
     // tests injecting field
     @Inject
-    protected ConversionService<?> conversionService;
+    protected ConversionService conversionService;
 
     // tests injecting constructor
-    public WildCardInject(ConversionService<?> conversionService) {
+    public WildCardInject(ConversionService conversionService) {
     }
 
     // tests injection method
     @Inject
-    public void setConversionService(ConversionService<?> conversionService) {
+    public void setConversionService(ConversionService conversionService) {
         this.conversionService = conversionService;
     }
 }

--- a/inject/src/main/java/io/micronaut/context/AbstractInitializableBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractInitializableBeanDefinition.java
@@ -759,7 +759,7 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
                 }
                 boolean requiresConversion = value != null && !requiredArgument.getType().isInstance(value);
                 if (requiresConversion) {
-                    Optional<?> converted = ConversionService.SHARED.convert(value, requiredArgument.getType(), ConversionContext.of(requiredArgument));
+                    Optional<?> converted = context.getConversionService().convert(value, requiredArgument.getType(), ConversionContext.of(requiredArgument));
                     Object finalValue = value;
                     value = converted.orElseThrow(() -> new BeanInstantiationException(resolutionContext, "Invalid value [" + finalValue + "] for argument: " + argumentName));
                     requiredArgumentValues.put(argumentName, value);

--- a/inject/src/main/java/io/micronaut/context/AbstractParametrizedBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractParametrizedBeanDefinition.java
@@ -23,7 +23,6 @@ import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationUtil;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.convert.ConversionContext;
-import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.type.Argument;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.ParametrizedBeanFactory;
@@ -106,7 +105,7 @@ public abstract class AbstractParametrizedBeanDefinition<T> extends AbstractBean
                 Object value = requiredArgumentValues.get(argumentName);
                 boolean requiresConversion = value != null && !requiredArgument.getType().isInstance(value);
                 if (requiresConversion) {
-                    Optional<?> converted = ConversionService.SHARED.convert(value, requiredArgument.getType(), ConversionContext.of(requiredArgument));
+                    Optional<?> converted = context.getConversionService().convert(value, requiredArgument.getType(), ConversionContext.of(requiredArgument));
                     Object finalValue = value;
                     value = converted.orElseThrow(() -> new BeanInstantiationException(resolutionContext, "Invalid value [" + finalValue + "] for argument: " + argumentName));
                     requiredArgumentValues.put(argumentName, value);

--- a/inject/src/main/java/io/micronaut/context/ApplicationContext.java
+++ b/inject/src/main/java/io/micronaut/context/ApplicationContext.java
@@ -19,13 +19,12 @@ import io.micronaut.context.env.Environment;
 import io.micronaut.context.env.PropertyPlaceholderResolver;
 import io.micronaut.context.env.PropertySource;
 import io.micronaut.context.env.SystemPropertiesPropertySource;
-import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.core.value.PropertyResolver;
 
-import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.annotation.Nullable;
 import java.util.Collections;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -58,11 +57,6 @@ import java.util.function.Consumer;
  * @since 1.0
  */
 public interface ApplicationContext extends BeanContext, PropertyResolver, PropertyPlaceholderResolver {
-
-    /**
-     * @return The default conversion service
-     */
-    @NonNull ConversionService<?> getConversionService();
 
     /**
      * @return The application environment

--- a/inject/src/main/java/io/micronaut/context/ApplicationContextConfiguration.java
+++ b/inject/src/main/java/io/micronaut/context/ApplicationContextConfiguration.java
@@ -15,11 +15,10 @@
  */
 package io.micronaut.context;
 
-import io.micronaut.core.convert.ConversionService;
-import io.micronaut.core.io.scan.ClassPathResourceLoader;
-
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.convert.MutableConversionService;
+import io.micronaut.core.io.scan.ClassPathResourceLoader;
 
 import java.util.Collections;
 import java.util.List;
@@ -85,12 +84,12 @@ public interface ApplicationContextConfiguration extends BeanContextConfiguratio
     }
 
     /**
-     * The default conversion service to use.
+     * The optional conversion service to use.
      *
      * @return The conversion service
      */
-    default @NonNull ConversionService<?> getConversionService() {
-        return ConversionService.SHARED;
+    default Optional<MutableConversionService> getConversionService() {
+        return Optional.empty();
     }
 
     /**

--- a/inject/src/main/java/io/micronaut/context/BeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/BeanContext.java
@@ -20,6 +20,7 @@ import io.micronaut.core.annotation.AnnotationMetadataResolver;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.attr.MutableAttributeHolder;
+import io.micronaut.core.convert.ConversionServiceProvider;
 import io.micronaut.core.type.Argument;
 import io.micronaut.inject.BeanIdentifier;
 import io.micronaut.inject.validation.BeanDefinitionValidator;
@@ -45,7 +46,8 @@ public interface BeanContext extends
         BeanDefinitionRegistry,
         ApplicationEventPublisher<Object>,
         AnnotationMetadataResolver,
-        MutableAttributeHolder {
+        MutableAttributeHolder,
+    ConversionServiceProvider {
 
     /**
      * Obtains the configuration for this context.

--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
@@ -29,7 +29,7 @@ import io.micronaut.core.annotation.AnnotationUtil;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.convert.ArgumentConversionContext;
-import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.convert.MutableConversionService;
 import io.micronaut.core.convert.TypeConverter;
 import io.micronaut.core.convert.TypeConverterRegistrar;
 import io.micronaut.core.io.scan.ClassPathResourceLoader;
@@ -62,7 +62,6 @@ import java.util.stream.Collectors;
  */
 public class DefaultApplicationContext extends DefaultBeanContext implements ApplicationContext {
 
-    private final ConversionService conversionService;
     private final ClassPathResourceLoader resourceLoader;
     private final ApplicationContextConfiguration configuration;
     private Environment environment;
@@ -116,7 +115,6 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
         super(configuration);
         ArgumentUtils.requireNonNull("configuration", configuration);
         this.configuration = configuration;
-        this.conversionService = createConversionService();
         this.resourceLoader = configuration.getResourceLoader();
     }
 
@@ -162,25 +160,15 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
         return false;
     }
 
-    /**
-     * Creates the default conversion service.
-     *
-     * @return The conversion service
-     */
-    protected @NonNull
-    ConversionService createConversionService() {
-        return ConversionService.SHARED;
+    @Override
+    @NonNull
+    public MutableConversionService getConversionService() {
+        return getEnvironment();
     }
 
     @Override
-    public @NonNull
-    ConversionService<?> getConversionService() {
-        return conversionService;
-    }
-
-    @Override
-    public @NonNull
-    Environment getEnvironment() {
+    @NonNull
+    public Environment getEnvironment() {
         if (environment == null) {
             environment = createEnvironment(configuration);
         }
@@ -188,16 +176,23 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
     }
 
     @Override
-    public synchronized @NonNull
-    ApplicationContext start() {
+    @NonNull
+    public synchronized ApplicationContext start() {
         startEnvironment();
         return (ApplicationContext) super.start();
     }
 
     @Override
+    protected void registerConversionService() {
+        // Conversion service is represented by the environment
+    }
+
+    @Override
     public synchronized @NonNull
     ApplicationContext stop() {
-        return (ApplicationContext) super.stop();
+        ApplicationContext stop = (ApplicationContext) super.stop();
+        environment = null;
+        return stop;
     }
 
     @Override
@@ -517,6 +512,7 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
      * @param beanContext The bean context
      */
     protected void initializeTypeConverters(BeanContext beanContext) {
+        MutableConversionService mutableConversionService = getConversionService();
         for (BeanRegistration<TypeConverter> typeConverterRegistration : beanContext.getBeanRegistrations(TypeConverter.class)) {
             TypeConverter typeConverter = typeConverterRegistration.getBean();
             List<Argument<?>> typeArguments = typeConverterRegistration.getBeanDefinition().getTypeArguments(TypeConverter.class);
@@ -524,12 +520,12 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
                 Class<?> source = typeArguments.get(0).getType();
                 Class<?> target = typeArguments.get(1).getType();
                 if (!(source == Object.class && target == Object.class)) {
-                    getConversionService().addConverter(source, target, typeConverter);
+                    mutableConversionService.addConverter(source, target, typeConverter);
                 }
             }
         }
         for (TypeConverterRegistrar registrar : beanContext.getBeansOfType(TypeConverterRegistrar.class)) {
-            registrar.register(conversionService);
+            registrar.register(mutableConversionService);
         }
     }
 
@@ -583,7 +579,7 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
 
         private List<PropertySource> propertySourceList;
 
-        BootstrapEnvironment(ClassPathResourceLoader resourceLoader, ConversionService conversionService, ApplicationContextConfiguration configuration, String... activeEnvironments) {
+        BootstrapEnvironment(ClassPathResourceLoader resourceLoader, MutableConversionService conversionService, ApplicationContextConfiguration configuration, String... activeEnvironments) {
             super(new ApplicationContextConfiguration() {
                 @Override
                 public Optional<Boolean> getDeduceEnvironments() {
@@ -621,8 +617,8 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
 
                 @NonNull
                 @Override
-                public ConversionService<?> getConversionService() {
-                    return conversionService;
+                public Optional<MutableConversionService> getConversionService() {
+                    return Optional.of(conversionService);
                 }
 
                 @NonNull
@@ -812,7 +808,7 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
         private BootstrapEnvironment createBootstrapEnvironment(String... environmentNames) {
             return new BootstrapEnvironment(
                     resourceLoader,
-                    conversionService,
+                    mutableConversionService,
                     configuration,
                     environmentNames);
         }

--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContextBuilder.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContextBuilder.java
@@ -46,21 +46,21 @@ import java.util.Set;
  * @since 1.0
  */
 public class DefaultApplicationContextBuilder implements ApplicationContextBuilder, ApplicationContextConfiguration {
-    private List<Object> singletons = new ArrayList<>();
-    private List<String> environments = new ArrayList<>();
-    private List<String> defaultEnvironments = new ArrayList<>();
-    private List<String> packages = new ArrayList<>();
-    private Map<String, Object> properties = new LinkedHashMap<>();
-    private List<PropertySource> propertySources = new ArrayList<>();
-    private Collection<String> configurationIncludes = new HashSet<>();
-    private Collection<String> configurationExcludes = new HashSet<>();
+    private final List<Object> singletons = new ArrayList<>();
+    private final List<String> environments = new ArrayList<>();
+    private final List<String> defaultEnvironments = new ArrayList<>();
+    private final List<String> packages = new ArrayList<>();
+    private final Map<String, Object> properties = new LinkedHashMap<>();
+    private final List<PropertySource> propertySources = new ArrayList<>();
+    private final Collection<String> configurationIncludes = new HashSet<>();
+    private final Collection<String> configurationExcludes = new HashSet<>();
     private Boolean deduceEnvironments = null;
     private ClassLoader classLoader = getClass().getClassLoader();
     private boolean envPropertySource = true;
-    private List<String> envVarIncludes = new ArrayList<>();
-    private List<String> envVarExcludes = new ArrayList<>();
+    private final List<String> envVarIncludes = new ArrayList<>();
+    private final List<String> envVarExcludes = new ArrayList<>();
     private String[] args = new String[0];
-    private Set<Class<? extends Annotation>> eagerInitAnnotated = new HashSet<>(3);
+    private final Set<Class<? extends Annotation>> eagerInitAnnotated = new HashSet<>(3);
     private String[] overrideConfigLocations;
     private boolean banner = true;
     private ClassPathResourceLoader classPathResourceLoader;
@@ -89,7 +89,7 @@ public class DefaultApplicationContextBuilder implements ApplicationContextBuild
     }
 
     @Override
-    @NonNull 
+    @NonNull
     public ApplicationContextBuilder enableDefaultPropertySources(boolean areEnabled) {
         this.enableDefaultPropertySources = areEnabled;
         return this;

--- a/inject/src/main/java/io/micronaut/context/converters/ContextConverterRegistrar.java
+++ b/inject/src/main/java/io/micronaut/context/converters/ContextConverterRegistrar.java
@@ -17,7 +17,7 @@ package io.micronaut.context.converters;
 
 import io.micronaut.context.BeanContext;
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.convert.MutableConversionService;
 import io.micronaut.core.convert.TypeConverterRegistrar;
 import io.micronaut.core.reflect.ClassUtils;
 import jakarta.inject.Singleton;
@@ -49,7 +49,7 @@ public class ContextConverterRegistrar implements TypeConverterRegistrar {
     }
 
     @Override
-    public void register(ConversionService<?> conversionService) {
+    public void register(MutableConversionService conversionService) {
         conversionService.addConverter(String[].class, Class[].class, (object, targetType, context) -> {
             Class[] classes = Arrays
                     .stream(object)

--- a/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
+++ b/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
@@ -314,15 +314,13 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
     }
 
     @Override
-    public <S, T> Environment addConverter(Class<S> sourceType, Class<T> targetType, TypeConverter<S, T> typeConverter) {
+    public <S, T> void addConverter(Class<S> sourceType, Class<T> targetType, TypeConverter<S, T> typeConverter) {
         mutableConversionService.addConverter(sourceType, targetType, typeConverter);
-        return this;
     }
 
     @Override
-    public <S, T> Environment addConverter(Class<S> sourceType, Class<T> targetType, Function<S, T> typeConverter) {
+    public <S, T> void addConverter(Class<S> sourceType, Class<T> targetType, Function<S, T> typeConverter) {
         mutableConversionService.addConverter(sourceType, targetType, typeConverter);
-        return this;
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
+++ b/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
@@ -20,6 +20,7 @@ import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.convert.ConversionContext;
+import io.micronaut.core.convert.MutableConversionService;
 import io.micronaut.core.convert.TypeConverter;
 import io.micronaut.core.io.ResourceLoader;
 import io.micronaut.core.io.ResourceResolver;
@@ -108,8 +109,8 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
     private final ClassLoader classLoader;
     private final Collection<String> packages = new ConcurrentLinkedQueue<>();
     private final BeanIntrospectionScanner annotationScanner;
-    private Collection<String> configurationIncludes = new HashSet<>(3);
-    private Collection<String> configurationExcludes = new HashSet<>(3);
+    private final Collection<String> configurationIncludes = new HashSet<>(3);
+    private final Collection<String> configurationExcludes = new HashSet<>(3);
     private final AtomicBoolean running = new AtomicBoolean(false);
     private Collection<PropertySourceLoader> propertySourceLoaderList;
     private final Map<String, PropertySourceLoader> loaderByFormatMap = new ConcurrentHashMap<>();
@@ -118,6 +119,7 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
     private final Boolean deduceEnvironments;
     private final ApplicationContextConfiguration configuration;
     private final Collection<String> configLocations;
+    protected final MutableConversionService mutableConversionService;
 
     /**
      * Construct a new environment for the given configuration.
@@ -125,7 +127,8 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
      * @param configuration The configuration
      */
     public DefaultEnvironment(@NonNull ApplicationContextConfiguration configuration) {
-        super(configuration.getConversionService());
+        super(configuration.getConversionService().orElseGet(MutableConversionService::create));
+        this.mutableConversionService = (MutableConversionService) conversionService;
         this.configuration = configuration;
         this.resourceLoader = configuration.getResourceLoader();
 
@@ -302,24 +305,22 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
 
     @Override
     public <T> Optional<T> convert(Object object, Class<T> targetType, ConversionContext context) {
-        return conversionService.convert(object, targetType, context);
+        return mutableConversionService.convert(object, targetType, context);
     }
 
     @Override
     public <S, T> boolean canConvert(Class<S> sourceType, Class<T> targetType) {
-        return conversionService.canConvert(sourceType, targetType);
+        return mutableConversionService.canConvert(sourceType, targetType);
     }
 
     @Override
-    public <S, T> Environment addConverter(Class<S> sourceType, Class<T> targetType, TypeConverter<S, T> typeConverter) {
-        conversionService.addConverter(sourceType, targetType, typeConverter);
-        return this;
+    public <S, T> void addConverter(Class<S> sourceType, Class<T> targetType, TypeConverter<S, T> typeConverter) {
+        mutableConversionService.addConverter(sourceType, targetType, typeConverter);
     }
 
     @Override
-    public <S, T> Environment addConverter(Class<S> sourceType, Class<T> targetType, Function<S, T> typeConverter) {
-        conversionService.addConverter(sourceType, targetType, typeConverter);
-        return this;
+    public <S, T> void addConverter(Class<S> sourceType, Class<T> targetType, Function<S, T> typeConverter) {
+        mutableConversionService.addConverter(sourceType, targetType, typeConverter);
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
+++ b/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
@@ -314,13 +314,15 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
     }
 
     @Override
-    public <S, T> void addConverter(Class<S> sourceType, Class<T> targetType, TypeConverter<S, T> typeConverter) {
+    public <S, T> Environment addConverter(Class<S> sourceType, Class<T> targetType, TypeConverter<S, T> typeConverter) {
         mutableConversionService.addConverter(sourceType, targetType, typeConverter);
+        return this;
     }
 
     @Override
-    public <S, T> void addConverter(Class<S> sourceType, Class<T> targetType, Function<S, T> typeConverter) {
+    public <S, T> Environment addConverter(Class<S> sourceType, Class<T> targetType, Function<S, T> typeConverter) {
         mutableConversionService.addConverter(sourceType, targetType, typeConverter);
+        return this;
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/context/env/DefaultPropertyPlaceholderResolver.java
+++ b/inject/src/main/java/io/micronaut/context/env/DefaultPropertyPlaceholderResolver.java
@@ -53,7 +53,7 @@ public class DefaultPropertyPlaceholderResolver implements PropertyPlaceholderRe
     private static final char COLON = ':';
 
     private final PropertyResolver environment;
-    private final ConversionService<?> conversionService;
+    private final ConversionService conversionService;
     private final String prefix;
     private Collection<PropertyExpressionResolver> expressionResolvers;
 

--- a/inject/src/main/java/io/micronaut/context/env/Environment.java
+++ b/inject/src/main/java/io/micronaut/context/env/Environment.java
@@ -17,7 +17,7 @@ package io.micronaut.context.env;
 
 import io.micronaut.context.LifeCycle;
 import io.micronaut.core.annotation.Nullable;
-import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.convert.MutableConversionService;
 import io.micronaut.core.io.ResourceLoader;
 import io.micronaut.core.io.scan.BeanIntrospectionScanner;
 import io.micronaut.core.reflect.ClassUtils;
@@ -53,7 +53,7 @@ import java.util.stream.Stream;
  * @author Graeme Rocher
  * @since 1.0
  */
-public interface Environment extends PropertyResolver, LifeCycle<Environment>, ConversionService<Environment>, ResourceLoader {
+public interface Environment extends PropertyResolver, LifeCycle<Environment>, MutableConversionService, ResourceLoader {
 
     /**
      * Constant for the name micronaut.

--- a/inject/src/main/java/io/micronaut/context/env/Environment.java
+++ b/inject/src/main/java/io/micronaut/context/env/Environment.java
@@ -53,7 +53,7 @@ import java.util.stream.Stream;
  * @author Graeme Rocher
  * @since 1.0
  */
-public interface Environment extends PropertyResolver, LifeCycle<Environment>, MutableConversionService, ResourceLoader {
+public interface Environment extends PropertyResolver, LifeCycle<Environment>, MutableConversionService<Environment>, ResourceLoader {
 
     /**
      * Constant for the name micronaut.

--- a/inject/src/main/java/io/micronaut/context/env/Environment.java
+++ b/inject/src/main/java/io/micronaut/context/env/Environment.java
@@ -53,7 +53,7 @@ import java.util.stream.Stream;
  * @author Graeme Rocher
  * @since 1.0
  */
-public interface Environment extends PropertyResolver, LifeCycle<Environment>, MutableConversionService<Environment>, ResourceLoader {
+public interface Environment extends PropertyResolver, LifeCycle<Environment>, MutableConversionService, ResourceLoader {
 
     /**
      * Constant for the name micronaut.

--- a/inject/src/main/java/io/micronaut/context/env/PropertyExpressionResolver.java
+++ b/inject/src/main/java/io/micronaut/context/env/PropertyExpressionResolver.java
@@ -44,7 +44,7 @@ public interface PropertyExpressionResolver {
      */
     @NonNull
     <T> Optional<T> resolve(@NonNull PropertyResolver propertyResolver,
-                            @NonNull ConversionService<?> conversionService,
+                            @NonNull ConversionService conversionService,
                             @NonNull String expression,
                             @NonNull Class<T> requiredType);
 

--- a/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
+++ b/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
@@ -77,7 +77,7 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
     private static final Pattern RANDOM_PATTERN = Pattern.compile("\\$\\{" + RANDOM_PREFIX + "(" + RANDOM_UPPER_LIMIT + "|" + RANDOM_RANGE + ")?\\}");
     private static final Object NO_VALUE = new Object();
     private static final PropertyCatalog[] CONVENTIONS = {PropertyCatalog.GENERATED, PropertyCatalog.RAW};
-    protected final ConversionService<?> conversionService;
+    protected final ConversionService conversionService;
     protected final PropertyPlaceholderResolver propertyPlaceholderResolver;
     protected final Map<String, PropertySource> propertySources = new ConcurrentHashMap<>(10);
     // properties are stored in an array of maps organized by character in the alphabet
@@ -96,7 +96,7 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
      *
      * @param conversionService The {@link ConversionService}
      */
-    public PropertySourcePropertyResolver(ConversionService<?> conversionService) {
+    public PropertySourcePropertyResolver(ConversionService conversionService) {
         this.conversionService = conversionService;
         this.propertyPlaceholderResolver = new DefaultPropertyPlaceholderResolver(this, conversionService);
     }

--- a/inject/src/main/java/io/micronaut/inject/annotation/AnnotationConvertersRegistrar.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AnnotationConvertersRegistrar.java
@@ -16,7 +16,7 @@
 package io.micronaut.inject.annotation;
 
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.convert.MutableConversionService;
 import io.micronaut.core.convert.TypeConverterRegistrar;
 import io.micronaut.core.reflect.ClassUtils;
 
@@ -36,7 +36,7 @@ import java.util.Optional;
 public final class AnnotationConvertersRegistrar implements TypeConverterRegistrar {
 
     @Override
-    public void register(ConversionService<?> conversionService) {
+    public void register(MutableConversionService conversionService) {
         conversionService.addConverter(io.micronaut.core.annotation.AnnotationValue.class, Annotation.class, (object, targetType, context) -> {
             Optional<Class> annotationClass = ClassUtils.forName(object.getAnnotationName(), targetType.getClassLoader());
             return annotationClass.map(aClass -> AnnotationMetadataSupport.buildAnnotation(aClass, object));

--- a/inject/src/test/groovy/io/micronaut/context/env/PropertySourcePropertyResolverSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/env/PropertySourcePropertyResolverSpec.groovy
@@ -661,7 +661,7 @@ class PropertySourcePropertyResolverSpec extends Specification {
                 @Override
                 @NonNull
                 <T> Optional<T> resolve(@NonNull PropertyResolver propertyResolver,
-                                        @NonNull ConversionService<? extends ConversionService> conversionService,
+                                        @NonNull ConversionService conversionService,
                                         @NonNull String expression,
                                         @NonNull Class<T> requiredType) {
                     assert requiredType == String.class
@@ -706,7 +706,7 @@ class PropertySourcePropertyResolverSpec extends Specification {
                 @Override
                 @NonNull
                 <T> Optional<T> resolve(@NonNull PropertyResolver propertyResolver,
-                                        @NonNull ConversionService<? extends ConversionService> conversionService,
+                                        @NonNull ConversionService conversionService,
                                         @NonNull String expression,
                                         @NonNull Class<T> requiredType) {
                     Optional.empty()

--- a/jackson-databind/src/main/java/io/micronaut/jackson/databind/convert/JacksonConverterRegistrar.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/databind/convert/JacksonConverterRegistrar.java
@@ -32,6 +32,7 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.convert.MutableConversionService;
 import io.micronaut.core.convert.TypeConverter;
 import io.micronaut.core.convert.TypeConverterRegistrar;
 import io.micronaut.core.convert.value.ConvertibleValues;
@@ -59,7 +60,7 @@ import java.util.Optional;
 public class JacksonConverterRegistrar implements TypeConverterRegistrar {
 
     private final BeanProvider<ObjectMapper> objectMapper;
-    private final ConversionService<?> conversionService;
+    private final ConversionService conversionService;
 
     /**
      * Default constructor.
@@ -69,13 +70,13 @@ public class JacksonConverterRegistrar implements TypeConverterRegistrar {
     @Inject
     protected JacksonConverterRegistrar(
             BeanProvider<ObjectMapper> objectMapper,
-            ConversionService<?> conversionService) {
+            ConversionService conversionService) {
         this.objectMapper = objectMapper;
         this.conversionService = conversionService;
     }
 
     @Override
-    public void register(ConversionService<?> conversionService) {
+    public void register(MutableConversionService conversionService) {
         conversionService.addConverter(
                 ArrayNode.class,
                 Object[].class,

--- a/jackson-databind/src/main/java/io/micronaut/jackson/databind/convert/ObjectNodeConvertibleValues.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/databind/convert/ObjectNodeConvertibleValues.java
@@ -43,13 +43,13 @@ import java.util.Set;
 public class ObjectNodeConvertibleValues<V> implements ConvertibleValues<V> {
 
     private final ObjectNode objectNode;
-    private final ConversionService<?> conversionService;
+    private final ConversionService conversionService;
 
     /**
      * @param objectNode        The node that maps to JSON object structure
      * @param conversionService To convert the JSON node into given type
      */
-    public ObjectNodeConvertibleValues(ObjectNode objectNode, ConversionService<?> conversionService) {
+    public ObjectNodeConvertibleValues(ObjectNode objectNode, ConversionService conversionService) {
         this.objectNode = objectNode;
         this.conversionService = conversionService;
     }

--- a/json-core/src/main/java/io/micronaut/json/convert/JsonConverterRegistrar.java
+++ b/json-core/src/main/java/io/micronaut/json/convert/JsonConverterRegistrar.java
@@ -23,6 +23,7 @@ import io.micronaut.core.bind.BeanPropertyBinder;
 import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.ConversionContext;
 import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.convert.MutableConversionService;
 import io.micronaut.core.convert.TypeConverter;
 import io.micronaut.core.convert.TypeConverterRegistrar;
 import io.micronaut.core.convert.value.ConvertibleValues;
@@ -54,13 +55,13 @@ import java.util.Optional;
 @Singleton
 public final class JsonConverterRegistrar implements TypeConverterRegistrar {
     private final BeanProvider<JsonMapper> objectCodec;
-    private final ConversionService<?> conversionService;
+    private final ConversionService conversionService;
     private final BeanProvider<BeanPropertyBinder> beanPropertyBinder;
 
     @Inject
     public JsonConverterRegistrar(
             BeanProvider<JsonMapper> objectCodec,
-            ConversionService<?> conversionService,
+            ConversionService conversionService,
             BeanProvider<BeanPropertyBinder> beanPropertyBinder
     ) {
         this.objectCodec = objectCodec;
@@ -69,7 +70,7 @@ public final class JsonConverterRegistrar implements TypeConverterRegistrar {
     }
 
     @Override
-    public void register(ConversionService<?> conversionService) {
+    public void register(MutableConversionService conversionService) {
         conversionService.addConverter(
                 JsonArray.class,
                 Object[].class,

--- a/json-core/src/main/java/io/micronaut/json/convert/JsonNodeConvertibleValues.java
+++ b/json-core/src/main/java/io/micronaut/json/convert/JsonNodeConvertibleValues.java
@@ -42,13 +42,13 @@ import java.util.Set;
 public class JsonNodeConvertibleValues<V> implements ConvertibleValues<V> {
 
     private final JsonNode objectNode;
-    private final ConversionService<?> conversionService;
+    private final ConversionService conversionService;
 
     /**
      * @param objectNode        The node that maps to JSON object structure
      * @param conversionService To convert the JSON node into given type
      */
-    public JsonNodeConvertibleValues(JsonNode objectNode, ConversionService<?> conversionService) {
+    public JsonNodeConvertibleValues(JsonNode objectNode, ConversionService conversionService) {
         if (!objectNode.isObject()) {
             throw new IllegalArgumentException("Expected object node");
         }
@@ -82,5 +82,10 @@ public class JsonNodeConvertibleValues<V> implements ConvertibleValues<V> {
         } else {
             return conversionService.convert(jsonNode, conversionContext);
         }
+    }
+
+    @Override
+    public ConversionService getConversionService() {
+        return conversionService;
     }
 }

--- a/management/src/main/java/io/micronaut/management/endpoint/processors/AbstractEndpointRouteBuilder.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/processors/AbstractEndpointRouteBuilder.java
@@ -65,7 +65,7 @@ abstract class AbstractEndpointRouteBuilder extends DefaultRouteBuilder implemen
      */
     AbstractEndpointRouteBuilder(ApplicationContext applicationContext,
                                  UriNamingStrategy uriNamingStrategy,
-                                 ConversionService<?> conversionService,
+                                 ConversionService conversionService,
                                  EndpointDefaultConfiguration endpointDefaultConfiguration) {
         super(applicationContext, uriNamingStrategy, conversionService);
         this.beanContext = applicationContext;

--- a/management/src/main/java/io/micronaut/management/endpoint/processors/DeleteEndpointRouteBuilder.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/processors/DeleteEndpointRouteBuilder.java
@@ -44,7 +44,7 @@ public class DeleteEndpointRouteBuilder extends AbstractEndpointRouteBuilder {
      */
     public DeleteEndpointRouteBuilder(ApplicationContext beanContext,
                                       UriNamingStrategy uriNamingStrategy,
-                                      ConversionService<?> conversionService,
+                                      ConversionService conversionService,
                                       EndpointDefaultConfiguration endpointDefaultConfiguration) {
         super(beanContext, uriNamingStrategy, conversionService, endpointDefaultConfiguration);
     }

--- a/management/src/main/java/io/micronaut/management/endpoint/processors/ReadEndpointRouteBuilder.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/processors/ReadEndpointRouteBuilder.java
@@ -44,7 +44,7 @@ public class ReadEndpointRouteBuilder extends AbstractEndpointRouteBuilder {
      */
     public ReadEndpointRouteBuilder(ApplicationContext beanContext,
                                     UriNamingStrategy uriNamingStrategy,
-                                    ConversionService<?> conversionService,
+                                    ConversionService conversionService,
                                     EndpointDefaultConfiguration endpointDefaultConfiguration) {
         super(beanContext, uriNamingStrategy, conversionService, endpointDefaultConfiguration);
     }

--- a/management/src/main/java/io/micronaut/management/endpoint/processors/WriteEndpointRouteBuilder.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/processors/WriteEndpointRouteBuilder.java
@@ -47,7 +47,7 @@ public class WriteEndpointRouteBuilder extends AbstractEndpointRouteBuilder {
      */
     public WriteEndpointRouteBuilder(ApplicationContext beanContext,
                                      UriNamingStrategy uriNamingStrategy,
-                                     ConversionService<?> conversionService,
+                                     ConversionService conversionService,
                                      EndpointDefaultConfiguration endpointDefaultConfiguration) {
         super(beanContext, uriNamingStrategy, conversionService, endpointDefaultConfiguration);
     }

--- a/router/src/main/java/io/micronaut/web/router/AbstractRouteMatch.java
+++ b/router/src/main/java/io/micronaut/web/router/AbstractRouteMatch.java
@@ -50,7 +50,7 @@ import java.util.function.Predicate;
 abstract class AbstractRouteMatch<T, R> implements MethodBasedRouteMatch<T, R> {
 
     protected final MethodExecutionHandle<T, R> executableMethod;
-    protected final ConversionService<?> conversionService;
+    protected final ConversionService conversionService;
     protected final DefaultRouteBuilder.AbstractRoute abstractRoute;
     protected final List<MediaType> consumedMediaTypes;
     protected final List<MediaType> producedMediaTypes;
@@ -61,7 +61,7 @@ abstract class AbstractRouteMatch<T, R> implements MethodBasedRouteMatch<T, R> {
      * @param abstractRoute     The abstract route builder
      * @param conversionService The conversion service
      */
-    protected AbstractRouteMatch(DefaultRouteBuilder.AbstractRoute abstractRoute, ConversionService<?> conversionService) {
+    protected AbstractRouteMatch(DefaultRouteBuilder.AbstractRoute abstractRoute, ConversionService conversionService) {
         this.abstractRoute = abstractRoute;
         //noinspection unchecked
         this.executableMethod = (MethodExecutionHandle<T, R>) abstractRoute.targetMethod;
@@ -208,7 +208,7 @@ abstract class AbstractRouteMatch<T, R> implements MethodBasedRouteMatch<T, R> {
 
     @Override
     public R invoke(Object... arguments) {
-        ConversionService<?> conversionService = this.conversionService;
+        ConversionService conversionService = this.conversionService;
 
         Argument[] targetArguments = getArguments();
         if (targetArguments.length == 0) {
@@ -245,7 +245,7 @@ abstract class AbstractRouteMatch<T, R> implements MethodBasedRouteMatch<T, R> {
         if (targetArguments.length == 0) {
             return executableMethod.invoke();
         } else {
-            ConversionService<?> conversionService = this.conversionService;
+            ConversionService conversionService = this.conversionService;
             Map<String, Object> uriVariables = getVariableValues();
             List<Object> argumentList = new ArrayList<>(argumentValues.size());
 

--- a/router/src/main/java/io/micronaut/web/router/AnnotatedFilterRouteBuilder.java
+++ b/router/src/main/java/io/micronaut/web/router/AnnotatedFilterRouteBuilder.java
@@ -57,7 +57,7 @@ public class AnnotatedFilterRouteBuilder extends DefaultRouteBuilder implements 
             BeanContext beanContext,
             ExecutionHandleLocator executionHandleLocator,
             UriNamingStrategy uriNamingStrategy,
-            ConversionService<?> conversionService,
+            ConversionService conversionService,
             @Nullable ServerContextPathProvider contextPathProvider) {
         super(executionHandleLocator, uriNamingStrategy, conversionService);
         this.contextPathProvider = contextPathProvider;

--- a/router/src/main/java/io/micronaut/web/router/AnnotatedMethodRouteBuilder.java
+++ b/router/src/main/java/io/micronaut/web/router/AnnotatedMethodRouteBuilder.java
@@ -54,7 +54,7 @@ public class AnnotatedMethodRouteBuilder extends DefaultRouteBuilder implements 
      * @param uriNamingStrategy The URI naming strategy
      * @param conversionService The conversion service
      */
-    public AnnotatedMethodRouteBuilder(ExecutionHandleLocator executionHandleLocator, UriNamingStrategy uriNamingStrategy, ConversionService<?> conversionService) {
+    public AnnotatedMethodRouteBuilder(ExecutionHandleLocator executionHandleLocator, UriNamingStrategy uriNamingStrategy, ConversionService conversionService) {
         super(executionHandleLocator, uriNamingStrategy, conversionService);
         httpMethodsHandlers.put(Get.class, (RouteDefinition definition) -> {
             final BeanDefinition bean = definition.beanDefinition;

--- a/router/src/main/java/io/micronaut/web/router/DefaultUriRouteMatch.java
+++ b/router/src/main/java/io/micronaut/web/router/DefaultUriRouteMatch.java
@@ -55,7 +55,7 @@ class DefaultUriRouteMatch<T, R> extends AbstractRouteMatch<T, R> implements Uri
      */
     DefaultUriRouteMatch(UriMatchInfo matchInfo,
                          DefaultRouteBuilder.DefaultUriRoute uriRoute,
-                         Charset defaultCharset, ConversionService<?> conversionService
+                         Charset defaultCharset, ConversionService conversionService
     ) {
         super(uriRoute, conversionService);
         this.uriRoute = uriRoute;

--- a/router/src/main/java/io/micronaut/web/router/ErrorRouteMatch.java
+++ b/router/src/main/java/io/micronaut/web/router/ErrorRouteMatch.java
@@ -46,7 +46,7 @@ class ErrorRouteMatch<T, R> extends AbstractRouteMatch<T, R> {
      * @param abstractRoute The abstract route
      * @param conversionService The conversion service
      */
-    ErrorRouteMatch(Throwable error, DefaultRouteBuilder.AbstractRoute abstractRoute, ConversionService<?> conversionService) {
+    ErrorRouteMatch(Throwable error, DefaultRouteBuilder.AbstractRoute abstractRoute, ConversionService conversionService) {
         super(abstractRoute, conversionService);
         this.error = error;
         this.variables = new LinkedHashMap<>();

--- a/router/src/main/java/io/micronaut/web/router/StatusRouteMatch.java
+++ b/router/src/main/java/io/micronaut/web/router/StatusRouteMatch.java
@@ -40,7 +40,7 @@ class StatusRouteMatch<T, R> extends AbstractRouteMatch<T, R> {
      * @param abstractRoute The abstract route
      * @param conversionService The conversion service
      */
-    StatusRouteMatch(HttpStatus httpStatus, DefaultRouteBuilder.AbstractRoute abstractRoute, ConversionService<?> conversionService) {
+    StatusRouteMatch(HttpStatus httpStatus, DefaultRouteBuilder.AbstractRoute abstractRoute, ConversionService conversionService) {
         super(abstractRoute, conversionService);
         this.httpStatus = httpStatus;
         this.requiredArguments = new ArrayList<>(Arrays.asList(getArguments()));

--- a/router/src/test/groovy/io/micronaut/context/router/EachBeanRouteBuilderSpec.groovy
+++ b/router/src/test/groovy/io/micronaut/context/router/EachBeanRouteBuilderSpec.groovy
@@ -59,7 +59,7 @@ class EachBeanRouteBuilderSpec extends Specification {
 
         MyRouteBuilder(ExecutionHandleLocator executionHandleLocator,
                        UriNamingStrategy uriNamingStrategy,
-                       ConversionService<?> conversionService,
+                       ConversionService conversionService,
                        BeanContext beanContext) {
             super(executionHandleLocator, uriNamingStrategy, conversionService)
 

--- a/runtime/src/main/java/io/micronaut/reactive/flow/converters/FlowConverterRegistrar.java
+++ b/runtime/src/main/java/io/micronaut/reactive/flow/converters/FlowConverterRegistrar.java
@@ -16,7 +16,7 @@
 package io.micronaut.reactive.flow.converters;
 
 import io.micronaut.context.annotation.Requires;
-import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.convert.MutableConversionService;
 import io.micronaut.core.convert.TypeConverterRegistrar;
 import jakarta.inject.Singleton;
 import kotlinx.coroutines.flow.Flow;
@@ -34,7 +34,7 @@ import reactor.core.publisher.Flux;
 @Requires(classes = {Flux.class, ReactiveFlowKt.class})
 public class FlowConverterRegistrar implements TypeConverterRegistrar {
     @Override
-    public void register(ConversionService<?> conversionService) {
+    public void register(MutableConversionService conversionService) {
         // Flow
         conversionService.addConverter(Flow.class, Flux.class, flow ->
                 Flux.from(ReactiveFlowKt.asPublisher(flow))

--- a/runtime/src/main/java/io/micronaut/runtime/http/codec/TextPlainCodec.java
+++ b/runtime/src/main/java/io/micronaut/runtime/http/codec/TextPlainCodec.java
@@ -59,15 +59,19 @@ public class TextPlainCodec implements MediaTypeCodec {
 
     private final Charset defaultCharset;
     private final List<MediaType> additionalTypes;
+    private final ConversionService conversionService;
 
     /**
-     * @param defaultCharset      The default charset used for serialization and deserialization
-     * @param codecConfiguration  The configuration for the codec
+     * @param defaultCharset     The default charset used for serialization and deserialization
+     * @param codecConfiguration The configuration for the codec
+     * @param conversionService  The conversion service
      */
     @Inject
     public TextPlainCodec(@Value("${" + ApplicationConfiguration.DEFAULT_CHARSET + "}") Optional<Charset> defaultCharset,
-                          @Named(CONFIGURATION_QUALIFIER) @Nullable CodecConfiguration codecConfiguration) {
+                          @Named(CONFIGURATION_QUALIFIER) @Nullable CodecConfiguration codecConfiguration,
+                          ConversionService conversionService) {
         this.defaultCharset = defaultCharset.orElse(StandardCharsets.UTF_8);
+        this.conversionService = conversionService;
         if (codecConfiguration != null) {
             this.additionalTypes = codecConfiguration.getAdditionalTypes();
         } else {
@@ -76,10 +80,12 @@ public class TextPlainCodec implements MediaTypeCodec {
     }
 
     /**
-     * @param defaultCharset The default charset used for serialization and deserialization
+     * @param defaultCharset    The default charset used for serialization and deserialization
+     * @param conversionService The conversion service
      */
-    public TextPlainCodec(Charset defaultCharset) {
+    public TextPlainCodec(Charset defaultCharset, ConversionService conversionService) {
         this.defaultCharset = defaultCharset != null ? defaultCharset : StandardCharsets.UTF_8;
+        this.conversionService = conversionService;
         this.additionalTypes = Collections.emptyList();
     }
 
@@ -97,7 +103,7 @@ public class TextPlainCodec implements MediaTypeCodec {
         if (CharSequence.class.isAssignableFrom(type.getType())) {
             return (T) text;
         }
-        return ConversionService.SHARED
+        return conversionService
             .convert(text, type)
             .orElseThrow(() -> new CodecException("Cannot decode byte buffer with value [" + text + "] to type: " + type));
     }
@@ -108,7 +114,7 @@ public class TextPlainCodec implements MediaTypeCodec {
         if (CharSequence.class.isAssignableFrom(type.getType())) {
             return (T) text;
         }
-        return ConversionService.SHARED
+        return conversionService
             .convert(text, type)
             .orElseThrow(() -> new CodecException("Cannot decode bytes with value [" + text + "] to type: " + type));
     }

--- a/runtime/src/test/groovy/io/micronaut/runtime/ConversionServiceIsResetSpec.groovy
+++ b/runtime/src/test/groovy/io/micronaut/runtime/ConversionServiceIsResetSpec.groovy
@@ -18,6 +18,7 @@ package io.micronaut.runtime
 import io.micronaut.context.ApplicationContext
 import io.micronaut.core.convert.ConversionContext
 import io.micronaut.core.convert.ConversionService
+import io.micronaut.core.convert.MutableConversionService
 import io.micronaut.core.convert.TypeConverter
 import spock.lang.Specification
 
@@ -32,7 +33,7 @@ class ConversionServiceIsResetSpec extends Specification {
                     return Optional.of(new B())
                 }
             }
-            ctx.getBean(ConversionService).addConverter(A, B, typeConverter)
+            ctx.getBean(MutableConversionService).addConverter(A, B, typeConverter)
 
         when:
             def result = ctx.getBean(ConversionService).convert(new A(), B)

--- a/runtime/src/test/groovy/io/micronaut/runtime/converters/time/TimeConverterRegistrarSpec.groovy
+++ b/runtime/src/test/groovy/io/micronaut/runtime/converters/time/TimeConverterRegistrarSpec.groovy
@@ -16,7 +16,7 @@
 package io.micronaut.runtime.converters.time
 
 import io.micronaut.core.convert.ConversionService
-import io.micronaut.core.convert.DefaultConversionService
+import io.micronaut.core.convert.DefaultMutableConversionService
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -35,7 +35,7 @@ class TimeConverterRegistrarSpec extends Specification {
     @Unroll
     void "test convert duration #val"() {
         given:
-        ConversionService conversionService = new DefaultConversionService()
+        ConversionService conversionService = new DefaultMutableConversionService()
         new TimeConverterRegistrar().register(conversionService)
 
 
@@ -55,7 +55,7 @@ class TimeConverterRegistrarSpec extends Specification {
     @Unroll
     void "test converts a #sourceObject.class.name to a #targetType.name"() {
         given:
-        ConversionService conversionService = new DefaultConversionService()
+        ConversionService conversionService = new DefaultMutableConversionService()
         new TimeConverterRegistrar().register(conversionService)
 
         expect:

--- a/runtime/src/test/groovy/io/micronaut/runtime/http/codec/TextPlainCodecSpec.groovy
+++ b/runtime/src/test/groovy/io/micronaut/runtime/http/codec/TextPlainCodecSpec.groovy
@@ -16,6 +16,7 @@
 package io.micronaut.runtime.http.codec
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.core.convert.MutableConversionService
 import io.micronaut.core.io.buffer.ByteBuffer
 import io.micronaut.core.io.buffer.ByteBufferFactory
 import io.micronaut.http.MediaType
@@ -26,7 +27,7 @@ import java.nio.charset.StandardCharsets
 
 class TextPlainCodecSpec extends Specification {
 
-    @Shared TextPlainCodec codec = new TextPlainCodec(StandardCharsets.UTF_8)
+    @Shared TextPlainCodec codec = new TextPlainCodec(StandardCharsets.UTF_8, MutableConversionService.create())
 
     void "test the buffer min and max are correct for special characters"() {
         given:

--- a/src/main/docs/guide/appendix/breaks.adoc
+++ b/src/main/docs/guide/appendix/breaks.adoc
@@ -50,6 +50,11 @@ Annotations with the retention CLASS are not available in the annotation metadat
 
 Interceptors with multiple interceptor bindings annotations now require the same set of annotations to be present at the intercepted point. In the Micronaut 3 an interceptor with multiple binding annotations would need at least one of the binding annotations to be present at the intercepted point.
 
+==== `ConversionService` and `ConversionService.SHARED` is no longer mutable
+
+New type converters can be added to api:core.convert.MutableConversionService[] retrieved from the bean context or by declaring a bean of type api:core.convert.TypeConverter[].
+To register a type converter into `ConversionService.SHARED`, the registration needs to be done via the service loader.
+
 == 3.3.0
 
 - The <<environmentEndpoint, environmental endpoint>> is now disabled by default. To enable it, you must update your endpoint config:

--- a/src/main/docs/guide/config/customTypeConverter.adoc
+++ b/src/main/docs/guide/config/customTypeConverter.adoc
@@ -21,3 +21,5 @@ snippet::io.micronaut.docs.config.converters.MapToLocalDateConverter[tags="impor
 <1> The class implements api:core.convert.TypeConverter[] which has two generic arguments, the type you are converting from, and the type you are converting to
 <2> The implementation delegates to the default shared conversion service to convert the values from the Map used to create a `LocalDate`
 <3> If an exception occurs during binding, call `reject(..)` which propagates additional information to the container
+
+NOTE: It's possible to add a custom type converter into `ConversionService.SHARED` by registering it via the service loader.

--- a/src/main/docs/guide/httpServer/binding.adoc
+++ b/src/main/docs/guide/httpServer/binding.adoc
@@ -90,7 +90,7 @@ WARNING: Since Java does not retain argument names in bytecode, you must compile
 
 Generally any type that can be converted from a String representation to a Java type via the link:{api}/io/micronaut/core/convert/ConversionService.html[ConversionService] API can be bound to.
 
-This includes most common Java types, however additional link:{api}/io/micronaut/core/convert/TypeConverter.html[TypeConverter] instances can be registered by creating `@Singleton` beans of type `TypeConverter`.
+This includes most common Java types, however additional link:{api}/io/micronaut/core/convert/TypeConverter.html[TypeConverter] instances can be registered via the service loader or by creating beans of type `TypeConverter`,
 
 The handling of nullability deserves special mention. Consider for example the following example:
 

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/config/converters/MapToLocalDateConverter.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/config/converters/MapToLocalDateConverter.groovy
@@ -15,18 +15,20 @@
  */
 package io.micronaut.docs.config.converters
 
-// tag::imports[]
+import io.micronaut.context.annotation.Prototype
 import io.micronaut.core.convert.ConversionContext
+
+// tag::imports[]
+
 import io.micronaut.core.convert.ConversionService
 import io.micronaut.core.convert.TypeConverter
 
-import jakarta.inject.Singleton
 import java.time.DateTimeException
 import java.time.LocalDate
 // end::imports[]
 
 // tag::class[]
-@Singleton
+@Prototype
 class MapToLocalDateConverter implements TypeConverter<Map, LocalDate> { // <1>
     @Override
     Optional<LocalDate> convert(Map propertyMap, Class<LocalDate> targetType, ConversionContext context) {

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/http/server/bind/annotation/ShoppingCartRequestArgumentBinder.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/http/server/bind/annotation/ShoppingCartRequestArgumentBinder.groovy
@@ -17,11 +17,11 @@ import jakarta.inject.Singleton
 class ShoppingCartRequestArgumentBinder
         implements AnnotatedRequestArgumentBinder<ShoppingCart, Object> { //<1>
 
-    private final ConversionService<?> conversionService
+    private final ConversionService conversionService
     private final JacksonObjectSerializer objectSerializer
 
     ShoppingCartRequestArgumentBinder(
-            ConversionService<?> conversionService,
+            ConversionService conversionService,
             JacksonObjectSerializer objectSerializer) {
         this.conversionService = conversionService
         this.objectSerializer = objectSerializer

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/config/converters/MapToLocalDateConverter.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/config/converters/MapToLocalDateConverter.kt
@@ -16,6 +16,7 @@
 package io.micronaut.docs.config.converters
 
 // tag::imports[]
+import io.micronaut.context.annotation.Prototype
 import io.micronaut.core.convert.ConversionContext
 import io.micronaut.core.convert.ConversionService
 import io.micronaut.core.convert.TypeConverter
@@ -26,7 +27,7 @@ import jakarta.inject.Singleton
 // end::imports[]
 
 // tag::class[]
-@Singleton
+@Prototype
 class MapToLocalDateConverter : TypeConverter<Map<*, *>, LocalDate> { // <1>
     override fun convert(propertyMap: Map<*, *>, targetType: Class<LocalDate>, context: ConversionContext): Optional<LocalDate> {
         val day = ConversionService.SHARED.convert(propertyMap["day"], Int::class.java)

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/http/server/bind/annotation/ShoppingCartRequestArgumentBinder.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/http/server/bind/annotation/ShoppingCartRequestArgumentBinder.kt
@@ -13,7 +13,7 @@ import jakarta.inject.Singleton
 
 @Singleton
 class ShoppingCartRequestArgumentBinder(
-        private val conversionService: ConversionService<*>,
+        private val conversionService: ConversionService,
         private val objectSerializer: JacksonObjectSerializer
 ) : AnnotatedRequestArgumentBinder<ShoppingCart, Any> { //<1>
 

--- a/test-suite/src/test/java/io/micronaut/docs/config/converters/MapToLocalDateConverter.java
+++ b/test-suite/src/test/java/io/micronaut/docs/config/converters/MapToLocalDateConverter.java
@@ -16,11 +16,12 @@
 package io.micronaut.docs.config.converters;
 
 // tag::imports[]
+
+import io.micronaut.context.annotation.Prototype;
 import io.micronaut.core.convert.ConversionContext;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.TypeConverter;
 
-import jakarta.inject.Singleton;
 import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.util.Map;
@@ -28,7 +29,7 @@ import java.util.Optional;
 // end::imports[]
 
 // tag::class[]
-@Singleton
+@Prototype
 public class MapToLocalDateConverter implements TypeConverter<Map, LocalDate> { // <1>
     @Override
     public Optional<LocalDate> convert(Map propertyMap, Class<LocalDate> targetType, ConversionContext context) {

--- a/test-suite/src/test/java/io/micronaut/docs/http/server/bind/annotation/ShoppingCartRequestArgumentBinder.java
+++ b/test-suite/src/test/java/io/micronaut/docs/http/server/bind/annotation/ShoppingCartRequestArgumentBinder.java
@@ -17,10 +17,10 @@ import java.util.Optional;
 public class ShoppingCartRequestArgumentBinder
         implements AnnotatedRequestArgumentBinder<ShoppingCart, Object> { //<1>
 
-    private final ConversionService<?> conversionService;
+    private final ConversionService conversionService;
     private final JacksonObjectSerializer objectSerializer;
 
-    public ShoppingCartRequestArgumentBinder(ConversionService<?> conversionService,
+    public ShoppingCartRequestArgumentBinder(ConversionService conversionService,
                                              JacksonObjectSerializer objectSerializer) {
         this.conversionService = conversionService;
         this.objectSerializer = objectSerializer;

--- a/websocket/src/main/java/io/micronaut/websocket/bind/WebSocketStateBinderRegistry.java
+++ b/websocket/src/main/java/io/micronaut/websocket/bind/WebSocketStateBinderRegistry.java
@@ -51,12 +51,13 @@ public class WebSocketStateBinderRegistry implements ArgumentBinderRegistry<WebS
      * Default constructor.
      *
      * @param requestBinderRegistry The request binder registry
+     * @param conversionService     The conversionService
      */
-    public WebSocketStateBinderRegistry(RequestBinderRegistry requestBinderRegistry) {
+    public WebSocketStateBinderRegistry(RequestBinderRegistry requestBinderRegistry, ConversionService conversionService) {
         this.requestBinderRegistry = requestBinderRegistry;
         ArgumentBinder<Object, WebSocketState> sessionBinder = (context, source) -> () -> Optional.of(source.getSession());
         this.byType.put(WebSocketSession.class, sessionBinder);
-        this.queryValueArgumentBinder = new QueryValueArgumentBinder<>(ConversionService.SHARED);
+        this.queryValueArgumentBinder = new QueryValueArgumentBinder<>(conversionService);
     }
 
     @Override


### PR DESCRIPTION
Fixes #7657

Hopefully replaced all the possible usages of `ConversionService.SHARED`.

Some use cases cannot work after this change:
The detached request body is being converted:
```
        when:
        def request = HttpRequest.POST('/', JsonObject.createObjectNode([:]))

        then:
        request.getBody(String).get() != '{}'
```

Not sure if it's something that is even make sense, the fix now it to use this:
```
        when:
        request.setConversionService(conversionService)

        then:
        request.getBody(String).get() == '{}'
```

