### PR TITLE
Expose ConnectionManager for use in Oracle Cloud Netty client

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -456,6 +456,15 @@ public class DefaultHttpClient implements
         return log;
     }
 
+    /**
+     * Access to the connection manager, for micronaut-oracle-cloud.
+     *
+     * @return The connection manager of this client
+     */
+    public ConnectionManager connectionManager() {
+        return connectionManager;
+    }
+
     @Override
     public HttpClient start() {
         if (!isRunning()) {
@@ -1859,7 +1868,7 @@ public class DefaultHttpClient implements
     /**
      * Key used for connection pooling and determining host/port.
      */
-    static final class RequestKey {
+    public static final class RequestKey {
         private final String host;
         private final int port;
         private final boolean secure;


### PR DESCRIPTION
This PR exposes some ConnectionManager APIs in the netty http client so that I can use them to implement connection pooling in oraclecloud-httpclient-netty. Unfortunately OCI is still peculiar about how requests are processed so the client cannot be implemented with the normal Micronaut HTTP client API, but ConnectionManager offers a good enough API to make use of the basic HTTP stack (SSL, HTTP2/HTTP3...) and connection pooling.

ConnectionManager did change a bit in 4.0.x, and connection pooling for oraclecloud-httpclient-netty isn't super urgent, which is why this PR is targeted to 4.0.x.

In local testing these changes in micronaut-core are sufficient to implement the pooling client. I need to do more thorough testing though.