### PR TITLE
build: update to SnakeYAML 1.33

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -139,7 +139,7 @@ managed-springboot = "2.7.0"
 managed-swagger = "2.2.2"
 managed-validation = "2.0.1.Final"
 managed-testcontainers = "1.17.3"
-managed-snakeyaml = "1.31"
+managed-snakeyaml = "1.33"
 micronaut-docs = "2.0.0"
 
 [libraries]


### PR DESCRIPTION
see: https://bitbucket.org/snakeyaml/snakeyaml/wiki/Changes

> Set the limit for incoming data to prevent a CVE report in NIST. By default it is 3MB