### PR TITLE
Configuration props for inner classes are now dollar prefixed

### DIFF
--- a/src/main/docs/guide/httpServer/hostResolution.adoc
+++ b/src/main/docs/guide/httpServer/hostResolution.adoc
@@ -11,6 +11,6 @@ The default implementation looks for host information in the following places in
 
 The behavior of which headers to pull the relevant data can be changed with the following configuration:
 
-include::{includedir}configurationProperties/io.micronaut.http.server.HttpServerConfiguration.HostResolutionConfiguration.adoc[]
+include::{includedir}configurationProperties/io.micronaut.http.server.HttpServerConfiguration$HostResolutionConfiguration.adoc[]
 
 The above configuration also supports an allowed host list. Configuring this list ensures any resolved host matches one of the supplied regular expression patterns. That is useful to prevent host cache poisoning attacks and is recommended to be configured.

--- a/src/main/docs/guide/httpServer/localeResolution.adoc
+++ b/src/main/docs/guide/httpServer/localeResolution.adoc
@@ -4,7 +4,7 @@ The api:core.util.LocaleResolver[] API does not need to be used directly. Simply
 
 There are several configuration options to control how to resolve the locale:
 
-include::{includedir}configurationProperties/io.micronaut.http.server.HttpServerConfiguration.HttpLocaleResolutionConfigurationProperties.adoc[]
+include::{includedir}configurationProperties/io.micronaut.http.server.HttpServerConfiguration$HttpLocaleResolutionConfigurationProperties.adoc[]
 
 Locales can be configured in the "en_GB" format, or in the BCP 47 (Language tag) format. If multiple methods are configured, the fixed locale takes precedence, followed by session/cookie, then header.
 

--- a/src/main/docs/guide/httpServer/serverConfiguration/threadPools.adoc
+++ b/src/main/docs/guide/httpServer/serverConfiguration/threadPools.adoc
@@ -4,7 +4,7 @@ The Netty worker event loop uses the "default" named event loop group. This can 
 
 IMPORTANT: The event loop configuration under `micronaut.server.netty.worker` is only used if the `event-loop-group` is set to a name which doesn't correspond to any `micronaut.netty.event-loops` configuration. This behavior is deprecated and will be removed in a future version. Use `micronaut.netty.event-loops.*` for any event loop group configuration beyond setting the name through `event-loop-group`. This does not apply to the parent event loop configuration (`micronaut.server.netty.parent`).
 
-include::{includedir}configurationProperties/io.micronaut.http.server.netty.configuration.NettyHttpServerConfiguration.Worker.adoc[]
+include::{includedir}configurationProperties/io.micronaut.http.server.netty.configuration.NettyHttpServerConfiguration$Worker.adoc[]
 
 TIP: The parent event loop can be configured with `micronaut.server.netty.parent` with the same configuration options.
 

--- a/src/main/docs/guide/httpServer/transfers.adoc
+++ b/src/main/docs/guide/httpServer/transfers.adoc
@@ -44,4 +44,4 @@ By default, file responses include caching headers. The following options determ
 
 include::{includedir}configurationProperties/io.micronaut.http.server.netty.types.files.FileTypeHandlerConfiguration.adoc[]
 
-include::{includedir}configurationProperties/io.micronaut.http.server.netty.types.files.FileTypeHandlerConfiguration.CacheControlConfiguration.adoc[]
+include::{includedir}configurationProperties/io.micronaut.http.server.netty.types.files.FileTypeHandlerConfiguration$CacheControlConfiguration.adoc[]


### PR DESCRIPTION
Now we publish on Java 17, this output filename has changed from:

```
file.OuterClass.Inner.adoc
```

to

```
file.OuterClass$Inner.adoc
```

This fixes the `validateAssembleDocs` task that occurs [prior to publishing as seen here](https://github.com/micronaut-projects/micronaut-core/actions/runs/3272488402/jobs/5383556505#step:11:1689)