### PR TITLE
Improve error messages for disabled beans

### DIFF
--- a/core-processor/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
+++ b/core-processor/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
@@ -1134,6 +1134,11 @@ public class AopProxyWriter extends AbstractClassFileWriter implements ProxyingB
         return proxyBeanDefinitionWriter.getTypeArguments();
     }
 
+    @Override
+    public Map<String, ClassElement> getTypeArgumentMap() {
+        return proxyBeanDefinitionWriter.getTypeArgumentMap();
+    }
+
     /**
      * Write the class to output via a visitor that manages output destination.
      *

--- a/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionReferenceWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionReferenceWriter.java
@@ -24,12 +24,15 @@ import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationUtil;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.type.Argument;
 import io.micronaut.core.type.DefaultArgument;
+import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.AdvisedBeanType;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.BeanDefinitionReference;
 import io.micronaut.inject.annotation.AnnotationMetadataReference;
+import io.micronaut.inject.ast.ClassElement;
 import jakarta.inject.Singleton;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Type;
@@ -37,6 +40,9 @@ import org.objectweb.asm.commons.GeneratorAdapter;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * Writes the bean definition class file to disk.
@@ -74,6 +80,7 @@ public class BeanDefinitionReferenceWriter extends AbstractAnnotationMetadataWri
     private final String beanDefinitionReferenceClassName;
     private final Type interceptedType;
     private final Type providedType;
+    private final Map<String, ClassElement> typeParameters;
     private boolean contextScope = false;
     private boolean requiresMethodProcessing;
 
@@ -90,6 +97,7 @@ public class BeanDefinitionReferenceWriter extends AbstractAnnotationMetadataWri
                 true);
         this.providedType = visitor.getProvidedType();
         this.beanTypeName = visitor.getBeanTypeName();
+        this.typeParameters = visitor.getTypeArgumentMap();
         this.beanDefinitionName = visitor.getBeanDefinitionName();
         this.beanDefinitionReferenceClassName = beanDefinitionName + REF_SUFFIX;
         this.beanDefinitionClassInternalName = getInternalName(beanDefinitionName) + REF_SUFFIX;
@@ -165,7 +173,6 @@ public class BeanDefinitionReferenceWriter extends AbstractAnnotationMetadataWri
                 interfaceInternalNames
         );
         Type beanDefinitionType = getTypeReferenceForName(beanDefinitionName);
-        writeAnnotationMetadataStaticInitializer(classWriter);
 
         GeneratorAdapter cv = startConstructor(classWriter);
 
@@ -241,11 +248,33 @@ public class BeanDefinitionReferenceWriter extends AbstractAnnotationMetadataWri
         getBeanType.returnValue();
         getBeanType.visitMaxs(2, 1);
 
+        if (CollectionUtils.isNotEmpty(typeParameters)) {
+            // start method: Argument<T> getGenericBeanType()
+            GeneratorAdapter getGenericType = startPublicMethodZeroArgs(classWriter, Argument.class, "getGenericBeanType");
+            pushCreateArgument(
+                beanDefinitionReferenceClassName,
+                beanDefinitionType,
+                classWriter,
+                getGenericType,
+                "T",
+                ClassElement.of(beanTypeName),
+                annotationMetadata,
+                typeParameters,
+                new HashMap<>(),
+                loadTypeMethods
+            );
+            getGenericType.returnValue();
+            getGenericType.visitMaxs(2, 1);
+        }
+
+        writeAnnotationMetadataStaticInitializer(classWriter);
+
         if (interceptedType != null) {
             super.implementInterceptedTypeMethod(interceptedType, classWriter);
         }
         for (GeneratorAdapter generatorAdapter : loadTypeMethods.values()) {
             generatorAdapter.visitMaxs(3, 1);
+            generatorAdapter.visitEnd();
         }
 
         return classWriter;

--- a/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionVisitor.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionVisitor.java
@@ -106,6 +106,12 @@ public interface BeanDefinitionVisitor extends OriginatingElements, Toggleable {
     );
 
     /**
+     * @return A map of the type arguments for the bean.
+     */
+    @NonNull
+    Map<String, ClassElement> getTypeArgumentMap();
+
+    /**
      * @return The name of the bean definition reference class.
      */
     @NonNull

--- a/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -751,6 +751,20 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
         return BeanDefinitionVisitor.super.getTypeArguments();
     }
 
