### PR TITLE
Implement support for injection of maps

### DIFF
--- a/core-processor/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
+++ b/core-processor/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
@@ -1236,14 +1236,15 @@ public class AopProxyWriter extends AbstractClassFileWriter implements ProxyingB
 
     @Override
     public void visitFieldInjectionPoint(
-            TypedElement declaringType,
-            FieldElement fieldType,
-            boolean requiresReflection) {
+        TypedElement declaringType,
+        FieldElement fieldType,
+        boolean requiresReflection, VisitorContext visitorContext) {
         deferredInjectionPoints.add(() ->
                 proxyBeanDefinitionWriter.visitFieldInjectionPoint(
                         declaringType,
                         fieldType,
-                        requiresReflection
+                        requiresReflection,
+                        visitorContext
                 )
         );
     }

--- a/core-processor/src/main/java/io/micronaut/inject/processing/DeclaredBeanElementCreator.java
+++ b/core-processor/src/main/java/io/micronaut/inject/processing/DeclaredBeanElementCreator.java
@@ -430,7 +430,12 @@ class DeclaredBeanElementCreator extends AbstractBeanElementCreator {
         }
         if (fieldAnnotationMetadata.hasStereotype(AnnotationUtil.INJECT)
             || fieldAnnotationMetadata.hasDeclaredStereotype(AnnotationUtil.QUALIFIER)) {
-            visitor.visitFieldInjectionPoint(fieldElement.getDeclaringType(), fieldElement, fieldElement.isReflectionRequired(classElement));
+            visitor.visitFieldInjectionPoint(
+                fieldElement.getDeclaringType(),
+                fieldElement,
+                fieldElement.isReflectionRequired(classElement),
+                visitorContext
+            );
             return true;
         }
         return false;

