### PR TITLE
Links to bootstrap configuration in documentation

### DIFF
--- a/src/main/docs/guide/cloud/cloudConfiguration/distributedConfigurationAwsParameterStore.adoc
+++ b/src/main/docs/guide/cloud/cloudConfiguration/distributedConfigurationAwsParameterStore.adoc
@@ -2,7 +2,7 @@ Micronaut supports configuration sharing via AWS System Manager Parameter Store.
 
 dependency:io.micronaut.aws:micronaut-aws-parameter-store[]
 
-To enable distributed configuration, create a `src/main/resources/bootstrap.yml` configuration file and add Parameter Store configuration:
+To enable distributed configuration, make sure https://docs.micronaut.io/latest/guide/#bootstrap[bootstrap] is enabled and create a `src/main/resources/bootstrap.yml` file with the following configuration:
 
 .bootstrap.yml
 [source,yaml]

--- a/src/main/docs/guide/cloud/cloudConfiguration/distributedConfigurationConsul.adoc
+++ b/src/main/docs/guide/cloud/cloudConfiguration/distributedConfigurationConsul.adoc
@@ -23,7 +23,7 @@ $ mn create-app my-app --features config-consul
 ----
 ====
 
-To enable distributed configuration, similar to Spring Boot and Grails, create a `src/main/resources/bootstrap.yml` configuration file and enable the configuration client:
+To enable distributed configuration, similar to Spring Boot and Grails, make sure https://docs.micronaut.io/latest/guide/#bootstrap[bootstrap] is enabled and create a `src/main/resources/bootstrap.yml` file with the following configuration:
 
 .bootstrap.yml
 [source,yaml]

--- a/src/main/docs/guide/cloud/cloudConfiguration/distributedConfigurationSpringCloud.adoc
+++ b/src/main/docs/guide/cloud/cloudConfiguration/distributedConfigurationSpringCloud.adoc
@@ -1,6 +1,6 @@
 Since 1.1, Micronaut features a native https://spring.io/projects/spring-cloud-config[Spring Cloud Configuration] for those who have not switched to a dedicated more complete solution like Consul.
 
-To enable support for Spring Cloud Configuration, create a `src/main/resources/bootstrap.yml` configuration file and add the following configuration:
+To enable support for Spring Cloud Configuration, make sure https://docs.micronaut.io/latest/guide/#bootstrap[bootstrap] is enabled and create a `src/main/resources/bootstrap.yml` file with the following configuration:
 
 .Integrating with Spring Cloud Configuration
 [source,yaml]

--- a/src/main/docs/guide/cloud/cloudConfiguration/distributedConfigurationVault.adoc
+++ b/src/main/docs/guide/cloud/cloudConfiguration/distributedConfigurationVault.adoc
@@ -1,6 +1,6 @@
 Micronaut integrates with https://www.vaultproject.io/[HashiCorp Vault] as a distributed configuration source.
 
-To enable support for Vault Configuration, create a `src/main/resources/bootstrap.yml` configuration file and add the following configuration:
+To enable support for Vault Configuration, make sure https://docs.micronaut.io/latest/guide/#bootstrap[bootstrap] is enabled and create a `src/main/resources/bootstrap.yml` file with the following configuration:
 
 .Integrating with HashiCorp Vault
 [source,yaml]


### PR DESCRIPTION
Working on my [Micronaut PoC with Hashicorp Vault](https://dev.to/rogervinas/top-5-server-side-frameworks-for-kotlin-in-2022-micronaut-2p5b) it take me a few time to figure out that I needed to enable bootstrap.

If you strictly follow [8.1.3 HashiCorp Vault Support](https://docs.micronaut.io/latest/guide/#distributedConfigurationVault) instructions you may expect it to work only adding `bootstrap.yaml`, which is not the case.

Adding a hint in all "Distributed Config" documentation hoping it helps other developers to make sure [bootstrap](https://docs.micronaut.io/latest/guide/#bootstrap) is enabled, for example adding `io.micronaut.discovery:micronaut-discovery-client` dependency.