### PR TITLE
Backport fixes from 4.0.x and fix ConvertibleValuesDeserializer

### DIFF
--- a/core/src/main/java/io/micronaut/core/convert/value/ConvertibleMultiValuesMap.java
+++ b/core/src/main/java/io/micronaut/core/convert/value/ConvertibleMultiValuesMap.java
@@ -25,6 +25,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -137,4 +138,20 @@ public class ConvertibleMultiValuesMap<V> implements ConvertibleMultiValues<V> {
         return Collections.unmodifiableMap(values);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ConvertibleMultiValuesMap<?> that = (ConvertibleMultiValuesMap<?>) o;
+        return values.equals(that.values);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(values);
+    }
 }

--- a/core/src/main/java/io/micronaut/core/convert/value/ConvertibleValuesMap.java
+++ b/core/src/main/java/io/micronaut/core/convert/value/ConvertibleValuesMap.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -103,5 +104,22 @@ public class ConvertibleValuesMap<V> implements ConvertibleValues<V> {
     @SuppressWarnings("unchecked")
     public static <V> ConvertibleValues<V> empty() {
         return EMPTY;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ConvertibleValuesMap<?> that = (ConvertibleValuesMap<?>) o;
+        return map.equals(that.map);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(map);
     }
 }

--- a/inject/src/main/java/io/micronaut/inject/beans/AbstractInitializableBeanIntrospection.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/AbstractInitializableBeanIntrospection.java
@@ -422,7 +422,7 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements BeanI
                 throw new IllegalArgumentException("Invalid bean [" + bean + "] for type: " + beanType);
             }
             if (isWriteOnly()) {
-                throw new UnsupportedOperationException("Cannot read from a write-only property");
+                throw new UnsupportedOperationException("Cannot read from a write-only property: " + getName());
             }
             return dispatchOne(ref.getMethodIndex, bean, null);
         }

