### PR TITLE
Require asm as an api dependency so it's pulled in transitively downstream

### DIFF
--- a/core-processor/build.gradle
+++ b/core-processor/build.gradle
@@ -5,8 +5,8 @@ plugins {
 dependencies {
     api project(":inject")
     api project(":aop")
-    implementation libs.asm.tree
-    implementation libs.bundles.asm
+    api libs.asm.tree
+    api libs.bundles.asm
 
     compileOnly libs.kotlin.stdlib.jdk8
     compileOnly libs.managed.validation


### PR DESCRIPTION
Without this, when we add mn.micronaut.core.processor to downstream modules, we get a NoClassDefFound exception on asm Opcodes

Example of failure https://ge.micronaut.io/s/q7acelospauhe/failure#1