### PR TITLE
ci: run japiCmp only once

### DIFF
--- a/.github/workflows/corretto.yml
+++ b/.github/workflows/corretto.yml
@@ -35,4 +35,4 @@ jobs:
         GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
         GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
         GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
-      run: unset HOSTNAME ; LANG=en_US.utf-8 LC_ALL=en_US.utf-8 ./gradlew check --no-daemon --parallel --continue
+      run: unset HOSTNAME ; LANG=en_US.utf-8 LC_ALL=en_US.utf-8 ./gradlew check --no-daemon --parallel --continue -x japiCmp

--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -50,9 +50,9 @@ jobs:
         run: |
           if ./gradlew tasks --no-daemon --all | grep -w "testNativeImage"
           then
-            ./gradlew check testNativeImage --continue --no-daemon
+            ./gradlew check testNativeImage -x japiCmp --continue --no-daemon
           else
-            ./gradlew check --continue --no-daemon
+            ./gradlew check --continue --no-daemon -x japiCmp
           fi
         env:
           TESTCONTAINERS_RYUK_DISABLED: true

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Build with Gradle
         id: gradle
         run: |
-          ./gradlew check --no-daemon --parallel --continue
+          ./gradlew check --no-daemon --parallel --continue -x japiCmp
         env:
           GH_TOKEN_PUBLIC_REPOS_READONLY: ${{ secrets.GH_TOKEN_PUBLIC_REPOS_READONLY }}
           GH_USERNAME: ${{ secrets.GH_USERNAME }}
@@ -74,8 +74,18 @@ jobs:
           check_name: Java CI / Test Report (${{ matrix.java }})
           report_paths: '**/build/test-results/test/TEST-*.xml'
           check_retries: 'true'
+      - name: Check Binary Compatibility
+        run: |
+          ./gradlew japiCmp
+        env:
+          GH_TOKEN_PUBLIC_REPOS_READONLY: ${{ secrets.GH_TOKEN_PUBLIC_REPOS_READONLY }}
+          GH_USERNAME: ${{ secrets.GH_USERNAME }}
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
+          GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
+        if: matrix.java == '17'
       - name: "📜 Upload binary compatibility check results"
-        if: always()
+        if: matrix.java == '17'
         uses: actions/upload-artifact@v3
         with:
           name: binary-compatibility-reports

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -48,7 +48,7 @@ jobs:
           [ -f ./setup.sh ] && ./setup.sh || true
       - name: Analyse with Gradle
         run: |
-          ./gradlew check sonarqube --no-daemon --parallel --continue
+          ./gradlew check sonarqube -x japiCmp --no-daemon --parallel --continue
         env:
           TESTCONTAINERS_RYUK_DISABLED: true
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}


### PR DESCRIPTION
This PR runs binary compatibility check only once for JDK 17. This change avoids multiple Github API requests, which may cause a rate-limiting failure.