### PR TITLE
Detect deadlocks when using BlockingHttpClient on the event loop

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/BlockHint.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/BlockHint.java
@@ -30,16 +30,7 @@ import io.netty.channel.EventLoop;
  * @since 4.0.0
  */
 @Internal
-final class BlockHint {
-    private final Thread blockedThread;
-    @Nullable
-    private final BlockHint next;
-
-    private BlockHint(Thread blockedThread, @Nullable BlockHint next) {
-        this.blockedThread = blockedThread;
-        this.next = next;
-    }
-
+record BlockHint(Thread blockedThread, @Nullable BlockHint next) {
     public static BlockHint willBlockThisThread() {
         return new BlockHint(Thread.currentThread(), null);
     }

--- a/http-client/src/main/java/io/micronaut/http/client/netty/BlockHint.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/BlockHint.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.client.netty;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.http.client.exceptions.HttpClientException;
+import io.netty.channel.EventLoop;
+
+/**
+ * Information about what threads are blocked waiting for a request to complete. This is used to
+ * detect deadlocks when the user does a {@link io.micronaut.http.client.BlockingHttpClient} on the
+ * event loop.
+ *
+ * @author Jonas Konrad
+ * @since 4.0.0
+ */
+@Internal
+final class BlockHint {
+    private final Thread blockedThread;
+    @Nullable
+    private final BlockHint next;
+
+    private BlockHint(Thread blockedThread, @Nullable BlockHint next) {
+        this.blockedThread = blockedThread;
+        this.next = next;
+    }
+
+    public static BlockHint willBlockThisThread() {
+        return new BlockHint(Thread.currentThread(), null);
+    }
+
+    @Nullable
+    public static BlockHint combine(@Nullable BlockHint a, @Nullable BlockHint b) {
+        if (a == null) {
+            return b;
+        } else if (b == null) {
+            return a;
+        } else if (a.next == null) {
+            return new BlockHint(a.blockedThread, b);
+        } else if (b.next == null) {
+            return new BlockHint(b.blockedThread, a);
+        } else {
+            throw new UnsupportedOperationException(
+                "would need to build a new linked list here, but we never need this");
+        }
+    }
+
+    void checkIsNotBlocked(EventLoop eventLoop) {
+        if (blocks(eventLoop)) {
+            throw createException();
+        }
+    }
+
+    @NonNull
+    static HttpClientException createException() {
+        return new HttpClientException(
+            "Failed to perform blocking request on the event loop because request execution " +
+                "would be dispatched on the same event loop. This would lead to a deadlock. " +
+                "Either configure the HTTP client to use a different event loop, or use the " +
+                "reactive HTTP client.");
+    }
+
+    boolean blocks(EventLoop eventLoop) {
+        BlockHint bh = this;
+        while (bh != null) {
+            if (eventLoop.inEventLoop(bh.blockedThread)) {
+                return true;
+            }
+            bh = bh.next;
+        }
+        return false;
+    }
+}

--- a/http-client/src/main/java/io/micronaut/http/client/netty/BlockHint.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/BlockHint.java
@@ -63,7 +63,8 @@ record BlockHint(Thread blockedThread, @Nullable BlockHint next) {
             "Failed to perform blocking request on the event loop because request execution " +
                 "would be dispatched on the same event loop. This would lead to a deadlock. " +
                 "Either configure the HTTP client to use a different event loop, or use the " +
-                "reactive HTTP client.");
+                "reactive HTTP client. " +
+                "https://docs.micronaut.io/latest/guide/index.html#clientConfiguration");
     }
 
     boolean blocks(EventLoop eventLoop) {

--- a/http-client/src/main/java/io/micronaut/http/client/netty/BlockHint.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/BlockHint.java
@@ -26,6 +26,8 @@ import io.netty.channel.EventLoop;
  * detect deadlocks when the user does a {@link io.micronaut.http.client.BlockingHttpClient} on the
  * event loop.
  *
+ * @param blockedThread Thread that is blocked
+ * @param next Next node in the linked list of blocked threads
  * @author Jonas Konrad
  * @since 4.0.0
  */

--- a/http-client/src/main/java/io/micronaut/http/client/netty/CancellableMonoSink.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/CancellableMonoSink.java
@@ -17,6 +17,7 @@ package io.micronaut.http.client.netty;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -30,14 +31,27 @@ import reactor.core.publisher.Sinks;
  * @param <T> Element type
  */
 @Internal
-final class CancellableMonoSink<T> implements Publisher<T>, Sinks.One<T>, Subscription {
+final class CancellableMonoSink<T> implements Publisher<T>, Sinks.One<T>, Subscription, PoolSink<T> {
     private static final Object EMPTY = new Object();
+
+    @Nullable
+    private final BlockHint blockHint;
 
     private T value;
     private Throwable failure;
     private boolean complete = false;
     private Subscriber<? super T> subscriber = null;
     private boolean subscriberWaiting = false;
+
+    CancellableMonoSink(@Nullable BlockHint blockHint) {
+        this.blockHint = blockHint;
+    }
+
+    @Override
+    @Nullable
+    public BlockHint getBlockHint() {
+        return blockHint;
+    }
 
     @Override
     public synchronized void subscribe(Subscriber<? super T> s) {

--- a/http-client/src/main/java/io/micronaut/http/client/netty/PoolResizer.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/PoolResizer.java
@@ -35,7 +35,7 @@ import java.util.function.Consumer;
  * {@link io.micronaut.http.client.HttpClientConfiguration.ConnectionPoolConfiguration}.
  * <p>
  * This class consists of various mutator methods (e.g. {@link #addPendingRequest}) that
- * may be called concurrently and in a reentrant fashion (e.g. inside {@link #openNewConnection)}).
+ * may be called concurrently and in a reentrant fashion (e.g. inside {@link #openNewConnection}).
  * These mutator methods update their respective fields and then mark this class as
  * {@link #dirty()}. The state management logic ensures that {@link #doSomeWork()} is called in a
  * serialized fashion (no concurrency or reentrancy) at least once after each {@link #dirty()}

--- a/http-client/src/main/java/io/micronaut/http/client/netty/PoolSink.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/PoolSink.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.client.netty;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.Nullable;
+import reactor.core.publisher.Sinks;
+
+/**
+ * Sink with an additional optional {@link BlockHint} as metadata.
+ *
+ * @param <T> The type that can be submitted to this sink.
+ * @author Jonas Konrad
+ * @since 4.0.0
+ */
+@Internal
+interface PoolSink<T> extends Sinks.One<T> {
+    @Nullable
+    BlockHint getBlockHint();
+}

--- a/http-client/src/test/groovy/io/micronaut/http/client/BlockingDeadlockSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/BlockingDeadlockSpec.groovy
@@ -1,0 +1,56 @@
+package io.micronaut.http.client
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.http.client.exceptions.HttpClientException
+import io.micronaut.http.netty.channel.EventLoopGroupRegistry
+import spock.lang.Specification
+
+import java.util.concurrent.ExecutionException
+
+class BlockingDeadlockSpec extends Specification {
+    def 'blocking on the same event loop should fail: connection already established'() {
+        given:
+        def ctx = ApplicationContext.run([
+                'micronaut.netty.event-loops.default.num-threads': 1
+        ])
+        def group = ctx.getBean(EventLoopGroupRegistry).getDefaultEventLoopGroup()
+        def client = ctx.createBean(HttpClient, 'https://micronaut.io').toBlocking()
+
+        when:
+        // establish pool connection
+        client.exchange('/')
+        group.submit(() -> {
+            client.exchange('/')
+        }).get()
+        then:
+        def e = thrown ExecutionException
+        e.cause instanceof HttpClientException
+        e.cause.message.contains("deadlock")
+
+        cleanup:
+        client.close()
+        group.shutdownGracefully()
+    }
+
+    def 'blocking on the same event loop should fail: new connection'() {
+        given:
+        def ctx = ApplicationContext.run([
+                'micronaut.netty.event-loops.default.num-threads': 1
+        ])
+        def group = ctx.getBean(EventLoopGroupRegistry).getDefaultEventLoopGroup()
+        def client = ctx.createBean(HttpClient, 'https://micronaut.io').toBlocking()
+
+        when:
+        group.submit(() -> {
+            client.exchange('/')
+        }).get()
+        then:
+        def e = thrown ExecutionException
+        e.cause instanceof HttpClientException
+        e.cause.message.contains("deadlock")
+
+        cleanup:
+        client.close()
+        group.shutdownGracefully()
+    }
+}


### PR DESCRIPTION
Keep track of the thread that called BlockingHttpClient.exchange, and throw an exception when the client attempts to use the same thread for the connection. Before this patch, the blocking call would time out, now it will fail with a specific exception.

The event loop group usually has many threads, and often a blocking call will wait on *another* thread of that event loop group by chance. Such uses currently only lead to sporadic read timeouts at the moment. This implementation is conservative: It will not fail when the same event loop group is used, it will only fail with the exact same thread. So the sporadic timeouts will be replaced by sporadic deadlock exceptions.

Relates to #8198