--- a/core-processor/src/main/java/io/micronaut/inject/processing/DeclaredBeanElementCreator.java
+++ b/core-processor/src/main/java/io/micronaut/inject/processing/DeclaredBeanElementCreator.java
@@ -381,6 +381,7 @@ class DeclaredBeanElementCreator extends AbstractBeanElementCreator {
      */
     protected void applyConfigurationInjectionIfNecessary(BeanDefinitionVisitor visitor,
                                                           MethodElement constructor) {
+        // default to do nothing
     }
 
     /**

--- a/core-processor/src/main/java/io/micronaut/inject/writer/AbstractBeanDefinitionBuilder.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/AbstractBeanDefinitionBuilder.java
@@ -824,7 +824,8 @@ public abstract class AbstractBeanDefinitionBuilder implements BeanElementBuilde
             beanDefinitionWriter.visitFieldInjectionPoint(
                     injectedField.getDeclaringType(),
                     ibf,
-                    ibf.isReflectionRequired()
+                    ibf.isReflectionRequired(),
+                    visitorContext
             );
         }
     }

--- a/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionVisitor.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionVisitor.java
@@ -279,10 +279,12 @@ public interface BeanDefinitionVisitor extends OriginatingElements, Toggleable {
      * @param declaringType      The declaring type. Either a Class or a string representing the name of the type
      * @param fieldElement       The field element
      * @param requiresReflection Whether accessing the field requires reflection
+     * @param visitorContext     The visitor context
      */
     void visitFieldInjectionPoint(TypedElement declaringType,
                                   FieldElement fieldElement,
-                                  boolean requiresReflection);
+                                  boolean requiresReflection,
+                                  VisitorContext visitorContext);
 
     /**
      * Visits an annotation injection point.

--- a/inject-java/src/test/groovy/io/micronaut/inject/constructor/mapinjection/A.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/constructor/mapinjection/A.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.constructor.mapinjection;
+
+public interface A {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/constructor/mapinjection/AImpl.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/constructor/mapinjection/AImpl.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.constructor.mapinjection;
+
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Named("one")
+public class AImpl implements A {
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/constructor/mapinjection/AnotherImpl.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/constructor/mapinjection/AnotherImpl.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.constructor.mapinjection;
+
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Named("two")
+public class AnotherImpl implements A {
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/constructor/mapinjection/B.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/constructor/mapinjection/B.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.constructor.mapinjection;
+
+import jakarta.inject.Inject;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class B {
+    private final LinkedHashMap<CharSequence, A> linked;
+    private Map<String, A> all;
+
+    @Inject
+    public B(Map<String, A> all, LinkedHashMap<CharSequence, A> linked) {
+        this.all = all;
+        this.linked = linked;
+    }
+
+    public Map<String, A> getAll() {
+        return all;
+    }
+
+    public LinkedHashMap<CharSequence, A> getLinked() {
+        return linked;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/constructor/mapinjection/ConstructorMapInjectionSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/constructor/mapinjection/ConstructorMapInjectionSpec.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.constructor.mapinjection
+
+import io.micronaut.context.BeanContext
+import io.micronaut.context.DefaultBeanContext
+import spock.lang.Specification
+
+class ConstructorMapInjectionSpec extends Specification {
+
+    void "test injection with constructor"() {
+        given:
+        BeanContext context = BeanContext.run()
+
+        when:"A bean is obtained that has a constructor with @Inject"
+        B b =  context.getBean(B)
+
+        then:"The implementation is injected"
+        b.all != null
+        b.all.size() == 2
+        b.all.values().contains(context.getBean(AImpl))
+        b.all.values().contains(context.getBean(AnotherImpl))
+        b.all['one'] instanceof AImpl
+        b.all == b.linked
+
+        cleanup:
+        context.close()
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/field/mapinjection/A.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/field/mapinjection/A.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.field.mapinjection;
+
+public interface A {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/field/mapinjection/AImpl.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/field/mapinjection/AImpl.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.field.mapinjection;
+
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Named("one")
+public class AImpl implements A {
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/field/mapinjection/Animal.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/field/mapinjection/Animal.java
@@ -1,0 +1,4 @@
+package io.micronaut.inject.field.mapinjection;
+
+public interface Animal {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/field/mapinjection/AnotherImpl.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/field/mapinjection/AnotherImpl.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.field.mapinjection;
+
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Named("two")
+public class AnotherImpl implements A {
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/field/mapinjection/B.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/field/mapinjection/B.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.field.mapinjection;
+
+import jakarta.inject.Inject;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class B {
+    @Inject
+    Map<String, A> all;
+
+    @Inject
+    LinkedHashMap<String, A> linked;
+
+    @Inject
+    Map<String, MapFactory.Foo> bean;
+
+    public Map<String, A> getAll() {
+        return all;
+    }
+
+    public LinkedHashMap<String, A> getLinked() {
+        return linked;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/field/mapinjection/B.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/field/mapinjection/B.java
@@ -26,6 +26,9 @@ public class B {
     Map<String, A> all;
 
     @Inject
+    Map<String, Animal> animalMap;
+
+    @Inject
     LinkedHashMap<String, A> linked;
 
     @Inject

--- a/inject-java/src/test/groovy/io/micronaut/inject/field/mapinjection/Cat.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/field/mapinjection/Cat.java
@@ -1,0 +1,7 @@
+package io.micronaut.inject.field.mapinjection;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+public class Cat implements Animal {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/field/mapinjection/Dog.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/field/mapinjection/Dog.java
@@ -1,0 +1,7 @@
+package io.micronaut.inject.field.mapinjection;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+public class Dog implements Animal {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/field/mapinjection/FieldMapInjectionSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/field/mapinjection/FieldMapInjectionSpec.groovy
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.field.mapinjection
+
+import io.micronaut.context.BeanContext
+import io.micronaut.context.DefaultBeanContext
+import spock.lang.Specification
+
+class FieldMapInjectionSpec extends Specification {
+    void "test injection via setter that takes a collection"() {
+        given:
+        BeanContext context = BeanContext.run()
+
+        when:
+        B b =  context.getBean(B)
+
+        then:
+        b.all != null
+        b.all.size() == 2
+        b.all.values().contains(context.getBean(AImpl))
+        b.all.values().contains(context.getBean(AnotherImpl))
+        b.all['one'] instanceof AImpl
+        b.all == b.linked
+        b.bean.size() == 1 // prioritize explicit beans
+
+        cleanup:
+        context.close()
+    }
+}
+

--- a/inject-java/src/test/groovy/io/micronaut/inject/field/mapinjection/FieldMapInjectionSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/field/mapinjection/FieldMapInjectionSpec.groovy
@@ -35,6 +35,8 @@ class FieldMapInjectionSpec extends Specification {
         b.all['one'] instanceof AImpl
         b.all == b.linked
         b.bean.size() == 1 // prioritize explicit beans
+        b.animalMap['dog'] instanceof Dog
+        b.animalMap['cat'] instanceof Cat
 
         cleanup:
         context.close()

--- a/inject-java/src/test/groovy/io/micronaut/inject/field/mapinjection/MapFactory.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/field/mapinjection/MapFactory.java
@@ -1,0 +1,19 @@
+package io.micronaut.inject.field.mapinjection;
+
+import io.micronaut.context.annotation.Factory;
+import jakarta.inject.Singleton;
+
+import java.util.Collections;
+import java.util.Map;
+
+@Factory
+public class MapFactory {
+
+    @Singleton
+    Map<String, Foo> foo() {
+      return Collections.singletonMap("one", new Foo());
+    }
+
+    public static class Foo {
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/EachPropertySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/EachPropertySpec.groovy
@@ -336,6 +336,13 @@ class EachPropertySpec extends Specification {
         bean2.configuration.inner.enabled == 'false'
 
 
+        when:
+        def map = applicationContext.mapOfType(MyBeanWithPrimary)
+
+        then:
+        map['one'].is(bean)
+        map['two'].is(bean2)
+
         cleanup:
         applicationContext.close()
     }

--- a/inject-java/src/test/groovy/io/micronaut/inject/method/mapinjection/A.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/method/mapinjection/A.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.method.mapinjection;
+
+public interface A {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/method/mapinjection/AImpl.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/method/mapinjection/AImpl.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.method.mapinjection;
+
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Named("one")
+public class AImpl implements A {
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/method/mapinjection/AnotherImpl.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/method/mapinjection/AnotherImpl.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.method.mapinjection;
+
+import jakarta.inject.Qualifier;
+import jakarta.inject.Singleton;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Singleton
+@Two
+public class AnotherImpl implements A {
+
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Qualifier
+@interface Two {}

--- a/inject-java/src/test/groovy/io/micronaut/inject/method/mapinjection/B.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/method/mapinjection/B.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.method.mapinjection;
+
+import io.micronaut.context.BeanContext;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Singleton
+public class B {
+    private Map<String, A> all;
+    private LinkedHashMap<CharSequence, A> linked;
+    private BeanContext beanContext;
+
+    @Inject
+    void setA(Map<String, A> a) {
+        this.all = a;
+    }
+
+    @Inject
+    private void setPrivate(LinkedHashMap<CharSequence, A> a, BeanContext beanContext) {
+        this.linked = a;
+    }
+
+    Map<String, A> getAll() {
+        return this.all;
+    }
+
+    public LinkedHashMap<CharSequence, A> getLinked() {
+        return linked;
+    }
+
+    public BeanContext getBeanContext() {
+        return beanContext;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/method/mapinjection/SetterMapInjectionSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/method/mapinjection/SetterMapInjectionSpec.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.method.mapinjection
+
+import io.micronaut.context.BeanContext
+import io.micronaut.context.DefaultBeanContext
+import spock.lang.Specification
+
+class SetterMapInjectionSpec extends Specification {
+    void "test injection via setter that takes an array"() {
+        given:
+        BeanContext context = BeanContext.run()
+
+        when:
+        B b =  context.getBean(B)
+
+        then:
+        b.all != null
+        b.all.size() == 2
+        b.all.values().contains(context.getBean(AImpl))
+        b.all.values().contains(context.getBean(AnotherImpl))
+        b.all['one'] instanceof AImpl
+        b.all == b.linked
+
+        cleanup:
+        context.close()
+
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/AbstractBeanResolutionContext.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractBeanResolutionContext.java
@@ -78,6 +78,11 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
         return context.streamOfType(this, beanType, qualifier);
     }
 
+    @Override
+    public <V, K extends CharSequence> Map<K, V> mapOfType(Argument<V> beanType, Qualifier<V> qualifier) {
+        return context.mapOfType(this, beanType, qualifier);
+    }
+
     @NonNull
     @Override
     public <T> Optional<T> findBean(@NonNull Argument<T> beanType, @Nullable Qualifier<T> qualifier) {

--- a/inject/src/main/java/io/micronaut/context/AbstractBeanResolutionContext.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractBeanResolutionContext.java
@@ -79,7 +79,7 @@ public abstract class AbstractBeanResolutionContext implements BeanResolutionCon
     }
 
     @Override
-    public <V, K extends CharSequence> Map<K, V> mapOfType(Argument<V> beanType, Qualifier<V> qualifier) {
+    public <V> Map<String, V> mapOfType(Argument<V> beanType, Qualifier<V> qualifier) {
         return context.mapOfType(this, beanType, qualifier);
     }
 

--- a/inject/src/main/java/io/micronaut/context/AbstractInitializableBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractInitializableBeanDefinition.java
@@ -1288,12 +1288,11 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
      * @param genericType       The generic type
      * @param qualifier         The qualifier
      * @return The resolved bean
-     * @param <K>               The key type
      * @param <V>               The bean type
      */
     @Internal
     @UsedByGeneratedCode
