### PR TITLE
Issues 8714: HttpClientIntroductionAdvice Subscriber may not have complete called by some Publisher implementations

### DIFF
--- a/http-client-core/src/main/java/io/micronaut/http/client/interceptor/HttpClientIntroductionAdvice.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/interceptor/HttpClientIntroductionAdvice.java
@@ -344,9 +344,11 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
                         CompletableFuture<Object> future = new CompletableFuture<>();
                         csPublisher.subscribe(new CompletionAwareSubscriber<Object>() {
                             AtomicReference<Object> reference = new AtomicReference<>();
+                            Subscription subscription;
 
                             @Override
                             protected void doOnSubscribe(Subscription subscription) {
+                                this.subscription = subscription;
                                 subscription.request(1);
                             }
 
@@ -355,6 +357,9 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
                                 if (Void.class != reactiveValueType) {
                                     reference.set(message);
                                 }
+                                // we only want the first item
+                                subscription.cancel();
+                                doOnComplete();
                             }
 
                             @Override

--- a/http-client-core/src/main/java/io/micronaut/http/client/interceptor/HttpClientIntroductionAdvice.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/interceptor/HttpClientIntroductionAdvice.java
@@ -347,9 +347,11 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
                         CompletableFuture<Object> future = new CompletableFuture<>();
                         csPublisher.subscribe(new CompletionAwareSubscriber<Object>() {
                             AtomicReference<Object> reference = new AtomicReference<>();
+                            Subscription subscription;
 
                             @Override
                             protected void doOnSubscribe(Subscription subscription) {
+                                this.subscription = subscription;
                                 subscription.request(1);
                             }
 
@@ -358,6 +360,9 @@ public class HttpClientIntroductionAdvice implements MethodInterceptor<Object, O
                                 if (Void.class != reactiveValueType) {
                                     reference.set(message);
                                 }
+                                // we only want the first item
+                                subscription.cancel();
+                                doOnComplete();
                             }
 
                             @Override

--- a/test-suite-kotlin/build.gradle
+++ b/test-suite-kotlin/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     testImplementation libs.kotlinx.coroutines.rx2
     testImplementation libs.kotlinx.coroutines.slf4j
     testImplementation libs.kotlinx.coroutines.reactor
+    testImplementation libs.kotlinx.coroutines.reactive
 
     // Adding these for now since micronaut-test isnt resolving correctly ... probably need to upgrade gradle there too
     testImplementation libs.junit.jupiter.api

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/http/client/SuspendClientFilter.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/http/client/SuspendClientFilter.kt
@@ -2,28 +2,33 @@ package io.micronaut.http.client
 
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.MutableHttpRequest
+import io.micronaut.http.annotation.Filter
 import io.micronaut.http.filter.ClientFilterChain
 import io.micronaut.http.filter.HttpClientFilter
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.flatMapMerge
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.reactive.asPublisher
+import kotlinx.coroutines.withContext
 import org.reactivestreams.Publisher
 
+@Filter
 class SuspendClientFilter : HttpClientFilter {
     override fun doFilter(request: MutableHttpRequest<*>, chain: ClientFilterChain): Publisher<out HttpResponse<*>> {
         // if request contains filterCheck, then do flow step, else proceed
-        if ((request.body.get() as String).contains(SuspendClientFilter.filterCheck)) {
-            return flow { emit("testString") }.flatMapMerge {
+        return if ((request.body.orElse(null) as? Map<*, *>)?.containsValue(filterCheck) == true) {
+            flow { emit(getValue()) }.flatMapMerge {
                 chain.proceed(request.header("myTestHeader", it)).asFlow()
             }.asPublisher()
         } else {
-            return chain.proceed(request)
+            chain.proceed(request)
         }
     }
 
     companion object {
         val filterCheck = java.util.UUID.randomUUID().toString()
+        suspend fun getValue() = withContext(Dispatchers.Default) { "testString" }
     }
 }
 

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/http/client/SuspendClientFilter.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/http/client/SuspendClientFilter.kt
@@ -1,0 +1,34 @@
+package io.micronaut.http.client
+
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MutableHttpRequest
+import io.micronaut.http.annotation.Filter
+import io.micronaut.http.filter.ClientFilterChain
+import io.micronaut.http.filter.HttpClientFilter
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.flatMapMerge
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.reactive.asFlow
+import kotlinx.coroutines.reactive.asPublisher
+import kotlinx.coroutines.withContext
+import org.reactivestreams.Publisher
+import java.util.UUID
+
+class SuspendClientFilter : HttpClientFilter {
+    override fun doFilter(request: MutableHttpRequest<*>, chain: ClientFilterChain): Publisher<out HttpResponse<*>> {
+        // if request contains filterCheck, then do flow step, else proceed
+        if (request.body().contains(SuspendClientFilter.filterCheck)) {
+            return flow { emit("testString") }.flatMapMerge {
+                chain.proceed(request.header("myTestHeader", it)).asFlow()
+            }.asPublisher()
+        } else {
+            return chain.proceed(request)
+        }
+    }
+
+    companion object {
+        val filterCheck = java.util.UUID.randomUUID().toString()
+    }
+}
+
+

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/http/client/SuspendClientFilter.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/http/client/SuspendClientFilter.kt
@@ -19,7 +19,7 @@ class SuspendClientFilter : HttpClientFilter {
         // if request contains filterCheck, then do flow step, else proceed
         return if ((request.body.orElse(null) as? Map<*, *>)?.containsValue(filterCheck) == true) {
             flow { emit(getValue()) }.flatMapMerge {
-                chain.proceed(request.header("myTestHeader", it)).asFlow()
+                chain.proceed(request).asFlow()
             }.asPublisher()
         } else {
             chain.proceed(request)

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/http/client/SuspendClientFilter.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/http/client/SuspendClientFilter.kt
@@ -2,22 +2,18 @@ package io.micronaut.http.client
 
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.MutableHttpRequest
-import io.micronaut.http.annotation.Filter
 import io.micronaut.http.filter.ClientFilterChain
 import io.micronaut.http.filter.HttpClientFilter
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.flatMapMerge
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.reactive.asPublisher
-import kotlinx.coroutines.withContext
 import org.reactivestreams.Publisher
-import java.util.UUID
 
 class SuspendClientFilter : HttpClientFilter {
     override fun doFilter(request: MutableHttpRequest<*>, chain: ClientFilterChain): Publisher<out HttpResponse<*>> {
         // if request contains filterCheck, then do flow step, else proceed
-        if (request.body().contains(SuspendClientFilter.filterCheck)) {
+        if ((request.body.get() as String).contains(SuspendClientFilter.filterCheck)) {
             return flow { emit("testString") }.flatMapMerge {
                 chain.proceed(request.header("myTestHeader", it)).asFlow()
             }.asPublisher()

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/http/client/SuspendClientSpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/http/client/SuspendClientSpec.kt
@@ -2,6 +2,7 @@ package io.micronaut.http.client
 
 import io.micronaut.context.ApplicationContext
 import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.SuspendClientFilter
 import io.micronaut.runtime.server.EmbeddedServer
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions
@@ -40,6 +41,16 @@ class SuspendClientSpec {
         }
 
         Assertions.assertNull(response)
+    }
+
+    @Test
+    fun testFlowAsPublisherInFilterStep() {
+        val server = ApplicationContext.run(EmbeddedServer::class.java, mapOf("spec.name" to "SuspendClientSpec"))
+        val ctx = server.applicationContext
+        val response = runBlocking {
+            ctx.getBean(SuspendClient::class.java).call(SuspendClientFilter.filterCheck)
+        }
+        Assertions.assertEquals(response, "{\"newState\":\"${SuspendClientFilter.filterCheck}\"}")
     }
 
 }

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/http/client/SuspendClientSpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/http/client/SuspendClientSpec.kt
@@ -12,45 +12,52 @@ class SuspendClientSpec {
 
     @Test
     fun testSuspendClientBody() {
-        val server = ApplicationContext.run(EmbeddedServer::class.java, mapOf("spec.name" to "SuspendClientSpec"))
+        val server = createServer()
         val ctx = server.applicationContext
         val response = runBlocking {
             ctx.getBean(SuspendClient::class.java).call("test")
         }
-
         Assertions.assertEquals(response, "{\"newState\":\"test\"}")
+        server.close()
     }
 
     @Test
     fun testNotFound() {
-        val server = ApplicationContext.run(EmbeddedServer::class.java, mapOf("spec.name" to "SuspendClientSpec"))
+        val server = createServer()
         val ctx = server.applicationContext
         val response = runBlocking {
             ctx.getBean(SuspendClient::class.java).notFound()
         }
 
         Assertions.assertEquals(response.status, HttpStatus.NOT_FOUND)
+        server.close()
     }
 
     @Test
     fun testNotFoundWithoutHttpResponseWrapper() {
-        val server = ApplicationContext.run(EmbeddedServer::class.java, mapOf("spec.name" to "SuspendClientSpec"))
+        val server = createServer()
         val ctx = server.applicationContext
         val response = runBlocking {
             ctx.getBean(SuspendClient::class.java).notFoundWithoutHttpResponseWrapper()
         }
 
         Assertions.assertNull(response)
+        server.close()
     }
 
     @Test
     fun testFlowAsPublisherInFilterStep() {
-        val server = ApplicationContext.run(EmbeddedServer::class.java, mapOf("spec.name" to "SuspendClientSpec"))
+        val server = createServer()
         val ctx = server.applicationContext
         val response = runBlocking {
             ctx.getBean(SuspendClient::class.java).call(SuspendClientFilter.filterCheck)
         }
         Assertions.assertEquals(response, "{\"newState\":\"${SuspendClientFilter.filterCheck}\"}")
+        server.close()
+    }
+
+    fun createServer() : EmbeddedServer {
+        return ApplicationContext.run(EmbeddedServer::class.java, mapOf("spec.name" to "SuspendClientSpec"))
     }
 
 }


### PR DESCRIPTION
I manually cancel the subscription as is dictated by the reactive streams spec, a subscriber must cancel when it does not need items anymore, and then completes on its own. Added a test for the specific bug I was seeing in the kotlin test suite.

I feel like this will need some fine tuning for edge cases like onComplete being called twice, perhaps by inlining the onComplete functionality and making onComplete a NOP

Unfortunately I was not able to build locally, I kept getting
```
An exception occurred applying plugin request [id: 'io.micronaut.build.internal.dependency-updates']
> Failed to apply plugin class 'io.micronaut.build.catalogs.MicronautVersionCatalogUpdatePlugin'.
   > Cannot add task 'dependencyUpdates' as a task with that name already exists.
```

Motivation for why here instead of kotlinx.coroutines:
https://github.com/Kotlin/kotlinx.coroutines/issues/3608#issuecomment-1416156578
https://github.com/reactive-streams/reactive-streams-jvm/issues/543