### PR TITLE
Optimize HttpRequestCertificateHandler

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/HttpPipelineBuilder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/HttpPipelineBuilder.java
@@ -16,6 +16,7 @@
 package io.micronaut.http.server.netty;
 
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.naming.Named;
 import io.micronaut.core.util.SupplierUtil;
 import io.micronaut.http.context.event.HttpRequestReceivedEvent;
@@ -106,8 +107,6 @@ final class HttpPipelineBuilder {
     private final HttpRequestDecoder requestDecoder;
     private final HttpResponseEncoder responseEncoder;
 
-    private final HttpRequestCertificateHandler requestCertificateHandler = new HttpRequestCertificateHandler();
-
     private final NettyServerCustomizer serverCustomizer;
 
     HttpPipelineBuilder(NettyHttpServer server, NettyEmbeddedServices embeddedServices, ServerSslConfiguration sslConfiguration, RoutingInBoundHandler routingInBoundHandler, HttpHostResolver hostResolver, NettyServerCustomizer serverCustomizer) {
@@ -147,14 +146,15 @@ final class HttpPipelineBuilder {
         private final Channel channel;
         private final ChannelPipeline pipeline;
 
-        private final boolean ssl;
+        @Nullable
+        private final SslHandler sslHandler;
 
         private final NettyServerCustomizer connectionCustomizer;
 
         ConnectionPipeline(Channel channel, boolean ssl) {
             this.channel = channel;
             this.pipeline = channel.pipeline();
-            this.ssl = ssl;
+            this.sslHandler = ssl ? sslContext.newHandler(channel.alloc()) : null;
             this.connectionCustomizer = serverCustomizer.specializeForChannel(channel, NettyServerCustomizer.ChannelRole.CONNECTION);
         }
 
@@ -211,7 +211,7 @@ final class HttpPipelineBuilder {
             if (server.getServerConfiguration().getHttpVersion() != io.micronaut.http.HttpVersion.HTTP_2_0) {
                 configureForHttp1();
             } else {
-                if (ssl) {
+                if (sslHandler != null) {
                     configureForAlpn();
                 } else {
                     configureForH2cSupport();
@@ -225,8 +225,7 @@ final class HttpPipelineBuilder {
         void insertOuterTcpHandlers() {
             insertPcapLoggingHandler("encapsulated");
 
-            if (ssl) {
-                SslHandler sslHandler = sslContext.newHandler(channel.alloc());
+            if (sslHandler != null) {
                 sslHandler.setHandshakeTimeoutMillis(sslConfiguration.getHandshakeTimeout().toMillis());
                 pipeline.addLast(ChannelPipelineCustomizer.HANDLER_SSL, sslHandler);
 
@@ -264,7 +263,7 @@ final class HttpPipelineBuilder {
 
             pipeline.addLast(ChannelPipelineCustomizer.HANDLER_HTTP_SERVER_CODEC, createServerCodec());
 
-            new StreamPipeline(channel, ssl, connectionCustomizer).insertHttp1DownstreamHandlers();
+            new StreamPipeline(channel, sslHandler, connectionCustomizer).insertHttp1DownstreamHandlers();
 
             connectionCustomizer.onInitialPipelineBuilt();
             connectionCustomizer.onStreamPipelineBuilt();
@@ -281,7 +280,7 @@ final class HttpPipelineBuilder {
             pipeline.addLast(new Http2MultiplexHandler(new ChannelInitializer<Channel>() {
                 @Override
                 protected void initChannel(@NonNull Channel ch) {
-                    StreamPipeline streamPipeline = new StreamPipeline(ch, ssl, connectionCustomizer.specializeForChannel(ch, NettyServerCustomizer.ChannelRole.REQUEST_STREAM));
+                    StreamPipeline streamPipeline = new StreamPipeline(ch, sslHandler, connectionCustomizer.specializeForChannel(ch, NettyServerCustomizer.ChannelRole.REQUEST_STREAM));
                     streamPipeline.insertHttp2FrameHandlers();
                     streamPipeline.streamCustomizer.onStreamPipelineBuilt();
                 }
@@ -364,7 +363,7 @@ final class HttpPipelineBuilder {
                     return new Http2ServerUpgradeCodec(connectionHandler, new Http2MultiplexHandler(new ChannelInitializer<Http2StreamChannel>() {
                         @Override
                         protected void initChannel(@NonNull Http2StreamChannel ch) {
-                            StreamPipeline streamPipeline = new StreamPipeline(ch, ssl, connectionCustomizer.specializeForChannel(ch, NettyServerCustomizer.ChannelRole.REQUEST_STREAM));
+                            StreamPipeline streamPipeline = new StreamPipeline(ch, sslHandler, connectionCustomizer.specializeForChannel(ch, NettyServerCustomizer.ChannelRole.REQUEST_STREAM));
                             streamPipeline.insertHttp2FrameHandlers();
                             streamPipeline.streamCustomizer.onStreamPipelineBuilt();
                         }
@@ -403,7 +402,7 @@ final class HttpPipelineBuilder {
 
                     // reconfigure for http1
                     // note: we have to reuse the serverCodec in case it still has some data buffered
-                    new StreamPipeline(channel, ssl, connectionCustomizer).insertHttp1DownstreamHandlers();
+                    new StreamPipeline(channel, sslHandler, connectionCustomizer).insertHttp1DownstreamHandlers();
                     connectionCustomizer.onStreamPipelineBuilt();
                     onRequestPipelineBuilt();
                     cp.fireChannelRead(ReferenceCountUtil.retain(msg));
@@ -427,19 +426,20 @@ final class HttpPipelineBuilder {
     final class StreamPipeline {
         private final Channel channel;
         private final ChannelPipeline pipeline;
-        private final boolean ssl;
+        @Nullable
+        private final SslHandler sslHandler;
 
         private final NettyServerCustomizer streamCustomizer;
 
-        private StreamPipeline(Channel channel, boolean ssl, NettyServerCustomizer streamCustomizer) {
+        private StreamPipeline(Channel channel, @Nullable SslHandler sslHandler, NettyServerCustomizer streamCustomizer) {
             this.channel = channel;
             this.pipeline = channel.pipeline();
-            this.ssl = ssl;
+            this.sslHandler = sslHandler;
             this.streamCustomizer = streamCustomizer;
         }
 
         void initializeChildPipelineForPushPromise(Channel childChannel) {
-            StreamPipeline promisePipeline = new StreamPipeline(childChannel, ssl, streamCustomizer.specializeForChannel(childChannel, NettyServerCustomizer.ChannelRole.PUSH_PROMISE_STREAM));
+            StreamPipeline promisePipeline = new StreamPipeline(childChannel, sslHandler, streamCustomizer.specializeForChannel(childChannel, NettyServerCustomizer.ChannelRole.PUSH_PROMISE_STREAM));
             promisePipeline.insertHttp2FrameHandlers();
             promisePipeline.streamCustomizer.onStreamPipelineBuilt();
         }
@@ -479,11 +479,11 @@ final class HttpPipelineBuilder {
             pipeline.addLast(ChannelPipelineCustomizer.HANDLER_HTTP_STREAM, new HttpStreamsServerHandler());
             pipeline.addLast(ChannelPipelineCustomizer.HANDLER_HTTP_CHUNK, new ChunkedWriteHandler());
             pipeline.addLast(HttpRequestDecoder.ID, requestDecoder);
-            if (server.getServerConfiguration().isDualProtocol() && server.getServerConfiguration().isHttpToHttpsRedirect() && !ssl) {
+            if (server.getServerConfiguration().isDualProtocol() && server.getServerConfiguration().isHttpToHttpsRedirect() && sslHandler == null) {
                 pipeline.addLast(ChannelPipelineCustomizer.HANDLER_HTTP_TO_HTTPS_REDIRECT, new HttpToHttpsRedirectHandler(sslConfiguration, hostResolver));
             }
-            if (ssl) {
-                pipeline.addLast("request-certificate-handler", requestCertificateHandler);
+            if (sslHandler != null) {
+                pipeline.addLast("request-certificate-handler", new HttpRequestCertificateHandler(sslHandler));
             }
             pipeline.addLast(HttpResponseEncoder.ID, responseEncoder);
             embeddedServices.getWebSocketUpgradeHandler(server).ifPresent(websocketHandler ->

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/ssl/HttpRequestCertificateHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/ssl/HttpRequestCertificateHandler.java
@@ -16,16 +16,15 @@
 package io.micronaut.http.server.netty.ssl;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.HttpAttributes;
 import io.micronaut.http.HttpMessage;
-import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.ssl.SslHandler;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
 import java.security.cert.Certificate;
-import java.util.Optional;
 
 /**
  * Adds the certificate to the decoded request.
@@ -34,35 +33,37 @@ import java.util.Optional;
  * @author Björn Heinrichs
  * @since 1.3.0
  */
-@ChannelHandler.Sharable
 @Internal
 public class HttpRequestCertificateHandler extends ChannelInboundHandlerAdapter {
+    private final SslHandler sslHandler;
+    private Certificate certificate;
+
+    public HttpRequestCertificateHandler(SslHandler sslHandler) {
+        this.sslHandler = sslHandler;
+    }
 
     @Override
     public void channelRead(final ChannelHandlerContext ctx, final Object msg) throws Exception {
-        if (msg instanceof HttpMessage) {
-            HttpMessage<?> request = (HttpMessage<?>) msg;
-            Optional<Certificate> certificate = getCertificate(ctx.pipeline().get(SslHandler.class));
-
-            if (certificate.isPresent()) {
-                request.setAttribute(HttpAttributes.X509_CERTIFICATE, certificate.get());
-            } else {
-                request.removeAttribute(HttpAttributes.X509_CERTIFICATE, Certificate.class);
+        if (msg instanceof HttpMessage<?> http) {
+            if (certificate == null) {
+                certificate = getCertificate(sslHandler);
+                if (certificate == null) {
+                    ctx.pipeline().remove(this);
+                    super.channelRead(ctx, msg);
+                    return;
+                }
             }
+            http.setAttribute(HttpAttributes.X509_CERTIFICATE, certificate);
         }
         super.channelRead(ctx, msg);
     }
 
-    private static Optional<Certificate> getCertificate(final SslHandler handler) {
-        if (handler == null) {
-            return Optional.empty();
-        }
+    @Nullable
+    private static Certificate getCertificate(final SslHandler handler) {
         try {
-            return Optional.of(
-                    handler.engine().getSession().getPeerCertificates()[0]
-            );
+            return handler.engine().getSession().getPeerCertificates()[0];
         } catch (SSLPeerUnverifiedException ex) {
-            return Optional.empty();
+            return null;
         }
     }
 }


### PR DESCRIPTION
there's an existing test in RequestCertificateSpec, this change just saves a bunch of getCertificate calls