### PR TITLE
fix validation of write-only config properties

### DIFF
--- a/core/src/main/java/io/micronaut/core/io/service/SoftServiceLoader.java
+++ b/core/src/main/java/io/micronaut/core/io/service/SoftServiceLoader.java
@@ -368,7 +368,7 @@ public final class SoftServiceLoader<S> implements Iterable<ServiceDefinition<S>
             return findAll(condition)
                     .map(ServiceDefinition::load)
                     .filter(s -> predicate == null || predicate.test(s))
-                    .collect(Collectors.toList());
+                    .toList();
         }
     }
 

--- a/inject-java/src/test/groovy/io/micronaut/inject/configproperties/writeonly/WriteOnlyConfigProperties.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configproperties/writeonly/WriteOnlyConfigProperties.java
@@ -1,0 +1,19 @@
+package io.micronaut.inject.configproperties.writeonly;
+
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+
+import javax.validation.constraints.NotBlank;
+
+@ConfigurationProperties("test")
+public class WriteOnlyConfigProperties {
+    private String name;
+
+    public void setName(@NotBlank String name) {
+        this.name = name;
+    }
+
+    public String name() {
+        return name;
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/configproperties/writeonly/WriteOnlyConfigPropertiesSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configproperties/writeonly/WriteOnlyConfigPropertiesSpec.groovy
@@ -1,0 +1,35 @@
+package io.micronaut.inject.configproperties.writeonly
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.exceptions.BeanInstantiationException
+import spock.lang.Specification
+
+class WriteOnlyConfigPropertiesSpec extends Specification {
+
+    void "test write-only config properties - valid"() {
+        given:
+        def context = ApplicationContext.run('test.name':'test')
+        def bean = context.getBean(WriteOnlyConfigProperties)
+
+        expect:
+        bean.name() == 'test'
+
+        cleanup:
+        context.close()
+    }
+
+    void "test write-only config properties - invalid"() {
+        given:
+        def context = ApplicationContext.run('test.name':'  ')
+
+        when:
+        def bean = context.getBean(WriteOnlyConfigProperties)
+
+        then:
+        def e = thrown(BeanInstantiationException)
+        e.message.contains("Validation failed for bean definition")
+
+        cleanup:
+        context.close()
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/AbstractInitializableBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/context/AbstractInitializableBeanDefinition.java
@@ -75,6 +75,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
@@ -1038,9 +1039,19 @@ public abstract class AbstractInitializableBeanDefinition<T> extends AbstractBea
                                                              String cliProperty) {
         MethodReference methodRef = methodInjection[methodIndex];
         Argument<?> argument = methodRef.arguments[argIndex];
-        try (BeanResolutionContext.Path ignored = resolutionContext.getPath()
+        try (BeanResolutionContext.Path path = resolutionContext.getPath()
                 .pushMethodArgumentResolve(this, methodRef.methodName, argument, methodRef.arguments)) {
-            return resolvePropertyValue(resolutionContext, context, argument, propertyValue, cliProperty, false);
+            Object val = resolvePropertyValue(resolutionContext, context, argument, propertyValue, cliProperty, false);
+            if (this instanceof ValidatedBeanDefinition validatedBeanDefinition) {
+                validatedBeanDefinition.validateBeanArgument(
+                    resolutionContext,
+                    Objects.requireNonNull(path.peek()).getInjectionPoint(),
+                    argument,
+                    argIndex,
+                    val
+                );
+            }
+            return val;
         }
     }
 
@@ -1088,9 +1099,19 @@ public abstract class AbstractInitializableBeanDefinition<T> extends AbstractBea
                                                      Argument<?> argument,
                                                      String propertyValue,
                                                      String cliProperty) {
-        try (BeanResolutionContext.Path ignored = resolutionContext.getPath()
+        try (BeanResolutionContext.Path path = resolutionContext.getPath()
                 .pushMethodArgumentResolve(this, setterName, argument, new Argument[]{argument})) {
-            return resolvePropertyValue(resolutionContext, context, argument, propertyValue, cliProperty, false);
+            Object val = resolvePropertyValue(resolutionContext, context, argument, propertyValue, cliProperty, false);
+            if (this instanceof ValidatedBeanDefinition validatedBeanDefinition) {
+                validatedBeanDefinition.validateBeanArgument(
+                    resolutionContext,
+                    Objects.requireNonNull(path.peek()).getInjectionPoint(),
+                    argument,
+                    0,
+                    val
+                );
+            }
+            return val;
         }
     }
 

--- a/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java
@@ -1115,6 +1115,9 @@ public class DefaultValidator implements Validator, ExecutableMethodValidator, R
         @SuppressWarnings("unchecked")
         final Class<T> rootBeanClass = (Class<T>) rootBean.getClass();
         for (BeanProperty<Object, Object> constrainedProperty : constrainedProperties) {
+            if (constrainedProperty.isWriteOnly()) {
+                continue;
+            }
             final Object propertyValue = constrainedProperty.get(object);
             //noinspection unchecked
             validateConstrainedPropertyInternal(


### PR DESCRIPTION
This PR fixes the R2DBC tests which are failing right now https://ge.micronaut.io/s/negfsow4qshaw/tests/:test-graalvm:mssql:test/example.controllers.SqlServerAppSpec?top-execution=1

They fail because the validator tries to validate write-only properties by reading them via an introspection. This PR disables that and instead validates via the bean argument.

Note that a further refinement would be to not generate an introspection here because it is not needed.

In addition when the new validator module is integrated the same change will need to be made to the forked module.