### PR TITLE
Use `Map.of` instead of custom implementation

### DIFF
--- a/benchmarks/src/jmh/java/io/micronaut/http/server/stack/FullHttpStackBenchmark.java
+++ b/benchmarks/src/jmh/java/io/micronaut/http/server/stack/FullHttpStackBenchmark.java
@@ -28,7 +28,6 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
-import org.openjdk.jmh.profile.AsyncProfiler;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
@@ -67,7 +66,7 @@ public class FullHttpStackBenchmark {
             .measurementIterations(30)
             .mode(Mode.AverageTime)
             .timeUnit(TimeUnit.NANOSECONDS)
-            .addProfiler(AsyncProfiler.class, "libPath=/home/yawkat/bin/async-profiler-2.9-linux-x64/build/libasyncProfiler.so;output=flamegraph")
+//            .addProfiler(AsyncProfiler.class, "libPath=/home/yawkat/bin/async-profiler-2.9-linux-x64/build/libasyncProfiler.so;output=flamegraph")
             .forks(1)
             .jvmArgsAppend("-Djmh.executor=CUSTOM", "-Djmh.executor.class=" + JmhFastThreadLocalExecutor.class.getName())
             .build();

--- a/core-processor/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataWriter.java
@@ -15,18 +15,17 @@
  */
 package io.micronaut.inject.annotation;
 
+import io.micronaut.context.expressions.AbstractEvaluatedExpression;
 import io.micronaut.core.annotation.AnnotationClassValue;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationMetadataDelegate;
-import io.micronaut.core.annotation.AnnotationUtil;
-import io.micronaut.core.expressions.EvaluatedExpressionReference;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.UsedByGeneratedCode;
+import io.micronaut.core.expressions.EvaluatedExpressionReference;
 import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.ast.ClassElement;
-import io.micronaut.context.expressions.AbstractEvaluatedExpression;
 import io.micronaut.inject.writer.AbstractAnnotationMetadataWriter;
 import io.micronaut.inject.writer.AbstractClassFileWriter;
 import io.micronaut.inject.writer.ClassGenerationException;
@@ -42,16 +41,13 @@ import org.objectweb.asm.commons.Method;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.Array;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Responsible for writing class files that are instances of {@link AnnotationMetadata}.
@@ -65,14 +61,6 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
     private static final Type TYPE_DEFAULT_ANNOTATION_METADATA = Type.getType(DefaultAnnotationMetadata.class);
     private static final Type TYPE_DEFAULT_ANNOTATION_METADATA_HIERARCHY = Type.getType(AnnotationMetadataHierarchy.class);
     private static final Type TYPE_ANNOTATION_CLASS_VALUE = Type.getType(AnnotationClassValue.class);
-
-    private static final org.objectweb.asm.commons.Method METHOD_LIST_OF = Method.getMethod(
-            ReflectionUtils.getRequiredInternalMethod(
-                    AnnotationUtil.class,
-                    "internListOf",
-                    Object[].class
-            )
-    );
 
     private static final org.objectweb.asm.commons.Method METHOD_REGISTER_ANNOTATION_DEFAULTS = Method.getMethod(
             ReflectionUtils.getRequiredInternalMethod(
@@ -162,10 +150,6 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
             AbstractEvaluatedExpression.class,
             Object.class
         ));
-
-    private static final Type ANNOTATION_UTIL_TYPE = Type.getType(AnnotationUtil.class);
-    private static final Type LIST_TYPE = Type.getType(List.class);
-    private static final String EMPTY_LIST = "EMPTY_LIST";
 
     private static final String LOAD_CLASS_PREFIX = "$micronaut_load_class_value_";
 
@@ -436,27 +420,6 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
         }
     }
 
