### PR TITLE
Remove use of shadow plugin

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -8,7 +8,6 @@ repositories {
 }
 
 dependencies {
-    implementation "gradle.plugin.com.github.johnrengelman:shadow:7.1.2"
     implementation "org.aim42:htmlSanityCheck:1.1.6"
     implementation "io.micronaut.build.internal:micronaut-gradle-plugins:5.3.15"
     implementation "org.tomlj:tomlj:1.1.0"

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.convention-library.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.convention-library.gradle
@@ -1,11 +1,9 @@
 plugins {
     id "io.micronaut.build.internal.base-module"
     id "io.micronaut.build.internal.convention-base"
-    id "com.github.johnrengelman.shadow"
 }
 
 configurations {
-    shadowCompile
     all {
         resolutionStrategy.eachDependency { DependencyResolveDetails details ->
             String group = details.requested.group
@@ -16,14 +14,9 @@ configurations {
     }
 }
 
-tasks.named("shadowJar") {
-    configurations = [project.configurations.shadowCompile]
-}
-
 micronautBuild {
     binaryCompatibility {
         // Enable before Micronaut 4 release
         enabled.set(false)
     }
 }
-

--- a/buildSrc/src/main/groovy/io/micronaut/build/internal/io.micronaut.build.internal.convention-core-library.gradle
+++ b/buildSrc/src/main/groovy/io/micronaut/build/internal/io.micronaut.build.internal.convention-core-library.gradle
@@ -1,7 +1,3 @@
 plugins {
     id "io.micronaut.build.internal.convention-library"
 }
-
-ext {
-    shadowJarEnabled = true
-}


### PR DESCRIPTION
This is now redundant, and it was causing strange errors because of incorrect published metadata: if the consumer was using a version of Java < 17, then there would be one compatible variant for both compilation and runtime, the `shadowRuntimeElements` variant, which would have the shadow jar as an artifact, but no dependency. This causes difficult to diagnose error messages, because of missing classes (typically, depending on `http-server-netty` wouldn't transitively bring the Micronaut runtime).