### PR TITLE
Fix STREAM_PIPELINE_ATTRIBUTE

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpRequest.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpRequest.java
@@ -527,7 +527,7 @@ public class NettyHttpRequest<T> extends AbstractNettyHttpRequest<T> implements 
             );
 
             int ourStream = ((Http2StreamChannel) channelHandlerContext.channel()).stream().id();
-            HttpPipelineBuilder.StreamPipeline originalStreamPipeline = channelHandlerContext.channel().attr(HttpPipelineBuilder.StreamPipelineAttributeKeyHolder.getInstance()).get();
+            HttpPipelineBuilder.StreamPipeline originalStreamPipeline = channelHandlerContext.channel().attr(HttpPipelineBuilder.STREAM_PIPELINE_ATTRIBUTE.get()).get();
 
             new Http2StreamChannelBootstrap(channelHandlerContext.channel().parent())
                     .handler(new ChannelInitializer<Http2StreamChannel>() {


### PR DESCRIPTION
Apparently there was a race condition with AttributeKey.newInstance being called multiple times