### PR TITLE
Improve the error message for missing beans when EachBean is used

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/EachPropertySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/EachPropertySpec.groovy
@@ -41,14 +41,14 @@ class EachPropertySpec extends Specification {
 
         then:
         def error = thrown(NoSuchBeanException)
-        error.message == 'No bean of type [io.micronaut.inject.foreach.MyConfiguration] exists. One or more configuration entries under the prefix [foo.bar.*] are missing. Provide the necessary configuration to resolve this issue.'
+        error.message == 'No bean of type [io.micronaut.inject.foreach.MyConfiguration] exists. No configuration entries found under the prefix: [foo.bar.*]. Provide the necessary configuration to resolve this issue.'
 
         when:
         context.getBean(MyConfiguration, Qualifiers.byName("baz"))
 
         then:
         error = thrown(NoSuchBeanException)
-        error.message == 'No bean of type [io.micronaut.inject.foreach.MyConfiguration] exists for the given qualifier: @Named(\'baz\'). One or more configuration entries under the prefix [foo.bar.baz] are missing. Provide the necessary configuration to resolve this issue.'
+        error.message == 'No bean of type [io.micronaut.inject.foreach.MyConfiguration] exists for the given qualifier: @Named(\'baz\'). No configuration entries found under the prefix: [foo.bar.baz]. Provide the necessary configuration to resolve this issue.'
 
         cleanup:
         context.close()
@@ -65,7 +65,7 @@ class EachPropertySpec extends Specification {
         def error = thrown(NoSuchBeanException)
         error.message.startsWith("No bean of type [io.micronaut.inject.foreach.MyBean] exists.")
         error.message.contains("* [MyBean] requires the presence of a bean of type [io.micronaut.inject.foreach.MyConfiguration] which does not exist.")
-        error.message.endsWith("* [MyConfiguration] requires the presence of configuration. One or more configuration entries under the prefix [foo.bar.*] are missing. Provide the necessary configuration to resolve this issue.")
+        error.message.endsWith("* [MyConfiguration] requires the presence of configuration. No configuration entries found under the prefix: [foo.bar.*]. Provide the necessary configuration to resolve this issue.")
 
         when:
         context.getBean(C.class, Qualifiers.byName("test"))
@@ -74,7 +74,7 @@ class EachPropertySpec extends Specification {
         error = thrown(NoSuchBeanException)
         error.message.contains('* [C] requires the presence of a bean of type [io.micronaut.inject.foreach.nested.B] with qualifier [@Named(\'test\')] which does not exist.')
         error.message.contains("* [B] requires the presence of a bean of type [io.micronaut.inject.foreach.nested.A] with qualifier [@Named('test')] which does not exist.")
-        error.message.endsWith('* [A] requires the presence of configuration. One or more configuration entries under the prefix [foo.test] are missing. Provide the necessary configuration to resolve this issue.')
+        error.message.endsWith('* [A] requires the presence of configuration. No configuration entries found under the prefix: [foo.test]. Provide the necessary configuration to resolve this issue.')
 
         cleanup:
         context.close()

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/nested/A.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/nested/A.java
@@ -1,0 +1,7 @@
+package io.micronaut.inject.foreach.nested;
+
+import io.micronaut.context.annotation.EachProperty;
+
+@EachProperty("foo")
+public class A {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/nested/B.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/nested/B.java
@@ -1,0 +1,7 @@
+package io.micronaut.inject.foreach.nested;
+
+import io.micronaut.context.annotation.EachBean;
+
+@EachBean(A.class)
+public class B {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/nested/C.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/nested/C.java
@@ -1,0 +1,7 @@
+package io.micronaut.inject.foreach.nested;
+
+import io.micronaut.context.annotation.EachBean;
+
+@EachBean(B.class)
+public class C {
+}

--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
@@ -350,7 +350,7 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
             prefix += "." + definition.stringValue(EachProperty.class, "primary").orElse("*");
         }
 
-        return "One or more configuration entries under the prefix [" + prefix + "] are missing. Provide the necessary configuration to resolve this issue.";
+        return "No configuration entries found under the prefix: [" + prefix + "]. Provide the necessary configuration to resolve this issue.";
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
@@ -258,15 +258,15 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
     }
 
     @Override
-    protected <T> NoSuchBeanException newNoSuchBeanException(@Nullable BeanResolutionContext resolutionContext, Argument<T> beanType, Qualifier<T> qualifier) {
+    protected <T> NoSuchBeanException newNoSuchBeanException(@Nullable BeanResolutionContext resolutionContext, Argument<T> beanType, Qualifier<T> qualifier, String message) {
         BeanDefinition<T> definition = findAnyBeanDefinition(resolutionContext, beanType);
         if (definition != null && definition.isIterable()) {
             if (definition.hasDeclaredAnnotation(EachProperty.class)) {
-                String message = computeEachPropertyMissingBeanMessage(qualifier, definition);
+                String propertyMissingMessage = computeEachPropertyMissingBeanMessage(qualifier, definition);
                 return new NoSuchBeanException(
                     beanType,
                     qualifier,
-                    message
+                    propertyMissingMessage
                 );
             } else if (definition.hasDeclaredAnnotation(EachBean.class)) {
 
@@ -289,12 +289,12 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
                     messageBuilder.append(" which does not exist.");
                     if (beanDefinition.hasDeclaredAnnotation(EachProperty.class)) {
                         messageBuilder.append(ls);
-                        String message = computeEachPropertyMissingBeanMessage(qualifier, beanDefinition);
+                        String propertyMissingMessage = computeEachPropertyMissingBeanMessage(qualifier, beanDefinition);
                         messageBuilder.append("* ")
                             .append("[")
                             .append(nextBeanType.getTypeString(true))
                             .append("] requires the presence of configuration. ")
-                            .append(message);
+                            .append(propertyMissingMessage);
                         break;
                     }
                     requiredBeanType = nextBeanType;
@@ -307,7 +307,7 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
                 );
             }
         }
-        return super.newNoSuchBeanException(resolutionContext, beanType, qualifier);
+        return super.newNoSuchBeanException(resolutionContext, beanType, qualifier, message);
     }
 
     @Nullable

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -2813,9 +2813,14 @@ public class DefaultBeanContext implements InitializableBeanContext {
             registration = null;
         }
         if ((registration == null || registration.bean == null) && throwNoSuchBean) {
-            throw new NoSuchBeanException(beanType, qualifier);
+            throw newNoSuchBeanException(resolutionContext, beanType, qualifier);
         }
         return registration;
+    }
+
+    @NonNull
+    protected <T> NoSuchBeanException newNoSuchBeanException(@Nullable BeanResolutionContext resolutionContext, @NonNull Argument<T> beanType, @NonNull Qualifier<T> qualifier) {
+        return new NoSuchBeanException(beanType, qualifier);
     }
 
     @Nullable

--- a/inject/src/main/java/io/micronaut/context/exceptions/NoSuchBeanException.java
+++ b/inject/src/main/java/io/micronaut/context/exceptions/NoSuchBeanException.java
@@ -28,18 +28,21 @@ import io.micronaut.core.type.Argument;
  */
 public class NoSuchBeanException extends BeanContextException {
 
+    private static final String MESSAGE_PREFIX = "No bean of type [";
+    private static final String MESSAGE_SUFFIX = "] exists.";
+
     /**
      * @param beanType The bean type
      */
     public NoSuchBeanException(@NonNull Class<?> beanType) {
-        super("No bean of type [" + beanType.getName() + "] exists." + additionalMessage());
+        super(MESSAGE_PREFIX + beanType.getName() + MESSAGE_SUFFIX + additionalMessage());
     }
 
     /**
      * @param beanType The bean type
      */
     public NoSuchBeanException(@NonNull Argument<?> beanType) {
-        super("No bean of type [" + beanType.getTypeName() + "] exists." + additionalMessage());
+        super(MESSAGE_PREFIX + beanType.getTypeName() + MESSAGE_SUFFIX + additionalMessage());
     }
 
     /**
@@ -48,7 +51,7 @@ public class NoSuchBeanException extends BeanContextException {
      * @param <T>       The type
      */
     public <T> NoSuchBeanException(@NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier) {
-        super("No bean of type [" + beanType.getName() + "] exists" + (qualifier != null ? " for the given qualifier: " + qualifier : "") + "." + additionalMessage());
+        super(MESSAGE_PREFIX + beanType.getName() + "] exists" + (qualifier != null ? " for the given qualifier: " + qualifier : "") + "." + additionalMessage());
     }
 
     /**
@@ -57,7 +60,18 @@ public class NoSuchBeanException extends BeanContextException {
      * @param <T>       The type
      */
     public <T> NoSuchBeanException(@NonNull Argument<T> beanType, @Nullable Qualifier<T> qualifier) {
-        super("No bean of type [" + beanType.getTypeName() + "] exists" + (qualifier != null ? " for the given qualifier: " + qualifier : "") + "." + additionalMessage());
+        super(MESSAGE_PREFIX + beanType.getTypeName() + "] exists" + (qualifier != null ? " for the given qualifier: " + qualifier : "") + "." + additionalMessage());
+    }
+
+    /**
+     * @param beanType  The bean type
+     * @param qualifier The qualifier
+     * @param message   The message
+     * @param <T>       The type
+     * @since 4.0.0
+     */
+    public <T> NoSuchBeanException(@NonNull Argument<T> beanType, @Nullable Qualifier<T> qualifier, String message) {
+        super(MESSAGE_PREFIX + beanType.getTypeName() + "] exists" + (qualifier != null ? " for the given qualifier: " + qualifier : "") + ". " + message);
     }
 
     /**

--- a/src/main/docs/guide/introduction/whatsNew.adoc
+++ b/src/main/docs/guide/introduction/whatsNew.adoc
@@ -2,6 +2,12 @@
 
 == 4.0.0
 
+=== Core Changes
+
+==== Improved Error Messages for Missing Beans
+
+When a bean annotated with ann:context.annotation.EachProperty[] or ann:context.annotation.Bean[] is not found due to missing configuration an error is thrown showing the configuration prefix necessary to resolve the issue.
+
 === Other Dependency Upgrades
 
 - Kotlin 1.7.10


### PR DESCRIPTION
When a bean annotated with `@EachProperty` is not found due to missing configuration the error message is not clear as to why the bean is missing. This PR improves the error handling to provide extended diagnosis of configuration errors.