### PR TITLE
Let SemanticVersion.isAtLeastMajorMinor be able to compare two different major versions.

### DIFF
--- a/core/src/main/java/io/micronaut/core/version/SemanticVersion.java
+++ b/core/src/main/java/io/micronaut/core/version/SemanticVersion.java
@@ -121,6 +121,12 @@ public class SemanticVersion implements Comparable<SemanticVersion> {
     }
 
     private static boolean isAtLeastMajorMinorImpl(SemanticVersion version, int majorVersion, int minorVersion) {
-        return version != null && version.major >= majorVersion && version.minor >= minorVersion;
+        if (version != null) {
+            if (version.major == majorVersion) {
+                return version.minor >= minorVersion;
+            }
+            return version.major > majorVersion;
+        }
+        return false;
     }
 }

--- a/core/src/test/groovy/io/micronaut/core/version/SemanticVersionSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/version/SemanticVersionSpec.groovy
@@ -22,6 +22,8 @@ class SemanticVersionSpec extends Specification {
     void "it compare two different major versions: #semver"(String semver) {
         expect:
         SemanticVersion.isAtLeastMajorMinor(semver, 3, 3)
+        SemanticVersion.isAtLeastMajorMinor(semver, 3, 0)
+        !SemanticVersion.isAtLeastMajorMinor(semver, 5, 3)
         !SemanticVersion.isAtLeastMajorMinor(semver, 5, 0)
 
         where:

--- a/core/src/test/groovy/io/micronaut/core/version/SemanticVersionSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/version/SemanticVersionSpec.groovy
@@ -19,4 +19,13 @@ class SemanticVersionSpec extends Specification {
         semver << ["1.0.0", "1.0.0.M1", "1.0.0.RC1", "1.0.0.BUILD-SNAPSHOT", "1.0.0-M1", "1.0.0-RC1", "1.0.0-BUILD-SNAPSHOT", "1.0.0-SNAPSHOT"]
     }
 
+    void "it compare two different major versions: #semver"(String semver) {
+        expect:
+        SemanticVersion.isAtLeastMajorMinor(semver, 3, 3)
+        !SemanticVersion.isAtLeastMajorMinor(semver, 5, 0)
+
+        where:
+        semver << ["4.0.0", "4.0.0.M1", "4.0.0.RC1", "4.0.0.BUILD-SNAPSHOT", "4.0.0-M1", "4.0.0-RC1", "4.0.0-BUILD-SNAPSHOT", "4.0.0-SNAPSHOT"]
+    }
+
 }


### PR DESCRIPTION
I'm playing around with Micronaut 4.0.0-SNAPSHOT version and found that the AOT plugin failed with such exception:

```
Caused by: java.lang.RuntimeException: This version of the AOT optimizer requires at least Micronaut 3.3 but found 4.0.0-SNAPSHOT
	at io.micronaut.aot.MicronautAotOptimizer.assertMinimalMicronautVersion(MicronautAotOptimizer.java:281)
```

It was because the current implementation of `isAtLeastMajorMinor` method will return false for comparing 4.0.0 and 3.3.0 versions.

```java
// returns: false
SemanticVersion.isAtLeastMajorMinor("4.0.0", 3, 3)
```