### PR TITLE
Update docs to the new configuration macro

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'io.micronaut.build.shared.settings' version '6.1.1'
+    id 'io.micronaut.build.shared.settings' version '6.2.0'
 }
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 

--- a/src/main/docs/guide/aop/caching.adoc
+++ b/src/main/docs/guide/aop/caching.adoc
@@ -20,10 +20,9 @@ In addition, if the underlying Cache implementation supports non-blocking cache 
 
 == Configuring Caches
 
-By default, https://github.com/ben-manes/caffeine[Caffeine] is used to create caches from application configuration. For example with `application.yml`:
+By default, https://github.com/ben-manes/caffeine[Caffeine] is used to create caches from application configuration. For example:
 
-.Cache Configuration Example
-[source,yaml]
+[configuration,title="Cache Configuration Example"]
 ----
 micronaut:
   caches:

--- a/src/main/docs/guide/aop/scheduling.adoc
+++ b/src/main/docs/guide/aop/scheduling.adoc
@@ -55,11 +55,10 @@ The above example allows the task execution frequency to be configured with the 
 
 Tasks executed by `@Scheduled` are run by default on a jdk:java.util.concurrent.ScheduledExecutorService[] configured to have twice the number of threads as available processors.
 
-You can configure this thread pool using `application.yml`, for example:
+You can configure this thread pool in your configuration file (e.g `application.yml`):
 
 //TODO: Move YAML snippet to ExecutorServiceConfigSpec
-.Configuring Scheduled Task Thread Pool
-[source,yaml]
+[configuration,title="Configuring Scheduled Task Thread Pool"]
 ----
 micronaut:
   executors:

--- a/src/main/docs/guide/appendix/breaks.adoc
+++ b/src/main/docs/guide/appendix/breaks.adoc
@@ -114,7 +114,7 @@ To register a type converter into `ConversionService.SHARED`, the registration n
 
 - The <<environmentEndpoint, environmental endpoint>> is now disabled by default. To enable it, you must update your endpoint config:
 
-[source,yaml]
+[configuration]
 ----
 endpoints:
   env:

--- a/src/main/docs/guide/cloud/clientSideLoadBalancing/netflixRibbon.adoc
+++ b/src/main/docs/guide/cloud/clientSideLoadBalancing/netflixRibbon.adoc
@@ -17,10 +17,10 @@ dependency:io.micronaut.netflix:micronaut-netflix-ribbon[]
 
 The api:http.client.LoadBalancer[] implementations will now be link:{micronautribbonapi}/io/micronaut/configuration/ribbon/RibbonLoadBalancer.html[RibbonLoadBalancer] instances.
 
-Ribbon's https://netflix.github.io/ribbon/ribbon-core-javadoc/com/netflix/client/config/CommonClientConfigKey.html[Configuration options] can be set using the `ribbon` namespace in configuration. For example in `application.yml`:
+Ribbon's https://netflix.github.io/ribbon/ribbon-core-javadoc/com/netflix/client/config/CommonClientConfigKey.html[Configuration options] can be set using the `ribbon` namespace in configuration. For example in your configuration file (e.g `application.yml`):
 
 .Configuring Ribbon
-[source,yaml]
+[configuration]
 ----
 ribbon:
   VipAddress: test
@@ -30,7 +30,7 @@ ribbon:
 Each discovered client can also be configured under `ribbon.clients`. For example given a `@Client(id = "hello-world")` you can configure Ribbon settings with:
 
 .Per Client Ribbon Settings
-[source,yaml]
+[configuration]
 ----
 ribbon:
   clients:

--- a/src/main/docs/guide/cloud/cloudConfiguration/distributedConfigurationAwsParameterStore.adoc
+++ b/src/main/docs/guide/cloud/cloudConfiguration/distributedConfigurationAwsParameterStore.adoc
@@ -5,7 +5,7 @@ dependency:io.micronaut.aws:micronaut-aws-parameter-store[]
 To enable distributed configuration, create a `src/main/resources/bootstrap.yml` configuration file and add Parameter Store configuration:
 
 .bootstrap.yml
-[source,yaml]
+[configuration]
 ----
 micronaut:
   application:

--- a/src/main/docs/guide/cloud/cloudConfiguration/distributedConfigurationConsul.adoc
+++ b/src/main/docs/guide/cloud/cloudConfiguration/distributedConfigurationConsul.adoc
@@ -23,10 +23,10 @@ $ mn create-app my-app --features config-consul
 ----
 ====
 
-To enable distributed configuration, similar to Spring Boot and Grails, create a `src/main/resources/bootstrap.yml` configuration file and enable the configuration client:
+To enable distributed configuration, similar to Spring Boot and Grails, create a `src/main/resources/bootstrap.[yml/toml/properties]` configuration file and enable the configuration client:
 
-.bootstrap.yml
-[source,yaml]
+.bootstrap configuration
+[configuration]
 ----
 micronaut:
   application:
@@ -66,7 +66,7 @@ Within the `/config` directory Micronaut searches values within the following di
 
 |===
 
-The value of `APPLICATION_NAME` is whatever your have configured `micronaut.application.name` to be in `bootstrap.yml`.
+The value of `APPLICATION_NAME` is whatever your have configured `micronaut.application.name` to be in your `bootstrap` configuration file.
 
 To see this in action, use the following cURL command to store a property called `foo.bar` with a value of `myvalue` in the directory `/config/application`.
 
@@ -88,8 +88,7 @@ You can set the `consul.client.config.format` option to configure the format wit
 
 For example, to configure JSON:
 
-.application.yml
-[source,yaml]
+[configuration]
 ----
 consul:
   client:
