### PR TITLE
Load ApplicationContextConfigurer with passed classloader instead of the class one

### DIFF
--- a/inject/src/main/java/io/micronaut/context/ApplicationContext.java
+++ b/inject/src/main/java/io/micronaut/context/ApplicationContext.java
@@ -256,7 +256,7 @@ public interface ApplicationContext extends BeanContext, PropertyResolver, Prope
      */
     static @NonNull ApplicationContextBuilder builder(@NonNull String... environments) {
         ArgumentUtils.requireNonNull("environments", environments);
-        return new DefaultApplicationContextBuilder()
+        return builder()
                 .environments(environments);
     }
 
@@ -270,7 +270,7 @@ public interface ApplicationContext extends BeanContext, PropertyResolver, Prope
     static @NonNull ApplicationContextBuilder builder(@NonNull Map<String, Object> properties, @NonNull String... environments) {
         ArgumentUtils.requireNonNull("environments", environments);
         ArgumentUtils.requireNonNull("properties", properties);
-        return new DefaultApplicationContextBuilder()
+        return builder()
                 .properties(properties)
                 .environments(environments);
     }
@@ -282,6 +282,14 @@ public interface ApplicationContext extends BeanContext, PropertyResolver, Prope
      */
     static @NonNull ApplicationContextBuilder builder() {
         return new DefaultApplicationContextBuilder();
+    }
+
+    /**
+     * @param classLoader The class loader to use
+     * @return The application context builder
+     */
+    static @NonNull ApplicationContextBuilder builder(ClassLoader classLoader) {
+        return new DefaultApplicationContextBuilder(classLoader);
     }
 
     /**
@@ -308,8 +316,8 @@ public interface ApplicationContext extends BeanContext, PropertyResolver, Prope
         ArgumentUtils.requireNonNull("environments", environments);
         ArgumentUtils.requireNonNull("classLoader", classLoader);
 
-        return builder(environments)
-                .classLoader(classLoader);
+        return builder(classLoader)
+            .environments(environments);
     }
 
     /**

--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContextBuilder.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContextBuilder.java
@@ -75,6 +75,11 @@ public class DefaultApplicationContextBuilder implements ApplicationContextBuild
         loadApplicationContextCustomizer(resolveClassLoader()).configure(this);
     }
 
+    DefaultApplicationContextBuilder(ClassLoader classLoader) {
+        loadApplicationContextCustomizer(classLoader).configure(this);
+        this.classLoader = classLoader;
+    }
+
     private ClassLoader resolveClassLoader() {
         final ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
         if (contextClassLoader != null) {
@@ -89,7 +94,7 @@ public class DefaultApplicationContextBuilder implements ApplicationContextBuild
     }
 
     @Override
-    @NonNull 
+    @NonNull
     public ApplicationContextBuilder enableDefaultPropertySources(boolean areEnabled) {
         this.enableDefaultPropertySources = areEnabled;
         return this;

--- a/inject/src/test/groovy/io/micronaut/context/ApplicationContextBuilderSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/ApplicationContextBuilderSpec.groovy
@@ -37,6 +37,29 @@ class ApplicationContextBuilderSpec extends Specification {
         config.resourceLoader.classLoader.is(loader)
         config.environments.contains('foo')
         config.deduceEnvironments.get() == false
+    }
 
+    void "test context configurer with own class loader"() {
+        given:
+        def loader = new GroovyClassLoader()
+        loader.parseClass("""
+    package io.micronaut.context
+    import io.micronaut.context.*
+
+    class TestContextConfigurer implements ApplicationContextConfigurer {
+
+        @Override
+        void configure(ApplicationContextBuilder builder) {
+            builder.environments("success")
+        }
+    }
+""")
+        loader.addURL(getClass().getResource("/test-meta-inf/"))
+
+        ApplicationContext context = ApplicationContext.builder(loader)
+            .start()
+
+        expect:
+        context.getEnvironment().getActiveNames().contains("success")
     }
 }


### PR DESCRIPTION
Currently ApplicationContextConfigurer are loaded with the class loader of the current class, but this seems not like the expected behavior, when passing an own ClassLoader. This pr corrects this behavior.
Hopefully this will not break anything.

Context: I'm currently writing an integration between Micronaut and the bukkit minecraft api (papermc) and they use an own class loader which I have to pass to Micronaut (via Micronaut.run(ClassLoader). This works fine, except for loading the `ApplicationContextConfigurer`.