### PR TITLE
Fix version parsing

### DIFF
--- a/core-bom/build.gradle
+++ b/core-bom/build.gradle
@@ -15,7 +15,9 @@ micronautBom {
 
 micronautBuild {
     binaryCompatibility {
-        def (major, minor, patch) = (version - '-SNAPSHOT').split('[.]').collect { it.toInteger() }
+        def dash = version.indexOf('-')
+        def v = dash > 0 ? version.substring(0, dash) : version
+        def (major, minor, patch) = v.split('[.]').collect { it.toInteger() }
         enabled = major > 4 || (major == 4 && minor > 0) || (major == 4 && minor == 0 && patch > 0)
     }
 }


### PR DESCRIPTION
The previous check assumed that we could only find `-SNAPSHOT`, but for a release, we may have `-M1` or `-beta-1`, etc.

Fixes error seen at https://ge.micronaut.io/s/aenwsqygoz6ik