### PR TITLE
Correct processing of the inner classes

### DIFF
--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -56,7 +56,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static javax.lang.model.element.ElementKind.ANNOTATION_TYPE;
 import static javax.lang.model.element.ElementKind.ENUM;
 
 /**
@@ -154,19 +153,14 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                 TypeElement groovyObjectTypeElement = elementUtils.getTypeElement("groovy.lang.GroovyObject");
                 TypeMirror groovyObjectType = groovyObjectTypeElement != null ? groovyObjectTypeElement.asType() : null;
                 // accumulate all the class elements for all annotated elements
-                annotations.forEach(annotation -> roundEnv.getElementsAnnotatedWith(annotation)
-                    .stream()
-                    // filtering annotation definitions, which are not processed
-                    .filter(element -> element.getKind() != ANNOTATION_TYPE)
-                    .forEach(element -> {
-                        TypeElement typeElement = modelUtils.classElementFor(element);
-                        if (typeElement == null) {
-                            return;
-                        }
-                        if (element.getKind() == ENUM) {
-                            final AnnotationMetadata am = annotationMetadataBuilder.lookupOrBuildForType(element);
+                annotations.forEach(annotation -> modelUtils.resolveTypeElements(
+                        roundEnv.getElementsAnnotatedWith(annotation)
+                    )
+                    .forEach(typeElement -> {
+                        if (typeElement.getKind() == ENUM) {
+                            final AnnotationMetadata am = annotationMetadataBuilder.lookupOrBuildForType(typeElement);
                             if (BeanDefinitionCreatorFactory.isDeclaredBeanInMetadata(am)) {
-                                error(element, "Enum types cannot be defined as beans");
+                                error(typeElement, "Enum types cannot be defined as beans");
                             }
                             return;
                         }

--- a/inject-java/src/test/groovy/io/micronaut/annotation/AnnotateClassSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/annotation/AnnotateClassSpec.groovy
@@ -1,0 +1,153 @@
+package io.micronaut.annotation
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.annotation.Prototype
+import io.micronaut.inject.ast.ClassElement
+import io.micronaut.inject.visitor.TypeElementVisitor
+import io.micronaut.inject.visitor.VisitorContext
+
+class AnnotateClassSpec extends AbstractTypeElementSpec {
+
+    void 'test annotating 1'() {
+        when:
+            def definition = buildBeanDefinition('addann.AnnotateClass', '''
+package addann;
+
+import io.micronaut.context.annotation.Executable;
+
+class AnnotateClass {
+
+    @Executable
+    public String myMethod1() {
+        return null;
+    }
+
+}
+
+''')
+        then:
+            definition.hasAnnotation(MyAnnotation)
+    }
+
+    void 'test annotating 2'() {
+        when:
+            def definition = buildBeanDefinition('addann.Foobar1$AnnotateClass', '''
+package addann;
+
+import io.micronaut.context.annotation.Executable;
+
+class Foobar1 {
+
+    @Executable
+    public String myMethod1() {
+        return null;
+    }
+
+    static class AnnotateClass {
+
+        @Executable
+        public String myMethod2() {
+            return null;
+        }
+
+    }
+
+}
+
+''')
+        then:
+            definition.hasAnnotation(MyAnnotation)
+    }
+
+    void 'test annotating 3'() {
+        when:
+            def definition = buildBeanDefinition('addann.Foobar2$AnnotateClass', '''
+package addann;
+
+import io.micronaut.context.annotation.Executable;
+
+class Foobar2 {
+
+    static class AnnotateClass {
+
+        @Executable
+        public String myMethod2() {
+            return null;
+        }
+
+    }
+
+}
+
+''')
+        then:
+            definition.hasAnnotation(MyAnnotation)
+    }
+
+    void 'test annotating 4'() {
+        when:
+            def definition = buildBeanDefinition('addann.Foobar3$AnnotateClass', '''
+package addann;
+
+import io.micronaut.context.annotation.Executable;
+import io.micronaut.core.annotation.Nullable;import io.micronaut.core.annotation.ReflectiveAccess;
+
+class Foobar3 {
+
+    static class AnnotateClass {
+
+        @Executable
+        @ReflectiveAccess
+        private String myMethod2() {
+            return null;
+        }
+
+    }
+
+}
+
+''')
+        then:
+            definition.hasAnnotation(MyAnnotation)
+    }
+
+    void 'test annotating 5'() {
+        when:
+            def definition = buildBeanDefinition('addann.Foobar4$AnnotateClass', '''
+package addann;
+
+import io.micronaut.context.annotation.Property;
+
+class Foobar4 {
+
+    static class AnnotateClass {
+
+        @Property(name = "xyz") // Make the BeanDefinitionInjectProcessor to see the class
+        private String myField;
+
+    }
+
+}
+
+''')
+        then:
+            definition.hasAnnotation(MyAnnotation)
+    }
+
+    static class AnnotateClassVisitor implements TypeElementVisitor<Object, Object> {
+        @Override
+        void visitClass(ClassElement element, VisitorContext context) {
+            if (element.getSimpleName().endsWith("AnnotateClass")) {
+                element.annotate(MyAnnotation)
+                element.annotate(Prototype)
+
+                // Validate the cache is working
+
+                def newClassElement = context.getClassElement(element.name).get()
+                assert newClassElement.hasAnnotation(MyAnnotation)
+                assert newClassElement.hasAnnotation(Prototype)
+            }
+        }
+    }
+
+}

--- a/inject-java/src/test/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
+++ b/inject-java/src/test/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
@@ -16,3 +16,4 @@ io.micronaut.annotation.AnnotateFieldSpec$AnnotationFieldVisitor
 io.micronaut.annotation.AnnotateFieldTypeSpec$AnnotateFieldTypeVisitor
 io.micronaut.annotation.AnnotateMethodParameterSpec$AnnotateMethodParameterVisitor
 io.micronaut.annotation.AnnotatePropertySpec$AnnotatePropertyVisitor
+io.micronaut.annotation.AnnotateClassSpec$AnnotateClassVisitor


### PR DESCRIPTION
When the inner class element is annotated, Javac wouldn't populate its class type, so we need to extract it.