### PR TITLE
remove javax.annotation.Nullable usage

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -12,7 +12,7 @@ micronautBuild {
 }
 
 dependencies {
-    compileOnly libs.managed.jsr305
+    compileOnly libs.managed.jakarta.annotation.api
     compileOnly libs.managed.graal
     compileOnly libs.kotlin.stdlib
 }

--- a/core/src/main/java/io/micronaut/core/annotation/NonNull.java
+++ b/core/src/main/java/io/micronaut/core/annotation/NonNull.java
@@ -15,8 +15,8 @@
  */
 package io.micronaut.core.annotation;
 
-import javax.annotation.Nonnull;
-import javax.annotation.meta.TypeQualifierNickname;
+import jakarta.annotation.Nonnull;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -43,6 +43,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Nonnull
-@TypeQualifierNickname
 public @interface NonNull {
 }

--- a/core/src/main/java/io/micronaut/core/annotation/Nullable.java
+++ b/core/src/main/java/io/micronaut/core/annotation/Nullable.java
@@ -15,9 +15,6 @@
  */
 package io.micronaut.core.annotation;
 
-import javax.annotation.Nonnull;
-import javax.annotation.meta.TypeQualifierNickname;
-import javax.annotation.meta.When;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -38,7 +35,6 @@ import java.lang.annotation.Target;
 @Target({ElementType.METHOD, ElementType.PARAMETER, ElementType.FIELD, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@Nonnull(when = When.MAYBE)
-@TypeQualifierNickname
+@jakarta.annotation.Nullable
 public @interface Nullable {
 }

--- a/core/src/main/java/io/micronaut/core/beans/BeanIntrospection.java
+++ b/core/src/main/java/io/micronaut/core/beans/BeanIntrospection.java
@@ -22,7 +22,6 @@ import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArgumentUtils;
 
 import io.micronaut.core.annotation.NonNull;
-import javax.annotation.concurrent.Immutable;
 import java.lang.annotation.Annotation;
 import java.util.Collection;
 import java.util.Collections;
@@ -44,7 +43,7 @@ import java.util.Optional;
  * @author graemerocher
  * @since 1.1
  */
-@Immutable
+//@Immutable
 public interface BeanIntrospection<T> extends AnnotationMetadataDelegate, BeanInfo<T> {
 
     /**

--- a/core/src/main/java/io/micronaut/core/beans/BeanIntrospector.java
+++ b/core/src/main/java/io/micronaut/core/beans/BeanIntrospector.java
@@ -19,7 +19,6 @@ import io.micronaut.core.beans.exceptions.IntrospectionException;
 import io.micronaut.core.util.ArgumentUtils;
 
 import io.micronaut.core.annotation.NonNull;
-import javax.annotation.concurrent.Immutable;
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
 import java.util.Collection;
@@ -34,7 +33,7 @@ import java.util.function.Predicate;
  * @see io.micronaut.core.annotation.Introspected
  * @see BeanIntrospection
  */
-@Immutable
+//@Immutable
 public interface BeanIntrospector {
 
     /**

--- a/core/src/main/java/io/micronaut/core/beans/BeanProperty.java
+++ b/core/src/main/java/io/micronaut/core/beans/BeanProperty.java
@@ -27,7 +27,6 @@ import io.micronaut.core.util.ArgumentUtils;
 
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
-import javax.annotation.concurrent.Immutable;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
@@ -45,7 +44,7 @@ import java.util.Optional;
  * @since 1.1
  * @see BeanIntrospection
  */
-@Immutable
+//@Immutable
 public interface BeanProperty<B, T> extends AnnotatedElement, AnnotationMetadataDelegate, ArgumentCoercible<T> {
 
     /**

--- a/core/src/main/java/io/micronaut/core/io/Readable.java
+++ b/core/src/main/java/io/micronaut/core/io/Readable.java
@@ -19,8 +19,12 @@ import io.micronaut.core.naming.Named;
 import io.micronaut.core.util.ArgumentUtils;
 
 import io.micronaut.core.annotation.NonNull;
-import javax.annotation.concurrent.Immutable;
-import java.io.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -32,7 +36,7 @@ import java.nio.file.Path;
  * @author graemerocher
  * @since 1.1.0
  */
-@Immutable
+//@Immutable
 public interface Readable extends Named {
 
     /**
@@ -41,7 +45,8 @@ public interface Readable extends Named {
      * @return The input stream
      * @throws IOException if an I/O exception occurs
      */
-    @NonNull InputStream asInputStream() throws IOException;
+    @NonNull
+    InputStream asInputStream() throws IOException;
 
     /**
      * Does the underlying readable resource exist.

--- a/core/src/main/java/io/micronaut/core/util/clhm/ConcurrentLinkedHashMap.java
+++ b/core/src/main/java/io/micronaut/core/util/clhm/ConcurrentLinkedHashMap.java
@@ -16,9 +16,6 @@
 
 package io.micronaut.core.util.clhm;
 
-import javax.annotation.concurrent.GuardedBy;
-import javax.annotation.concurrent.Immutable;
-import javax.annotation.concurrent.ThreadSafe;
 import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
@@ -101,7 +98,7 @@ import static io.micronaut.core.util.clhm.ConcurrentLinkedHashMap.DrainStatus.RE
  * @see <a href="https://code.google.com/p/concurrentlinkedhashmap/">
  *      https://code.google.com/p/concurrentlinkedhashmap/</a>
  */
-@ThreadSafe
+// @ThreadSafe
 public final class ConcurrentLinkedHashMap<K, V> extends AbstractMap<K, V>
         implements ConcurrentMap<K, V>, Serializable {
 
@@ -181,14 +178,14 @@ public final class ConcurrentLinkedHashMap<K, V> extends AbstractMap<K, V>
     private final int concurrencyLevel;
 
     // These fields provide support to bound the map by a maximum capacity
-    @GuardedBy("evictionLock")
+    // @GuardedBy("evictionLock")
     private final long[] readBufferReadCount;
-    @GuardedBy("evictionLock")
+    // @GuardedBy("evictionLock")
     private final LinkedDeque<Node<K, V>> evictionDeque;
 
-    @GuardedBy("evictionLock") // must write under lock
+    // @GuardedBy("evictionLock") // must write under lock
     private final AtomicLong weightedSize;
-    @GuardedBy("evictionLock") // must write under lock
+    // @GuardedBy("evictionLock") // must write under lock
     private final AtomicLong capacity;
 
     private final Lock evictionLock;
@@ -300,12 +297,12 @@ public final class ConcurrentLinkedHashMap<K, V> extends AbstractMap<K, V>
         notifyListener();
     }
 
-    @GuardedBy("evictionLock")
+    // @GuardedBy("evictionLock")
     private boolean hasOverflowed() {
         return weightedSize.get() > capacity.get();
     }
 
-    @GuardedBy("evictionLock")
+    // @GuardedBy("evictionLock")
     private void evict() {
         // Attempts to evict entries from the map if it exceeds the maximum
         // capacity. If the eviction fails due to a concurrent removal of the
@@ -416,14 +413,14 @@ public final class ConcurrentLinkedHashMap<K, V> extends AbstractMap<K, V>
     }
 
     /** Drains the read and write buffers up to an amortized threshold. */
-    @GuardedBy("evictionLock")
+    // @GuardedBy("evictionLock")
     void drainBuffers() {
         drainReadBuffers();
         drainWriteBuffer();
     }
 
     /** Drains the read buffers, each up to an amortized threshold. */
-    @GuardedBy("evictionLock")
+    // @GuardedBy("evictionLock")
     void drainReadBuffers() {
         final int start = (int) Thread.currentThread().getId();
         final int end = start + NUMBER_OF_READ_BUFFERS;
@@ -432,7 +429,7 @@ public final class ConcurrentLinkedHashMap<K, V> extends AbstractMap<K, V>
         }
     }
 
-    @GuardedBy("evictionLock")
+    // @GuardedBy("evictionLock")
     private void drainReadBuffer(int bufferIndex) {
         final long writeCount = readBufferWriteCount[bufferIndex].get();
         for (int i = 0; i < READ_BUFFER_DRAIN_THRESHOLD; i++) {
@@ -450,7 +447,7 @@ public final class ConcurrentLinkedHashMap<K, V> extends AbstractMap<K, V>
         readBufferDrainAtWriteCount[bufferIndex].lazySet(writeCount);
     }
 
-    @GuardedBy("evictionLock")
+    // @GuardedBy("evictionLock")
     private void applyRead(Node<K, V> node) {
         // An entry may be scheduled for reordering despite having been removed.
         // This can occur when the entry was concurrently read while a writer was
@@ -462,7 +459,7 @@ public final class ConcurrentLinkedHashMap<K, V> extends AbstractMap<K, V>
     }
 
     /** Drains the read buffer up to an amortized threshold. */
-    @GuardedBy("evictionLock")
+    // @GuardedBy("evictionLock")
     void drainWriteBuffer() {
         for (int i = 0; i < WRITE_BUFFER_DRAIN_THRESHOLD; i++) {
             final Runnable task = writeBuffer.poll();
@@ -514,7 +511,7 @@ public final class ConcurrentLinkedHashMap<K, V> extends AbstractMap<K, V>
      *
      * @param node the entry in the page replacement policy
      */
-    @GuardedBy("evictionLock")
+    // @GuardedBy("evictionLock")
     void makeDead(Node<K, V> node) {
         for (;;) {
             WeightedValue<V> current = node.get();
@@ -1148,7 +1145,7 @@ public final class ConcurrentLinkedHashMap<K, V> extends AbstractMap<K, V>
      *
      * @param <V> The value type
      **/
-    @Immutable
+    // @Immutable
     private static final class WeightedValue<V> {
         final int weight;
         final V value;
@@ -1197,9 +1194,9 @@ public final class ConcurrentLinkedHashMap<K, V> extends AbstractMap<K, V>
     private static final class Node<K, V> extends AtomicReference<WeightedValue<V>>
             implements Linked<Node<K, V>> {
         final K key;
-        @GuardedBy("evictionLock")
+        // @GuardedBy("evictionLock")
         Node<K, V> prev;
-        @GuardedBy("evictionLock")
+        // @GuardedBy("evictionLock")
         Node<K, V> next;
         WeightedValue<V> weightedValue;
 
@@ -1211,25 +1208,25 @@ public final class ConcurrentLinkedHashMap<K, V> extends AbstractMap<K, V>
         }
 
         @Override
-        @GuardedBy("evictionLock")
+        // @GuardedBy("evictionLock")
         public Node<K, V> getPrevious() {
             return prev;
         }
 
         @Override
-        @GuardedBy("evictionLock")
+        // @GuardedBy("evictionLock")
         public void setPrevious(Node<K, V> prev) {
             this.prev = prev;
         }
 
         @Override
-        @GuardedBy("evictionLock")
+        // @GuardedBy("evictionLock")
         public Node<K, V> getNext() {
             return next;
         }
 
         @Override
-        @GuardedBy("evictionLock")
+        // @GuardedBy("evictionLock")
         public void setNext(Node<K, V> next) {
             this.next = next;
         }
@@ -1505,7 +1502,7 @@ public final class ConcurrentLinkedHashMap<K, V> extends AbstractMap<K, V>
         INSTANCE;
 
         @Override public void onEviction(Object key, Object value) {
-
+            // discard
         }
     }
 
@@ -1590,7 +1587,7 @@ public final class ConcurrentLinkedHashMap<K, V> extends AbstractMap<K, V>
         }
 
         @Override
-        @GuardedBy("evictionLock")
+        // @GuardedBy("evictionLock")
         public void run() {
             weightedSize.lazySet(weightedSize.get() + weight);
 
@@ -1611,7 +1608,7 @@ public final class ConcurrentLinkedHashMap<K, V> extends AbstractMap<K, V>
         }
 
         @Override
-        @GuardedBy("evictionLock")
+        // @GuardedBy("evictionLock")
         public void run() {
             // add may not have been processed yet
             evictionDeque.remove(node);
@@ -1630,7 +1627,7 @@ public final class ConcurrentLinkedHashMap<K, V> extends AbstractMap<K, V>
         }
 
         @Override
-        @GuardedBy("evictionLock")
+        // @GuardedBy("evictionLock")
         public void run() {
             weightedSize.lazySet(weightedSize.get() + weightDifference);
             applyRead(node);

--- a/core/src/main/java/io/micronaut/core/util/clhm/EntryWeigher.java
+++ b/core/src/main/java/io/micronaut/core/util/clhm/EntryWeigher.java
@@ -16,8 +16,6 @@
 
 package io.micronaut.core.util.clhm;
 
-import javax.annotation.concurrent.ThreadSafe;
-
 /**
  * A class that can determine the weight of an entry. The total weight threshold
  * is used to determine when an eviction is required.
@@ -28,7 +26,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * @see <a href="https://code.google.com/p/concurrentlinkedhashmap/">
  *      https://code.google.com/p/concurrentlinkedhashmap/</a>
  */
-@ThreadSafe
+//@ThreadSafe
 public interface EntryWeigher<K, V> {
 
     /**

--- a/core/src/main/java/io/micronaut/core/util/clhm/EvictionListener.java
+++ b/core/src/main/java/io/micronaut/core/util/clhm/EvictionListener.java
@@ -16,8 +16,6 @@
 
 package io.micronaut.core.util.clhm;
 
-import javax.annotation.concurrent.ThreadSafe;
-
 /**
  * A listener registered for notification when an entry is evicted. An instance
  * may be called concurrently by multiple threads to process entries. An
@@ -38,7 +36,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * @see <a href="https://code.google.com/p/concurrentlinkedhashmap/">
  *      https://code.google.com/p/concurrentlinkedhashmap/</a>
  */
-@ThreadSafe
+//@ThreadSafe
 public interface EvictionListener<K, V> {
 
     /**

--- a/core/src/main/java/io/micronaut/core/util/clhm/LinkedDeque.java
+++ b/core/src/main/java/io/micronaut/core/util/clhm/LinkedDeque.java
@@ -16,7 +16,6 @@
 
 package io.micronaut.core.util.clhm;
 
-import javax.annotation.concurrent.NotThreadSafe;
 import java.util.AbstractCollection;
 import java.util.Collection;
 import java.util.Deque;
@@ -45,7 +44,7 @@ import java.util.NoSuchElementException;
  * @see <a href="https://code.google.com/p/concurrentlinkedhashmap/">
  *      https://code.google.com/p/concurrentlinkedhashmap/</a>
  */
-@NotThreadSafe
+//@NotThreadSafe
 final class LinkedDeque<E extends Linked<E>> extends AbstractCollection<E> implements Deque<E> {
 
     // This class provides a doubly-linked list that is optimized for the virtual

--- a/retry/src/test/groovy/io/micronaut/retry/intercept/CircuitBreakerSpec.groovy
+++ b/retry/src/test/groovy/io/micronaut/retry/intercept/CircuitBreakerSpec.groovy
@@ -25,6 +25,7 @@ import io.micronaut.retry.event.RetryEventListener
 import jakarta.inject.Singleton
 import org.reactivestreams.Publisher
 import reactor.core.publisher.Mono
+import spock.lang.Retry
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
 import io.micronaut.core.async.annotation.SingleResult
@@ -35,7 +36,7 @@ import io.micronaut.core.async.annotation.SingleResult
  */
 class CircuitBreakerSpec extends Specification{
 
-
+    @Retry
     void "test blocking circuit breaker"() {
         given:
         ApplicationContext context = ApplicationContext.run()


### PR DESCRIPTION
Now that there are versions of `@Nullable` in the jakarata annotations we can remove the `javax.annotation` dependency which produces compiler warnings if any nullable annotation is used and jsr305 is no on the classpath.

Note that jakarta annotation does not have the thread safety annotations, but since these are for documentation purposes only we can leave them as comments.