### PR TITLE
Deprecate JacksonConfig construtor for removal in 4.0.0

### DIFF
--- a/http-server/src/main/java/io/micronaut/http/server/exceptions/response/HateoasErrorResponseProcessor.java
+++ b/http-server/src/main/java/io/micronaut/http/server/exceptions/response/HateoasErrorResponseProcessor.java
@@ -51,7 +51,9 @@ public class HateoasErrorResponseProcessor implements ErrorResponseProcessor<Jso
      * {@link HateoasErrorResponseProcessor#HateoasErrorResponseProcessor(JsonConfiguration)}
      *
      * @param jacksonConfiguration the configuration to use for processing.
+     * @deprecated Use {@link HateoasErrorResponseProcessor(JsonConfiguration)}
      */
+    @Deprecated
     public HateoasErrorResponseProcessor(JacksonConfiguration jacksonConfiguration) {
         this((JsonConfiguration) jacksonConfiguration);
     }


### PR DESCRIPTION
Removing it will fix using Groovy with Serde and the default ErrorResponseProcessor