### PR TITLE
Avoid the hierarchy annotaiton metadata for @Introspected(classes=)

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
@@ -100,16 +100,12 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                 if (isIntrospected(context, ce)) {
                     return;
                 }
-                final AnnotationMetadata typeMetadata = ce.getAnnotationMetadata();
-                final AnnotationMetadata resolvedMetadata = typeMetadata == AnnotationMetadata.EMPTY_METADATA
-                    ? element.getAnnotationMetadata()
-                    : new AnnotationMetadataHierarchy(element.getAnnotationMetadata(), typeMetadata);
                 final BeanIntrospectionWriter writer = new BeanIntrospectionWriter(
                     element.getName(),
                     index.getAndIncrement(),
                     element,
                     ce,
-                    metadata ? resolvedMetadata : null,
+                    metadata ? ce.getAnnotationMetadata() : null,
                     context
                 );
 

--- a/core/src/main/java/io/micronaut/core/annotation/Introspected.java
+++ b/core/src/main/java/io/micronaut/core/annotation/Introspected.java
@@ -67,7 +67,7 @@ public @interface Introspected {
      Introspected.Visibility[] DEFAULT_VISIBILITY = {Introspected.Visibility.DEFAULT};
 
     /**
-     * By default {@link Introspected} applies to the class it is applied on. However if classes are specified
+     * By default {@link Introspected} applies to the class it is applied on. However, if classes are specified
      * introspections will instead be generated for each class specified. This is useful in cases where you cannot
      * alter the source code and wish to generate introspections for already compiled classes.
      *


### PR DESCRIPTION
Stop adding all the annotations from class that uses `@Introspected(classes=)` to the classes that it imports.

For example, given
```java
class MyClass {}

@MyAnn
@Introspected(classes=MyClass.class)
class MyImportClass {}
```
`@MyAnn` will be present on the `MyClass` introspection even though it wasn't explicitly defined on it. Additionally, the `@Introspected(classes=MyClass.class)` will be present, too. This can be a problem when user wants to import multiple classes like `@Introspected(classes={MyCalss1.class, ..., MyClass1000.class})` creating huge introspections for all the classes.

I couldn't find any documentation for this behavior, so I think it makes sense to remove it. I also don't know of any implementations that could depend on it. But if needed, additional annotations during import can be added by creating a type element visitor. 