### PR TITLE
Fixes for generic type arguments and their annotations

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/ast/annotation/ElementAnnotationMetadataFactory.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/annotation/ElementAnnotationMetadataFactory.java
@@ -16,11 +16,8 @@
 package io.micronaut.inject.ast.annotation;
 
 import io.micronaut.core.annotation.AnnotationMetadata;
-import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.inject.ast.Element;
-
-import java.util.function.Function;
 
 /**
  * Element's annotation metadata factory.
@@ -58,43 +55,4 @@ public interface ElementAnnotationMetadataFactory {
     @NonNull
     ElementAnnotationMetadataFactory readOnly();
 
-    /**
-     * Creates a factory wrapper that would override the annotation metadata value for the provided native type.
-     * @param nativeType The native type
-     * @param fn The function to build the annotation metadata
-     * @return a new factory
-     */
-    @Experimental
-    @NonNull
-    default ElementAnnotationMetadataFactory overrideForNativeType(Object nativeType,
-                                                                   Function<Element, ElementAnnotationMetadata> fn) {
-        ElementAnnotationMetadataFactory thisFactory = this;
-        return new ElementAnnotationMetadataFactory() {
-
-            private boolean fetched;
-
-            @Override
-            public ElementAnnotationMetadata build(Element element) {
-                if (!fetched && element.getNativeType().equals(nativeType)) {
-                    fetched = true;
-                    return fn.apply(element);
-                }
-                return thisFactory.build(element);
-            }
-
-            @Override
-            public ElementAnnotationMetadata build(Element element, AnnotationMetadata annotationMetadata) {
-                if (!fetched && element.getNativeType().equals(nativeType)) {
-                    fetched = true;
-                    return fn.apply(element);
-                }
-                return thisFactory.build(element, annotationMetadata);
-            }
-
-            @Override
-            public ElementAnnotationMetadataFactory readOnly() {
-                throw new IllegalStateException("Not supported!");
-            }
-        };
-    }
 }

--- a/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -2086,7 +2086,8 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
                     generics,
                     new HashSet<>(),
                     new HashMap<>(),
-                    loadTypeMethods
+                    loadTypeMethods,
+                    propertyType.isTypeVariable() || propertyType.isGenericPlaceholder()
             );
         }
 

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyClassElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyClassElement.java
@@ -437,7 +437,8 @@ public class GroovyClassElement extends AbstractGroovyElement implements Arrayab
                             cn,
                             elementAnnotationMetadataFactory,
                             Collections.singletonMap(cn.getName(), newInfo),
-                            cn.isArray() ? computeDimensions(cn) : 0
+                            cn.isArray() ? computeDimensions(cn) : 0,
+                                true
                         )));
                     }
                 }

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/BeanIntrospectionSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/BeanIntrospectionSpec.groovy
@@ -2183,4 +2183,60 @@ class Test {
             introspection.beanProperties.size() == 2
     }
 
+    @Issue('https://github.com/micronaut-projects/micronaut-core/issues/2059')
+    void "test annotation metadata doesn't cause stackoverflow"() {
+        BeanIntrospection introspection = buildBeanIntrospection('test.Test','''\
+package test;
+
+import io.micronaut.core.annotation.*;
+
+@Introspected
+public class Test {
+    int num;
+    String str;
+
+    @Creator
+    public <T extends Enum<T>> Test(int num, String str, Class<T> enumClass) {
+        this(num, str + enumClass.getName());
+    }
+
+    public <T extends Enum<T>> Test(int num, String str) {
+        this.num = num;
+        this.str = str;
+    }
+}
+
+
+''')
+        expect:
+            introspection != null
+    }
+
+    void "test annotation metadata doesn't cause stackoverflow 2"() {
+        def bd = buildBeanDefinition('test.SessionFactoryFactory','''\
+package test;
+
+import io.micronaut.aop.interceptors.Mutating
+
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Prototype
+import org.hibernate.SessionFactory
+import org.hibernate.engine.spi.SessionFactoryDelegatingImpl
+
+@Factory
+class SessionFactoryFactory {
+
+    @Mutating("name")
+    @Prototype
+    SessionFactory sessionFactory() {
+        return new SessionFactoryDelegatingImpl(null)
+    }
+}
+
+
+''')
+        expect:
+            bd != null
+    }
+
 }

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
@@ -24,7 +24,6 @@ import io.micronaut.core.convert.TypeConverter
 import io.micronaut.core.reflect.InstantiationUtils
 import io.micronaut.core.reflect.exception.InstantiationException
 import io.micronaut.core.type.Argument
-import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.ExecutableMethod
 import io.micronaut.inject.beans.visitor.IntrospectedTypeElementVisitor
 import io.micronaut.inject.visitor.TypeElementVisitor
@@ -832,7 +831,6 @@ public record Foo(int x, int y){
         obj.y() == 10
     }
 
