### PR TITLE
fix: WebSocketMessageEncoder @Requires classes

### DIFF
--- a/http-netty/src/main/java/io/micronaut/http/netty/websocket/WebSocketMessageEncoder.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/websocket/WebSocketMessageEncoder.java
@@ -16,6 +16,7 @@
 package io.micronaut.http.netty.websocket;
 
 import io.micronaut.buffer.netty.NettyByteBufferFactory;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.codec.MediaTypeCodec;
@@ -38,6 +39,7 @@ import java.util.Optional;
  * @author sdelamo
  * @since 1.0
  */
+@Requires(classes = WebSocketSessionException.class)
 @Singleton
 public class WebSocketMessageEncoder {
 


### PR DESCRIPTION
WebSocketMessageEncoder  should not be loaded unless classes  WebSocketSessionException class is present