### PR TITLE
Use bean property writer type as the property type. Correct annotations creation for fields.

### DIFF
--- a/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/AllElementsVisitor.java
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/AllElementsVisitor.java
@@ -15,11 +15,13 @@
  */
 package io.micronaut.inject.visitor;
 
+import io.micronaut.core.annotation.AnnotationMetadataProvider;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.Element;
 import io.micronaut.inject.ast.FieldElement;
 import io.micronaut.inject.ast.MethodElement;
+import io.micronaut.inject.ast.TypedElement;
 
 import java.util.*;
 
@@ -63,18 +65,42 @@ public class AllElementsVisitor implements TypeElementVisitor<Controller, Object
     @Override
     public void visitClass(ClassElement element, VisitorContext context) {
         visit(element);
+        element.getBeanProperties(); // Preload properties for tests otherwise it fails because the compiler is done
+        element.getAnnotationMetadata();
         VISITED_CLASS_ELEMENTS.add(element);
     }
 
     @Override
     public void visitMethod(MethodElement element, VisitorContext context) {
-        visit(element);
         VISITED_METHOD_ELEMENTS.add(element);
+        // Preload
+        element.getReturnType().getBeanProperties().forEach(AnnotationMetadataProvider::getAnnotationMetadata);
+        Arrays.stream(element.getParameters()).flatMap(p -> p.getType().getBeanProperties().stream()).forEach(propertyElement -> {
+            initialize(propertyElement);
+            propertyElement.getField().ifPresent(this::initialize);
+            propertyElement.getWriteMethod().ifPresent(methodElement -> {
+                initialize(methodElement.getReturnType());
+                Arrays.stream(methodElement.getParameters()).forEach(this::initialize);
+            });
+            propertyElement.getReadMethod().ifPresent(methodElement -> {
+                initialize(methodElement.getReturnType());
+                Arrays.stream(methodElement.getParameters()).forEach(this::initialize);
+            });
+        });
+        element.getAnnotationMetadata();
+        visit(element);
+    }
+
+    private void initialize(TypedElement typedElement) {
+        typedElement.getAnnotationMetadata();
+        typedElement.getType().getAnnotationMetadata();
+        typedElement.getGenericType().getAnnotationMetadata();
     }
 
     @Override
     public void visitField(FieldElement element, VisitorContext context) {
         visit(element);
+        element.getAnnotationMetadata();
     }
 
     void visit(Element element) {

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/PropertyElementSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/PropertyElementSpec.groovy
@@ -155,4 +155,167 @@ class Response<T> {
         AllElementsVisitor.VISITED_METHOD_ELEMENTS[1].returnType.beanProperties.size() == 1
         AllElementsVisitor.VISITED_METHOD_ELEMENTS[1].returnType.beanProperties[0].type.name == 'java.lang.Integer'
     }
+
+    void "test get annotations from type after bean properties "() {
+        buildBeanDefinition('test.TestController', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
+
+@Controller
+class TestController {
+
+    @Post("/path")
+    public void processSync(@Body MyDto dto) {
+    }
+}
+
+class MyDto {
+
+    private Parameters parameters;
+
+    public Parameters getParameters() {
+        return parameters;
+    }
+
+    public void setParameters(Parameters parameters) {
+        this.parameters = parameters;
+    }
+}
+
+@Introspected
+class Parameters {
+
+    private Integer stampWidth;
+    private Integer stampHeight;
+    private int pageNumber;
+
+    public Integer getStampWidth() {
+        return stampWidth;
+    }
+
+    public void setStampWidth(Integer stampWidth) {
+        this.stampWidth = stampWidth;
+    }
+
+    public Integer getStampHeight() {
+        return stampHeight;
+    }
+
+    public void setStampHeight(Integer stampHeight) {
+        this.stampHeight = stampHeight;
+    }
+
+    public int getPageNumber() {
+        return pageNumber;
+    }
+
+    public void setPageNumber(int pageNumber) {
+        this.pageNumber = pageNumber;
+    }
+}
+''')
+        expect:
+            AllElementsVisitor.VISITED_CLASS_ELEMENTS.size() == 1
+
+            def method = AllElementsVisitor.VISITED_METHOD_ELEMENTS[0]
+            def parameter = method.parameters[0]
+
+            def beanProperty = parameter.type.beanProperties.get(0)
+            beanProperty.type.annotationNames.sort() == [
+                    'io.micronaut.context.annotation.BeanProperties',
+                    'io.micronaut.core.annotation.Introspected'
+            ]
+            beanProperty.field.get().type.annotationNames.sort() == [
+                    'io.micronaut.context.annotation.BeanProperties',
+                    'io.micronaut.core.annotation.Introspected'
+            ]
+            beanProperty.readMethod.get().returnType.annotationNames.sort() == [
+                    'io.micronaut.context.annotation.BeanProperties',
+                    'io.micronaut.core.annotation.Introspected'
+            ]
+            beanProperty.writeMethod.get().parameters[0].type.annotationNames.sort() == [
+                    'io.micronaut.context.annotation.BeanProperties',
+                    'io.micronaut.core.annotation.Introspected'
+            ]
+    }
+
+    void "test get annotations from type after bean properties for field access"() {
+        buildBeanDefinition('test.TestController', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
+
+@Controller
+class TestController {
+
+    @Post("/path")
+    public void processSync(@Body MyDto dto) {
+    }
+}
+
+@Introspected(accessKind = Introspected.AccessKind.FIELD)
+class MyDto {
+
+    public Parameters parameters;
+}
+
+@Introspected
+class Parameters {
+
+    private Integer stampWidth;
+    private Integer stampHeight;
+    private int pageNumber;
+
+    public Integer getStampWidth() {
+        return stampWidth;
+    }
+
+    public void setStampWidth(Integer stampWidth) {
+        this.stampWidth = stampWidth;
+    }
+
+    public Integer getStampHeight() {
+        return stampHeight;
+    }
+
+    public void setStampHeight(Integer stampHeight) {
+        this.stampHeight = stampHeight;
+    }
+
+    public int getPageNumber() {
+        return pageNumber;
+    }
+
+    public void setPageNumber(int pageNumber) {
+        this.pageNumber = pageNumber;
+    }
+}
+''')
+        expect:
+            AllElementsVisitor.VISITED_CLASS_ELEMENTS.size() == 1
+
+            def method = AllElementsVisitor.VISITED_METHOD_ELEMENTS[0]
+            def parameter = method.parameters[0]
+
+            def beanProperty = parameter.type.beanProperties.get(0)
+            beanProperty.type.annotationNames.sort() == [
+                    'io.micronaut.context.annotation.BeanProperties',
+                    'io.micronaut.core.annotation.Introspected'
+            ]
+            beanProperty.field.get().type.annotationNames.sort() == [
+                    'io.micronaut.context.annotation.BeanProperties',
+                    'io.micronaut.core.annotation.Introspected'
+            ]
+            beanProperty.field.get().genericType.annotationNames.sort() == [
+                    'io.micronaut.context.annotation.BeanProperties',
+                    'io.micronaut.core.annotation.Introspected'
+            ]
+    }
 }

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaFieldElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaFieldElement.java
@@ -89,7 +89,7 @@ class JavaFieldElement extends AbstractJavaElement implements FieldElement {
                     variableElement.asType(),
                     visitorContext,
                     owningType.getGenericTypeInfo(),
-                    false
+                    true
                 );
             }
         }