-    @Requires({ jvm.isJava14Compatible() })
     void "test serializing records respects json annotations"() {
         given:
         BeanIntrospection introspection = buildBeanIntrospection('json.test.Foo', '''
@@ -1928,13 +1926,16 @@ package test;
 import io.micronaut.core.annotation.*;
 import javax.validation.constraints.*;
 import java.util.List;
+import java.util.Set;
 
 @Introspected
 public class Test {
     List<@Size(min=1, max=2) List<@NotEmpty List<@NotNull String>>> deepList;
+    List<List<List<List<List<List<String>>>>>> deepList2;
 
     Test(List<List<List<String>>> deepList) { this.deepList = deepList; }
     List<List<List<String>>> getDeepList() { return deepList; }
+    List<List<List<List<List<List<String>>>>>> getDeepList2() { return deepList2; }
 }
 ''')
         expect:

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/GenericUtils.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/GenericUtils.java
@@ -67,27 +67,6 @@ public class GenericUtils {
      * Builds type argument information for the given type.
      *
      * @param element The element
-     * @return The type argument information
-     */
-    public Map<String, Map<String, TypeMirror>> buildGenericTypeArgumentElementInfo(@NonNull Element element) {
-        return buildGenericTypeArgumentElementInfo(element, null);
-    }
-
-    /**
-     * Builds type argument information for the given type.
-     *
-     * @param element The element
-     * @param declaredType The declared type
-     * @return The type argument information
-     */
-    public Map<String, Map<String, TypeMirror>> buildGenericTypeArgumentElementInfo(@NonNull Element element, @Nullable DeclaredType declaredType) {
-        return buildGenericTypeArgumentInfo(element, declaredType, Collections.emptyMap());
-    }
-
-    /**
-     * Builds type argument information for the given type.
-     *
-     * @param element The element
      * @param declaredType The declared type
      * @param boundTypes The type variables
      * @return The type argument information
@@ -141,26 +120,6 @@ public class GenericUtils {
             }
         }
         return Collections.emptyList();
-    }
-
-    /**
-     * Return the first type argument for the given type mirror. For example for Optional&lt;String&gt; this will
-     * return {@code String}.
-     *
-     * @param type The type
-     * @return The first argument.
-     */
-    protected Optional<TypeMirror> getFirstTypeArgument(TypeMirror type) {
-        TypeMirror typeMirror = null;
-
-        if (type instanceof DeclaredType) {
-            DeclaredType declaredType = (DeclaredType) type;
-            List<? extends TypeMirror> typeArguments = declaredType.getTypeArguments();
-            if (CollectionUtils.isNotEmpty(typeArguments)) {
-                typeMirror = typeArguments.get(0);
-            }
-        }
-        return Optional.ofNullable(typeMirror);
     }
 
     /**
@@ -240,14 +199,6 @@ public class GenericUtils {
     }
 
     /**
-     * @param mirror The {@link TypeMirror}
-     * @return The resolved type reference
-     */
-    protected TypeMirror resolveTypeReference(TypeMirror mirror) {
-        return resolveTypeReference(mirror, Collections.emptyMap());
-    }
-
-    /**
      * Resolve a type reference to use for the given type mirror taking into account generic type variables.
      *
      * @param mirror     The mirror
@@ -305,153 +256,6 @@ public class GenericUtils {
         }
 
         return boundTypes;
-    }
-
-    /**
-     * Takes a type element and the bound generic information and re-aligns for the new type.
-     *
-     * @param typeElement The type element
-     * @param typeArguments The type arguments
-     * @param genericsInfo The generic info
-     * @return The aligned generics
-     */
-    public Map<String, Map<String, TypeMirror>> alignNewGenericsInfo(
-            TypeElement typeElement,
-            List<? extends TypeMirror> typeArguments,
-            Map<String, TypeMirror> genericsInfo) {
-        String typeName = typeElement.getQualifiedName().toString();
-        List<? extends TypeParameterElement> typeParameters = typeElement.getTypeParameters();
-        Map<String, TypeMirror> resolved = alignNewGenericsInfo(typeParameters, typeArguments, genericsInfo);
-        if (!resolved.isEmpty()) {
-            return Collections.singletonMap(
-                    typeName,
-                    resolved
-            );
-        }
-        return Collections.emptyMap();
-    }
-
-    /**
-     * Takes the bound generic information and re-aligns for the new type.
-     *
-     * @param typeParameters The type parameters
-     * @param typeArguments The type arguments
-     * @param genericsInfo The generic info
-     * @return The aligned generics
-     */
-    public Map<String, TypeMirror> alignNewGenericsInfo(
-            List<? extends TypeParameterElement> typeParameters,
-            List<? extends TypeMirror> typeArguments,
-            Map<String, TypeMirror> genericsInfo) {
-        if (typeArguments.size() == typeParameters.size()) {
-
-            Map<String, TypeMirror> resolved = CollectionUtils.newHashMap(typeArguments.size());
-            Iterator<? extends TypeMirror> i = typeArguments.iterator();
-            for (TypeParameterElement typeParameter : typeParameters) {
-                TypeMirror typeParameterMirror = i.next();
-                String variableName = typeParameter.getSimpleName().toString();
-                resolveVariableForMirror(genericsInfo, resolved, variableName, typeParameterMirror);
-            }
-            return resolved;
-        }
-        return Collections.emptyMap();
-    }
-
-    private void resolveVariableForMirror(Map<String, TypeMirror> genericsInfo,
-                                          Map<String, TypeMirror> resolved,
-                                          String variableName,
-                                          TypeMirror mirror) {
-        if (mirror instanceof TypeVariable) {
-            TypeVariable tv = (TypeVariable) mirror;
-            resolveTypeVariable(genericsInfo, resolved, variableName, tv);
-        } else {
-            if (mirror instanceof WildcardType) {
-                WildcardType wt = (WildcardType) mirror;
-                TypeMirror extendsBound = wt.getExtendsBound();
-                if (extendsBound != null) {
-                    resolveVariableForMirror(genericsInfo, resolved, variableName, extendsBound);
-                } else {
-                    TypeMirror superBound = wt.getSuperBound();
-                    resolveVariableForMirror(genericsInfo, resolved, variableName, superBound);
-                }
-            } else if (mirror instanceof DeclaredType) {
-                DeclaredType dt = (DeclaredType) mirror;
-                List<? extends TypeMirror> typeArguments = dt.getTypeArguments();
-                if (CollectionUtils.isNotEmpty(typeArguments) && CollectionUtils.isNotEmpty(genericsInfo)) {
-                    List<TypeMirror> resolvedArguments = new ArrayList<>(typeArguments.size());
-                    for (TypeMirror typeArgument : typeArguments) {
-                        if (typeArgument instanceof TypeVariable) {
-                            TypeVariable tv = (TypeVariable) typeArgument;
-                            String name = tv.toString();
-                            TypeMirror bound = genericsInfo.get(name);
-                            if (bound != null) {
-                                resolvedArguments.add(bound);
-                            } else {
-                                resolvedArguments.add(typeArgument);
-                            }
-                        } else {
-                            resolvedArguments.add(typeArgument);
-                        }
-                    }
-                    TypeMirror[] typeMirrors = resolvedArguments.toArray(new TypeMirror[0]);
-                    TypeElement typeElement = (TypeElement) dt.asElement();
-
-                    DeclaredType declaredType =  typeUtils.getDeclaredType(typeElement, typeMirrors);
-                    resolved.put(variableName, new PreservedAnnotationsTypeMirror(typeElement, mirror, declaredType));
-                } else {
-                    resolved.put(variableName, mirror);
-                }
-            } else if (mirror instanceof ArrayType) {
-                resolved.put(variableName, mirror);
-            }
-        }
-    }
-
-    private void resolveTypeVariable(
-            Map<String, TypeMirror> genericsInfo,
-            Map<String, TypeMirror> resolved,
-            String variableName,
-            TypeVariable variable) {
-        String name = variable.toString();
-        TypeMirror element = genericsInfo.get(name);
-        if (element != null) {
-            if (element instanceof DeclaredType dt) {
-                List<? extends TypeMirror> typeArguments = dt.getTypeArguments();
-                for (TypeMirror typeArgument : typeArguments) {
-                    if (typeArgument instanceof TypeVariable tv) {
-                        TypeMirror upperBound = tv.getUpperBound();
-                        if (upperBound instanceof DeclaredType) {
-                            resolved.put(variableName, upperBound);
-                            break;
-                        }
-                        TypeMirror lowerBound = tv.getLowerBound();
-                        if (lowerBound instanceof DeclaredType) {
-                            resolved.put(variableName, lowerBound);
-                            break;
-                        }
-                    }
-                }
-                if (!resolved.containsKey(variableName)) {
-                    resolved.put(variableName, element);
-                }
-            } else {
-                resolved.put(variableName, element);
-            }
-        } else {
-            TypeMirror upperBound = variable.getUpperBound();
-            if (upperBound instanceof TypeVariable upperTypeVariable) {
-                resolveTypeVariable(genericsInfo, resolved, variableName, upperTypeVariable);
-            } else if (upperBound instanceof DeclaredType) {
-                resolved.put(variableName, upperBound);
-            } else {
-                TypeMirror lowerBound = variable.getLowerBound();
-                if (lowerBound instanceof TypeVariable lowerTypeVariable) {
-                    resolveTypeVariable(genericsInfo, resolved, variableName, lowerTypeVariable);
-                } else if (lowerBound instanceof DeclaredType) {
-                    resolved.put(variableName, lowerBound);
-                }
-            }
-        }
     }
 
     private void resolveGenericTypeParameter(Map<String, TypeMirror> resolvedParameters, String parameterName, TypeMirror mirror, Map<String, TypeMirror> boundTypes) {

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/GenericUtils.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/GenericUtils.java
@@ -395,7 +395,7 @@ public class GenericUtils {
                         }
                     }
                     TypeMirror[] typeMirrors = resolvedArguments.toArray(new TypeMirror[0]);
-                    resolved.put(variableName, typeUtils.getDeclaredType((TypeElement) dt.asElement(), typeMirrors));
+                    resolved.put(variableName, mirror);
                 } else {
                     resolved.put(variableName, mirror);
                 }

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/JavaElementAnnotationMetadataFactory.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/JavaElementAnnotationMetadataFactory.java
@@ -15,7 +15,10 @@
  */
 package io.micronaut.annotation.processing;
 
+import io.micronaut.annotation.processing.visitor.AbstractJavaElement;
+import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.inject.ast.annotation.AbstractElementAnnotationMetadataFactory;
+import io.micronaut.inject.ast.annotation.ElementAnnotationMetadata;
 import io.micronaut.inject.ast.annotation.ElementAnnotationMetadataFactory;
 
 import javax.lang.model.element.AnnotationMirror;
@@ -29,6 +32,9 @@ import javax.lang.model.element.Element;
  */
 public final class JavaElementAnnotationMetadataFactory extends AbstractElementAnnotationMetadataFactory<Element, AnnotationMirror> {
 
+    private static final ElementAnnotationMetadata EMPTY = new ElementAnnotationMetadata() {
+    };
+
     public JavaElementAnnotationMetadataFactory(boolean isReadOnly, JavaAnnotationMetadataBuilder metadataBuilder) {
         super(isReadOnly, metadataBuilder);
     }
@@ -38,4 +44,27 @@ public final class JavaElementAnnotationMetadataFactory extends AbstractElementA
         return new JavaElementAnnotationMetadataFactory(true, (JavaAnnotationMetadataBuilder) metadataBuilder);
     }
 
+    @Override
+    public ElementAnnotationMetadata build(io.micronaut.inject.ast.Element element) {
+        AbstractJavaElement javaElement = (AbstractJavaElement) element;
+        if (notAllowedAnnotations(javaElement)) {
+            return EMPTY;
+        }
+        return super.build(element);
+    }
+
+    private static boolean notAllowedAnnotations(AbstractJavaElement javaElement) {
+        return !(javaElement.getNativeType() instanceof Element);
+    }
+
+    @Override
+    public ElementAnnotationMetadata build(io.micronaut.inject.ast.Element element, AnnotationMetadata defaultAnnotationMetadata) {
+        if (defaultAnnotationMetadata == null) {
+            AbstractJavaElement javaElement = (AbstractJavaElement) element;
+            if (notAllowedAnnotations(javaElement)) {
+                return EMPTY;
+            }
+        }
+        return super.build(element, defaultAnnotationMetadata);
+    }
 }

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/PreservedAnnotationsTypeMirror.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/PreservedAnnotationsTypeMirror.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.annotation.processing;
+
+import io.micronaut.core.annotation.Internal;
+
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ElementVisitor;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.Name;
+import javax.lang.model.element.NestingKind;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.TypeParameterElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.TypeVisitor;
+import java.lang.annotation.Annotation;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Custom {@link DeclaredType} that preserves annotations while new type is created using {@link javax.lang.model.util.Types#getDeclaredType(TypeElement, TypeMirror...)}.
+ *
+ * @author Denis Stepanov
+ * @since 4.0.0
+ */
+@Internal
+final class PreservedAnnotationsTypeMirror implements DeclaredType {
+
+    private final TypeElement typeElement;
+    private final TypeMirror typeMirror;
+    private final DeclaredType declaredType;
+
+    PreservedAnnotationsTypeMirror(TypeElement typeElement, TypeMirror typeMirror, DeclaredType declaredType) {
+        this.typeElement = typeElement;
+        this.typeMirror = typeMirror;
+        this.declaredType = declaredType;
+    }
+
+    @Override
+    public TypeKind getKind() {
+        return typeMirror.getKind();
+    }
+
+    @Override
+    public List<? extends AnnotationMirror> getAnnotationMirrors() {
+        return typeMirror.getAnnotationMirrors();
+    }
+
+    @Override
+    public <A extends Annotation> A getAnnotation(Class<A> annotationType) {
+        return typeMirror.getAnnotation(annotationType);
+    }
+
+    @Override
+    public <A extends Annotation> A[] getAnnotationsByType(Class<A> annotationType) {
+        return typeMirror.getAnnotationsByType(annotationType);
+    }
+
+    @Override
+    public <R, P> R accept(TypeVisitor<R, P> v, P p) {
+        throw new IllegalStateException("Not supported");
+    }
+
+    @Override
+    public Element asElement() {
+        return new TypeElement() {
+            @Override
+            public TypeMirror asType() {
+                return typeElement.asType();
+            }
+
+            @Override
+            public List<? extends Element> getEnclosedElements() {
+                return typeElement.getEnclosedElements();
+            }
+
+            @Override
+            public NestingKind getNestingKind() {
+                return typeElement.getNestingKind();
+            }
+
+            @Override
+            public Name getQualifiedName() {
+                return typeElement.getQualifiedName();
+            }
+
+            @Override
+            public Name getSimpleName() {
+                return typeElement.getSimpleName();
+            }
+
+            @Override
+            public TypeMirror getSuperclass() {
+                return typeElement.getSuperclass();
+            }
+
+            @Override
+            public List<? extends TypeMirror> getInterfaces() {
+                return typeElement.getInterfaces();
+            }
+
+            @Override
+            public List<? extends TypeParameterElement> getTypeParameters() {
+                return typeElement.getTypeParameters();
+            }
+
+            @Override
+            public Element getEnclosingElement() {
+                return typeElement.getEnclosingElement();
+            }
+
+            @Override
+            public ElementKind getKind() {
+                return typeElement.getKind();
+            }
+
+            @Override
+            public Set<Modifier> getModifiers() {
+                return typeElement.getModifiers();
+            }
+
+            @Override
+            public List<? extends AnnotationMirror> getAnnotationMirrors() {
+                return typeMirror.getAnnotationMirrors();
+            }
+
+            @Override
+            public <A extends Annotation> A getAnnotation(Class<A> annotationType) {
+                return typeMirror.getAnnotation(annotationType);
+            }
+
+            @Override
+            public <A extends Annotation> A[] getAnnotationsByType(Class<A> annotationType) {
+                return typeMirror.getAnnotationsByType(annotationType);
+            }
+
+            @Override
+            public <R, P> R accept(ElementVisitor<R, P> v, P p) {
+                throw new IllegalStateException("Not supported");
+            }
+        };
+    }
+
+    @Override
+    public TypeMirror getEnclosingType() {
+        return declaredType.getEnclosingType();
+    }
+
+    @Override
+    public List<? extends TypeMirror> getTypeArguments() {
+        return declaredType.getTypeArguments();
+    }
+}

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/AbstractJavaElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/AbstractJavaElement.java
@@ -453,10 +453,13 @@ public abstract class AbstractJavaElement implements io.micronaut.inject.ast.Ele
         Supplier<ClassElement> bound = boundGenerics.get(tv.toString());
         if (bound != null) {
             ClassElement classElement = bound.get();
-            if (!(classElement instanceof WildcardElement)) {
+            if (classElement instanceof WildcardElement wildcardElement) {
+                if (!wildcardElement.getType().getName().equals("java.lang.Object")) {
+                    return wildcardElement;
+                }
+            } else {
                 return classElement;
             }
-//            return mirrorToClassElement(bound., visitorContext, genericsInfo, includeTypeAnnotations, isTypeVariable);
         }
         // type variable is still free.
         List<? extends TypeMirror> boundsUnresolved = upperBound instanceof IntersectionType ?

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/AbstractJavaElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/AbstractJavaElement.java
@@ -335,9 +335,9 @@ public abstract class AbstractJavaElement implements io.micronaut.inject.ast.Ele
                 if (visitorContext.getModelUtils().resolveKind(typeElement, ElementKind.ENUM).isPresent()) {
                     return new JavaEnumElement(
                         typeElement,
-                        resolveElementAnnotationMetadataFactory(typeElement, dt, includeTypeAnnotations),
+                        elementAnnotationMetadataFactory,
                         visitorContext
-                    );
+                    ).withAnnotationMetadata(createAnnotationMetadata(typeElement, dt, includeTypeAnnotations));
                 }
                 genericsInfo = visitorContext.getGenericUtils().alignNewGenericsInfo(
                     typeElement,
@@ -346,12 +346,12 @@ public abstract class AbstractJavaElement implements io.micronaut.inject.ast.Ele
                 );
                 return new JavaClassElement(
                     typeElement,
-                    resolveElementAnnotationMetadataFactory(typeElement, dt, includeTypeAnnotations),
+                    elementAnnotationMetadataFactory,
                     visitorContext,
                     typeArguments,
                     genericsInfo,
                     isTypeVariable
-                );
+                ).withAnnotationMetadata(createAnnotationMetadata(typeElement, dt, includeTypeAnnotations));
             }
             return PrimitiveElement.VOID;
         }