--- a/jackson-databind/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/modules/BeanIntrospectionModule.java
@@ -347,7 +347,9 @@ public class BeanIntrospectionModule extends SimpleModule {
                     final List<BeanPropertyWriter> newProperties = new ArrayList<>(properties);
                     Map<String, BeanProperty<Object, Object>> named = new LinkedHashMap<>();
                     for (BeanProperty<Object, Object> beanProperty : beanProperties) {
-                        named.put(getName(config, namingStrategy, beanProperty), beanProperty);
+                        if (!beanProperty.isWriteOnly()) {
+                            named.put(getName(config, namingStrategy, beanProperty), beanProperty);
+                        }
                     }
                     for (int i = 0; i < properties.size(); i++) {
                         final BeanPropertyWriter existing = properties.get(i);

--- a/jackson-databind/src/main/java/io/micronaut/jackson/serialize/ConvertibleMultiValuesSerializer.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/serialize/ConvertibleMultiValuesSerializer.java
@@ -50,12 +50,12 @@ public class ConvertibleMultiValuesSerializer extends JsonSerializer<Convertible
             if (len > 0) {
                 gen.writeFieldName(fieldName);
                 if (len == 1) {
-                    gen.writeObject(v.get(0));
+                    serializers.defaultSerializeValue(v.get(0), gen);
                 } else {
                     gen.writeStartArray();
 
                     for (Object o : v) {
-                        gen.writeObject(o);
+                        serializers.defaultSerializeValue(o, gen);
                     }
                     gen.writeEndArray();
                 }

--- a/jackson-databind/src/main/java/io/micronaut/jackson/serialize/ConvertibleValuesSerializer.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/serialize/ConvertibleValuesSerializer.java
@@ -47,7 +47,7 @@ public class ConvertibleValuesSerializer extends JsonSerializer<ConvertibleValue
             Object v = entry.getValue();
             if (v != null) {
                 gen.writeFieldName(fieldName);
-                gen.writeObject(v);
+                serializers.defaultSerializeValue(v, gen);
             }
         }
         gen.writeEndObject();

--- a/jackson-databind/src/test/groovy/io/micronaut/jackson/modules/BeanIntrospectionModuleSpec.groovy
+++ b/jackson-databind/src/test/groovy/io/micronaut/jackson/modules/BeanIntrospectionModuleSpec.groovy
@@ -33,6 +33,7 @@ import io.micronaut.jackson.JacksonConfiguration
 import io.micronaut.jackson.modules.testcase.EmailTemplate
 import io.micronaut.jackson.modules.testcase.Notification
 import io.micronaut.jackson.modules.testclasses.HTTPCheck
+import io.micronaut.jackson.modules.testclasses.InstanceInfo
 import io.micronaut.jackson.modules.wrappers.BooleanWrapper
 import io.micronaut.jackson.modules.wrappers.DoubleWrapper
 import io.micronaut.jackson.modules.wrappers.IntWrapper
@@ -121,6 +122,31 @@ class BeanIntrospectionModuleSpec extends Specification {
         check == read
 
     }
+
+    void "test serialize/deserialize wrap/unwrap -* constructors & JsonRootName"() {
+        given:
+        ApplicationContext ctx = ApplicationContext.run(
+                'jackson.deserialization.UNWRAP_ROOT_VALUE': true,
+                'jackson.serialization.WRAP_ROOT_VALUE': true
+        )
+        ObjectMapper objectMapper = ctx.getBean(ObjectMapper)
+
+        when:
+        InstanceInfo check = new InstanceInfo("test")
+
+        def result = objectMapper.writeValueAsString(check)
+
+        then:
+        result == '{"instance":{"hostName":"test"}}'
+
+        when:
+        def read = objectMapper.readValue(result, InstanceInfo)
+
+        then:
+        check == read
+
+    }
+
 
     void "test serialize/deserialize convertible values"() {
         given:

--- a/jackson-databind/src/test/groovy/io/micronaut/jackson/modules/BeanIntrospectionModuleSpec.groovy
+++ b/jackson-databind/src/test/groovy/io/micronaut/jackson/modules/BeanIntrospectionModuleSpec.groovy
@@ -33,10 +33,15 @@ import io.micronaut.jackson.JacksonConfiguration
 import io.micronaut.jackson.modules.testcase.EmailTemplate
 import io.micronaut.jackson.modules.testcase.Notification
 import io.micronaut.jackson.modules.testclasses.HTTPCheck
-import io.micronaut.jackson.modules.wrappers.*
+import io.micronaut.jackson.modules.wrappers.BooleanWrapper
+import io.micronaut.jackson.modules.wrappers.DoubleWrapper
+import io.micronaut.jackson.modules.wrappers.IntWrapper
+import io.micronaut.jackson.modules.wrappers.IntegerWrapper
+import io.micronaut.jackson.modules.wrappers.LongWrapper
+import io.micronaut.jackson.modules.wrappers.StringWrapper
 import spock.lang.Issue
-import spock.lang.Unroll
 import spock.lang.Specification
+import spock.lang.Unroll
 
 import java.beans.ConstructorProperties
 import java.time.LocalDateTime
@@ -83,7 +88,7 @@ class BeanIntrospectionModuleSpec extends Specification {
         def result = objectMapper.writeValueAsString(check)
 
         then:
-        result == '{"HTTPCheck":{"Header":{"Accept":[{"String":"application/json"},{"String":"application/xml"}]}}}'
+        result == '{"HTTPCheck":{"Header":{"Accept":["application/json","application/xml"]}}}'
 
         when:
         def read = objectMapper.readValue(result, HTTPCheck)

--- a/jackson-databind/src/test/groovy/io/micronaut/jackson/modules/BeanIntrospectionModuleSpec.groovy
+++ b/jackson-databind/src/test/groovy/io/micronaut/jackson/modules/BeanIntrospectionModuleSpec.groovy
@@ -32,6 +32,7 @@ import io.micronaut.http.hateoas.JsonError
 import io.micronaut.jackson.JacksonConfiguration
 import io.micronaut.jackson.modules.testcase.EmailTemplate
 import io.micronaut.jackson.modules.testcase.Notification
+import io.micronaut.jackson.modules.testclasses.HTTPCheck
 import io.micronaut.jackson.modules.wrappers.*
 import spock.lang.Issue
 import spock.lang.Unroll
@@ -41,6 +42,29 @@ import java.beans.ConstructorProperties
 import java.time.LocalDateTime
 
 class BeanIntrospectionModuleSpec extends Specification {
+
+    void "test serialize/deserialize convertible values"() {
+        given:
+        ApplicationContext ctx = ApplicationContext.run()
+        ObjectMapper objectMapper = ctx.getBean(ObjectMapper)
+
+        when:
+        HTTPCheck check = new HTTPCheck(headers:[
+                Accept:['application/json', 'application/xml']
+        ] )
+
+        def result = objectMapper.writeValueAsString(check)
+
+        then:
+        result == '{"Header":{"Accept":["application/json","application/xml"]}}'
+
+        when:
+        def read = objectMapper.readValue(result, HTTPCheck)
+
+        then:
+        check.header.getAll("Accept") == read.header.getAll("Accept")
+
+    }
 
     void "Bean introspection works with a bean without JsonIgnore annotations"() {
         given:

--- a/jackson-databind/src/test/groovy/io/micronaut/jackson/modules/BeanIntrospectionModuleSpec.groovy
+++ b/jackson-databind/src/test/groovy/io/micronaut/jackson/modules/BeanIntrospectionModuleSpec.groovy
@@ -43,6 +43,56 @@ import java.time.LocalDateTime
 
 class BeanIntrospectionModuleSpec extends Specification {
 
+    void "test serialize/deserialize wrap/unwrap - simple"() {
+        given:
+        ApplicationContext ctx = ApplicationContext.run(
+                'jackson.deserialization.UNWRAP_ROOT_VALUE': true,
+                'jackson.serialization.WRAP_ROOT_VALUE': true
+        )
+        ObjectMapper objectMapper = ctx.getBean(ObjectMapper)
+
+        when:
+        Author author = new Author(name:"Bob")
+
+        def result = objectMapper.writeValueAsString(author)
+
+        then:
+        result == '{"Author":{"name":"Bob"}}'
+
+        when:
+        def read = objectMapper.readValue(result, Author)
+
+        then:
+        author == read
+
+    }
+
+    void "test serialize/deserialize wrap/unwrap - complex"() {
+        given:
+        ApplicationContext ctx = ApplicationContext.run(
+                'jackson.deserialization.UNWRAP_ROOT_VALUE': true,
+                'jackson.serialization.WRAP_ROOT_VALUE': true
+        )
+        ObjectMapper objectMapper = ctx.getBean(ObjectMapper)
+
+        when:
+        HTTPCheck check = new HTTPCheck(headers:[
+                Accept:['application/json', 'application/xml']
+        ] )
+
+        def result = objectMapper.writeValueAsString(check)
+
+        then:
+        result == '{"HTTPCheck":{"Header":{"Accept":[{"String":"application/json"},{"String":"application/xml"}]}}}'
+
+        when:
+        def read = objectMapper.readValue(result, HTTPCheck)
+
+        then:
+        check == read
+
+    }
+
     void "test serialize/deserialize convertible values"() {
         given:
         ApplicationContext ctx = ApplicationContext.run()
@@ -622,6 +672,7 @@ class BeanIntrospectionModuleSpec extends Specification {
     }
 
     @Introspected
+    @EqualsAndHashCode
     static class Author {
         String name
     }

--- a/jackson-databind/src/test/groovy/io/micronaut/jackson/modules/BeanIntrospectionModuleSpec.groovy
+++ b/jackson-databind/src/test/groovy/io/micronaut/jackson/modules/BeanIntrospectionModuleSpec.groovy
@@ -72,7 +72,7 @@ class BeanIntrospectionModuleSpec extends Specification {
 
     }
 
-    void "test serialize/deserialize wrap/unwrap - complex"() {
+    void "test serialize/deserialize wrap/unwrap -* complex"() {
         given:
         ApplicationContext ctx = ApplicationContext.run(
                 'jackson.deserialization.UNWRAP_ROOT_VALUE': true,
@@ -92,6 +92,30 @@ class BeanIntrospectionModuleSpec extends Specification {
 
         when:
         def read = objectMapper.readValue(result, HTTPCheck)
+
+        then:
+        check == read
+
+    }
+
+    void "test serialize/deserialize wrap/unwrap -* constructors"() {
+        given:
+        ApplicationContext ctx = ApplicationContext.run(
+                'jackson.deserialization.UNWRAP_ROOT_VALUE': true,
+                'jackson.serialization.WRAP_ROOT_VALUE': true
+        )
+        ObjectMapper objectMapper = ctx.getBean(ObjectMapper)
+
+        when:
+        IntrospectionCreator check = new IntrospectionCreator("test")
+
+        def result = objectMapper.writeValueAsString(check)
+
+        then:
+        result == '{"IntrospectionCreator":{"label":"TEST"}}'
+
+        when:
+        def read = objectMapper.readValue(result, IntrospectionCreator)
 
         then:
         check == read
@@ -906,6 +930,7 @@ class BeanIntrospectionModuleSpec extends Specification {
     }
 
     @Introspected
+    @EqualsAndHashCode
     static class IntrospectionCreator {
         private final String name
 

--- a/jackson-databind/src/test/groovy/io/micronaut/jackson/modules/testclasses/HTTPCheck.java
+++ b/jackson-databind/src/test/groovy/io/micronaut/jackson/modules/testclasses/HTTPCheck.java
@@ -8,6 +8,7 @@ import io.micronaut.core.convert.value.ConvertibleMultiValues;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 @JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy.class)
 @Introspected
@@ -28,5 +29,18 @@ public class HTTPCheck {
         } else {
             this.headers = ConvertibleMultiValues.of(headers);
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        HTTPCheck httpCheck = (HTTPCheck) o;
+        return headers.equals(httpCheck.headers);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(headers);
     }
 }

--- a/jackson-databind/src/test/groovy/io/micronaut/jackson/modules/testclasses/HTTPCheck.java
+++ b/jackson-databind/src/test/groovy/io/micronaut/jackson/modules/testclasses/HTTPCheck.java
@@ -1,0 +1,32 @@
+package io.micronaut.jackson.modules.testclasses;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.convert.value.ConvertibleMultiValues;
+
+import java.util.List;
+import java.util.Map;
+
+@JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy.class)
+@Introspected
+public class HTTPCheck {
+    private ConvertibleMultiValues<String> headers = ConvertibleMultiValues.empty();
+
+    public ConvertibleMultiValues<String> getHeader() {
+        return headers;
+    }
+
+    /**
+     * @param headers The headers
+     */
+    @JsonProperty("Header")
+    public void setHeaders(Map<CharSequence, List<String>> headers) {
+        if (headers == null) {
+            this.headers = ConvertibleMultiValues.empty();
+        } else {
+            this.headers = ConvertibleMultiValues.of(headers);
+        }
+    }
+}

--- a/jackson-databind/src/test/groovy/io/micronaut/jackson/modules/testclasses/InstanceInfo.java
+++ b/jackson-databind/src/test/groovy/io/micronaut/jackson/modules/testclasses/InstanceInfo.java
@@ -1,0 +1,37 @@
+package io.micronaut.jackson.modules.testclasses;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
+import io.micronaut.core.annotation.Introspected;
+
+import java.util.Objects;
+
+@JsonRootName("instance")
+@Introspected
+public class InstanceInfo {
+    private final String hostName;
+
+    @JsonCreator
+    InstanceInfo(
+        @JsonProperty("hostName") String hostName) {
+        this.hostName = hostName;
+    }
+
+    public String getHostName() {
+        return hostName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        InstanceInfo that = (InstanceInfo) o;
+        return hostName.equals(that.hostName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(hostName);
+    }
+}


### PR DESCRIPTION
- Don't include write only properties in serialization (#8457)
- Add test for unwrap problems
