### PR TITLE
ci: sync as in project template

### DIFF
--- a/.github/workflows/corretto.yml
+++ b/.github/workflows/corretto.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['8', '11']
+        java: ['8', '11', '17']
     container: amazoncorretto:${{ matrix.java }}
     steps:
     - name: Display Java and Linux version
@@ -30,6 +30,8 @@ jobs:
           ${{ runner.os }}-micronaut-core-wrapper-
     - name: Build with Gradle
       env:
+        GH_TOKEN_PUBLIC_REPOS_READONLY: ${{ secrets.GH_TOKEN_PUBLIC_REPOS_READONLY }}
+        GH_USERNAME: ${{ secrets.GH_USERNAME }}
         GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
         GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
         GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}

--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -19,11 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '17', '19']
+        java: [ '17']
         graalvm: [ 'latest' ]
-        include:
-          - graalvm: 'dev'
-            java: '19'
     steps:
        # https://github.com/actions/virtual-environments/issues/709
       - name: Free disk space

--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '17']
+        java: ['11', '17']
         graalvm: [ 'latest' ]
     steps:
        # https://github.com/actions/virtual-environments/issues/709

--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -19,8 +19,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['11', '17']
+        java: ['17']
         graalvm: ['latest', 'dev']
+        include:
+          - graalvm: 'latest'
+            java: '11'
     steps:
        # https://github.com/actions/virtual-environments/issues/709
       - name: Free disk space
@@ -42,6 +45,7 @@ jobs:
           version: ${{ matrix.graalvm }}
           java-version: ${{ matrix.java }}
           components: 'native-image'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build with Gradle
         run: |
           if ./gradlew tasks --no-daemon --all | grep -w "testNativeImage"
@@ -58,7 +62,7 @@ jobs:
            PREDICTIVE_TEST_SELECTION: "${{ github.event_name == 'pull_request' && 'true' || 'false' }}"
       - name: Publish Test Report
         if: always()
-        uses: mikepenz/action-junit-report@v3.2.0
+        uses: mikepenz/action-junit-report@v3.5.2
         with:
           check_name: GraalVM CE CI / Test Report (Java ${{ matrix.java }})
           report_paths: '**/build/test-results/test/TEST-*.xml'

--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['17']
-        graalvm: ['latest', 'dev']
+        java: [ '17', '19']
+        graalvm: [ 'latest' ]
         include:
-          - graalvm: 'latest'
-            java: '11'
+          - graalvm: 'dev'
+            java: '19'
     steps:
        # https://github.com/actions/virtual-environments/issues/709
       - name: Free disk space

--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -20,13 +20,13 @@ jobs:
     strategy:
       matrix:
         graalvm: [ 'latest', 'dev' ]
-         java: [ '17' ]
-         include:
-           - graalvm: 'dev'
-             java: '19'
-         exclude:
-           - graalvm: 'dev'
-             java: '17'      
+        java: [ '17' ]
+        include:
+          - graalvm: 'dev'
+            java: '19'
+        exclude:
+          - graalvm: 'dev'
+            java: '17'
     steps:
        # https://github.com/actions/virtual-environments/issues/709
       - name: Free disk space

--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -19,22 +19,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        graalvm: [ 'latest', 'dev' ]
+        graalvm: [ 'latest']
         java: [ '17' ]
-        include:
-          - graalvm: 'dev'
-            java: '19'
-        exclude:
-          - graalvm: 'dev'
-            java: '17'
     steps:
-       # https://github.com/actions/virtual-environments/issues/709
+      # https://github.com/actions/virtual-environments/issues/709
       - name: Free disk space
         run: |
-         sudo rm -rf "/usr/local/share/boost"
-         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-         sudo apt-get clean
-         df -h
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          sudo apt-get clean
+          df -h
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
         with:
@@ -49,7 +43,10 @@ jobs:
           java-version: ${{ matrix.java }}
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2.3.3
       - name: Build with Gradle
+        id: gradle
         run: |
           if ./gradlew tasks --no-daemon --all | grep -w "testNativeImage"
           then
@@ -58,14 +55,28 @@ jobs:
             ./gradlew check --continue --no-daemon
           fi
         env:
-           TESTCONTAINERS_RYUK_DISABLED: true
-           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-           GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
-           GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
-           PREDICTIVE_TEST_SELECTION: "${{ github.event_name == 'pull_request' && 'true' || 'false' }}"
+          TESTCONTAINERS_RYUK_DISABLED: true
+          GH_TOKEN_PUBLIC_REPOS_READONLY: ${{ secrets.GH_TOKEN_PUBLIC_REPOS_READONLY }}
+          GH_USERNAME: ${{ secrets.GH_USERNAME }}
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
+          GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
+          PREDICTIVE_TEST_SELECTION: "${{ github.event_name == 'pull_request' && 'true' || 'false' }}"
+      - name: Add build scan URL as PR comment
+        uses: actions/github-script@v5
+        if: github.event_name == 'pull_request' && failure()
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '❌ ${{ github.workflow }} ${{ matrix.java }} ${{ matrix.graalvm }} failed: ${{ steps.gradle.outputs.build-scan-url }}'
+            })
       - name: Publish Test Report
         if: always()