@@ -116,8 +115,7 @@ You can setup a Git repository that contains files like `application.yml`, `hell
 
 In this case, each key in Consul represents a file with an extension, for example `/config/application.yml`, and you must configure the `FILE` format:
 
-.application.yml
-[source,yaml]
+[configuration]
 ----
 consul:
   client:

--- a/src/main/docs/guide/cloud/cloudConfiguration/distributedConfigurationSpringCloud.adoc
+++ b/src/main/docs/guide/cloud/cloudConfiguration/distributedConfigurationSpringCloud.adoc
@@ -1,9 +1,9 @@
 Since 1.1, Micronaut features a native https://spring.io/projects/spring-cloud-config[Spring Cloud Configuration] for those who have not switched to a dedicated more complete solution like Consul.
 
-To enable support for Spring Cloud Configuration, create a `src/main/resources/bootstrap.yml` configuration file and add the following configuration:
+To enable support for Spring Cloud Configuration, create a `src/main/resources/bootstrap.[yml/toml/properties]` configuration file and add the following configuration:
 
 .Integrating with Spring Cloud Configuration
-[source,yaml]
+[configuration]
 ----
 micronaut:
   application:

--- a/src/main/docs/guide/cloud/cloudConfiguration/distributedConfigurationVault.adoc
+++ b/src/main/docs/guide/cloud/cloudConfiguration/distributedConfigurationVault.adoc
@@ -1,9 +1,9 @@
 Micronaut integrates with https://www.vaultproject.io/[HashiCorp Vault] as a distributed configuration source.
 
-To enable support for Vault Configuration, create a `src/main/resources/bootstrap.yml` configuration file and add the following configuration:
+To enable support for Vault Configuration, create a `src/main/resources/bootstrap.[yml/toml/properties]` configuration file and add the following configuration:
 
 .Integrating with HashiCorp Vault
-[source,yaml]
+[configuration]
 ----
 micronaut:
   application:

--- a/src/main/docs/guide/cloud/serviceDiscovery/serviceDiscoveryManual.adoc
+++ b/src/main/docs/guide/cloud/serviceDiscovery/serviceDiscoveryManual.adoc
@@ -3,7 +3,7 @@ If you do not wish to involve a service discovery server like Consul or you inte
 To do this, use the `micronaut.http.services` setting. For example:
 
 .Manually configuring services
-[source,yaml]
+[configuration]
 ----
 micronaut:
   http:
@@ -23,13 +23,12 @@ TIP: You can override this configuration in production by specifying an environm
 Note that by default no health checking will happen to assert that the referenced services are operational. You can alter that by enabling health checking and optionally specifying a health check path (the default is `/health`):
 
 .Enabling Health Checking
-[source,yaml]
+[configuration]
 ----
 micronaut:
   http:
     services:
       foo:
-        ...
         health-check: true # <1>
         health-check-interval: 15s # <2>
         health-check-uri: /health # <3>

--- a/src/main/docs/guide/cloud/serviceDiscovery/serviceDiscoveryRoute53.adoc
+++ b/src/main/docs/guide/cloud/serviceDiscovery/serviceDiscoveryRoute53.adoc
@@ -14,14 +14,14 @@ Here are the steps:
 4. Add Service ID to your application configuration file like so:
 
 .Sample application.yml
-[source,yaml]
+[configuration]
 ----
 aws:
   route53:
-    registration
-    enabled: true
-    aws-service-id: srv-978fs98fsdf
-    namespace: micronaut.io
+    registration:
+        enabled: true
+        aws-service-id: srv-978fs98fsdf
+        namespace: micronaut.io
 micronaut:
   application:
     name: something
@@ -34,7 +34,7 @@ dependency:io.micronaut.aws:micronaut-aws-route53[]
 6. On the client side, you need the same dependencies and fewer configuration options:
 
 .Sample application.yml
-[source,yaml]
+[configuration]
 ----
 aws:
   route53:
@@ -120,28 +120,28 @@ You will get a service ID and an ARN back from this command if successful. Write
 Add the configuration to make your applications register with Route 53 Auto-discovery:
 
 .Registration Properties
-[source,yaml]
+[configuration]
 ----
 aws:
   route53:
     registration:
       enabled: true
-      aws-service-id=<enter the service id you got after creation on aws cli>
+      aws-service-id: <enter the service id you got after creation on aws cli>
     discovery:
-      namespace-id=<enter the namespace id you got after creating the namespace>
+      namespace-id: <enter the namespace id you got after creating the namespace>
 ----
 
 ==== Discovery Client Configuration
 
 .Discovery Properties
-[source,yaml]
+[configuration]
 ----
 aws:
   route53:
     discovery:
-      client
-      enabled: true
-      aws-service-id: <enter the service id you got after creation on aws cli>
+      client:
+        enabled: true
+        aws-service-id: <enter the service id you got after creation on aws cli>
 ----
 
 You can also call the following methods by getting the bean "Route53AutoNamingClient":

--- a/src/main/docs/guide/config/bootstrap.adoc
+++ b/src/main/docs/guide/config/bootstrap.adoc
@@ -1,4 +1,4 @@
-Most application configuration is stored in `application.yml`, environment-specific files like `application-{environment}.{extension}`, environment and system properties, etc.
+Most application configuration is stored in your configuration file (e.g `application.yml`), environment-specific files like `application-{environment}.{extension}`, environment and system properties, etc.
 These configure the application context.
 But during application startup, before the application context is created, a "bootstrap" context can be created to store configuration necessary to retrieve additional configuration for the main context. Typically that additional configuration is in some remote source.
 

--- a/src/main/docs/guide/config/configurationProperties.adoc
+++ b/src/main/docs/guide/config/configurationProperties.adoc
@@ -118,8 +118,7 @@ Durations can be specified by appending the unit with a number. Supported units 
 
 For example to configure the default HTTP client read timeout:
 
-.Using Duration Values
-[source,yaml]
+[configuration,title="Using Duration Values"]
 ----
 micronaut:
   http:
@@ -131,8 +130,7 @@ micronaut:
 
 Lists and arrays can be specified in Java properties files as comma-separated values, or in YAML using native YAML lists. The generic types are used to convert the values. For example in YAML:
 
-.Specifying lists or arrays in YAML
-[source,yaml]
+[configuration,title="Specifying lists or arrays in YAML"]
 ----
 my:
   app:
@@ -142,24 +140,6 @@ my:
     urls:
       - http://foo.com
       - http://bar.com
-----
-
-Or in Java properties file format:
-
-.Specifying lists or arrays in Java properties comma-separated
-[source,properties]
-----
-my.app.integers=1,2
-my.app.urls=http://foo.com,http://bar.com
-----
-
-Alternatively you can use an index:
-
-.Specifying lists or arrays in Java properties using index
-[source,properties]
-----
-my.app.integers[0]=1
-my.app.integers[1]=2
 ----
 
 For the above example configurations you can define properties to bind to with the target type supplied via generics:

--- a/src/main/docs/guide/config/propertySource.adoc
+++ b/src/main/docs/guide/config/propertySource.adoc
@@ -62,7 +62,7 @@ It is important to note that it is not recommended to store sensitive configurat
 It is good practise to instead externalize sensitive configuration completely from the application code using preferably a external secret manager system (there are many options here, many provided by Cloud providers) or environment variables that are set during the deployment of the application. You can also use property placeholders (see the following section), to customize names of the environment variables to use and supply default values:
 
 .Using Property Value Placeholders to Define Secure Configuration
-[source,java]
+[configuration]
 ----
 datasources:
   default:
@@ -87,10 +87,9 @@ As mentioned in the previous section, Micronaut includes a property placeholder 
 
 TIP: Programmatic usage is also possible via the api:io.micronaut.context.env.PropertyPlaceholderResolver[] interface.
 
-The basic syntax is to wrap a reference to a property in `${...}`. For example in `application.yml`:
+The basic syntax is to wrap a reference to a property in `${...}`. For example:
 
-.Defining Property Placeholders
-[source,yaml]
+[configuration,title="Defining Property Placeholders"]
 ----
 myapp:
   endpoint: http://${micronaut.server.host}:${micronaut.server.port}/foo
@@ -100,8 +99,7 @@ The above example embeds references to the `micronaut.server.host` and `micronau
 
 You can specify default values by defining a value after the `:` character. For example:
 
