### PR TITLE
Groovy properties shouldn't become executable methods

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/processing/DeclaredBeanElementCreator.java
+++ b/core-processor/src/main/java/io/micronaut/inject/processing/DeclaredBeanElementCreator.java
@@ -459,6 +459,10 @@ class DeclaredBeanElementCreator extends AbstractBeanElementCreator {
         if (!methodElement.hasStereotype(Executable.class)) {
             return false;
         }
+        if (methodElement.isSynthetic()) {
+            // Synthetic methods cannot be executable as @Executable cannot be put on a field
+            return false;
+        }
         if (getElementAnnotationMetadata(methodElement).hasStereotype(Executable.class)) {
             // @Executable annotated on the method
             // Throw error if it cannot be accessed without the reflection

--- a/inject-groovy/src/test/groovy/io/micronaut/aop/introduction/with_around/IntroductionWithAroundOnConcreteClassSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/aop/introduction/with_around/IntroductionWithAroundOnConcreteClassSpec.groovy
@@ -78,8 +78,8 @@ class Test {}
         def proxyTargetBeanDefinition = applicationContext.getProxyTargetBeanDefinition(clazz, null)
         def beanDefinition = applicationContext.getBeanDefinition(clazz, null)
         then:
-        proxyTargetBeanDefinition.getExecutableMethods().size() == 5
-        beanDefinition.getExecutableMethods().size() == 5
+        proxyTargetBeanDefinition.getExecutableMethods().size() == 1
+        beanDefinition.getExecutableMethods().size() == 1
     }
 
     void "test executable methods count for around with executable"() {

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/executable/ExecutableBeanSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/executable/ExecutableBeanSpec.groovy
@@ -54,7 +54,7 @@ class ExecutableController {
         definition.executableMethods*.name.toSorted() == ['round', 'sum'].toSorted()
     }
 
-    void "test executable at class level and a property field"() {
+    void "test executable at class level 2"() {
         given:
         BeanDefinition definition = buildBeanDefinition('test.ExecutableController','''\
 package test

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/executable/ExecutableBeanSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/executable/ExecutableBeanSpec.groovy
@@ -20,6 +20,40 @@ import io.micronaut.inject.BeanDefinition
 
 class ExecutableBeanSpec extends AbstractBeanDefinitionSpec {
 
+    void "test executable at class level"() {
+        given:
+        BeanDefinition definition = buildBeanDefinition('test.ExecutableController','''\
+package test
+
+import io.micronaut.context.annotation.Executable;
+import io.micronaut.inject.annotation.*;
+
+@jakarta.inject.Singleton
+@Executable
+class ExecutableController {
+    String foo
+
+    @Executable
+    public int round(float num) {
+        return Math.round(num);
+    }
+
+    @Executable
+    public int sum(int a, int b) {
+        return doSum()
+    }
+
+    private int doSum() {
+        return a + b
+    }
+}
+''')
+        expect:
+        definition != null
+        definition.executableMethods.size() == 2
+        definition.executableMethods*.name == ['round', 'sum'] as Set
+    }
+
     void "test executable on stereotype"() {
         given:
         BeanDefinition definition = buildBeanDefinition('test.ExecutableController','''\
@@ -105,14 +139,14 @@ class MyBean  {
         @RepeatableExecutable("b")
     ])
     void run() {
-        
+
     }
-    
-       
+
+
     @RepeatableExecutable("a")
     @RepeatableExecutable("b")
     void run2() {
-        
+
     }
 }
 ''')

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/executable/ExecutableBeanSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/executable/ExecutableBeanSpec.groovy
@@ -51,7 +51,40 @@ class ExecutableController {
         expect:
         definition != null
         definition.executableMethods.size() == 2
-        definition.executableMethods*.name == ['round', 'sum'] as Set
+        definition.executableMethods*.name.toSorted() == ['round', 'sum'].toSorted()
+    }
+
+    void "test executable at class level and a property field"() {
+        given:
+        BeanDefinition definition = buildBeanDefinition('test.ExecutableController','''\
+package test
+
+import io.micronaut.context.annotation.Executable;
+import io.micronaut.inject.annotation.*;
+
+@jakarta.inject.Singleton
+@Executable
+class ExecutableController {
+    String foo
+
+    public int round(float num) {
+        return Math.round(num);
+    }
+
+    @Executable
+    public int sum(int a, int b) {
+        return doSum()
+    }
+
+    private int doSum() {
+        return a + b
+    }
+}
+''')
+        expect:
+        definition != null
+        definition.executableMethods.size() == 2
+        definition.executableMethods*.name.toSorted() == ['round', 'sum'].toSorted()
     }
 
     void "test executable on stereotype"() {

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/executable/ExecutableBeanSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/executable/ExecutableBeanSpec.groovy
@@ -71,7 +71,6 @@ class ExecutableController {
         return Math.round(num);
     }
 
-    @Executable
     public int sum(int a, int b) {
         return doSum()
     }


### PR DESCRIPTION
Micronaut 4 is treating Groovy properties as executable methods when the executable annotation is on the type level.

The Kafka module is failing on upgrade to 4.0.x because of this bug.