### PR TITLE
Allow context annotations at build time

### DIFF
--- a/inject/src/main/resources/META-INF/native-image/io.micronaut/micronaut-inject/native-image.properties
+++ b/inject/src/main/resources/META-INF/native-image/io.micronaut/micronaut-inject/native-image.properties
@@ -15,6 +15,7 @@
 #
 
 Args = -H:EnableURLProtocols=http,https \
+       --initialize-at-build-time=io.micronaut.context.annotation \
        --initialize-at-build-time=io.micronaut.inject.annotation \
        --initialize-at-build-time=io.micronaut.runtime.converters.time \
        --initialize-at-run-time=io.micronaut.context.env.CachedEnvironment


### PR DESCRIPTION
Otherwise we get failures with Primary when compiled under Graal