### PR TITLE
Introduce workaround for javadoc generation

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.convention-library.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.convention-library.gradle
@@ -20,3 +20,11 @@ micronautBuild {
         enabled.set(false)
     }
 }
+
+// Workaround for javadoc not finding java source
+// files for classes written in an alternate language (Kotlin, Groovy)
+configurations {
+    internalJavadocClasspathElements {
+        outgoing.artifact(tasks.named("jar"))
+    }
+}


### PR DESCRIPTION
Previously, the application of the `shadow` plugin caused an extra artifact to be present on classpath by accident. This artifact contained all the classes of a project, including those not written in Java. With the removal, javadoc started to fail.

As a workaround, we will now add the classes of the project itself to the artifacts it exposes on classpath. This means that the `javadoc` task will see both java sources, but also their compiled version. While it will not find sources for the classes written in Kotlin or Java, this will fix javadoc generation.