### PR TITLE
Introduce `@Vetoed` to exclude particular classes, methods and fields from processing

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -2184,15 +2184,11 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
             } else {
                 return defaultMetadata;
             }
-        } else if (annotationMetadata instanceof AnnotationMetadataHierarchy) {
-            AnnotationMetadataHierarchy hierarchy = (AnnotationMetadataHierarchy) annotationMetadata;
+        } else if (annotationMetadata instanceof AnnotationMetadataHierarchy hierarchy) {
             AnnotationMetadata declaredMetadata = annotate(hierarchy.getDeclaredMetadata(), annotationValue);
-            return hierarchy.createSibling(
-                declaredMetadata
-            );
-        } else {
-            throw new IllegalStateException("Unrecognized annotation metadata: " + annotationMetadata);
+            return hierarchy.createSibling(declaredMetadata);
         }
+        throw new IllegalStateException("Unrecognized annotation metadata: " + annotationMetadata);
     }
 
     /**
@@ -2204,6 +2200,9 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
      * @since 3.0.0
      */
     public AnnotationMetadata removeAnnotation(AnnotationMetadata annotationMetadata, String annotationType) {
+        if (annotationMetadata.isEmpty()) {
+            return annotationMetadata;
+        }
         // we only care if the metadata is an hierarchy or default mutable
         final boolean isHierarchy = annotationMetadata instanceof AnnotationMetadataHierarchy;
         AnnotationMetadata declaredMetadata = annotationMetadata;
@@ -2212,8 +2211,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         }
         // if it is anything else other than DefaultAnnotationMetadata here it is probably empty
         // in which case nothing needs to be done
