### PR TITLE
Remove managed logging from catalog

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.convention-base.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.convention-base.gradle
@@ -89,7 +89,8 @@ dependencies {
         transitive = false
     }
 
-    api libs.managed.slf4j.api
+    api platform(libs.boms.micronaut.logging)
+    api libs.slf4j.api
     compileOnly libs.caffeine
     compileOnly libs.bundles.asm
 

--- a/context/build.gradle
+++ b/context/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     compileOnly project(':core-reactive')
     compileOnly project(':core-processor')
     compileOnly libs.log4j
-    compileOnly libs.managed.logback.classic
+    compileOnly libs.logback.classic
 
     // Support validation annotations
     compileOnly platform(libs.test.boms.micronaut.validation)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,11 +32,10 @@ jcache = "1.1.1"
 junit5 = "5.9.1"
 junit-platform="1.9.1"
 ktor = "1.6.8"
-managed-logback = "1.4.6"
 logbook-netty = "2.14.0"
-log4j = "2.19.0"
 micronaut-aws = "3.9.2"
 micronaut-groovy = "4.0.0-SNAPSHOT"
+micronaut-logging = "1.0.0-SNAPSHOT"
 micronaut-session = "1.0.0-SNAPSHOT"
 micronaut-sql = "4.7.2"
 micronaut-test = "4.0.0-SNAPSHOT"
@@ -71,7 +70,6 @@ managed-netty-http3 = "0.0.16.Final"
 managed-reactive-streams = "1.0.4"
 # This should be kept aligned with https://github.com/micronaut-projects/micronaut-reactor/blob/master/gradle.properties from the BOM
 managed-reactor = "3.4.24"
-managed-slf4j = "2.0.4"
 managed-snakeyaml = "2.0"
 managed-java-parser-core = "3.24.9"
 managed-ksp = "1.8.0-1.0.9"
@@ -89,6 +87,8 @@ boms-kotlin = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "manag
 boms-kotlin-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-bom", version.ref = "managed-kotlin-coroutines" }
 boms-netty = { module = "io.netty:netty-bom", version.ref = "managed-netty" }
 boms-jackson = { module = "com.fasterxml.jackson:jackson-bom", version.ref = "managed-jackson" }
+
+boms-micronaut-logging = { module = "io.micronaut.logging:micronaut-logging-bom", version.ref = "micronaut-logging" }
 
 #
 # Libraries which start with managed- are managed by Micronaut in the sense
@@ -145,9 +145,9 @@ managed-reactive-streams = { module = "org.reactivestreams:reactive-streams", ve
 managed-reactor = { module = "io.projectreactor:reactor-core", version.ref = "managed-reactor" }
 managed-reactor-test = { module = "io.projectreactor:reactor-test", version.ref = "managed-reactor" }
 
-managed-slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "managed-slf4j" }
-managed-slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "managed-slf4j" }
-managed-logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "managed-logback" }
+slf4j-api = { module = "org.slf4j:slf4j-api" }
+slf4j-simple = { module = "org.slf4j:slf4j-simple" }
+logback-classic = { module = "ch.qos.logback:logback-classic" }
 
 managed-snakeyaml = { module = "org.yaml:snakeyaml", version.ref = "managed-snakeyaml" }
 
@@ -211,7 +211,7 @@ jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "j
 
 kotlin-kotest-junit5 = { module = "io.kotest:kotest-runner-junit5-jvm" }
 
-log4j = { module = "org.apache.logging.log4j:log4j-core", version.ref = "log4j" }
+log4j = { module = "org.apache.logging.log4j:log4j-core" }
 
 logbook-netty = { module = "org.zalando:logbook-netty", version.ref = "logbook-netty" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -146,7 +146,6 @@ managed-reactor = { module = "io.projectreactor:reactor-core", version.ref = "ma
 managed-reactor-test = { module = "io.projectreactor:reactor-test", version.ref = "managed-reactor" }
 
 slf4j-api = { module = "org.slf4j:slf4j-api" }
-slf4j-simple = { module = "org.slf4j:slf4j-simple" }
 logback-classic = { module = "ch.qos.logback:logback-classic" }
 
 managed-snakeyaml = { module = "org.yaml:snakeyaml", version.ref = "managed-snakeyaml" }

--- a/http-client/build.gradle
+++ b/http-client/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     testImplementation project(":jackson-databind")
     testImplementation project(":http-server-netty")
     testImplementation libs.wiremock
-    testImplementation libs.managed.logback.classic
+    testImplementation libs.logback.classic
 
     if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_15)) {
         testImplementation libs.bcpkix

--- a/http-server-netty/build.gradle
+++ b/http-server-netty/build.gradle
@@ -89,7 +89,7 @@ dependencies {
             classifier = Os.isArch("aarch64") ? "osx-aarch_64" : "osx-x86_64"
         }
     }
