### PR TITLE
Fix GraalVM native image support

### DIFF
--- a/http-netty/src/main/resources/META-INF/native-image/io.micronaut/micronaut-http-netty/native-image.properties
+++ b/http-netty/src/main/resources/META-INF/native-image/io.micronaut/micronaut-http-netty/native-image.properties
@@ -1,1 +1,0 @@
-Args = --features=io.micronaut.http.netty.graal.HttpNettyFeature

--- a/inject/src/main/resources/META-INF/native-image/io.micronaut/micronaut-inject/native-image.properties
+++ b/inject/src/main/resources/META-INF/native-image/io.micronaut/micronaut-inject/native-image.properties
@@ -18,5 +18,4 @@ Args = -H:EnableURLProtocols=http,https \
        --initialize-at-build-time=io.micronaut.context.annotation \
        --initialize-at-build-time=io.micronaut.inject.annotation \
        --initialize-at-build-time=io.micronaut.runtime.converters.time \
-       --initialize-at-run-time=io.micronaut.inject.provider.JakartaProviderBeanDefinition \
        --initialize-at-run-time=io.micronaut.context.env.CachedEnvironment


### PR DESCRIPTION
The merge up from 3.8.x was incorrect and broke the GraalVM configuration. This fixes that.