### PR TITLE
log: remove failed from healthStatus logging

### DIFF
--- a/management/src/main/java/io/micronaut/management/health/monitor/HealthMonitorTask.java
+++ b/management/src/main/java/io/micronaut/management/health/monitor/HealthMonitorTask.java
@@ -105,7 +105,7 @@ public class HealthMonitorTask {
             public void onNext(HealthResult healthResult) {
                 HealthStatus status = healthResult.getStatus();
                 if (LOG.isDebugEnabled()) {
-                    LOG.debug("Health monitor check failed with status {}", status);
+                    LOG.debug("Health monitor check with status {}", status);
                 }
                 currentHealthStatus.update(status);
             }


### PR DESCRIPTION
instead of: 

`Health monitor failed check with status {}`

Say: 

`Health monitor check with status {}`

Since HealthStatus can be UP or DOWN