### PR TITLE
Add support for Jakarta nulllable annotations. 

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/annotation/internal/JakartaNonnullTransformer.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/internal/JakartaNonnullTransformer.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.annotation.internal;
+
+import io.micronaut.core.annotation.AnnotationUtil;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.inject.annotation.NamedAnnotationTransformer;
+import io.micronaut.inject.visitor.VisitorContext;
+
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A transformer that remaps {@link jakarta.annotation.Nonnull} to {@code javax.annotation.Nonnull}.
+ * @since 4.0
+ */
+public class JakartaNonnullTransformer implements NamedAnnotationTransformer {
+
+    @Override
+    public @NonNull String getName() {
+        return "jakarta.annotation.Nonnull";
+    }
+
+    @Override
+    public List<AnnotationValue<?>> transform(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
+        return Collections.singletonList(
+                AnnotationValue.builder(AnnotationUtil.NON_NULL).build()
+        );
+    }
+}
+

--- a/core-processor/src/main/java/io/micronaut/inject/annotation/internal/JakartaNullableTransformer.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/internal/JakartaNullableTransformer.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.annotation.internal;
+
+import io.micronaut.core.annotation.AnnotationUtil;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.inject.annotation.NamedAnnotationTransformer;
+import io.micronaut.inject.visitor.VisitorContext;
+
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A transformer that remaps {@link jakarta.annotation.Nullable} to {@code javax.annotation.Nullable}.
+ * @since 4.0
+ */
+public class JakartaNullableTransformer implements NamedAnnotationTransformer {
+
+    @Override
+    public @NonNull String getName() {
+        return "jakarta.annotation.Nullable";
+    }
+
+    @Override
+    public List<AnnotationValue<?>> transform(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
+        return Collections.singletonList(
+                AnnotationValue.builder(AnnotationUtil.NULLABLE).build()
+        );
+    }
+}
+

--- a/core-processor/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationTransformer
+++ b/core-processor/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationTransformer
@@ -5,4 +5,5 @@ io.micronaut.inject.annotation.internal.KotlinNotNullMapper
 io.micronaut.inject.annotation.internal.JakartaPostConstructTransformer
 io.micronaut.inject.annotation.internal.JakartaPreDestroyTransformer
 io.micronaut.inject.annotation.internal.JakartaNullableTransformer
+io.micronaut.inject.annotation.internal.JakartaNonnullTransformer
 io.micronaut.inject.beans.visitor.IntrospectedToBeanPropertiesTransformer

--- a/core-processor/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationTransformer
+++ b/core-processor/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationTransformer
@@ -4,4 +4,5 @@ io.micronaut.inject.annotation.internal.KotlinNullableMapper
 io.micronaut.inject.annotation.internal.KotlinNotNullMapper
 io.micronaut.inject.annotation.internal.JakartaPostConstructTransformer
 io.micronaut.inject.annotation.internal.JakartaPreDestroyTransformer
+io.micronaut.inject.annotation.internal.JakartaNullableTransformer
 io.micronaut.inject.beans.visitor.IntrospectedToBeanPropertiesTransformer

--- a/inject-java/src/test/groovy/io/micronaut/annotation/NonNullabilityAnnotationsSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/annotation/NonNullabilityAnnotationsSpec.groovy
@@ -1,0 +1,74 @@
+package io.micronaut.annotation
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.core.annotation.AnnotationUtil
+import io.micronaut.core.beans.BeanMethod
+import io.micronaut.inject.ast.ElementQuery
+
+class NonNullabilityAnnotationsSpec extends AbstractTypeElementSpec {
+
+    void "test map nonnull annotation for #packageName in beans"() {
+        given:
+        def element = buildClassElement("""
+package test;
+import ${packageName}.*;
+@jakarta.inject.Singleton
+class Test {
+    ${annotation}
+    String notNullableMethod(${annotation} String test) {
+        return "";
+    }
+}
+""")
+        def nullableMethod = element.getEnclosedElement(ElementQuery.ALL_METHODS.named({ String st -> st == 'notNullableMethod' })).get()
+
+        expect:
+        !nullableMethod.isNullable()
+        nullableMethod.isNonNull()
+        !nullableMethod.parameters[0].isNullable()
+        nullableMethod.parameters[0].isNonNull()
+
+        where:
+        packageName                       | annotation
+        "io.micronaut.core.annotation"    | "@NonNull"
+        "edu.umd.cs.findbugs.annotations" | "@NonNull"
+        "javax.annotation"                | "@Nonnull"
+        "jakarta.annotation"              | "@Nonnull"
+        "org.jetbrains.annotations"       | "@NotNull"
+    }
+
+    void "test map nonnull annotation for #packageName in introspections"() {
+        given:
+        def introspection = buildBeanIntrospection("test.Test", """
+package test;
+
+import ${packageName}.*;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.context.annotation.Executable;
+
+@Introspected
+class Test {
+    ${annotation}
+    @Executable
+    String notNullableMethod(${annotation} String test) {
+        return "";
+    }
+}
+""")
+        BeanMethod nullableMethod = introspection.getBeanMethods()[0]
+
+        expect:
+        !nullableMethod.getAnnotationMetadata().hasStereotype(AnnotationUtil.NULLABLE)
+        nullableMethod.getAnnotationMetadata().hasStereotype(AnnotationUtil.NON_NULL)
+        !nullableMethod.arguments[0].isNullable()
+        nullableMethod.arguments[0].isNonNull()
+
+        where:
+        packageName                       | annotation
+        "io.micronaut.core.annotation"    | "@NonNull"
+        "edu.umd.cs.findbugs.annotations" | "@NonNull"
+        "javax.annotation"                | "@Nonnull"
+        "jakarta.annotation"              | "@Nonnull"
+        "org.jetbrains.annotations"       | "@NotNull"
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/annotation/NullabilityAnnotationsSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/annotation/NullabilityAnnotationsSpec.groovy
@@ -29,7 +29,7 @@ class Test {
         !nullableMethod.parameters[0].isNonNull()
 
         where:
-        packageName << ["io.micronaut.core.annotation", "javax.annotation", "org.jetbrains.annotations", "edu.umd.cs.findbugs.annotations"]
+        packageName << ["io.micronaut.core.annotation", "javax.annotation", "org.jetbrains.annotations", "jakarta.annotation","edu.umd.cs.findbugs.annotations"]
     }
 
     void "test map nullable annotation for #packageName in introspections"() {
@@ -59,6 +59,6 @@ class Test {
         !nullableMethod.arguments[0].isNonNull()
 
         where:
-        packageName << ["io.micronaut.core.annotation", "javax.annotation", "org.jetbrains.annotations", "edu.umd.cs.findbugs.annotations"]
+        packageName << ["io.micronaut.core.annotation", "javax.annotation", "org.jetbrains.annotations", "jakarta.annotation","edu.umd.cs.findbugs.annotations"]
     }
 }


### PR DESCRIPTION
Add a `NamedAnnotationTransformer` to transform `Nullable` annotation from Jakarta.