--- a/inject-java/src/test/groovy/io/micronaut/visitors/PropertyElementSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/PropertyElementSpec.groovy
@@ -15,10 +15,9 @@
  */
 package io.micronaut.visitors
 
-import io.micronaut.http.annotation.Get
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.http.annotation.Get
 import io.micronaut.inject.ast.ClassElement
-import io.micronaut.inject.ast.ElementQuery
 import spock.lang.IgnoreIf
 import spock.util.environment.Jvm
 
@@ -269,10 +268,98 @@ class Parameters {
         def method = AllElementsVisitor.VISITED_METHOD_ELEMENTS[0]
         def parameter = method.parameters[0]
 
-        def fieldTypeAnnotations = parameter.type.beanProperties.get(0).type.annotationNames
+        def beanProperty = parameter.type.beanProperties.get(0)
+        beanProperty.type.annotationNames.sort() == [
+                'io.micronaut.context.annotation.BeanProperties',
+                'io.micronaut.core.annotation.Introspected'
+        ]
+        beanProperty.field.get().type.annotationNames.sort() == [
+                'io.micronaut.context.annotation.BeanProperties',
+                'io.micronaut.core.annotation.Introspected'
+        ]
+        beanProperty.readMethod.get().returnType.annotationNames.sort() == [
+                'io.micronaut.context.annotation.BeanProperties',
+                'io.micronaut.core.annotation.Introspected'
+        ]
+        beanProperty.writeMethod.get().parameters[0].type.annotationNames.sort() == [
+                'io.micronaut.context.annotation.BeanProperties',
+                'io.micronaut.core.annotation.Introspected'
+        ]
+    }
 
