### PR TITLE
init at build time before instantiating reference

### DIFF
--- a/core/src/main/java/io/micronaut/core/graal/ServiceLoaderInitialization.java
+++ b/core/src/main/java/io/micronaut/core/graal/ServiceLoaderInitialization.java
@@ -78,7 +78,7 @@ final class ServiceLoaderFeature implements Feature {
                         if (GraalReflectionConfigurer.class.isAssignableFrom(c)) {
                             continue;
                         } else if (BeanInfo.class.isAssignableFrom(c)) {
-
+                            RuntimeClassInitialization.initializeAtBuildTime(c);
                             BeanInfo<?> beanInfo;
                             try {
                                 beanInfo = (BeanInfo<?>) c.getDeclaredConstructor().newInstance();
@@ -105,7 +105,7 @@ final class ServiceLoaderFeature implements Feature {
                                 }
                             }
                         }
-                        RuntimeClassInitialization.initializeAtBuildTime(c);
+
                         RuntimeReflection.registerForReflectiveInstantiation(c);
                         RuntimeReflection.register(c);
                     }


### PR DESCRIPTION
Fix error:

```
Error: Classes that should be initialized at run time got initialized during image building:
 io.micronaut.data.model.$DefaultPageSerializer$Definition$Reference was unintentionally initialized at build time. To see why io.micronaut.data.model.$DefaultPageSerializer$Definition$Reference got initialized use --trace-class-initialization=io.micronaut.data.model.$DefaultPageSerializer$Definition$Reference
io.micronaut.data.runtime.criteria.$RuntimeCriteriaBuilder$Definition$Reference was unintentionally initialized at build time. 
```