-        uses: mikepenz/action-junit-report@v3.5.2
+        uses: mikepenz/action-junit-report@v3.7.1
         with:
           check_name: GraalVM CE CI / Test Report (Java ${{ matrix.java }})
           report_paths: '**/build/test-results/test/TEST-*.xml'

--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -19,8 +19,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['11', '17']
-        graalvm: [ 'latest' ]
+        graalvm: [ 'latest', 'dev' ]
+         java: [ '17' ]
+         include:
+           - graalvm: 'dev'
+             java: '19'
+         exclude:
+           - graalvm: 'dev'
+             java: '17'      
     steps:
        # https://github.com/actions/virtual-environments/issues/709
       - name: Free disk space

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -60,7 +60,7 @@ jobs:
            PREDICTIVE_TEST_SELECTION: "${{ github.event_name == 'pull_request' && 'true' || 'false' }}"
       - name: Publish Test Report
         if: always()
-        uses: mikepenz/action-junit-report@v3.2.0
+        uses: mikepenz/action-junit-report@v3.5.2
         with:
           check_name: Java CI / Test Report (${{ matrix.java }})
           report_paths: '**/build/test-results/test/TEST-*.xml'

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -21,25 +21,21 @@ jobs:
       matrix:
         java: ['8', '11', '17']
     steps:
-       # https://github.com/actions/virtual-environments/issues/709
+      # https://github.com/actions/virtual-environments/issues/709
       - name: Free disk space
         run: |
-         sudo rm -rf "/usr/local/share/boost"
-         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-         sudo apt-get clean
-         df -h
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          sudo apt-get clean
+          df -h
       - uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2.3.3
       - name: Optional setup step
         env:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
@@ -48,32 +44,47 @@ jobs:
         run: |
           [ -f ./setup.sh ] && ./setup.sh || true
       - name: Build with Gradle
+        id: gradle
         run: |
-          # Awful hack for kapt and JDK 16. See https://youtrack.jetbrains.com/issue/KT-45545
-          if [ ${{ matrix.java }} == 16 ]; then export GRADLE_OPTS="-Dorg.gradle.jvmargs=--illegal-access=permit"; fi
           ./gradlew check --no-daemon --parallel --continue
         env:
-           TESTCONTAINERS_RYUK_DISABLED: true
-           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-           GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
-           GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
-           PREDICTIVE_TEST_SELECTION: "${{ github.event_name == 'pull_request' && 'true' || 'false' }}"
+          GH_TOKEN_PUBLIC_REPOS_READONLY: ${{ secrets.GH_TOKEN_PUBLIC_REPOS_READONLY }}
+          GH_USERNAME: ${{ secrets.GH_USERNAME }}
+          TESTCONTAINERS_RYUK_DISABLED: true
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
+          GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
+          PREDICTIVE_TEST_SELECTION: "${{ github.event_name == 'pull_request' && 'true' || 'false' }}"
+      - name: Add build scan URL as PR comment
+        uses: actions/github-script@v5
+        if: github.event_name == 'pull_request' && failure()
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '❌ ${{ github.workflow }} failed: ${{ steps.gradle.outputs.build-scan-url }}'
+            })
       - name: Publish Test Report
         if: always()
-        uses: mikepenz/action-junit-report@v3.5.2
+        uses: mikepenz/action-junit-report@v3.7.1
         with:
           check_name: Java CI / Test Report (${{ matrix.java }})
           report_paths: '**/build/test-results/test/TEST-*.xml'
           check_retries: 'true'
       - name: "📜 Upload binary compatibility check results"
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: binary-compatibility-reports
           path: "**/build/reports/binary-compatibility-*.html"
       - name: Publish to Sonatype Snapshots
         if: success() && github.event_name == 'push' && matrix.java == '11'
         env:
