### PR TITLE
Mark HateoasErrorResponseProcessorReplacement as Secondary

### DIFF
--- a/http-server/src/main/java/io/micronaut/http/server/exceptions/response/HateoasErrorResponseProcessorReplacement.java
+++ b/http-server/src/main/java/io/micronaut/http/server/exceptions/response/HateoasErrorResponseProcessorReplacement.java
@@ -17,6 +17,7 @@ package io.micronaut.http.server.exceptions.response;
 
 import io.micronaut.context.annotation.Replaces;
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.annotation.Secondary;
 import io.micronaut.context.env.groovy.GroovyPropertySourceLoader;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.http.MutableHttpResponse;
@@ -31,6 +32,7 @@ import jakarta.inject.Singleton;
  */
 @Deprecated
 @Singleton
+@Secondary
 @Requires(classes = GroovyPropertySourceLoader.class)
 @Replaces(HateoasErrorResponseProcessor.class)
 public class HateoasErrorResponseProcessorReplacement implements ErrorResponseProcessor<JsonError> {

--- a/test-suite-groovy/src/test/groovy/io/micronaut/http/server/exceptions/response/ErrorResponseProcessorSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/http/server/exceptions/response/ErrorResponseProcessorSpec.groovy
@@ -1,0 +1,53 @@
+package io.micronaut.http.server.exceptions.response
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.annotation.NonNull
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MutableHttpResponse
+import spock.lang.Specification
+import jakarta.inject.Singleton
+
+class ErrorResponseProcessorSpec extends Specification {
+
+    def "by default you get a hateoas replacement under groovy"() {
+        given:
+        def ctx = ApplicationContext.run()
+
+        when:
+        def bean = ctx.getBean(ErrorResponseProcessor)
+
+        then:
+        bean instanceof HateoasErrorResponseProcessorReplacement
+
+        cleanup:
+        ctx.close()
+    }
+
+    def "default can simply be replaced by binding a different processor"() {
+        given:
+        def ctx = ApplicationContext.run(
+                'spec.name': 'CustomErrorResponseProcessor'
+        )
+
+        when:
+        def bean = ctx.getBean(ErrorResponseProcessor)
+
+        then:
+        bean instanceof CustomErrorResponseProcessor
+
+        cleanup:
+        ctx.close()
+    }
+
+    @Singleton
+    @Requires(property = 'spec.name', value = 'CustomErrorResponseProcessor')
+    static class CustomErrorResponseProcessor implements ErrorResponseProcessor<String> {
+
+        @NonNull
+        @Override
+        MutableHttpResponse<String> processResponse(@NonNull ErrorContext errorContext, @NonNull MutableHttpResponse baseResponse) {
+            return HttpResponse.ok("test")
+        }
+    }
+}


### PR DESCRIPTION
Currently in a Groovy project, if you pull in problem-json, you end up with two ErrorResponseProcessors.

One for Problem-json and the other for Hateoas.

Marking the replacement as Secondary (as the HateoasErrorResponseProcessor was) fixes this