### PR TITLE
Retrieving beans from bean context in expressions

### DIFF
--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/access/BeanContextAccess.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/access/BeanContextAccess.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.expressions.parser.ast.access;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.expressions.parser.ast.ExpressionNode;
+import io.micronaut.expressions.parser.ast.types.TypeIdentifier;
+import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
+import io.micronaut.inject.ast.ClassElement;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.GeneratorAdapter;
+import org.objectweb.asm.commons.Method;
+
+import static io.micronaut.expressions.parser.ast.util.TypeDescriptors.EVALUATION_CONTEXT_TYPE;
+import static org.objectweb.asm.Opcodes.CHECKCAST;
+
+/**
+ * Expression AST node used for to retrieve beans from bean context.
+ *
+ * @author Sergey Gavrilov
+ * @since 4.0.0
+ */
+@Internal
+public class BeanContextAccess extends ExpressionNode {
+
+    private static final Method GET_BEAN_METHOD =
+        new Method("getBean", Type.getType(Object.class),
+            new Type[]{Type.getType(Class.class)});
+
+    private final TypeIdentifier typeIdentifier;
+
+    public BeanContextAccess(TypeIdentifier typeIdentifier) {
+        this.typeIdentifier = typeIdentifier;
+    }
+
+    @Override
+    protected void generateBytecode(ExpressionVisitorContext ctx) {
+        GeneratorAdapter mv = ctx.methodVisitor();
+        mv.loadArg(0);
+
+        Type beanType = typeIdentifier.resolveType(ctx);
+        mv.push(beanType);
+
+        // invoke getBean method
+        mv.invokeInterface(EVALUATION_CONTEXT_TYPE, GET_BEAN_METHOD);
+
+        // cast the return value to the correct type
+        mv.visitTypeInsn(CHECKCAST, beanType.getInternalName());
+    }
+
+    @Override
+    protected ClassElement doResolveClassElement(ExpressionVisitorContext ctx) {
+        return typeIdentifier.resolveClassElement(ctx);
+    }
+
+    @Override
+    protected Type doResolveType(ExpressionVisitorContext ctx) {
+        return typeIdentifier.doResolveType(ctx);
+    }
+}

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/token/TokenType.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/token/TokenType.java
@@ -27,6 +27,7 @@ import io.micronaut.core.annotation.Internal;
 public enum TokenType {
     WHITESPACE,
     IDENTIFIER,
+    BEAN_CONTEXT,
     TYPE_IDENTIFIER,
     EXPRESSION_CONTEXT_REF,
     DOT,

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/token/Tokenizer.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/token/Tokenizer.java
@@ -26,6 +26,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static io.micronaut.expressions.parser.token.TokenType.AND;
+import static io.micronaut.expressions.parser.token.TokenType.BEAN_CONTEXT;
 import static io.micronaut.expressions.parser.token.TokenType.BOOL;
 import static io.micronaut.expressions.parser.token.TokenType.COLON;
 import static io.micronaut.expressions.parser.token.TokenType.COMMA;
@@ -94,6 +95,7 @@ public final class Tokenizer {
         "^instanceof\\b", INSTANCEOF,
         "^matches\\b", MATCHES,
         "^empty\\b", EMPTY,
+        "^ctx\\b", BEAN_CONTEXT,
 
         // LITERALS
         "^null\\b", NULL,          // NULL

--- a/inject-groovy/src/test/groovy/io/micronaut/expressions/BeanContextAccessExpressionsSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/expressions/BeanContextAccessExpressionsSpec.groovy
@@ -1,0 +1,50 @@
+package io.micronaut.expressions
+
+import io.micronaut.ast.transform.test.AbstractEvaluatedExpressionsSpec
+
+class BeanContextAccessExpressionsSpec extends AbstractEvaluatedExpressionsSpec {
+
+    void "test bean context access"() {
+        given:
+        def ctx = buildContext("""
+            package test
+
+            import io.micronaut.context.annotation.Value
+
+            @jakarta.inject.Singleton
+            class AccessedBean {
+
+                String firstValue() {
+                    return "firstValue"
+                }
+
+                String secondValue() {
+                    return "secondValue"
+                }
+
+            }
+
+            @jakarta.inject.Singleton
+            class Expr {
+
+                @Value("#{ ctx[T(test.AccessedBean)].firstValue() }")
+                String firstValue
+
+                @Value("#{ ctx[test.AccessedBean].secondValue() }")
+                String secondValue
+
+            }
+        """)
+
+        def type = ctx.classLoader.loadClass('test.Expr')
+        def bean = ctx.getBean(type)
+
+        expect:
+        bean.firstValue == 'firstValue'
+        bean.secondValue == 'secondValue'
+
+        cleanup:
+        ctx.close()
+    }
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/expressions/BeanContextAccessExpressionsSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/expressions/BeanContextAccessExpressionsSpec.groovy
@@ -1,0 +1,50 @@
+package io.micronaut.expressions
+
+import io.micronaut.annotation.processing.test.AbstractEvaluatedExpressionsSpec
+
+class BeanContextAccessExpressionsSpec extends AbstractEvaluatedExpressionsSpec {
+
+    void "test bean context access"() {
+        given:
+        def ctx = buildContext("""
+            package test;
+
+            import io.micronaut.context.annotation.Value;
+
+            @jakarta.inject.Singleton
+            class AccessedBean {
+
+                String firstValue() {
+                    return "firstValue";
+                }
+
+                String secondValue() {
+                    return "secondValue";
+                }
+
+            }
+
+            @jakarta.inject.Singleton
+            class Expr {
+
+                @Value("#{ ctx[T(test.AccessedBean)].firstValue() }")
+                public String firstValue;
+
+                @Value("#{ ctx[test.AccessedBean].secondValue() }")
+                public String secondValue;
+
+            }
+        """)
+
+        def type = ctx.classLoader.loadClass('test.Expr')
+        def bean = ctx.getBean(type)
+
+        expect:
+        bean.firstValue == 'firstValue'
+        bean.secondValue == 'secondValue'
+
+        cleanup:
+        ctx.close()
+    }
+
+}

--- a/src/main/docs/guide/config/evaluatedExpressions.adoc
+++ b/src/main/docs/guide/config/evaluatedExpressions.adoc
@@ -62,6 +62,7 @@ The Evaluated Expressions syntax supports the following functionality:
 * Type References
 * Method Invocation
 * Property Access
+* Retrieving Beans from Bean Context
 
 === Literal Values
 
@@ -193,7 +194,7 @@ limited.
 
 === Dot and Safe Navigation Operator
 
-The dot operator can be use to access methods and properties of a value within an expression. For example:
+The dot operator can be used to access methods and properties of a value within an expression. For example:
 
 .Dot operator usage
 [source]
@@ -406,4 +407,17 @@ class ContextConsumer {
     public String value;
 
 }
+----
+
+==== Retrieving Beans from Bean Context
+
+A predefined syntax construct `ctx[...]` can be used to retrieve beans from bean
+context. The argument inside square brackets has to be a fully qualified class name (note that `T(...)` wrapper is
+optional and can be omitted for simplicity).
+
+.Retrieving beans from bean context
+[source]
+----
+#{ ctx[T(io.micronaut.example.ContextBean)] }
+#{ ctx[io.micronaut.example.ContextBean] }
 ----


### PR DESCRIPTION
Allows to retrieve beans from context in expressions with the following syntax
```
ctx[T(io.micronaut.example.TestBean)]
```
or simply
```
ctx[io.micronaut.example.TestBean]
```

@graemerocher 