### PR TITLE
Unwrap optionals with safe navigation in expressions

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/expressions/ContextPropertyAccessExpressionsSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/expressions/ContextPropertyAccessExpressionsSpec.groovy
@@ -142,6 +142,101 @@ class ContextPropertyAccessExpressionsSpec extends AbstractEvaluatedExpressionsS
         expr == null
     }
 
+    void "test multi-level context property access safe navigation - success"() {
+        given:
+        Object expr = evaluateAgainstContext("#{ foo?.bar?.name }",
+                """
+            @jakarta.inject.Singleton
+            class Context {
+                public Foo getFoo() {
+                    return new Foo();
+                }
+            }
+
+            class Foo {
+                private Bar bar = new Bar();
+                public Bar getBar() {
+                    return bar;
+                }
+            }
+
+            class Bar {
+                private String name = "test";
+                public String getName() {
+                    return name;
+                }
+            }
+        """)
+
+        expect:
+        expr == "test"
+    }
+
+    void "test multi-level context property access safe navigation with optionals"() {
+        given:
+        Object expr = evaluateAgainstContext("#{ foo?.bar?.name }",
+                """
+            import java.util.Optional;
+
+            @jakarta.inject.Singleton
+            class Context {
+                public Optional<Foo> getFoo() {
+                    return Optional.of(new Foo());
+                }
+            }
+
+            class Foo {
+                private Bar bar;
+                public Optional<Bar> getBar() {
+                    return Optional.ofNullable(bar);
+                }
+            }
+
+            class Bar {
+                private String name = "test";
+                public String getName() {
+                    return name;
+                }
+            }
+        """)
+
+        expect:
+        expr == null
+    }
+
+    void "test multi-level context property access safe navigation with optionals - success"() {
+        given:
+        Object expr = evaluateAgainstContext("#{ foo?.bar?.name }",
+                """
+            import java.util.Optional;
+
+            @jakarta.inject.Singleton
+            class Context {
+                public Optional<Foo> getFoo() {
+                    return Optional.of(new Foo());
+                }
+            }
+
+            class Foo {
+                private Bar bar = new Bar();
+                public Optional<Bar> getBar() {
+                    return Optional.ofNullable(bar);
+                }
+            }
+
+            class Bar {
+                private String name = "test";
+                public String getName() {
+                    return name;
+                }
+            }
+        """)
+
+        expect:
+        expr == "test"
+    }
+
+
     void "test multi-level context property access non-safe navigation"() {
         when:
         Object expr = evaluateAgainstContext("#{ foo.bar.name }",

--- a/src/main/docs/guide/config/evaluatedExpressions.adoc
+++ b/src/main/docs/guide/config/evaluatedExpressions.adoc
@@ -210,6 +210,8 @@ You can also use the safe dereference operator `?.` to navigate paths in a null 
 #{ foo?.bar?.name == "Fred" }
 ----
 
+TIP: When used, the safe dereference operator will also automatically unwrap Java's `Optional` type.
+
 === Type References
 
 A predefined syntax construct `T(...)` can be used to reference a class. The value inside brackets should be fully


### PR DESCRIPTION
Makes it easier to use expressions with APIs that return `Optional`