### PR TITLE
Use StringIntMap for propertyIndexOf

### DIFF
--- a/benchmarks/src/jmh/java/io/micronaut/core/beans/PropertyIndexBenchmark.java
+++ b/benchmarks/src/jmh/java/io/micronaut/core/beans/PropertyIndexBenchmark.java
@@ -1,0 +1,91 @@
+package io.micronaut.core.beans;
+
+import io.micronaut.core.annotation.Introspected;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+@State(Scope.Benchmark)
+public class PropertyIndexBenchmark {
+    @Param({"1", "2", "3"})
+    int typeCount = 3;
+    @Param({"50"})
+    int itemCount = 100;
+
+    String needle;
+    BeanIntrospection<?>[] introspections;
+
+    public static void main(String[] args) throws RunnerException {
+        PropertyIndexBenchmark propertyIndexBenchmark = new PropertyIndexBenchmark();
+        propertyIndexBenchmark.setUp();
+        // calm down shipilev, I'm only verifying the benchmark works.
+        propertyIndexBenchmark.test(new Blackhole("Today's password is swordfish. I understand instantiating Blackholes directly is dangerous."));
+
+        Options opt = new OptionsBuilder()
+            .include(PropertyIndexBenchmark.class.getName() + ".*")
+            .warmupIterations(5)
+            .measurementIterations(5)
+            .mode(Mode.AverageTime)
+            .timeUnit(TimeUnit.NANOSECONDS)
+            .forks(1)
+            .build();
+
+        new Runner(opt).run();
+    }
+
+    @Setup
+    public void setUp() {
+        introspections = IntStream.range(0, itemCount)
+            .mapToObj(i -> switch (ThreadLocalRandom.current().nextInt(typeCount)) {
+                case 0 -> BeanA.class;
+                case 1 -> BeanB.class;
+                case 2 -> BeanC.class;
+                default -> throw new AssertionError();
+            })
+            .map(BeanIntrospector.SHARED::getIntrospection)
+            .toArray(BeanIntrospection[]::new);
+        needle = "foo";
+    }
+
+    @Benchmark
+    public void test(Blackhole blackhole) {
+        String needle = this.needle;
+        for (BeanIntrospection<?> introspection : introspections) {
+            blackhole.consume(introspection.propertyIndexOf(needle));
+        }
+    }
+
+    @Introspected
+    public record BeanA(
+        String foo,
+        String bar
+    ) {
+    }
+
+    @Introspected
+    public record BeanB(
+        String baz,
+        int foo
+    ) {
+    }
+
+    @Introspected
+    public record BeanC(
+        String fizz,
+        double buzz,
+        int foo
+    ) {
+    }
+}

--- a/core/src/main/java/io/micronaut/core/util/StringIntMap.java
+++ b/core/src/main/java/io/micronaut/core/util/StringIntMap.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.core.util;
+
+import io.micronaut.core.annotation.Internal;
+
+/**
+ * Fixed-size String->int map optimized for very fast read operations.
+ *
+ * @author Jonas Konrad
+ * @since 4.0.0
+ */
+@Internal
+public final class StringIntMap {
+    private final int mask;
+    private final String[] keys;
+    private final int[] values;
+
+    /**
+     * Create a new map. The given size <b>must not</b> be exceeded by {@link #put} operations, or
+     * there may be infinite loops. There is no sanity check for this for performance reasons!
+     *
+     * @param size The maximum size of the map
+     */
+    public StringIntMap(int size) {
+        // min size: at least one slot, aim for 50% load factor
+        int tableSize = (size * 2) + 1;
+        // round to next power of two for efficient hash code masking
+        tableSize = Integer.highestOneBit(tableSize) * 2;
+        this.mask = tableSize - 1;
+        this.keys = new String[tableSize];
+        this.values = new int[keys.length];
+    }
+
+    private int probe(String key) {
+        int n = keys.length;
+        int i = key.hashCode() & mask;
+        while (true) {
+            String candidate = keys[i];
+            if (candidate == null) {
+                return ~i;
+            } else if (candidate.equals(key)) {
+                return i;
+            } else {
+                i++;
+                if (i == n) {
+                    i = 0;
+                }
+            }
+        }
+    }
+
+    public int get(String key, int def) {
+        int i = probe(key);
+        return i < 0 ? def : values[i];
+    }
+
+    public void put(String key, int value) {
+        int tableIndex = ~probe(key);
+        if (tableIndex < 0) {
+            throw new IllegalArgumentException("Duplicate key");
+        }
+        keys[tableIndex] = key;
+        values[tableIndex] = value;
+    }
+}

