### PR TITLE
Fix SingleResult was unintentionally initialized at build time

### DIFF
--- a/core-reactive/src/main/resources/META-INF/native-image/io.micronaut/micronaut-core-reactive/native-image.properties
+++ b/core-reactive/src/main/resources/META-INF/native-image/io.micronaut/micronaut-core-reactive/native-image.properties
@@ -1,0 +1,1 @@
+Args = --initialize-at-build-time=io.micronaut.core.async.annotation


### PR DESCRIPTION
Fixes 

```
**Error: Classes that should be initialized at run time got initialized during image building:
------------------------------------------------------------------------------------------------------------------------
 io.micronaut.core.async.annotation.SingleResult was unintentionally initialized at build time. jdk.proxy4.$Proxy111 caused initialization of this class with the following trace: 
        at io.micronaut.core.async.annotation.SingleResult.<clinit>(SingleResult.java:40)
        at java.lang.Class.forName0(Unknown Source)
        at java.lang.Class.forName(Class.java:375)
        at jdk.proxy4.$Proxy111.<clinit>(Unknown Source)
```