+    @Override
+    @NonNull
+    public Map<String, ClassElement> getTypeArgumentMap() {
+        if (hasTypeArguments()) {
+            Map<String, ClassElement> args = this.typeArguments.get(this.getBeanTypeName());
+            if (CollectionUtils.isNotEmpty(args)) {
+                return Collections.unmodifiableMap(args);
+            }
+        }
+        return Collections.emptyMap();
+    }
+
+
+
     /**
      * @return The name of the bean definition reference class.
      */

--- a/core/src/main/java/io/micronaut/core/beans/BeanInfo.java
+++ b/core/src/main/java/io/micronaut/core/beans/BeanInfo.java
@@ -17,6 +17,8 @@ package io.micronaut.core.beans;
 
 import io.micronaut.core.annotation.AnnotationMetadataProvider;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.type.Argument;
+import io.micronaut.core.type.ArgumentCoercible;
 
 /**
  * Top level interface for obtaining bean information.
@@ -24,10 +26,23 @@ import io.micronaut.core.annotation.NonNull;
  * @param <T> The type of the bean
  * @since 4.0.0
  */
-public interface BeanInfo<T> extends AnnotationMetadataProvider {
+public interface BeanInfo<T> extends AnnotationMetadataProvider, ArgumentCoercible<T> {
     /**
      * @return The bean type
      */
     @NonNull
     Class<T> getBeanType();
+
+    /**
+     * @return The generic bean type
+     */
+    @NonNull
+    default Argument<T> getGenericBeanType() {
+        return Argument.of(getBeanType());
+    }
+
+    @Override
+    default Argument<T> asArgument() {
+        return getGenericBeanType();
+    }
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/beans/BeanDefinitionSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beans/BeanDefinitionSpec.groovy
@@ -4,6 +4,7 @@ import io.micronaut.core.annotation.AnnotationUtil
 import io.micronaut.core.annotation.Order
 import io.micronaut.core.order.Ordered
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.inject.BeanDefinitionReference
 import io.micronaut.inject.qualifiers.Qualifiers
 import spock.lang.Issue
 
@@ -11,6 +12,7 @@ import jakarta.inject.Named
 import jakarta.inject.Qualifier
 
 class BeanDefinitionSpec extends AbstractTypeElementSpec {
+
 
     void 'test dynamic instantiate with constructor'() {
         given:
@@ -111,10 +113,10 @@ class Test {
 }
 
 interface X {
-    
+
 }
 class Y implements X {
-    
+
 }
 
 ''')
@@ -164,10 +166,10 @@ class Test {
 }
 
 interface X {
-    
+
 }
 class Y implements X {
-    
+
 }
 
 ''')
@@ -175,6 +177,36 @@ class Y implements X {
         then:
         def e = thrown(RuntimeException)
         e.message.contains("Bean defines an exposed type [limittypes.Y] that is not implemented by the bean type")
+    }
+
+    void "test generics from factory"() {
+        when:
+        def ref = buildBeanDefinitionReference('limittypes.Test$Method0', '''
+package limittypes;
+
+import io.micronaut.context.annotation.*;
+import jakarta.inject.Singleton;
+
+@Factory
+class Test {
+
+    @Singleton
+    X<Y> method() {
+        return new Y();
+    }
+}
+
+interface X<T> {
+
+}
+class Y implements X<Y> {
+
+}
+
+''')
+
+        then:
+        ref.getGenericBeanType().getTypeString(true) == 'X<Y>'
     }
 
     void "test exposed bean types with factory invalid type"() {

--- a/inject-java/src/test/groovy/io/micronaut/inject/requires/RequiresSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/requires/RequiresSpec.groovy
@@ -49,7 +49,38 @@ class MyBean {
         getBean(context, 'test.MyBean')
 
         then:
-        thrown(NoSuchBeanException)
+        def e = thrown(NoSuchBeanException)
+        def lines = e.message.readLines().collect { it.trim() }
+        lines[0] == 'No bean of type [test.MyBean] exists. The following matching beans are disabled by bean requirements:'
+        lines[1] == '* Bean of type [test.MyBean] is disabled because:'
+        lines[2] == '- Java major version [17] must be at least 800'
+
+        cleanup:
+        context.close()
+    }
+
+    void "test requires property equals - error"() {
+        given:
+        ApplicationContext context = buildContext( '''
+package test;
+
+import io.micronaut.context.annotation.*;
+
+@Requires(property="foo", value="bar")
+@jakarta.inject.Singleton
+class MyBean {
+}
+''')
+
+        when:"the bean doesn't exist"
+        getBean(context, 'test.MyBean')
+
+        then:
+        def e = thrown(NoSuchBeanException)
+        def lines = e.message.readLines().collect { it.trim() }
+        lines[0] == 'No bean of type [test.MyBean] exists. The following matching beans are disabled by bean requirements:'
+        lines[1] == '* Bean of type [test.MyBean] is disabled because:'
+        lines[2] == '- Required property [foo] with value [bar] not present'
 
         cleanup:
         context.close()

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -197,7 +197,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
     private final BeanContextConfiguration beanContextConfiguration;
     private final Collection<BeanDefinitionReference> beanDefinitionsClasses = new ConcurrentLinkedQueue<>();
 
-    private final Collection<BeanDefinitionReference> disabledBeans = new ConcurrentLinkedQueue<>();
+    private final Map<BeanKey<?>, BeanDefinitionReference> disabledBeans = new ConcurrentHashMap<>(20);
     private final Map<String, List<String>> disabledConfigurations = new ConcurrentHashMap<>(5);
     private final Map<String, BeanConfiguration> beanConfigurations = new HashMap<>(10);
     private final Map<BeanKey, Boolean> containsBeanCache = new ConcurrentHashMap<>(30);
@@ -393,7 +393,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
                 Argument<Object> argument = (Argument<Object>) beanType.getGenericBeanType();
                 @SuppressWarnings("unchecked")
                 Qualifier<Object> declaredQualifier = (Qualifier<Object>) beanType.getDeclaredQualifier();
-                this.disabledBeans.add(new DisabledBean<>(
+                this.disabledBeans.put(new BeanKey<Object>(argument, declaredQualifier), new DisabledBean<>(
                     argument,
                     declaredQualifier,
                     reasons
@@ -3018,7 +3018,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
                 beanType,
                 true,
                 null,
-                disabledBeans
+                disabledBeans.values()
             );
             if (qualifier != null) {
                 beanDefinitions = qualifier

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -25,6 +25,8 @@ import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.annotation.Prototype;
 import io.micronaut.context.annotation.Replaces;
 import io.micronaut.context.annotation.Secondary;
+import io.micronaut.context.condition.ConditionContext;
+import io.micronaut.context.condition.Failure;
 import io.micronaut.context.env.PropertyPlaceholderResolver;
 import io.micronaut.context.event.ApplicationEventListener;
 import io.micronaut.context.event.ApplicationEventPublisher;
@@ -103,6 +105,7 @@ import io.micronaut.inject.InjectionPoint;
 import io.micronaut.inject.MethodExecutionHandle;
 import io.micronaut.inject.ParametrizedBeanFactory;
 import io.micronaut.inject.ProxyBeanDefinition;
+import io.micronaut.inject.QualifiedBeanType;
 import io.micronaut.inject.ValidatedBeanDefinition;
 import io.micronaut.inject.proxy.InterceptedBeanProxy;
 import io.micronaut.inject.qualifiers.AnyQualifier;
@@ -193,6 +196,9 @@ public class DefaultBeanContext implements InitializableBeanContext {
 
     private final BeanContextConfiguration beanContextConfiguration;
     private final Collection<BeanDefinitionReference> beanDefinitionsClasses = new ConcurrentLinkedQueue<>();
+
+    private final Collection<BeanDefinitionReference> disabledBeans = new ConcurrentLinkedQueue<>();
+    private final Map<String, List<String>> disabledConfigurations = new ConcurrentHashMap<>(5);
     private final Map<String, BeanConfiguration> beanConfigurations = new HashMap<>(10);
     private final Map<BeanKey, Boolean> containsBeanCache = new ConcurrentHashMap<>(30);
     private final Map<CharSequence, Object> attributes = Collections.synchronizedMap(new HashMap<>(5));
@@ -370,6 +376,35 @@ public class DefaultBeanContext implements InitializableBeanContext {
     protected void registerConversionService() {
         conversionService = MutableConversionService.create();
         registerSingleton(MutableConversionService.class, conversionService,  null, false);
+    }
+
+    /**
+     * Tracks when a bean or configuration is disabled.
+     * @param conditionContext The conditional context
+     * @param <C> The component type
+     */
+    @Internal
+    <C extends AnnotationMetadataProvider> void trackDisabledComponent(@NonNull ConditionContext<C> conditionContext) {
+        C component = conditionContext.getComponent();
+        List<String> reasons = conditionContext.getFailures().stream().map(Failure::getMessage).toList();
+        if (component instanceof QualifiedBeanType<?> beanType) {
+            try {
+                @SuppressWarnings("unchecked")
+                Argument<Object> argument = (Argument<Object>) beanType.getGenericBeanType();
+                @SuppressWarnings("unchecked")
+                Qualifier<Object> declaredQualifier = (Qualifier<Object>) beanType.getDeclaredQualifier();
+                this.disabledBeans.add(new DisabledBean<>(
+                    argument,
+                    declaredQualifier,
+                    reasons
+                ));
+            } catch (Exception | NoClassDefFoundError e) {
+                // it is theoretically possible that resolving the generic type results in an error
+                // in this case just ignore this as the maps built here are purely to aid error diganosis
+            }
+        } else if (component instanceof BeanConfiguration configuration) {
+            this.disabledConfigurations.put(configuration.getName(), reasons);
+        }
     }
 
     /**
@@ -883,7 +918,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
                 null,
                 beanType,
                 qualifier,
-                e.getMessage()
+                "Bean of type [" + beanType.getTypeString(true) + "] disabled for reason: " + e.getMessage()
             );
         }
     }
@@ -2178,6 +2213,16 @@ public class DefaultBeanContext implements InitializableBeanContext {
             beanDefinitionsClasses = this.beanDefinitionsClasses;
         }
 
+        return collectBeanCandidates(resolutionContext, beanType, filterProxied, predicate, beanDefinitionsClasses);
+    }
+
+    @NonNull
+    private <T> Set<BeanDefinition<T>> collectBeanCandidates(
+        BeanResolutionContext resolutionContext,
+        Argument<T> beanType,
+        boolean filterProxied,
+        Predicate<BeanDefinition<T>> predicate,
+        Collection<BeanDefinitionReference> beanDefinitionsClasses) {
         Set<BeanDefinition<T>> candidates;
         if (!beanDefinitionsClasses.isEmpty()) {
 
@@ -2925,8 +2970,80 @@ public class DefaultBeanContext implements InitializableBeanContext {
         if (message != null) {
             return new NoSuchBeanException(beanType, qualifier, message);
         } else {
-            return new NoSuchBeanException(beanType, qualifier);
+            String disabledMessage = resolveDisabledBeanMessage(resolutionContext, beanType, qualifier);
+
+            if (disabledMessage != null) {
+                return new NoSuchBeanException(beanType, qualifier, disabledMessage);
+            } else {
+                return new NoSuchBeanException(beanType, qualifier);
+            }
         }
+    }
+
+    /**
+     * Resolves the message to use for a disabled bean.
+     * @param resolutionContext The resolution context
+     * @param beanType The bean type
+     * @param qualifier The qualifier
+     * @return The message or null if none exists
+     * @param <T> The bean type
+     */
+    @Nullable
+    protected  <T> String resolveDisabledBeanMessage(BeanResolutionContext resolutionContext, Argument<T> beanType, Qualifier<T> qualifier) {
+        String disabledMessage = null;
+        for (Map.Entry<String, List<String>> entry : disabledConfigurations.entrySet()) {
+            String pkg = entry.getKey();
+            if (beanType.getTypeName().startsWith(pkg + ".")) {
+                StringBuilder messageBuilder = new StringBuilder();
+                String ls = System.getProperty("line.separator");
+                messageBuilder.append("The bean [")
+                              .append(beanType.getTypeString(true))
+                              .append("] is disabled because it is within the package [")
+                              .append(pkg)
+                               .append("] which is disabled due to bean requirements: ")
+                              .append(ls);
+                for (String failure : entry.getValue()) {
+                    messageBuilder.append("* ").append(failure).append(ls);
+                }
+
+                disabledMessage = messageBuilder.toString();
+                break;
+            }
+        }
+
+        if (disabledMessage == null) {
+
+            Set<BeanDefinition<T>> beanDefinitions = collectBeanCandidates(
+                resolutionContext,
+                beanType,
+                true,
+                null,
+                disabledBeans
+            );
+            if (qualifier != null) {
+                beanDefinitions = qualifier
+                    .reduce(beanType.getType(), beanDefinitions.stream())
+                    .collect(Collectors.toSet());
+            }
+
+            if (!beanDefinitions.isEmpty()) {
+                StringBuilder messageBuilder = new StringBuilder();
+                String ls = System.getProperty("line.separator");
+                messageBuilder.append("The following matching beans are disabled by bean requirements: ").append(ls);
+                for (BeanDefinition<T> beanDefinition : beanDefinitions) {
+                    messageBuilder.append("* Bean of type [").append(beanDefinition.asArgument().getTypeString(false))
+                        .append("] is disabled because: ").append(ls);
+                    if (beanDefinition instanceof DisabledBean<T> disabledBean) {
+                        for (String failure : disabledBean.reasons()) {
+                            messageBuilder.append("   - ").append(failure).append(ls);
+                        }
+                    }
+                }
+
+                disabledMessage = messageBuilder.toString();
+            }
+        }
+        return disabledMessage;
     }
 
     @Nullable
@@ -3201,24 +3318,30 @@ public class DefaultBeanContext implements InitializableBeanContext {
                                                                          boolean throwNonUnique,
                                                                          boolean filterProxied) {
 
-        Predicate<BeanDefinition<T>> predicate = new Predicate<BeanDefinition<T>>() {
-            @Override
-            public boolean test(BeanDefinition<T> candidate) {
-                if (candidate.isAbstract()) {
-                    return false;
-                }
-                if (qualifier != null) {
-                    if (candidate instanceof NoInjectionBeanDefinition) {
-                        NoInjectionBeanDefinition noInjectionBeanDefinition = (NoInjectionBeanDefinition) candidate;
-                        return qualifier.contains(noInjectionBeanDefinition.getQualifier());
-                    }
-                }
-                return true;
-
+        Predicate<BeanDefinition<T>> predicate = candidate -> {
+            if (candidate.isAbstract()) {
+                return false;
             }
+            if (qualifier != null) {
+                if (candidate instanceof NoInjectionBeanDefinition<T> noInjectionBeanDefinition) {
+                    return qualifier.contains(noInjectionBeanDefinition.getQualifier());
+                }
+            }
+            return true;
         };
 
         Collection<BeanDefinition<T>> candidates = new ArrayList<>(findBeanCandidates(resolutionContext, beanType, filterProxied, predicate));
+        return pickOneBean(beanType, qualifier, throwNonUnique, filterProxied, predicate, candidates);
+    }
+
+    @NonNull
+    private <T> Optional<BeanDefinition<T>> pickOneBean(
+        Argument<T> beanType,
+        Qualifier<T> qualifier,
+        boolean throwNonUnique,
+        boolean filterProxied,
+        Predicate<BeanDefinition<T>> predicate,
+        Collection<BeanDefinition<T>> candidates) {
         if (candidates.isEmpty()) {
             return Optional.empty();
         }
@@ -3234,8 +3357,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
 
                 Stream<BeanDefinition<T>> candidateStream = candidates.stream().filter(c -> {
                     if (!c.isAbstract()) {
-                        if (c instanceof NoInjectionBeanDefinition) {
-                            NoInjectionBeanDefinition noInjectionBeanDefinition = (NoInjectionBeanDefinition) c;
+                        if (c instanceof NoInjectionBeanDefinition<T> noInjectionBeanDefinition) {
                             return qualifier.contains(noInjectionBeanDefinition.getQualifier());
                         }
                         return true;
@@ -3253,9 +3375,9 @@ public class DefaultBeanContext implements InitializableBeanContext {
                 }
 
                 definition = lastChanceResolve(
-                        beanType,
-                        qualifier,
-                        throwNonUnique,
+                    beanType,
+                    qualifier,
+                    throwNonUnique,
                         beanDefinitionList
                 );
             } else {
@@ -3266,10 +3388,10 @@ public class DefaultBeanContext implements InitializableBeanContext {
                         LOG.debug("Searching for @Primary for type [{}] from candidates: {} ", beanType.getName(), candidates);
                     }
                     definition = lastChanceResolve(
-                            beanType,
-                            qualifier,
-                            throwNonUnique,
-                            candidates
+                        beanType,
+                        qualifier,
+                        throwNonUnique,
+                        candidates
                     );
                 }
             }
@@ -3284,16 +3406,20 @@ public class DefaultBeanContext implements InitializableBeanContext {
         return Optional.ofNullable(definition);
     }
 
-    private <T> void filterProxiedTypes(Collection<BeanDefinition<T>> candidates, boolean filterProxied, boolean filterDelegates, Predicate<BeanDefinition<T>> predicate) {
+    private <T> void filterProxiedTypes(
+        Collection<BeanDefinition<T>> candidates,
+        boolean filterProxied,
+        boolean filterDelegates,
+        Predicate<BeanDefinition<T>> predicate) {
         int count = candidates.size();
         Set<Class<?>> proxiedTypes = new HashSet<>(count);
         Iterator<BeanDefinition<T>> i = candidates.iterator();
         Collection<BeanDefinition<T>> delegates = filterDelegates ? new ArrayList<>(count) : Collections.emptyList();
         while (i.hasNext()) {
             BeanDefinition<T> candidate = i.next();
-            if (candidate instanceof ProxyBeanDefinition) {
+            if (candidate instanceof ProxyBeanDefinition<T> proxyBeanDefinition) {
                 if (filterProxied) {
-                    proxiedTypes.add(((ProxyBeanDefinition) candidate).getTargetDefinitionType());
+                    proxiedTypes.add(proxyBeanDefinition.getTargetDefinitionType());
                 } else {
                     proxiedTypes.add(candidate.getClass());
                 }
@@ -3305,8 +3431,8 @@ public class DefaultBeanContext implements InitializableBeanContext {
                     if (!delegates.contains(delegate) && (predicate == null || predicate.test(delegate))) {
                         delegates.add(delegate);
                     }
-                } else if (filterProxied && delegate instanceof ProxyBeanDefinition) {
-                    proxiedTypes.add(((ProxyBeanDefinition) delegate).getTargetDefinitionType());
+                } else if (filterProxied && delegate instanceof ProxyBeanDefinition<T> proxyBeanDefinition) {
+                    proxiedTypes.add(proxyBeanDefinition.getTargetDefinitionType());
                 }
             }
         }
@@ -3333,7 +3459,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
         if (candidates.size() > 1) {
             List<BeanDefinition<T>> primary = candidates.stream()
                     .filter(BeanDefinition::isPrimary)
-                    .collect(Collectors.toList());
+                    .toList();
             if (!primary.isEmpty()) {
                 candidates = primary;
             }
@@ -3342,7 +3468,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
             return candidates.iterator().next();
         }
         BeanDefinition<T> definition = null;
-        candidates = candidates.stream().filter(candidate -> !candidate.hasDeclaredStereotype(Secondary.class)).collect(Collectors.toList());
+        candidates = candidates.stream().filter(candidate -> !candidate.hasDeclaredStereotype(Secondary.class)).toList();
         if (candidates.size() == 1) {
             return candidates.iterator().next();
         } else if (candidates.stream().anyMatch(candidate -> candidate.hasAnnotation(Order.class))) {

--- a/inject/src/main/java/io/micronaut/context/DisabledBean.java
+++ b/inject/src/main/java/io/micronaut/context/DisabledBean.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.context;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.type.Argument;
+import io.micronaut.inject.BeanDefinition;
+import io.micronaut.inject.BeanDefinitionReference;
+
+import java.util.List;
+
+/**
+ * Data about a disabled bean. Used to improve error reporting.
+ *
+ * @param type The bean type
+ * @param qualifier The qualifier
+ * @param reasons The reasons the bean is disabled
+ * @param <T> The bean type
+ */
+@Internal
+record DisabledBean<T>(
+    @NonNull Argument<T> type,
+    @Nullable Qualifier<T> qualifier,
+    @NonNull List<String> reasons)
+    implements BeanDefinition<T>, BeanDefinitionReference<T> {
+
+    @Override
+    public boolean isEnabled(BeanContext context, BeanResolutionContext resolutionContext) {
+        return true;
+    }
+
+    @Override
+    public boolean isSingleton() {
+        return BeanDefinition.super.isSingleton();
+    }
+
+    @Override
+    public Qualifier<T> getDeclaredQualifier() {
+        return qualifier;
+    }
+
+    @Override
+    public Class<T> getBeanType() {
+        return type.getType();
+    }
+
+    @Override
+    public Argument<T> asArgument() {
+        return type;
+    }
+
+    @Override
+    public Argument<T> getGenericBeanType() {
+        return type;
+    }
+
+    @Override
+    public String getBeanDefinitionName() {
+        return type.getTypeName();
+    }
+
+    @Override
+    public BeanDefinition<T> load() {
+        return this;
+    }
+
+    @Override
+    public boolean isPresent() {
+        return true;
+    }
+}

--- a/inject/src/main/java/io/micronaut/inject/BeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/inject/BeanDefinition.java
@@ -22,18 +22,13 @@ import io.micronaut.context.annotation.DefaultScope;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.EachProperty;
 import io.micronaut.context.annotation.Provided;
-import io.micronaut.core.annotation.AnnotationMetadata;
-import io.micronaut.core.annotation.AnnotationMetadataDelegate;
 import io.micronaut.core.annotation.AnnotationUtil;
-import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.naming.Named;
 import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.type.ArgumentCoercible;
-import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
-import io.micronaut.inject.qualifiers.Qualifiers;
 import jakarta.inject.Singleton;
 
 import java.lang.annotation.Annotation;
@@ -52,7 +47,7 @@ import java.util.stream.Stream;
  * @author Graeme Rocher
  * @since 1.0
  */
-public interface BeanDefinition<T> extends AnnotationMetadataDelegate, Named, BeanType<T>, ArgumentCoercible<T> {
+public interface BeanDefinition<T> extends QualifiedBeanType<T>, Named, BeanType<T>, ArgumentCoercible<T> {
 
     /**
      * Attribute used to store a dynamic bean name.
@@ -96,11 +91,12 @@ public interface BeanDefinition<T> extends AnnotationMetadataDelegate, Named, Be
     }
 
     @Override
+    @SuppressWarnings("java:S3776")
     default boolean isCandidateBean(@Nullable Argument<?> beanType) {
         if (beanType == null) {
             return false;
         }
-        if (BeanType.super.isCandidateBean(beanType)) {
+        if (QualifiedBeanType.super.isCandidateBean(beanType)) {
             final Argument<?>[] typeArguments = beanType.getTypeParameters();
             final int len = typeArguments.length;
             Class<?> beanClass = beanType.getType();
@@ -157,7 +153,7 @@ public interface BeanDefinition<T> extends AnnotationMetadataDelegate, Named, Be
      * @see Provided
      */
     @SuppressWarnings("DeprecatedIsStillUsed")
-    @Deprecated
+    @Deprecated(forRemoval = true, since = "2.0.0")
     default boolean isProvided() {
         return getAnnotationMetadata().hasDeclaredStereotype(Provided.class);
     }
@@ -421,48 +417,23 @@ public interface BeanDefinition<T> extends AnnotationMetadataDelegate, Named, Be
         return Modifier.isAbstract(getBeanType().getModifiers());
     }
 
+    @Override
+    default Argument<T> getGenericBeanType() {
+        return asArgument();
+    }
+
     /**
      * Resolve the declared qualifier for this bean.
      * @return The qualifier or null if this isn't one
      */
     default @Nullable Qualifier<T> getDeclaredQualifier() {
-        AnnotationMetadata annotationMetadata = getTargetAnnotationMetadata();
-        if (annotationMetadata instanceof AnnotationMetadataHierarchy) {
-            // Beans created by a factory will have AnnotationMetadataHierarchy = producing element + factory class
-            // All qualifiers are removed from the factory class anyway, so we can skip the hierarchy
-            annotationMetadata = annotationMetadata.getDeclaredMetadata();
-        }
-        List<AnnotationValue<Annotation>> annotations = annotationMetadata.getAnnotationValuesByStereotype(AnnotationUtil.QUALIFIER);
-        if (!annotations.isEmpty()) {
-            if (annotations.size() == 1) {
-                final AnnotationValue<Annotation> annotationValue = annotations.iterator().next();
-                if (annotationValue.getAnnotationName().equals(Qualifier.PRIMARY)) {
-                    // primary is the same as null
-                    return null;
-                }
-                return (Qualifier<T>) Qualifiers.byAnnotation(annotationMetadata, annotationValue);
-            } else {
-                Qualifier<T>[] qualifiers = new Qualifier[annotations.size()];
-                int i = 0;
-                for (AnnotationValue<Annotation> annotationValue : annotations) {
-                    qualifiers[i++] = (Qualifier<T>) Qualifiers.byAnnotation(annotationMetadata, annotationValue);
-                }
-                return Qualifiers.byQualifiers(qualifiers);
-            }
-        } else {
-            Qualifier<T> qualifier = resolveDynamicQualifier();
-            if (qualifier == null) {
-                String name = annotationMetadata.stringValue(AnnotationUtil.NAMED).orElse(null);
-                qualifier = name != null ? Qualifiers.byAnnotation(annotationMetadata, name) : null;
-            }
-            return qualifier;
-        }
+        return QualifiedBeanType.super.getDeclaredQualifier();
     }
 
     /**
      * @return Method that can be overridden to resolve a dynamic qualifier
      */
     default @Nullable Qualifier<T> resolveDynamicQualifier() {
-        return null;
+        return QualifiedBeanType.super.resolveDynamicQualifier();
     }
 }

--- a/inject/src/main/java/io/micronaut/inject/BeanDefinitionReference.java
+++ b/inject/src/main/java/io/micronaut/inject/BeanDefinitionReference.java
@@ -46,7 +46,7 @@ import jakarta.inject.Singleton;
  * @since 1.0
  */
 @Internal
-public interface BeanDefinitionReference<T> extends BeanType<T> {
+public interface BeanDefinitionReference<T> extends QualifiedBeanType<T> {
 
     /**
      * @return The class name of the backing {@link BeanDefinition}

--- a/inject/src/main/java/io/micronaut/inject/QualifiedBeanType.java
+++ b/inject/src/main/java/io/micronaut/inject/QualifiedBeanType.java
@@ -31,6 +31,7 @@ import java.util.List;
  * An interface for a {@link BeanType} that allows qualifiers.
  *
  * @param <T> The bean type
+ * @since 4.0.0
  */
 public interface QualifiedBeanType<T> extends BeanType<T>, AnnotationMetadataDelegate {
 

--- a/inject/src/main/java/io/micronaut/inject/QualifiedBeanType.java
+++ b/inject/src/main/java/io/micronaut/inject/QualifiedBeanType.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject;
+
+import io.micronaut.context.Qualifier;
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.AnnotationMetadataDelegate;
+import io.micronaut.core.annotation.AnnotationUtil;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
+import io.micronaut.inject.qualifiers.Qualifiers;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+
+/**
+ * An interface for a {@link BeanType} that allows qualifiers.
+ *
+ * @param <T> The bean type
+ */
+public interface QualifiedBeanType<T> extends BeanType<T>, AnnotationMetadataDelegate {
+
+    /**
+     * Resolve the declared qualifier for this bean.
+     * @return The qualifier or null if this isn't one
+     */
+    @SuppressWarnings("java:S3776")
+    default @Nullable Qualifier<T> getDeclaredQualifier() {
+        AnnotationMetadata annotationMetadata = getTargetAnnotationMetadata();
+        if (annotationMetadata instanceof AnnotationMetadataHierarchy) {
+            // Beans created by a factory will have AnnotationMetadataHierarchy = producing element + factory class
+            // All qualifiers are removed from the factory class anyway, so we can skip the hierarchy
+            annotationMetadata = annotationMetadata.getDeclaredMetadata();
+        }
+        List<AnnotationValue<Annotation>> annotations = annotationMetadata.getAnnotationValuesByStereotype(AnnotationUtil.QUALIFIER);
+        if (!annotations.isEmpty()) {
+            if (annotations.size() == 1) {
+                final AnnotationValue<Annotation> annotationValue = annotations.iterator().next();
+                if (annotationValue.getAnnotationName().equals(Qualifier.PRIMARY)) {
+                    // primary is the same as null
+                    return null;
+                }
+                return (Qualifier<T>) Qualifiers.byAnnotation(annotationMetadata, annotationValue);
+            } else {
+                Qualifier<T>[] qualifiers = new Qualifier[annotations.size()];
+                int i = 0;
+                for (AnnotationValue<Annotation> annotationValue : annotations) {
+                    qualifiers[i++] = (Qualifier<T>) Qualifiers.byAnnotation(annotationMetadata, annotationValue);
+                }
+                return Qualifiers.byQualifiers(qualifiers);
+            }
+        } else {
+            Qualifier<T> qualifier = resolveDynamicQualifier();
+            if (qualifier == null) {
+                String name = annotationMetadata.stringValue(AnnotationUtil.NAMED).orElse(null);
+                qualifier = name != null ? Qualifiers.byAnnotation(annotationMetadata, name) : null;
+            }
+            return qualifier;
+        }
+    }
+
+    /**
+     * @return Method that can be overridden to resolve a dynamic qualifier
+     */
+    default @Nullable Qualifier<T> resolveDynamicQualifier() {
+        return null;
+    }
+}


### PR DESCRIPTION
When a bean is disabled a `NoSuchBeanException` is thrown however the error doesn't provide diagnosis on why the bean was not found. This PR tracks disabled beans and configuration packages and propagates the failures in the error message so you don't have to enable trace logging with `io.micronaut.context.condition` at the cost of slightly increased memory usage to store these errors. 

This additional storage is probably not a big deal however since Micronaut AOT can optimize away the disabled beans during compilation for production deployment.