### PR TITLE
Allow user to explicity turn off the localhost drive-by CORS check

### DIFF
--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/CorsSimpleRequestTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/CorsSimpleRequestTest.java
@@ -52,6 +52,7 @@ public class CorsSimpleRequestTest {
 
     private static final String SPECNAME = "CorsSimpleRequestTest";
     private static final String PROPERTY_MICRONAUT_SERVER_CORS_ENABLED = "micronaut.server.cors.enabled";
+    private static final String PROPERTY_MICRONAUT_SERVER_CORS_LOCALHOST_PASS_THROUGH = "micronaut.server.cors.localhost-pass-through";
 
     /**
      * @see <a href="https://github.com/micronaut-projects/micronaut-core/security/advisories/GHSA-583g-g682-crxf">GHSA-583g-g682-crxf</a>
@@ -72,6 +73,18 @@ public class CorsSimpleRequestTest {
             Collections.singletonMap(PROPERTY_MICRONAUT_SERVER_CORS_ENABLED, StringUtils.TRUE),
             createRequest("https://foo.com"),
             CorsSimpleRequestTest::isForbidden
+        );
+    }
+
+    @Test
+    void corsSimpleRequestAllowedForLocalhostAndAnyWhenSpecificallyTurnedOff() throws IOException {
+        asserts(SPECNAME,
+            CollectionUtils.mapOf(
+                PROPERTY_MICRONAUT_SERVER_CORS_ENABLED, StringUtils.TRUE,
+                PROPERTY_MICRONAUT_SERVER_CORS_LOCALHOST_PASS_THROUGH, StringUtils.TRUE
+            ),
+            createRequest("https://foo.com"),
+            CorsSimpleRequestTest::isSuccessful
         );
     }
 

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/CorsSimpleRequestTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/CorsSimpleRequestTest.java
@@ -76,6 +76,12 @@ public class CorsSimpleRequestTest {
         );
     }
 
+    /**
+     * Test that a simple request is allowed for localhost and origin:any when specifically turned off.
+     * @see <a href="https://github.com/micronaut-projects/micronaut-core/pull/8751">PR-8751</a>
+     *
+     * @throws IOException
+     */
     @Test
     void corsSimpleRequestAllowedForLocalhostAndAnyWhenSpecificallyTurnedOff() throws IOException {
         asserts(SPECNAME,

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/SimpleRequestWithCorsNotEnabledTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/SimpleRequestWithCorsNotEnabledTest.java
@@ -69,6 +69,12 @@ public class SimpleRequestWithCorsNotEnabledTest {
             });
     }
 
+    /**
+     * This test verifies a CORS simple request is allowed when invoked against a Micronaut application running in localhost without cors enabled but with localhost-pass-through switched on.
+     * @see <a href="https://github.com/micronaut-projects/micronaut-core/pull/8751">PR-8751</a>
+     *
+     * @throws IOException
+     */
     @Test
     void corsSimpleRequestAllowedForLocalhostAndAnyWhenConfiguredToAllowIt() throws IOException {
         asserts(SPECNAME,

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/SimpleRequestWithCorsNotEnabledTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/SimpleRequestWithCorsNotEnabledTest.java
@@ -18,6 +18,7 @@ package io.micronaut.http.server.tck.tests.cors;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.event.ApplicationEventListener;
 import io.micronaut.context.event.ApplicationEventPublisher;
+import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.annotation.Controller;
@@ -43,7 +44,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
     "checkstyle:MissingJavadocType",
 })
 public class SimpleRequestWithCorsNotEnabledTest {
+
     private static final String SPECNAME = "SimpleRequestWithCorsNotEnabledTest";
+    private static final String PROPERTY_MICRONAUT_SERVER_CORS_LOCALHOST_PASS_THROUGH = "micronaut.server.cors.localhost-pass-through";
 
     /**
      * @see <a href="https://github.com/micronaut-projects/micronaut-core/security/advisories/GHSA-583g-g682-crxf">GHSA-583g-g682-crxf</a>
@@ -64,6 +67,21 @@ public class SimpleRequestWithCorsNotEnabledTest {
                     .build());
                 assertEquals(0, refreshCounter.getRefreshCount());
             });
+    }
+
+    @Test
+    void corsSimpleRequestAllowedForLocalhostAndAnyWhenConfiguredToAllowIt() throws IOException {
+        asserts(SPECNAME,
+            Collections.singletonMap(PROPERTY_MICRONAUT_SERVER_CORS_LOCALHOST_PASS_THROUGH, StringUtils.TRUE),
+            createRequest("https://sdelamo.github.io"),
+            (server, request) -> {
+                RefreshCounter refreshCounter = server.getApplicationContext().getBean(RefreshCounter.class);
+                assertEquals(0, refreshCounter.getRefreshCount());
+                AssertionUtils.assertDoesNotThrow(server, request, HttpResponseAssertion.builder()
+                    .status(HttpStatus.OK)
+                    .build());
+                assertEquals(1, refreshCounter.getRefreshCount());
+        });
     }
 
     /**

--- a/http-server/src/main/java/io/micronaut/http/server/HttpServerConfiguration.java
+++ b/http-server/src/main/java/io/micronaut/http/server/HttpServerConfiguration.java
@@ -664,9 +664,11 @@ public class HttpServerConfiguration implements ServerContextPathProvider {
 
         public static final boolean DEFAULT_ENABLED = false;
         public static final boolean DEFAULT_SINGLE_HEADER = false;
+        public static final boolean DEFAULT_LOCALHOST_PASS_THROUGH = false;
 
         private boolean enabled = DEFAULT_ENABLED;
         private boolean singleHeader = DEFAULT_SINGLE_HEADER;
+        private boolean localhostPassThrough = DEFAULT_LOCALHOST_PASS_THROUGH;
 
         private Map<String, CorsOriginConfiguration> configurations = Collections.emptyMap();
 
@@ -678,6 +680,13 @@ public class HttpServerConfiguration implements ServerContextPathProvider {
         @Override
         public boolean isEnabled() {
             return enabled;
+        }
+
+        /**
+         * @return Whether localhost pass-through is enabled. Defaults to {@value #DEFAULT_LOCALHOST_PASS_THROUGH}.
+         */
+        public boolean isLocalhostPassThrough() {
+            return localhostPassThrough;
         }
 
         /**
@@ -706,6 +715,16 @@ public class HttpServerConfiguration implements ServerContextPathProvider {
          */
         public void setEnabled(boolean enabled) {
             this.enabled = enabled;
+        }
+
+        /**
+         * Sets whether localhost pass-through is enabled. Default value {@value #DEFAULT_LOCALHOST_PASS_THROUGH}.
+         * Setting this to true will allow requests to be made to localhost from any origin.
+         *
+         * @param localhostPassThrough True if localhost pass-through is enabled
+         */
+        public void setLocalhostPassThrough(boolean localhostPassThrough) {
+            this.localhostPassThrough = localhostPassThrough;
         }
 
         /**

--- a/http-server/src/main/java/io/micronaut/http/server/HttpServerConfiguration.java
+++ b/http-server/src/main/java/io/micronaut/http/server/HttpServerConfiguration.java
@@ -684,6 +684,7 @@ public class HttpServerConfiguration implements ServerContextPathProvider {
 
         /**
          * @return Whether localhost pass-through is enabled. Defaults to {@value #DEFAULT_LOCALHOST_PASS_THROUGH}.
+         * @since 3.8.5
          */
         public boolean isLocalhostPassThrough() {
             return localhostPassThrough;
@@ -722,6 +723,7 @@ public class HttpServerConfiguration implements ServerContextPathProvider {
          * Setting this to true will allow requests to be made to localhost from any origin.
          *
          * @param localhostPassThrough True if localhost pass-through is enabled
+         * @since 3.8.5
          */
         public void setLocalhostPassThrough(boolean localhostPassThrough) {
             this.localhostPassThrough = localhostPassThrough;

--- a/http-server/src/main/java/io/micronaut/http/server/cors/CorsFilter.java
+++ b/http-server/src/main/java/io/micronaut/http/server/cors/CorsFilter.java
@@ -105,12 +105,12 @@ public class CorsFilter implements HttpServerFilter {
             if (!validateMethodToMatch(request, corsOriginConfiguration).isPresent()) {
                 return forbidden();
             }
-            if (!corsConfiguration.isLocalhostPassThrough() && shouldDenyToPreventDriveByLocalhostAttack(corsOriginConfiguration, request)) {
+            if (shouldDenyToPreventDriveByLocalhostAttack(corsOriginConfiguration, request)) {
                 LOG.trace("The resolved configuration allows any origin. To prevent drive-by-localhost attacks the request is forbidden");
                 return forbidden();
             }
             return Publishers.then(chain.proceed(request), resp -> decorateResponseWithHeaders(request, resp, corsOriginConfiguration));
-        } else if (!corsConfiguration.isLocalhostPassThrough() && shouldDenyToPreventDriveByLocalhostAttack(origin, request)) {
+        } else if (shouldDenyToPreventDriveByLocalhostAttack(origin, request)) {
             LOG.trace("the request specifies an origin different than localhost. To prevent drive-by-localhost attacks the request is forbidden");
             return forbidden();
         }
@@ -126,6 +126,9 @@ public class CorsFilter implements HttpServerFilter {
      */
     protected boolean shouldDenyToPreventDriveByLocalhostAttack(@NonNull CorsOriginConfiguration corsOriginConfiguration,
                                                                 @NonNull HttpRequest<?> request) {
+        if (corsConfiguration.isLocalhostPassThrough()) {
+            return false;
+        }
         if (httpHostResolver == null) {
             return false;
         }
@@ -148,6 +151,9 @@ public class CorsFilter implements HttpServerFilter {
      */
     protected boolean shouldDenyToPreventDriveByLocalhostAttack(@NonNull String origin,
                                                                 @NonNull HttpRequest<?> request) {
+        if (corsConfiguration.isLocalhostPassThrough()) {
+            return false;
+        }
         if (httpHostResolver == null) {
             return false;
         }

--- a/http-server/src/main/java/io/micronaut/http/server/cors/CorsFilter.java
+++ b/http-server/src/main/java/io/micronaut/http/server/cors/CorsFilter.java
@@ -105,12 +105,12 @@ public class CorsFilter implements HttpServerFilter {
             if (!validateMethodToMatch(request, corsOriginConfiguration).isPresent()) {
                 return forbidden();
             }
-            if (shouldDenyToPreventDriveByLocalhostAttack(corsOriginConfiguration, request)) {
+            if (!corsConfiguration.isLocalhostPassThrough() && shouldDenyToPreventDriveByLocalhostAttack(corsOriginConfiguration, request)) {
                 LOG.trace("The resolved configuration allows any origin. To prevent drive-by-localhost attacks the request is forbidden");
                 return forbidden();
             }
             return Publishers.then(chain.proceed(request), resp -> decorateResponseWithHeaders(request, resp, corsOriginConfiguration));
-        } else if (shouldDenyToPreventDriveByLocalhostAttack(origin, request)) {
+        } else if (!corsConfiguration.isLocalhostPassThrough() && shouldDenyToPreventDriveByLocalhostAttack(origin, request)) {
             LOG.trace("the request specifies an origin different than localhost. To prevent drive-by-localhost attacks the request is forbidden");
             return forbidden();
         }


### PR DESCRIPTION
To disallow drive-by localhost attacks on a server under development, we added an Origin check for all requests even if Cors itself was disabled.

However, under certain circumstances (such as those described in #8749), this is not the required behavior.

This PR adds a new configuration setting `micronaut.server.cors.localhost-pass-through` which defaults to false (for the current behavior).

Setting this to `true` will skip this localhost/origin test and the request will be allowed."