### PR TITLE
doc: reorder HTTP Clients implementations

### DIFF
--- a/src/main/docs/guide/httpClient.adoc
+++ b/src/main/docs/guide/httpClient.adoc
@@ -1,15 +1,3 @@
-[TIP]
-.Using the CLI
-====
-If you create your project using the Micronaut CLI, the `http-client` dependency is included by default.
-====
-
 Client communication between Microservices is a critical component of any Microservice architecture. With that in mind, Micronaut includes an HTTP client that has both a low-level API and a higher-level AOP-driven API.
 
 TIP: Regardless whether you choose to use Micronaut's HTTP server, you may wish to use the Micronaut HTTP client in your application since it is a feature-rich client implementation.
-
-To use the HTTP client, add the `http-client` dependency to your build:
-
-dependency:micronaut-http-client[]
-
-Since the higher level API is built on the low-level HTTP client, we first introduce the low-level client.

--- a/src/main/docs/guide/httpClient/httpClientImplementations.adoc
+++ b/src/main/docs/guide/httpClient/httpClientImplementations.adoc
@@ -1,0 +1,1 @@
+There are several implementations of the Micronaut HTTP Client.

--- a/src/main/docs/guide/httpClient/httpClientImplementations/javanetClient.adoc
+++ b/src/main/docs/guide/httpClient/httpClientImplementations/javanetClient.adoc
@@ -1,0 +1,15 @@
+To use an implementation based on https://openjdk.org/groups/net/httpclient/intro.html[Java HTTP Client], add the following dependency to your build:
+
+dependency:micronaut-http-client-javanet[]
+
+NOTE: This implementation of the Micronaut HTTP Client is available since Micronaut Framework 4.0.
+
+The implementation based on https://openjdk.org/groups/net/httpclient/intro.html[Java HTTP Client] does not support the following features:
+
+* Proxy Support.
+* Client Filters.
+* Http2.
+* Streaming support.
+* Multipart requests.
+
+If you require any of these, we recommend you use the <<nettyHttpClient, implementation of the HTTP Client based on Netty>>.

--- a/src/main/docs/guide/httpClient/httpClientImplementations/nettyHttpClient.adoc
+++ b/src/main/docs/guide/httpClient/httpClientImplementations/nettyHttpClient.adoc
@@ -1,0 +1,3 @@
+To use an implementation based on https://netty.io[Netty], add the following dependency to your build:
+
+dependency:micronaut-http-client[]

--- a/src/main/docs/guide/httpClient/javanetClient.adoc
+++ b/src/main/docs/guide/httpClient/javanetClient.adoc
@@ -1,3 +1,0 @@
-As of Micronaut 4.0.0, you can use a java client based on java.net.HttpClient in place of the netty based default. To do so, replace the http-client dependency in your build with:
-
-dependency:micronaut-http-client-javanet[]

--- a/src/main/docs/guide/httpClient/javanetClient/unsupportedFeatures.adoc
+++ b/src/main/docs/guide/httpClient/javanetClient/unsupportedFeatures.adoc
@@ -1,9 +1,0 @@
-Currently, there are several things supported by the default Http Client that are not-supported or implemented for the Java.net client.  These include:
-
-1. Proxy Support.
-1. Client Filters.
-1. Http2.
-1. Streaming support.
-1. Multipart requests.
-
-If you require any of these, we recommend you use the default Micronaut Http Client.

--- a/src/main/docs/guide/httpClient/lowLevelOrHighLevel.adoc
+++ b/src/main/docs/guide/httpClient/lowLevelOrHighLevel.adoc
@@ -1,0 +1,1 @@
+Since the higher level API is built on the low-level HTTP client, we first introduce the low-level client.

--- a/src/main/docs/guide/introduction/whatsNew.adoc
+++ b/src/main/docs/guide/introduction/whatsNew.adoc
@@ -5,6 +5,8 @@
 
 * <<virtualThreads, Support for Virtual Threads>>
 
+* <<javanetClient, Additional implementation of the HTTP Client based on Java HTTP Client>>
+
 ==== Injection of Maps
 
 It is now possible to inject a `java.util.Map` of beans where the key is the bean name. The name of the bean is derived from the <<qualifiers, qualifier>> or (if not present) the simple name of the class.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -149,6 +149,12 @@ httpServer:
   graphql: GraphQL Support
 httpClient:
   title: The HTTP Client
+  httpClientImplementations:
+    title: HTTP Client Implementations
+    nettyHttpClient: HTTP Client based on Netty
+    javanetClient:
+      title: HTTP Client based on Java HTTP Client
+  lowLevelOrHighLevel: Low-Level and High-Level APIs
   lowLevelHttpClient:
     title: Using the Low-Level HTTP Client
     clientBasics: Sending your first HTTP request
@@ -172,9 +178,6 @@ httpClient:
   clientFilter: HTTP Client Filters
   clientHttp2: HTTP/2 Support
   clientSample: HTTP Client Sample
-  javanetClient:
-    title: Using the JDK HTTP Client
-    unsupportedFeatures: Unsupported Features
 cloud:
   title: Cloud Native Features
   cloudConfiguration:


### PR DESCRIPTION
* link from the what's ne section
* moves  implementations to the top of the HTTP Client section
* Collapses the unsupported features in the same asciidoc
* Link to OpenJDK Java HTTP Client