-        if (declaredMetadata instanceof DefaultAnnotationMetadata) {
-            final DefaultAnnotationMetadata defaultMetadata = (DefaultAnnotationMetadata) declaredMetadata;
+        if (declaredMetadata instanceof DefaultAnnotationMetadata defaultMetadata) {
             T annotationMirror = getAnnotationMirror(annotationType).orElse(null);
             if (annotationMirror != null) {
                 String repeatableName = getRepeatableNameForType(annotationMirror);
@@ -2227,12 +2225,9 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
             }
 
             if (isHierarchy) {
-                return ((AnnotationMetadataHierarchy) annotationMetadata).createSibling(
-                    declaredMetadata
-                );
-            } else {
-                return declaredMetadata;
+                return ((AnnotationMetadataHierarchy) annotationMetadata).createSibling(declaredMetadata);
             }
+            return declaredMetadata;
         } else {
             throw new IllegalStateException("Unrecognized annotation metadata: " + annotationMetadata);
         }
@@ -2247,6 +2242,9 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
      * @since 3.0.0
      */
     public AnnotationMetadata removeStereotype(AnnotationMetadata annotationMetadata, String annotationType) {
+        if (annotationMetadata.isEmpty()) {
+            return annotationMetadata;
+        }
         // we only care if the metadata is an hierarchy or default mutable
         final boolean isHierarchy = annotationMetadata instanceof AnnotationMetadataHierarchy;
         AnnotationMetadata declaredMetadata = annotationMetadata;
@@ -2255,8 +2253,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         }
         // if it is anything else other than DefaultAnnotationMetadata here it is probably empty
         // in which case nothing needs to be done
-        if (declaredMetadata instanceof DefaultAnnotationMetadata) {
-            final DefaultAnnotationMetadata defaultMetadata = (DefaultAnnotationMetadata) declaredMetadata;
+        if (declaredMetadata instanceof DefaultAnnotationMetadata defaultMetadata) {
             T annotationMirror = getAnnotationMirror(annotationType).orElse(null);
             if (annotationMirror != null) {
                 String repeatableName = getRepeatableNameForType(annotationMirror);
@@ -2268,17 +2265,12 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
             } else {
                 defaultMetadata.removeStereotype(annotationType);
             }
-
             if (isHierarchy) {
-                return ((AnnotationMetadataHierarchy) annotationMetadata).createSibling(
-                    declaredMetadata
-                );
-            } else {
-                return declaredMetadata;
+                return ((AnnotationMetadataHierarchy) annotationMetadata).createSibling(declaredMetadata);
             }
-        } else {
-            throw new IllegalStateException("Unrecognized annotation metadata: " + annotationMetadata);
+            return declaredMetadata;
         }
+        throw new IllegalStateException("Unrecognized annotation metadata: " + annotationMetadata);
     }
 
     /**
@@ -2292,6 +2284,9 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
     public @NonNull <T1 extends Annotation> AnnotationMetadata removeAnnotationIf(
         @NonNull AnnotationMetadata annotationMetadata,
         @NonNull Predicate<AnnotationValue<T1>> predicate) {
+        if (annotationMetadata.isEmpty()) {
+            return annotationMetadata;
+        }
         // we only care if the metadata is an hierarchy or default mutable
         final boolean isHierarchy = annotationMetadata instanceof AnnotationMetadataHierarchy;
         AnnotationMetadata declaredMetadata = annotationMetadata;
@@ -2300,21 +2295,14 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         }
         // if it is anything else other than DefaultAnnotationMetadata here it is probably empty
         // in which case nothing needs to be done
-        if (declaredMetadata instanceof DefaultAnnotationMetadata) {
-            final DefaultAnnotationMetadata defaultMetadata = (DefaultAnnotationMetadata) declaredMetadata;
-
+        if (declaredMetadata instanceof DefaultAnnotationMetadata defaultMetadata) {
             defaultMetadata.removeAnnotationIf(predicate);
-
             if (isHierarchy) {
-                return ((AnnotationMetadataHierarchy) annotationMetadata).createSibling(
-                    declaredMetadata
-                );
-            } else {
-                return declaredMetadata;
+                return ((AnnotationMetadataHierarchy) annotationMetadata).createSibling(declaredMetadata);
             }
-        } else {
-            throw new IllegalStateException("Unrecognized annotation metadata: " + annotationMetadata);
+            return declaredMetadata;
         }
+        throw new IllegalStateException("Unrecognized annotation metadata: " + annotationMetadata);
     }
 
     /**

--- a/core-processor/src/main/java/io/micronaut/inject/processing/DeclaredBeanElementCreator.java
+++ b/core-processor/src/main/java/io/micronaut/inject/processing/DeclaredBeanElementCreator.java
@@ -24,6 +24,7 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NextMajorVersion;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.annotation.Vetoed;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.ElementQuery;
 import io.micronaut.inject.ast.FieldElement;
@@ -150,8 +151,10 @@ class DeclaredBeanElementCreator extends AbstractBeanElementCreator {
         }
         List<MemberElement> memberElements = new ArrayList<>(classElement.getEnclosedElements(memberQuery));
         memberElements.removeIf(processedFields::contains);
-        // Process subtype fields first
         for (MemberElement memberElement : memberElements) {
+            if (memberElement.hasAnnotation(Vetoed.class)) {
+                continue;
+            }
             if (memberElement instanceof FieldElement fieldElement) {
                 visitFieldInternal(visitor, fieldElement);
             } else if (memberElement instanceof MethodElement methodElement) {

--- a/core/src/main/java/io/micronaut/core/annotation/Vetoed.java
+++ b/core/src/main/java/io/micronaut/core/annotation/Vetoed.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.core.annotation;
 
 import java.lang.annotation.Documented;

--- a/core/src/main/java/io/micronaut/core/annotation/Vetoed.java
+++ b/core/src/main/java/io/micronaut/core/annotation/Vetoed.java
@@ -1,0 +1,16 @@
+package io.micronaut.core.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Veto the processing of the element.
+ */
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.PACKAGE})
+@Retention(RetentionPolicy.CLASS)
+@Documented
+public @interface Vetoed {
+}

--- a/core/src/main/java/io/micronaut/core/annotation/Vetoed.java
+++ b/core/src/main/java/io/micronaut/core/annotation/Vetoed.java
@@ -8,6 +8,9 @@ import java.lang.annotation.Target;
 
 /**
  * Veto the processing of the element.
+ *
+ * @author Denis Stepanov
+ * @since 4.0.0
  */
 @Target({ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.PACKAGE})
 @Retention(RetentionPolicy.CLASS)

--- a/http-server/src/main/java/io/micronaut/http/server/RouteExecutor.java
+++ b/http-server/src/main/java/io/micronaut/http/server/RouteExecutor.java
@@ -87,7 +87,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import static io.micronaut.core.util.KotlinUtils.isKotlinCoroutineSuspended;
 import static io.micronaut.http.HttpAttributes.AVAILABLE_HTTP_METHODS;

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -23,14 +23,15 @@ import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationUtil;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Vetoed;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.util.CollectionUtils;
-import io.micronaut.inject.processing.ProcessingException;
 import io.micronaut.inject.annotation.AbstractAnnotationMetadataBuilder;
 import io.micronaut.inject.ast.annotation.ElementAnnotationMetadataFactory;
 import io.micronaut.inject.processing.BeanDefinitionCreator;
 import io.micronaut.inject.processing.BeanDefinitionCreatorFactory;
 import io.micronaut.inject.processing.JavaModelUtils;
