### PR TITLE
Fix bug with custom conditions and EachBean definitions

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/condition/EachBeanConditionSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/condition/EachBeanConditionSpec.groovy
@@ -1,0 +1,42 @@
+package io.micronaut.inject.foreach.condition
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.inject.qualifiers.Qualifiers
+import spock.lang.Specification
+
+class EachBeanConditionSpec extends Specification {
+
+    void "test each bean with custom condition - failure"() {
+        given:
+        def ctx = ApplicationContext.run(
+                'foo.one.enabled':false,
+                'foo.two.enabled':false,
+                'configs.two.name':'two'
+        )
+
+        expect:
+        ctx.containsBean(XConfigOne)
+        ctx.containsBean(XConfigMany, Qualifiers.byName("two"))
+        !ctx.containsBean(XClient, Qualifiers.byName("one"))
+        !ctx.containsBean(XClient, Qualifiers.byName("two"))
+
+        cleanup:
+        ctx.close()
+    }
+
+    void "test each bean with custom condition - success"() {
+        given:
+        def ctx = ApplicationContext.run(
+                'configs.two.enabled':true
+        )
+
+        expect:
+        ctx.containsBean(XConfigOne)
+        ctx.containsBean(XConfigMany, Qualifiers.byName("two"))
+        ctx.containsBean(XClient, Qualifiers.byName("one"))
+        ctx.containsBean(XClient, Qualifiers.byName("two"))
+
+        cleanup:
+        ctx.close()
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/condition/XClient.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/condition/XClient.java
@@ -1,0 +1,9 @@
+package io.micronaut.inject.foreach.condition;
+
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Requires;
+
+@EachBean(XConfig.class)
+@Requires(condition = XCondition.class)
+public class XClient {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/condition/XCondition.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/condition/XCondition.java
@@ -1,0 +1,27 @@
+package io.micronaut.inject.foreach.condition;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.Qualifier;
+import io.micronaut.context.condition.Condition;
+import io.micronaut.context.condition.ConditionContext;
+import io.micronaut.core.naming.Named;
+import io.micronaut.inject.QualifiedBeanType;
+
+public class XCondition implements Condition {
+    @Override
+    public boolean matches(ConditionContext context) {
+        BeanContext beanContext = context.getBeanContext();
+        if (beanContext instanceof ApplicationContext appCtx &&
+            context.getComponent() instanceof QualifiedBeanType<?> qualifiedBeanType) {
+            Qualifier<?> declaredQualifier = qualifiedBeanType.getDeclaredQualifier();
+            if (declaredQualifier instanceof Named named) {
+                return appCtx.getProperty(
+                    "foo." + named.getName() + ".enabled",
+                    Boolean.class
+                ).orElse(true);
+            }
+        }
+        return true;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/condition/XConfig.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/condition/XConfig.java
@@ -1,0 +1,7 @@
+package io.micronaut.inject.foreach.condition;
+
+public interface XConfig {
+    String getName();
+
+    void setName(String name);
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/condition/XConfigMany.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/condition/XConfigMany.java
@@ -1,0 +1,18 @@
+package io.micronaut.inject.foreach.condition;
+
+import io.micronaut.context.annotation.EachProperty;
+
+@EachProperty("configs")
+public class XConfigMany implements XConfig {
+    private String name;
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/condition/XConfigOne.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/condition/XConfigOne.java
@@ -1,0 +1,29 @@
+package io.micronaut.inject.foreach.condition;
+
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Named("one")
+public class XConfigOne implements XConfig {
+    private String name;
+    private boolean enabled;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
@@ -512,7 +512,9 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
                         qualifier = PrimaryQualifier.INSTANCE;
                     }
                     BeanDefinitionDelegate<?> delegate = BeanDefinitionDelegate.create(candidate, (Qualifier<T>) qualifier);
-                    transformedCandidates.add((BeanDefinition<T>) delegate);
+                    if (delegate.isEnabled(this, resolutionContext)) {
+                        transformedCandidates.add((BeanDefinition<T>) delegate);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Conditions were not being executed for `@EachBean` definitions without an upstream `@EachProperty`, this fixes that.