### PR TITLE
Idea(8855)/http services health indicator

### DIFF
--- a/http-client-core/build.gradle
+++ b/http-client-core/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     implementation libs.managed.reactor
 
     api project(":runtime")
+    api project(":management")
 
     compileOnly libs.kotlin.stdlib
 }

--- a/http-client-core/src/main/java/io/micronaut/http/client/ServiceHttpClientConfiguration.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/ServiceHttpClientConfiguration.java
@@ -66,12 +66,19 @@ public class ServiceHttpClientConfiguration extends HttpClientConfiguration impl
     @SuppressWarnings("WeakerAccess")
     public static final long DEFAULT_HEALTHCHECKINTERVAL_SECONDS = 30;
 
+    /**
+     * The default health indicator value.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static final boolean DEFAULT_HEALTH_INDICATOR = false;
+
     private final String serviceId;
     private final ServiceConnectionPoolConfiguration connectionPoolConfiguration;
     private List<URI> urls = Collections.emptyList();
     private String healthCheckUri = DEFAULT_HEALTHCHECKURI;
     private boolean healthCheck = DEFAULT_HEALTHCHECK;
     private Duration healthCheckInterval = Duration.ofSeconds(DEFAULT_HEALTHCHECKINTERVAL_SECONDS);
+    private boolean healthIndicator = DEFAULT_HEALTH_INDICATOR;
     private String path;
 
     /**
@@ -241,6 +248,23 @@ public class ServiceHttpClientConfiguration extends HttpClientConfiguration impl
         if (healthCheckInterval != null) {
             this.healthCheckInterval = healthCheckInterval;
         }
+    }
+
+    /**
+     * Whether service health indicator should be created.
+     *
+     * @return True if a health indicator should be created
+     */
+    public boolean isHealthIndicator() {
+        return healthIndicator;
+    }
+
+    /**
+     * Sets whether a service health indicator should be created. Default value ({@value #DEFAULT_HEALTH_INDICATOR}).
+     * @param healthIndicator True if health indicator should be created
+     */
+    public void setHealthIndicator(boolean healthIndicator) {
+        this.healthIndicator = healthIndicator;
     }
 
     @Override

--- a/http-client-core/src/main/java/io/micronaut/http/client/ServiceHttpClientHealthIndicatorFactory.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/ServiceHttpClientHealthIndicatorFactory.java
@@ -1,0 +1,57 @@
+package io.micronaut.http.client;
+
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.async.publisher.Publishers;
+import io.micronaut.discovery.StaticServiceInstanceList;
+import io.micronaut.health.HealthStatus;
+import io.micronaut.management.health.indicator.HealthIndicator;
+import io.micronaut.management.endpoint.health.HealthEndpoint;
+import io.micronaut.management.health.indicator.HealthResult;
+import org.reactivestreams.Publisher;
+
+import java.net.URI;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Factory
+@EachBean(ServiceHttpClientConfiguration.class)
+@Requires(beans = HealthEndpoint.class)
+public class ServiceHttpClientHealthIndicatorFactory implements HealthIndicator {
+
+    private final ServiceHttpClientConfiguration configuration;
+    private final Collection<URI> loadBalancerUrls;
+    private final Collection<URI> originalUrls;
+    private final HealthResult.Builder serviceHealthBuilder;
+
+    public ServiceHttpClientHealthIndicatorFactory(@Parameter ServiceHttpClientConfiguration configuration, @Parameter StaticServiceInstanceList instanceList) {
+        this.configuration = configuration;
+        this.loadBalancerUrls = instanceList.getLoadBalancedURIs();
+        this.originalUrls = configuration.getUrls();
+        this.serviceHealthBuilder = HealthResult.builder(configuration.getServiceId());
+    }
+
+    @Override
+    public Publisher<HealthResult> getResult() {
+        if (!configuration.isHealthIndicator() || !configuration.isHealthCheck()) {
+            return Publishers.empty();
+        }
+
+        return Publishers.just(determineServiceHealth());
+    }
+
+    private HealthResult determineServiceHealth() {
+        Map<String, Object> details = new LinkedHashMap<>(2);
+        details.put("allUrls", originalUrls);
+        details.put("availableUrls", loadBalancerUrls);
+
+        if (loadBalancerUrls.isEmpty()) {
+            return serviceHealthBuilder.status(HealthStatus.DOWN).details(details).build();
+        }
+
+        return serviceHealthBuilder.status(HealthStatus.UP).details(details).build();
+    }
+}

