### PR TITLE
Fix delegating to intercepted method in Kotlin

### DIFF
--- a/core-processor/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
+++ b/core-processor/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
@@ -692,7 +692,7 @@ public class AopProxyWriter extends AbstractClassFileWriter implements ProxyingB
         GeneratorAdapter overriddenMethodGenerator = new GeneratorAdapter(overridden, ACC_PUBLIC, methodElement.getName(), desc);
         overriddenMethodGenerator.loadThis();
         int i = 0;
-        for (ParameterElement param : methodElement.getSuspendParameters()) {
+        for (ParameterElement param : overriddenBy.getSuspendParameters()) {
             overriddenMethodGenerator.loadArg(i++);
             pushCastToType(overriddenMethodGenerator, param.getGenericType());
         }

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/multiple/CoroutineCrudRepository.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/multiple/CoroutineCrudRepository.kt
@@ -1,0 +1,101 @@
+package io.micronaut.docs.server.suspend.multiple
+
+import kotlinx.coroutines.flow.Flow
+
+interface CoroutineCrudRepository<E, ID> {
+
+    /**
+     * Saves the given valid entity, returning a possibly new entity representing the saved state. Note that certain implementations may not be able to detect whether a save or update should be performed and may always perform an insert. The [.update] method can be used in this case to explicitly request an update.
+     *
+     * @param entity The entity to save. Must not be null.
+     * @return The saved entity will never be null.
+     * @param <S> The generic type
+     */
+    suspend fun <S : E> save(entity: S): S
+
+    /**
+     * This method issues an explicit update for the given entity. The method differs from [.save] in that an update will be generated regardless if the entity has been saved previously or not. If the entity has no assigned ID then an exception will be thrown.
+     *
+     * @param entity The entity to save. Must not be null.
+     * @return The updated entity will never be null.
+     * @param <S> The generic type
+     */
+    suspend fun <S : E> update(entity: S): S
+
+    /**
+     * This method issues an explicit update for the given entities. The method differs from [.saveAll] in that an update will be generated regardless if the entity has been saved previously or not. If the entity has no assigned ID then an exception will be thrown.
+     *
+     * @param entities The entities to update. Must not be null.
+     * @return The updated entities will never be null.
+     * @param <S> The generic type
+     */
+    fun <S : E> updateAll(entities: Iterable<S>): Flow<S>
+
+    /**
+     * Saves all given entities, possibly returning new instances representing the saved state.
+     *
+     * @param entities The entities to saved. Must not be null.
+     * @param <S> The generic type
+     * @return The saved entities objects. will never be null.
+     */
+    fun <S : E> saveAll(entities: Iterable<S>): Flow<S>
+
+    /**
+     * Retrieves an entity by its id.
+     *
+     * @param id The ID of the entity to retrieve. Must not be null.
+     * @return the entity with the given id or none.
+     */
+    suspend fun findById(id: ID): E?
+
+    /**
+     * Returns whether an entity with the given id exists.
+     *
+     * @param id must not be null.
+     * @return true if an entity with the given id exists, false otherwise.
+     */
+    suspend fun existsById(id: ID): Boolean
+
+    /**
+     * Returns all instances of the type.
+     *
+     * @return all entities
+     */
+    fun findAll(): Flow<E>
+
+    /**
+     * Returns the number of entities available.
+     *
+     * @return the number of entities
+     */
+    suspend fun count(): Long
+
+    /**
+     * Deletes the entity with the given id.
+     *
+     * @param id the id.
+     */
+    suspend fun deleteById(id: ID): Int
+
+    /**
+     * Deletes a given entity.
+     *
+     * @param entity The entity to delete
+     * @return the number of entities deleted
+     */
+    suspend fun delete(entity: E): Int
+
+    /**
+     * Deletes the given entities.
+     *
+     * @param entities The entities to delete
+     * @return the number of entities deleted
+     */
+    suspend fun deleteAll(entities: Iterable<E>): Int
+
+    /**
+     * Deletes all entities managed by the repository.
+     * @return the number of entities deleted
+     */
+    suspend fun deleteAll(): Int
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/multiple/CustomRepository.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/multiple/CustomRepository.kt
@@ -16,7 +16,10 @@
 package io.micronaut.docs.server.suspend.multiple
 
 @MyRepository
-interface CustomRepository {
+interface CustomRepository : CoroutineCrudRepository<SomeEntity, Long> {
+
+    // As of Kotlin version 1.7.20 and KAPT, this will generate JVM signature: "SomeEntity findById(long id, continuation)"
+    override suspend fun findById(id: Long): SomeEntity?
 
     suspend fun xyz(): String
 

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/multiple/InterceptorSpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/multiple/InterceptorSpec.kt
@@ -29,6 +29,8 @@ class InterceptorSpec : StringSpec() {
 
     private var myService = context.getBean(MyService::class.java)
 
+    private var repository = context.getBean(CustomRepository::class.java)
+
     init {
         "test correct interceptors calls" {
             runBlocking {
@@ -43,6 +45,16 @@ class InterceptorSpec : StringSpec() {
                 MyService.events[5] shouldBe "intercept1-end"
                 MyService.events[6] shouldBe "repository-count1"
                 MyService.events[7] shouldBe "repository-count2"
+            }
+        }
+
+        "test calling generic method" {
+            runBlocking {
+                MyService.events.clear()
+                // Validate that no bytecode error is produced
+                repository.findById(111)
+                MyService.events.size shouldBeExactly 1
+                MyService.events[0] shouldBe "repository-findById"
             }
         }
     }

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/multiple/SomeEntity.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/suspend/multiple/SomeEntity.kt
@@ -1,0 +1,4 @@
+package io.micronaut.docs.server.suspend.multiple
+
+class SomeEntity {
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/respository/CoroutineCrudRepository.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/respository/CoroutineCrudRepository.kt
@@ -1,0 +1,2 @@
+package io.micronaut.respository
+

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/respository/CoroutineCrudRepository.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/respository/CoroutineCrudRepository.kt
@@ -1,2 +1,0 @@
-package io.micronaut.respository
-


### PR DESCRIPTION
Corrected some casting because in some cases Kotlin will generate a method with primitive type instead of a generic-object one.