### PR TITLE
refactor: Extract http headers utils

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -34,7 +34,6 @@ import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
-import io.micronaut.core.util.SupplierUtil;
 import io.micronaut.http.HttpAttributes;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpResponseWrapper;
@@ -90,6 +89,7 @@ import io.micronaut.http.netty.stream.StreamedHttpResponse;
 import io.micronaut.http.sse.Event;
 import io.micronaut.http.uri.UriBuilder;
 import io.micronaut.http.uri.UriTemplate;
+import io.micronaut.http.util.HttpHeadersUtil;
 import io.micronaut.jackson.databind.JacksonDatabindMapper;
 import io.micronaut.json.JsonMapper;
 import io.micronaut.json.codec.JsonMediaTypeCodec;
@@ -183,9 +183,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
 import static io.micronaut.scheduling.instrument.InvocationInstrumenter.NOOP;
 
 /**
@@ -211,9 +209,6 @@ public class DefaultHttpClient implements
     private static final int DEFAULT_HTTP_PORT = 80;
     private static final int DEFAULT_HTTPS_PORT = 443;
 
-    private static final Supplier<Pattern> HEADER_MASK_PATTERNS = SupplierUtil.memoized(() ->
-        Pattern.compile(".*(password|cred|cert|key|secret|token|auth|signat).*", Pattern.CASE_INSENSITIVE)
-    );
     /**
      * Which headers <i>not</i> to copy from the first request when redirecting to a second request. There doesn't
      * appear to be a spec for this. {@link java.net.HttpURLConnection} seems to drop all headers, but that would be a
@@ -1754,7 +1749,7 @@ public class DefaultHttpClient implements
 
     private void traceRequest(io.micronaut.http.HttpRequest<?> request, io.netty.handler.codec.http.HttpRequest nettyRequest) {
         HttpHeaders headers = nettyRequest.headers();
-        traceHeaders(headers);
+        HttpHeadersUtil.trace(log, headers.names(), headers::getAll);
         if (io.micronaut.http.HttpMethod.permitsRequestBody(request.getMethod()) && request.getBody().isPresent() && nettyRequest instanceof FullHttpRequest) {
             FullHttpRequest fullHttpRequest = (FullHttpRequest) nettyRequest;
             ByteBuf content = fullHttpRequest.content();
@@ -1776,30 +1771,6 @@ public class DefaultHttpClient implements
         log.trace("----");
         log.trace(content.toString(defaultCharset));
         log.trace("----");
-    }
-
-    private void traceHeaders(HttpHeaders headers) {
-        for (String name : headers.names()) {
-            boolean isMasked = HEADER_MASK_PATTERNS.get().matcher(name).matches();
-            List<String> all = headers.getAll(name);
-            if (all.size() > 1) {
-                for (String value : all) {
-                    String maskedValue = isMasked ? mask(value) : value;
-                    log.trace("{}: {}", name, maskedValue);
-                }
-            } else if (!all.isEmpty()) {
-                String maskedValue = isMasked ? mask(all.get(0)) : all.get(0);
-                log.trace("{}: {}", name, maskedValue);
-            }
-        }
-    }
-
-    @Nullable
-    private String mask(@Nullable String value) {
-        if (value == null) {
-            return null;
-        }
-        return "*MASKED*";
     }
 
     private static MediaTypeCodecRegistry createDefaultMediaTypeRegistry() {
@@ -2116,7 +2087,7 @@ public class DefaultHttpClient implements
             HttpHeaders headers = msg.headers();
             if (log.isTraceEnabled()) {
                 log.trace("HTTP Client Response Received ({}) for Request: {} {}", msg.status(), finalRequest.getMethodName(), finalRequest.getUri());
-                traceHeaders(headers);
+                HttpHeadersUtil.trace(log, headers.names(), headers::getAll);
             }
             buildResponse(responsePromise, msg, httpStatus);
         }

--- a/http-client/src/test/groovy/io/micronaut/http/client/netty/DefaultClientHeaderMaskTest.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/netty/DefaultClientHeaderMaskTest.groovy
@@ -43,22 +43,17 @@ class DefaultClientHeaderMaskTest extends Specification {
         logger.setLevel(Level.TRACE)
         appender.start()
 
-        DefaultHttpHeaders httpHeaders = new DefaultHttpHeaders()
-        httpHeaders.add("Authorization", "Bearer foo")
-        httpHeaders.add("Proxy-Authorization", "AWS4-HMAC-SHA256 bar")
-        httpHeaders.add("Cookie", "baz")
-        httpHeaders.add("Set-Cookie", "qux")
-        httpHeaders.add("X-Forwarded-For", "quux")
-        httpHeaders.add("X-Forwarded-Host", "quuz")
-        httpHeaders.add("X-Real-IP", "waldo")
-        httpHeaders.add("X-Forwarded-For", "fred")
-        httpHeaders.add("Credential", "foo")
-        httpHeaders.add("Signature", "bar probably secret")
-
         def response = client.toBlocking().exchange(HttpRequest.GET("/masking").headers {headers ->
-            httpHeaders.each { entry ->
-                headers.add(entry.key, entry.value)
-            }
+            headers.add("Authorization", "Bearer foo")
+            headers.add("Proxy-Authorization", "AWS4-HMAC-SHA256 bar")
+            headers.add("Cookie", "baz")
+            headers.add("Set-Cookie", "qux")
+            headers.add("X-Forwarded-For", "quux")
+            headers.add("X-Forwarded-Host", "quuz")
+            headers.add("X-Real-IP", "waldo")
+            headers.add("X-Forwarded-For", "fred")
+            headers.add("Credential", "foo")
+            headers.add("Signature", "bar probably secret")
         }, String)
 
         then:

--- a/http-client/src/test/groovy/io/micronaut/http/client/netty/DefaultClientHeaderMaskTest.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/netty/DefaultClientHeaderMaskTest.groovy
@@ -1,10 +1,11 @@
 package io.micronaut.http.client.netty
 
 import ch.qos.logback.classic.Level
+import io.micronaut.context.ApplicationContext
+import io.micronaut.http.client.HttpClient
 import org.slf4j.Logger
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.AppenderBase
-import io.micronaut.http.util.HttpHeadersUtil
 import io.netty.handler.codec.http.DefaultHttpHeaders
 import org.slf4j.LoggerFactory
 import spock.lang.Specification
@@ -16,10 +17,17 @@ class DefaultClientHeaderMaskTest extends Specification {
 
     def "check mask detects common security headers"() {
         given:
+        ApplicationContext ctx = ApplicationContext.run()
+        HttpClient client = ctx.createBean(HttpClient, "http://localhost:8080")
+
+        expect:
+        client instanceof DefaultHttpClient
+
+        when:
         MemoryAppender appender = new MemoryAppender()
         Logger log = LoggerFactory.getLogger(DefaultHttpClient.class)
 
-        expect:
+        then:
         log instanceof ch.qos.logback.classic.Logger
 
         when:
@@ -28,22 +36,26 @@ class DefaultClientHeaderMaskTest extends Specification {
         logger.setLevel(Level.TRACE)
         appender.start()
 
-        DefaultHttpHeaders headers = new DefaultHttpHeaders()
-        headers.add("Authorization", "Bearer foo")
-        headers.add("Proxy-Authorization", "AWS4-HMAC-SHA256 bar")
-        headers.add("Cookie", "baz")
-        headers.add("Set-Cookie", "qux")
-        headers.add("X-Forwarded-For", "quux")
-        headers.add("X-Forwarded-Host", "quuz")
-        headers.add("X-Real-IP", "waldo")
-        headers.add("X-Forwarded-For", "fred")
-        headers.add("Credential", "foo")
-        headers.add("Signature", "bar probably secret")
+        DefaultHttpHeaders httpHeaders = new DefaultHttpHeaders()
+        httpHeaders.add("Authorization", "Bearer foo")
+        httpHeaders.add("Proxy-Authorization", "AWS4-HMAC-SHA256 bar")
+        httpHeaders.add("Cookie", "baz")
+        httpHeaders.add("Set-Cookie", "qux")
+        httpHeaders.add("X-Forwarded-For", "quux")
+        httpHeaders.add("X-Forwarded-Host", "quuz")
+        httpHeaders.add("X-Real-IP", "waldo")
+        httpHeaders.add("X-Forwarded-For", "fred")
+        httpHeaders.add("Credential", "foo")
+        httpHeaders.add("Signature", "bar probably secret")
 
-        HttpHeadersUtil.trace(log, headers.names(), headers::getAll)
+        def request = Mock(io.micronaut.http.HttpRequest)
+        def nettyRequest = Stub(io.netty.handler.codec.http.HttpRequest) {
+            headers() >> httpHeaders
+        }
+        ((io.micronaut.http.client.netty.DefaultHttpClient) client).traceRequest(request, nettyRequest)
 
         then:
-        appender.events.size() == headers.size()
+        appender.events.size() == httpHeaders.size()
         appender.events.join("\n") == """Authorization: *MASKED*
             |Proxy-Authorization: *MASKED*
             |Cookie: baz
@@ -57,6 +69,7 @@ class DefaultClientHeaderMaskTest extends Specification {
 
         cleanup:
         appender.stop()
+        ctx.close()
     }
 
     static class MemoryAppender extends AppenderBase<ILoggingEvent> {

--- a/http/build.gradle
+++ b/http/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     testAnnotationProcessor project(":inject-java")
     testImplementation project(":inject")
     testImplementation project(":runtime")
+    testImplementation(libs.managed.logback)
 }
 
 tasks.named("compileKotlin") {

--- a/http/src/main/java/io/micronaut/http/util/HttpHeadersUtil.java
+++ b/http/src/main/java/io/micronaut/http/util/HttpHeadersUtil.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.util;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.util.SupplierUtil;
+import io.micronaut.http.HttpHeaders;
+import org.slf4j.Logger;
+
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+
+/**
+ * Utility class to work with {@link io.micronaut.http.HttpHeaders} or HTTP Headers.
+ * @author Sergio del Amo
+ * @since 3.8.0
+ */
+public final class HttpHeadersUtil {
+    private static final Supplier<Pattern> HEADER_MASK_PATTERNS = SupplierUtil.memoized(() ->
+        Pattern.compile(".*(password|cred|cert|key|secret|token|auth|signat).*", Pattern.CASE_INSENSITIVE)
+    );
+
+    private HttpHeadersUtil() {
+
+    }
+
+    /**
+     * Trace HTTP Headers.
+     * @param log Logger
+     * @param httpHeaders HTTP Headers
+     */
+    public static void trace(@NonNull Logger log,
+                             @NonNull HttpHeaders httpHeaders) {
+        trace(log, httpHeaders.names(), httpHeaders::getAll);
+    }
+
+    /**
+     * Trace HTTP Headers.
+     * @param log Logger
+     * @param names HTTP Header names
+     * @param getAllHeaders Function to get all the header values for a particular header name
+     */
+    public static void trace(@NonNull Logger log,
+                             @NonNull Set<String> names,
+                             @NonNull Function<String, List<String>> getAllHeaders) {
+        names.forEach(name -> trace(log, name, getAllHeaders));
+    }
+
+    /**
+     * Trace HTTP Headers.
+     * @param log Logger
+     * @param name HTTP Header name
+     * @param getAllHeaders Function to get all the header values for a particular header name
+     */
+    public static void trace(@NonNull Logger log,
+                             @NonNull String name,
+                             @NonNull Function<String, List<String>> getAllHeaders) {
+        boolean isMasked = HEADER_MASK_PATTERNS.get().matcher(name).matches();
+        List<String> all = getAllHeaders.apply(name);
+        if (all.size() > 1) {
+            for (String value : all) {
+                String maskedValue = isMasked ? mask(value) : value;
+                log.trace("{}: {}", name, maskedValue);
+            }
+        } else if (!all.isEmpty()) {
+            String maskedValue = isMasked ? mask(all.get(0)) : all.get(0);
+            log.trace("{}: {}", name, maskedValue);
+        }
+    }
+
+    @Nullable
+    private static String mask(@Nullable String value) {
+        if (value == null) {
+            return null;
+        }
+        return "*MASKED*";
+    }
+}