--- a/http-client-core/src/main/java/io/micronaut/http/client/ServiceHttpClientHealthIndicatorFactory.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/ServiceHttpClientHealthIndicatorFactory.java
@@ -45,8 +45,8 @@ public class ServiceHttpClientHealthIndicatorFactory implements HealthIndicator 
 
     private HealthResult determineServiceHealth() {
         Map<String, Object> details = new LinkedHashMap<>(2);
-        details.put("allUrls", originalUrls);
-        details.put("availableUrls", loadBalancerUrls);
+        details.put("all_urls", originalUrls);
+        details.put("available_urls", loadBalancerUrls);
 
         if (loadBalancerUrls.isEmpty()) {
             return serviceHealthBuilder.status(HealthStatus.DOWN).details(details).build();

--- a/http-client-core/src/main/java/io/micronaut/http/client/ServiceHttpClientHealthIndicatorFactory.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/ServiceHttpClientHealthIndicatorFactory.java
@@ -37,7 +37,7 @@ import java.util.Map;
  * Returns {@link HealthStatus#DOWN} if there are no available URLs in the load balancer.</p>
  *
  * @author Alexander Simpson
- * @since 3.8
+ * @since 3.8.9
  */
 @Factory
 @EachBean(ServiceHttpClientConfiguration.class)
@@ -49,6 +49,10 @@ public class ServiceHttpClientHealthIndicatorFactory implements HealthIndicator 
     private final Collection<URI> originalUrls;
     private final HealthResult.Builder serviceHealthBuilder;
 
+    /**
+     * @param configuration Configuration for the individual service http client.
+     * @param instanceList Instance List for the individual service http client. Used to obtain available load balancer URLs.
+     */
     public ServiceHttpClientHealthIndicatorFactory(@Parameter ServiceHttpClientConfiguration configuration, @Parameter StaticServiceInstanceList instanceList) {
         this.configuration = configuration;
         this.loadBalancerUrls = instanceList.getLoadBalancedURIs();

--- a/http-client-core/src/main/java/io/micronaut/http/client/ServiceHttpClientHealthIndicatorFactory.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/ServiceHttpClientHealthIndicatorFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.http.client;
 
 import io.micronaut.context.annotation.EachBean;
@@ -7,8 +22,8 @@ import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.discovery.StaticServiceInstanceList;
 import io.micronaut.health.HealthStatus;
-import io.micronaut.management.health.indicator.HealthIndicator;
 import io.micronaut.management.endpoint.health.HealthEndpoint;
+import io.micronaut.management.health.indicator.HealthIndicator;
 import io.micronaut.management.health.indicator.HealthResult;
 import org.reactivestreams.Publisher;
 
@@ -17,6 +32,13 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+/**
+ * <p>A {@link io.micronaut.management.health.indicator.HealthIndicator} used to display available load balancer URLs.
+ * Returns {@link HealthStatus#DOWN} if there are no available URLs in the load balancer.</p>
+ *
+ * @author Alexander Simpson
+ * @since 3.8
+ */
 @Factory
 @EachBean(ServiceHttpClientConfiguration.class)
 @Requires(beans = HealthEndpoint.class)

--- a/http-client-core/src/test/groovy/io/micronaut/http/client/ServiceHttpClientHealthIndicatorFactorySpec.groovy
+++ b/http-client-core/src/test/groovy/io/micronaut/http/client/ServiceHttpClientHealthIndicatorFactorySpec.groovy
@@ -1,0 +1,74 @@
+package io.micronaut.http.client
+
+import io.micronaut.discovery.StaticServiceInstanceList
+import io.micronaut.health.HealthStatus
+import io.micronaut.runtime.ApplicationConfiguration
+import reactor.core.publisher.Mono
+import spock.lang.Specification
+
+class ServiceHttpClientHealthIndicatorFactorySpec extends Specification {
+
+    def static uri1 = new URI("http://localhost:8080")
+    def static uri2 = new URI("http://localhost:8081")
+    def instanceList = new StaticServiceInstanceList("some-http-service", [uri1, uri2])
+
+    def serviceHttpConfiguration = new ServiceHttpClientConfiguration("some-http-service", null, null, GroovyMock(ApplicationConfiguration))
+
+    def "Health Indicator is set to true and is healthy"() {
+        given:
+        serviceHttpConfiguration.setHealthCheck(true)
+        serviceHttpConfiguration.setHealthIndicator(true)
+        def healthIndicator = new ServiceHttpClientHealthIndicatorFactory(serviceHttpConfiguration, instanceList)
+
+        when:
+        def result = Mono.from(healthIndicator.getResult()).block()
+
+        then:
+        HealthStatus.UP == result.status
+
+        0 * _
+    }
+
+    def "Health Indicator and check are true, instance list is updated - #scenario"() {
+        given:
+        serviceHttpConfiguration.setHealthCheck(true)
+        serviceHttpConfiguration.setHealthIndicator(true)
+        def healthIndicator = new ServiceHttpClientHealthIndicatorFactory(serviceHttpConfiguration, instanceList)
+
+        when: "uri is removed from list"
+        instanceList.getLoadBalancedURIs().removeAll(urisToRemove)
+
+        def result = Mono.from(healthIndicator.getResult()).block()
+
+        then:
+        expectedStatus == result.status
+
+        0 * _
+
+        where:
+        scenario                | urisToRemove || expectedStatus
+        "one uri is removed"    | [uri1]       || HealthStatus.UP
+        "both uris are removed" | [uri1, uri2] || HealthStatus.DOWN
+    }
+
+    def "Calling getResult but #scenario, so result is null"() {
+        given:
+        serviceHttpConfiguration.setHealthCheck(healthCheck)
+        serviceHttpConfiguration.setHealthIndicator(indicator)
+        def healthIndicator = new ServiceHttpClientHealthIndicatorFactory(serviceHttpConfiguration, instanceList)
+
+        when:
+        def result = Mono.from(healthIndicator.getResult()).block()
+
+        then:
+        null == result
+
+        0 * _
+
+        where:
+        scenario                                           | healthCheck | indicator
+        "health check is set to false"                     | false       | true
+        "health indicator is set to false"                 | true        | false
+        "both indicator and health check are set to false" | false       | false
+    }
+}

--- a/src/main/docs/guide/cloud/serviceDiscovery/serviceDiscoveryManual.adoc
+++ b/src/main/docs/guide/cloud/serviceDiscovery/serviceDiscoveryManual.adoc
@@ -32,10 +32,13 @@ micronaut:
         health-check: true
         health-check-interval: 15s
         health-check-uri: /health
+        health-indicator: true
 ----
 
 - `health-check` indicates whether to health check the service
 - `health-check-interval` is the interval between checks
 - `health-check-uri` specifies the endpoint URI of the health check request
+- `health-indicator` indicates whether to create a health indicator for the given service. Requires `health-check` to also be true
 
-Micronaut starts a background thread to check the health status of the service and if any of the configured services respond with an error code, they are removed from the list of available services.
+The Micronaut framework starts a background thread to check the health status of the service and if any of the configured services respond with an error code, they are removed from the list of available services.
+If indicators are created, they will return a `DOWN` status when the list of available services is empty.


### PR DESCRIPTION
Discussion Reference: https://github.com/micronaut-projects/micronaut-core/discussions/8855 

**What this does:**
- Adds additional configuration to service http clients (health-indicator)
- Provides a health indicator for each service http client

**Why:**
- Allows us to use the health endpoint, if configured, to validate application health
- Ties into the current health check on service http clients to determine health

**Example use:**
Configuration:
![image](https://user-images.githubusercontent.com/22035731/229890919-c19a3781-f0d6-4303-aa50-7705144d3dab.png)

Healthy Response:
![image](https://user-images.githubusercontent.com/22035731/229891396-be1716a4-ad77-4f53-9680-ee6c88263aa7.png)

Unhealthy Service:
![image](https://user-images.githubusercontent.com/22035731/229891680-cf7928e7-6abb-4846-bd5f-311691b78b46.png)
