### PR TITLE
Enable test for streaming h2c requests

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/ConnectionManager.java
@@ -855,31 +855,25 @@ class ConnectionManager {
                     requestKey.getPort()
                 );
             } else {
-                switch (httpVersion.getPlaintextMode()) {
-                    case HTTP_1:
-                        initializer = new ChannelInitializer<Channel>() {
-                            @Override
-                            protected void initChannel(@NonNull Channel ch) throws Exception {
-                                configureProxy(ch.pipeline(), false, requestKey.getHost(), requestKey.getPort());
-                                initHttp1(ch);
-                                ch.pipeline().addLast(ChannelPipelineCustomizer.HANDLER_ACTIVITY_LISTENER, new ChannelInboundHandlerAdapter() {
-                                    @Override
-                                    public void channelActive(@NonNull ChannelHandlerContext ctx) throws Exception {
-                                        super.channelActive(ctx);
-                                        ctx.pipeline().remove(this);
-                                        NettyClientCustomizer channelCustomizer = clientCustomizer.specializeForChannel(ch, NettyClientCustomizer.ChannelRole.CONNECTION);
-                                        new Http1ConnectionHolder(ch, channelCustomizer).init(true);
-                                    }
-                                });
-                            }
-                        };
-                        break;
-                    case H2C:
-                        initializer = new Http2UpgradeInitializer(this);
-                        break;
-                    default:
-                        throw new AssertionError("Unknown plaintext mode");
-                }
+                initializer = switch (httpVersion.getPlaintextMode()) {
+                    case HTTP_1 -> new ChannelInitializer<>() {
+                        @Override
+                        protected void initChannel(@NonNull Channel ch) throws Exception {
+                            configureProxy(ch.pipeline(), false, requestKey.getHost(), requestKey.getPort());
+                            initHttp1(ch);
+                            ch.pipeline().addLast(ChannelPipelineCustomizer.HANDLER_ACTIVITY_LISTENER, new ChannelInboundHandlerAdapter() {
+                                @Override
+                                public void channelActive(@NonNull ChannelHandlerContext ctx) throws Exception {
+                                    super.channelActive(ctx);
+                                    ctx.pipeline().remove(this);
+                                    NettyClientCustomizer channelCustomizer = clientCustomizer.specializeForChannel(ch, NettyClientCustomizer.ChannelRole.CONNECTION);
+                                    new Http1ConnectionHolder(ch, channelCustomizer).init(true);
+                                }
+                            });
+                        }
+                    };
+                    case H2C -> new Http2UpgradeInitializer(this);
+                };
             }
             ChannelFuture channelFuture = doConnect(requestKey, initializer);
             if (blockHint != null && blockHint.blocks(channelFuture.channel().eventLoop())) {

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/http2/H2cSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/http2/H2cSpec.groovy
@@ -40,9 +40,7 @@ import org.reactivestreams.Publisher
 import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
 import reactor.core.publisher.Flux
-import spock.lang.Ignore
 import spock.lang.Issue
-import spock.lang.PendingFeature
 import spock.lang.Specification
 
 import java.nio.charset.StandardCharsets
@@ -52,7 +50,7 @@ import java.util.concurrent.TimeUnit
 @MicronautTest
 @Property(name = "micronaut.server.http-version", value = "2.0")
 //@Property(name = "micronaut.server.port", value = "8912")
-@Property(name = "micronaut.http.client.http-version", value = "2.0")
+@Property(name = "micronaut.http.client.plaintext-mode", value = "h2c")
 @Property(name = "micronaut.server.ssl.enabled", value = "false")
 @Issue('https://github.com/micronaut-projects/micronaut-core/issues/5005')
 class H2cSpec extends Specification {
@@ -150,6 +148,7 @@ class H2cSpec extends Specification {
         streamingHttpClient.dataStream(HttpRequest.GET(url)).subscribe(new Subscriber<ByteBuffer<?>>() {
             @Override
             void onSubscribe(Subscription s) {
+                s.request(Long.MAX_VALUE)
             }
 
             @Override
@@ -171,19 +170,12 @@ class H2cSpec extends Specification {
         return composed.toString(StandardCharsets.UTF_8)
     }
 
-    @PendingFeature
-    @Ignore
-    // todo: streaming h2c is currently broken. This is because addFinalHandler is called after the stream receivers
-    //  have been registered to the pipeline. This means that http2 messages aren't transformed to http messages
-    //  properly.
     void 'test using micronaut http client: stream'() {
         expect:
         stream("http://localhost:${embeddedServer.port}/h2c/test") == 'foo'
         stream("http://localhost:${embeddedServer.port}/h2c/testStream") == 'foo'
     }
 
-    @PendingFeature
-    @Ignore
     void 'test using micronaut http client: stream reverse'() {
         // order matters because the client reuses connections
         expect:


### PR DESCRIPTION
Also fixes the subscription, moves the config to the new plaintext-mode property, and changes a switch in ConnectionManager to java 17 switch expression.

Fixes #6282