### PR TITLE
Re-enable PTS and Test Distribution for Kotlin

### DIFF
--- a/test-suite-kotlin/build.gradle
+++ b/test-suite-kotlin/build.gradle
@@ -101,12 +101,3 @@ tasks.named("compileTestKotlin") {
 tasks.named("test") {
     useJUnitPlatform()
 }
-
-tasks.withType(Test).configureEach {
-    distribution {
-        enabled = false
-    }
-    predictiveSelection {
-        enabled = false
-    }
-}


### PR DESCRIPTION
We had to disable Predictive Test Selection and Test Distribution for Kotest tests as Kotest was unsupported.

As of micronaut-test-4.0.0-M2, we use a supported version of Kotest 5, so this pr reverses

https://github.com/micronaut-projects/micronaut-core/pull/8612

To re-enable these Gradle features