-    private static void pushListOfString(GeneratorAdapter methodVisitor, List<String> names) {
-        if (names != null) {
-            names = names.stream().filter(Objects::nonNull).collect(Collectors.toList());
-        }
-        if (names == null || names.isEmpty()) {
-            methodVisitor.getStatic(Type.getType(Collections.class), EMPTY_LIST, LIST_TYPE);
-            return;
-        }
-        int totalSize = names.size();
-        // start a new array
-        pushNewArray(methodVisitor, Object.class, totalSize);
-        int i = 0;
-        for (String name : names) {
-            // use the property name as the key
-            pushStoreStringInArray(methodVisitor, i++, totalSize, name);
-            // use the property type as the value
-        }
-        // invoke the AbstractBeanDefinition.createMap method
-        methodVisitor.invokeStatic(ANNOTATION_UTIL_TYPE, METHOD_LIST_OF);
-    }
-
     private static void instantiateInternal(
             Type owningType,
             ClassWriter declaringClassWriter,
@@ -569,8 +532,7 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
             }
         } else if (value instanceof String) {
             methodVisitor.push(value.toString());
-        } else if (value instanceof AnnotationClassValue) {
-            AnnotationClassValue acv = (AnnotationClassValue) value;
+        } else if (value instanceof AnnotationClassValue<?> acv) {
             if (acv.isInstantiated()) {
                 methodVisitor.visitTypeInsn(NEW, TYPE_ANNOTATION_CLASS_VALUE.getInternalName());
                 methodVisitor.visitInsn(DUP);
@@ -600,11 +562,11 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
                     );
                 }
             }
-        } else if (value instanceof Collection) {
-            if (((Collection<?>) value).isEmpty()) {
+        } else if (value instanceof Collection<?> collection) {
+            if (collection.isEmpty()) {
                 pushEmptyObjectsArray(methodVisitor);
             } else {
-                List array = Arrays.asList(((Collection) value).toArray());
+                List array = CollectionUtils.iterableToList(collection);
                 int len = array.size();
                 boolean first = true;
                 Class<?> arrayType = Object.class;
@@ -657,8 +619,7 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
             if (boxValue) {
                 pushBoxPrimitiveIfNecessary(ReflectionUtils.getPrimitiveType(value.getClass()), methodVisitor);
             }
-        } else if (value instanceof io.micronaut.core.annotation.AnnotationValue) {
-            io.micronaut.core.annotation.AnnotationValue data = (io.micronaut.core.annotation.AnnotationValue) value;
+        } else if (value instanceof io.micronaut.core.annotation.AnnotationValue<?> data) {
             String annotationName = data.getAnnotationName();
             Map<CharSequence, Object> values = data.getValues();
             Type annotationValueType = Type.getType(io.micronaut.core.annotation.AnnotationValue.class);
@@ -698,13 +659,56 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
                         () -> pushValue(declaringType, declaringClassWriter, methodVisitor, v,
                             defaultsStorage, loadTypeMethods, false));
                 }
+            } else {
+                throw new IllegalStateException();
             }
 
             methodVisitor.invokeConstructor(type, CONSTRUCTOR_CONTEXT_EVALUATED_EXPRESSION);
-
         } else {
-            methodVisitor.visitInsn(ACONST_NULL);
+            throw new IllegalStateException("Unsupported Map value:  " + value + " " + value.getClass().getName());
         }