@@ -403,20 +403,17 @@ public abstract class AbstractJavaElement implements io.micronaut.inject.ast.Ele
         return PrimitiveElement.VOID;
     }
 
-    @NonNull
-    private ElementAnnotationMetadataFactory resolveElementAnnotationMetadataFactory(TypeElement typeElement, DeclaredType dt, boolean includeTypeAnnotations) {
-        return elementAnnotationMetadataFactory.overrideForNativeType(typeElement, element -> {
-            AnnotationUtils annotationUtils = visitorContext
-                .getAnnotationUtils();
-            AnnotationMetadata newAnnotationMetadata;
-            List<? extends AnnotationMirror> annotationMirrors = dt.getAnnotationMirrors();
-            if (!annotationMirrors.isEmpty()) {
-                newAnnotationMetadata = annotationUtils.newAnnotationBuilder().buildDeclared(typeElement, annotationMirrors, includeTypeAnnotations);
-            } else {
-                newAnnotationMetadata = includeTypeAnnotations ? annotationUtils.newAnnotationBuilder().lookupOrBuildForType(typeElement).copyAnnotationMetadata() : AnnotationMetadata.EMPTY_METADATA;
-            }
-            return elementAnnotationMetadataFactory.build(element, newAnnotationMetadata);
-        });
+    private AnnotationMetadata createAnnotationMetadata(TypeElement typeElement, DeclaredType dt, boolean includeTypeAnnotations) {
+        AnnotationUtils annotationUtils = visitorContext
+            .getAnnotationUtils();
+        AnnotationMetadata newAnnotationMetadata;
+        List<? extends AnnotationMirror> annotationMirrors = dt.getAnnotationMirrors();
+        if (!annotationMirrors.isEmpty()) {
+            newAnnotationMetadata = annotationUtils.newAnnotationBuilder().buildDeclared(typeElement, annotationMirrors, includeTypeAnnotations);
+        } else {
+            newAnnotationMetadata = includeTypeAnnotations ? annotationUtils.newAnnotationBuilder().lookupOrBuildForType(typeElement).copyAnnotationMetadata() : AnnotationMetadata.EMPTY_METADATA;
+        }
+        return newAnnotationMetadata;
     }
 
     private ClassElement resolveTypeVariable(JavaVisitorContext visitorContext,

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/AbstractJavaElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/AbstractJavaElement.java
@@ -356,15 +356,15 @@ public abstract class AbstractJavaElement implements io.micronaut.inject.ast.Ele
             return PrimitiveElement.VOID;
         }
         if (returnType instanceof TypeVariable tv) {
-            return resolveTypeVariable(visitorContext, genericsInfo, includeTypeAnnotations, tv, tv);
+            return resolveTypeVariable(visitorContext, genericsInfo, includeTypeAnnotations, tv, tv, isTypeVariable);
         }
         if (returnType instanceof ArrayType at) {
             TypeMirror componentType = at.getComponentType();
             ClassElement arrayType;
             if (componentType instanceof TypeVariable tv && componentType.getKind() == TypeKind.TYPEVAR) {
-                arrayType = resolveTypeVariable(visitorContext, genericsInfo, includeTypeAnnotations, tv, at);
+                arrayType = resolveTypeVariable(visitorContext, genericsInfo, includeTypeAnnotations, tv, at, isTypeVariable);
             } else {
-                arrayType = mirrorToClassElement(componentType, visitorContext, genericsInfo, includeTypeAnnotations);
+                arrayType = mirrorToClassElement(componentType, visitorContext, genericsInfo, includeTypeAnnotations, isTypeVariable);
             }
             return arrayType.toArray();
         }
@@ -423,13 +423,14 @@ public abstract class AbstractJavaElement implements io.micronaut.inject.ast.Ele
                                              Map<String, Map<String, TypeMirror>> genericsInfo,
                                              boolean includeTypeAnnotations,
                                              TypeVariable tv,
-                                             TypeMirror declaration) {
+                                             TypeMirror declaration,
+                                             boolean isTypeVariable) {
         TypeMirror upperBound = tv.getUpperBound();
         Map<String, TypeMirror> boundGenerics = resolveBoundGenerics(visitorContext, genericsInfo);
 
         TypeMirror bound = boundGenerics.get(tv.toString());
         if (bound != null && bound != declaration) {
-            return mirrorToClassElement(bound, visitorContext, genericsInfo, includeTypeAnnotations, true);
+            return mirrorToClassElement(bound, visitorContext, genericsInfo, includeTypeAnnotations, isTypeVariable);
         }
         // type variable is still free.
         List<? extends TypeMirror> boundsUnresolved = upperBound instanceof IntersectionType ?
@@ -439,7 +440,8 @@ public abstract class AbstractJavaElement implements io.micronaut.inject.ast.Ele
             .map(tm -> (JavaClassElement) mirrorToClassElement(tm,
                 visitorContext,
                 genericsInfo,
-                includeTypeAnnotations))
+                includeTypeAnnotations,
+                isTypeVariable))
             .toList();
         return new JavaGenericPlaceholderElement(tv, bounds, elementAnnotationMetadataFactory, 0);
     }

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
@@ -24,6 +24,7 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.reflect.ClassUtils;
+import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.core.util.SupplierUtil;
 import io.micronaut.inject.ast.ArrayableClassElement;
