### PR TITLE
Tweak uri to account for WebLogic/Windows URIs

### DIFF
--- a/core/src/main/java/io/micronaut/core/io/IOUtils.java
+++ b/core/src/main/java/io/micronaut/core/io/IOUtils.java
@@ -137,11 +137,9 @@ public class IOUtils {
                 if (!jarUri.startsWith(SCHEME_FILE + COLON)) {
                     // Special case WebLogic classloader
                     // https://github.com/micronaut-projects/micronaut-core/issues/8636
-                    if (jarUri.startsWith("/")) {
-                        jarUri = SCHEME_FILE + COLON + jarUri;
-                    } else {
-                        jarUri = SCHEME_FILE + COLON + "/" + jarUri;
-                    }
+                    jarUri = jarUri.startsWith("/") ?
+                        SCHEME_FILE + COLON + jarUri :
+                        SCHEME_FILE + COLON + "/" + jarUri;
                 }
                 // now, add the !/ at the end again so that loadNestedJarUri can handle it:
                 jarUri += "!/";

--- a/core/src/main/java/io/micronaut/core/io/IOUtils.java
+++ b/core/src/main/java/io/micronaut/core/io/IOUtils.java
@@ -140,7 +140,11 @@ public class IOUtils {
                 if (!jarUri.startsWith(SCHEME_FILE + COLON)) {
                     // Special case WebLogic classloader
                     // https://github.com/micronaut-projects/micronaut-core/issues/8636
-                    jarUri = SCHEME_FILE + COLON + jarUri;
+					if (jarUri.startsWith("/")) {
+						jarUri = SCHEME_FILE + COLON + jarUri;
+					} else {
+						jarUri = SCHEME_FILE + COLON + "/" + jarUri;
+					}
                 }
                 // now, add the !/ at the end again so that loadNestedJarUri can handle it:
                 jarUri += "!/";

--- a/core/src/main/java/io/micronaut/core/io/IOUtils.java
+++ b/core/src/main/java/io/micronaut/core/io/IOUtils.java
@@ -140,11 +140,11 @@ public class IOUtils {
                 if (!jarUri.startsWith(SCHEME_FILE + COLON)) {
                     // Special case WebLogic classloader
                     // https://github.com/micronaut-projects/micronaut-core/issues/8636
-					if (jarUri.startsWith("/")) {
-						jarUri = SCHEME_FILE + COLON + jarUri;
-					} else {
-						jarUri = SCHEME_FILE + COLON + "/" + jarUri;
-					}
+                    if (jarUri.startsWith("/")) {
+                        jarUri = SCHEME_FILE + COLON + jarUri;
+                    } else {
+                        jarUri = SCHEME_FILE + COLON + "/" + jarUri;
+                    }
                 }
                 // now, add the !/ at the end again so that loadNestedJarUri can handle it:
                 jarUri += "!/";

--- a/core/src/main/java/io/micronaut/core/io/IOUtils.java
+++ b/core/src/main/java/io/micronaut/core/io/IOUtils.java
@@ -51,7 +51,10 @@ import java.util.stream.Stream;
  */
 @SuppressWarnings("java:S1118")
 public class IOUtils {
-    private static final Logger LOG = LoggerFactory.getLogger(IOUtils.class);
+    // Do NOT introduce a static logger into this class, as it is used
+    // by our features at image build time: this will prevent the native
+    // images from building. If you need a logger, introduce it for debugging
+    // but remove it before committing your changes.
 
     private static final int BUFFER_MAX = 8192;
     private static final String SCHEME_FILE = "file";
@@ -89,15 +92,9 @@ public class IOUtils {
     @Blocking
     @SuppressWarnings({"java:S2095", "java:S1141", "java:S3776"})
     public static void eachFile(@NonNull URI uri, String path, @NonNull Consumer<Path> consumer) {
-        if (LOG.isTraceEnabled()) {
-            LOG.trace("uri: {} path: {}", uri, path);
-        }
         List<Closeable> toClose = new ArrayList<>();
         try {
             Path myPath = resolvePath(uri, path, toClose, IOUtils::loadNestedJarUri);
-            if (LOG.isTraceEnabled()) {
-                LOG.trace("resolve path: {}", myPath);
-            }
             if (myPath != null) {
                 try (Stream<Path> walk = Files.walk(myPath, 1)) {
                     for (Iterator<Path> it = walk.iterator(); it.hasNext();) {

--- a/core/src/test/groovy/io/micronaut/core/io/IOUtilsSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/io/IOUtilsSpec.groovy
@@ -132,7 +132,7 @@ class IOUtilsSpec extends Specification {
     @Unroll
     void "resolvePath"(String path, String expected, String uriStr) {
         given:
-        List<Closeable> toClose = new ArrayList<>();
+        List<Closeable> toClose = new ArrayList<>()
         URI uri = new URI(uriStr)
 
         expect:
@@ -142,6 +142,22 @@ class IOUtilsSpec extends Specification {
         path                                                             | expected                                                          | uriStr
         "META-INF/micronaut/io.micronaut.inject.BeanDefinitionReference" | "/META-INF/micronaut/io.micronaut.inject.BeanDefinitionReference" | "jar:file:/Users/sdelamo/.m2/repository/io/micronaut/micronaut-json-core/3.5.7/micronaut-json-core-3.5.7.jar!/META-INF/micronaut/io.micronaut.inject.BeanDefinitionReference"
         "META-INF/micronaut/io.micronaut.inject.BeanConfiguration"       | "/META-INF/micronaut/io.micronaut.inject.BeanConfiguration"       | "jar:file:/Users/sdelamo/.m2/repository/io/micronaut/micronaut-jackson-databind/3.5.7/micronaut-jackson-databind-3.5.7.jar!/META-INF/micronaut/io.micronaut.inject.BeanConfiguration"
-        "META-INF/micronaut/io.micronaut.inject.BeanConfiguration"       | "/META-INF/micronaut/io.micronaut.inject.BeanConfiguration"        | "zip:/u01/oracle/user_projects/domains/base_domain/servers/AdminServer/tmp/_WL_user/issue8386-0.1/y2p3pa/war/WEB-INF/lib/micronaut-jackson-databind-3.5.7.jar!/META-INF/micronaut/io.micronaut.inject.BeanConfiguration/"
+        "META-INF/micronaut/io.micronaut.inject.BeanConfiguration"       | "/META-INF/micronaut/io.micronaut.inject.BeanConfiguration"       | "zip:/u01/oracle/user_projects/domains/base_domain/servers/AdminServer/tmp/_WL_user/issue8386-0.1/y2p3pa/war/WEB-INF/lib/micronaut-jackson-databind-3.5.7.jar!/META-INF/micronaut/io.micronaut.inject.BeanConfiguration/"
+        "META-INF/micronaut/io.micronaut.inject.BeanConfiguration"       | "/META-INF/micronaut/io.micronaut.inject.BeanConfiguration"       | "zip:C:/oracle/user_projects/domains/base_domain/servers/AdminServer/tmp/_WL_user/issue8386-0.1/y2p3pa/war/WEB-INF/lib/micronaut-jackson-databind-3.5.7.jar!/META-INF/micronaut/io.micronaut.inject.BeanConfiguration/"
     }
+
+	void "resolvePath will fix jar uri on Windows/WebLogic"() {
+		given:
+			URI uri = new URI("zip:C:/oracle/path/to/micronaut-inject-3.5.7.jar!/META-INF/micronaut/io.micronaut.inject.BeanConfiguration/")
+			String theJarUri = null
+
+		when:
+			IOUtils.resolvePath(uri, "xyz", []) { List<Closeable> closeables, String jarUri ->
+				theJarUri = jarUri
+				Paths.get("/")
+			}
+
+		then:
+			theJarUri == "file:/C:/oracle/path/to/micronaut-inject-3.5.7.jar!/"
+	}
 }

--- a/core/src/test/groovy/io/micronaut/core/io/IOUtilsSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/io/IOUtilsSpec.groovy
@@ -146,18 +146,18 @@ class IOUtilsSpec extends Specification {
         "META-INF/micronaut/io.micronaut.inject.BeanConfiguration"       | "/META-INF/micronaut/io.micronaut.inject.BeanConfiguration"       | "zip:C:/oracle/user_projects/domains/base_domain/servers/AdminServer/tmp/_WL_user/issue8386-0.1/y2p3pa/war/WEB-INF/lib/micronaut-jackson-databind-3.5.7.jar!/META-INF/micronaut/io.micronaut.inject.BeanConfiguration/"
     }
 
-	void "resolvePath will fix jar uri on Windows/WebLogic"() {
-		given:
-			URI uri = new URI("zip:C:/oracle/path/to/micronaut-inject-3.5.7.jar!/META-INF/micronaut/io.micronaut.inject.BeanConfiguration/")
-			String theJarUri = null
+    void "resolvePath will fix jar uri on Windows/WebLogic"() {
+        given:
+            URI uri = new URI("zip:C:/oracle/path/to/micronaut-inject-3.5.7.jar!/META-INF/micronaut/io.micronaut.inject.BeanConfiguration/")
+            String theJarUri = null
 
-		when:
-			IOUtils.resolvePath(uri, "xyz", []) { List<Closeable> closeables, String jarUri ->
-				theJarUri = jarUri
-				Paths.get("/")
-			}
+        when:
+            IOUtils.resolvePath(uri, "xyz", []) { List<Closeable> closeables, String jarUri ->
+                theJarUri = jarUri
+                Paths.get("/")
+            }
 
-		then:
-			theJarUri == "file:/C:/oracle/path/to/micronaut-inject-3.5.7.jar!/"
-	}
+        then:
+            theJarUri == "file:/C:/oracle/path/to/micronaut-inject-3.5.7.jar!/"
+    }
 }


### PR DESCRIPTION
WebLogic on Windows was not checked earlier. It has some classloader URIs that start with "file:C:/path/to....".  The recent adjustment to URIs wasn't sufficient to cover this, but this new PR should work.