### PR TITLE
Virtual thread support

### DIFF
--- a/context/src/main/java/io/micronaut/scheduling/LoomSupport.java
+++ b/context/src/main/java/io/micronaut/scheduling/LoomSupport.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2003-2021 the original author or authors.
+ * Copyright 2017-2021 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/context/src/main/java/io/micronaut/scheduling/LoomSupport.java
+++ b/context/src/main/java/io/micronaut/scheduling/LoomSupport.java
@@ -26,15 +26,18 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 
+/**
+ * @since 4.0.0
+ */
 @Internal
 public final class LoomSupport {
-    private static final boolean supported;
+    private static final boolean SUPPORTED;
     private static Throwable failure;
 
-    private static final MethodHandle MH_newThreadPerTaskExecutor;
-    private static final MethodHandle MH_ofVirtual;
-    private static final MethodHandle MH_name;
-    private static final MethodHandle MH_factory;
+    private static final MethodHandle MH_NEW_THREAD_PER_TASK_EXECUTOR;
+    private static final MethodHandle MH_OF_VIRTUAL;
+    private static final MethodHandle MH_NAME;
+    private static final MethodHandle MH_FACTORY;
 
     static {
         boolean sup;
@@ -67,17 +70,18 @@ public final class LoomSupport {
             failure = e;
         }
 
-        supported = sup;
-        MH_newThreadPerTaskExecutor = newThreadPerTaskExecutor;
-        MH_ofVirtual = ofVirtual;
-        MH_name = name;
-        MH_factory = factory;
+        SUPPORTED = sup;
+        MH_NEW_THREAD_PER_TASK_EXECUTOR = newThreadPerTaskExecutor;
+        MH_OF_VIRTUAL = ofVirtual;
+        MH_NAME = name;
+        MH_FACTORY = factory;
     }
 
-    private LoomSupport() {}
+    private LoomSupport() {
+    }
 
     public static boolean isSupported() {
-        return supported;
+        return SUPPORTED;
     }
 
     public static void checkSupported() {
@@ -89,7 +93,7 @@ public final class LoomSupport {
     public static ExecutorService newThreadPerTaskExecutor(ThreadFactory threadFactory) {
         checkSupported();
         try {
-            return (ExecutorService) MH_newThreadPerTaskExecutor.invokeExact(threadFactory);
+            return (ExecutorService) MH_NEW_THREAD_PER_TASK_EXECUTOR.invokeExact(threadFactory);
         } catch (Throwable e) {
             throw new RuntimeException(e);
         }
@@ -98,9 +102,9 @@ public final class LoomSupport {
     public static ThreadFactory newVirtualThreadFactory(String namePrefix) {
         checkSupported();
         try {
-            Object builder = MH_ofVirtual.invoke();
-            builder = MH_name.invoke(builder, namePrefix, 1L);
-            return (ThreadFactory) MH_factory.invoke(builder);
+            Object builder = MH_OF_VIRTUAL.invoke();
+            builder = MH_NAME.invoke(builder, namePrefix, 1L);
+            return (ThreadFactory) MH_FACTORY.invoke(builder);
         } catch (Throwable e) {
             throw new RuntimeException(e);
         }

--- a/context/src/main/java/io/micronaut/scheduling/LoomSupport.java
+++ b/context/src/main/java/io/micronaut/scheduling/LoomSupport.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.scheduling;
 
+import io.micronaut.context.condition.Condition;
+import io.micronaut.context.condition.ConditionContext;
 import io.micronaut.core.annotation.Internal;
 
 import java.lang.invoke.MethodHandle;
@@ -101,6 +103,23 @@ public final class LoomSupport {
             return (ThreadFactory) MH_factory.invoke(builder);
         } catch (Throwable e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Condition that only matches if virtual threads are supported on this platform.
+     */
+    @Internal
+    public static class LoomCondition implements Condition {
+        @SuppressWarnings("rawtypes")
+        @Override
+        public boolean matches(ConditionContext context) {
+            if (isSupported()) {
+                return true;
+            } else {
+                context.fail("Virtual threads support not available: " + failure.getMessage());
+                return false;
+            }
         }
     }
 }

--- a/context/src/main/java/io/micronaut/scheduling/LoomSupport.java
+++ b/context/src/main/java/io/micronaut/scheduling/LoomSupport.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.scheduling;
+
+import io.micronaut.core.annotation.Internal;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+@Internal
+public final class LoomSupport {
+    private static final boolean supported;
+    private static Throwable failure;
+
+    private static final MethodHandle MH_newThreadPerTaskExecutor;
+    private static final MethodHandle MH_ofVirtual;
+    private static final MethodHandle MH_name;
+    private static final MethodHandle MH_factory;
+
+    static {
+        boolean sup;
+        MethodHandle newThreadPerTaskExecutor;
+        MethodHandle ofVirtual;
+        MethodHandle name;
+        MethodHandle factory;
+        try {
+            newThreadPerTaskExecutor = MethodHandles.lookup()
+                .findStatic(Executors.class, "newThreadPerTaskExecutor", MethodType.methodType(ExecutorService.class, ThreadFactory.class));
+            Class<?> builderCl = Class.forName("java.lang.Thread$Builder");
+            Class<?> ofVirtualCl = Class.forName("java.lang.Thread$Builder$OfVirtual");
+            ofVirtual = MethodHandles.lookup()
+                .findStatic(Thread.class, "ofVirtual", MethodType.methodType(ofVirtualCl));
+            name = MethodHandles.lookup()
+                .findVirtual(builderCl, "name", MethodType.methodType(builderCl, String.class, long.class));
+            factory = MethodHandles.lookup()
+                .findVirtual(builderCl, "factory", MethodType.methodType(ThreadFactory.class));
+
+            // invoke, this will throw an UnsupportedOperationException if we don't have --enable-preview
+            ofVirtual.invoke();
+
+            sup = true;
+        } catch (Throwable e) {
+            newThreadPerTaskExecutor = null;
+            ofVirtual = null;
+            name = null;
+            factory = null;
+            sup = false;
+            failure = e;
+        }
+
+        supported = sup;
+        MH_newThreadPerTaskExecutor = newThreadPerTaskExecutor;
+        MH_ofVirtual = ofVirtual;
+        MH_name = name;
+        MH_factory = factory;
+    }
+
+    private LoomSupport() {}
+
+    public static boolean isSupported() {
+        return supported;
+    }
+
+    public static void checkSupported() {
+        if (!isSupported()) {
+            throw new UnsupportedOperationException("Virtual threads are not supported on this JVM, you may have to pass --enable-preview", failure);
+        }
+    }
+
+    public static ExecutorService newThreadPerTaskExecutor(ThreadFactory threadFactory) {
+        checkSupported();
+        try {
+            return (ExecutorService) MH_newThreadPerTaskExecutor.invokeExact(threadFactory);
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static ThreadFactory newVirtualThreadFactory(String namePrefix) {
+        checkSupported();
+        try {
+            Object builder = MH_ofVirtual.invoke();
+            builder = MH_name.invoke(builder, namePrefix, 1L);
+            return (ThreadFactory) MH_factory.invoke(builder);
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/context/src/main/java/io/micronaut/scheduling/TaskExecutors.java
+++ b/context/src/main/java/io/micronaut/scheduling/TaskExecutors.java
@@ -15,8 +15,6 @@
  */
 package io.micronaut.scheduling;
 
-import java.util.concurrent.Executors;
-
 /**
  * The names of common task schedulers.
  *
@@ -27,7 +25,7 @@ public interface TaskExecutors {
 
     /**
      * The name of the {@link java.util.concurrent.ExecutorService} used to schedule I/O tasks. By
-     * default, this is a {@link Executors#newCachedThreadPool() cached thread pool}.
+     * default, this is a {@link java.util.concurrent.Executors#newCachedThreadPool() cached thread pool}.
      */
     String IO = "io";
 

--- a/context/src/main/java/io/micronaut/scheduling/TaskExecutors.java
+++ b/context/src/main/java/io/micronaut/scheduling/TaskExecutors.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.scheduling;
 
+import java.util.concurrent.Executors;
+
 /**
  * The names of common task schedulers.
  *
@@ -24,9 +26,23 @@ package io.micronaut.scheduling;
 public interface TaskExecutors {
 
     /**
-     * The name of the {@link java.util.concurrent.ExecutorService} used to schedule I/O tasks.
+     * The name of the {@link java.util.concurrent.ExecutorService} used to schedule I/O tasks. By
+     * default, this is a {@link Executors#newCachedThreadPool() cached thread pool}.
      */
     String IO = "io";
+
+    /**
+     * The name of the {@link java.util.concurrent.ExecutorService} used to schedule blocking tasks.
+     * If available, this will use {@link #VIRTUAL virtual threads}. Otherwise it will fall back to
+     * {@link #IO}.
+     */
+    String BLOCKING = "blocking";
+
+    /**
+     * Executor that runs tasks on virtual threads. This requires JDK 19+, and
+     * {@code --enable-preview}.
+     */
+    String VIRTUAL = "virtual";
 
     /**
      * The name of the {@link java.util.concurrent.ScheduledExecutorService} used to schedule background tasks.

--- a/context/src/main/java/io/micronaut/scheduling/executor/DefaultExecutorSelector.java
+++ b/context/src/main/java/io/micronaut/scheduling/executor/DefaultExecutorSelector.java
@@ -53,6 +53,7 @@ public class DefaultExecutorSelector implements ExecutorSelector {
      * Default constructor.
      * @param beanLocator The bean locator
      * @param ioExecutor The IO executor
+     * @param blockingExecutor The blocking executor
      */
     @Inject
     protected DefaultExecutorSelector(

--- a/context/src/main/java/io/micronaut/scheduling/executor/DefaultExecutorSelector.java
+++ b/context/src/main/java/io/micronaut/scheduling/executor/DefaultExecutorSelector.java
@@ -47,6 +47,7 @@ public class DefaultExecutorSelector implements ExecutorSelector {
     private static final String EXECUTE_ON = ExecuteOn.class.getName();
     private final BeanLocator beanLocator;
     private final Supplier<ExecutorService> ioExecutor;
+    private final Supplier<ExecutorService> blockingExecutor;
 
     /**
      * Default constructor.
@@ -54,9 +55,13 @@ public class DefaultExecutorSelector implements ExecutorSelector {
      * @param ioExecutor The IO executor
      */
     @Inject
-    protected DefaultExecutorSelector(BeanLocator beanLocator, @jakarta.inject.Named(TaskExecutors.IO) BeanProvider<ExecutorService> ioExecutor) {
+    protected DefaultExecutorSelector(
+        BeanLocator beanLocator,
+        @jakarta.inject.Named(TaskExecutors.IO) BeanProvider<ExecutorService> ioExecutor,
+        @jakarta.inject.Named(TaskExecutors.BLOCKING) BeanProvider<ExecutorService> blockingExecutor) {
         this.beanLocator = beanLocator;
         this.ioExecutor = SupplierUtil.memoized(ioExecutor::get);
+        this.blockingExecutor = SupplierUtil.memoized(blockingExecutor::get);
     }
 
     @Override
@@ -77,7 +82,7 @@ public class DefaultExecutorSelector implements ExecutorSelector {
             if (method.hasStereotype(NonBlocking.class)) {
                 return Optional.empty();
             } else if (method.hasStereotype(Blocking.class)) {
-                return Optional.of(ioExecutor.get());
+                return Optional.of(blockingExecutor.get());
             } else {
                 TypeInformation<?> returnType = method.getReturnType();
                 if (returnType.isWrapperType()) {
@@ -89,11 +94,13 @@ public class DefaultExecutorSelector implements ExecutorSelector {
                 if (returnType.isAsyncOrReactive()) {
                     return Optional.empty();
                 } else {
-                    return Optional.of(ioExecutor.get());
+                    return Optional.of(blockingExecutor.get());
                 }
             }
         } else if (threadSelection == ThreadSelection.IO) {
             return Optional.of(ioExecutor.get());
+        } else if (threadSelection == ThreadSelection.BLOCKING) {
+            return Optional.of(blockingExecutor.get());
         }
         return Optional.empty();
     }

--- a/context/src/main/java/io/micronaut/scheduling/executor/ExecutorConfiguration.java
+++ b/context/src/main/java/io/micronaut/scheduling/executor/ExecutorConfiguration.java
@@ -75,6 +75,9 @@ public interface ExecutorConfiguration {
      */
     @Min(1L) Integer getCorePoolSize();
 
+    /**
+     * @return Whether the pool should use virtual threads.
+     */
     boolean isVirtual();
 
     /**

--- a/context/src/main/java/io/micronaut/scheduling/executor/ExecutorConfiguration.java
+++ b/context/src/main/java/io/micronaut/scheduling/executor/ExecutorConfiguration.java
@@ -75,6 +75,8 @@ public interface ExecutorConfiguration {
      */
     @Min(1L) Integer getCorePoolSize();
 
+    boolean isVirtual();
+
     /**
      * @return The class to use as the {@link ThreadFactory}
      */

--- a/context/src/main/java/io/micronaut/scheduling/executor/ExecutorFactory.java
+++ b/context/src/main/java/io/micronaut/scheduling/executor/ExecutorFactory.java
@@ -60,11 +60,15 @@ public class ExecutorFactory {
      */
     @EachBean(ExecutorConfiguration.class)
     protected ThreadFactory eventLoopGroupThreadFactory(ExecutorConfiguration configuration) {
+        String name = configuration.getName();
         if (configuration.isVirtual()) {
-            return LoomSupport.newVirtualThreadFactory(configuration.getName() + "-executor");
+            if (name == null) {
+                name = "virtual";
+            }
+            return LoomSupport.newVirtualThreadFactory(name + "-executor");
         }
-        if (configuration.getName() != null) {
-            return new NamedThreadFactory(configuration.getName() + "-executor");
+        if (name != null) {
+            return new NamedThreadFactory(name + "-executor");
         }
         return threadFactory;
     }

--- a/context/src/main/java/io/micronaut/scheduling/executor/ExecutorType.java
+++ b/context/src/main/java/io/micronaut/scheduling/executor/ExecutorType.java
@@ -45,7 +45,7 @@ public enum ExecutorType {
     WORK_STEALING,
 
     /**
-     * @see java.util.concurrent.Executors#newVirtualThreadPerTaskExecutor()
+     * @see java.util.concurrent.Executors#newThreadPerTaskExecutor()
      */
     THREAD_PER_TASK
 }

--- a/context/src/main/java/io/micronaut/scheduling/executor/ExecutorType.java
+++ b/context/src/main/java/io/micronaut/scheduling/executor/ExecutorType.java
@@ -42,5 +42,10 @@ public enum ExecutorType {
     /**
      * @see java.util.concurrent.Executors#newWorkStealingPool()
      */
-    WORK_STEALING
+    WORK_STEALING,
+
+    /**
+     * @see java.util.concurrent.Executors#newVirtualThreadPerTaskExecutor()
+     */
+    THREAD_PER_TASK
 }

--- a/context/src/main/java/io/micronaut/scheduling/executor/IOExecutorServiceConfig.java
+++ b/context/src/main/java/io/micronaut/scheduling/executor/IOExecutorServiceConfig.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.scheduling.executor;
 
+import io.micronaut.context.BeanProvider;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.scheduling.LoomSupport;
@@ -22,24 +23,54 @@ import io.micronaut.scheduling.TaskExecutors;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 
+import java.util.concurrent.ExecutorService;
+
 /**
  * Configures the default I/O thread pool if none is configured by the user.
  *
  * @author Graeme Rocher
  * @since 1.0
  */
-@Requires(missingProperty = ExecutorConfiguration.PREFIX_IO)
 @Factory
 public class IOExecutorServiceConfig {
 
     /**
-     * @return The default thread pool configurations
+     * @return The default IO pool configuration
      */
     @Singleton
     @Named(TaskExecutors.IO)
-    ExecutorConfiguration configuration() {
-        UserExecutorConfiguration cfg = UserExecutorConfiguration.of(TaskExecutors.IO, LoomSupport.isSupported() ? ExecutorType.THREAD_PER_TASK : ExecutorType.CACHED);
-        cfg.setVirtual(LoomSupport.isSupported());
+    @Requires(missingProperty = ExecutorConfiguration.PREFIX_IO)
+    ExecutorConfiguration io() {
+        return UserExecutorConfiguration.of(TaskExecutors.IO, ExecutorType.CACHED);
+    }
+
+    /**
+     * @return The default virtual executor configuration
+     */
+    @Singleton
+    @Named(TaskExecutors.VIRTUAL)
+    @Requires(
+        missingProperty = ExecutorConfiguration.PREFIX + "." + TaskExecutors.VIRTUAL,
+        condition = LoomSupport.LoomCondition.class)
+    ExecutorConfiguration virtual() {
+        // sanity check
+        LoomSupport.checkSupported();
+        UserExecutorConfiguration cfg = UserExecutorConfiguration.of(TaskExecutors.VIRTUAL, ExecutorType.THREAD_PER_TASK);
+        cfg.setVirtual(true);
         return cfg;
+    }
+
+    @Singleton
+    @Named(TaskExecutors.BLOCKING)
+    @Requires(missingProperty = ExecutorConfiguration.PREFIX + "." + TaskExecutors.BLOCKING)
+    ExecutorService blocking(
+        @Named(TaskExecutors.IO) BeanProvider<ExecutorService> io,
+        @Named(TaskExecutors.VIRTUAL) BeanProvider<ExecutorService> virtual
+    ) {
+        if (virtual.isPresent()) {
+            return virtual.get();
+        } else {
+            return io.get();
+        }
     }
 }

--- a/context/src/main/java/io/micronaut/scheduling/executor/IOExecutorServiceConfig.java
+++ b/context/src/main/java/io/micronaut/scheduling/executor/IOExecutorServiceConfig.java
@@ -32,7 +32,7 @@ import java.util.concurrent.ExecutorService;
  * @since 1.0
  */
 @Factory
-public class IOExecutorServiceConfig {
+public final class IOExecutorServiceConfig {
 
     /**
      * @return The default IO pool configuration
@@ -60,6 +60,13 @@ public class IOExecutorServiceConfig {
         return cfg;
     }
 
+    /**
+     * The blocking executor.
+     *
+     * @param io IO executor (fallback)
+     * @param virtual Virtual thread executor (used if available)
+     * @return The blocking executor
+     */
     @Singleton
     @Named(TaskExecutors.BLOCKING)
     @Requires(missingProperty = ExecutorConfiguration.PREFIX + "." + TaskExecutors.BLOCKING)

--- a/context/src/main/java/io/micronaut/scheduling/executor/IOExecutorServiceConfig.java
+++ b/context/src/main/java/io/micronaut/scheduling/executor/IOExecutorServiceConfig.java
@@ -17,6 +17,7 @@ package io.micronaut.scheduling.executor;
 
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.scheduling.LoomSupport;
 import io.micronaut.scheduling.TaskExecutors;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
@@ -37,6 +38,8 @@ public class IOExecutorServiceConfig {
     @Singleton
     @Named(TaskExecutors.IO)
     ExecutorConfiguration configuration() {
-        return UserExecutorConfiguration.of(TaskExecutors.IO, ExecutorType.CACHED);
+        UserExecutorConfiguration cfg = UserExecutorConfiguration.of(TaskExecutors.IO, LoomSupport.isSupported() ? ExecutorType.THREAD_PER_TASK : ExecutorType.CACHED);
+        cfg.setVirtual(LoomSupport.isSupported());
+        return cfg;
     }
 }

--- a/context/src/main/java/io/micronaut/scheduling/executor/ThreadSelection.java
+++ b/context/src/main/java/io/micronaut/scheduling/executor/ThreadSelection.java
@@ -25,7 +25,7 @@ public enum ThreadSelection {
     /**
      * Automatically select the thread to run operations on based on the return type and/or {@link io.micronaut.core.annotation.Blocking} or {@link io.micronaut.core.annotation.NonBlocking} annotations.
      *
-     * <p>This is the default strategy in 1.x and will run operations on the I/O thread pool if the return type
+     * <p>This is the default strategy in 1.x and will run operations on the {@link io.micronaut.scheduling.TaskExecutors#BLOCKING blocking executor} if the return type
      * of the method is not a reactive top and the method is not annotated with {@link io.micronaut.core.annotation.NonBlocking}</p>
      *
      * <p>If the return type is a reactive type and the method is not annotated with {@link io.micronaut.core.annotation.Blocking} then the server event loop thread will used to run the operation.</p>
@@ -39,5 +39,9 @@ public enum ThreadSelection {
     /**
      * I/O selection will run all operations regardless of return type and annotations on the I/O thread pool and will never schedule an operation on the server event loop thread.
      */
-    IO
+    IO,
+    /**
+     * I/O selection will run all operations regardless of return type and annotations on the {@link io.micronaut.scheduling.TaskExecutors#BLOCKING blocking executor} and will never schedule an operation on the server event loop thread.
+     */
+    BLOCKING
 }

--- a/context/src/main/java/io/micronaut/scheduling/executor/UserExecutorConfiguration.java
+++ b/context/src/main/java/io/micronaut/scheduling/executor/UserExecutorConfiguration.java
@@ -120,6 +120,9 @@ public class UserExecutorConfiguration implements ExecutorConfiguration {
         return virtual;
     }
 
+    /**
+     * @param virtual Whether the pool should use virtual threads
+     */
     public void setVirtual(boolean virtual) {
         this.virtual = virtual;
     }

--- a/context/src/main/java/io/micronaut/scheduling/executor/UserExecutorConfiguration.java
+++ b/context/src/main/java/io/micronaut/scheduling/executor/UserExecutorConfiguration.java
@@ -67,6 +67,7 @@ public class UserExecutorConfiguration implements ExecutorConfiguration {
      * @param type the type
      * @param parallelism the parallelism
      * @param corePoolSize the core pool size
+     * @param virtual whether to use virtual threads
      * @param threadFactoryClass the thread factory class
      */
     @ConfigurationInject

--- a/context/src/main/java/io/micronaut/scheduling/executor/UserExecutorConfiguration.java
+++ b/context/src/main/java/io/micronaut/scheduling/executor/UserExecutorConfiguration.java
@@ -47,7 +47,7 @@ public class UserExecutorConfiguration implements ExecutorConfiguration {
     private ExecutorType type;
     private Integer parallelism;
     private Integer corePoolSize;
-    private boolean virtual = false;
+    private boolean virtual;
     private Class<? extends ThreadFactory> threadFactoryClass;
 
     /**
@@ -75,14 +75,14 @@ public class UserExecutorConfiguration implements ExecutorConfiguration {
                                         @Nullable ExecutorType type,
                                         @Nullable Integer parallelism,
                                         @Nullable Integer corePoolSize,
-                                        boolean virtual,
+                                        @Nullable Boolean virtual,
                                         @Nullable Class<? extends ThreadFactory> threadFactoryClass) {
         this.name = name;
         this.nThreads = nThreads == null ? AVAILABLE_PROCESSORS * 2 : nThreads;
         this.type = type == null ? ExecutorType.SCHEDULED : type;
         this.parallelism = parallelism == null ? AVAILABLE_PROCESSORS : parallelism;
         this.corePoolSize = corePoolSize == null ? AVAILABLE_PROCESSORS * 2 : corePoolSize;
-        this.virtual = virtual;
+        this.virtual = virtual == null ? false : virtual;
         this.threadFactoryClass = threadFactoryClass;
     }
 

--- a/context/src/main/java/io/micronaut/scheduling/executor/UserExecutorConfiguration.java
+++ b/context/src/main/java/io/micronaut/scheduling/executor/UserExecutorConfiguration.java
@@ -16,12 +16,11 @@
 package io.micronaut.scheduling.executor;
 
 import io.micronaut.context.annotation.ConfigurationInject;
-import io.micronaut.core.annotation.NonNull;
 import io.micronaut.context.annotation.EachProperty;
 import io.micronaut.context.annotation.Parameter;
-import io.micronaut.core.util.ArgumentUtils;
-
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.util.ArgumentUtils;
 
 import javax.validation.constraints.Min;
 import java.util.Optional;
@@ -48,6 +47,7 @@ public class UserExecutorConfiguration implements ExecutorConfiguration {
     private ExecutorType type;
     private Integer parallelism;
     private Integer corePoolSize;
+    private boolean virtual = false;
     private Class<? extends ThreadFactory> threadFactoryClass;
 
     /**
@@ -56,7 +56,7 @@ public class UserExecutorConfiguration implements ExecutorConfiguration {
      * @param name The name
      */
     private UserExecutorConfiguration(@Parameter String name) {
-        this(name, null, null, null, null, null);
+        this(name, null, null, null, null, false, null);
     }
 
     /**
@@ -75,12 +75,14 @@ public class UserExecutorConfiguration implements ExecutorConfiguration {
                                         @Nullable ExecutorType type,
                                         @Nullable Integer parallelism,
                                         @Nullable Integer corePoolSize,
+                                        boolean virtual,
                                         @Nullable Class<? extends ThreadFactory> threadFactoryClass) {
         this.name = name;
         this.nThreads = nThreads == null ? AVAILABLE_PROCESSORS * 2 : nThreads;
         this.type = type == null ? ExecutorType.SCHEDULED : type;
         this.parallelism = parallelism == null ? AVAILABLE_PROCESSORS : parallelism;
         this.corePoolSize = corePoolSize == null ? AVAILABLE_PROCESSORS * 2 : corePoolSize;
+        this.virtual = virtual;
         this.threadFactoryClass = threadFactoryClass;
     }
 
@@ -111,6 +113,15 @@ public class UserExecutorConfiguration implements ExecutorConfiguration {
     @Min(1L)
     public Integer getCorePoolSize() {
         return corePoolSize;
+    }
+
+    @Override
+    public boolean isVirtual() {
+        return virtual;
+    }
+
+    public void setVirtual(boolean virtual) {
+        this.virtual = virtual;
     }
 
     @Override

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
@@ -160,7 +160,7 @@ public class NettyHttpServer implements NettyEmbeddedServer {
                 .getEventPublisher(HttpRequestTerminatedEvent.class);
         final Supplier<ExecutorService> ioExecutor = SupplierUtil.memoized(() ->
                 nettyEmbeddedServices.getExecutorSelector()
-                        .select(TaskExecutors.IO).orElse(null)
+                        .select(TaskExecutors.BLOCKING).orElse(null)
         );
         this.httpContentProcessorResolver = new DefaultHttpContentProcessorResolver(
                 nettyEmbeddedServices.getApplicationContext(),

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/NettyBinderRegistrar.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/NettyBinderRegistrar.java
@@ -60,7 +60,7 @@ class NettyBinderRegistrar implements BeanCreatedEventListener<RequestBinderRegi
                          HttpContentProcessorResolver httpContentProcessorResolver,
                          BeanLocator beanLocator,
                          BeanProvider<HttpServerConfiguration> httpServerConfiguration,
-                         @Named(TaskExecutors.IO) BeanProvider<ExecutorService> executorService) {
+                         @Named(TaskExecutors.BLOCKING) BeanProvider<ExecutorService> executorService) {
         this.conversionService = conversionService;
         this.httpContentProcessorResolver = httpContentProcessorResolver;
         this.beanLocator = beanLocator;

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/jackson/JsonViewServerFilter.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/jackson/JsonViewServerFilter.java
@@ -67,7 +67,7 @@ public class JsonViewServerFilter implements HttpServerFilter {
      */
     public JsonViewServerFilter(
             JsonViewCodecResolver jsonViewCodecResolver,
-            @Named(TaskExecutors.IO) ExecutorService executorService) {
+            @Named(TaskExecutors.BLOCKING) ExecutorService executorService) {
         this.codecFactory = jsonViewCodecResolver;
         this.executorService = executorService;
     }

--- a/management/src/main/java/io/micronaut/management/health/indicator/AbstractHealthIndicator.java
+++ b/management/src/main/java/io/micronaut/management/health/indicator/AbstractHealthIndicator.java
@@ -41,7 +41,7 @@ public abstract class AbstractHealthIndicator<T> implements HealthIndicator {
      * @param executorService The executor service
      */
     @Inject
-    public void setExecutorService(@Named(TaskExecutors.IO) ExecutorService executorService) {
+    public void setExecutorService(@Named(TaskExecutors.BLOCKING) ExecutorService executorService) {
         this.executorService = executorService;
     }
 

--- a/management/src/main/java/io/micronaut/management/health/indicator/jdbc/JdbcIndicator.java
+++ b/management/src/main/java/io/micronaut/management/health/indicator/jdbc/JdbcIndicator.java
@@ -71,7 +71,7 @@ public class JdbcIndicator implements HealthIndicator {
      * @param dataSourceResolver The data source resolver
      * @param healthAggregator   The health aggregator
      */
-    public JdbcIndicator(@Named(TaskExecutors.IO) ExecutorService executorService,
+    public JdbcIndicator(@Named(TaskExecutors.BLOCKING) ExecutorService executorService,
                          DataSource[] dataSources,
                          @Nullable DataSourceResolver dataSourceResolver,
                          HealthAggregator<?> healthAggregator) {

--- a/runtime/src/test/groovy/io/micronaut/runtime/executor/ExecutorServiceConfigSpec.groovy
+++ b/runtime/src/test/groovy/io/micronaut/runtime/executor/ExecutorServiceConfigSpec.groovy
@@ -17,6 +17,7 @@ package io.micronaut.runtime.executor
 
 import io.micronaut.context.ApplicationContext
 import io.micronaut.inject.qualifiers.Qualifiers
+import io.micronaut.scheduling.LoomSupport
 import io.micronaut.scheduling.TaskExecutors
 import io.micronaut.scheduling.executor.ExecutorConfiguration
 import io.micronaut.scheduling.executor.UserExecutorConfiguration
@@ -33,6 +34,7 @@ import java.util.concurrent.ThreadPoolExecutor
  * @since 1.0
  */
 class ExecutorServiceConfigSpec extends Specification {
+    static final int expectedExecutorCount = LoomSupport.isSupported() ? 6 : 5
 
     @Unroll
     void "test configure custom executor with invalidate cache: #invalidateCache"() {
@@ -53,7 +55,7 @@ class ExecutorServiceConfigSpec extends Specification {
         Collection<ExecutorService> executorServices = ctx.getBeansOfType(ExecutorService.class)
 
         then:
-        executorServices.size() == 4
+        executorServices.size() == expectedExecutorCount
 
         when:
         ThreadPoolExecutor poolExecutor = ctx.getBean(ThreadPoolExecutor, Qualifiers.byName("one"))
@@ -61,7 +63,7 @@ class ExecutorServiceConfigSpec extends Specification {
 
         then:
         forkJoinPool instanceof ForkJoinPool
-        executorServices.size() == 4
+        executorServices.size() == expectedExecutorCount
         poolExecutor.corePoolSize == 5
         ctx.getBean(ExecutorService.class, Qualifiers.byName(TaskExecutors.IO)) // the default IO executor
         ctx.getBean(ExecutorService.class, Qualifiers.byName(TaskExecutors.SCHEDULED)) // the default IO executor
@@ -113,7 +115,7 @@ class ExecutorServiceConfigSpec extends Specification {
         ExecutorService forkJoinPool = ctx.getBean(ExecutorService, Qualifiers.byName("two"))
 
         then:
-        executorServices.size() == 4
+        executorServices.size() == expectedExecutorCount
         poolExecutor.corePoolSize == 5
         ctx.getBean(ExecutorService.class, Qualifiers.byName(TaskExecutors.IO)) instanceof ThreadPoolExecutor
         ctx.getBean(ExecutorService.class, Qualifiers.byName(TaskExecutors.SCHEDULED)) instanceof ScheduledExecutorService
@@ -129,7 +131,7 @@ class ExecutorServiceConfigSpec extends Specification {
         executorServices = ctx.getBeansOfType(ExecutorService)
 
         then:
-        executorServices.size() == 4
+        executorServices.size() == expectedExecutorCount
         moreConfigs.size() == 4
         configs.size() == 2
 
@@ -168,7 +170,7 @@ class ExecutorServiceConfigSpec extends Specification {
         Collection<ExecutorService> executorServices = ctx.getBeansOfType(ExecutorService.class)
 
         then:
-        executorServices.size() == 3
+        executorServices.size() == expectedExecutorCount - 1
         ctx.getBean(ExecutorService.class, Qualifiers.byName(TaskExecutors.IO)) instanceof ThreadPoolExecutor
 
         when:
@@ -180,7 +182,7 @@ class ExecutorServiceConfigSpec extends Specification {
         executorServices = ctx.getBeansOfType(ExecutorService)
 
         then:
-        executorServices.size() == 3
+        executorServices.size() == expectedExecutorCount - 1
         moreConfigs.size() == 3
         configs.size() == 2
 


### PR DESCRIPTION
This PR introduces basic virtual thread support to micronaut-context. Virtual threads are available with `--enable-preview` on Java 19. The changes in this PR:

- Introduce a new `ExecutorType.THREAD_PER_TASK`. This uses the new `newThreadPerTaskExecutor`, which launches a new (hopefully virtual) thread for each submitted task.
- Introduce a new setting `ExecutorConfiguration.virtual` that changes the `ThreadFactory` to create virtual threads.
- Change the `TaskExecutors.IO` thread pool to use a virtual thread-per-task executor if virtual threads are available.

I have done preliminary benchmarking of virtual threads using our existing `ExecuteOn` machinery. Unfortunately, there is still overhead associated with dispatching controller methods on virtual threads. For this reason, I'm not proposing making virtual thread dispatch the default. I will have to investigate further whether there are optimization opportunities (removing thread locals?) that could help here.

Replacing the `IO` executor with a virtual thread pool seems like a good path forward. Existing users of `IO` will benefit from virtual threads without moving to a new executor. We also have a few internal uses of the IO executor.

Changing the IO executor to a virtual thread pool could be incompatible with the old executor, however. Virtual threads run on a mostly-fixed-size thread pool, and if many of the virtual threads are pinned (e.g. from a synchronized block), the carrier threads might be exhausted. The old IO pool was a cached pool, and would never exhaust its threads.

On implementation: 19-specific code is packaged into the new `LoomSupport` class, and accessed through static final MethodHandles. My understanding is that static final MHs carry no call overhead. I have yet to test it with graal however.

@melix suggested an approach based on multi-release jars (first commits of #8153). On Java 19, the full LoomSupport class would load, and on previous Java versions, it would be replaced by a stub class that does nothing. However this solution did not work out: Using the preview APIs apparently sets a flag in the class file that prevents it from being loaded on a non-preview Java 19 VM (there's a LinkageError). Fixing this would require guarding all accesses to the class (not just calls into new APIs) against such linkage errors, which is annoying (but probably possible).

@dstepanov proposed an alternative approach using bytecode generation (1265e9f25c8125c4c03a35f3abeae29eeaca39c4). It creates a new Executor bean with a new name (not `IO`), directly calling the `newVirtualThreadPerTaskExecutor` method, using existing machinery in micronaut-inject. My initial concern with this was that the executor cannot be configured, e.g. with the thread name. However most of the `ExecutorConfiguration` options (eg thread pool sizes) make no sense for virtual threads anyway, so this might not be a deal-breaker. Unfortunately, I could not get this approach to inject the executor properly. I'm also not sure of the failure mode on non-preview JDK 19: The bean is gated to only apply on JDK 19+, but the call to `newVirtualThreadPerTaskExecutor` will fail if `--enable-preview` is not set.

I think the ideal solution would be something like the `LoomSupport` class, but calling the API methods directly (with bytecode generation to avoid the failure when `--enable-preview` is missing). It's not as elegant as @dstepanov's approach that uses existing codegen infrastructure, but it won't be a big problem with ASM.