### PR TITLE
Check for equality in the body for server TCK tests

### DIFF
--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/AssertionUtils.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/AssertionUtils.java
@@ -57,7 +57,7 @@ public final class AssertionUtils {
         HttpResponse<?> response = thrown.getResponse();
         assertEquals(assertion.getHttpStatus(), response.getStatus());
         assertHeaders(response, assertion.getHeaders());
-        assertBody(response, assertion.getBody());
+        assertBody(response, assertion.getBody(), assertion.getContains());
         assertion.getResponseConsumer().ifPresent(httpResponseConsumer -> httpResponseConsumer.accept(response));
     }
 
@@ -69,6 +69,18 @@ public final class AssertionUtils {
         assertThrows(server, request, HttpResponseAssertion.builder()
             .status(expectedStatus)
             .body(expectedBody)
+            .headers(expectedHeaders)
+            .build());
+    }
+
+    public static void assertThrowsAndContains(@NonNull ServerUnderTest server,
+                                    @NonNull HttpRequest<?> request,
+                                    @NonNull HttpStatus expectedStatus,
+                                    @Nullable String expectedBody,
+                                    @Nullable Map<String, String> expectedHeaders) {
+        assertThrows(server, request, HttpResponseAssertion.builder()
+            .status(expectedStatus)
+            .containsBody(expectedBody)
             .headers(expectedHeaders)
             .build());
     }
@@ -85,6 +97,18 @@ public final class AssertionUtils {
             .build());
     }
 
