### PR TITLE
Don't apply AOP advice to Groovy synthetic getters/setters

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/processing/DeclaredBeanElementCreator.java
+++ b/core-processor/src/main/java/io/micronaut/inject/processing/DeclaredBeanElementCreator.java
@@ -268,7 +268,11 @@ class DeclaredBeanElementCreator extends AbstractBeanElementCreator {
     protected boolean visitPropertyReadElement(BeanDefinitionVisitor visitor,
                                                PropertyElement propertyElement,
                                                MethodElement readElement) {
-        return visitAopAndExecutableMethod(visitor, readElement);
+        if (!readElement.isSynthetic()) {
+            return visitAopAndExecutableMethod(visitor, readElement);
+        } else {
+            return false;
+        }
     }
 
     /**
@@ -313,7 +317,11 @@ class DeclaredBeanElementCreator extends AbstractBeanElementCreator {
             visitMethodInjectionPoint(visitor, writeElement);
             return true;
         }
-        return visitAopAndExecutableMethod(visitor, writeElement);
+        if (!writeElement.isSynthetic()) {
+            return visitAopAndExecutableMethod(visitor, writeElement);
+        } else {
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
Found while working on the KSP module. AOP advice is currently being applied to Groovy properties when AOP advice is on the type.