### PR TITLE
Add back the platform for the server-tck tests

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'io.micronaut.build.shared.settings' version '6.2.2'
+    id 'io.micronaut.build.shared.settings' version '6.3.3'
 }
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 

--- a/test-suite-http-server-tck-jdk/build.gradle.kts
+++ b/test-suite-http-server-tck-jdk/build.gradle.kts
@@ -14,3 +14,7 @@ tasks.withType(Test::class) {
     // These restricted headers are set in the server TCK
     systemProperty("jdk.httpclient.allowRestrictedHeaders", "Host,Connection,Content-Length")
 }
+
+tasks.named<Test>("test") {
+    useJUnitPlatform()
+}

--- a/test-suite-http-server-tck-netty/build.gradle
+++ b/test-suite-http-server-tck-netty/build.gradle
@@ -54,7 +54,7 @@ tasks.named("check") { task ->
     }
 }
 
-test {
+tasks.named("test") {
     useJUnitPlatform()
 }
 

--- a/test-suite-http-server-tck-netty/build.gradle
+++ b/test-suite-http-server-tck-netty/build.gradle
@@ -54,6 +54,10 @@ tasks.named("check") { task ->
     }
 }
 
+test {
+    useJUnitPlatform()
+}
+
 def openGraalModules = [
         "org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk",
         "org.graalvm.nativeimage.builder/com.oracle.svm.core.configure",


### PR DESCRIPTION
Not sure where this was lost, but no tests were being executed