-    protected final <K extends CharSequence, V> Map<K, V> getMapOfTypeForMethodArgument(
+    protected final <V> Map<String, V> getMapOfTypeForMethodArgument(
         BeanResolutionContext resolutionContext,
         BeanContext context,
         int methodIndex,
@@ -1302,7 +1301,7 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
         Qualifier<V> qualifier) {
         @SuppressWarnings("ConstantConditions")
         MethodReference methodRef = methodInjection[methodIndex];
-        Argument<Map<K, V>> argument = resolveArgument(context, argIndex, methodRef.arguments);
+        Argument<Map<String, V>> argument = resolveArgument(context, argIndex, methodRef.arguments);
         try (BeanResolutionContext.Path ignored =
                  resolutionContext.getPath().pushMethodArgumentResolve(this, methodRef.methodName, argument, methodRef.arguments, methodRef.requiresReflection)) {
             return resolveMapOfType(resolutionContext, argument, resolveEnvironmentArgument(context, genericType), qualifier);
@@ -1609,12 +1608,11 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
      * @param genericType       The generic type
      * @param qualifier         The qualifier
      * @return The resolved bean
-     * @param <K>               The key type
      * @param <V>               The bean type
      */
     @Internal
     @UsedByGeneratedCode
-    protected final <K extends CharSequence, V> Map<K, V> getMapOfTypeForConstructorArgument(
+    protected final <V> Map<String, V> getMapOfTypeForConstructorArgument(
         BeanResolutionContext resolutionContext,
         BeanContext context,
         int argIndex,
@@ -1624,7 +1622,7 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
         if (constructorMethodRef == null) {
             throw new IllegalStateException("No constructor found for bean: " + getBeanType());
         }
-        Argument<Map<K, V>> argument = resolveArgument(context, argIndex, constructorMethodRef.arguments);
+        Argument<Map<String, V>> argument = resolveArgument(context, argIndex, constructorMethodRef.arguments);
         try (BeanResolutionContext.Path ignored = resolutionContext.getPath().pushConstructorResolve(this, argument)) {
             return resolveMapOfType(resolutionContext, argument, resolveEnvironmentArgument(context, genericType), qualifier);
         }
@@ -1949,13 +1947,12 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
      * @param fieldIndex        The field index
      * @param genericType       The generic type
      * @param qualifier         The qualifier
-     * @param <K>               The key type
      * @param <V>               The bean type
      * @return The resolved bean
      */
     @Internal
     @UsedByGeneratedCode
-    protected final <K extends CharSequence, V> Map<K, V> getMapOfTypeForField(
+    protected final <V> Map<String, V> getMapOfTypeForField(
         BeanResolutionContext resolutionContext,
         BeanContext context, int fieldIndex,
         Argument<V> genericType,
@@ -1963,7 +1960,7 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
         @SuppressWarnings("ConstantConditions")
         FieldReference fieldRef = fieldInjection[fieldIndex];
         @SuppressWarnings("unchecked")
-        Argument<Map<K, V>> argument = resolveEnvironmentArgument(context, fieldRef.argument);
+        Argument<Map<String, V>> argument = resolveEnvironmentArgument(context, fieldRef.argument);
         try (BeanResolutionContext.Path ignored = resolutionContext.getPath()
             .pushFieldResolve(this, argument, fieldRef.requiresReflection)) {
             return resolveMapOfType(resolutionContext, argument, resolveEnvironmentArgument(context, genericType), qualifier);
@@ -2272,16 +2269,16 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
         return resolutionContext.streamOfType(resultGenericType, qualifier);
     }
 
-    private <K extends CharSequence, V> Map<K, V> resolveMapOfType(
+    private <V> Map<String, V> resolveMapOfType(
         BeanResolutionContext resolutionContext,
-        Argument<Map<K, V>> argument,
+        Argument<Map<String, V>> argument,
         Argument<V> resultGenericType,
         Qualifier<V> qualifier) {
         if (resultGenericType == null) {
             throw new DependencyInjectionException(resolutionContext, "Type " + argument.getType() + " has no generic argument");
         }
         qualifier = qualifier == null ? resolveQualifier(resolutionContext, resultGenericType) : qualifier;
-        Map<K, V> map = resolutionContext.mapOfType(resultGenericType, qualifier);
+        Map<String, V> map = resolutionContext.mapOfType(resultGenericType, qualifier);
         if (argument.isInstance(map)) {
             return map;
         } else {

--- a/inject/src/main/java/io/micronaut/context/AbstractInitializableBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractInitializableBeanDefinition.java
@@ -1277,6 +1277,39 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
     }
 
     /**
+     * Obtains all bean definitions for the method at the given index and the argument at the given index
+     * <p>
+     * Warning: this method is used by internal generated code and should not be called by user code.
+     *
+     * @param resolutionContext The resolution context
+     * @param context           The context
+     * @param methodIndex       The method index
+     * @param argIndex          The argument index
+     * @param genericType       The generic type
+     * @param qualifier         The qualifier
+     * @return The resolved bean
+     * @param <K>               The key type
+     * @param <V>               The bean type
+     */
+    @Internal
+    @UsedByGeneratedCode
+    protected final <K extends CharSequence, V> Map<K, V> getMapOfTypeForMethodArgument(
+        BeanResolutionContext resolutionContext,
+        BeanContext context,
+        int methodIndex,
+        int argIndex,
+        Argument<V> genericType,
+        Qualifier<V> qualifier) {
+        @SuppressWarnings("ConstantConditions")
+        MethodReference methodRef = methodInjection[methodIndex];
+        Argument<Map<K, V>> argument = resolveArgument(context, argIndex, methodRef.arguments);
+        try (BeanResolutionContext.Path ignored =
+                 resolutionContext.getPath().pushMethodArgumentResolve(this, methodRef.methodName, argument, methodRef.arguments, methodRef.requiresReflection)) {
+            return resolveMapOfType(resolutionContext, argument, resolveEnvironmentArgument(context, genericType), qualifier);
+        }
+    }
+
+    /**
      * Obtains a bean definition for a constructor at the given index
      * <p>
      * Warning: this method is used by internal generated code and should not be called by user code.
@@ -1562,6 +1595,38 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
         Argument<K> argument = resolveArgument(context, argIndex, constructorMethodRef.arguments);
         try (BeanResolutionContext.Path ignored = resolutionContext.getPath().pushConstructorResolve(this, argument)) {
             return resolveStreamOfType(resolutionContext, argument, resolveEnvironmentArgument(context, genericType), qualifier);
+        }
+    }
+
+    /**
+     * Obtains all bean definitions for a constructor argument at the given index
+     * <p>
+     * Warning: this method is used by internal generated code and should not be called by user code.
+     *
+     * @param resolutionContext The resolution context
+     * @param context           The context
+     * @param argIndex          The argument index
+     * @param genericType       The generic type
+     * @param qualifier         The qualifier
+     * @return The resolved bean
+     * @param <K>               The key type
+     * @param <V>               The bean type
+     */
+    @Internal
+    @UsedByGeneratedCode
+    protected final <K extends CharSequence, V> Map<K, V> getMapOfTypeForConstructorArgument(
+        BeanResolutionContext resolutionContext,
+        BeanContext context,
+        int argIndex,
+        Argument<V> genericType,
+        Qualifier<V> qualifier) {
+        MethodReference constructorMethodRef = (MethodReference) constructor;
+        if (constructorMethodRef == null) {
+            throw new IllegalStateException("No constructor found for bean: " + getBeanType());
+        }
+        Argument<Map<K, V>> argument = resolveArgument(context, argIndex, constructorMethodRef.arguments);
+        try (BeanResolutionContext.Path ignored = resolutionContext.getPath().pushConstructorResolve(this, argument)) {
+            return resolveMapOfType(resolutionContext, argument, resolveEnvironmentArgument(context, genericType), qualifier);
         }
     }
 
@@ -1874,6 +1939,37 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
         }
     }
 
+    /**
+     * Obtains a bean definition for the field at the given index and the argument at the given index
+     * <p>
+     * Warning: this method is used by internal generated code and should not be called by user code.
+     *
+     * @param resolutionContext The resolution context
+     * @param context           The context
+     * @param fieldIndex        The field index
+     * @param genericType       The generic type
+     * @param qualifier         The qualifier
+     * @param <K>               The key type
+     * @param <V>               The bean type
+     * @return The resolved bean
+     */
+    @Internal
+    @UsedByGeneratedCode
+    protected final <K extends CharSequence, V> Map<K, V> getMapOfTypeForField(
+        BeanResolutionContext resolutionContext,
+        BeanContext context, int fieldIndex,
+        Argument<V> genericType,
+        Qualifier<V> qualifier) {
+        @SuppressWarnings("ConstantConditions")
+        FieldReference fieldRef = fieldInjection[fieldIndex];
+        @SuppressWarnings("unchecked")
+        Argument<Map<K, V>> argument = resolveEnvironmentArgument(context, fieldRef.argument);
+        try (BeanResolutionContext.Path ignored = resolutionContext.getPath()
+            .pushFieldResolve(this, argument, fieldRef.requiresReflection)) {
+            return resolveMapOfType(resolutionContext, argument, resolveEnvironmentArgument(context, genericType), qualifier);
+        }
+    }
+
     @Internal
     @UsedByGeneratedCode
     protected final boolean containsPropertiesValue(BeanResolutionContext resolutionContext, BeanContext context, String value) {
@@ -2174,6 +2270,25 @@ public class AbstractInitializableBeanDefinition<T> extends AbstractBeanContextC
         }
         qualifier = qualifier == null ? resolveQualifier(resolutionContext, argument) : qualifier;
         return resolutionContext.streamOfType(resultGenericType, qualifier);
+    }
+
+    private <K extends CharSequence, V> Map<K, V> resolveMapOfType(
+        BeanResolutionContext resolutionContext,
+        Argument<Map<K, V>> argument,
+        Argument<V> resultGenericType,
+        Qualifier<V> qualifier) {
+        if (resultGenericType == null) {
+            throw new DependencyInjectionException(resolutionContext, "Type " + argument.getType() + " has no generic argument");
+        }
+        qualifier = qualifier == null ? resolveQualifier(resolutionContext, resultGenericType) : qualifier;
+        Map<K, V> map = resolutionContext.mapOfType(resultGenericType, qualifier);
+        if (argument.isInstance(map)) {
+            return map;
+        } else {
+            return resolutionContext.getContext().getConversionService().convertRequired(
+                map, argument
+            );
+        }
     }
 
     private <K> Optional<K> resolveOptionalBean(BeanResolutionContext resolutionContext, Argument<K> argument, Argument<K> resultGenericType, Qualifier<K> qualifier) {

--- a/inject/src/main/java/io/micronaut/context/BeanLocator.java
+++ b/inject/src/main/java/io/micronaut/context/BeanLocator.java
@@ -23,6 +23,8 @@ import io.micronaut.core.type.Argument;
 import io.micronaut.inject.BeanDefinition;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -229,6 +231,59 @@ public interface BeanLocator {
         );
     }
 
+    /**
+     * Obtain a map of beans of the given type where the key is the qualifier.
+     *
+     * @param beanType  The potentially parameterized bean type
+     * @param qualifier The qualifier
+     * @param <V>       The bean concrete type
+     * @return A map of instances
+     * @see io.micronaut.inject.qualifiers.Qualifiers
+     * @since 4.0.0
+     */
+    default @NonNull <V> Map<String, V> mapOfType(@NonNull Argument<V> beanType, @Nullable Qualifier<V> qualifier) {
+        return Collections.emptyMap();
+    }
+
+    /**
+     * Obtain a map of beans of the given type where the key is the qualifier.
+     *
+     * @param beanType  The potentially parameterized bean type
+     * @param qualifier The qualifier
+     * @param <V>       The bean concrete type
+     * @return A map of instances
+     * @see io.micronaut.inject.qualifiers.Qualifiers
+     * @since 4.0.0
+     */
+    default @NonNull <V> Map<String, V> mapOfType(@NonNull Class<V> beanType, @Nullable Qualifier<V> qualifier) {
+        return mapOfType(Argument.of(beanType), qualifier);
+    }
+
+    /**
+     * Obtain a map of beans of the given type where the key is the qualifier.
+     *
+     * @param beanType  The potentially parameterized bean type
+     * @param <V>       The bean concrete type
+     * @return A map of instances
+     * @see io.micronaut.inject.qualifiers.Qualifiers
+     * @since 4.0.0
+     */
+    default @NonNull <V> Map<String, V> mapOfType(@NonNull Class<V> beanType) {
+        return mapOfType(Argument.of(beanType), null);
+    }
+
+    /**
+     * Obtain a map of beans of the given type where the key is the qualifier.
+     *
+     * @param beanType  The potentially parameterized bean type
+     * @param <V>       The bean concrete type
+     * @return A map of instances
+     * @see io.micronaut.inject.qualifiers.Qualifiers
+     * @since 4.0.0
+     */
+    default @NonNull <V> Map<String, V> mapOfType(@NonNull Argument<V> beanType) {
+        return mapOfType(beanType, null);
+    }
 
     /**
      * Resolves the proxy target for a given bean type. If the bean has no proxy then the original bean is returned.

--- a/inject/src/main/java/io/micronaut/context/BeanResolutionContext.java
+++ b/inject/src/main/java/io/micronaut/context/BeanResolutionContext.java
@@ -31,6 +31,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -83,6 +84,21 @@ public interface BeanResolutionContext extends ValueResolver<CharSequence>, Auto
      */
     @NonNull
     <T> Stream<T> streamOfType(@NonNull  Argument<T> beanType, @Nullable  Qualifier<T> qualifier);
+
+    /**
+     * Obtains a map of beans of the given type and qualifier.
+     *
+     * @param beanType          The bean type
+     * @param qualifier         The qualifier
+     * @param <K>               The key type
+     * @param <V>               The bean type
+     * @return A map of beans, never {@code null}.
+     * @since 4.0.0
+     */
+    @NonNull
+    default <V, K extends CharSequence> Map<K, V> mapOfType(@NonNull Argument<V> beanType, @Nullable Qualifier<V> qualifier) {
+        return Collections.emptyMap();
+    }
 
     /**
      * Find an optional bean of the given type and qualifier.

--- a/inject/src/main/java/io/micronaut/context/BeanResolutionContext.java
+++ b/inject/src/main/java/io/micronaut/context/BeanResolutionContext.java
@@ -90,13 +90,12 @@ public interface BeanResolutionContext extends ValueResolver<CharSequence>, Auto
      *
      * @param beanType          The bean type
      * @param qualifier         The qualifier
-     * @param <K>               The key type
      * @param <V>               The bean type
      * @return A map of beans, never {@code null}.
      * @since 4.0.0
      */
     @NonNull
-    default <V, K extends CharSequence> Map<K, V> mapOfType(@NonNull Argument<V> beanType, @Nullable Qualifier<V> qualifier) {
+    default <V> Map<String, V> mapOfType(@NonNull Argument<V> beanType, @Nullable Qualifier<V> qualifier) {
         return Collections.emptyMap();
     }
 

--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContextBuilder.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContextBuilder.java
@@ -68,7 +68,6 @@ public class DefaultApplicationContextBuilder implements ApplicationContextBuild
     private boolean allowEmptyProviders = false;
     private Boolean bootstrapEnvironment = null;
     private boolean enableDefaultPropertySources = true;
-    ;
 
     /**
      * Default constructor.

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -951,7 +951,6 @@ public class DefaultBeanContext implements InitializableBeanContext {
      * @param resolutionContext  The resolution context
      * @param beanType           The bean type
      * @param qualifier          The qualifier
-     * @param <K>                The key type
      * @param <V>                The bean type
      * @return A map of beans, never {@code null}.
      * @since 4.0.0

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -72,6 +72,7 @@ import io.micronaut.core.io.ResourceLoader;
 import io.micronaut.core.io.scan.ClassPathResourceLoader;
 import io.micronaut.core.io.service.SoftServiceLoader;
 import io.micronaut.core.naming.NameResolver;
+import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.naming.Named;
 import io.micronaut.core.order.OrderUtil;
 import io.micronaut.core.order.Ordered;
@@ -991,10 +992,19 @@ public class DefaultBeanContext implements InitializableBeanContext {
     @NonNull
     private static String resolveKey(BeanRegistration<?> reg) {
         BeanDefinition<?> definition = reg.beanDefinition;
+        BeanIdentifier identifier = reg.identifier;
         if (definition instanceof NameResolver resolver) {
-            return resolver.resolveName().orElse(reg.identifier.getName());
+            return resolver.resolveName().orElse(identifier.getName());
+        } else {
+            String name = identifier.getName();
+            if (name.equals(Primary.SIMPLE_NAME)) {
+                Class<?> candidateType = reg.beanDefinition.getBeanType();
+                String candidateSimpleName = candidateType.getSimpleName();
+                return NameUtils.decapitalize(candidateSimpleName);
+            } else {
+                return name;
+            }
         }
-        return reg.identifier.getName();
     }
 
     /**

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -967,10 +967,14 @@ public class DefaultBeanContext implements InitializableBeanContext {
                         reg -> reg.bean
                     ));
                 } catch (IllegalStateException e) { // occurs for duplicate keys
+                    List<BeanDefinition<V>> beanDefinitions = beanRegistrations.stream().map(reg -> reg.beanDefinition).toList();
                     throw new DependencyInjectionException(
                         resolutionContext,
                         "Injecting a map of beans requires each bean to define a qualifier. Multiple beans were found missing a qualifier resulting in duplicate keys: " + e.getMessage(),
-                        e
+                        new NonUniqueBeanException(
+                            beanType.getType(),
+                            beanDefinitions.iterator()
+                        )
                     );
                 }
             }

--- a/src/main/docs/guide/introduction/whatsNew.adoc
+++ b/src/main/docs/guide/introduction/whatsNew.adoc
@@ -4,6 +4,10 @@
 
 === Core Changes
 
+==== Injection of Maps
+
+It is now possible to inject a `java.util.Map` of beans where the key is the bean name. The name of the bean is derived from the <<qualifiers, qualifier>> or (if not present) the simple name of the class.
+
 ==== Improved Error Messages for Missing Beans
 
 When a bean annotated with ann:context.annotation.EachProperty[] or ann:context.annotation.Bean[] is not found due to missing configuration an error is thrown showing the configuration prefix necessary to resolve the issue.

--- a/src/main/docs/guide/ioc/types.adoc
+++ b/src/main/docs/guide/ioc/types.adoc
@@ -8,9 +8,13 @@ In addition to being able to inject beans, Micronaut natively supports injecting
 |An `Optional` of a bean. `empty()` is injected if the bean doesn't exist
 |`Optional<Engine>`
 
-|link:{jdkapi}/java/util/Collection.html[java.lang.Collection]
+|link:{jdkapi}/java/util/Collection.html[java.util.Collection]
 |An `Collection` or subtype of `Collection` (e.g. `List`, `Set`, etc.)
 |`Collection<Engine>`
+
+|link:{jdkapi}/java/util/Map.html[java.util.Map]
+|An `Map` or subtype of `Map` (e.g. `LinkedHashMap`, `TreeMap`, etc.) where the key is the qualifier
+|`Map<String, Engine>`
 
 |link:{jdkapi}/java/util/stream/Stream.html[java.util.stream.Stream]
 |A lazy `Stream` of beans


### PR DESCRIPTION
This PR adds support for injecting of maps. It attempts to be backwards compatible by first looking up a bean that implements map and then falling back to map resolution. 

An error occurs if multiple beans exist that do not define a qualifier.