### PR TITLE
Don't include write only properties in serialization

### DIFF
--- a/inject/src/main/java/io/micronaut/inject/beans/AbstractInitializableBeanIntrospection.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/AbstractInitializableBeanIntrospection.java
@@ -422,7 +422,7 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements BeanI
                 throw new IllegalArgumentException("Invalid bean [" + bean + "] for type: " + beanType);
             }
             if (isWriteOnly()) {
-                throw new UnsupportedOperationException("Cannot read from a write-only property");
+                throw new UnsupportedOperationException("Cannot read from a write-only property: " + getName());
             }
             return dispatchOne(ref.getMethodIndex, bean, null);
         }

--- a/jackson-databind/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
@@ -335,7 +335,9 @@ public class BeanIntrospectionModule extends SimpleModule {
                     final List<BeanPropertyWriter> newProperties = new ArrayList<>(properties);
                     Map<String, BeanProperty<Object, Object>> named = new LinkedHashMap<>();
                     for (BeanProperty<Object, Object> beanProperty : beanProperties) {
-                        named.put(getName(config, namingStrategy, beanProperty), beanProperty);
+                        if (!beanProperty.isWriteOnly()) {
+                            named.put(getName(config, namingStrategy, beanProperty), beanProperty);
+                        }
                     }
                     for (int i = 0; i < properties.size(); i++) {
                         final BeanPropertyWriter existing = properties.get(i);

--- a/jackson-databind/src/test/groovy/io/micronaut/jackson/modules/BeanIntrospectionModuleSpec.groovy
+++ b/jackson-databind/src/test/groovy/io/micronaut/jackson/modules/BeanIntrospectionModuleSpec.groovy
@@ -32,6 +32,7 @@ import io.micronaut.http.hateoas.JsonError
 import io.micronaut.jackson.JacksonConfiguration
 import io.micronaut.jackson.modules.testcase.EmailTemplate
 import io.micronaut.jackson.modules.testcase.Notification
+import io.micronaut.jackson.modules.testclasses.HTTPCheck
 import io.micronaut.jackson.modules.wrappers.*
 import spock.lang.Issue
 import spock.lang.Unroll
@@ -41,6 +42,29 @@ import java.beans.ConstructorProperties
 import java.time.LocalDateTime
 
 class BeanIntrospectionModuleSpec extends Specification {
+
+    void "test serialize/deserialize convertible values"() {
+        given:
+        ApplicationContext ctx = ApplicationContext.run()
+        ObjectMapper objectMapper = ctx.getBean(ObjectMapper)
+
+        when:
+        HTTPCheck check = new HTTPCheck(headers:[
+                Accept:['application/json', 'application/xml']
+        ] )
+
+        def result = objectMapper.writeValueAsString(check)
+
+        then:
+        result == '{"Header":{"Accept":["application/json","application/xml"]}}'
+
+        when:
+        def read = objectMapper.readValue(result, HTTPCheck)
+
+        then:
+        check.header.getAll("Accept") == read.header.getAll("Accept")
+
+    }
 
     void "Bean introspection works with a bean without JsonIgnore annotations"() {
         given:

--- a/jackson-databind/src/test/groovy/io/micronaut/jackson/modules/testclasses/HTTPCheck.java
+++ b/jackson-databind/src/test/groovy/io/micronaut/jackson/modules/testclasses/HTTPCheck.java
@@ -1,0 +1,32 @@
+package io.micronaut.jackson.modules.testclasses;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.convert.value.ConvertibleMultiValues;
+
+import java.util.List;
+import java.util.Map;
+
+@JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy.class)
+@Introspected
+public class HTTPCheck {
+    private ConvertibleMultiValues<String> headers = ConvertibleMultiValues.empty();
+
+    public ConvertibleMultiValues<String> getHeader() {
+        return headers;
+    }
+
+    /**
+     * @param headers The headers
+     */
+    @JsonProperty("Header")
+    public void setHeaders(Map<CharSequence, List<String>> headers) {
+        if (headers == null) {
+            this.headers = ConvertibleMultiValues.empty();
+        } else {
+            this.headers = ConvertibleMultiValues.of(headers);
+        }
+    }
+}


### PR DESCRIPTION
When using the bean introspection module it is possible that write only properties are including for serialization leading to:

```
 Caused by: java.lang.UnsupportedOperationException: Cannot read from a write-only property
  	at io.micronaut.inject.beans.AbstractInitializableBeanIntrospection$BeanPropertyImpl.get(AbstractInitializableBeanIntrospection.java:425)
  	at io.micronaut.jackson.modules.BeanIntrospectionModule$BeanIntrospectionPropertyWriter.serializeAsField(BeanIntrospectionModule.java:875)
  	at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:774)

```