### PR TITLE
Run Corretto nightly instead of every merge

### DIFF
--- a/.github/workflows/corretto.yml
+++ b/.github/workflows/corretto.yml
@@ -1,8 +1,8 @@
 name: Corretto CI
 on:
-  push:
-    branches:
-      - '[1-9]+.[0-9]+.x'
+  schedule:
+    - cron: "0 1 * * 1-5" # Mon-Fri at 1am UTC
+  workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -39,6 +39,7 @@ jobs:
         env:
           GH_TOKEN_PUBLIC_REPOS_READONLY: ${{ secrets.GH_TOKEN_PUBLIC_REPOS_READONLY }}
           GH_USERNAME: ${{ secrets.GH_USERNAME }}
+          MICRONAUT_TEST_USE_VENDOR: true
           TESTCONTAINERS_RYUK_DISABLED: true
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}


### PR DESCRIPTION
This also introduces an environment variable so the tests should not come from the cache

https://github.com/micronaut-projects/micronaut-build/pull/519

This is for 3.9.x, so it will need merging up to 4.0.x