### PR TITLE
Fail when the request is with the incorrect type

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -3,6 +3,7 @@ plugins {
 }
 
 repositories {
+    mavenCentral()
     gradlePluginPortal()
 }
 

--- a/http-client/src/main/java/io/micronaut/http/client/netty/MutableHttpRequestWrapper.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/MutableHttpRequestWrapper.java
@@ -18,9 +18,9 @@ package io.micronaut.http.client.netty;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.ConversionContext;
 import io.micronaut.core.convert.ConversionService;
-import io.micronaut.core.type.Argument;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpRequestWrapper;
 import io.micronaut.http.MutableHttpHeaders;
@@ -79,13 +79,12 @@ final class MutableHttpRequestWrapper<B> extends HttpRequestWrapper<B> implement
         }
     }
 
-    @NonNull
     @Override
-    public <T> Optional<T> getBody(@NonNull Argument<T> type) {
+    public <T> Optional<T> getBody(ArgumentConversionContext<T> conversionContext) {
         if (body == null) {
-            return getDelegate().getBody(type);
+            return getDelegate().getBody(conversionContext);
         } else {
-            return conversionService.convert(body, ConversionContext.of(type));
+            return conversionService.convert(body, conversionContext);
         }
     }
 

--- a/http-client/src/main/java/io/micronaut/http/client/netty/NettyClientHttpRequest.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/NettyClientHttpRequest.java
@@ -17,7 +17,7 @@ package io.micronaut.http.client.netty;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.convert.ConversionContext;
+import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.value.MutableConvertibleValues;
 import io.micronaut.core.convert.value.MutableConvertibleValuesMap;
@@ -175,8 +175,8 @@ class NettyClientHttpRequest<B> implements MutableHttpRequest<B>, NettyHttpReque
     }
 
     @Override
-    public <T> Optional<T> getBody(Argument<T> type) {
-        return getBody().flatMap(b -> conversionService.convert(b, ConversionContext.of(type)));
+    public <T> Optional<T> getBody(ArgumentConversionContext<T> conversionContext) {
+        return getBody().flatMap(b -> conversionService.convert(b, conversionContext));
     }
 
     @Override

--- a/http-netty/src/main/java/io/micronaut/http/netty/NettyMutableHttpResponse.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/NettyMutableHttpResponse.java
@@ -21,7 +21,6 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.annotation.TypeHint;
 import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.core.convert.ArgumentConversionContext;
-import io.micronaut.core.convert.ConversionContext;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.value.MutableConvertibleValues;
 import io.micronaut.core.convert.value.MutableConvertibleValuesMap;
@@ -247,10 +246,9 @@ public class NettyMutableHttpResponse<B> implements MutableHttpResponse<B>, Nett
         return getBody(Argument.of(type));
     }
 
-    @SuppressWarnings("unchecked")
     @Override
