### PR TITLE
Support Range requests when returning SystemFiles

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/types/files/NettySystemFileCustomizableResponseType.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/types/files/NettySystemFileCustomizableResponseType.java
@@ -17,8 +17,12 @@ package io.micronaut.http.server.netty.types.files;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.util.SupplierUtil;
+import io.micronaut.http.HttpHeaders;
+import io.micronaut.http.HttpMethod;
 import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpStatus;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.http.netty.NettyMutableHttpResponse;
@@ -51,6 +55,8 @@ import java.io.RandomAccessFile;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+import static io.micronaut.http.HttpHeaders.CONTENT_RANGE;
+
 /**
  * Writes a {@link File} to the Netty context.
  *
@@ -62,6 +68,7 @@ import java.util.function.Supplier;
 public class NettySystemFileCustomizableResponseType extends SystemFile implements NettyFileCustomizableResponseType {
 
     private static final int LENGTH_8K = 8192;
+    private static final String UNIT_BYTES = "bytes";
     private static final Logger LOG = LoggerFactory.getLogger(NettySystemFileCustomizableResponseType.class);
 
     protected Optional<FileCustomizableResponseType> delegate = Optional.empty();
@@ -99,7 +106,6 @@ public class NettySystemFileCustomizableResponseType extends SystemFile implemen
      */
     @Override
     public void process(MutableHttpResponse response) {
-        response.header(io.micronaut.http.HttpHeaders.CONTENT_LENGTH, String.valueOf(getLength()));
         delegate.ifPresent(type -> type.process(response));
     }
 
@@ -108,7 +114,35 @@ public class NettySystemFileCustomizableResponseType extends SystemFile implemen
 
         if (response instanceof NettyMutableHttpResponse) {
 
-            NettyMutableHttpResponse nettyResponse = ((NettyMutableHttpResponse) response);
+            NettyMutableHttpResponse<?> nettyResponse = ((NettyMutableHttpResponse<?>) response);
+
+            // Parse the range headers (if any), and determine the position and content length
+            // Only `bytes` ranges are supported. Only single ranges are supported. Invalid ranges fall back to returning the full response.
+            // See https://httpwg.org/specs/rfc9110.html#field.range
+            long fileLength = getLength();
+            String rangeHeader = request.getHeaders().get(HttpHeaders.RANGE);
+            long position = 0;
+            long contentLength = fileLength;
+            if (rangeHeader != null
+                && request.getMethod() == HttpMethod.GET // A server MUST ignore a Range header field received with a request method that is unrecognized or for which range handling is not defined.
+                && rangeHeader.startsWith(UNIT_BYTES) // An origin server MUST ignore a Range header field that contains a range unit it does not understand.
+                && response.status() == HttpStatus.OK // The Range header field is evaluated after evaluating the precondition header fields defined in Section 13.1, and only if the result in absence of the Range header field would be a 200 (OK) response.
+            ) {
+                IntRange range = parseRangeHeader(rangeHeader, fileLength);
+                if (range != null // A server that supports range requests MAY ignore or reject a Range header field that contains an invalid ranges-specifier (Section 14.1.1)
+                    && range.firstPos < range.lastPos // A server that supports range requests MAY ignore a Range header field when the selected representation has no content (i.e., the selected representation's data is of zero length).
+                    && range.firstPos < fileLength
+                    && range.lastPos < fileLength
+                ) {
+                    position = range.firstPos;
+                    contentLength = range.lastPos + 1 - range.firstPos;
+                    response.status(HttpStatus.PARTIAL_CONTENT);
+                    response.header(CONTENT_RANGE, String.format("%s %d-%d/%d", UNIT_BYTES, range.firstPos, range.lastPos, fileLength));
+                }
+            }
+
+            response.header(HttpHeaders.ACCEPT_RANGES, UNIT_BYTES);
+            response.header(HttpHeaders.CONTENT_LENGTH, Long.toString(contentLength));
 
             // Write the request data
             final DefaultHttpResponse finalResponse = new DefaultHttpResponse(nettyResponse.getNettyHttpVersion(), nettyResponse.getNettyHttpStatus(), nettyResponse.getNettyHeaders());
@@ -121,25 +155,59 @@ public class NettySystemFileCustomizableResponseType extends SystemFile implemen
 
             // Write the content.
             if (context.pipeline().get(SslHandler.class) == null &&
-                    context.pipeline().get(SmartHttpContentCompressor.class).shouldSkip(finalResponse) &&
-                    !(context.channel() instanceof Http2StreamChannel)) {
+                context.pipeline().get(SmartHttpContentCompressor.class).shouldSkip(finalResponse) &&
+                !(context.channel() instanceof Http2StreamChannel)) {
                 // SSL not enabled - can use zero-copy file transfer.
-                context.write(new DefaultFileRegion(file.raf.getChannel(), 0, getLength()), context.newProgressivePromise())
-                        .addListener(file);
+                context.write(new DefaultFileRegion(file.raf.getChannel(), position, contentLength), context.newProgressivePromise())
+                    .addListener(file);
                 return context.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT);
             } else {
                 // SSL enabled - cannot use zero-copy file transfer.
                 try {
                     // HttpChunkedInput will write the end marker (LastHttpContent) for us.
-                    final HttpChunkedInput chunkedInput = new HttpChunkedInput(new ChunkedFile(file.raf, 0, getLength(), LENGTH_8K));
+                    final HttpChunkedInput chunkedInput = new HttpChunkedInput(new ChunkedFile(file.raf, position, contentLength, LENGTH_8K));
                     return context.writeAndFlush(chunkedInput, context.newProgressivePromise())
-                            .addListener(file);
+                        .addListener(file);
                 } catch (IOException e) {
                     throw new CustomizableResponseTypeException("Could not read file", e);
                 }
             }
         } else {
             throw new IllegalArgumentException("Unsupported response type. Not a Netty response: " + response);
+        }
+    }
+
+    @Nullable
+    private static IntRange parseRangeHeader(String value, long contentLength) {
+        int equalsIdx = value.indexOf('=');
+        if (equalsIdx < 0 || equalsIdx == value.length() - 1) {
+            return null; // Malformed range
+        }
+
+        int minusIdx = value.indexOf('-', equalsIdx + 1);
+        if (minusIdx < 0) {
+            return null; // Malformed range
+        }
+
+        String from = value.substring(equalsIdx + 1, minusIdx).trim();
+        String to = value.substring(minusIdx + 1).trim();
+        try {
+            long fromPosition = from.isEmpty() ? 0 : Long.parseLong(from);
+            long toPosition = to.isEmpty() ? contentLength - 1 : Long.parseLong(to);
+            return new IntRange(fromPosition, toPosition);
+        } catch (NumberFormatException e) {
+            return null; // Malformed range
+        }
+    }
+
+    // See https://httpwg.org/specs/rfc9110.html#rule.int-range
+    private static class IntRange {
+        private final long firstPos;
+        private final long lastPos;
+
+        IntRange(long firstPos, long lastPos) {
+            this.firstPos = firstPos;
+            this.lastPos = lastPos;
         }
     }
 