-.Using Default Values
-[source,yaml]
+[configuration,title="Using Default Values"]
 ----
 myapp:
   endpoint: http://${micronaut.server.host:localhost}:${micronaut.server.port:8080}/foo
@@ -110,7 +108,7 @@ myapp:
 The above example defaults to `localhost` and port `8080` if no value is found (rather than throwing an exception). Note that if the default value contains a `:` character, you must escape it using backticks:
 
 .Using Backticks
-[source,yaml]
+[configuration]
 ----
 myapp:
   endpoint: ${server.address:`http://localhost:8080`}/foo
@@ -152,7 +150,7 @@ NOTE: The configuration above does not have any impact on property placeholders.
 
 You can use `random` values by using the following properties. These can be used in configuration files as variables like the following.
 
-[source,yaml]
+[configuration]
 ----
 micronaut:
   application:
@@ -195,7 +193,7 @@ The `random.int`, `random.integer`, `random.long` and `random.float` properties 
 - `(max)` where max is an exclusive value
 - `[min,max]` where min being inclusive and max being exclusive values.
 
-[source,yaml]
+[configuration]
 ----
 instance:
   id: ${random.int[5,10]}
@@ -209,4 +207,3 @@ NOTE: The range could vary from negative to positive as well.
 For beans that inject required properties, the injection and potential failure will not occur until the bean is requested. To verify at startup that the properties exist and can be injected, the bean can be annotated with ann:io.micronaut.context.annotation.Context[]. Context-scoped beans are injected at startup, and startup fails if any required properties are missing or cannot be converted to the required type.
 
 IMPORTANT: It is recommended to use this feature sparingly to ensure fast startup.
-

--- a/src/main/docs/guide/config/valueAnnotation.adoc
+++ b/src/main/docs/guide/config/valueAnnotation.adoc
@@ -92,7 +92,7 @@ The above instead injects the value of the `my.url` property resolved from appli
 You can also use this feature to resolve sub maps. For example, consider the following configuration:
 
 .Example `application.yml` configuration
-[source,yaml]
+[configuration]
 ----
 datasources:
   default:

--- a/src/main/docs/guide/configurations/dataAccess/mongoSupport.adoc
+++ b/src/main/docs/guide/configurations/dataAccess/mongoSupport.adoc
@@ -13,10 +13,10 @@ Micronaut can automatically configure the native MongoDB Java driver. To use thi
 
 dependency:micronaut-mongo-reactive[groupId="io.micronaut.mongodb"]
 
-Then configure the URI of the MongoDB server in `application.yml`:
+Then configure the URI of the MongoDB server in your configuration file (e.g `application.yml`):
 
 .Configuring a MongoDB server
-[source,yaml]
+[configuration]
 ----
 mongodb:
   uri: mongodb://username:password@localhost:27017/databaseName
@@ -30,7 +30,7 @@ To use the blocking driver, add a dependency to your build on the mongo-java-dri
 
 [source,groovy]
 ----
-compile "org.mongodb:mongo-java-driver"
+runtimeOnly "org.mongodb:mongo-java-driver"
 ----
 
 Then the blocking https://mongodb.github.io/mongo-java-driver/3.7/javadoc/com/mongodb/MongoClient.html[MongoClient] will be available for injection.

--- a/src/main/docs/guide/configurations/dataAccess/neo4jSupport.adoc
+++ b/src/main/docs/guide/configurations/dataAccess/neo4jSupport.adoc
@@ -13,10 +13,10 @@ To configure the Neo4j Bolt driver, first add the `neo4j-bolt` module to your bu
 
 dependency::micronaut-neo4j-bolt[groupId="io.micronaut.neo4j"]
 
-Then configure the URI of the Neo4j server in `application.yml`:
+Then configure the URI of the Neo4j server in your configuration file (e.g `application.yml`):
 
 .Configuring `neo4j.uri`
-[source,yaml]
+[configuration]
 ----
 neo4j:
   uri: bolt://localhost

--- a/src/main/docs/guide/configurations/dataAccess/redisSupport.adoc
+++ b/src/main/docs/guide/configurations/dataAccess/redisSupport.adoc
@@ -18,10 +18,10 @@ To configure the Lettuce driver, first add the `redis-lettuce` module to your bu
 compile "io.micronaut.redis:micronaut-redis-lettuce"
 ----
 
-Then configure the URI of the Redis server in `application.yml`:
+Then configure the URI of the Redis server in your configuration file (e.g `application.yml`):
 
 .Configuring `redis.uri`
-[source,yaml]
+[configuration]
 ----
 redis:
   uri: redis://localhost

--- a/src/main/docs/guide/configurations/otherConfigurations/rabbitmq.adoc
+++ b/src/main/docs/guide/configurations/otherConfigurations/rabbitmq.adoc
@@ -15,7 +15,7 @@ A RabbitMQ connection factory bean will be provided based on the configuration v
 
 For example:
 
-[source,yaml]
+[configuration]
 ----
 rabbitmq:
   uri: amqp://user:pass@host:10000/vhost

--- a/src/main/docs/guide/httpClient/clientAnnotation/clientAnnotationStreaming.adoc
+++ b/src/main/docs/guide/httpClient/clientAnnotation/clientAnnotationStreaming.adoc
@@ -49,10 +49,10 @@ When streaming responses from servers, the underlying HTTP client will not apply
 
 Instead, the `read-idle-timeout` setting (which defaults to 5 minutes) dictates when to close a connection after it becomes idle.
 
-If you stream data from a server that defines a longer delay than 5 minutes between items, you should adjust `readIdleTimeout`. The following configuration in `application.yml` demonstrates how:
+If you stream data from a server that defines a longer delay than 5 minutes between items, you should adjust `readIdleTimeout`. The following configuration in your configuration file (e.g `application.yml`) demonstrates how:
 
 .Adjusting the readIdleTimeout
-[source,yaml]
+[configuration]
 ----
 micronaut:
   http:

