### PR TITLE
fix: graal error for private @Property

### DIFF
--- a/runtime/src/main/java/io/micronaut/logging/impl/LogbackLoggingSystem.java
+++ b/runtime/src/main/java/io/micronaut/logging/impl/LogbackLoggingSystem.java
@@ -45,7 +45,7 @@ public final class LogbackLoggingSystem implements LoggingSystem {
 
     private static final String DEFAULT_LOGBACK_LOCATION = "logback.xml";
 
-    private String logbackXmlLocation;
+    private final String logbackXmlLocation;
 
     public LogbackLoggingSystem(@Nullable @Property(name = "logger.config") String logbackXmlLocation) {
         this.logbackXmlLocation = logbackXmlLocation != null ? logbackXmlLocation : DEFAULT_LOGBACK_LOCATION;


### PR DESCRIPTION
Changes to inject @Property(name = "logger.config") via constructor injection.

Graal 22.3 and Micronaut 3.8.0 was throwing:

```
Caused by: java.lang.NoSuchFieldError: No field 'logbackXmlLocation' found for type: io.micronaut.management.endpoint.loggers.impl.LogbackLoggingSystem
195	at io.micronaut.core.reflect.ReflectionUtils.lambda$getRequiredField$2(ReflectionUtils.java:294)
196	at java.base@17.0.5/java.util.Optional.orElseThrow(Optional.java:403)
197	at io.micronaut.core.reflect.ReflectionUtils.getRequiredField(ReflectionUtils.java:294)
198	at io.micronaut.context.AbstractInitializableBeanDefinition.setFieldWithReflection(AbstractInitializableBeanDefinition.java:979)
199	... 113 common frames omitted
```