### PR TITLE
Fix index out of bounds when chain.proceed is called too often

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -1638,7 +1638,7 @@ public class DefaultHttpClient implements
             public Publisher<? extends io.micronaut.http.HttpResponse<?>> proceed(MutableHttpRequest<?> request) {
 
                 int pos = integer.incrementAndGet();
-                if (pos > len) {
+                if (pos >= len) {
                     throw new IllegalStateException("The FilterChain.proceed(..) method should be invoked exactly once per filter execution. The method has instead been invoked multiple times by an erroneous filter definition.");
                 }
                 HttpClientFilter httpFilter = filters.get(pos);


### PR DESCRIPTION
No functional change, just changes the error.

Fixes #8393