--- a/core/src/test/groovy/io/micronaut/core/util/StringIntMapSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/util/StringIntMapSpec.groovy
@@ -1,0 +1,39 @@
+package io.micronaut.core.util
+
+import spock.lang.Specification
+
+class StringIntMapSpec extends Specification {
+    def simple() {
+        given:
+        def map = new StringIntMap(4)
+
+        when:
+        map.put("foo", 1)
+        then:
+        map.get("foo", -1) == 1
+        map.get("bar", -1) == -1
+
+        when:
+        map.put("bar", 2)
+        then:
+        map.get("foo", -1) == 1
+        map.get("bar", -1) == 2
+        map.get("fizz", -1) == -1
+
+        when:
+        map.put("fizz", 3)
+        then:
+        map.get("foo", -1) == 1
+        map.get("bar", -1) == 2
+        map.get("fizz", -1) == 3
+        map.get("buzz", -1) == -1
+
+        when:
+        map.put("buzz", 4)
+        then:
+        map.get("foo", -1) == 1
+        map.get("bar", -1) == 2
+        map.get("fizz", -1) == 3
+        map.get("buzz", -1) == 4
+    }
+}

--- a/inject/src/main/java/io/micronaut/inject/beans/AbstractInitializableBeanIntrospection.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/AbstractInitializableBeanIntrospection.java
@@ -31,6 +31,7 @@ import io.micronaut.core.reflect.exception.InstantiationException;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.type.ReturnType;
 import io.micronaut.core.util.ArgumentUtils;
+import io.micronaut.core.util.StringIntMap;
 import io.micronaut.inject.ExecutableMethod;
 import io.micronaut.inject.annotation.EvaluatedAnnotationMetadata;
 
@@ -64,6 +65,7 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements BeanI
     private final Argument<?>[] constructorArguments;
     private final List<BeanProperty<B, Object>> beanProperties;
     private final List<BeanMethod<B, Object>> beanMethods;
+    private final StringIntMap beanPropertyIndex;
 
     private BeanConstructor<B> beanConstructor;
 
