### PR TITLE
Fix bug preventing scheduled jobs from being ran in the specified time zone

### DIFF
--- a/context/src/main/java/io/micronaut/scheduling/NextFireTime.java
+++ b/context/src/main/java/io/micronaut/scheduling/NextFireTime.java
@@ -34,6 +34,7 @@ final class NextFireTime implements Supplier<Duration> {
     private Duration duration;
     private ZonedDateTime nextFireTime;
     private final CronExpression cron;
+    private final ZoneId zoneId;
 
     /**
      * Default constructor.
@@ -41,8 +42,7 @@ final class NextFireTime implements Supplier<Duration> {
      * @param cron A cron expression
      */
     NextFireTime(CronExpression cron) {
-        this.cron = cron;
-        nextFireTime = ZonedDateTime.now();
+        this(cron, ZoneId.systemDefault());
     }
 
     /**
@@ -51,12 +51,13 @@ final class NextFireTime implements Supplier<Duration> {
      */
     NextFireTime(CronExpression cron, ZoneId zoneId) {
         this.cron = cron;
+        this.zoneId = zoneId;
         nextFireTime = ZonedDateTime.now(zoneId);
     }
 
     @Override
     public Duration get() {
-        ZonedDateTime now = ZonedDateTime.now();
+        ZonedDateTime now = ZonedDateTime.now(zoneId);
         // check if the task have fired too early
         computeNextFireTime(now.isAfter(nextFireTime) ? now : nextFireTime);
         return duration;
@@ -64,6 +65,6 @@ final class NextFireTime implements Supplier<Duration> {
 
     private void computeNextFireTime(ZonedDateTime currentFireTime) {
         nextFireTime = cron.nextTimeAfter(currentFireTime);
-        duration = Duration.ofMillis(nextFireTime.toInstant().toEpochMilli() - ZonedDateTime.now().toInstant().toEpochMilli());
+        duration = Duration.ofMillis(nextFireTime.toInstant().toEpochMilli() - ZonedDateTime.now(zoneId).toInstant().toEpochMilli());
     }
 }


### PR DESCRIPTION
This change attempts to address #8085. I have confirmed this change works by fiddling with the existing tests locally, but I am not sure how to write an automated test for this. In order to test this properly, I believe the cron expression will need to contain a particular hour which means we'll need to instruct `ZonedDateTime.now()` to return a predetermined value. This is where I got stuck. I attempted to use `Mockito.mockStatic(ZonedDateTime.class)` with the appropriate stubs, but I was not successful. Any guidance is appreciated.