### PR TITLE
Client tests use blocking and non-blocking client

### DIFF
--- a/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/AuthTest.java
+++ b/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/AuthTest.java
@@ -23,25 +23,24 @@ import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
 import io.micronaut.http.tck.AssertionUtils;
 import io.micronaut.http.tck.HttpResponseAssertion;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
+import java.util.Map;
 
+import static io.micronaut.http.tck.ServerUnderTest.BLOCKING_CLIENT_PROPERTY;
 import static io.micronaut.http.tck.TestScenario.asserts;
 
-@SuppressWarnings({
-    "java:S2259", // The tests will show if it's null
-    "java:S5960", // We're allowed assertions, as these are used in tests only
-    "checkstyle:MissingJavadocType",
-    "checkstyle:DesignForExtension",
-})
 class AuthTest {
 
     private static final String SPEC_NAME = "AuthTest";
 
-    @Test
-    void authTest() throws IOException {
+    @ParameterizedTest(name = "blocking={0}")
+    @ValueSource(booleans = {true, false})
+    void authTest(boolean blocking) throws IOException {
         asserts(SPEC_NAME,
+            Map.of(BLOCKING_CLIENT_PROPERTY, blocking),
             HttpRequest.GET("/auth-test").basicAuth("Tim", "Yates"),
             (server, request) -> AssertionUtils.assertDoesNotThrow(server, request,
                 HttpResponseAssertion.builder()

--- a/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/CookieTest.java
+++ b/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/CookieTest.java
@@ -26,27 +26,25 @@ import io.micronaut.http.cookie.Cookie;
 import io.micronaut.http.tck.AssertionUtils;
 import io.micronaut.http.tck.BodyAssertion;
 import io.micronaut.http.tck.HttpResponseAssertion;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import static io.micronaut.http.tck.ServerUnderTest.BLOCKING_CLIENT_PROPERTY;
 import static io.micronaut.http.tck.TestScenario.asserts;
 
-@SuppressWarnings({
-    "java:S2259", // The tests will show if it's null
-    "java:S5960", // We're allowed assertions, as these are used in tests only
-    "checkstyle:MissingJavadocType",
-    "checkstyle:DesignForExtension",
-})
 class CookieTest {
 
     private static final String SPEC_NAME = "CookieTest";
 
-    @Test
-    void cookieBinding() throws IOException {
+    @ParameterizedTest(name = "blocking={0}")
+    @ValueSource(booleans = {true, false})
+    void cookieBinding(boolean blocking) throws IOException {
         asserts(SPEC_NAME,
+            Map.of(BLOCKING_CLIENT_PROPERTY, blocking),
             HttpRequest.GET("/cookies-test/bind")
                 .cookie(Cookie.of("one", "foo"))
                 .cookie(Cookie.of("two", "bar")),
@@ -58,9 +56,11 @@ class CookieTest {
         );
     }
 
-    @Test
-    void getCookiesFromRequest() throws IOException {
+    @ParameterizedTest(name = "blocking={0}")
+    @ValueSource(booleans = {true, false})
+    void getCookiesFromRequest(boolean blocking) throws IOException {
         asserts(SPEC_NAME,
+            Map.of(BLOCKING_CLIENT_PROPERTY, blocking),
             HttpRequest.GET("/cookies-test/all")
                 .cookie(Cookie.of("one", "foo"))
                 .cookie(Cookie.of("two", "bar")),
@@ -72,9 +72,11 @@ class CookieTest {
         );
     }
 
-    @Test
-    void testNoCookies() throws IOException {
+    @ParameterizedTest(name = "blocking={0}")
+    @ValueSource(booleans = {true, false})
+    void testNoCookies(boolean blocking) throws IOException {
         asserts(SPEC_NAME,
+            Map.of(BLOCKING_CLIENT_PROPERTY, blocking),
             HttpRequest.GET("/cookies-test/all"),
             (server, request) -> AssertionUtils.assertDoesNotThrow(server, request,
                 HttpResponseAssertion.builder()

--- a/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/DontFollowRedirectsTest.java
+++ b/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/DontFollowRedirectsTest.java
@@ -24,22 +24,30 @@ import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
 import io.micronaut.http.tck.AssertionUtils;
 import io.micronaut.http.tck.HttpResponseAssertion;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.net.URI;
-import java.util.Collections;
+import java.util.Map;
 
+import static io.micronaut.http.tck.ServerUnderTest.BLOCKING_CLIENT_PROPERTY;
 import static io.micronaut.http.tck.TestScenario.asserts;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class DontFollowRedirectsTest {
+class DontFollowRedirectsTest {
+
     private static final String SPEC_NAME = "DisableRedirectTest";
 
-    @Test
-    void dontFollowRedirects() throws IOException {
+    @ParameterizedTest(name = "blocking={0}")
+    @ValueSource(booleans = {true, false})
+    void dontFollowRedirects(boolean blocking) throws IOException {
         asserts(SPEC_NAME,
-            Collections.singletonMap("micronaut.http.client.follow-redirects", StringUtils.FALSE),
+            Map.of(
+                "micronaut.http.client.follow-redirects", StringUtils.FALSE,
+                BLOCKING_CLIENT_PROPERTY, blocking
+            ),
             HttpRequest.GET("/redirect/redirect"),
             (server, request) -> AssertionUtils.assertDoesNotThrow(server, request, HttpResponseAssertion.builder()
                 .status(HttpStatus.SEE_OTHER)

--- a/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/ExceptionOnErrorStatusTest.java
+++ b/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/ExceptionOnErrorStatusTest.java
@@ -24,21 +24,27 @@ import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
 import io.micronaut.http.tck.AssertionUtils;
 import io.micronaut.http.tck.HttpResponseAssertion;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
-import java.util.Collections;
+import java.util.Map;
 
+import static io.micronaut.http.tck.ServerUnderTest.BLOCKING_CLIENT_PROPERTY;
 import static io.micronaut.http.tck.TestScenario.asserts;
 
 class ExceptionOnErrorStatusTest {
 
     private static final String SPEC_NAME = "ExceptionOnErrorStatusTest";
 
-    @Test
-    void exceptionOnErrorStatus() throws IOException {
+    @ParameterizedTest(name = "blocking={0}")
+    @ValueSource(booleans = {true, false})
+    void exceptionOnErrorStatus(boolean blocking) throws IOException {
         asserts(SPEC_NAME,
-            Collections.singletonMap("micronaut.http.client.exception-on-error-status", StringUtils.FALSE),
+            Map.of(
+                "micronaut.http.client.exception-on-error-status", StringUtils.FALSE,
+                BLOCKING_CLIENT_PROPERTY, blocking
+            ),
             HttpRequest.GET("/unprocessable"),
             (server, request) -> AssertionUtils.assertDoesNotThrow(server, request, HttpResponseAssertion.builder()
                 .status(HttpStatus.UNPROCESSABLE_ENTITY)

--- a/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/HttpMethodDeleteTest.java
+++ b/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/HttpMethodDeleteTest.java
@@ -29,25 +29,26 @@ import io.micronaut.http.tck.HttpResponseAssertion;
 import io.micronaut.http.tck.ServerUnderTest;
 import io.micronaut.http.tck.ServerUnderTestProviderUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
+import java.util.Map;
 
+import static io.micronaut.http.tck.ServerUnderTest.BLOCKING_CLIENT_PROPERTY;
 import static io.micronaut.http.tck.TestScenario.asserts;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@SuppressWarnings({
-    "java:S2259", // The tests will show if it's null
-    "java:S5960", // We're allowed assertions, as these are used in tests only
-    "checkstyle:MissingJavadocType",
-    "checkstyle:DesignForExtension",
-})
 class HttpMethodDeleteTest {
 
     private static final String SPEC_NAME = "HttpMethodDeleteTest";
 
-    @Test
-    void deleteMethodMapping() throws IOException {
-        asserts(SPEC_NAME, HttpRequest.DELETE("/delete"), (server, request) ->
+    @ParameterizedTest(name = "blocking={0}")
+    @ValueSource(booleans = {true, false})
+    void deleteMethodMapping(boolean blocking) throws IOException {
+        asserts(SPEC_NAME,
+            Map.of(BLOCKING_CLIENT_PROPERTY, blocking),
+            HttpRequest.DELETE("/delete"), (server, request) ->
             AssertionUtils.assertDoesNotThrow(server, request,
                 HttpResponseAssertion.builder()
                     .status(HttpStatus.NO_CONTENT)
@@ -63,9 +64,11 @@ class HttpMethodDeleteTest {
         }
     }
 
-    @Test
-    void deleteMethodMappingWithStringResponse() throws IOException {
+    @ParameterizedTest(name = "blocking={0}")
+    @ValueSource(booleans = {true, false})
+    void deleteMethodMappingWithStringResponse(boolean blocking) throws IOException {
         asserts(SPEC_NAME,
+            Map.of(BLOCKING_CLIENT_PROPERTY, blocking),
             HttpRequest.DELETE("/delete/string-response"),
             (server, request) ->
                 AssertionUtils.assertDoesNotThrow(server, request,
@@ -76,9 +79,11 @@ class HttpMethodDeleteTest {
         );
     }
 
-    @Test
-    void deleteMethodMappingWithObjectResponse() throws IOException {
+    @ParameterizedTest(name = "blocking={0}")
+    @ValueSource(booleans = {true, false})
+    void deleteMethodMappingWithObjectResponse(boolean blocking) throws IOException {
         asserts(SPEC_NAME,
+            Map.of(BLOCKING_CLIENT_PROPERTY, blocking),
             HttpRequest.DELETE("/delete/object-response"),
             (server, request) ->
                 AssertionUtils.assertDoesNotThrow(server, request,

--- a/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/HttpMethodPostTest.java
+++ b/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/HttpMethodPostTest.java
@@ -22,25 +22,24 @@ import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
 import io.micronaut.http.tck.AssertionUtils;
 import io.micronaut.http.tck.HttpResponseAssertion;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
+import java.util.Map;
 
+import static io.micronaut.http.tck.ServerUnderTest.BLOCKING_CLIENT_PROPERTY;
 import static io.micronaut.http.tck.TestScenario.asserts;
 
-@SuppressWarnings({
-    "java:S2259", // The tests will show if it's null
-    "java:S5960", // We're allowed assertions, as these are used in tests only
-    "checkstyle:MissingJavadocType",
-    "checkstyle:DesignForExtension",
-})
 class HttpMethodPostTest {
 
     private static final String SPEC_NAME = "HttpMethodPostTest";
 
-    @Test
-    void postBody() throws IOException {
+    @ParameterizedTest(name = "blocking={0}")
+    @ValueSource(booleans = {true, false})
+    void postBody(boolean blocking) throws IOException {
         asserts(SPEC_NAME,
+            Map.of(BLOCKING_CLIENT_PROPERTY, blocking),
             HttpRequest.POST("/post/object-body", new Person("Tim", 49)),
             (server, request) ->
                 AssertionUtils.assertDoesNotThrow(server, request,

--- a/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/StatusTest.java
+++ b/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/StatusTest.java
@@ -29,25 +29,24 @@ import io.micronaut.http.server.exceptions.response.ErrorResponseProcessor;
 import io.micronaut.http.tck.AssertionUtils;
 import io.micronaut.http.tck.HttpResponseAssertion;
 import jakarta.inject.Singleton;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
+import java.util.Map;
 
+import static io.micronaut.http.tck.ServerUnderTest.BLOCKING_CLIENT_PROPERTY;
 import static io.micronaut.http.tck.TestScenario.asserts;
 
-@SuppressWarnings({
-    "java:S2259", // The tests will show if it's null
-    "java:S5960", // We're allowed assertions, as these are used in tests only
-    "checkstyle:MissingJavadocType",
-    "checkstyle:DesignForExtension",
-})
-public class StatusTest {
+class StatusTest {
 
     private static final String SPEC_NAME = "StatusTest";
 
-    @Test
-    void returnStatus() throws IOException {
+    @ParameterizedTest(name = "blocking={0}")
+    @ValueSource(booleans = {true, false})
+    void returnStatus(boolean blocking) throws IOException {
         asserts(SPEC_NAME,
+            Map.of(BLOCKING_CLIENT_PROPERTY, blocking),
             HttpRequest.GET("/status/http-status"),
             (server, request) ->
                 AssertionUtils.assertThrows(server, request,
@@ -57,9 +56,11 @@ public class StatusTest {
         );
     }
 
-    @Test
-    void responseStatus() throws IOException {
+    @ParameterizedTest(name = "blocking={0}")
+    @ValueSource(booleans = {true, false})
+    void responseStatus(boolean blocking) throws IOException {
         asserts(SPEC_NAME,
+            Map.of(BLOCKING_CLIENT_PROPERTY, blocking),
             HttpRequest.GET("/status/response-status"),
             (server, request) ->
                 AssertionUtils.assertThrows(server, request,
@@ -69,9 +70,11 @@ public class StatusTest {
         );
     }
 
-    @Test
-    void atStatus() throws IOException {
+    @ParameterizedTest(name = "blocking={0}")
+    @ValueSource(booleans = {true, false})
+    void atStatus(boolean blocking) throws IOException {
         asserts(SPEC_NAME,
+            Map.of(BLOCKING_CLIENT_PROPERTY, blocking),
             HttpRequest.GET("/status/at-status"),
             (server, request) ->
                 AssertionUtils.assertThrows(server, request,
@@ -81,9 +84,11 @@ public class StatusTest {
         );
     }
 
-    @Test
-    void exceptionStatus() throws IOException {
+    @ParameterizedTest(name = "blocking={0}")
+    @ValueSource(booleans = {true, false})
+    void exceptionStatus(boolean blocking) throws IOException {
         asserts(SPEC_NAME,
+            Map.of(BLOCKING_CLIENT_PROPERTY, blocking),
             HttpRequest.GET("/status/exception-status"),
             (server, request) ->
                 AssertionUtils.assertThrows(server, request,

--- a/http-tck/src/main/java/io/micronaut/http/tck/ServerUnderTest.java
+++ b/http-tck/src/main/java/io/micronaut/http/tck/ServerUnderTest.java
@@ -34,6 +34,13 @@ import java.util.Optional;
 @Experimental
 public interface ServerUnderTest extends ApplicationContextProvider, Closeable, AutoCloseable {
 
+    /**
+     * The property name used to signify we want to use a non-blocking client.
+     *
+     * This is used as the implementation varies for the javanet client.
+     */
+    String BLOCKING_CLIENT_PROPERTY = "use.blocking.client";
+
     /*
      * Perform an HTTP request for the given request against the server under test and returns the the full HTTP response
      * @param request  The {@link HttpRequest} to execute

--- a/test-suite-http-client-tck-javanet/src/test/java/javanet/JavanetHttpMethodTests.java
+++ b/test-suite-http-client-tck-javanet/src/test/java/javanet/JavanetHttpMethodTests.java
@@ -1,4 +1,4 @@
-package netty;
+package javanet;
 
 import org.junit.platform.suite.api.SelectPackages;
 import org.junit.platform.suite.api.Suite;


### PR DESCRIPTION
For netty, the blocking client is basically the non-blocking client with a Flux wrapper.

For javanet, this is not the case, and the blocking client makes use of the blocking methods in HttpClient.

To ensure both implementations are working, this PR adds a property to the server under test as to whether it should test with a blocking or non-blocking client.