### PR TITLE
Rollback changes that have broken Micronaut Serialization

### DIFF
--- a/core/src/main/java/io/micronaut/core/type/Argument.java
+++ b/core/src/main/java/io/micronaut/core/type/Argument.java
@@ -549,7 +549,7 @@ public interface Argument<T> extends TypeInformation<T>, AnnotatedElement, Type 
      */
     @NonNull
     static <T> Argument<List<T>> listOf(@NonNull Class<T> type) {
-        return listOf(Argument.ofTypeVariable(type, "E"));
+        return listOf(Argument.of(type, "E"));
     }
 
     /**
@@ -575,7 +575,7 @@ public interface Argument<T> extends TypeInformation<T>, AnnotatedElement, Type 
      */
     @NonNull
     static <T> Argument<Set<T>> setOf(@NonNull Class<T> type) {
-        return setOf(Argument.ofTypeVariable(type, "E"));
+        return setOf(Argument.of(type, "E"));
     }
 
     /**
@@ -603,7 +603,7 @@ public interface Argument<T> extends TypeInformation<T>, AnnotatedElement, Type 
      */
     @NonNull
     static <K, V> Argument<Map<K, V>> mapOf(@NonNull Class<K> keyType, @NonNull Class<V> valueType) {
-        return mapOf(Argument.ofTypeVariable(keyType, "K"), Argument.ofTypeVariable(valueType, "V"));
+        return mapOf(Argument.of(keyType, "K"), Argument.of(valueType, "V"));
     }
 
     /**
@@ -632,7 +632,7 @@ public interface Argument<T> extends TypeInformation<T>, AnnotatedElement, Type 
      */
     @NonNull
     static <T> Argument<Optional<T>> optionalOf(@NonNull Class<T> optionalValueClass) {
-        return optionalOf(Argument.ofTypeVariable(optionalValueClass, "T"));
+        return optionalOf(Argument.of(optionalValueClass, "T"));
     }
 
     /**

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/AbstractGroovyElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/AbstractGroovyElement.java
@@ -263,7 +263,7 @@ public abstract class AbstractGroovyElement implements Element {
         if (genericsType.isPlaceholder()) {
             return resolvePlaceholder(declaredElement, genericsOwner, genericsType, redirectType, parentTypeArguments, visitedTypes, isRawType);
         }
-        return newClassElement(declaredElement, genericsType.getType(), parentTypeArguments, visitedTypes, true, isRawType);
+        return newClassElement(declaredElement, genericsType.getType(), parentTypeArguments, visitedTypes, genericsType.isPlaceholder(), isRawType);
     }
 
     @NonNull

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/beans/BeanDefinitionSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/beans/BeanDefinitionSpec.groovy
@@ -268,13 +268,13 @@ interface Deserializer<T> {
             def deserializerTypeParam = definition.getTypeArguments("test.Deserializer")[0]
 
         then: "The first is a placeholder"
-            serdeTypeParam.isTypeVariable() //
-            (serdeTypeParam instanceof GenericPlaceholder)
+            !serdeTypeParam.isTypeVariable() //
+            !(serdeTypeParam instanceof GenericPlaceholder)
         and:
-            serializerTypeParam.isTypeVariable()
-            (serializerTypeParam instanceof GenericPlaceholder)
-            deserializerTypeParam.isTypeVariable()
-            (deserializerTypeParam instanceof GenericPlaceholder)
+            !serializerTypeParam.isTypeVariable()
+            !(serializerTypeParam instanceof GenericPlaceholder)
+            !deserializerTypeParam.isTypeVariable()
+            !(deserializerTypeParam instanceof GenericPlaceholder)
     }
 
     void "test isTypeVariable array"() {

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/AbstractJavaElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/AbstractJavaElement.java
@@ -461,7 +461,7 @@ public abstract class AbstractJavaElement implements io.micronaut.inject.ast.Ele
                 String variableName = typeParameter.getSimpleName().toString();
                 resolved.put(
                         variableName,
-                        newClassElement(getNativeType(), typeParameterMirror, parentTypeArguments, visitedTypes, true, false, typeParameter)
+                        newClassElement(getNativeType(), typeParameterMirror, parentTypeArguments, visitedTypes, typeParameterMirror instanceof TypeVariable, false, typeParameter)
                 );
             }
         } else {

--- a/inject-java/src/test/groovy/io/micronaut/inject/beans/BeanDefinitionSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beans/BeanDefinitionSpec.groovy
@@ -1,8 +1,10 @@
 package io.micronaut.inject.beans
 
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.ApplicationContext
 import io.micronaut.core.annotation.AnnotationUtil
 import io.micronaut.core.annotation.Order
+import io.micronaut.core.type.Argument
 import io.micronaut.core.type.GenericPlaceholder
 import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.qualifiers.Qualifiers
@@ -496,13 +498,15 @@ public class Test {
 
     void "test isTypeVariable"() {
         given:
-            BeanDefinition definition = buildBeanDefinition('test', 'Test', '''
+        ApplicationContext context = buildContext( '''
 package test;
 import javax.validation.constraints.*;
-import java.util.List;
+import java.util.*;
+import io.micronaut.core.annotation.*;
+import io.micronaut.context.annotation.*;
 
 @jakarta.inject.Singleton
-public class Test implements Serde<Object> {
+class Test implements Serde<Object> {
 }
 
 interface Serde<T> extends Serializer<T>, Deserializer<T> {
@@ -514,15 +518,30 @@ interface Serializer<T> {
 interface Deserializer<T> {
 }
 
+@jakarta.inject.Singleton
+@Order(-100)
+class ArrayListTest<E> implements Serde<ArrayList<E>> {
+}
+
+@jakarta.inject.Singleton
+class SetTest<E> implements Serde<HashSet<E>> {
+}
 
         ''')
+
+        BeanDefinition<?> definition = getBeanDefinition(context, 'test.Test')
+
 
         when: "Micronaut Serialization use-case"
             def serdeTypeParam = definition.getTypeArguments("test.Serde")[0]
             def serializerTypeParam = definition.getTypeArguments("test.Serializer")[0]
             def deserializerTypeParam = definition.getTypeArguments("test.Deserializer")[0]
+            def listDeser = context.getBean(Argument.of(context.classLoader.loadClass('test.Deserializer'), Argument.listOf(String)))
+            def collectionDeser = context.getBean(Argument.of(context.classLoader.loadClass('test.Deserializer'), Argument.of(Collection.class, String)))
 
         then: "The first is a placeholder"
+            listDeser.getClass().name == 'test.ArrayListTest'
+            listDeser.is(collectionDeser)
             !serdeTypeParam.isTypeVariable() //
             !(serdeTypeParam instanceof GenericPlaceholder)
         and: "threat resolved placeholder as not a type variable"

--- a/inject-java/src/test/groovy/io/micronaut/inject/beans/BeanDefinitionSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/beans/BeanDefinitionSpec.groovy
@@ -523,13 +523,13 @@ interface Deserializer<T> {
             def deserializerTypeParam = definition.getTypeArguments("test.Deserializer")[0]
 
         then: "The first is a placeholder"
-            serdeTypeParam.isTypeVariable() //
-            (serdeTypeParam instanceof GenericPlaceholder)
+            !serdeTypeParam.isTypeVariable() //
+            !(serdeTypeParam instanceof GenericPlaceholder)
         and: "threat resolved placeholder as not a type variable"
-            serializerTypeParam.isTypeVariable()
-            (serializerTypeParam instanceof GenericPlaceholder)
-            deserializerTypeParam.isTypeVariable()
-            (deserializerTypeParam instanceof GenericPlaceholder)
+            !serializerTypeParam.isTypeVariable()
+            !(serializerTypeParam instanceof GenericPlaceholder)
+            !deserializerTypeParam.isTypeVariable()
+            !(deserializerTypeParam instanceof GenericPlaceholder)
     }
 
     void "test isTypeVariable array"() {


### PR DESCRIPTION
Modifying the test results in reverting to match the behaviour in 3.8.x.

The `isTypeVariable()` method should only return `true` in the case where the type argument is a placeholder (ie `List<T>`) not in the case where the argument is a concrete type (ie `List<String>`)