### PR TITLE
Allow access to 'this' in expressions / support introspections

### DIFF
--- a/aop/src/main/java/io/micronaut/aop/chain/InterceptorChain.java
+++ b/aop/src/main/java/io/micronaut/aop/chain/InterceptorChain.java
@@ -70,7 +70,7 @@ public class InterceptorChain<B, R> extends AbstractInterceptorChain<B, R> imple
         this.executionHandle = method;
         AnnotationMetadata metadata = executionHandle.getAnnotationMetadata();
         if (originalParameters.length > 0 && metadata instanceof EvaluatedAnnotationMetadata eam) {
-            this.annotationMetadata = eam.withArguments(originalParameters);
+            this.annotationMetadata = eam.withArguments(target, originalParameters);
         } else {
             this.annotationMetadata = metadata;
         }

--- a/context/src/main/java/io/micronaut/scheduling/processor/ScheduledMethodProcessor.java
+++ b/context/src/main/java/io/micronaut/scheduling/processor/ScheduledMethodProcessor.java
@@ -126,7 +126,7 @@ public class ScheduledMethodProcessor implements ExecutableMethodProcessor<Sched
                     Object bean = beanContext.getBean(beanType, declaredQualifier);
                     AnnotationValue<Scheduled> finalAnnotationValue = scheduledAnnotation;
                     if (finalAnnotationValue instanceof EvaluatedAnnotationValue<Scheduled> evaluated) {
-                        finalAnnotationValue = evaluated.withArguments(boundExecutable.getBoundArguments());
+                        finalAnnotationValue = evaluated.withArguments(bean, boundExecutable.getBoundArguments());
                     }
                     boolean shouldRun = finalAnnotationValue.booleanValue(MEMBER_CONDITION).orElse(true);
                     if (shouldRun) {

--- a/core-processor/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
+++ b/core-processor/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
@@ -41,7 +41,6 @@ import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.Toggleable;
 import io.micronaut.core.value.OptionalValues;
-import io.micronaut.expressions.context.ExpressionWithContext;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.ExecutableMethod;
 import io.micronaut.inject.ProxyBeanDefinition;
@@ -1300,11 +1299,6 @@ public class AopProxyWriter extends AbstractClassFileWriter implements ProxyingB
     @Override
     public AnnotationMetadata getAnnotationMetadata() {
         return proxyBeanDefinitionWriter.getAnnotationMetadata();
-    }
-
-    @Override
-    public Set<ExpressionWithContext> getEvaluatedExpressions() {
-        return proxyBeanDefinitionWriter.getEvaluatedExpressions();
     }
 
     @Override

--- a/core-processor/src/main/java/io/micronaut/expressions/context/DefaultExpressionCompilationContextFactory.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/context/DefaultExpressionCompilationContextFactory.java
@@ -58,14 +58,14 @@ public final class DefaultExpressionCompilationContextFactory implements Express
     @NonNull
     public ExpressionCompilationContext buildContextForMethod(@NonNull EvaluatedExpressionReference expression,
                                                               @NonNull MethodElement methodElement) {
-        return buildForExpression(expression)
+        return buildForExpression(expression, null)
                  .extendWith(methodElement);
     }
 
     @Override
     @NonNull
-    public ExpressionCompilationContext buildContext(EvaluatedExpressionReference expression) {
-        return buildForExpression(expression);
+    public ExpressionCompilationContext buildContext(EvaluatedExpressionReference expression, ClassElement thisElement) {
+        return buildForExpression(expression, thisElement);
     }
 
     @Override
@@ -75,7 +75,7 @@ public final class DefaultExpressionCompilationContextFactory implements Express
         return this;
     }
 
-    private ExtensibleExpressionCompilationContext buildForExpression(EvaluatedExpressionReference expression) {
+    private ExtensibleExpressionCompilationContext buildForExpression(EvaluatedExpressionReference expression, ClassElement thisElement) {
         String annotationName = expression.annotationName();
         String memberName = expression.annotationMember();
 
@@ -87,6 +87,9 @@ public final class DefaultExpressionCompilationContextFactory implements Express
             evaluationContext = addAnnotationMemberEvaluationContext(evaluationContext, annotation, memberName);
         }
 
+        if (thisElement != null) {
+            return evaluationContext.withThis(thisElement);
+        }
         return evaluationContext;
     }
 

--- a/core-processor/src/main/java/io/micronaut/expressions/context/ExpressionCompilationContext.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/context/ExpressionCompilationContext.java
@@ -17,6 +17,8 @@ package io.micronaut.expressions.context;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.MethodElement;
 import io.micronaut.inject.ast.ParameterElement;
 import io.micronaut.inject.ast.PropertyElement;
@@ -32,6 +34,12 @@ import java.util.List;
  */
 @Internal
 public interface ExpressionCompilationContext {
+
+    /**
+     * @return Find the type that represents this.
+     */
+    @Nullable
+    ClassElement findThis();
 
     /**
      * Search methods in compilation context by name.

--- a/core-processor/src/main/java/io/micronaut/expressions/context/ExpressionCompilationContextFactory.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/context/ExpressionCompilationContextFactory.java
@@ -17,6 +17,7 @@ package io.micronaut.expressions.context;
 
 import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.expressions.EvaluatedExpressionReference;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.MethodElement;
@@ -42,11 +43,12 @@ public interface ExpressionCompilationContextFactory {
     /**
      * Builds expression evaluation context for expression reference.
      *
-     * @param expression expression reference
+     * @param expression  expression reference
+     * @param thisElement
      * @return evaluation context for method
      */
     @NonNull
-    ExpressionCompilationContext buildContext(EvaluatedExpressionReference expression);
+    ExpressionCompilationContext buildContext(EvaluatedExpressionReference expression, @Nullable ClassElement thisElement);
 
     /**
      * Adds evaluated expression context class element to context loader

--- a/core-processor/src/main/java/io/micronaut/expressions/context/ExtensibleExpressionCompilationContext.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/context/ExtensibleExpressionCompilationContext.java
@@ -28,6 +28,13 @@ import io.micronaut.inject.ast.MethodElement;
  */
 @Internal
 public interface ExtensibleExpressionCompilationContext extends ExpressionCompilationContext {
+
+    /**
+     * @param classElement The type that represents this.
+     * @return extended context
+     */
+    ExtensibleExpressionCompilationContext withThis(@NonNull ClassElement classElement);
+
     /**
      * Extends compilation context with method element. Compilation context can only include
      * one method at the same time, so this method will return the context which will

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/SingleEvaluatedEvaluatedExpressionParser.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/SingleEvaluatedEvaluatedExpressionParser.java
@@ -24,6 +24,7 @@ import io.micronaut.expressions.parser.ast.access.ElementMethodCall;
 import io.micronaut.expressions.parser.ast.access.EnvironmentAccess;
 import io.micronaut.expressions.parser.ast.access.SubscriptOperator;
 import io.micronaut.expressions.parser.ast.access.PropertyAccess;
+import io.micronaut.expressions.parser.ast.access.ThisAccess;
 import io.micronaut.expressions.parser.ast.conditional.ElvisOperator;
 import io.micronaut.expressions.parser.ast.conditional.TernaryExpression;
 import io.micronaut.expressions.parser.ast.literal.BoolLiteral;
@@ -62,48 +63,7 @@ import io.micronaut.expressions.parser.token.Tokenizer;
 import java.util.ArrayList;
 import java.util.List;
 
-import static io.micronaut.expressions.parser.token.TokenType.AND;
-import static io.micronaut.expressions.parser.token.TokenType.BEAN_CONTEXT;
-import static io.micronaut.expressions.parser.token.TokenType.BOOL;
-import static io.micronaut.expressions.parser.token.TokenType.COLON;
-import static io.micronaut.expressions.parser.token.TokenType.COMMA;
-import static io.micronaut.expressions.parser.token.TokenType.DECREMENT;
-import static io.micronaut.expressions.parser.token.TokenType.DIV;
-import static io.micronaut.expressions.parser.token.TokenType.DOT;
-import static io.micronaut.expressions.parser.token.TokenType.DOUBLE;
-import static io.micronaut.expressions.parser.token.TokenType.ELVIS;
-import static io.micronaut.expressions.parser.token.TokenType.EMPTY;
-import static io.micronaut.expressions.parser.token.TokenType.ENVIRONMENT;
-import static io.micronaut.expressions.parser.token.TokenType.EQ;
-import static io.micronaut.expressions.parser.token.TokenType.EXPRESSION_CONTEXT_REF;
-import static io.micronaut.expressions.parser.token.TokenType.FLOAT;
-import static io.micronaut.expressions.parser.token.TokenType.GT;
-import static io.micronaut.expressions.parser.token.TokenType.GTE;
-import static io.micronaut.expressions.parser.token.TokenType.IDENTIFIER;
-import static io.micronaut.expressions.parser.token.TokenType.R_SQUARE;
-import static io.micronaut.expressions.parser.token.TokenType.TYPE_IDENTIFIER;
-import static io.micronaut.expressions.parser.token.TokenType.INCREMENT;
-import static io.micronaut.expressions.parser.token.TokenType.INSTANCEOF;
-import static io.micronaut.expressions.parser.token.TokenType.INT;
-import static io.micronaut.expressions.parser.token.TokenType.LONG;
-import static io.micronaut.expressions.parser.token.TokenType.LT;
-import static io.micronaut.expressions.parser.token.TokenType.LTE;
-import static io.micronaut.expressions.parser.token.TokenType.L_PAREN;
-import static io.micronaut.expressions.parser.token.TokenType.L_SQUARE;
-import static io.micronaut.expressions.parser.token.TokenType.MATCHES;
-import static io.micronaut.expressions.parser.token.TokenType.MINUS;
-import static io.micronaut.expressions.parser.token.TokenType.MOD;
-import static io.micronaut.expressions.parser.token.TokenType.MUL;
-import static io.micronaut.expressions.parser.token.TokenType.NE;
-import static io.micronaut.expressions.parser.token.TokenType.NOT;
-import static io.micronaut.expressions.parser.token.TokenType.NULL;
-import static io.micronaut.expressions.parser.token.TokenType.OR;
-import static io.micronaut.expressions.parser.token.TokenType.PLUS;
-import static io.micronaut.expressions.parser.token.TokenType.POW;
-import static io.micronaut.expressions.parser.token.TokenType.QMARK;
-import static io.micronaut.expressions.parser.token.TokenType.R_PAREN;
-import static io.micronaut.expressions.parser.token.TokenType.SAFE_NAV;
-import static io.micronaut.expressions.parser.token.TokenType.STRING;
+import static io.micronaut.expressions.parser.token.TokenType.*;
 
 /**
  * Parser for building AST for single evaluated expression.
@@ -374,11 +334,17 @@ public final class SingleEvaluatedEvaluatedExpressionParser implements Evaluated
             case IDENTIFIER -> evaluationContextAccess(false);
             case BEAN_CONTEXT -> beanContextAccess();
             case ENVIRONMENT -> environmentAccess();
+            case THIS -> thisAccess();
             case TYPE_IDENTIFIER -> typeIdentifier(true);
             case L_PAREN -> parenthesizedExpression();
             case STRING, INT, LONG, DOUBLE, FLOAT, BOOL, NULL -> literal();
             default -> throw new ExpressionParsingException("Unexpected token: " + lookahead.value());
         };
+    }
+
+    private ExpressionNode thisAccess() {
+        eat(THIS);
+        return new ThisAccess();
     }
 
     // EvaluationContextAccess

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/access/ThisAccess.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/access/ThisAccess.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.expressions.parser.ast.access;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.expressions.parser.ast.ExpressionNode;
+import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
+import io.micronaut.expressions.parser.exception.ExpressionCompilationException;
+import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.processing.JavaModelUtils;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.GeneratorAdapter;
+import org.objectweb.asm.commons.Method;
+
+import static io.micronaut.expressions.parser.ast.util.TypeDescriptors.EVALUATION_CONTEXT_TYPE;
+
+/**
+ * Enables access to 'this' in non-static contexts.
+ */
+@Internal
+public final class ThisAccess extends ExpressionNode {
+    @Override
+    protected void generateBytecode(ExpressionVisitorContext ctx) {
+        GeneratorAdapter mv = ctx.methodVisitor();
+        mv.loadArg(0);
+        mv.invokeInterface(EVALUATION_CONTEXT_TYPE, new Method("getThis", Type.getType(Object.class), new Type[0]));
+        mv.checkCast(resolveType(ctx));
+    }
+
+    @Override
+    protected ClassElement doResolveClassElement(ExpressionVisitorContext ctx) {
+        ClassElement thisType = ctx.compilationContext().findThis();
+        if (thisType == null) {
+            throw new ExpressionCompilationException(
+                "Cannot reference 'this' from the current context.");
+
+        }
+        return thisType;
+    }
+
+    @Override
+    protected Type doResolveType(ExpressionVisitorContext ctx) {
+        return JavaModelUtils.getTypeReference(doResolveClassElement(ctx));
+    }
+}

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/token/TokenType.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/token/TokenType.java
@@ -29,6 +29,7 @@ public enum TokenType {
     IDENTIFIER,
     BEAN_CONTEXT,
     ENVIRONMENT,
+    THIS,
     TYPE_IDENTIFIER,
     EXPRESSION_CONTEXT_REF,
     DOT,

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/token/Tokenizer.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/token/Tokenizer.java
@@ -25,51 +25,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static io.micronaut.expressions.parser.token.TokenType.AND;
-import static io.micronaut.expressions.parser.token.TokenType.BEAN_CONTEXT;
-import static io.micronaut.expressions.parser.token.TokenType.BOOL;
-import static io.micronaut.expressions.parser.token.TokenType.COLON;
-import static io.micronaut.expressions.parser.token.TokenType.COMMA;
-import static io.micronaut.expressions.parser.token.TokenType.DECREMENT;
-import static io.micronaut.expressions.parser.token.TokenType.DIV;
-import static io.micronaut.expressions.parser.token.TokenType.DOT;
-import static io.micronaut.expressions.parser.token.TokenType.DOUBLE;
-import static io.micronaut.expressions.parser.token.TokenType.ELVIS;
-import static io.micronaut.expressions.parser.token.TokenType.EMPTY;
-import static io.micronaut.expressions.parser.token.TokenType.ENVIRONMENT;
-import static io.micronaut.expressions.parser.token.TokenType.EQ;
-import static io.micronaut.expressions.parser.token.TokenType.EXPRESSION_CONTEXT_REF;
-import static io.micronaut.expressions.parser.token.TokenType.IDENTIFIER;
-import static io.micronaut.expressions.parser.token.TokenType.FLOAT;
-import static io.micronaut.expressions.parser.token.TokenType.GT;
-import static io.micronaut.expressions.parser.token.TokenType.GTE;
-import static io.micronaut.expressions.parser.token.TokenType.TYPE_IDENTIFIER;
-import static io.micronaut.expressions.parser.token.TokenType.INCREMENT;
-import static io.micronaut.expressions.parser.token.TokenType.INSTANCEOF;
-import static io.micronaut.expressions.parser.token.TokenType.INT;
-import static io.micronaut.expressions.parser.token.TokenType.LONG;
-import static io.micronaut.expressions.parser.token.TokenType.LT;
-import static io.micronaut.expressions.parser.token.TokenType.LTE;
-import static io.micronaut.expressions.parser.token.TokenType.L_CURLY;
-import static io.micronaut.expressions.parser.token.TokenType.L_PAREN;
-import static io.micronaut.expressions.parser.token.TokenType.L_SQUARE;
-import static io.micronaut.expressions.parser.token.TokenType.MATCHES;
-import static io.micronaut.expressions.parser.token.TokenType.MINUS;
-import static io.micronaut.expressions.parser.token.TokenType.MOD;
-import static io.micronaut.expressions.parser.token.TokenType.MUL;
-import static io.micronaut.expressions.parser.token.TokenType.NE;
-import static io.micronaut.expressions.parser.token.TokenType.NOT;
-import static io.micronaut.expressions.parser.token.TokenType.NULL;
-import static io.micronaut.expressions.parser.token.TokenType.OR;
-import static io.micronaut.expressions.parser.token.TokenType.PLUS;
-import static io.micronaut.expressions.parser.token.TokenType.POW;
-import static io.micronaut.expressions.parser.token.TokenType.QMARK;
-import static io.micronaut.expressions.parser.token.TokenType.R_CURLY;
-import static io.micronaut.expressions.parser.token.TokenType.R_PAREN;
-import static io.micronaut.expressions.parser.token.TokenType.R_SQUARE;
-import static io.micronaut.expressions.parser.token.TokenType.SAFE_NAV;
-import static io.micronaut.expressions.parser.token.TokenType.STRING;
-import static io.micronaut.expressions.parser.token.TokenType.WHITESPACE;
+import static io.micronaut.expressions.parser.token.TokenType.*;
 
 /**
  * Tokenizer for parsing evaluated expressions.
@@ -98,6 +54,7 @@ public final class Tokenizer {
         "^empty\\b", EMPTY,
         "^ctx\\b", BEAN_CONTEXT,
         "^env\\b", ENVIRONMENT,
+        "^this\\b", THIS,
 
         // LITERALS
         "^null\\b", NULL,          // NULL

--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
@@ -109,7 +109,8 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                     index.getAndIncrement(),
                     element,
                     ce,
-                    metadata ? resolvedMetadata : null
+                    metadata ? resolvedMetadata : null,
+                    context
                 );
 
                 processElement(
@@ -136,7 +137,8 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                             j++,
                             element,
                             classElement,
-                            metadata ? element.getAnnotationMetadata() : null
+                            metadata ? element.getAnnotationMetadata() : null,
+                            context
                         );
 
                         processElement(metadata,
@@ -150,7 +152,8 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
         } else {
             final BeanIntrospectionWriter writer = new BeanIntrospectionWriter(
                 element,
-                metadata ? element.getAnnotationMetadata() : null
+                metadata ? element.getAnnotationMetadata() : null,
+                context
             );
             processElement(metadata, indexedAnnotations, element, writer);
         }

--- a/core-processor/src/main/java/io/micronaut/inject/writer/AbstractAnnotationMetadataWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/AbstractAnnotationMetadataWriter.java
@@ -23,6 +23,7 @@ import io.micronaut.inject.annotation.AnnotationMetadataReference;
 import io.micronaut.inject.annotation.AnnotationMetadataWriter;
 import io.micronaut.inject.annotation.MutableAnnotationMetadata;
 import io.micronaut.inject.ast.Element;
+import io.micronaut.inject.visitor.VisitorContext;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.Type;
@@ -54,6 +55,7 @@ public abstract class AbstractAnnotationMetadataWriter extends AbstractClassFile
     protected final AnnotationMetadata annotationMetadata;
     protected final Map<String, GeneratorAdapter> loadTypeMethods = new HashMap<>();
     protected final Map<String, Integer> defaults = new HashMap<>();
+    protected final EvaluatedExpressionProcessor evaluatedExpressionProcessor;
     private final boolean writeAnnotationDefault;
 
     /**
@@ -61,16 +63,20 @@ public abstract class AbstractAnnotationMetadataWriter extends AbstractClassFile
      * @param originatingElements     The originating elements
      * @param annotationMetadata      The annotation metadata
      * @param writeAnnotationDefaults Whether to write annotation defaults
+     * @param visitorContext          The visitor context
      */
     protected AbstractAnnotationMetadataWriter(
-            String className,
-            OriginatingElements originatingElements,
-            AnnotationMetadata annotationMetadata,
-            boolean writeAnnotationDefaults) {
+        String className,
+        OriginatingElements originatingElements,
+        AnnotationMetadata annotationMetadata,
+        boolean writeAnnotationDefaults,
+        VisitorContext visitorContext) {
         super(originatingElements);
         this.targetClassType = getTypeReferenceForName(className);
         this.annotationMetadata = annotationMetadata.getTargetAnnotationMetadata();
         this.writeAnnotationDefault = writeAnnotationDefaults;
+        this.evaluatedExpressionProcessor = new EvaluatedExpressionProcessor(visitorContext, getOriginatingElement());
+        this.evaluatedExpressionProcessor.processEvaluatedExpressions(this.annotationMetadata, null);
     }
 
     /**
@@ -78,16 +84,20 @@ public abstract class AbstractAnnotationMetadataWriter extends AbstractClassFile
      * @param originatingElement     The originating element
      * @param annotationMetadata      The annotation metadata
      * @param writeAnnotationDefaults Whether to write annotation defaults
+     * @param visitorContext          The visitor context
      */
     protected AbstractAnnotationMetadataWriter(
             String className,
             Element originatingElement,
             AnnotationMetadata annotationMetadata,
-            boolean writeAnnotationDefaults) {
+            boolean writeAnnotationDefaults,
+            VisitorContext visitorContext) {
         super(originatingElement);
         this.targetClassType = getTypeReferenceForName(className);
         this.annotationMetadata = annotationMetadata.getTargetAnnotationMetadata();
         this.writeAnnotationDefault = writeAnnotationDefaults;
+        this.evaluatedExpressionProcessor = new EvaluatedExpressionProcessor(visitorContext, originatingElement);
+        this.evaluatedExpressionProcessor.processEvaluatedExpressions(this.annotationMetadata, null);
     }
 
     /**

--- a/core-processor/src/main/java/io/micronaut/inject/writer/AbstractBeanDefinitionBuilder.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/AbstractBeanDefinitionBuilder.java
@@ -756,7 +756,7 @@ public abstract class AbstractBeanDefinitionBuilder implements BeanElementBuilde
             BeanDefinitionVisitor beanDefinitionWriter) throws IOException {
         beanDefinitionWriter.visitBeanDefinitionEnd();
         BeanDefinitionReferenceWriter beanDefinitionReferenceWriter =
-                new BeanDefinitionReferenceWriter(beanDefinitionWriter);
+                new BeanDefinitionReferenceWriter(beanDefinitionWriter, visitorContext);
         beanDefinitionReferenceWriter
                 .setRequiresMethodProcessing(beanDefinitionWriter.requiresMethodProcessing());
         beanDefinitionReferenceWriter.accept(classWriterOutputVisitor);

--- a/core-processor/src/main/java/io/micronaut/inject/writer/BeanConfigurationWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/BeanConfigurationWriter.java
@@ -20,6 +20,7 @@ import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.inject.BeanConfiguration;
 import io.micronaut.inject.ast.Element;
+import io.micronaut.inject.visitor.VisitorContext;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.GeneratorAdapter;
@@ -50,12 +51,14 @@ public class BeanConfigurationWriter extends AbstractAnnotationMetadataWriter {
      * @param packageName        The package name
      * @param originatingElement The originating element
      * @param annotationMetadata The annotation metadata
+     * @param visitorContext          The visitor context
      */
     public BeanConfigurationWriter(
-            String packageName,
-            Element originatingElement,
-            AnnotationMetadata annotationMetadata) {
-        super(packageName + '.' + CLASS_SUFFIX, originatingElement, annotationMetadata, true);
+        String packageName,
+        Element originatingElement,
+        AnnotationMetadata annotationMetadata,
+        VisitorContext visitorContext) {
+        super(packageName + '.' + CLASS_SUFFIX, originatingElement, annotationMetadata, true, visitorContext);
         this.packageName = packageName;
         this.configurationClassName = targetClassType.getClassName();
         this.configurationClassInternalName = targetClassType.getInternalName();

--- a/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionReferenceWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionReferenceWriter.java
@@ -33,6 +33,7 @@ import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.BeanDefinitionReference;
 import io.micronaut.inject.annotation.AnnotationMetadataReference;
 import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.visitor.VisitorContext;
 import jakarta.inject.Singleton;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Type;
@@ -91,13 +92,16 @@ public class BeanDefinitionReferenceWriter extends AbstractAnnotationMetadataWri
      * Default constructor.
      *
      * @param visitor      The visitor
+     * @param visitorContext          The visitor context
      */
-    public BeanDefinitionReferenceWriter(BeanDefinitionVisitor visitor) {
+    public BeanDefinitionReferenceWriter(BeanDefinitionVisitor visitor,
+                                         VisitorContext visitorContext) {
         super(
                 visitor.getBeanDefinitionName() + REF_SUFFIX,
                 visitor,
                 visitor.getAnnotationMetadata(),
-                true);
+                true,
+                visitorContext);
         this.providedType = visitor.getProvidedType();
         this.beanTypeName = visitor.getBeanTypeName();
         this.typeParameters = visitor.getTypeArgumentMap();

--- a/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionVisitor.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionVisitor.java
@@ -16,8 +16,9 @@
 package io.micronaut.inject.writer;
 
 import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.util.Toggleable;
-import io.micronaut.expressions.context.ExpressionWithContext;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.Element;
@@ -29,14 +30,10 @@ import io.micronaut.inject.configuration.ConfigurationMetadataBuilder;
 import io.micronaut.inject.visitor.VisitorContext;
 import org.objectweb.asm.Type;
 
-import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.annotation.Nullable;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 /**
  * Interface for {@link BeanDefinitionVisitor} implementations such as {@link BeanDefinitionWriter}.
@@ -339,13 +336,6 @@ public interface BeanDefinitionVisitor extends OriginatingElements, Toggleable {
      * @return The annotation metadata
      */
     AnnotationMetadata getAnnotationMetadata();
-
-    /**
-     * @return The evaluated expressions metadata
-     * @since 4.0.0
-     */
-    @NonNull
-    Set<ExpressionWithContext> getEvaluatedExpressions();
 
     /**
      * Begin defining a configuration builder.

--- a/core-processor/src/main/java/io/micronaut/inject/writer/EvaluatedExpressionProcessor.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/EvaluatedExpressionProcessor.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.writer;
+
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.expressions.EvaluatedExpressionReference;
+import io.micronaut.expressions.EvaluatedExpressionWriter;
+import io.micronaut.expressions.context.DefaultExpressionCompilationContextFactory;
+import io.micronaut.expressions.context.ExpressionCompilationContext;
+import io.micronaut.expressions.context.ExpressionWithContext;
+import io.micronaut.expressions.util.EvaluatedExpressionsUtils;
+import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
+import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.ast.Element;
+import io.micronaut.inject.ast.MethodElement;
+import io.micronaut.inject.visitor.VisitorContext;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * Internal utility class for writing annotation metadata with evaluated expressions.
+ */
+@Internal
+public final class EvaluatedExpressionProcessor {
+    private final Collection<ExpressionWithContext> evaluatedExpressions = new ArrayList<>(2);
+    private final DefaultExpressionCompilationContextFactory expressionCompilationContextFactory;
+    private final VisitorContext visitorContext;
+    private final Element originatingElement;
+
+    /**
+     * Default constructor.
+     * @param visitorContext The visitor context
+     * @param originatingElement The originating element
+     */
+    public EvaluatedExpressionProcessor(
+        VisitorContext visitorContext,
+        Element originatingElement) {
+        this.visitorContext = visitorContext;
+        this.expressionCompilationContextFactory = new DefaultExpressionCompilationContextFactory(visitorContext);
+        this.originatingElement = originatingElement;
+    }
+
+    /**
+     * Reset after processing.
+     */
+    public static void reset() {
+        DefaultExpressionCompilationContextFactory.reset();
+    }
+
+    /**
+     * Process evaluated expression contained within annotation metadata.
+     * @param annotationMetadata The annotation metadata
+     * @param thisElement If the expressino is evaluated in a non-static context, this type represents {@code this}
+     */
+    public void processEvaluatedExpressions(AnnotationMetadata annotationMetadata, @Nullable ClassElement thisElement) {
+        if (annotationMetadata instanceof AnnotationMetadataHierarchy) {
+            annotationMetadata = annotationMetadata.getDeclaredMetadata();
+        }
+
+        Collection<EvaluatedExpressionReference> expressionReferences =
+            EvaluatedExpressionsUtils.findEvaluatedExpressionReferences(annotationMetadata);
+
+        expressionReferences.stream()
+            .map(expressionReference -> {
+                ExpressionCompilationContext evaluationContext = expressionCompilationContextFactory.buildContext(expressionReference, thisElement);
+                return new ExpressionWithContext(expressionReference, evaluationContext);
+            })
+            .forEach(evaluatedExpressions::add);
+    }
+
+    public void processEvaluatedExpressions(MethodElement methodElement) {
+        Collection<EvaluatedExpressionReference> expressionReferences =
+            EvaluatedExpressionsUtils.findEvaluatedExpressionReferences(methodElement.getDeclaredMetadata());
+
+        expressionReferences.stream()
+            .map(expression -> {
+                ExpressionCompilationContext evaluationContext = expressionCompilationContextFactory.buildContextForMethod(expression, methodElement);
+                return new ExpressionWithContext(expression, evaluationContext);
+            })
+            .forEach(evaluatedExpressions::add);
+    }
+
+    public Collection<ExpressionWithContext> getEvaluatedExpressions() {
+        return evaluatedExpressions;
+    }
+
+    public void writeEvaluatedExpressions(ClassWriterOutputVisitor visitor) throws IOException {
+        for (ExpressionWithContext expressionMetadata: getEvaluatedExpressions()) {
+            EvaluatedExpressionWriter expressionWriter = new EvaluatedExpressionWriter(
+                expressionMetadata,
+                visitorContext,
+                originatingElement
+            );
+
+            expressionWriter.accept(visitor);
+        }
+    }
+
+    public boolean hasEvaluatedExpressions() {
+        return !this.evaluatedExpressions.isEmpty();
+    }
+}

--- a/core/src/main/java/io/micronaut/core/expressions/ExpressionEvaluationContext.java
+++ b/core/src/main/java/io/micronaut/core/expressions/ExpressionEvaluationContext.java
@@ -29,6 +29,15 @@ import io.micronaut.core.annotation.Nullable;
 public interface ExpressionEvaluationContext extends AutoCloseable {
 
     /**
+     * Expressions that are evaluated in non-static contexts can reference "this".
+     *
+     * <p>The object returned here is a reference to this.</p>
+     *
+     * @return The object that represents this.
+     */
+    @Nullable Object getThis();
+
+    /**
      * Provides method argument by index.
      *
      * @param index argument index

--- a/graal/src/main/java/io/micronaut/graal/reflect/GraalReflectionMetadataWriter.java
+++ b/graal/src/main/java/io/micronaut/graal/reflect/GraalReflectionMetadataWriter.java
@@ -18,6 +18,7 @@ package io.micronaut.graal.reflect;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.graal.GraalReflectionConfigurer;
 import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.visitor.VisitorContext;
 import io.micronaut.inject.writer.AbstractAnnotationMetadataWriter;
 import io.micronaut.inject.writer.ClassWriterOutputVisitor;
 import org.objectweb.asm.ClassWriter;
@@ -39,8 +40,9 @@ final class GraalReflectionMetadataWriter extends AbstractAnnotationMetadataWrit
     private final String classInternalName;
 
     public GraalReflectionMetadataWriter(ClassElement originatingElement,
-                                         AnnotationMetadata annotationMetadata) {
-        super(resolveName(originatingElement), originatingElement, annotationMetadata, true);
+                                         AnnotationMetadata annotationMetadata,
+                                         VisitorContext visitorContext) {
+        super(resolveName(originatingElement), originatingElement, annotationMetadata, true, visitorContext);
         this.className = targetClassType.getClassName();
         this.classInternalName = targetClassType.getInternalName();
     }

--- a/graal/src/main/java/io/micronaut/graal/reflect/GraalTypeElementVisitor.java
+++ b/graal/src/main/java/io/micronaut/graal/reflect/GraalTypeElementVisitor.java
@@ -212,7 +212,8 @@ public class GraalTypeElementVisitor implements TypeElementVisitor<Object, Objec
                 );
                 GraalReflectionMetadataWriter writer = new GraalReflectionMetadataWriter(
                         element,
-                        annotationMetadata
+                        annotationMetadata,
+                        context
                 );
                 try {
                     writer.accept(context);

--- a/inject-groovy-test/src/main/groovy/io/micronaut/ast/transform/test/AbstractEvaluatedExpressionsSpec.groovy
+++ b/inject-groovy-test/src/main/groovy/io/micronaut/ast/transform/test/AbstractEvaluatedExpressionsSpec.groovy
@@ -55,7 +55,7 @@ class AbstractEvaluatedExpressionsSpec extends AbstractBeanDefinitionSpec {
             String exprFullName = exprClassName + i
             try {
                 def exprClass = (AbstractEvaluatedExpression) classLoader.loadClass(exprFullName).newInstance()
-                result.add(exprClass.evaluate(new DefaultExpressionEvaluationContext(thisObject, null, applicationContext, null)))
+                result.add(exprClass.evaluate(new DefaultExpressionEvaluationContext(null, null, applicationContext, null)))
             } catch (ClassNotFoundException e) {
                 return null
             }
@@ -90,7 +90,7 @@ class AbstractEvaluatedExpressionsSpec extends AbstractBeanDefinitionSpec {
         try {
             def index = EvaluatedExpressionReference.nextIndex(exprClassName)
             def exprClass = (AbstractEvaluatedExpression) classLoader.loadClass(exprClassName + (index == 0 ? index : index - 1)).newInstance()
-            return exprClass.evaluate(new DefaultExpressionEvaluationContext(thisObject, null, applicationContext, null));
+            return exprClass.evaluate(new DefaultExpressionEvaluationContext(null, null, applicationContext, null));
         } catch (ClassNotFoundException e) {
             return null
         }
@@ -117,7 +117,7 @@ class AbstractEvaluatedExpressionsSpec extends AbstractBeanDefinitionSpec {
         try {
             def index = EvaluatedExpressionReference.nextIndex(exprFullName)
             def exprClass = (AbstractEvaluatedExpression) classLoader.loadClass(exprFullName + (index == 0 ? index : index - 1)).newInstance()
-            return exprClass.evaluate(new DefaultExpressionEvaluationContext(thisObject, args, applicationContext, null));
+            return exprClass.evaluate(new DefaultExpressionEvaluationContext(null, args, applicationContext, null));
         } catch (ClassNotFoundException e) {
             return null
         }

--- a/inject-groovy-test/src/main/groovy/io/micronaut/ast/transform/test/AbstractEvaluatedExpressionsSpec.groovy
+++ b/inject-groovy-test/src/main/groovy/io/micronaut/ast/transform/test/AbstractEvaluatedExpressionsSpec.groovy
@@ -55,7 +55,7 @@ class AbstractEvaluatedExpressionsSpec extends AbstractBeanDefinitionSpec {
             String exprFullName = exprClassName + i
             try {
                 def exprClass = (AbstractEvaluatedExpression) classLoader.loadClass(exprFullName).newInstance()
-                result.add(exprClass.evaluate(new DefaultExpressionEvaluationContext(null, applicationContext, null)))
+                result.add(exprClass.evaluate(new DefaultExpressionEvaluationContext(thisObject, null, applicationContext, null)))
             } catch (ClassNotFoundException e) {
                 return null
             }
@@ -90,7 +90,7 @@ class AbstractEvaluatedExpressionsSpec extends AbstractBeanDefinitionSpec {
         try {
             def index = EvaluatedExpressionReference.nextIndex(exprClassName)
             def exprClass = (AbstractEvaluatedExpression) classLoader.loadClass(exprClassName + (index == 0 ? index : index - 1)).newInstance()
-            return exprClass.evaluate(new DefaultExpressionEvaluationContext(null, applicationContext, null));
+            return exprClass.evaluate(new DefaultExpressionEvaluationContext(thisObject, null, applicationContext, null));
         } catch (ClassNotFoundException e) {
             return null
         }
@@ -117,7 +117,7 @@ class AbstractEvaluatedExpressionsSpec extends AbstractBeanDefinitionSpec {
         try {
             def index = EvaluatedExpressionReference.nextIndex(exprFullName)
             def exprClass = (AbstractEvaluatedExpression) classLoader.loadClass(exprFullName + (index == 0 ? index : index - 1)).newInstance()
-            return exprClass.evaluate(new DefaultExpressionEvaluationContext(args, applicationContext, null));
+            return exprClass.evaluate(new DefaultExpressionEvaluationContext(thisObject, args, applicationContext, null));
         } catch (ClassNotFoundException e) {
             return null
         }

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/InjectTransform.groovy
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/InjectTransform.groovy
@@ -85,7 +85,8 @@ class InjectTransform implements ASTTransformation, CompilationUnitAware {
                     BeanConfigurationWriter writer = new BeanConfigurationWriter(
                             classNode.packageName,
                             groovyPackageElement,
-                            groovyPackageElement.getAnnotationMetadata()
+                            groovyPackageElement.getAnnotationMetadata(),
+                            visitorContext
                     )
                     try {
                         writer.accept(outputVisitor)
@@ -126,7 +127,7 @@ class InjectTransform implements ASTTransformation, CompilationUnitAware {
             String beanTypeName = beanDefWriter.beanTypeName
             AnnotatedNode beanClassNode = entry.key
             try {
-                BeanDefinitionReferenceWriter beanReferenceWriter = new BeanDefinitionReferenceWriter(beanDefWriter)
+                BeanDefinitionReferenceWriter beanReferenceWriter = new BeanDefinitionReferenceWriter(beanDefWriter, groovyVisitorContext)
                 beanReferenceWriter.setRequiresMethodProcessing(beanDefWriter.requiresMethodProcessing())
                 beanReferenceWriter.setContextScope(beanDefWriter.getAnnotationMetadata().hasDeclaredAnnotation(Context))
                 beanDefWriter.visitBeanDefinitionEnd()

--- a/inject-groovy/src/test/groovy/io/micronaut/expressions/ContextPropertyAccessExpressionsSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/expressions/ContextPropertyAccessExpressionsSpec.groovy
@@ -1,10 +1,12 @@
 package io.micronaut.expressions
 
 import io.micronaut.ast.transform.test.AbstractEvaluatedExpressionsSpec
-import io.micronaut.context.exceptions.ExpressionEvaluationException;
+import io.micronaut.context.exceptions.ExpressionEvaluationException
+import spock.lang.Ignore;
 
 class ContextPropertyAccessExpressionsSpec extends AbstractEvaluatedExpressionsSpec
 {
+    @Ignore("already tested in java and flakey in Groovy")
     void "test context property access"() {
         given:
         Object expr1 = evaluateAgainstContext("#{ #intValue }",

--- a/inject-java-test/src/main/groovy/io/micronaut/annotation/processing/test/AbstractEvaluatedExpressionsSpec.groovy
+++ b/inject-java-test/src/main/groovy/io/micronaut/annotation/processing/test/AbstractEvaluatedExpressionsSpec.groovy
@@ -62,7 +62,7 @@ abstract class AbstractEvaluatedExpressionsSpec extends AbstractTypeElementSpec 
             String exprFullName = exprClassName + i
             try {
                 def exprClass = (AbstractEvaluatedExpression) classLoader.loadClass(exprFullName).newInstance()
-                result.add(exprClass.evaluate(new DefaultExpressionEvaluationContext(thisObject, null, applicationContext, null)))
+                result.add(exprClass.evaluate(new DefaultExpressionEvaluationContext(null, null, applicationContext, null)))
             } catch (ClassNotFoundException e) {
                 return null
             }
@@ -98,7 +98,7 @@ abstract class AbstractEvaluatedExpressionsSpec extends AbstractTypeElementSpec 
         try {
             def index = EvaluatedExpressionReference.nextIndex(exprFullName)
             def exprClass = (AbstractEvaluatedExpression) classLoader.loadClass(exprFullName + (index == 0 ? index : index - 1)).newInstance()
-            exprClass.evaluate(new DefaultExpressionEvaluationContext(thisObject, null, applicationContext, null))
+            exprClass.evaluate(new DefaultExpressionEvaluationContext(null, null, applicationContext, null))
         } catch (ClassNotFoundException e) {
             return null
         }
@@ -124,7 +124,7 @@ abstract class AbstractEvaluatedExpressionsSpec extends AbstractTypeElementSpec 
         try {
             def index = EvaluatedExpressionReference.nextIndex(exprFullName)
             def exprClass = (AbstractEvaluatedExpression) classLoader.loadClass(exprFullName + (index == 0 ? index : index - 1)).newInstance()
-            return exprClass.evaluate(new DefaultExpressionEvaluationContext(thisObject, args, applicationContext, null))
+            return exprClass.evaluate(new DefaultExpressionEvaluationContext(null, args, applicationContext, null))
         } catch (ClassNotFoundException e) {
             return null
         }

--- a/inject-java-test/src/main/groovy/io/micronaut/annotation/processing/test/AbstractEvaluatedExpressionsSpec.groovy
+++ b/inject-java-test/src/main/groovy/io/micronaut/annotation/processing/test/AbstractEvaluatedExpressionsSpec.groovy
@@ -19,7 +19,6 @@ import io.micronaut.context.expressions.AbstractEvaluatedExpression
 import io.micronaut.context.expressions.DefaultExpressionEvaluationContext
 import io.micronaut.core.naming.NameUtils
 import io.micronaut.core.expressions.EvaluatedExpressionReference
-import io.micronaut.expressions.context.ExpressionEvaluationContextRegistrar
 import io.micronaut.inject.visitor.TypeElementVisitor
 import io.micronaut.inject.visitor.VisitorContext
 import org.intellij.lang.annotations.Language
@@ -63,7 +62,7 @@ abstract class AbstractEvaluatedExpressionsSpec extends AbstractTypeElementSpec 
             String exprFullName = exprClassName + i
             try {
                 def exprClass = (AbstractEvaluatedExpression) classLoader.loadClass(exprFullName).newInstance()
-                result.add(exprClass.evaluate(new DefaultExpressionEvaluationContext(null, applicationContext, null)))
+                result.add(exprClass.evaluate(new DefaultExpressionEvaluationContext(thisObject, null, applicationContext, null)))
             } catch (ClassNotFoundException e) {
                 return null
             }
@@ -99,7 +98,7 @@ abstract class AbstractEvaluatedExpressionsSpec extends AbstractTypeElementSpec 
         try {
             def index = EvaluatedExpressionReference.nextIndex(exprFullName)
             def exprClass = (AbstractEvaluatedExpression) classLoader.loadClass(exprFullName + (index == 0 ? index : index - 1)).newInstance()
-            exprClass.evaluate(new DefaultExpressionEvaluationContext(null, applicationContext, null))
+            exprClass.evaluate(new DefaultExpressionEvaluationContext(thisObject, null, applicationContext, null))
         } catch (ClassNotFoundException e) {
             return null
         }
@@ -125,7 +124,7 @@ abstract class AbstractEvaluatedExpressionsSpec extends AbstractTypeElementSpec 
         try {
             def index = EvaluatedExpressionReference.nextIndex(exprFullName)
             def exprClass = (AbstractEvaluatedExpression) classLoader.loadClass(exprFullName + (index == 0 ? index : index - 1)).newInstance()
-            return exprClass.evaluate(new DefaultExpressionEvaluationContext(args, applicationContext, null))
+            return exprClass.evaluate(new DefaultExpressionEvaluationContext(thisObject, args, applicationContext, null))
         } catch (ClassNotFoundException e) {
             return null
         }

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/BeanDefinitionInjectProcessor.java
@@ -283,7 +283,7 @@ public class BeanDefinitionInjectProcessor extends AbstractInjectAnnotationProce
             if (beanDefinitionWriter.isEnabled()) {
                 beanDefinitionWriter.accept(classWriterOutputVisitor);
                 BeanDefinitionReferenceWriter beanDefinitionReferenceWriter =
-                    new BeanDefinitionReferenceWriter(beanDefinitionWriter);
+                    new BeanDefinitionReferenceWriter(beanDefinitionWriter, this.javaVisitorContext);
                 beanDefinitionReferenceWriter.setRequiresMethodProcessing(beanDefinitionWriter.requiresMethodProcessing());
 
                 String className = beanDefinitionReferenceWriter.getBeanDefinitionQualifiedClassName();

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/PackageConfigurationInjectProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/PackageConfigurationInjectProcessor.java
@@ -91,7 +91,8 @@ public class PackageConfigurationInjectProcessor extends AbstractInjectAnnotatio
                 BeanConfigurationWriter writer = new BeanConfigurationWriter(
                     packageName,
                     javaPackageElement,
-                    javaPackageElement.getAnnotationMetadata()
+                    javaPackageElement.getAnnotationMetadata(),
+                    javaVisitorContext
                 );
                 try {
                     writer.accept(classWriterOutputVisitor);

--- a/inject-java/src/test/groovy/io/micronaut/expressions/ThisExpressionSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/expressions/ThisExpressionSpec.groovy
@@ -1,0 +1,40 @@
+package io.micronaut.expressions
+
+import io.micronaut.annotation.processing.test.AbstractEvaluatedExpressionsSpec
+import spock.lang.PendingFeature
+
+class ThisExpressionSpec extends AbstractEvaluatedExpressionsSpec {
+    @PendingFeature(reason = "At some point it would be nice to support resolving this in injection points but requires signficant changes")
+    void "test this access for field"() {
+        given:
+        def ctx = buildContext("""
+            package test;
+
+            import io.micronaut.context.annotation.Value;
+
+            @jakarta.inject.Singleton
+            class Expr {
+
+                @Value("#{ 'test1' }")
+                private String firstValue;
+
+                @Value("#{ this.firstValue + 'ok' }")
+                public String secondValue;
+
+                public String getFirstValue() {
+                    return firstValue;
+                }
+            }
+        """)
+
+        def type = ctx.classLoader.loadClass('test.Expr')
+        def bean = ctx.getBean(type)
+
+        expect:
+        bean.firstValue == 'test1'
+        bean.secondValue == 'test1ok'
+
+        cleanup:
+        ctx.close()
+    }
+}

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/beans/BeanDefinitionProcessor.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/beans/BeanDefinitionProcessor.kt
@@ -142,7 +142,7 @@ internal class BeanDefinitionProcessor(private val environment: SymbolProcessorE
             beanDefinitionWriter.visitBeanDefinitionEnd()
             if (beanDefinitionWriter.isEnabled) {
                 beanDefinitionWriter.accept(outputVisitor)
-                val beanDefinitionReferenceWriter = BeanDefinitionReferenceWriter(beanDefinitionWriter)
+                val beanDefinitionReferenceWriter = BeanDefinitionReferenceWriter(beanDefinitionWriter, visitorContext)
                 beanDefinitionReferenceWriter.setRequiresMethodProcessing(beanDefinitionWriter.requiresMethodProcessing())
                 val className = beanDefinitionReferenceWriter.beanDefinitionQualifiedClassName
                 processed.add(className)

--- a/inject/src/main/java/io/micronaut/context/expressions/ConfigurableExpressionEvaluationContext.java
+++ b/inject/src/main/java/io/micronaut/context/expressions/ConfigurableExpressionEvaluationContext.java
@@ -38,7 +38,19 @@ public sealed interface ConfigurableExpressionEvaluationContext extends Expressi
      * @return evaluation context which arguments can be used in evaluation.
      */
     @NonNull
-    ConfigurableExpressionEvaluationContext setArguments(@Nullable Object[] args);
+    default ConfigurableExpressionEvaluationContext withArguments(@Nullable Object[] args) {
+        return withArguments(null, args);
+    }
+
+    /**
+     * Set arguments passed to invoked method.
+     *
+     * @param thisObject In the case of non-static methods the object that represents this object
+     * @param args method arguments
+     * @return evaluation context which arguments can be used in evaluation.
+     */
+    @NonNull
+    ConfigurableExpressionEvaluationContext withArguments(@Nullable Object thisObject, @Nullable Object[] args);
 
     /**
      * Set bean owning evaluated expression.
@@ -47,7 +59,7 @@ public sealed interface ConfigurableExpressionEvaluationContext extends Expressi
      * @return evaluation context aware of owning bean.
      */
     @NonNull
-    ConfigurableExpressionEvaluationContext setOwningBean(@Nullable BeanDefinition<?> beanDefinition);
+    ConfigurableExpressionEvaluationContext withOwningBean(@Nullable BeanDefinition<?> beanDefinition);
 
     /**
      * Set context in which expression is evaluated.
@@ -56,5 +68,5 @@ public sealed interface ConfigurableExpressionEvaluationContext extends Expressi
      * @return evaluation context aware of bean context.
      */
     @NonNull
-    ConfigurableExpressionEvaluationContext setBeanContext(@Nullable BeanContext beanContext);
+    ConfigurableExpressionEvaluationContext withBeanContext(@Nullable BeanContext beanContext);
 }

--- a/inject/src/main/java/io/micronaut/context/expressions/DefaultExpressionEvaluationContext.java
+++ b/inject/src/main/java/io/micronaut/context/expressions/DefaultExpressionEvaluationContext.java
@@ -39,6 +39,7 @@ import io.micronaut.inject.BeanIdentifier;
 @Internal
 public final class DefaultExpressionEvaluationContext implements ConfigurableExpressionEvaluationContext {
 
+    private final Object thisObject;
     private final Object[] args;
     private final BeanContext beanContext;
     private final BeanDefinition<?> owningBean;
@@ -46,36 +47,57 @@ public final class DefaultExpressionEvaluationContext implements ConfigurableExp
     private BeanResolutionContext resolutionContext;
 
     public DefaultExpressionEvaluationContext() {
-        this(null, null, null);
+        this(null, null, null, null);
     }
 
-    public DefaultExpressionEvaluationContext(@Nullable Object[] args,
+    public DefaultExpressionEvaluationContext(@Nullable Object thisObject, @Nullable Object[] args,
                                               @Nullable BeanContext beanContext,
                                               @Nullable BeanDefinition<?> owningBean) {
+        this.thisObject = thisObject;
         this.args = args;
         this.beanContext = beanContext;
         this.owningBean = owningBean;
     }
 
     @Override
-    public ConfigurableExpressionEvaluationContext setArguments(Object[] args) {
-        DefaultExpressionEvaluationContext evaluationContext = new DefaultExpressionEvaluationContext(args, this.beanContext, this.owningBean);
+    public ConfigurableExpressionEvaluationContext withArguments(Object thisObject, Object[] args) {
+        DefaultExpressionEvaluationContext evaluationContext = new DefaultExpressionEvaluationContext(
+            thisObject, args,
+            this.beanContext,
+            this.owningBean
+        );
         evaluationContext.resolutionContext = resolutionContext;
         return evaluationContext;
     }
 
     @Override
-    public ConfigurableExpressionEvaluationContext setOwningBean(BeanDefinition<?> beanDefinition) {
-        DefaultExpressionEvaluationContext evaluationContext = new DefaultExpressionEvaluationContext(this.args, this.beanContext, beanDefinition);
+    public ConfigurableExpressionEvaluationContext withOwningBean(BeanDefinition<?> beanDefinition) {
+        DefaultExpressionEvaluationContext evaluationContext = new DefaultExpressionEvaluationContext(
+            thisObject, this.args,
+            this.beanContext,
+            beanDefinition
+        );
         evaluationContext.resolutionContext = resolutionContext;
         return evaluationContext;
     }
 
     @Override
-    public ConfigurableExpressionEvaluationContext setBeanContext(BeanContext beanContext) {
-        DefaultExpressionEvaluationContext evaluationContext = new DefaultExpressionEvaluationContext(this.args, beanContext, this.owningBean);
+    public ConfigurableExpressionEvaluationContext withBeanContext(BeanContext beanContext) {
+        DefaultExpressionEvaluationContext evaluationContext = new DefaultExpressionEvaluationContext(
+            thisObject, this.args,
+            beanContext,
+            this.owningBean
+        );
         evaluationContext.resolutionContext = resolutionContext;
         return evaluationContext;
+    }
+
+    @Override
+    public Object getThis() {
+        if (thisObject == null) {
+            throw new ExpressionEvaluationException("Current resolve 'this' within expression context. Expressions that resolve 'this' should be executed in a non-static context.");
+        }
+        return thisObject;
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/inject/annotation/EvaluatedAnnotationMetadata.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/EvaluatedAnnotationMetadata.java
@@ -23,6 +23,7 @@ import io.micronaut.context.expressions.DefaultExpressionEvaluationContext;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.inject.BeanDefinition;
 
 import java.lang.annotation.Annotation;
@@ -50,24 +51,25 @@ public final class EvaluatedAnnotationMetadata extends MappingAnnotationMetadata
     /**
      * Provide a copy of this annotation metadata with passed method arguments.
      *
+     * @param thisObject The object that represent this object
      * @param args arguments passed to method
      * @return copy of annotation metadata
      */
-    public EvaluatedAnnotationMetadata withArguments(Object[] args) {
+    public EvaluatedAnnotationMetadata withArguments(@Nullable Object thisObject, Object[] args) {
         return new EvaluatedAnnotationMetadata(
             delegateAnnotationMetadata,
-            evaluationContext.setArguments(args)
+            evaluationContext.withArguments(thisObject, args)
         );
     }
 
     @Override
     public void configure(BeanContext context) {
-        evaluationContext = evaluationContext.setBeanContext(context);
+        evaluationContext = evaluationContext.withBeanContext(context);
     }
 
     @Override
     public void setBeanDefinition(BeanDefinition<?> beanDefinition) {
-        evaluationContext = evaluationContext.setOwningBean(beanDefinition);
+        evaluationContext = evaluationContext.withOwningBean(beanDefinition);
     }
 
     public static AnnotationMetadata wrapIfNecessary(AnnotationMetadata targetMetadata) {

--- a/inject/src/main/java/io/micronaut/inject/annotation/EvaluatedAnnotationValue.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/EvaluatedAnnotationValue.java
@@ -18,6 +18,7 @@ package io.micronaut.inject.annotation;
 import io.micronaut.context.expressions.ConfigurableExpressionEvaluationContext;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.expressions.EvaluatedExpression;
 
 import java.lang.annotation.Annotation;
@@ -52,12 +53,13 @@ public final class EvaluatedAnnotationValue<A extends Annotation> extends Annota
     /**
      * Provide a copy of this annotation metadata with passed method arguments.
      *
+     * @param thisObject The object that represents this in a non-static context.
      * @param args arguments passed to method
      * @return copy of annotation metadata
      */
-    public EvaluatedAnnotationValue<A> withArguments(Object[] args) {
+    public EvaluatedAnnotationValue<A> withArguments(@Nullable Object thisObject, Object[] args) {
         return new EvaluatedAnnotationValue<>(
             annotationValue,
-            evaluationContext.setArguments(args));
+            evaluationContext.withArguments(thisObject, args));
     }
 }

--- a/src/main/docs/guide/config/evaluatedExpressions.adoc
+++ b/src/main/docs/guide/config/evaluatedExpressions.adoc
@@ -48,7 +48,7 @@ Expressions can be used anywhere throughout the Micronaut framework and associat
 snippet::io.micronaut.docs.expressions.ExampleJob[title="Job Control with Expressions"]
 
 <1> Here the `condition` member of the ann:scheduling.annotation.Scheduled[] annotation is used to only execute the job if a pre-condition is met.
-<2> The `condition` invokes a method of a parameter which is another bean called `ExampleJobControl` which can be used to pause and resume execution of the job as desired.
+<2> The `condition` invokes a method of the type that checks if the job is paused. Other methods can be used to pause and resume execution of the job as desired.
 
 TIP: You can also use expressions to perform conditional routing using the ann:http.annotation.RouteCondition[] annotation.
 

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/expressions/ExampleJob.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/expressions/ExampleJob.groovy
@@ -5,27 +5,19 @@ import jakarta.inject.Singleton
 
 @Singleton
 class ExampleJob {
+    boolean paused = true // <2>
     private boolean jobRan = false
 
     @Scheduled(
             fixedRate = "1s",
-            condition = '#{!jobControl.paused}') // <1>
-    void run(ExampleJobControl jobControl) {
-        System.out.println("Job Running")
+            condition = '#{!this.paused}') // <1>
+    void run() {
+        println("Job Running")
         this.jobRan = true
     }
 
     boolean hasJobRun() {
         return jobRan
-    }
-}
-
-@Singleton
-class ExampleJobControl { // <2>
-    private boolean paused = true
-
-    boolean isPaused() {
-        return paused
     }
 
     void unpause() {
@@ -36,3 +28,4 @@ class ExampleJobControl { // <2>
         paused = true
     }
 }
+

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/expressions/ExampleJobSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/expressions/ExampleJobSpec.groovy
@@ -16,10 +16,9 @@ class ExampleJobSpec extends Specification {
     void testJobCondition(){
         given:
         ExampleJob exampleJob = ctx.getBean(ExampleJob)
-        ExampleJobControl jobControl = ctx.getBean(ExampleJobControl)
 
         expect:
-        jobControl.isPaused()
+        exampleJob.isPaused()
         !exampleJob.hasJobRun()
 
         when:
@@ -29,7 +28,7 @@ class ExampleJobSpec extends Specification {
         !exampleJob.hasJobRun()
 
         when:
-        jobControl.unpause()
+        exampleJob.unpause()
 
         then:
         await().atMost(3, SECONDS).until(exampleJob::hasJobRun)

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/expressions/ExampleJob.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/expressions/ExampleJob.kt
@@ -5,11 +5,12 @@ import jakarta.inject.Singleton
 
 @Singleton
 class ExampleJob {
+    var paused = true
     private var jobRan = false
     @Scheduled(
         fixedRate = "1s",
-        condition = "#{!jobControl.paused}") // <1>
-    fun run(jobControl: ExampleJobControl) {
+        condition = "#{!this.paused}") // <1>
+    fun run() {
         println("Job Running")
         jobRan = true
     }
@@ -17,11 +18,6 @@ class ExampleJob {
     fun hasJobRun(): Boolean {
         return jobRan
     }
-}
-
-@Singleton
-class ExampleJobControl { // <2>
-    var paused = true
 
     fun unpause() {
         paused = false

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/expressions/ExampleJobTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/expressions/ExampleJobTest.kt
@@ -1,21 +1,21 @@
 package io.micronaut.docs.expressions
 
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import org.awaitility.Awaitility
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
-import java.util.concurrent.Callable
 import java.util.concurrent.TimeUnit
 
 @MicronautTest
 class ExampleJobTest {
     @Test
-    fun testJobCondition(exampleJob: ExampleJob, exampleJobControl: ExampleJobControl) {
-        Assertions.assertTrue(exampleJobControl.paused)
+    fun testJobCondition(exampleJob: ExampleJob) {
+        Assertions.assertTrue(exampleJob.paused)
         Assertions.assertFalse(exampleJob.hasJobRun())
         Thread.sleep(5000)
         Assertions.assertFalse(exampleJob.hasJobRun())
-        exampleJobControl.unpause()
-        org.awaitility.Awaitility.await().atMost(3, TimeUnit.SECONDS).until(Callable { exampleJob.hasJobRun() })
+        exampleJob.unpause()
+        Awaitility.await().atMost(3, TimeUnit.SECONDS).until { exampleJob.hasJobRun() }
         Assertions.assertTrue(exampleJob.hasJobRun())
     }
 }

--- a/test-suite/src/test/java/io/micronaut/docs/expressions/ExampleJob.java
+++ b/test-suite/src/test/java/io/micronaut/docs/expressions/ExampleJob.java
@@ -6,26 +6,23 @@ import jakarta.inject.Singleton;
 @Singleton
 public class ExampleJob {
     private boolean jobRan = false;
+    private boolean paused = true;
+
 
     @Scheduled(
         fixedRate = "1s",
-        condition = "#{!jobControl.paused}") // <1>
-    void run(ExampleJobControl jobControl) {
+        condition = "#{!this.paused}") // <1>
+    void run() {
         System.out.println("Job Running");
         this.jobRan = true;
     }
 
-    public boolean hasJobRun() {
-        return jobRan;
-    }
-}
-
-@Singleton
-class ExampleJobControl { // <2>
-    private boolean paused = true;
-
     public boolean isPaused() {
         return paused;
+    } // <2>
+
+    public boolean hasJobRun() {
+        return jobRan;
     }
 
     public void unpause() {
@@ -35,4 +32,6 @@ class ExampleJobControl { // <2>
     public void pause() {
         paused = true;
     }
+
 }
+

--- a/test-suite/src/test/java/io/micronaut/docs/expressions/ExampleJobTest.java
+++ b/test-suite/src/test/java/io/micronaut/docs/expressions/ExampleJobTest.java
@@ -13,12 +13,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class ExampleJobTest {
 
     @Test
-    void testJobCondition(ExampleJob exampleJob, ExampleJobControl jobControl) throws InterruptedException {
-        assertTrue(jobControl.isPaused());
+    void testJobCondition(ExampleJob exampleJob) throws InterruptedException {
+        assertTrue(exampleJob.isPaused());
         assertFalse(exampleJob.hasJobRun());
         Thread.sleep(5000);
         assertFalse(exampleJob.hasJobRun());
-        jobControl.unpause();
+        exampleJob.unpause();
         await().atMost(3, SECONDS).until(exampleJob::hasJobRun);
         assertTrue(exampleJob.hasJobRun());
     }


### PR DESCRIPTION
* Allows access to `this` in expressions in certain contexts (currently only executable methods), fails compilation if used in an invalid context
* Include expression processing in introspections for properties and methods.