--- a/http/src/test/groovy/io/micronaut/http/util/HttpHeadersUtilSpec.groovy
+++ b/http/src/test/groovy/io/micronaut/http/util/HttpHeadersUtilSpec.groovy
@@ -1,0 +1,78 @@
+package io.micronaut.http.util
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.AppenderBase
+import io.micronaut.http.HttpHeaders
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import spock.lang.Specification
+
+import java.util.concurrent.BlockingQueue
+import java.util.concurrent.LinkedBlockingQueue
+
+class HttpHeadersUtilSpec extends Specification {
+    def "check masking works for #value"() {
+        expect:
+        expected == HttpHeadersUtil.mask(value)
+
+        where:
+        value       | expected
+        null        | null
+        "foo"       | "*MASKED*"
+        "Tim Yates" | "*MASKED*"
+    }
+
+    def "check mask detects common security headers"() {
+        given:
+        MemoryAppender appender = new MemoryAppender()
+        Logger log = LoggerFactory.getLogger(HttpHeadersUtilSpec.class)
+
+        expect:
+        log instanceof ch.qos.logback.classic.Logger
+
+        when:
+        ch.qos.logback.classic.Logger logger = (ch.qos.logback.classic.Logger) log
+        logger.addAppender(appender)
+        logger.setLevel(Level.TRACE)
+        appender.start()
+
+        HttpHeaders headers = new MockHttpHeaders([
+                "Authorization": ["Bearer foo"],
+                "Proxy-Authorization": ["AWS4-HMAC-SHA256 bar"],
+                "Cookie": ["baz"],
+                "Set-Cookie": ["qux"],
+                "X-Forwarded-For": ["quux", "fred"],
+                "X-Forwarded-Host": ["quuz"],
+                "X-Real-IP": ["waldo"],
+                "Credential": ["foo"],
+                "Signature": ["bar probably secret"]])
+
+        HttpHeadersUtil.trace(log, headers)
+
+        then:
+        appender.events.size() == headers.values().collect { it -> it.size() }.sum()
+        appender.events.contains("Authorization: *MASKED*")
+        appender.events.contains("Cookie: baz")
+        appender.events.contains("Credential: *MASKED*")
+        appender.events.contains("Set-Cookie: qux")
+        appender.events.contains("Proxy-Authorization: *MASKED*")
+        appender.events.contains("Signature: *MASKED*")
+        appender.events.contains("X-Forwarded-For: quux")
+        appender.events.contains("X-Forwarded-For: fred")
+        appender.events.contains("X-Forwarded-Host: quuz")
+        appender.events.contains("X-Real-IP: waldo")
+
+        cleanup:
+        appender.stop()
+    }
+
+    static class MemoryAppender extends AppenderBase<ILoggingEvent> {
+        final BlockingQueue<String> events = new LinkedBlockingQueue<>()
+
+        @Override
+        protected void append(ILoggingEvent e) {
+            events.add(e.formattedMessage)
+        }
+    }
+}

