### PR TITLE
HTTP Server TCK Body assertion

### DIFF
--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/AssertionUtils.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/AssertionUtils.java
@@ -98,11 +98,11 @@ public final class AssertionUtils {
         assertion.getResponseConsumer().ifPresent(httpResponseConsumer -> httpResponseConsumer.accept(response));
     }
 
-    private static void assertBody(@NonNull HttpResponse<?> response,  @Nullable String expectedBody) {
-        if (expectedBody != null) {
+    private static void assertBody(@NonNull HttpResponse<?> response,  @Nullable BodyAssertion bodyAssertion) {
+        if (bodyAssertion != null) {
             Optional<String> bodyOptional = response.getBody(String.class);
             assertTrue(bodyOptional.isPresent());
-            bodyOptional.ifPresent(body -> assertTrue(body.contains(expectedBody)));
+            bodyOptional.ifPresent(bodyAssertion::evaluate);
         }
     }
 

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/BodyAssertion.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/BodyAssertion.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.tck;
+
+import io.micronaut.core.annotation.Experimental;
+
+import java.util.function.BiFunction;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * HTTP Reponse's body assertions.
+ */
+@Experimental
+public final class BodyAssertion {
+    private final String expected;
+    private final BiFunction<String, String, Boolean> evaluator;
+
+    private BodyAssertion(String expected, BiFunction<String, String, Boolean> evaluator) {
+        this.expected = expected;
+        this.evaluator = evaluator;
+    }
+
+    /**
+     * Evaluates the HTTP Response Body.
+     * @param body The HTTP Response Body
+     */
+    public void evaluate(String body) {
+        assertTrue(this.evaluator.apply(expected, body));
+    }
+
+    /**
+     *
+     * @return a Builder;
+     */
+    public static BodyAssertion.Builder builder() {
+        return new BodyAssertion.Builder();
+    }
+
+    /**
+     * BodyAssertion Builder.
+     */
+    public static class Builder {
+
+        private String body;
+
+        /**
+         *
+         * @param expected Expected Body
+         * @return The Builder
+         */
+        public Builder body(String expected) {
+            this.body = expected;
+            return this;
+        }
+
+        /**
+         *
+         * @return a body assertion which verifiers the HTTP Response's body contains the expected body
+         */
+        public BodyAssertion contains() {
+            return new BodyAssertion(this.body, (expected, body) -> body.contains(expected));
+        }
+
+        /**
+         *
+         * @return a body assertion which verifiers the HTTP Response's body is equals to the expected body
+         */
+        public BodyAssertion equals() {
+            return new BodyAssertion(this.body, (expected, body) -> body.equals(expected));
+        }
+    }
+}

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/HttpResponseAssertion.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/HttpResponseAssertion.java
@@ -34,21 +34,20 @@ import java.util.function.Consumer;
  */
 @Experimental
 public final class HttpResponseAssertion {
-
     private final HttpStatus httpStatus;
     private final Map<String, String> headers;
-    private final String body;
+    private final BodyAssertion bodyAssertion;
 
     @Nullable
     private final Consumer<HttpResponse<?>> responseConsumer;
 
     private HttpResponseAssertion(HttpStatus httpStatus,
                                   Map<String, String> headers,
-                                  String body,
+                                  BodyAssertion bodyAssertion,
                                   @Nullable Consumer<HttpResponse<?>> responseConsumer) {
         this.httpStatus = httpStatus;
         this.headers = headers;
-        this.body = body;
+        this.bodyAssertion = bodyAssertion;
         this.responseConsumer = responseConsumer;
     }
 
@@ -77,8 +76,9 @@ public final class HttpResponseAssertion {
      *
      * @return Expected HTTP Response body
      */
-    public String getBody() {
-        return body;
+
+    public BodyAssertion getBody() {
+        return bodyAssertion;
     }
 
     /**
@@ -95,7 +95,7 @@ public final class HttpResponseAssertion {
     public static class Builder {
         private HttpStatus httpStatus;
         private Map<String, String> headers;
-        private String body;
+        private BodyAssertion bodyAssertion;
 
         private Consumer<HttpResponse<?>> responseConsumer;
 
@@ -135,11 +135,21 @@ public final class HttpResponseAssertion {
 
         /**
          *
-         * @param body Response Body
+         * @param containsBody Response Body
          * @return HTTP Response Assertion Builder
          */
-        public Builder body(String body) {
-            this.body = body;
+        public Builder body(String containsBody) {
+            this.bodyAssertion = BodyAssertion.builder().body(containsBody).contains();
+            return this;
+        }
+
+        /**
+         *
+         * @param bodyAssertion Response Body Assertion
+         * @return HTTP Response Assertion Builder
+         */
+        public Builder body(BodyAssertion bodyAssertion) {
+            this.bodyAssertion = bodyAssertion;
             return this;
         }
 
@@ -158,7 +168,7 @@ public final class HttpResponseAssertion {
          * @return HTTP Response Assertion
          */
         public HttpResponseAssertion build() {
-            return new HttpResponseAssertion(Objects.requireNonNull(httpStatus), headers, body, responseConsumer);
+            return new HttpResponseAssertion(Objects.requireNonNull(httpStatus), headers, bodyAssertion, responseConsumer);
         }
     }
 }

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/BodyTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/BodyTest.java
@@ -26,6 +26,7 @@ import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
 import io.micronaut.http.annotation.Status;
 import io.micronaut.http.server.tck.AssertionUtils;
+import io.micronaut.http.server.tck.BodyAssertion;
 import io.micronaut.http.server.tck.HttpResponseAssertion;
 import static io.micronaut.http.server.tck.TestScenario.asserts;
 import org.junit.jupiter.api.Test;
@@ -88,6 +89,19 @@ public class BodyTest {
                     .build()));
     }
 
+    @Test
+    void testCustomListBodyPOJOReactiveTypes() throws IOException {
+        String body = "[{\"x\":10,\"y\":20},{\"x\":30,\"y\":40}]";
+        asserts(SPEC_NAME,
+            HttpRequest.POST("/response-body/pojo-flux", body)
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON),
+            (server, request) -> AssertionUtils.assertDoesNotThrow(server, request,
+                HttpResponseAssertion.builder()
+                    .status(HttpStatus.CREATED)
+                    .body(BodyAssertion.builder().body(body).equals())
+                    .build()));
+    }
+
     @Controller("/response-body")
     @Requires(property = "spec.name", value = SPEC_NAME)
     static class BodyController {
@@ -108,6 +122,12 @@ public class BodyTest {
         @Status(HttpStatus.CREATED)
         @SingleResult
         Publisher<Point> post(@Body Publisher<Point> data) {
+            return data;
+        }
+
+        @Post(uri = "/pojo-flux")
+        @Status(HttpStatus.CREATED)
+        Publisher<Point> postMany(@Body Publisher<Point> data) {
             return data;
         }
 


### PR DESCRIPTION
Close #8583

This is an alternative implementation to the previously linked PR. 

I think this implementation is a more flexible and it allows us easily to add feature comparisons to the HTTP Response's body such as regex. 

@timyates what do you think?