@@ -85,6 +87,10 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements BeanI
             this.beanProperties = Collections.unmodifiableList(beanProperties);
         } else {
             this.beanProperties = Collections.emptyList();
+        }
+        this.beanPropertyIndex = new StringIntMap(beanProperties.size());
+        for (int i = 0; i < beanProperties.size(); i++) {
+            beanPropertyIndex.put(beanProperties.get(i).getName(), i);
         }
         if (methodsRefs != null) {
             List<BeanMethod<B, Object>> beanMethods = new ArrayList<>(methodsRefs.length);
@@ -118,6 +124,11 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements BeanI
     @UsedByGeneratedCode
     protected BeanProperty<B, Object> getPropertyByIndex(int index) {
         return beanProperties.get(index);
+    }
+
+    @Override
+    public int propertyIndexOf(String name) {
+        return beanPropertyIndex.get(name, -1);
     }
 
     /**

--- a/inject/src/main/java/io/micronaut/inject/beans/AbstractInitializableBeanIntrospection.java
+++ b/inject/src/main/java/io/micronaut/inject/beans/AbstractInitializableBeanIntrospection.java
@@ -63,8 +63,9 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements BeanI
     private final AnnotationMetadata annotationMetadata;
     private final AnnotationMetadata constructorAnnotationMetadata;
     private final Argument<?>[] constructorArguments;
-    private final List<BeanProperty<B, Object>> beanProperties;
-    private final List<BeanMethod<B, Object>> beanMethods;
+    private final BeanProperty<B, Object>[] beanProperties;
+    private final List<BeanProperty<B, Object>> beanPropertiesList;
+    private final List<BeanMethod<B, Object>> beanMethodsList;
     private final StringIntMap beanPropertyIndex;
 
     private BeanConstructor<B> beanConstructor;
@@ -84,22 +85,24 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements BeanI
             for (BeanPropertyRef beanPropertyRef : propertiesRefs) {
                 beanProperties.add(new BeanPropertyImpl<>(beanPropertyRef));
             }
-            this.beanProperties = Collections.unmodifiableList(beanProperties);
+            this.beanProperties = beanProperties.toArray(BeanProperty[]::new);
+            this.beanPropertiesList = Collections.unmodifiableList(beanProperties);
         } else {
-            this.beanProperties = Collections.emptyList();
+            this.beanProperties = new BeanProperty[0];
+            this.beanPropertiesList = Collections.emptyList();
         }
-        this.beanPropertyIndex = new StringIntMap(beanProperties.size());
-        for (int i = 0; i < beanProperties.size(); i++) {
-            beanPropertyIndex.put(beanProperties.get(i).getName(), i);
+        this.beanPropertyIndex = new StringIntMap(beanProperties.length);
+        for (int i = 0; i < beanProperties.length; i++) {
+            beanPropertyIndex.put(beanProperties[i].getName(), i);
         }
         if (methodsRefs != null) {
             List<BeanMethod<B, Object>> beanMethods = new ArrayList<>(methodsRefs.length);
             for (BeanMethodRef beanMethodRef : methodsRefs) {
                 beanMethods.add(new BeanMethodImpl<>(beanMethodRef));
             }
-            this.beanMethods = Collections.unmodifiableList(beanMethods);
+            this.beanMethodsList = Collections.unmodifiableList(beanMethods);
         } else {
-            this.beanMethods = Collections.emptyList();
+            this.beanMethodsList = Collections.emptyList();
         }
     }
 
@@ -123,7 +126,7 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements BeanI
     @Internal
     @UsedByGeneratedCode
     protected BeanProperty<B, Object> getPropertyByIndex(int index) {
-        return beanProperties.get(index);
+        return beanProperties[index];
     }
 
     @Override
@@ -278,7 +281,7 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements BeanI
     @Override
     public BeanConstructor<B> getConstructor() {
         if (beanConstructor == null) {
-            beanConstructor = new BeanConstructor<B>() {
+            beanConstructor = new BeanConstructor<>() {
                 @Override
                 public Class<B> getDeclaringBeanType() {
                     return beanType;
@@ -319,7 +322,7 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements BeanI
     public Optional<BeanProperty<B, Object>> getProperty(@NonNull String name) {
         ArgumentUtils.requireNonNull("name", name);
         int index = propertyIndexOf(name);
-        return index == -1 ? Optional.empty() : Optional.of(beanProperties.get(index));
+        return index == -1 ? Optional.empty() : Optional.of(beanProperties[index]);
     }
 
     @Override
@@ -330,7 +333,7 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements BeanI
     @NonNull
     @Override
     public Collection<BeanProperty<B, Object>> getBeanProperties() {
-        return beanProperties;
+        return beanPropertiesList;
     }
 
     @NonNull
@@ -342,7 +345,7 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements BeanI
     @NonNull
     @Override
     public Collection<BeanMethod<B, Object>> getBeanMethods() {
-        return beanMethods;
+        return beanMethodsList;
     }
 
     @Override
@@ -375,16 +378,16 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements BeanI
     private static final class IndexedCollections<T> extends AbstractCollection<T> {
 
         private final int[] indexed;
-        private final List<T> list;
+        private final T[] array;
 
-        private IndexedCollections(int[] indexed, List<T> list) {
+        private IndexedCollections(int[] indexed, T[] array) {
             this.indexed = indexed;
-            this.list = list;
+            this.array = array;
         }
 
         @Override
         public Iterator<T> iterator() {
-            return new Iterator<T>() {
+            return new Iterator<>() {
 
                 int i = -1;
 
@@ -399,7 +402,7 @@ public abstract class AbstractInitializableBeanIntrospection<B> implements BeanI
                         throw new NoSuchElementException();
                     }
                     int index = indexed[++i];
-                    return list.get(index);
+                    return array[index];
                 }
             };
         }


### PR DESCRIPTION
This patch replaces the propertyIndexOf method generated for each introspection with an optimized String->int map. For cases where propertyIndexOf may be called for many different types, this avoids a megamorphic call site (benchmark about 5x as fast). On the other hand, for cases where propertyIndexOf is only called with one or two different introspections at the same call site, this is slightly slower (benchmark about 0.65x as fast).

imo this tradeoff is acceptable, because the speedup for megamorphic case far exceeds the slowdown for the monomorphic case. Monomorphic call sites should also be less "hot" in practical code, so performance of propertyIndexOf matters less. Finally, the absolute performance difference is quite small for the monomorphic case, in the benchmark it's 70ns so roughly 1.5ns per item, while for the megamorphic case it's roughly 30ns per item.

Benchmark results, before this change:
```
Benchmark                    (itemCount)  (typeCount)  Mode  Cnt    Score   Error  Units
PropertyIndexBenchmark.test           50            1  avgt    5  115.205 ± 1.016  ns/op
PropertyIndexBenchmark.test           50            2  avgt    5  118.745 ± 0.106  ns/op
PropertyIndexBenchmark.test           50            3  avgt    5  832.091 ± 8.271  ns/op
```

After this change:
```
Benchmark                    (itemCount)  (typeCount)  Mode  Cnt    Score   Error  Units
PropertyIndexBenchmark.test           50            1  avgt    5  183.315 ± 0.435  ns/op
PropertyIndexBenchmark.test           50            2  avgt    5  162.453 ± 0.881  ns/op
PropertyIndexBenchmark.test           50            3  avgt    5  162.690 ± 1.004  ns/op
```