### PR TITLE
fix: graal error for private @Property

### DIFF
--- a/runtime/src/main/java/io/micronaut/retry/annotation/CircuitBreaker.java
+++ b/runtime/src/main/java/io/micronaut/retry/annotation/CircuitBreaker.java
@@ -97,7 +97,7 @@ public @interface CircuitBreaker {
     Class<? extends RetryPredicate> predicate() default DefaultRetryPredicate.class;
 
     /**
-     * If {@code true} and the circuit is opened, it throws the original exception wrapped
+     * If {@code true} and the circuit is opened, it throws the original exception wrapped.
      * in a {@link io.micronaut.retry.exception.CircuitOpenException}
      * @return Whether to wrap the original exception in a {@link io.micronaut.retry.exception.CircuitOpenException}
      */


### PR DESCRIPTION
While deploying a GraalVM native executable of a lambda function with 22.3 and MN 3.8.0 I was getting:
```
Caused by: java.lang.NoSuchFieldError: No field 'logbackXmlLocation' found for type: io.micronaut.logging.impl.LogbackLoggingSystem
at io.micronaut.core.reflect.ReflectionUtils.lambda$getRequiredField$2(ReflectionUtils.java:294)
at java.util.Optional.orElseThrow(Optional.java:408)
at io.micronaut.core.reflect.ReflectionUtils.getRequiredField(ReflectionUtils.java:294)
at io.micronaut.context.AbstractInitializableBeanDefinition.setFieldWithReflection(AbstractInitializableBeanDefinition.java:979)
io.micronaut.context.exceptions.BeanInstantiationException: Bean definition [io.micronaut.logging.impl.LogbackLoggingSystem] could not be loaded: Error instantiating bean of type  [io.micronaut.logging.impl.LogbackLoggingSystem]

Caused by: io.micronaut.context.exceptions.DependencyInjectionException: Error instantiating bean of type  [io.micronaut.logging.impl.LogbackLoggingSystem]
Message: Error setting field value: No field 'logbackXmlLocation' found for type: io.micronaut.logging.impl.LogbackLoggingSystem
Path Taken: new LogbackLoggingSystem()
at io.micronaut.context.AbstractInitializableBeanDefinition.setFieldWithReflection(AbstractInitializableBeanDefinition.java:986)
at io.micronaut.logging.impl.$LogbackLoggingSystem$Definition.injectBean(Unknown Source)
```

This PR changes LogbackLoggingSystem to use constructor injection for the property `logger.config` to avoid such an error.