+    }
+
+    public static boolean isSupportedMapValue(Object value) {
+        if (value == null) {
+            return false;
+        } else if (value instanceof Boolean) {
+            return true;
+        } else if (value instanceof String) {
+            return true;
+        } else if (value instanceof AnnotationClassValue<?>) {
+            return true;
+        } else if (value instanceof Enum<?>) {
+            return true;
+        } else if (value.getClass().isArray()) {
+            return true;
+        } else if (value instanceof Collection<?>) {
+            return true;
+        } else if (value instanceof Map) {
+            return true;
+        } else if (value instanceof Long) {
+            return true;
+        } else if (value instanceof Double) {
+            return true;
+        } else if (value instanceof Float) {
+            return true;
+        } else if (value instanceof Byte) {
+            return true;
+        } else if (value instanceof Short) {
+            return true;
+        } else if (value instanceof Character) {
+            return true;
+        } else if (value instanceof Number) {
+            return true;
+        } else if (value instanceof io.micronaut.core.annotation.AnnotationValue<?>) {
+            return true;
+        } else if (value instanceof EvaluatedExpressionReference) {
+            return true;
+        } else if (value instanceof Class<?>) {
+            // The class should be added as AnnotationClassValue
+            return false;
+        }
+        return false;
     }
 
     private static void pushEmptyObjectsArray(GeneratorAdapter methodVisitor) {

--- a/core-processor/src/main/java/io/micronaut/inject/writer/AbstractClassFileWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/AbstractClassFileWriter.java
@@ -16,7 +16,6 @@
 package io.micronaut.inject.writer;
 
 import io.micronaut.core.annotation.AnnotationMetadata;
-import io.micronaut.core.annotation.AnnotationUtil;
 import io.micronaut.core.annotation.Generated;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
@@ -55,9 +54,9 @@ import java.nio.file.Files;
 import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -69,6 +68,8 @@ import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
+import static io.micronaut.inject.annotation.AnnotationMetadataWriter.isSupportedMapValue;
 
 /**
  * Abstract class that writes generated classes to disk and provides convenience methods for building classes.
@@ -157,34 +158,40 @@ public abstract class AbstractClassFileWriter implements Opcodes, OriginatingEle
             )
     );
 
-    private static final Type ANNOTATION_UTIL_TYPE = Type.getType(AnnotationUtil.class);
     private static final Type MAP_TYPE = Type.getType(Map.class);
-    private static final String EMPTY_MAP = "EMPTY_MAP";
+    private static final Type LIST_TYPE = Type.getType(List.class);
 
     private static final org.objectweb.asm.commons.Method[] MAP_OF;
+    private static final org.objectweb.asm.commons.Method[] LIST_OF;
     private static final org.objectweb.asm.commons.Method MAP_BY_ARRAY;
+    private static final org.objectweb.asm.commons.Method MAP_ENTRY;
+    private static final org.objectweb.asm.commons.Method LIST_BY_ARRAY;
 
     static {
         MAP_OF = new Method[11];
-        for (int i = 1; i < MAP_OF.length; i++) {
+        for (int i = 0; i < MAP_OF.length; i++) {
             Class[] mapArgs = new Class[i * 2];
             for (int k = 0; k < i * 2; k += 2) {
-                mapArgs[k] = String.class;
+                mapArgs[k] = Object.class;
                 mapArgs[k + 1] = Object.class;
             }
-            MAP_OF[i] = org.objectweb.asm.commons.Method.getMethod(ReflectionUtils.getRequiredMethod(AnnotationUtil.class, "mapOf", mapArgs));
+            MAP_OF[i] = org.objectweb.asm.commons.Method.getMethod(ReflectionUtils.getRequiredMethod(Map.class, "of", mapArgs));
         }
-        MAP_BY_ARRAY = org.objectweb.asm.commons.Method.getMethod(ReflectionUtils.getRequiredMethod(AnnotationUtil.class, "mapOf", Object[].class));
+        MAP_ENTRY = org.objectweb.asm.commons.Method.getMethod(ReflectionUtils.getRequiredMethod(Map.class, "entry", Object.class, Object.class));
+        MAP_BY_ARRAY = org.objectweb.asm.commons.Method.getMethod(ReflectionUtils.getRequiredMethod(Map.class, "ofEntries", Map.Entry[].class));
     }
 
-    private static final org.objectweb.asm.commons.Method INTERN_MAP_OF_METHOD = org.objectweb.asm.commons.Method.getMethod(
-            ReflectionUtils.getRequiredInternalMethod(
-                    AnnotationUtil.class,
-                    "internMapOf",
-                    String.class,
-                    Object.class
-            )
-    );
+    static {
+        LIST_OF = new Method[11];
+        for (int i = 0; i < LIST_OF.length; i++) {
+            Class[] listArgs = new Class[i];
+            for (int k = 0; k < i; k += 1) {
+                listArgs[k] = Object.class;
+            }
+            LIST_OF[i] = org.objectweb.asm.commons.Method.getMethod(ReflectionUtils.getRequiredMethod(List.class, "of", listArgs));
+        }
+        LIST_BY_ARRAY = org.objectweb.asm.commons.Method.getMethod(ReflectionUtils.getRequiredMethod(List.class, "of", Object[].class));
+    }
 
     protected final OriginatingElements originatingElements;
 
@@ -235,7 +242,7 @@ public abstract class AbstractClassFileWriter implements Opcodes, OriginatingEle
             Map<String, Integer> defaults,
             Map<String, GeneratorAdapter> loadTypeMethods) {
         if (types == null || types.isEmpty()) {
-            generatorAdapter.visitInsn(ACONST_NULL);
+            pushNewArray(generatorAdapter, Argument.class, 0);
             return;
         }
         pushTypeArgumentElements(annotationMetadataWithDefaults, owningType, owningTypeWriter, generatorAdapter, declaringElementName, null, types, new HashSet<>(5), defaults, loadTypeMethods);
@@ -1798,44 +1805,71 @@ public abstract class AbstractClassFileWriter implements Opcodes, OriginatingEle
         return returnType;
     }
 
-    public static <T> void pushStringMapOf(GeneratorAdapter generatorAdapter, Map<? extends CharSequence, T> annotationData,
+    public static <T> void pushStringMapOf(GeneratorAdapter generatorAdapter,
+                                           Map<? extends CharSequence, T> annotationData,
                                            boolean skipEmpty,
                                            T empty,
                                            Consumer<T> pushValue) {
         Set<? extends Map.Entry<String, T>> entrySet = annotationData != null ? annotationData.entrySet()
                 .stream()
-                .filter(e -> !skipEmpty || (e.getKey() != null && e.getValue() != null))
+                .filter(e -> !skipEmpty || (e.getKey() != null && isSupportedMapValue(e.getValue())))
                 .map(e -> e.getValue() == null && empty != null ? new AbstractMap.SimpleEntry<>(e.getKey().toString(), empty) : new AbstractMap.SimpleEntry<>(e.getKey().toString(), e.getValue()))
                 .collect(Collectors.toCollection(() -> new TreeSet<>(Map.Entry.comparingByKey()))) : null;
         if (entrySet == null || entrySet.isEmpty()) {
-            generatorAdapter.getStatic(Type.getType(Collections.class), EMPTY_MAP, MAP_TYPE);
+            invokeInterfaceStatic(generatorAdapter, MAP_TYPE, MAP_OF[0]);
             return;
         }
-        if (entrySet.size() == 1 && entrySet.iterator().next().getValue() == Collections.EMPTY_MAP) {
+        if (entrySet.size() < MAP_OF.length) {
             for (Map.Entry<String, T> entry : entrySet) {
                 generatorAdapter.push(entry.getKey());
                 pushValue.accept(entry.getValue());
             }
-            generatorAdapter.invokeStatic(ANNOTATION_UTIL_TYPE, INTERN_MAP_OF_METHOD);
-        } else if (entrySet.size() < MAP_OF.length) {
-            for (Map.Entry<String, T> entry : entrySet) {
-                generatorAdapter.push(entry.getKey());
-                pushValue.accept(entry.getValue());
-            }
-            generatorAdapter.invokeStatic(ANNOTATION_UTIL_TYPE, MAP_OF[entrySet.size()]);
+            invokeInterfaceStatic(generatorAdapter, MAP_TYPE, MAP_OF[entrySet.size()]);
         } else {
-            int totalSize = entrySet.size() * 2;
+            int totalSize = entrySet.size();
             // start a new array
-            pushNewArray(generatorAdapter, Object.class, totalSize);
+            pushNewArray(generatorAdapter, Map.Entry.class, totalSize);
             int i = 0;
             for (Map.Entry<? extends CharSequence, T> entry : entrySet) {
-                // use the property name as the key
-                String memberName = entry.getKey().toString();
-                pushStoreStringInArray(generatorAdapter, i++, totalSize, memberName);
-                // use the property type as the value
-                pushStoreInArray(generatorAdapter, i++, totalSize, () -> pushValue.accept(entry.getValue()));
+
+                pushStoreInArray(generatorAdapter, i++, totalSize, () -> {
+                    generatorAdapter.push(entry.getKey().toString());
+                    pushValue.accept(entry.getValue());
+                    invokeInterfaceStatic(generatorAdapter, MAP_TYPE, MAP_ENTRY);
+                });
+
             }
-            generatorAdapter.invokeStatic(ANNOTATION_UTIL_TYPE, MAP_BY_ARRAY);
+            invokeInterfaceStatic(generatorAdapter, MAP_TYPE, MAP_BY_ARRAY);
         }
     }
+
+    public static void pushListOfString(GeneratorAdapter methodVisitor, List<String> names) {
+        if (names != null) {
+            names = names.stream().filter(Objects::nonNull).toList();
+        }
+        if (names == null || names.isEmpty()) {
+            invokeInterfaceStatic(methodVisitor, LIST_TYPE, LIST_OF[0]);
+            return;
+        }
+        if (names.size() < LIST_OF.length) {
+            for (String name : names) {
+                methodVisitor.push(name);
+            }
+            invokeInterfaceStatic(methodVisitor, LIST_TYPE, LIST_OF[names.size()]);
+        } else {
+            int totalSize = names.size();
+            // start a new array
+            pushNewArray(methodVisitor, String.class, totalSize);
+            int i = 0;
+            for (String name : names) {
+                pushStoreStringInArray(methodVisitor, i++, totalSize, name);
+            }
+            invokeInterfaceStatic(methodVisitor, LIST_TYPE, LIST_BY_ARRAY);
+        }
+    }
+
+    private static void invokeInterfaceStatic(GeneratorAdapter methodVisitor, Type type, org.objectweb.asm.commons.Method method) {
+        methodVisitor.visitMethodInsn(INVOKESTATIC, type.getInternalName(), method.getName(), method.getDescriptor(), true);
+    }
+
 }

--- a/inject/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadata.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadata.java
@@ -175,40 +175,6 @@ abstract class AbstractAnnotationMetadata implements AnnotationMetadata {
         return annotations;
     }
 
-    /**
-     * Adds any annotation values found in the values map to the results.
-     *
-     * @param results The results
-     * @param values The values
-     */
-    protected final void addAnnotationValuesFromData(List results, Map<CharSequence, Object> values) {
-        if (values != null) {
-            Object v = values.get(AnnotationMetadata.VALUE_MEMBER);
-            if (v instanceof io.micronaut.core.annotation.AnnotationValue[]) {
-                io.micronaut.core.annotation.AnnotationValue[] avs = (io.micronaut.core.annotation.AnnotationValue[]) v;
-                for (io.micronaut.core.annotation.AnnotationValue av : avs) {
-                    addValuesToResults(results, av);
-                }
-            } else if (v instanceof Collection) {
-                Collection c = (Collection) v;
-                for (Object o : c) {
-                    if (o instanceof io.micronaut.core.annotation.AnnotationValue) {
-                        addValuesToResults(results, ((io.micronaut.core.annotation.AnnotationValue) o));
-                    }
-                }
-            }
-        }
-    }
-
-    /**
-     * Adds a values instance to the results.
-     *
-     * @param results The results
-     * @param values The values
-     */
-    protected void addValuesToResults(List<io.micronaut.core.annotation.AnnotationValue> results, io.micronaut.core.annotation.AnnotationValue values) {
-        results.add(values);
-    }
 
     private Annotation[] initializeAnnotations(Set<String> names) {
         if (CollectionUtils.isNotEmpty(names)) {

--- a/inject/src/main/java/io/micronaut/inject/annotation/DefaultAnnotationMetadata.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/DefaultAnnotationMetadata.java
@@ -37,6 +37,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Array;
 import java.util.AbstractMap;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -994,7 +995,7 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     @Override
     public @NonNull <T extends Annotation> List<AnnotationValue<T>> getAnnotationValuesByType(@Nullable Class<T> annotationType) {
         if (annotationType == null) {
-            return Collections.emptyList();
+            return List.of();
         }
         final String annotationTypeName = annotationType.getName();
         List<AnnotationValue<T>> results = annotationValuesByType.get(annotationTypeName);
@@ -1005,11 +1006,11 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
             } else if (allAnnotations != null) {
                 final Map<CharSequence, Object> values = allAnnotations.get(annotationTypeName);
                 if (values != null) {
-                    results = Collections.singletonList(newAnnotationValue(annotationTypeName, values));
+                    results = List.of(newAnnotationValue(annotationTypeName, values));
                 }
             }
             if (results == null) {
-                results = Collections.emptyList();
+                results = List.of();
             }
             annotationValuesByType.put(annotationTypeName, results);
         }
@@ -1019,11 +1020,11 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     @Override
     public <T extends Annotation> List<AnnotationValue<T>> getAnnotationValuesByName(String annotationType) {
         if (annotationType == null) {
-            return Collections.emptyList();
+            return List.of();
         }
         String repeatableTypeName = findRepeatableAnnotationContainerInternal(annotationType);
         if (repeatableTypeName == null) {
-            return Collections.emptyList();
+            return List.of();
         }
         List<AnnotationValue<T>> results = resolveRepeatableAnnotations(repeatableTypeName, allAnnotations, allStereotypes);
         if (results != null) {
@@ -1032,14 +1033,14 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
         if (allAnnotations != null) {
             final Map<CharSequence, Object> values = allAnnotations.get(annotationType);
             if (values != null) {
-                results = Collections.singletonList(newAnnotationValue(annotationType, values));
+                results = List.of(newAnnotationValue(annotationType, values));
             }
         }
         if (results == null) {
-            results = Collections.emptyList();
+            results = List.of();
         }
         annotationValuesByType.put(annotationType, results);
-        return Collections.emptyList();
+        return List.of();
     }
 
     @NonNull
@@ -1051,26 +1052,26 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     @Override
     public <T extends Annotation> List<AnnotationValue<T>> getDeclaredAnnotationValuesByType(@NonNull Class<T> annotationType) {
         if (annotationType == null) {
-            return Collections.emptyList();
+            return List.of();
         }
         List<AnnotationValue<T>> results = resolveAnnotationValuesByType(annotationType, declaredAnnotations, declaredStereotypes);
         if (results != null) {
             return results;
         }
-        return Collections.emptyList();
+        return List.of();
     }
 
     @Override
     public <T extends Annotation> List<AnnotationValue<T>> getDeclaredAnnotationValuesByName(String annotationType) {
         if (annotationType == null) {
-            return Collections.emptyList();
+            return List.of();
         }
         String repeatableTypeName = findRepeatableAnnotationContainerInternal(annotationType);
         List<AnnotationValue<T>> results = resolveRepeatableAnnotations(repeatableTypeName, declaredAnnotations, declaredStereotypes);
         if (results != null) {
             return results;
         }
-        return Collections.emptyList();
+        return List.of();
     }
 
     @SuppressWarnings("unchecked")
@@ -1165,7 +1166,7 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     @Override
     public List<String> getAnnotationNamesByStereotype(@Nullable String stereotype) {
         if (stereotype == null) {
-            return Collections.emptyList();
+            return List.of();
         }
         if (annotationsByStereotype != null) {
             List<String> annotations = annotationsByStereotype.get(stereotype);
@@ -1174,18 +1175,18 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
             }
         }
         if (allAnnotations != null && allAnnotations.containsKey(stereotype)) {
-            return StringUtils.internListOf(stereotype);
+            return List.of(stereotype);
         }
         if (declaredAnnotations != null && declaredAnnotations.containsKey(stereotype)) {
-            return StringUtils.internListOf(stereotype);
+            return List.of(stereotype);
         }
-        return Collections.emptyList();
+        return List.of();
     }
 
     @Override
     public <T extends Annotation> List<AnnotationValue<T>> getAnnotationValuesByStereotype(String stereotype) {
         if (stereotype == null) {
-            return Collections.emptyList();
+            return List.of();
         }
         if (annotationsByStereotype != null) {
             List<String> annotations = annotationsByStereotype.get(stereotype);
@@ -1215,16 +1216,16 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
         if (declaredAnnotations != null) {
             return getDeclaredAnnotationValuesByName(stereotype);
         }
-        return Collections.emptyList();
+        return List.of();
     }
 
     @NonNull
     @Override
     public Set<String> getAnnotationNames() {
         if (allAnnotations != null) {
-            return allAnnotations.keySet();
+            return Collections.unmodifiableSet(allAnnotations.keySet());
         }
-        return Collections.emptySet();
+        return Set.of();
     }
 
     @NonNull
@@ -1233,7 +1234,7 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
         if (allStereotypes != null) {
             return Collections.unmodifiableSet(allStereotypes.keySet());
         }
-        return Collections.emptySet();
+        return Set.of();
     }
 
     @NonNull
@@ -1242,23 +1243,23 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
         if (declaredStereotypes != null) {
             return Collections.unmodifiableSet(declaredStereotypes.keySet());
         }
-        return Collections.emptySet();
+        return Set.of();
     }
 
     @NonNull
     @Override
     public Set<String> getDeclaredAnnotationNames() {
         if (declaredAnnotations != null) {
-            return declaredAnnotations.keySet();
+            return Collections.unmodifiableSet(declaredAnnotations.keySet());
         }
-        return Collections.emptySet();
+        return Set.of();
     }
 
     @NonNull
     @Override
     public List<String> getDeclaredAnnotationNamesByStereotype(@Nullable String stereotype) {
         if (stereotype == null) {
-            return Collections.emptyList();
+            return List.of();
         }
         if (annotationsByStereotype != null) {
             List<String> annotations = annotationsByStereotype.get(stereotype);
@@ -1269,14 +1270,14 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
                     return Collections.unmodifiableList(annotations);
                 } else {
                     // no declared
-                    return Collections.emptyList();
+                    return List.of();
                 }
             }
         }
         if (declaredAnnotations != null && declaredAnnotations.containsKey(stereotype)) {
-            return StringUtils.internListOf(stereotype);
+            return List.of(stereotype);
         }
