### PR TITLE
Disable prediction and distribution for test-suite-kotlin

### DIFF
--- a/test-suite-kotlin/build.gradle
+++ b/test-suite-kotlin/build.gradle
@@ -82,3 +82,12 @@ tasks.named("compileTestKotlin") {
 tasks.named("test") {
     useJUnitPlatform()
 }
+
+tasks.withType(Test).configureEach {
+    distribution {
+        enabled = false
+    }
+    predictiveSelection {
+        enabled = false
+    }
+}


### PR DESCRIPTION
We were seeing strange behaviour if one of the test-suite-kotlin tests failed

After checking with the Gradle team, they said:

> 
> The issue seems to be due to the tests in test-suite-kotlin being run with Test Distribution. Unfortunately we don't support Kotest for Test Distribution for the time being.
> We have added a check to detect such cases in Gradle Enterprise 3.11.2, which means that from that version onwards, your build will fail with an explicit error message. Therefore we would recommend you to disable Test Distribution and Predictive Test Selection for test-suite-kotlin, to avoid any issues once you update Gradle Enterprise.

This change should disable test-distribution and predictive tests for the test-suite-kotlin module