### PR TITLE
Fix the Hateoas/Groovy/Serde error in a binary compatible way

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -413,6 +413,7 @@ log4j = { module = "org.apache.logging.log4j:log4j-core", version.ref = "log4j" 
 logbook-netty = { module = "org.zalando:logbook-netty", version.ref = "logbook-netty" }
 
 micronaut-docs = { module = "io.micronaut.docs:micronaut-docs-asciidoc-config-props", version.ref = "micronaut-docs" }
+micronaut-runtime-groovy = { module = "io.micronaut.groovy:micronaut-runtime-groovy", version.ref = "managed-micronaut-groovy" }
 
 mysql-driver = { module = "mysql:mysql-connector-java" }
 

--- a/http-server/build.gradle
+++ b/http-server/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     api project(":router")
     compileOnly libs.kotlinx.coroutines.core
     compileOnly libs.kotlinx.coroutines.reactor
+    compileOnly(libs.micronaut.runtime.groovy)
     implementation libs.managed.reactor
     annotationProcessor project(":inject-java")
 

--- a/http-server/src/main/java/io/micronaut/http/server/exceptions/response/HateoasErrorResponseProcessor.java
+++ b/http-server/src/main/java/io/micronaut/http/server/exceptions/response/HateoasErrorResponseProcessor.java
@@ -50,8 +50,10 @@ public class HateoasErrorResponseProcessor implements ErrorResponseProcessor<Jso
      * Constructor for binary compatibility. Equivalent to
      * {@link HateoasErrorResponseProcessor#HateoasErrorResponseProcessor(JsonConfiguration)}
      *
+     * @deprecated Use {@link HateoasErrorResponseProcessor#HateoasErrorResponseProcessor(JsonConfiguration)} instead.
      * @param jacksonConfiguration the configuration to use for processing.
      */
+    @Deprecated
     public HateoasErrorResponseProcessor(JacksonConfiguration jacksonConfiguration) {
         this((JsonConfiguration) jacksonConfiguration);
     }
@@ -59,6 +61,11 @@ public class HateoasErrorResponseProcessor implements ErrorResponseProcessor<Jso
     @Override
     @NonNull
     public MutableHttpResponse<JsonError> processResponse(@NonNull ErrorContext errorContext, @NonNull MutableHttpResponse<?> response) {
+        return getJsonErrorMutableHttpResponse(alwaysSerializeErrorsAsList, errorContext, response);
+    }
+
+    @NonNull
+    static MutableHttpResponse<JsonError> getJsonErrorMutableHttpResponse(boolean alwaysSerializeErrorsAsList, ErrorContext errorContext, MutableHttpResponse<?> response) {
         if (errorContext.getRequest().getMethod() == HttpMethod.HEAD) {
             return (MutableHttpResponse<JsonError>) response;
         }

--- a/http-server/src/main/java/io/micronaut/http/server/exceptions/response/HateoasErrorResponseProcessorReplacement.java
+++ b/http-server/src/main/java/io/micronaut/http/server/exceptions/response/HateoasErrorResponseProcessorReplacement.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.exceptions.response;
+
+import io.micronaut.context.annotation.Replaces;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.env.groovy.GroovyPropertySourceLoader;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.http.MutableHttpResponse;
+import io.micronaut.http.hateoas.JsonError;
+import io.micronaut.json.JsonConfiguration;
+import jakarta.inject.Singleton;
+
+/**
+ * @deprecated Replacement is no longer necessary for Micronaut Framework 4.0 since {@link io.micronaut.http.server.exceptions.response.HateoasErrorResponseProcessor} jackson constructor will be removed.
+ * @author Tim Yates
+ * @since 3.7.3
+ */
+@Deprecated
+@Singleton
+@Requires(classes = GroovyPropertySourceLoader.class)
+@Replaces(HateoasErrorResponseProcessor.class)
+public class HateoasErrorResponseProcessorReplacement implements ErrorResponseProcessor<JsonError> {
+
+    private final boolean alwaysSerializeErrorsAsList;
+
+    public HateoasErrorResponseProcessorReplacement(JsonConfiguration jacksonConfiguration) {
+        this.alwaysSerializeErrorsAsList = jacksonConfiguration.isAlwaysSerializeErrorsAsList();
+    }
+
+    @Override
+    @NonNull
+    public MutableHttpResponse<JsonError> processResponse(@NonNull ErrorContext errorContext,
+                                                          @NonNull MutableHttpResponse<?> response) {
+        return HateoasErrorResponseProcessor.getJsonErrorMutableHttpResponse(alwaysSerializeErrorsAsList, errorContext, response);
+    }
+}

--- a/test-suite-groovy/build.gradle
+++ b/test-suite-groovy/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     testImplementation project(":function-web")
     testRuntimeOnly(platform(libs.boms.micronaut.aws))
     testRuntimeOnly libs.aws.java.sdk.lambda
+    testRuntimeOnly(libs.micronaut.runtime.groovy)
 
     testImplementation libs.managed.reactor
 }


### PR DESCRIPTION
When trying to use Groovy and Serde and the default ErrorProcessor, Groovy throws a ClassNotFound exception.

This fix adds a replacement for the HateoasErrorResponseProcessor that (if groovy-runtime is on the classpath) doesn't use JacksonConfiguration.

It also deprecates the JacksonConfiguration constructor for removal in 4.0.0

Fixes #8184