### PR TITLE
Add a test module to verify simple native execution

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -10,5 +10,6 @@ dependencies {
     implementation "gradle.plugin.com.github.johnrengelman:shadow:7.1.2"
     implementation "org.aim42:htmlSanityCheck:1.1.6"
     implementation "io.micronaut.build.internal:micronaut-gradle-plugins:5.3.15"
+    implementation "org.graalvm.buildtools.native:org.graalvm.buildtools.native.gradle.plugin:0.9.14"
     implementation "org.tomlj:tomlj:1.0.0"
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -62,6 +62,7 @@ include "test-suite-helper"
 include "test-suite-javax-inject"
 include "test-suite-jakarta-inject-bean-import"
 include "test-suite-kotlin"
+include "test-suite-graal"
 include "test-suite-groovy"
 include "test-utils"
 

--- a/test-suite-graal/build.gradle
+++ b/test-suite-graal/build.gradle
@@ -1,0 +1,67 @@
+plugins {
+    id "io.micronaut.build.internal.common"
+    id 'org.graalvm.buildtools.native'
+}
+
+micronautBuild {
+    enableBom = false
+    enableProcessing = false
+}
+
+dependencies {
+    annotationProcessor libs.bundles.asm
+    annotationProcessor project(":inject-java")
+    implementation project(":context")
+    implementation project(":core")
+    implementation project(":inject")
+    implementation project(":graal")
+    implementation project(":http-server-netty")
+    implementation project(":http-client")
+    implementation project(":validation")
+    implementation project(":inject-java")
+
+    testAnnotationProcessor libs.bundles.asm
+    testAnnotationProcessor project(":inject-java")
+    testImplementation libs.managed.micronaut.test.junit5
+}
+
+tasks.withType(Test).configureEach {
+    useJUnitPlatform()
+}
+
+configurations {
+    // Exclude Groovy from the nativeTestCompilation classpath
+    all {
+        exclude group: 'org.codehaus.groovy'
+    }
+    nativeImageTestClasspath {
+        exclude module: 'groovy-test'
+    }
+}
+
+tasks.named("check") { task ->
+    def graal = ["jvmci.Compiler", "java.vendor.version", "java.vendor"].any {
+        println "$it ${System.getProperty(it)}"
+        System.getProperty(it)?.toLowerCase(Locale.ENGLISH)?.contains("graal")
+    }
+    if (graal) {
+        task.dependsOn("nativeTest")
+    }
+}
+
+def openGraalModules = [
+        "org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk",
+        "org.graalvm.nativeimage.builder/com.oracle.svm.core.configure",
+        "org.graalvm.sdk/org.graalvm.nativeimage.impl"
+]
+
+graalvmNative {
+    toolchainDetection = false
+    binaries {
+        all {
+            openGraalModules.each { module ->
+                jvmArgs.add("--add-exports=" + module + "=ALL-UNNAMED")
+            }
+        }
+    }
+}

--- a/test-suite-graal/gradle.properties
+++ b/test-suite-graal/gradle.properties
@@ -1,0 +1,1 @@
+skipDocumentation=true

--- a/test-suite-graal/src/main/java/io/micronaut/test/graal/HomeController.java
+++ b/test-suite-graal/src/main/java/io/micronaut/test/graal/HomeController.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.test.graal;
+
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import java.util.Collections;
+import java.util.Map;
+
+@Controller
+public class HomeController {
+
+    @Get
+    Map<String, Object> index() {
+        return Collections.singletonMap("message", "Hello World");
+    }
+}

--- a/test-suite-graal/src/test/java/io/micronaut/test/graal/HomeControllerTest.java
+++ b/test-suite-graal/src/test/java/io/micronaut/test/graal/HomeControllerTest.java
@@ -1,0 +1,25 @@
+package io.micronaut.test.graal;
+
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@MicronautTest
+class HomeControllerTest {
+
+    @Inject
+    @Client("/")
+    HttpClient httpClient;
+
+    @Test
+    void helloWorld() {
+        assertEquals("Hello World",
+            httpClient.toBlocking().retrieve("/", Map.class).get("message"));
+    }
+}


### PR DESCRIPTION
We detect issues with native compilation quite far down the release chain.

This causes problems, and delays when releasing a new version of Micronaut, especially minor or major releases.

This commit adds a new module test-suite-graal which runs nativeTest against a simple micronaut application.