@@ -243,7 +244,7 @@ public class JavaClassElement extends AbstractJavaElement implements ArrayableCl
             Map<String, Map<String, TypeMirror>> data = visitorContext.getGenericUtils().buildGenericTypeArgumentElementInfo(classElement, null, getBoundTypeMirrors());
             Map<String, TypeMirror> forType = data.get(type);
             if (forType != null) {
-                Map<String, ClassElement> typeArgs = new LinkedHashMap<>(forType.size());
+                Map<String, ClassElement> typeArgs = CollectionUtils.newLinkedHashMap(forType.size());
                 for (Map.Entry<String, TypeMirror> entry : forType.entrySet()) {
                     TypeMirror v = entry.getValue();
                     ClassElement ce = v != null ? mirrorToClassElement(v, visitorContext, Collections.emptyMap(), visitorContext.getConfiguration().includeTypeLevelAnnotationsInGenericArguments()) : null;
@@ -266,13 +267,7 @@ public class JavaClassElement extends AbstractJavaElement implements ArrayableCl
 
     @Override
     public Collection<ClassElement> getInterfaces() {
-        final List<? extends TypeMirror> interfaces = classElement.getInterfaces();
-        if (!interfaces.isEmpty()) {
-            return Collections.unmodifiableList(interfaces.stream().map((mirror) ->
-                mirrorToClassElement(mirror, visitorContext, genericTypeInfo)).collect(Collectors.toList())
-            );
-        }
-        return Collections.emptyList();
+        return classElement.getInterfaces().stream().map(mirror -> mirrorToClassElement(mirror, visitorContext, genericTypeInfo)).toList();
     }
 
     @Override

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
@@ -764,11 +764,13 @@ public class JavaClassElement extends AbstractJavaElement implements ArrayableCl
     private Map<String, ClassElement> resolveTypeArguments() {
         List<? extends TypeParameterElement> typeParameters = classElement.getTypeParameters();
         Iterator<? extends TypeParameterElement> tpi = typeParameters.iterator();
+        Iterator<? extends TypeMirror> tai = typeArguments.iterator();
 
         Map<String, ClassElement> map = new LinkedHashMap<>();
         while (tpi.hasNext()) {
             TypeParameterElement tpe = tpi.next();
-            ClassElement classElement = mirrorToClassElement(tpe.asType(), visitorContext, this.genericTypeInfo, visitorContext.getConfiguration().includeTypeLevelAnnotationsInGenericArguments());
+            TypeMirror tme = tai.hasNext() ? tai.next() : null;
+            ClassElement classElement = mirrorToClassElement(tpe.asType(), visitorContext, this.genericTypeInfo, visitorContext.getConfiguration().includeTypeLevelAnnotationsInGenericArguments(), tme instanceof TypeVariable);
             map.put(tpe.toString(), classElement);
         }
 

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaElementFactory.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaElementFactory.java
@@ -15,9 +15,7 @@
  */
 package io.micronaut.annotation.processing.visitor;
 
-import io.micronaut.annotation.processing.JavaElementAnnotationMetadataFactory;
 import io.micronaut.annotation.processing.PostponeToNextRoundException;
-import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.inject.ast.ClassElement;
@@ -51,12 +49,6 @@ public class JavaElementFactory implements ElementFactory<Element, TypeElement, 
 
     public JavaElementFactory(JavaVisitorContext visitorContext) {
         this.visitorContext = Objects.requireNonNull(visitorContext, "Visitor context cannot be null");
-    }
-
-    private ElementAnnotationMetadataFactory defaultAnnotationMetadata(Object nativeType,
-                                                                       AnnotationMetadata annotationMetadata) {
-        JavaElementAnnotationMetadataFactory elementAnnotationMetadataFactory = visitorContext.getElementAnnotationMetadataFactory();
-        return elementAnnotationMetadataFactory.overrideForNativeType(nativeType, element -> elementAnnotationMetadataFactory.build(element, annotationMetadata));
     }
 
     @NonNull

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaElementFactory.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaElementFactory.java
@@ -36,6 +36,7 @@ import javax.lang.model.type.TypeMirror;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Supplier;
 
 /**
  * An implementation of {@link ElementFactory} for Java.
@@ -217,7 +218,7 @@ public class JavaElementFactory implements ElementFactory<Element, TypeElement, 
     public JavaMethodElement newMethodElement(ClassElement owningType,
                                               @NonNull ExecutableElement method,
                                               @NonNull ElementAnnotationMetadataFactory annotationMetadataFactory,
-                                              @Nullable Map<String, Map<String, TypeMirror>> genericTypes) {
+                                              @Nullable Map<String, Map<String, Supplier<ClassElement>>> genericTypes) {
         validateOwningClass(owningType);
         failIfPostponeIsNeeded(owningType, method);
         final JavaClassElement javaDeclaringClass = (JavaClassElement) owningType;

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaEnumElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaEnumElement.java
@@ -17,9 +17,9 @@ package io.micronaut.annotation.processing.visitor;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.inject.ast.ClassElement;
-import io.micronaut.inject.ast.annotation.ElementAnnotationMetadataFactory;
 import io.micronaut.inject.ast.EnumConstantElement;
 import io.micronaut.inject.ast.EnumElement;
+import io.micronaut.inject.ast.annotation.ElementAnnotationMetadataFactory;
 
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
@@ -66,6 +66,11 @@ class JavaEnumElement extends JavaClassElement implements EnumElement {
     }
 
     @Override
+    protected JavaClassElement copyThis() {
+        return new JavaEnumElement(classElement, elementAnnotationMetadataFactory, visitorContext, arrayDimensions);
+    }
+
+    @Override
     public List<String> values() {
         if (values != null) {
             return values;
@@ -107,4 +112,5 @@ class JavaEnumElement extends JavaClassElement implements EnumElement {
     public ClassElement withArrayDimensions(int arrayDimensions) {
         return new JavaEnumElement(classElement, elementAnnotationMetadataFactory, visitorContext, arrayDimensions);
     }
+
 }

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaMethodElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaMethodElement.java
@@ -42,6 +42,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
@@ -267,7 +268,7 @@ public class JavaMethodElement extends AbstractJavaElement implements MethodElem
      * @param info The info
      * @return The return type
      */
-    protected ClassElement returnType(Map<String, Map<String, TypeMirror>> info) {
+    protected ClassElement returnType(Map<String, Map<String, Supplier<ClassElement>>> info) {
         VariableElement varElement = CollectionUtils.last(executableElement.getParameters());
         if (isSuspend(varElement)) {
             DeclaredType dType = (DeclaredType) varElement.asType();

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaParameterElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaParameterElement.java
@@ -26,6 +26,7 @@ import io.micronaut.inject.ast.ParameterElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
 import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * Implementation of the {@link ParameterElement} interface for Java.
@@ -102,7 +103,7 @@ class JavaParameterElement extends AbstractJavaElement implements ParameterEleme
     public ClassElement getGenericType() {
         if (this.genericTypeElement == null) {
             TypeMirror returnType = getNativeType().asType();
-            Map<String, Map<String, TypeMirror>> declaredGenericInfo = owningType.getGenericTypeInfo();
+            Map<String, Map<String, Supplier<ClassElement>>> declaredGenericInfo = owningType.getGenericTypeInfo();
             this.genericTypeElement = parameterizedClassElement(returnType, visitorContext, declaredGenericInfo);
         }
         return this.genericTypeElement;

--- a/inject-java/src/test/groovy/io/micronaut/inject/beans/BeanDefinitionSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beans/BeanDefinitionSpec.groovy
@@ -397,6 +397,29 @@ public class NumberThingManager extends AbstractThingManager<NumberThing<?>> {}
         definition.getTypeArguments("test.AbstractThingManager")[0].getTypeVariables().get("T").getType() == Number.class
     }
 
+    void "test building a bean with generics wildcard extending"() {
+        when:
+        def definition = buildBeanDefinition('test.NumberThingManager', '''
+package test;
+
+import jakarta.inject.Singleton;
+
+interface Thing<T> {}
+
+interface NumberThing<T extends Number & Comparable<T>> extends Thing<T> {}
+
+class AbstractThingManager<T extends Thing<?>> {}
+
+@Singleton
+public class NumberThingManager extends AbstractThingManager<NumberThing<? extends Double>> {}
+''')
+
+        then:
+        noExceptionThrown()
+        definition != null
+        definition.getTypeArguments("test.AbstractThingManager")[0].getTypeVariables().get("T").getType() == Double.class
+    }
+
     void "test a bean definition in a package with uppercase letters"() {
         when:
         def definition = buildBeanDefinition('test.A', 'TestBean', '''

--- a/inject-java/src/test/groovy/io/micronaut/inject/beans/BeanDefinitionSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beans/BeanDefinitionSpec.groovy
@@ -3,6 +3,10 @@ package io.micronaut.inject.beans
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.micronaut.core.annotation.AnnotationUtil
 import io.micronaut.core.annotation.Order
+import io.micronaut.core.order.Ordered
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.inject.BeanDefinition
+import io.micronaut.inject.BeanDefinitionReference
 import io.micronaut.inject.qualifiers.Qualifiers
 import spock.lang.Issue
 
@@ -409,5 +413,62 @@ class TestBean {
         then:
         noExceptionThrown()
         definition != null
+    }
+
+    void "test deep type parameters are created in definition"() {
+        given:
+        BeanDefinition definition = buildBeanDefinition('test','Test','''
+package test;
+import java.util.List;
+
+@jakarta.inject.Singleton
+public class Test {
+    List<List<List<String>>> deepList;
+    public Test(List<List<List<String>>> deepList) { this.deepList = deepList; }
+}
+        ''')
+
+        expect:
+        definition != null
+        def constructor = definition.getConstructor()
+
+        def param = constructor.getArguments()[0]
+        param.getTypeParameters().length == 1
+        def param1 = param.getTypeParameters()[0]
+        param1.getTypeParameters().length == 1
+        def param2 = param1.getTypeParameters()[0]
+        param2.getTypeParameters().length == 1
+        def param3 = param2.getTypeParameters()[0]
+    }
+
+    void "test annotation metadata present on deep type parameters of definition"() {
+        given:
+        BeanDefinition definition = buildBeanDefinition('test','Test','''
+package test;
+import javax.validation.constraints.*;
+import java.util.List;
+
+@jakarta.inject.Singleton
+public class Test {
+    public Test(List<@Size(min=1) List<@NotEmpty List<@NotNull String>>> deepList) { }
+}
+        ''')
+
+        when:
+        definition != null
+        def constructor = definition.getConstructor()
+        def param = constructor.getArguments()[0]
+        def param1 = param.getTypeParameters()[0]
+        def param2 = param1.getTypeParameters()[0]
+        def param3 = param2.getTypeParameters()[0]
+
+        then:
+        param.getAnnotationMetadata().getAnnotationNames().size() == 0
+        param1.getAnnotationMetadata().getAnnotationNames().size() == 1
+        param1.getAnnotationMetadata().getAnnotationNames().asList() == ['javax.validation.constraints.Size$List']
+        param2.getAnnotationMetadata().getAnnotationNames().size() == 1
+        param2.getAnnotationMetadata().getAnnotationNames().asList() == ['javax.validation.constraints.NotEmpty$List']
+        param3.getAnnotationMetadata().getAnnotationNames().size() == 1
+        param3.getAnnotationMetadata().getAnnotationNames().asList() == ['javax.validation.constraints.NotNull$List']
     }
 }

--- a/inject-java/src/test/groovy/io/micronaut/inject/beans/BeanDefinitionSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beans/BeanDefinitionSpec.groovy
@@ -3,10 +3,7 @@ package io.micronaut.inject.beans
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.micronaut.core.annotation.AnnotationUtil
 import io.micronaut.core.annotation.Order
-import io.micronaut.core.order.Ordered
-import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.micronaut.inject.BeanDefinition
-import io.micronaut.inject.BeanDefinitionReference
 import io.micronaut.inject.qualifiers.Qualifiers
 import spock.lang.Issue
 

--- a/inject-java/src/test/groovy/io/micronaut/visitors/AllElementsVisitor.java
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/AllElementsVisitor.java
@@ -46,6 +46,10 @@ public class AllElementsVisitor implements TypeElementVisitor<Controller, Object
         visit(element);
         element.getBeanProperties(); // Preload properties for tests otherwise it fails because the compiler is done
         element.getAnnotationMetadata();
+        element.getSuperType().ifPresent(superType -> {
+            superType.getAllTypeArguments();
+            superType.getTypeArguments();
+        });
         VISITED_CLASS_ELEMENTS.add(element);
     }
 


### PR DESCRIPTION
Couldn't build type introspection and type definition for such types as `List<@Size(min=1, max=2) List<@NotEmpty List<@NotNull String>>>`, which seemed to cause other issues when attempting to change to new validation in core.

In particular:
* deep generic arguments were missing
* deep generic arguments were missing annotation metadata
