### PR TITLE
Fix race condition in FilterRunner

### DIFF
--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/stack/InvocationStackSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/stack/InvocationStackSpec.groovy
@@ -178,7 +178,7 @@ class InvocationStackSpec extends Specification {
         }
 
         boolean isKnownStack(String className, boolean allowExecutor) {
-            if (allowExecutor && className.startsWith("java.util.concurrent")) {
+            if (className.startsWith("java.util.concurrent")) {
                 return true
             }
             if (className.startsWith("io.netty")) {

--- a/http/src/test/groovy/io/micronaut/http/filter/FilterRunnerSpec.groovy
+++ b/http/src/test/groovy/io/micronaut/http/filter/FilterRunnerSpec.groovy
@@ -15,7 +15,6 @@ import io.micronaut.inject.ExecutableMethod
 import org.reactivestreams.Publisher
 import reactor.core.publisher.Flux
 import reactor.util.context.Context
-import spock.lang.Ignore
 import spock.lang.Specification
 
 import java.lang.reflect.Method
@@ -612,7 +611,6 @@ class FilterRunnerSpec extends Specification {
         events == ["before1 thread-outside", "before2 thread-before", "before3 thread-before", "terminal thread-before", "after3 thread-before", "after2 thread-after", "after1 thread-after"]
     }
 
-    @Ignore
     def 'around filter with blocking continuation'() {
         given:
         def events = []


### PR DESCRIPTION
Before this change, processRequestFilter returned nextFilterProcessing, which is completed when the downstream filters should be called (e.g. when a legacy filter subscribes to the publisher returned by chain.proceed). The return value of processRequestFilter was "subscribed to" by filterRequest, which would trigger downstream filters when nextFilterProcessing completes.

The problem is that the "subscription" (i.e. the flatMap call) and the "completion" (i.e. the subscribe) could happen on different threads, as would happen with the test `io.micronaut.http.server.netty.filters.FiltersSpec#test filters order and threads with subscribeOn for #method`. This could lead to a race condition where whichever thread came second would actually execute the downstream filters. The test asserts that the downstream filters are run on the io executor, but this would sometimes fail.

This behavior is intended and unfortunately I believe there are filters that actually rely on this subscribeOn behavior.

This patch changes the downstream subscriptions like flatMap to happen *before* the doFilter method is ever called. This ensures that the completion of nextFilterProcessing always happens after the "subscription".

This also fixes `around filter with blocking continuation`.