### PR TITLE
Include stereotypes into the mapped/remapped annotation value, keep `@Inherited`

### DIFF
--- a/aop/src/main/java/io/micronaut/aop/InterceptorBinding.java
+++ b/aop/src/main/java/io/micronaut/aop/InterceptorBinding.java
@@ -32,6 +32,12 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target({ElementType.ANNOTATION_TYPE, ElementType.TYPE})
 @Repeatable(InterceptorBindingDefinitions.class)
 public @interface InterceptorBinding {
+
+    /**
+     * The bind members name.
+     */
+    String META_BIND_MEMBERS = "bindMembers";
+
     /**
      * When declared on an interceptor, the value of this annotation can be used to indicate the annotation the
      * {@link MethodInterceptor} binds to at runtime.

--- a/aop/src/main/java/io/micronaut/aop/chain/DefaultInterceptorRegistry.java
+++ b/aop/src/main/java/io/micronaut/aop/chain/DefaultInterceptorRegistry.java
@@ -34,6 +34,7 @@ import io.micronaut.core.order.OrderUtil;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.type.Executable;
 import io.micronaut.inject.ExecutableMethod;
+import io.micronaut.inject.qualifiers.InterceptorBindingQualifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,8 +42,6 @@ import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-
-import static io.micronaut.inject.qualifiers.InterceptorBindingQualifier.META_MEMBER_MEMBERS;
 
 /**
  * Default implementation of the interceptor registry interface.
@@ -179,7 +178,7 @@ public class DefaultInterceptorRegistry implements InterceptorRegistry {
 
     private boolean matches(AnnotationValue<?> interceptorAnnotationValue, Collection<AnnotationValue<?>> interceptPointBindings) {
         final AnnotationValue<Annotation> memberBinding = interceptorAnnotationValue
-            .getAnnotation(META_MEMBER_MEMBERS).orElse(null);
+            .getAnnotation(InterceptorBindingQualifier.META_BINDING_VALUES).orElse(null);
         final String annotationName = interceptorAnnotationValue.stringValue().orElse(null);
         if (annotationName == null) {
             // This shouldn't happen
@@ -194,7 +193,7 @@ public class DefaultInterceptorRegistry implements InterceptorRegistry {
                 return true;
             }
             AnnotationValue<Annotation> otherMembers =
-                applicableValue.getAnnotation(META_MEMBER_MEMBERS).orElse(null);
+                applicableValue.getAnnotation(InterceptorBindingQualifier.META_BINDING_VALUES).orElse(null);
             if (!memberBinding.equals(otherMembers)) {
                 continue;
             }

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.convention-base.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.convention-base.gradle
@@ -15,10 +15,6 @@ repositories {
     maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots/" }
 }
 
-configurations.all {
-    resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
-}
-
 configurations {
     testRuntimeClasspath {
         // Use AOP from here, not from maven

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.convention-base.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.convention-base.gradle
@@ -15,6 +15,10 @@ repositories {
     maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots/" }
 }
 
+configurations.all {
+    resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
+}
+
 configurations {
     testRuntimeClasspath {
         // Use AOP from here, not from maven

--- a/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -19,14 +19,12 @@ import io.micronaut.context.annotation.AliasFor;
 import io.micronaut.context.annotation.Aliases;
 import io.micronaut.context.annotation.DefaultScope;
 import io.micronaut.context.annotation.NonBinding;
-import io.micronaut.context.annotation.Type;
 import io.micronaut.core.annotation.AnnotatedElement;
 import io.micronaut.core.annotation.AnnotationClassValue;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationMetadataDelegate;
 import io.micronaut.core.annotation.AnnotationUtil;
 import io.micronaut.core.annotation.AnnotationValue;
-import io.micronaut.core.annotation.AnnotationValueBuilder;
 import io.micronaut.core.annotation.InstantiatedMember;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
@@ -35,9 +33,7 @@ import io.micronaut.core.io.service.SoftServiceLoader;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
-import io.micronaut.inject.qualifiers.InterceptorBindingQualifier;
 import io.micronaut.inject.visitor.VisitorContext;
-import jakarta.inject.Qualifier;
 
 import java.lang.annotation.Annotation;
 import java.lang.annotation.RetentionPolicy;
@@ -45,8 +41,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -75,13 +72,13 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
     private static final Map<String, List<AnnotationMapper<?>>> ANNOTATION_MAPPERS = new HashMap<>(10);
     private static final Map<String, List<AnnotationTransformer<?>>> ANNOTATION_TRANSFORMERS = new HashMap<>(5);
     private static final Map<String, List<AnnotationRemapper>> ANNOTATION_REMAPPERS = new HashMap<>(5);
+    private static final List<AnnotationRemapper> ALL_ANNOTATION_REMAPPERS = new ArrayList<>(5);
     private static final Map<Object, CachedAnnotationMetadata> MUTATED_ANNOTATION_METADATA = new HashMap<>(100);
-    private static final Map<String, Set<String>> NON_BINDING_CACHE = new HashMap<>(50);
     private static final Map<String, Map<CharSequence, Object>> ANNOTATION_DEFAULTS = new HashMap<>(20);
 
     static {
         for (AnnotationMapper<?> mapper : SoftServiceLoader.load(AnnotationMapper.class, AbstractAnnotationMetadataBuilder.class.getClassLoader())
-            .disableFork().collectAll()) {
+                .disableFork().collectAll()) {
             try {
                 String name = null;
                 if (mapper instanceof TypedAnnotationMapper<?> typedAnnotationMapper) {
@@ -98,7 +95,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         }
 
         for (AnnotationTransformer<?> transformer : SoftServiceLoader.load(AnnotationTransformer.class, AbstractAnnotationMetadataBuilder.class.getClassLoader())
-            .disableFork().collectAll()) {
+                .disableFork().collectAll()) {
             try {
                 String name = null;
                 if (transformer instanceof TypedAnnotationTransformer<?> typedAnnotationTransformer) {
@@ -115,10 +112,12 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         }
 
         for (AnnotationRemapper mapper : SoftServiceLoader.load(AnnotationRemapper.class, AbstractAnnotationMetadataBuilder.class.getClassLoader())
-            .disableFork().collectAll()) {
+                .disableFork().collectAll()) {
             try {
                 String name = mapper.getPackageName();
-                if (StringUtils.isNotEmpty(name)) {
+                if (name.equals(AnnotationRemapper.ALL_PACKAGES)) {
+                    ALL_ANNOTATION_REMAPPERS.add(mapper);
+                } else if (StringUtils.isNotEmpty(name)) {
                     ANNOTATION_REMAPPERS.computeIfAbsent(name, s -> new ArrayList<>(2)).add(mapper);
                 }
             } catch (Throwable e) {
@@ -157,46 +156,14 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         MutableAnnotationMetadata annotationMetadata = new MutableAnnotationMetadata();
         try {
             AnnotationMetadata metadata = buildInternalMulti(
-                Collections.emptyList(),
-                element,
-                annotationMetadata, true, true
+                    Collections.emptyList(),
+                    element,
+                    annotationMetadata, true, true
             );
             if (metadata.isEmpty()) {
                 return AnnotationMetadata.EMPTY_METADATA;
             }
             return metadata;
-        } catch (RuntimeException e) {
-            return metadataForError(e);
-        }
-    }
-
-    /**
-     * Build only metadata for declared annotations.
-     *
-     * @param element                The element
-     * @param annotations            The annotations
-     * @param includeTypeAnnotations Whether to include type level annotations in the metadata for the element
-     * @return The {@link AnnotationMetadata}
-     */
-    public AnnotationMetadata buildDeclared(T element, List<? extends A> annotations, boolean includeTypeAnnotations) {
-        if (CollectionUtils.isEmpty(annotations)) {
-            return AnnotationMetadata.EMPTY_METADATA;
-        }
-        MutableAnnotationMetadata annotationMetadata = new MutableAnnotationMetadata();
-        if (includeTypeAnnotations) {
-            buildInternalMulti(
-                Collections.emptyList(),
-                element,
-                annotationMetadata, false, true
-            );
-        }
-        try {
-            addAnnotations(annotationMetadata, element, false, true,
-                annotations, Collections.emptyList());
-            if (annotationMetadata.isEmpty()) {
-                return AnnotationMetadata.EMPTY_METADATA;
-            }
-            return annotationMetadata;
         } catch (RuntimeException e) {
             return metadataForError(e);
         }
@@ -255,22 +222,9 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
      * @since 4.0.0
      */
     public CachedAnnotationMetadata lookupOrBuild(Object key, T element) {
-        return lookupOrBuild(key, element, false);
-    }
-
-    /**
-     * Lookup or build new annotation metadata.
-     *
-     * @param key                    The cache key
-     * @param element                The type element
-     * @param includeTypeAnnotations Whether to include type level annotations in the metadata for the element
-     * @return The annotation metadata
-     * @since 4.0.0
-     */
-    private CachedAnnotationMetadata lookupOrBuild(Object key, T element, boolean includeTypeAnnotations) {
         CachedAnnotationMetadata cachedAnnotationMetadata = MUTATED_ANNOTATION_METADATA.get(key);
         if (cachedAnnotationMetadata == null) {
-            AnnotationMetadata annotationMetadata = buildInternal(includeTypeAnnotations, false, element);
+            AnnotationMetadata annotationMetadata = buildInternal(element);
             cachedAnnotationMetadata = new DefaultCachedAnnotationMetadata(annotationMetadata);
             // Don't use `computeIfAbsent` as it can lead to a concurrent exception because the cache is accessed during in `buildInternal`
             MUTATED_ANNOTATION_METADATA.put(key, cachedAnnotationMetadata);
@@ -278,13 +232,13 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         return cachedAnnotationMetadata;
     }
 
-    private AnnotationMetadata buildInternal(boolean inheritTypeAnnotations, boolean declaredOnly, T element) {
+    private AnnotationMetadata buildInternal(T element) {
         MutableAnnotationMetadata annotationMetadata = new MutableAnnotationMetadata();
         try {
             return buildInternalMulti(
-                Collections.emptyList(),
-                element,
-                annotationMetadata, inheritTypeAnnotations, declaredOnly
+                    Collections.emptyList(),
+                    element,
+                    annotationMetadata, false, false
             );
         } catch (RuntimeException e) {
             return metadataForError(e);
@@ -375,12 +329,12 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
      * @param annotationValues   The values to populate
      */
     protected abstract void readAnnotationRawValues(
-        T originatingElement,
-        String annotationName,
-        T member,
-        String memberName,
-        Object annotationValue,
-        Map<CharSequence, Object> annotationValues);
+            T originatingElement,
+            String annotationName,
+            T member,
+            String memberName,
+            Object annotationValue,
+            Map<CharSequence, Object> annotationValues);
 
     /**
      * Validates an annotation value.
@@ -403,7 +357,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         final AnnotatedElementValidator elementValidator = getElementValidator();
         if (elementValidator != null && !erroneousElements.contains(member)) {
             boolean shouldValidate = !(annotationName.equals(AliasFor.class.getName())) &&
-                (!(resolvedValue instanceof String) || !resolvedValue.toString().contains("${"));
+                    (!(resolvedValue instanceof String) || !resolvedValue.toString().contains("${"));
             if (shouldValidate) {
                 shouldValidate = isValidationRequired(member);
             }
@@ -564,20 +518,20 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                 if (aliasMember.isPresent() && !(aliasAnnotation.isPresent() || aliasAnnotationName.isPresent())) {
                     String aliasedNamed = aliasMember.get();
                     readAnnotationRawValues(annotationElement,
-                        annotationTypeName,
-                        member,
-                        aliasedNamed,
-                        annotationValue,
-                        resolvedValues);
+                            annotationTypeName,
+                            member,
+                            aliasedNamed,
+                            annotationValue,
+                            resolvedValues);
                 }
             }
             String memberName = getAnnotationMemberName(member);
             readAnnotationRawValues(annotationElement,
-                annotationTypeName,
-                member,
-                memberName,
-                annotationValue,
-                resolvedValues);
+                    annotationTypeName,
+                    member,
+                    memberName,
+                    annotationValue,
+                    resolvedValues);
         }
         return new AnnotationValue<>(annotationTypeName, resolvedValues);
     }
@@ -644,11 +598,11 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
             if (!defaultValues.containsKey(memberName)) {
                 Object annotationValue = entry.getValue();
                 readAnnotationRawValues(originatingElement,
-                    annotationName,
-                    member,
-                    memberName,
-                    annotationValue,
-                    defaultValues);
+                        annotationName,
+                        member,
+                        memberName,
+                        annotationValue,
+                        defaultValues);
             }
         }
         return defaultValues;
@@ -710,11 +664,11 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
     }
 
     private AnnotationMetadata buildInternalMulti(
-        List<T> parents,
-        T element,
-        MutableAnnotationMetadata annotationMetadata,
-        boolean inheritTypeAnnotations,
-        boolean declaredOnly) {
+            List<T> parents,
+            T element,
+            MutableAnnotationMetadata annotationMetadata,
+            boolean inheritTypeAnnotations,
+            boolean declaredOnly) {
         List<T> hierarchy = buildHierarchy(element, inheritTypeAnnotations, declaredOnly);
         for (T parent : parents) {
             final List<T> parentHierarchy = buildHierarchy(parent, inheritTypeAnnotations, declaredOnly);
@@ -738,17 +692,16 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
             boolean originatingElementIsSameParent = parents.contains(currentElement);
             boolean isDeclared = currentElement == element;
             addAnnotations(
-                annotationMetadata,
-                currentElement,
-                originatingElementIsSameParent,
-                isDeclared,
-                annotationHierarchy,
-                Collections.emptyList()
+                    annotationMetadata,
+                    currentElement,
+                    originatingElementIsSameParent,
+                    isDeclared,
+                    annotationHierarchy
             );
 
         }
         if (!annotationMetadata.hasDeclaredStereotype(AnnotationUtil.SCOPE) && annotationMetadata.hasDeclaredStereotype(
-            DefaultScope.class)) {
+                DefaultScope.class)) {
             Optional<String> value = annotationMetadata.stringValue(DefaultScope.class);
             value.ifPresent(name -> annotationMetadata.addDeclaredAnnotation(name, Collections.emptyMap()));
         }
@@ -763,42 +716,36 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
 
     private void addAnnotations(MutableAnnotationMetadata annotationMetadata,
                                 T element,
-                                boolean originatingElementIsSameParent,
+                                boolean alwaysIncludeAnnotation,
                                 boolean isDeclared,
-                                List<? extends A> annotationHierarchy,
-                                List<String> parentAnnotations) {
+                                List<? extends A> annotationHierarchy) {
         Stream<? extends A> stream = annotationHierarchy.stream();
-        Stream<ProcessedAnnotation> annotationValues = annotationMirrorToAnnotationValue(stream,
-            element, originatingElementIsSameParent, annotationMetadata, isDeclared, false);
-        addAnnotations(annotationMetadata, annotationValues, isDeclared, parentAnnotations);
+        Stream<ProcessedAnnotation> annotationValues = annotationMirrorToAnnotationValue(stream, element);
+        addAnnotations(annotationMetadata, annotationValues, isDeclared, alwaysIncludeAnnotation);
     }
 
     @NonNull
     private Stream<ProcessedAnnotation> annotationMirrorToAnnotationValue(Stream<? extends A> stream,
-                                                                          T element,
-                                                                          boolean originatingElementIsSameParent,
-                                                                          MutableAnnotationMetadata annotationMetadata,
-                                                                          boolean isDeclared,
-                                                                          boolean isStereotype) {
+                                                                          T element) {
         return stream
-            .filter(annotationMirror -> {
-                String annotationName = getAnnotationTypeName(annotationMirror);
-                if (AnnotationUtil.INTERNAL_ANNOTATION_NAMES.contains(annotationName)
-                    || isExcludedAnnotation(element, annotationName)) {
-                    return false;
-                }
-                if (DEPRECATED_ANNOTATION_NAMES.containsKey(annotationName)) {
-                    addWarning(element,
-                        "Usages of deprecated annotation " + annotationName + " found. You should use " + DEPRECATED_ANNOTATION_NAMES.get(
-                            annotationName) + " instead.");
-                }
-                return isStereotype || isDeclared || isInheritedAnnotation(annotationMirror) || originatingElementIsSameParent;
-            }).map(annotationMirror -> createAnnotationValue(element, annotationMirror, annotationMetadata));
+                .filter(annotationMirror -> {
+                    String annotationName = getAnnotationTypeName(annotationMirror);
+                    if (!annotationName.equals(AnnotationUtil.ANN_INHERITED)
+                            && (AnnotationUtil.INTERNAL_ANNOTATION_NAMES.contains(annotationName) || isExcludedAnnotation(element, annotationName))) {
+                        return false;
+                    }
+                    if (DEPRECATED_ANNOTATION_NAMES.containsKey(annotationName)) {
+                        addWarning(element,
+                                "Usages of deprecated annotation " + annotationName + " found. You should use " + DEPRECATED_ANNOTATION_NAMES.get(
+                                        annotationName) + " instead.");
+                    }
+                    return true;
+                }).map(annotationMirror -> createAnnotationValue(element, annotationMirror));
     }
 
+    // The value of this method can be cached
     private ProcessedAnnotation createAnnotationValue(T originatingElement,
-                                                      A annotationMirror,
-                                                      MutableAnnotationMetadata metadata) {
+                                                      A annotationMirror) {
         String annotationName = getAnnotationTypeName(annotationMirror);
         final T annotationType = getTypeForAnnotation(annotationMirror);
         RetentionPolicy retentionPolicy = getRetentionPolicy(annotationType);
@@ -809,7 +756,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
             annotationValues = new LinkedHashMap<>(3);
         } else {
             annotationValues = new LinkedHashMap<>(5);
-            Set<String> nonBindingMembers = new HashSet<>(2);
+            Set<String> nonBindingMembers = new LinkedHashSet<>(2);
             for (Map.Entry<? extends T, ?> entry : elementValues.entrySet()) {
                 T member = entry.getKey();
 
@@ -821,11 +768,11 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                 if (hasAnnotations(member)) {
                     final MutableAnnotationMetadata memberMetadata = new MutableAnnotationMetadata();
                     final List<? extends A> annotationsForMember = getAnnotationsForType(member)
-                        .stream().filter((a) -> !getAnnotationTypeName(a).equals(annotationName))
-                        .toList();
+                            .stream().filter((a) -> !getAnnotationTypeName(a).equals(annotationName))
+                            .toList();
 
                     addAnnotations(memberMetadata, member, false,
-                        true, annotationsForMember, Collections.emptyList());
+                            true, annotationsForMember);
 
                     boolean isInstantiatedMember = memberMetadata.hasAnnotation(InstantiatedMember.class);
 
@@ -843,35 +790,31 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                 }
 
                 readAnnotationRawValues(originatingElement,
-                    annotationName,
-                    member,
-                    getAnnotationMemberName(member),
-                    annotationValue,
-                    annotationValues);
+                        annotationName,
+                        member,
+                        getAnnotationMemberName(member),
+                        annotationValue,
+                        annotationValues);
 
             }
 
             if (!nonBindingMembers.isEmpty()) {
-                if (hasAnnotation(annotationType, AnnotationUtil.QUALIFIER) || hasAnnotation(annotationType, Qualifier.class)) {
-                    metadata.addDeclaredStereotype(
-                        Collections.singletonList(getAnnotationTypeName(annotationMirror)),
-                        AnnotationUtil.QUALIFIER,
-                        Collections.singletonMap("nonBinding", nonBindingMembers)
-                    );
-                }
+                nonBindingMembers.add(AnnotationUtil.NON_BINDING_ATTRIBUTE);
+                annotationValues.put(AnnotationUtil.NON_BINDING_ATTRIBUTE, nonBindingMembers.toArray(String[]::new));
             }
         }
 
         Map<CharSequence, Object> defaultValues = getCachedAnnotationDefaults(annotationName, annotationType);
 
         return new ProcessedAnnotation(
-            annotationType,
-            new AnnotationValue<>(annotationName, annotationValues, defaultValues, retentionPolicy)
+                annotationType,
+                new AnnotationValue<>(annotationName, annotationValues, defaultValues, retentionPolicy)
         );
     }
 
     /**
      * Get the cached annotation defaults.
+     *
      * @param annotationName The annotation name
      * @param annotationType The annotation type
      * @return The defaults
@@ -904,20 +847,20 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         if (aliases.isPresent()) {
             for (AnnotationValue<AliasFor> av : aliases.get().<AliasFor>getAnnotations(AnnotationMetadata.VALUE_MEMBER)) {
                 processAnnotationAlias(
-                    annotationValues,
-                    annotationValue,
-                    av,
-                    introducedAnnotations
+                        annotationValues,
+                        annotationValue,
+                        av,
+                        introducedAnnotations
                 );
             }
         } else {
             Optional<AnnotationValue<AliasFor>> aliasForValues = getAnnotationValues(originatingElement, annotationMember, AliasFor.class);
             if (aliasForValues.isPresent()) {
                 processAnnotationAlias(
-                    annotationValues,
-                    annotationValue,
-                    aliasForValues.get(),
-                    introducedAnnotations
+                        annotationValues,
+                        annotationValue,
+                        aliasForValues.get(),
+                        introducedAnnotations
                 );
             }
         }
@@ -926,108 +869,196 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
     private void addAnnotations(MutableAnnotationMetadata annotationMetadata,
                                 Stream<ProcessedAnnotation> stream,
                                 boolean isDeclared,
-                                List<String> parentAnnotations) {
-        stream = filterAndTransformAnnotations(stream, parentAnnotations);
+                                boolean alwaysIncludeAnnotation) {
 
+        ProcessingContext processingContext = new ProcessingContext(createVisitorContext());
+
+        List<AnnotationValue<?>> annotationValues = stream
+                .flatMap(processedAnnotation -> processAnnotation(processingContext, processedAnnotation))
+                .<AnnotationValue<?>>map(ProcessedAnnotation::getAnnotationValue)
+                .toList();
+
+        addAnnotations(annotationMetadata, isDeclared, false, alwaysIncludeAnnotation, List.of(
+                Map.entry(
+                        List.of(), annotationValues
+                )
+        ));
+    }
+
+    private void addAnnotations(MutableAnnotationMetadata annotationMetadata,
+                                boolean isDeclared,
+                                boolean isStereotype,
+                                boolean alwaysIncludeAnnotation,
+                                List<Map.Entry<List<String>, List<AnnotationValue<?>>>> annotations) {
+
+        // We need to add annotations by their levels:
+        // 1. The annotation
+        // 2. Stereotypes defined on the annotation
+        // 3. The stereotypes of the stereotypes added in #2
+        // 3. The stereotypes of the stereotypes added in #3 etc
+
+        List<Map.Entry<List<String>, List<AnnotationValue<?>>>> stereotypes = new ArrayList<>(annotations.size());
+
+        for (Map.Entry<List<String>, List<AnnotationValue<?>>> e : annotations) {
+            List<String> parentAnnotations = e.getKey();
+            for (AnnotationValue<?> annotationValue : e.getValue()) {
+                if (annotationValue.getAnnotationName().equals(AnnotationUtil.ANN_INHERITED)) {
+                    continue;
+                }
+                if (isDeclared || isStereotype || alwaysIncludeAnnotation || isInherited(annotationValue.getStereotypes())) {
+
+                    addAnnotation(
+                            annotationMetadata,
+                            parentAnnotations,
+                            isDeclared,
+                            isStereotype,
+                            annotationValue);
+
+                    List<String> newParentAnnotations = CollectionUtils.concat(parentAnnotations, annotationValue.getAnnotationName());
+
+                    if (annotationValue.getStereotypes() != null) {
+                        stereotypes.add(Map.entry(
+                                newParentAnnotations,
+                                annotationValue.getStereotypes()
+                        ));
+                    }
+
+                }
+            }
+
+        }
+
+        if (!stereotypes.isEmpty()) {
+            addAnnotations(annotationMetadata, isDeclared, true, alwaysIncludeAnnotation, stereotypes);
+        }
+    }
+
+    private boolean isInherited(@Nullable List<AnnotationValue<?>> stereotypes) {
+        if (stereotypes == null) {
+            return false;
+        }
+        return stereotypes.stream().anyMatch(av -> av.getAnnotationName().equals(AnnotationUtil.ANN_INHERITED));
+    }
+
+    private Stream<ProcessedAnnotation> processAnnotation(ProcessingContext context,
+                                                          ProcessedAnnotation processedAnnotation) {
+
+        AnnotationValue<?> annotationValue = processedAnnotation.getAnnotationValue();
+        if (AnnotationUtil.INTERNAL_ANNOTATION_NAMES.contains(annotationValue.getAnnotationName()) || context.isProcessed(annotationValue)) {
+            return Stream.empty();
+        }
+        // The method is invoked recursively till the stereotypes are set.
+        // That will build an annotation value tree with annotations and it's stereotypes.
+        // After that we start transforming, starting from the stereotypes moving up in the hierarchy.
+        ProcessedAnnotation annotationWithStereotypes = addStereotypes(context, processedAnnotation);
+        return transform(context, annotationWithStereotypes)
+                .flatMap(this::flattenRepeatable)
+                .map(ann -> processAliases(context, ann));
+    }
+
+    private ProcessedAnnotation processAliases(ProcessingContext context, ProcessedAnnotation ann) {
+        // Aliases produces by the annotations are added to the stereotypes collection
         List<ProcessedAnnotation> introducedAliasForAnnotations = new ArrayList<>();
-
-        stream = stream.map(processedAnnotation -> processAliases(processedAnnotation, introducedAliasForAnnotations));
-
-        List<ProcessedAnnotation> processedAnnotations = addAnnotations(stream, annotationMetadata, isDeclared, false, parentAnnotations).toList();
-
-        if (CollectionUtils.isNotEmpty(introducedAliasForAnnotations)) {
-            // Add annotation created by @AliasFor
-            addStereotypeAnnotations(
-                introducedAliasForAnnotations.stream(),
-                null,
-                parentAnnotations,
-                annotationMetadata,
-                isDeclared
+        ProcessedAnnotation newAnn = processAliases(ann, introducedAliasForAnnotations);
+        if (!introducedAliasForAnnotations.isEmpty()) {
+            newAnn = newAnn.withAnnotationValue(
+                    newAnn.getAnnotationValue().mutate()
+                            .stereotypes(
+                                    introducedAliasForAnnotations.stream()
+                                            .flatMap(a -> processAnnotation(context, a))
+                                            .<AnnotationValue<?>>map(ProcessedAnnotation::getAnnotationValue)
+                                            .toList()
+                            ).build()
             );
         }
+        return newAnn;
+    }
 
-        // After annotations are processes process their stereotypes
-        for (ProcessedAnnotation processedAnnotation : processedAnnotations) {
-            processStereotypes(annotationMetadata, isDeclared, parentAnnotations, processedAnnotation);
+    private ProcessedAnnotation addStereotypes(ProcessingContext context, ProcessedAnnotation processedAnnotation) {
+        AnnotationValue<?> annotationValue = processedAnnotation.getAnnotationValue();
+        if (processedAnnotation.annotationType != null && annotationValue.getDefaultValues() == null) {
+            Map<CharSequence, Object> annotationDefaults = getCachedAnnotationDefaults(
+                    annotationValue.getAnnotationName(),
+                    processedAnnotation.annotationType
+            );
+            processedAnnotation = processedAnnotation.withAnnotationValue(
+                    annotationValue.mutate().defaultValues(annotationDefaults).build()
+            );
         }
+        List<ProcessedAnnotation> stereotypes = getStereotypes(context, processedAnnotation);
+        List<ProcessedAnnotation> addedStereotypes = getAddedStereotypes(context, processedAnnotation.annotationType);
+        if (!addedStereotypes.isEmpty()) {
+            stereotypes = CollectionUtils.concat(stereotypes, addedStereotypes);
+        }
+
+        return processedAnnotation.withStereotypes(
+                stereotypes
+        );
     }
 
-    private Stream<ProcessedAnnotation> processInterceptors(Stream<ProcessedAnnotation> annotationValues,
-                                                            MutableAnnotationMetadata annotationMetadata,
-                                                            String lastParent,
-                                                            LinkedList<AnnotationValueBuilder<?>> interceptorBindings) {
+    private List<ProcessedAnnotation> getStereotypes(ProcessingContext context, ProcessedAnnotation processedAnnotation) {
+        AnnotationValue<?> annotationValue = processedAnnotation.getAnnotationValue();
+        ProcessingContext newContext = context.withParent(processedAnnotation.annotationValue);
 
-        return annotationValues
-            .map(processedAnnotation -> {
-                AnnotationValue<?> annotationValue = processedAnnotation.getAnnotationValue();
-                String annotationName = annotationValue.getAnnotationName();
+        if (annotationValue.getStereotypes() != null) {
+            // The annotation has the stereotypes set manually
+            // Let's flatten repeatable
+            return annotationValue.getStereotypes().stream()
+                    .map(this::toProcessedAnnotation)
+                    .flatMap(this::flattenRepeatable)
+                    .toList();
+        }
 
-                addToInterceptorBindingsIfNecessary(interceptorBindings, lastParent, annotationName);
-
-                final boolean hasInterceptorBinding = !interceptorBindings.isEmpty();
-                if (hasInterceptorBinding && AnnotationUtil.ANN_INTERCEPTOR_BINDING.equals(annotationName)) {
-                    annotationValue = handleMemberBinding(annotationMetadata, lastParent, annotationValue);
-                    interceptorBindings.getLast().members(annotationValue.getValues());
-                    return processedAnnotation.withAnnotationValue(annotationValue);
-                }
-                if (hasInterceptorBinding && Type.class.getName().equals(annotationName)) {
-                    final Object o = annotationValue.getValues().get(AnnotationMetadata.VALUE_MEMBER);
-                    AnnotationClassValue<?> interceptorType = null;
-                    if (o instanceof AnnotationClassValue<?> annotationClassValue) {
-                        interceptorType = annotationClassValue;
-                    } else if (o instanceof AnnotationClassValue<?>[] annotationClassValues) {
-                        if (annotationClassValues.length > 0) {
-                            interceptorType = annotationClassValues[0];
-                        }
+        if (processedAnnotation.annotationType == null) {
+            // The annotation is not on the classpath
+            // We set an empty collection to mark that stereotypes are processed
+            return Collections.emptyList();
+        } else if (annotationValue.getDefaultValues() == null) {
+            Map<CharSequence, Object> annotationDefaults = getCachedAnnotationDefaults(
+                    annotationValue.getAnnotationName(),
+                    processedAnnotation.annotationType
+            );
+            processedAnnotation = processedAnnotation.withAnnotationValue(
+                    annotationValue.mutate().defaultValues(annotationDefaults).build()
+            );
+        }
+        List<? extends A> nativeStereotypes = getAnnotationsForType(processedAnnotation.annotationType);
+        if (nativeStereotypes.isEmpty()) {
+            // We set an empty collection to mark that stereotypes are processed
+            return Collections.emptyList();
+        }
+        String annotationName = annotationValue.getAnnotationName();
+        String packageName = NameUtils.getPackageName(annotationName);
+        boolean excludesStereotypes = AnnotationUtil.STEREOTYPE_EXCLUDES.contains(packageName) || annotationName.endsWith(".Nullable");
+        return annotationMirrorToAnnotationValue(nativeStereotypes.stream(), processedAnnotation.annotationType)
+                .filter(stereotypeAnnotation -> {
+                    AnnotationValue<?> stereotypeAnnotationValue = stereotypeAnnotation.getAnnotationValue();
+                    String stereotypeName = stereotypeAnnotationValue.getAnnotationName();
+                    if (stereotypeName.equals(AnnotationUtil.ANN_INHERITED)) {
+                        return true;
                     }
-                    if (interceptorType != null) {
-                        for (AnnotationValueBuilder<?> interceptorBinding : interceptorBindings) {
-                            interceptorBinding.member("interceptorType", interceptorType);
-                        }
+                    if (excludesStereotypes) {
+                        return false;
                     }
-                }
-                return processedAnnotation;
-            });
+                    // special case: don't add stereotype for @Nonnull when it's marked as UNKNOWN/MAYBE/NEVER.
+                    // https://github.com/micronaut-projects/micronaut-core/issues/6795
+                    if (stereotypeName.equals("javax.annotation.Nonnull")) {
+                        String when = Objects.toString(stereotypeAnnotationValue.getValues().get("when"));
+                        return !(when.equals("UNKNOWN") || when.equals("MAYBE") || when.equals("NEVER"));
+                    }
+                    return true;
+                }).flatMap(stereotype -> processAnnotation(newContext, stereotype)).toList();
     }
 
-    private Stream<ProcessedAnnotation> addAnnotations(Stream<ProcessedAnnotation> annotationValues,
-                                                       MutableAnnotationMetadata annotationMetadata,
-                                                       boolean isDeclared,
-                                                       boolean isStereotype,
-                                                       List<String> parentAnnotations) {
-        return annotationValues
-            .peek(processedAnnotation -> {
-                addAnnotationDefaults(annotationMetadata, processedAnnotation);
-                addAnnotation(annotationMetadata, parentAnnotations, isDeclared, isStereotype, processedAnnotation);
-            });
-    }
-
-    private Stream<ProcessedAnnotation> filterAndTransformAnnotations(Stream<ProcessedAnnotation> annotationValues, List<String> parentAnnotations) {
-        return annotationValues
-            .filter(processedAnnotation -> {
-                AnnotationValue<?> annotationValue = processedAnnotation.getAnnotationValue();
-                return !AnnotationUtil.INTERNAL_ANNOTATION_NAMES.contains(annotationValue.getAnnotationName())
-                    && !parentAnnotations.contains(annotationValue.getAnnotationName());
-            })
-            .flatMap(this::transform)
-            .flatMap(this::flattenRepeatable);
-    }
-
-    private Stream<ProcessedAnnotation> transform(ProcessedAnnotation toTransform) {
+    private Stream<ProcessedAnnotation> transform(ProcessingContext context, ProcessedAnnotation toTransform) {
         // Transform annotation using:
         // - io.micronaut.inject.annotation.AnnotationMapper
         // - io.micronaut.inject.annotation.AnnotationRemapper
         // - io.micronaut.inject.annotation.AnnotationTransformer
         // Each result of the transformation will be also transformed
-        // To eliminate infinity loops "processedVisitors" will track and eliminate processed mappers/transformers
-        Set<Class<?>> processedVisitors = new HashSet<>();
-        return transform(toTransform, processedVisitors);
-    }
-
-    private Stream<ProcessedAnnotation> transform(ProcessedAnnotation toTransform, Set<Class<?>> processedVisitors) {
-        return processAnnotationMappers(toTransform, processedVisitors)
-            .flatMap(annotation -> processAnnotationRemappers(annotation, processedVisitors))
-            .flatMap(annotation -> processAnnotationTransformers(annotation, processedVisitors));
+        return processAnnotationMappers(context, toTransform)
+                .flatMap(annotation -> processAnnotationRemappers(context, annotation))
+                .flatMap(annotation -> processAnnotationTransformers(context, annotation));
     }
 
     private Stream<ProcessedAnnotation> flattenRepeatable(ProcessedAnnotation processedAnnotation) {
@@ -1035,39 +1066,28 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         AnnotationValue<?> annotationValue = processedAnnotation.getAnnotationValue();
         List<AnnotationValue<Annotation>> repeatableAnnotations = annotationValue.getAnnotations(AnnotationMetadata.VALUE_MEMBER);
         boolean isRepeatableAnnotationContainer = !repeatableAnnotations.isEmpty() && repeatableAnnotations.stream()
-            .allMatch(value -> {
-                T annotationMirror = getAnnotationMirror(value.getAnnotationName()).orElse(null);
-                return annotationMirror != null && getRepeatableNameForType(annotationMirror) != null;
-            });
+                .allMatch(value -> {
+                    T annotationMirror = getAnnotationMirror(value.getAnnotationName()).orElse(null);
+                    return annotationMirror != null && getRepeatableNameForType(annotationMirror) != null;
+                });
         if (isRepeatableAnnotationContainer) {
             // Repeatable annotations container is being added with values
             // We will add every repeatable annotation separately to properly detect its container and run transformations
             Map<CharSequence, Object> containerValues = new LinkedHashMap<>(annotationValue.getValues());
             containerValues.remove(AnnotationMetadata.VALUE_MEMBER);
             return Stream.concat(
-                Stream.of(
-                    // Add repeatable container for possible stereotype annotation retrieval
-                    // and additional members defined in the container annotation
-                    toProcessedAnnotation(new AnnotationValue<>(
-                        annotationValue.getAnnotationName(),
-                        containerValues,
-                        getRetentionPolicy(annotationValue.getAnnotationName())))
-                ),
-                repeatableAnnotations.stream().map(this::toProcessedAnnotation)
+                    Stream.of(
+                            // Add repeatable container for possible stereotype annotation retrieval
+                            // and additional members defined in the container annotation
+                            toProcessedAnnotation(new AnnotationValue<>(
+                                    annotationValue.getAnnotationName(),
+                                    containerValues,
+                                    getRetentionPolicy(annotationValue.getAnnotationName())))
+                    ),
+                    repeatableAnnotations.stream().map(this::toProcessedAnnotation)
             );
         }
         return Stream.of(processedAnnotation);
-    }
-
-    private void addAnnotationDefaults(MutableAnnotationMetadata annotationMetadata, ProcessedAnnotation processedAnnotation) {
-        AnnotationValue<?> annotationValue = processedAnnotation.getAnnotationValue();
-        String annotationName = annotationValue.getAnnotationName();
-        T annotationType = processedAnnotation.getAnnotationType();
-        Map<CharSequence, Object> annotationDefaults = annotationValue.getDefaultValues();
-        if (annotationDefaults == null && annotationType != null) {
-            annotationDefaults = getCachedAnnotationDefaults(annotationName, annotationType);
-        }
-        annotationMetadata.addDefaultAnnotationValues(annotationName, annotationDefaults, annotationValue.getRetentionPolicy());
     }
 
     private ProcessedAnnotation processAliases(ProcessedAnnotation processedAnnotation, List<ProcessedAnnotation> introducedAnnotations) {
@@ -1083,11 +1103,11 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
             T member = getAnnotationMember(annotationType, key);
             if (member != null) {
                 handleAnnotationAlias(
-                    annotationType,
-                    newValues,
-                    member,
-                    value,
-                    introducedAnnotations
+                        annotationType,
+                        newValues,
+                        member,
+                        value,
+                        introducedAnnotations
                 );
             }
         }
@@ -1097,38 +1117,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
             return processedAnnotation;
         }
         return processedAnnotation.withAnnotationValue(
-            AnnotationValue.builder(annotationValue).members(newValues).build()
-        );
-    }
-
-    private void processStereotypes(MutableAnnotationMetadata annotationMetadata,
-                                    boolean isDeclared,
-                                    List<String> parentAnnotations,
-                                    ProcessedAnnotation processedAnnotation) {
-        AnnotationValue<?> annotationValue = processedAnnotation.getAnnotationValue();
-        String annotationName = annotationValue.getAnnotationName();
-        String packageName = NameUtils.getPackageName(annotationName);
-        if (AnnotationUtil.STEREOTYPE_EXCLUDES.contains(packageName) || annotationName.endsWith(".Nullable")) {
-            return;
-        }
-        T annotationType = processedAnnotation.getAnnotationType();
-        List<String> newParentAnnotations = new ArrayList<>(parentAnnotations);
-        newParentAnnotations.add(annotationName);
-
-        Stream<ProcessedAnnotation> stereotypes;
-        if (annotationType == null || CollectionUtils.isNotEmpty(annotationValue.getStereotypes())) {
-            // Annotation is not on the classpath or a transformer/mapper provided a value with custom stereotypes
-            stereotypes = annotationValue.getStereotypes() == null ? Stream.empty() : annotationValue.getStereotypes().stream().map(this::toProcessedAnnotation);
-        } else {
-            stereotypes = annotationMirrorToAnnotationValue(getAnnotationsForType(annotationType).stream(),
-                annotationType, false, annotationMetadata, isDeclared, true);
-        }
-        addStereotypeAnnotations(
-            stereotypes,
-            annotationType,
-            newParentAnnotations,
-            annotationMetadata,
-            isDeclared
+                annotationValue.mutate().members(newValues).build()
         );
     }
 
@@ -1136,38 +1125,45 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                                List<String> parentAnnotations,
                                boolean isDeclared,
                                boolean isStereotype,
-                               ProcessedAnnotation processedAnnotation) {
-        AnnotationValue<?> annotationValue = processedAnnotation.getAnnotationValue();
-        String repeatableContainer = processedAnnotation.getAnnotationType() == null ? null : getRepeatableNameForType(processedAnnotation.getAnnotationType());
+                               AnnotationValue<?> annotationValue) {
+
+        String annotationName = annotationValue.getAnnotationName();
+        Map<CharSequence, Object> annotationDefaults = annotationValue.getDefaultValues();
+        if (annotationDefaults != null) {
+            mutableAnnotationMetadata.addDefaultAnnotationValues(annotationName, annotationDefaults, annotationValue.getRetentionPolicy());
+        }
+
+        T annotationMirror = getAnnotationMirror(annotationName).orElse(null);
+        String repeatableContainer = annotationMirror != null ? getRepeatableNameForType(annotationMirror) : null;
         if (isStereotype) {
             if (repeatableContainer != null) {
                 if (isDeclared) {
                     mutableAnnotationMetadata.addDeclaredRepeatableStereotype(
-                        parentAnnotations,
-                        repeatableContainer,
-                        annotationValue
+                            parentAnnotations,
+                            repeatableContainer,
+                            annotationValue
                     );
                 } else {
                     mutableAnnotationMetadata.addRepeatableStereotype(
-                        parentAnnotations,
-                        repeatableContainer,
-                        annotationValue
+                            parentAnnotations,
+                            repeatableContainer,
+                            annotationValue
                     );
                 }
             } else {
                 if (isDeclared) {
                     mutableAnnotationMetadata.addDeclaredStereotype(
-                        parentAnnotations,
-                        annotationValue.getAnnotationName(),
-                        annotationValue.getValues(),
-                        annotationValue.getRetentionPolicy()
+                            parentAnnotations,
+                            annotationValue.getAnnotationName(),
+                            annotationValue.getValues(),
+                            annotationValue.getRetentionPolicy()
                     );
                 } else {
                     mutableAnnotationMetadata.addStereotype(
-                        parentAnnotations,
-                        annotationValue.getAnnotationName(),
-                        annotationValue.getValues(),
-                        annotationValue.getRetentionPolicy()
+                            parentAnnotations,
+                            annotationValue.getAnnotationName(),
+                            annotationValue.getValues(),
+                            annotationValue.getRetentionPolicy()
                     );
                 }
             }
@@ -1181,15 +1177,15 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
             } else {
                 if (isDeclared) {
                     mutableAnnotationMetadata.addDeclaredAnnotation(
-                        annotationValue.getAnnotationName(),
-                        annotationValue.getValues(),
-                        annotationValue.getRetentionPolicy()
+                            annotationValue.getAnnotationName(),
+                            annotationValue.getValues(),
+                            annotationValue.getRetentionPolicy()
                     );
                 } else {
                     mutableAnnotationMetadata.addAnnotation(
-                        annotationValue.getAnnotationName(),
-                        annotationValue.getValues(),
-                        annotationValue.getRetentionPolicy()
+                            annotationValue.getAnnotationName(),
+                            annotationValue.getValues(),
+                            annotationValue.getRetentionPolicy()
                     );
                 }
             }
@@ -1207,299 +1203,169 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         return AnnotationUtil.INTERNAL_ANNOTATION_NAMES.contains(annotationName);
     }
 
-    /**
-     * Test whether the annotation mirror is inherited.
-     *
-     * @param annotationMirror The mirror
-     * @return True if it is
-     */
-    protected abstract boolean isInheritedAnnotation(@NonNull A annotationMirror);
-
-    private void addStereotypeAnnotations(Stream<ProcessedAnnotation> stream,
-                                          @Nullable
-                                          T element,
-                                          List<String> parentAnnotations,
-                                          MutableAnnotationMetadata metadata,
-                                          boolean isDeclared) {
-
-        final String lastParent = CollectionUtils.last(parentAnnotations);
-        LinkedList<AnnotationValueBuilder<?>> interceptorBindings = new LinkedList<>();
-
-        stream = filterAndTransformAnnotations(stream, parentAnnotations);
-
-        stream = stream.filter(processedAnnotation -> {
-            AnnotationValue<?> annotationValue = processedAnnotation.getAnnotationValue();
-
-            String annotationName = annotationValue.getAnnotationName();
-            if (!AnnotationUtil.INTERNAL_ANNOTATION_NAMES.contains(annotationName) && !parentAnnotations.contains(annotationName)) {
-                if (AnnotationUtil.ADVICE_STEREOTYPES.contains(lastParent)) {
-                    if (AnnotationUtil.ANN_INTERCEPTOR_BINDING.equals(annotationName)) {
-                        // skip @InterceptorBinding stereotype handled in last round
-                        return false;
-                    }
-                }
-            }
-
-            // special case: don't add stereotype for @Nonnull when it's marked as UNKNOWN/MAYBE/NEVER.
-            // https://github.com/micronaut-projects/micronaut-core/issues/6795
-            if (annotationValue.getAnnotationName().equals("javax.annotation.Nonnull")) {
-                String when = Objects.toString(annotationValue.getValues().get("when"));
-                return !(when.equals("UNKNOWN") || when.equals("MAYBE") || when.equals("NEVER"));
-            }
-            return true;
-        });
-        stream = processInterceptors(stream, metadata, lastParent, interceptorBindings);
-
-        List<ProcessedAnnotation> introducedAliasForAnnotations = new ArrayList<>();
-
-        stream = stream.map(processedAnnotation -> processAliases(processedAnnotation, introducedAliasForAnnotations));
-
-        List<ProcessedAnnotation> processedAnnotations = addAnnotations(stream, metadata, isDeclared, true, parentAnnotations).toList();
-
-        if (CollectionUtils.isNotEmpty(introducedAliasForAnnotations)) {
-            // Add annotation created by @AliasFor
-            addStereotypeAnnotations(
-                introducedAliasForAnnotations.stream(),
-                null,
-                parentAnnotations,
-                metadata,
-                isDeclared
-            );
+    private List<ProcessedAnnotation> getAddedStereotypes(ProcessingContext context,
+                                                            T element) {
+        if (element == null) {
+            return List.of();
         }
-
-        // After annotations are processes process their stereotypes
-        for (ProcessedAnnotation processedAnnotation : processedAnnotations) {
-            processStereotypes(metadata, isDeclared, parentAnnotations, processedAnnotation);
+        CachedAnnotationMetadata modifiedStereotypes = MUTATED_ANNOTATION_METADATA.get(element);
+        if (modifiedStereotypes == null || modifiedStereotypes.isEmpty() || !modifiedStereotypes.isMutated()) {
+            return List.of();
         }
-
-        handleAnnotationsWithMutatedMetadata(element, parentAnnotations, metadata, isDeclared, lastParent);
-
-        if (!interceptorBindings.isEmpty()) {
-            for (AnnotationValueBuilder<?> interceptorBinding : interceptorBindings) {
-                if (isDeclared) {
-                    metadata.addDeclaredRepeatable(AnnotationUtil.ANN_INTERCEPTOR_BINDINGS, interceptorBinding.build());
-                } else {
-                    metadata.addRepeatable(AnnotationUtil.ANN_INTERCEPTOR_BINDINGS, interceptorBinding.build());
-                }
-            }
-        }
-    }
-
-    private void handleAnnotationsWithMutatedMetadata(T element,
-                                                      List<String> parentAnnotations,
-                                                      MutableAnnotationMetadata metadata,
-                                                      boolean isDeclared,
-                                                      String lastParent) {
-        if (lastParent != null && element != null) {
-            CachedAnnotationMetadata modifiedStereotypes = MUTATED_ANNOTATION_METADATA.get(element);
-            if (modifiedStereotypes != null && !modifiedStereotypes.isEmpty() && modifiedStereotypes.isMutated()) {
-                for (String stereotypeName : modifiedStereotypes.getStereotypeAnnotationNames()) {
+        return Stream.concat(
+                modifiedStereotypes.getStereotypeAnnotationNames().stream().flatMap(stereotypeName -> {
                     final AnnotationValue<Annotation> a = modifiedStereotypes.getAnnotation(stereotypeName);
                     if (a == null) {
-                        continue;
+                        return Stream.of();
                     }
+                    AnnotationValue<?> parent = null;
                     final List<String> stereotypeParents = modifiedStereotypes.getAnnotationNamesByStereotype(stereotypeName);
-                    List<String> newParentAnnotations = new ArrayList<>(parentAnnotations);
-                    newParentAnnotations.addAll(stereotypeParents);
+                    for (String stereotype : stereotypeParents) {
+                        AnnotationValue<Annotation> annotationValue = AnnotationValue.builder(stereotype).build();
+                        if (parent == null) {
+                            parent = annotationValue;
+                        } else {
+                            parent = parent.mutate().stereotype(annotationValue).build();
+                        }
+                    }
+                    if (parent == null) {
+                        return processAnnotation(
+                                context.withParents(stereotypeParents),
+                                toProcessedAnnotation(a)
+                        );
+                    } else {
+                        return processAnnotation(
+                                context.withParents(stereotypeParents),
+                                toProcessedAnnotation(parent.mutate().stereotype(a).build())
+                        );
+                    }
 
-                    addStereotypeAnnotations(
-                        Stream.of(toProcessedAnnotation(a)),
-                        null,
-                        newParentAnnotations,
-                        metadata,
-                        isDeclared
-                    );
-                }
-
-                for (String annotationName : modifiedStereotypes.getAnnotationNames()) {
+                }),
+                modifiedStereotypes.getAnnotationNames().stream().flatMap(annotationName -> {
                     AnnotationValue<Annotation> a = modifiedStereotypes.getAnnotation(annotationName);
                     if (a == null) {
-                        continue;
+                        return Stream.empty();
                     }
-                    addStereotypeAnnotations(
-                        Stream.of(toProcessedAnnotation(a)),
-                        null,
-                        parentAnnotations,
-                        metadata,
-                        isDeclared
+                    return processAnnotation(
+                            context,
+                            toProcessedAnnotation(a)
                     );
-                }
-
-            }
-        }
+                })
+        ).toList();
     }
 
-    private AnnotationValue<?> handleMemberBinding(DefaultAnnotationMetadata metadata, String lastParent, AnnotationValue<?> annotationValue) {
-        Map<CharSequence, Object> data = annotationValue.getValues();
-        if (!data.containsKey(InterceptorBindingQualifier.META_MEMBER_MEMBERS)) {
-            return annotationValue;
-        }
-        data = new LinkedHashMap<>(data);
-        final Object o = data.remove(InterceptorBindingQualifier.META_MEMBER_MEMBERS);
-        if (o instanceof Boolean && ((Boolean) o)) {
-            Map<CharSequence, Object> values = metadata.getValues(lastParent);
-            if (!values.isEmpty()) {
-                Set<String> nonBinding = NON_BINDING_CACHE.computeIfAbsent(lastParent, (annotationName) -> {
-                    final HashSet<String> nonBindingResult = new HashSet<>(5);
-                    Map<String, ? extends T> members = getAnnotationMembers(lastParent);
-                    if (CollectionUtils.isNotEmpty(members)) {
-                        members.forEach((name, ann) -> {
-                            if (hasSimpleAnnotation(ann, NonBinding.class.getSimpleName())) {
-                                nonBindingResult.add(name);
-                            }
-                        });
-                    }
-                    return nonBindingResult.isEmpty() ? Collections.emptySet() : nonBindingResult;
-                });
-
-                if (!nonBinding.isEmpty()) {
-                    values = new HashMap<>(values);
-                    values.keySet().removeAll(nonBinding);
-                }
-                final AnnotationValueBuilder<Annotation> builder =
-                    AnnotationValue
-                        .builder(lastParent)
-                        .members(values);
-                data.put(
-                    InterceptorBindingQualifier.META_MEMBER_MEMBERS,
-                    builder.build()
-                );
-
-            }
-        }
-        return AnnotationValue.builder(annotationValue).members(data).build();
-    }
-
-    /**
-     * Gets the annotation members for the given type.
-     *
-     * @param annotationType The annotation type
-     * @return The members
-     * @since 3.3.0
-     */
-    @NonNull
-    protected abstract Map<String, ? extends T> getAnnotationMembers(@NonNull String annotationType);
-
-    /**
-     * Returns true if a simple meta annotation is present for the given element and annotation type.
-     *
-     * @param element    The element
-     * @param simpleName The simple name, ie {@link Class#getSimpleName()}
-     * @return True an annotation with the given simple name exists on the element
-     */
-    protected abstract boolean hasSimpleAnnotation(T element, String simpleName);
-
-    private void addToInterceptorBindingsIfNecessary(List<AnnotationValueBuilder<?>> interceptorBindings,
-                                                     String lastParent,
-                                                     String annotationName) {
-        if (lastParent != null) {
-            AnnotationValueBuilder<?> interceptorBinding = null;
-            if (AnnotationUtil.ANN_AROUND.equals(annotationName) || AnnotationUtil.ANN_INTERCEPTOR_BINDING.equals(annotationName)) {
-                interceptorBinding = AnnotationValue.builder(AnnotationUtil.ANN_INTERCEPTOR_BINDING)
-                    .member(AnnotationMetadata.VALUE_MEMBER, new AnnotationClassValue<>(lastParent))
-                    .member("kind", "AROUND");
-            } else if (AnnotationUtil.ANN_INTRODUCTION.equals(annotationName)) {
-                interceptorBinding = AnnotationValue.builder(AnnotationUtil.ANN_INTERCEPTOR_BINDING)
-                    .member(AnnotationMetadata.VALUE_MEMBER, new AnnotationClassValue<>(lastParent))
-                    .member("kind", "INTRODUCTION");
-            } else if (AnnotationUtil.ANN_AROUND_CONSTRUCT.equals(annotationName)) {
-                interceptorBinding = AnnotationValue.builder(AnnotationUtil.ANN_INTERCEPTOR_BINDING)
-                    .member(AnnotationMetadata.VALUE_MEMBER, new AnnotationClassValue<>(lastParent))
-                    .member("kind", "AROUND_CONSTRUCT");
-            }
-            if (interceptorBinding != null) {
-                interceptorBindings.add(interceptorBinding);
-            }
-        }
-    }
-
-    private <K> List<K> eliminateProcessed(List<K> visitors, Set<Class<?>> processedVisitors) {
+    private <K> List<K> eliminateProcessed(ProcessingContext context, List<K> visitors) {
         if (visitors == null) {
             return null;
         }
-        return visitors.stream().filter(v -> !processedVisitors.contains(v.getClass())).toList();
+        return visitors.stream().filter(v -> !context.processedVisitors.contains(v.getClass())).toList();
     }
 
-    private Stream<ProcessedAnnotation> processAnnotationRemappers(ProcessedAnnotation processedAnnotation,
-                                                                   Set<Class<?>> processedVisitors) {
+    private Stream<ProcessedAnnotation> processAnnotationRemappers(ProcessingContext context,
+                                                                   ProcessedAnnotation processedAnnotation) {
         AnnotationValue<?> annotationValue = processedAnnotation.getAnnotationValue();
         String packageName = NameUtils.getPackageName(annotationValue.getAnnotationName());
         List<AnnotationRemapper> annotationRemappers = ANNOTATION_REMAPPERS.get(packageName);
-        annotationRemappers = eliminateProcessed(annotationRemappers, processedVisitors);
-        if (CollectionUtils.isEmpty(annotationRemappers)) {
-            return Stream.of(processedAnnotation);
+        if (annotationRemappers == null) {
+            annotationRemappers = ALL_ANNOTATION_REMAPPERS;
+        } else {
+            annotationRemappers = CollectionUtils.concat(annotationRemappers, ALL_ANNOTATION_REMAPPERS);
         }
-        VisitorContext visitorContext = createVisitorContext();
-        List<ProcessedAnnotation> result = new ArrayList<>();
-        for (AnnotationRemapper annotationRemapper : annotationRemappers) {
-            processedVisitors.add(annotationRemapper.getClass());
-            for (AnnotationValue<?> newAnnotationValue : annotationRemapper.remap(annotationValue, visitorContext)) {
-                if (newAnnotationValue == annotationValue) {
-                    result.add(processedAnnotation); // Retain the same value
-                } else {
-                    result.add(toProcessedAnnotation(newAnnotationValue));
-                }
-            }
-        }
-        // Transform new remapped annotations
-        return result.stream().flatMap(annotation -> transform(annotation, processedVisitors));
+        annotationRemappers = eliminateProcessed(context, annotationRemappers);
+        return remapAnnotation(
+                context,
+                processedAnnotation,
+                annotationValue,
+                annotationRemappers.iterator()
+        );
     }
 
-    private <K extends Annotation> Stream<ProcessedAnnotation> processAnnotationTransformers(ProcessedAnnotation processedAnnotation,
-                                                                                             Set<Class<?>> processedVisitors) {
+    private Stream<ProcessedAnnotation> remapAnnotation(ProcessingContext context,
+                                                        ProcessedAnnotation processedAnnotation,
+                                                        AnnotationValue<?> annotationValue,
+                                                        Iterator<AnnotationRemapper> remappers) {
+        if (!remappers.hasNext()) {
+            return Stream.of(processedAnnotation);
+        }
+        AnnotationRemapper annotationRemapper = remappers.next();
+        ProcessingContext newContext = context.withProcessedVisitor(annotationRemapper.getClass());
+        return annotationRemapper.remap(annotationValue, context.visitorContext).stream().flatMap(newAnnotationValue -> {
+            if (newAnnotationValue == annotationValue) {
+                // Value didn't change, continue with other remappers
+                return remapAnnotation(newContext, processedAnnotation, annotationValue, remappers);
+            }
+            if (annotationValue.getAnnotationName().equals(newAnnotationValue.getAnnotationName())) {
+                // Retain the same value native element
+                return processAnnotation(newContext, processedAnnotation.withAnnotationValue(newAnnotationValue));
+            }
+            return processAnnotation(newContext, toProcessedAnnotation(newAnnotationValue));
+        });
+    }
+
+    private <K extends Annotation> Stream<ProcessedAnnotation> processAnnotationTransformers(ProcessingContext context,
+                                                                                             ProcessedAnnotation processedAnnotation) {
         AnnotationValue<K> annotationValue = (AnnotationValue<K>) processedAnnotation.getAnnotationValue();
         List<AnnotationTransformer<K>> annotationTransformers = getAnnotationTransformers(annotationValue.getAnnotationName());
-        annotationTransformers = eliminateProcessed(annotationTransformers, processedVisitors);
+        annotationTransformers = eliminateProcessed(context, annotationTransformers);
         if (CollectionUtils.isEmpty(annotationTransformers)) {
             return Stream.of(processedAnnotation);
         }
-        VisitorContext visitorContext = createVisitorContext();
-        List<ProcessedAnnotation> result = new ArrayList<>();
-        for (AnnotationTransformer<K> annotationTransformer : annotationTransformers) {
-            processedVisitors.add(annotationTransformer.getClass());
-            for (AnnotationValue<?> newAnnotationValue : annotationTransformer.transform(annotationValue, visitorContext)) {
-                if (newAnnotationValue == annotationValue) {
-                    result.add(processedAnnotation); // Retain the same value
-                } else {
-                    result.add(toProcessedAnnotation(newAnnotationValue));
-                }
-            }
-        }
-        // Transform new transformed annotations
-        return result.stream().flatMap(annotation -> transform(annotation, processedVisitors));
+        Iterator<AnnotationTransformer<K>> transformers = annotationTransformers.iterator();
+        return transformAnnotation(context, processedAnnotation, annotationValue, transformers);
     }
 
-    private <K extends Annotation> Stream<ProcessedAnnotation> processAnnotationMappers(ProcessedAnnotation processedAnnotation,
-                                                                                        Set<Class<?>> processedVisitors) {
+    private <K extends Annotation> Stream<ProcessedAnnotation> transformAnnotation(ProcessingContext context,
+                                                                                   ProcessedAnnotation processedAnnotation,
+                                                                                   AnnotationValue<K> annotationValue,
+                                                                                   Iterator<AnnotationTransformer<K>> transformers) {
+        if (!transformers.hasNext()) {
+            return Stream.of(processedAnnotation);
+        }
+        AnnotationTransformer<K> annotationTransformer = transformers.next();
+        ProcessingContext newContext = context.withProcessedVisitor(annotationTransformer.getClass());
+        return annotationTransformer.transform(annotationValue, context.visitorContext).stream().flatMap(newAnnotationValue -> {
+            if (newAnnotationValue == annotationValue) {
+                // Value didn't change, continue with other transformers
+                return transformAnnotation(newContext, processedAnnotation, annotationValue, transformers);
+            }
+            if (annotationValue.getAnnotationName().equals(newAnnotationValue.getAnnotationName())) {
+                // Retain the same value native element
+                return processAnnotation(newContext, processedAnnotation.withAnnotationValue(newAnnotationValue));
+            }
+            return processAnnotation(newContext, toProcessedAnnotation(newAnnotationValue));
+        });
+    }
+
+    private <K extends Annotation> Stream<ProcessedAnnotation> processAnnotationMappers(ProcessingContext context, ProcessedAnnotation processedAnnotation) {
         AnnotationValue<K> annotationValue = (AnnotationValue<K>) processedAnnotation.getAnnotationValue();
         List<AnnotationMapper<K>> mappers = getAnnotationMappers(annotationValue.getAnnotationName());
-        mappers = eliminateProcessed(mappers, processedVisitors);
+        mappers = eliminateProcessed(context, mappers);
         if (CollectionUtils.isEmpty(mappers)) {
             return Stream.of(processedAnnotation);
         }
-        VisitorContext visitorContext = createVisitorContext();
-        List<ProcessedAnnotation> result = new ArrayList<>();
-        result.add(processedAnnotation); // Mapper retains the original value
-        for (AnnotationMapper<K> mapper : mappers) {
-            processedVisitors.add(mapper.getClass());
-            List<AnnotationValue<?>> mappedToAnnotationValues = mapper.map(annotationValue, visitorContext);
-            if (mappedToAnnotationValues != null) {
-                for (AnnotationValue<?> mappedToAnnotationValue : mappedToAnnotationValues) {
-                    if (mappedToAnnotationValue != annotationValue) {
-                        result.add(toProcessedAnnotation(mappedToAnnotationValue));
-                    }
-                    // else: Mapper returned the same value, but it's already included
-                }
+        return mappers.stream().flatMap(mapper -> {
+            Stream<ProcessedAnnotation> mappedAnnotationsStream;
+            ProcessingContext newContext = context.withProcessedVisitor(mapper.getClass());
+            List<AnnotationValue<?>> mappedToAnnotationValues = mapper.map(annotationValue, context.visitorContext);
+            if (mappedToAnnotationValues == null) {
+                mappedAnnotationsStream = Stream.empty();
+            } else {
+                mappedAnnotationsStream = mappedToAnnotationValues
+                        .stream()
+                        .filter(newAnnotationValue -> newAnnotationValue != annotationValue)
+                        .flatMap(newAnnotationValue -> processAnnotation(newContext, toProcessedAnnotation(newAnnotationValue)));
             }
-        }
-        // Transform new mapped annotations
-        return result.stream().flatMap(annotation -> transform(annotation, processedVisitors));
+            return Stream.concat(
+                    Stream.of(processedAnnotation), // Mapper retains the original value
+                    mappedAnnotationsStream
+            );
+        });
     }
 
     private ProcessedAnnotation toProcessedAnnotation(AnnotationValue<?> av) {
         return new ProcessedAnnotation(
-            getAnnotationMirror(av.getAnnotationName()).orElse(null),
-            av
+                getAnnotationMirror(av.getAnnotationName()).orElse(null),
+                av
         );
     }
 
@@ -1534,9 +1400,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
      */
     @Internal
     public static Set<String> getMappedAnnotationNames() {
-        final HashSet<String> all = new HashSet<>(ANNOTATION_MAPPERS.keySet());
-        all.addAll(ANNOTATION_TRANSFORMERS.keySet());
-        return all;
+        return CollectionUtils.concat(ANNOTATION_MAPPERS.keySet(), ANNOTATION_TRANSFORMERS.keySet());
     }
 
     /**
@@ -1560,10 +1424,10 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                                                                @NonNull AnnotationValue<A2> annotationValue) {
         return modify(annotationMetadata, metadata -> {
             addAnnotations(
-                metadata,
-                Stream.of(toProcessedAnnotation(annotationValue)),
-                true,
-                Collections.emptyList()
+                    metadata,
+                    Stream.of(toProcessedAnnotation(annotationValue)),
+                    true,
+                    false
             );
         });
     }
@@ -1658,6 +1522,42 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
     }
 
     /**
+     * The context of the annotation processing.
+     *
+     * @param visitorContext    The visitor context
+     * @param parentAnnotations The parent annotations
+     * @param processedVisitors The processed visitors
+     * @since 4.0.0
+     */
+    private record ProcessingContext(@NonNull VisitorContext visitorContext,
+                                     @NonNull Set<String> parentAnnotations,
+                                     @NonNull Set<Class<?>> processedVisitors) {
+
+        ProcessingContext(VisitorContext visitorContext) {
+            this(visitorContext, Collections.emptySet(), Collections.emptySet());
+        }
+
+        boolean isProcessed(AnnotationValue<?> annotationValue) {
+            return parentAnnotations.contains(annotationValue.getAnnotationName());
+        }
+
+        ProcessingContext withParent(AnnotationValue<?> parent) {
+            Set<String> parents = CollectionUtils.concat(parentAnnotations, parent.getAnnotationName());
+            return new ProcessingContext(visitorContext, Collections.unmodifiableSet(parents), processedVisitors);
+        }
+
+        ProcessingContext withParents(List<String> newParents) {
+            Set<String> parents = CollectionUtils.concat(parentAnnotations, newParents);
+            return new ProcessingContext(visitorContext, Collections.unmodifiableSet(parents), processedVisitors);
+        }
+
+        public ProcessingContext withProcessedVisitor(Class<?> processedVisitor) {
+            Set<Class<?>> visitors = CollectionUtils.concat(processedVisitors, processedVisitor);
+            return new ProcessingContext(visitorContext, parentAnnotations, Collections.unmodifiableSet(visitors));
+        }
+    }
+
+    /**
      * Simple tuple object combining the annotation value plus the native annotation type.
      * NOTE: Some implementation like Groovy don't return correct annotation native type with type hierarchies.
      * We need to carry the provided type.
@@ -1669,13 +1569,22 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         private final T annotationType;
         private final AnnotationValue<?> annotationValue;
 
-        private ProcessedAnnotation(@Nullable T annotationType, AnnotationValue<?> annotationValue) {
+        private ProcessedAnnotation(@Nullable T annotationType,
+                                    AnnotationValue<?> annotationValue) {
             this.annotationType = annotationType;
             this.annotationValue = annotationValue;
         }
 
         public ProcessedAnnotation withAnnotationValue(AnnotationValue<?> annotationValue) {
             return new ProcessedAnnotation(annotationType, annotationValue);
+        }
+
+        public ProcessedAnnotation withStereotypes(List<ProcessedAnnotation> stereotypes) {
+            return new ProcessedAnnotation(annotationType,
+                    annotationValue.mutate()
+                            .replaceStereotypes(stereotypes.stream().<AnnotationValue<?>>map(ProcessedAnnotation::getAnnotationValue).toList())
+                            .build()
+            );
         }
 
         @Nullable
@@ -1686,6 +1595,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         public AnnotationValue<?> getAnnotationValue() {
             return annotationValue;
         }
+
     }
 
     /**

--- a/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -744,8 +744,9 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
     }
 
     // The value of this method can be cached
-    private ProcessedAnnotation createAnnotationValue(T originatingElement,
-                                                      A annotationMirror) {
+    @NonNull
+    private ProcessedAnnotation createAnnotationValue(@NonNull T originatingElement,
+                                                      @NonNull A annotationMirror) {
         String annotationName = getAnnotationTypeName(annotationMirror);
         final T annotationType = getTypeForAnnotation(annotationMirror);
         RetentionPolicy retentionPolicy = getRetentionPolicy(annotationType);
@@ -866,8 +867,8 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         }
     }
 
-    private void addAnnotations(MutableAnnotationMetadata annotationMetadata,
-                                Stream<ProcessedAnnotation> stream,
+    private void addAnnotations(@NonNull MutableAnnotationMetadata annotationMetadata,
+                                @NonNull Stream<ProcessedAnnotation> stream,
                                 boolean isDeclared,
                                 boolean alwaysIncludeAnnotation) {
 
@@ -885,11 +886,11 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         ));
     }
 
-    private void addAnnotations(MutableAnnotationMetadata annotationMetadata,
+    private void addAnnotations(@NonNull MutableAnnotationMetadata annotationMetadata,
                                 boolean isDeclared,
                                 boolean isStereotype,
                                 boolean alwaysIncludeAnnotation,
-                                List<Map.Entry<List<String>, List<AnnotationValue<?>>>> annotations) {
+                                @NonNull List<Map.Entry<List<String>, List<AnnotationValue<?>>>> annotations) {
 
         // We need to add annotations by their levels:
         // 1. The annotation
@@ -940,8 +941,9 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         return stereotypes.stream().anyMatch(av -> av.getAnnotationName().equals(AnnotationUtil.ANN_INHERITED));
     }
 
-    private Stream<ProcessedAnnotation> processAnnotation(ProcessingContext context,
-                                                          ProcessedAnnotation processedAnnotation) {
+    @NonNull
+    private Stream<ProcessedAnnotation> processAnnotation(@NonNull ProcessingContext context,
+                                                          @NonNull ProcessedAnnotation processedAnnotation) {
 
         AnnotationValue<?> annotationValue = processedAnnotation.getAnnotationValue();
         if (AnnotationUtil.INTERNAL_ANNOTATION_NAMES.contains(annotationValue.getAnnotationName()) || context.isProcessed(annotationValue)) {
@@ -956,10 +958,12 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                 .map(ann -> processAliases(context, ann));
     }
 
-    private ProcessedAnnotation processAliases(ProcessingContext context, ProcessedAnnotation ann) {
+    @NonNull
+    private ProcessedAnnotation processAliases(@NonNull ProcessingContext context,
+                                               @NonNull ProcessedAnnotation processedAnnotation) {
         // Aliases produces by the annotations are added to the stereotypes collection
         List<ProcessedAnnotation> introducedAliasForAnnotations = new ArrayList<>();
-        ProcessedAnnotation newAnn = processAliases(ann, introducedAliasForAnnotations);
+        ProcessedAnnotation newAnn = processAliases(processedAnnotation, introducedAliasForAnnotations);
         if (!introducedAliasForAnnotations.isEmpty()) {
             newAnn = newAnn.withAnnotationValue(
                     newAnn.getAnnotationValue().mutate()
@@ -974,7 +978,9 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         return newAnn;
     }
 
-    private ProcessedAnnotation addStereotypes(ProcessingContext context, ProcessedAnnotation processedAnnotation) {
+    @NonNull
+    private ProcessedAnnotation addStereotypes(@NonNull ProcessingContext context,
+                                               @NonNull ProcessedAnnotation processedAnnotation) {
         AnnotationValue<?> annotationValue = processedAnnotation.getAnnotationValue();
         if (processedAnnotation.annotationType != null && annotationValue.getDefaultValues() == null) {
             Map<CharSequence, Object> annotationDefaults = getCachedAnnotationDefaults(
@@ -996,7 +1002,9 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         );
     }
 
-    private List<ProcessedAnnotation> getStereotypes(ProcessingContext context, ProcessedAnnotation processedAnnotation) {
+    @NonNull
+    private List<ProcessedAnnotation> getStereotypes(@NonNull ProcessingContext context,
+                                                     @NonNull ProcessedAnnotation processedAnnotation) {
         AnnotationValue<?> annotationValue = processedAnnotation.getAnnotationValue();
         ProcessingContext newContext = context.withParent(processedAnnotation.annotationValue);
 
@@ -1050,7 +1058,9 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                 }).flatMap(stereotype -> processAnnotation(newContext, stereotype)).toList();
     }
 
-    private Stream<ProcessedAnnotation> transform(ProcessingContext context, ProcessedAnnotation toTransform) {
+    @NonNull
+    private Stream<ProcessedAnnotation> transform(@NonNull ProcessingContext context,
+                                                  @NonNull ProcessedAnnotation toTransform) {
         // Transform annotation using:
         // - io.micronaut.inject.annotation.AnnotationMapper
         // - io.micronaut.inject.annotation.AnnotationRemapper
@@ -1061,7 +1071,8 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                 .flatMap(annotation -> processAnnotationTransformers(context, annotation));
     }
 
-    private Stream<ProcessedAnnotation> flattenRepeatable(ProcessedAnnotation processedAnnotation) {
+    @NonNull
+    private Stream<ProcessedAnnotation> flattenRepeatable(@NonNull ProcessedAnnotation processedAnnotation) {
         // In a case of a repeatable container process it as a stream of repeatable annotation values
         AnnotationValue<?> annotationValue = processedAnnotation.getAnnotationValue();
         List<AnnotationValue<Annotation>> repeatableAnnotations = annotationValue.getAnnotations(AnnotationMetadata.VALUE_MEMBER);
@@ -1090,7 +1101,9 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         return Stream.of(processedAnnotation);
     }
 
-    private ProcessedAnnotation processAliases(ProcessedAnnotation processedAnnotation, List<ProcessedAnnotation> introducedAnnotations) {
+    @NonNull
+    private ProcessedAnnotation processAliases(@NonNull ProcessedAnnotation processedAnnotation,
+                                               @NonNull List<ProcessedAnnotation> introducedAnnotations) {
         T annotationType = processedAnnotation.getAnnotationType();
         if (annotationType == null) {
             return processedAnnotation;
@@ -1121,11 +1134,11 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         );
     }
 
-    private void addAnnotation(MutableAnnotationMetadata mutableAnnotationMetadata,
-                               List<String> parentAnnotations,
+    private void addAnnotation(@NonNull MutableAnnotationMetadata mutableAnnotationMetadata,
+                               @NonNull List<String> parentAnnotations,
                                boolean isDeclared,
                                boolean isStereotype,
-                               AnnotationValue<?> annotationValue) {
+                               @NonNull AnnotationValue<?> annotationValue) {
 
         String annotationName = annotationValue.getAnnotationName();
         Map<CharSequence, Object> annotationDefaults = annotationValue.getDefaultValues();
@@ -1203,8 +1216,9 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         return AnnotationUtil.INTERNAL_ANNOTATION_NAMES.contains(annotationName);
     }
 
-    private List<ProcessedAnnotation> getAddedStereotypes(ProcessingContext context,
-                                                            T element) {
+    @NonNull
+    private List<ProcessedAnnotation> getAddedStereotypes(@NonNull ProcessingContext context,
+                                                          @Nullable T element) {
         if (element == null) {
             return List.of();
         }
@@ -1254,15 +1268,17 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         ).toList();
     }
 
-    private <K> List<K> eliminateProcessed(ProcessingContext context, List<K> visitors) {
+    @NonNull
+    private <K> List<K> eliminateProcessed(@NonNull ProcessingContext context, @NonNull List<K> visitors) {
         if (visitors == null) {
-            return null;
+            return Collections.emptyList();
         }
         return visitors.stream().filter(v -> !context.processedVisitors.contains(v.getClass())).toList();
     }
 
-    private Stream<ProcessedAnnotation> processAnnotationRemappers(ProcessingContext context,
-                                                                   ProcessedAnnotation processedAnnotation) {
+    @NonNull
+    private Stream<ProcessedAnnotation> processAnnotationRemappers(@NonNull ProcessingContext context,
+                                                                   @NonNull ProcessedAnnotation processedAnnotation) {
         AnnotationValue<?> annotationValue = processedAnnotation.getAnnotationValue();
         String packageName = NameUtils.getPackageName(annotationValue.getAnnotationName());
         List<AnnotationRemapper> annotationRemappers = ANNOTATION_REMAPPERS.get(packageName);
@@ -1280,10 +1296,11 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         );
     }
 
-    private Stream<ProcessedAnnotation> remapAnnotation(ProcessingContext context,
-                                                        ProcessedAnnotation processedAnnotation,
-                                                        AnnotationValue<?> annotationValue,
-                                                        Iterator<AnnotationRemapper> remappers) {
+    @NonNull
+    private Stream<ProcessedAnnotation> remapAnnotation(@NonNull ProcessingContext context,
+                                                        @NonNull ProcessedAnnotation processedAnnotation,
+                                                        @NonNull AnnotationValue<?> annotationValue,
+                                                        @NonNull Iterator<AnnotationRemapper> remappers) {
         if (!remappers.hasNext()) {
             return Stream.of(processedAnnotation);
         }
@@ -1302,8 +1319,8 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         });
     }
 
-    private <K extends Annotation> Stream<ProcessedAnnotation> processAnnotationTransformers(ProcessingContext context,
-                                                                                             ProcessedAnnotation processedAnnotation) {
+    private <K extends Annotation> Stream<ProcessedAnnotation> processAnnotationTransformers(@NonNull ProcessingContext context,
+                                                                                             @NonNull ProcessedAnnotation processedAnnotation) {
         AnnotationValue<K> annotationValue = (AnnotationValue<K>) processedAnnotation.getAnnotationValue();
         List<AnnotationTransformer<K>> annotationTransformers = getAnnotationTransformers(annotationValue.getAnnotationName());
         annotationTransformers = eliminateProcessed(context, annotationTransformers);
@@ -1314,10 +1331,11 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         return transformAnnotation(context, processedAnnotation, annotationValue, transformers);
     }
 
-    private <K extends Annotation> Stream<ProcessedAnnotation> transformAnnotation(ProcessingContext context,
-                                                                                   ProcessedAnnotation processedAnnotation,
-                                                                                   AnnotationValue<K> annotationValue,
-                                                                                   Iterator<AnnotationTransformer<K>> transformers) {
+    @NonNull
+    private <K extends Annotation> Stream<ProcessedAnnotation> transformAnnotation(@NonNull ProcessingContext context,
+                                                                                   @NonNull ProcessedAnnotation processedAnnotation,
+                                                                                   @NonNull AnnotationValue<K> annotationValue,
+                                                                                   @NonNull Iterator<AnnotationTransformer<K>> transformers) {
         if (!transformers.hasNext()) {
             return Stream.of(processedAnnotation);
         }
@@ -1336,7 +1354,9 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         });
     }
 
-    private <K extends Annotation> Stream<ProcessedAnnotation> processAnnotationMappers(ProcessingContext context, ProcessedAnnotation processedAnnotation) {
+    @NonNull
+    private <K extends Annotation> Stream<ProcessedAnnotation> processAnnotationMappers(@NonNull ProcessingContext context,
+                                                                                        @NonNull ProcessedAnnotation processedAnnotation) {
         AnnotationValue<K> annotationValue = (AnnotationValue<K>) processedAnnotation.getAnnotationValue();
         List<AnnotationMapper<K>> mappers = getAnnotationMappers(annotationValue.getAnnotationName());
         mappers = eliminateProcessed(context, mappers);
@@ -1362,7 +1382,8 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         });
     }
 
-    private ProcessedAnnotation toProcessedAnnotation(AnnotationValue<?> av) {
+    @NonNull
+    private ProcessedAnnotation toProcessedAnnotation(@NonNull AnnotationValue<?> av) {
         return new ProcessedAnnotation(
                 getAnnotationMirror(av.getAnnotationName()).orElse(null),
                 av
@@ -1533,25 +1554,28 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                                      @NonNull Set<String> parentAnnotations,
                                      @NonNull Set<Class<?>> processedVisitors) {
 
-        ProcessingContext(VisitorContext visitorContext) {
+        ProcessingContext(@NonNull VisitorContext visitorContext) {
             this(visitorContext, Collections.emptySet(), Collections.emptySet());
         }
 
-        boolean isProcessed(AnnotationValue<?> annotationValue) {
+        boolean isProcessed(@NonNull AnnotationValue<?> annotationValue) {
             return parentAnnotations.contains(annotationValue.getAnnotationName());
         }
 
-        ProcessingContext withParent(AnnotationValue<?> parent) {
+        @NonNull
+        ProcessingContext withParent(@NonNull AnnotationValue<?> parent) {
             Set<String> parents = CollectionUtils.concat(parentAnnotations, parent.getAnnotationName());
             return new ProcessingContext(visitorContext, Collections.unmodifiableSet(parents), processedVisitors);
         }
 
-        ProcessingContext withParents(List<String> newParents) {
+        @NonNull
+        ProcessingContext withParents(@NonNull List<String> newParents) {
             Set<String> parents = CollectionUtils.concat(parentAnnotations, newParents);
             return new ProcessingContext(visitorContext, Collections.unmodifiableSet(parents), processedVisitors);
         }
 
-        public ProcessingContext withProcessedVisitor(Class<?> processedVisitor) {
+        @NonNull
+        public ProcessingContext withProcessedVisitor(@NonNull Class<?> processedVisitor) {
             Set<Class<?>> visitors = CollectionUtils.concat(processedVisitors, processedVisitor);
             return new ProcessingContext(visitorContext, parentAnnotations, Collections.unmodifiableSet(visitors));
         }

--- a/core-processor/src/main/java/io/micronaut/inject/annotation/AnnotationRemapper.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/AnnotationRemapper.java
@@ -16,6 +16,7 @@
 package io.micronaut.inject.annotation;
 
 import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.Experimental;
 import io.micronaut.inject.visitor.VisitorContext;
 
 import io.micronaut.core.annotation.NonNull;
@@ -34,10 +35,18 @@ import java.util.List;
  * similar in function, for example {@code javax.annotation.Nullable} and {@code io.micronaut.core.annotation.Nullable}. One can
  * remap these to a single annotation internally at compilation time.</p>
  *
+ * NOTE: Remapping all packages is an experimental feature and might be replaced in the future with more efficient way.
+ *
  * @author graemerocher
  * @since 1.2.0
  */
 public interface AnnotationRemapper {
+
+    /**
+     * Return this value in {@link #getPackageName()} to trigger remap on all annotations.
+     */
+    @Experimental
+    String ALL_PACKAGES = "*";
 
     /**
      * @return The package name of the annotation.

--- a/core-processor/src/main/java/io/micronaut/inject/annotation/internal/InterceptorBindingMembers.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/internal/InterceptorBindingMembers.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.annotation.internal;
+
+import io.micronaut.aop.Around;
+import io.micronaut.aop.AroundConstruct;
+import io.micronaut.aop.InterceptorBinding;
+import io.micronaut.aop.InterceptorKind;
+import io.micronaut.aop.Introduction;
+import io.micronaut.context.annotation.Type;
+import io.micronaut.core.annotation.AnnotationClassValue;
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.AnnotationUtil;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.AnnotationValueBuilder;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.inject.annotation.AnnotationRemapper;
+import io.micronaut.inject.qualifiers.InterceptorBindingQualifier;
+import io.micronaut.inject.visitor.VisitorContext;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The remapped for various interceptor annotation stereotypes.
+ *
+ * @author Denis Stepanov
+ * @since 4.0.0
+ */
+@Internal
+public final class InterceptorBindingMembers implements AnnotationRemapper {
+
+    private static final Set<String> SKIP_ANNOTATIONS = Set.of(
+            Around.class.getName(), AroundConstruct.class.getName(), InterceptorBinding.class.getName(), Introduction.class.getName()
+    );
+
+    @Override
+    public String getPackageName() {
+        return ALL_PACKAGES;
+    }
+
+    @Override
+    public List<AnnotationValue<?>> remap(AnnotationValue<?> annotationValue, VisitorContext visitorContext) {
+        if (annotationValue.getStereotypes() == null) {
+            return List.of(annotationValue);
+        }
+        String annotationName = annotationValue.getAnnotationName();
+        if (SKIP_ANNOTATIONS.contains(annotationName)) {
+            return List.of(annotationValue.mutate().replaceStereotypes(Collections.emptyList()).build());
+        }
+
+        List<AnnotationValueBuilder<?>> interceptorBindings = new ArrayList<>();
+        for (AnnotationValue<?> stereotype : annotationValue.getStereotypes()) {
+            String stereotypeName = stereotype.getAnnotationName();
+            AnnotationValueBuilder<?> newInterceptorBinding = null;
+            if (InterceptorBinding.class.getName().equals(stereotypeName)) {
+                newInterceptorBinding = stereotype.mutate()
+                        .member(AnnotationMetadata.VALUE_MEMBER, new AnnotationClassValue<>(annotationName));
+
+                if (stereotype.booleanValue(InterceptorBinding.META_BIND_MEMBERS).orElse(false)) {
+                    String[] nonBinding = annotationValue.stringValues(AnnotationUtil.NON_BINDING_ATTRIBUTE);
+                    Map<CharSequence, Object> bindingValues = annotationValue.getValues();
+                    bindingValues = new LinkedHashMap<>(bindingValues);
+                    Arrays.asList(nonBinding).forEach(bindingValues.keySet()::remove);
+
+                    AnnotationValue<Annotation> binding = AnnotationValue.builder(annotationValue.getAnnotationName())
+                            .members(bindingValues)
+                            .build();
+                    newInterceptorBinding.member(InterceptorBindingQualifier.META_BINDING_VALUES, binding);
+                }
+            } else if (Around.class.getName().equals(stereotypeName)) {
+                newInterceptorBinding = AnnotationValue.builder(InterceptorBinding.class)
+                        .member(AnnotationMetadata.VALUE_MEMBER, new AnnotationClassValue<>(annotationName))
+                        .member("kind", InterceptorKind.AROUND);
+//                annotationValue = AnnotationValue.builder(annotationValue).removeStereotype(stereotype).build();
+            } else if (Introduction.class.getName().equals(stereotypeName)) {
+                newInterceptorBinding = AnnotationValue.builder(InterceptorBinding.class)
+                        .member(AnnotationMetadata.VALUE_MEMBER, new AnnotationClassValue<>(annotationName))
+                        .member("kind", InterceptorKind.INTRODUCTION);
+//                annotationValue = AnnotationValue.builder(annotationValue).removeStereotype(stereotype).build();
+            } else if (AroundConstruct.class.getName().equals(stereotypeName)) {
+                newInterceptorBinding = AnnotationValue.builder(InterceptorBinding.class)
+                        .member(AnnotationMetadata.VALUE_MEMBER, new AnnotationClassValue<>(annotationName))
+                        .member("kind", InterceptorKind.AROUND_CONSTRUCT);
+//                annotationValue = AnnotationValue.builder(annotationValue).removeStereotype(stereotype).build();
+            }
+            if (newInterceptorBinding != null) {
+                interceptorBindings.add(newInterceptorBinding);
+            }
+        }
+        final boolean hasInterceptorBinding = !interceptorBindings.isEmpty();
+        if (hasInterceptorBinding) {
+            for (AnnotationValue<?> av : annotationValue.getStereotypes()) {
+                if (Type.class.getName().equals(av.getAnnotationName())) {
+                    final Object o = av.getValues().get(AnnotationMetadata.VALUE_MEMBER);
+                    AnnotationClassValue<?> interceptorType = null;
+                    if (o instanceof AnnotationClassValue<?> annotationClassValue) {
+                        interceptorType = annotationClassValue;
+                    } else if (o instanceof AnnotationClassValue<?>[] annotationClassValues) {
+                        if (annotationClassValues.length > 0) {
+                            interceptorType = annotationClassValues[0];
+                        }
+                    }
+                    if (interceptorType != null) {
+                        for (AnnotationValueBuilder<?> interceptorBinding : interceptorBindings) {
+                            interceptorBinding.member("interceptorType", interceptorType);
+                        }
+                    }
+//                    annotationValue = AnnotationValue.builder(annotationValue).removeStereotype(av).build();
+                    break;
+                }
+            }
+        }
+
+        if (!interceptorBindings.isEmpty()) {
+            AnnotationValue<?>[] interceptors = interceptorBindings.stream().map(AnnotationValueBuilder::build).toArray(AnnotationValue<?>[]::new);
+            AnnotationValue<Annotation> interceptorsContainer = AnnotationValue.builder(AnnotationUtil.ANN_INTERCEPTOR_BINDINGS)
+                    .values(interceptors)
+                    .build();
+            annotationValue = annotationValue.mutate()
+                    .stereotype(interceptorsContainer)
+                    .build();
+        }
+        return List.of(annotationValue);
+    }
+
+}

--- a/core-processor/src/main/java/io/micronaut/inject/annotation/internal/InterceptorBindingMembers.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/internal/InterceptorBindingMembers.java
@@ -91,17 +91,14 @@ public final class InterceptorBindingMembers implements AnnotationRemapper {
                 newInterceptorBinding = AnnotationValue.builder(InterceptorBinding.class)
                         .member(AnnotationMetadata.VALUE_MEMBER, new AnnotationClassValue<>(annotationName))
                         .member("kind", InterceptorKind.AROUND);
-//                annotationValue = AnnotationValue.builder(annotationValue).removeStereotype(stereotype).build();
             } else if (Introduction.class.getName().equals(stereotypeName)) {
                 newInterceptorBinding = AnnotationValue.builder(InterceptorBinding.class)
                         .member(AnnotationMetadata.VALUE_MEMBER, new AnnotationClassValue<>(annotationName))
                         .member("kind", InterceptorKind.INTRODUCTION);
-//                annotationValue = AnnotationValue.builder(annotationValue).removeStereotype(stereotype).build();
             } else if (AroundConstruct.class.getName().equals(stereotypeName)) {
                 newInterceptorBinding = AnnotationValue.builder(InterceptorBinding.class)
                         .member(AnnotationMetadata.VALUE_MEMBER, new AnnotationClassValue<>(annotationName))
                         .member("kind", InterceptorKind.AROUND_CONSTRUCT);
-//                annotationValue = AnnotationValue.builder(annotationValue).removeStereotype(stereotype).build();
             }
             if (newInterceptorBinding != null) {
                 interceptorBindings.add(newInterceptorBinding);
@@ -125,7 +122,6 @@ public final class InterceptorBindingMembers implements AnnotationRemapper {
                             interceptorBinding.member("interceptorType", interceptorType);
                         }
                     }
-//                    annotationValue = AnnotationValue.builder(annotationValue).removeStereotype(av).build();
                     break;
                 }
             }

--- a/core-processor/src/main/java/io/micronaut/inject/annotation/internal/QualifierBindingMembers.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/internal/QualifierBindingMembers.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.annotation.internal;
+
+import io.micronaut.core.annotation.AnnotationUtil;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.inject.annotation.AnnotationRemapper;
+import io.micronaut.inject.visitor.VisitorContext;
+import jakarta.inject.Qualifier;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * The remapped adds a non-binding attribute to any qualifiers that are stereotypes.
+ *
+ * @author Denis Stepanov
+ * @since 4.0.0
+ */
+@Internal
+public final class QualifierBindingMembers implements AnnotationRemapper {
+
+    @Override
+    public String getPackageName() {
+        return ALL_PACKAGES;
+    }
+
+    @Override
+    public List<AnnotationValue<?>> remap(AnnotationValue<?> annotation, VisitorContext visitorContext) {
+        if (annotation.getStereotypes() != null) {
+            String[] nonBindingMembers = annotation.stringValues(AnnotationUtil.NON_BINDING_ATTRIBUTE);
+            if (nonBindingMembers.length > 0) {
+                Optional<AnnotationValue<?>> qualifier = annotation.getStereotypes()
+                        .stream()
+                        .filter(av -> av.getAnnotationName().equals(AnnotationUtil.QUALIFIER) || av.getAnnotationName().equals(Qualifier.class.getName()))
+                        .findFirst();
+                if (qualifier.isPresent()) {
+                    AnnotationValue<?> originalQualifier = qualifier.get();
+                    AnnotationValue<?> newQualifier = originalQualifier.mutate()
+                            .member(AnnotationUtil.NON_BINDING_ATTRIBUTE, nonBindingMembers).build();
+                    annotation = annotation.mutate().replaceStereotype(originalQualifier, newQualifier).build();
+                }
+            }
+        }
+        return List.of(annotation);
+    }
+}

--- a/core-processor/src/main/java/io/micronaut/inject/processing/BeanDefinitionCreatorFactory.java
+++ b/core-processor/src/main/java/io/micronaut/inject/processing/BeanDefinitionCreatorFactory.java
@@ -43,7 +43,7 @@ public abstract class BeanDefinitionCreatorFactory {
     @NonNull
     public static BeanDefinitionCreator produce(ClassElement classElement, VisitorContext visitorContext) {
         boolean isAbstract = classElement.isAbstract();
-        boolean isIntroduction = classElement.hasStereotype(AnnotationUtil.ANN_INTRODUCTION);
+        boolean isIntroduction = isIntroduction(classElement);
         if (ConfigurationReaderBeanElementCreator.isConfigurationProperties(classElement)) {
             if (classElement.isInterface()) {
                 return new IntroductionInterfaceBeanElementCreator(classElement, visitorContext);
@@ -121,6 +121,10 @@ public abstract class BeanDefinitionCreatorFactory {
         return concreteClassMetadata.hasDeclaredStereotype(Bean.class) ||
             concreteClassMetadata.hasStereotype(AnnotationUtil.SCOPE) ||
             concreteClassMetadata.hasStereotype(DefaultScope.class);
+    }
+
+    public static boolean isIntroduction(AnnotationMetadata metadata) {
+        return InterceptedMethodUtil.hasIntroductionStereotype(metadata);
     }
 
 }

--- a/core-processor/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationRemapper
+++ b/core-processor/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationRemapper
@@ -1,3 +1,5 @@
 io.micronaut.inject.annotation.internal.FindBugsRemapper
 io.micronaut.inject.annotation.internal.JakartaRemapper
+io.micronaut.inject.annotation.internal.QualifierBindingMembers
+io.micronaut.inject.annotation.internal.InterceptorBindingMembers
 

--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationUtil.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationUtil.java
@@ -15,12 +15,20 @@
  */
 package io.micronaut.core.annotation;
 
-import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
 
-import java.lang.annotation.*;
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 import java.lang.reflect.AnnotatedElement;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -43,7 +51,6 @@ public class AnnotationUtil {
             "javax.annotation.meta.TypeQualifierNickname",
             "kotlin.annotation.Retention",
             "kotlin.Annotation",
-            Inherited.class.getName(),
             SuppressWarnings.class.getName(),
             Override.class.getName(),
             Repeatable.class.getName(),
@@ -138,15 +145,6 @@ public class AnnotationUtil {
     public static final String ANN_INTERCEPTOR_BINDING_QUALIFIER = "io.micronaut.inject.qualifiers.InterceptorBindingQualifier";
 
     /**
-     * The advice stereotypes.
-     */
-    public static final Set<String> ADVICE_STEREOTYPES = CollectionUtils.setOf(
-            ANN_AROUND,
-            ANN_AROUND_CONSTRUCT,
-            ANN_INTRODUCTION
-    );
-
-    /**
      * Name of the repeatable interceptor bindings type.
      */
     public static final String ANN_INTERCEPTOR_BINDINGS = "io.micronaut.aop.InterceptorBindingDefinitions";
@@ -185,6 +183,16 @@ public class AnnotationUtil {
      * The meta annotation used for post-construct declarations.
      */
     public static final String POST_CONSTRUCT = "javax.annotation.PostConstruct";
+
+    /**
+     * The annotation attribute containing all the attributes marked as non binding.
+     */
+    public static final String NON_BINDING_ATTRIBUTE = "$nonBinding";
+
+    /**
+     * The inherited annotation.
+     */
+    public static final String ANN_INHERITED = Inherited.class.getName();
 
     private static final Map<Integer, List<String>> INTERN_LIST_POOL = new ConcurrentHashMap<>();
     private static final Map<String, Map<String, Object>> INTERN_MAP_POOL = new ConcurrentHashMap<>();

--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationValue.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationValue.java
@@ -43,6 +43,9 @@ import java.util.stream.Stream;
  * <p>If a member is not present then the methods of the class will attempt to resolve the default value for a given annotation member. In this sense the behaviour of this class is similar to how
  * a implementation of {@link Annotation} behaves.</p>
  *
+ * NOTE: During the mapping or remapping, nullable stereotypes value means that
+ * the stereotypes will be filled from the annotation definition, when empty collection will skip it.
+ *
  * @param <A> The annotation type
  * @author Graeme Rocher
  * @since 1.0
@@ -177,6 +180,16 @@ public class AnnotationValue<A extends Annotation> implements AnnotationValueRes
         this.valueMapper = valueMapper;
         this.retentionPolicy = RetentionPolicy.RUNTIME;
         this.stereotypes = null;
+    }
+
+    /**
+     * Creates a builder with the initial value of this annotation.
+     *
+     * @return The builder with this annotation value
+     * @since 4.0.0
+     */
+    public AnnotationValueBuilder<A> mutate() {
+        return builder(this);
     }
 
     /**

--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationValueBuilder.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationValueBuilder.java
@@ -20,9 +20,11 @@ import io.micronaut.core.reflect.ReflectionUtils;
 import java.lang.annotation.Annotation;
 import java.lang.annotation.RetentionPolicy;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * A build for annotation values.
@@ -84,7 +86,7 @@ public class AnnotationValueBuilder<T extends Annotation> {
         this.annotationName = value.getAnnotationName();
         this.values.putAll(value.getValues());
         this.defaultValues = value.getDefaultValues();
-        this.stereotypes = value.getStereotypes();
+        this.stereotypes = value.getStereotypes() == null ? null : new ArrayList<>(value.getStereotypes());
         this.retentionPolicy = retentionPolicy != null ? retentionPolicy : RetentionPolicy.RUNTIME;
     }
 
@@ -112,6 +114,77 @@ public class AnnotationValueBuilder<T extends Annotation> {
             }
             stereotypes.add(annotation);
         }
+        return this;
+    }
+
+    /**
+     * Replaces the stereotype annotation.
+     *
+     * @param originalAnnotationValue The original annotation value
+     * @param newAnnotationValue The new annotation value
+     * @return This builder
+     * @since 4.0.0
+     */
+    @NonNull
+    public AnnotationValueBuilder<T> replaceStereotype(@NonNull AnnotationValue<?> originalAnnotationValue,
+                                                       @NonNull AnnotationValue<?> newAnnotationValue) {
+        Objects.requireNonNull(stereotypes);
+        List<AnnotationValue<?>> values = new ArrayList<>(stereotypes);
+        int index = values.indexOf(originalAnnotationValue);
+        if (index < 0) {
+            throw new IllegalArgumentException("Unknown original annotation value!");
+        }
+        values.set(index, newAnnotationValue);
+        stereotypes = values;
+        return this;
+    }
+
+    /**
+     * Removes the stereotype annotation.
+     *
+     * @param annotationValueToRemove The annotation value to remove
+     * @return This builder
+     * @since 4.0.0
+     */
+    @NonNull
+    public AnnotationValueBuilder<T> removeStereotype(@NonNull AnnotationValue<?> annotationValueToRemove) {
+        Objects.requireNonNull(stereotypes);
+        List<AnnotationValue<?>> values = new ArrayList<>(stereotypes);
+        int index = values.indexOf(annotationValueToRemove);
+        if (index < 0) {
+            throw new IllegalArgumentException("Unknown annotation value!");
+        }
+        values.remove(index);
+        stereotypes = values;
+        return this;
+    }
+
+    /**
+     * Adds a stereotypes of the annotation.
+     *
+     * @param newStereotypes The stereotypes
+     * @return This builder
+     * @since 4.0.0
+     */
+    @NonNull
+    public AnnotationValueBuilder<T> stereotypes(@NonNull Collection<AnnotationValue<?>> newStereotypes) {
+        if (stereotypes == null) {
+            stereotypes = new ArrayList<>(10);
+        }
+        stereotypes.addAll(newStereotypes);
+        return this;
+    }
+
+    /**
+     * Replaces stereotypes of the annotation.
+     *
+     * @param newStereotypes The stereotypes
+     * @return This builder
+     * @since 4.0.0
+     */
+    @NonNull
+    public AnnotationValueBuilder<T> replaceStereotypes(@NonNull Collection<AnnotationValue<?>> newStereotypes) {
+        stereotypes = new ArrayList<>(newStereotypes);
         return this;
     }
 

--- a/core/src/main/java/io/micronaut/core/util/CollectionUtils.java
+++ b/core/src/main/java/io/micronaut/core/util/CollectionUtils.java
@@ -32,6 +32,70 @@ import java.util.*;
 public class CollectionUtils {
 
     /**
+     * The method will merge the set and element into a new set.
+     *
+     * @param set     The set
+     * @param element The element
+     * @param <E>     The element type
+     * @return The new set
+     * @since 4.0.0
+     */
+    public static <E> Set<E> concat(Set<E> set, E element) {
+        Set<E> newList = CollectionUtils.newHashSet(set.size() + 1);
+        newList.addAll(set);
+        newList.add(element);
+        return newList;
+    }
+
+    /**
+     * The method will merge two sets into a new set.
+     *
+     * @param set1       The first set
+     * @param collection The second collection
+     * @param <E>        The element type
+     * @return The new set
+     * @since 4.0.0
+     */
+    public static <E> Set<E> concat(Set<E> set1, Collection<E> collection) {
+        Set<E> newSet = newHashSet(set1.size() + collection.size());
+        newSet.addAll(set1);
+        newSet.addAll(collection);
+        return newSet;
+    }
+
+    /**
+     * The method will merge the list and element into a new list.
+     *
+     * @param list    The list
+     * @param element The element
+     * @param <E>     The element type
+     * @return The new list
+     * @since 4.0.0
+     */
+    public static <E> List<E> concat(List<E> list, E element) {
+        List<E> newList = new ArrayList<>(list.size() + 1);
+        newList.addAll(list);
+        newList.add(element);
+        return newList;
+    }
+
+    /**
+     * The method will merge two list into a new list.
+     *
+     * @param list1      The first list
+     * @param collection The second collection
+     * @param <E>        The element type
+     * @return The new list
+     * @since 4.0.0
+     */
+    public static <E> List<E> concat(List<E> list1, Collection<E> collection) {
+        List<E> newList = new ArrayList<>(list1.size() + collection.size());
+        newList.addAll(list1);
+        newList.addAll(collection);
+        return newList;
+    }
+
+    /**
      * Create new {@link HashSet} sized to fit all the elements of the size provided.
      * @param size The size to fit all the elements
      * @param <E> The element type
@@ -279,7 +343,7 @@ public class CollectionUtils {
             if (o == null) {
                 continue;
             } else {
-                if (CharSequence.class.isInstance(o)) {
+                if (o instanceof CharSequence) {
                     builder.append(o);
                 } else {
                     Optional<String> converted = ConversionService.SHARED.convert(o, String.class);

--- a/inject-groovy-test/src/main/groovy/io/micronaut/ast/transform/test/AbstractBeanDefinitionSpec.groovy
+++ b/inject-groovy-test/src/main/groovy/io/micronaut/ast/transform/test/AbstractBeanDefinitionSpec.groovy
@@ -218,9 +218,9 @@ abstract class AbstractBeanDefinitionSpec extends Specification {
         return element
     }
 
-
+    @CompileStatic
     protected AnnotationMetadata writeAndLoadMetadata(String className, AnnotationMetadata toWrite) {
-        def stream = new ByteArrayOutputStream()
+        ByteArrayOutputStream stream = new ByteArrayOutputStream()
         new AnnotationMetadataWriter(className, null, toWrite, true)
                 .writeTo(stream)
         className = className + AnnotationMetadata.CLASS_NAME_SUFFIX
@@ -228,7 +228,7 @@ abstract class AbstractBeanDefinitionSpec extends Specification {
             @Override
             protected Class<?> findClass(String name) throws ClassNotFoundException {
                 if (name == className) {
-                    def bytes = stream.toByteArray()
+                    byte[] bytes = stream.toByteArray()
                     return super.defineClass(name, bytes, 0, bytes.length)
                 }
                 return super.findClass(name)

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/annotation/GroovyAnnotationMetadataBuilder.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/annotation/GroovyAnnotationMetadataBuilder.java
@@ -59,7 +59,6 @@ import org.codehaus.groovy.control.CompilationUnit;
 import org.codehaus.groovy.control.SourceUnit;
 
 import java.lang.annotation.Annotation;
-import java.lang.annotation.Inherited;
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -384,41 +383,6 @@ public class GroovyAnnotationMetadataBuilder extends AbstractAnnotationMetadataB
             }
         }
         return defaultValues;
-    }
-
-    @Override
-    protected boolean isInheritedAnnotation(@NonNull AnnotationNode annotationMirror) {
-        final List<AnnotationNode> annotations = annotationMirror.getClassNode().getAnnotations();
-        if (CollectionUtils.isNotEmpty(annotations)) {
-            return annotations.stream().anyMatch((ann) ->
-                    ann.getClassNode().getName().equals(Inherited.class.getName())
-            );
-        }
-        return false;
-    }
-
-    @Override
-    protected Map<String, ? extends AnnotatedNode> getAnnotationMembers(String annotationType) {
-        final AnnotatedNode node = getAnnotationMirror(annotationType).orElse(null);
-        if (node instanceof final ClassNode cn) {
-            if (cn.isAnnotationDefinition()) {
-                return cn.getDeclaredMethodsMap();
-            }
-        }
-        return Collections.emptyMap();
-    }
-
-    @Override
-    protected boolean hasSimpleAnnotation(AnnotatedNode element, String simpleName) {
-        if (element != null) {
-            final List<AnnotationNode> annotations = element.getAnnotations();
-            for (AnnotationNode ann : annotations) {
-                if (ann.getClassNode().getNameWithoutPackage().equalsIgnoreCase(simpleName)) {
-                    return true;
-                }
-            }
-        }
-        return false;
     }
 
     @Override

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/configproperties/InheritedConfigurationReaderPrefixSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/configproperties/InheritedConfigurationReaderPrefixSpec.groovy
@@ -37,7 +37,7 @@ class MyBean  {
         beanDefinition.getInjectedMethods()[0].name == 'setMyValue'
         def metadata = beanDefinition.getInjectedMethods()[0].getAnnotationMetadata()
         metadata.hasAnnotation(Property)
-        metadata.getValue(Property, "name", String).get() == 'simple.my-value'
+        metadata.getValue(Property, "name", String).get() == 'endpoints.my-value'
     }
 
     void "property path is overriding the existing one without base prefix"() {
@@ -56,7 +56,7 @@ class MyBean  {
         beanDefinition.getInjectedMethods()[0].name == 'setMyValue'
         def metadata = beanDefinition.getInjectedMethods()[0].getAnnotationMetadata()
         metadata.hasAnnotation(Property)
-        metadata.getValue(Property, "name", String).get() == 'simple.my-value'
+        metadata.getValue(Property, "name", String).get() == 'endpoints.my-value'
     }
 
     void "property path is broken because alias is pointing to another alias 2"() {

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -72,8 +72,6 @@ import static javax.lang.model.element.ElementKind.ENUM;
 @SupportedOptions({AbstractInjectAnnotationProcessor.MICRONAUT_PROCESSING_INCREMENTAL, AbstractInjectAnnotationProcessor.MICRONAUT_PROCESSING_ANNOTATIONS, BeanDefinitionWriter.OMIT_CONFPROP_INJECTION_POINTS})
 public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProcessor {
 
-    private static final String AROUND_TYPE = AnnotationUtil.ANN_AROUND;
-    private static final String INTRODUCTION_TYPE = AnnotationUtil.ANN_INTRODUCTION;
     private static final String[] ANNOTATION_STEREOTYPES = new String[]{
         AnnotationUtil.POST_CONSTRUCT,
         AnnotationUtil.PRE_DESTROY,
@@ -90,10 +88,10 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
         "io.micronaut.context.annotation.Value",
         "io.micronaut.context.annotation.Property",
         "io.micronaut.context.annotation.Executable",
-        AROUND_TYPE,
+        AnnotationUtil.ANN_AROUND,
         AnnotationUtil.ANN_INTERCEPTOR_BINDINGS,
         AnnotationUtil.ANN_INTERCEPTOR_BINDING,
-        INTRODUCTION_TYPE
+        AnnotationUtil.ANN_INTRODUCTION
     };
 
     private Set<String> beanDefinitions;
@@ -178,7 +176,7 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
                             beanDefinitions.add(name);
                         } else {
                             AnnotationMetadata annotationMetadata = annotationMetadataBuilder.lookupOrBuildForType(typeElement);
-                            if (annotationMetadata.hasStereotype(INTRODUCTION_TYPE) || annotationMetadata.hasStereotype(ConfigurationReader.class)) {
+                            if (BeanDefinitionCreatorFactory.isIntroduction(annotationMetadata) || annotationMetadata.hasStereotype(ConfigurationReader.class)) {
                                 beanDefinitions.add(name);
                             }
                         }

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/JavaAnnotationMetadataBuilder.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/JavaAnnotationMetadataBuilder.java
@@ -48,7 +48,6 @@ import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 import javax.tools.Diagnostic;
 import java.lang.annotation.Annotation;
-import java.lang.annotation.Inherited;
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -183,51 +182,6 @@ public class JavaAnnotationMetadataBuilder extends AbstractAnnotationMetadataBui
 
         }
         return RetentionPolicy.RUNTIME;
-    }
-
-    @Override
-    protected boolean isInheritedAnnotation(@NonNull AnnotationMirror annotationMirror) {
-        final List<? extends AnnotationMirror> annotationMirrors = annotationMirror.getAnnotationType().asElement().getAnnotationMirrors();
-        for (AnnotationMirror mirror : annotationMirrors) {
-            if (getAnnotationTypeName(mirror).equals(Inherited.class.getName())) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    @Override
-    protected Map<String, Element> getAnnotationMembers(String annotationType) {
-        final Element element = getAnnotationMirror(annotationType).orElse(null);
-        if (element != null && element.getKind() == ElementKind.ANNOTATION_TYPE) {
-            final List<? extends Element> elements = element.getEnclosedElements();
-            if (elements.isEmpty()) {
-                return Collections.emptyMap();
-            } else {
-                Map<String, Element> members = new LinkedHashMap<>(elements.size());
-                for (Element method : elements) {
-                    members.put(method.getSimpleName().toString(), method);
-                }
-                return Collections.unmodifiableMap(members);
-            }
-        }
-        return Collections.emptyMap();
-    }
-
-    @Override
-    protected boolean hasSimpleAnnotation(Element element, String simpleName) {
-        if (element != null) {
-            final List<? extends AnnotationMirror> mirrors = element.getAnnotationMirrors();
-            for (AnnotationMirror mirror : mirrors) {
-                final String s = mirror.getAnnotationType()
-                    .asElement()
-                    .getSimpleName().toString();
-                if (s.equalsIgnoreCase(simpleName)) {
-                    return true;
-                }
-            }
-        }
-        return false;
     }
 
     @Override

--- a/inject-java/src/test/groovy/io/micronaut/annotation/mapping/MyGet1.java
+++ b/inject-java/src/test/groovy/io/micronaut/annotation/mapping/MyGet1.java
@@ -1,0 +1,14 @@
+package io.micronaut.annotation.mapping;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.METHOD})
+public @interface MyGet1 {
+}

--- a/inject-java/src/test/groovy/io/micronaut/annotation/mapping/MyGet2.java
+++ b/inject-java/src/test/groovy/io/micronaut/annotation/mapping/MyGet2.java
@@ -1,0 +1,14 @@
+package io.micronaut.annotation.mapping;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.METHOD})
+public @interface MyGet2 {
+}

--- a/inject-java/src/test/groovy/io/micronaut/annotation/mapping/TransformNotInheritedAnnotationSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/annotation/mapping/TransformNotInheritedAnnotationSpec.groovy
@@ -1,0 +1,56 @@
+package io.micronaut.annotation.mapping
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.core.annotation.AnnotationValue
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.HttpMethodMapping
+import io.micronaut.inject.annotation.TypedAnnotationTransformer
+import io.micronaut.inject.visitor.VisitorContext
+
+class TransformNotInheritedAnnotationSpec extends AbstractTypeElementSpec {
+
+    void 'test transforming'() {
+        given:
+            def definition = buildBeanDefinition('addann.TransformNotInherited', '''
+package addann;
+
+import io.micronaut.context.annotation.Bean;
+
+interface MyInterface {
+
+    @io.micronaut.annotation.mapping.MyGet1
+    String getHelloWorld();
+}
+
+@Bean
+class TransformNotInherited implements MyInterface {
+
+    @Override
+    public String getHelloWorld() {
+        return "Hello world";
+    }
+}
+''')
+        expect:
+            definition.getRequiredMethod("getHelloWorld").hasAnnotation(Get)
+            definition.getRequiredMethod("getHelloWorld").hasStereotype(HttpMethodMapping)
+    }
+
+    static class TheAnnotationMapper implements TypedAnnotationTransformer<MyGet1> {
+
+
+        @Override
+        List<AnnotationValue<?>> transform(AnnotationValue<MyGet1> annotation, VisitorContext visitorContext) {
+            return List.of(
+                    AnnotationValue.builder(Get.class).build()
+            )
+        }
+
+        @Override
+        Class<MyGet1> annotationType() {
+            return MyGet1.class
+        }
+    }
+
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/annotation/mapping/TransformToInheritedAnnotationSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/annotation/mapping/TransformToInheritedAnnotationSpec.groovy
@@ -1,0 +1,59 @@
+package io.micronaut.annotation.mapping
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.core.annotation.AnnotationValue
+import io.micronaut.inject.annotation.TypedAnnotationTransformer
+import io.micronaut.inject.visitor.VisitorContext
+
+import java.lang.annotation.Inherited
+
+class TransformToInheritedAnnotationSpec extends AbstractTypeElementSpec {
+
+    void 'test transforming'() {
+        given:
+            def definition = buildBeanDefinition('addann.TransformToInherited', '''
+package addann;
+
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Executable;
+
+interface MyInterfaceX {
+
+    @io.micronaut.annotation.mapping.MyGet2
+    @Executable
+    String getHelloWorld();
+}
+
+@Bean
+class TransformToInherited implements MyInterfaceX {
+
+    @Override
+    public String getHelloWorld() {
+        return "Hello world";
+    }
+}
+''')
+        expect:
+            definition.getRequiredMethod("getHelloWorld").hasAnnotation(MyGet2)
+    }
+
+    static class TheAnnotationMapper implements TypedAnnotationTransformer<MyGet2> {
+
+
+        @Override
+        List<AnnotationValue<?>> transform(AnnotationValue<MyGet2> annotation, VisitorContext visitorContext) {
+            return List.of(
+                    annotation.mutate().stereotype(
+                            AnnotationValue.builder(Inherited).build()
+                    ).build()
+            )
+        }
+
+        @Override
+        Class<MyGet2> annotationType() {
+            return MyGet2.class
+        }
+    }
+
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/configproperties/InheritedConfigurationReaderPrefixSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configproperties/InheritedConfigurationReaderPrefixSpec.groovy
@@ -45,7 +45,7 @@ class MyBean  {
             beanDefinition.getInjectedMethods()[0].name == 'setMyValue'
             def metadata = beanDefinition.getInjectedMethods()[0].getAnnotationMetadata()
             metadata.hasAnnotation(Property)
-            metadata.getValue(Property, "name", String).get() == 'simple.my-value'
+            metadata.getValue(Property, "name", String).get() == 'endpoints.my-value'
     }
 
     void "property path is overriding the existing one without base prefix"() {
@@ -72,7 +72,7 @@ class MyBean  {
             beanDefinition.getInjectedMethods()[0].name == 'setMyValue'
             def metadata = beanDefinition.getInjectedMethods()[0].getAnnotationMetadata()
             metadata.hasAnnotation(Property)
-            metadata.getValue(Property, "name", String).get() == 'simple.my-value'
+            metadata.getValue(Property, "name", String).get() == 'endpoints.my-value'
     }
 
     void "property path is broken because alias is pointing to another alias 2"() {

--- a/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/annotationmember/NonBindingQualifierSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/qualifiers/annotationmember/NonBindingQualifierSpec.groovy
@@ -1,11 +1,7 @@
 package io.micronaut.inject.qualifiers.annotationmember
 
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
-import io.micronaut.context.ApplicationContext
 import io.micronaut.core.annotation.AnnotationUtil
-import io.micronaut.inject.BeanDefinition
-
-import jakarta.inject.Qualifier
 
 class NonBindingQualifierSpec extends AbstractTypeElementSpec {
 
@@ -28,7 +24,7 @@ class Test {
 
 @Singleton
 @Cylinders(value = 6, description = "6-cylinder V6 engine")
-class V6Engine implements Engine { 
+class V6Engine implements Engine {
 
     @Override
     public int getCylinders() {
@@ -37,8 +33,8 @@ class V6Engine implements Engine {
 }
 
 @Singleton
-@Cylinders(value = 8, description = "8-cylinder V8 engine") 
-class V8Engine implements Engine { 
+@Cylinders(value = 8, description = "8-cylinder V8 engine")
+class V8Engine implements Engine {
     @Override
     public int getCylinders() {
         return 8;
@@ -49,12 +45,12 @@ interface Engine {
     int getCylinders();
 }
 
-@Qualifier 
+@Qualifier
 @Retention(RUNTIME)
 @interface Cylinders {
     int value();
 
-    @NonBinding 
+    @NonBinding
     String description() default "";
 }
 ''')
@@ -90,7 +86,7 @@ class Test {
 
     @NonBinding
     String description() default "";
-    
+
 }
 
 ''')
@@ -100,7 +96,7 @@ class Test {
         definition
                 .getAnnotationMetadata()
                 .getAnnotation(AnnotationUtil.QUALIFIER)
-                .stringValues("nonBinding") as Set == ['description'] as Set
+                .stringValues(AnnotationUtil.NON_BINDING_ATTRIBUTE) as Set == ['description', AnnotationUtil.NON_BINDING_ATTRIBUTE] as Set
         definition
             .annotationMetadata
             .getAnnotationNameByStereotype(AnnotationUtil.QUALIFIER).get() == 'annotationmember.Cylinders'

--- a/inject-java/src/test/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationTransformer
+++ b/inject-java/src/test/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationTransformer
@@ -2,3 +2,5 @@ io.micronaut.inject.beanbuilder.TestInterceptorBindingTransformer
 io.micronaut.aop.compile.AroundCompileSpec$TestStereotypeAnnTransformer
 io.micronaut.aop.compile.AroundConstructCompileSpec$TestStereotypeAnnTransformer
 io.micronaut.annotation.mapping.TransformsToRepeatableAnnotationSpec$TheAnnotationTransformer
+io.micronaut.annotation.mapping.TransformNotInheritedAnnotationSpec$TheAnnotationMapper
+io.micronaut.annotation.mapping.TransformToInheritedAnnotationSpec$TheAnnotationMapper

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/annotation/KotlinAnnotationMetadataBuilder.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/annotation/KotlinAnnotationMetadataBuilder.kt
@@ -35,7 +35,6 @@ import io.micronaut.inject.visitor.VisitorContext
 import io.micronaut.kotlin.processing.getBinaryName
 import io.micronaut.kotlin.processing.getClassDeclaration
 import io.micronaut.kotlin.processing.visitor.KotlinVisitorContext
-import java.lang.annotation.Inherited
 import java.lang.annotation.RetentionPolicy
 import java.lang.reflect.Method
 import java.util.*
@@ -542,12 +541,6 @@ internal class KotlinAnnotationMetadataBuilder(private val symbolProcessorEnviro
             }
     }
 
-    override fun isInheritedAnnotation(annotationMirror: KSAnnotation): Boolean {
-        return annotationMirror.annotationType.resolve().declaration.annotations.any {
-            it.annotationType.resolve().declaration.qualifiedName?.asString() == Inherited::class.qualifiedName
-        }
-    }
-
     private fun populateTypeHierarchy(element: KSClassDeclaration, hierarchy: MutableList<KSAnnotated>) {
         element.superTypes.forEach {
             val t = it.resolve()
@@ -584,25 +577,4 @@ internal class KotlinAnnotationMetadataBuilder(private val symbolProcessorEnviro
          return value
     }
 
-    override fun getAnnotationMembers(annotationType: String): MutableMap<String, out KSAnnotated> {
-        val annotationMirror = getAnnotationMirror(annotationType)
-        val members = mutableMapOf<String, KSAnnotated>()
-        if (annotationMirror.isPresent) {
-            (annotationMirror.get().getClassDeclaration(visitorContext)).getDeclaredProperties()
-                .forEach {
-                    members[it.simpleName.asString()] = it
-                }
-        }
-        return members
-    }
-
-    override fun hasSimpleAnnotation(element: KSAnnotated, simpleName: String): Boolean {
-        val annotationMirrors: MutableList<KSAnnotation> = element.annotations.toMutableList()
-        if (element is KSPropertyDeclaration) {
-            annotationMirrors.addAll(element.getter!!.annotations)
-        }
-        return annotationMirrors.any {
-            it.annotationType.resolve().declaration.simpleName.asString() == simpleName
-        }
-    }
 }

--- a/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataSupport.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataSupport.java
@@ -296,6 +296,19 @@ public final class AnnotationMetadataSupport {
     }
 
     /**
+     * Registers repeatable annotation containers.
+     *
+     * @param repeatable          the repeatable annotations
+     * @param repeatableContainer the repeatable annotation container
+     * @MyRepeatable -> @MyRepeatableContainer
+     * @since 4.0.0
+     */
+    @Internal
+    static void registerRepeatableAnnotation(@NonNull String repeatable, @NonNull String repeatableContainer) {
+        REPEATABLE_ANNOTATIONS_CONTAINERS.put(repeatable, repeatableContainer);
+    }
+
+    /**
      * @param annotation The annotation
      * @return The proxy class
      */

--- a/inject/src/main/java/io/micronaut/inject/annotation/MutableAnnotationMetadata.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/MutableAnnotationMetadata.java
@@ -17,7 +17,6 @@ package io.micronaut.inject.annotation;
 
 import io.micronaut.context.env.DefaultPropertyPlaceholderResolver;
 import io.micronaut.core.annotation.AnnotationMetadata;
-import io.micronaut.core.annotation.AnnotationUtil;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
@@ -921,7 +920,7 @@ public class MutableAnnotationMetadata extends DefaultAnnotationMetadata {
         annotations.entrySet().removeIf(entry -> {
             final String annotationName = entry.getKey();
             if (predicate.test(newAnnotationValue(annotationName, entry.getValue()))) {
-                removeFromStereotypes(annotationName, annotations);
+                removeFromStereotypes(annotationName);
                 return true;
             }
             return false;
@@ -946,7 +945,7 @@ public class MutableAnnotationMetadata extends DefaultAnnotationMetadata {
         }
         if (declaredAnnotations != null) {
             declaredAnnotations.remove(annotationType);
-            removeFromStereotypes(annotationType, declaredAnnotations);
+            removeFromStereotypes(annotationType);
         }
         if (annotationRepeatableContainer != null) {
             annotationRepeatableContainer.remove(annotationType);
@@ -982,19 +981,19 @@ public class MutableAnnotationMetadata extends DefaultAnnotationMetadata {
         }
     }
 
-    private void removeFromStereotypes(String annotationType, Map<String, Map<CharSequence, Object>> declaredAnnotations) {
-        if (annotationsByStereotype == null) {
+    private void removeFromStereotypes(String annotationType) {
+        if (annotationsByStereotype == null || annotationsByStereotype.isEmpty()) {
             return;
         }
         final Iterator<Map.Entry<String, List<String>>> i = annotationsByStereotype.entrySet().iterator();
-        Set<String> toBeRemoved = CollectionUtils.setOf(annotationType);
+        Set<String> removeNext = new LinkedHashSet<>();
         while (i.hasNext()) {
             final Map.Entry<String, List<String>> entry = i.next();
             final String stereotypeName = entry.getKey();
             final List<String> value = entry.getValue();
-            if (value.removeAll(toBeRemoved)) {
+            if (value.remove(annotationType)) {
                 if (value.isEmpty()) {
-                    toBeRemoved.add(stereotypeName);
+                    removeNext.add(stereotypeName);
                     i.remove();
                     if (allStereotypes != null) {
                         this.allStereotypes.remove(stereotypeName);
@@ -1005,33 +1004,12 @@ public class MutableAnnotationMetadata extends DefaultAnnotationMetadata {
                     if (annotationDefaultValues != null) {
                         annotationDefaultValues.remove(stereotypeName);
                     }
-                }
-
-                if (AnnotationUtil.ANN_AROUND.equals(stereotypeName) || AnnotationUtil.ANN_INTRODUCTION.equals(stereotypeName) || AnnotationUtil.ANN_AROUND_CONSTRUCT.equals(stereotypeName)) {
-                    // purge from interceptor binding
-                    purgeInterceptorBindings(declaredAnnotations, toBeRemoved);
-                    purgeInterceptorBindings(this.allAnnotations, toBeRemoved);
+                    removeNext.add(stereotypeName);
                 }
             }
         }
-    }
-
-    private void purgeInterceptorBindings(Map<String, Map<CharSequence, Object>> declaredAnnotations, Set<String> toBeRemoved) {
-        if (declaredAnnotations == null) {
-            return;
-        }
-        final Map<CharSequence, Object> v = declaredAnnotations.get(AnnotationUtil.ANN_INTERCEPTOR_BINDINGS);
-        if (v != null) {
-            final Object o = v.get(AnnotationMetadata.VALUE_MEMBER);
-            if (o instanceof Collection<?>) {
-                Collection<AnnotationValue<?>> col = (Collection) o;
-                col.removeIf(av -> Arrays.stream(av.annotationClassValues(AnnotationMetadata.VALUE_MEMBER))
-                        .anyMatch(acv -> toBeRemoved.contains(acv.getName())));
-
-                if (col.isEmpty()) {
-                    declaredAnnotations.remove(AnnotationUtil.ANN_INTERCEPTOR_BINDINGS);
-                }
-            }
+        for (String stereotype : removeNext) {
+            removeFromStereotypes(stereotype);
         }
     }
 

--- a/inject/src/main/java/io/micronaut/inject/qualifiers/AnnotationMetadataQualifier.java
+++ b/inject/src/main/java/io/micronaut/inject/qualifiers/AnnotationMetadataQualifier.java
@@ -34,7 +34,7 @@ import java.lang.annotation.Annotation;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -166,8 +166,8 @@ final class AnnotationMetadataQualifier<T> implements Qualifier<T> {
 
     @NonNull
     private static Set<String> resolveNonBindingMembers(AnnotationMetadata annotationMetadata) {
-        final String[] nonBindingArray = annotationMetadata.stringValues(AnnotationUtil.QUALIFIER, "nonBinding");
-        return ArrayUtils.isNotEmpty(nonBindingArray) ? new HashSet<>(Arrays.asList(nonBindingArray)) : Collections.emptySet();
+        final String[] nonBindingArray = annotationMetadata.stringValues(AnnotationUtil.QUALIFIER, AnnotationUtil.NON_BINDING_ATTRIBUTE);
+        return ArrayUtils.isNotEmpty(nonBindingArray) ? new LinkedHashSet<>(Arrays.asList(nonBindingArray)) : Collections.emptySet();
     }
 
     @Override


### PR DESCRIPTION
This PR changes the way how annotations are processed. Now, we include stereotypes into the `AnnotationValue` and recursively build the tree of the annotations and their stereotypes before mappers/transformers are run, making them more powerful. That allowed me to extract some specific code related to qualifiers and interceptors into its own remappers, which also gained the ability to be executed on all annotations.

Now we also include `@Inherited` stereotype into stereotypes of `AnnotationValue` and check if the annotation is inherited after the transformation, allowing the remappers to make the annotation inherited, something that is needed for JAX-RS and Validation. The change in the processing also returns the behavior of Micronaut 3, allowing remapping non-inherited annotation to an inherited one https://github.com/micronaut-projects/micronaut-serialization/blob/master/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/JsonIgnoreSpec.groovy#L438