+          GH_TOKEN_PUBLIC_REPOS_READONLY: ${{ secrets.GH_TOKEN_PUBLIC_REPOS_READONLY }}
+          GH_USERNAME: ${{ secrets.GH_USERNAME }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
           java-version: '11'
+          distribution: 'temurin'
       - name: Publish to Sonatype Snapshots
         if: success()
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ on:
     types: [published]
 jobs:
   release:
+    outputs:
+      artifacts-sha256: ${{ steps.hash.outputs.artifacts-sha256 }} # Computed hashes for build artifacts.
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -19,8 +21,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
           java-version: '11'
+          distribution: 'temurin'
       - name: Set the current release version
         id: release_version
         run: echo ::set-output name=release_version::${GITHUB_REF:11}
@@ -31,6 +33,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish to Sonatype OSSRH
+        id: publish
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
@@ -42,13 +45,46 @@ jobs:
           GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
         run: |
           echo $GPG_FILE | base64 -d > secring.gpg
-          ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+          # Publish both locally and to Sonatype.
+          # The artifacts stored locally will be used to generate the SLSA provenance.
+          ./gradlew publishAllPublicationsToBuildRepository publishToSonatype closeAndReleaseSonatypeStagingRepository
+          # Read the current version from gradle.properties.
+          VERSION=$(./gradlew properties | grep 'version:' | awk '{print $2}')
+          # Read the project group from gradle.properties.
+          GROUP_PATH=$(./gradlew properties| grep "projectGroup" | awk '{print $2}' | sed 's/\./\//g')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "group=$GROUP_PATH" >> "$GITHUB_OUTPUT"
+      - name: Generate subject
+        id: hash
+        run: |
+          # Find the relevant published artifacts in the local repository.
+          ARTIFACTS=$(find  build/repo/${{ steps.publish.outputs.group }}/*/${{ steps.publish.outputs.version }}/* \
+              -regextype sed -regex '\(.*\.jar\|.*\.pom\|.*\.module\|.*\.toml\)')
+          # Compute the hashes for the artifacts.
+          # Set the hash as job output for debugging.
+          echo "artifacts-sha256=$(sha256sum $ARTIFACTS | base64 -w0)" >> "$GITHUB_OUTPUT"
+          # Store the hash in a file, which is uploaded as a workflow artifact.
+          echo $(sha256sum $ARTIFACTS | base64 -w0) > artifacts-sha256
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        with:
+          name: gradle-build-outputs
+          path: build/repo/${{ steps.publish.outputs.group }}/*/${{ steps.publish.outputs.version }}/*
+          retention-days: 5
+      - name: Upload artifacts-sha256
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        with:
+          name: artifacts-sha256
+          path: artifacts-sha256
+          retention-days: 5
       - name: Generate docs
+        run: ./gradlew docs
         env:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
           GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
-        run: ./gradlew docs
+          GH_TOKEN_PUBLIC_REPOS_READONLY: ${{ secrets.GH_TOKEN_PUBLIC_REPOS_READONLY }}
+          GH_USERNAME: ${{ secrets.GH_USERNAME }}
       - name: Export Gradle Properties
         uses: micronaut-projects/github-actions/export-gradle-properties@master
       - name: Publish to Github Pages
@@ -86,3 +122,57 @@ jobs:
           MICRONAUT_BUILD_EMAIL: ${{ secrets.MICRONAUT_BUILD_EMAIL }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  provenance-subject:
+    needs: [release]
+    runs-on: ubuntu-latest
+    outputs:
+      artifacts-sha256: ${{ steps.set-hash.outputs.artifacts-sha256 }}
+    steps:
+      - name: Download artifacts-sha256
+        uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
+        with:
+          name: artifacts-sha256
+      # The SLSA provenance generator expects the hash digest of artifacts to be passed as a job
+      # output. So we need to download the artifacts-sha256 and set it as job output. The hash of
+      # the artifacts should be set as output directly in the release job. But due to a known bug
+      # in GitHub Actions we have to use a workaround.
+      # See https://github.com/community/community/discussions/37942.
+      - name: Set artifacts-sha256 as output
+        id: set-hash
+        shell: bash
+        run: echo "artifacts-sha256=$(cat artifacts-sha256)" >> "$GITHUB_OUTPUT"
+
+  provenance:
+    needs: [release, provenance-subject]
+    permissions:
+      actions: read # To read the workflow path.
+      id-token: write # To sign the provenance.
+      contents: write # To add assets to a release.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.4.0
+    with:
+      base64-subjects: "${{ needs.provenance-subject.outputs.artifacts-sha256 }}"
+      upload-assets: true # Upload to a new release.
+      compile-generator: true # Build the generator from source.
+
+  github_release:
+    needs: [release]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+      - name: Download artifacts
+        uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1
+        with:
+          name: gradle-build-outputs
+          path: build/repo
+      - name: Upload assets
+        # Upload the artifacts and SLSA L3 provenance as assets to the existing
+        # release. Note that the provenance will attest to each artifact file and
+        # not the aggregated ZIP file.
+        run: |
+          find build/repo -regextype sed -regex '\(.*\.jar\|.*\.pom\|.*\.module\|.*\.toml\)' | xargs zip artifacts.zip
+          gh release upload ${{ github.ref_name }} artifacts.zip
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -18,13 +18,13 @@ jobs:
     if: github.repository != 'micronaut-projects/micronaut-project-template'
     runs-on: ubuntu-latest
     steps:
-       # https://github.com/actions/virtual-environments/issues/709
+      # https://github.com/actions/virtual-environments/issues/709
       - name: Free disk space
         run: |
-         sudo rm -rf "/usr/local/share/boost"
-         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-         sudo apt-get clean
-         df -h
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          sudo apt-get clean
+          df -h
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -37,8 +37,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
           java-version: 11
+          distribution: 'temurin'
       - name: Optional setup step
         env:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}


### PR DESCRIPTION
- Add build scan step
- Use `temurin` instead of `adopt` for JDK distro
- Add 17 to correto github actions
- remove `dev` from GraalVM matrix. 
- add SLA provenance logic
- Add `GH_TOKEN_PUBLIC_REPOS_READONLY` and `GH_TOKEN` environment variables