### PR TITLE
docs: fix Route Compile-Time validation

### DIFF
--- a/src/main/docs/guide/httpServer/routing.adoc
+++ b/src/main/docs/guide/httpServer/routing.adoc
@@ -140,22 +140,13 @@ snippet::io.micronaut.docs.server.routes.MyRoutes[tags="imports,class", indent=0
 <2> Use `@Inject` to inject a method with the controller to route to
 <3> Use methods such as link:{api}/io/micronaut/web/router/RouteBuilder.html[`RouteBuilder::GET(String,Class,String,Class...)`] to route to controller methods. Note that even though the issues controller is used, the route has no knowledge of its `@Controller` annotation and thus the full path must be specified.
 
-
-
-
 TIP: Unfortunately due to type erasure, a Java method lambda reference cannot be used with the API. For Groovy there is a `GroovyRouteBuilder` class which can be subclassed that allows passing Groovy method references.
 
 == Route Compile-Time Validation
 
-Micronaut supports validating route arguments at compile time with the validation library. To get started, add the `validation` dependency to your build:
+Micronaut supports validating route arguments at compile time with the validation library. To get started, add the `micronaut-http-validation` dependency to your build:
 
-[source,groovy]
-.build.gradle
-----
-annotationProcessor "io.micronaut:micronaut-validation" // Java only
-kapt "io.micronaut:micronaut-validation" // Kotlin only
-implementation "io.micronaut:micronaut-validation"
-----
+dependency:io.micronaut:micronaut-http-validation[scope='annotationProcessor']
 
 With the correct dependency on your classpath, route arguments will automatically be checked at compile time. Compilation will fail if any of the following conditions are met:
 
@@ -167,7 +158,7 @@ An optional variable is one that allows the route to match a URI even if the val
 * {blank}
  The URI template contains a variable that is missing from the method arguments.
 
-NOTE: To disable route compile-time validation, set the system property `-Dmicronaut.route.validation=false`. For Java and Kotlin users using Gradle, the same effect can be achieved by removing the `validation` dependency from the `annotationProcessor`/`kapt` scope.
+NOTE: To disable route compile-time validation, set the system property `-Dmicronaut.route.validation=false`. For Java and Kotlin users using Gradle, the same effect can be achieved by removing the `micronaut-http-validation` dependency from the `annotationProcessor`/`kapt` scope.
 
 == Routing non-standard HTTP methods
 


### PR DESCRIPTION
The annotation processor is `micronaut-http-validation`

This was changed in Micronaut Framework 3.0