### PR TITLE
Remove jackson databind as a transtive of GraalVM module

### DIFF
--- a/graal/build.gradle
+++ b/graal/build.gradle
@@ -4,7 +4,6 @@ plugins {
 dependencies {
     annotationProcessor project(":inject-java")
     api project(":core-processor")
-    implementation libs.managed.jackson.databind
 
     testImplementation project(":inject")
     testImplementation project(":http")


### PR DESCRIPTION
Seems to be a left over from when we used to output JSON files