-        fieldTypeAnnotations
-        fieldTypeAnnotations.size() == 1
-        fieldTypeAnnotations.iterator().next() == 'io.micronaut.core.annotation.Introspected'
+    void "test get annotations from type after bean properties for field access"() {
+        buildBeanDefinition('test.TestController', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
+
+@Controller
+class TestController {
+
+    @Post("/path")
+    public void processSync(@Body MyDto dto) {
+    }
+}
+
+@Introspected(accessKind = Introspected.AccessKind.FIELD)
+class MyDto {
+
+    public Parameters parameters;
+}
+
+@Introspected
+class Parameters {
+
+    private Integer stampWidth;
+    private Integer stampHeight;
+    private int pageNumber;
+
+    public Integer getStampWidth() {
+        return stampWidth;
+    }
+
+    public void setStampWidth(Integer stampWidth) {
+        this.stampWidth = stampWidth;
+    }
+
+    public Integer getStampHeight() {
+        return stampHeight;
+    }
+
+    public void setStampHeight(Integer stampHeight) {
+        this.stampHeight = stampHeight;
+    }
+
+    public int getPageNumber() {
+        return pageNumber;
+    }
+
+    public void setPageNumber(int pageNumber) {
+        this.pageNumber = pageNumber;
+    }
+}
+''')
+        expect:
+        AllElementsVisitor.VISITED_CLASS_ELEMENTS.size() == 1
+
+        def method = AllElementsVisitor.VISITED_METHOD_ELEMENTS[0]
+        def parameter = method.parameters[0]
+
+        def beanProperty = parameter.type.beanProperties.get(0)
+        beanProperty.type.annotationNames.sort() == [
+                'io.micronaut.context.annotation.BeanProperties',
+                'io.micronaut.core.annotation.Introspected'
+        ]
+        beanProperty.field.get().type.annotationNames.sort() == [
+                'io.micronaut.context.annotation.BeanProperties',
+                'io.micronaut.core.annotation.Introspected'
+        ]
+        beanProperty.field.get().genericType.annotationNames.sort() == [
+                'io.micronaut.context.annotation.BeanProperties',
+                'io.micronaut.core.annotation.Introspected'
+        ]
     }
 }

--- a/inject/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -215,7 +215,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
      * @return The {@link AnnotationMetadata}
      */
     public CachedAnnotationMetadata lookupOrBuildForParameter(T owningType, T methodElement, T parameterElement) {
-        return lookupOrBuild(true, owningType, methodElement, parameterElement);
+        return lookupOrBuild(false, owningType, methodElement, parameterElement);
     }
 
     /**

--- a/inject/src/main/java/io/micronaut/inject/ast/utils/AstBeanPropertiesUtils.java
+++ b/inject/src/main/java/io/micronaut/inject/ast/utils/AstBeanPropertiesUtils.java
@@ -26,7 +26,6 @@ import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.FieldElement;
 import io.micronaut.inject.ast.MemberElement;
 import io.micronaut.inject.ast.MethodElement;
-import io.micronaut.inject.ast.ParameterElement;
 import io.micronaut.inject.ast.PrimitiveElement;
 import io.micronaut.inject.ast.PropertyElement;
 
@@ -145,10 +144,7 @@ public final class AstBeanPropertiesUtils {
                 } else if (value.writeAccessKind == BeanProperties.AccessKind.METHOD
                     && value.setter != null
                     && value.setter.getParameters().length > 0) {
-                    ParameterElement parameter = value.setter.getParameters()[0];
-                    if (!parameter.getType().equals(value.type)) {
-                        value.type = parameter.getGenericType();
-                    }
+                    value.type = value.setter.getParameters()[0].getGenericType();
                 }
 
                 if (value.readAccessKind != null || value.writeAccessKind != null) {
@@ -327,14 +323,11 @@ public final class AstBeanPropertiesUtils {
     }
 
     private static boolean isAccessible(MemberElement memberElement, BeanProperties.Visibility visibility) {
-        switch (visibility) {
-            case DEFAULT:
-                return !memberElement.isPrivate() && (memberElement.isAccessible() || memberElement.getDeclaringType().hasDeclaredStereotype(BeanProperties.class));
-            case PUBLIC:
-                return memberElement.isPublic();
-            default:
-                return false;
-        }
+        return switch (visibility) {
+            case DEFAULT ->
+                !memberElement.isPrivate() && (memberElement.isAccessible() || memberElement.getDeclaringType().hasDeclaredStereotype(BeanProperties.class));
+            case PUBLIC -> memberElement.isPublic();
+        };
     }
 
     private static boolean shouldExclude(Set<String> includes, Set<String> excludes, String propertyName) {


### PR DESCRIPTION
Fixes #8213