### PR TITLE
Fix broken MethodElement.overrides implementation

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/ast/MethodElement.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/MethodElement.java
@@ -240,6 +240,15 @@ public interface MethodElement extends MemberElement {
         if (this.equals(overridden) || isStatic() || overridden.isStatic()) {
             return false;
         }
+        ClassElement thisType = getDeclaringType();
+        ClassElement thatType = overridden.getDeclaringType();
+        if (thisType.getName().equals(thatType.getName())) {
+            return false;
+        }
+        if (!thisType.isAssignable(thatType)) {
+            // not a parent class
+            return false;
+        }
         MethodElement newMethod = this;
         if (newMethod.isAbstract() && !newMethod.isDefault() && (!overridden.isAbstract() || overridden.isDefault())) {
             return false;

--- a/core-processor/src/main/java/io/micronaut/inject/processing/IntroductionInterfaceBeanElementCreator.java
+++ b/core-processor/src/main/java/io/micronaut/inject/processing/IntroductionInterfaceBeanElementCreator.java
@@ -67,7 +67,7 @@ final class IntroductionInterfaceBeanElementCreator extends AbstractBeanElementC
 
         // The introduction will include overridden methods* (find(List) <- find(Iterable)*) but ordinary class introduction doesn't
         // Because of the caching we need to process declared methods first
-        List<MethodElement> allMethods = new ArrayList<>(classElement.getEnclosedElements(ElementQuery.ALL_METHODS.includeOverriddenMethods().includeOverriddenMethods()));
+        List<MethodElement> allMethods = new ArrayList<>(classElement.getEnclosedElements(ElementQuery.ALL_METHODS.includeOverriddenMethods()));
         List<MethodElement> methods = new ArrayList<>(allMethods);
         List<MethodElement> nonAbstractMethods = methods.stream().filter(m -> !m.isAbstract()).toList();
         // Remove abstract methods overridden by non-abstract ones

--- a/inject-java/src/test/groovy/io/micronaut/inject/configproperties/InterfaceConfigurationPropertiesSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configproperties/InterfaceConfigurationPropertiesSpec.groovy
@@ -19,15 +19,21 @@ class InterfaceConfigurationPropertiesSpec extends AbstractTypeElementSpec {
 package test;
 
 import io.micronaut.context.annotation.*;
+import io.micronaut.core.bind.annotation.Bindable;
+import io.micronaut.core.util.Toggleable;
 import java.time.Duration;
 
 @ConfigurationProperties("foo.bar")
-interface MyConfig {
+interface MyConfig extends Toggleable {
     @javax.validation.constraints.NotBlank
     String getHost();
 
     @javax.validation.constraints.Min(10L)
     int getServerPort();
+
+    @Bindable(defaultValue = "true")
+    @Override
+    boolean isEnabled();
 }
 
 ''')
@@ -46,6 +52,7 @@ interface MyConfig {
         then:
         config.host == 'test'
         config.serverPort == 9999
+        config.enabled
 
         cleanup:
         context.close()


### PR DESCRIPTION
The Micronaut Servlet module is broken because the current `MethodElement.overrides` implementation doesn't take into account whether the overriding candidate is from a parent class or interface. This results in the following exception because `Toggelable.isEnabled()` (a default method) is considered to override the abstract implementation that exists in `ServletStaticResourceConfiguration`:

```

Message: Receiver class io.micronaut.servlet.engine.server.ServletStaticResourceConfiguration$Intercepted does not define or inherit an implementation of the resolved method 'abstract boolean isEnabled()' of interface io.micronaut.servlet.engine.server.ServletStaticResourceConfiguration.
Path Taken: new UndertowServer(ApplicationContext applicationContext,ApplicationConfiguration applicationConfiguration,Undertow undertow) --> new UndertowServer(ApplicationContext applicationContext,ApplicationConfiguration applicationConfiguration,[Undertow undertow])
	at app//io.micronaut.context.DefaultBeanContext.resolveByBeanFactory(DefaultBeanContext.java:2381)
	at app//io.micronaut.context.DefaultBeanContext.doCreateBean(DefaultBeanContext.java:2329)
	at app//io.micronaut.context.DefaultBeanContext.doCreateBean(DefaultBeanContext.java:2341)
	at app//io.micronaut.context.DefaultBeanContext.createRegistration(DefaultBeanContext.java:3115)
```	

The fix here alters the logic to return `false` from `overrides` if the candidate method is not from a parent class or interface.