+    public static <T> void assertDoesNotThrowAndContains(@NonNull ServerUnderTest server,
+                                          @NonNull HttpRequest<T> request,
+                                          @NonNull HttpStatus expectedStatus,
+                                          @Nullable String expectedBody,
+                                          @Nullable Map<String, String> expectedHeaders) {
+        assertDoesNotThrow(server, request, HttpResponseAssertion.builder()
+            .status(expectedStatus)
+            .containsBody(expectedBody)
+            .headers(expectedHeaders)
+            .build());
+    }
+
     public static <T> void assertDoesNotThrow(@NonNull ServerUnderTest server,
                                               @NonNull HttpRequest<T> request,
                                               @NonNull HttpResponseAssertion assertion) {
@@ -94,15 +118,21 @@ public final class AssertionUtils {
         HttpResponse<?> response = Assertions.assertDoesNotThrow(executable);
         assertEquals(assertion.getHttpStatus(), response.getStatus());
         assertHeaders(response, assertion.getHeaders());
-        assertBody(response, assertion.getBody());
+        assertBody(response, assertion.getBody(), assertion.getContains());
         assertion.getResponseConsumer().ifPresent(httpResponseConsumer -> httpResponseConsumer.accept(response));
     }
 
-    private static void assertBody(@NonNull HttpResponse<?> response,  @Nullable String expectedBody) {
+    private static void assertBody(@NonNull HttpResponse<?> response,  @Nullable String expectedBody, boolean contains) {
         if (expectedBody != null) {
             Optional<String> bodyOptional = response.getBody(String.class);
             assertTrue(bodyOptional.isPresent());
-            bodyOptional.ifPresent(body -> assertTrue(body.contains(expectedBody)));
+            bodyOptional.ifPresent(body -> {
+                if (contains) {
+                    assertTrue(body.contains(expectedBody));
+                } else {
+                    assertEquals(expectedBody, body);
+                }
+            });
         }
     }
 

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/HttpResponseAssertion.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/HttpResponseAssertion.java
@@ -38,6 +38,7 @@ public final class HttpResponseAssertion {
     private final HttpStatus httpStatus;
     private final Map<String, String> headers;
     private final String body;
+    private final boolean contains;
 
     @Nullable
     private final Consumer<HttpResponse<?>> responseConsumer;
@@ -45,10 +46,12 @@ public final class HttpResponseAssertion {
     private HttpResponseAssertion(HttpStatus httpStatus,
                                   Map<String, String> headers,
                                   String body,
+                                  boolean contains,
                                   @Nullable Consumer<HttpResponse<?>> responseConsumer) {
         this.httpStatus = httpStatus;
         this.headers = headers;
         this.body = body;
+        this.contains = contains;
         this.responseConsumer = responseConsumer;
     }
 
@@ -90,12 +93,20 @@ public final class HttpResponseAssertion {
     }
 
     /**
+     * @return true if the body is expected to contain the expected body.
+     */
+    public boolean getContains() {
+        return contains;
+    }
+
+    /**
      * HTTP Response Assertion Builder.
      */
     public static class Builder {
         private HttpStatus httpStatus;
         private Map<String, String> headers;
         private String body;
+        private boolean contains = false;
 
         private Consumer<HttpResponse<?>> responseConsumer;
 
@@ -134,12 +145,25 @@ public final class HttpResponseAssertion {
         }
 
         /**
+         * Set the expected contents of a body
          *
          * @param body Response Body
          * @return HTTP Response Assertion Builder
          */
         public Builder body(String body) {
             this.body = body;
+            return this;
+        }
+
+        /**
+         * Set the expected partial contents of a body
+         *
+         * @param body Response Body
+         * @return HTTP Response Assertion Builder
+         */
+        public Builder containsBody(String body) {
+            this.body = body;
+            this.contains = true;
             return this;
         }
 
@@ -158,7 +182,7 @@ public final class HttpResponseAssertion {
          * @return HTTP Response Assertion
          */
         public HttpResponseAssertion build() {
-            return new HttpResponseAssertion(Objects.requireNonNull(httpStatus), headers, body, responseConsumer);
+            return new HttpResponseAssertion(Objects.requireNonNull(httpStatus), headers, body, contains, responseConsumer);
         }
     }
 }

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/HttpResponseAssertion.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/HttpResponseAssertion.java
@@ -145,7 +145,7 @@ public final class HttpResponseAssertion {
         }
 
         /**
-         * Set the expected contents of a body
+         * Set the expected contents of a body.
          *
          * @param body Response Body
          * @return HTTP Response Assertion Builder
@@ -156,7 +156,7 @@ public final class HttpResponseAssertion {
         }
 
         /**
-         * Set the expected partial contents of a body
+         * Set the expected partial contents of a body.
          *
          * @param body Response Body
          * @return HTTP Response Assertion Builder

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/BodyTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/BodyTest.java
@@ -88,6 +88,18 @@ public class BodyTest {
                     .build()));
     }
 
+    @Test
+    void testCustomListBodyPOJOReactiveTypes() throws IOException {
+        asserts(SPEC_NAME,
+            HttpRequest.POST("/response-body/pojo-flux", "[{\"x\":10,\"y\":20},{\"x\":30,\"y\":40}]")
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON),
+            (server, request) -> AssertionUtils.assertDoesNotThrow(server, request,
+                HttpResponseAssertion.builder()
+                    .status(HttpStatus.CREATED)
+                    .body("[{\"x\":10,\"y\":20},{\"x\":30,\"y\":40}]")
+                    .build()));
+    }
+
     @Controller("/response-body")
     @Requires(property = "spec.name", value = SPEC_NAME)
     static class BodyController {
@@ -108,6 +120,12 @@ public class BodyTest {
         @Status(HttpStatus.CREATED)
         @SingleResult
         Publisher<Point> post(@Body Publisher<Point> data) {
+            return data;
+        }
+
+        @Post(uri = "/pojo-flux")
+        @Status(HttpStatus.CREATED)
+        Publisher<Point> postMany(@Body Publisher<Point> data) {
             return data;
         }
 

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/ErrorHandlerTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/ErrorHandlerTest.java
@@ -101,7 +101,7 @@ public class ErrorHandlerTest {
             ObjectMapper objectMapper = server.getApplicationContext().getBean(ObjectMapper.class);
             HttpRequest<?> request = HttpRequest.POST("/json/errors/global", objectMapper.writeValueAsString(new RequestObject(101)))
                 .header(HttpHeaders.CONTENT_TYPE, io.micronaut.http.MediaType.APPLICATION_JSON);
-            AssertionUtils.assertDoesNotThrow(server, request,
+            AssertionUtils.assertDoesNotThrowAndContains(server, request,
                 HttpStatus.OK,
                 "{\"message\":\"Error: bad things when post and body in request\",\"",
                 Collections.singletonMap(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON));

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/FilterErrorTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/FilterErrorTest.java
@@ -69,7 +69,7 @@ public class FilterErrorTest {
                 AssertionUtils.assertThrows(server, request,
                     HttpResponseAssertion.builder()
                         .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                        .body("from exception handler")
+                        .containsBody("from exception handler")
                         .build());
                 ExceptionException filter = server.getApplicationContext().getBean(ExceptionException.class);
                 assertEquals(1, filter.executedCount.get());
@@ -116,7 +116,8 @@ public class FilterErrorTest {
                 AssertionUtils.assertThrows(server, request,
                     HttpResponseAssertion.builder()
                         .status(HttpStatus.BAD_REQUEST)
-                        .body("from NEXT filter exception handle").build());
+                        .containsBody("from NEXT filter exception handle")
+                        .build());
 
                 First first = server.getApplicationContext().getBean(First.class);
                 Next next = server.getApplicationContext().getBean(Next.class);


### PR DESCRIPTION
And add a method to check for partial body contents.

Previously, we always checked for contains, which made checking lists potentially problematic.

This also adds a test for Publisher bodys with multiple entries