### PR TITLE
fix: TextStreamCodec requires bean of type ByteBufferFactory

### DIFF
--- a/http-server/src/main/java/io/micronaut/http/server/codec/TextStreamCodec.java
+++ b/http-server/src/main/java/io/micronaut/http/server/codec/TextStreamCodec.java
@@ -53,6 +53,7 @@ import java.util.List;
 @Singleton
 @Internal
 @BootstrapContextCompatible
+@Requires(bean = ByteBufferFactory.class)
 public class TextStreamCodec implements MediaTypeCodec {
 
     public static final String CONFIGURATION_QUALIFIER = "text-stream";

--- a/http-server/src/main/java/io/micronaut/http/server/codec/TextStreamCodec.java
+++ b/http-server/src/main/java/io/micronaut/http/server/codec/TextStreamCodec.java
@@ -18,6 +18,7 @@ package io.micronaut.http.server.codec;
 import io.micronaut.context.BeanProvider;
 import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.io.buffer.ByteBuffer;
 import io.micronaut.core.io.buffer.ByteBufferFactory;


### PR DESCRIPTION
Otherwise, you get: 

```
Error starting Micronaut container: Bean definition [io.micronaut.http.server.codec.TextStreamCodec] could not be loaded: Failed to inject value for parameter [byteBufferFactory] of class: io.micronaut.http.server.codec.TextStreamCodec?
```

Already in 4.0.x via: https://github.com/micronaut-projects/micronaut-core/pull/8484