### PR TITLE
Add missing backtick in configurationProperties.adoc

### DIFF
--- a/src/main/docs/guide/config/configurationProperties.adoc
+++ b/src/main/docs/guide/config/configurationProperties.adoc
@@ -84,7 +84,7 @@ public class EngineConfig {
 <1> Micronaut will use an empty prefix for getters and setters.
 <2> Define the getters and setters with an empty prefix.
 
-Now you can inject `EngineConfig` and use it with `engineConfig.manufacturer()` and `engineConfig.cylinders() to retrieve the values from configuration.
+Now you can inject `EngineConfig` and use it with `engineConfig.manufacturer()` and `engineConfig.cylinders()` to retrieve the values from configuration.
 
 == Property Type Conversion
 


### PR DESCRIPTION
**Issue:**
<img width="1302" alt="image" src="https://user-images.githubusercontent.com/11317222/220641074-ca70cd94-7d3d-49ca-8d68-a2c51a26c82a.png">
