### PR TITLE
Groovy annotations and generic improvements

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -78,7 +78,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
     private static final Map<String, List<AnnotationMapper<?>>> ANNOTATION_MAPPERS = new HashMap<>(10);
     private static final Map<String, List<AnnotationTransformer<?>>> ANNOTATION_TRANSFORMERS = new HashMap<>(5);
     private static final Map<String, List<AnnotationRemapper>> ANNOTATION_REMAPPERS = new HashMap<>(5);
-    private static final Map<MetadataKey<?>, CachedAnnotationMetadata> MUTATED_ANNOTATION_METADATA = new HashMap<>(100);
+    private static final Map<Object, CachedAnnotationMetadata> MUTATED_ANNOTATION_METADATA = new HashMap<>(100);
     private static final Map<String, Set<String>> NON_BINDING_CACHE = new HashMap<>(50);
     private static final Map<String, Map<CharSequence, Object>> ANNOTATION_DEFAULTS = new HashMap<>(20);
 
@@ -254,6 +254,21 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
             T element = elements[elements.length - 1];
             return buildInternal(inheritTypeAnnotations, false, element);
         });
+    }
+
+    /**
+     * Lookup or build new annotation metadata.
+     *
+     * @param key                    The cache key
+     * @param element                The type element
+     * @param includeTypeAnnotations Whether to include type level annotations in the metadata for the element
+     * @return The annotation metadata
+     */
+    public CachedAnnotationMetadata lookupOrBuild(Object key, T element, boolean includeTypeAnnotations) {
+        return MUTATED_ANNOTATION_METADATA.computeIfAbsent(
+            key,
+            metadataKey -> new DefaultCachedAnnotationMetadata(buildInternal(includeTypeAnnotations, false, element))
+        );
     }
 
     private AnnotationMetadata buildInternal(boolean inheritTypeAnnotations, boolean declaredOnly, T element) {

--- a/core-processor/src/main/java/io/micronaut/inject/ast/ClassElement.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/ClassElement.java
@@ -458,6 +458,18 @@ public interface ClassElement extends TypedElement {
     }
 
     /**
+     * Find a method with a name.
+     *
+     * @param name The method name
+     * @return The method
+     * @since 4.0.0
+     */
+    @NonNull
+    default Optional<MethodElement> findMethod(String name) {
+        return getEnclosedElement(ElementQuery.ALL_METHODS.named(name));
+    }
+
+    /**
      * Return the elements that match the given query.
      *
      * @param query The query to use.

--- a/core-processor/src/main/java/io/micronaut/inject/ast/GenericElement.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/GenericElement.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.ast;
+
+import io.micronaut.core.annotation.Experimental;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Represents a generic element that can appear as a type argument.
+ *
+ * @since 4.0.0
+ * @author Denis Stepanov
+ */
+@Experimental
+public interface GenericElement extends ClassElement {
+
+    /**
+     * The native type that represents the generic element.
+     * It is expected that the generic element representing 'T extends java.lang.Number`
+     * should be equal to the class element `java.lang.Number`.
+     * To find matching placeholders we can use this method to match the native generic type.
+     *
+     * @return The generic native type
+     */
+    @NotNull
+    default Object getGenericNativeType() {
+        return getNativeType();
+    }
+
+}

--- a/core-processor/src/main/java/io/micronaut/inject/ast/GenericPlaceholderElement.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/GenericPlaceholderElement.java
@@ -31,7 +31,7 @@ import java.util.Optional;
  * @author graemerocher
  */
 @Experimental
-public interface GenericPlaceholderElement extends ClassElement {
+public interface GenericPlaceholderElement extends GenericElement {
 
     /**
      * Returns the bounds of this the generic placeholder empty. Always returns a non-empty list.

--- a/core-processor/src/main/java/io/micronaut/inject/ast/MethodElement.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/MethodElement.java
@@ -19,10 +19,12 @@ import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationMetadataProvider;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.AnnotationValueBuilder;
+import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.core.util.ArrayUtils;
+import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.annotation.AbstractAnnotationMetadataBuilder;
 import io.micronaut.inject.ast.beans.BeanElementBuilder;
 
@@ -30,6 +32,7 @@ import java.lang.annotation.Annotation;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -54,6 +57,36 @@ public interface MethodElement extends MemberElement {
      */
     default List<? extends GenericPlaceholderElement> getDeclaredTypeVariables() {
         return Collections.emptyList();
+    }
+
+    /**
+     * The type arguments for this method element.
+     * The type arguments should include the type arguments added to the method plus the type arguments of the declaring class.
+     *
+     * @return The type arguments for this method element
+     * @since 4.0.0
+     */
+    @Experimental
+    @NonNull
+    default Map<String, ClassElement> getTypeArguments() {
+        Map<String, ClassElement> typeArguments = getDeclaringType().getTypeArguments();
+        Map<String, ClassElement> methodTypeArguments = getDeclaredTypeArguments();
+        Map<String, ClassElement> newTypeArguments = CollectionUtils.newLinkedHashMap(typeArguments.size() + methodTypeArguments.size());
+        newTypeArguments.putAll(typeArguments);
+        newTypeArguments.putAll(methodTypeArguments);
+        return newTypeArguments;
+    }
+
+    /**
+     * The declared type arguments for this method element.
+     *
+     * @return The declared type arguments for this method element
+     * @since 4.0.0
+     */
+    @Experimental
+    @NonNull
+    default Map<String, ClassElement> getDeclaredTypeArguments() {
+        return Collections.emptyMap();
     }
 
     /**

--- a/core-processor/src/main/java/io/micronaut/inject/ast/WildcardElement.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/WildcardElement.java
@@ -28,7 +28,8 @@ import java.util.List;
  * @author Jonas Konrad
  */
 @Experimental
-public interface WildcardElement extends ClassElement {
+public interface WildcardElement extends GenericElement {
+
     /**
      * @return The upper bounds of this wildcard. Never empty. To match this wildcard, a type must be assignable to all
      * upper bounds (must extend all upper bounds).

--- a/core-processor/src/main/java/io/micronaut/inject/ast/annotation/AbstractElementAnnotationMetadataFactory.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/annotation/AbstractElementAnnotationMetadataFactory.java
@@ -89,6 +89,58 @@ public abstract class AbstractElementAnnotationMetadataFactory<K, A> implements 
         throw new IllegalStateException("Unknown element: " + element.getClass() + " with native type: " + element.getNativeType());
     }
 
+    /**
+     * Lookup annotation metadata for the package.
+     * @param packageElement The element
+     * @return The annotation metadata
+     */
+    protected AbstractAnnotationMetadataBuilder.CachedAnnotationMetadata lookupForPackage(PackageElement packageElement) {
+        return metadataBuilder.lookupOrBuildForType((K) packageElement.getNativeType());
+    }
+
+    /**
+     * Lookup annotation metadata for the parameter.
+     * @param parameterElement The element
+     * @return The annotation metadata
+     */
+    protected AbstractAnnotationMetadataBuilder.CachedAnnotationMetadata lookupForParameter(ParameterElement parameterElement) {
+        return metadataBuilder.lookupOrBuildForParameter(
+                (K) parameterElement.getMethodElement().getOwningType().getNativeType(),
+                (K) parameterElement.getMethodElement().getNativeType(),
+                (K) parameterElement.getNativeType()
+        );
+    }
+
+    /**
+     * Lookup annotation metadata for the field.
+     * @param fieldElement The element
+     * @return The annotation metadata
+     */
+    protected AbstractAnnotationMetadataBuilder.CachedAnnotationMetadata lookupForField(FieldElement fieldElement) {
+        return metadataBuilder.lookupOrBuildForField(
+                (K) fieldElement.getOwningType().getNativeType(),
+                (K) fieldElement.getNativeType()
+        );
+    }
+
+    /**
+     * Lookup annotation metadata for the method.
+     * @param methodElement The element
+     * @return The annotation metadata
+     */
+    protected AbstractAnnotationMetadataBuilder.CachedAnnotationMetadata lookupForMethod(MethodElement methodElement) {
+        return metadataBuilder.lookupOrBuildForMethod((K) methodElement.getOwningType().getNativeType(), (K) methodElement.getNativeType());
+    }
+
+    /**
+     * Lookup annotation metadata for the class.
+     * @param classElement The element
+     * @return The annotation metadata
+     */
+    protected AbstractAnnotationMetadataBuilder.CachedAnnotationMetadata lookupForClass(ClassElement classElement) {
+        return metadataBuilder.lookupOrBuildForType((K) classElement.getNativeType());
+    }
+
     @NonNull
     private AbstractElementAnnotationMetadata buildForProperty(@Nullable AnnotationMetadata defaultAnnotationMetadata, @NonNull PropertyElement propertyElement) {
         return new AbstractElementAnnotationMetadata(defaultAnnotationMetadata) {
@@ -112,10 +164,7 @@ public abstract class AbstractElementAnnotationMetadataFactory<K, A> implements 
 
             @Override
             protected AbstractAnnotationMetadataBuilder.CachedAnnotationMetadata lookup() {
-                return metadataBuilder.lookupOrBuildForField(
-                    (K) enumConstantElement.getOwningType().getNativeType(),
-                    (K) enumConstantElement.getNativeType()
-                );
+                return lookupForField(enumConstantElement);
             }
 
             @Override
@@ -131,7 +180,7 @@ public abstract class AbstractElementAnnotationMetadataFactory<K, A> implements 
 
             @Override
             protected AbstractAnnotationMetadataBuilder.CachedAnnotationMetadata lookup() {
-                return metadataBuilder.lookupOrBuildForType((K) packageElement.getNativeType());
+                return lookupForPackage(packageElement);
             }
 
             @Override
@@ -147,11 +196,7 @@ public abstract class AbstractElementAnnotationMetadataFactory<K, A> implements 
 
             @Override
             protected AbstractAnnotationMetadataBuilder.CachedAnnotationMetadata lookup() {
-                return metadataBuilder.lookupOrBuildForParameter(
-                    (K) parameterElement.getMethodElement().getOwningType().getNativeType(),
-                    (K) parameterElement.getMethodElement().getNativeType(),
-                    (K) parameterElement.getNativeType()
-                );
+                return lookupForParameter(parameterElement);
             }
 
             @Override
@@ -168,10 +213,7 @@ public abstract class AbstractElementAnnotationMetadataFactory<K, A> implements 
 
             @Override
             protected AbstractAnnotationMetadataBuilder.CachedAnnotationMetadata lookup() {
-                return metadataBuilder.lookupOrBuildForField(
-                    (K) fieldElement.getOwningType().getNativeType(),
-                    (K) fieldElement.getNativeType()
-                );
+                return lookupForField(fieldElement);
             }
 
             @Override
@@ -188,7 +230,7 @@ public abstract class AbstractElementAnnotationMetadataFactory<K, A> implements 
 
             @Override
             protected AbstractAnnotationMetadataBuilder.CachedAnnotationMetadata lookup() {
-                return metadataBuilder.lookupOrBuildForMethod((K) methodElement.getOwningType().getNativeType(), (K) methodElement.getNativeType());
+                return lookupForMethod(methodElement);
             }
 
             @Override
@@ -205,10 +247,7 @@ public abstract class AbstractElementAnnotationMetadataFactory<K, A> implements 
 
             @Override
             protected AbstractAnnotationMetadataBuilder.CachedAnnotationMetadata lookup() {
-                return metadataBuilder.lookupOrBuildForMethod(
-                    (K) constructorElement.getOwningType().getNativeType(),
-                    (K) constructorElement.getNativeType()
-                );
+                return lookupForMethod(constructorElement);
             }
 
             @Override
@@ -224,7 +263,7 @@ public abstract class AbstractElementAnnotationMetadataFactory<K, A> implements 
 
             @Override
             protected AbstractAnnotationMetadataBuilder.CachedAnnotationMetadata lookup() {
-                return metadataBuilder.lookupOrBuildForType((K) classElement.getNativeType());
+                return lookupForClass(classElement);
             }
 
             @Override
@@ -233,6 +272,7 @@ public abstract class AbstractElementAnnotationMetadataFactory<K, A> implements 
             }
         };
     }
+
 
     /**
      * Abstract implementation of {@link ElementAnnotationMetadata}.

--- a/core-processor/src/main/java/io/micronaut/inject/writer/AbstractClassFileWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/AbstractClassFileWriter.java
@@ -394,11 +394,13 @@ public abstract class AbstractClassFileWriter implements Opcodes, OriginatingEle
         boolean hasAnnotationMetadata = !annotationMetadata.isEmpty();
 
         boolean isRecursiveType = false;
-        if (classElement instanceof GenericPlaceholderElement) {
-            if (visitedTypes.contains(classElement)) {
+        if (classElement instanceof GenericPlaceholderElement placeholderElement) {
+            // Prevent placeholder recursion
+            Object genericNativeType = placeholderElement.getGenericNativeType();
+            if (visitedTypes.contains(genericNativeType)) {
                 isRecursiveType = true;
             } else {
-                visitedTypes.add(classElement);
+                visitedTypes.add(genericNativeType);
             }
         }
 

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/InjectTransform.groovy
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/InjectTransform.groovy
@@ -20,13 +20,14 @@ import groovy.transform.CompileStatic
 import io.micronaut.ast.groovy.utils.AstMessageUtils
 import io.micronaut.ast.groovy.utils.InMemoryByteCodeGroovyClassLoader
 import io.micronaut.ast.groovy.utils.InMemoryClassWriterOutputVisitor
+import io.micronaut.ast.groovy.visitor.GroovyNativeElement
 import io.micronaut.ast.groovy.visitor.GroovyPackageElement
 import io.micronaut.ast.groovy.visitor.GroovyVisitorContext
 import io.micronaut.context.annotation.Configuration
 import io.micronaut.context.annotation.Context
-import io.micronaut.inject.processing.ProcessingException
 import io.micronaut.inject.processing.BeanDefinitionCreator
 import io.micronaut.inject.processing.BeanDefinitionCreatorFactory
+import io.micronaut.inject.processing.ProcessingException
 import io.micronaut.inject.visitor.VisitorConfiguration
 import io.micronaut.inject.writer.BeanConfigurationWriter
 import io.micronaut.inject.writer.BeanDefinitionReferenceWriter
@@ -126,7 +127,7 @@ class InjectTransform implements ASTTransformation, CompilationUnitAware {
                     }
                 })
             } catch (ProcessingException ex) {
-                groovyVisitorContext.fail(ex.getMessage(), ex.getOriginatingElement() as ASTNode)
+                groovyVisitorContext.fail(ex.getMessage(), (ex.getOriginatingElement() as GroovyNativeElement).annotatedNode())
             }
         }
 

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/annotation/GroovyAnnotationMetadataBuilder.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/annotation/GroovyAnnotationMetadataBuilder.java
@@ -23,6 +23,7 @@ import io.micronaut.ast.groovy.utils.AstMessageUtils;
 import io.micronaut.ast.groovy.utils.ExtendedParameter;
 import io.micronaut.ast.groovy.visitor.GroovyVisitorContext;
 import io.micronaut.core.annotation.AnnotationClassValue;
+import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.convert.ConversionService;
@@ -270,9 +271,16 @@ public class GroovyAnnotationMetadataBuilder extends AbstractAnnotationMetadataB
     @Override
     protected List<? extends AnnotationNode> getAnnotationsForType(AnnotatedNode element) {
         List<AnnotationNode> annotations = element.getAnnotations();
-        List<AnnotationNode> expanded = new ArrayList<>(annotations.size());
+        List<AnnotationNode> typeAnnotations = element instanceof ClassNode classNode ? classNode.getTypeAnnotations() : Collections.emptyList();
+        List<AnnotationNode> expanded = new ArrayList<>(annotations.size() + typeAnnotations.size());
+        expandAnnotations(annotations, expanded);
+        expandAnnotations(typeAnnotations, expanded);
+        return expanded;
+    }
+
+    private void expandAnnotations(List<AnnotationNode> annotations, List<AnnotationNode> expanded) {
         for (AnnotationNode node : annotations) {
-            Expression value = node.getMember("value");
+            Expression value = node.getMember(AnnotationMetadata.VALUE_MEMBER);
             boolean repeatable = false;
             if (value instanceof ListExpression listExpression) {
                 for (Expression expression : listExpression.getExpressions()) {
@@ -289,7 +297,6 @@ public class GroovyAnnotationMetadataBuilder extends AbstractAnnotationMetadataB
                 expanded.add(node);
             }
         }
-        return expanded;
     }
 
     @Override

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/annotation/GroovyElementAnnotationMetadataFactory.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/annotation/GroovyElementAnnotationMetadataFactory.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.ast.groovy.annotation;
 
+import io.micronaut.ast.groovy.utils.ExtendedParameter;
 import io.micronaut.ast.groovy.visitor.GroovyNativeElement;
 import io.micronaut.inject.annotation.AbstractAnnotationMetadataBuilder;
 import io.micronaut.inject.ast.ClassElement;
@@ -52,8 +53,8 @@ public final class GroovyElementAnnotationMetadataFactory extends AbstractElemen
 
     @Override
     protected AbstractAnnotationMetadataBuilder.CachedAnnotationMetadata lookupForParameter(ParameterElement parameterElement) {
-        GroovyNativeElement groovyNativeElement = (GroovyNativeElement) parameterElement.getNativeType();
-        return metadataBuilder.lookupOrBuild(groovyNativeElement, groovyNativeElement.annotatedNode(), false);
+        GroovyNativeElement.Parameter parameter = (GroovyNativeElement.Parameter) parameterElement.getNativeType();
+        return metadataBuilder.lookupOrBuild(parameter, new ExtendedParameter(parameter.methodNode(), parameter.annotatedNode()), false);
     }
 
     @Override

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/annotation/GroovyElementAnnotationMetadataFactory.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/annotation/GroovyElementAnnotationMetadataFactory.java
@@ -15,6 +15,13 @@
  */
 package io.micronaut.ast.groovy.annotation;
 
+import io.micronaut.ast.groovy.visitor.GroovyNativeElement;
+import io.micronaut.inject.annotation.AbstractAnnotationMetadataBuilder;
+import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.ast.FieldElement;
+import io.micronaut.inject.ast.MethodElement;
+import io.micronaut.inject.ast.PackageElement;
+import io.micronaut.inject.ast.ParameterElement;
 import io.micronaut.inject.ast.annotation.AbstractElementAnnotationMetadataFactory;
 import io.micronaut.inject.ast.annotation.ElementAnnotationMetadataFactory;
 import org.codehaus.groovy.ast.AnnotatedNode;
@@ -35,6 +42,36 @@ public final class GroovyElementAnnotationMetadataFactory extends AbstractElemen
     @Override
     public ElementAnnotationMetadataFactory readOnly() {
         return new GroovyElementAnnotationMetadataFactory(true, (GroovyAnnotationMetadataBuilder) metadataBuilder);
+    }
+
+    @Override
+    protected AbstractAnnotationMetadataBuilder.CachedAnnotationMetadata lookupForPackage(PackageElement packageElement) {
+        GroovyNativeElement groovyNativeElement = (GroovyNativeElement) packageElement.getNativeType();
+        return metadataBuilder.lookupOrBuild(groovyNativeElement, groovyNativeElement.annotatedNode(), true);
+    }
+
+    @Override
+    protected AbstractAnnotationMetadataBuilder.CachedAnnotationMetadata lookupForParameter(ParameterElement parameterElement) {
+        GroovyNativeElement groovyNativeElement = (GroovyNativeElement) parameterElement.getNativeType();
+        return metadataBuilder.lookupOrBuild(groovyNativeElement, groovyNativeElement.annotatedNode(), false);
+    }
+
+    @Override
+    protected AbstractAnnotationMetadataBuilder.CachedAnnotationMetadata lookupForField(FieldElement fieldElement) {
+        GroovyNativeElement groovyNativeElement = (GroovyNativeElement) fieldElement.getNativeType();
+        return metadataBuilder.lookupOrBuild(groovyNativeElement, groovyNativeElement.annotatedNode(), false);
+    }
+
+    @Override
+    protected AbstractAnnotationMetadataBuilder.CachedAnnotationMetadata lookupForMethod(MethodElement methodElement) {
+        GroovyNativeElement groovyNativeElement = (GroovyNativeElement) methodElement.getNativeType();
+        return metadataBuilder.lookupOrBuild(groovyNativeElement, groovyNativeElement.annotatedNode(), false);
+    }
+
+    @Override
+    protected AbstractAnnotationMetadataBuilder.CachedAnnotationMetadata lookupForClass(ClassElement classElement) {
+        GroovyNativeElement groovyNativeElement = (GroovyNativeElement) classElement.getNativeType();
+        return metadataBuilder.lookupOrBuild(groovyNativeElement, groovyNativeElement.annotatedNode(), true);
     }
 
 }

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyAnnotationElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyAnnotationElement.java
@@ -17,7 +17,6 @@ package io.micronaut.ast.groovy.visitor;
 
 import io.micronaut.inject.ast.AnnotationElement;
 import io.micronaut.inject.ast.annotation.ElementAnnotationMetadataFactory;
-import org.codehaus.groovy.ast.ClassNode;
 
 /**
  * Groovy implementation of {@link io.micronaut.inject.ast.AnnotationElement}.
@@ -28,8 +27,8 @@ import org.codehaus.groovy.ast.ClassNode;
 final class GroovyAnnotationElement extends GroovyClassElement implements AnnotationElement {
 
     public GroovyAnnotationElement(GroovyVisitorContext visitorContext,
-                                   ClassNode classNode,
+                                   GroovyNativeElement nativeElement,
                                    ElementAnnotationMetadataFactory annotationMetadataFactory) {
-        super(visitorContext, classNode, annotationMetadataFactory);
+        super(visitorContext, nativeElement, annotationMetadataFactory);
     }
 }

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyConstructorElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyConstructorElement.java
@@ -30,19 +30,21 @@ public class GroovyConstructorElement extends GroovyMethodElement implements Con
     /**
      * @param owningType                The owning class
      * @param visitorContext            The visitor context
+     * @param nativeElement      The native element
      * @param methodNode                The {@link ConstructorNode}
      * @param annotationMetadataFactory The annotation metadata
      */
     GroovyConstructorElement(GroovyClassElement owningType,
                              GroovyVisitorContext visitorContext,
+                             GroovyNativeElement nativeElement,
                              ConstructorNode methodNode,
                              ElementAnnotationMetadataFactory annotationMetadataFactory) {
-        super(owningType, visitorContext, methodNode, annotationMetadataFactory);
+        super(owningType, visitorContext, nativeElement, methodNode, annotationMetadataFactory);
     }
 
     @Override
     protected AbstractGroovyElement copyConstructor() {
-        return new GroovyConstructorElement(getOwningType(), visitorContext, (ConstructorNode) getNativeType(), elementAnnotationMetadataFactory);
+        return new GroovyConstructorElement(getOwningType(), visitorContext, getNativeType(), (ConstructorNode) getNativeType().annotatedNode(), elementAnnotationMetadataFactory);
     }
 
     @Override

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyEnumConstantElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyEnumConstantElement.java
@@ -19,11 +19,10 @@ import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.inject.ast.ClassElement;
-import io.micronaut.inject.ast.annotation.ElementAnnotationMetadataFactory;
 import io.micronaut.inject.ast.ElementModifier;
 import io.micronaut.inject.ast.EnumConstantElement;
 import io.micronaut.inject.ast.FieldElement;
-import org.codehaus.groovy.ast.AnnotatedNode;
+import io.micronaut.inject.ast.annotation.ElementAnnotationMetadataFactory;
 import org.codehaus.groovy.ast.FieldNode;
 
 import java.util.Set;
@@ -43,21 +42,20 @@ public final class GroovyEnumConstantElement extends AbstractGroovyElement imple
      * @param declaringEnum             The declaring enum
      * @param visitorContext            The visitor context
      * @param variable                  The {@link org.codehaus.groovy.ast.Variable}
-     * @param annotatedNode             The annotated node
      * @param annotationMetadataFactory The annotation medatada
      */
     GroovyEnumConstantElement(GroovyClassElement declaringEnum,
                               GroovyVisitorContext visitorContext,
-                              FieldNode variable, AnnotatedNode annotatedNode,
+                              FieldNode variable,
                               ElementAnnotationMetadataFactory annotationMetadataFactory) {
-        super(visitorContext, annotatedNode, annotationMetadataFactory);
+        super(visitorContext, new GroovyNativeElement.Field(variable, declaringEnum.getNativeType()), annotationMetadataFactory);
         this.declaringEnum = declaringEnum;
         this.variable = variable;
     }
 
     @Override
     protected AbstractGroovyElement copyConstructor() {
-        return new GroovyEnumConstantElement(declaringEnum, visitorContext, variable, getNativeType(), elementAnnotationMetadataFactory);
+        return new GroovyEnumConstantElement(declaringEnum, visitorContext, variable, elementAnnotationMetadataFactory);
     }
 
     @Override
@@ -129,11 +127,6 @@ public final class GroovyEnumConstantElement extends AbstractGroovyElement imple
     @Override
     public String getName() {
         return variable.getName();
-    }
-
-    @Override
-    public FieldNode getNativeType() {
-        return variable;
     }
 
     @Override

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyEnumElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyEnumElement.java
@@ -16,10 +16,9 @@
 package io.micronaut.ast.groovy.visitor;
 
 import io.micronaut.inject.ast.ClassElement;
-import io.micronaut.inject.ast.annotation.ElementAnnotationMetadataFactory;
 import io.micronaut.inject.ast.EnumConstantElement;
 import io.micronaut.inject.ast.EnumElement;
-import org.codehaus.groovy.ast.ClassNode;
+import io.micronaut.inject.ast.annotation.ElementAnnotationMetadataFactory;
 import org.codehaus.groovy.ast.FieldNode;
 
 import java.util.ArrayList;
@@ -38,27 +37,27 @@ class GroovyEnumElement extends GroovyClassElement implements EnumElement {
     protected List<String> values;
 
     /**
-     * @param visitorContext     The visitor context
-     * @param classNode          The {@link ClassNode}
+     * @param visitorContext            The visitor context
+     * @param nativeElement             The native element
      * @param annotationMetadataFactory The annotation metadata factory
      */
     GroovyEnumElement(GroovyVisitorContext visitorContext,
-                      ClassNode classNode,
+                      GroovyNativeElement nativeElement,
                       ElementAnnotationMetadataFactory annotationMetadataFactory) {
-        this(visitorContext, classNode, annotationMetadataFactory, 0);
+        this(visitorContext, nativeElement, annotationMetadataFactory, 0);
     }
 
     /**
-     * @param visitorContext     The visitor context
-     * @param classNode          The {@link ClassNode}
+     * @param visitorContext            The visitor context
+     * @param nativeElement             The native element
      * @param annotationMetadataFactory The annotation metadata
-     * @param arrayDimensions    The number of array dimensions factory
+     * @param arrayDimensions           The number of array dimensions factory
      */
     GroovyEnumElement(GroovyVisitorContext visitorContext,
-                      ClassNode classNode,
+                      GroovyNativeElement nativeElement,
                       ElementAnnotationMetadataFactory annotationMetadataFactory,
                       int arrayDimensions) {
-        super(visitorContext, classNode, annotationMetadataFactory, null, arrayDimensions);
+        super(visitorContext, nativeElement, annotationMetadataFactory, null, arrayDimensions);
     }
 
     @Override
@@ -82,14 +81,13 @@ class GroovyEnumElement extends GroovyClassElement implements EnumElement {
     private void initEnum() {
         values = new ArrayList<>();
         enumConstants = new ArrayList<>();
-        ClassNode nativeType = getNativeType();
-        for (FieldNode field : nativeType.getFields()) {
+        for (FieldNode field : classNode.getFields()) {
             if (field.getName().equals("MAX_VALUE") || field.getName().equals("MIN_VALUE")) {
                 continue;
             }
             if (field.isEnum()) {
                 values.add(field.getName());
-                enumConstants.add(new GroovyEnumConstantElement(this, visitorContext, field, field, elementAnnotationMetadataFactory));
+                enumConstants.add(new GroovyEnumConstantElement(this, visitorContext, field, elementAnnotationMetadataFactory));
             }
         }
 
@@ -99,7 +97,7 @@ class GroovyEnumElement extends GroovyClassElement implements EnumElement {
 
     @Override
     public ClassElement withArrayDimensions(int arrayDimensions) {
-        return new GroovyEnumElement(visitorContext, classNode, elementAnnotationMetadataFactory, arrayDimensions);
+        return new GroovyEnumElement(visitorContext, getNativeType(), elementAnnotationMetadataFactory, arrayDimensions);
     }
 
 }

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyFieldElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyFieldElement.java
@@ -50,7 +50,7 @@ public class GroovyFieldElement extends AbstractGroovyElement implements FieldEl
                        GroovyClassElement owningType,
                        FieldNode fieldNode,
                        ElementAnnotationMetadataFactory annotationMetadataFactory) {
-        super(visitorContext, fieldNode, annotationMetadataFactory);
+        super(visitorContext, new GroovyNativeElement.Field(fieldNode, owningType.getNativeType()), annotationMetadataFactory);
         this.owningType = owningType;
         this.fieldNode = fieldNode;
     }
@@ -63,11 +63,6 @@ public class GroovyFieldElement extends AbstractGroovyElement implements FieldEl
     @Override
     public FieldElement withAnnotationMetadata(AnnotationMetadata annotationMetadata) {
         return (FieldElement) super.withAnnotationMetadata(annotationMetadata);
-    }
-
-    @Override
-    public FieldNode getNativeType() {
-        return fieldNode;
     }
 
     @Override
@@ -162,7 +157,7 @@ public class GroovyFieldElement extends AbstractGroovyElement implements FieldEl
         if (declaringClass == null) {
             throw new IllegalStateException("Declaring class could not be established");
         }
-        if (owningType.getNativeType().equals(declaringClass)) {
+        if (owningType.getNativeType().annotatedNode().equals(declaringClass)) {
             return owningType;
         }
         Map<String, ClassElement> typeArguments = getOwningType().getTypeArguments(declaringClass.getName());

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyNativeElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyNativeElement.java
@@ -27,7 +27,7 @@ import org.codehaus.groovy.ast.PackageNode;
  * @author Denis Stepanov
  * @since 4.0.0
  */
-public interface GroovyNativeElement {
+public sealed interface GroovyNativeElement {
 
     /**
      * @return The annotated node representing the type.

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyNativeElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyNativeElement.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.ast.groovy.visitor;
+
+import org.codehaus.groovy.ast.AnnotatedNode;
+import org.codehaus.groovy.ast.ClassNode;
+import org.codehaus.groovy.ast.FieldNode;
+import org.codehaus.groovy.ast.MethodNode;
+import org.codehaus.groovy.ast.PackageNode;
+
+/**
+ * Groovy's native element.
+ *
+ * @author Denis Stepanov
+ * @since 4.0.0
+ */
+public interface GroovyNativeElement {
+
+    /**
+     * @return The annotated node representing the type.
+     */
+    AnnotatedNode annotatedNode();
+
+    /**
+     * The class element.
+     *
+     * @param annotatedNode The class node
+     */
+    record Class(ClassNode annotatedNode) implements GroovyNativeElement {
+    }
+
+    /**
+     * The class element with an owner (Generic type etc).
+     *
+     * @param annotatedNode The class node
+     * @param owner         The owner
+     */
+    record ClassWithOwner(ClassNode annotatedNode,
+                          GroovyNativeElement owner) implements GroovyNativeElement {
+    }
+
+    /**
+     * The method element.
+     *
+     * @param annotatedNode The method node
+     */
+    record Method(MethodNode annotatedNode) implements GroovyNativeElement {
+    }
+
+    /**
+     * The parameter element.
+     *
+     * @param annotatedNode The parameter element.
+     * @param methodNode    The method element.
+     */
+    record Parameter(org.codehaus.groovy.ast.Parameter annotatedNode,
+                     MethodNode methodNode) implements GroovyNativeElement {
+    }
+
+    /**
+     * The package element.
+     *
+     * @param annotatedNode The package node
+     */
+    record Package(PackageNode annotatedNode) implements GroovyNativeElement {
+    }
+
+    /**
+     * The field element.
+     *
+     * @param annotatedNode The field node
+     * @param owner         The owner node
+     */
+    record Field(FieldNode annotatedNode,
+                 GroovyNativeElement owner) implements GroovyNativeElement {
+    }
+
+    /**
+     * The placeholder element.
+     *
+     * @param annotatedNode The placeholder node
+     * @param owner         The owner node
+     * @param variableName  The variable name
+     */
+    record Placeholder(ClassNode annotatedNode,
+                       GroovyNativeElement owner,
+                       String variableName) implements GroovyNativeElement {
+    }
+
+}

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyPackageElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyPackageElement.java
@@ -41,7 +41,7 @@ public class GroovyPackageElement extends AbstractGroovyElement implements Packa
     public GroovyPackageElement(GroovyVisitorContext visitorContext,
                                 PackageNode packageNode,
                                 ElementAnnotationMetadataFactory annotationMetadataFactory) {
-        super(visitorContext, packageNode, annotationMetadataFactory);
+        super(visitorContext, new GroovyNativeElement.Package(packageNode), annotationMetadataFactory);
         this.packageNode = packageNode;
     }
 
@@ -78,12 +78,6 @@ public class GroovyPackageElement extends AbstractGroovyElement implements Packa
     @Override
     public boolean isPublic() {
         return true;
-    }
-
-    @NonNull
-    @Override
-    public PackageNode getNativeType() {
-        return packageNode;
     }
 
 }

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyParameterElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyParameterElement.java
@@ -20,11 +20,9 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.inject.ast.ClassElement;
-import io.micronaut.inject.ast.annotation.ElementAnnotationMetadataFactory;
 import io.micronaut.inject.ast.ParameterElement;
+import io.micronaut.inject.ast.annotation.ElementAnnotationMetadataFactory;
 import org.codehaus.groovy.ast.Parameter;
-
-import java.util.Map;
 
 /**
  * Implementation of {@link ParameterElement} for Groovy.
@@ -45,21 +43,23 @@ public class GroovyParameterElement extends AbstractGroovyElement implements Par
      *
      * @param methodElement             The parent method element
      * @param visitorContext            The visitor context
+     * @param nativeElement             The nativeElement
      * @param parameter                 The parameter
      * @param elementAnnotationMetadata The annotation metadata
      */
     GroovyParameterElement(GroovyMethodElement methodElement,
                            GroovyVisitorContext visitorContext,
+                           GroovyNativeElement nativeElement,
                            Parameter parameter,
                            ElementAnnotationMetadataFactory elementAnnotationMetadata) {
-        super(visitorContext, parameter, elementAnnotationMetadata);
+        super(visitorContext, nativeElement, elementAnnotationMetadata);
         this.parameter = parameter;
         this.methodElement = methodElement;
     }
 
     @Override
     protected AbstractGroovyElement copyConstructor() {
-        return new GroovyParameterElement(methodElement, visitorContext, parameter, elementAnnotationMetadataFactory);
+        return new GroovyParameterElement(methodElement, visitorContext, getNativeType(), parameter, elementAnnotationMetadataFactory);
     }
 
     @Override
@@ -86,9 +86,7 @@ public class GroovyParameterElement extends AbstractGroovyElement implements Par
     @Override
     public ClassElement getGenericType() {
         if (genericType == null) {
-            Map<String, ClassElement> parentTypeArguments = getMethodElement().getDeclaringType().getTypeArguments();
-            Map<String, ClassElement> methodTypeArguments = resolveTypeArguments(methodElement.getNativeType(), parentTypeArguments);
-            genericType = newClassElement(parameter.getType(), methodTypeArguments);
+            genericType = newClassElement(parameter.getType(), methodElement.getTypeArguments());
         }
         return genericType;
     }
@@ -106,11 +104,6 @@ public class GroovyParameterElement extends AbstractGroovyElement implements Par
     @Override
     public boolean isPublic() {
         return true;
-    }
-
-    @Override
-    public Parameter getNativeType() {
-        return parameter;
     }
 
     @Override

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyPropertyElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyPropertyElement.java
@@ -24,13 +24,12 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.Element;
-import io.micronaut.inject.ast.annotation.ElementAnnotationMetadataFactory;
 import io.micronaut.inject.ast.FieldElement;
 import io.micronaut.inject.ast.MemberElement;
 import io.micronaut.inject.ast.MethodElement;
-import io.micronaut.inject.ast.annotation.MutableAnnotationMetadataDelegate;
 import io.micronaut.inject.ast.PropertyElement;
-import org.codehaus.groovy.ast.AnnotatedNode;
+import io.micronaut.inject.ast.annotation.ElementAnnotationMetadataFactory;
+import io.micronaut.inject.ast.annotation.MutableAnnotationMetadataDelegate;
 
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
@@ -192,17 +191,17 @@ final class GroovyPropertyElement extends AbstractGroovyElement implements Prope
         return (MemberElement) super.withAnnotationMetadata(annotationMetadata);
     }
 
-    private static AnnotatedNode selectNativeType(MethodElement getter,
+    private static GroovyNativeElement selectNativeType(MethodElement getter,
                                                   MethodElement setter,
                                                   FieldElement field) {
         if (getter instanceof AbstractGroovyElement) {
-            return (AnnotatedNode) getter.getNativeType();
+            return (GroovyNativeElement) getter.getNativeType();
         }
         if (setter instanceof AbstractGroovyElement) {
-            return (AnnotatedNode) setter.getNativeType();
+            return (GroovyNativeElement) setter.getNativeType();
         }
         if (field instanceof AbstractGroovyElement) {
-            return (AnnotatedNode) field.getNativeType();
+            return (GroovyNativeElement) field.getNativeType();
         }
         throw new IllegalStateException();
     }

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyVisitorContext.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyVisitorContext.java
@@ -194,8 +194,8 @@ public class GroovyVisitorContext implements VisitorContext {
 
     @Override
     public void fail(String message, @Nullable Element element) {
-        if (element instanceof AbstractGroovyElement) {
-            AstMessageUtils.error(sourceUnit, ((AbstractGroovyElement) element).getNativeType(), message);
+        if (element instanceof AbstractGroovyElement abstractGroovyElement) {
+            AstMessageUtils.error(sourceUnit, abstractGroovyElement.getNativeType().annotatedNode(), message);
         } else {
             AstMessageUtils.error(sourceUnit, null, message);
         }
@@ -207,8 +207,8 @@ public class GroovyVisitorContext implements VisitorContext {
 
     @Override
     public void warn(String message, @Nullable Element element) {
-        if (element instanceof AbstractGroovyElement) {
-            AstMessageUtils.warning(sourceUnit, ((AbstractGroovyElement) element).getNativeType(), message);
+        if (element instanceof AbstractGroovyElement abstractGroovyElement) {
+            AstMessageUtils.warning(sourceUnit, abstractGroovyElement.getNativeType().annotatedNode(), message);
         } else {
             AstMessageUtils.warning(sourceUnit, null, message);
         }

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyWildcardElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyWildcardElement.java
@@ -45,7 +45,7 @@ final class GroovyWildcardElement extends GroovyClassElement implements Wildcard
                           ElementAnnotationMetadataFactory annotationMetadataFactory) {
         super(
                 upperType.visitorContext,
-                upperType.classNode,
+                upperType.getNativeType(),
             annotationMetadataFactory,
                 upperType.getTypeArguments(),
             0

--- a/inject-groovy/src/test/groovy/io/micronaut/ast/groovy/visitor/GroovyClassElementSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/ast/groovy/visitor/GroovyClassElementSpec.groovy
@@ -26,7 +26,7 @@ class GroovyClassElementSpec extends AbstractClassElementSpec {
     @Override
     protected List<ClassElement> getClassElements() {
         def visitorContext = new GroovyVisitorContext(Mock(SourceUnit), null)
-        return [new GroovyClassElement(visitorContext, ClassHelper.OBJECT_TYPE, null),
-                new GroovyEnumElement(visitorContext, ClassHelper.Enum_Type, null)]
+        return [new GroovyClassElement(visitorContext, new GroovyNativeElement.Class(ClassHelper.OBJECT_TYPE), null),
+                new GroovyEnumElement(visitorContext, new GroovyNativeElement.Class(ClassHelper.Enum_Type), null)]
     }
 }

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/BeanIntrospectionSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/BeanIntrospectionSpec.groovy
@@ -2277,5 +2277,44 @@ class Test extends RecursiveGenerics<Test> {
             introspection != null
     }
 
+    void "test type_use annotations"() {
+        given:
+            def introspection = buildBeanIntrospection('test.Test', '''
+package test;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.context.annotation.*;
+import io.micronaut.inject.visitor.*;
+@Introspected
+class Test {
+    @io.micronaut.inject.visitor.TypeUseRuntimeAnn
+    private String name;
+    @io.micronaut.inject.visitor.TypeUseClassAnn
+    private String secondName;
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+    public String getSecondName() {
+        return name;
+    }
+    public void setSecondName(String secondName) {
+        this.secondName = secondName;
+    }
+}
+''')
+            def nameField = introspection.getProperty("name").orElse(null)
+            def secondNameField = introspection.getProperty("secondName").orElse(null)
+
+        expect:
+            nameField
+            secondNameField
+
+            nameField.hasStereotype(TypeUseRuntimeAnn)
+            nameField.hasStereotype("io.micronaut.inject.visitor.TypeUseRuntimeAnn")
+            !secondNameField.hasStereotype(TypeUseClassAnn)
+            !secondNameField.hasStereotype("io.micronaut.inject.visitor.TypeUseClassAnn")
+    }
 
 }

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/ClassElementSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/ClassElementSpec.groovy
@@ -1888,7 +1888,29 @@ class Test<T extends Number> {
 
             ce.findMethod("method10").get().getGenericReturnType().getTypeArguments("test.Test").get("T") == numberType
             ce.findMethod("method10").get().getReturnType().getTypeArguments("test.Test").get("T") == numberType
+    }
 
+    void "test inherit parameter annotation"() {
+        ClassElement ce = buildClassElement('''
+package test;
+import java.util.List;
+
+interface MyApi {
+
+    String get(@io.micronaut.inject.visitor.MyParameter('X-username') String username)
+}
+
+class UserController implements MyApi {
+
+    @Override
+    String get(String username) {
+    }
+
+}
+
+''')
+        expect:
+            ce.findMethod("get").get().getParameters()[0].hasAnnotation(MyParameter)
     }
 
     private void assertListGenericArgument(ClassElement type, Closure cl) {

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/MyParameter.java
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/MyParameter.java
@@ -1,0 +1,20 @@
+package io.micronaut.inject.visitor;
+
+import jakarta.inject.Qualifier;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Qualifier
+@Inherited
+public @interface MyParameter {
+
+    String value() default "";
+}

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/TypeUseClassAnn.java
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/TypeUseClassAnn.java
@@ -1,0 +1,11 @@
+package io.micronaut.inject.visitor;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE_USE)
+@Retention(RetentionPolicy.CLASS)
+@interface TypeUseClassAnn {
+}

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/TypeUseRuntimeAnn.java
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/TypeUseRuntimeAnn.java
@@ -1,0 +1,11 @@
+package io.micronaut.inject.visitor;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE_USE)
+@Retention(RetentionPolicy.RUNTIME)
+@interface TypeUseRuntimeAnn {
+}

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaGenericPlaceholderElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaGenericPlaceholderElement.java
@@ -63,6 +63,11 @@ final class JavaGenericPlaceholderElement extends JavaClassElement implements Ge
     }
 
     @Override
+    public Object getGenericNativeType() {
+        return realTypeVariable;
+    }
+
+    @Override
     public boolean isTypeVariable() {
         return true;
     }
@@ -70,26 +75,6 @@ final class JavaGenericPlaceholderElement extends JavaClassElement implements Ge
     @Override
     public boolean isRawType() {
         return isRawType;
-    }
-
-    @Override
-    public int hashCode() {
-        return realTypeVariable.hashCode();
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null) {
-            return false;
-        }
-        io.micronaut.inject.ast.Element that = (io.micronaut.inject.ast.Element) o;
-        if (that instanceof JavaGenericPlaceholderElement placeholderElement) {
-            return placeholderElement.realTypeVariable.equals(realTypeVariable);
-        }
-        return false;
     }
 
     @Override


### PR DESCRIPTION
Unfortunately, Groovy's `ClassNode` is not contextually equal, so I had to implement a custom native type for Groovy.
This supports reading annotations of generic arguments and type annotations. I also added more tests for generic types and fixed some cases.