-    public <T> Optional<T> getBody(Argument<T> type) {
-        return bodyConvertor.convert(type, body);
+    public <T> Optional<T> getBody(ArgumentConversionContext<T> conversionContext) {
+        return bodyConvertor.convert(conversionContext, body);
     }
 
     @Override
@@ -355,14 +353,14 @@ public class NettyMutableHttpResponse<B> implements MutableHttpResponse<B>, Nett
         return new BodyConvertor() {
 
             @Override
-            public Optional convert(Argument valueType, Object value) {
+            public Optional convert(ArgumentConversionContext conversionContext, Object value) {
                 if (value == null) {
                     return Optional.empty();
                 }
-                if (Argument.OBJECT_ARGUMENT.equalsType(valueType)) {
+                if (Argument.OBJECT_ARGUMENT.equalsType(conversionContext.getArgument())) {
                     return Optional.of(value);
                 }
-                return convertFromNext(conversionService, valueType, value);
+                return convertFromNext(conversionService, conversionContext, value);
             }
 
         };
@@ -372,31 +370,39 @@ public class NettyMutableHttpResponse<B> implements MutableHttpResponse<B>, Nett
 
         private BodyConvertor<T> nextConvertor;
 
-        public abstract Optional<T> convert(Argument<T> valueType, T value);
+        public abstract Optional<T> convert(ArgumentConversionContext<T> valueType, T value);
 
-        protected synchronized Optional<T> convertFromNext(ConversionService conversionService, Argument<T> conversionValueType, T value) {
+        protected synchronized Optional<T> convertFromNext(ConversionService conversionService, ArgumentConversionContext<T> conversionContext, T value) {
             if (nextConvertor == null) {
                 Optional<T> conversion;
-                ArgumentConversionContext<T> context = ConversionContext.of(conversionValueType);
                 if (value instanceof ByteBuffer) {
-                    conversion = conversionService.convert(((ByteBuffer) value).asNativeBuffer(), context);
+                    conversion = conversionService.convert(((ByteBuffer) value).asNativeBuffer(), conversionContext);
                 } else {
-                    conversion = conversionService.convert(value, context);
+                    conversion = conversionService.convert(value, conversionContext);
                 }
                 nextConvertor = new BodyConvertor<T>() {
 
                     @Override
-                    public Optional<T> convert(Argument<T> valueType, T value) {
-                        if (conversionValueType.equalsType(valueType)) {
+                    public Optional<T> convert(ArgumentConversionContext<T> currentConversionContext, T value) {
+                        if (currentConversionContext == conversionContext) {
                             return conversion;
                         }
-                        return convertFromNext(conversionService, valueType, value);
+                        if (currentConversionContext.getArgument().equalsType(conversionContext.getArgument())) {
+                            conversionContext.getLastError().ifPresent(error -> {
+                                error.getOriginalValue().ifPresentOrElse(
+                                    originalValue -> currentConversionContext.reject(originalValue, error.getCause()),
+                                    () -> currentConversionContext.reject(error.getCause())
+                                );
+                            });
+                            return conversion;
+                        }
+                        return convertFromNext(conversionService, currentConversionContext, value);
                     }
 
                 };
                 return conversion;
             }
-            return nextConvertor.convert(conversionValueType, value);
+            return nextConvertor.convert(conversionContext, value);
         }
 
         public void cleanup() {

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
@@ -370,15 +370,15 @@ final class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.microna
                 // MultipartBody will subscribe to the request body in MultipartBodyArgumentBinder
                 return false;
             }
+            if (Arrays.stream(methodBasedRouteMatch.getArguments()).anyMatch(argument -> HttpRequest.class.equals(argument.getType()))) {
+                // HttpRequest argument in the method
+                return true;
+            }
         }
         Optional<Argument<?>> bodyArgument = routeMatch.getBodyArgument()
             .filter(argument -> argument.getAnnotationMetadata().hasAnnotation(Body.class));
-        if (bodyArgument.isEmpty() || !routeMatch.isSatisfied(bodyArgument.get().getName())) {
+        if (bodyArgument.isPresent() && !routeMatch.isSatisfied(bodyArgument.get().getName())) {
             // Body argument in the method
-            return true;
-        }
-        if (routeMatch.getRequiredArguments().stream().anyMatch(argument -> HttpRequest.class.equals(argument.getType()))) {
-            // HttpRequest argument in the method
             return true;
         }
         // Might be some body parts

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
@@ -367,7 +367,7 @@ final class RoutingInBoundHandler extends SimpleChannelInboundHandler<io.microna
         }
         Optional<Argument<?>> bodyArgument = routeMatch.getBodyArgument()
             .filter(argument -> argument.getAnnotationMetadata().hasAnnotation(Body.class));
-        if (bodyArgument.isEmpty() || !routeMatch.isSatisfied(bodyArgument.get().getName())) {
+        if (bodyArgument.isPresent() && !routeMatch.isSatisfied(bodyArgument.get().getName())) {
             // Body argument in the method
             return true;
         }

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/JsonBodyBindingSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/binding/JsonBodyBindingSpec.groovy
@@ -273,20 +273,22 @@ class JsonBodyBindingSpec extends AbstractMicronautSpec {
         )).blockFirst()
 
         then:
-        HttpClientResponseException ex = thrown()
-        ex.response.code() == HttpStatus.BAD_REQUEST.code
-        ex.response.getBody(Map).get()._embedded.errors[0].message.contains("Required argument [HttpRequest request] not specified")
+        response.code() == HttpStatus.OK.code
+        response.body() == 'not found'
     }
 
     void "test request generic type conversion error"() {
         when:
         String json = '[1,2,3]'
-        HttpResponse<String> response = Flux.from(rxClient.exchange(
+        Flux.from(rxClient.exchange(
                 HttpRequest.POST('/json/request-generic', json), String
         )).blockFirst()
 
         then:
-        response.body() == "not found"
+        def e = thrown(HttpClientResponseException)
+        def response = e.response
+        response.getStatus() == HttpStatus.BAD_REQUEST
+        response.body().toString().contains("no int/Int-argument constructor/factory method to deserialize from Number value")
     }
 
     @Issue("https://github.com/micronaut-projects/micronaut-core/issues/5088")

--- a/http-server/src/main/java/io/micronaut/http/server/RouteExecutor.java
+++ b/http-server/src/main/java/io/micronaut/http/server/RouteExecutor.java
@@ -20,6 +20,7 @@ import io.micronaut.context.exceptions.BeanCreationException;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.http.codec.CodecException;
 import io.micronaut.http.reactive.execution.ReactiveExecutionFlow;
 import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.core.execution.ExecutionFlow;
@@ -647,8 +648,9 @@ public final class RouteExecutor {
         if (errorRoute == null) {
             // Second try is by status route if the status is known
             HttpStatus errorStatus = null;
-            if (cause instanceof UnsatisfiedRouteException) {
+            if (cause instanceof UnsatisfiedRouteException || cause instanceof CodecException) {
                 // when arguments do not match, then there is UnsatisfiedRouteException, we can handle this with a routed bad request
+                // or when incoming request body is not in the expected format
                 errorStatus = HttpStatus.BAD_REQUEST;
             } else if (cause instanceof HttpStatusException) {
                 errorStatus = ((HttpStatusException) cause).getStatus();

--- a/http-server/src/main/java/io/micronaut/http/server/binding/RequestArgumentSatisfier.java
+++ b/http-server/src/main/java/io/micronaut/http/server/binding/RequestArgumentSatisfier.java
@@ -73,7 +73,7 @@ public class RequestArgumentSatisfier {
      * @return The route
      */
     public RouteMatch<?> fulfillArgumentRequirements(RouteMatch<?> route, HttpRequest<?> request, boolean satisfyOptionals) {
-        Collection<Argument> requiredArguments = route.getRequiredArguments();
+        Collection<Argument<?>> requiredArguments = route.getRequiredArguments();
         Map<String, Object> argumentValues;
 
         if (requiredArguments.isEmpty()) {
@@ -82,7 +82,7 @@ public class RequestArgumentSatisfier {
         } else {
             argumentValues = new LinkedHashMap<>(requiredArguments.size());
             // Begin try fulfilling the argument requirements
-            for (Argument argument : requiredArguments) {
+            for (Argument<?> argument : requiredArguments) {
                 getValueForArgument(argument, request, satisfyOptionals).ifPresent(value ->
                     argumentValues.put(argument.getName(), value));
             }

--- a/http/src/main/java/io/micronaut/http/HttpMessage.java
+++ b/http/src/main/java/io/micronaut/http/HttpMessage.java
@@ -16,6 +16,7 @@
 package io.micronaut.http;
 
 import io.micronaut.core.attr.MutableAttributeHolder;
+import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.ConversionContext;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.value.MutableConvertibleValues;
@@ -80,8 +81,20 @@ public interface HttpMessage<B> extends MutableAttributeHolder {
      * @return An {@link Optional} of the type or {@link Optional#empty()} if the body cannot be returned as the given type
      */
     default @NonNull <T> Optional<T> getBody(@NonNull Argument<T> type) {
-        ArgumentUtils.requireNonNull("type", type);
-        return getBody().flatMap(b -> ConversionService.SHARED.convert(b, ConversionContext.of(type)));
+        return getBody(ConversionContext.of(type));
+    }
+
+    /**
+     * Return the body, will use the provided conversion context if needed.
+     *
+     * @param conversionContext The body conversion context
+     * @param <T>               The generic type
+     * @return An {@link Optional} of the type or {@link Optional#empty()} if the body cannot be returned as the given type
+     * @since 4.0.0
+     */
+    default @NonNull <T> Optional<T> getBody(@NonNull ArgumentConversionContext<T> conversionContext) {
+        ArgumentUtils.requireNonNull("conversionContext", conversionContext);
+        return getBody().flatMap(b -> ConversionService.SHARED.convert(b, conversionContext));
     }
 
     /**

--- a/http/src/main/java/io/micronaut/http/HttpMessageWrapper.java
+++ b/http/src/main/java/io/micronaut/http/HttpMessageWrapper.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.http;
 
+import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.value.MutableConvertibleValues;
 import io.micronaut.core.type.Argument;
 
@@ -68,5 +69,10 @@ public class HttpMessageWrapper<B> implements HttpMessage<B> {
     @Override
     public <T> Optional<T> getBody(Argument<T> type) {
         return delegate.getBody(type);
+    }
+
+    @Override
+    public <T> Optional<T> getBody(ArgumentConversionContext<T> conversionContext) {
+        return delegate.getBody(conversionContext);
     }
 }

--- a/http/src/main/java/io/micronaut/http/bind/binders/DefaultBodyAnnotationBinder.java
+++ b/http/src/main/java/io/micronaut/http/bind/binders/DefaultBodyAnnotationBinder.java
@@ -64,21 +64,18 @@ public class DefaultBodyAnnotationBinder<T> implements BodyArgumentBinder<T> {
 
                 Optional<T> value = values.get(component, context);
                 return newResult(value.orElse(null), context);
-            } else {
-                //noinspection unchecked
-                return BindingResult.EMPTY;
             }
-        } else {
-            Optional<?> body = source.getBody();
-            if (!body.isPresent()) {
-
-                return BindingResult.EMPTY;
-            } else {
-                Object o = body.get();
-                Optional<T> converted = conversionService.convert(o, context);
-                return newResult(converted.orElse(null), context);
-            }
+            //noinspection unchecked
+            return BindingResult.EMPTY;
         }
+        Optional<?> body = source.getBody();
+        if (body.isEmpty()) {
+            //noinspection unchecked
+            return BindingResult.EMPTY;
+        }
+        Object o = body.get();
+        Optional<T> converted = conversionService.convert(o, context);
+        return newResult(converted.orElse(null), context);
     }
 
     @SuppressWarnings("java:S3655") // false positive

--- a/router/src/main/java/io/micronaut/web/router/DefaultRouteBuilder.java
+++ b/router/src/main/java/io/micronaut/web/router/DefaultRouteBuilder.java
@@ -423,7 +423,7 @@ public abstract class DefaultRouteBuilder implements RouteBuilder {
         protected List<MediaType> producesMediaTypes;
         protected String bodyArgumentName;
         protected Argument<?> bodyArgument;
-        protected final Map<String, Argument> requiredInputs;
+        protected final Map<String, Argument<?>> requiredInputs;
         protected final Class<?> declaringType;
         protected boolean consumesMediaTypesContainsAll;
         protected boolean producesMediaTypesContainsAll;
@@ -456,15 +456,15 @@ public abstract class DefaultRouteBuilder implements RouteBuilder {
             isVoid = RouteInfo.super.isVoid();
             specifiedSingle = RouteInfo.super.isSpecifiedSingle();
             isAsyncOrReactive = RouteInfo.super.isAsyncOrReactive();
-            for (Argument argument : targetMethod.getArguments()) {
+            for (Argument<?> argument : targetMethod.getArguments()) {
                 if (argument.getAnnotationMetadata().hasAnnotation(Body.class)) {
                     this.bodyArgument = argument;
                 }
             }
-            Argument[] requiredArguments = targetMethod.getArguments();
+            Argument<?>[] requiredArguments = targetMethod.getArguments();
             if (requiredArguments.length > 0) {
-                Map<String, Argument> requiredInputs = new LinkedHashMap<>(requiredArguments.length);
-                for (Argument requiredArgument : requiredArguments) {
+                Map<String, Argument<?>> requiredInputs = new LinkedHashMap<>(requiredArguments.length);
+                for (Argument<?> requiredArgument : requiredArguments) {
                     String inputName = resolveInputName(requiredArgument);
                     requiredInputs.put(inputName, requiredArgument);
                 }

--- a/router/src/main/java/io/micronaut/web/router/DefaultUriRouteMatch.java
+++ b/router/src/main/java/io/micronaut/web/router/DefaultUriRouteMatch.java
@@ -67,17 +67,17 @@ class DefaultUriRouteMatch<T, R> extends AbstractRouteMatch<T, R> implements Uri
     @Override
     public UriRouteMatch<T, R> decorate(Function<RouteMatch<R>, R> executor) {
         Map<String, Object> variables = getVariableValues();
-        List<Argument> arguments = getRequiredArguments();
-        RouteMatch thisRoute = this;
-        return new DefaultUriRouteMatch<T, R>(matchInfo, uriRoute, defaultCharset, conversionService) {
+        List<Argument<?>> arguments = getRequiredArguments();
+        RouteMatch<R> thisRoute = this;
+        return new DefaultUriRouteMatch<>(matchInfo, uriRoute, defaultCharset, conversionService) {
             @Override
-            public List<Argument> getRequiredArguments() {
+            public List<Argument<?>> getRequiredArguments() {
                 return arguments;
             }
 
             @Override
-            public R execute(Map argumentValues) {
-                return (R) executor.apply(thisRoute);
+            public R execute(Map<String, Object> argumentValues) {
+                return executor.apply(thisRoute);
             }
 
             @Override
@@ -88,11 +88,11 @@ class DefaultUriRouteMatch<T, R> extends AbstractRouteMatch<T, R> implements Uri
     }
 
     @Override
-    protected RouteMatch<R> newFulfilled(Map<String, Object> newVariables, List<Argument> requiredArguments) {
+    protected RouteMatch<R> newFulfilled(Map<String, Object> newVariables, List<Argument<?>> requiredArguments) {
         return new DefaultUriRouteMatch<T, R>(matchInfo, uriRoute, defaultCharset, conversionService) {
 
             @Override
-            public List<Argument> getRequiredArguments() {
+            public List<Argument<?>> getRequiredArguments() {
                 return requiredArguments;
             }
 

--- a/router/src/main/java/io/micronaut/web/router/ErrorRouteMatch.java
+++ b/router/src/main/java/io/micronaut/web/router/ErrorRouteMatch.java
@@ -19,13 +19,12 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.type.Argument;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * Represents a match for an error.
@@ -50,7 +49,7 @@ class ErrorRouteMatch<T, R> extends AbstractRouteMatch<T, R> {
         super(abstractRoute, conversionService);
         this.error = error;
         this.variables = new LinkedHashMap<>();
-        for (Argument argument : getArguments()) {
+        for (Argument<?> argument : getArguments()) {
             if (argument.getType().isInstance(error)) {
                 variables.put(argument.getName(), error);
             }
@@ -58,11 +57,15 @@ class ErrorRouteMatch<T, R> extends AbstractRouteMatch<T, R> {
     }
 
     @Override
-    public Collection<Argument> getRequiredArguments() {
-        return Arrays
-            .stream(getArguments())
-            .filter(argument -> !argument.getType().isInstance(error))
-            .collect(Collectors.toList());
+    public Collection<Argument<?>> getRequiredArguments() {
+        Argument<?>[] arguments = getArguments();
+        List<Argument<?>> list = new ArrayList<>(arguments.length);
+        for (Argument<?> argument : arguments) {
+            if (!argument.getType().isInstance(error)) {
+                list.add(argument);
+            }
+        }
+        return list;
     }
 
     @Override
@@ -76,10 +79,10 @@ class ErrorRouteMatch<T, R> extends AbstractRouteMatch<T, R> {
     }
 
     @Override
-    protected RouteMatch<R> newFulfilled(Map<String, Object> newVariables, List<Argument> requiredArguments) {
+    protected RouteMatch<R> newFulfilled(Map<String, Object> newVariables, List<Argument<?>> requiredArguments) {
         return new ErrorRouteMatch<T, R>(error, abstractRoute, conversionService) {
             @Override
-            public Collection<Argument> getRequiredArguments() {
+            public Collection<Argument<?>> getRequiredArguments() {
                 return requiredArguments;
             }
 
@@ -93,17 +96,17 @@ class ErrorRouteMatch<T, R> extends AbstractRouteMatch<T, R> {
     @Override
     public RouteMatch<R> decorate(Function<RouteMatch<R>, R> executor) {
         Map<String, Object> variables = getVariableValues();
-        Collection<Argument> arguments = getRequiredArguments();
-        RouteMatch thisRoute = this;
-        return new ErrorRouteMatch(error, abstractRoute, conversionService) {
+        Collection<Argument<?>> arguments = getRequiredArguments();
+        RouteMatch<R> thisRoute = this;
+        return new ErrorRouteMatch<>(error, abstractRoute, conversionService) {
             @Override
-            public Collection<Argument> getRequiredArguments() {
+            public Collection<Argument<?>> getRequiredArguments() {
                 return arguments;
             }
 
             @Override
-            public T execute(Map argumentValues) {
-                return (T) executor.apply(thisRoute);
+            public R execute(Map<String, Object> argumentValues) {
+                return executor.apply(thisRoute);
             }
 
             @Override

--- a/router/src/main/java/io/micronaut/web/router/MethodBasedRouteMatch.java
+++ b/router/src/main/java/io/micronaut/web/router/MethodBasedRouteMatch.java
@@ -38,7 +38,7 @@ public interface MethodBasedRouteMatch<T, R> extends RouteMatch<R>, MethodExecut
      * @return The required arguments in order to invoke this route
      */
     @Override
-    default Collection<Argument> getRequiredArguments() {
+    default Collection<Argument<?>> getRequiredArguments() {
         return Arrays.asList(getArguments());
     }
 }

--- a/router/src/main/java/io/micronaut/web/router/RouteMatch.java
+++ b/router/src/main/java/io/micronaut/web/router/RouteMatch.java
@@ -91,7 +91,7 @@ public interface RouteMatch<R> extends Callable<R>, Predicate<HttpRequest>, Rout
      *
      * @return The required arguments in order to invoke this route
      */
-    default Collection<Argument> getRequiredArguments() {
+    default Collection<Argument<?>> getRequiredArguments() {
         return Collections.emptyList();
     }
 

--- a/router/src/main/java/io/micronaut/web/router/StatusRouteMatch.java
+++ b/router/src/main/java/io/micronaut/web/router/StatusRouteMatch.java
@@ -33,7 +33,7 @@ import java.util.function.Function;
 class StatusRouteMatch<T, R> extends AbstractRouteMatch<T, R> {
 
     final HttpStatus httpStatus;
-    private final ArrayList<Argument> requiredArguments;
+    private final ArrayList<Argument<?>> requiredArguments;
 
     /**
      * @param httpStatus The HTTP status
@@ -52,7 +52,7 @@ class StatusRouteMatch<T, R> extends AbstractRouteMatch<T, R> {
     }
 
     @Override
-    public Collection<Argument> getRequiredArguments() {
+    public Collection<Argument<?>> getRequiredArguments() {
         return requiredArguments;
     }
 
@@ -67,10 +67,10 @@ class StatusRouteMatch<T, R> extends AbstractRouteMatch<T, R> {
     }
 
     @Override
-    protected RouteMatch<R> newFulfilled(Map<String, Object> newVariables, List<Argument> requiredArguments) {
+    protected RouteMatch<R> newFulfilled(Map<String, Object> newVariables, List<Argument<?>> requiredArguments) {
         return new StatusRouteMatch<T, R>(httpStatus, abstractRoute, conversionService) {
             @Override
-            public Collection<Argument> getRequiredArguments() {
+            public Collection<Argument<?>> getRequiredArguments() {
                 return requiredArguments;
             }
 
@@ -84,11 +84,11 @@ class StatusRouteMatch<T, R> extends AbstractRouteMatch<T, R> {
     @Override
     public RouteMatch<R> decorate(Function<RouteMatch<R>, R> executor) {
         Map<String, Object> variables = getVariableValues();
-        Collection<Argument> arguments = getRequiredArguments();
+        Collection<Argument<?>> arguments = getRequiredArguments();
         RouteMatch thisRoute = this;
         return new StatusRouteMatch<T, R>(httpStatus, abstractRoute, conversionService) {
             @Override
-            public Collection<Argument> getRequiredArguments() {
+            public Collection<Argument<?>> getRequiredArguments() {
                 return arguments;
             }
 

--- a/router/src/main/java/io/micronaut/web/router/UriRouteMatch.java
+++ b/router/src/main/java/io/micronaut/web/router/UriRouteMatch.java
@@ -47,12 +47,12 @@ public interface UriRouteMatch<T, R> extends UriMatchInfo, MethodBasedRouteMatch
      * @return The required arguments in order to invoke this route
      */
     @Override
-    default List<Argument> getRequiredArguments() {
-        Argument[] arguments = getArguments();
+    default List<Argument<?>> getRequiredArguments() {
+        Argument<?>[] arguments = getArguments();
         if (ArrayUtils.isNotEmpty(arguments)) {
             Map<String, Object> matchVariables = getVariableValues();
-            List<Argument> actualArguments = new ArrayList<>(arguments.length);
-            for (Argument argument : arguments) {
+            List<Argument<?>> actualArguments = new ArrayList<>(arguments.length);
+            for (Argument<?> argument : arguments) {
                 if (!matchVariables.containsKey(argument.getName())) {
                     actualArguments.add(argument);
                 }


### PR DESCRIPTION
I want to align the Netty HTTP server behavior with the Servlet project.

This:
```
String requestGeneric(HttpRequest<Foo> request) {
 request.getBody()...
}
```
Should fail on `request.getBody()` and return `BAD_REQUEST` when the body is something incompatible like an array, current behavior is an empty body.
