### PR TITLE
fix IncompatibleClassChangeError in ConfigurationProperties

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -1436,9 +1436,10 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
 
                 Type declaringTypeRef = JavaModelUtils.getTypeReference(declaringType);
                 String methodDescriptor = getMethodDescriptor(methodElement.getReturnType(), Arrays.asList(methodElement.getParameters()));
-                injectMethodVisitor.visitMethodInsn(isInterface ? INVOKEINTERFACE : INVOKEVIRTUAL,
+                boolean isDeclaringTypeInterface = declaringType.getType().isInterface();
+                injectMethodVisitor.visitMethodInsn(isDeclaringTypeInterface ? INVOKEINTERFACE : INVOKEVIRTUAL,
                         declaringTypeRef.getInternalName(), methodElement.getName(),
-                        methodDescriptor, isInterface);
+                        methodDescriptor, isDeclaringTypeInterface);
 
                 if (!methodElement.getReturnType().isVoid()) {
                     injectMethodVisitor.pop();

--- a/inject-java/src/test/groovy/io/micronaut/inject/configproperties/ConfigPropertiesParseSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configproperties/ConfigPropertiesParseSpec.groovy
@@ -17,6 +17,46 @@ import java.time.Duration
 
 class ConfigPropertiesParseSpec extends AbstractTypeElementSpec {
 
+    void "test configuration properties implementing interface"() {
+        when:
+        def context = buildContext('''
+package jdbctest;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+
+@ConfigurationProperties("jdbc")
+class TestConfiguration extends AbstractConfiguration implements BasicJdbcConfiguration {
+    private String url;
+    @Override public void setUrl(String url) {
+        this.url = url;
+    }
+    @Override public String getUrl() {
+        return url;
+    }
+}
+class AbstractConfiguration {
+    private String username;
+    public String getUsername() {
+        return username;
+    }
+    public void setUsername(String username) {
+        this.username = username;
+    }
+}
+interface BasicJdbcConfiguration {
+    String getUrl();
+    void setUrl(String url);
+    String getUsername();
+    void setUsername(String username);
+}
+''')
+        def bean = getBean(context, 'jdbctest.TestConfiguration')
+
+        then:
+        bean.url == 'test'
+        bean.username == 'foo'
+    }
+
     @Issue("https://github.com/micronaut-projects/micronaut-core/issues/8574")
     void "test configuration properties inherited from parent with multiple overloads"() {
         when:
@@ -208,6 +248,8 @@ class MyConfig {
     protected void configureContext(ApplicationContextBuilder contextBuilder) {
         contextBuilder.properties(
                 'foo.bar.host':'bar',
+                'jdbc.url':'test',
+                'jdbc.username':'foo',
                 "micronaut.session.http.test.write-mode": "test",
                 "micronaut.session.http.test.uri": "http://localhost:9999",
                 "micronaut.session.http.test.uris": "http://localhost:9999",


### PR DESCRIPTION
If a `MethodElement` is used to invoke a method that is an interface and IncomptibleClassChangeError occurs. This fixes that. This issue is currently causing the Micronaut SQL module build to fail.