### PR TITLE
Retrieving environment properties in expressions

### DIFF
--- a/core-processor/src/main/java/io/micronaut/expressions/parser/SingleEvaluatedEvaluatedExpressionParser.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/SingleEvaluatedEvaluatedExpressionParser.java
@@ -21,6 +21,7 @@ import io.micronaut.expressions.parser.ast.access.BeanContextAccess;
 import io.micronaut.expressions.parser.ast.access.ContextElementAccess;
 import io.micronaut.expressions.parser.ast.access.ContextMethodCall;
 import io.micronaut.expressions.parser.ast.access.ElementMethodCall;
+import io.micronaut.expressions.parser.ast.access.EnvironmentAccess;
 import io.micronaut.expressions.parser.ast.access.SubscriptOperator;
 import io.micronaut.expressions.parser.ast.access.PropertyAccess;
 import io.micronaut.expressions.parser.ast.conditional.ElvisOperator;
@@ -72,6 +73,7 @@ import static io.micronaut.expressions.parser.token.TokenType.DOT;
 import static io.micronaut.expressions.parser.token.TokenType.DOUBLE;
 import static io.micronaut.expressions.parser.token.TokenType.ELVIS;
 import static io.micronaut.expressions.parser.token.TokenType.EMPTY;
+import static io.micronaut.expressions.parser.token.TokenType.ENVIRONMENT;
 import static io.micronaut.expressions.parser.token.TokenType.EQ;
 import static io.micronaut.expressions.parser.token.TokenType.EXPRESSION_CONTEXT_REF;
 import static io.micronaut.expressions.parser.token.TokenType.FLOAT;
@@ -361,6 +363,7 @@ public final class SingleEvaluatedEvaluatedExpressionParser implements Evaluated
     // PrimaryExpression
     //  : EvaluationContextAccess
     //  | BeanContextAccess
+    //  | EnvironmentAccess
     //  | TypeIdentifier
     //  | ParenthesizedExpression
     //  | Literal
@@ -370,6 +373,7 @@ public final class SingleEvaluatedEvaluatedExpressionParser implements Evaluated
             case EXPRESSION_CONTEXT_REF -> evaluationContextAccess(true);
             case IDENTIFIER -> evaluationContextAccess(false);
             case BEAN_CONTEXT -> beanContextAccess();
+            case ENVIRONMENT -> environmentAccess();
             case TYPE_IDENTIFIER -> typeIdentifier(true);
             case L_PAREN -> parenthesizedExpression();
             case STRING, INT, LONG, DOUBLE, FLOAT, BOOL, NULL -> literal();
@@ -413,6 +417,17 @@ public final class SingleEvaluatedEvaluatedExpressionParser implements Evaluated
 
         eat(R_SQUARE);
         return new BeanContextAccess(typeIdentifier);
