### PR TITLE
fix primitive import with test

### DIFF
--- a/inject-java-test/src/test/groovy/io/micronaut/inject/beanimport/BeanImportSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/beanimport/BeanImportSpec.groovy
@@ -9,8 +9,38 @@ import io.smallrye.faulttolerance.DefaultExistingCircuitBreakerNames
 import io.smallrye.faulttolerance.DefaultFallbackHandlerProvider
 import io.smallrye.faulttolerance.DefaultFaultToleranceOperationProvider
 import io.smallrye.faulttolerance.ExecutorHolder
+import jakarta.inject.Named
+
+import java.nio.charset.StandardCharsets
 
 class BeanImportSpec extends AbstractTypeElementSpec {
+
+    void "test bean import with primitive array constructor"() {
+        given:
+        ApplicationContext context = buildContext('''
+package beanimporttest1;
+
+import io.micronaut.context.annotation.*;
+import jakarta.inject.Named;
+import java.nio.charset.StandardCharsets;
+
+@Import(classes=io.micronaut.inject.beanimport.UpstreamByteConstructorBean.class)
+class Application {}
+
+@Factory
+class BytesFactory {
+    @Bean
+    @Named("some-bytes")
+    byte[] myBytes() {
+        return "test".getBytes(StandardCharsets.UTF_8);
+    }
+}
+''')
+        def bean = context.getBean(UpstreamByteConstructorBean)
+
+        expect:
+        bean.toString() == 'test'
+    }
 
     void 'test bean import for package'() {
         given:
@@ -82,5 +112,18 @@ class Application {}
                 .preDestroyMethods.first().requiresReflection()
         cleanup:
         context.close()
+    }
+}
+class UpstreamByteConstructorBean {
+
+    private final byte[] bytes;
+
+    public UpstreamByteConstructorBean(@Named("some-bytes") byte[] bytes) {
+        this.bytes = bytes;
+    }
+
+    @Override
+    public String toString() {
+        return new String(bytes, StandardCharsets.UTF_8);
     }
 }

--- a/inject/src/main/java/io/micronaut/inject/processing/JavaModelUtils.java
+++ b/inject/src/main/java/io/micronaut/inject/processing/JavaModelUtils.java
@@ -267,11 +267,11 @@ public class JavaModelUtils {
      */
     public static Type getTypeReference(TypedElement type) {
         ClassElement classElement = type.getType();
-        if (type.isPrimitive()) {
+        if (classElement.isPrimitive()) {
             String internalName = NAME_TO_TYPE_MAP.get(classElement.getName());
-            if (type.isArray()) {
+            if (classElement.isArray()) {
                 StringBuilder name = new StringBuilder(internalName);
-                for (int i = 0; i < type.getArrayDimensions(); i++) {
+                for (int i = 0; i < classElement.getArrayDimensions(); i++) {
                     name.insert(0, "[");
                 }
                 return Type.getObjectType(name.toString());
@@ -279,19 +279,19 @@ public class JavaModelUtils {
                 return Type.getType(internalName);
             }
         } else {
-            Object nativeType = type.getNativeType();
+            Object nativeType = classElement.getNativeType();
             if (nativeType instanceof Class) {
                 Class<?> t = (Class<?>) nativeType;
                 return Type.getType(t);
             } else {
-                String internalName = type.getType().getName().replace('.', '/');
+                String internalName = classElement.getName().replace('.', '/');
                 if (internalName.isEmpty()) {
                     return Type.getType(Object.class);
                 }
-                if (type.isArray()) {
+                if (classElement.isArray()) {
                     StringBuilder name = new StringBuilder(internalName);
                     name.insert(0, "L");
-                    for (int i = 0; i < type.getArrayDimensions(); i++) {
+                    for (int i = 0; i < classElement.getArrayDimensions(); i++) {
                         name.insert(0, "[");
                     }
                     name.append(";");


### PR DESCRIPTION
Primitive types in constructors of imported beans where handled improperly, an array of primitives in synthesized as a type with the name of the primitive (e.g. byte[] becomes Lbyte; instead of [B;).

This is caused by a bug in JavaModelUtils.getTypeReference where the given type element is used instead of the actual class element.

Fixes https://github.com/micronaut-projects/micronaut-core/issues/8635
