### PR TITLE
test: pass request parameter to chain.proceed

### DIFF
--- a/http-client/src/test/groovy/io/micronaut/http/client/ResponseAndStreamSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/ResponseAndStreamSpec.groovy
@@ -57,7 +57,7 @@ class ResponseAndStreamSpec extends Specification {
         @Override
         Publisher<MutableHttpResponse<?>> doFilter(
                 HttpRequest<?> request, ServerFilterChain chain) {
-            return Flux.from(chain.proceed()).map { MutableHttpResponse<?> response ->
+            return Flux.from(chain.proceed(request)).map { MutableHttpResponse<?> response ->
                 return response.body(Flux.fromIterable([
                         "chunk1",
                         "chunk2",


### PR DESCRIPTION
Test aws extremely flaky. No idea how this ever passed.

https://ge.micronaut.io/scans/tests?tests.container=io.micronaut.http.client.ResponseAndStreamSpec