### PR TITLE
Fix regression where AliasFor is no longer recursive 

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -679,7 +679,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                     introducedAnnotations.add(newAnnotation);
                     ProcessedAnnotation newNewAnnotation = processAliases(newAnnotation, introducedAnnotations);
                     if (newNewAnnotation != newAnnotation) {
-                        introducedAnnotations.add(introducedAnnotations.indexOf(newAnnotation), newNewAnnotation);
+                        introducedAnnotations.set(introducedAnnotations.indexOf(newAnnotation), newNewAnnotation);
                     }
                 }
             }

--- a/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -671,12 +671,10 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                 aliasedAnnotation = aliasAnnotation.orElseGet(aliasAnnotationName::get);
                 String aliasedMemberName = aliasMember.get();
                 if (annotationValue != null) {
-                    introducedAnnotations.add(
-                        toProcessedAnnotation(
+                    ProcessedAnnotation newAnnotation = toProcessedAnnotation(
                             AnnotationValue.builder(aliasedAnnotation, getRetentionPolicy(aliasedAnnotation))
-                                .members(Collections.singletonMap(aliasedMemberName, annotationValue))
-                                .build()
-                        )
+                                    .members(Collections.singletonMap(aliasedMemberName, annotationValue))
+                                    .build()
                     );
                     introducedAnnotations.add(newAnnotation);
                     ProcessedAnnotation newNewAnnotation = processAliases(newAnnotation, introducedAnnotations);

--- a/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -660,9 +660,10 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                                         Object annotationValue,
                                         AnnotationValue<AliasFor> aliasForAnnotation,
                                         List<ProcessedAnnotation> introducedAnnotations) {
-        Optional<String> aliasAnnotation = aliasForAnnotation.stringValue("annotation");
-        Optional<String> aliasAnnotationName = aliasForAnnotation.stringValue("annotationName");
-        Optional<String> aliasMember = aliasForAnnotation.stringValue("member");
+        // Filter out empty values for Groovy
+        Optional<String> aliasAnnotation = aliasForAnnotation.stringValue("annotation").filter(v -> !v.equals(Annotation.class.getName()));
+        Optional<String> aliasAnnotationName = aliasForAnnotation.stringValue("annotationName").filter(v -> !v.isEmpty());
+        Optional<String> aliasMember = aliasForAnnotation.stringValue("member").filter(v -> !v.isEmpty());
 
         if (aliasAnnotation.isPresent() || aliasAnnotationName.isPresent()) {
             if (aliasMember.isPresent()) {
@@ -677,6 +678,11 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                                 .build()
                         )
                     );
+                    introducedAnnotations.add(newAnnotation);
+                    ProcessedAnnotation newNewAnnotation = processAliases(newAnnotation, introducedAnnotations);
+                    if (newNewAnnotation != newAnnotation) {
+                        introducedAnnotations.add(introducedAnnotations.indexOf(newAnnotation), newNewAnnotation);
+                    }
                 }
             }
         } else if (aliasMember.isPresent()) {

--- a/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -38,7 +38,6 @@ import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.qualifiers.InterceptorBindingQualifier;
 import io.micronaut.inject.visitor.VisitorContext;
 import jakarta.inject.Qualifier;
-import org.jetbrains.annotations.NotNull;
 
 import java.lang.annotation.Annotation;
 import java.lang.annotation.RetentionPolicy;
@@ -660,10 +659,9 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                                         Object annotationValue,
                                         AnnotationValue<AliasFor> aliasForAnnotation,
                                         List<ProcessedAnnotation> introducedAnnotations) {
-        // Filter out empty values for Groovy
-        Optional<String> aliasAnnotation = aliasForAnnotation.stringValue("annotation").filter(v -> !v.equals(Annotation.class.getName()));
-        Optional<String> aliasAnnotationName = aliasForAnnotation.stringValue("annotationName").filter(v -> !v.isEmpty());
-        Optional<String> aliasMember = aliasForAnnotation.stringValue("member").filter(v -> !v.isEmpty());
+        Optional<String> aliasAnnotation = aliasForAnnotation.stringValue("annotation");
+        Optional<String> aliasAnnotationName = aliasForAnnotation.stringValue("annotationName");
+        Optional<String> aliasMember = aliasForAnnotation.stringValue("member");
 
         if (aliasAnnotation.isPresent() || aliasAnnotationName.isPresent()) {
             if (aliasMember.isPresent()) {
@@ -775,7 +773,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         addAnnotations(annotationMetadata, annotationValues, isDeclared, parentAnnotations);
     }
 
-    @NotNull
+    @NonNull
     private Stream<ProcessedAnnotation> annotationMirrorToAnnotationValue(Stream<? extends A> stream,
                                                                           T element,
                                                                           boolean originatingElementIsSameParent,
@@ -872,8 +870,14 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         );
     }
 
-    @NotNull
-    private Map<CharSequence, Object> getCachedAnnotationDefaults(String annotationName, T annotationType) {
+    /**
+     * Get the cached annotation defaults.
+     * @param annotationName The annotation name
+     * @param annotationType The annotation type
+     * @return The defaults
+     */
+    @NonNull
+    protected Map<CharSequence, Object> getCachedAnnotationDefaults(String annotationName, T annotationType) {
         Map<CharSequence, Object> defaultValues;
         final Map<CharSequence, Object> defaults = ANNOTATION_DEFAULTS.get(annotationName);
         if (defaults != null) {

--- a/core/src/main/java/io/micronaut/core/convert/converters/MultiValuesConverterFactory.java
+++ b/core/src/main/java/io/micronaut/core/convert/converters/MultiValuesConverterFactory.java
@@ -257,15 +257,15 @@ public class MultiValuesConverterFactory {
             ArgumentConversionContext<T> context = (ArgumentConversionContext<T>) conversionContext;
 
             String format = conversionContext.getAnnotationMetadata()
-                    .getValue(Format.class, String.class).orElse(null);
+                    .stringValue(Format.class).orElse(null);
             if (format == null) {
                 return Optional.empty();
             }
 
-            String name = conversionContext.getAnnotationMetadata().getValue(Bindable.class, String.class)
+            String name = conversionContext.getAnnotationMetadata().stringValue(Bindable.class)
                     .orElse(context.getArgument().getName());
             String defaultValue = conversionContext.getAnnotationMetadata()
-                    .getValue(Bindable.class, "defaultValue", String.class)
+                    .stringValue(Bindable.class, "defaultValue")
                     .orElse(null);
 
             switch (normalizeFormatName(format)) {
@@ -524,7 +524,7 @@ public class MultiValuesConverterFactory {
                 Object[] constructorParameters = new Object[constructorArguments.length];
                 for (int i = 0; i < constructorArguments.length; ++i) {
                     Argument<?> argument = constructorArguments[i];
-                    String name = argument.getAnnotationMetadata().getValue(Bindable.class, String.class)
+                    String name = argument.getAnnotationMetadata().stringValue(Bindable.class)
                             .orElse(argument.getName());
                     constructorParameters[i] = conversionService.convert(values.get(name), ConversionContext.of(argument))
                             .orElse(null);
@@ -575,12 +575,12 @@ public class MultiValuesConverterFactory {
             // noinspection unchecked
             ArgumentConversionContext<Object> context = (ArgumentConversionContext<Object>) conversionContext;
 
-            String format = conversionContext.getAnnotationMetadata().getValue(Format.class, String.class).orElse(null);
+            String format = conversionContext.getAnnotationMetadata().stringValue(Format.class).orElse(null);
             if (format == null) {
                 return Optional.empty();
             }
 
-            String name = conversionContext.getAnnotationMetadata().getValue(Bindable.class, String.class)
+            String name = conversionContext.getAnnotationMetadata().stringValue(Bindable.class)
                     .orElse(context.getArgument().getName());
 
             MutableConvertibleMultiValuesMap<String> parameters = new MutableConvertibleMultiValuesMap<>();
@@ -775,7 +775,7 @@ public class MultiValuesConverterFactory {
             }
 
             for (BeanProperty<Object, Object> property: beanWrapper.getBeanProperties()) {
-                String key = property.getValue(Bindable.class, String.class).orElse(property.getName());
+                String key = property.stringValue(Bindable.class).orElse(property.getName());
                 ArgumentConversionContext<String> conversionContext =
                         ConversionContext.STRING.with(property.getAnnotationMetadata());
                 conversionService.convert(property.get(object), conversionContext).ifPresent(value -> {

--- a/http-client/src/test/resources/logback.xml
+++ b/http-client/src/test/resources/logback.xml
@@ -12,4 +12,6 @@
         <appender-ref ref="STDOUT" />
     </root>
 
+    <logger name="io.micronaut.http.client" level="trace" />
+
 </configuration>

--- a/http-client/src/test/resources/logback.xml
+++ b/http-client/src/test/resources/logback.xml
@@ -12,6 +12,6 @@
         <appender-ref ref="STDOUT" />
     </root>
 
-    <logger name="io.micronaut.http.client" level="trace" />
+<!--    <logger name="io.micronaut.http.client" level="trace" />-->
 
 </configuration>

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/configproperties/InheritedConfigurationReaderPrefixSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/configproperties/InheritedConfigurationReaderPrefixSpec.groovy
@@ -37,7 +37,7 @@ class MyBean  {
         beanDefinition.getInjectedMethods()[0].name == 'setMyValue'
         def metadata = beanDefinition.getInjectedMethods()[0].getAnnotationMetadata()
         metadata.hasAnnotation(Property)
-        metadata.getValue(Property, "name", String).get() == 'endpoints.my-value'
+        metadata.getValue(Property, "name", String).get() == 'simple.my-value'
     }
 
     void "property path is overriding the existing one without base prefix"() {
@@ -75,7 +75,7 @@ class MyBean  {
             beanDefinition.getInjectedMethods()[0].name == 'setMyValue'
             def metadata = beanDefinition.getInjectedMethods()[0].getAnnotationMetadata()
             metadata.hasAnnotation(Property)
-            metadata.getValue(Property, "name", String).get() == 'endpoints.my-value'
+            metadata.getValue(Property, "name", String).get() == 'endpoints.simple.my-value'
     }
 
     void "property path is overriding the existing one"() {

--- a/inject-java/src/test/groovy/io/micronaut/visitors/ClassElementSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/ClassElementSpec.groovy
@@ -27,11 +27,13 @@ import io.micronaut.inject.ast.ElementModifier
 import io.micronaut.inject.ast.ElementQuery
 import io.micronaut.inject.ast.EnumElement
 import io.micronaut.inject.ast.FieldElement
+import io.micronaut.inject.ast.GenericPlaceholderElement
 import io.micronaut.inject.ast.MemberElement
 import io.micronaut.inject.ast.MethodElement
 import io.micronaut.inject.ast.PackageElement
 import io.micronaut.inject.ast.PrimitiveElement
 import io.micronaut.inject.ast.PropertyElement
+import io.micronaut.inject.ast.WildcardElement
 import jakarta.inject.Singleton
 import spock.lang.IgnoreIf
 import spock.lang.Issue

--- a/inject-java/src/test/groovy/io/micronaut/visitors/ClassElementSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/ClassElementSpec.groovy
@@ -27,13 +27,11 @@ import io.micronaut.inject.ast.ElementModifier
 import io.micronaut.inject.ast.ElementQuery
 import io.micronaut.inject.ast.EnumElement
 import io.micronaut.inject.ast.FieldElement
-import io.micronaut.inject.ast.GenericPlaceholderElement
 import io.micronaut.inject.ast.MemberElement
 import io.micronaut.inject.ast.MethodElement
 import io.micronaut.inject.ast.PackageElement
 import io.micronaut.inject.ast.PrimitiveElement
 import io.micronaut.inject.ast.PropertyElement
-import io.micronaut.inject.ast.WildcardElement
 import jakarta.inject.Singleton
 import spock.lang.IgnoreIf
 import spock.lang.Issue
@@ -2300,6 +2298,57 @@ class MyBean {
         then:
             returnType.hasAnnotation(MyEntity.class)
             returnType.hasAnnotation(Introspected.class)
+    }
+
+    void "test alias for recursion"() {
+        given:
+            ClassElement ce = buildClassElement('''\
+package test;
+
+import io.micronaut.inject.annotation.*;
+import io.micronaut.context.annotation.*;
+import io.micronaut.test.annotation.MockBean;
+import jakarta.inject.Singleton;
+import jakarta.inject.Inject;
+import java.util.List;
+import java.lang.Integer;
+
+@Singleton
+class MathInnerServiceSpec {
+
+    @Inject
+    MathService mathService;
+
+    @MockBean(MathService.class)
+    static class MyMock implements MathService {
+
+        @Override
+        public Integer compute(Integer num) {
+            return 50;
+        }
+    }
+}
+
+interface MathService {
+
+    Integer compute(Integer num);
+}
+
+
+@Singleton
+class MathServiceImpl implements MathService {
+
+    @Override
+    public Integer compute(Integer num) {
+        return num * 4; // should never be called
+    }
+}
+
+''')
+        when:
+            def replaces = ce.getEnclosedElements(ElementQuery.ALL_INNER_CLASSES).get(0).getAnnotation(Replaces)
+        then:
+            replaces.stringValue("bean").get() == "test.MathService"
     }
 
     void "test how the type annotations from the type are propagated"() {

--- a/inject-java/src/test/groovy/io/micronaut/visitors/ClassElementSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/ClassElementSpec.groovy
@@ -17,6 +17,7 @@ package io.micronaut.visitors
 
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.micronaut.annotation.processing.visitor.JavaClassElement
+import io.micronaut.context.annotation.Replaces
 import io.micronaut.context.exceptions.BeanContextException
 import io.micronaut.core.annotation.AnnotationUtil
 import io.micronaut.core.annotation.Introspected

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -2585,7 +2585,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
 
     private <T> boolean checkIfReplaces(BeanDefinition<T> replacingCandidate, BeanDefinition<T> definitionToBeReplaced, AnnotationMetadata annotationMetadata) {
         final AnnotationValue<Replaces> replacesAnnotation = replacingCandidate.getAnnotation(Replaces.class);
-        final Class replacedBeanType = replacesAnnotation.classValue(Replaces.MEMBER_BEAN).orElse(getCanonicalBeanType(replacingCandidate));
+        final Class replacedBeanType = replacesAnnotation.classValue(AnnotationMetadata.VALUE_MEMBER).orElse(getCanonicalBeanType(replacingCandidate));
         final Optional<String> named = replacesAnnotation.stringValue(Replaces.MEMBER_NAMED);
         final Optional<AnnotationClassValue<?>> qualifier = replacesAnnotation.annotationClassValue(Replaces.MEMBER_QUALIFIER);
 

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -110,7 +110,6 @@ import io.micronaut.inject.ProxyBeanDefinition;
 import io.micronaut.inject.QualifiedBeanType;
 import io.micronaut.inject.ValidatedBeanDefinition;
 import io.micronaut.inject.provider.AbstractProviderDefinition;
-import io.micronaut.inject.provider.BeanProviderDefinition;
 import io.micronaut.inject.proxy.InterceptedBeanProxy;
 import io.micronaut.inject.qualifiers.AnyQualifier;
 import io.micronaut.inject.qualifiers.Qualified;
@@ -2585,7 +2584,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
 
     private <T> boolean checkIfReplaces(BeanDefinition<T> replacingCandidate, BeanDefinition<T> definitionToBeReplaced, AnnotationMetadata annotationMetadata) {
         final AnnotationValue<Replaces> replacesAnnotation = replacingCandidate.getAnnotation(Replaces.class);
-        final Class replacedBeanType = replacesAnnotation.classValue(AnnotationMetadata.VALUE_MEMBER).orElse(getCanonicalBeanType(replacingCandidate));
+        final Class replacedBeanType = replacesAnnotation.classValue(Replaces.MEMBER_BEAN).orElse(getCanonicalBeanType(replacingCandidate));
         final Optional<String> named = replacesAnnotation.stringValue(Replaces.MEMBER_NAMED);
         final Optional<AnnotationClassValue<?>> qualifier = replacesAnnotation.annotationClassValue(Replaces.MEMBER_QUALIFIER);
 

--- a/inject/src/main/java/io/micronaut/context/annotation/Replaces.java
+++ b/inject/src/main/java/io/micronaut/context/annotation/Replaces.java
@@ -46,6 +46,7 @@ public @interface Replaces {
     /**
      * @return The bean type that this bean replaces
      */
+    @AliasFor(member = "value")
     Class<?> bean() default void.class;
 
     /**

--- a/test-suite/src/test/groovy/io/micronaut/test/replacesbug/MathInnerServiceSpec.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/test/replacesbug/MathInnerServiceSpec.groovy
@@ -1,0 +1,46 @@
+package io.micronaut.test.replacesbug
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.annotation.MockBean
+import jakarta.inject.Singleton
+import spock.lang.Specification
+
+import jakarta.inject.Inject
+
+@MicronautTest
+class MathInnerServiceSpec extends Specification {
+
+    @Inject
+    MathService mathService
+
+    void "should compute use inner mock"() {
+        when:
+        def result = mathService.compute(10)
+
+        then:
+        result == 50
+    }
+
+    @MockBean(MathService)
+    static class MyMock implements MathService {
+
+        @Override
+        Integer compute(Integer num) {
+            return 50
+        }
+    }
+}
+
+interface MathService {
+
+    Integer compute(Integer num);
+}
+
+@Singleton
+class MathServiceImpl implements MathService {
+
+    @Override
+    Integer compute(Integer num) {
+        return num * 4 // should never be called
+    }
+}


### PR DESCRIPTION
The Micronaut Test module is failing because bean replacements are not working correctly. It seems to be a regression in the way `@AliasFor` is processed since the change here works around the issue. 