### PR TITLE
Mask headers that match know credentials

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -184,7 +184,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static io.micronaut.scheduling.instrument.InvocationInstrumenter.NOOP;
 
@@ -211,10 +210,8 @@ public class DefaultHttpClient implements
     private static final int DEFAULT_HTTP_PORT = 80;
     private static final int DEFAULT_HTTPS_PORT = 443;
 
-    private static final Supplier<List<Pattern>> HEADER_MASK_PATTERNS = SupplierUtil.memoized(() ->
-        Stream.of(".*password.*", ".*cred.*", ".*cert.*", ".*key.*", ".*secret.*", ".*token.*", ".*auth.*", ".*signa.*")
-            .map(s -> Pattern.compile(s, Pattern.CASE_INSENSITIVE))
-            .collect(Collectors.toList())
+    private static final Supplier<Pattern> HEADER_MASK_PATTERNS = SupplierUtil.memoized(() ->
+        Pattern.compile(".*(password|cred|cert|key|secret|token|auth|signat).*", Pattern.CASE_INSENSITIVE)
     );
     /**
      * Which headers <i>not</i> to copy from the first request when redirecting to a second request. There doesn't
@@ -1775,7 +1772,7 @@ public class DefaultHttpClient implements
 
     private void traceHeaders(HttpHeaders headers) {
         for (String name : headers.names()) {
-            boolean isMasked = HEADER_MASK_PATTERNS.get().stream().anyMatch(pattern -> pattern.matcher(name).matches());
+            boolean isMasked = HEADER_MASK_PATTERNS.get().matcher(name).matches();
             List<String> all = headers.getAll(name);
             if (all.size() > 1) {
                 for (String value : all) {

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -1786,7 +1786,7 @@ public class DefaultHttpClient implements
         }
     }
 
-    String mask(String value) {
+    private String mask(String value) {
         if (value == null) {
             return null;
         }

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -1786,11 +1786,12 @@ public class DefaultHttpClient implements
         }
     }
 
-    private String mask(String value) {
+    @Nullable
+    private String mask(@Nullable String value) {
         if (value == null) {
             return null;
         }
-        return "*MASKED* [" + value.length() + " chars]";
+        return "*MASKED*";
     }
 
     private static MediaTypeCodecRegistry createDefaultMediaTypeRegistry() {

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -34,6 +34,7 @@ import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
+import io.micronaut.core.util.SupplierUtil;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpResponseWrapper;
 import io.micronaut.http.HttpStatus;
@@ -181,7 +182,9 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static io.micronaut.scheduling.instrument.InvocationInstrumenter.NOOP;
 
@@ -208,6 +211,11 @@ public class DefaultHttpClient implements
     private static final int DEFAULT_HTTP_PORT = 80;
     private static final int DEFAULT_HTTPS_PORT = 443;
 
+    private static final Supplier<List<Pattern>> HEADER_MASK_PATTERNS = SupplierUtil.memoized(() ->
+        Stream.of(".*password.*", ".*cred.*", ".*cert.*", ".*key.*", ".*secret.*", ".*token.*", ".*auth.*", ".*signa.*")
+            .map(s -> Pattern.compile(s, Pattern.CASE_INSENSITIVE))
+            .collect(Collectors.toList())
+    );
     /**
      * Which headers <i>not</i> to copy from the first request when redirecting to a second request. There doesn't
      * appear to be a spec for this. {@link java.net.HttpURLConnection} seems to drop all headers, but that would be a
@@ -1767,15 +1775,25 @@ public class DefaultHttpClient implements
 
     private void traceHeaders(HttpHeaders headers) {
         for (String name : headers.names()) {
+            boolean isMasked = HEADER_MASK_PATTERNS.get().stream().anyMatch(pattern -> pattern.matcher(name).matches());
             List<String> all = headers.getAll(name);
             if (all.size() > 1) {
                 for (String value : all) {
-                    log.trace("{}: {}", name, value);
+                    String maskedValue = isMasked ? mask(value) : value;
+                    log.trace("{}: {}", name, maskedValue);
                 }
             } else if (!all.isEmpty()) {
-                log.trace("{}: {}", name, all.get(0));
+                String maskedValue = isMasked ? mask(all.get(0)) : all.get(0);
+                log.trace("{}: {}", name, maskedValue);
             }
         }
+    }
+
+    String mask(String value) {
+        if (value == null) {
+            return null;
+        }
+        return "*MASKED* [" + value.length() + " chars]";
     }
 
     private static MediaTypeCodecRegistry createDefaultMediaTypeRegistry() {

--- a/http-client/src/test/groovy/io/micronaut/http/client/netty/DefaultClientHeaderMaskTest.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/netty/DefaultClientHeaderMaskTest.groovy
@@ -15,7 +15,7 @@ import java.util.concurrent.TimeUnit
 
 class DefaultClientHeaderMaskTest extends Specification {
 
-    def "check masking works"() {
+    def "check masking works for #value"() {
         given:
         def ctx = ApplicationContext.run()
         def client = ctx.createBean(DefaultHttpClient, "http://localhost:8080")

--- a/http-client/src/test/groovy/io/micronaut/http/client/netty/DefaultClientHeaderMaskTest.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/netty/DefaultClientHeaderMaskTest.groovy
@@ -1,0 +1,87 @@
+package io.micronaut.http.client.netty
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.AppenderBase
+import io.micronaut.context.ApplicationContext
+import io.netty.handler.codec.http.DefaultHttpHeaders
+import org.slf4j.LoggerFactory
+import spock.lang.Specification
+
+import java.util.concurrent.BlockingQueue
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+
+class DefaultClientHeaderMaskTest extends Specification {
+
+    def "check masking works"() {
+        given:
+        def ctx = ApplicationContext.run()
+        def client = ctx.createBean(DefaultHttpClient, "http://localhost:8080")
+
+        expect:
+        client.mask(value) == expected
+
+        cleanup:
+        ctx.close()
+
+        where:
+        value       | expected
+        null        | null
+        "foo"       | "*MASKED* [3 chars]"
+        "Tim Yates" | "*MASKED* [9 chars]"
+    }
+
+    def "check mask detects common security headers"() {
+        given:
+        MemoryAppender appender = new MemoryAppender()
+        Logger logger = (Logger) LoggerFactory.getLogger(DefaultHttpClient.class)
+        logger.addAppender(appender)
+        logger.setLevel(Level.TRACE)
+        appender.start()
+
+        DefaultHttpHeaders headers = new DefaultHttpHeaders()
+        headers.add("Authorization", "Bearer foo")
+        headers.add("Proxy-Authorization", "AWS4-HMAC-SHA256 bar")
+        headers.add("Cookie", "baz")
+        headers.add("Set-Cookie", "qux")
+        headers.add("X-Forwarded-For", "quux")
+        headers.add("X-Forwarded-Host", "quuz")
+        headers.add("X-Real-IP", "waldo")
+        headers.add("X-Forwarded-For", "fred")
+        headers.add("Credential", "foo")
+        headers.add("Signature", "bar probably secret")
+        def ctx = ApplicationContext.run()
+        def client = ctx.createBean(DefaultHttpClient, "http://localhost:8080")
+
+        when:
+        client.traceHeaders(headers)
+
+        then:
+        appender.events.size() == 10
+        appender.events.join("\n") == """Authorization: *MASKED* [10 chars]
+            |Proxy-Authorization: *MASKED* [20 chars]
+            |Cookie: baz
+            |Set-Cookie: qux
+            |X-Forwarded-For: quux
+            |X-Forwarded-For: fred
+            |X-Forwarded-Host: quuz
+            |X-Real-IP: waldo
+            |Credential: *MASKED* [3 chars]
+            |Signature: *MASKED* [19 chars]""".stripMargin()
+
+        cleanup:
+        ctx.close()
+        appender.stop()
+    }
+
+    static class MemoryAppender extends AppenderBase<ILoggingEvent> {
+        final BlockingQueue<String> events = new LinkedBlockingQueue<>()
+
+        @Override
+        protected void append(ILoggingEvent e) {
+            events.add(e.formattedMessage)
+        }
+    }
+}

--- a/http-client/src/test/groovy/io/micronaut/http/client/netty/DefaultClientHeaderMaskTest.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/netty/DefaultClientHeaderMaskTest.groovy
@@ -29,8 +29,8 @@ class DefaultClientHeaderMaskTest extends Specification {
         where:
         value       | expected
         null        | null
-        "foo"       | "*MASKED* [3 chars]"
-        "Tim Yates" | "*MASKED* [9 chars]"
+        "foo"       | "*MASKED*"
+        "Tim Yates" | "*MASKED*"
     }
 
     def "check mask detects common security headers"() {
@@ -60,16 +60,16 @@ class DefaultClientHeaderMaskTest extends Specification {
 
         then:
         appender.events.size() == 10
-        appender.events.join("\n") == """Authorization: *MASKED* [10 chars]
-            |Proxy-Authorization: *MASKED* [20 chars]
+        appender.events.join("\n") == """Authorization: *MASKED*
+            |Proxy-Authorization: *MASKED*
             |Cookie: baz
             |Set-Cookie: qux
             |X-Forwarded-For: quux
             |X-Forwarded-For: fred
             |X-Forwarded-Host: quuz
             |X-Real-IP: waldo
-            |Credential: *MASKED* [3 chars]
-            |Signature: *MASKED* [19 chars]""".stripMargin()
+            |Credential: *MASKED*
+            |Signature: *MASKED*""".stripMargin()
 
         cleanup:
         ctx.close()


### PR DESCRIPTION
When trace logging is enabled, all headers are logged.

We should avoid this, as it may be captured by logging or build software.

We could make this configurable, if we think it's worth the extra effort.