### PR TITLE
Correct record constructor search algorithm. Fixes #8187

### DIFF
--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
@@ -62,7 +62,7 @@ class Test<T extends CharSequence> {
     public void setArray(T[] array) {
         this.array = array;
     }
-    
+
     @Executable
     T[] myMethod() {
         return array;
@@ -90,7 +90,7 @@ class Test {
     public String getOne() {
         this.invoked = true;
         return one;
-    } 
+    }
 }
 ''');
 
@@ -158,7 +158,7 @@ class Test {
     public String getOne() {
         this.invoked = true;
         return one;
-    } 
+    }
 }
 ''');
 
@@ -227,7 +227,7 @@ class Test {
     String three; // package protected
     protected String four; // not included since protected
     private String five; // not included since private
-    
+
     Test(int two) {
         this.two = two;
     }
@@ -280,7 +280,7 @@ class Test {
     String three; // package protected
     protected String four; // not included since protected
     private String five; // not included since private
-    
+
     Test(int two) {
         this.two = two;
     }
@@ -309,7 +309,7 @@ package beanctor;
 public class Test {
 
     private final String another;
-    
+
     @com.fasterxml.jackson.annotation.JsonCreator
     Test(String another) {
         this.another = another;
@@ -356,7 +356,7 @@ public class MethodTest extends SuperType implements SomeInt {
     public String invokeMe(String str) {
         return str;
     }
-    
+
     @Executable
     int invokePrim(int i) {
         return i;
@@ -368,7 +368,7 @@ class SuperType {
     String superMethod(String str) {
         return str;
     }
-    
+
     @Executable
     public String invokeMe(String str) {
         return str;
@@ -380,7 +380,7 @@ interface SomeInt {
     default boolean ok() {
         return true;
     }
-    
+
     default String getName() {
         return "ok";
     }
@@ -494,7 +494,7 @@ import java.net.URL;
 public class CopyMe {
 
     private final String another;
-    
+
     CopyMe(String another) {
         this.another = another;
     }
@@ -502,7 +502,7 @@ public class CopyMe {
     public String getAnother() {
         return another;
     }
-    
+
     public CopyMe alterAnother(String a) {
         return this.another == a ? this : new CopyMe(a.toUpperCase());
     }
@@ -538,7 +538,7 @@ public class CopyMe {
     private URL url;
     private final String name;
     private final String another;
-    
+
     CopyMe(String name, String another) {
         this.name = name;
         this.another = another;
@@ -551,15 +551,15 @@ public class CopyMe {
     public void setUrl(URL url) {
         this.url = url;
     }
-    
+
     public String getName() {
         return name;
     }
-    
+
     public String getAnother() {
         return another;
     }
-    
+
     public CopyMe withAnother(String a) {
         return this.another == a ? this : new CopyMe(this.name, a.toUpperCase());
     }
@@ -625,6 +625,41 @@ public record Foo(int x, int y){
         def obj = introspection.instantiate(5, 10)
 
         then:
+        obj.x() == 5
+        obj.y() == 10
+    }
+
+    @Requires({ jvm.isJava14Compatible() })
+    @Issue('https://github.com/micronaut-projects/micronaut-core/issues/8187')
+    void "test secondary constructor for Java 14+ records with initializer"() {
+        given:
+        BeanIntrospection introspection = buildBeanIntrospection('test.Foo', '''
+package test;
+
+import io.micronaut.core.annotation.Creator;
+import java.util.List;
+import javax.validation.constraints.Min;
+
+@io.micronaut.core.annotation.Introspected
+public record Foo(int x, int y){
+    public Foo {
+        if (x < 0) {
+            throw new IllegalArgumentException("Invalid argument");
+        }
+    }
+    public Foo(int x) {
+        this(x, 20);
+    }
+    public Foo() {
+        this(20, 20);
+    }
+}
+''')
+        when:
+        def obj = introspection.instantiate(5, 10)
+
+        then:
+        introspection.getConstructorArguments().length == 2
         obj.x() == 5
         obj.y() == 10
     }
@@ -729,7 +764,7 @@ public class Foo {
     public List<Long> getValue() {
         return value;
     }
-    
+
     public void setValue(List<Long> value) {
         this.value = value;
     }
@@ -850,7 +885,7 @@ public interface MyInterface {
     @Executable
     default String name() {
         return getName();
-    }    
+    }
 }
 
 class MyImpl implements MyInterface {
@@ -884,7 +919,7 @@ class Test {}
 
 public interface MyInterface {
     @Executable
-    String name();    
+    String name();
 }
 
 class MyImpl implements MyInterface {
@@ -1000,7 +1035,7 @@ class Foo extends GenBase<String> {
 
 abstract class GenBase<T> {
     abstract T getName();
-    
+
     public T getOther() {
         return (T) "other";
     }
@@ -1032,7 +1067,7 @@ class Foo implements GenBase<Long> {
     public Long getValue() {
         return value;
     }
-    
+
     public void setValue(Long value) {
         this.value = value;
     }
@@ -1040,7 +1075,7 @@ class Foo implements GenBase<Long> {
 
 interface GenBase<T> {
     T getValue();
-    
+
     void setValue(T t);
 }
 ''')
@@ -1070,7 +1105,7 @@ import io.micronaut.core.annotation.Creator;
 @io.micronaut.core.annotation.Introspected
 interface Foo {
     String getName();
-    
+
     @Creator
     static Foo create(String name) {
         return () -> name;
@@ -1097,7 +1132,7 @@ import io.micronaut.core.annotation.Creator;
 @io.micronaut.core.annotation.Introspected
 interface Foo<T> {
     String getName();
-    
+
     @Creator
     static <T1> Foo<T1> create(String name) {
         return () -> name;
@@ -1388,11 +1423,11 @@ public class ValidatedConfig {
     public void setUrl(URL url) {
         this.url = url;
     }
-    
+
     public static class Inner {
-    
+
     }
-    
+
 }
 ''')
         expect:
@@ -1455,21 +1490,21 @@ class ValidatedConfig {
     public void setUrl(URL url) {
         this.url = url;
     }
-    
+
     public static class Inner {
-    
+
     }
-    
+
     @ConfigurationProperties("another")
     static class Another {
-    
+
         private URL url;
 
         @NotNull
         public URL getUrl() {
             return url;
         }
-    
+
         public void setUrl(URL url) {
             this.url = url;
         }
@@ -1633,17 +1668,17 @@ import java.time.Duration;
 class MyConfig {
     private String host;
     private int serverPort;
-    
+
     @ConfigurationInject
     MyConfig(@javax.validation.constraints.NotBlank String host, int serverPort) {
         this.host = host;
         this.serverPort = serverPort;
     }
-    
+
     public String getHost() {
         return host;
     }
-    
+
     public int getServerPort() {
         return serverPort;
     }
@@ -1705,7 +1740,7 @@ public class Test {
     public <T extends Enum<T>> Test(int num, String str, Class<T> enumClass) {
         this(num, str + enumClass.getName());
     }
-    
+
     @Creator
     public <T extends Enum<T>> Test(int num, String str) {
         this.num = num;
@@ -1740,7 +1775,7 @@ class Test {
     }
     public String getTest() {
         return test;
-    } 
+    }
 }
 
 
@@ -1760,7 +1795,7 @@ class Test<T extends B> {
     private T child;
     public T getChild() {
         return child;
-    } 
+    }
 }
 class B<T extends Test> {}
 
@@ -1800,7 +1835,7 @@ class Address {
     @NotBlank(groups = GroupThree.class, message = "different message")
     @Size(min = 5, max = 20, groups = GroupTwo.class)
     private String street;
-    
+
     public String getStreet() {
         return this.street;
     }
@@ -1834,7 +1869,7 @@ class Book {
         this.title = title;
         this.author = author;
     }
-    
+
     @io.micronaut.core.annotation.Creator
     public Book(String title) {
         this.title = title;
@@ -1843,7 +1878,7 @@ class Book {
     public String getTitle() {
         return title;
     }
-    
+
     void setTitle(String title) {
         this.title = title;
     }
@@ -1908,12 +1943,12 @@ class Book {
     private String title;
 
     public Book() {
-    }   
+    }
 
     public String getTitle() {
         return title;
     }
-    
+
     public void setTitle(String title) {
         this.title = title;
     }
@@ -1967,23 +2002,23 @@ import com.fasterxml.jackson.annotation.*;
 class Test {
     private String name;
     private int age;
-    
+
     @JsonCreator
     Test(@JsonProperty("name") String name) {
         this.name = name;
     }
-    
+
     Test(int age) {
         this.age = age;
     }
-    
+
     public int getAge() {
         return age;
     }
     public void setAge(int age) {
         this.age = age;
     }
-    
+
     public String getName() {
         return this.name;
     }
@@ -2140,11 +2175,11 @@ import java.util.*;
 @Introspected
 class Test {
     private Status status;
-    
+
     public void setStatus(Status status) {
         this.status = status;
     }
-    
+
     public Status getStatus() {
         return this.status;
     }
@@ -2200,9 +2235,9 @@ class Test {
     @Size(max=100)
     private int age;
     private int[] primitiveArray;
-    
+
     private long v;
-    
+
     public Test(String name, @Size(max=100) int age, int[] primitiveArray) {
         this.name = name;
         this.age = age;
@@ -2219,28 +2254,28 @@ class Test {
     public void setAge(int age) {
         this.age = age;
     }
-    
+
     public void setId(Long id) {
         this.id = id;
     }
-    
+
     public Long getId() {
         return this.id;
     }
-    
+
     public void setVersion(Long version) {
         this.version = version;
     }
-    
+
     public Long getVersion() {
         return this.version;
     }
-    
+
     @Version
     public long getAnotherVersion() {
         return v;
     }
-    
+
     public void setAnotherVersion(long v) {
         this.v = v;
     }
@@ -2314,8 +2349,8 @@ class Test {
     private String name;
     @Size(max=100)
     private int age;
-    
-    
+
+
     public String getName() {
         return this.name;
     }
@@ -2328,19 +2363,19 @@ class Test {
     public void setAge(int age) {
         this.age = age;
     }
-    
+
     public void setId(Long id) {
         this.id = id;
     }
-    
+
     public Long getId() {
         return this.id;
     }
-    
+
     public void setVersion(Long version) {
         this.version = version;
     }
-    
+
     public Long getVersion() {
         return this.version;
     }
@@ -2491,33 +2526,33 @@ class Test extends ParentBean {
     private String name;
     @Size(max=100)
     private int age;
-    
+
     private List<Number> list;
     private String[] stringArray;
     private int[] primitiveArray;
     private boolean flag;
     private TypeConverter<String, Collection> genericsTest;
     private TypeConverter<String, Object[]> genericsArrayTest;
-    
+
     public TypeConverter<String, Collection> getGenericsTest() {
         return genericsTest;
     }
-    
+
     public TypeConverter<String, Object[]> getGenericsArrayTest() {
         return genericsArrayTest;
     }
-    
+
     public String getReadOnly() {
         return readOnly;
     }
     public boolean isFlag() {
         return flag;
     }
-    
+
     public void setFlag(boolean flag) {
         this.flag = flag;
     }
-    
+
     public String getName() {
         return this.name;
     }
@@ -2530,11 +2565,11 @@ class Test extends ParentBean {
     public void setAge(int age) {
         this.age = age;
     }
-    
+
     public List<Number> getList() {
         return this.list;
     }
-    
+
     public void setList(List<Number> l) {
         this.list = l;
     }
@@ -2558,11 +2593,11 @@ class Test extends ParentBean {
 
 class ParentBean {
     private List<byte[]> listOfBytes;
-    
+
     public List<byte[]> getListOfBytes() {
         return this.listOfBytes;
     }
-    
+
     public void setListOfBytes(List<byte[]> list) {
         this.listOfBytes = list;
     }
@@ -2867,12 +2902,12 @@ import com.fasterxml.jackson.annotation.*;
 @Introspected
 class Test {
     private Map<String, String> properties;
-    
+
     @Creator
     Test(Map<String, String> properties) {
         this.properties = properties;
     }
-    
+
     public Map<String, String> getProperties() {
         return properties;
     }
@@ -2895,16 +2930,16 @@ import io.micronaut.core.annotation.*;
 @Introspected
 class Test {
     private String name;
-    
+
     private Test(String name) {
         this.name = name;
     }
-    
+
     @Creator
     public static Test forName(String name) {
         return new Test(name);
     }
-    
+
     public String getName() {
         return name;
     }
@@ -2990,16 +3025,16 @@ import io.micronaut.core.annotation.*;
 @Introspected
 class Test {
     private String name;
-    
+
     private Test(String name) {
         this.name = name;
     }
-    
+
     @Creator
     public static Test forName() {
         return new Test("default");
     }
-    
+
     public String getName() {
         return name;
     }
@@ -3037,21 +3072,21 @@ import io.micronaut.core.annotation.*;
 @Introspected
 class Test {
     private String name;
-    
+
     private Test(String name) {
         this.name = name;
     }
-    
+
     @Creator
     public static Test forName() {
         return new Test("default");
     }
-    
+
     @Creator
     public static Test forName(String name) {
         return new Test(name);
     }
-    
+
     public String getName() {
         return name;
     }
@@ -3091,22 +3126,22 @@ class Test {
 
     private final String name;
     public static final Companion Companion = new Companion();
-    
+
     public final String getName() {
         return name;
     }
-    
+
     private Test(String name) {
         this.name = name;
     }
-    
+
     public static final class Companion {
-        
+
         @Creator
         public final Test forName(String name) {
             return new Test(name);
         }
-        
+
         private Companion() {
         }
     }
@@ -3165,7 +3200,7 @@ public enum Test {
     Test(int number) {
         this.number = number;
     }
-    
+
     public int getNumber() {
         return number;
     }
@@ -3286,7 +3321,7 @@ import java.util.Map;
 class Test {
 
     public Test(Map<String, List<Action>> map) {
-    
+
     }
 }
 
@@ -3320,7 +3355,7 @@ class Test {
 
     public Test() {
     }
-    
+
     public int[] getOneDimension() {
         return oneDimension;
     }
@@ -3336,7 +3371,7 @@ class Test {
     public void setTwoDimensions(int[][] twoDimensions) {
         this.twoDimensions = twoDimensions;
     }
-    
+
     public int[][][] getThreeDimensions() {
         return threeDimensions;
     }
@@ -3394,13 +3429,13 @@ class Test {
 
     public Test() {
     }
-    
+
     public String[] getOneDimension() {
         return oneDimension;
     }
 
     public void setOneDimension(String[] oneDimension) {
-        this.oneDimension = oneDimension;     
+        this.oneDimension = oneDimension;
     }
 
     public String[][] getTwoDimensions() {
@@ -3410,7 +3445,7 @@ class Test {
     public void setTwoDimensions(String[][] twoDimensions) {
         this.twoDimensions = twoDimensions;
     }
-    
+
     public String[][][] getThreeDimensions() {
         return threeDimensions;
     }
@@ -3469,13 +3504,13 @@ class Test {
 
     public Test() {
     }
-    
+
     public SomeEnum[] getOneDimension() {
         return oneDimension;
     }
 
     public void setOneDimension(SomeEnum[] oneDimension) {
-        this.oneDimension = oneDimension;     
+        this.oneDimension = oneDimension;
     }
 
     public SomeEnum[][] getTwoDimensions() {
@@ -3485,7 +3520,7 @@ class Test {
     public void setTwoDimensions(SomeEnum[][] twoDimensions) {
         this.twoDimensions = twoDimensions;
     }
-    
+
     public SomeEnum[][][] getThreeDimensions() {
         return threeDimensions;
     }
@@ -3600,11 +3635,11 @@ import io.micronaut.core.annotation.Introspected;
 class Test {
 
     private final String xForwardedFor;
-    
+
     Test(String xForwardedFor) {
         this.xForwardedFor = xForwardedFor;
     }
-    
+
     public String getXForwardedFor() {
         return xForwardedFor;
     }
@@ -3665,19 +3700,19 @@ import io.micronaut.core.annotation.Introspected;
 abstract class Test {
     private String name;
     private String author;
-    
+
     public String getName() {
         return name;
     }
-    
+
     public void setName(String name) {
         this.name = name;
     }
-    
+
     public String getAuthor() {
         return author;
     }
-    
+
     public void setAuthor(String author) {
         this.author = author;
     }
@@ -3771,23 +3806,23 @@ import io.micronaut.core.annotation.Introspected;
 abstract class Test {
     private String name;
     private String author;
-    
+
     public String getName() {
         return name;
     }
-    
+
     public void setName(String name) {
         this.name = name;
     }
-    
+
     public String getAuthor() {
         return author;
     }
-    
+
     public void setAuthor(String author) {
         this.author = author;
     }
-    
+
     public int getAge() {
         return 0;
     }
@@ -3851,7 +3886,7 @@ import java.util.Set;
 public class Test {
 
     private Set<Author> authors;
-    
+
     public Set<Author> getAuthors() {
         return authors;
     }
@@ -3893,7 +3928,7 @@ public class Test {
     public String getFoo() {
         return "bar";
     }
-    
+
     @JsonProperty
     public void setFoo(String s) {
     }
@@ -3947,11 +3982,11 @@ import io.micronaut.core.annotation.Introspected;
 public class Test {
     @JsonProperty
     String foo;
-    
+
     public String getFoo() {
         return foo;
     }
-    
+
     public void setFoo(String s) {
         this.foo = s;
     }
@@ -4008,12 +4043,12 @@ import io.micronaut.core.annotation.Introspected;
 public class Test {
     @JsonProperty("field")
     String foo;
-    
+
     @JsonProperty("getter")
     public String getFoo() {
         return foo;
     }
-    
+
     @JsonProperty("setter")
     public void setFoo(String s) {
         this.foo = s;
@@ -4073,11 +4108,11 @@ import io.micronaut.core.annotation.Introspected;
 public class Test {
     @JsonProperty("field")
     String foo;
-    
+
     public String getFoo() {
         return foo;
     }
-    
+
     @JsonProperty("setter")
     public void setFoo(String s) {
         this.foo = s;
@@ -4102,15 +4137,15 @@ import io.micronaut.core.annotation.Introspected;
 @Introspected
 public class Test {
     private final java.util.ArrayList<String> foo;
-    
+
     public Test(java.util.List<String> foo) {
         this.foo = null;
     }
-    
+
     public java.util.List<String> getFoo() {
         return null;
     }
-    
+
 }
 ''')
 


### PR DESCRIPTION
Modifies `ModelUtils.concreteConstructorFor` to do a comparison of the record components vs the constructor parameters to ensure the correct constructor is picked for records.

Fixes #8187 