### PR TITLE
Exclude maven copy of aop for testRuntime

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.convention-base.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.convention-base.gradle
@@ -16,7 +16,7 @@ repositories {
 }
 
 configurations {
-    all {
+    testRuntimeClasspath {
         // Use AOP from here, not from maven
         exclude group: 'io.micronaut', module: 'micronaut-aop'
     }


### PR DESCRIPTION
Previously, due to laziness I'd excluded it it from every configuration, including publishing 😳