### PR TITLE
Update upgrade documentation

### DIFF
--- a/src/main/docs/guide/introduction/upgrading.adoc
+++ b/src/main/docs/guide/introduction/upgrading.adoc
@@ -109,9 +109,9 @@ If you use Maven, update the parent POM version and `micronaut.version` property
 
 === Build Plugin Update
 
-If you use the Micronaut Gradle plugin, update the version to `2.0.3`
+If you use the Micronaut Gradle plugin, update the version to `3.6.3`
 
-`id("io.micronaut.application") version "2.0.3"`
+`id("io.micronaut.application") version "3.6.3"`
 
 For Maven users the plugin version is updated automatically when you update the Micronaut version.
 

--- a/src/main/docs/guide/introduction/upgrading.adoc
+++ b/src/main/docs/guide/introduction/upgrading.adoc
@@ -109,7 +109,7 @@ If you use Maven, update the parent POM version and `micronaut.version` property
 
 === Build Plugin Update
 
-If you use the [Micronaut Gradle plugin](https://micronaut-projects.github.io/micronaut-gradle-plugin/latest/) update to the [latest version](https://github.com/micronaut-projects/micronaut-gradle-plugin/releases/latest).
+If you use the https://micronaut-projects.github.io/micronaut-gradle-plugin/latest/[Micronaut Gradle plugin] update to the https://github.com/micronaut-projects/micronaut-gradle-plugin/releases/latest[latest version].
 
 For Maven users the plugin version is updated automatically when you update the Micronaut version.
 

--- a/src/main/docs/guide/introduction/upgrading.adoc
+++ b/src/main/docs/guide/introduction/upgrading.adoc
@@ -109,9 +109,7 @@ If you use Maven, update the parent POM version and `micronaut.version` property
 
 === Build Plugin Update
 
-If you use the Micronaut Gradle plugin, update the version to `3.6.3`
-
-`id("io.micronaut.application") version "3.6.3"`
+If you use the [Micronaut Gradle plugin](https://micronaut-projects.github.io/micronaut-gradle-plugin/latest/) update to the [latest version](https://github.com/micronaut-projects/micronaut-gradle-plugin/releases/latest).
 
 For Maven users the plugin version is updated automatically when you update the Micronaut version.
 


### PR DESCRIPTION
The gradle plugin version does not match the required version for the project to be configured properly. Correcting the version to the one that is shown in the public launch.micronaut website. A screenshot is attached for reference

![image](https://user-images.githubusercontent.com/3684197/207393676-4cb036d7-b64d-4e96-9428-6518854f3e1c.png)

