### PR TITLE
Add tests and refine behaviour of registerSingleton

### DIFF
--- a/inject-groovy/src/test/groovy/io/micronaut/inject/constructor/ConstructorFactorySpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/constructor/ConstructorFactorySpec.groovy
@@ -32,8 +32,7 @@ class ConstructorFactorySpec extends Specification {
 
     void "test injection with constructor supplied by a provider"() {
         given:
-        BeanContext context = new DefaultBeanContext()
-        context.start()
+        BeanContext context = BeanContext.run()
 
         when:"A bean is obtained which has a constructor that depends on a bean provided by a provider"
         B b =  context.getBean(B)
@@ -44,7 +43,10 @@ class ConstructorFactorySpec extends Specification {
         b.a.c != null
         b.a.c2 != null
         b.a.d != null
-        b.a.is(context.getBean(AImpl))
+        b.a.is(context.getBean(A))
+
+        cleanup:
+        context.close()
     }
 
     static interface A {

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/field/FieldArrayFactorySpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/field/FieldArrayFactorySpec.groovy
@@ -31,8 +31,7 @@ class FieldArrayFactorySpec extends Specification {
 
     void "test injection with field supplied by a provider"() {
         given:
-        BeanContext context = new DefaultBeanContext()
-        context.start()
+        BeanContext context = BeanContext.run()
 
         when:"A bean is obtained which has a field that depends on a bean provided by a provider"
         B b =  context.getBean(B)
@@ -42,7 +41,10 @@ class FieldArrayFactorySpec extends Specification {
         b.all[0] instanceof AImpl
         b.all[0].c != null
         b.all[0].c2 != null
-        b.all[0].is(context.getBean(AImpl))
+        b.all[0].is(context.getBean(A))
+
+        cleanup:
+        context.close()
     }
 
     static interface A {

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/field/FieldFactorySpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/field/FieldFactorySpec.groovy
@@ -31,8 +31,7 @@ class FieldFactorySpec extends Specification {
 
     void "test injection with field supplied by a provider"() {
         given:
-        BeanContext context = new DefaultBeanContext()
-        context.start()
+        BeanContext context = BeanContext.run()
 
         when:"A bean is obtained which has a field that depends on a bean provided by a provider"
         B b =  context.getBean(B)
@@ -42,7 +41,10 @@ class FieldFactorySpec extends Specification {
         b.a instanceof AImpl
         b.a.c != null
         b.a.c2 != null
-        b.a.is(context.getBean(AImpl))
+        b.a.is(context.getBean(A))
+
+        cleanup:
+        context.close()
     }
 
     static interface A {

--- a/inject-java/src/test/groovy/io/micronaut/inject/constructor/factoryinjection/ConstructorFactorySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/constructor/factoryinjection/ConstructorFactorySpec.groovy
@@ -23,8 +23,7 @@ class ConstructorFactorySpec extends Specification {
 
     void "test injection with constructor supplied by a provider"() {
         given:
-        BeanContext context = new DefaultBeanContext()
-        context.start()
+        BeanContext context = BeanContext.run()
 
         when:"A bean is obtained which has a constructor that depends on a bean provided by a provider"
         B b =  context.getBean(B)
@@ -35,6 +34,9 @@ class ConstructorFactorySpec extends Specification {
         b.a.c != null
         b.a.c2 != null
         b.a.d != null
-        b.a.is(context.getBean(AImpl))
+        b.a.is(context.getBean(A))
+
+        cleanup:
+        context.close()
     }
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/context/RegisterSingletonSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/context/RegisterSingletonSpec.groovy
@@ -24,6 +24,8 @@ import jakarta.inject.Singleton
 import spock.lang.Issue
 import spock.lang.Specification
 
+import java.lang.reflect.Proxy
+
 class RegisterSingletonSpec extends Specification {
 
     void "test register singleton and exposed type"() {
@@ -38,13 +40,13 @@ class RegisterSingletonSpec extends Specification {
 
         then:
         def codecs = context.getBeansOfType(Codec)
-        codecs.size() == 5
+        codecs.size() == 6
         codecs.find { it in FooCodec }
         codecs.find { it in BarCodec }
         codecs.find { it in BazCodec }
         codecs.find { it in StuffCodec }
         codecs.find { it in OtherCodec }
-        !codecs.find { it in Closure }
+        codecs.find { it in Proxy }
         context.getBeansOfType(FooCodec).size() == 0 // not an exposed type, should this be correct?
         context.getBeansOfType(BarCodec).size() == 1 // BarCodec type is exposed
         context.findBean(FooCodec).isEmpty()

--- a/inject-java/src/test/groovy/io/micronaut/inject/context/RegisterSingletonSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/context/RegisterSingletonSpec.groovy
@@ -20,6 +20,7 @@ import io.micronaut.context.DefaultBeanContext
 import io.micronaut.context.RuntimeBeanDefinition
 import io.micronaut.context.annotation.Bean
 import io.micronaut.context.annotation.Type
+import io.micronaut.core.type.Argument
 import io.micronaut.inject.qualifiers.Qualifiers
 import jakarta.inject.Named
 import jakarta.inject.Singleton
@@ -29,6 +30,20 @@ import spock.lang.Specification
 import java.lang.reflect.Proxy
 
 class RegisterSingletonSpec extends Specification {
+
+    void "test register singleton with generic types"() {
+        given:
+        BeanContext context = BeanContext.run()
+
+        when:
+        context.registerSingleton(new TestReporter())
+
+        then:
+        context.containsBean(Argument.of(Reporter, Span))
+
+        cleanup:
+        context.close()
+    }
 
     void "test register singleton and exposed type"() {
         given:
@@ -147,4 +162,8 @@ class RegisterSingletonSpec extends Specification {
     @Singleton
     @Named("foo")
     static class ToBeReplacedCodec implements Codec {}
+
+    static interface Reporter<B> {}
+    static class Span {}
+    static class TestReporter implements Reporter<Span> {}
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/context/RegisterSingletonSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/context/RegisterSingletonSpec.groovy
@@ -21,6 +21,7 @@ import io.micronaut.context.RuntimeBeanDefinition
 import io.micronaut.context.annotation.Bean
 import io.micronaut.context.annotation.Type
 import io.micronaut.inject.qualifiers.Qualifiers
+import jakarta.inject.Named
 import jakarta.inject.Singleton
 import spock.lang.Issue
 import spock.lang.Specification
@@ -37,6 +38,7 @@ class RegisterSingletonSpec extends Specification {
         context.registerBeanDefinition(
                 RuntimeBeanDefinition.builder(Codec, ()-> new OverridingCodec())
                         .singleton(true)
+                        .qualifier(Qualifiers.byName("foo"))
                         .replaces(ToBeReplacedCodec)
                         .build()
         ) // replaces ToBeReplacedCodec
@@ -47,11 +49,12 @@ class RegisterSingletonSpec extends Specification {
 
         then:
         def codecs = context.getBeansOfType(Codec)
-        codecs.size() == 6
+        codecs.size() == 7
         codecs.find { it in FooCodec }
         codecs.find { it in BarCodec }
         codecs.find { it in BazCodec }
-        !codecs.find { it in OverridingCodec }
+        !codecs.find { it in ToBeReplacedCodec }
+        codecs.find { it in OverridingCodec }
         codecs.find { it in OtherCodec }
         codecs.find { it in StuffCodec }
         codecs.find { it in Proxy }
@@ -142,5 +145,6 @@ class RegisterSingletonSpec extends Specification {
     static class OtherCodec implements Codec {}
 
     @Singleton
+    @Named("foo")
     static class ToBeReplacedCodec implements Codec {}
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/context/RegisterSingletonSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/context/RegisterSingletonSpec.groovy
@@ -34,7 +34,7 @@ class RegisterSingletonSpec extends Specification {
 
         when:
         context.registerSingleton(Codec, {  } as Codec) // adds a new codec
-        context.registerSingleton(Codec, new FooCodec()) // overrides above codec since no qualifier
+        context.registerSingleton(Codec, new FooCodec()) // adds another codec
         context.registerSingleton(new BarCodec()) // should be registered with bean type BarCodec
         context.registerSingleton(Codec, new BazCodec(), Qualifiers.byName("baz"))
 
@@ -47,11 +47,12 @@ class RegisterSingletonSpec extends Specification {
         codecs.find { it in StuffCodec }
         codecs.find { it in OtherCodec }
         codecs.find { it in Proxy }
-        context.getBeansOfType(FooCodec).size() == 0 // not an exposed type, should this be correct?
+        codecs == context.getBeansOfType(Codec) // second resolve returns the same result
+        context.getBeansOfType(FooCodec).size() == 0 // not an exposed type
         context.getBeansOfType(BarCodec).size() == 1 // BarCodec type is exposed
-        context.findBean(FooCodec).isEmpty()
-        context.findBean(StuffCodec).isEmpty()
-        context.findBean(OtherCodec).isPresent()
+        context.findBean(FooCodec).isEmpty() // not an exposed type
+        context.findBean(StuffCodec).isEmpty() // not an exposed type
+        context.findBean(OtherCodec).isPresent() // an exposed type
 
         cleanup:
         context.close()

--- a/inject-java/src/test/groovy/io/micronaut/inject/field/arrayfactoryinjection/FieldArrayFactorySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/field/arrayfactoryinjection/FieldArrayFactorySpec.groovy
@@ -35,7 +35,7 @@ class FieldArrayFactorySpec extends Specification {
         b.all[0] instanceof AImpl
         ((AImpl)b.all[0]).c != null
         ((AImpl)b.all[0]).c2 != null
-        b.all[0].is(context.getBean(AImpl))
+        b.all[0].is(context.getBean(A))
     }
 }
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/field/factoryinjection/FieldFactorySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/field/factoryinjection/FieldFactorySpec.groovy
@@ -25,8 +25,7 @@ class FieldFactorySpec extends Specification {
 
     void "test injection with field supplied by a provider"() {
         given:
-        BeanContext context = new DefaultBeanContext()
-        context.start()
+        BeanContext context = BeanContext.run()
 
         when:"A bean is obtained which has a field that depends on a bean provided by a provider"
         B b =  context.getBean(B)
@@ -36,7 +35,10 @@ class FieldFactorySpec extends Specification {
         b.a instanceof AImpl
         b.a.c != null
         b.a.c2 != null
-        b.a.is(context.getBean(AImpl))
+        b.a.is(context.getBean(A))
+
+        cleanup:
+        context.close()
     }
 
 

--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
@@ -255,7 +255,13 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
                         .qualifier(PrimaryQualifier.INSTANCE);
 
         //noinspection resource
-        registerBeanDefinition(definition.build());
+
+        RuntimeBeanDefinition<? extends Environment> beanDefinition = definition.build();
+        BeanDefinition<? extends Environment> existing = findBeanDefinition(beanDefinition.getBeanType()).orElse(null);
+        if (existing instanceof RuntimeBeanDefinition<?> runtimeBeanDefinition) {
+            removeBeanDefinition(runtimeBeanDefinition);
+        }
+        registerBeanDefinition(beanDefinition);
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -730,7 +730,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
         BeanDefinition<T> beanDefinition;
         if (inject && running.get()) {
             // Bean cannot be injected before the start of the context
-            beanDefinition = findBeanDefinition(type, qualifier).orElse(null);
+            beanDefinition = findConcreteCandidate(null, Argument.of(type), qualifier, false).orElse(null);
             if (beanDefinition == null) {
                 // Purge cache miss
                 purgeCacheForBeanInstance(singleton);

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1663,19 +1663,6 @@ public class DefaultBeanContext implements InitializableBeanContext {
     @NonNull
     public <B> BeanContext registerBeanDefinition(@NonNull RuntimeBeanDefinition<B> definition) {
         Objects.requireNonNull(definition, "Bean definition cannot be null");
-        BeanDefinition<B> existing = findBeanDefinition(definition.getGenericBeanType(), definition.getDeclaredQualifier()).orElse(null);
-        if (existing instanceof RuntimeBeanDefinition<B> runtimeBeanDefinition) {
-            this.beanDefinitionsClasses.remove(runtimeBeanDefinition);
-        }
-        for (Class<?> indexedType : indexedTypes) {
-            if (definition.isCandidateBean(Argument.of(indexedType))) {
-                Collection<BeanDefinitionReference> index = resolveTypeIndex(indexedType);
-                if (existing instanceof RuntimeBeanDefinition<B> runtimeBeanDefinition) {
-                    index.remove(runtimeBeanDefinition);
-                }
-                index.add(definition);
-            }
-        }
         this.beanDefinitionsClasses.add(definition);
         Class<B> beanType = definition.getBeanType();
         purgeCacheForBeanType(beanType);

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1677,6 +1677,17 @@ public class DefaultBeanContext implements InitializableBeanContext {
     }
 
     /**
+     * The definition to remove.
+     * @param definition The definitino to remove
+     * @param <B> The bean type
+     */
+    @Internal
+    <B> void removeBeanDefinition(RuntimeBeanDefinition<B> definition) {
+        this.beanDefinitionsClasses.remove(definition);
+        purgeCacheForBeanType(definition.getBeanType());
+    }
+
+    /**
      * Get a bean of the given type.
      *
      * @param resolutionContext The bean context resolution

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -758,14 +758,6 @@ public class DefaultBeanContext implements InitializableBeanContext {
             );
             singletonScope.registerSingletonBean(registration, qualifier);
             registerBeanDefinition(runtimeBeanDefinition);
-
-            for (Class<?> indexedType : indexedTypes) {
-                if (indexedType == type || indexedType.isAssignableFrom(type)) {
-                    final Collection<BeanDefinitionReference> indexed = resolveTypeIndex(indexedType);
-                    indexed.add(runtimeBeanDefinition);
-                    break;
-                }
-            }
         }
         return this;
     }
@@ -1663,8 +1655,15 @@ public class DefaultBeanContext implements InitializableBeanContext {
     @NonNull
     public <B> BeanContext registerBeanDefinition(@NonNull RuntimeBeanDefinition<B> definition) {
         Objects.requireNonNull(definition, "Bean definition cannot be null");
-        this.beanDefinitionsClasses.add(definition);
         Class<B> beanType = definition.getBeanType();
+        this.beanDefinitionsClasses.add(definition);
+        for (Class<?> indexedType : indexedTypes) {
+            if (indexedType == beanType || indexedType.isAssignableFrom(beanType)) {
+                final Collection<BeanDefinitionReference> indexed = resolveTypeIndex(indexedType);
+                indexed.add(definition);
+                break;
+            }
+        }
         purgeCacheForBeanType(beanType);
         return this;
     }
@@ -1683,6 +1682,14 @@ public class DefaultBeanContext implements InitializableBeanContext {
      */
     @Internal
     <B> void removeBeanDefinition(RuntimeBeanDefinition<B> definition) {
+        Class<B> beanType = definition.getBeanType();
+        for (Class<?> indexedType : indexedTypes) {
+            if (indexedType == beanType || indexedType.isAssignableFrom(beanType)) {
+                final Collection<BeanDefinitionReference> indexed = resolveTypeIndex(indexedType);
+                indexed.remove(definition);
+                break;
+            }
+        }
         this.beanDefinitionsClasses.remove(definition);
         purgeCacheForBeanType(definition.getBeanType());
     }

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1677,7 +1677,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
 
     /**
      * The definition to remove.
-     * @param definition The definitino to remove
+     * @param definition The definition to remove
      * @param <B> The bean type
      */
     @Internal

--- a/inject/src/main/java/io/micronaut/context/DefaultRuntimeBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultRuntimeBeanDefinition.java
@@ -62,7 +62,7 @@ final class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextCondition
     private final boolean isSingleton;
     private final Class<? extends Annotation> scope;
     private final Class<?>[] exposedTypes;
-    private final Map<Class<?>, List<Argument<?>>> typeArguments;
+    private Map<Class<?>, List<Argument<?>>> typeArguments;
 
     DefaultRuntimeBeanDefinition(
         @NonNull Argument<T> beanType,
@@ -98,7 +98,14 @@ final class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextCondition
                 return args;
             }
         }
-        return RuntimeBeanDefinition.super.getTypeArguments(type);
+        List<Argument<?>> list = RuntimeBeanDefinition.super.getTypeArguments(type);
+        if (CollectionUtils.isNotEmpty(list)) {
+            synchronized (this.beanType) {
+                typeArguments = new HashMap<>(3);
+                typeArguments.put(type, list);
+            }
+        }
+        return list;
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/context/DefaultRuntimeBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultRuntimeBeanDefinition.java
@@ -34,6 +34,7 @@ import io.micronaut.inject.qualifiers.TypeArgumentQualifier;
 
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -89,23 +90,30 @@ final class DefaultRuntimeBeanDefinition<T> extends AbstractBeanContextCondition
 
     @Override
     public List<Argument<?>> getTypeArguments(Class<?> type) {
-        if (type == getBeanType()) {
+        Class<T> bt = getBeanType();
+        if (type == bt) {
             return getTypeArguments();
         }
-        if (typeArguments != null) {
-            List<Argument<?>> args = typeArguments.get(type);
-            if (args != null) {
-                return args;
+        if (type != null && type.isAssignableFrom(bt)) {
+            if (typeArguments != null) {
+                List<Argument<?>> args = typeArguments.get(type);
+                if (args != null) {
+                    return args;
+                }
             }
-        }
-        List<Argument<?>> list = RuntimeBeanDefinition.super.getTypeArguments(type);
-        if (CollectionUtils.isNotEmpty(list)) {
-            synchronized (this.beanType) {
-                typeArguments = new HashMap<>(3);
+            List<Argument<?>> list = RuntimeBeanDefinition.super.getTypeArguments(type);
+            if (CollectionUtils.isNotEmpty(list)) {
+                if (typeArguments == null) {
+                    synchronized (this.beanType) {
+                        typeArguments = new LinkedHashMap<>(3);
+                    }
+                }
                 typeArguments.put(type, list);
             }
+            return list;
+        } else {
+            return Collections.emptyList();
         }
-        return list;
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/context/RuntimeBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/RuntimeBeanDefinition.java
@@ -185,7 +185,17 @@ public interface RuntimeBeanDefinition<T> extends BeanDefinitionReference<T>, Be
          * @param qualifier The qualifier
          * @return This builder
          */
+        @NonNull
         Builder<B> qualifier(@Nullable Qualifier<B> qualifier);
+
+        /**
+         * Adds this type as a bean replacement of the given type.
+         * @param otherType The other type
+         * @return This bean builder
+         * @since 4.0.0
+         */
+        @NonNull
+        Builder<B> replaces(@Nullable Class<? extends B> otherType);
 
         /**
          * The qualifier to use.
@@ -193,6 +203,7 @@ public interface RuntimeBeanDefinition<T> extends BeanDefinitionReference<T>, Be
          * @return This builder
          * @since 3.7.0
          */
+        @NonNull
         default Builder<B> named(@Nullable String name) {
             if (name == null) {
                 qualifier(null);
@@ -207,6 +218,7 @@ public interface RuntimeBeanDefinition<T> extends BeanDefinitionReference<T>, Be
          * @param scope The scope
          * @return This builder
          */
+        @NonNull
         Builder<B> scope(@Nullable Class<? extends Annotation> scope);
 
         /**
@@ -214,6 +226,7 @@ public interface RuntimeBeanDefinition<T> extends BeanDefinitionReference<T>, Be
          * @param isSingleton True if it is singleton
          * @return This builder
          */
+        @NonNull
         Builder<B> singleton(boolean isSingleton);
 
         /**
@@ -221,6 +234,7 @@ public interface RuntimeBeanDefinition<T> extends BeanDefinitionReference<T>, Be
          * @param types The exposed types
          * @return This builder
          */
+        @NonNull
         Builder<B> exposedTypes(Class<?>...types);
 
         /**
@@ -228,6 +242,7 @@ public interface RuntimeBeanDefinition<T> extends BeanDefinitionReference<T>, Be
          * @param arguments The arguments
          * @return This builder
          */
+        @NonNull
         Builder<B> typeArguments(Argument<?>... arguments);
 
         /**
@@ -236,6 +251,7 @@ public interface RuntimeBeanDefinition<T> extends BeanDefinitionReference<T>, Be
          * @param arguments The arguments
          * @return This builder
          */
+        @NonNull
         Builder<B> typeArguments(Class<?> implementedType, Argument<?>... arguments);
 
         /**
@@ -243,6 +259,7 @@ public interface RuntimeBeanDefinition<T> extends BeanDefinitionReference<T>, Be
          * @param annotationMetadata The annotation metadata
          * @return This builder
          */
+        @NonNull
         Builder<B> annotationMetadata(@Nullable AnnotationMetadata annotationMetadata);
 
         /**

--- a/inject/src/main/java/io/micronaut/context/SingletonScope.java
+++ b/inject/src/main/java/io/micronaut/context/SingletonScope.java
@@ -112,13 +112,6 @@ final class SingletonScope {
             DefaultBeanContext.BeanKey<T> beanKey = new DefaultBeanContext.BeanKey<>(beanDefinition, beanDefinition.getDeclaredQualifier());
             singletonByArgumentAndQualifier.put(beanKey, registration);
         }
-        if (registration.bean != null && registration.bean.getClass() != beanDefinition.getBeanType()) {
-            // If the actual type differs, allow to inject the actual implementation for cases like:
-            // `MyInterface factoryBean() { new Impl.. }`
-            // This might be something to remove in 4.0
-            DefaultBeanContext.BeanKey<T> concrete = new DefaultBeanContext.BeanKey<>((Class<T>) registration.bean.getClass(), qualifier);
-            singletonByArgumentAndQualifier.put(concrete, registration);
-        }
         return registration;
     }
 

--- a/inject/src/main/java/io/micronaut/context/SingletonScope.java
+++ b/inject/src/main/java/io/micronaut/context/SingletonScope.java
@@ -390,17 +390,12 @@ final class SingletonScope {
             if (beanDefinition.getBeanType() != that.beanDefinition.getBeanType()) {
                 return false;
             }
-            Qualifier<?> qualifier = beanDefinition.getDeclaredQualifier();
-            Qualifier<?> thatQualifier = that.beanDefinition.getDeclaredQualifier();
-            if (qualifier == thatQualifier) {
-                return true;
-            }
-            return qualifier != null && qualifier.equals(thatQualifier);
+            return beanDefinition.getBeanDefinitionName().equals(that.beanDefinition.getBeanDefinitionName());
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(beanDefinition.getBeanType(), beanDefinition.getDeclaredQualifier());
+            return Objects.hash(beanDefinition.getBeanDefinitionName());
         }
     }
 

--- a/runtime/src/test/groovy/io/micronaut/runtime/executor/ExecutorServiceConfigSpec.groovy
+++ b/runtime/src/test/groovy/io/micronaut/runtime/executor/ExecutorServiceConfigSpec.groovy
@@ -58,7 +58,7 @@ class ExecutorServiceConfigSpec extends Specification {
         executorServices.size() == expectedExecutorCount
 
         when:
-        ThreadPoolExecutor poolExecutor = ctx.getBean(ThreadPoolExecutor, Qualifiers.byName("one"))
+        ThreadPoolExecutor poolExecutor = (ThreadPoolExecutor) ctx.getBean(ExecutorService, Qualifiers.byName("one"))
         ExecutorService forkJoinPool = ctx.getBean(ExecutorService, Qualifiers.byName("two"))
 
         then:
@@ -111,7 +111,7 @@ class ExecutorServiceConfigSpec extends Specification {
 
         when:
         Collection<ExecutorService> executorServices = ctx.getBeansOfType(ExecutorService.class)
-        ThreadPoolExecutor poolExecutor = ctx.getBean(ThreadPoolExecutor, Qualifiers.byName("one"))
+        ThreadPoolExecutor poolExecutor = (ThreadPoolExecutor) ctx.getBean(ExecutorService, Qualifiers.byName("one"))
         ExecutorService forkJoinPool = ctx.getBean(ExecutorService, Qualifiers.byName("two"))
 
         then:

--- a/src/main/docs/guide/appendix/breaks.adoc
+++ b/src/main/docs/guide/appendix/breaks.adoc
@@ -13,6 +13,23 @@ The `micronaut-runtime` module has been split into separate modules depending on
 
 In addition, since `micronaut-retry` is now optional declarative clients annotated with ann:http.client.annotation.Client[] no longer invoke fallbacks by default. To restore the previous behaviour add `micronaut-retry` to your classpath and annotate any declarative clients with ann:retry.annotation.Recoverable[].
 
+==== Calling `registerSingleton(bean)` no longer overrides existing beans
+
+If you call `registerSingleton(bean)` on the api:context.BeanContext[] this will no longer override existing beans if the type and qualifier match, instead two beans will now exist which may lead to a api:context.exceptions.NonUniqueBeanException[].
+
+If you require replacing an existing bean you must formalize the replacement using the api:context.RuntimeBeanDefinition[] API, for example:
+
+[source,java]
+----
+context.registerBeanDefinition(
+    RuntimeBeanDefinition.builder(Codec.class, ()-> new OverridingCodec())
+            .singleton(true)
+            // the type of the bean to replace
+            .replaces(ToBeReplacedCodec.class)
+            .build()
+);
+----
+
 ==== WebSocket No Longer Required
 
 The `micronaut-websocket` API is no longer a required dependency of the HTTP server. If you are using annotations such as ann:websocket.annotation.ServerWebSocket[] you should add the `micronaut-websocket` dependency to your application classpath:


### PR DESCRIPTION
There are a number of inconsistencies with `registerSingleton`. Currently the following problems exist:

* Calling `registerSingleton` when the bean type and qualifier match an existing bean type and qualifier doesn't override the bean (it does in Micronaut 3.x but probably shouldn't)
* Calling `registerSingleton` twice consecutively overrides the previously defined bean if the type and qualifier match
* If the registered type and the type of the instance differ (say `Foo` as the bean type but `FooImpl` for the implementation) then `getBeansOfType(Foo.class)` correctly contains the bean and `getBeansOfType(FooImpl.class)` correctly doesn't contain the bean. However the bean can be incorrectly located by `findBean(FooImpl.class)`

This PR tries to address these issues in the following ways:

* Calling `registerSingleton` always adds a new bean and never overrides
* If you want to use `registerSingleton` for bean replacement then you must call `replaces(TypeToReplace)` using the `RuntimeBeanDefinition` API thus formalizing the way to replace a bean.
* Beans that are registered with a particular type (`Foo`) and a particular impl (`FooImpl`) cannot be located by either `getBeansOfType(FooImpl)` or any bean lookup methods like `getBean`, `findBean` etc.
* Also improves handling of runtime beans with generics