### PR TITLE
Still emit response if return type is Void

### DIFF
--- a/http-client-core/src/main/java/io/micronaut/http/client/HttpClient.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/HttpClient.java
@@ -152,9 +152,15 @@ public interface HttpClient extends Closeable, LifeCycle<HttpClient> {
      * @param <E>      The error type
      * @return A {@link Publisher} that emits a result of the given type
      */
+    @SuppressWarnings("unchecked")
     default <I, O, E> Publisher<O> retrieve(@NonNull HttpRequest<I> request, @NonNull Argument<O> bodyType, @NonNull Argument<E> errorType) {
         // note: this default impl isn't used by us anymore, it's overridden by DefaultHttpClient
-        return Flux.from(exchange(request, bodyType, errorType)).map(response -> {
+        Flux<HttpResponse<O>> exchange = Flux.from(exchange(request, bodyType, errorType));
+        if (bodyType.getType() == void.class) {
+            // exchange() returns a HttpResponse<Void>, we can't map the Void body properly, so just drop it and complete
+            return (Publisher<O>) exchange.ignoreElements();
+        }
+        return exchange.map(response -> {
             if (bodyType.getType() == HttpStatus.class) {
                 return (O) response.getStatus();
             } else {

--- a/http-client-core/src/main/java/io/micronaut/http/client/interceptor/HttpClientIntroductionAdvice.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/interceptor/HttpClientIntroductionAdvice.java
@@ -55,8 +55,8 @@ import io.micronaut.http.annotation.HttpMethodMapping;
 import io.micronaut.http.annotation.Produces;
 import io.micronaut.http.client.BlockingHttpClient;
 import io.micronaut.http.client.HttpClient;
-import io.micronaut.http.client.ReactiveClientResultTransformer;
 import io.micronaut.http.client.HttpClientRegistry;
+import io.micronaut.http.client.ReactiveClientResultTransformer;
 import io.micronaut.http.client.StreamingHttpClient;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.http.client.bind.ClientArgumentRequestBinder;
@@ -426,7 +426,7 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
         Class<?> argumentType = reactiveValueArgument.getType();
         if (Void.class == argumentType || returnType.isVoid()) {
             request.getHeaders().remove(HttpHeaders.ACCEPT);
-            return httpClient.exchange(request, Argument.VOID, errorType);
+            return httpClient.retrieve(request, Argument.VOID, errorType);
         } else {
             if (HttpResponse.class.isAssignableFrom(argumentType)) {
                 return httpClient.exchange(request, reactiveValueArgument, errorType);

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -755,7 +755,12 @@ public class DefaultHttpClient implements
     @Override
     public <I, O, E> Publisher<O> retrieve(io.micronaut.http.HttpRequest<I> request, Argument<O> bodyType, Argument<E> errorType) {
         // mostly same as default impl, but with exception customization
-        return Flux.from(exchange(request, bodyType, errorType)).map(response -> {
+        Flux<HttpResponse<O>> exchange = Flux.from(exchange(request, bodyType, errorType));
+        if (bodyType.getType() == void.class) {
+            // exchange() returns a HttpResponse<Void>, we can't map the Void body properly, so just drop it and complete
+            return (Publisher<O>) exchange.ignoreElements();
+        }
+        return exchange.map(response -> {
             if (bodyType.getType() == HttpStatus.class) {
                 return (O) response.getStatus();
             } else {

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -1490,10 +1490,6 @@ public class DefaultHttpClient implements
                 new FullHttpResponseHandler<>(responsePromise, poolHandle, secure, finalRequest, bodyType, errorType));
         poolHandle.notifyRequestPipelineBuilt();
         Publisher<HttpResponse<O>> publisher = new NettyFuturePublisher<>(responsePromise, true);
-        if (bodyType != null && bodyType.isVoid()) {
-            // don't emit response if bodyType is void
-            publisher = Flux.from(publisher).filter(r -> false);
-        }
         publisher.subscribe(new ForwardingSubscriber<>(emitter));
 
         requestWriter.write(channel, secure, emitter);


### PR DESCRIPTION
Before this patch, HttpClient would remove the actual response from the response publisher if the expected body type is Void. I don't see a reason to do this, and it leads to HTTP filters not seeing the response as they should. 

However there is an outstanding bug that this uncovered: If there is a declarative client method that is supposed to return Publisher<X>, it instead always returns a Publisher<HttpResponse<X>> (the type returned from HttpClient.exchange). The code here does not convert properly when the `returnType` is `Publisher<Void>` and the result is another publisher: https://github.com/micronaut-projects/micronaut-core/blob/f81eceaba3ac8c550e56288779c686d6f50ea286/aop/src/main/java/io/micronaut/aop/internal/intercepted/PublisherInterceptedMethod.java#L112-L118 – this causes a class cast exception in `HttpGetSpec.test simple get with Publisher<Void> return`.

@dstepanov do you have any idea how to fix this?

Fixes #8366