### PR TITLE
remove the transitive dependency on Guava from core-processor

### DIFF
--- a/core-processor/build.gradle
+++ b/core-processor/build.gradle
@@ -7,7 +7,10 @@ dependencies {
     api project(":aop")
     api libs.asm.tree
     api libs.bundles.asm
-    api 'com.github.javaparser:javaparser-symbol-solver-core:3.24.7'
+    api(libs.managed.java.parser.core) {
+        exclude group:'org.javassist', module:'javassist'
+        exclude group:'com.google.guava', module:'guava'
+    }
 
     compileOnly libs.kotlin.stdlib.jdk8
     compileOnly libs.managed.validation

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -74,6 +74,7 @@ managed-reactor = "3.4.24"
 managed-slf4j = "2.0.4"
 managed-snakeyaml = "1.33"
 managed-validation = "2.0.1.Final"
+managed-java-parser-core = "3.24.7"
 micronaut-docs = "2.0.0"
 
 [libraries]
@@ -107,6 +108,7 @@ managed-jackson-datatype-jsr310 = { module = "com.fasterxml.jackson.datatype:jac
 managed-jackson-module-afterburner = { module = "com.fasterxml.jackson.module:jackson-module-afterburner", version.ref = "managed-jackson" }
 managed-jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "managed-jackson" }
 managed-jackson-module-parameterNames = { module = "com.fasterxml.jackson.module:jackson-module-parameter-names", version.ref = "managed-jackson" }
+managed-java-parser-core = { module = "com.github.javaparser:javaparser-symbol-solver-core", version.ref = "managed-java-parser-core" }
 
 managed-methvin-directoryWatcher = { module = "io.methvin:directory-watcher", version.ref = "managed-methvin-directory-watcher" }
 


### PR DESCRIPTION
We don't use any of the classes from the Java parser that requires Gruava and this transitively pulls in findbugs which causes issues so we should remove it.