### PR TITLE
fix: properly handle primitive types in bean import

### DIFF
--- a/inject/src/main/java/io/micronaut/inject/processing/JavaModelUtils.java
+++ b/inject/src/main/java/io/micronaut/inject/processing/JavaModelUtils.java
@@ -267,11 +267,11 @@ public class JavaModelUtils {
      */
     public static Type getTypeReference(TypedElement type) {
         ClassElement classElement = type.getType();
-        if (type.isPrimitive()) {
+        if (classElement.isPrimitive()) {
             String internalName = NAME_TO_TYPE_MAP.get(classElement.getName());
-            if (type.isArray()) {
+            if (classElement.isArray()) {
                 StringBuilder name = new StringBuilder(internalName);
-                for (int i = 0; i < type.getArrayDimensions(); i++) {
+                for (int i = 0; i < classElement.getArrayDimensions(); i++) {
                     name.insert(0, "[");
                 }
                 return Type.getObjectType(name.toString());
@@ -279,19 +279,19 @@ public class JavaModelUtils {
                 return Type.getType(internalName);
             }
         } else {
-            Object nativeType = type.getNativeType();
+            Object nativeType = classElement.getNativeType();
             if (nativeType instanceof Class) {
                 Class<?> t = (Class<?>) nativeType;
                 return Type.getType(t);
             } else {
-                String internalName = type.getType().getName().replace('.', '/');
+                String internalName = classElement.getName().replace('.', '/');
                 if (internalName.isEmpty()) {
                     return Type.getType(Object.class);
                 }
-                if (type.isArray()) {
+                if (classElement.isArray()) {
                     StringBuilder name = new StringBuilder(internalName);
                     name.insert(0, "L");
-                    for (int i = 0; i < type.getArrayDimensions(); i++) {
+                    for (int i = 0; i < classElement.getArrayDimensions(); i++) {
                         name.insert(0, "[");
                     }
                     name.append(";");


### PR DESCRIPTION
Primitive types in constructors of imported beans where handled improperly, an array of primitives in synthesized as a type with the name of the primitive (e.g. byte[] becomes Lbyte; instead of `[B;`).

This is caused by a bug in JavaModelUtils.getTypeReference where the given type element is used instead of the actual class element.