+import io.micronaut.inject.processing.ProcessingException;
 import io.micronaut.inject.visitor.BeanElementVisitor;
 import io.micronaut.inject.visitor.VisitorConfiguration;
 import io.micronaut.inject.writer.AbstractBeanDefinitionBuilder;
@@ -185,15 +186,16 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                         }
 
                         String name = typeElement.getQualifiedName().toString();
-                        if (!beanDefinitions.contains(name) && !processed.contains(name) && !name.endsWith(BeanDefinitionVisitor.PROXY_SUFFIX)) {
-                            boolean isInterface = JavaModelUtils.resolveKind(typeElement, ElementKind.INTERFACE).isPresent();
-                            if (!isInterface) {
+                        if (beanDefinitions.contains(name) || processed.contains(name) || name.endsWith(BeanDefinitionVisitor.PROXY_SUFFIX)) {
+                            return;
+                        }
+                        boolean isInterface = JavaModelUtils.resolveKind(typeElement, ElementKind.INTERFACE).isPresent();
+                        if (!isInterface) {
+                            beanDefinitions.add(name);
+                        } else {
+                            AnnotationMetadata annotationMetadata = annotationMetadataBuilder.lookupOrBuildForType(typeElement);
+                            if (annotationMetadata.hasStereotype(INTRODUCTION_TYPE) || annotationMetadata.hasStereotype(ConfigurationReader.class)) {
                                 beanDefinitions.add(name);
-                            } else {
-                                AnnotationMetadata annotationMetadata = annotationMetadataBuilder.lookupOrBuildForType(typeElement);
-                                if (annotationMetadata.hasStereotype(INTRODUCTION_TYPE) || annotationMetadata.hasStereotype(ConfigurationReader.class)) {
-                                    beanDefinitions.add(name);
-                                }
                             }
                         }
                     }));
@@ -219,6 +221,9 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                             }
                             JavaClassElement classElement = javaVisitorContext.getElementFactory()
                                 .newClassElement(typeElement, annotationMetadataFactory);
