### PR TITLE
Make Snakeyaml a managed dependency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,7 +52,6 @@ micrometer = "1.9.5"
 neo4j-java-driver = "1.4.5"
 selenium = "3.141.59"
 smallrye = "5.5.0"
-snakeyaml = "1.33"
 spock = "2.2-groovy-4.0"
 spotbugs = "4.7.1"
 systemlambda = "1.2.1"
@@ -75,6 +74,7 @@ managed-reactive-streams = "1.0.4"
 # This should be kept aligned with https://github.com/micronaut-projects/micronaut-reactor/blob/master/gradle.properties from the BOM
 managed-reactor = "3.4.24"
 managed-slf4j = "2.0.4"
+managed-snakeyaml = "1.33"
 managed-validation = "2.0.1.Final"
 micronaut-docs = "2.0.0"
 
@@ -129,6 +129,8 @@ managed-reactor = { module = "io.projectreactor:reactor-core", version.ref = "ma
 
 managed-slf4j = { module = "org.slf4j:slf4j-api", version.ref = "managed-slf4j" }
 managed-slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "managed-slf4j" }
+
+managed-snakeyaml = { module = "org.yaml:snakeyaml", version.ref = "managed-snakeyaml" }
 
 managed-validation = { module = "javax.validation:validation-api", version.ref = "managed-validation" }
 
@@ -240,7 +242,6 @@ selenium-driver-firefox = { module = "org.seleniumhq.selenium:selenium-firefox-d
 selenium-driver-htmlunit = { module = "org.seleniumhq.selenium:htmlunit-driver", version.ref = "htmlunit" }
 
 smallrye = { module = "io.smallrye:smallrye-fault-tolerance", version.ref = "smallrye" }
-snakeyaml = { module = "org.yaml:snakeyaml", version.ref = "snakeyaml" }
 spock = { module = "org.spockframework:spock-core", version.ref = "spock" }
 spotbugs = { module = "com.github.spotbugs:spotbugs-annotations", version.ref = "spotbugs" }
 

--- a/inject-groovy/build.gradle
+++ b/inject-groovy/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     testImplementation(libs.neo4j.bolt)
     testImplementation libs.managed.groovy.json
     testImplementation libs.blaze.persistence.core
-    testImplementation libs.snakeyaml
+    testImplementation libs.managed.snakeyaml
     testImplementation libs.managed.reactor
 
     functionalTestImplementation(testFixtures(project(":test-suite")))

--- a/inject-java/build.gradle
+++ b/inject-java/build.gradle
@@ -45,7 +45,7 @@ dependencies {
         exclude module: 'micronaut-runtime'
     }
     testImplementation libs.javax.annotation.api
-    testImplementation libs.snakeyaml
+    testImplementation libs.managed.snakeyaml
     testRuntimeOnly libs.javax.el.impl
     testRuntimeOnly libs.javax.el
 }

--- a/inject/build.gradle
+++ b/inject/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     api libs.managed.jakarta.annotation.api
     api project(':core')
 
-    compileOnly libs.snakeyaml
+    compileOnly libs.managed.snakeyaml
     compileOnly libs.managed.groovy
     compileOnly libs.kotlin.stdlib.jdk8
     compileOnly libs.managed.validation
@@ -26,7 +26,7 @@ dependencies {
     testImplementation project(":inject-groovy")
     testImplementation project(":inject-test-utils")
     testImplementation libs.systemlambda
-    testImplementation libs.snakeyaml
+    testImplementation libs.managed.snakeyaml
     testRuntimeOnly libs.junit.jupiter.engine
 
 }

--- a/jackson-databind/build.gradle
+++ b/jackson-databind/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     testImplementation project(":inject-java-test")
     testImplementation project(":inject-groovy")
     testImplementation "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
-    testImplementation libs.snakeyaml
+    testImplementation libs.managed.snakeyaml
     if (!JavaVersion.current().isJava9Compatible()) {
         testImplementation files(org.gradle.internal.jvm.Jvm.current().toolsJar)
     }

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     compileOnly libs.kotlinx.coroutines.core
     compileOnly libs.kotlinx.coroutines.reactive
     testImplementation libs.logback
-    testImplementation libs.snakeyaml
+    testImplementation libs.managed.snakeyaml
     testAnnotationProcessor project(":inject-java")
     testImplementation libs.jsr107
     testImplementation libs.jcache

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -4,5 +4,5 @@ plugins {
 
 dependencies {
     api libs.managed.groovy
-    testImplementation libs.snakeyaml
+    testImplementation libs.managed.snakeyaml
 }


### PR DESCRIPTION
We have a lot of modules including mn.snakeyaml, so exposing this in the core bom will prevent duplication all over the place