### PR TITLE
Cleanup context after test finishes

### DIFF
--- a/retry/src/test/groovy/io/micronaut/retry/intercept/CircuitBreakerSpec.groovy
+++ b/retry/src/test/groovy/io/micronaut/retry/intercept/CircuitBreakerSpec.groovy
@@ -186,6 +186,9 @@ class CircuitBreakerSpec extends Specification{
 
         then:"It executes until successful"
         result == 2
+
+        cleanup:
+        context.stop()
     }
 
     @Singleton


### PR DESCRIPTION
CircuitBreakerSpec seems quite flakey and I don't know why

Whilst staring at it, I spotted we weren't cleaning up a context though, so this fixes that