### PR TITLE
Deflake the BinaryWebSocketSpec

### DIFF
--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/BinaryChatClientWebSocket.java
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/BinaryChatClientWebSocket.java
@@ -46,7 +46,7 @@ public abstract class BinaryChatClientWebSocket implements AutoCloseable{
         this.topic = topic;
         this.username = username;
         this.session = session;
-        System.out.println("Client session opened for username = " + username);
+        System.out.println("Client session " + session.getId() + " opened for username = " + username);
     }
 
     public String getTopic() {
@@ -72,7 +72,7 @@ public abstract class BinaryChatClientWebSocket implements AutoCloseable{
     @OnMessage
     public void onMessage(
             byte[] message) {
-        System.out.println("Client received message = " + new String(message));
+        System.out.println("Client " + username + " received message = " + new String(message));
         replies.add(new String(message));
     }
 

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/BinaryChatClientWebSocket.java
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/BinaryChatClientWebSocket.java
@@ -33,7 +33,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Future;
 
 @ClientWebSocket("/binary/chat/{topic}/{username}")
-public abstract class BinaryChatClientWebSocket implements AutoCloseable {
+public abstract class BinaryChatClientWebSocket implements AutoCloseable{
 
     private WebSocketSession session;
     private String topic;
@@ -70,8 +70,9 @@ public abstract class BinaryChatClientWebSocket implements AutoCloseable {
     }
 
     @OnMessage
-    public void onMessage(byte[] message) {
-        System.out.println("Client for " + username + " on topic " + topic + " received message = " + new String(message));
+    public void onMessage(
+            byte[] message) {
+        System.out.println("Client received message = " + new String(message));
         replies.add(new String(message));
     }
 

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/BinaryChatClientWebSocket.java
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/BinaryChatClientWebSocket.java
@@ -33,7 +33,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Future;
 
 @ClientWebSocket("/binary/chat/{topic}/{username}")
-public abstract class BinaryChatClientWebSocket implements AutoCloseable{
+public abstract class BinaryChatClientWebSocket implements AutoCloseable {
 
     private WebSocketSession session;
     private String topic;
@@ -70,9 +70,8 @@ public abstract class BinaryChatClientWebSocket implements AutoCloseable{
     }
 
     @OnMessage
-    public void onMessage(
-            byte[] message) {
-        System.out.println("Client received message = " + new String(message));
+    public void onMessage(byte[] message) {
+        System.out.println("Client for " + username + " on topic " + topic + " received message = " + new String(message));
         replies.add(new String(message));
     }
 

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/BinaryChatServerWebSocket.java
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/BinaryChatServerWebSocket.java
@@ -36,7 +36,7 @@ public class BinaryChatServerWebSocket {
             if(isValid(topic, session, openSession)) {
                 String msg = "[" + username + "] Joined!";
                 System.out.println("Server sending msg = " + msg);
-                openSession.sendSync(msg.getBytes());
+                openSession.sendAsync(msg.getBytes());
             }
         }
     }
@@ -55,7 +55,7 @@ public class BinaryChatServerWebSocket {
             if(isValid(topic, session, openSession)) {
                 String msg = "[" + username + "] " + new String(message);
                 System.out.println("Server sending msg = " + msg);
-                openSession.sendSync(msg.getBytes());
+                openSession.sendAsync(msg.getBytes());
             }
         }
     }
@@ -72,7 +72,7 @@ public class BinaryChatServerWebSocket {
             if(isValid(topic, session, openSession)) {
                 String msg = "[" + username + "] Disconnected!";
                 System.out.println("Server sending msg = " + msg);
-                openSession.sendSync(msg.getBytes());
+                openSession.sendAsync(msg.getBytes());
             }
         }
     }

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/BinaryWebSocketSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/BinaryWebSocketSpec.groovy
@@ -98,11 +98,19 @@ class BinaryWebSocketSpec extends Specification {
         then:
         conditions.eventually {
             !bob.session.isOpen()
+        }
+
+        when:
+        fred.send("Damn bob left".bytes)
+
+        then:
+        conditions.eventually {
             fred.replies.contains("[bob] Disconnected!")
             !bob.replies.contains("[bob] Disconnected!")
         }
 
         cleanup:
+        wsClient.close()
         embeddedServer.close()
     }
 

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/BinaryWebSocketSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/BinaryWebSocketSpec.groovy
@@ -32,17 +32,14 @@ import jakarta.inject.Singleton
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import spock.lang.Issue
-import spock.lang.Retry
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
 
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 
-@Retry
 class BinaryWebSocketSpec extends Specification {
 
-    @Retry
     void "test binary websocket exchange"() {
         given:
         EmbeddedServer embeddedServer = ApplicationContext.builder('micronaut.server.netty.log-level':'TRACE').run(EmbeddedServer)
@@ -117,7 +114,6 @@ class BinaryWebSocketSpec extends Specification {
         }
 
         cleanup:
-        wsClient.close()
         embeddedServer.close()
     }
 

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/BinaryWebSocketSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/BinaryWebSocketSpec.groovy
@@ -66,7 +66,6 @@ class BinaryWebSocketSpec extends Specification {
             fred.replies.size() == 1
         }
 
-
         when:"A message is sent"
         fred.send("Hello bob!".bytes)
 
@@ -83,7 +82,6 @@ class BinaryWebSocketSpec extends Specification {
 
         then:
         conditions.eventually {
-
             fred.replies.contains("[bob] Hi fred. How are things?")
             fred.replies.size() == 2
             bob.replies.contains("[fred] Hello bob!")
@@ -96,19 +94,10 @@ class BinaryWebSocketSpec extends Specification {
 
         when:
         bob.close()
-        sleep(1000)
-
 
         then:
         conditions.eventually {
             !bob.session.isOpen()
-        }
-
-        when:
-        fred.send("Damn bob left".bytes)
-
-        then:
-        conditions.eventually {
             fred.replies.contains("[bob] Disconnected!")
             !bob.replies.contains("[bob] Disconnected!")
         }


### PR DESCRIPTION
Step 1. Remove the Retry annotation as Flakey test detection checks this and it makes it hard to see the failure. (also, nested retry annotations smell bad)

Trying to see it fail locally with

```
while ./gradlew :http-server-netty:test --tests BinaryWebSocketSpec; do :; done
```

[Got one](https://ge.micronaut.io/s/ah74fuy6zujg2/tests/overview?outcome=failed)

[After a long time](https://ge.micronaut.io/scans?search.rootProjectNames=micronaut&search.startTimeMax=1675699159532&search.startTimeMin=1675641600000&search.tasks=:http-server-netty:test&search.timeZoneId=Europe/London&search.usernames=tim)...