--- a/src/main/docs/guide/httpClient/clientAnnotation/clientHeaders.adoc
+++ b/src/main/docs/guide/httpClient/clientAnnotation/clientHeaders.adoc
@@ -10,10 +10,10 @@ snippet::io.micronaut.docs.annotation.headers.PetClient[tags="class", indent=0, 
 
 The above example defines a ann:http.annotation.Header[] annotation on the `PetClient` interface that reads the `pet.client.id` property using property placeholder configuration.
 
-Then set the following in `application.yml` to populate the value:
+Then set the following in your configuration file (e.g `application.yml`) to populate the value:
 
 .Configuring Headers in YAML
-[source,yaml]
+[configuration]
 ----
 pet:
   client:

--- a/src/main/docs/guide/httpClient/clientAnnotation/clientJackson.adoc
+++ b/src/main/docs/guide/httpClient/clientAnnotation/clientJackson.adoc
@@ -1,11 +1,11 @@
 As mentioned previously, Jackson is used for message encoding to JSON. A default Jackson `ObjectMapper` is configured and used by Micronaut HTTP clients.
 
-You can override the settings used to construct the `ObjectMapper` with properties defined by the api:jackson.JacksonConfiguration[] class in `application.yml`.
+You can override the settings used to construct the `ObjectMapper` with properties defined by the api:jackson.JacksonConfiguration[] class in your configuration file (e.g `application.yml`).
 
 For example, the following configuration enables indented output for Jackson:
 
 .Example Jackson Configuration
-[source,yaml]
+[configuration]
 ----
 jackson:
   serialization:

--- a/src/main/docs/guide/httpClient/clientAnnotation/netflixHystrix.adoc
+++ b/src/main/docs/guide/httpClient/clientAnnotation/netflixHystrix.adoc
@@ -34,10 +34,10 @@ TIP: For information on how to customize the Hystrix thread pool, group, and pro
 
 == Enabling Hystrix Stream and Dashboard
 
-You can enable a Server Sent Event stream to feed into the https://github.com/Netflix-Skunkworks/hystrix-dashboard[Hystrix Dashboard] by setting the `hystrix.stream.enabled` setting to `true` in `application.yml`:
+You can enable a Server Sent Event stream to feed into the https://github.com/Netflix-Skunkworks/hystrix-dashboard[Hystrix Dashboard] by setting the `hystrix.stream.enabled` setting to `true` in your configuration file (e.g `application.yml`):
 
 .Enabling Hystrix Stream
-[source,yaml]
+[configuration]
 ----
 hystrix:
   stream:

--- a/src/main/docs/guide/httpClient/clientHttp2.adoc
+++ b/src/main/docs/guide/httpClient/clientHttp2.adoc
@@ -1,7 +1,7 @@
 By default, Micronaut's HTTP client is configured to support HTTP 1.1. To enable support for HTTP/2, set the supported HTTP version in configuration:
 
 .Enabling HTTP/2 in Clients
-[source,yaml]
+[configuration]
 ----
 micronaut:
   http:

--- a/src/main/docs/guide/httpClient/lowLevelHttpClient/clientBasics.adoc
+++ b/src/main/docs/guide/httpClient/lowLevelHttpClient/clientBasics.adoc
@@ -60,10 +60,9 @@ To debug requests being sent and received from the HTTP client you can enable tr
 
 ==== Client Specific Debugging / Tracing
 
-To enable client-specific logging you can configure the default logger for all HTTP clients. You can also configure different loggers for different clients using <<_client_specific_configuration, Client-Specific Configuration>>. For example, in `application.yml`:
+To enable client-specific logging you can configure the default logger for all HTTP clients. You can also configure different loggers for different clients using <<_client_specific_configuration, Client-Specific Configuration>>. For example, in your configuration file (e.g `application.yml`):
 
-.application.yml
-[source,xml]
+[configuration]
 ----
 micronaut:
   http:

--- a/src/main/docs/guide/httpClient/lowLevelHttpClient/clientConfiguration.adoc
+++ b/src/main/docs/guide/httpClient/lowLevelHttpClient/clientConfiguration.adoc
@@ -1,9 +1,9 @@
 === Global Configuration for All Clients
 
-The default HTTP client configuration is a <<configurationProperties, Configuration Properties>> named api:http.client.DefaultHttpClientConfiguration[] that allows configuring the default behaviour for all HTTP clients. For example, in `application.yml`:
+The default HTTP client configuration is a <<configurationProperties, Configuration Properties>> named api:http.client.DefaultHttpClientConfiguration[] that allows configuring the default behaviour for all HTTP clients. For example, in your configuration file (e.g `application.yml`):
 
 .Altering default HTTP client configuration
-[source,yaml]
+[configuration]
 ----
 micronaut:
   http:
@@ -15,10 +15,10 @@ The above example sets the `readTimeout` property of the api:http.client.HttpCli
 
 === Client Specific Configuration
 
-To have separate configuration per-client, there are a couple of options. You can configure <<serviceDiscoveryManual, Service Discovery>> manually in `application.yml` and apply per-client configuration:
+To have separate configuration per-client, there are a couple of options. You can configure <<serviceDiscoveryManual, Service Discovery>> manually in your configuration file (e.g `application.yml`) and apply per-client configuration:
 
 .Manually configuring HTTP services
-[source,yaml]
+[configuration]
 ----
 micronaut:
   http:
@@ -88,7 +88,7 @@ Each HTTP/1.1 connection can only support one request at a time, but can be reus
 To remove the overhead of opening a new connection for each request, the Micronaut HTTP Client will reuse HTTP connections wherever possible. They are managed in a _connection pool_. HTTP/1.1 connections are kept around using keep-alive and are used for new requests, and for HTTP/2, a single connection is used for all requests.
 
 .Manually configuring HTTP services
-[source,yaml]
+[configuration]
 ----
 micronaut:
   http:
@@ -114,7 +114,7 @@ By default, Micronaut shares a common Netty `EventLoopGroup` for worker threads 
 This `EventLoopGroup` can be configured via the `micronaut.netty.event-loops.default` property:
 
 .Configuring The Default Event Loop
-[source,yaml]
+[configuration]
 ----
 micronaut:
   netty:
@@ -133,7 +133,7 @@ For example, if your interactions with an HTTP client involve CPU-intensive work
 The following example configures an additional event loop group called "other" with 10 threads:
 
 .Configuring Additional Event Loops
-[source,yaml]
+[configuration]
 ----
 micronaut:
   netty:
@@ -146,7 +146,7 @@ micronaut:
 Once an additional event loop has been configured you can alter the HTTP client configuration to use it:
 
 .Altering the Event Loop Group used by Clients
-[source,yaml]
+[configuration]
 ----
 micronaut:
   http:

--- a/src/main/docs/guide/httpServer/apiVersioning.adoc
+++ b/src/main/docs/guide/httpServer/apiVersioning.adoc
@@ -7,10 +7,10 @@ snippet::io.micronaut.docs.web.router.version.VersionedController[tags="imports,
 <1> The `helloV1` method is declared as version `1`
 <2> The `helloV2` method is declared as version `2`
 
-Then enable versioning by setting `micronaut.router.versioning.enabled` to `true` in `application.yml`:
+Then enable versioning by setting `micronaut.router.versioning.enabled` to `true` in your configuration file (e.g `application.yml`):
 
 .Enabling Versioning
-[source,yaml]
+[configuration]
 ----
 micronaut:
   router:
@@ -21,7 +21,7 @@ micronaut:
 By default Micronaut has two strategies for resolving the version based on an HTTP header named `X-API-VERSION` or a request parameter named `api-version`, however this is configurable. A full configuration example can be seen below:
 
 .Configuring Versioning
-[source,yaml]
+[configuration]
 ----
 micronaut:
   router:
@@ -50,7 +50,7 @@ If this is not enough you can also implement the api:web.router.version.resoluti
 It is possible to supply a default version through configuration.
 
 .Configuring Default Version
-[source,yaml]
+[configuration]
 ----
 micronaut:
   router:
@@ -90,7 +90,7 @@ include::{includedir}configurationProperties/io.micronaut.http.client.intercepto
 For example to use `Accept-Version` as the header name:
 
 .Configuring Client Versioning
-[source,yaml]
+[configuration]
 ----
 micronaut:
   http:
@@ -105,7 +105,7 @@ micronaut:
 The `default` key refers to the default configuration. You can specify client-specific configuration by using the value passed to `@Client` (typically the service ID). For example:
 
 .Configuring Versioning
-[source,yaml]
+[configuration]
 ----
 micronaut:
   http:

--- a/src/main/docs/guide/httpServer/consumesAnnotation.adoc
+++ b/src/main/docs/guide/httpServer/consumesAnnotation.adoc
@@ -10,7 +10,7 @@ snippet::io.micronaut.docs.server.consumes.ConsumesController[tags="imports,claz
 
 Normally JSON parsing only happens if the content type is `application/json`. The other api:io.micronaut.http.codec.MediaTypeCodec[] classes behave similarly in that they have predefined content types they can process. To extend the list of media types that a given codec processes, provide configuration that will be stored in api:io.micronaut.http.codec.CodecConfiguration[]:
 
-[source,yaml]
+[configuration]
 ----
 micronaut:
   codec:

--- a/src/main/docs/guide/httpServer/formData.adoc
+++ b/src/main/docs/guide/httpServer/formData.adoc
@@ -6,7 +6,7 @@ In practice this means that to bind regular form data, the only change required 
 
 snippet::io.micronaut.docs.server.json.PersonController[tags="class,regular,endclass", indent=0, title="Binding Form Data to POJOs"]
 
-TIP: To avoid denial of service attacks, collection types and arrays created during binding are limited by the setting `jackson.arraySizeThreshold` in `application.yml`
+TIP: To avoid denial of service attacks, collection types and arrays created during binding are limited by the setting `jackson.arraySizeThreshold` in your configuration file (e.g `application.yml`)
 
 Alternatively, instead of using a POJO you can bind form data directly to method parameters (which works with JSON too!):
 

--- a/src/main/docs/guide/httpServer/http2Server.adoc
+++ b/src/main/docs/guide/httpServer/http2Server.adoc
@@ -5,7 +5,7 @@ Since Micronaut 2.x, Micronaut's Netty-based HTTP server can be configured to su
 The first step is to set the supported HTTP version in the server configuration:
 
 .Enabling HTTP/2 Support
-[source,yaml]
+[configuration]
 ----
 micronaut:
   server:
@@ -17,7 +17,7 @@ With this configuration, Micronaut enables support for the `h2c` protocol (see h
 Since browsers don't support `h2c` and in general https://httpwg.org/specs/rfc7540.html#discover-https[HTTP/2 over TLS] (the `h2` protocol), it is recommended for production that you enable <<https, HTTPS support>>. For development this can be done with:
 
 .Enabling `h2` Protocol Support
-[source,yaml]
+[configuration]
 ----
 micronaut:
   server:

--- a/src/main/docs/guide/httpServer/jsonBinding.adoc
+++ b/src/main/docs/guide/httpServer/jsonBinding.adoc
@@ -60,7 +60,7 @@ All Jackson configuration keys start with `jackson`.
 
 Example:
 
-[source,yaml]
+[configuration]
 ----
 jackson:
   serializationInclusion: ALWAYS
@@ -81,7 +81,7 @@ All features can be configured with their name as the key and a boolean to indic
 
 Example:
 
-[source,yaml]
+[configuration]
 ----
 jackson:
   serialization:
@@ -99,7 +99,7 @@ This can be achieved by providing your own `JsonFactory` bean, or by providing a
 
 === Support for `@JsonView`
 
-You can use the `@JsonView` annotation on controller methods if you set `jackson.json-view.enabled` to `true` in `application.yml`.
+You can use the `@JsonView` annotation on controller methods if you set `jackson.json-view.enabled` to `true` in your configuration file (e.g `application.yml`).
 
 Jackson's `@JsonView` annotation lets you control which properties are exposed on a per-response basis. See https://www.baeldung.com/jackson-json-view-annotation[Jackson JSON Views] for more information.
 
@@ -124,7 +124,7 @@ During JSON parsing, the framework may convert any incoming data to an intermedi
 
 If you need full accuracy for number types, use the following configuration:
 
-[source,yaml]
+[configuration]
 ----
 jackson:
   deserialization:

--- a/src/main/docs/guide/httpServer/reactiveServer.adoc
+++ b/src/main/docs/guide/httpServer/reactiveServer.adoc
@@ -5,7 +5,7 @@ This makes it critical that if you do any blocking I/O operations (for example i
 For example the following configuration configures the I/O thread pool as a fixed thread pool with 75 threads (similar to what a traditional blocking server such as Tomcat uses in the thread-per-request model):
 
 .Configuring the IO thread pool
-[source,yaml]
+[configuration]
 ----
 micronaut:
   executors:

--- a/src/main/docs/guide/httpServer/reactiveServer/bodyAnnotation.adoc
+++ b/src/main/docs/guide/httpServer/reactiveServer/bodyAnnotation.adoc
@@ -10,7 +10,7 @@ snippet::io.micronaut.docs.server.body.MessageController[tags="imports,class,ech
 
 Note that reading the request body is done in a non-blocking manner in that the request contents are read as the data becomes available and accumulated into the String passed to the method.
 
-TIP: The `micronaut.server.maxRequestSize` setting in `application.yml` limits the size of the data (the default maximum request size is 10MB) read/buffered by the server. `@Size` is *not* a replacement for this setting.
+TIP: The `micronaut.server.maxRequestSize` setting in your configuration file (e.g `application.yml`) limits the size of the data (the default maximum request size is 10MB) read/buffered by the server. `@Size` is *not* a replacement for this setting.
 
 Regardless of the limit, for a large amount of data accumulating the data into a String in-memory may lead to memory strain on the server. A better approach is to include a Reactive library in your project (such as `Reactor`, `RxJava`,or `Akka`) that supports the Reactive streams implementation and stream the data it becomes available:
 

--- a/src/main/docs/guide/httpServer/serverConfiguration.adoc
+++ b/src/main/docs/guide/httpServer/serverConfiguration.adoc
@@ -1,9 +1,9 @@
 The HTTP server features a number of configuration options. They are defined in the api:http.server.netty.configuration.NettyHttpServerConfiguration[] configuration class, which extends api:http.server.HttpServerConfiguration[].
 
-The following example shows how to tweak configuration options for the server via `application.yml`:
+The following example shows how to tweak configuration options for the server via your configuration file (e.g `application.yml`):
 
 .Configuring HTTP server settings
-[source,yaml]
+[configuration]
 ----
 micronaut:
   server:
@@ -48,7 +48,7 @@ dependency:netty-transport-native-epoll[groupId="io.netty",scope="runtimeOnly",c
 Then configure the default event loop group to prefer native transports:
 
 .Configuring The Default Event Loop to Prefer Native Transports
-[source,yaml]
+[configuration]
 ----
 micronaut:
   netty:

--- a/src/main/docs/guide/httpServer/serverConfiguration/accessLogger.adoc
+++ b/src/main/docs/guide/httpServer/serverConfiguration/accessLogger.adoc
@@ -1,9 +1,9 @@
 In the spirit of https://httpd.apache.org/docs/current/mod/mod_log_config.html[apache mod_log_config] and https://tomcat.apache.org/tomcat-10.0-doc/config/valve.html#Access_Logging[Tomcat Access Log Valve], it is possible to enable an access logger for the HTTP server (this works for both HTTP/1 and HTTP/2).
 
-To enable and configure the access logger, in `application.yml` set:
+To enable and configure the access logger, in your configuration file (e.g `application.yml`) set:
 
 .Enabling the access logger
-[source,yaml]
+[configuration]
 ----
 micronaut:
   server:
@@ -19,7 +19,7 @@ micronaut:
 If you wish to not log access to certain paths, you can specify regular expression filters in the configuration:
 
 .Filtering the access logs
-[source,yaml]
+[configuration]
 ----
 micronaut:
   server:

--- a/src/main/docs/guide/httpServer/serverConfiguration/cors.adoc
+++ b/src/main/docs/guide/httpServer/serverConfiguration/cors.adoc
@@ -1,7 +1,7 @@
-Micronaut supports CORS (link:https://www.w3.org/TR/cors/[Cross Origin Resource Sharing]) out of the box. By default, CORS requests are rejected. To enable processing of CORS requests, modify your configuration. For example with `application.yml`:
+Micronaut supports CORS (link:https://www.w3.org/TR/cors/[Cross Origin Resource Sharing]) out of the box. By default, CORS requests are rejected. To enable processing of CORS requests, modify your configuration. For example:
 
 .CORS Configuration Example
-[source,yaml]
+[configuration]
 ----
 micronaut:
   server:
@@ -14,7 +14,7 @@ By only enabling CORS processing, a "wide open" strategy is adopted that allows 
 To change the settings for all origins or a specific origin, change the configuration to provide one or more "configurations". By providing any configuration, the default "wide open" configuration is not configured.
 
 .CORS Configurations
-[source,yaml]
+[configuration]
 ----
 micronaut:
   server:
@@ -44,7 +44,7 @@ For multiple valid origins, set the `allowedOrigins` key of the configuration to
 Regular expressions are passed to link:{javase}java/util/regex/Pattern.html#compile-java.lang.String-[Pattern#compile] and compared to the request origin with link:{javase}java/util/regex/Matcher.html#matches--[Matcher#matches].
 
 .Example CORS Configuration
-[source,yaml]
+[configuration]
 ----
 micronaut:
   server:
@@ -64,7 +64,7 @@ To allow any request method for a given configuration, don't include the `allowe
 For multiple allowed methods, set the `allowedMethods` key of the configuration to a list of strings.
 
 .Example CORS Configuration
-[source,yaml]
+[configuration]
 ----
 micronaut:
   server:
@@ -84,7 +84,7 @@ To allow any request header for a given configuration, don't include the `allowe
 For multiple allowed headers, set the `allowedHeaders` key of the configuration to a list of strings.
 
 .Example CORS Configuration
-[source,yaml]
+[configuration]
 ----
 micronaut:
   server:
@@ -102,7 +102,7 @@ micronaut:
 To configure the headers that are sent in the response to a CORS request through the `Access-Control-Expose-Headers` header, include a list of strings for the `exposedHeaders` key in your configuration. None are exposed by default.
 
 .Example CORS Configuration
-[source,yaml]
+[configuration]
 ----
 micronaut:
   server:
@@ -120,7 +120,7 @@ micronaut:
 Credentials are allowed by default for CORS requests. To disallow credentials, set the `allowCredentials` option to `false`.
 
 .Example CORS Configuration
-[source,yaml]
+[configuration]
 ----
 micronaut:
   server:
@@ -136,7 +136,7 @@ micronaut:
 The default maximum age that preflight requests can be cached is 30 minutes. To change that behavior, specify a value in seconds.
 
 .Example CORS Configuration
-[source,yaml]
+[configuration]
 ----
 micronaut:
   server:
@@ -151,7 +151,7 @@ micronaut:
 
 By default, when a header has multiple values, multiple headers are sent, each with a single value. It is possible to change the behavior to send a single header with a comma-separated list of values by setting a configuration option.
 
-[source,yaml]
+[configuration]
 ----
 micronaut:
   server:

--- a/src/main/docs/guide/httpServer/serverConfiguration/dualProtocol.adoc
+++ b/src/main/docs/guide/httpServer/serverConfiguration/dualProtocol.adoc
@@ -1,7 +1,7 @@
-Micronaut supports binding both HTTP and HTTPS. To enable dual protocol support, modify your configuration. For example with `application.yml`:
+Micronaut supports binding both HTTP and HTTPS. To enable dual protocol support, modify your configuration. For example:
 
 .Dual Protocol Configuration Example
-[source,yaml]
+[configuration]
 ----
 micronaut:
   server:
@@ -14,10 +14,10 @@ micronaut:
 <2> Enabling both HTTP and HTTPS is an opt-in feature - setting the `dualProtocol` flag enables it. By default Micronaut only enables one
 
 
-It is also possible to redirect automatically all HTTP request to HTTPS. Besides the previous configuration, you need to enable this option. For example, with `application.yml`:
+It is also possible to redirect automatically all HTTP request to HTTPS. Besides the previous configuration, you need to enable this option. For example:
 
 .Enable HTTP to HTTPS Redirects
-[source,yaml]
+[configuration]
 ----
 micronaut:
   server:

--- a/src/main/docs/guide/httpServer/serverConfiguration/https.adoc
+++ b/src/main/docs/guide/httpServer/serverConfiguration/https.adoc
@@ -1,7 +1,7 @@
-Micronaut supports HTTPS out of the box. By default HTTPS is disabled and all requests are served using HTTP. To enable HTTPS support, modify your configuration. For example with `application.yml`:
+Micronaut supports HTTPS out of the box. By default HTTPS is disabled and all requests are served using HTTP. To enable HTTPS support, modify your configuration. For example:
 
 .HTTPS Configuration Example
-[source,yaml]
+[configuration]
 ----
 micronaut:
   server:
@@ -40,7 +40,7 @@ During the creation of the `server.p12` file it is necessary to define a passwor
 Now modify your configuration:
 
 .HTTPS Configuration Example
-[source,yaml]
+[configuration]
 ----
 micronaut:
   ssl:
@@ -95,7 +95,7 @@ WARNING: If either `srcstorepass` or `alias` are not the same as defined in the 
 Now modify your configuration:
 
 .HTTPS Configuration Example
-[source,yaml]
+[configuration]
 ----
 micronaut:
   ssl:

--- a/src/main/docs/guide/httpServer/serverConfiguration/threadPools.adoc
+++ b/src/main/docs/guide/httpServer/serverConfiguration/threadPools.adoc
@@ -11,7 +11,7 @@ TIP: The parent event loop can be configured with `micronaut.server.netty.parent
 The server can also be configured to use a different named worker event loop:
 
 .Using a different event loop for the server
-[source,yaml]
+[configuration]
 ----
 micronaut:
   server:

--- a/src/main/docs/guide/httpServer/serverConfiguration/threadPools/blockingOperations.adoc
+++ b/src/main/docs/guide/httpServer/serverConfiguration/threadPools/blockingOperations.adoc
@@ -1,7 +1,7 @@
 When dealing with blocking operations, Micronaut shifts the blocking operations to an unbound, caching I/O thread pool by default. You can configure the I/O thread pool using the api:scheduling.executor.ExecutorConfiguration[] named `io`. For example:
 
 .Configuring the Server I/O Thread Pool
-[source,yaml]
+[configuration]
 ----
 micronaut:
   executors:

--- a/src/main/docs/guide/httpServer/sessions.adoc
+++ b/src/main/docs/guide/httpServer/sessions.adoc
@@ -20,14 +20,14 @@ To quickly get up and running with Redis sessions you must also have the `redis-
 .build.gradle
 [source,groovy]
 ----
-compile "io.micronaut-session:micronaut-session"
-compile "io.micronaut.redis:micronaut-redis-lettuce"
+implementation "io.micronaut-session:micronaut-session"
+implementation "io.micronaut.redis:micronaut-redis-lettuce"
 ----
 
-And enable Redis sessions via configuration in `application.yml`:
+And enable Redis sessions via configuration in your configuration file (e.g `application.yml`):
 
 .Enabling Redis Sessions
-[source,yaml]
+[configuration]
 ----
 redis:
   uri: redis://localhost:6379
@@ -44,10 +44,10 @@ link:{micronautsessionapi}/io/micronaut/session/Session.html[Session] resolution
 
 By default, sessions are resolved using link:{micronautsessionapi}/io/micronaut/session/http/HttpSessionFilter.html[HttpSessionFilter] that looks for session identifiers via either an HTTP header (using the `Authorization-Info` or `X-Auth-Token` headers) or via a Cookie named `SESSION`.
 
-You can disable either header resolution or cookie resolution via configuration in `application.yml`:
+You can disable either header resolution or cookie resolution via configuration in your configuration file (e.g `application.yml`):
 
 .Disabling Cookie Resolution
-[source,yaml]
+[configuration]
 ----
 micronaut:
   session:

--- a/src/main/docs/guide/httpServer/websocket/websocketServer.adoc
+++ b/src/main/docs/guide/httpServer/websocket/websocketServer.adoc
@@ -71,7 +71,7 @@ $ mn create-websocket-server MyChat
 By default, Micronaut times out idle connections with no activity after five minutes. Normally this is not a problem as browsers automatically reconnect WebSocket sessions, however you can control this behaviour by setting the `micronaut.server.idle-timeout` setting (a negative value results in no timeout):
 
 .Setting the Connection Timeout for the Server
-[source,yaml]
+[configuration]
 ----
 micronaut:
   server:
@@ -81,7 +81,7 @@ micronaut:
 If you use Micronaut's WebSocket client you may also wish to set the timeout on the client:
 
 .Setting the Connection Timeout for the Client
-[source,yaml]
+[configuration]
 ----
 micronaut:
   http:

--- a/src/main/docs/guide/ioc/contextEvents.adoc
+++ b/src/main/docs/guide/ioc/contextEvents.adoc
@@ -26,11 +26,11 @@ If your listener performs work that might take a while, use the ann:scheduling.a
 
 snippet::io.micronaut.docs.context.events.async.SampleEventListener,io.micronaut.docs.context.events.async.SampleEventListenerSpec[tags="imports,class",indent=0,title="Asynchronously listening for Events with `@EventListener`"]
 
-The event listener by default runs on the `scheduled` executor. You can configure this thread pool as required in `application.yml`:
+The event listener by default runs on the `scheduled` executor. You can configure this thread pool as required in your configuration file (e.g `application.yml`):
 
 //TODO: Move YAML snippet to ExecutorServiceConfigSpec
 .Configuring Scheduled Task Thread Pool
-[source,yaml]
+[configuration]
 ----
 micronaut:
   executors:

--- a/src/main/docs/guide/logging/loggingConfiguration.adoc
+++ b/src/main/docs/guide/logging/loggingConfiguration.adoc
@@ -1,6 +1,6 @@
-Log levels can be configured via properties defined in `application.yml` (and environment variables) with the `logger.levels` prefix:
+Log levels can be configured via properties defined in your configuration file (e.g `application.yml`) (and environment variables) with the `logger.levels` prefix:
 
-[source,yaml]
+[configuration]
 ----
 logger:
   levels:
@@ -23,7 +23,7 @@ You can also set a custom Logback XML configuration file to be used via `logger.
 
 To disable a logger, you need to set the logger level to `OFF`:
 
-[source,yaml]
+[configuration]
 ----
 logger:
   levels:

--- a/src/main/docs/guide/management/buildingEndpoints/endpointConfiguration.adoc
+++ b/src/main/docs/guide/management/buildingEndpoints/endpointConfiguration.adoc
@@ -17,7 +17,7 @@ The configuration values for the endpoint override those for `all`. If `endpoint
 
 For all endpoints, the following configuration values can be set.
 
-[source,yaml]
+[configuration]
 ----
 endpoints:
   <any endpoint id>:

--- a/src/main/docs/guide/management/providedEndpoints.adoc
+++ b/src/main/docs/guide/management/providedEndpoints.adoc
@@ -65,7 +65,7 @@ this should be used with care because private and sensitive information will be 
 
 By default, all management endpoints are exposed over the same port as the application. You can alter this behaviour by specifying the `endpoints.all.port` setting:
 
-[source,yaml]
+[configuration]
 ----
 endpoints:
   all:

--- a/src/main/docs/guide/management/providedEndpoints/beansEndpoint.adoc
+++ b/src/main/docs/guide/management/providedEndpoints/beansEndpoint.adoc
@@ -7,7 +7,7 @@ To execute the beans endpoint, send a GET request to /beans.
 To configure the beans endpoint, supply configuration through `endpoints.beans`.
 
 .Beans Endpoint Configuration Example
-[source,yaml]
+[configuration]
 ----
 endpoints:
   beans:

--- a/src/main/docs/guide/management/providedEndpoints/environmentEndpoint.adoc
+++ b/src/main/docs/guide/management/providedEndpoints/environmentEndpoint.adoc
@@ -5,7 +5,7 @@ The environment endpoint returns information about the api:context.env.Environme
 To enable and configure the environment endpoint, supply configuration through `endpoints.env`.
 
 .Environment Endpoint Configuration Example
-[source,yaml]
+[configuration]
 ----
 endpoints:
   env:

--- a/src/main/docs/guide/management/providedEndpoints/healthEndpoint.adoc
+++ b/src/main/docs/guide/management/providedEndpoints/healthEndpoint.adoc
@@ -7,7 +7,7 @@ To execute the health endpoint, send a GET request to /health. Additionally the 
 To configure the health endpoint, supply configuration through `endpoints.health`.
 
 .Health Endpoint Configuration Example
-[source,yaml]
+[configuration]
 ----
 endpoints:
   health:
@@ -25,7 +25,7 @@ The `details-visible` setting controls whether health detail will be exposed to 
 For example, setting:
 
 .Using `details-visible`
-[source,yaml]
+[configuration]
 ----
 endpoints:
   health:
@@ -50,10 +50,10 @@ The `endpoints.health.status.http-mapping` setting controls which status codes t
 
 |===
 
-You can provide custom mappings in `application.yml`:
+You can provide custom mappings in your configuration file (e.g `application.yml`):
 
 .Custom Health Status Codes
-[source,yaml]
+[configuration]
 ----
 endpoints:
   health:
@@ -90,7 +90,7 @@ All Micronaut provided health indicators are exposed on /health and /health/read
 A health indicator is provided that determines the health of the application based on the amount of free disk space. Configuration for the disk space health indicator can be provided under the `endpoints.health.disk-space` key.
 
 .Disk Space Indicator Configuration Example
-[source,yaml]
+[configuration]
 ----
 endpoints:
   health:

--- a/src/main/docs/guide/management/providedEndpoints/infoEndpoint.adoc
+++ b/src/main/docs/guide/management/providedEndpoints/infoEndpoint.adoc
@@ -7,7 +7,7 @@ To execute the info endpoint, send a GET request to /info.
 To configure the info endpoint, supply configuration through `endpoints.info`.
 
 .Info Endpoint Configuration Example
-[source,yaml]
+[configuration]
 ----
 endpoints:
   info:

--- a/src/main/docs/guide/management/providedEndpoints/loggersEndpoint.adoc
+++ b/src/main/docs/guide/management/providedEndpoints/loggersEndpoint.adoc
@@ -68,7 +68,7 @@ $ curl http://localhost:8080/loggers/ROOT
 To configure the loggers endpoint, supply configuration through `endpoints.loggers`.
 
 .Loggers Endpoint Configuration Example
-[source,yaml]
+[configuration]
 ----
 endpoints:
   loggers:

--- a/src/main/docs/guide/management/providedEndpoints/refreshEndpoint.adoc
+++ b/src/main/docs/guide/management/providedEndpoints/refreshEndpoint.adoc
@@ -19,7 +19,7 @@ $ curl -X POST http://localhost:8080/refresh -H 'Content-Type: application/json'
 To configure the refresh endpoint, supply configuration through `endpoints.refresh`.
 
 .Beans Endpoint Configuration Example
-[source,yaml]
+[configuration]
 ----
 endpoints:
   refresh:

--- a/src/main/docs/guide/management/providedEndpoints/routesEndpoint.adoc
+++ b/src/main/docs/guide/management/providedEndpoints/routesEndpoint.adoc
@@ -7,7 +7,7 @@ To execute the routes endpoint, send a GET request to /routes.
 To configure the routes endpoint, supply configuration through `endpoints.routes`.
 
 .Routes Endpoint Configuration Example
-[source,yaml]
+[configuration]
 ----
 endpoints:
   routes:

--- a/src/main/docs/guide/management/providedEndpoints/stopEndpoint.adoc
+++ b/src/main/docs/guide/management/providedEndpoints/stopEndpoint.adoc
@@ -7,7 +7,7 @@ To execute the stop endpoint, send a POST request to /stop.
 To configure the stop endpoint, supply configuration through `endpoints.stop`.
 
 .Stop Endpoint Configuration Example
-[source,yaml]
+[configuration]
 ----
 endpoints:
   stop:

--- a/src/main/docs/guide/management/providedEndpoints/threadDumpEndpoint.adoc
+++ b/src/main/docs/guide/management/providedEndpoints/threadDumpEndpoint.adoc
@@ -7,7 +7,7 @@ To execute the threaddump endpoint, send a GET request to /threaddump.
 To configure the threaddump endpoint, supply configuration through `endpoints.threaddump`.
 
 .Threaddump Endpoint Configuration Example
-[source,yaml]
+[configuration]
 ----
 endpoints:
   threaddump:

--- a/src/main/docs/guide/quickStart.adoc
+++ b/src/main/docs/guide/quickStart.adoc
@@ -1,4 +1,3 @@
 The following sections walk you through a Quick Start on how to use Micronaut to setup a basic "Hello World" application.
 
 Before getting started ensure you have a Java 8 or higher JDK installed, and it is recommended that you use a <<ideSetup,suitable IDE>> such as IntelliJ IDEA.
-


### PR DESCRIPTION
This commit reworks the YAML documentation samples to use the new `[configuration]` macro which generates a list of samples in multiple config languages instead.

It also fixes a couple of issues which were discovered as part of doing so.