### PR TITLE
Allow Tag annotation at build time for the TCK

### DIFF
--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/ErrorHandlerTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/ErrorHandlerTest.java
@@ -104,7 +104,7 @@ public class ErrorHandlerTest {
                 .header(HttpHeaders.CONTENT_TYPE, io.micronaut.http.MediaType.APPLICATION_JSON);
             AssertionUtils.assertDoesNotThrow(server, request,
                 HttpStatus.OK,
-                "{\"message\":\"Error: bad things when post and body in request\",\"",
+                "\"message\":\"Error: bad things when post and body in request\",\"",
                 Collections.singletonMap(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON));
         }
     }

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/ErrorHandlerTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/ErrorHandlerTest.java
@@ -104,7 +104,7 @@ public class ErrorHandlerTest {
                 .header(HttpHeaders.CONTENT_TYPE, io.micronaut.http.MediaType.APPLICATION_JSON);
             AssertionUtils.assertDoesNotThrow(server, request,
                 HttpStatus.OK,
-                "\"message\":\"Error: bad things when post and body in request\",\"",
+                "\"message\":\"Error: bad things when post and body in request\"",
                 Collections.singletonMap(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON));
         }
     }

--- a/http-tck/src/main/resources/META-INF/native-image/io.micronaut.http.tck/micronaut-http-tck/native-image.properties
+++ b/http-tck/src/main/resources/META-INF/native-image/io.micronaut.http.tck/micronaut-http-tck/native-image.properties
@@ -1,0 +1,1 @@
+Args = --initialize-at-build-time=org.junit.platform.engine.TestTag


### PR DESCRIPTION
Using the Tag annotation in the TCK tests means that `org.junit.platform.engine.TestTag` is initialized at build time