### PR TITLE
Fix Cors for alternate local addresses

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['11, '17']
+        java: ['11', '17']
         graalvm: ['latest']
     steps:
        # https://github.com/actions/virtual-environments/issues/709

--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -19,11 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['17']
-        graalvm: ['latest', 'dev']
-        include:
-          - graalvm: 'latest'
-            java: '11'
+        java: ['11, '17']
+        graalvm: ['latest']
     steps:
        # https://github.com/actions/virtual-environments/issues/709
       - name: Free disk space

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/cors/CorsFilterSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/cors/CorsFilterSpec.groovy
@@ -127,8 +127,8 @@ class CorsFilterSpec extends Specification {
         ['.*']                              | 'http://www.bar.com'
         ['^http://www\\.(foo|bar)\\.com$']  | 'http://www.bar.com'
         ['^http://www\\.(foo|bar)\\.com$']  | 'http://www.foo.com'
-        ['.*bar$', '.*foo$']                | 'asdfasdf foo'
-        ['.*bar$', '.*foo$']                | 'asdfasdf bar'
+        ['.*bar$', '.*foo$']                | 'http://asdfasdf.foo'
+        ['.*bar$', '.*foo$']                | 'http://asdfasdf.bar'
     }
 
     void "test handleRequest with disallowed method"() {

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/cors/CorsFilterSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/cors/CorsFilterSpec.groovy
@@ -127,6 +127,8 @@ class CorsFilterSpec extends Specification {
         ['.*']                              | 'http://www.bar.com'
         ['^http://www\\.(foo|bar)\\.com$']  | 'http://www.bar.com'
         ['^http://www\\.(foo|bar)\\.com$']  | 'http://www.foo.com'
+        ['.*bar$', '.*foo$']                | 'asdfasdf foo'
+        ['.*bar$', '.*foo$']                | 'asdfasdf bar'
         ['.*bar$', '.*foo$']                | 'http://asdfasdf.foo'
         ['.*bar$', '.*foo$']                | 'http://asdfasdf.bar'
     }

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/RequestSupplier.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/RequestSupplier.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.tck;
+
+import io.micronaut.http.HttpRequest;
+
+import java.util.function.Function;
+
+/**
+ * Allows defining an HttpRequest based on some property of the server (ie: Port).
+ *
+ * @author Tim Yates
+ * @since 3.8.3
+ */
+@FunctionalInterface
+public interface RequestSupplier extends Function<ServerUnderTest, HttpRequest<?>> {
+}

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/TestScenario.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/TestScenario.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 original authors
+ * Copyright 2017-2023 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,12 +32,12 @@ public final class TestScenario {
     private final String specName;
     private final Map<String, Object> configuration;
 
-    private final HttpRequest<?> request;
+    private final RequestSupplier request;
     private final BiConsumer<ServerUnderTest, HttpRequest<?>> assertion;
 
     private TestScenario(String specName,
                          Map<String, Object> configuration,
-                         HttpRequest<?> request,
+                         RequestSupplier request,
                          BiConsumer<ServerUnderTest, HttpRequest<?>> assertion) {
         this.specName = specName;
         this.configuration = configuration;
@@ -56,6 +56,26 @@ public final class TestScenario {
     public static void asserts(String specName,
                                Map<String, Object> configuration,
                                HttpRequest<?> request,
+                               BiConsumer<ServerUnderTest, HttpRequest<?>> assertion) throws IOException {
+        TestScenario.builder()
+            .specName(specName)
+            .configuration(configuration)
+            .request(request)
+            .assertion(assertion)
+            .run();
+    }
+
+    /**
+     *
+     * @param specName Value for {@literal spec.name} property. Used to avoid bean pollution.
+     * @param configuration Test Scenario configuration
+     * @param request HTTP Request to be sent in the test scenario
+     * @param assertion Assertion for a request and server.
+     * @throws IOException Exception thrown while getting the server under test.
+     */
+    public static void asserts(String specName,
+                               Map<String, Object> configuration,
+                               RequestSupplier request,
                                BiConsumer<ServerUnderTest, HttpRequest<?>> assertion) throws IOException {
         TestScenario.builder()
             .specName(specName)
@@ -93,7 +113,7 @@ public final class TestScenario {
     private void run() throws IOException {
         try (ServerUnderTest server = ServerUnderTestProviderUtils.getServerUnderTestProvider().getServer(specName, configuration)) {
             if (assertion != null) {
-                assertion.accept(server, request);
+                assertion.accept(server, request.apply(server));
             }
         }
     }
@@ -109,7 +129,7 @@ public final class TestScenario {
 
         private BiConsumer<ServerUnderTest, HttpRequest<?>> assertion;
 
-        private HttpRequest<?> request;
+        private RequestSupplier request;
 
         /**
          *
@@ -127,7 +147,17 @@ public final class TestScenario {
          * @return The Test Scneario Builder
          */
         public Builder request(HttpRequest<?> request) {
-            this.request =  request;
+            this.request = (server) -> request;
+            return this;
+        }
+
+        /**
+         *
+         * @param request HTTP Request supplier that given a server, provides the request to be sent in the test scenario
+         * @return The Test Scenario Builder
+         */
+        public Builder request(RequestSupplier request) {
+            this.request = request;
             return this;
         }
 

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/TestScenario.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/TestScenario.java
@@ -147,7 +147,7 @@ public final class TestScenario {
          * @return The Test Scneario Builder
          */
         public Builder request(HttpRequest<?> request) {
-            this.request = (server) -> request;
+            this.request = server -> request;
             return this;
         }
 

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/CorsSimpleRequestTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/CorsSimpleRequestTest.java
@@ -185,7 +185,7 @@ public class CorsSimpleRequestTest {
     }
 
     private RequestSupplier createRequestFor(String host, String origin) {
-        return (server) -> createRequest(server.getPort().map(p -> "http://" + host + ":" + p + "/refresh").orElseThrow(() -> new RuntimeException("Unknown port for " + server)), origin);
+        return server -> createRequest(server.getPort().map(p -> "http://" + host + ":" + p + "/refresh").orElseThrow(() -> new RuntimeException("Unknown port for " + server)), origin);
     }
 
     static void isForbidden(ServerUnderTest server, HttpRequest<?> request) {

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/CorsSimpleRequestTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/CorsSimpleRequestTest.java
@@ -30,6 +30,8 @@ import io.micronaut.http.annotation.Status;
 import io.micronaut.http.client.multipart.MultipartBody;
 import io.micronaut.http.server.tck.AssertionUtils;
 import io.micronaut.http.server.tck.HttpResponseAssertion;
+import io.micronaut.http.server.tck.RequestSupplier;
+import io.micronaut.http.server.tck.ServerUnderTest;
 import io.micronaut.runtime.context.scope.refresh.RefreshEvent;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -69,15 +71,30 @@ public class CorsSimpleRequestTest {
         asserts(SPECNAME,
             Collections.singletonMap(PROPERTY_MICRONAUT_SERVER_CORS_ENABLED, StringUtils.TRUE),
             createRequest("https://foo.com"),
-            (server, request) -> {
-                RefreshCounter refreshCounter = server.getApplicationContext().getBean(RefreshCounter.class);
-                assertEquals(0, refreshCounter.getRefreshCount());
-                AssertionUtils.assertThrows(server, request, HttpResponseAssertion.builder()
-                        .status(HttpStatus.FORBIDDEN)
-                        .assertResponse(response -> assertFalse(response.getHeaders().contains("Vary")))
-                    .build());
-                assertEquals(0, refreshCounter.getRefreshCount());
-        });
+            CorsSimpleRequestTest::isForbidden
+        );
+    }
+
+    /**
+     * @see <a href="https://github.com/micronaut-projects/micronaut-core/security/advisories/GHSA-583g-g682-crxf">GHSA-583g-g682-crxf</a>
+     *
+     * A malicious/compromised website can make HTTP requests to 127.0.0.1. Normally, such requests would trigger a CORS preflight check which would prevent the request; however, some requests are "simple" and do not require a preflight check. These endpoints, if enabled and not secured, are vulnerable to being triggered.
+     * Example with Javascript:
+     * <pre>
+     * let url = "http://127.0.0.1:8080/refresh";
+     * let body = new FormData();
+     * body.append("force", "true");
+     * fetch(url, { method: "POST", body });
+     * </pre>
+     * @throws IOException may throw the try for resources
+     */
+    @Test
+    void corsSimpleRequestNotAllowedFor127AndAny() throws IOException {
+        asserts(SPECNAME,
+            Collections.singletonMap(PROPERTY_MICRONAUT_SERVER_CORS_ENABLED, StringUtils.TRUE),
+            createRequestFor("127.0.0.1", "https://foo.com"),
+            CorsSimpleRequestTest::isForbidden
+        );
     }
 
     /**
@@ -89,14 +106,8 @@ public class CorsSimpleRequestTest {
         asserts(SPECNAME,
             Collections.singletonMap(PROPERTY_MICRONAUT_SERVER_CORS_ENABLED, StringUtils.TRUE),
             createRequest("http://localhost:8000"),
-            (server, request) -> {
-                RefreshCounter refreshCounter = server.getApplicationContext().getBean(RefreshCounter.class);
-                assertEquals(0, refreshCounter.getRefreshCount());
-                AssertionUtils.assertDoesNotThrow(server, request, HttpResponseAssertion.builder()
-                    .status(HttpStatus.OK)
-                    .build());
-                assertEquals(1, refreshCounter.getRefreshCount());
-            });
+            CorsSimpleRequestTest::isSuccessful
+        );
     }
 
     /**
@@ -108,20 +119,13 @@ public class CorsSimpleRequestTest {
     void corsSimpleRequestAllowedForLocalhostAnd127Origin() throws IOException {
         asserts(SPECNAME,
             Collections.singletonMap(PROPERTY_MICRONAUT_SERVER_CORS_ENABLED, StringUtils.TRUE),
-            (server) -> createRequest(server.getPort().map(p -> "http://localhost:" + p + "/refresh").orElseThrow(() -> new RuntimeException("Unknown port for " + server)), "http://127.0.0.1:8000"),
-            (server, request) -> {
-                RefreshCounter refreshCounter = server.getApplicationContext().getBean(RefreshCounter.class);
-                assertEquals(0, refreshCounter.getRefreshCount());
-                AssertionUtils.assertThrows(server, request, HttpResponseAssertion.builder()
-                    .status(HttpStatus.FORBIDDEN)
-                    .assertResponse(response -> assertFalse(response.getHeaders().contains("Vary")))
-                    .build());
-                assertEquals(0, refreshCounter.getRefreshCount());
-            });
+            createRequestFor("localhost", "http://127.0.0.1:8000"),
+            CorsSimpleRequestTest::isForbidden
+        );
     }
 
     /**
-     * A request to 127.0.0.1 with an origin of localhost should fail despite them both being local.
+     * A request to 127.0.0.1 with an origin of localhost should succeed as they're both local.
      *
      * @throws IOException
      */
@@ -129,16 +133,9 @@ public class CorsSimpleRequestTest {
     void corsSimpleRequestAllowedFor127RequestAndLocalhostOrigin() throws IOException {
         asserts(SPECNAME,
             Collections.singletonMap(PROPERTY_MICRONAUT_SERVER_CORS_ENABLED, StringUtils.TRUE),
-            (server) -> createRequest(server.getPort().map(p -> "http://127.0.0.1:" + p + "/refresh").orElseThrow(() -> new RuntimeException("Unknown port for " + server)), "http://localhost:8000"),
-            (server, request) -> {
-                RefreshCounter refreshCounter = server.getApplicationContext().getBean(RefreshCounter.class);
-                assertEquals(0, refreshCounter.getRefreshCount());
-                AssertionUtils.assertThrows(server, request, HttpResponseAssertion.builder()
-                    .status(HttpStatus.FORBIDDEN)
-                    .assertResponse(response -> assertFalse(response.getHeaders().contains("Vary")))
-                    .build());
-                assertEquals(0, refreshCounter.getRefreshCount());
-            });
+            createRequestFor("127.0.0.1", "http://localhost:8000"),
+            CorsSimpleRequestTest::isSuccessful
+        );
     }
 
     /**
@@ -171,6 +168,29 @@ public class CorsSimpleRequestTest {
                     .build());
                 assertEquals(1, refreshCounter.getRefreshCount());
             });
+    }
+
+    private RequestSupplier createRequestFor(String host, String origin) {
+        return (server) -> createRequest(server.getPort().map(p -> "http://" + host + ":" + p + "/refresh").orElseThrow(() -> new RuntimeException("Unknown port for " + server)), origin);
+    }
+
+    static void isForbidden(ServerUnderTest server, HttpRequest<?> request) {
+        RefreshCounter refreshCounter = server.getApplicationContext().getBean(RefreshCounter.class);
+        assertEquals(0, refreshCounter.getRefreshCount());
+        AssertionUtils.assertThrows(server, request, HttpResponseAssertion.builder()
+            .status(HttpStatus.FORBIDDEN)
+            .assertResponse(response -> assertFalse(response.getHeaders().contains("Vary")))
+            .build());
+        assertEquals(0, refreshCounter.getRefreshCount());
+    }
+
+    static void isSuccessful(ServerUnderTest server, HttpRequest<?> request) {
+        RefreshCounter refreshCounter = server.getApplicationContext().getBean(RefreshCounter.class);
+        assertEquals(0, refreshCounter.getRefreshCount());
+        AssertionUtils.assertDoesNotThrow(server, request, HttpResponseAssertion.builder()
+            .status(HttpStatus.OK)
+            .build());
+        assertEquals(1, refreshCounter.getRefreshCount());
     }
 
     static HttpRequest<?> createRequest(String origin) {

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/CorsSimpleRequestTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/CorsSimpleRequestTest.java
@@ -111,7 +111,7 @@ public class CorsSimpleRequestTest {
     }
 
     /**
-     * A request to localhost with an origin of 127.0.0.1 should be allowed as they are both local
+     * A request to localhost with an origin of 127.0.0.1 should be allowed as they are both local.
      *
      * @throws IOException
      */
@@ -125,7 +125,7 @@ public class CorsSimpleRequestTest {
     }
 
     /**
-     * Spoof attempt with origin should fail
+     * Spoof attempt with origin should fail.
      *
      * @throws IOException
      */

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/CorsSimpleRequestTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/CorsSimpleRequestTest.java
@@ -125,6 +125,20 @@ public class CorsSimpleRequestTest {
     }
 
     /**
+     * Spoof attempt with origin should fail
+     *
+     * @throws IOException
+     */
+    @Test
+    void corsSimpleRequestFailsForLocalhostAndSpoofed127Origin() throws IOException {
+        asserts(SPECNAME,
+            Collections.singletonMap(PROPERTY_MICRONAUT_SERVER_CORS_ENABLED, StringUtils.TRUE),
+            createRequestFor("localhost", "http://127.0.0.1.hac0r.com:8000"),
+            CorsSimpleRequestTest::isForbidden
+        );
+    }
+
+    /**
      * A request to 127.0.0.1 with an origin of localhost should succeed as they're both local.
      *
      * @throws IOException

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/CorsSimpleRequestTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/CorsSimpleRequestTest.java
@@ -111,7 +111,7 @@ public class CorsSimpleRequestTest {
     }
 
     /**
-     * A request to localhost with an origin of 127.0.0.1 should fail despite them both being local.
+     * A request to localhost with an origin of 127.0.0.1 should be allowed as they are both local
      *
      * @throws IOException
      */
@@ -120,7 +120,7 @@ public class CorsSimpleRequestTest {
         asserts(SPECNAME,
             Collections.singletonMap(PROPERTY_MICRONAUT_SERVER_CORS_ENABLED, StringUtils.TRUE),
             createRequestFor("localhost", "http://127.0.0.1:8000"),
-            CorsSimpleRequestTest::isForbidden
+            CorsSimpleRequestTest::isSuccessful
         );
     }
 

--- a/http-server/src/main/java/io/micronaut/http/server/cors/CorsFilter.java
+++ b/http-server/src/main/java/io/micronaut/http/server/cors/CorsFilter.java
@@ -40,6 +40,8 @@ import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.InetAddress;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -121,7 +123,7 @@ public class CorsFilter implements HttpServerFilter {
      *
      * @param corsOriginConfiguration CORS Origin configuration for request's HTTP Header origin.
      * @param request HTTP Request
-     * @return {@literal true} if the resolved host starts with {@literal http://localhost} and the CORS configuration has any for allowed origins.
+     * @return {@literal true} if the resolved host is localhost or a 127.0.0.1 address and the CORS configuration has any for allowed origins.
      */
     protected boolean shouldDenyToPreventDriveByLocalhostAttack(@NonNull CorsOriginConfiguration corsOriginConfiguration,
                                                                 @NonNull HttpRequest<?> request) {
@@ -132,12 +134,17 @@ public class CorsFilter implements HttpServerFilter {
         if (origin == null) {
             return false;
         }
-        if (origin.startsWith(LOCALHOST)) {
+        if (isLocal(origin)) {
             return false;
         }
         String host = httpHostResolver.resolve(request);
-        return isAny(corsOriginConfiguration.getAllowedOrigins()) && host.startsWith(LOCALHOST);
+        return isAny(corsOriginConfiguration.getAllowedOrigins()) && isLocal(host);
+    }
 
+    private boolean isLocal(@NonNull String hostString) {
+        URI uri = URI.create(hostString);
+        String host = uri.getHost();
+        return "localhost".equals(host) || "127.0.0.1".equals(host);
     }
 
     /**

--- a/http-server/src/main/java/io/micronaut/http/server/cors/CorsFilter.java
+++ b/http-server/src/main/java/io/micronaut/http/server/cors/CorsFilter.java
@@ -158,8 +158,17 @@ public class CorsFilter implements HttpServerFilter {
      * We only need to check host for starting with "localhost" "127." (as there are multiple loopback addresses on linux)
      *
      * This is fine for host, as the request had to get here.
+     *
+     * We check the first character as a performance optimization prior to calling startsWith.
      */
     private boolean isHostLocal(@NonNull String hostString) {
+        if (hostString.isEmpty()) {
+            return false;
+        }
+        char initialChar = hostString.charAt(0);
+        if (initialChar != 'h' && initialChar != 'w') {
+            return false;
+        }
         return hostString.startsWith("http://localhost")
             || hostString.startsWith("https://localhost")
             || hostString.startsWith("http://127.")

--- a/http-server/src/main/java/io/micronaut/http/server/cors/CorsFilter.java
+++ b/http-server/src/main/java/io/micronaut/http/server/cors/CorsFilter.java
@@ -64,7 +64,6 @@ import static io.micronaut.http.annotation.Filter.MATCH_ALL_PATTERN;
 public class CorsFilter implements HttpServerFilter {
     private static final Logger LOG = LoggerFactory.getLogger(CorsFilter.class);
     private static final ArgumentConversionContext<HttpMethod> CONVERSION_CONTEXT_HTTP_METHOD = ImmutableArgumentConversionContext.of(HttpMethod.class);
-    private static final String LOCALHOST = "http://localhost";
 
     protected final HttpServerConfiguration.CorsConfiguration corsConfiguration;
 
@@ -123,7 +122,7 @@ public class CorsFilter implements HttpServerFilter {
      *
      * @param corsOriginConfiguration CORS Origin configuration for request's HTTP Header origin.
      * @param request HTTP Request
-     * @return {@literal true} if the resolved host is localhost or a 127.0.0.1 address and the CORS configuration has any for allowed origins.
+     * @return {@literal true} if the resolved host is localhost or 127.0.0.1 address and the CORS configuration has any for allowed origins.
      */
     protected boolean shouldDenyToPreventDriveByLocalhostAttack(@NonNull CorsOriginConfiguration corsOriginConfiguration,
                                                                 @NonNull HttpRequest<?> request) {
@@ -151,7 +150,7 @@ public class CorsFilter implements HttpServerFilter {
      *
      * @param origin HTTP Header {@link HttpHeaders#ORIGIN} value.
      * @param request HTTP Request
-     * @return {@literal true} if the resolved host starts with {@literal http://localhost} and origin does not start with localhost deny it.
+     * @return {@literal true} if the resolved host is localhost or 127.0.0.1 and origin is not one of these then deny it.
      */
     protected boolean shouldDenyToPreventDriveByLocalhostAttack(@NonNull String origin,
                                                                 @NonNull HttpRequest<?> request) {
@@ -159,7 +158,7 @@ public class CorsFilter implements HttpServerFilter {
             return false;
         }
         String host = httpHostResolver.resolve(request);
-        return !origin.startsWith(LOCALHOST) && host.startsWith(LOCALHOST);
+        return !isLocal(origin) && isLocal(host);
     }
 
     @Override

--- a/http-server/src/main/java/io/micronaut/http/server/cors/CorsFilter.java
+++ b/http-server/src/main/java/io/micronaut/http/server/cors/CorsFilter.java
@@ -21,6 +21,7 @@ import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.ConversionContext;
 import io.micronaut.core.convert.ImmutableArgumentConversionContext;
+import io.micronaut.core.io.socket.SocketUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.HttpMethod;
@@ -183,9 +184,13 @@ public class CorsFilter implements HttpServerFilter {
      * For Origin, we need to be more strict as otherwise an address like 127.malicious.com would be allowed.
      */
     private boolean isOriginLocal(@NonNull String hostString) {
-        URI uri = URI.create(hostString);
-        String host = uri.getHost();
-        return "localhost".equals(host) || "127.0.0.1".equals(host);
+        try {
+            URI uri = URI.create(hostString);
+            String host = uri.getHost();
+            return SocketUtils.LOCALHOST.equals(host) || "127.0.0.1".equals(host);
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
     }
 
     @Override

--- a/http-server/src/main/java/io/micronaut/http/server/cors/CorsFilter.java
+++ b/http-server/src/main/java/io/micronaut/http/server/cors/CorsFilter.java
@@ -163,7 +163,11 @@ public class CorsFilter implements HttpServerFilter {
         return hostString.startsWith("http://localhost")
             || hostString.startsWith("https://localhost")
             || hostString.startsWith("http://127.")
-            || hostString.startsWith("https://127.");
+            || hostString.startsWith("https://127.")
+            || hostString.startsWith("ws://localhost")
+            || hostString.startsWith("wss://localhost")
+            || hostString.startsWith("ws://127.")
+            || hostString.startsWith("wss://127.");
     }
 
     /*


### PR DESCRIPTION
It was raised in https://github.com/micronaut-projects/micronaut-core/issues/8560#issuecomment-1379453245 that we have not completed the circle with CORS and localhost drive-by protection

This PR adds a check for 127.0.01 in addition to localhost.

Currently it has a couple of missing parts which are up for discussion:

1.  For local connections, It does not take the Origin/Server port into account, which it should do to be spec compliant.  I feel that adding this (whilst simple) could hamper local development of multiple services, or front-ends.
2. If the Origin is `localhost` and the request is 127.0.0.1, we currently allow this (and vice versa).  Again this is not spec compliant (I think), but if we have an origin of either of the two, I'm currently happy with the risk.
3. We do not check all 127.0.0.0/8 addresses (which are local).  To do so would require some level of parsing, and I worry that the cost to each request will outweigh the benefit to people with a 127.0.0.32 address (I've never seen anything other than 127.0.01 -- but I admit I've not been specifically looking)

Please comment with your thoughts on these 3 issues (and any others you think about)