### PR TITLE
fix: 403 for cors simple requests & CorsFilter off

### DIFF
--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/cors/CorsFilterEnabledSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/cors/CorsFilterEnabledSpec.groovy
@@ -12,8 +12,8 @@ class CorsFilterEnabledSpec extends Specification {
     @Shared
     ApplicationContext applicationContext = ApplicationContext.run()
 
-    void "CorsFilter is not enabled by default"() {
+    void "CorsFilter is enabled by default"() {
         expect:
-        !applicationContext.containsBean(CorsFilter)
+        applicationContext.containsBean(CorsFilter)
     }
 }

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/cors/CorsFilterSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/cors/CorsFilterSpec.groovy
@@ -16,6 +16,7 @@
 package io.micronaut.http.server.netty.cors
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.core.annotation.Nullable
 import io.micronaut.core.async.publisher.Publishers
 import io.micronaut.core.util.StringUtils
 import io.micronaut.http.*
@@ -25,6 +26,7 @@ import io.micronaut.http.filter.ServerFilterChain
 import io.micronaut.http.server.HttpServerConfiguration
 import io.micronaut.http.server.cors.CorsFilter
 import io.micronaut.http.server.cors.CorsOriginConfiguration
+import io.micronaut.http.server.util.HttpHostResolver
 import io.micronaut.runtime.server.EmbeddedServer
 import io.micronaut.web.router.RouteMatch
 import io.micronaut.web.router.Router
@@ -559,6 +561,11 @@ class CorsFilterSpec extends Specification {
     }
 
     private CorsFilter buildCorsHandler(HttpServerConfiguration.CorsConfiguration config) {
-        new CorsFilter(config ?: enabledCorsConfiguration())
+        new CorsFilter(config ?: enabledCorsConfiguration(), new HttpHostResolver() {
+            @Override
+            String resolve(@Nullable HttpRequest request) {
+                return "http://micronautexample.com";
+            }
+        })
     }
 }

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/cors/CorsOriginConverterEnabledSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/cors/CorsOriginConverterEnabledSpec.groovy
@@ -12,8 +12,8 @@ class CorsOriginConverterEnabledSpec extends Specification {
     @Shared
     ApplicationContext applicationContext = ApplicationContext.run()
 
-    void "CorsOriginConverter is not enabled by default"() {
+    void "CorsOriginConverter is enabled by default"() {
         expect:
-        !applicationContext.containsBean(CorsOriginConverter)
+        applicationContext.containsBean(CorsOriginConverter)
     }
 }

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/cors/NettyCorsSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/cors/NettyCorsSpec.groovy
@@ -15,7 +15,9 @@
  */
 package io.micronaut.http.server.netty.cors
 
+import io.micronaut.context.annotation.Replaces
 import io.micronaut.context.annotation.Requires
+import io.micronaut.core.annotation.Nullable
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus
@@ -25,6 +27,8 @@ import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Post
 import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.http.server.netty.AbstractMicronautSpec
+import io.micronaut.http.server.util.HttpHostResolver
+import jakarta.inject.Singleton
 import reactor.core.publisher.Flux
 
 import static io.micronaut.http.HttpHeaders.*
@@ -309,6 +313,16 @@ class NettyCorsSpec extends AbstractMicronautSpec {
         'micronaut.server.cors.configurations.bar.maxAge': 150,
         'micronaut.server.cors.configurations.bar.allowCredentials': false,
         'micronaut.server.dateHeader': false]
+    }
+
+    @Requires(property = 'spec.name', value = 'NettyCorsSpec')
+    @Replaces(HttpHostResolver.class)
+    @Singleton
+    static class HttpHostResolverReplacement implements HttpHostResolver {
+        @Override
+        String resolve(@Nullable HttpRequest request) {
+            "https://micronautexample.com"
+        }
     }
 
     @Controller('/test')

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/CorsDisabledByDefaultTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/CorsDisabledByDefaultTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.tck.tests.cors;
+
+import io.micronaut.context.annotation.Replaces;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.annotation.Status;
+import io.micronaut.http.server.tck.AssertionUtils;
+import io.micronaut.http.server.tck.HttpResponseAssertion;
+import io.micronaut.http.server.util.HttpHostResolver;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static io.micronaut.http.server.tck.TestScenario.asserts;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@SuppressWarnings({
+    "java:S2259", // The tests will show if it's null
+    "java:S5960", // We're allowed assertions, as these are used in tests only
+    "checkstyle:MissingJavadocType",
+})
+public class CorsDisabledByDefaultTest {
+
+    private static final String SPECNAME = "CorsDisabledByDefaultTest";
+
+    /**
+     * By default CORS is disabled no cors headers are present in response.
+     * @throws IOException may throw the try for resources
+     */
+    @Test
+    void corsDisabledByDefault() throws IOException {
+        asserts(SPECNAME,
+            createRequest("https://foo.com"),
+            (server, request) -> {
+                AssertionUtils.assertDoesNotThrow(server, request, HttpResponseAssertion.builder()
+                    .status(HttpStatus.OK)
+                    .assertResponse(response -> {
+                        assertNull(response.getHeaders().get("Access-Control-Allow-Origin"));
+                        assertNull(response.getHeaders().get("Vary"));
+                        assertNull(response.getHeaders().get("Access-Control-Allow-Credentials"));
+                        assertNull(response.getHeaders().get("Access-Control-Allow-Methods"));
+                        assertNull(response.getHeaders().get("Access-Control-Allow-Headers"));
+                        assertNull(response.getHeaders().get("Access-Control-Max-Age"));
+                    })
+                    .build());
+            });
+    }
+
+    static HttpRequest<?> createRequest(String origin) {
+        return HttpRequest.POST("/refresh", Collections.emptyMap())
+            .header("Content-Type", MediaType.APPLICATION_JSON)
+            .header("Origin", origin)
+            .header("Accept-Encoding", "gzip, deflate")
+            .header("Connection", "keep-alive")
+            .header("Accept", "*/*")
+            .header("User-Agent", "Mozilla / 5.0 (Macintosh; Intel Mac OS X 10_15_7)AppleWebKit / 605.1 .15 (KHTML, like Gecko)Version / 16.1 Safari / 605.1 .15")
+            .header("Referer", origin)
+            .header("Accept-Language", "en - GB, en");
+    }
+
+    @Requires(property = "spec.name", value = SPECNAME)
+    @Controller
+    static class RefreshController {
+        @Post("/refresh")
+        @Status(HttpStatus.OK)
+        void refresh() {
+        }
+    }
+
+    @Requires(property = "spec.name", value = SPECNAME)
+    @Replaces(HttpHostResolver.class)
+    @Singleton
+    static class HttpHostResolverReplacement implements HttpHostResolver {
+        @Override
+        public String resolve(@Nullable HttpRequest request) {
+            return "https://micronautexample.com";
+        }
+    }
+}

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/SimpleRequestWithCorsNotEnabledTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/SimpleRequestWithCorsNotEnabledTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.tck.tests.cors;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.event.ApplicationEventListener;
+import io.micronaut.context.event.ApplicationEventPublisher;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.annotation.Status;
+import io.micronaut.http.server.tck.AssertionUtils;
+import io.micronaut.http.server.tck.HttpResponseAssertion;
+import io.micronaut.runtime.context.scope.refresh.RefreshEvent;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static io.micronaut.http.server.tck.TestScenario.asserts;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+@SuppressWarnings({
+    "java:S2259", // The tests will show if it's null
+    "java:S5960", // We're allowed assertions, as these are used in tests only
+    "checkstyle:MissingJavadocType",
+})
+public class SimpleRequestWithCorsNotEnabledTest {
+    private static final String SPECNAME = "SimpleRequestWithCorsNotEnabledTest";
+
+    /**
+     * @see <a href="https://github.com/micronaut-projects/micronaut-core/security/advisories/GHSA-583g-g682-crxf">GHSA-583g-g682-crxf</a>
+     * A malicious/compromised website can make HTTP requests to localhost. This test verifies a CORS simple request is denied when invoked against a Micronaut application running in localhost without cors enabled.
+     * @throws IOException scenario step fails
+     */
+    @Test
+    void corsSimpleRequestNotAllowedForLocalhostAndAny() throws IOException {
+        asserts(SPECNAME,
+            createRequest(),
+            (server, request) -> {
+            RefreshCounter refreshCounter = server.getApplicationContext().getBean(RefreshCounter.class);
+                assertEquals(0, refreshCounter.getRefreshCount());
+
+                AssertionUtils.assertThrows(server, request, HttpResponseAssertion.builder()
+                    .status(HttpStatus.FORBIDDEN)
+                    .assertResponse(response -> assertFalse(response.getHeaders().contains("Vary")))
+                    .build());
+                assertEquals(0, refreshCounter.getRefreshCount());
+            });
+    }
+
+    private static HttpRequest<?> createRequest() {
+        return HttpRequest.POST("/refresh", Collections.emptyMap())
+            .header("Accept", "*/*")
+            .header("Accept-Encoding", "gzip, deflate, br")
+            .header("Accept-Language", "en-GB,en-US;q=0.9,en;q=0.8")
+            .header("Connection", "keep-alive")
+            .header("Content-Length", "0")
+            .header("Host", "localhost:8080")
+            .header("Origin", "https://sdelamo.github.io")
+            .header("sec-ch-ua", "\"Not?A_Brand\";v=\"8\", \"Chromium\";v=\"108\", \"Google Chrome\";v=\"108\"")
+            .header("sec-ch-ua-mobile", "?0")
+            .header("sec-ch-ua-platform", "\"macOS\"")
+            .header("Sec-Fetch-Dest", "empty")
+            .header("Sec-Fetch-Mode", "cors")
+            .header("Sec-Fetch-Site", "cross-site")
+            .header("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36");
+    }
+
+    @Requires(property = "spec.name", value = SPECNAME)
+    @Controller
+    static class RefreshController {
+        @Inject
+        ApplicationEventPublisher<RefreshEvent> refreshEventApplicationEventPublisher;
+
+        @Post("/refresh")
+        @Status(HttpStatus.OK)
+        void refresh() {
+            refreshEventApplicationEventPublisher.publishEvent(new RefreshEvent());
+        }
+    }
+
+    @Requires(property = "spec.name", value = SPECNAME)
+    @Singleton
+    static class RefreshCounter implements ApplicationEventListener<RefreshEvent> {
+        private int refreshCount = 0;
+
+        @Override
+        public void onApplicationEvent(RefreshEvent event) {
+            refreshCount++;
+        }
+
+        public int getRefreshCount() {
+            return refreshCount;
+        }
+    }
+}

