### PR TITLE
Property type: select the type with the most generic argument annotations

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/ast/utils/AstBeanPropertiesUtils.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/utils/AstBeanPropertiesUtils.java
@@ -150,9 +150,15 @@ public final class AstBeanPropertiesUtils {
                 // and it has more type arguments annotations - use it as the property type
                 if (value.field != null
                     && value.field.getType().equals(value.type)
-                    && hasGenericTypeAnnotations(value.field.getType())
-                    && !hasGenericTypeAnnotations(value.type.getType())) {
+                    && countGenericTypeAnnotations(value.field.getType()) > countGenericTypeAnnotations(value.type.getType())) {
                     value.type = value.field.getGenericType();
+                }
+                // In a case when the getter's type is the same as the selected property type,
+                // and it has more type arguments annotations - use it as the property type
+                if (value.getter != null
+                    && value.getter.getGenericReturnType().equals(value.type)
+                    && countGenericTypeAnnotations(value.getter.getGenericReturnType()) > countGenericTypeAnnotations(value.type.getType())) {
+                    value.type = value.getter.getGenericReturnType();
                 }
                 if (value.readAccessKind != null || value.writeAccessKind != null) {
                     value.isExcluded = shouldExclude(includes, excludes, propertyName)
@@ -169,8 +175,8 @@ public final class AstBeanPropertiesUtils {
         return Collections.emptyList();
     }
 
-    private static boolean hasGenericTypeAnnotations(ClassElement cl) {
-        return cl.getTypeArguments().values().stream().anyMatch(t -> !t.getAnnotationMetadata().isEmpty());
+    private static int countGenericTypeAnnotations(ClassElement cl) {
+        return cl.getTypeArguments().values().stream().mapToInt(t -> t.getAnnotationMetadata().getAnnotationNames().size()).sum();
     }
 
     private static boolean isExcludedBecauseOfMissingAccess(BeanPropertyData value) {

--- a/inject-java/src/test/groovy/io/micronaut/visitors/ClassElementAnnotationsRetaining.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/ClassElementAnnotationsRetaining.groovy
@@ -1,0 +1,178 @@
+package io.micronaut.visitors
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.inject.ast.ClassElement
+import io.micronaut.inject.ast.PropertyElement
+/**
+ * This spec puts annotations in different places on properties and verifies that
+ * the annotations are present in the ClassElement.
+ */
+class ClassElementAnnotationsRetaining extends AbstractTypeElementSpec {
+
+    void 'test type argument annotation on the property without a setter'() {
+        given:
+            // Put an annotation on the property type argument
+            // Do not define a setter
+            def code = '''
+package test;
+import java.util.List;
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import io.micronaut.core.annotation.Introspected;
+@Introspected
+class SaladWithSetter {
+    List<@Valid Ingredient> ingredients;
+    public List<Ingredient> getIngredients() {
+        return ingredients;
+    }
+    @Introspected
+    public record Ingredient(
+        @NotBlank String name
+    ) {}
+}
+'''
+
+        when:
+            ClassElement classElement = buildClassElement(code)
+            PropertyElement propertyElement = classElement.getBeanProperties().iterator().next()
+
+        then:
+            def propertyTypeArgument = propertyElement.type.typeArguments.get("E")
+            propertyTypeArgument.annotationMetadata.hasStereotype("javax.validation.Valid")
+    }
+
+    void 'test type argument annotation on the getter'() {
+        given:
+            // Put an annotation on the property type argument
+            // Do not define a setter
+            def code = '''
+package test;
+import java.util.List;
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import io.micronaut.core.annotation.Introspected;
+@Introspected
+class SaladWithSetter {
+    List<Ingredient> ingredients;
+    public List<@Valid Ingredient> getIngredients() {
+        return ingredients;
+    }
+    @Introspected
+    public record Ingredient(
+        @NotBlank String name
+    ) {}
+}
+'''
+
+        when:
+            ClassElement classElement = buildClassElement(code)
+            PropertyElement propertyElement = classElement.getBeanProperties().iterator().next()
+
+        then:
+            def propertyTypeArgument = propertyElement.type.typeArguments.get("E")
+            propertyTypeArgument.annotationMetadata.hasStereotype("javax.validation.Valid")
+    }
+
+    void 'test type argument annotation on the setter'() {
+        given:
+            // Put an annotation on the setter type argument
+            def code = '''
+package test;
+import java.util.List;
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import io.micronaut.core.annotation.Introspected;
+@Introspected
+class SaladWithSetter {
+    List<Ingredient> ingredients;
+    public List<Ingredient> getIngredients() {
+        return ingredients;
+    }
+    public void setIngredients(List<@Valid Ingredient> ingredients) {
+        this.ingredients = ingredients;
+    }
+    @Introspected
+    public record Ingredient(
+        @NotBlank String name
+    ) {}
+}
+'''
+
+        when:
+            ClassElement classElement = buildClassElement(code)
+            PropertyElement propertyElement = classElement.getBeanProperties().iterator().next()
+
+        then:
+            def propertyTypeArgument = propertyElement.type.typeArguments.get("E")
+            propertyTypeArgument.annotationMetadata.hasStereotype("javax.validation.Valid")
+    }
+
+    void 'test type argument annotation on the property with a setter'() {
+        given:
+            // Put an annotation on the property type argument
+            // Define a setter
+            def code = '''
+package test;
+import java.util.List;
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import io.micronaut.core.annotation.Introspected;
+@Introspected
+class SaladWithSetter {
+    List<@Valid Ingredient> ingredients;
+    public List<Ingredient> getIngredients() {
+        return ingredients;
+    }
+    public void setIngredients(List<Ingredient> ingredients) {
+        this.ingredients = ingredients;
+    }
+    @Introspected
+    public record Ingredient(
+        @NotBlank String name
+    ) {}
+}
+'''
+
+        when:
+            ClassElement classElement = buildClassElement(code)
+            PropertyElement propertyElement = classElement.getBeanProperties().iterator().next()
+
+        then:
+            def propertyTypeArgument = propertyElement.type.typeArguments.get("E")
+            propertyTypeArgument.annotationMetadata.hasStereotype("javax.validation.Valid")
+    }
+
+    void 'test annotation on the property with a setter'() {
+        given:
+            // Put an annotation on the property
+            // Define a setter
+            def code = '''
+package test;
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import io.micronaut.core.annotation.Introspected;
+@Introspected
+class SaladWithSetter {
+    @Valid Ingredient ingredient;
+    public Ingredient getIngredient() {
+        return ingredient;
+    }
+    public void setIngredient(Ingredient ingredient) {
+        this.ingredient = ingredient;
+    }
+    @Introspected
+    public record Ingredient(
+        @NotBlank String name
+    ) {}
+}
+'''
+
+        when:
+            ClassElement classElement = buildClassElement(code)
+            PropertyElement propertyElement = classElement.getBeanProperties().iterator().next()
+
+        then:
+            propertyElement.annotationMetadata.hasStereotype("javax.validation.Valid")
+    }
+
+}


### PR DESCRIPTION
Fixes https://github.com/micronaut-projects/micronaut-core/issues/8301

@andriy-dmytruk I think it might be useful for you to have read and write type exposed from the property element instead of one. WDYT? The fix is to select the type with the most type annotations, which I'm not sure is the best for the real word scenario.