+    }
+
+    // EnvironmentAccess
+    //  : 'env' '[' Expression ']'
+    //  ;
+    private ExpressionNode environmentAccess() {
+        eat(ENVIRONMENT);
+        eat(L_SQUARE);
+        ExpressionNode propertyName = expression();
+        eat(R_SQUARE);
+        return new EnvironmentAccess(propertyName);
     }
 
     // MethodOrFieldAccess

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/access/EnvironmentAccess.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/access/EnvironmentAccess.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.expressions.parser.ast.access;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.expressions.parser.ast.ExpressionNode;
+import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
+import io.micronaut.expressions.parser.exception.ExpressionCompilationException;
+import io.micronaut.inject.ast.ClassElement;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.GeneratorAdapter;
+import org.objectweb.asm.commons.Method;
+
+import static io.micronaut.expressions.parser.ast.util.TypeDescriptors.EVALUATION_CONTEXT_TYPE;
+import static io.micronaut.expressions.parser.ast.util.TypeDescriptors.STRING;
+
+/**
+ * Expression AST node used for retrieving properties from environment at runtime.
+ *
+ * @author Sergey Gavrilov
+ * @since 4.0.0
+ */
+@Internal
+public final class EnvironmentAccess extends ExpressionNode {
+
+    private static final ClassElement STRING_ELEMENT = ClassElement.of(String.class);
+
+    private static final Method GET_PROPERTY_METHOD =
+        new Method("getProperty", Type.getType(String.class),
+            new Type[]{Type.getType(String.class)});
+
+    private final ExpressionNode propertyName;
+
+    public EnvironmentAccess(ExpressionNode propertyName) {
+        this.propertyName = propertyName;
+    }
+
+    @Override
+    protected void generateBytecode(ExpressionVisitorContext ctx) {
+        GeneratorAdapter mv = ctx.methodVisitor();
+        mv.loadArg(0);
+        propertyName.compile(ctx);
+        // invoke getProperty method
+        mv.invokeInterface(EVALUATION_CONTEXT_TYPE, GET_PROPERTY_METHOD);
+    }
+
+    @Override
+    protected ClassElement doResolveClassElement(ExpressionVisitorContext ctx) {
+        resolveType(ctx);
+        return STRING_ELEMENT;
+    }
+
+    @Override
+    protected Type doResolveType(ExpressionVisitorContext ctx) {
+        Type propertyNameType = propertyName.resolveType(ctx);
+        if (!propertyNameType.equals(STRING)) {
+            throw new ExpressionCompilationException("Invalid environment access operation. The expression inside environment " +
+                                                         "access must resolve to String value of property name");
+        }
+
+        // Property value is always returned as string
+        return STRING;
+    }
+
+}

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/token/TokenType.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/token/TokenType.java
@@ -28,6 +28,7 @@ public enum TokenType {
     WHITESPACE,
     IDENTIFIER,
     BEAN_CONTEXT,
+    ENVIRONMENT,
     TYPE_IDENTIFIER,
     EXPRESSION_CONTEXT_REF,
     DOT,

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/token/Tokenizer.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/token/Tokenizer.java
@@ -36,6 +36,7 @@ import static io.micronaut.expressions.parser.token.TokenType.DOT;
 import static io.micronaut.expressions.parser.token.TokenType.DOUBLE;
 import static io.micronaut.expressions.parser.token.TokenType.ELVIS;
 import static io.micronaut.expressions.parser.token.TokenType.EMPTY;
+import static io.micronaut.expressions.parser.token.TokenType.ENVIRONMENT;
 import static io.micronaut.expressions.parser.token.TokenType.EQ;
 import static io.micronaut.expressions.parser.token.TokenType.EXPRESSION_CONTEXT_REF;
 import static io.micronaut.expressions.parser.token.TokenType.IDENTIFIER;
@@ -96,6 +97,7 @@ public final class Tokenizer {
         "^matches\\b", MATCHES,
         "^empty\\b", EMPTY,
         "^ctx\\b", BEAN_CONTEXT,
+        "^env\\b", ENVIRONMENT,
 
         // LITERALS
         "^null\\b", NULL,          // NULL

--- a/core/src/main/java/io/micronaut/core/expressions/ExpressionEvaluationContext.java
+++ b/core/src/main/java/io/micronaut/core/expressions/ExpressionEvaluationContext.java
@@ -16,6 +16,7 @@
 package io.micronaut.core.expressions;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.Nullable;
 
 /**
  * Context that can be used by evaluated expression to obtain objects required
@@ -43,4 +44,12 @@ public interface ExpressionEvaluationContext extends AutoCloseable {
      * @return bean instance
      */
     <T> T getBean(Class<T> type);
+
+    /**
+     * Provides property by name.
+     * @param name property name
+     * @return property value or null
+     */
+    @Nullable
+    String getProperty(String name);
 }

--- a/inject-groovy/src/test/groovy/io/micronaut/expressions/EnvironmentAccessExpressionsSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/expressions/EnvironmentAccessExpressionsSpec.groovy
@@ -1,0 +1,51 @@
+package io.micronaut.expressions
+
+import io.micronaut.ast.transform.test.AbstractEvaluatedExpressionsSpec
+import io.micronaut.context.env.PropertySource
+
+class EnvironmentAccessExpressionsSpec extends AbstractEvaluatedExpressionsSpec {
+
+    void "test environment access"() {
+        given:
+        def ctx = buildContext("""
+            package test
+
+            import io.micronaut.context.annotation.Value
+
+            @jakarta.inject.Singleton
+            class Expr {
+
+                @Value("#{ env['first.property'] }")
+                String firstProperty
+
+                @Value("#{ env['second' + '.' + 'property'] }")
+                String secondProperty
+
+                @Value("#{ env [ 'third.property' ].toUpperCase() }")
+                String thirdProperty
+
+                @Value("#{ env['nullable.property']?.toUpperCase() }")
+                String nullableProperty
+
+            }
+        """)
+
+        def type = ctx.classLoader.loadClass('test.Expr')
+
+        ctx.environment.addPropertySource(PropertySource.of("test",
+                ['first.property': 'firstValue',
+                 'second.property': 'secondValue',
+                 'third.property': 'thirdValue']))
+
+        def bean = ctx.getBean(type)
+
+        expect:
+        bean.firstProperty == 'firstValue'
+        bean.secondProperty == 'secondValue'
+        bean.thirdProperty == 'THIRDVALUE'
+        bean.nullableProperty == null
+
+        cleanup:
+        ctx.close()
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/expressions/EnvironmentAccessExpressionsSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/expressions/EnvironmentAccessExpressionsSpec.groovy
@@ -1,0 +1,51 @@
+package io.micronaut.expressions
+
+import io.micronaut.annotation.processing.test.AbstractEvaluatedExpressionsSpec
+import io.micronaut.context.env.PropertySource
+
+class EnvironmentAccessExpressionsSpec extends AbstractEvaluatedExpressionsSpec {
+
+    void "test environment access"() {
+        given:
+        def ctx = buildContext("""
+            package test;
+
+            import io.micronaut.context.annotation.Value;
+
+            @jakarta.inject.Singleton
+            class Expr {
+
+                @Value("#{ env['first.property'] }")
+                public String firstProperty;
+
+                @Value("#{ env['second' + '.' + 'property'] }")
+                public String secondProperty;
+
+                @Value("#{ env [ 'third.property' ].toUpperCase() }")
+                public String thirdProperty;
+
+                @Value("#{ env['nullable.property']?.toUpperCase() }")
+                public String nullableProperty;
+
+            }
+        """)
+
+        def type = ctx.classLoader.loadClass('test.Expr')
+
+        ctx.environment.addPropertySource(PropertySource.of("test",
+                ['first.property': 'firstValue',
+                 'second.property': 'secondValue',
+                 'third.property': 'thirdValue']))
+
+        def bean = ctx.getBean(type)
+
+        expect:
+        bean.firstProperty == 'firstValue'
+        bean.secondProperty == 'secondValue'
+        bean.thirdProperty == 'THIRDVALUE'
+        bean.nullableProperty == null
+
+        cleanup:
+        ctx.close()
+    }
+}

--- a/inject/src/main/java/io/micronaut/context/expressions/DefaultExpressionEvaluationContext.java
+++ b/inject/src/main/java/io/micronaut/context/expressions/DefaultExpressionEvaluationContext.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.context.expressions;
 
+import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.BeanContext;
 import io.micronaut.context.BeanRegistration;
 import io.micronaut.context.BeanResolutionContext;
@@ -85,6 +86,17 @@ public final class DefaultExpressionEvaluationContext implements ConfigurableExp
         }
 
         return args[index];
+    }
+
+    @Override
+    public String getProperty(String name) {
+        if (beanContext == null || !(beanContext instanceof ApplicationContext applicationContext)) {
+            throw new ExpressionEvaluationException("Can not obtain environment property [" + name + "] " +
+                                                        "since application context is not set");
+        }
+
+        return applicationContext.getProperty(name, String.class)
+                   .orElse(null);
     }
 
     @Override

--- a/src/main/docs/guide/config/evaluatedExpressions.adoc
+++ b/src/main/docs/guide/config/evaluatedExpressions.adoc
@@ -63,6 +63,7 @@ The Evaluated Expressions syntax supports the following functionality:
 * Method Invocation
 * Property Access
 * Retrieving Beans from Bean Context
+* Retrieving Environment Properties
 
 === Literal Values
 
@@ -420,4 +421,16 @@ optional and can be omitted for simplicity).
 ----
 #{ ctx[T(io.micronaut.example.ContextBean)] }
 #{ ctx[io.micronaut.example.ContextBean] }
+----
+
+==== Retrieving Environment Properties
+
+A syntax construct `env[...]` can be used to retrieve environment properties by name.
+The expression inside square brackets has to resolve to string value, otherwise compilation will fail. If property
+value will be absent at runtime, the expression will return `null`
+
+.Retrieving Environment Properties
+[source]
+----
+#{ env['test.property'] }
 ----


### PR DESCRIPTION
Allows retrieving properties in expressions using syntax
```
#{ env['test.property' ]}
```

Any expression resolving to string can be used inside square brackets (not only string literals). The expression itself returns string property value or null if value is not set

@graemerocher 
