### PR TITLE
use ObjectUtils::coerceToBoolean in Utils classes

### DIFF
--- a/core/src/main/java/io/micronaut/core/util/CollectionUtils.java
+++ b/core/src/main/java/io/micronaut/core/util/CollectionUtils.java
@@ -163,7 +163,7 @@ public class CollectionUtils {
      * @return True if it is empty or null
      */
     public static boolean isEmpty(@Nullable Map map) {
-        return map == null || map.isEmpty();
+        return !isNotEmpty(map);
     }
 
     /**
@@ -173,7 +173,7 @@ public class CollectionUtils {
      * @return True if it is not null and not empty
      */
     public static boolean isNotEmpty(@Nullable Map map) {
-        return map != null && !map.isEmpty();
+        return ObjectUtils.coerceToBoolean(map);
     }
 
     /**
@@ -183,7 +183,7 @@ public class CollectionUtils {
      * @return True if it is empty or null
      */
     public static boolean isEmpty(@Nullable Collection collection) {
-        return collection == null || collection.isEmpty();
+        return !isNotEmpty(collection);
     }
 
     /**
@@ -193,7 +193,7 @@ public class CollectionUtils {
      * @return True if it is not null and not empty
      */
     public static boolean isNotEmpty(@Nullable Collection collection) {
-        return collection != null && !collection.isEmpty();
+        return ObjectUtils.coerceToBoolean(collection);
     }
 
     /**

--- a/core/src/main/java/io/micronaut/core/util/StringUtils.java
+++ b/core/src/main/java/io/micronaut/core/util/StringUtils.java
@@ -72,7 +72,7 @@ public final class StringUtils {
      * @return True if str is empty or null
      */
     public static boolean isEmpty(@Nullable CharSequence str) {
-        return str == null || str.length() == 0;
+        return !isNotEmpty(str);
     }
 
     /**
@@ -82,7 +82,7 @@ public final class StringUtils {
      * @return True if str is not null and not empty
      */
     public static boolean isNotEmpty(@Nullable CharSequence str) {
-        return !isEmpty(str);
+        return ObjectUtils.coerceToBoolean(str);
     }
 
     /**

--- a/core/src/test/groovy/io/micronaut/core/util/CollectionUtilsSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/util/CollectionUtilsSpec.groovy
@@ -1,0 +1,50 @@
+package io.micronaut.core.util
+
+import spock.lang.Specification
+
+class CollectionUtilsSpec extends Specification {
+
+    void "test isEmpty for collection"(List<String> list) {
+        expect:
+        CollectionUtils.isEmpty(list as List<String>) == expected
+
+        where:
+        list || expected
+        [''] || false
+        []   || true
+        null || true
+    }
+
+    void "test isNotEmpty for collection"(List<String> list) {
+        expect:
+        CollectionUtils.isNotEmpty(list as List<String>) == expected
+
+        where:
+        list || expected
+        [''] || true
+        []   || false
+        null || false
+    }
+
+    void "test isNotEmpty for map"(Map<String, String> map) {
+        expect:
+        CollectionUtils.isNotEmpty(map as Map<String, String> ) == expected
+
+        where:
+        map          || expected
+        [foo: 'bar'] || true
+        [:]          || false
+        null         || false
+    }
+
+    void "test isEmpty for map"(Map<String, String> map) {
+        expect:
+        CollectionUtils.isEmpty(map  as Map<String, String>) == expected
+
+        where:
+        map          || expected
+        [foo: 'bar'] || false
+        [:]          || true
+        null         || true
+    }
+}

--- a/core/src/test/groovy/io/micronaut/core/util/StringUtilsSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/util/StringUtilsSpec.groovy
@@ -110,6 +110,30 @@ class StringUtilsSpec extends Specification {
         'aa'     | 'a' | ''
     }
 
+    void "test isEmpty"(CharSequence sequence) {
+        expect:
+        StringUtils.isEmpty(sequence) == expected
+
+        where:
+        sequence || expected
+        ''    || true
+        null  || true
+        'foo' || false
+    }
+
+
+    void "test isNotEmpty"(CharSequence sequence) {
+        expect:
+        StringUtils.isNotEmpty(sequence) == expected
+
+        where:
+        sequence || expected
+        ''       || false
+        null     || false
+        'foo'    || true
+    }
+
+
     @Unroll
     void "test split string omit empty #string = #expected"() {
         expect:


### PR DESCRIPTION
To avoid having the logic of coercing from string, collection and map to boolean duplicated. 