@@ -150,7 +218,7 @@ public class NettySystemFileCustomizableResponseType extends SystemFile implemen
     private static final class FileHolder implements ChannelFutureListener {
         //to avoid initializing Netty at build time
         private static final Supplier<ResourceLeakDetector<RandomAccessFile>> LEAK_DETECTOR = SupplierUtil.memoized(() ->
-                ResourceLeakDetectorFactory.instance().newResourceLeakDetector(RandomAccessFile.class));
+            ResourceLeakDetectorFactory.instance().newResourceLeakDetector(RandomAccessFile.class));
 
         final RandomAccessFile raf;
         final long length;

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/types/FileTypeHandlerSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/types/FileTypeHandlerSpec.groovy
@@ -47,13 +47,16 @@ import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
 import java.util.concurrent.ExecutorService
 
+import static io.micronaut.http.HttpHeaders.ACCEPT_RANGES
 import static io.micronaut.http.HttpHeaders.CACHE_CONTROL
 import static io.micronaut.http.HttpHeaders.CONTENT_DISPOSITION
 import static io.micronaut.http.HttpHeaders.CONTENT_LENGTH
+import static io.micronaut.http.HttpHeaders.CONTENT_RANGE
 import static io.micronaut.http.HttpHeaders.CONTENT_TYPE
 import static io.micronaut.http.HttpHeaders.DATE
 import static io.micronaut.http.HttpHeaders.EXPIRES
 import static io.micronaut.http.HttpHeaders.LAST_MODIFIED
+import static io.micronaut.http.HttpHeaders.RANGE
 
 class FileTypeHandlerSpec extends AbstractMicronautSpec {
 
@@ -89,6 +92,34 @@ class FileTypeHandlerSpec extends AbstractMicronautSpec {
         then:
         response.code() == HttpStatus.NOT_MODIFIED.code
         response.header(DATE)
+    }
+
+    void "test 206 is returned for Byte-Range queries"() {
+        when:
+        MutableHttpRequest<?> request = HttpRequest.GET('/test/html')
+        request.headers.add(RANGE, range)
+        def response = rxClient.toBlocking().exchange(request, String)
+
+        then:
+        response.code() == expectedStatus
+        response.header(ACCEPT_RANGES) == "bytes"
+        response.header(CONTENT_RANGE) == expectedContentRange
+        response.header(CONTENT_LENGTH) == Long.toString(expectedContent.length())
+        response.body() == expectedContent
+
+        where:
+        range          | expectedStatus | expectedContentRange                                     | expectedContent
+        ""             | 200            | null                                                     | tempFileContents
+        "bytes"        | 200            | null                                                     | tempFileContents
+        "bytes="       | 200            | null                                                     | tempFileContents
+        "bytes=2"      | 200            | null                                                     | tempFileContents
+        "bytes=9000-"  | 200            | null                                                     | tempFileContents
+        "bytes=0-9000" | 200            | null                                                     | tempFileContents
+        "bytes=abc-10" | 200            | null                                                     | tempFileContents
+        "bytes=0-def"  | 200            | null                                                     | tempFileContents
+        "bytes=0-"     | 206            | "bytes 0-${tempFile.length() - 1}/${tempFile.length()}"  | tempFileContents
+        "bytes=10-"    | 206            | "bytes 10-${tempFile.length() - 1}/${tempFile.length()}" | tempFileContents.substring(10)
+        "bytes=1-2"    | 206            | "bytes 1-2/${tempFile.length()}"                         | tempFileContents.substring(1, 3)
     }
 
     void "test cache control can be overridden"() {
@@ -314,7 +345,7 @@ class FileTypeHandlerSpec extends AbstractMicronautSpec {
         @Get('/custom-cache-control')
         HttpResponse<File> cacheControl() {
             HttpResponse.ok(tempFile)
-                        .header(CACHE_CONTROL, "public, immutable, max-age=31556926")
+                    .header(CACHE_CONTROL, "public, immutable, max-age=31556926")
         }
 
         @Get('/different-name')


### PR DESCRIPTION
This is to add [Range](https://httpwg.org/specs/rfc9110.html#field.range) support for serving `java.io.File`s and `SystemFile`s, which is important when streaming videos or other large media (where eg. Chrome might decide to send multiple requests and jump around in the file in order to retrieve metadata used for seeking).

I don't seem to have permissions to link to an issue, but this should resolve #7911