--- a/http-server/src/main/java/io/micronaut/http/server/cors/CorsFilter.java
+++ b/http-server/src/main/java/io/micronaut/http/server/cors/CorsFilter.java
@@ -109,6 +109,9 @@ public class CorsFilter implements HttpServerFilter {
                 return forbidden();
             }
             return Publishers.then(chain.proceed(request), resp -> decorateResponseWithHeaders(request, resp, corsOriginConfiguration));
+        } else if (shouldDenyToPreventDriveByLocalhostAttack(origin, request)) {
+            LOG.trace("the request specifies an origin different than localhost. To prevent drive-by-localhost attacks the request is forbidden");
+            return forbidden();
         }
         LOG.trace("CORS configuration not found for {} origin", origin);
         return chain.proceed(request);
@@ -128,6 +131,21 @@ public class CorsFilter implements HttpServerFilter {
         String host = httpHostResolver.resolve(request);
         return isAny(corsOriginConfiguration.getAllowedOrigins()) && host.startsWith(LOCALHOST);
 
+    }
+
+    /**
+     *
+     * @param origin HTTP Header {@link HttpHeaders#ORIGIN} value.
+     * @param request HTTP Request
+     * @return {@literal true} if the resolved host starts with {@literal http://localhost} and origin does not start with localhost deny it.
+     */
+    protected boolean shouldDenyToPreventDriveByLocalhostAttack(@NonNull String origin,
+                                                                @NonNull HttpRequest<?> request) {
+        if (httpHostResolver == null) {
+            return false;
+        }
+        String host = httpHostResolver.resolve(request);
+        return !origin.startsWith(LOCALHOST) && host.startsWith(LOCALHOST);
     }
 
     @Override
