### PR TITLE
Make evaluation context objects effectively singleton

### DIFF
--- a/inject-groovy/src/test/groovy/io/micronaut/expressions/TestExpressionsInjectionSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/expressions/TestExpressionsInjectionSpec.groovy
@@ -130,14 +130,16 @@ class TestExpressionsInjectionSpec extends AbstractBeanDefinitionSpec {
             }
 
             class Expr {
-                private final Integer wrapper
-                private final int primitive
-                private final String contextValue
+                public final Integer wrapper
+                public final int primitive
+                public final String contextValue
+                public final String contextValue2
 
-                Expr(Integer wrapper, int primitive, String contextValue) {
+                Expr(Integer wrapper, int primitive, String contextValue, String contextValue2) {
                     this.wrapper = wrapper
                     this.primitive = primitive
                     this.contextValue = contextValue
+                    this.contextValue2 = contextValue2;
                 }
             }
 
@@ -146,8 +148,9 @@ class TestExpressionsInjectionSpec extends AbstractBeanDefinitionSpec {
                 @Bean
                 Expr factoryBean(@Value('#{ 25 }') Integer wrapper,
                                  @Value('#{ 23 }') int primitive,
-                                 @Value('#{ #contextValue }') String contextValue) {
-                    return new Expr(wrapper, primitive, contextValue)
+                                 @Value('#{ #contextValue }') String contextValue,
+                                 @Value("#{ contextValue + ' ' + contextValue }") String contextValue2) {
+                    return new Expr(wrapper, primitive, contextValue, contextValue2)
                 }
             }
         """)
@@ -159,6 +162,7 @@ class TestExpressionsInjectionSpec extends AbstractBeanDefinitionSpec {
         bean.wrapper == 25
         bean.primitive == 23
         bean.contextValue == "context value"
+        bean.contextValue2 == "context value context value"
 
         cleanup:
         ctx.close()

--- a/inject/src/main/java/io/micronaut/context/expressions/ConfigurableExpressionEvaluationContext.java
+++ b/inject/src/main/java/io/micronaut/context/expressions/ConfigurableExpressionEvaluationContext.java
@@ -29,7 +29,7 @@ import io.micronaut.inject.BeanDefinition;
  * @author Sergey Gavrilov
  */
 @Internal
-public interface ConfigurableExpressionEvaluationContext extends ExpressionEvaluationContext {
+public sealed interface ConfigurableExpressionEvaluationContext extends ExpressionEvaluationContext permits DefaultExpressionEvaluationContext {
 
     /**
      * Set arguments passed to invoked method.

--- a/inject/src/main/java/io/micronaut/inject/DefaultBeanIdentifier.java
+++ b/inject/src/main/java/io/micronaut/inject/DefaultBeanIdentifier.java
@@ -26,7 +26,7 @@ import java.util.Objects;
  * @since 1.0
  */
 @Internal
-class DefaultBeanIdentifier implements BeanIdentifier {
+final class DefaultBeanIdentifier implements BeanIdentifier {
 
     private final String id;
 

--- a/src/main/docs/guide/config/evaluatedExpressions.adoc
+++ b/src/main/docs/guide/config/evaluatedExpressions.adoc
@@ -267,14 +267,13 @@ The available methods can be extended by extended the evaluation context. There 
 
 NOTE: The api:TypeElementVisitor[] has to be on the annotation processor classpath, therefore needs to be defined in a separate module that can be included on this classpath.
 
-Once a class is registered within evaluation context the methods and properties of the class are available for referencing in evaluated expressions. Any context reference
-needs to be prefixed with `#` sign.
+Once a class is registered within evaluation context the methods and properties of the class are available for referencing in evaluated expressions.
 
 Consider the following example:
 
 snippet::io.micronaut.docs.expressions.CustomEvaluationContext[title="User-defined evaluated expression context"]
 
-NOTE: The class should be resolvable as a bean can use `jakarta.inject` annotations to inject other types if necessary.
+NOTE: The class should be resolvable as a bean can use `jakarta.inject` annotations to inject other types if necessary. In addition, for performance reasons all evaluation context classes are effectively singleton regardless of the defined scope.
 
 Registering this class can be achieved with a custom implementation of api:expressions.context.ExpressionEvaluationContextRegistrar[] that is registered via service loader as a api:inject.visitor.TypeElementVisitor[] (create a new `META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor` file referencing the new class) and placed on the annotation processor classpath:
 


### PR DESCRIPTION
To ensure that the performance of evaluating expressions we should specify that any context objects are effectively singleton and cache them in the evaluation context. This is eliminates questions about how/where these objects are destroyed (singletons are always destroyed by the bean context).