-        return Collections.emptyList();
+        return List.of();
     }
 
     @NonNull
@@ -1535,16 +1536,16 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
         if (!hasStereotype(repeatableTypeName)) {
             return null;
         }
-        List<AnnotationValue<T>> results = new ArrayList<>();
+        List<AnnotationValue<T>> results = null;
         if (sourceAnnotations != null) {
             Map<CharSequence, Object> values = sourceAnnotations.get(repeatableTypeName);
-            addAnnotationValuesFromData(results, values);
+            results = collectResult(results, values);
         }
         if (sourceStereotypes != null) {
             Map<CharSequence, Object> values = sourceStereotypes.get(repeatableTypeName);
-            addAnnotationValuesFromData(results, values);
+            results = collectResult(results, values);
         }
-        return results;
+        return results == null ? List.of() : results;
     }
 
     @Nullable
@@ -1596,5 +1597,32 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     @Nullable
     protected String findRepeatableAnnotationContainerInternal(@NonNull String annotation) {
         return AnnotationMetadataSupport.getRepeatableAnnotation(annotation);
+    }
+
+    private <T extends Annotation> List<AnnotationValue<T>> collectResult(List<AnnotationValue<T>> results, Map<CharSequence, Object> values) {
+        if (values != null) {
+            Object v = values.get(AnnotationMetadata.VALUE_MEMBER);
+            if (v instanceof AnnotationValue<?>[] avs) {
+                List<AnnotationValue<T>> result = (List) Arrays.asList(avs);
+                if (results == null) {
+                    return result;
+                } else {
+                    return CollectionUtils.concat(results, result);
+                }
+            } else if (v instanceof Collection<?> c) {
+                List<AnnotationValue<T>> result = new ArrayList<>(c.size());
+                for (Object o : c) {
+                    if (o instanceof io.micronaut.core.annotation.AnnotationValue<?> av) {
+                        result.add((AnnotationValue<T>) av);
+                    }
+                }
+                if (results == null) {
+                    return result;
+                } else {
+                    return CollectionUtils.concat(results, result);
+                }
+            }
+        }
+        return results;
     }
 }


### PR DESCRIPTION
It looks like Java's `Map.of` is more performant than our `ImmutableSortedStringsArrayMap`, I think it's better to use the native implementation.

We still have to keep the previous implementation till everything is recompiled and all nulls in map values are eliminated.

There are some stats:
Before:
AnnotationValueBenchmark.benchMarkGetValue  thrpt    5  4686109.127 ± 176737.942  ops/s
After:
AnnotationValueBenchmark.benchMarkGetValue  thrpt    5  4999775.733 ± 276019.217  ops/s

Before:
FullHttpStackBenchmark.test  MICRONAUT  avgt   30  20530.775 ± 252.348  ns/op
After:
FullHttpStackBenchmark.test  MICRONAUT  avgt   30  19438.006 ± 94.318  ns/op
