### PR TITLE
build: remove build breaking unicode filename

### DIFF
--- a/http-server-netty/src/test/resources/public/测试-0.0.yml
+++ b/http-server-netty/src/test/resources/public/测试-0.0.yml
@@ -1,4 +1,0 @@
-openapi: 3.0.1
-info:
-  title: 测试
-  version: "0.0"


### PR DESCRIPTION
The file contains non-standard (UTF-8, ASCII) but Unicode characters (in the file name) which bricks the build on my machine with "FileNotFoundException: ??????-0.0.yml"