+                            if (classElement.hasAnnotation(Vetoed.class) || classElement.getPackage().hasAnnotation(Vetoed.class)) {
+                                continue;
+                            }
                             BeanDefinitionCreator beanDefinitionCreator = BeanDefinitionCreatorFactory.produce(classElement, javaVisitorContext);
                             for (BeanDefinitionVisitor writer : beanDefinitionCreator.build()) {
                                 if (processed.add(writer.getBeanDefinitionName())) {

--- a/inject-java/src/test/groovy/io/micronaut/inject/vetoed/BeanProducer.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/vetoed/BeanProducer.java
@@ -1,0 +1,14 @@
+package io.micronaut.inject.vetoed;
+
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Factory;
+
+@Factory
+public class BeanProducer {
+
+    @Bean
+    VetoedBean2 produce() {
+        return new VetoedBean2();
+    }
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/vetoed/ParentOfVetoedBean.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/vetoed/ParentOfVetoedBean.java
@@ -1,0 +1,13 @@
+package io.micronaut.inject.vetoed;
+
+import io.micronaut.context.BeanContext;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class ParentOfVetoedBean extends VetoedSuperclassBean {
+
+    public ParentOfVetoedBean(BeanContext beanContext) {
+        super(beanContext);
+    }
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/vetoed/VetoedBean1.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/vetoed/VetoedBean1.java
@@ -1,0 +1,9 @@
+package io.micronaut.inject.vetoed;
+
+import io.micronaut.core.annotation.Vetoed;
+import jakarta.inject.Singleton;
+
+@Vetoed
+@Singleton
+public class VetoedBean1 {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/vetoed/VetoedBean2.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/vetoed/VetoedBean2.java
@@ -1,0 +1,15 @@
+package io.micronaut.inject.vetoed;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.core.annotation.Vetoed;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+@Vetoed
+@Singleton
+public class VetoedBean2 {
+
+    @Inject
+    public BeanContext beanContext;
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/vetoed/VetoedExecutableMethodsBean.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/vetoed/VetoedExecutableMethodsBean.java
@@ -1,0 +1,26 @@
+package io.micronaut.inject.vetoed;
+
+import io.micronaut.context.annotation.Executable;
+import io.micronaut.core.annotation.Vetoed;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Executable
+public class VetoedExecutableMethodsBean {
+
+    void foo() {
+    }
+
+    @Vetoed
+    void bar() {
+    }
+
+    void abc() {
+    }
+
+    @Executable
+    @Vetoed
+    void xyz() {
+    }
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/vetoed/VetoedMethodsAndFieldsBean.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/vetoed/VetoedMethodsAndFieldsBean.java
@@ -1,0 +1,22 @@
+package io.micronaut.inject.vetoed;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.core.annotation.Vetoed;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class VetoedMethodsAndFieldsBean {
+
+    @Inject
+    @Vetoed
+    public BeanContext fieldInjection;
+    public BeanContext methodInjection;
+
+    @Vetoed
+    @Inject
+    public void setMethodInjection(BeanContext methodInjection) {
+        this.methodInjection = methodInjection;
+    }
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/vetoed/VetoedSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/vetoed/VetoedSpec.groovy
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.vetoed
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.inject.vetoed.pkg.VetoedPackageBean
+import spock.lang.Specification
+
+class VetoedSpec extends Specification {
+
+    void "test vetoed package"() {
+        when:
+            ApplicationContext context = ApplicationContext.run()
+        then:
+            context.findBean(VetoedPackageBean).isEmpty()
+        cleanup:
+            context.stop()
+    }
+
+    void "test vetoed bean"() {
+        when:
+            ApplicationContext context = ApplicationContext.run()
+        then:
+            context.findBean(VetoedBean1).isEmpty()
+        cleanup:
+            context.stop()
+    }
+
+    void "test produced vetoed bean"() {
+        when:
+            ApplicationContext context = ApplicationContext.run()
+        then:
+            context.getBeanDefinitions(VetoedBean2).size() == 1
+        cleanup:
+            context.stop()
+    }
+
+    void "test vetoed bean parent"() {
+        when:
+            ApplicationContext context = ApplicationContext.run()
+            def bean = context.getBean(ParentOfVetoedBean)
+        then: "injection in the vetoed superclass is working"
+            bean.fieldInjection
+            bean.methodInjection
+            bean.constructorInjection
+        cleanup:
+            context.stop()
+    }
+
+    void "test vetoed methods and fields bean"() {
+        when:
+            ApplicationContext context = ApplicationContext.run()
+            def bean = context.getBean(VetoedMethodsAndFieldsBean)
+        then:
+            bean.fieldInjection == null
+            bean.methodInjection == null
+        cleanup:
+            context.stop()
+    }
+
+    void "test vetoed executable methods bean"() {
+        when:
+            ApplicationContext context = ApplicationContext.run()
+            def bean = context.getBeanDefinition(VetoedExecutableMethodsBean)
+        then:
+            bean.executableMethods.collect {it.methodName } == ["foo", "abc"]
+        cleanup:
+            context.stop()
+    }
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/vetoed/VetoedSuperclassBean.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/vetoed/VetoedSuperclassBean.java
@@ -1,0 +1,25 @@
+package io.micronaut.inject.vetoed;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.core.annotation.Vetoed;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+@Vetoed
+@Singleton
+public class VetoedSuperclassBean {
+
+    public final BeanContext constructorInjection;
+    @Inject
+    public BeanContext fieldInjection;
+    public BeanContext methodInjection;
+
+    public VetoedSuperclassBean(BeanContext constructorInjection) {
+        this.constructorInjection = constructorInjection;
+    }
+
+    @Inject
+    public void setMethodInjection(BeanContext methodInjection) {
+        this.methodInjection = methodInjection;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/vetoed/pkg/VetoedPackageBean.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/vetoed/pkg/VetoedPackageBean.java
@@ -1,0 +1,7 @@
+package io.micronaut.inject.vetoed.pkg;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+public class VetoedPackageBean {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/vetoed/pkg/package-info.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/vetoed/pkg/package-info.java
@@ -1,0 +1,4 @@
+@Vetoed
+package io.micronaut.inject.vetoed.pkg;
+
+import io.micronaut.core.annotation.Vetoed;

--- a/src/main/docs/guide/ioc/beans.adoc
+++ b/src/main/docs/guide/ioc/beans.adoc
@@ -20,3 +20,5 @@ Micronaut supports the following types of dependency injection:
 * Field injection
 * JavaBean property injection
 * Method parameter injection
+
+NOTE: Classes or particular fields, methods can be excluded by adding an annotation ann:core.annotation.Vetoed[]


### PR DESCRIPTION
There is a use case in Micronaut Groovy function where methods annotated `@Internal` are expected to be excluded, it would be better to use this new `@Vetoed` for this case, and this is also needed for the CDI implementation.