### PR TITLE
Embedded HTTP benchmark, various small perf improvements

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -22,6 +22,8 @@ dependencies {
     api project(":inject")
     api project(":inject-java-test")
     api project(":http-server")
+    api project(":http-server-netty")
+    api project(":jackson-databind")
     api project(":router")
     api project(":runtime")
 

--- a/benchmarks/src/jmh/java/io/micronaut/http/server/stack/FullHttpStackBenchmark.java
+++ b/benchmarks/src/jmh/java/io/micronaut/http/server/stack/FullHttpStackBenchmark.java
@@ -57,7 +57,7 @@ public class FullHttpStackBenchmark {
 
         Options opt = new OptionsBuilder()
             .include(FullHttpStackBenchmark.class.getName() + ".*")
-            .warmupIterations(4)
+            .warmupIterations(15)
             .measurementIterations(30)
             .mode(Mode.AverageTime)
             .timeUnit(TimeUnit.NANOSECONDS)
@@ -83,6 +83,8 @@ public class FullHttpStackBenchmark {
             Stack stack = this.stack.openChannel();
             ctx = stack.closeable;
             channel = stack.serverChannel;
+
+            channel.freezeTime();
 
             EmbeddedChannel clientChannel = new EmbeddedChannel();
             clientChannel.pipeline().addLast(new HttpClientCodec());
@@ -126,6 +128,7 @@ public class FullHttpStackBenchmark {
 
         private ByteBuf exchange() {
             channel.writeInbound(requestBytes.retainedDuplicate());
+            channel.runPendingTasks();
             CompositeByteBuf response = PooledByteBufAllocator.DEFAULT.compositeBuffer();
             while (true) {
                 ByteBuf part = channel.readOutbound();

--- a/benchmarks/src/jmh/java/io/micronaut/http/server/stack/FullHttpStackBenchmark.java
+++ b/benchmarks/src/jmh/java/io/micronaut/http/server/stack/FullHttpStackBenchmark.java
@@ -1,0 +1,181 @@
+package io.micronaut.http.server.stack;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.http.server.netty.NettyHttpServer;
+import io.micronaut.runtime.server.EmbeddedServer;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpClientCodec;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.codec.http.HttpVersion;
+import org.junit.jupiter.api.Assertions;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.profile.AsyncProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+public class FullHttpStackBenchmark {
+    @Benchmark
+    public void test(Holder holder) {
+        ByteBuf response = holder.exchange();
+        if (!holder.responseBytes.equals(response)) {
+            throw new AssertionError("Response did not match");
+        }
+        response.release();
+    }
+
+    public static void main(String[] args) throws Exception {
+        // simple test that everything works properly
+        for (StackFactory stack : StackFactory.values()) {
+            Holder holder = new Holder();
+            holder.stack = stack;
+            holder.setUp();
+            holder.tearDown();
+        }
+
+        Options opt = new OptionsBuilder()
+            .include(FullHttpStackBenchmark.class.getName() + ".*")
+            .warmupIterations(4)
+            .measurementIterations(30)
+            .mode(Mode.AverageTime)
+            .timeUnit(TimeUnit.NANOSECONDS)
+            .addProfiler(AsyncProfiler.class, "libPath=/home/yawkat/bin/async-profiler-2.9-linux-x64/build/libasyncProfiler.so;output=flamegraph")
+            .forks(1)
+            .build();
+
+        new Runner(opt).run();
+    }
+
+    @State(Scope.Thread)
+    public static class Holder {
+        @Param({"MICRONAUT"/*, "PURE_NETTY"*/})
+        StackFactory stack = StackFactory.MICRONAUT;
+
+        AutoCloseable ctx;
+        EmbeddedChannel channel;
+        ByteBuf requestBytes;
+        ByteBuf responseBytes;
+
+        @Setup
+        public void setUp() {
+            Stack stack = this.stack.openChannel();
+            ctx = stack.closeable;
+            channel = stack.serverChannel;
+
+            EmbeddedChannel clientChannel = new EmbeddedChannel();
+            clientChannel.pipeline().addLast(new HttpClientCodec());
+            clientChannel.pipeline().addLast(new HttpObjectAggregator(1000));
+
+            FullHttpRequest request = new DefaultFullHttpRequest(
+                HttpVersion.HTTP_1_1,
+                HttpMethod.POST,
+                "/search/find",
+                Unpooled.wrappedBuffer("{\"haystack\": [\"xniomb\", \"seelzp\", \"nzogdq\", \"omblsg\", \"idgtlm\", \"ydonzo\"], \"needle\": \"idg\"}".getBytes(StandardCharsets.UTF_8))
+            );
+            request.headers().add(HttpHeaderNames.CONTENT_LENGTH, request.content().readableBytes());
+            request.headers().add(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.APPLICATION_JSON);
+            request.headers().add(HttpHeaderNames.ACCEPT, HttpHeaderValues.APPLICATION_JSON);
+            clientChannel.writeOutbound(request);
+            clientChannel.flushOutbound();
+
+            requestBytes = PooledByteBufAllocator.DEFAULT.buffer();
+            while (true) {
+                ByteBuf part = clientChannel.readOutbound();
+                if (part == null) {
+                    break;
+                }
+                requestBytes.writeBytes(part);
+            }
+
+            // sanity check: run req/resp once and see that the response is correct
+            responseBytes = exchange();
+            clientChannel.writeInbound(responseBytes.retainedDuplicate());
+            FullHttpResponse response = clientChannel.readInbound();
+            //System.out.println(response);
+            //System.out.println(response.content().toString(StandardCharsets.UTF_8));
+            Assertions.assertEquals(HttpResponseStatus.OK, response.status());
+            Assertions.assertEquals("application/json", response.headers().get(HttpHeaderNames.CONTENT_TYPE));
+            Assertions.assertEquals("keep-alive", response.headers().get(HttpHeaderNames.CONNECTION));
+            String expectedResponseBody = "{\"listIndex\":4,\"stringIndex\":0}";
+            Assertions.assertEquals(expectedResponseBody, response.content().toString(StandardCharsets.UTF_8));
+            Assertions.assertEquals(expectedResponseBody.length(), response.headers().getInt(HttpHeaderNames.CONTENT_LENGTH));
+            response.release();
+        }
+
+        private ByteBuf exchange() {
+            channel.writeInbound(requestBytes.retainedDuplicate());
+            CompositeByteBuf response = PooledByteBufAllocator.DEFAULT.compositeBuffer();
+            while (true) {
+                ByteBuf part = channel.readOutbound();
+                if (part == null) {
+                    break;
+                }
+                response.addComponent(true, part);
+            }
+            return response;
+        }
+
+        @TearDown
+        public void tearDown() throws Exception {
+            ctx.close();
+            requestBytes.release();
+            responseBytes.release();
+        }
+    }
+
+    public enum StackFactory {
+        MICRONAUT {
+            @Override
+            Stack openChannel() {
+                ApplicationContext ctx = ApplicationContext.run(Map.of(
+                    "spec.name", "FullHttpStackBenchmark",
+                    "micronaut.server.date-header", false // disabling this makes the response identical each time
+                ));
+                EmbeddedServer server = ctx.getBean(EmbeddedServer.class);
+                EmbeddedChannel channel = ((NettyHttpServer) server).buildEmbeddedChannel(false);
+                return new Stack(channel, ctx);
+            }
+        },
+        PURE_NETTY {
+            @Override
+            Stack openChannel() {
+                HttpObjectAggregator aggregator = new HttpObjectAggregator(10_000_000);
+                aggregator.setMaxCumulationBufferComponents(100000);
+                EmbeddedChannel channel = new EmbeddedChannel();
+                channel.pipeline().addLast(new HttpServerCodec());
+                channel.pipeline().addLast(aggregator);
+                channel.pipeline().addLast(new RequestHandler());
+                return new Stack(channel, () -> {
+                });
+            }
+        };
+
+        abstract Stack openChannel();
+    }
+
+    private record Stack(EmbeddedChannel serverChannel, AutoCloseable closeable) {
+    }
+
+}

--- a/benchmarks/src/jmh/java/io/micronaut/http/server/stack/FullHttpStackBenchmark.java
+++ b/benchmarks/src/jmh/java/io/micronaut/http/server/stack/FullHttpStackBenchmark.java
@@ -57,7 +57,7 @@ public class FullHttpStackBenchmark {
 
         Options opt = new OptionsBuilder()
             .include(FullHttpStackBenchmark.class.getName() + ".*")
-            .warmupIterations(15)
+            .warmupIterations(20)
             .measurementIterations(30)
             .mode(Mode.AverageTime)
             .timeUnit(TimeUnit.NANOSECONDS)

--- a/benchmarks/src/jmh/java/io/micronaut/http/server/stack/JmhFastThreadLocalExecutor.java
+++ b/benchmarks/src/jmh/java/io/micronaut/http/server/stack/JmhFastThreadLocalExecutor.java
@@ -1,0 +1,26 @@
+package io.micronaut.http.server.stack;
+
+import io.micronaut.core.annotation.NonNull;
+import io.netty.util.concurrent.FastThreadLocalThread;
+
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public final class JmhFastThreadLocalExecutor extends ThreadPoolExecutor {
+    public JmhFastThreadLocalExecutor(int maxThreads, String prefix) {
+        super(maxThreads, maxThreads,
+            60L, TimeUnit.SECONDS,
+            new SynchronousQueue<>(),
+            new ThreadFactory() {
+                final AtomicInteger counter = new AtomicInteger();
+
+                @Override
+                public Thread newThread(@NonNull Runnable r) {
+                    return new FastThreadLocalThread(r, prefix + "-jmh-worker-ftl-" + counter.incrementAndGet());
+                }
+            });
+    }
+}

--- a/benchmarks/src/jmh/java/io/micronaut/http/server/stack/RequestHandler.java
+++ b/benchmarks/src/jmh/java/io/micronaut/http/server/stack/RequestHandler.java
@@ -1,0 +1,120 @@
+package io.micronaut.http.server.stack;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufInputStream;
+import io.netty.buffer.ByteBufOutputStream;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslProvider;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.util.List;
+
+@ChannelHandler.Sharable
+final class RequestHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectReader reader = objectMapper.readerFor(SearchController.Input.class);
+    private final ObjectWriter writerResult = objectMapper.writerFor(SearchController.Result.class);
+    private final ObjectWriter writerStatus = objectMapper.writerFor(Status.class);
+
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx, FullHttpRequest msg) throws Exception {
+        FullHttpResponse response = computeResponse(ctx, msg);
+        response.headers().add(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE);
+        response.headers().add(HttpHeaderNames.CONTENT_LENGTH, response.content().readableBytes());
+        ctx.writeAndFlush(response, ctx.voidPromise());
+        ctx.read();
+    }
+
+    private FullHttpResponse computeResponse(ChannelHandlerContext ctx, FullHttpRequest msg) {
+        try {
+            String path = URI.create(msg.uri()).getPath();
+            if (path.equals("/search/find")) {
+                return computeResponseSearch(ctx, msg);
+            }
+            if (path.equals("/status")) {
+                return computeResponseStatus(ctx, msg);
+            }
+            return new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.NOT_FOUND);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private FullHttpResponse computeResponseSearch(ChannelHandlerContext ctx, FullHttpRequest msg) throws IOException {
+        if (!msg.method().equals(HttpMethod.POST)) {
+            return new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.METHOD_NOT_ALLOWED);
+        }
+        if (!msg.headers().contains(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.APPLICATION_JSON, true)) {
+            return new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.UNSUPPORTED_MEDIA_TYPE);
+        }
+
+        ByteBuf content = msg.content();
+        SearchController.Input input;
+        if (content.hasArray()) {
+            input = reader.readValue(content.array(), content.readerIndex() + content.arrayOffset(), content.readableBytes());
+        } else {
+            input = reader.readValue((InputStream) new ByteBufInputStream(content));
+        }
+
+        SearchController.Result result = find(input.haystack(), input.needle());
+        if (result == null) {
+            return new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.NOT_FOUND);
+        } else {
+            return serialize(ctx, writerResult, result);
+        }
+    }
+
+    private FullHttpResponse serialize(ChannelHandlerContext ctx, ObjectWriter writer, Object result) throws IOException {
+        ByteBuf buffer = ctx.alloc().buffer();
+        writer.writeValue((OutputStream) new ByteBufOutputStream(buffer), result);
+        DefaultFullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, buffer);
+        response.headers().add(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.APPLICATION_JSON);
+        return response;
+    }
+
+    private FullHttpResponse computeResponseStatus(ChannelHandlerContext ctx, FullHttpRequest msg) throws IOException {
+        if (!msg.method().equals(HttpMethod.GET)) {
+            return new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.METHOD_NOT_ALLOWED);
+        }
+
+        Status status = new Status(
+            ctx.channel().getClass().getName(),
+            SslContext.defaultServerProvider()
+        );
+
+        return serialize(ctx, writerStatus, status);
+    }
+
+    private static SearchController.Result find(List<String> haystack, String needle) {
+        for (int listIndex = 0; listIndex < haystack.size(); listIndex++) {
+            String s = haystack.get(listIndex);
+            int stringIndex = s.indexOf(needle);
+            if (stringIndex != -1) {
+                return new SearchController.Result(listIndex, stringIndex);
+            }
+        }
+        return null;
+    }
+
+    record Status(String channelImplementation,
+                  SslProvider sslProvider) {
+    }
+}

--- a/benchmarks/src/jmh/java/io/micronaut/http/server/stack/SearchController.java
+++ b/benchmarks/src/jmh/java/io/micronaut/http/server/stack/SearchController.java
@@ -1,0 +1,39 @@
+package io.micronaut.http.server.stack;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.MutableHttpResponse;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
+
+import java.util.List;
+
+@Controller("/search")
+@Requires(property = "spec.name", value = "FullHttpStackBenchmark")
+public class SearchController {
+    @Post("find")
+    public HttpResponse<?> find(@Body Input input) {
+        return find(input.haystack, input.needle);
+    }
+
+    private static MutableHttpResponse<?> find(List<String> haystack, String needle) {
+        for (int listIndex = 0; listIndex < haystack.size(); listIndex++) {
+            String s = haystack.get(listIndex);
+            int stringIndex = s.indexOf(needle);
+            if (stringIndex != -1) {
+                return HttpResponse.ok(new Result(listIndex, stringIndex));
+            }
+        }
+        return HttpResponse.notFound();
+    }
+
+    @Introspected
+    record Input(List<String> haystack, String needle) {
+    }
+
+    @Introspected
+    record Result(int listIndex, int stringIndex) {
+    }
+}

--- a/core/src/main/java/io/micronaut/core/execution/DelayedExecutionFlow.java
+++ b/core/src/main/java/io/micronaut/core/execution/DelayedExecutionFlow.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.core.execution;
 
 import io.micronaut.core.annotation.Nullable;

--- a/core/src/main/java/io/micronaut/core/execution/DelayedExecutionFlow.java
+++ b/core/src/main/java/io/micronaut/core/execution/DelayedExecutionFlow.java
@@ -1,0 +1,29 @@
+package io.micronaut.core.execution;
+
+import io.micronaut.core.annotation.Nullable;
+
+/**
+ * {@link ExecutionFlow} that can be completed similar to a
+ * {@link java.util.concurrent.CompletableFuture}.
+ *
+ * @param <T> The type of this flow
+ */
+public sealed interface DelayedExecutionFlow<T> extends ExecutionFlow<T> permits DelayedExecutionFlowImpl {
+    static <T> DelayedExecutionFlow<T> create() {
+        return new DelayedExecutionFlowImpl<>();
+    }
+
+    /**
+     * Complete this flow normally.
+     *
+     * @param result The result value
+     */
+    void complete(@Nullable T result);
+
+    /**
+     * Complete this flow with an exception.
+     *
+     * @param exc The exception
+     */
+    void completeExceptionally(Throwable exc);
+}

--- a/core/src/main/java/io/micronaut/core/execution/DelayedExecutionFlowImpl.java
+++ b/core/src/main/java/io/micronaut/core/execution/DelayedExecutionFlowImpl.java
@@ -1,0 +1,434 @@
+package io.micronaut.core.execution;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+@SuppressWarnings("rawtypes")
+final class DelayedExecutionFlowImpl<T> implements DelayedExecutionFlow<T> {
+    private static final Logger LOG = LoggerFactory.getLogger(DelayedExecutionFlowImpl.class);
+
+    /**
+     * Object used as a stand-in for a {@code null} completion to distinguish it from the
+     * uncompleted state.
+     */
+    private static final Object NULL = new Object();
+
+    /**
+     * The head of the linked list of steps in this flow.
+     */
+    private final Head head = new Head();
+    /**
+     * The tail of the linked list of steps in this flow.
+     */
+    private Step tail = head;
+
+    /**
+     * Perform the given step with the given item. Continue on until there is either no more steps,
+     * either because onComplete was hit or because the consumer is not finished adding all the
+     * steps, or until a step does not finish immediately, e.g. flatMap returning a non-immediate
+     * flow.
+     *
+     * @param step The step to execute first
+     * @param item The input item for the step
+     */
+    private static void work(Step step, Object item) {
+        while (true) {
+            item = step.apply(item);
+            if (item == null) {
+                // step suspended
+                break;
+            }
+            step = step.atomicSetOutput(item);
+            if (step == null) {
+                break;
+            }
+        }
+    }
+
+    /**
+     * Complete this flow with the given result.
+     *
+     * @param result The result object. May be a {@link Failure}, {@link #NULL}, or any other
+     *               successful value.
+     */
+    private void complete0(@NonNull Object result) {
+        Step immediateStep = head.atomicSetOutput(result);
+        if (immediateStep != null) {
+            work(immediateStep, result);
+        }
+    }
+
+    @Override
+    public void complete(T result) {
+        complete0(result == null ? NULL : result);
+    }
+
+    @Override
+    public void completeExceptionally(Throwable exc) {
+        complete0(new Failure(exc));
+    }
+
+    /**
+     * Add a new step to this flow.
+     *
+     * @param next The new step
+     * @param <R> The return type of the flow for generics support
+     * @return This flow
+     */
+    @SuppressWarnings("unchecked")
+    private <R> ExecutionFlow<R> next(Step next) {
+        Step oldTail = tail;
+        tail = next;
+        Object output = oldTail.atomicSetNext(next);
+        if (output != null) {
+            work(next, output);
+        }
+        return (ExecutionFlow<R>) this;
+    }
+
+    @Override
+    public <R> ExecutionFlow<R> map(Function<? super T, ? extends R> transformer) {
+        return next(new Map(transformer));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <R> ExecutionFlow<R> flatMap(Function<? super T, ? extends ExecutionFlow<? extends R>> transformer) {
+        return next(new FlatMap((Function<Object, ? extends ExecutionFlow>) transformer));
+    }
+
+    @Override
+    public <R> ExecutionFlow<R> then(Supplier<? extends ExecutionFlow<? extends R>> supplier) {
+        return next(new Then<>(supplier));
+    }
+
+    @Override
+    public ExecutionFlow<T> onErrorResume(Function<? super Throwable, ? extends ExecutionFlow<? extends T>> fallback) {
+        return next(new OnErrorResume(fallback));
+    }
+
+    @Override
+    public ExecutionFlow<T> putInContext(String key, Object value) {
+        return this;
+    }
+
+    @Override
+    public void onComplete(BiConsumer<? super T, Throwable> fn) {
+        next(new OnComplete<>(fn));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Nullable
+    @Override
+    public ImperativeExecutionFlow<T> tryComplete() {
+        Object tailOutput = tail.output;
+        if (tailOutput != null) {
+            if (tailOutput instanceof Failure failure) {
+                return (ImperativeExecutionFlow<T>) new ImperativeExecutionFlowImpl(null, failure.t);
+            } else if (tailOutput == NULL) {
+                return (ImperativeExecutionFlow<T>) new ImperativeExecutionFlowImpl(null, null);
+            } else {
+                return (ImperativeExecutionFlow<T>) new ImperativeExecutionFlowImpl(tailOutput, null);
+            }
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Special wrapper for exception results.
+     *
+     * @param t The exception of the failure
+     */
+    private record Failure(Throwable t) {
+    }
+
+    private abstract static class Step {
+        /**
+         * The next step to take, or {@code null} if there is no next step yet.
+         */
+        private volatile Step next;
+        /**
+         * The output of this step, or {@code null} if this step has not completed yet.
+         */
+        private volatile Object output;
+
+        /**
+         * Apply this step. Must call one of {@link #returnImmediate}, {@link #returnFlow},
+         * {@link #returnError} or {@link #returnUnchanged}.
+         *
+         * @param input The input for the step
+         * @return The return value of the {@code return*} method called
+         */
+        abstract Object apply(Object input);
+
+        /**
+         * Atomically set the output of this step. If this returns non-null, the caller must call
+         * {@link #work(Step, Object)} with the returned step.
+         *
+         * @param output The output of this step
+         * @return The next step to execute using {@link #work(Step, Object)}, or {@code null} if
+         * the next step will be executed later
+         */
+        @Nullable
+        final Step atomicSetOutput(Object output) {
+            if (this.output != null) {
+                // this is a best-effort check, the output field isn't always set
+                throw new IllegalStateException("Already completed");
+            }
+            Step next = this.next;
+            if (next != null) {
+                return next;
+            }
+            this.output = output;
+            next = this.next;
+            if (next != null) {
+                // another thread completed at the same time! one or both threads hit this sync
+                // block.
+                synchronized (this) {
+                    // deconfliction path
+                    next = this.next;
+                    if (next != null) {
+                        // our sync block was executed first, unset output so the other thread aborts
+                        this.output = null;
+                        return next;
+                    }
+                }
+            }
+            // no next step yet.
+            return null;
+        }
+
+        /**
+         * Atomically set the next step. If this returns non-null, the caller must call
+         * {@link #work(Step, Object)} with the returned output value.
+         *
+         * @param next The next step to execute
+         * @return The output value of this step, to be passed to {@link #work(Step, Object)}, or
+         * {@code null} if the output is not yet known and the given step will be executed later
+         */
+        @Nullable
+        final Object atomicSetNext(Step next) {
+            if (this.next != null) {
+                // this is a best-effort check, the next field isn't always set
+                throw new IllegalStateException("Already added a next step");
+            }
+            Object output = this.output;
+            if (output != null) {
+                return output;
+            }
+            this.next = next;
+            output = this.output;
+            if (output != null) {
+                // another thread completed at the same time! one or both threads hit this sync
+                // block.
+                synchronized (this) {
+                    // deconfliction path
+                    output = this.output;
+                    if (output != null) {
+                        // our sync block was executed first, unset next so the other thread aborts
+                        this.next = null;
+                        return output;
+                    }
+                }
+            }
+            // no output yet.
+            return null;
+        }
+
+        /**
+         * Return a flow from this step (e.g. from flatMap).
+         *
+         * @param outputFlow The flow to return
+         * @return The value to return from {@link #work}
+         */
+        final Object returnFlow(ExecutionFlow<?> outputFlow) {
+            ImperativeExecutionFlow<?> complete = outputFlow.tryComplete();
+            if (complete != null) {
+                Throwable error = complete.getError();
+                if (error == null) {
+                    return returnImmediate(complete.getValue());
+                } else {
+                    return returnError(error);
+                }
+            }
+
+            outputFlow.onComplete((v, t) -> {
+                Object result;
+                if (t == null) {
+                    result = v == null ? NULL : v;
+                } else {
+                    result = new Failure(t);
+                }
+                Step step = atomicSetOutput(result);
+                if (step != null) {
+                    work(step, result);
+                }
+            });
+            return null;
+        }
+
+        /**
+         * Return an immediate successful value from this step (e.g. from map).
+         *
+         * @param o The value to return
+         * @return The value to return from {@link #work}
+         */
+        final Object returnImmediate(@Nullable Object o) {
+            return o == null ? NULL : o;
+        }
+
+        /**
+         * Signal that this step made no change to the input (e.g. a {@code map} when the flow has
+         * an error).
+         *
+         * @param input The input passed to {@link #apply}
+         * @return The value to return from {@link #work}
+         */
+        final Object returnUnchanged(Object input) {
+            return input;
+        }
+
+        /**
+         * Return an immediate failed value from this step (e.g. from map).
+         *
+         * @param e The exception to return
+         * @return The value to return from {@link #work}
+         */
+        final Object returnError(Throwable e) {
+            return new Failure(e);
+        }
+    }
+
+    /**
+     * Mock step used as the head of the linked list of steps.
+     */
+    private static class Head extends Step {
+        @Override
+        Object apply(Object input) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static class Map extends Step {
+        private final Function transformer;
+
+        private Map(Function transformer) {
+            this.transformer = transformer;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        Object apply(Object input) {
+            try {
+                if (input instanceof Failure) {
+                    return returnUnchanged(input);
+                } else if (input == NULL) {
+                    return returnImmediate(transformer.apply(null));
+                } else {
+                    return returnImmediate(transformer.apply(input));
+                }
+            } catch (Exception e) {
+                return returnError(e);
+            }
+        }
+    }
+
+    private static class FlatMap extends Step {
+        private final Function<Object, ? extends ExecutionFlow> transformer;
+
+        private FlatMap(Function<Object, ? extends ExecutionFlow> transformer) {
+            this.transformer = transformer;
+        }
+
+        @Override
+        Object apply(Object input) {
+            if (input instanceof Failure) {
+                return returnUnchanged(input);
+            } else {
+                try {
+                    if (input == NULL) {
+                        return returnFlow(transformer.apply(null));
+                    } else {
+                        return returnFlow(transformer.apply(input));
+                    }
+                } catch (Exception e) {
+                    return returnError(e);
+                }
+            }
+        }
+    }
+
+    private static class Then<R> extends Step {
+        private final Supplier<? extends ExecutionFlow<? extends R>> transformer;
+
+        private Then(Supplier<? extends ExecutionFlow<? extends R>> transformer) {
+            this.transformer = transformer;
+        }
+
+        @Override
+        Object apply(Object input) {
+            if (input instanceof Failure) {
+                return returnUnchanged(input);
+            } else {
+                try {
+                    return returnFlow(transformer.get());
+                } catch (Exception e) {
+                    return returnError(e);
+                }
+            }
+        }
+    }
+
+    private static class OnErrorResume extends Step {
+        private final Function<? super Throwable, ? extends ExecutionFlow<?>> fallback;
+
+        private OnErrorResume(Function<? super Throwable, ? extends ExecutionFlow<?>> fallback) {
+            this.fallback = fallback;
+        }
+
+        @Override
+        Object apply(Object input) {
+            if (input instanceof Failure failure) {
+                try {
+                    return returnFlow(fallback.apply(failure.t));
+                } catch (Exception e) {
+                    return returnError(e);
+                }
+            } else {
+                return returnUnchanged(input);
+            }
+        }
+    }
+
+    private static class OnComplete<E> extends Step {
+        private final BiConsumer<? super E, Throwable> consumer;
+
+        public OnComplete(BiConsumer<? super E, Throwable> consumer) {
+            this.consumer = consumer;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        Object apply(Object input) {
+            try {
+                if (input instanceof Failure failure) {
+                    consumer.accept(null, failure.t);
+                } else if (input == NULL) {
+                    consumer.accept(null, null);
+                } else {
+                    consumer.accept((E) input, null);
+                }
+            } catch (Exception e) {
+                LOG.error("Failed to execute onComplete", e);
+            }
+            return null;
+        }
+    }
+}

--- a/core/src/main/java/io/micronaut/core/execution/DelayedExecutionFlowImpl.java
+++ b/core/src/main/java/io/micronaut/core/execution/DelayedExecutionFlowImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.core.execution;
 
 import io.micronaut.core.annotation.NonNull;
@@ -309,14 +324,14 @@ final class DelayedExecutionFlowImpl<T> implements DelayedExecutionFlow<T> {
     /**
      * Mock step used as the head of the linked list of steps.
      */
-    private static class Head extends Step {
+    private static final class Head extends Step {
         @Override
         Object apply(Object input) {
             throw new UnsupportedOperationException();
         }
     }
 
-    private static class Map extends Step {
+    private static final class Map extends Step {
         private final Function transformer;
 
         private Map(Function transformer) {
@@ -340,7 +355,7 @@ final class DelayedExecutionFlowImpl<T> implements DelayedExecutionFlow<T> {
         }
     }
 
-    private static class FlatMap extends Step {
+    private static final class FlatMap extends Step {
         private final Function<Object, ? extends ExecutionFlow> transformer;
 
         private FlatMap(Function<Object, ? extends ExecutionFlow> transformer) {
@@ -365,7 +380,7 @@ final class DelayedExecutionFlowImpl<T> implements DelayedExecutionFlow<T> {
         }
     }
 
-    private static class Then<R> extends Step {
+    private static final class Then<R> extends Step {
         private final Supplier<? extends ExecutionFlow<? extends R>> transformer;
 
         private Then(Supplier<? extends ExecutionFlow<? extends R>> transformer) {
@@ -386,7 +401,7 @@ final class DelayedExecutionFlowImpl<T> implements DelayedExecutionFlow<T> {
         }
     }
 
-    private static class OnErrorResume extends Step {
+    private static final class OnErrorResume extends Step {
         private final Function<? super Throwable, ? extends ExecutionFlow<?>> fallback;
 
         private OnErrorResume(Function<? super Throwable, ? extends ExecutionFlow<?>> fallback) {
@@ -407,7 +422,7 @@ final class DelayedExecutionFlowImpl<T> implements DelayedExecutionFlow<T> {
         }
     }
 
-    private static class OnComplete<E> extends Step {
+    private static final class OnComplete<E> extends Step {
         private final BiConsumer<? super E, Throwable> consumer;
 
         public OnComplete(BiConsumer<? super E, Throwable> consumer) {

--- a/core/src/main/java/io/micronaut/core/execution/ExecutionFlow.java
+++ b/core/src/main/java/io/micronaut/core/execution/ExecutionFlow.java
@@ -83,7 +83,7 @@ public interface ExecutionFlow<T> {
      */
     @NonNull
     static <T> ExecutionFlow<T> async(@NonNull Executor executor, @NonNull Supplier<? extends ExecutionFlow<T>> supplier) {
-        CompletableFuture<T> completableFuture = new CompletableFuture<>();
+        DelayedExecutionFlow<T> completableFuture = DelayedExecutionFlow.create();
         executor.execute(() -> supplier.get().onComplete((t, throwable) -> {
             if (throwable != null) {
                 if (throwable instanceof CompletionException completionException) {
@@ -94,7 +94,7 @@ public interface ExecutionFlow<T> {
                 completableFuture.complete(t);
             }
         }));
-        return CompletableFutureExecutionFlow.just(completableFuture);
+        return completableFuture;
     }
 
     /**
@@ -176,9 +176,10 @@ public interface ExecutionFlow<T> {
                 if (throwable instanceof CompletionException completionException) {
                     throwable = completionException.getCause();
                 }
-                CompletableFuture.failedFuture(throwable);
+                completableFuture.completeExceptionally(throwable);
+            } else {
+                completableFuture.complete(value);
             }
-            CompletableFuture.completedFuture(value);
         });
         return completableFuture;
     }

--- a/core/src/test/groovy/io/micronaut/core/execution/DelayedExecutionFlowSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/execution/DelayedExecutionFlowSpec.groovy
@@ -1,0 +1,81 @@
+package io.micronaut.core.execution
+
+import org.apache.groovy.internal.util.Function
+import spock.lang.Specification
+
+import java.util.concurrent.CompletableFuture
+
+class DelayedExecutionFlowSpec extends Specification {
+    def "single thread permutations"(List<Integer> orderOfCompletion) {
+        given:
+        List<CompletableFuture<String>> futures = [null, new CompletableFuture<String>(), new CompletableFuture<String>(), new CompletableFuture<String>()]
+        List<String> results = ["step0", "step2", "step3", "step5"]
+        ExecutionFlow<String> inputFlow = new DelayedExecutionFlowImpl<>()
+        ExecutionFlow<String> flowStep2 = CompletableFutureExecutionFlow.just(futures[1])
+        ExecutionFlow<String> flowStep3 = CompletableFutureExecutionFlow.just(futures[2])
+        ExecutionFlow<String> flowStep5 = CompletableFutureExecutionFlow.just(futures[3])
+        String output = null
+        List<Function<ExecutionFlow<String>, ExecutionFlow<String>>> permTestSteps = [
+                (ExecutionFlow<String> prev) -> prev.map {
+                    assert it == "step0"
+                    return "step1"
+                },
+                (ExecutionFlow<String> prev) -> prev.flatMap {
+                    assert it == "step1"
+                    return flowStep2
+                },
+                (ExecutionFlow<String> prev) -> prev.then {
+                    return flowStep3
+                },
+                (ExecutionFlow<String> prev) -> prev.map {
+                    assert it == "step3"
+                    throw new RuntimeException("step4")
+                },
+                (ExecutionFlow<String> prev) -> prev.map {
+                    throw new AssertionError("should not be called")
+                },
+                (ExecutionFlow<String> prev) -> prev.flatMap {
+                    throw new AssertionError("should not be called")
+                },
+                (ExecutionFlow<String> prev) -> prev.then {
+                    throw new AssertionError("should not be called")
+                },
+                (ExecutionFlow<String> prev) -> prev.onErrorResume {
+                    assert it.message == "step4"
+                    return flowStep5
+                },
+                (ExecutionFlow<String> prev) -> prev.onComplete((s, t) -> output = s),
+        ]
+
+        ExecutionFlow<String> flow = inputFlow
+        for (int i = 0; i < permTestSteps.size(); i++) {
+            for (int j = 0; j < orderOfCompletion.size(); j++) {
+                if (orderOfCompletion[j] == i) {
+                    if (j == 0) {
+                        inputFlow.complete(results[j])
+                    } else {
+                        futures[j].complete(results[j])
+                    }
+                }
+            }
+            flow = permTestSteps[i](flow)
+        }
+
+        where:
+        orderOfCompletion << powerSet([0, 1, 2, 3, 4, 5, 6, 7, 8], 4)
+    }
+
+    private static <T> List<List<T>> powerSet(List<T> base, int exp) {
+        if (exp == 0) {
+            return [[]]
+        }
+        List<List<T>> output = []
+        List<List<T>> next = powerSet(base, exp - 1)
+        for (T t : base) {
+            for (List<T> head : next) {
+                output.add(head + t)
+            }
+        }
+        return output
+    }
+}

--- a/http-netty/build.gradle
+++ b/http-netty/build.gradle
@@ -21,6 +21,7 @@ dependencies {
 
     testImplementation project(":runtime")
     testImplementation project(":websocket")
+    testImplementation project(":jackson-databind")
 }
 
 spotless {

--- a/http-netty/src/main/java/io/micronaut/http/netty/NettyHttpHeaders.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/NettyHttpHeaders.java
@@ -20,6 +20,7 @@ import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.type.MutableHeaders;
 import io.micronaut.http.HttpHeaderValues;
+import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.MutableHttpHeaders;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
@@ -241,5 +242,18 @@ public class NettyHttpHeaders implements MutableHttpHeaders {
     @Override
     public void setConversionService(ConversionService conversionService) {
         this.conversionService = conversionService;
+    }
+
+    @Override
+    public Optional<MediaType> contentType() {
+        // optimization to avoid ConversionService
+        String str = get(HttpHeaders.CONTENT_TYPE);
+        if (str != null) {
+            try {
+                return Optional.of(MediaType.of(str));
+            } catch (IllegalArgumentException ignored) {
+            }
+        }
+        return Optional.empty();
     }
 }

--- a/http-netty/src/main/java/io/micronaut/http/netty/stream/HttpStreamsHandler.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/stream/HttpStreamsHandler.java
@@ -230,7 +230,12 @@ abstract class HttpStreamsHandler<In extends HttpMessage, Out extends HttpMessag
 
                 currentlyStreamedMessage = inMsg;
                 // It has a body, stream it
-                HandlerPublisher<? extends HttpContent> publisher = new HandlerPublisher<HttpContent>(ctx.executor(), HttpContent.class) {
+                HandlerPublisher<? extends HttpContent> publisher = new HandlerPublisher<HttpContent>(ctx.executor()) {
+                    @Override
+                    protected boolean acceptInboundMessage(Object msg) {
+                        return msg instanceof HttpContent;
+                    }
+
                     @Override
                     protected void cancelled() {
                         if (ctx.executor().inEventLoop()) {

--- a/http-netty/src/main/java/io/micronaut/http/netty/stream/HttpStreamsServerHandler.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/stream/HttpStreamsServerHandler.java
@@ -246,7 +246,12 @@ public class HttpStreamsServerHandler extends HttpStreamsHandler<HttpRequest, Ht
         } else {
             // First, insert new handlers in the chain after us for handling the websocket
             ChannelPipeline pipeline = ctx.pipeline();
-            HandlerPublisher<WebSocketFrame> publisher = new HandlerPublisher<>(ctx.executor(), WebSocketFrame.class);
+            HandlerPublisher<WebSocketFrame> publisher = new HandlerPublisher<>(ctx.executor()) {
+                @Override
+                protected boolean acceptInboundMessage(Object msg) {
+                    return msg instanceof WebSocketFrame;
+                }
+            };
             HandlerSubscriber<WebSocketFrame> subscriber = new HandlerSubscriber<>(ctx.executor());
             pipeline.addAfter(ctx.executor(), ctx.name(), "websocket-subscriber", subscriber);
             pipeline.addAfter(ctx.executor(), ctx.name(), "websocket-publisher", publisher);

--- a/http-netty/src/test/groovy/io/micronaut/http/netty/reactive/HandlerPublisherSpec.groovy
+++ b/http-netty/src/test/groovy/io/micronaut/http/netty/reactive/HandlerPublisherSpec.groovy
@@ -27,7 +27,12 @@ class HandlerPublisherSpec extends Specification {
          */
 
         def embeddedChannel = new EmbeddedChannel()
-        def handlerPublisher = new HandlerPublisher(embeddedChannel.eventLoop(), Object)
+        def handlerPublisher = new HandlerPublisher(embeddedChannel.eventLoop()) {
+            @Override
+            protected boolean acceptInboundMessage(Object msg) {
+                return true
+            }
+        }
         boolean killOnNextRead = false
         embeddedChannel.pipeline().addLast(new ChannelDuplexHandler() {
             @Override

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpRequest.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpRequest.java
@@ -287,7 +287,7 @@ public class NettyHttpRequest<T> extends AbstractNettyHttpRequest<T> implements 
             synchronized (this) { // double check
                 attributes = this.attributes;
                 if (attributes == null) {
-                    attributes = new MutableConvertibleValuesMap<>(new HashMap<>(4));
+                    attributes = new MutableConvertibleValuesMap<>(new HashMap<>(8));
                     this.attributes = attributes;
                 }
             }

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/cors/CorsFilterSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/cors/CorsFilterSpec.groovy
@@ -49,6 +49,8 @@ import static io.micronaut.http.HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS
 import static io.micronaut.http.HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN
 import static io.micronaut.http.HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS
 import static io.micronaut.http.HttpHeaders.ACCESS_CONTROL_MAX_AGE
+import static io.micronaut.http.HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD
+import static io.micronaut.http.HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS
 import static io.micronaut.http.HttpHeaders.VARY
 
 class CorsFilterSpec extends Specification {

--- a/http-server/src/main/java/io/micronaut/http/server/cors/CorsFilter.java
+++ b/http-server/src/main/java/io/micronaut/http/server/cors/CorsFilter.java
@@ -15,13 +15,14 @@
  */
 package io.micronaut.http.server.cors;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
-import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.ConversionContext;
 import io.micronaut.core.convert.ImmutableArgumentConversionContext;
 import io.micronaut.core.io.socket.SocketUtils;
+import io.micronaut.core.order.Ordered;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.HttpMethod;
@@ -29,14 +30,13 @@ import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.MutableHttpResponse;
-import io.micronaut.http.annotation.Filter;
-import io.micronaut.http.filter.HttpServerFilter;
-import io.micronaut.http.filter.ServerFilterChain;
+import io.micronaut.http.annotation.RequestFilter;
+import io.micronaut.http.annotation.ResponseFilter;
+import io.micronaut.http.annotation.ServerFilter;
 import io.micronaut.http.filter.ServerFilterPhase;
 import io.micronaut.http.server.HttpServerConfiguration;
 import io.micronaut.http.server.util.HttpHostResolver;
 import org.jetbrains.annotations.NotNull;
-import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,7 +49,16 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static io.micronaut.http.HttpAttributes.AVAILABLE_HTTP_METHODS;
-import static io.micronaut.http.HttpHeaders.*;
+import static io.micronaut.http.HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS;
+import static io.micronaut.http.HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS;
+import static io.micronaut.http.HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS;
+import static io.micronaut.http.HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN;
+import static io.micronaut.http.HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS;
+import static io.micronaut.http.HttpHeaders.ACCESS_CONTROL_MAX_AGE;
+import static io.micronaut.http.HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS;
+import static io.micronaut.http.HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD;
+import static io.micronaut.http.HttpHeaders.ORIGIN;
+import static io.micronaut.http.HttpHeaders.VARY;
 import static io.micronaut.http.annotation.Filter.MATCH_ALL_PATTERN;
 
 /**
@@ -59,8 +68,8 @@ import static io.micronaut.http.annotation.Filter.MATCH_ALL_PATTERN;
  * @author Graeme Rocher
  * @since 1.0
  */
-@Filter(MATCH_ALL_PATTERN)
-public class CorsFilter implements HttpServerFilter {
+@ServerFilter(MATCH_ALL_PATTERN)
+public class CorsFilter implements Ordered {
     private static final Logger LOG = LoggerFactory.getLogger(CorsFilter.class);
     private static final ArgumentConversionContext<HttpMethod> CONVERSION_CONTEXT_HTTP_METHOD = ImmutableArgumentConversionContext.of(HttpMethod.class);
 
@@ -79,17 +88,19 @@ public class CorsFilter implements HttpServerFilter {
         this.httpHostResolver = httpHostResolver;
     }
 
-    @Override
-    public Publisher<MutableHttpResponse<?>> doFilter(HttpRequest<?> request, ServerFilterChain chain) {
+    @RequestFilter
+    @Nullable
+    @Internal
+    public final HttpResponse<?> filterRequest(HttpRequest<?> request) {
         String origin = request.getHeaders().getOrigin().orElse(null);
         if (origin == null) {
             LOG.trace("Http Header " + HttpHeaders.ORIGIN + " not present. Proceeding with the request.");
-            return chain.proceed(request);
+            return null; // proceed
         }
         CorsOriginConfiguration corsOriginConfiguration = getConfiguration(request).orElse(null);
         if (corsOriginConfiguration != null) {
             if (CorsUtil.isPreflightRequest(request)) {
-                return handlePreflightRequest(request, chain, corsOriginConfiguration);
+                return handlePreflightRequest(request, corsOriginConfiguration);
             }
             if (!validateMethodToMatch(request, corsOriginConfiguration).isPresent()) {
                 return forbidden();
@@ -98,13 +109,25 @@ public class CorsFilter implements HttpServerFilter {
                 LOG.trace("The resolved configuration allows any origin. To prevent drive-by-localhost attacks the request is forbidden");
                 return forbidden();
             }
-            return Publishers.then(chain.proceed(request), resp -> decorateResponseWithHeaders(request, resp, corsOriginConfiguration));
+            return null; // proceed
         } else if (shouldDenyToPreventDriveByLocalhostAttack(origin, request)) {
             LOG.trace("the request specifies an origin different than localhost. To prevent drive-by-localhost attacks the request is forbidden");
             return forbidden();
         }
         LOG.trace("CORS configuration not found for {} origin", origin);
-        return chain.proceed(request);
+        return null; // proceed
+    }
+
+    @ResponseFilter
+    @Internal
+    public final void filterResponse(HttpRequest<?> request, MutableHttpResponse<?> response) {
+        CorsOriginConfiguration corsOriginConfiguration = getConfiguration(request).orElse(null);
+        if (corsOriginConfiguration != null) {
+            if (CorsUtil.isPreflightRequest(request)) {
+                decorateResponseWithHeadersForPreflightRequest(request, response, corsOriginConfiguration);
+            }
+            decorateResponseWithHeaders(request, response, corsOriginConfiguration);
+        }
     }
 
     /**
@@ -347,8 +370,8 @@ public class CorsFilter implements HttpServerFilter {
     }
 
     @NotNull
-    private static Publisher<MutableHttpResponse<?>> forbidden() {
-        return Publishers.just(HttpResponse.status(HttpStatus.FORBIDDEN));
+    private static MutableHttpResponse<Object> forbidden() {
+        return HttpResponse.status(HttpStatus.FORBIDDEN);
     }
 
     @NonNull
@@ -375,24 +398,20 @@ public class CorsFilter implements HttpServerFilter {
     }
 
     @NonNull
-    private Publisher<MutableHttpResponse<?>> handlePreflightRequest(@NonNull HttpRequest<?> request,
-                                                                     @NonNull ServerFilterChain chain,
+    private MutableHttpResponse<?> handlePreflightRequest(@NonNull HttpRequest<?> request,
                                                                      @NonNull CorsOriginConfiguration corsOriginConfiguration) {
         Optional<HttpStatus> statusOptional = validatePreflightRequest(request, corsOriginConfiguration);
         if (statusOptional.isPresent()) {
             HttpStatus status = statusOptional.get();
             if (status.getCode() >= 400) {
-                return Publishers.just(HttpResponse.status(status));
+                return HttpResponse.status(status);
             }
             MutableHttpResponse<?> resp = HttpResponse.status(status);
             decorateResponseWithHeadersForPreflightRequest(request, resp, corsOriginConfiguration);
             decorateResponseWithHeaders(request, resp, corsOriginConfiguration);
-            return Publishers.just(resp);
+            return resp;
         }
-        return Publishers.then(chain.proceed(request), resp -> {
-            decorateResponseWithHeadersForPreflightRequest(request, resp, corsOriginConfiguration);
-            decorateResponseWithHeaders(request, resp, corsOriginConfiguration);
-        });
+        return null;
     }
 
     @NonNull

--- a/http/src/main/java/io/micronaut/http/reactive/execution/ReactorExecutionFlowImpl.java
+++ b/http/src/main/java/io/micronaut/http/reactive/execution/ReactorExecutionFlowImpl.java
@@ -17,7 +17,6 @@ package io.micronaut.http.reactive.execution;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Nullable;
-import io.micronaut.core.execution.CompletableFutureExecutionFlow;
 import io.micronaut.core.execution.ExecutionFlow;
 import io.micronaut.core.execution.ImperativeExecutionFlow;
 import org.reactivestreams.Publisher;
@@ -129,8 +128,6 @@ final class ReactorExecutionFlowImpl implements ReactiveExecutionFlow<Object> {
     static <R> Mono<Object> toMono(ExecutionFlow<R> next) {
         if (next instanceof ReactorExecutionFlowImpl reactiveFlowImpl) {
             return reactiveFlowImpl.value;
-        } else if (next instanceof CompletableFutureExecutionFlow<?> completableFutureFlow) {
-            return Mono.fromCompletionStage(completableFutureFlow.toCompletableFuture());
         } else if (next instanceof ImperativeExecutionFlow<?> imperativeFlow) {
             Mono<Object> m;
             if (imperativeFlow.getError() != null) {
@@ -150,8 +147,9 @@ final class ReactorExecutionFlowImpl implements ReactiveExecutionFlow<Object> {
                 });
             }
             return m;
+        } else {
+            return Mono.fromCompletionStage(next.toCompletableFuture());
         }
-        throw new IllegalStateException();
     }
 
     static <R> Mono<Object> toMono(Supplier<ExecutionFlow<R>> next) {


### PR DESCRIPTION
This PR contains a benchmark for the full http stack using EmbeddedChannel. It's almost as close to reality as testing TCP directly, but it's on a single thread so it's a bit easier to work with. It stresses the full HTTP stack including netty handlers, routing, filters, serialization and so on.

There are a few minor optimizations with relatively small diffs. There is also one fairly big change: Introducing a new DelayedExecutionFlow which acts kind of like CompletableFuture, but is faster (it doesn't have to support multiple downstreams for every CF). 

The changes are separated into individual commits, so you can look at each commit one by one if you want. But they don't cross over each other very much anyway.

I'm not done optimizing, but because the DelayedExecutionFlow is a fairly big diff I want to make this PR before it blows up further.