### PR TITLE
Removed mention of default null check behaviour from javadoc

### DIFF
--- a/core/src/main/java/io/micronaut/core/annotation/NonNull.java
+++ b/core/src/main/java/io/micronaut/core/annotation/NonNull.java
@@ -32,9 +32,6 @@ import java.lang.annotation.Target;
  * <p>Should be used at parameter, return value, and field level. Method overrides should repeat parent {@code @NonNull} annotations unless
  * they behave differently.</p>
  *
- * <p>Use {@code @NonNull} Api (scope = parameters + return values) to set the default behavior to non-nullable in order to avoid annotating
- * your whole codebase with {@code @NonNull}.</p>
- *
  * @author graemerocher
  * @see Nullable
  * @since 2.4


### PR DESCRIPTION
@NonNullApi annotation doesn't exist in micronaut and there is no way to set the default behavior to non-nullable, so this entire paragraph should be removed.