### PR TITLE
Fix incorrect dependency substitution

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.convention-base.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.convention-base.gradle
@@ -62,7 +62,11 @@ configurations.all {
     resolutionStrategy.dependencySubstitution {
         rootProject.subprojects.each {
             if (!it.name.startsWith('test-')) {
-                substitute module("io.micronaut:micronaut-${it.name}") using project(":${it.name}") because "we want to test with what we're building"
+                if (it.name.contains('bom')) {
+                    substitute platform(module("io.micronaut:micronaut-${it.name}")) using platform(project(":${it.name}")) because "we want to test with what we're building"
+                } else {
+                    substitute module("io.micronaut:micronaut-${it.name}") using project(":${it.name}") because "we want to test with what we're building"
+                }
             }
         }
     }

--- a/buildSrc/src/main/groovy/io/micronaut/build/internal/ext/DefaultMicronautCoreExtension.java
+++ b/buildSrc/src/main/groovy/io/micronaut/build/internal/ext/DefaultMicronautCoreExtension.java
@@ -38,6 +38,8 @@ public abstract class DefaultMicronautCoreExtension implements MicronautCoreExte
         dep.exclude(module("micronaut-runtime"));
         dep.exclude(module("micronaut-inject"));
         dep.exclude(module("micronaut-bom"));
+        dep.exclude(module("micronaut-core-bom"));
+        dep.exclude(module("micronaut-platform"));
     }
 
     @Override


### PR DESCRIPTION
This commit fixes the build issue which is seen when upgrading to latest Micronaut validation snapshot:

https://ge.micronaut.io/s/ye2u5kc7pus3u/dependencies?focusedDependency=WzEsMSw3ODEsWzEsMSxbNzUzLDc4MV1dXQ&toggled=W1sxXSxbMSwxXSxbMSwxLFs3NTNdXV0

The problem was that a platform dependency wasn't subsistuted with a platform dependency but with a regular dependency, messing up with dependency resolution.