--- a/http/src/test/groovy/io/micronaut/http/util/MockHttpHeaders.java
+++ b/http/src/test/groovy/io/micronaut/http/util/MockHttpHeaders.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.util;
+
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.convert.ArgumentConversionContext;
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.http.MutableHttpHeaders;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class MockHttpHeaders implements MutableHttpHeaders {
+
+    private final Map<CharSequence, List<String>> headers;
+
+    public MockHttpHeaders(Map<CharSequence, List<String>> headers) {
+        this.headers = headers;
+    }
+
+    @Override
+    public MutableHttpHeaders add(CharSequence header, CharSequence value) {
+        headers.compute(header, (key, val) -> {
+            if (val == null) {
+                val = new ArrayList<>();
+            }
+            val.add(value.toString());
+            return val;
+        });
+        return this;
+    }
+
+    @Override
+    public MutableHttpHeaders remove(CharSequence header) {
+        headers.remove(header);
+        return this;
+    }
+
+    @Override
+    public List<String> getAll(CharSequence name) {
+        List<String> values = headers.get(name);
+        if (values == null) {
+            return Collections.emptyList();
+        } else {
+            return values;
+        }
+    }
+
+    @Nullable
+    @Override
+    public String get(CharSequence name) {
+        List<String> values = headers.get(name);
+        if (values == null || values.isEmpty()) {
+            return null;
+        } else {
+            return values.get(0);
+        }
+    }
+
+    @Override
+    public Set<String> names() {
+        return headers.keySet().stream().map(CharSequence::toString).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Collection<List<String>> values() {
+        return headers.values();
+    }
+
+    @Override
+    public <T> Optional<T> get(CharSequence name, ArgumentConversionContext<T> conversionContext) {
+        return ConversionService.SHARED.convert(get(name), conversionContext);
+    }
+}


### PR DESCRIPTION
This PR extracts the HTTP Header logging utility with masking to its own util class. Thus, allowing us, or the framework users, to use it in other places.