@@ -249,6 +267,9 @@ public class CorsFilter implements HttpServerFilter {
 
     @NonNull
     private Optional<CorsOriginConfiguration> getConfiguration(@NonNull String requestOrigin) {
+        if (!corsConfiguration.isEnabled()) {
+            return Optional.empty();
+        }
         return corsConfiguration.getConfigurations().values().stream()
             .filter(config -> {
                 List<String> allowedOrigins = config.getAllowedOrigins();

--- a/http-server/src/main/java/io/micronaut/http/server/cors/package-info.java
+++ b/http-server/src/main/java/io/micronaut/http/server/cors/package-info.java
@@ -19,10 +19,4 @@
  * @author Graeme Rocher
  * @since 1.0
  */
-@Configuration
-@Requires(property = "micronaut.server.cors.enabled", value = StringUtils.TRUE)
 package io.micronaut.http.server.cors;
-
-import io.micronaut.context.annotation.Configuration;
-import io.micronaut.context.annotation.Requires;
-import io.micronaut.core.util.StringUtils;


### PR DESCRIPTION
Related to: see: https://github.com/micronaut-projects/micronaut-core/security/advisories/GHSA-583g-g682-crxf#advisory-comment-77446

I created a test which reproduces a scenario for a developer running an application in localhost without cors enabled .

These are the steps to reproduce.

Clone: https://github.com/sdelamo/simple-request-attacks

inside that repository there is a sample app.

```
$ cd micronaut-stop
```

Run the app with `./gradlew run`, open your browser, and visit [https://sdelamo.github.io/simple-request-attacks/stopEndpoint.html](https://sdelamo.github.io/simple-request-attacks/stopEndpoint.html) in Chrome.

The application stops. It should return 503 instead.

Safari has protections built-in, and you will not be able to reproduce it with Safari. Use Chrome.

