### PR TITLE
Performance improvements + Java style improvements

### DIFF
--- a/aop/src/main/java/io/micronaut/aop/chain/AbstractInterceptorChain.java
+++ b/aop/src/main/java/io/micronaut/aop/chain/AbstractInterceptorChain.java
@@ -34,14 +34,11 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 /**
  * Abstract interceptor chain implementation.
@@ -99,11 +96,11 @@ abstract class AbstractInterceptorChain<B, R> implements InvocationContext<B, R>
                 localParameters = this.parameters;
                 if (localParameters == null) {
                     Argument[] arguments = getArguments();
-                    localParameters = new LinkedHashMap<>(arguments.length);
+                    localParameters = CollectionUtils.newLinkedHashMap(arguments.length);
                     for (int i = 0; i < arguments.length; i++) {
                         Argument argument = arguments[i];
                         int finalIndex = i;
-                        localParameters.put(argument.getName(), new MutableArgumentValue<Object>() {
+                        localParameters.put(argument.getName(), new MutableArgumentValue<>() {
                             @Override
                             public AnnotationMetadata getAnnotationMetadata() {
                                 return argument.getAnnotationMetadata();
@@ -186,60 +183,59 @@ abstract class AbstractInterceptorChain<B, R> implements InvocationContext<B, R>
      * @since 3.3.0
      */
     protected static @NonNull Collection<AnnotationValue<?>> resolveInterceptorValues(@NonNull AnnotationMetadata annotationMetadata,
-                                                                             @NonNull InterceptorKind kind) {
+                                                                                      @NonNull InterceptorKind kind) {
         annotationMetadata = annotationMetadata.getTargetAnnotationMetadata();
-        if (annotationMetadata instanceof AnnotationMetadataHierarchy) {
+        if (annotationMetadata instanceof AnnotationMetadataHierarchy annotationMetadataHierarchy) {
             final List<AnnotationValue<InterceptorBinding>> declaredValues =
-                    annotationMetadata.getDeclaredMetadata().getAnnotationValuesByType(InterceptorBinding.class);
+                    annotationMetadataHierarchy.getDeclaredMetadata().getAnnotationValuesByType(InterceptorBinding.class);
             final List<AnnotationValue<InterceptorBinding>> parentValues =
-                    ((AnnotationMetadataHierarchy) annotationMetadata).getRootMetadata()
+                    annotationMetadataHierarchy.getRootMetadata()
                     .getAnnotationValuesByType(InterceptorBinding.class);
-            if (CollectionUtils.isNotEmpty(declaredValues) || CollectionUtils.isNotEmpty(parentValues)) {
-                Set<AnnotationValue<?>> resolved = new HashSet<>(declaredValues.size() + parentValues.size());
-                Set<String> declared = new HashSet<>(declaredValues.size());
-                for (AnnotationValue<InterceptorBinding> declaredValue : declaredValues) {
-                    final String annotationName = declaredValue.stringValue().orElse(null);
-                    if (annotationName != null) {
-                        final InterceptorKind specifiedkind = declaredValue.enumValue("kind", InterceptorKind.class).orElse(null);
-                        if (specifiedkind == null || specifiedkind.equals(kind)) {
-                            if (!annotationMetadata.isRepeatableAnnotation(annotationName)) {
-                                declared.add(annotationName);
-                            }
-                            resolved.add(declaredValue);
-                        }
-                    }
-                }
-                for (AnnotationValue<InterceptorBinding> parentValue : parentValues) {
-                    final String annotationName = parentValue.stringValue().orElse(null);
-                    if (annotationName != null && !declared.contains(annotationName)) {
-                        final InterceptorKind specifiedkind = parentValue.enumValue("kind", InterceptorKind.class).orElse(null);
-                        if (specifiedkind == null || specifiedkind.equals(kind)) {
-                            resolved.add(parentValue);
-                        }
-                    }
-                }
-
-                return resolved;
-            } else {
+            if (CollectionUtils.isEmpty(declaredValues) && CollectionUtils.isEmpty(parentValues)) {
                 return Collections.emptyList();
             }
+            Set<AnnotationValue<?>> resolved = CollectionUtils.newHashSet(declaredValues.size() + parentValues.size());
+            Set<String> declared = CollectionUtils.newHashSet(declaredValues.size());
+            for (AnnotationValue<InterceptorBinding> declaredValue : declaredValues) {
+                final String annotationName = declaredValue.stringValue().orElse(null);
+                if (annotationName != null) {
+                    final InterceptorKind specifiedKind = declaredValue.enumValue("kind", InterceptorKind.class).orElse(null);
+                    if (specifiedKind == null || specifiedKind.equals(kind)) {
+                        if (!annotationMetadata.isRepeatableAnnotation(annotationName)) {
+                            declared.add(annotationName);
+                        }
+                        resolved.add(declaredValue);
+                    }
+                }
+            }
+            for (AnnotationValue<InterceptorBinding> parentValue : parentValues) {
+                final String annotationName = parentValue.stringValue().orElse(null);
+                if (annotationName != null && !declared.contains(annotationName)) {
+                    final InterceptorKind specifiedKind = parentValue.enumValue("kind", InterceptorKind.class).orElse(null);
+                    if (specifiedKind == null || specifiedKind.equals(kind)) {
+                        resolved.add(parentValue);
+                    }
+                }
+            }
+
+            return resolved;
         } else {
             List<AnnotationValue<InterceptorBinding>> bindings = annotationMetadata
                     .getAnnotationValuesByType(InterceptorBinding.class);
-            if (CollectionUtils.isNotEmpty(bindings)) {
-                return bindings
-                        .stream()
-                        .filter(av -> {
-                            if (!av.stringValue().isPresent()) {
-                                return false;
-                            }
-                            final InterceptorKind specifiedkind = av.enumValue("kind", InterceptorKind.class).orElse(null);
-                            return specifiedkind == null || specifiedkind.equals(kind);
-                        })
-                        .collect(Collectors.toSet());
-            } else {
+            if (CollectionUtils.isEmpty(bindings)) {
                 return Collections.emptyList();
             }
+            Set<AnnotationValue<?>> selectedBindings = CollectionUtils.newHashSet(bindings.size());
+            for (AnnotationValue<InterceptorBinding> av : bindings) {
+                if (av.stringValue().isEmpty()) {
+                    continue;
+                }
+                final InterceptorKind specifiedKind = av.enumValue("kind", InterceptorKind.class).orElse(null);
+                if (specifiedKind == null || specifiedKind.equals(kind)) {
+                    selectedBindings.add(av);
+                }
+            }
+            return selectedBindings;
         }
     }
 }

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -23,10 +23,6 @@ dependencies {
 jmh {
     includes = ['io.micronaut.http.server.StartupBenchmark']
     duplicateClassesStrategy = DuplicatesStrategy.WARN
-//    warmupIterations = 2
-//    iterations = 3
-//    fork = 1
-//    jvmArgs = ["-agentpath:/Applications/YourKit-Java-Profiler-2018.04.app/Contents/Resources/bin/mac/libyjpagent.jnilib"]
 }
 
 tasks.named("processJmhResources") {

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -7,7 +7,8 @@ dependencies {
     annotationProcessor project(":inject-java")
     jmhAnnotationProcessor project(":inject-java")
     jmhAnnotationProcessor libs.bundles.asm
-    
+    jmhAnnotationProcessor libs.jmh.generator.annprocess
+
     annotationProcessor project(":validation")
     compileOnly project(":validation")
     api project(":inject")
@@ -17,15 +18,14 @@ dependencies {
     api project(":router")
     api project(":runtime")
 
-    jmh libs.jmh
-    jmh libs.jmh.generator.annprocess
+    jmh libs.jmh.core
 }
 jmh {
     includes = ['io.micronaut.http.server.StartupBenchmark']
     duplicateClassesStrategy = DuplicatesStrategy.WARN
-    warmupIterations = 2
-    iterations = 3
-    fork = 1
+//    warmupIterations = 2
+//    iterations = 3
+//    fork = 1
 //    jvmArgs = ["-agentpath:/Applications/YourKit-Java-Profiler-2018.04.app/Contents/Resources/bin/mac/libyjpagent.jnilib"]
 }
 

--- a/benchmarks/src/jmh/java/io/micronaut/http/server/StartupBenchmark.java
+++ b/benchmarks/src/jmh/java/io/micronaut/http/server/StartupBenchmark.java
@@ -18,17 +18,20 @@ package io.micronaut.http.server;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.http.server.binding.TestController;
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
 
 @State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
 public class StartupBenchmark {
 
     @Benchmark
-    public void startup() {
-        try (ApplicationContext context = ApplicationContext.run()) {
-            final TestController controller =
-                    context.getBean(TestController.class);
-        }
+    public void startup(Blackhole blackhole) {
+        ApplicationContext context = ApplicationContext.run();
+        final TestController controller = context.getBean(TestController.class);
+        blackhole.consume(controller);
     }
 }

--- a/benchmarks/src/jmh/java/io/micronaut/supplier/SupplierBenchmark.java
+++ b/benchmarks/src/jmh/java/io/micronaut/supplier/SupplierBenchmark.java
@@ -1,0 +1,91 @@
+package io.micronaut.supplier;
+
+import io.micronaut.core.util.SupplierUtil;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+public class SupplierBenchmark {
+
+    private Supplier<String> memoizedLambda = memoizedUsingLambda(() -> "test");
+    private Supplier<String> memoizedNonEmptyUsingLambda = memoizedNonEmptyUsingLambda(() -> "test");
+    private Supplier<String> memoized = SupplierUtil.memoized(() -> "test");
+    private Supplier<String> memoizedNonEmpty = SupplierUtil.memoizedNonEmpty(() -> "test");
+
+    @Benchmark
+    public void memoizedLambda(Blackhole blackhole) {
+        blackhole.consume(memoizedLambda.get());
+    }
+
+    @Benchmark
+    public void memoizedNonEmptyUsingLambda(Blackhole blackhole) {
+        blackhole.consume(memoizedNonEmptyUsingLambda.get());
+    }
+
+    @Benchmark
+    public void memoized(Blackhole blackhole) {
+        blackhole.consume(memoized.get());
+    }
+
+
+    @Benchmark
+    public void memoizedNonEmpty(Blackhole blackhole) {
+        blackhole.consume(memoizedNonEmpty.get());
+    }
+
+    private static <T> Supplier<T> memoizedUsingLambda(Supplier<T> actual) {
+        return new Supplier<T>() {
+            Supplier<T> delegate = this::initialize;
+            boolean initialized;
+
+            @Override
+            public T get() {
+                return delegate.get();
+            }
+
+            private synchronized T initialize() {
+                if (!initialized) {
+                    T value = actual.get();
+                    delegate = () -> value;
+                    initialized = true;
+                }
+                return delegate.get();
+            }
+        };
+    }
+
+    private static <T> Supplier<T> memoizedNonEmptyUsingLambda(Supplier<T> actual) {
+        return new Supplier<T>() {
+            Supplier<T> delegate = this::initialize;
+            boolean initialized;
+
+            @Override
+            public T get() {
+                return delegate.get();
+            }
+
+            private synchronized T initialize() {
+                if (!initialized) {
+                    T value = actual.get();
+                    if (value == null) {
+                        return null;
+                    }
+                    if (value instanceof Optional && !((Optional) value).isPresent()) {
+                        return value;
+                    }
+                    delegate = () -> value;
+                    initialized = true;
+                }
+                return delegate.get();
+            }
+        };
+    }
+}

--- a/buffer-netty/src/main/java/io/micronaut/buffer/netty/NettyByteBufferFactory.java
+++ b/buffer-netty/src/main/java/io/micronaut/buffer/netty/NettyByteBufferFactory.java
@@ -59,13 +59,13 @@ public class NettyByteBufferFactory implements ByteBufferFactory<ByteBufAllocato
     }
 
     /**
-     * @param allocatorSupplier The {@link ByteBufAllocator}
+     * @param allocator The {@link ByteBufAllocator}
      */
-    public NettyByteBufferFactory(ByteBufAllocator allocatorSupplier) {
+    public NettyByteBufferFactory(ByteBufAllocator allocator) {
         this.allocatorSupplier = new Supplier<ByteBufAllocator>() {
             @Override
             public ByteBufAllocator get() {
-                return allocatorSupplier;
+                return allocator;
             }
         };
     }

--- a/buffer-netty/src/main/java/io/micronaut/buffer/netty/NettyByteBufferFactory.java
+++ b/buffer-netty/src/main/java/io/micronaut/buffer/netty/NettyByteBufferFactory.java
@@ -26,6 +26,8 @@ import io.netty.buffer.Unpooled;
 import jakarta.annotation.PostConstruct;
 import jakarta.inject.Singleton;
 
+import java.util.function.Supplier;
+
 /**
  * A {@link ByteBufferFactory} implementation for Netty.
  *
@@ -42,20 +44,30 @@ public class NettyByteBufferFactory implements ByteBufferFactory<ByteBufAllocato
      */
     public static final NettyByteBufferFactory DEFAULT = new NettyByteBufferFactory();
 
-    private final ByteBufAllocator allocator;
+    private final Supplier<ByteBufAllocator> allocatorSupplier;
 
     /**
      * Default constructor.
      */
     public NettyByteBufferFactory() {
-        this.allocator = ByteBufAllocator.DEFAULT;
+        this.allocatorSupplier = new Supplier<ByteBufAllocator>() {
+            @Override
+            public ByteBufAllocator get() {
+                return ByteBufAllocator.DEFAULT;
+            }
+        };
     }
 
     /**
-     * @param allocator The {@link ByteBufAllocator}
+     * @param allocatorSupplier The {@link ByteBufAllocator}
      */
-    public NettyByteBufferFactory(ByteBufAllocator allocator) {
-        this.allocator = allocator;
+    public NettyByteBufferFactory(ByteBufAllocator allocatorSupplier) {
+        this.allocatorSupplier = new Supplier<ByteBufAllocator>() {
+            @Override
+            public ByteBufAllocator get() {
+                return allocatorSupplier;
+            }
+        };
     }
 
     @PostConstruct
@@ -71,22 +83,22 @@ public class NettyByteBufferFactory implements ByteBufferFactory<ByteBufAllocato
 
     @Override
     public ByteBufAllocator getNativeAllocator() {
-        return allocator;
+        return allocatorSupplier.get();
     }
 
     @Override
     public ByteBuffer<ByteBuf> buffer() {
-        return new NettyByteBuffer(allocator.buffer());
+        return new NettyByteBuffer(allocatorSupplier.get().buffer());
     }
 
     @Override
     public ByteBuffer<ByteBuf> buffer(int initialCapacity) {
-        return new NettyByteBuffer(allocator.buffer(initialCapacity));
+        return new NettyByteBuffer(allocatorSupplier.get().buffer(initialCapacity));
     }
 
     @Override
     public ByteBuffer<ByteBuf> buffer(int initialCapacity, int maxCapacity) {
-        return new NettyByteBuffer(allocator.buffer(initialCapacity, maxCapacity));
+        return new NettyByteBuffer(allocatorSupplier.get().buffer(initialCapacity, maxCapacity));
     }
 
     @Override

--- a/context/src/main/java/io/micronaut/runtime/context/env/ConfigurationIntroductionAdvice.java
+++ b/context/src/main/java/io/micronaut/runtime/context/env/ConfigurationIntroductionAdvice.java
@@ -106,10 +106,11 @@ public class ConfigurationIntroductionAdvice implements MethodInterceptor<Object
         );
 
         if (defaultValue != null) {
-            return value.orElseGet(() -> environment.convertRequired(
-                defaultValue,
-                argument
-            ));
+            Object result = value.orElse(null);
+            if (result == null) {
+                return environment.convertRequired(defaultValue, argument);
+            }
+            return result;
         } else if (rt.isOptional()) {
             return value.orElse(Optional.empty());
         } else if (context.isNullable()) {

--- a/core-processor/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataWriter.java
@@ -113,7 +113,6 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
                     Map.class,
                     Map.class,
                     Map.class,
-                    boolean.class,
                     boolean.class
             )
     );
@@ -410,14 +409,6 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
                     continue;
                 }
 
-//                Label falseCondition = new Label();
-//
-//                staticInit.push(annotationName);
-//                staticInit.invokeStatic(TYPE_DEFAULT_ANNOTATION_METADATA, METHOD_ARE_DEFAULTS_REGISTERED);
-//                staticInit.push(true);
-//                staticInit.ifCmp(Type.BOOLEAN_TYPE, GeneratorAdapter.EQ, falseCondition);
-//                staticInit.visitLabel(new Label());
-
                 invokeLoadClassValueMethod(owningType, classWriter, staticInit, loadTypeMethods, new AnnotationClassValue(annotationName));
 
                 if (!typeOnly) {
@@ -426,18 +417,13 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
                 } else {
                     staticInit.invokeStatic(TYPE_DEFAULT_ANNOTATION_METADATA, METHOD_REGISTER_ANNOTATION_TYPE);
                 }
-//                staticInit.visitLabel(falseCondition);
             }
-            if (annotationMetadata.repeated != null && !annotationMetadata.repeated.isEmpty()) {
-                Map<String, String> repeated = new HashMap<>();
-                for (Map.Entry<String, String> e : annotationMetadata.repeated.entrySet()) {
-                    repeated.put(e.getValue(), e.getKey());
-                }
-                AnnotationMetadataSupport.removeCoreRepeatableAnnotations(repeated);
-                if (!repeated.isEmpty()) {
-                    pushStringMapOf(staticInit, repeated, true, null, v -> pushValue(owningType, classWriter, staticInit, v, defaultsStorage, loadTypeMethods, true));
-                    staticInit.invokeStatic(TYPE_DEFAULT_ANNOTATION_METADATA, METHOD_REGISTER_REPEATABLE_ANNOTATIONS);
-                }
+        }
+        if (annotationMetadata.annotationRepeatableContainer != null && !annotationMetadata.annotationRepeatableContainer.isEmpty()) {
+            AnnotationMetadataSupport.registerRepeatableAnnotations(annotationMetadata.annotationRepeatableContainer);
+            if (!annotationMetadata.annotationRepeatableContainer.isEmpty()) {
+                pushStringMapOf(staticInit, annotationMetadata.annotationRepeatableContainer, true, null, v -> pushValue(owningType, classWriter, staticInit, v, defaultsStorage, loadTypeMethods, true));
+                staticInit.invokeStatic(TYPE_DEFAULT_ANNOTATION_METADATA, METHOD_REGISTER_REPEATABLE_ANNOTATIONS);
             }
         }
     }
@@ -496,8 +482,6 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
         pushStringMapOf(generatorAdapter, annotationsByStereotype, false, Collections.emptyList(), list -> pushListOfString(generatorAdapter, list));
         // 6th argument: has property expressions
         generatorAdapter.push(annotationMetadata.hasPropertyExpressions());
-        // 7th argument: use repeatable annotations
-        generatorAdapter.push(true);
 
         // invoke the constructor
         generatorAdapter.invokeConstructor(TYPE_DEFAULT_ANNOTATION_METADATA, CONSTRUCTOR_ANNOTATION_METADATA);

--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationUtil.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationUtil.java
@@ -613,7 +613,9 @@ public class AnnotationUtil {
     public static int calculateHashCode(Map<? extends CharSequence, Object> values) {
         int hashCode = 0;
 
-        for (Map.Entry<? extends CharSequence, Object> member : values.entrySet()) {
+        // Performance optimization to use the Object as the type otherwise
+        // the bytecode will produce the type-check introducing type-check pollution
+        for (Map.Entry<? extends Object, Object> member : values.entrySet()) {
             Object value = member.getValue();
 
             int nameHashCode = member.getKey().hashCode();

--- a/core/src/main/java/io/micronaut/core/annotation/ImmutableSortedStringsArrayMap.java
+++ b/core/src/main/java/io/micronaut/core/annotation/ImmutableSortedStringsArrayMap.java
@@ -71,7 +71,8 @@ final class ImmutableSortedStringsArrayMap<V> implements Map<String, V> {
     }
 
     private int findKeyIndex(Object key) {
-        if (!(key instanceof Comparable)) {
+        // Performance optimization to check for the String first to avoid the type-check pollution
+        if (!(key instanceof String) && !(key instanceof Comparable)) {
             return -1;
         }
         int v = index[reduceHashCode(key.hashCode(), keys.length)];

--- a/core/src/main/java/io/micronaut/core/convert/TypeConverter.java
+++ b/core/src/main/java/io/micronaut/core/convert/TypeConverter.java
@@ -72,6 +72,12 @@ public interface TypeConverter<S, T> {
      * @return The converter instance
      */
     static <ST, TT> TypeConverter<ST, TT> of(Class<ST> sourceType, Class<TT> targetType, Function<ST, TT> converter) {
-        return (object, targetType1, context) -> Optional.ofNullable(converter.apply(object));
+        // Keep the anonymous class instead of Lambda to reduce the Lambda invocation overhead during the startup
+        return new TypeConverter<ST, TT>() {
+            @Override
+            public Optional<TT> convert(ST object, Class<TT> targetType1, ConversionContext context) {
+                return Optional.ofNullable(converter.apply(object));
+            }
+        };
     }
 }

--- a/core/src/main/java/io/micronaut/core/io/file/DefaultFileSystemResourceLoader.java
+++ b/core/src/main/java/io/micronaut/core/io/file/DefaultFileSystemResourceLoader.java
@@ -66,7 +66,7 @@ public class DefaultFileSystemResourceLoader implements FileSystemResourceLoader
      * @param path The path
      */
     public DefaultFileSystemResourceLoader(Path path) {
-        this.baseDir = SupplierUtil.memoizedNonEmpty(() -> {
+        this.baseDir = SupplierUtil.memoized(() -> {
             Path baseDirPath;
             try {
                 baseDirPath = path.normalize().toRealPath();

--- a/core/src/main/java/io/micronaut/core/io/file/FileSystemResourceLoader.java
+++ b/core/src/main/java/io/micronaut/core/io/file/FileSystemResourceLoader.java
@@ -23,6 +23,11 @@ import io.micronaut.core.io.ResourceLoader;
 public interface FileSystemResourceLoader extends ResourceLoader {
 
     /**
+     * The resource name prefix.
+     */
+    String PREFIX = "file:";
+
+    /**
      * Creation method.
      * @return loader
      */
@@ -38,6 +43,6 @@ public interface FileSystemResourceLoader extends ResourceLoader {
      */
     @Override
     default boolean supportsPrefix(String path) {
-        return path.startsWith("file:");
+        return path.startsWith(PREFIX);
     }
 }

--- a/core/src/main/java/io/micronaut/core/io/service/SoftServiceLoader.java
+++ b/core/src/main/java/io/micronaut/core/io/service/SoftServiceLoader.java
@@ -46,6 +46,8 @@ import java.util.stream.Stream;
  */
 public final class SoftServiceLoader<S> implements Iterable<ServiceDefinition<S>> {
     public static final String META_INF_SERVICES = "META-INF/services";
+    private static final MethodHandles.Lookup LOOKUP = MethodHandles.publicLookup();
+    private static final MethodType VOID_TYPE = MethodType.methodType(void.class);
 
     private static final Map<String, SoftServiceLoader.StaticServiceLoader<?>> STATIC_SERVICES =
             StaticOptimizations.get(Optimizations.class)
@@ -58,11 +60,11 @@ public final class SoftServiceLoader<S> implements Iterable<ServiceDefinition<S>
     private final Predicate<String> condition;
     private boolean allowFork = true;
 
-    private SoftServiceLoader(Class<S> serviceType, ClassLoader classLoader) {
+    private SoftServiceLoader(Class<S> serviceType, @Nullable ClassLoader classLoader) {
         this(serviceType, classLoader, (String name) -> true);
     }
 
-    private SoftServiceLoader(Class<S> serviceType, ClassLoader classLoader, Predicate<String> condition) {
+    private SoftServiceLoader(Class<S> serviceType, @Nullable ClassLoader classLoader, Predicate<String> condition) {
         this.serviceType = serviceType;
         this.classLoader = classLoader == null ? ClassLoader.getSystemClassLoader() : classLoader;
         this.condition = condition == null ? (String name) -> true : condition;
@@ -183,14 +185,15 @@ public final class SoftServiceLoader<S> implements Iterable<ServiceDefinition<S>
             try {
                 @SuppressWarnings("unchecked") final Class<S> loadedClass =
                         (Class<S>) Class.forName(className, false, classLoader);
-                S result = loadedClass.getDeclaredConstructor().newInstance();
+                // MethodHandler should more performant than the basic reflection
+                S result = (S) LOOKUP.findConstructor(loadedClass, VOID_TYPE).invoke();
                 if (predicate != null && !predicate.test(result)) {
                     return null;
                 }
                 return result;
-            } catch (NoClassDefFoundError | ClassNotFoundException | NoSuchMethodException e) {
+            } catch (NoClassDefFoundError | ClassNotFoundException | NoSuchMethodException | IllegalAccessException e) {
                 // Ignore
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 throw new ServiceLoadingException(e);
             }
             return null;
@@ -284,8 +287,6 @@ public final class SoftServiceLoader<S> implements Iterable<ServiceDefinition<S>
      * @param <S> The service type
      */
     public static final class StaticDefinition<S> implements ServiceDefinition<S> {
-        private static final MethodHandles.Lookup LOOKUP = MethodHandles.publicLookup();
-        private static final MethodType VOID_TYPE = MethodType.methodType(void.class);
 
         private final String name;
         private final Supplier<S> value;

--- a/core/src/main/java/io/micronaut/core/reflect/ClassUtils.java
+++ b/core/src/main/java/io/micronaut/core/reflect/ClassUtils.java
@@ -19,7 +19,6 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.optim.StaticOptimizations;
-import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
 import org.slf4j.Logger;
@@ -36,7 +35,6 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -61,7 +59,6 @@ public class ClassUtils {
      * because this class is used both at compilation time and runtime, and we don't want logging at compilation time.
      */
     public static final String PROPERTY_MICRONAUT_CLASSLOADER_LOGGING = "micronaut.classloader.logging";
-    public static final int EMPTY_OBJECT_ARRAY_HASH_CODE = Arrays.hashCode(ArrayUtils.EMPTY_OBJECT_ARRAY);
     public static final Map<String, Class<?>> COMMON_CLASS_MAP = new HashMap<>(34);
     public static final Map<String, Class<?>> BASIC_TYPE_MAP = new HashMap<>(18);
 
@@ -77,8 +74,8 @@ public class ClassUtils {
 
     private static final boolean ENABLE_CLASS_LOADER_LOGGING = Boolean.getBoolean(PROPERTY_MICRONAUT_CLASSLOADER_LOGGING);
     private static final Set<String> MISSING_TYPES = StaticOptimizations.get(Optimizations.class)
-            .map(Optimizations::getMissingTypes)
-            .orElse(Collections.emptySet());
+        .map(Optimizations::getMissingTypes)
+        .orElse(Collections.emptySet());
 
     static {
         REFLECTION_LOGGER = getLogger(ClassUtils.class);
@@ -87,26 +84,26 @@ public class ClassUtils {
     @SuppressWarnings("unchecked")
     private static final Map<String, Class<?>> PRIMITIVE_TYPE_MAP = CollectionUtils.mapOf(
         "int", Integer.TYPE,
-            "boolean", Boolean.TYPE,
-            "long", Long.TYPE,
-            "byte", Byte.TYPE,
-            "double", Double.TYPE,
-            "float", Float.TYPE,
-            "char", Character.TYPE,
-            "short", Short.TYPE,
-            "void", void.class
+        "boolean", Boolean.TYPE,
+        "long", Long.TYPE,
+        "byte", Byte.TYPE,
+        "double", Double.TYPE,
+        "float", Float.TYPE,
+        "char", Character.TYPE,
+        "short", Short.TYPE,
+        "void", void.class
     );
 
     @SuppressWarnings("unchecked")
     private static final Map<String, Class<?>> PRIMITIVE_ARRAY_MAP = CollectionUtils.mapOf(
-            "int", int[].class,
-            "boolean", boolean[].class,
-            "long", long[].class,
-            "byte", byte[].class,
-            "double", double[].class,
-            "float", float[].class,
-            "char", char[].class,
-            "short", short[].class
+        "int", int[].class,
+        "boolean", boolean[].class,
+        "long", long[].class,
+        "byte", byte[].class,
+        "double", double[].class,
+        "float", float[].class,
+        "char", char[].class,
+        "short", short[].class
     );
 
     static {
@@ -170,6 +167,7 @@ public class ClassUtils {
 
     /**
      * Returns the array type for the given primitive type name.
+     *
      * @param primitiveType The primitive type name
      * @return The array type
      */

--- a/core/src/main/java/io/micronaut/core/type/Argument.java
+++ b/core/src/main/java/io/micronaut/core/type/Argument.java
@@ -15,19 +15,23 @@
  */
 package io.micronaut.core.type;
 
-import io.micronaut.core.annotation.*;
-import io.micronaut.core.naming.NameUtils;
+import io.micronaut.core.annotation.AnnotatedElement;
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.annotation.UsedByGeneratedCode;
 import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.util.ArrayUtils;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
-import java.util.Collections;
 
 /**
  * Represents an argument to a method or constructor or type.
@@ -432,7 +436,7 @@ public interface Argument<T> extends TypeInformation<T>, AnnotatedElement, Type 
         if (ArrayUtils.isEmpty(typeParameters)) {
             return of(type);
         }
-        return new DefaultArgument<>(type, NameUtils.decapitalize(type.getSimpleName()), AnnotationMetadata.EMPTY_METADATA, typeParameters);
+        return new DefaultArgument<>(type, null, AnnotationMetadata.EMPTY_METADATA, typeParameters);
     }
 
     /**
@@ -507,6 +511,7 @@ public interface Argument<T> extends TypeInformation<T>, AnnotatedElement, Type 
 
     /**
      * Creates a new argument for the given type and name.
+     * NOTE: This method should be avoided as it does use the reflection to retrieve the type parameter names.
      *
      * @param type               The type
      * @param annotationMetadata The annotation metadata
@@ -530,7 +535,7 @@ public interface Argument<T> extends TypeInformation<T>, AnnotatedElement, Type 
         Argument<?>[] typeArguments = new Argument[len];
         for (int i = 0; i < parameters.length; i++) {
             TypeVariable<Class<T>> parameter = parameters[i];
-            typeArguments[i] = Argument.of(typeParameters[i], parameter.getName());
+            typeArguments[i] = Argument.ofTypeVariable(typeParameters[i], parameter.getName());
         }
         return new DefaultArgument<>(type, annotationMetadata != null ? annotationMetadata : AnnotationMetadata.EMPTY_METADATA, typeArguments);
     }
@@ -544,8 +549,7 @@ public interface Argument<T> extends TypeInformation<T>, AnnotatedElement, Type 
      */
     @NonNull
     static <T> Argument<List<T>> listOf(@NonNull Class<T> type) {
-        //noinspection unchecked
-        return of((Class<List<T>>) ((Class) List.class), type);
+        return listOf(Argument.ofTypeVariable(type, "E"));
     }
 
     /**
@@ -559,7 +563,7 @@ public interface Argument<T> extends TypeInformation<T>, AnnotatedElement, Type 
     @NonNull
     static <T> Argument<List<T>> listOf(@NonNull Argument<T> type) {
         //noinspection unchecked
-        return of((Class<List<T>>) ((Class) List.class), type);
+        return of((Class<List<T>>) ((Class) List.class), "list", type);
     }
 
     /**
@@ -571,8 +575,7 @@ public interface Argument<T> extends TypeInformation<T>, AnnotatedElement, Type 
      */
     @NonNull
     static <T> Argument<Set<T>> setOf(@NonNull Class<T> type) {
-        //noinspection unchecked
-        return of((Class<Set<T>>) ((Class) Set.class), type);
+        return setOf(Argument.ofTypeVariable(type, "E"));
     }
 
     /**
@@ -586,7 +589,7 @@ public interface Argument<T> extends TypeInformation<T>, AnnotatedElement, Type 
     @NonNull
     static <T> Argument<Set<T>> setOf(@NonNull Argument<T> type) {
         //noinspection unchecked
-        return of((Class<Set<T>>) ((Class) Set.class), type);
+        return of((Class<Set<T>>) ((Class) Set.class), "set", type);
     }
 
     /**
@@ -600,8 +603,7 @@ public interface Argument<T> extends TypeInformation<T>, AnnotatedElement, Type 
      */
     @NonNull
     static <K, V> Argument<Map<K, V>> mapOf(@NonNull Class<K> keyType, @NonNull Class<V> valueType) {
-        //noinspection unchecked
-        return of((Class<Map<K, V>>) ((Class) Map.class), keyType, valueType);
+        return mapOf(Argument.ofTypeVariable(keyType, "K"), Argument.ofTypeVariable(valueType, "V"));
     }
 
     /**
@@ -617,7 +619,34 @@ public interface Argument<T> extends TypeInformation<T>, AnnotatedElement, Type 
     @NonNull
     static <K, V> Argument<Map<K, V>> mapOf(@NonNull Argument<K> keyType, @NonNull Argument<V> valueType) {
         //noinspection unchecked
-        return of((Class<Map<K, V>>) ((Class) Map.class), keyType, valueType);
+        return of((Class<Map<K, V>>) ((Class) Map.class), "map", keyType, valueType);
+    }
+
+    /**
+     * Creates a new argument representing an optional.
+     *
+     * @param optionalValueClass   The optional type
+     * @param <T>       The optional type
+     * @return The argument instance
+     * @since 4.0.0
+     */
+    @NonNull
+    static <T> Argument<Optional<T>> optionalOf(@NonNull Class<T> optionalValueClass) {
+        return optionalOf(Argument.ofTypeVariable(optionalValueClass, "T"));
+    }
+
+    /**
+     * Creates a new argument representing an optional.
+     *
+     * @param optionalValueArgument   The optional type
+     * @param <T>       The optional type
+     * @return The argument instance
+     * @since 4.0.0
+     */
+    @NonNull
+    static <T> Argument<Optional<T>> optionalOf(@NonNull Argument<T> optionalValueArgument) {
+        //noinspection unchecked
+        return of((Class<Optional<T>>) ((Class) Optional.class), "optional", optionalValueArgument);
     }
 
 }

--- a/core/src/main/java/io/micronaut/core/type/DefaultArgument.java
+++ b/core/src/main/java/io/micronaut/core/type/DefaultArgument.java
@@ -19,6 +19,7 @@ import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.ObjectUtils;
@@ -26,7 +27,19 @@ import io.micronaut.core.util.ObjectUtils;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.Vector;
 
 /**
  * Represents an argument to a constructor or method.
@@ -60,6 +73,7 @@ public class DefaultArgument<T> implements Argument<T>, ArgumentCoercible<T> {
     private final Argument<?>[] typeParameterArray;
     private final AnnotationMetadata annotationMetadata;
     private final boolean isTypeVar;
+    private String namePrecalculated;
 
     /**
      * @param type               The type
@@ -214,10 +228,13 @@ public class DefaultArgument<T> implements Argument<T>, ArgumentCoercible<T> {
     @Override
     @NonNull
     public String getName() {
-        if (name == null) {
-            return getType().getSimpleName();
+        if (name != null) {
+            return name;
         }
-        return name;
+        if (namePrecalculated == null) {
+            namePrecalculated = NameUtils.decapitalize(type.getSimpleName());
+        }
+        return namePrecalculated;
     }
 
     @Override

--- a/core/src/main/java/io/micronaut/core/type/TypeInformation.java
+++ b/core/src/main/java/io/micronaut/core/type/TypeInformation.java
@@ -199,7 +199,7 @@ public interface TypeInformation<T> extends TypeVariableResolver, AnnotationMeta
      * @since 2.0
      */
     default boolean isSpecifiedSingle() {
-        return RuntimeTypeInformation.isSpecifiedSingle(this);
+        return RuntimeTypeInformation.isSpecifiedSingle(getType(), this);
     }
 
     /**

--- a/core/src/main/java/io/micronaut/core/util/CollectionUtils.java
+++ b/core/src/main/java/io/micronaut/core/util/CollectionUtils.java
@@ -32,6 +32,57 @@ import java.util.*;
 public class CollectionUtils {
 
     /**
+     * Create new {@link HashSet} sized to fit all the elements of the size provided.
+     * @param size The size to fit all the elements
+     * @param <E> The element type
+     * @return a new {@link HashSet} with reallocated size
+     * @since 4.0.0
+     */
+    public static <E> HashSet<E> newHashSet(int size) {
+        return new HashSet<>(calculateHashSetSize(size));
+    }
+
+    /**
+     * Create new {@link LinkedHashSet} sized to fit all the elements of the size provided.
+     * @param size The size to fit all the elements
+     * @param <E> The element type
+     * @return a new {@link LinkedHashSet} with reallocated size
+     * @since 4.0.0
+     */
+    public static <E> LinkedHashSet<E> newLinkedHashSet(int size) {
+        return new LinkedHashSet<>(calculateHashSetSize(size));
+    }
+
+    /**
+     * Create new {@link HashMap} sized to fit all the elements of the size provided.
+     * @param size The size to fit all the elements
+     * @param <K> The key type
+     * @param <V> The value type
+     * @return a new {@link HashMap} with reallocated size
+     * @since 4.0.0
+     */
+    public static <K, V> HashMap<K, V> newHashMap(int size) {
+        return new HashMap<>(calculateHashSetSize(size));
+    }
+
+    /**
+     * Create new {@link LinkedHashMap} sized to fit all the elements of the size provided.
+     * @param size The size to fit all the elements
+     * @param <K> The key type
+     * @param <V> The value type
+     * @return a new {@link LinkedHashMap} with reallocated size
+     * @since 4.0.0
+     */
+    public static <K, V> LinkedHashMap<K, V> newLinkedHashMap(int size) {
+        return new LinkedHashMap<>(calculateHashSetSize(size));
+    }
+
+    private static int calculateHashSetSize(int size) {
+        // Based on the calculation in new HashSet(Collection)
+        return Math.max((int) (size / .75f) + 1, 16);
+    }
+
+    /**
      * Is the given type an iterable or map type.
      * @param type The type
      * @return True if it is iterable or map

--- a/core/src/main/java/io/micronaut/core/util/EnvironmentProperties.java
+++ b/core/src/main/java/io/micronaut/core/util/EnvironmentProperties.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.Function;
 
 /**
  * A mapping from environment variable names to Micronaut
@@ -100,7 +101,13 @@ public final class EnvironmentProperties {
                 return result;
             }
         }
-        return cache.computeIfAbsent(env, EnvironmentProperties::computePropertiesFor);
+        // Keep the anonymous class instead of Lambda to reduce the Lambda invocation overhead during the startup
+        return cache.computeIfAbsent(env, new Function<String, List<String>>() {
+            @Override
+            public List<String> apply(String env1) {
+                return computePropertiesFor(env1);
+            }
+        });
     }
 
     private static List<String> computePropertiesFor(String env) {

--- a/core/src/main/java/io/micronaut/core/util/StreamUtils.java
+++ b/core/src/main/java/io/micronaut/core/util/StreamUtils.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.core.util;
 
+import io.micronaut.core.annotation.NextMajorVersion;
+
 import java.util.*;
 import java.util.function.BiConsumer;
 import java.util.function.BinaryOperator;
@@ -189,7 +191,10 @@ public class StreamUtils {
     /**
      * @param <T> The type
      * @return An immutable collection
+     * @deprecated use Stream#toList
      */
+    @Deprecated(forRemoval = true)
+    @NextMajorVersion("Remove after Micronaut 4 milestone 1")
     public static <T> Collector<T, Collection<T>, Collection<T>> toImmutableCollection() {
         return toImmutableCollection(ArrayList::new);
     }

--- a/core/src/main/java/io/micronaut/core/value/MapPropertyResolver.java
+++ b/core/src/main/java/io/micronaut/core/value/MapPropertyResolver.java
@@ -20,11 +20,13 @@ import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.util.StringUtils;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * A {@link PropertyResolver} that resolves values from a backing map.
@@ -74,17 +76,23 @@ public class MapPropertyResolver implements PropertyResolver {
     public Collection<String> getPropertyEntries(@NonNull String name) {
         if (StringUtils.isNotEmpty(name)) {
             String prefix = name + ".";
-            return map.keySet().stream().filter(k -> k.startsWith(prefix))
-                    .map(k -> {
-                        String withoutPrefix = k.substring(prefix.length());
-                        int i = withoutPrefix.indexOf('.');
-                        if (i > -1) {
-                            return withoutPrefix.substring(0, i);
-                        }
-                        return withoutPrefix;
-                    })
-                    // to list to retain order from linked hash map
-                    .toList();
+            Set<String> strings = map.keySet();
+            // to list to retain order from linked hash map
+            List<String> entries = new ArrayList<>(strings.size());
+            for (String k : strings) {
+                if (k.startsWith(prefix)) {
+                    String withoutPrefix = k.substring(prefix.length());
+                    int i = withoutPrefix.indexOf('.');
+                    String e;
+                    if (i > -1) {
+                        e = withoutPrefix.substring(0, i);
+                    } else {
+                        e = withoutPrefix;
+                    }
+                    entries.add(e);
+                }
+            }
+            return entries;
         }
         return Collections.emptySet();
     }

--- a/core/src/test/groovy/io/micronaut/core/convert/DefaultConversionServiceSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/convert/DefaultConversionServiceSpec.groovy
@@ -3,12 +3,10 @@ package io.micronaut.core.convert
 import io.micronaut.core.convert.exceptions.ConversionErrorException
 import io.micronaut.core.type.Argument
 import spock.lang.Specification
-import spock.lang.Unroll
 
 import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
 import java.time.DayOfWeek
-
 /**
  * Created by graemerocher on 12/06/2017.
  */
@@ -104,7 +102,7 @@ class DefaultConversionServiceSpec extends Specification {
         then:
         def e = thrown(ConversionErrorException)
         e.conversionError.originalValue.get() == 'junk'
-        e.message == 'Failed to convert argument [Integer] for value [junk] due to: For input string: "junk"'
+        e.message == 'Failed to convert argument [integer] for value [junk] due to: For input string: "junk"'
     }
 
     void "test conversion service with type arguments"() {

--- a/core/src/test/groovy/io/micronaut/core/type/ArgumentSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/type/ArgumentSpec.groovy
@@ -111,8 +111,26 @@ class ArgumentSpec extends Specification {
 
     void "test equals/hashcode"() {
         expect:
-        Argument.of(Optional.class, Integer.class).hashCode() == Argument.of(Optional.class, Integer.class).hashCode()
-        Argument.of(Optional.class, Integer.class) == Argument.of(Optional.class, Integer.class)
+        Argument.optionalOf(Integer.class).getName() == Argument.of(Optional.class, Integer.class).getName()
+        Argument.optionalOf(Integer.class).getName() == "optional"
+        Argument.optionalOf(Integer.class).hashCode() == Argument.of(Optional.class, Integer.class).hashCode()
+        Argument.optionalOf(Integer.class) == Argument.of(Optional.class, Integer.class)
+        assertArgumentWithOneTypeParameter(Argument.of(Optional.class, Integer.class), Argument.optionalOf(Integer.class))
+        assertArgumentWithOneTypeParameter(Argument.of(List.class, Integer.class), Argument.listOf(Integer.class))
+        assertArgumentWithOneTypeParameter(Argument.of(Set.class, Integer.class), Argument.setOf(Integer.class))
+        assertArgumentWithOneTypeParameter(Argument.of(Map.class, Integer.class, String.class), Argument.mapOf(Integer.class, String.class))
+    }
+
+    void assertArgumentWithOneTypeParameter(Argument a1, Argument a2) {
+        assertArgument(a1, a2)
+        assert a1.getTypeParameters() == a2.getTypeParameters()
+        assertArgument(a1.getTypeParameters()[0], a2.getTypeParameters()[0])
+    }
+
+    void assertArgument(Argument a1, Argument a2) {
+        assert a1 == a2
+        assert a1.hashCode() == a2.hashCode()
+        assert a1.name == a2.name
     }
 
     void "test generic list"() {

--- a/graal/src/main/java/io/micronaut/graal/reflect/GraalReflectionMetadataWriter.java
+++ b/graal/src/main/java/io/micronaut/graal/reflect/GraalReflectionMetadataWriter.java
@@ -15,9 +15,6 @@
  */
 package io.micronaut.graal.reflect;
 
-import java.io.IOException;
-import java.io.OutputStream;
-
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.graal.GraalReflectionConfigurer;
 import io.micronaut.inject.ast.ClassElement;
@@ -26,6 +23,9 @@ import io.micronaut.inject.writer.ClassWriterOutputVisitor;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.GeneratorAdapter;
+
+import java.io.IOException;
+import java.io.OutputStream;
 
 /**
  * Generates Runtime executed Graal configuration.
@@ -40,7 +40,7 @@ final class GraalReflectionMetadataWriter extends AbstractAnnotationMetadataWrit
 
     public GraalReflectionMetadataWriter(ClassElement originatingElement,
                                          AnnotationMetadata annotationMetadata) {
-        super(resolveName(originatingElement), originatingElement, annotationMetadata, false);
+        super(resolveName(originatingElement), originatingElement, annotationMetadata, true);
         this.className = targetClassType.getClassName();
         this.classInternalName = targetClassType.getInternalName();
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -175,8 +175,8 @@ jcache = { module = "javax.cache:cache-api", version.ref = "jcache" }
 
 jetty-alpn-openjdk8-client = { module = "org.eclipse.jetty:jetty-alpn-openjdk8-client", version.ref = "jetty" }
 
-jmh = { module = "org.openjdk.jmh:jmh-core", version.ref = "jmh" }
-jmh-generator-annprocess = { module = "org.openjdk.jmh:jmh-core", version.ref = "jmh" }
+jmh-core = { module = "org.openjdk.jmh:jmh-core", version.ref = "jmh" }
+jmh-generator-annprocess = { module = "org.openjdk.jmh:jmh-generator-annprocess", version.ref = "jmh" }
 
 jsr107 = { module = "org.jsr107.ri:cache-ri-impl", version.ref = "jsr107" }
 jsr305 = { module = "com.google.code.findbugs:jsr305", version.ref = "jsr305" }

--- a/http-client/src/test/groovy/io/micronaut/http/client/HttpGetSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/HttpGetSpec.groovy
@@ -244,7 +244,7 @@ class HttpGetSpec extends Specification {
     void "test simple get request with POJO list"() {
         when:
         Flux<HttpResponse<List<Book>>> flowable = Flux.from(client.exchange(
-                HttpRequest.GET("/get/pojoList"), Argument.of(List, Book)
+                HttpRequest.GET("/get/pojoList"), Argument.listOf(Book)
         ))
 
         HttpResponse<List<Book>> response = flowable.blockFirst()

--- a/http-client/src/test/groovy/io/micronaut/http/client/HttpHeadSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/HttpHeadSpec.groovy
@@ -190,7 +190,7 @@ class HttpHeadSpec extends Specification {
     void "test simple get request with POJO list"() {
         when:
         Flux<HttpResponse<List<Book>>> flowable = Flux.from(client.exchange(
-                HttpRequest.HEAD("/head/pojoList"), Argument.of(List, Book)
+                HttpRequest.HEAD("/head/pojoList"), Argument.listOf(Book)
         ))
 
         HttpResponse<List<Book>> response = flowable.blockFirst()

--- a/http-client/src/test/groovy/io/micronaut/http/client/HttpPostSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/HttpPostSpec.groovy
@@ -325,7 +325,7 @@ class HttpPostSpec extends Specification {
         List<Boolean> booleans = blockingHttpClient.retrieve(
                 HttpRequest.POST("/post/booleans", "[true, true, false]"),
 
-                Argument.of(List.class, Boolean.class)
+                Argument.listOf(Boolean.class)
         )
 
         expect:

--- a/http-client/src/test/groovy/io/micronaut/http/client/StreamRequestSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/StreamRequestSpec.groovy
@@ -15,19 +15,22 @@
  */
 package io.micronaut.http.client
 
-import io.micronaut.core.async.annotation.SingleResult
 import groovy.transform.EqualsAndHashCode
 import groovy.transform.ToString
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Property
 import io.micronaut.context.annotation.Requires
-import io.micronaut.core.annotation.NonNull
+import io.micronaut.core.async.annotation.SingleResult
 import io.micronaut.core.type.Argument
 import io.micronaut.http.HttpHeaders
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.MediaType
-import io.micronaut.http.annotation.*
+import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Header
+import io.micronaut.http.annotation.Post
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.runtime.server.EmbeddedServer
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
@@ -35,12 +38,10 @@ import jakarta.inject.Inject
 import org.reactivestreams.Publisher
 import reactor.core.publisher.Flux
 import reactor.core.publisher.FluxSink
-import reactor.core.publisher.Mono
 import spock.lang.Specification
 
 import java.nio.charset.StandardCharsets
 import java.time.Duration
-
 /**
  * @author graemerocher
  * @since 1.0
@@ -133,7 +134,7 @@ class StreamRequestSpec extends Specification {
                 }
                 emitter.complete()
         }, FluxSink.OverflowStrategy.BUFFER
-        )), Argument.of(List, Book))).blockFirst()
+        )), Argument.listOf(Book))).blockFirst()
 
         then:
         result.body().size() == 5
@@ -156,7 +157,7 @@ class StreamRequestSpec extends Specification {
                 emitter.complete()
         }, FluxSink.OverflowStrategy.BUFFER
 
-        )), Argument.of(List, Book))).blockFirst()
+        )), Argument.listOf(Book))).blockFirst()
 
         then:
         result.body().size() == 5

--- a/http-client/src/test/groovy/io/micronaut/http/client/docs/basics/HelloControllerTest.java
+++ b/http-client/src/test/groovy/io/micronaut/http/client/docs/basics/HelloControllerTest.java
@@ -103,7 +103,7 @@ public class HelloControllerTest {
         // tag::jsonmaptypes[]
         response = Flux.from(client.retrieve(
                 GET("/greet/John"),
-                Argument.of(Map.class, String.class, String.class) // <1>
+                Argument.mapOf(String.class, String.class) // <1>
         ));
         // end::jsonmaptypes[]
 

--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/converters/KQueueChannelOptionFactory.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/converters/KQueueChannelOptionFactory.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.http.netty.channel.converters;
 
+import io.micronaut.context.annotation.Prototype;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.env.Environment;
 import io.micronaut.core.annotation.Internal;
@@ -26,7 +27,6 @@ import io.netty.channel.kqueue.AcceptFilter;
 import io.netty.channel.kqueue.KQueue;
 import io.netty.channel.kqueue.KQueueChannelOption;
 import io.netty.channel.unix.UnixChannelOption;
-import jakarta.inject.Singleton;
 
 import java.util.Map;
 import java.util.Optional;
@@ -36,7 +36,7 @@ import java.util.Optional;
  * @author croudet
  */
 @Internal
-@Singleton
+@Prototype
 @Requires(classes = KQueue.class, condition = KQueueAvailabilityCondition.class)
 public class KQueueChannelOptionFactory implements ChannelOptionFactory, TypeConverterRegistrar {
 

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
@@ -16,6 +16,7 @@
 package io.micronaut.http.server.netty;
 
 import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.DefaultApplicationContext;
 import io.micronaut.context.env.CachedEnvironment;
 import io.micronaut.context.env.Environment;
 import io.micronaut.context.event.ApplicationEventPublisher;
@@ -260,6 +261,10 @@ public class NettyHttpServer implements NettyEmbeddedServer {
     public synchronized NettyEmbeddedServer start() {
         if (!isRunning()) {
             if (isDefault && !applicationContext.isRunning()) {
+                if (applicationContext instanceof DefaultApplicationContext defaultApplicationContext) {
+                    // Stop did remove the existing environment
+                    defaultApplicationContext.setEnvironment(environment);
+                }
                 applicationContext.start();
             }
             //suppress unused
@@ -572,7 +577,6 @@ public class NettyHttpServer implements NettyEmbeddedServer {
     }
 
     private void fireStartupEvents() {
-        Optional<String> applicationName = serverConfiguration.getApplicationConfiguration().getName();
         applicationContext.getEventPublisher(ServerStartupEvent.class)
                 .publishEvent(new ServerStartupEvent(this));
     }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/NettyBinderRegistrar.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/NettyBinderRegistrar.java
@@ -17,6 +17,7 @@ package io.micronaut.http.server.netty.binders;
 
 import io.micronaut.context.BeanLocator;
 import io.micronaut.context.BeanProvider;
+import io.micronaut.context.annotation.Prototype;
 import io.micronaut.context.event.BeanCreatedEvent;
 import io.micronaut.context.event.BeanCreatedEventListener;
 import io.micronaut.core.annotation.Internal;
@@ -27,7 +28,6 @@ import io.micronaut.http.server.netty.HttpContentProcessorResolver;
 import io.micronaut.http.server.netty.multipart.MultipartBodyArgumentBinder;
 import io.micronaut.scheduling.TaskExecutors;
 import jakarta.inject.Named;
-import jakarta.inject.Singleton;
 
 import java.util.concurrent.ExecutorService;
 
@@ -37,7 +37,7 @@ import java.util.concurrent.ExecutorService;
  * @author graemerocher
  * @since 2.0.0
  */
-@Singleton
+@Prototype
 @Internal
 class NettyBinderRegistrar implements BeanCreatedEventListener<RequestBinderRegistry> {
 

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/converters/NettyConverters.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/converters/NettyConverters.java
@@ -16,6 +16,7 @@
 package io.micronaut.http.server.netty.converters;
 
 import io.micronaut.context.BeanProvider;
+import io.micronaut.context.annotation.Prototype;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.MutableConversionService;
@@ -33,7 +34,6 @@ import io.netty.buffer.ByteBufInputStream;
 import io.netty.channel.ChannelOption;
 import io.netty.handler.codec.http.multipart.Attribute;
 import io.netty.handler.codec.http.multipart.FileUpload;
-import jakarta.inject.Singleton;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -47,13 +47,13 @@ import java.util.Optional;
  * @author graemerocher
  * @since 1.0
  */
-@Singleton
+@Prototype
 @Internal
 public class NettyConverters implements TypeConverterRegistrar {
 
     private final ConversionService conversionService;
     private final BeanProvider<MediaTypeCodecRegistry> decoderRegistryProvider;
-    private final ChannelOptionFactory channelOptionFactory;
+    private final BeanProvider<ChannelOptionFactory> channelOptionFactory;
 
     /**
      * Default constructor.
@@ -64,7 +64,7 @@ public class NettyConverters implements TypeConverterRegistrar {
     public NettyConverters(ConversionService conversionService,
                            //Prevent early initialization of the codecs
                            BeanProvider<MediaTypeCodecRegistry> decoderRegistryProvider,
-                           ChannelOptionFactory channelOptionFactory) {
+                           BeanProvider<ChannelOptionFactory> channelOptionFactory) {
         this.conversionService = conversionService;
         this.decoderRegistryProvider = decoderRegistryProvider;
         this.channelOptionFactory = channelOptionFactory;
@@ -78,7 +78,7 @@ public class NettyConverters implements TypeConverterRegistrar {
                 (object, targetType, context) -> {
                     String str = object.toString();
                     String name = NameUtils.underscoreSeparate(str).toUpperCase(Locale.ENGLISH);
-                    return Optional.of(channelOptionFactory.channelOption(name));
+                    return Optional.of(channelOptionFactory.get().channelOption(name));
                 }
         );
 
@@ -109,7 +109,7 @@ public class NettyConverters implements TypeConverterRegistrar {
         conversionService.addConverter(
                 String.class,
                 ChannelOption.class,
-                s -> channelOptionFactory.channelOption(NameUtils.environmentName(s))
+                s -> channelOptionFactory.get().channelOption(NameUtils.environmentName(s))
         );
     }
 

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/NettyStartStopSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/NettyStartStopSpec.groovy
@@ -15,6 +15,7 @@ class NettyStartStopSpec extends Specification {
 
     void "stopping and starting the netty server in a named application should work"() {
         given:
+        StartListener.globalEventCount.set(0)
         EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
                 'spec.name': 'NettyStartStopSpec',
                 'micronaut.application.name': 'example'
@@ -28,7 +29,8 @@ class NettyStartStopSpec extends Specification {
         server.start()
 
         then:
-        listener.eventCount.get() == 2
+        StartListener.globalEventCount.get() == 2
+        listener.eventCount.get() == 1
         server.applicationContext.isRunning()
 
         cleanup:
@@ -40,10 +42,12 @@ class NettyStartStopSpec extends Specification {
     @Requires(property = "spec.name", value = "NettyStartStopSpec")
     static class StartListener implements ApplicationEventListener<ServiceReadyEvent> {
 
+        static AtomicInteger globalEventCount = new AtomicInteger(0)
         AtomicInteger eventCount = new AtomicInteger(0)
 
         @Override
         void onApplicationEvent(ServiceReadyEvent event) {
+            globalEventCount.incrementAndGet()
             eventCount.incrementAndGet()
         }
     }

--- a/http/src/main/java/io/micronaut/http/converters/HttpConverterRegistrar.java
+++ b/http/src/main/java/io/micronaut/http/converters/HttpConverterRegistrar.java
@@ -15,13 +15,14 @@
  */
 package io.micronaut.http.converters;
 
+import io.micronaut.context.annotation.Prototype;
 import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.core.convert.MutableConversionService;
 import io.micronaut.core.convert.TypeConverterRegistrar;
 import io.micronaut.core.io.Readable;
 import io.micronaut.core.io.ResourceLoader;
 import io.micronaut.core.io.ResourceResolver;
-import jakarta.inject.Singleton;
+import jakarta.inject.Provider;
 
 import java.net.URL;
 import java.util.Optional;
@@ -32,17 +33,17 @@ import java.util.Optional;
  * @author graemerocher
  * @since 2.0
  */
-@Singleton
+@Prototype
 public class HttpConverterRegistrar implements TypeConverterRegistrar {
 
-    private final ResourceResolver resourceResolver;
+    private final Provider<ResourceResolver> resourceResolver;
 
     /**
      * Default constructor.
      *
      * @param resourceResolver The resource resolver
      */
-    protected HttpConverterRegistrar(ResourceResolver resourceResolver) {
+    protected HttpConverterRegistrar(Provider<ResourceResolver> resourceResolver) {
         this.resourceResolver = resourceResolver;
     }
 
@@ -53,14 +54,14 @@ public class HttpConverterRegistrar implements TypeConverterRegistrar {
                 Readable.class,
                 (object, targetType, context) -> {
                     String pathStr = object.toString();
-                    Optional<ResourceLoader> supportingLoader = resourceResolver.getSupportingLoader(pathStr);
+                    Optional<ResourceLoader> supportingLoader = resourceResolver.get().getSupportingLoader(pathStr);
                     if (!supportingLoader.isPresent()) {
                         context.reject(pathStr, new ConfigurationException(
                                 "No supported resource loader for path [" + pathStr + "]. Prefix the path with a supported prefix such as 'classpath:' or 'file:'"
                         ));
                         return Optional.empty();
                     } else {
-                        final Optional<URL> resource = resourceResolver.getResource(pathStr);
+                        final Optional<URL> resource = resourceResolver.get().getResource(pathStr);
                         if (resource.isPresent()) {
                             return Optional.of(Readable.of(resource.get()));
                         } else {

--- a/inject-java/src/test/groovy/io/micronaut/inject/factory/nullreturn/NullableFactory.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/factory/nullreturn/NullableFactory.java
@@ -15,14 +15,12 @@
  */
 package io.micronaut.inject.factory.nullreturn;
 
-import io.micronaut.context.annotation.*;
-
-import io.micronaut.core.annotation.Nullable;
-import io.micronaut.context.condition.Condition;
-import io.micronaut.context.condition.ConditionContext;
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Prototype;
 import io.micronaut.context.exceptions.DisabledBeanException;
-import io.micronaut.core.annotation.AnnotationMetadataProvider;
-
+import io.micronaut.core.annotation.Nullable;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 
@@ -34,6 +32,7 @@ public class NullableFactory {
     public int dCalls = 0;
     public int d2Calls = 0;
     public int d3Calls = 0;
+    public int d4Calls = 0;
 
     @Prototype
     A getA(@Parameter String name) {
@@ -111,6 +110,12 @@ public class NullableFactory {
         }
     }
 
+    @EachBean(C.class)
+    D4 getD4(@Nullable C c, @Nullable @Parameter B b) {
+        d4Calls++;
+        return new D4();
+    }
+
     @EachBean(D.class)
     E getE(D d, F f) {
         return new E();
@@ -142,6 +147,7 @@ class C {
 class D {}
 class D2 {}
 class D3 {}
+class D4 {}
 class E {}
 class F {}
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxybeanwithpredestroy/ProxyBeanWithPreDestroySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxybeanwithpredestroy/ProxyBeanWithPreDestroySpec.groovy
@@ -15,10 +15,9 @@
  */
 package io.micronaut.inject.lifecycle.proxybeanwithpredestroy
 
+import io.micronaut.context.ApplicationContext
 import io.micronaut.context.BeanContext
-import io.micronaut.context.DefaultBeanContext
 import spock.lang.Specification
-
 // proxyTarget = false proxies are always destroyed
 class ProxyBeanWithPreDestroySpec extends Specification {
 
@@ -42,7 +41,7 @@ class ProxyBeanWithPreDestroySpec extends Specification {
 
     void "test cannot destroyed a proxy bean by the class name"() {
         given:
-            BeanContext context = new DefaultBeanContext()
+            BeanContext context = ApplicationContext.builder().properties("spec": getClass().getSimpleName()).build()
             context.start()
 
         when:
@@ -60,7 +59,7 @@ class ProxyBeanWithPreDestroySpec extends Specification {
 
     void "test that a pre-destroy hook works"() {
         given:
-            BeanContext context = new DefaultBeanContext()
+            BeanContext context = ApplicationContext.builder().properties("spec": getClass().getSimpleName()).build()
             context.start()
 
         when:
@@ -89,7 +88,7 @@ class ProxyBeanWithPreDestroySpec extends Specification {
 
     void "test that a pre-destroy hook works when destroyed by registration"() {
         given:
-            BeanContext context = new DefaultBeanContext()
+            BeanContext context = ApplicationContext.builder().properties("spec": getClass().getSimpleName()).build()
             context.start()
 
         when:
@@ -121,7 +120,7 @@ class ProxyBeanWithPreDestroySpec extends Specification {
 
     void "test that a bean with a pre-destroy hook works closed on close"() {
         given:
-            BeanContext context = new DefaultBeanContext()
+            BeanContext context = ApplicationContext.builder().properties("spec": getClass().getSimpleName()).build()
             context.start()
 
         when:
@@ -147,7 +146,7 @@ class ProxyBeanWithPreDestroySpec extends Specification {
 
     void "test that destroy events run in the right phase"() {
         given:
-            BeanContext context = new DefaultBeanContext()
+            BeanContext context = ApplicationContext.builder().properties("spec": getClass().getSimpleName()).build()
             context.start()
 
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxybeanwithpredestroy/package-info.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxybeanwithpredestroy/package-info.java
@@ -1,0 +1,5 @@
+
+@Requires(property = "spec", value = "ProxyBeanWithPreDestroySpec")
+package io.micronaut.inject.lifecycle.proxybeanwithpredestroy;
+
+import io.micronaut.context.annotation.Requires;

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanprototypewithpredestroy/ProxyLazyCachedTargetPrototypeBeanWithPreDestroySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanprototypewithpredestroy/ProxyLazyCachedTargetPrototypeBeanWithPreDestroySpec.groovy
@@ -15,8 +15,8 @@
  */
 package io.micronaut.inject.lifecycle.proxytargetbeanprototypewithpredestroy
 
+import io.micronaut.context.ApplicationContext
 import io.micronaut.context.BeanContext
-import io.micronaut.context.DefaultBeanContext
 import spock.lang.Specification
 
 class ProxyLazyCachedTargetPrototypeBeanWithPreDestroySpec extends Specification {
@@ -41,7 +41,7 @@ class ProxyLazyCachedTargetPrototypeBeanWithPreDestroySpec extends Specification
 
     void "test that a lazy target bean with a pre-destroy hook works"() {
         given:
-            BeanContext context = new DefaultBeanContext()
+            BeanContext context = ApplicationContext.builder().properties("spec": getClass().getSimpleName()).build()
             context.start()
 
         when:
@@ -71,7 +71,7 @@ class ProxyLazyCachedTargetPrototypeBeanWithPreDestroySpec extends Specification
 
     void "test that a proxy pre-destroy is not called on not-initialized target"() {
         given:
-            BeanContext context = new DefaultBeanContext()
+            BeanContext context = ApplicationContext.builder().properties("spec": getClass().getSimpleName()).build()
             context.start()
 
         when:
@@ -100,7 +100,7 @@ class ProxyLazyCachedTargetPrototypeBeanWithPreDestroySpec extends Specification
 
     void "test that a lazy proxy bean with a pre-destroy hook works when destroyed by registration"() {
         given:
-            BeanContext context = new DefaultBeanContext()
+            BeanContext context = ApplicationContext.builder().properties("spec": getClass().getSimpleName()).build()
             context.start()
 
         when:
@@ -133,7 +133,7 @@ class ProxyLazyCachedTargetPrototypeBeanWithPreDestroySpec extends Specification
 
     void "test that a lazy proxy bean with a pre-destroy hook is not called on not-initialized target"() {
         given:
-            BeanContext context = new DefaultBeanContext()
+            BeanContext context = ApplicationContext.builder().properties("spec": getClass().getSimpleName()).build()
             context.start()
 
         when:
@@ -164,7 +164,7 @@ class ProxyLazyCachedTargetPrototypeBeanWithPreDestroySpec extends Specification
 
     void "test that a bean with a pre-destroy hook works closed on close"() {
         given:
-            BeanContext context = new DefaultBeanContext()
+            BeanContext context = ApplicationContext.builder().properties("spec": getClass().getSimpleName()).build()
             context.start()
 
         when:
@@ -192,7 +192,7 @@ class ProxyLazyCachedTargetPrototypeBeanWithPreDestroySpec extends Specification
 
     void "test proxies are prototypes and dependent beans not destroyed when created by `getBean(<ProxyClass>)`"() {
         given:
-            BeanContext context = new DefaultBeanContext()
+            BeanContext context = ApplicationContext.builder().properties("spec": getClass().getSimpleName()).build()
             context.start()
 
         when:
@@ -221,9 +221,8 @@ class ProxyLazyCachedTargetPrototypeBeanWithPreDestroySpec extends Specification
 
     void "test that destroy events run in the right phase"() {
         given:
-            BeanContext context = new DefaultBeanContext()
+            BeanContext context = ApplicationContext.builder().properties("spec": getClass().getSimpleName()).build()
             context.start()
-
 
         when:
             def pre = context.getBean(CPreDestroyEventListener)

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanprototypewithpredestroy/package-info.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanprototypewithpredestroy/package-info.java
@@ -1,0 +1,5 @@
+
+@Requires(property = "spec", value = "ProxyLazyCachedTargetPrototypeBeanWithPreDestroySpec")
+package io.micronaut.inject.lifecycle.proxytargetbeanprototypewithpredestroy;
+
+import io.micronaut.context.annotation.Requires;

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanwithpredestroy/ProxyTargetBeanWithPreDestroySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanwithpredestroy/ProxyTargetBeanWithPreDestroySpec.groovy
@@ -15,8 +15,8 @@
  */
 package io.micronaut.inject.lifecycle.proxytargetbeanwithpredestroy
 
+import io.micronaut.context.ApplicationContext
 import io.micronaut.context.BeanContext
-import io.micronaut.context.DefaultBeanContext
 import spock.lang.Specification
 
 class ProxyTargetBeanWithPreDestroySpec extends Specification {
@@ -41,7 +41,7 @@ class ProxyTargetBeanWithPreDestroySpec extends Specification {
 
     void "test cannot destroyed a proxy bean by the class name"() {
         given:
-            BeanContext context = new DefaultBeanContext()
+            BeanContext context = ApplicationContext.builder().properties("spec": getClass().getSimpleName()).build()
             context.start()
 
         when:
@@ -59,7 +59,7 @@ class ProxyTargetBeanWithPreDestroySpec extends Specification {
 
     void "test that a lazy target bean with a pre-destroy hook works"() {
         given:
-            BeanContext context = new DefaultBeanContext()
+            BeanContext context = ApplicationContext.builder().properties("spec": getClass().getSimpleName()).build()
             context.start()
 
         when:
@@ -89,7 +89,7 @@ class ProxyTargetBeanWithPreDestroySpec extends Specification {
 
     void "test that a proxy pre-destroy is not called on not-initialized target"() {
         given:
-            BeanContext context = new DefaultBeanContext()
+            BeanContext context = ApplicationContext.builder().properties("spec": getClass().getSimpleName()).build()
             context.start()
 
         when:
@@ -118,7 +118,7 @@ class ProxyTargetBeanWithPreDestroySpec extends Specification {
 
     void "test that a lazy proxy bean with a pre-destroy hook works when destroyed by registration"() {
         given:
-            BeanContext context = new DefaultBeanContext()
+            BeanContext context = ApplicationContext.builder().properties("spec": getClass().getSimpleName()).build()
             context.start()
 
         when:
@@ -151,7 +151,7 @@ class ProxyTargetBeanWithPreDestroySpec extends Specification {
 
     void "test that a lazy proxy bean with a pre-destroy hook is not called on not-initialized target"() {
         given:
-            BeanContext context = new DefaultBeanContext()
+            BeanContext context = ApplicationContext.builder().properties("spec": getClass().getSimpleName()).build()
             context.start()
 
         when:
@@ -182,7 +182,7 @@ class ProxyTargetBeanWithPreDestroySpec extends Specification {
 
     void "test that a bean with a pre-destroy hook works closed on close"() {
         given:
-            BeanContext context = new DefaultBeanContext()
+            BeanContext context = ApplicationContext.builder().properties("spec": getClass().getSimpleName()).build()
             context.start()
 
         when:
@@ -210,7 +210,7 @@ class ProxyTargetBeanWithPreDestroySpec extends Specification {
 
     void "test proxies are prototypes and dependent beans not destroyed when created by `getBean(<ProxyClass>)`"() {
         given:
-            BeanContext context = new DefaultBeanContext()
+            BeanContext context = ApplicationContext.builder().properties("spec": getClass().getSimpleName()).build()
             context.start()
 
         when:
@@ -238,7 +238,7 @@ class ProxyTargetBeanWithPreDestroySpec extends Specification {
 
     void "test that destroy events run in the right phase"() {
         given:
-            BeanContext context = new DefaultBeanContext()
+            BeanContext context = ApplicationContext.builder().properties("spec": getClass().getSimpleName()).build()
             context.start()
 
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanwithpredestroy/package-info.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/lifecycle/proxytargetbeanwithpredestroy/package-info.java
@@ -1,0 +1,5 @@
+
+@Requires(property = "spec", value = "ProxyTargetBeanWithPreDestroySpec")
+package io.micronaut.inject.lifecycle.proxytargetbeanwithpredestroy;
+
+import io.micronaut.context.annotation.Requires;

--- a/inject/src/main/java/io/micronaut/context/AbstractExecutableMethodsDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractExecutableMethodsDefinition.java
@@ -63,7 +63,7 @@ public abstract class AbstractExecutableMethodsDefinition<T> implements Executab
     }
 
     @Override
-    public Collection<ExecutableMethod<T, Object>> getExecutableMethods() {
+    public Collection<ExecutableMethod<T, ?>> getExecutableMethods() {
         if (executableMethodsList == null) {
             // Initialize the collection
             for (int i = 0, methodsReferencesLength = methodsReferences.length; i < methodsReferencesLength; i++) {

--- a/inject/src/main/java/io/micronaut/context/AbstractExecutableMethodsDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractExecutableMethodsDefinition.java
@@ -63,7 +63,7 @@ public abstract class AbstractExecutableMethodsDefinition<T> implements Executab
     }
 
     @Override
-    public Collection<ExecutableMethod<T, ?>> getExecutableMethods() {
+    public Collection<ExecutableMethod<T, Object>> getExecutableMethods() {
         if (executableMethodsList == null) {
             // Initialize the collection
             for (int i = 0, methodsReferencesLength = methodsReferences.length; i < methodsReferencesLength; i++) {

--- a/inject/src/main/java/io/micronaut/context/AbstractInitializableBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractInitializableBeanDefinition.java
@@ -596,7 +596,7 @@ public abstract class AbstractInitializableBeanDefinition<T> extends AbstractBea
     }
 
     @Override
-    public final Collection<ExecutableMethod<T, Object>> getExecutableMethods() {
+    public final Collection<ExecutableMethod<T, ?>> getExecutableMethods() {
         if (executableMethodsDefinition == null) {
             return Collections.emptyList();
         }

--- a/inject/src/main/java/io/micronaut/context/AbstractInitializableBeanDefinitionReference.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractInitializableBeanDefinitionReference.java
@@ -176,8 +176,12 @@ public abstract class AbstractInitializableBeanDefinitionReference<T> extends Ab
     @Override
     public BeanDefinition load(BeanContext context) {
         BeanDefinition definition = load();
-        if (context instanceof ApplicationContext && definition instanceof EnvironmentConfigurable) {
-            ((EnvironmentConfigurable) definition).configure(((ApplicationContext) context).getEnvironment());
+        if (context instanceof DefaultApplicationContext applicationContext
+            && definition instanceof EnvironmentConfigurable environmentConfigurable) {
+            // Performance optimization to check for the actual class to avoid the type-check pollution
+            environmentConfigurable.configure(applicationContext.getEnvironment());
+        } else if (context instanceof ApplicationContext applicationContext && definition instanceof EnvironmentConfigurable environmentConfigurable) {
+            environmentConfigurable.configure(applicationContext.getEnvironment());
         }
         return definition;
     }

--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
@@ -28,6 +28,7 @@ import io.micronaut.context.env.PropertySource;
 import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.context.exceptions.DependencyInjectionException;
 import io.micronaut.context.exceptions.NoSuchBeanException;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.convert.ArgumentConversionContext;
@@ -173,6 +174,14 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
             environment = createEnvironment(configuration);
         }
         return environment;
+    }
+
+    /**
+     * @param environment The environment
+     */
+    @Internal
+    public void setEnvironment(Environment environment) {
+        this.environment = environment;
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
@@ -265,7 +265,7 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
     }
 
     @Override
-    protected void initializeContext(List<BeanDefinitionReference> contextScopeBeans, List<BeanDefinitionReference> processedBeans, List<BeanDefinitionReference> parallelBeans) {
+    protected void initializeContext(List<BeanDefinitionProducer> contextScopeBeans, List<BeanDefinitionProducer> processedBeans, List<BeanDefinitionProducer> parallelBeans) {
         initializeTypeConverters(this);
         super.initializeContext(contextScopeBeans, processedBeans, parallelBeans);
     }
@@ -456,7 +456,7 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
                     @SuppressWarnings("unchecked")
                     Class<Object> declaringClass = (Class<Object>) candidate.getBeanType().getDeclaringClass();
                     if (declaringClass != null) {
-                        Collection<BeanDefinition<Object>> beanCandidates = findBeanCandidates(resolutionContext, Argument.of(declaringClass), null, true);
+                        Collection<BeanDefinition<Object>> beanCandidates = findBeanCandidates(resolutionContext, Argument.of(declaringClass), null);
                         for (BeanDefinition<Object> beanCandidate : beanCandidates) {
                             if (beanCandidate instanceof BeanDefinitionDelegate<Object> delegate) {
                                 ConfigurationPath cp = delegate.getConfigurationPath().orElse(configurationPath).copy();
@@ -810,12 +810,12 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
         }
 
         @Override
-        protected void initializeContext(List<BeanDefinitionReference> contextScopeBeans, List<BeanDefinitionReference> processedBeans, List<BeanDefinitionReference> parallelBeans) {
+        protected void initializeContext(List<BeanDefinitionProducer> contextScopeBeans, List<BeanDefinitionProducer> processedBeans, List<BeanDefinitionProducer> parallelBeans) {
             // no-op .. @Context scope beans are not started for bootstrap
         }
 
         @Override
-        protected void processParallelBeans(List<BeanDefinitionReference> parallelBeans) {
+        protected void processParallelBeans(List<BeanDefinitionProducer> parallelBeans) {
             // no-op
         }
 

--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContextBuilder.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContextBuilder.java
@@ -408,9 +408,7 @@ public class DefaultApplicationContextBuilder implements ApplicationContextBuild
      */
     @NonNull
     private static ApplicationContextConfigurer loadApplicationContextCustomizer(@Nullable ClassLoader classLoader) {
-        SoftServiceLoader<ApplicationContextConfigurer> loader = classLoader != null ? SoftServiceLoader.load(
-                ApplicationContextConfigurer.class, classLoader
-        ) : SoftServiceLoader.load(ApplicationContextConfigurer.class);
+        SoftServiceLoader<ApplicationContextConfigurer> loader = SoftServiceLoader.load(ApplicationContextConfigurer.class, classLoader);
         List<ApplicationContextConfigurer> configurers = new ArrayList<>(10);
         loader.collectAll(configurers);
         if (configurers.isEmpty()) {

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -465,6 +465,8 @@ public class DefaultBeanContext implements InitializableBeanContext {
             proxyTargetBeans.clear();
             attributes.clear();
             beanIndex.clear();
+            beanConfigurationsList = null;
+            beanDefinitionReferences = null;
             beanInitializedEventListeners = null;
             beanCreationEventListeners = null;
             beanPreDestroyEventListeners = null;

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1528,7 +1528,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
                                     @NonNull Argument<T> beanType,
                                     @Nullable Qualifier<T> qualifier) {
         BeanDefinition<T> definition = getProxyTargetBeanDefinition(beanType, qualifier);
-        return resolveBeanRegistration(resolutionContext, definition, beanType, null).bean;
+        return resolveBeanRegistration(resolutionContext, definition, beanType, qualifier).bean;
     }
 
     @NonNull

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1680,12 +1680,11 @@ public class DefaultBeanContext implements InitializableBeanContext {
         Class<B> beanType = definition.getBeanType();
         for (Class<?> indexedType : indexedTypes) {
             if (indexedType == beanType || indexedType.isAssignableFrom(beanType)) {
-                final Collection<BeanDefinitionProducer> indexed = resolveTypeIndex(indexedType);
-                indexed.remove(definition);
+                resolveTypeIndex(indexedType).forEach(p -> p.disable(definition));
                 break;
             }
         }
-        this.beanDefinitionsClasses.remove(definition);
+        beanDefinitionsClasses.forEach(p -> p.disable(definition));
         purgeCacheForBeanType(definition.getBeanType());
     }
 
@@ -4229,5 +4228,11 @@ public class DefaultBeanContext implements InitializableBeanContext {
             return reference != null && reference.isCandidateBean(beanType);
         }
 
+        public void disable(BeanDefinitionReference<?> reference) {
+            BeanDefinitionReference ref = this.reference;
+            if (ref != null && ref.equals(reference)) {
+                this.reference = null;
+            }
+        }
     }
 }

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -85,7 +85,6 @@ import io.micronaut.core.type.ReturnType;
 import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
-import io.micronaut.core.util.StreamUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.core.util.clhm.ConcurrentLinkedHashMap;
 import io.micronaut.core.value.PropertyResolver;
@@ -140,12 +139,10 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -174,6 +171,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
         return Integer.compare(order1, order2);
     };
 
+
     protected final AtomicBoolean running = new AtomicBoolean(false);
     protected final AtomicBoolean initializing = new AtomicBoolean(false);
     protected final AtomicBoolean terminating = new AtomicBoolean(false);
@@ -183,10 +181,13 @@ public class DefaultBeanContext implements InitializableBeanContext {
     private final SingletonScope singletonScope = new SingletonScope();
 
     private final BeanContextConfiguration beanContextConfiguration;
-    private final Collection<BeanDefinitionReference> beanDefinitionsClasses = new ConcurrentLinkedQueue<>();
-    private final Collection<BeanDefinitionReference> proxyTargetBeans = new ConcurrentLinkedQueue<>();
 
-    private final Map<BeanKey<?>, BeanDefinitionReference> disabledBeans = new ConcurrentHashMap<>(20);
+    // The collection should be modified only when new bean definition is added
+    // That should't happen that offen, so we can use CopyOnWriteArrayList
+    private final Collection<BeanDefinitionProducer> beanDefinitionsClasses = new CopyOnWriteArrayList<>();
+    private final Collection<BeanDefinitionProducer> proxyTargetBeans = new CopyOnWriteArrayList<>();
+
+    private final Map<BeanKey<?>, BeanDefinitionProducer> disabledBeans = new ConcurrentHashMap<>(20);
     private final Map<String, List<String>> disabledConfigurations = new ConcurrentHashMap<>(5);
     private final Map<String, BeanConfiguration> beanConfigurations = new HashMap<>(10);
     private final Map<BeanKey, Boolean> containsBeanCache = new ConcurrentHashMap<>(30);
@@ -202,7 +203,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
 
     private final Map<Argument, Collection<BeanDefinition>> beanCandidateCache = new ConcurrentLinkedHashMap.Builder<Argument, Collection<BeanDefinition>>().maximumWeightedCapacity(30).build();
 
-    private final Map<Class<?>, Collection<BeanDefinitionReference>> beanIndex = new ConcurrentHashMap<>(12);
+    private final Map<Class<?>, Collection<BeanDefinitionProducer>> beanIndex = new ConcurrentHashMap<>(12);
 
     private final ClassLoader classLoader;
     private final Set<Class<?>> thisInterfaces = CollectionUtils.setOf(
@@ -387,11 +388,11 @@ public class DefaultBeanContext implements InitializableBeanContext {
                 Argument<Object> argument = (Argument<Object>) beanType.getGenericBeanType();
                 @SuppressWarnings("unchecked")
                 Qualifier<Object> declaredQualifier = (Qualifier<Object>) beanType.getDeclaredQualifier();
-                this.disabledBeans.put(new BeanKey<>(argument, declaredQualifier), new DisabledBean<>(
+                this.disabledBeans.put(new BeanKey<>(argument, declaredQualifier), new BeanDefinitionProducer(new DisabledBean<>(
                     argument,
                     declaredQualifier,
                     reasons
-                ));
+                )));
             } catch (Exception | NoClassDefFoundError e) {
                 // it is theoretically possible that resolving the generic type results in an error
                 // in this case just ignore this as the maps built here are purely to aid error diagnosis
@@ -450,12 +451,20 @@ public class DefaultBeanContext implements InitializableBeanContext {
                 }
             }
 
+            singlesInCreation.clear();
             singletonBeanRegistrations.clear();
             beanConcreteCandidateCache.clear();
             beanCandidateCache.clear();
+            beanProxyTargetCache.clear();
             containsBeanCache.clear();
             beanConfigurations.clear();
+            disabledConfigurations.clear();
             singletonScope.clear();
+            beanDefinitionsClasses.clear();
+            disabledBeans.clear();
+            proxyTargetBeans.clear();
+            attributes.clear();
+            beanIndex.clear();
             beanInitializedEventListeners = null;
             beanCreationEventListeners = null;
             beanPreDestroyEventListeners = null;
@@ -1306,8 +1315,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
 
     private <T> void destroyProxyTargetBean(@NonNull BeanRegistration<T> registration, boolean dependent) {
         Set<Object> destroyed = Collections.emptySet();
-        if (registration instanceof BeanDisposingRegistration) {
-            BeanDisposingRegistration<?> disposingRegistration = (BeanDisposingRegistration<?>) registration;
+        if (registration instanceof BeanDisposingRegistration<?> disposingRegistration) {
             if (disposingRegistration.getDependents() != null) {
                 destroyed = Collections.newSetFromMap(new IdentityHashMap<>());
                 for (BeanRegistration<?> beanRegistration : disposingRegistration.getDependents()) {
@@ -1319,7 +1327,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
         BeanDefinition<T> proxyTargetBeanDefinition = findProxyTargetBeanDefinition(registration.beanDefinition)
                 .orElseThrow(() -> new IllegalStateException("Cannot find a proxy target bean definition for: " + registration.beanDefinition));
         Optional<CustomScope<?>> declaredScope = customScopeRegistry.findDeclaredScope(proxyTargetBeanDefinition);
-        if (!declaredScope.isPresent()) {
+        if (declaredScope.isEmpty()) {
             if (proxyTargetBeanDefinition.isSingleton()) {
                 return;
             }
@@ -1490,7 +1498,6 @@ public class DefaultBeanContext implements InitializableBeanContext {
         return list;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     @NonNull
     public <T> T getProxyTargetBean(@NonNull Class<T> beanType, @Nullable Qualifier<T> qualifier) {
@@ -1583,7 +1590,9 @@ public class DefaultBeanContext implements InitializableBeanContext {
         // first traverse component definition classes and load candidates
         Collection candidates;
         if (!beanDefinitionsClasses.isEmpty()) {
-            Stream<BeanDefinitionReference> reduced = qualifier.reduce(Object.class, beanDefinitionsClasses.stream());
+            Stream<BeanDefinitionReference> reduced = qualifier.reduce(Object.class, beanDefinitionsClasses.stream()
+                    .filter(p -> p.isReferenceEnabled(this))
+                    .map(BeanDefinitionProducer::getReference));
             Stream<BeanDefinition> candidateStream = qualifier.reduce(Object.class,
                     reduced
                             .map(ref -> ref.load(this))
@@ -1609,12 +1618,11 @@ public class DefaultBeanContext implements InitializableBeanContext {
         }
 
         if (!beanDefinitionsClasses.isEmpty()) {
-            List collection = beanDefinitionsClasses
+            return beanDefinitionsClasses
                     .stream()
-                    .map(ref -> ref.load(this))
-                    .filter(candidate -> candidate.isEnabled(this))
+                    .filter(p -> p.isDefinitionEnabled(this))
+                    .map(p -> p.getDefinition(this))
                     .collect(Collectors.toList());
-            return collection;
         }
 
         return (Collection<BeanDefinition<?>>) Collections.emptyMap();
@@ -1626,7 +1634,8 @@ public class DefaultBeanContext implements InitializableBeanContext {
     public Collection<BeanDefinitionReference<?>> getBeanDefinitionReferences() {
         if (!beanDefinitionsClasses.isEmpty()) {
             final List refs = beanDefinitionsClasses.stream()
-                    .filter(ref -> ref.isEnabled(this))
+                    .filter(p -> p.isReferenceEnabled(this))
+                    .map(BeanDefinitionProducer::getReference)
                     .toList();
 
             return refs;
@@ -1634,17 +1643,17 @@ public class DefaultBeanContext implements InitializableBeanContext {
         return Collections.emptyList();
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     @NonNull
     public <B> BeanContext registerBeanDefinition(@NonNull RuntimeBeanDefinition<B> definition) {
         Objects.requireNonNull(definition, "Bean definition cannot be null");
         Class<B> beanType = definition.getBeanType();
-        this.beanDefinitionsClasses.add(definition);
+        BeanDefinitionProducer producer = new BeanDefinitionProducer(definition);
+        this.beanDefinitionsClasses.add(producer);
         for (Class<?> indexedType : indexedTypes) {
             if (indexedType == beanType || indexedType.isAssignableFrom(beanType)) {
-                final Collection<BeanDefinitionReference> indexed = resolveTypeIndex(indexedType);
-                indexed.add(definition);
+                final Collection<BeanDefinitionProducer> indexed = resolveTypeIndex(indexedType);
+                indexed.add(producer);
                 break;
             }
         }
@@ -1669,7 +1678,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
         Class<B> beanType = definition.getBeanType();
         for (Class<?> indexedType : indexedTypes) {
             if (indexedType == beanType || indexedType.isAssignableFrom(beanType)) {
-                final Collection<BeanDefinitionReference> indexed = resolveTypeIndex(indexedType);
+                final Collection<BeanDefinitionProducer> indexed = resolveTypeIndex(indexedType);
                 indexed.remove(definition);
                 break;
             }
@@ -1987,142 +1996,117 @@ public class DefaultBeanContext implements InitializableBeanContext {
     /**
      * Initialize the context with the given {@link io.micronaut.context.annotation.Context} scope beans.
      *
-     * @param contextScopeBeans The context scope beans
+     * @param eagerInitBeans The context scope beans
      * @param processedBeans    The beans that require {@link ExecutableMethodProcessor} handling
      * @param parallelBeans     The parallel bean definitions
      */
+    @Internal
     protected void initializeContext(
-            @NonNull List<BeanDefinitionReference> contextScopeBeans,
-            @NonNull List<BeanDefinitionReference> processedBeans,
-            @NonNull List<BeanDefinitionReference> parallelBeans) {
+            @NonNull List<BeanDefinitionProducer> eagerInitBeans,
+            @NonNull List<BeanDefinitionProducer> processedBeans,
+            @NonNull List<BeanDefinitionProducer> parallelBeans) {
 
-        if (CollectionUtils.isNotEmpty(contextScopeBeans)) {
-            final List<BeanDefinition> contextBeans = new ArrayList<>(contextScopeBeans.size());
-
-            for (BeanDefinitionReference contextScopeBean : contextScopeBeans) {
+        if (CollectionUtils.isNotEmpty(eagerInitBeans)) {
+            final List<BeanDefinition<Object>> eagerInit = new ArrayList<>(eagerInitBeans.size());
+            for (BeanDefinitionProducer contextScopeBean : eagerInitBeans) {
                 try {
-                    loadContextScopeBean(contextScopeBean, contextBeans::add);
+                    loadEagerBeans(contextScopeBean, eagerInit);
                 } catch (Throwable e) {
-                    throw new BeanInstantiationException("Bean definition [" + contextScopeBean.getName() + "] could not be loaded: " + e.getMessage(), e);
+                    throw new BeanInstantiationException("Bean definition [" + contextScopeBean.getReference().getName() + "] could not be loaded: " + e.getMessage(), e);
                 }
             }
-            filterReplacedBeans(null, (Collection) contextBeans);
-            OrderUtil.sort(contextBeans);
-            for (BeanDefinition contextScopeDefinition : contextBeans) {
+            filterReplacedBeans(null, eagerInit);
+            OrderUtil.sort(eagerInit);
+            for (BeanDefinition eagerInitDefinition : eagerInit) {
                 try {
-                    loadContextScopeBean(contextScopeDefinition);
+                    initializeEagerBean(eagerInitDefinition);
                 } catch (DisabledBeanException e) {
                     if (AbstractBeanContextConditional.ConditionLog.LOG.isDebugEnabled()) {
-                        AbstractBeanContextConditional.ConditionLog.LOG.debug("Bean of type [{}] disabled for reason: {}", contextScopeDefinition.getBeanType().getSimpleName(), e.getMessage());
+                        AbstractBeanContextConditional.ConditionLog.LOG.debug("Bean of type [{}] disabled for reason: {}", eagerInitDefinition.getBeanType().getSimpleName(), e.getMessage());
                     }
                 } catch (Throwable e) {
-                    throw new BeanInstantiationException("Bean definition [" + contextScopeDefinition.getName() + "] could not be loaded: " + e.getMessage(), e);
+                    throw new BeanInstantiationException("Bean definition [" + eagerInitDefinition.getName() + "] could not be loaded: " + e.getMessage(), e);
                 }
             }
         }
 
         if (!processedBeans.isEmpty()) {
+            List<BeanDefinitionMethodReference<Object, Object>> methodsToProcess = new ArrayList<>();
+            for (BeanDefinitionProducer processedBeanProducer : processedBeans) {
+                if (!processedBeanProducer.isDefinitionEnabled(this)) {
+                    continue;
+                }
+                BeanDefinition<Object> definition = processedBeanProducer.getDefinition(this);
+                for (ExecutableMethod<Object, Object> method : definition.getExecutableMethods()) {
+                    if (method.hasStereotype(Executable.class)) {
+                        methodsToProcess.add(BeanDefinitionMethodReference.of(definition, method));
+                    }
+                }
+            }
 
-            @SuppressWarnings("unchecked") Stream<BeanDefinitionMethodReference<?, ?>> methodStream = processedBeans
-                    .stream()
-                    // is the bean reference enabled
-                    .filter(ref -> ref.isEnabled(this))
-                    // ok - continue and load it
-                    .map((Function<BeanDefinitionReference, BeanDefinition<?>>) reference -> {
-                        try {
-                            return reference.load(this);
-                        } catch (Exception e) {
-                            throw new BeanInstantiationException("Bean definition [" + reference.getName() + "] could not be loaded: " + e.getMessage(), e);
-                        }
-                    })
-                    // is the bean itself enabled
-                    .filter(bean -> bean.isEnabled(this))
-                    // ok continue and get all of the ExecutableMethod references
-                    .flatMap(beanDefinition ->
-                            beanDefinition.getExecutableMethods()
-                                    .parallelStream()
-                                    .filter(method -> method.hasStereotype(Executable.class))
-                                    .map((Function<ExecutableMethod<?, ?>, BeanDefinitionMethodReference<?, ?>>) executableMethod ->
-                                            BeanDefinitionMethodReference.of((BeanDefinition) beanDefinition, executableMethod)
-                                    )
-                    );
-
+            Map<Class<? extends Annotation>, List<BeanDefinitionMethodReference<?, ?>>> byAnnotation = CollectionUtils.newHashMap(methodsToProcess.size());
             // group the method references by annotation type such that we have a map of Annotation -> MethodReference
             // ie. Class<Scheduled> -> @Scheduled void someAnnotation()
-            Map<Class<? extends Annotation>, List<BeanDefinitionMethodReference<?, ?>>> byAnnotation = new HashMap<>(processedBeans.size());
-            methodStream.forEach(reference -> {
-                List<Class<? extends Annotation>> annotations = reference.getAnnotationTypesByStereotype(Executable.class);
-                annotations.forEach(annotation -> byAnnotation.compute(annotation, (ann, list) -> {
-                    if (list == null) {
-                        list = new ArrayList<>(10);
+            for (BeanDefinitionMethodReference<?, ?> executableMethod : methodsToProcess) {
+                List<Class<? extends Annotation>> annotations = executableMethod.getAnnotationTypesByStereotype(Executable.class);
+                for (Class<? extends Annotation> annotation : annotations) {
+                    List<BeanDefinitionMethodReference<?, ?>> references = byAnnotation.get(annotation);
+                    if (references == null) {
+                        references = new ArrayList<>(10);
+                        byAnnotation.put(annotation, references);
                     }
-                    list.add(reference);
-                    return list;
-                }));
-            });
+                    references.add(executableMethod);
+                }
+            }
 
             // Find ExecutableMethodProcessor for each annotation and process the BeanDefinitionMethodReference
-            byAnnotation.forEach((annotationType, methods) ->
-                    streamOfType(ExecutableMethodProcessor.class, Qualifiers.byTypeArguments(annotationType))
-                            .forEach(processor -> {
-                                if (processor instanceof LifeCycle<?>) {
-                                    ((LifeCycle<?>) processor).start();
-                                }
-                                for (BeanDefinitionMethodReference<?, ?> method : methods) {
+            for (Map.Entry<Class<? extends Annotation>, List<BeanDefinitionMethodReference<?, ?>>> entry : byAnnotation.entrySet()) {
+                Class<? extends Annotation> annotationType = entry.getKey();
+                List<BeanDefinitionMethodReference<?, ?>> methods = entry.getValue();
+                streamOfType(ExecutableMethodProcessor.class, Qualifiers.byTypeArguments(annotationType))
+                    .forEach(processor -> {
+                        if (processor instanceof LifeCycle<?>) {
+                            ((LifeCycle<?>) processor).start();
+                        }
+                        for (BeanDefinitionMethodReference<?, ?> method : methods) {
 
-                                    BeanDefinition<?> beanDefinition = method.getBeanDefinition();
+                            BeanDefinition<?> beanDefinition = method.getBeanDefinition();
 
-                                    // Only process the method if the the annotation is not declared at the class level
-                                    // If declared at the class level it will already have been processed by AnnotationProcessorListener
-                                    if (!beanDefinition.hasStereotype(annotationType)) {
-                                        //noinspection unchecked
-                                        if (method.hasDeclaredStereotype(Parallel.class)) {
-                                            ForkJoinPool.commonPool().execute(() -> {
-                                                try {
-                                                    processor.process(beanDefinition, method);
-                                                } catch (Throwable e) {
-                                                    if (LOG.isErrorEnabled()) {
-                                                        LOG.error("Error processing bean method " + beanDefinition + "." + method + " with processor (" + processor + "): " + e.getMessage(), e);
-                                                    }
-                                                    Boolean shutdownOnError = method.booleanValue(Parallel.class, "shutdownOnError").orElse(true);
-                                                    if (shutdownOnError) {
-                                                        stop();
-                                                    }
-                                                }
-                                            });
-                                        } else {
+                            // Only process the method if the annotation is not declared at the class level
+                            // If declared at the class level it will already have been processed by AnnotationProcessorListener
+                            if (!beanDefinition.hasStereotype(annotationType)) {
+                                if (method.hasDeclaredStereotype(Parallel.class)) {
+                                    ForkJoinPool.commonPool().execute(() -> {
+                                        try {
                                             processor.process(beanDefinition, method);
+                                        } catch (Throwable e) {
+                                            if (LOG.isErrorEnabled()) {
+                                                LOG.error("Error processing bean method " + beanDefinition + "." + method + " with processor (" + processor + "): " + e.getMessage(), e);
+                                            }
+                                            Boolean shutdownOnError = method.booleanValue(Parallel.class, "shutdownOnError").orElse(true);
+                                            if (shutdownOnError) {
+                                                stop();
+                                            }
                                         }
-                                    }
+                                    });
+                                } else {
+                                    processor.process(beanDefinition, method);
                                 }
+                            }
+                        }
 
-                                if (processor instanceof LifeCycle<?>) {
-                                    ((LifeCycle<?>) processor).stop();
-                                }
+                        if (processor instanceof LifeCycle<?>) {
+                            ((LifeCycle<?>) processor).stop();
+                        }
 
-                            }));
+                    });
+            }
         }
 
         if (CollectionUtils.isNotEmpty(parallelBeans)) {
             processParallelBeans(parallelBeans);
         }
-        final Runnable runnable = () ->
-                beanDefinitionsClasses.removeIf((BeanDefinitionReference beanDefinitionReference) ->
-                        !beanDefinitionReference.isEnabled(this));
-        ForkJoinPool.commonPool().execute(runnable);
-    }
-
-    /**
-     * Find bean candidates for the given type.
-     *
-     * @param <T>      The bean generic type
-     * @param beanType The bean type
-     * @param filter   A bean definition to filter out
-     * @return The candidates
-     */
-    @NonNull
-    protected <T> Collection<BeanDefinition<T>> findBeanCandidates(@NonNull Class<T> beanType, @Nullable BeanDefinition<?> filter) {
-        return findBeanCandidates(null, Argument.of(beanType), filter, true);
+        ForkJoinPool.commonPool().execute(() -> beanDefinitionsClasses.forEach(p -> p.isReferenceEnabled(this)));
     }
 
     /**
@@ -2132,14 +2116,12 @@ public class DefaultBeanContext implements InitializableBeanContext {
      * @param resolutionContext The current resolution context
      * @param beanType          The bean type
      * @param filter            A bean definition to filter out
-     * @param filterProxied     Whether to filter out bean proxy targets
      * @return The candidates
      */
     @NonNull
     protected <T> Collection<BeanDefinition<T>> findBeanCandidates(@Nullable BeanResolutionContext resolutionContext,
                                                                    @NonNull Argument<T> beanType,
-                                                                   @Nullable BeanDefinition<?> filter,
-                                                                   boolean filterProxied) {
+                                                                   @Nullable BeanDefinition<?> filter) {
         Predicate<BeanDefinition<T>> predicate = filter == null ? null : definition -> !definition.equals(filter);
         return findBeanCandidates(resolutionContext, beanType, true, predicate);
     }
@@ -2166,7 +2148,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
         }
         // first traverse component definition classes and load candidates
 
-        Collection<BeanDefinitionReference> beanDefinitionsClasses;
+        Collection<BeanDefinitionProducer> beanDefinitionsClasses;
 
         if (indexedTypes.contains(beanClass)) {
             beanDefinitionsClasses = beanIndex.get(beanClass);
@@ -2191,29 +2173,25 @@ public class DefaultBeanContext implements InitializableBeanContext {
         BeanResolutionContext resolutionContext,
         Argument<T> beanType,
         boolean collectIterables,
+        @Nullable
         Predicate<BeanDefinition<T>> predicate,
-        Collection<BeanDefinitionReference> beanDefinitionsClasses) {
+        Collection<BeanDefinitionProducer> beanDefinitionProducers) {
         Set<BeanDefinition<T>> candidates;
-        if (!beanDefinitionsClasses.isEmpty()) {
+        if (!beanDefinitionProducers.isEmpty()) {
 
             candidates = new HashSet<>();
-            for (BeanDefinitionReference reference : beanDefinitionsClasses) {
-                if (!reference.isCandidateBean(beanType) || !reference.isEnabled(this, resolutionContext)) {
+            for (BeanDefinitionProducer producer : beanDefinitionProducers) {
+                if (producer.isDisabled() || !producer.isReferenceCandidateBean(beanType) || !producer.isReferenceEnabled(this, resolutionContext)) {
                     continue;
                 }
-                BeanDefinition<T> loadedBean;
-                try {
-                    loadedBean = reference.load(this);
-                } catch (Throwable e) {
-                    throw new BeanContextException("Error loading bean [" + reference.getName() + "]: " + e.getMessage(), e);
-                }
+                BeanDefinition<T> loadedBean = producer.getDefinition(this);
                 if (!loadedBean.isCandidateBean(beanType)) {
                     continue;
                 }
                 if (predicate != null && !predicate.test(loadedBean)) {
                     continue;
                 }
-                if (!loadedBean.isEnabled(this, resolutionContext)) {
+                if (!producer.isDefinitionEnabled(this, resolutionContext)) {
                     continue;
                 }
 
@@ -2267,50 +2245,52 @@ public class DefaultBeanContext implements InitializableBeanContext {
         if (LOG.isDebugEnabled()) {
             LOG.debug("Finding candidate beans for instance: {}", instance);
         }
-        Collection<BeanDefinitionReference<T>> beanDefinitionsClasses = ((Collection) this.beanDefinitionsClasses);
+        Collection<BeanDefinitionProducer> beanProducers = this.beanDefinitionsClasses;
         final Class<?> beanClass = instance.getClass();
         Argument<?> beanType = Argument.of(beanClass);
         Collection<BeanDefinition<T>> beanDefinitions = (Collection<BeanDefinition<T>>) ((Map) beanCandidateCache).get(beanType);
-        if (beanDefinitions == null) {
-            // first traverse component definition classes and load candidates
-            if (!beanDefinitionsClasses.isEmpty()) {
-                List<BeanDefinition<T>> candidates = new ArrayList<>();
-                for (BeanDefinitionReference<T> reference : beanDefinitionsClasses) {
-                    if (!reference.isEnabled(this)) {
-                        continue;
-                    }
-                    Class<?> candidateType = reference.getBeanType();
-                    if (candidateType == null || !candidateType.isInstance(instance)) {
-                        continue;
-                    }
-                    BeanDefinition<T> candidate = reference.load(this);
-                    if (!candidate.isEnabled(this)) {
-                        continue;
-                    }
-                    candidates.add(candidate);
-                }
-
-                if (candidates.size() > 1) {
-                    // try narrow to exact type
-                    candidates = candidates
-                            .stream()
-                            .filter(candidate ->
-                                candidate.getBeanType() == beanClass
-                            )
-                            .collect(Collectors.toList());
-                }
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Resolved bean candidates {} for instance: {}", candidates, instance);
-                }
-                beanDefinitions = candidates;
-            } else {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("No bean candidates found for instance: {}", instance);
-                }
-                beanDefinitions = Collections.emptySet();
-            }
-            beanCandidateCache.put(beanType, (Collection) beanDefinitions);
+        if (beanDefinitions != null) {
+            return beanDefinitions;
         }
+        // first traverse component definition classes and load candidates
+        if (!beanDefinitionsClasses.isEmpty()) {
+            List<BeanDefinition<T>> candidates = new ArrayList<>();
+            for (BeanDefinitionProducer producer : beanProducers) {
+                if (producer.isDisabled() || !producer.isReferenceEnabled(this)) {
+                    continue;
+                }
+                BeanDefinitionReference<T> reference = producer.getReference();
+                Class<?> candidateType = reference.getBeanType();
+                if (candidateType == null || !candidateType.isInstance(instance)) {
+                    continue;
+                }
+                BeanDefinition<T> candidate = reference.load(this);
+                if (!candidate.isEnabled(this)) {
+                    continue;
+                }
+                candidates.add(candidate);
+            }
+
+            if (candidates.size() > 1) {
+                // try narrow to exact type
+                candidates = candidates
+                        .stream()
+                        .filter(candidate ->
+                            candidate.getBeanType() == beanClass
+                        )
+                        .collect(Collectors.toList());
+            }
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Resolved bean candidates {} for instance: {}", candidates, instance);
+            }
+            beanDefinitions = candidates;
+        } else {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("No bean candidates found for instance: {}", instance);
+            }
+            beanDefinitions = Collections.emptySet();
+        }
+        beanCandidateCache.put(beanType, (Collection) beanDefinitions);
         return beanDefinitions;
     }
 
@@ -2453,10 +2433,10 @@ public class DefaultBeanContext implements InitializableBeanContext {
                                                               @NonNull BeanDefinition<T> beanDefinition) {
         Map<String, Object> convertedValues;
         if (argumentValues == null) {
-            convertedValues = requiredArguments.length == 0 ? null : new LinkedHashMap<>();
+            convertedValues = requiredArguments.length == 0 ? null : CollectionUtils.newLinkedHashMap(requiredArguments.length);
             argumentValues = Collections.emptyMap();
         } else {
-            convertedValues = new LinkedHashMap<>();
+            convertedValues = CollectionUtils.newLinkedHashMap(requiredArguments.length);
         }
         if (convertedValues == null) {
             return Collections.emptyMap();
@@ -2509,16 +2489,20 @@ public class DefaultBeanContext implements InitializableBeanContext {
      *
      * @param parallelBeans The parallel beans
      */
-    protected void processParallelBeans(List<BeanDefinitionReference> parallelBeans) {
+    @Internal
+    protected void processParallelBeans(List<BeanDefinitionProducer> parallelBeans) {
         if (!parallelBeans.isEmpty()) {
-            List<BeanDefinitionReference> finalParallelBeans = parallelBeans.stream().filter(bdr -> bdr.isEnabled(this)).collect(Collectors.toList());
+            List<BeanDefinitionProducer> finalParallelBeans = parallelBeans.stream()
+                    .filter(p -> p.isReferenceEnabled(this))
+                    .toList();
             if (!finalParallelBeans.isEmpty()) {
                 new Thread(() -> {
-                    Collection<BeanDefinition> parallelDefinitions = new ArrayList<>();
-                    finalParallelBeans.forEach(beanDefinitionReference -> {
+                    Collection<BeanDefinition<Object>> parallelDefinitions = new ArrayList<>();
+                    finalParallelBeans.forEach(producer -> {
                         try {
-                            loadContextScopeBean(beanDefinitionReference, parallelDefinitions::add);
+                            loadEagerBeans(producer, parallelDefinitions);
                         } catch (Throwable e) {
+                            BeanDefinitionReference<Object> beanDefinitionReference = producer.getReference();
                             LOG.error("Parallel Bean definition [" + beanDefinitionReference.getName() + "] could not be loaded: " + e.getMessage(), e);
                             Boolean shutdownOnError = beanDefinitionReference.getAnnotationMetadata().booleanValue(Parallel.class, "shutdownOnError").orElse(true);
                             if (shutdownOnError) {
@@ -2531,7 +2515,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
 
                     parallelDefinitions.forEach(beanDefinition -> ForkJoinPool.commonPool().execute(() -> {
                         try {
-                            loadContextScopeBean(beanDefinition);
+                            initializeEagerBean(beanDefinition);
                         } catch (Throwable e) {
                             LOG.error("Parallel Bean definition [" + beanDefinition.getName() + "] could not be loaded: " + e.getMessage(), e);
                             Boolean shutdownOnError = beanDefinition.getAnnotationMetadata().booleanValue(Parallel.class, "shutdownOnError").orElse(true);
@@ -2692,7 +2676,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
         Class<T> bt = getCanonicalBeanType(definitionToBeReplaced);
         if (annotationMetadata.hasAnnotation(DefaultImplementation.class)) {
             Optional<Class> defaultImpl = annotationMetadata.classValue(DefaultImplementation.class);
-            if (!defaultImpl.isPresent()) {
+            if (defaultImpl.isEmpty()) {
                 defaultImpl = annotationMetadata.classValue(DefaultImplementation.class, "name");
             }
             if (defaultImpl.filter(impl -> impl == bt).isPresent()) {
@@ -2715,18 +2699,19 @@ public class DefaultBeanContext implements InitializableBeanContext {
         }
     }
 
-    private void loadContextScopeBean(BeanDefinitionReference contextScopeBean, Consumer<BeanDefinition> beanDefinitionConsumer) {
-        if (contextScopeBean.isEnabled(this)) {
-            BeanDefinition beanDefinition = contextScopeBean.load(this);
+    private void loadEagerBeans(BeanDefinitionProducer producer, Collection<BeanDefinition<Object>> collector) {
+        if (producer.isReferenceEnabled(this)) {
+            BeanDefinitionReference<Object> reference = producer.getReference();
+            BeanDefinition<Object> beanDefinition = reference.load(this);
             try (BeanResolutionContext resolutionContext = newResolutionContext(beanDefinition, null)) {
                 if (beanDefinition.isEnabled(this, resolutionContext)) {
-                    beanDefinitionConsumer.accept(beanDefinition);
+                    collector.add(beanDefinition);
                 }
             }
         }
     }
 
-    private void loadContextScopeBean(BeanDefinition<Object> beanDefinition) {
+    private void initializeEagerBean(BeanDefinition<Object> beanDefinition) {
         if (beanDefinition.isIterable() || beanDefinition.hasStereotype(ConfigurationReader.class.getName())) {
             Set<BeanDefinition<Object>> beanCandidates = new HashSet<>(5);
 
@@ -3328,38 +3313,46 @@ public class DefaultBeanContext implements InitializableBeanContext {
     }
 
     private void readAllBeanDefinitionClasses() {
-        List<BeanDefinitionReference> contextScopeBeans = new ArrayList<>(20);
-        List<BeanDefinitionReference> processedBeans = new ArrayList<>(10);
-        List<BeanDefinitionReference> parallelBeans = new ArrayList<>(10);
+        List<BeanDefinitionProducer> eagerInitBeans = new ArrayList<>(20);
+        List<BeanDefinitionProducer> processedBeans = new ArrayList<>(10);
+        List<BeanDefinitionProducer> parallelBeans = new ArrayList<>(10);
 
         List<BeanDefinitionReference> beanDefinitionReferences = resolveBeanDefinitionReferences();
-        List<BeanDefinitionReference> toRemove = new ArrayList<>(beanDefinitionReferences.size());
-        beanDefinitionsClasses.addAll(beanDefinitionReferences);
 
-        Set<BeanConfiguration> configurationsDisabled = new HashSet<>();
-        for (BeanConfiguration bc : beanConfigurations.values()) {
+        List<BeanDefinitionProducer> producers = new ArrayList<>(beanDefinitionReferences.size());
+        List<BeanDefinitionProducer> proxyTargetBeans = new ArrayList<>(beanDefinitionReferences.size());
+        for (BeanDefinitionReference beanDefinitionReference : beanDefinitionReferences) {
+            producers.add(new BeanDefinitionProducer(beanDefinitionReference));
+        }
+        beanDefinitionsClasses.addAll(producers);
+
+        Collection<BeanConfiguration> allConfigurations = beanConfigurations.values();
+        List<BeanConfiguration> configurationsDisabled = new ArrayList<>(allConfigurations.size());
+        for (BeanConfiguration bc : allConfigurations) {
             if (!bc.isEnabled(this)) {
                 configurationsDisabled.add(bc);
             }
         }
 
         reference:
-        for (BeanDefinitionReference beanDefinitionReference : beanDefinitionReferences) {
+        for (BeanDefinitionProducer beanDefinitionProducer : producers) {
+            BeanDefinitionReference beanDefinitionReference = beanDefinitionProducer.reference;
             for (BeanConfiguration disableConfiguration : configurationsDisabled) {
                 if (disableConfiguration.isWithin(beanDefinitionReference)) {
-                    toRemove.add(beanDefinitionReference);
+                    beanDefinitionProducer.referenceEnabled = false;
                     continue reference;
                 }
             }
 
             if (beanDefinitionReference.isProxiedBean()) {
-                toRemove.add(beanDefinitionReference);
+                beanDefinitionProducer.referenceEnabled = false;
+                BeanDefinitionProducer proxyBeanProducer = new BeanDefinitionProducer(beanDefinitionReference);
                 if (beanDefinitionReference.requiresMethodProcessing()) {
-                    processedBeans.add(beanDefinitionReference);
+                    processedBeans.add(proxyBeanProducer);
                 }
                 // retain only if proxy target otherwise the target is never used
                 if (beanDefinitionReference.isProxyTarget()) {
-                    this.proxyTargetBeans.add(beanDefinitionReference);
+                    proxyTargetBeans.add(proxyBeanProducer);
                 }
                 continue;
             }
@@ -3370,34 +3363,35 @@ public class DefaultBeanContext implements InitializableBeanContext {
                 //noinspection ForLoopReplaceableByForEach
                 for (int i = 0; i < indexes.length; i++) {
                     Class<?> indexedType = indexes[i];
-                    resolveTypeIndex(indexedType).add(beanDefinitionReference);
+                    resolveTypeIndex(indexedType).add(beanDefinitionProducer);
                 }
             } else {
                 if (annotationMetadata.hasStereotype(ADAPTER_TYPE)) {
                     final Class<?> aClass = annotationMetadata.classValue(ADAPTER_TYPE, AnnotationMetadata.VALUE_MEMBER).orElse(null);
                     if (indexedTypes.contains(aClass)) {
-                        resolveTypeIndex(aClass).add(beanDefinitionReference);
+                        resolveTypeIndex(aClass).add(beanDefinitionProducer);
                     }
                 }
             }
             if (isEagerInit(beanDefinitionReference)) {
-                contextScopeBeans.add(beanDefinitionReference);
+                eagerInitBeans.add(beanDefinitionProducer);
             } else if (annotationMetadata.hasDeclaredStereotype(PARALLEL_TYPE)) {
-                parallelBeans.add(beanDefinitionReference);
+                parallelBeans.add(beanDefinitionProducer);
             }
 
             if (beanDefinitionReference.requiresMethodProcessing()) {
-                processedBeans.add(beanDefinitionReference);
+                processedBeans.add(beanDefinitionProducer);
             }
 
         }
 
-        this.beanDefinitionsClasses.removeAll(toRemove);
         this.beanDefinitionReferences = null;
         this.beanConfigurationsList = null;
 
+        this.proxyTargetBeans.addAll(proxyTargetBeans);
+
         initializeEventListeners();
-        initializeContext(contextScopeBeans, processedBeans, parallelBeans);
+        initializeContext(eagerInitBeans, processedBeans, parallelBeans);
     }
 
     private boolean isEagerInit(BeanDefinitionReference beanDefinitionReference) {
@@ -3407,7 +3401,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
     }
 
     @NonNull
-    private Collection<BeanDefinitionReference> resolveTypeIndex(Class<?> indexedType) {
+    private Collection<BeanDefinitionProducer> resolveTypeIndex(Class<?> indexedType) {
         return beanIndex.computeIfAbsent(indexedType, aClass -> {
             indexedTypes.add(indexedType);
             return new ArrayList<>(20);
@@ -3532,21 +3526,15 @@ public class DefaultBeanContext implements InitializableBeanContext {
             }
             addCandidateToList(resolutionContext, definition, beanType, qualifier, beansOfTypeList);
         }
-        Collection<BeanRegistration<T>> result = beansOfTypeList;
         if (beansOfTypeList != Collections.EMPTY_SET) {
-            Stream<BeanRegistration<T>> stream = beansOfTypeList.stream();
             if (Ordered.class.isAssignableFrom(beanType.getType())) {
-                result = stream
-                        .sorted(OrderUtil.COMPARATOR)
-                        .collect(StreamUtils.toImmutableCollection());
-            } else {
-                if (hasOrderAnnotation) {
-                    stream = stream.sorted(BEAN_REGISTRATION_COMPARATOR);
-                }
-                result = stream.collect(StreamUtils.toImmutableCollection());
+                return beansOfTypeList.stream().sorted(OrderUtil.COMPARATOR).toList();
+            }
+            if (hasOrderAnnotation) {
+                return beansOfTypeList.stream().sorted(BEAN_REGISTRATION_COMPARATOR).toList();
             }
         }
-        return result;
+        return beansOfTypeList;
     }
 
     private <T> void logResolvedExistingBeanRegistrations(Argument<T> beanType, Qualifier<T> qualifier, Collection<BeanRegistration<T>> existing) {
@@ -4146,5 +4134,98 @@ public class DefaultBeanContext implements InitializableBeanContext {
         Map<BeanDefinition<?>, List<List<Argument<?>>>> getFoundTargets() {
             return foundTargets;
         }
+    }
+
+    /**
+     * The class adds the caching of the enabled decision + the definition instance.
+     * NOTE: The class can be accesed in multiple threads, we do allow for the fields to be possibly intitialized concurrently - multiple times.
+     *
+     * @since 4.0.0
+     */
+    @Internal
+    final static class BeanDefinitionProducer {
+
+        @Nullable
+        private volatile BeanDefinitionReference reference;
+        @Nullable
+        private volatile BeanDefinition definition;
+        @Nullable
+        private volatile Boolean referenceEnabled;
+        @Nullable
+        private volatile Boolean definitionEnabled;
+
+        BeanDefinitionProducer(@NonNull BeanDefinitionReference reference) {
+            this.reference = reference;
+        }
+
+        public boolean isReferenceEnabled(DefaultBeanContext context) {
+            return isReferenceEnabled(context, null);
+        }
+
+        public boolean isReferenceEnabled(DefaultBeanContext context, @Nullable BeanResolutionContext resolutionContext) {
+            if (reference == null) {
+                return false;
+            }
+            if (referenceEnabled == null) {
+                if (reference.isEnabled(context, resolutionContext)) {
+                    referenceEnabled = true;
+                } else {
+                    referenceEnabled = false;
+                    reference = null;
+                }
+            }
+            return referenceEnabled;
+        }
+
+        public boolean isDisabled() {
+            return reference == null || referenceEnabled != null && !referenceEnabled || definitionEnabled != null && !definitionEnabled;
+        }
+
+        public boolean isDefinitionEnabled(DefaultBeanContext defaultBeanContext) {
+            return isDefinitionEnabled(defaultBeanContext, null);
+        }
+
+        public boolean isDefinitionEnabled(DefaultBeanContext context, @Nullable BeanResolutionContext resolutionContext) {
+            if (definitionEnabled == null) {
+                if (isReferenceEnabled(context, resolutionContext)) {
+                    definition = getDefinition(context);
+                    if (definition.isEnabled(context, resolutionContext)) {
+                        definitionEnabled = true;
+                    } else {
+                        definitionEnabled = false;
+                        definition = null;
+                    }
+                } else {
+                    definitionEnabled = false;
+                }
+            }
+            return definitionEnabled;
+        }
+
+        public <T> BeanDefinitionReference<T> getReference() {
+            if (reference == null || referenceEnabled == null || !referenceEnabled) {
+                throw new IllegalStateException("The reference is not enabled");
+            }
+            return reference;
+        }
+
+        public <T> BeanDefinition<T> getDefinition(BeanContext beanContext) {
+            if (definitionEnabled != null && !definitionEnabled) {
+                throw new IllegalStateException("The definition is not enabled");
+            }
+            try {
+                if (definition == null) {
+                    definition = getReference().load(beanContext);
+                }
+                return definition;
+            } catch (Throwable e) {
+                throw new BeanInstantiationException("Bean definition [" + reference.getName() + "] could not be loaded: " + e.getMessage(), e);
+            }
+        }
+
+        public <T> boolean isReferenceCandidateBean(Argument<T> beanType) {
+            return reference != null && reference.isCandidateBean(beanType);
+        }
+
     }
 }

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -2036,9 +2036,9 @@ public class DefaultBeanContext implements InitializableBeanContext {
                     continue;
                 }
                 BeanDefinition<Object> definition = processedBeanProducer.getDefinition(this);
-                for (ExecutableMethod<Object, Object> method : definition.getExecutableMethods()) {
+                for (ExecutableMethod<Object, ?> method : definition.getExecutableMethods()) {
                     if (method.hasStereotype(Executable.class)) {
-                        methodsToProcess.add(BeanDefinitionMethodReference.of(definition, method));
+                        methodsToProcess.add(BeanDefinitionMethodReference.of(definition, (ExecutableMethod<Object, Object>) method));
                     }
                 }
             }
@@ -2510,7 +2510,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
                         }
                     });
 
-                    filterReplacedBeans(null, (Collection) parallelDefinitions);
+                    filterReplacedBeans(null, parallelDefinitions);
 
                     parallelDefinitions.forEach(beanDefinition -> ForkJoinPool.commonPool().execute(() -> {
                         try {
@@ -4132,7 +4132,13 @@ public class DefaultBeanContext implements InitializableBeanContext {
         }
 
         public boolean isDisabled() {
-            return reference == null || referenceEnabled != null && !referenceEnabled || definitionEnabled != null && !definitionEnabled;
+            if (reference == null) {
+                return true;
+            }
+            if (referenceEnabled != null && !referenceEnabled) {
+                return true;
+            }
+            return definitionEnabled != null && !definitionEnabled;
         }
 
         public boolean isDefinitionEnabled(DefaultBeanContext defaultBeanContext) {

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1697,12 +1697,11 @@ public class DefaultBeanContext implements InitializableBeanContext {
         Class<B> beanType = definition.getBeanType();
         for (Class<?> indexedType : indexedTypes) {
             if (indexedType == beanType || indexedType.isAssignableFrom(beanType)) {
-                final Collection<BeanDefinitionProducer> indexed = resolveTypeIndex(indexedType);
-                indexed.remove(definition);
+                resolveTypeIndex(indexedType).forEach(p -> p.disable(definition));
                 break;
             }
         }
-        this.beanDefinitionsClasses.remove(definition);
+        beanDefinitionsClasses.forEach(p -> p.disable(definition));
         purgeCacheForBeanType(definition.getBeanType());
     }
 
@@ -4246,5 +4245,11 @@ public class DefaultBeanContext implements InitializableBeanContext {
             return reference != null && reference.isCandidateBean(beanType);
         }
 
+        public void disable(BeanDefinitionReference<?> reference) {
+            BeanDefinitionReference ref = this.reference;
+            if (ref != null && ref.equals(reference)) {
+                this.reference = null;
+            }
+        }
     }
 }

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -183,7 +183,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
     private final BeanContextConfiguration beanContextConfiguration;
 
     // The collection should be modified only when new bean definition is added
-    // That should't happen that offen, so we can use CopyOnWriteArrayList
+    // That shouldn't happen that often, so we can use CopyOnWriteArrayList
     private final Collection<BeanDefinitionProducer> beanDefinitionsClasses = new CopyOnWriteArrayList<>();
     private final Collection<BeanDefinitionProducer> proxyTargetBeans = new CopyOnWriteArrayList<>();
 

--- a/inject/src/main/java/io/micronaut/context/DisabledBean.java
+++ b/inject/src/main/java/io/micronaut/context/DisabledBean.java
@@ -88,4 +88,9 @@ record DisabledBean<T>(
     public boolean isPresent() {
         return true;
     }
+
+    @Override
+    public int hashCode() {
+        return type.typeHashCode();
+    }
 }

--- a/inject/src/main/java/io/micronaut/context/RequiresCondition.java
+++ b/inject/src/main/java/io/micronaut/context/RequiresCondition.java
@@ -92,26 +92,25 @@ public class RequiresCondition implements Condition {
 
     @Override
     public boolean matches(ConditionContext context) {
+        List<AnnotationValue<Requires>> requirements = annotationMetadata.getAnnotationValuesByType(Requires.class);
+        if (requirements.isEmpty()) {
+            return true;
+        }
         AnnotationMetadataProvider component = context.getComponent();
         boolean isBeanReference = component instanceof BeanDefinitionReference;
-
-        List<AnnotationValue<Requires>> requirements = annotationMetadata.getAnnotationValuesByType(Requires.class);
-
-        if (!requirements.isEmpty()) {
-            // here we use AnnotationMetadata to avoid loading the classes referenced in the annotations directly
-            if (isBeanReference) {
-                for (AnnotationValue<Requires> requirement : requirements) {
-                    processPreStartRequirements(context, requirement);
-                    if (context.isFailing()) {
-                        return false;
-                    }
+        // here we use AnnotationMetadata to avoid loading the classes referenced in the annotations directly
+        if (isBeanReference) {
+            for (AnnotationValue<Requires> requirement : requirements) {
+                processPreStartRequirements(context, requirement);
+                if (context.isFailing()) {
+                    return false;
                 }
-            } else {
-                for (AnnotationValue<Requires> requires : requirements) {
-                    processPostStartRequirements(context, requires);
-                    if (context.isFailing()) {
-                        return false;
-                    }
+            }
+        } else {
+            for (AnnotationValue<Requires> requires : requirements) {
+                processPostStartRequirements(context, requires);
+                if (context.isFailing()) {
+                    return false;
                 }
             }
         }
@@ -133,7 +132,7 @@ public class RequiresCondition implements Condition {
             BeanContext beanContext = context.getBeanContext();
             String minimumVersion = requirements.stringValue(MEMBER_VERSION).orElse(null);
             Optional<BeanConfiguration> beanConfiguration = beanContext.findBeanConfiguration(configurationName);
-            if (!beanConfiguration.isPresent()) {
+            if (beanConfiguration.isEmpty()) {
                 context.fail("Required configuration [" + configurationName + "] is not active");
                 return false;
             } else {
@@ -172,11 +171,10 @@ public class RequiresCondition implements Condition {
             return;
         }
 
-        if (!matchesProperty(context, requirements)) {
+        if (!matchesProperty(context,  requirements)) {
             return;
         }
-
-        if (!matchesMissingProperty(context, requirements)) {
+        if (!matchesMissingProperty(context,  requirements)) {
             return;
         }
 
@@ -302,8 +300,7 @@ public class RequiresCondition implements Condition {
             String[] env = requirements.stringValues(MEMBER_ENV);
             if (ArrayUtils.isNotEmpty(env)) {
                 BeanContext beanContext = context.getBeanContext();
-                if (beanContext instanceof ApplicationContext) {
-                    ApplicationContext applicationContext = (ApplicationContext) beanContext;
+                if (beanContext instanceof ApplicationContext applicationContext) {
                     Environment environment = applicationContext.getEnvironment();
                     Set<String> activeNames = environment.getActiveNames();
                     boolean result = Arrays.stream(env).anyMatch(activeNames::contains);
@@ -317,8 +314,7 @@ public class RequiresCondition implements Condition {
             String[] env = requirements.stringValues(MEMBER_NOT_ENV);
             if (ArrayUtils.isNotEmpty(env)) {
                 BeanContext beanContext = context.getBeanContext();
-                if (beanContext instanceof ApplicationContext) {
-                    ApplicationContext applicationContext = (ApplicationContext) beanContext;
+                if (beanContext instanceof ApplicationContext applicationContext) {
                     Environment environment = applicationContext.getEnvironment();
                     Set<String> activeNames = environment.getActiveNames();
                     boolean result = Arrays.stream(env).noneMatch(activeNames::contains);
@@ -340,51 +336,47 @@ public class RequiresCondition implements Condition {
             final AnnotationClassValue<?> annotationClassValue = requirements.annotationClassValue(MEMBER_CONDITION).orElse(null);
             if (annotationClassValue == null) {
                 return true;
-            } else {
-                final Object instance = annotationClassValue.getInstance().orElse(null);
-                if (instance instanceof Condition) {
-                    final boolean conditionResult = ((Condition) instance).matches(context);
-                    if (!conditionResult) {
-                        context.fail("Custom condition [" + instance.getClass() + "] failed evaluation");
-                    }
-                    return conditionResult;
-                } else {
-
-                    final Class<?> conditionClass = annotationClassValue.getType().orElse(null);
-                    if (conditionClass == null || conditionClass == TrueCondition.class || !Condition.class.isAssignableFrom(conditionClass)) {
-                        return true;
-                    }
-                    // try first via instantiated metadata
-                    Optional<? extends Condition> condition = InstantiationUtils.tryInstantiate((Class<? extends Condition>) conditionClass);
-                    if (condition.isPresent()) {
-                        boolean conditionResult = condition.get().matches(context);
-                        if (!conditionResult) {
-                            context.fail("Custom condition [" + conditionClass + "] failed evaluation");
-                        }
-                        return conditionResult;
-                    } else {
-                        // maybe a Groovy closure
-                        Optional<Constructor<?>> constructor = ReflectionUtils.findConstructor((Class) conditionClass, Object.class, Object.class);
-                        boolean conditionResult = constructor.flatMap(ctor ->
-                                InstantiationUtils.tryInstantiate(ctor, null, null)
-                        ).flatMap(obj -> {
-                            Optional<Method> method = ReflectionUtils.findMethod(obj.getClass(), "call", ConditionContext.class);
-                            if (method.isPresent()) {
-                                Object result = ReflectionUtils.invokeMethod(obj, method.get(), context);
-                                if (result instanceof Boolean) {
-                                    return Optional.of((Boolean) result);
-                                }
-                            }
-                            return Optional.empty();
-                        }).orElse(false);
-                        if (!conditionResult) {
-                            context.fail("Custom condition [" + conditionClass + "] failed evaluation");
-                        }
-                        return conditionResult;
-
+            }
+            final Object instance = annotationClassValue.getInstance().orElse(null);
+            if (instance instanceof Condition condition) {
+                final boolean conditionResult = condition.matches(context);
+                if (!conditionResult) {
+                    context.fail("Custom condition [" + instance.getClass() + "] failed evaluation");
+                }
+                return conditionResult;
+            }
+            final Class<?> conditionClass = annotationClassValue.getType().orElse(null);
+            if (conditionClass == null || conditionClass == TrueCondition.class || !Condition.class.isAssignableFrom(conditionClass)) {
+                return true;
+            }
+            // try first via instantiated metadata
+            Optional<? extends Condition> condition = InstantiationUtils.tryInstantiate((Class<? extends Condition>) conditionClass);
+            if (condition.isPresent()) {
+                boolean conditionResult = condition.get().matches(context);
+                if (!conditionResult) {
+                    context.fail("Custom condition [" + conditionClass + "] failed evaluation");
+                }
+                return conditionResult;
+            }
+            // maybe a Groovy closure
+            Optional<Constructor<?>> constructor = ReflectionUtils.findConstructor((Class) conditionClass, Object.class, Object.class);
+            boolean conditionResult = constructor.flatMap(ctor ->
+                    InstantiationUtils.tryInstantiate(ctor, null, null)
+            ).flatMap(obj -> {
+                Optional<Method> method = ReflectionUtils.findMethod(obj.getClass(), "call", ConditionContext.class);
+                if (method.isPresent()) {
+                    Object result = ReflectionUtils.invokeMethod(obj, method.get(), context);
+                    if (result instanceof Boolean) {
+                        return Optional.of((Boolean) result);
                     }
                 }
+                return Optional.empty();
+            }).orElse(false);
+            if (!conditionResult) {
+                context.fail("Custom condition [" + conditionClass + "] failed evaluation");
             }
+            return conditionResult;
+
         }
         return !context.isFailing();
     }
@@ -525,7 +517,7 @@ public class RequiresCondition implements Condition {
         if (requirements.contains(attr)) {
             AnnotationClassValue[] classValues = requirements.annotationClassValues(attr);
             for (AnnotationClassValue classValue : classValues) {
-                if (!classValue.getType().isPresent()) {
+                if (classValue.getType().isEmpty()) {
                     context.fail("Class [" + classValue.getName() + "] is not present");
                     return false;
                 }
@@ -541,16 +533,16 @@ public class RequiresCondition implements Condition {
                 BeanContext beanContext = context.getBeanContext();
                 if (beanContext instanceof ApplicationContext) {
                     ApplicationContext applicationContext = (ApplicationContext) beanContext;
-                    final AnnotationClassValue[] classValues = classNames.get();
+                    final AnnotationClassValue<?>[] classValues = classNames.get();
                     for (AnnotationClassValue<?> classValue : classValues) {
                         final Optional<? extends Class<?>> entityType = classValue.getType();
-                        if (!entityType.isPresent()) {
+                        if (entityType.isEmpty()) {
                             context.fail("Annotation type [" + classValue.getName() + "] not present on classpath");
                             return false;
                         } else {
                             Environment environment = applicationContext.getEnvironment();
                             Class annotationType = entityType.get();
-                            if (!environment.scan(annotationType).findFirst().isPresent()) {
+                            if (environment.scan(annotationType).findFirst().isEmpty()) {
                                 context.fail("No entities found in packages [" + String.join(", ", environment.getPackages()) + "] for annotation: " + annotationType);
                                 return false;
                             }
@@ -573,7 +565,7 @@ public class RequiresCondition implements Condition {
             }
             if (ArrayUtils.isNotEmpty(beans)) {
                 BeanContext beanContext = context.getBeanContext();
-                for (Class type : beans) {
+                for (Class<?> type : beans) {
                     if (!beanContext.containsBean(type)) {
                         context.fail("No bean of type [" + type + "] present within context");
                         return false;
@@ -590,7 +582,6 @@ public class RequiresCondition implements Condition {
             AnnotationMetadataProvider component = context.getComponent();
             if (ArrayUtils.isNotEmpty(missingBeans) && component instanceof BeanDefinition) {
                 BeanDefinition bd = (BeanDefinition) component;
-
                 DefaultBeanContext beanContext = (DefaultBeanContext) context.getBeanContext();
 
                 for (Class<?> type : missingBeans) {
@@ -598,8 +589,7 @@ public class RequiresCondition implements Condition {
                     final Collection<? extends BeanDefinition<?>> beanDefinitions = beanContext.findBeanCandidates(
                             context.getBeanResolutionContext(),
                             Argument.of(type),
-                            bd,
-                            true
+                            bd
                     );
                     for (BeanDefinition<?> beanDefinition : beanDefinitions) {
                         if (!beanDefinition.isAbstract()) {
@@ -631,7 +621,7 @@ public class RequiresCondition implements Condition {
                 }
                 resolver = new ResourceResolver(resourceLoaders);
                 for (String resourcePath : resourcePaths) {
-                    if (!resolver.getResource(resourcePath).isPresent()) {
+                    if (resolver.getResource(resourcePath).isEmpty()) {
                         context.fail("Resource [" + resourcePath + "] does not exist");
                         return false;
                     }
@@ -643,22 +633,18 @@ public class RequiresCondition implements Condition {
 
     private boolean matchesCurrentOs(ConditionContext context, AnnotationValue<Requires> requirements) {
         if (requirements.contains(MEMBER_OS)) {
-            final List<Requires.Family> os = Arrays.asList(requirements.enumValues(MEMBER_OS, Requires.Family.class));
+            final Set<Requires.Family> os = requirements.enumValuesSet(MEMBER_OS, Requires.Family.class);
             Requires.Family currentOs = OperatingSystem.getCurrent().getFamily();
-            if (!os.isEmpty()) {
-                if (!os.contains(currentOs)) {
-                    context.fail("The current operating system [" + currentOs.name() + "] is not one of the required systems [" + os + "]");
-                    return false;
-                }
+            if (!os.contains(currentOs)) {
+                context.fail("The current operating system [" + currentOs.name() + "] is not one of the required systems [" + os + "]");
+                return false;
             }
         } else if (requirements.contains(MEMBER_NOT_OS)) {
             Requires.Family currentOs = OperatingSystem.getCurrent().getFamily();
-            final List<Requires.Family> notOs = Arrays.asList(requirements.enumValues(MEMBER_NOT_OS, Requires.Family.class));
-            if (!notOs.isEmpty()) {
-                if (notOs.contains(currentOs)) {
-                    context.fail("The current operating system [" + currentOs.name() + "] is one of the disallowed systems [" + notOs + "]");
-                    return false;
-                }
+            final Set<Requires.Family> notOs = requirements.enumValuesSet(MEMBER_NOT_OS, Requires.Family.class);
+            if (notOs.contains(currentOs)) {
+                context.fail("The current operating system [" + currentOs.name() + "] is one of the disallowed systems [" + notOs + "]");
+                return false;
             }
         }
         return true;

--- a/inject/src/main/java/io/micronaut/context/converters/ContextConverterRegistrar.java
+++ b/inject/src/main/java/io/micronaut/context/converters/ContextConverterRegistrar.java
@@ -16,11 +16,11 @@
 package io.micronaut.context.converters;
 
 import io.micronaut.context.BeanContext;
+import io.micronaut.context.annotation.Prototype;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.convert.MutableConversionService;
 import io.micronaut.core.convert.TypeConverterRegistrar;
 import io.micronaut.core.reflect.ClassUtils;
-import jakarta.inject.Singleton;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -33,7 +33,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * @author graemerocher
  * @since 2.0
  */
-@Singleton
+@Prototype
 @Internal
 public class ContextConverterRegistrar implements TypeConverterRegistrar {
 

--- a/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
+++ b/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
@@ -33,6 +33,7 @@ import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.optim.StaticOptimizations;
 import io.micronaut.core.order.OrderUtil;
 import io.micronaut.core.reflect.ClassUtils;
+import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.BeanConfiguration;
 import org.slf4j.Logger;
@@ -435,11 +436,17 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
     }
 
     private void readConstantPropertySources(String name, List<PropertySource> propertySources) {
-        Set<String> propertySourceNames = Stream.concat(Stream.of(name), getActiveNames().stream().map(env -> name + "-" + env))
-                .collect(Collectors.toSet());
-        getConstantPropertySources().stream()
-                .filter(p -> propertySourceNames.contains(p.getName()))
-                .forEach(propertySources::add);
+        Set<String> activeNames = getActiveNames();
+        Set<String> propertySourceNames = CollectionUtils.newHashSet(activeNames.size() + 1);
+        propertySourceNames.add(name);
+        for (String env : activeNames) {
+            propertySourceNames.add(name + "-" + env);
+        }
+        for (PropertySource p : getConstantPropertySources()) {
+            if (propertySourceNames.contains(p.getName())) {
+                propertySources.add(p);
+            }
+        }
     }
 
     /**

--- a/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
+++ b/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
@@ -58,8 +58,6 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * <p>A {@link PropertyResolver} that resolves from one or many {@link PropertySource} instances.</p>
@@ -211,16 +209,22 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
                     name, false, PropertyCatalog.NORMALIZED);
             if (entries != null) {
                 String prefix = name + '.';
-                return entries.keySet().stream().filter(k -> k.startsWith(prefix))
-                              .map(k -> {
-                                  String withoutPrefix = k.substring(prefix.length());
-                                  int i = withoutPrefix.indexOf('.');
-                                  if (i > -1) {
-                                      return withoutPrefix.substring(0, i);
-                                  }
-                                  return withoutPrefix;
-                              })
-                              .collect(Collectors.toSet());
+                Set<String> result = new HashSet<>();
+                Set<String> strings = entries.keySet();
+                for (String k : strings) {
+                    if (k.startsWith(prefix)) {
+                        String withoutPrefix = k.substring(prefix.length());
+                        int i = withoutPrefix.indexOf('.');
+                        String s;
+                        if (i > -1) {
+                            s = withoutPrefix.substring(0, i);
+                        } else {
+                            s = withoutPrefix;
+                        }
+                        result.add(s);
+                    }
+                }
+                return result;
             }
         }
         return Collections.emptySet();

--- a/inject/src/main/java/io/micronaut/context/event/ApplicationEventPublisherFactory.java
+++ b/inject/src/main/java/io/micronaut/context/event/ApplicationEventPublisherFactory.java
@@ -85,7 +85,7 @@ public final class ApplicationEventPublisherFactory<T>
 
     @Override
     public boolean isCandidateBean(Argument<?> beanType) {
-        return InstantiatableBeanDefinition.super.isCandidateBean(beanType);
+        return beanType.isAssignableFrom(ApplicationEventPublisher.class);
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/context/event/ApplicationEventPublisherFactory.java
+++ b/inject/src/main/java/io/micronaut/context/event/ApplicationEventPublisherFactory.java
@@ -214,7 +214,7 @@ public final class ApplicationEventPublisherFactory<T>
     private ApplicationEventPublisher<Object> createEventPublisher(Argument<?> eventType, BeanContext beanContext) {
         return new ApplicationEventPublisher<Object>() {
 
-            private final Supplier<List<ApplicationEventListener>> lazyListeners = SupplierUtil.memoizedNonEmpty(() -> {
+            private final Supplier<List<ApplicationEventListener>> lazyListeners = SupplierUtil.memoized(() -> {
                 List<ApplicationEventListener> listeners = new ArrayList<>(
                         beanContext.getBeansOfType(ApplicationEventListener.class, Qualifiers.byTypeArguments(eventType.getType()))
                 );

--- a/inject/src/main/java/io/micronaut/inject/BeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/inject/BeanDefinition.java
@@ -267,7 +267,7 @@ public interface BeanDefinition<T> extends QualifiedBeanType<T>, Named, BeanType
     /**
      * @return The {@link ExecutableMethod} instances for this definition
      */
-    default Collection<ExecutableMethod<T, ?>> getExecutableMethods() {
+    default Collection<ExecutableMethod<T, Object>> getExecutableMethods() {
         return Collections.emptyList();
     }
 

--- a/inject/src/main/java/io/micronaut/inject/BeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/inject/BeanDefinition.java
@@ -267,7 +267,7 @@ public interface BeanDefinition<T> extends QualifiedBeanType<T>, Named, BeanType
     /**
      * @return The {@link ExecutableMethod} instances for this definition
      */
-    default Collection<ExecutableMethod<T, Object>> getExecutableMethods() {
+    default Collection<ExecutableMethod<T, ?>> getExecutableMethods() {
         return Collections.emptyList();
     }
 

--- a/inject/src/main/java/io/micronaut/inject/DelegatingBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/inject/DelegatingBeanDefinition.java
@@ -135,7 +135,7 @@ public interface DelegatingBeanDefinition<T> extends BeanDefinition<T> {
     }
 
     @Override
-    default Collection<ExecutableMethod<T, ?>> getExecutableMethods() {
+    default Collection<ExecutableMethod<T, Object>> getExecutableMethods() {
         return getTarget().getExecutableMethods();
     }
 

--- a/inject/src/main/java/io/micronaut/inject/DelegatingBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/inject/DelegatingBeanDefinition.java
@@ -135,7 +135,7 @@ public interface DelegatingBeanDefinition<T> extends BeanDefinition<T> {
     }
 
     @Override
-    default Collection<ExecutableMethod<T, Object>> getExecutableMethods() {
+    default Collection<ExecutableMethod<T, ?>> getExecutableMethods() {
         return getTarget().getExecutableMethods();
     }
 

--- a/inject/src/main/java/io/micronaut/inject/ExecutableMethodsDefinition.java
+++ b/inject/src/main/java/io/micronaut/inject/ExecutableMethodsDefinition.java
@@ -58,6 +58,6 @@ public interface ExecutableMethodsDefinition<T> {
      * @return The {@link ExecutableMethod} instances for this definition
      */
     @NonNull
-    Collection<ExecutableMethod<T, Object>> getExecutableMethods();
+    Collection<ExecutableMethod<T, ?>> getExecutableMethods();
 
 }

--- a/inject/src/main/java/io/micronaut/inject/ExecutableMethodsDefinition.java
+++ b/inject/src/main/java/io/micronaut/inject/ExecutableMethodsDefinition.java
@@ -58,6 +58,6 @@ public interface ExecutableMethodsDefinition<T> {
      * @return The {@link ExecutableMethod} instances for this definition
      */
     @NonNull
-    Collection<ExecutableMethod<T, ?>> getExecutableMethods();
+    Collection<ExecutableMethod<T, Object>> getExecutableMethods();
 
 }

--- a/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataHierarchy.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataHierarchy.java
@@ -115,12 +115,24 @@ public final class AnnotationMetadataHierarchy implements AnnotationMetadata, En
 
     @Override
     public Optional<Class<? extends Annotation>> getAnnotationType(@NonNull String name) {
-        return getAnnotationType((metadata) -> metadata.getAnnotationType(name));
+        for (AnnotationMetadata metadata1 : hierarchy) {
+            final Optional<Class<? extends Annotation>> annotationType = ((Function<AnnotationMetadata, Optional<Class<? extends Annotation>>>) (metadata) -> metadata.getAnnotationType(name)).apply(metadata1);
+            if (annotationType.isPresent()) {
+                return annotationType;
+            }
+        }
+        return Optional.empty();
     }
 
     @Override
     public Optional<Class<? extends Annotation>> getAnnotationType(@NonNull String name, @NonNull ClassLoader classLoader) {
-        return getAnnotationType((metadata) -> metadata.getAnnotationType(name, classLoader));
+        for (AnnotationMetadata metadata1 : hierarchy) {
+            final Optional<Class<? extends Annotation>> annotationType = ((Function<AnnotationMetadata, Optional<Class<? extends Annotation>>>) (metadata) -> metadata.getAnnotationType(name, classLoader)).apply(metadata1);
+            if (annotationType.isPresent()) {
+                return annotationType;
+            }
+        }
+        return Optional.empty();
     }
 
     /**
@@ -389,7 +401,7 @@ public final class AnnotationMetadataHierarchy implements AnnotationMetadata, En
         for (AnnotationMetadata am : hierarchy) {
             list.addAll(Arrays.asList(am.classValues(annotation, member)));
         }
-        return ArrayUtils.toArray(list, Class[]::new);
+        return list.toArray(new Class[0]);
     }
 
     @Override
@@ -808,7 +820,7 @@ public final class AnnotationMetadataHierarchy implements AnnotationMetadata, En
         for (AnnotationMetadata am : hierarchy) {
             list.addAll(Arrays.asList(am.classValues(annotation, member)));
         }
-        return ArrayUtils.toArray(list, Class[]::new);
+        return list.toArray(new Class[0]);
     }
 
     @Override
@@ -868,7 +880,7 @@ public final class AnnotationMetadataHierarchy implements AnnotationMetadata, En
                 strings.addAll(Arrays.asList(am.stringValues(annotation, member)));
             }
         }
-        return ArrayUtils.toArray(strings, String[]::new);
+        return strings.toArray(new String[0]);
     }
 
     @Override
@@ -881,7 +893,7 @@ public final class AnnotationMetadataHierarchy implements AnnotationMetadata, En
                 strings.addAll(Arrays.asList(am.stringValues(annotation, member)));
             }
         }
-        return ArrayUtils.toArray(strings, String[]::new);
+        return strings.toArray(new String[0]);
     }
 
     @NonNull
@@ -965,16 +977,6 @@ public final class AnnotationMetadataHierarchy implements AnnotationMetadata, En
     @Override
     public Iterator<AnnotationMetadata> iterator() {
         return ArrayUtils.reverseIterator(hierarchy);
-    }
-
-    private Optional<Class<? extends Annotation>> getAnnotationType(Function<AnnotationMetadata, Optional<Class<? extends Annotation>>> annotationTypeSupplier) {
-        for (AnnotationMetadata metadata : hierarchy) {
-            final Optional<Class<? extends Annotation>> annotationType = annotationTypeSupplier.apply(metadata);
-            if (annotationType.isPresent()) {
-                return annotationType;
-            }
-        }
-        return Optional.empty();
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataSupport.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataSupport.java
@@ -15,15 +15,44 @@
  */
 package io.micronaut.inject.annotation;
 
-import io.micronaut.context.annotation.*;
-import io.micronaut.core.annotation.*;
+import io.micronaut.context.annotation.AliasFor;
+import io.micronaut.context.annotation.Aliases;
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Configuration;
+import io.micronaut.context.annotation.ConfigurationBuilder;
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.EachProperty;
+import io.micronaut.context.annotation.Executable;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Primary;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.PropertySource;
+import io.micronaut.context.annotation.Prototype;
+import io.micronaut.context.annotation.Provided;
+import io.micronaut.context.annotation.Replaces;
+import io.micronaut.context.annotation.Requirements;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.annotation.Secondary;
+import io.micronaut.context.annotation.Type;
+import io.micronaut.context.annotation.Value;
+import io.micronaut.core.annotation.AnnotationClassValue;
+import io.micronaut.core.annotation.AnnotationUtil;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.AnnotationValueProvider;
+import io.micronaut.core.annotation.Indexed;
+import io.micronaut.core.annotation.Indexes;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.annotation.UsedByGeneratedCode;
 import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.core.reflect.InstantiationUtils;
 import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.util.StringUtils;
-
-import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.annotation.Nullable;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
@@ -32,15 +61,19 @@ import jakarta.inject.Qualifier;
 import jakarta.inject.Scope;
 import jakarta.inject.Singleton;
 
-import javax.validation.constraints.NotNull;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
-import java.util.*;
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Consumer;
 
 /**
  * Support method for {@link io.micronaut.core.annotation.AnnotationMetadata}.
@@ -52,7 +85,7 @@ import java.util.function.Consumer;
 public final class AnnotationMetadataSupport {
 
     private static final Map<String, Map<String, Object>> ANNOTATION_DEFAULTS = new ConcurrentHashMap<>(20);
-    private static final Map<String, String> REPEATABLE_ANNOTATIONS = new ConcurrentHashMap<>(20);
+    private static final Map<String, String> REPEATABLE_ANNOTATIONS_CONTAINERS = new ConcurrentHashMap<>(20);
 
     private static final Map<Class<? extends Annotation>, Optional<Constructor<InvocationHandler>>> ANNOTATION_PROXY_CACHE = new ConcurrentHashMap<>(20);
     private static final Map<String, Class<? extends Annotation>> ANNOTATION_TYPES = new ConcurrentHashMap<>(20);
@@ -95,10 +128,10 @@ public final class AnnotationMetadataSupport {
 
 
         for (Map.Entry<Class<? extends Annotation>, Class<? extends Annotation>> e : getCoreRepeatableAnnotations()) {
-            REPEATABLE_ANNOTATIONS.put(e.getKey().getName(), e.getValue().getName());
+            REPEATABLE_ANNOTATIONS_CONTAINERS.put(e.getKey().getName(), e.getValue().getName());
         }
 
-        REPEATABLE_ANNOTATIONS.put("io.micronaut.aop.InterceptorBinding", "io.micronaut.aop.InterceptorBindingDefinitions");
+        REPEATABLE_ANNOTATIONS_CONTAINERS.put("io.micronaut.aop.InterceptorBinding", "io.micronaut.aop.InterceptorBindingDefinitions");
     }
 
     /**
@@ -129,7 +162,7 @@ public final class AnnotationMetadataSupport {
      */
     @Internal
     public static String getRepeatableAnnotation(String annotation) {
-        return REPEATABLE_ANNOTATIONS.get(annotation);
+        return REPEATABLE_ANNOTATIONS_CONTAINERS.get(annotation);
     }
 
     /**
@@ -232,34 +265,22 @@ public final class AnnotationMetadataSupport {
     static void registerAnnotationType(AnnotationClassValue<?> annotationClassValue) {
         final String name = annotationClassValue.getName();
         if (!ANNOTATION_TYPES.containsKey(name)) {
-            annotationClassValue.getType().ifPresent((Consumer<Class<?>>) aClass -> {
-                if (Annotation.class.isAssignableFrom(aClass)) {
-                    ANNOTATION_TYPES.put(name, (Class<? extends Annotation>) aClass);
-                }
-            });
+            Class<?> aClass = annotationClassValue.getType().orElse(null);
+            if (aClass != null && Annotation.class.isAssignableFrom(aClass)) {
+                ANNOTATION_TYPES.put(name, (Class<? extends Annotation>) aClass);
+            }
         }
     }
 
     /**
-     * Registers repeatable annotations.
+     * Registers repeatable annotation containers.
+     * @MyRepeatable -> @MyRepeatableContainer
      *
      * @param repeatableAnnotations the repeatable annotations
      */
     @Internal
     static void registerRepeatableAnnotations(Map<String, String> repeatableAnnotations) {
-        REPEATABLE_ANNOTATIONS.putAll(repeatableAnnotations);
-    }
-
-    /**
-     * Remove Core repeatable annotations.
-     *
-     * @param repeatableAnnotations the repeatable annotations
-     */
-    @Internal
-    static void removeCoreRepeatableAnnotations(@NotNull Map<String, String> repeatableAnnotations) {
-        for (Map.Entry<Class<? extends Annotation>, Class<? extends Annotation>> e : getCoreRepeatableAnnotations()) {
-            repeatableAnnotations.remove(e.getKey().getName());
-        }
+        REPEATABLE_ANNOTATIONS_CONTAINERS.putAll(repeatableAnnotations);
     }
 
     /**

--- a/inject/src/main/java/io/micronaut/inject/annotation/DefaultAnnotationMetadata.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/DefaultAnnotationMetadata.java
@@ -21,6 +21,7 @@ import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationUtil;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NextMajorVersion;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.annotation.UsedByGeneratedCode;
@@ -33,7 +34,6 @@ import io.micronaut.core.util.StringUtils;
 import io.micronaut.core.value.OptionalValues;
 
 import java.lang.annotation.Annotation;
-import java.lang.annotation.Repeatable;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.Array;
 import java.util.AbstractMap;
@@ -85,14 +85,12 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     @Nullable
     Map<String, Map<CharSequence, Object>> annotationDefaultValues;
     @Nullable
-    Map<String, String> repeated;
+    Map<String, String> annotationRepeatableContainer;
     @Nullable
     Set<String> sourceRetentionAnnotations;
     private Map<String, List> annotationValuesByType = new ConcurrentHashMap<>(2);
 
     private final boolean hasPropertyExpressions;
-    // This should be removed in the next major version
-    private final boolean useRepeatableDefaults;
 
     /**
      * Constructs empty annotation metadata.
@@ -100,7 +98,6 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     @Internal
     protected DefaultAnnotationMetadata() {
         hasPropertyExpressions = false;
-        useRepeatableDefaults = false;
     }
 
     /**
@@ -115,11 +112,11 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     @Internal
     @UsedByGeneratedCode
     public DefaultAnnotationMetadata(
-            @Nullable Map<String, Map<CharSequence, Object>> declaredAnnotations,
-            @Nullable Map<String, Map<CharSequence, Object>> declaredStereotypes,
-            @Nullable Map<String, Map<CharSequence, Object>> allStereotypes,
-            @Nullable Map<String, Map<CharSequence, Object>> allAnnotations,
-            @Nullable Map<String, List<String>> annotationsByStereotype) {
+        @Nullable Map<String, Map<CharSequence, Object>> declaredAnnotations,
+        @Nullable Map<String, Map<CharSequence, Object>> declaredStereotypes,
+        @Nullable Map<String, Map<CharSequence, Object>> allStereotypes,
+        @Nullable Map<String, Map<CharSequence, Object>> allAnnotations,
+        @Nullable Map<String, List<String>> annotationsByStereotype) {
         this(declaredAnnotations, declaredStereotypes, allStereotypes, allAnnotations, annotationsByStereotype, true);
     }
 
@@ -136,12 +133,12 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     @Internal
     @UsedByGeneratedCode
     public DefaultAnnotationMetadata(
-            @Nullable Map<String, Map<CharSequence, Object>> declaredAnnotations,
-            @Nullable Map<String, Map<CharSequence, Object>> declaredStereotypes,
-            @Nullable Map<String, Map<CharSequence, Object>> allStereotypes,
-            @Nullable Map<String, Map<CharSequence, Object>> allAnnotations,
-            @Nullable Map<String, List<String>> annotationsByStereotype,
-            boolean hasPropertyExpressions) {
+        @Nullable Map<String, Map<CharSequence, Object>> declaredAnnotations,
+        @Nullable Map<String, Map<CharSequence, Object>> declaredStereotypes,
+        @Nullable Map<String, Map<CharSequence, Object>> allStereotypes,
+        @Nullable Map<String, Map<CharSequence, Object>> allAnnotations,
+        @Nullable Map<String, List<String>> annotationsByStereotype,
+        boolean hasPropertyExpressions) {
         this(declaredAnnotations, declaredStereotypes, allStereotypes, allAnnotations, annotationsByStereotype, hasPropertyExpressions, false);
     }
 
@@ -155,17 +152,20 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
      * @param annotationsByStereotype The annotations by stereotype
      * @param hasPropertyExpressions  Whether property expressions exist in the metadata
      * @param useRepeatableDefaults   Use repeatable defaults
+     * @deprecated use the constructor without useRepeatableDefaults
      */
     @Internal
     @UsedByGeneratedCode
+    @NextMajorVersion("Remove after Micronaut 4 Milestone 1")
+    @Deprecated(forRemoval = true, since = "4")
     public DefaultAnnotationMetadata(
-            @Nullable Map<String, Map<CharSequence, Object>> declaredAnnotations,
-            @Nullable Map<String, Map<CharSequence, Object>> declaredStereotypes,
-            @Nullable Map<String, Map<CharSequence, Object>> allStereotypes,
-            @Nullable Map<String, Map<CharSequence, Object>> allAnnotations,
-            @Nullable Map<String, List<String>> annotationsByStereotype,
-            boolean hasPropertyExpressions,
-            boolean useRepeatableDefaults) {
+        @Nullable Map<String, Map<CharSequence, Object>> declaredAnnotations,
+        @Nullable Map<String, Map<CharSequence, Object>> declaredStereotypes,
+        @Nullable Map<String, Map<CharSequence, Object>> allStereotypes,
+        @Nullable Map<String, Map<CharSequence, Object>> allAnnotations,
+        @Nullable Map<String, List<String>> annotationsByStereotype,
+        boolean hasPropertyExpressions,
+        boolean useRepeatableDefaults) {
         super(declaredAnnotations, allAnnotations);
         this.declaredAnnotations = declaredAnnotations;
         this.declaredStereotypes = declaredStereotypes;
@@ -173,19 +173,18 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
         this.allAnnotations = allAnnotations;
         this.annotationsByStereotype = annotationsByStereotype;
         this.hasPropertyExpressions = hasPropertyExpressions;
-        this.useRepeatableDefaults = useRepeatableDefaults;
     }
 
     @NonNull
     @Override
     public AnnotationMetadata getDeclaredMetadata() {
         return new DefaultAnnotationMetadata(
-                this.declaredAnnotations,
-                this.declaredStereotypes,
-                null,
-                null,
-                annotationsByStereotype,
-                hasPropertyExpressions
+            this.declaredAnnotations,
+            this.declaredStereotypes,
+            null,
+            null,
+            annotationsByStereotype,
+            hasPropertyExpressions
         );
     }
 
@@ -264,9 +263,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     public <E extends Enum<E>> Optional<E> enumValue(@NonNull Class<? extends Annotation> annotation, @NonNull String member, Class<E> enumType, @Nullable Function<Object, Object> valueMapper) {
         ArgumentUtils.requireNonNull("annotation", annotation);
         ArgumentUtils.requireNonNull("member", member);
-        final Repeatable repeatable = annotation.getAnnotation(Repeatable.class);
-        if (repeatable != null) {
-            Object v = getRawSingleValue(repeatable.value().getName(), VALUE_MEMBER, valueMapper);
+        String repeatableTypeName = findRepeatableAnnotationContainerInternal(annotation.getName());
+        if (repeatableTypeName != null) {
+            Object v = getRawSingleValue(repeatableTypeName, VALUE_MEMBER, valueMapper);
             if (v instanceof AnnotationValue) {
                 return ((AnnotationValue<?>) v).enumValue(member, enumType, valueMapper);
             }
@@ -300,9 +299,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     public <E extends Enum<E>> E[] enumValues(@NonNull Class<? extends Annotation> annotation, @NonNull String member, Class<E> enumType, @Nullable Function<Object, Object> valueMapper) {
         ArgumentUtils.requireNonNull("annotation", annotation);
         ArgumentUtils.requireNonNull("enumType", enumType);
-        final Repeatable repeatable = annotation.getAnnotation(Repeatable.class);
-        if (repeatable != null) {
-            Object v = getRawValue(repeatable.value().getName(), member);
+        String repeatableTypeName = findRepeatableAnnotationContainerInternal(annotation.getName());
+        if (repeatableTypeName != null) {
+            Object v = getRawValue(repeatableTypeName, member);
             if (v instanceof AnnotationValue) {
                 return ((AnnotationValue<?>) v).enumValues(member, enumType);
             }
@@ -372,9 +371,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     public <T> Class<T>[] classValues(@NonNull Class<? extends Annotation> annotation, @NonNull String member) {
         ArgumentUtils.requireNonNull("annotation", annotation);
         ArgumentUtils.requireNonNull("member", member);
-        final Repeatable repeatable = annotation.getAnnotation(Repeatable.class);
-        if (repeatable != null) {
-            Object v = getRawSingleValue(repeatable.value().getName(), member, null);
+        String repeatableTypeName = findRepeatableAnnotationContainerInternal(annotation.getName());
+        if (repeatableTypeName != null) {
+            Object v = getRawSingleValue(repeatableTypeName, member, null);
             if (v instanceof AnnotationValue) {
                 Class<?>[] classes = ((AnnotationValue<?>) v).classValues(member);
                 return (Class<T>[]) classes;
@@ -404,9 +403,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     public Optional<Class> classValue(@NonNull Class<? extends Annotation> annotation, @NonNull String member, Function<Object, Object> valueMapper) {
         ArgumentUtils.requireNonNull("annotation", annotation);
         ArgumentUtils.requireNonNull("member", member);
-        final Repeatable repeatable = annotation.getAnnotation(Repeatable.class);
-        if (repeatable != null) {
-            Object v = getRawSingleValue(repeatable.value().getName(), member, valueMapper);
+        String repeatableTypeName = findRepeatableAnnotationContainerInternal(annotation.getName());
+        if (repeatableTypeName != null) {
+            Object v = getRawSingleValue(repeatableTypeName, member, valueMapper);
             if (v instanceof AnnotationValue) {
                 return (Optional) ((AnnotationValue<?>) v).classValue(member, valueMapper);
             }
@@ -476,9 +475,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     public OptionalInt intValue(@NonNull Class<? extends Annotation> annotation, @NonNull String member, @Nullable Function<Object, Object> valueMapper) {
         ArgumentUtils.requireNonNull("annotation", annotation);
         ArgumentUtils.requireNonNull("member", member);
-        final Repeatable repeatable = annotation.getAnnotation(Repeatable.class);
-        if (repeatable != null) {
-            Object v = getRawSingleValue(repeatable.value().getName(), VALUE_MEMBER, valueMapper);
+        String repeatableTypeName = findRepeatableAnnotationContainerInternal(annotation.getName());
+        if (repeatableTypeName != null) {
+            Object v = getRawSingleValue(repeatableTypeName, VALUE_MEMBER, valueMapper);
             if (v instanceof AnnotationValue) {
                 return ((AnnotationValue<?>) v).intValue(member, valueMapper);
             }
@@ -513,9 +512,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     public Optional<Boolean> booleanValue(@NonNull Class<? extends Annotation> annotation, @NonNull String member, Function<Object, Object> valueMapper) {
         ArgumentUtils.requireNonNull("annotation", annotation);
         ArgumentUtils.requireNonNull("member", member);
-        final Repeatable repeatable = annotation.getAnnotation(Repeatable.class);
-        if (repeatable != null) {
-            Object v = getRawSingleValue(repeatable.value().getName(), VALUE_MEMBER, null);
+        String repeatableTypeName = findRepeatableAnnotationContainerInternal(annotation.getName());
+        if (repeatableTypeName != null) {
+            Object v = getRawSingleValue(repeatableTypeName, VALUE_MEMBER, null);
             if (v instanceof AnnotationValue) {
                 return ((AnnotationValue<?>) v).booleanValue(member, valueMapper);
             }
@@ -573,9 +572,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     public OptionalLong longValue(@NonNull Class<? extends Annotation> annotation, @NonNull String member, @Nullable Function<Object, Object> valueMapper) {
         ArgumentUtils.requireNonNull("annotation", annotation);
         ArgumentUtils.requireNonNull("member", member);
-        final Repeatable repeatable = annotation.getAnnotation(Repeatable.class);
-        if (repeatable != null) {
-            Object v = getRawSingleValue(repeatable.value().getName(), VALUE_MEMBER, valueMapper);
+        String repeatableTypeName = findRepeatableAnnotationContainerInternal(annotation.getName());
+        if (repeatableTypeName != null) {
+            Object v = getRawSingleValue(repeatableTypeName, VALUE_MEMBER, valueMapper);
             if (v instanceof AnnotationValue) {
                 return ((AnnotationValue<?>) v).longValue(member, valueMapper);
             }
@@ -660,9 +659,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     @Override
     public Optional<String> stringValue(@NonNull Class<? extends Annotation> annotation, @NonNull String member, Function<Object, Object> valueMapper) {
         ArgumentUtils.requireNonNull("annotation", annotation);
-        final Repeatable repeatable = annotation.getAnnotation(Repeatable.class);
-        if (repeatable != null) {
-            Object v = getRawSingleValue(repeatable.value().getName(), VALUE_MEMBER, valueMapper);
+        String repeatableTypeName = findRepeatableAnnotationContainerInternal(annotation.getName());
+        if (repeatableTypeName != null) {
+            Object v = getRawSingleValue(repeatableTypeName, VALUE_MEMBER, valueMapper);
             if (v instanceof AnnotationValue) {
                 return ((AnnotationValue<?>) v).stringValue(member, valueMapper);
             }
@@ -696,9 +695,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     @NonNull
     public String[] stringValues(@NonNull Class<? extends Annotation> annotation, @NonNull String member, Function<Object, Object> valueMapper) {
         ArgumentUtils.requireNonNull("annotation", annotation);
-        final Repeatable repeatable = annotation.getAnnotation(Repeatable.class);
-        if (repeatable != null) {
-            Object v = getRawValue(repeatable.value().getName(), member);
+        String repeatableTypeName = findRepeatableAnnotationContainerInternal(annotation.getName());
+        if (repeatableTypeName != null) {
+            Object v = getRawValue(repeatableTypeName, member);
             if (v instanceof AnnotationValue) {
                 return ((AnnotationValue<?>) v).stringValues(member, valueMapper);
             }
@@ -748,7 +747,10 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     @NonNull
     public Optional<String> stringValue(@NonNull String annotation, @NonNull String member, @Nullable Function<Object, Object> valueMapper) {
         Object rawValue = getRawSingleValue(annotation, member, valueMapper);
-        if (rawValue instanceof CharSequence) {
+        if (rawValue instanceof String s) {
+            // Performance optimization to check for the actual class first to avoid the type-check polution
+            return Optional.of(s);
+        } else if (rawValue instanceof CharSequence) {
             return Optional.of(rawValue.toString());
         } else if (rawValue instanceof Class) {
             String name = ((Class) rawValue).getName();
@@ -776,9 +778,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     public boolean isTrue(@NonNull Class<? extends Annotation> annotation, @NonNull String member, Function<Object, Object> valueMapper) {
         ArgumentUtils.requireNonNull("annotation", annotation);
         ArgumentUtils.requireNonNull("member", member);
-        final Repeatable repeatable = annotation.getAnnotation(Repeatable.class);
-        if (repeatable != null) {
-            Object v = getRawSingleValue(repeatable.value().getName(), VALUE_MEMBER, valueMapper);
+        String repeatableTypeName = findRepeatableAnnotationContainerInternal(annotation.getName());
+        if (repeatableTypeName != null) {
+            Object v = getRawSingleValue(repeatableTypeName, VALUE_MEMBER, valueMapper);
             if (v instanceof AnnotationValue) {
                 return ((AnnotationValue<?>) v).isTrue(member, valueMapper);
             }
@@ -849,9 +851,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     public OptionalDouble doubleValue(@NonNull Class<? extends Annotation> annotation, @NonNull String member, @Nullable Function<Object, Object> valueMapper) {
         ArgumentUtils.requireNonNull("annotation", annotation);
         ArgumentUtils.requireNonNull("member", member);
-        final Repeatable repeatable = annotation.getAnnotation(Repeatable.class);
-        if (repeatable != null) {
-            Object v = getRawSingleValue(repeatable.value().getName(), VALUE_MEMBER, valueMapper);
+        String repeatableTypeName = findRepeatableAnnotationContainerInternal(annotation.getName());
+        if (repeatableTypeName != null) {
+            Object v = getRawSingleValue(repeatableTypeName, VALUE_MEMBER, valueMapper);
             if (v instanceof AnnotationValue) {
                 return ((AnnotationValue<?>) v).doubleValue(member, valueMapper);
             }
@@ -892,15 +894,13 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     }
 
     @Override
-    public @NonNull
-    <T> Optional<T> getValue(@NonNull Class<? extends Annotation> annotation, @NonNull String member, @NonNull Class<T> requiredType) {
+    public @NonNull <T> Optional<T> getValue(@NonNull Class<? extends Annotation> annotation, @NonNull String member, @NonNull Class<T> requiredType) {
         ArgumentUtils.requireNonNull("annotation", annotation);
         ArgumentUtils.requireNonNull("member", member);
         ArgumentUtils.requireNonNull("requiredType", requiredType);
 
-        final Repeatable repeatable = annotation.getAnnotation(Repeatable.class);
-        final boolean isRepeatable = repeatable != null;
-        if (isRepeatable) {
+        String repeatableTypeName = findRepeatableAnnotationContainerInternal(annotation.getName());
+        if (repeatableTypeName != null) {
             List<? extends AnnotationValue<? extends Annotation>> values = getAnnotationValuesByType(annotation);
             if (!values.isEmpty()) {
                 return values.iterator().next().get(member, requiredType);
@@ -913,8 +913,7 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     }
 
     @Override
-    public @NonNull
-    <T> Optional<T> getValue(@NonNull String annotation, @NonNull String member, @NonNull Argument<T> requiredType) {
+    public @NonNull <T> Optional<T> getValue(@NonNull String annotation, @NonNull String member, @NonNull Argument<T> requiredType) {
         return getValue(annotation, member, requiredType, null);
     }
 
@@ -944,7 +943,7 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
                         rawValue = valueMapper.apply(rawValue);
                     }
                     resolved = ConversionService.SHARED.convert(
-                            rawValue, requiredType
+                        rawValue, requiredType
                     );
                 }
             } else if (allStereotypes != null) {
@@ -956,7 +955,7 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
                             rawValue = valueMapper.apply(rawValue);
                         }
                         resolved = ConversionService.SHARED.convert(
-                                rawValue, requiredType
+                            rawValue, requiredType
                         );
                     }
                 }
@@ -971,8 +970,7 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     }
 
     @Override
-    public @NonNull
-    <T> Optional<T> getDefaultValue(@NonNull String annotation, @NonNull String member, @NonNull Class<T> requiredType) {
+    public @NonNull <T> Optional<T> getDefaultValue(@NonNull String annotation, @NonNull String member, @NonNull Class<T> requiredType) {
         ArgumentUtils.requireNonNull("annotation", annotation);
         ArgumentUtils.requireNonNull("member", member);
         ArgumentUtils.requireNonNull("requiredType", requiredType);
@@ -991,8 +989,7 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
 
     @SuppressWarnings("unchecked")
     @Override
-    public @NonNull
-    <T extends Annotation> List<AnnotationValue<T>> getAnnotationValuesByType(@Nullable Class<T> annotationType) {
+    public @NonNull <T extends Annotation> List<AnnotationValue<T>> getAnnotationValuesByType(@Nullable Class<T> annotationType) {
         if (annotationType != null) {
             final String annotationTypeName = annotationType.getName();
             List<AnnotationValue<T>> results = annotationValuesByType.get(annotationTypeName);
@@ -1021,17 +1018,14 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     @Override
     public <T extends Annotation> List<AnnotationValue<T>> getAnnotationValuesByName(String annotationType) {
         if (annotationType != null) {
-            String repeatableTypeName = getRepeatedName(annotationType);
-            if (repeatableTypeName == null) {
-                repeatableTypeName = AnnotationMetadataSupport.getRepeatableAnnotation(annotationType);
-            }
+            String repeatableTypeName = findRepeatableAnnotationContainerInternal(annotationType);
             if (repeatableTypeName != null) {
 
                 List<AnnotationValue<T>> results =
-                        resolveRepeatableAnnotations(repeatableTypeName,
-                                                     allAnnotations,
-                                                     allStereotypes
-                );
+                    resolveRepeatableAnnotations(repeatableTypeName,
+                        allAnnotations,
+                        allStereotypes
+                    );
                 if (results != null) {
                     return results;
                 } else if (allAnnotations != null) {
@@ -1051,8 +1045,7 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     }
 
     @Override
-    public @NonNull
-    <T extends Annotation> List<AnnotationValue<T>> getDeclaredAnnotationValuesByType(@NonNull Class<T> annotationType) {
+    public @NonNull <T extends Annotation> List<AnnotationValue<T>> getDeclaredAnnotationValuesByType(@NonNull Class<T> annotationType) {
         if (annotationType != null) {
             Map<String, Map<CharSequence, Object>> sourceAnnotations = this.declaredAnnotations;
             Map<String, Map<CharSequence, Object>> sourceStereotypes = this.declaredStereotypes;
@@ -1070,15 +1063,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
         if (annotationType != null) {
             Map<String, Map<CharSequence, Object>> sourceAnnotations = this.declaredAnnotations;
             Map<String, Map<CharSequence, Object>> sourceStereotypes = this.declaredStereotypes;
-            String repeatableTypeName = getRepeatedName(annotationType);
-            if (repeatableTypeName == null) {
-                repeatableTypeName = AnnotationMetadataSupport.getRepeatableAnnotation(annotationType);
-            }
+            String repeatableTypeName = findRepeatableAnnotationContainerInternal(annotationType);
             List<AnnotationValue<T>> results =
-                    resolveRepeatableAnnotations(repeatableTypeName,
-                                                 sourceAnnotations,
-                                                 sourceStereotypes
-                    );
+                resolveRepeatableAnnotations(repeatableTypeName, sourceAnnotations, sourceStereotypes);
             if (results != null) {
                 return results;
             }
@@ -1094,8 +1081,8 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
             List<AnnotationValue<T>> values = getAnnotationValuesByType(annotationClass);
 
             return values.stream()
-                    .map(entries -> AnnotationMetadataSupport.buildAnnotation(annotationClass, entries))
-                    .toArray(value -> (T[]) Array.newInstance(annotationClass, value));
+                .map(entries -> AnnotationMetadataSupport.buildAnnotation(annotationClass, entries))
+                .toArray(value -> (T[]) Array.newInstance(annotationClass, value));
         }
 
         //noinspection unchecked
@@ -1108,8 +1095,8 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
             List<AnnotationValue<T>> values = getAnnotationValuesByType(annotationClass);
 
             return values.stream()
-                    .map(entries -> AnnotationMetadataSupport.buildAnnotation(annotationClass, entries))
-                    .toArray(value -> (T[]) Array.newInstance(annotationClass, value));
+                .map(entries -> AnnotationMetadataSupport.buildAnnotation(annotationClass, entries))
+                .toArray(value -> (T[]) Array.newInstance(annotationClass, value));
         }
 
         //noinspection unchecked
@@ -1212,10 +1199,7 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
             if (annotations != null) {
                 List<AnnotationValue<T>> result = new ArrayList<>(annotations.size());
                 for (String annotation : annotations) {
-                    String repeatableTypeName = getRepeatedName(annotation);
-                    if (repeatableTypeName == null) {
-                        repeatableTypeName = AnnotationMetadataSupport.getRepeatableAnnotation(annotation);
-                    }
+                    String repeatableTypeName = findRepeatableAnnotationContainerInternal(annotation);
                     if (repeatableTypeName != null) {
                         List<AnnotationValue<T>> results =
                             resolveRepeatableAnnotations(repeatableTypeName,
@@ -1314,8 +1298,7 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
 
     @SuppressWarnings("Duplicates")
     @Override
-    public @NonNull
-    <T extends Annotation> Optional<AnnotationValue<T>> findAnnotation(@NonNull String annotation) {
+    public @NonNull <T extends Annotation> Optional<AnnotationValue<T>> findAnnotation(@NonNull String annotation) {
         ArgumentUtils.requireNonNull("annotation", annotation);
         if (allAnnotations != null && StringUtils.isNotEmpty(annotation)) {
             Map<CharSequence, Object> values = allAnnotations.get(annotation);
@@ -1333,8 +1316,7 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
 
     @SuppressWarnings("Duplicates")
     @Override
-    public @NonNull
-    <T extends Annotation> Optional<AnnotationValue<T>> findDeclaredAnnotation(@NonNull String annotation) {
+    public @NonNull <T extends Annotation> Optional<AnnotationValue<T>> findDeclaredAnnotation(@NonNull String annotation) {
         ArgumentUtils.requireNonNull("annotation", annotation);
         if (declaredAnnotations != null && StringUtils.isNotEmpty(annotation)) {
             Map<CharSequence, Object> values = declaredAnnotations.get(annotation);
@@ -1351,8 +1333,7 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     }
 
     @Override
-    public @NonNull
-    <T> OptionalValues<T> getValues(@NonNull String annotation, @NonNull Class<T> valueType) {
+    public @NonNull <T> OptionalValues<T> getValues(@NonNull String annotation, @NonNull Class<T> valueType) {
         ArgumentUtils.requireNonNull("annotation", annotation);
         ArgumentUtils.requireNonNull("valueType", valueType);
         if (allAnnotations != null && StringUtils.isNotEmpty(annotation)) {
@@ -1388,8 +1369,7 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     }
 
     @Override
-    public @NonNull
-    <T> Optional<T> getDefaultValue(@NonNull String annotation, @NonNull String member, @NonNull Argument<T> requiredType) {
+    public @NonNull <T> Optional<T> getDefaultValue(@NonNull String annotation, @NonNull String member, @NonNull Argument<T> requiredType) {
         ArgumentUtils.requireNonNull("annotation", annotation);
         ArgumentUtils.requireNonNull("member", member);
         ArgumentUtils.requireNonNull("requiredType", requiredType);
@@ -1403,30 +1383,22 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
 
     @Override
     public boolean isRepeatableAnnotation(Class<? extends Annotation> annotation) {
-        if (useRepeatableDefaults) {
-            return isRepeatableAnnotation(annotation.getName());
-        } else {
-            return super.isRepeatableAnnotation(annotation);
-        }
+        return isRepeatableAnnotation(annotation.getName());
     }
 
     @Override
     public boolean isRepeatableAnnotation(String annotation) {
-        return AnnotationMetadataSupport.getRepeatableAnnotation(annotation) != null;
+        return findRepeatableAnnotationContainerInternal(annotation) != null;
     }
 
     @Override
     public Optional<String> findRepeatableAnnotation(Class<? extends Annotation> annotation) {
-        if (useRepeatableDefaults) {
-            return findRepeatableAnnotation(annotation.getName());
-        } else {
-            return super.findRepeatableAnnotation(annotation);
-        }
+        return findRepeatableAnnotation(annotation.getName());
     }
 
     @Override
     public Optional<String> findRepeatableAnnotation(String annotation) {
-        return Optional.ofNullable(AnnotationMetadataSupport.getRepeatableAnnotation(annotation));
+        return Optional.ofNullable(findRepeatableAnnotationContainerInternal(annotation));
     }
 
     @Override
@@ -1437,15 +1409,15 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     @Override
     public DefaultAnnotationMetadata clone() {
         DefaultAnnotationMetadata cloned = new DefaultAnnotationMetadata(
-                declaredAnnotations != null ? cloneMapOfMapValue(declaredAnnotations) : null,
-                declaredStereotypes != null ? cloneMapOfMapValue(declaredStereotypes) : null,
-                allStereotypes != null ? cloneMapOfMapValue(allStereotypes) : null,
-                allAnnotations != null ? cloneMapOfMapValue(allAnnotations) : null,
-                annotationsByStereotype != null ? cloneMapOfListValue(annotationsByStereotype) : null,
-                hasPropertyExpressions
+            declaredAnnotations != null ? cloneMapOfMapValue(declaredAnnotations) : null,
+            declaredStereotypes != null ? cloneMapOfMapValue(declaredStereotypes) : null,
+            allStereotypes != null ? cloneMapOfMapValue(allStereotypes) : null,
+            allAnnotations != null ? cloneMapOfMapValue(allAnnotations) : null,
+            annotationsByStereotype != null ? cloneMapOfListValue(annotationsByStereotype) : null,
+            hasPropertyExpressions
         );
-        if (repeated != null) {
-            cloned.repeated = new HashMap<>(repeated);
+        if (annotationRepeatableContainer != null) {
+            cloned.annotationRepeatableContainer = new HashMap<>(annotationRepeatableContainer);
         }
         if (sourceRetentionAnnotations != null) {
             cloned.sourceRetentionAnnotations = new HashSet<>(sourceRetentionAnnotations);
@@ -1458,14 +1430,14 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
 
     protected final <X, Y, K> Map<K, Map<X, Y>> cloneMapOfMapValue(Map<K, Map<X, Y>> toClone) {
         return toClone.entrySet().stream()
-                .map(e -> new AbstractMap.SimpleEntry<>(e.getKey(), cloneMap(e.getValue())))
-                .collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue, (a, b) -> a, LinkedHashMap::new));
+            .map(e -> new AbstractMap.SimpleEntry<>(e.getKey(), cloneMap(e.getValue())))
+            .collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue, (a, b) -> a, LinkedHashMap::new));
     }
 
     protected final <K, V> Map<K, List<V>> cloneMapOfListValue(Map<K, List<V>> toClone) {
         return toClone.entrySet().stream()
-                .map(e -> new AbstractMap.SimpleEntry<>(e.getKey(), new ArrayList<>(e.getValue())))
-                .collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue, (a, b) -> a, LinkedHashMap::new));
+            .map(e -> new AbstractMap.SimpleEntry<>(e.getKey(), new ArrayList<>(e.getValue())))
+            .collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue, (a, b) -> a, LinkedHashMap::new));
     }
 
     protected final <K, V> Map<K, V> cloneMap(Map<K, V> map) {
@@ -1508,7 +1480,7 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     @SuppressWarnings("WeakerAccess")
     protected void addAnnotation(String annotation, Map<CharSequence, Object> values, RetentionPolicy retentionPolicy) {
         if (annotation != null) {
-            String repeatedName = getRepeatedName(annotation);
+            String repeatedName = findRepeatableAnnotationContainerInternal(annotation);
             Object v = values.get(AnnotationMetadata.VALUE_MEMBER);
             if (v instanceof io.micronaut.core.annotation.AnnotationValue[]) {
                 io.micronaut.core.annotation.AnnotationValue[] avs = (io.micronaut.core.annotation.AnnotationValue[]) v;
@@ -1728,7 +1700,7 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     @SuppressWarnings("WeakerAccess")
     protected final void addStereotype(List<String> parentAnnotations, String stereotype, Map<CharSequence, Object> values, RetentionPolicy retentionPolicy) {
         if (stereotype != null) {
-            String repeatedName = getRepeatedName(stereotype);
+            String repeatedName = findRepeatableAnnotationContainerInternal(stereotype);
             if (repeatedName != null) {
                 Object v = values.get(AnnotationMetadata.VALUE_MEMBER);
                 if (v instanceof io.micronaut.core.annotation.AnnotationValue[]) {
@@ -1756,12 +1728,12 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
 
                 // add to stereotypes
                 addAnnotation(
-                        stereotype,
-                        values,
-                        null,
-                        allStereotypes,
-                        false,
-                        retentionPolicy
+                    stereotype,
+                    values,
+                    null,
+                    allStereotypes,
+                    false,
+                    retentionPolicy
                 );
             }
         }
@@ -1792,7 +1764,7 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     @SuppressWarnings("WeakerAccess")
     protected void addDeclaredStereotype(List<String> parentAnnotations, String stereotype, Map<CharSequence, Object> values, RetentionPolicy retentionPolicy) {
         if (stereotype != null) {
-            String repeatedName = getRepeatedName(stereotype);
+            String repeatedName = findRepeatableAnnotationContainerInternal(stereotype);
             if (repeatedName != null) {
                 Object v = values.get(AnnotationMetadata.VALUE_MEMBER);
                 if (v instanceof io.micronaut.core.annotation.AnnotationValue[]) {
@@ -1820,12 +1792,12 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
                 }
 
                 addAnnotation(
-                        stereotype,
-                        values,
-                        declaredStereotypes,
-                        allStereotypes,
-                        true,
-                        retentionPolicy
+                    stereotype,
+                    values,
+                    declaredStereotypes,
+                    allStereotypes,
+                    true,
+                    retentionPolicy
                 );
             }
 
@@ -1854,9 +1826,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     protected void addDeclaredAnnotation(String annotation, Map<CharSequence, Object> values, RetentionPolicy retentionPolicy) {
         if (annotation != null) {
             boolean hasOtherMembers = false;
-            String repeatedName = getRepeatedName(annotation);
+            String repeatedName = findRepeatableAnnotationContainerInternal(annotation);
             if (repeatedName != null) {
-                for (Map.Entry<CharSequence, Object> entry: values.entrySet()) {
+                for (Map.Entry<CharSequence, Object> entry : values.entrySet()) {
                     if (entry.getKey().equals(AnnotationMetadata.VALUE_MEMBER)) {
                         Object v = entry.getValue();
                         if (v instanceof io.micronaut.core.annotation.AnnotationValue[]) {
@@ -1900,13 +1872,11 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     }
 
     private <T extends Annotation> List<io.micronaut.core.annotation.AnnotationValue<T>> resolveAnnotationValuesByType(Class<T> annotationType, Map<String, Map<CharSequence, Object>> sourceAnnotations, Map<String, Map<CharSequence, Object>> sourceStereotypes) {
-        Repeatable repeatable = annotationType.getAnnotation(Repeatable.class);
-        if (repeatable != null) {
-            Class<? extends Annotation> repeatableType = repeatable.value();
-            final String repeatableTypeName = repeatableType.getName();
+        String repeatableTypeName = findRepeatableAnnotationContainerInternal(annotationType.getName());
+        if (repeatableTypeName != null) {
             return resolveRepeatableAnnotations(repeatableTypeName,
-                                                sourceStereotypes,
-                                                sourceAnnotations
+                sourceStereotypes,
+                sourceAnnotations
             );
         }
         return null;
@@ -2025,13 +1995,6 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
         return getAnnotationsByStereotypeInternal().computeIfAbsent(stereotype, s -> new ArrayList<>());
     }
 
-    private String getRepeatedName(String annotation) {
-        if (repeated != null) {
-            return repeated.get(annotation);
-        }
-        return null;
-    }
-
     @SuppressWarnings("MagicNumber")
     private Map<String, List<String>> getAnnotationsByStereotypeInternal() {
         Map<String, List<String>> annotations = this.annotationsByStereotype;
@@ -2083,24 +2046,23 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     }
 
     private void addRepeatableInternal(
-            String annotationName,
-            io.micronaut.core.annotation.AnnotationValue annotationValue,
-            Map<String, Map<CharSequence, Object>> allAnnotations,
-            RetentionPolicy retentionPolicy) {
+        String annotationName,
+        io.micronaut.core.annotation.AnnotationValue annotationValue,
+        Map<String, Map<CharSequence, Object>> allAnnotations,
+        RetentionPolicy retentionPolicy) {
         addRepeatableInternal(annotationName, AnnotationMetadata.VALUE_MEMBER, annotationValue, allAnnotations, retentionPolicy);
     }
 
     private void addRepeatableInternal(
-            String annotationName,
-            String member,
-            io.micronaut.core.annotation.AnnotationValue annotationValue,
-            Map<String, Map<CharSequence, Object>> allAnnotations,
-            RetentionPolicy retentionPolicy) {
-        if (repeated == null) {
-            repeated = new HashMap<>(2);
+        String annotationName,
+        String member,
+        io.micronaut.core.annotation.AnnotationValue annotationValue,
+        Map<String, Map<CharSequence, Object>> allAnnotations,
+        RetentionPolicy retentionPolicy) {
+        if (annotationRepeatableContainer == null) {
+            annotationRepeatableContainer = new HashMap<>(2);
         }
-
-        repeated.put(annotationName, annotationValue.getAnnotationName());
+        annotationRepeatableContainer.put(annotationValue.getAnnotationName(), annotationName);
         if (retentionPolicy == RetentionPolicy.SOURCE) {
             addSourceRetentionAnnotation(annotationName);
         }
@@ -2138,16 +2100,17 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
      */
     @Internal
     public static AnnotationMetadata mutateMember(
-            AnnotationMetadata annotationMetadata,
-            String annotationName,
-            String member,
-            Object value) {
+        AnnotationMetadata annotationMetadata,
+        String annotationName,
+        String member,
+        Object value) {
 
         return mutateMember(annotationMetadata, annotationName, Collections.singletonMap(member, value));
     }
 
     /**
      * Include the annotation metadata from the other instance of {@link DefaultAnnotationMetadata}.
+     *
      * @param annotationMetadata The annotation metadata
      * @since 4.0.0
      */
@@ -2202,11 +2165,11 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
                 }
             }
         }
-        if (annotationMetadata.repeated != null) {
-            if (repeated == null) {
-                repeated = new LinkedHashMap<>(annotationMetadata.repeated);
+        if (annotationMetadata.annotationRepeatableContainer != null) {
+            if (annotationRepeatableContainer == null) {
+                annotationRepeatableContainer = new LinkedHashMap<>(annotationMetadata.annotationRepeatableContainer);
             } else {
-                repeated.putAll(annotationMetadata.repeated);
+                annotationRepeatableContainer.putAll(annotationMetadata.annotationRepeatableContainer);
             }
         }
         if (annotationMetadata.sourceRetentionAnnotations != null) {
@@ -2248,7 +2211,7 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
                 final Map<String, Map<CharSequence, Object>> additionalDefaults = damSource.annotationDefaultValues;
                 if (additionalDefaults != null) {
                     existingDefaults.putAll(
-                            additionalDefaults
+                        additionalDefaults
                     );
                 }
             } else {
@@ -2278,11 +2241,11 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
         if (target instanceof DefaultAnnotationMetadata && source instanceof DefaultAnnotationMetadata) {
             DefaultAnnotationMetadata damTarget = (DefaultAnnotationMetadata) target;
             DefaultAnnotationMetadata damSource = (DefaultAnnotationMetadata) source;
-            if (damSource.repeated != null && !damSource.repeated.isEmpty()) {
-                if (damTarget.repeated == null) {
-                    damTarget.repeated = new HashMap<>(damSource.repeated);
+            if (damSource.annotationRepeatableContainer != null && !damSource.annotationRepeatableContainer.isEmpty()) {
+                if (damTarget.annotationRepeatableContainer == null) {
+                    damTarget.annotationRepeatableContainer = new HashMap<>(damSource.annotationRepeatableContainer);
                 } else {
-                    damTarget.repeated.putAll(damSource.repeated);
+                    damTarget.annotationRepeatableContainer.putAll(damSource.annotationRepeatableContainer);
                 }
             }
         }
@@ -2301,9 +2264,9 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
      */
     @Internal
     public static AnnotationMetadata mutateMember(
-            AnnotationMetadata annotationMetadata,
-            String annotationName,
-            Map<CharSequence, Object> members) {
+        AnnotationMetadata annotationMetadata,
+        String annotationName,
+        Map<CharSequence, Object> members) {
         if (StringUtils.isEmpty(annotationName)) {
             throw new IllegalArgumentException("Argument [annotationName] cannot be blank");
         }
@@ -2327,7 +2290,7 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
             defaultMetadata = defaultMetadata.clone();
 
             defaultMetadata
-                    .addDeclaredAnnotation(annotationName, members);
+                .addDeclaredAnnotation(annotationName, members);
 
             return defaultMetadata;
         }
@@ -2335,11 +2298,12 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
 
     /**
      * Removes an annotation for the given predicate.
+     *
      * @param predicate The predicate
-     * @param <A> The annotation
+     * @param <A>       The annotation
      */
     protected <A extends Annotation> void removeAnnotationIf(
-            @NonNull Predicate<AnnotationValue<A>> predicate) {
+        @NonNull Predicate<AnnotationValue<A>> predicate) {
         removeAnnotationsIf(predicate, this.declaredAnnotations);
         removeAnnotationsIf(predicate, this.allAnnotations);
     }
@@ -2359,6 +2323,7 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
 
     /**
      * Removes an annotation for the given annotation type.
+     *
      * @param annotationType The annotation type
      * @since 3.0.0
      */
@@ -2375,14 +2340,15 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
                 declaredAnnotations.remove(annotationType);
                 removeFromStereotypes(annotationType, declaredAnnotations);
             }
-            if (this.repeated != null) {
-                this.repeated.remove(annotationType);
+            if (this.annotationRepeatableContainer != null) {
+                this.annotationRepeatableContainer.remove(annotationType);
             }
         }
     }
 
     /**
      * Removes a stereotype annotation for the given annotation type.
+     *
      * @param annotationType The annotation type
      * @since 3.0.0
      */
@@ -2451,7 +2417,7 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
                 if (o instanceof Collection) {
                     Collection<AnnotationValue<?>> col = (Collection) o;
                     col.removeIf(av -> Arrays.stream(av.annotationClassValues(AnnotationMetadata.VALUE_MEMBER))
-                            .anyMatch(acv -> toBeRemoved.contains(acv.getName())));
+                        .anyMatch(acv -> toBeRemoved.contains(acv.getName())));
 
                     if (col.isEmpty()) {
                         declaredAnnotations.remove(AnnotationUtil.ANN_INTERCEPTOR_BINDINGS);
@@ -2459,5 +2425,15 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
                 }
             }
         }
+    }
+
+    private String findRepeatableAnnotationContainerInternal(String annotation) {
+        if (annotationRepeatableContainer != null) {
+            String repeatedName = annotationRepeatableContainer.get(annotation);
+            if (repeatedName != null) {
+                return repeatedName;
+            }
+        }
+        return AnnotationMetadataSupport.getRepeatableAnnotation(annotation);
     }
 }

--- a/inject/src/main/java/io/micronaut/inject/annotation/MutableAnnotationMetadata.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/MutableAnnotationMetadata.java
@@ -107,8 +107,8 @@ public class MutableAnnotationMetadata extends DefaultAnnotationMetadata {
         if (annotationDefaultValues != null) {
             cloned.annotationDefaultValues = new LinkedHashMap<>(annotationDefaultValues);
         }
-        if (repeated != null) {
-            cloned.repeated = new HashMap<>(repeated);
+        if (annotationRepeatableContainer != null) {
+            cloned.annotationRepeatableContainer = new HashMap<>(annotationRepeatableContainer);
         }
         if (sourceRetentionAnnotations != null) {
             cloned.sourceRetentionAnnotations = new HashSet<>(sourceRetentionAnnotations);

--- a/inject/src/main/java/io/micronaut/inject/provider/AbstractProviderDefinition.java
+++ b/inject/src/main/java/io/micronaut/inject/provider/AbstractProviderDefinition.java
@@ -78,6 +78,11 @@ public abstract class AbstractProviderDefinition<T> implements InstantiatableBea
     }
 
     @Override
+    public boolean isCandidateBean(Argument<?> beanType) {
+        return beanType.isAssignableFrom(getBeanType());
+    }
+
+    @Override
     public boolean isEnabled(@NonNull BeanContext context, @Nullable BeanResolutionContext resolutionContext) {
         return isPresent();
     }

--- a/inject/src/main/java/io/micronaut/inject/qualifiers/InterceptorBindingQualifier.java
+++ b/inject/src/main/java/io/micronaut/inject/qualifiers/InterceptorBindingQualifier.java
@@ -30,7 +30,6 @@ import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -52,29 +51,19 @@ public final class InterceptorBindingQualifier<T> implements Qualifier<T> {
     private final Set<Class<?>> supportedInterceptorTypes;
 
     InterceptorBindingQualifier(AnnotationMetadata annotationMetadata) {
-        final List<AnnotationValue<Annotation>> annotationValues = annotationMetadata
-                .findAnnotation(AnnotationUtil.ANN_INTERCEPTOR_BINDING_QUALIFIER)
-                .map(av -> av.getAnnotations(AnnotationMetadata.VALUE_MEMBER))
-                .orElse(Collections.emptyList());
-        this.supportedAnnotationNames = new HashMap<>(annotationValues.size());
-        for (AnnotationValue<Annotation> annotationValue : annotationValues) {
-            final String name = annotationValue.stringValue().orElse(null);
-            if (name != null) {
-                final AnnotationValue<Annotation> members =
-                        annotationValue.getAnnotation(META_MEMBER_MEMBERS).orElse(null);
-                if (members != null) {
-                    List<AnnotationValue<?>> existing = supportedAnnotationNames
-                            .computeIfAbsent(name, k -> new ArrayList<>(5));
-                    existing.add(members);
-                } else {
-                    supportedAnnotationNames.put(name, null);
-                }
-            }
+        final Collection<AnnotationValue<?>> annotationValues;
+        AnnotationValue<Annotation> av = annotationMetadata.findAnnotation(AnnotationUtil.ANN_INTERCEPTOR_BINDING_QUALIFIER).orElse(null);
+        if (av == null) {
+            annotationValues = Collections.emptyList();
+        } else {
+            annotationValues = (Collection) av.getAnnotations(AnnotationMetadata.VALUE_MEMBER);
         }
-        this.supportedInterceptorTypes = annotationValues
-                .stream()
-                .flatMap(av -> av.classValue(META_MEMBER_INTERCEPTOR_TYPE).map(Stream::of).orElse(Stream.empty()))
-                .collect(Collectors.toSet());
+        supportedAnnotationNames = findSupportedAnnotations(annotationValues);
+        Set<Class<?>> supportedInterceptorTypes = CollectionUtils.newHashSet(annotationValues.size());
+        for (AnnotationValue<?> annotationValue : annotationValues) {
+            annotationValue.classValue(META_MEMBER_INTERCEPTOR_TYPE).ifPresent(supportedInterceptorTypes::add);
+        }
+        this.supportedInterceptorTypes = supportedInterceptorTypes;
     }
 
     /**
@@ -83,25 +72,30 @@ public final class InterceptorBindingQualifier<T> implements Qualifier<T> {
      */
     InterceptorBindingQualifier(Collection<AnnotationValue<?>> bindingAnnotations) {
         if (CollectionUtils.isNotEmpty(bindingAnnotations)) {
-            this.supportedAnnotationNames = new HashMap<>(bindingAnnotations.size());
-            for (AnnotationValue<?> bindingAnnotation : bindingAnnotations) {
-                final String name = bindingAnnotation.stringValue().orElse(null);
-                if (name != null) {
-                    final AnnotationValue<Annotation> members =
-                            bindingAnnotation.getAnnotation(META_MEMBER_MEMBERS).orElse(null);
-                    if (members != null) {
-                        List<AnnotationValue<?>> existing = supportedAnnotationNames
-                                .computeIfAbsent(name, k -> new ArrayList<>(5));
-                        existing.add(members);
-                    } else {
-                        supportedAnnotationNames.putIfAbsent(name, null);
-                    }
-                }
-            }
+            supportedAnnotationNames = findSupportedAnnotations(bindingAnnotations);
         } else {
             this.supportedAnnotationNames = Collections.emptyMap();
         }
         this.supportedInterceptorTypes = Collections.emptySet();
+    }
+
+    private static Map<String, List<AnnotationValue<?>>> findSupportedAnnotations(Collection<AnnotationValue<?>> annotationValues) {
+        final Map<String, List<AnnotationValue<?>>> supportedAnnotationNames = CollectionUtils.newHashMap(annotationValues.size());
+        for (AnnotationValue<?> annotationValue : annotationValues) {
+            final String name = annotationValue.stringValue().orElse(null);
+            if (name != null) {
+                final AnnotationValue<?> members =
+                    annotationValue.getAnnotation(META_MEMBER_MEMBERS).orElse(null);
+                if (members != null) {
+                    List<AnnotationValue<?>> existing = supportedAnnotationNames
+                        .computeIfAbsent(name, k -> new ArrayList<>(5));
+                    existing.add(members);
+                } else {
+                    supportedAnnotationNames.put(name, null);
+                }
+            }
+        }
+        return supportedAnnotationNames;
     }
 
     @Override

--- a/jackson-databind/src/main/java/io/micronaut/jackson/databind/convert/JacksonConverterRegistrar.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/databind/convert/JacksonConverterRegistrar.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.node.ContainerNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import io.micronaut.context.BeanProvider;
+import io.micronaut.context.annotation.Prototype;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
@@ -41,7 +42,6 @@ import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.jackson.JacksonConfiguration;
 import jakarta.inject.Inject;
-import jakarta.inject.Singleton;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -55,7 +55,7 @@ import java.util.Optional;
  * @author graemerocher
  * @since 2.0
  */
-@Singleton
+@Prototype
 @Internal
 public class JacksonConverterRegistrar implements TypeConverterRegistrar {
 

--- a/json-core/src/main/java/io/micronaut/json/convert/JsonConverterRegistrar.java
+++ b/json-core/src/main/java/io/micronaut/json/convert/JsonConverterRegistrar.java
@@ -16,6 +16,7 @@
 package io.micronaut.json.convert;
 
 import io.micronaut.context.BeanProvider;
+import io.micronaut.context.annotation.Prototype;
 import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.bind.ArgumentBinder;
@@ -33,7 +34,6 @@ import io.micronaut.json.JsonMapper;
 import io.micronaut.json.tree.JsonArray;
 import io.micronaut.json.tree.JsonNode;
 import jakarta.inject.Inject;
-import jakarta.inject.Singleton;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -52,7 +52,7 @@ import java.util.Optional;
  * @since 3.1
  */
 @Experimental
-@Singleton
+@Prototype
 public final class JsonConverterRegistrar implements TypeConverterRegistrar {
     private final BeanProvider<JsonMapper> objectCodec;
     private final ConversionService conversionService;

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/basics/HelloControllerSpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/basics/HelloControllerSpec.kt
@@ -61,7 +61,7 @@ class HelloControllerSpec: StringSpec() {
             // tag::jsonmaptypes[]
             response = Flux.from(client.retrieve(
                     GET<Any>("/greet/John"),
-                    Argument.of(Map::class.java, String::class.java, String::class.java) // <1>
+                    Argument.mapOf(String::class.java, String::class.java) // <1>
             ))
             // end::jsonmaptypes[]
 

--- a/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java
@@ -1753,7 +1753,7 @@ public class DefaultValidator implements Validator, ExecutableMethodValidator, R
             Set<ConstraintViolation<T>> errors = validate(introspection, bean);
             failOnError(resolutionContext, errors, beanType);
         } else if (bean instanceof Intercepted && definition.hasStereotype(ConfigurationReader.class)) {
-            final Collection<ExecutableMethod<T, ?>> executableMethods = definition.getExecutableMethods();
+            final Collection<ExecutableMethod<T, Object>> executableMethods = definition.getExecutableMethods();
             if (CollectionUtils.isNotEmpty(executableMethods)) {
                 Set<ConstraintViolation<Object>> errors = new HashSet<>();
                 final DefaultConstraintValidatorContext context = new DefaultConstraintValidatorContext(bean);

--- a/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java
@@ -1753,7 +1753,7 @@ public class DefaultValidator implements Validator, ExecutableMethodValidator, R
             Set<ConstraintViolation<T>> errors = validate(introspection, bean);
             failOnError(resolutionContext, errors, beanType);
         } else if (bean instanceof Intercepted && definition.hasStereotype(ConfigurationReader.class)) {
-            final Collection<ExecutableMethod<T, Object>> executableMethods = definition.getExecutableMethods();
+            final Collection<ExecutableMethod<T, ?>> executableMethods = definition.getExecutableMethods();
             if (CollectionUtils.isNotEmpty(executableMethods)) {
                 Set<ConstraintViolation<Object>> errors = new HashSet<>();
                 final DefaultConstraintValidatorContext context = new DefaultConstraintValidatorContext(bean);

--- a/validation/src/test/groovy/io/micronaut/validation/ValidatedSpec.groovy
+++ b/validation/src/test/groovy/io/micronaut/validation/ValidatedSpec.groovy
@@ -112,7 +112,7 @@ class ValidatedSpec extends Specification {
 
         then:
         def e = thrown(ConstraintViolationException)
-        e.message == "String: must not be null"
+        e.message == "string: must not be null"
 
         cleanup:
         beanContext.close()
@@ -128,7 +128,7 @@ class ValidatedSpec extends Specification {
 
         then:
         def e = thrown(ConstraintViolationException)
-        e.message == "Bar: must not be null"
+        e.message == "bar: must not be null"
 
         cleanup:
         beanContext.close()
@@ -144,7 +144,7 @@ class ValidatedSpec extends Specification {
 
         then:
         def e = thrown(ConstraintViolationException)
-        e.message == "Bar.prop: must not be null"
+        e.message == "bar.prop: must not be null"
 
         cleanup:
         beanContext.close()
@@ -160,7 +160,7 @@ class ValidatedSpec extends Specification {
 
         then:
         def e = thrown(ConstraintViolationException)
-        e.message == "List[0].prop: must not be null"
+        e.message == "list[0].prop: must not be null"
 
         cleanup:
         beanContext.close()
@@ -176,7 +176,7 @@ class ValidatedSpec extends Specification {
 
         then:
         def e = thrown(ConstraintViolationException)
-        e.message == "Map[barObj].prop: must not be null"
+        e.message == "map[barObj].prop: must not be null"
 
         cleanup:
         beanContext.close()

--- a/websocket/src/main/java/io/micronaut/websocket/context/DefaultWebSocketBeanRegistry.java
+++ b/websocket/src/main/java/io/micronaut/websocket/context/DefaultWebSocketBeanRegistry.java
@@ -65,7 +65,7 @@ class DefaultWebSocketBeanRegistry implements WebSocketBeanRegistry {
             Qualifier<T> qualifier = Qualifiers.byStereotype(stereotype);
             BeanDefinition<T> beanDefinition = beanContext.getBeanDefinition(type, qualifier);
             T bean = beanContext.getBean(type, qualifier);
-            Collection<ExecutableMethod<T, Object>> executableMethods = beanDefinition.getExecutableMethods();
+            Collection<ExecutableMethod<T, ?>> executableMethods = beanDefinition.getExecutableMethods();
             MethodExecutionHandle<T, ?> onOpen = null;
             MethodExecutionHandle<T, ?> onClose = null;
             MethodExecutionHandle<T, ?> onMessage = null;

--- a/websocket/src/main/java/io/micronaut/websocket/context/DefaultWebSocketBeanRegistry.java
+++ b/websocket/src/main/java/io/micronaut/websocket/context/DefaultWebSocketBeanRegistry.java
@@ -65,7 +65,7 @@ class DefaultWebSocketBeanRegistry implements WebSocketBeanRegistry {
             Qualifier<T> qualifier = Qualifiers.byStereotype(stereotype);
             BeanDefinition<T> beanDefinition = beanContext.getBeanDefinition(type, qualifier);
             T bean = beanContext.getBean(type, qualifier);
-            Collection<ExecutableMethod<T, ?>> executableMethods = beanDefinition.getExecutableMethods();
+            Collection<ExecutableMethod<T, Object>> executableMethods = beanDefinition.getExecutableMethods();
             MethodExecutionHandle<T, ?> onOpen = null;
             MethodExecutionHandle<T, ?> onClose = null;
             MethodExecutionHandle<T, ?> onMessage = null;


### PR DESCRIPTION
Some performance improvements:
- MethodLookup is now instantiating the services, it should be faster and avoid reflection caches
- Detected some typecast problems in a basic HelloWorld
- Removed reflection uses to find the repeatable annotation container
- `BeanDefinitionProducer` to cache some of the `enabled` checks and the definition instance
- Introduced `CollectionUtils.newSet/../Map` helper methods to create set/map collection with an expected element count
- Reduced some of the streams and lambdas spotted in the profiled (might be a bit of controversial)
- Supplier memorize methods rewritten to use double-check locking, inspired by Guava

Styling in some classes to use the variable defined in the `instanceof`, eliminated some of the embeddings by using fast return.