### PR TITLE
build: bump up Reactor to 3.5.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -130,7 +130,7 @@ managed-netty = "4.1.84.Final"
 managed-reactive-pg-client = "0.11.4"
 managed-reactive-streams = "1.0.4"
 # This should be kept aligned with https://github.com/micronaut-projects/micronaut-reactor/blob/master/gradle.properties from the BOM
-managed-reactor = "3.4.23"
+managed-reactor = "3.5.0"
 managed-rxjava1 = "1.3.8"
 managed-rxjava1-interop = "0.13.7"
 managed-slf4j = "1.7.36"


### PR DESCRIPTION

[Micronaut Reactor `2.5.0`](https://github.com/micronaut-projects/micronaut-aws/releases/tag/v2.5.0)  updates to [Project Reactor](https://projectreactor.io/) `3.5.0`.