-    testImplementation libs.managed.logback.classic
+    testImplementation libs.logback.classic
 
     // Adding these for now since micronaut-test isnt resolving correctly ... probably need to upgrade gradle there too
     testImplementation libs.junit.jupiter.api

--- a/http/build.gradle
+++ b/http/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     testImplementation project(":jackson-databind")
     testImplementation project(":inject")
     testImplementation project(":runtime")
-    testImplementation(libs.managed.logback.classic)
+    testImplementation(libs.logback.classic)
 }
 
 tasks.named("compileKotlin") {

--- a/management/build.gradle
+++ b/management/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     testRuntimeOnly libs.h2
     testRuntimeOnly libs.mysql.driver
 
-    compileOnly libs.managed.logback.classic
+    compileOnly libs.logback.classic
     compileOnly libs.log4j
 
 }

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     compileOnly libs.caffeine
     compileOnly libs.managed.kotlinx.coroutines.core
     compileOnly libs.managed.kotlinx.coroutines.reactive
-    testImplementation libs.managed.logback.classic
+    testImplementation libs.logback.classic
     testImplementation libs.managed.snakeyaml
     testAnnotationProcessor project(":inject-java")
     testImplementation libs.jsr107

--- a/test-suite-geb/build.gradle
+++ b/test-suite-geb/build.gradle
@@ -38,5 +38,5 @@ dependencies {
     testImplementation project(':http-server-netty')
     testImplementation project(":jackson-databind")
 
-    testRuntimeOnly libs.managed.logback.classic
+    testRuntimeOnly libs.logback.classic
 }

--- a/test-suite-http-server-tck-netty/build.gradle
+++ b/test-suite-http-server-tck-netty/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     testImplementation(projects.httpServerNetty)
     testImplementation(projects.httpClient)
     testImplementation(libs.junit.platform.engine)
-    testImplementation(libs.managed.logback.classic)
+    testImplementation(libs.logback.classic)
     testImplementation(platform(libs.test.boms.micronaut.validation))
     testImplementation(libs.micronaut.validation) {
         exclude(group: "io.micronaut")

--- a/test-suite-logback/build.gradle
+++ b/test-suite-logback/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     testImplementation(projects.context)
 
     testImplementation(projects.injectGroovy)
-    testImplementation(libs.managed.logback.classic)
+    testImplementation(libs.logback.classic)
 
     testImplementation(projects.management)
     testImplementation(projects.httpClient)

--- a/test-suite/build.gradle
+++ b/test-suite/build.gradle
@@ -89,7 +89,7 @@ dependencies {
     testRuntimeOnly(platform(libs.test.boms.micronaut.aws))
     testRuntimeOnly libs.h2
     testRuntimeOnly libs.junit.vintage
-    testRuntimeOnly libs.managed.logback.classic
+    testRuntimeOnly libs.logback.classic
     testRuntimeOnly libs.aws.java.sdk.lambda
 
     // needed for HTTP/2 tests
@@ -103,7 +103,7 @@ dependencies {
     }
     testImplementation libs.managed.netty.incubator.codec.http3
     testImplementation libs.logbook.netty
-    testImplementation libs.managed.logback.classic
+    testImplementation libs.logback.classic
 
     if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_15)) {
         testImplementation libs.bcpkix


### PR DESCRIPTION
We have micronaut-logging which publishes a BOM containing the managed logging libraries we want to use.

This PR stops exporting logger versions as managed dependencies.

This is a breaking change upstream, as any modules using mn.logback.classic will now need to change to importing micronaut-logging, and then using mnLogging.logback.classic