### PR TITLE
Support for Comparable types in expressions

### DIFF
--- a/core-processor/src/main/java/io/micronaut/expressions/parser/SingleEvaluatedEvaluatedExpressionParser.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/SingleEvaluatedEvaluatedExpressionParser.java
@@ -324,6 +324,7 @@ public final class SingleEvaluatedEvaluatedExpressionParser implements Evaluated
     //  : EvaluationContextAccess
     //  | BeanContextAccess
     //  | EnvironmentAccess
+    //  | ThisAccess
     //  | TypeIdentifier
     //  | ParenthesizedExpression
     //  | Literal
@@ -342,6 +343,9 @@ public final class SingleEvaluatedEvaluatedExpressionParser implements Evaluated
         };
     }
 
+    // ThisAccess
+    //  : 'this'
+    //  ;
     private ExpressionNode thisAccess() {
         eat(THIS);
         return new ThisAccess();

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/ExpressionNode.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/ExpressionNode.java
@@ -19,6 +19,7 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
 import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.ast.PrimitiveElement;
 import org.objectweb.asm.Type;
 
 /**
@@ -88,7 +89,14 @@ public abstract class ExpressionNode {
      * @param ctx The expression compilation context
      * @return The resolved type
      */
-    protected abstract ClassElement doResolveClassElement(ExpressionVisitorContext ctx);
+    protected ClassElement doResolveClassElement(ExpressionVisitorContext ctx) {
+        Type type = doResolveType(ctx);
+        try {
+            return PrimitiveElement.valueOf(type.getClassName());
+        } catch (IllegalArgumentException e) {
+            return ClassElement.of(type.getClassName());
+        }
+    }
 
     /**
      * Resolves expression AST node type.

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/binary/BinaryOperator.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/binary/BinaryOperator.java
@@ -17,10 +17,7 @@ package io.micronaut.expressions.parser.ast.operator.binary;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
-import io.micronaut.expressions.parser.ast.conditional.ElvisOperator;
 import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
-import io.micronaut.inject.ast.ClassElement;
-import io.micronaut.inject.ast.PrimitiveElement;
 import org.objectweb.asm.Type;
 
 /**
@@ -30,7 +27,11 @@ import org.objectweb.asm.Type;
  * @since 4.0.0
  */
 @Internal
-public abstract sealed class BinaryOperator extends ExpressionNode permits AddOperator, EqOperator, LogicalOperator, MathOperator, PowOperator, RelationalOperator {
+public abstract sealed class BinaryOperator extends ExpressionNode permits AddOperator,
+                                                                           EqOperator,
+                                                                           LogicalOperator,
+                                                                           MathOperator,
+                                                                           PowOperator {
     protected final ExpressionNode leftOperand;
     protected final ExpressionNode rightOperand;
 
@@ -44,16 +45,6 @@ public abstract sealed class BinaryOperator extends ExpressionNode permits AddOp
         Type leftType = leftOperand.resolveType(ctx);
         Type rightType = rightOperand.resolveType(ctx);
         return resolveOperationType(leftType, rightType);
-    }
-
-    @Override
-    protected ClassElement doResolveClassElement(ExpressionVisitorContext ctx) {
-        Type type = doResolveType(ctx);
-        try {
-            return PrimitiveElement.valueOf(type.getClassName());
-        } catch (IllegalArgumentException e) {
-            return ClassElement.of(type.getClassName());
-        }
     }
 
     protected abstract Type resolveOperationType(Type leftOperandType,

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/binary/ComparablesComparisonOperation.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/binary/ComparablesComparisonOperation.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.expressions.parser.ast.operator.binary;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.expressions.parser.ast.ExpressionNode;
+import io.micronaut.expressions.parser.ast.util.TypeDescriptors;
+import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
+import io.micronaut.expressions.parser.exception.ExpressionCompilationException;
+import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.ast.PrimitiveElement;
+import io.micronaut.inject.processing.JavaModelUtils;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.GeneratorAdapter;
+import org.objectweb.asm.commons.Method;
+
+import java.util.Optional;
+
+import static io.micronaut.expressions.parser.ast.util.EvaluatedExpressionCompilationUtils.pushBoxPrimitiveIfNecessary;
+import static io.micronaut.expressions.parser.ast.util.TypeDescriptors.toBoxedIfNecessary;
+import static org.objectweb.asm.Opcodes.GOTO;
+import static org.objectweb.asm.Opcodes.IFGE;
+import static org.objectweb.asm.Opcodes.IFGT;
+import static org.objectweb.asm.Opcodes.IFLE;
+import static org.objectweb.asm.Opcodes.IFLT;
+import static org.objectweb.asm.Type.BOOLEAN_TYPE;
+
+/**
+ * Expression AST node for relational operations (>, <, >=, <=) on
+ * types that implement {@link Comparable} interface.
+ *
+ * @since 4.0.0
+ * @author Sergey Gavrilov
+ */
+@Internal
+public final class ComparablesComparisonOperation extends ExpressionNode {
+
+    private static final String COMPARABLE_CLASS_NAME = Comparable.class.getName();
+
+    private final ExpressionNode leftOperand;
+    private final ExpressionNode rightOperand;
+    private final int comparisonOpcode;
+
+    private ClassElement comparableTypeArgument;
+    private ComparisonType comparisonType;
+
+    public ComparablesComparisonOperation(ExpressionNode leftOperand,
+                                          ExpressionNode rightOperand,
+                                          int comparisonOpcode) {
+        this.leftOperand = leftOperand;
+        this.rightOperand = rightOperand;
+        this.comparisonOpcode = comparisonOpcode;
+    }
+
+    @Override
+    protected Type doResolveType(ExpressionVisitorContext ctx) {
+        // resolving non-primitive class elements is necessary to handle cases
+        // when one of expression nodes is of primitive type, but other expression node
+        // is comparable to respective boxed type
+        ClassElement leftClassElement = resolveNonPrimitiveClassElement(leftOperand, ctx);
+        ClassElement rightClassElement = resolveNonPrimitiveClassElement(rightOperand, ctx);
+
+        ClassElement leftComparableTypeArgument = resolveComparableTypeArgument(leftClassElement);
+        ClassElement rightComparableTypeArgument = resolveComparableTypeArgument(rightClassElement);
+
+        if (leftComparableTypeArgument != null && rightClassElement.isAssignable(leftComparableTypeArgument)) {
+            comparisonType = ComparisonType.LEFT;
+            comparableTypeArgument = leftComparableTypeArgument;
+        } else if (rightComparableTypeArgument != null && leftClassElement.isAssignable(rightComparableTypeArgument)) {
+            comparisonType = ComparisonType.RIGHT;
+            comparableTypeArgument = rightComparableTypeArgument;
+        } else {
+            throw new ExpressionCompilationException(
+                "Comparison operation can only be applied to numeric types or types that are " +
+                    "Comparable to each other");
+        }
+
+        return BOOLEAN_TYPE;
+    }
+
+    /**
+     * Resolves {@link ClassElement} of passed {@link ExpressionNode}, returning original
+     * {@link ClassElement} of node when it is of object type or boxed type in case
+     * {@link ExpressionNode} resolves to primitive type.
+     */
+    private ClassElement resolveNonPrimitiveClassElement(ExpressionNode expressionNode,
+                                                         ExpressionVisitorContext ctx) {
+        ClassElement classElement = expressionNode.resolveClassElement(ctx);
+        if (classElement instanceof PrimitiveElement) {
+            return ctx.visitorContext()
+                       .getClassElement(toBoxedIfNecessary(expressionNode.resolveType(ctx)).getClassName())
+                       .orElseThrow();
+        }
+        return classElement;
+    }
+
+    @Nullable
+    private ClassElement resolveComparableTypeArgument(ClassElement classElement) {
+        return Optional.ofNullable(classElement
+                                       .getAllTypeArguments()
+                                       .get(COMPARABLE_CLASS_NAME))
+                   .map(types -> types.get("T"))
+                   .orElse(null);
+    }
+
+    @Override
+    public void generateBytecode(ExpressionVisitorContext ctx) {
+        GeneratorAdapter mv = ctx.methodVisitor();
+
+        Label elseLabel = new Label();
+        Label endOfCmpLabel = new Label();
+
+        if (comparisonType == ComparisonType.LEFT) {
+            pushCompareToMethodCall(leftOperand, rightOperand, ctx);
+            mv.visitJumpInsn(comparisonOpcode, elseLabel);
+        } else {
+            pushCompareToMethodCall(rightOperand, leftOperand, ctx);
+            mv.visitJumpInsn(invertInstruction(comparisonOpcode), elseLabel);
+        }
+
+        mv.push(true);
+        mv.visitJumpInsn(GOTO, endOfCmpLabel);
+        mv.visitLabel(elseLabel);
+        mv.push(false);
+        mv.visitLabel(endOfCmpLabel);
+    }
+
+    private void pushCompareToMethodCall(ExpressionNode comparableNode,
+                                         ExpressionNode comparedNode,
+                                         ExpressionVisitorContext ctx) {
+        GeneratorAdapter mv = ctx.methodVisitor();
+        ClassElement comparableClass = comparableNode.resolveClassElement(ctx);
+
+        Type comparableType = comparableNode.resolveType(ctx);
+        Type comparedType = comparedNode.resolveType(ctx);
+
+        comparableNode.compile(ctx);
+        pushBoxPrimitiveIfNecessary(comparableType, mv);
+
+        comparedNode.compile(ctx);
+        pushBoxPrimitiveIfNecessary(comparedType, mv);
+
+        if (comparableClass.isInterface()) {
+            mv.invokeInterface(comparableType,
+                new Method("compareTo", TypeDescriptors.INT,
+                    new org.objectweb.asm.Type[]{TypeDescriptors.OBJECT}));
+        } else {
+            mv.invokeVirtual(comparableType,
+                new Method("compareTo", TypeDescriptors.INT,
+                new org.objectweb.asm.Type[]{JavaModelUtils.getTypeReference(comparableTypeArgument)}));
+        }
+    }
+
+    private Integer invertInstruction(Integer instruction) {
+        return switch (instruction) {
+                       case IFLE -> IFGE;
+                       case IFLT -> IFGT;
+                       case IFGE -> IFLE;
+                       case IFGT -> IFLT;
+                       default -> instruction;
+                   };
+    }
+
+    private enum ComparisonType {
+
+        /**
+         * Comparison type for cases when left compared value implements {@link Comparable}
+         * interface and right element of comparison expression is assignable to generic
+         * type parameter of left value.
+         */
+        LEFT,
+
+        /**
+         * Comparison type for cases when right compared value implements {@link Comparable}
+         * interface and left element of comparison expression is assignable to generic
+         * type parameter of right value.
+         */
+        RIGHT
+    }
+}

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/binary/NumericComparisonOperation.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/binary/NumericComparisonOperation.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.expressions.parser.ast.operator.binary;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.expressions.parser.ast.ExpressionNode;
+import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
+import io.micronaut.expressions.parser.exception.ExpressionCompilationException;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.GeneratorAdapter;
+
+import static io.micronaut.expressions.parser.ast.util.EvaluatedExpressionCompilationUtils.pushPrimitiveCastIfNecessary;
+import static io.micronaut.expressions.parser.ast.util.EvaluatedExpressionCompilationUtils.pushUnboxPrimitiveIfNecessary;
+import static io.micronaut.expressions.parser.ast.util.TypeDescriptors.DOUBLE;
+import static io.micronaut.expressions.parser.ast.util.TypeDescriptors.FLOAT;
+import static io.micronaut.expressions.parser.ast.util.TypeDescriptors.LONG;
+import static io.micronaut.expressions.parser.ast.util.TypeDescriptors.computeNumericOperationTargetType;
+import static io.micronaut.expressions.parser.ast.util.TypeDescriptors.isNumeric;
+import static io.micronaut.expressions.parser.ast.util.TypeDescriptors.isOneOf;
+import static org.objectweb.asm.Opcodes.DCMPL;
+import static org.objectweb.asm.Opcodes.FCMPL;
+import static org.objectweb.asm.Opcodes.GOTO;
+import static org.objectweb.asm.Opcodes.LCMP;
+import static org.objectweb.asm.Type.BOOLEAN_TYPE;
+
+/**
+ * Expression AST node for relational operations (>, <, >=, <=) on
+ * numeric types.
+ *
+ * @since 4.0.0
+ * @author Sergey Gavrilov
+ */
+@Internal
+public final class NumericComparisonOperation extends ExpressionNode {
+
+    private final ExpressionNode leftOperand;
+    private final ExpressionNode rightOperand;
+    private final int intComparisonOpcode;
+    private final int nonIntComparisonOpcode;
+
+    public NumericComparisonOperation(ExpressionNode leftOperand,
+                                      ExpressionNode rightOperand,
+                                      int intComparisonOpcode,
+                                      int nonIntComparisonOpcode) {
+        this.leftOperand = leftOperand;
+        this.rightOperand = rightOperand;
+        this.intComparisonOpcode = intComparisonOpcode;
+        this.nonIntComparisonOpcode = nonIntComparisonOpcode;
+    }
+
+    @Override
+    protected Type doResolveType(ExpressionVisitorContext ctx) {
+        Type leftType = leftOperand.resolveType(ctx);
+        Type rightType = rightOperand.resolveType(ctx);
+
+        if (!isNumeric(leftType) || !isNumeric(rightType)) {
+            throw new ExpressionCompilationException(
+                "Numeric comparison operation can only be applied to numeric types");
+        }
+
+        return BOOLEAN_TYPE;
+    }
+
+    @Override
+    public void generateBytecode(ExpressionVisitorContext ctx) {
+        GeneratorAdapter mv = ctx.methodVisitor();
+
+        Label elseLabel = new Label();
+        Label endOfCmpLabel = new Label();
+
+        Type leftType = leftOperand.resolveType(ctx);
+        Type rightType = rightOperand.resolveType(ctx);
+
+        Type targetType = computeNumericOperationTargetType(leftType, rightType);
+
+        leftOperand.compile(ctx);
+        pushUnboxPrimitiveIfNecessary(leftType, mv);
+        pushPrimitiveCastIfNecessary(leftType, targetType, mv);
+
+        rightOperand.compile(ctx);
+        pushUnboxPrimitiveIfNecessary(rightType, mv);
+        pushPrimitiveCastIfNecessary(rightType, targetType, mv);
+
+        if (isOneOf(targetType, DOUBLE, FLOAT, LONG)) {
+            String targetDescriptor = targetType.getDescriptor();
+            switch (targetDescriptor) {
+                case "D" -> mv.visitInsn(DCMPL);
+                case "F" -> mv.visitInsn(FCMPL);
+                case "J" -> mv.visitInsn(LCMP);
+                default -> { }
+            }
+            mv.visitJumpInsn(nonIntComparisonOpcode, elseLabel);
+        } else {
+            mv.visitJumpInsn(intComparisonOpcode, elseLabel);
+        }
+
+        mv.push(true);
+        mv.visitJumpInsn(GOTO, endOfCmpLabel);
+        mv.visitLabel(elseLabel);
+        mv.push(false);
+        mv.visitLabel(endOfCmpLabel);
+    }
+}

--- a/inject-groovy-test/src/main/groovy/io/micronaut/ast/transform/test/AbstractEvaluatedExpressionsSpec.groovy
+++ b/inject-groovy-test/src/main/groovy/io/micronaut/ast/transform/test/AbstractEvaluatedExpressionsSpec.groovy
@@ -64,6 +64,53 @@ class AbstractEvaluatedExpressionsSpec extends AbstractBeanDefinitionSpec {
         return result
     }
 
+    Object evaluateMultipleAgainstContext(@Language("groovy") String contextClass, String... expressions) {
+
+        String expr = ""
+        for (int i = 0; i < expressions.length; i++) {
+            expr += """
+
+                @Value("${expressions[i]}")
+                public Object field${i}
+
+            """
+        }
+
+        def cls = """
+            package test;
+            import io.micronaut.context.annotation.Value;
+            import jakarta.inject.Singleton;
+
+            ${contextClass}
+
+            @Singleton
+            class Expr {
+                ${expr}
+            }
+        """.stripIndent().stripLeading()
+
+        def applicationContext = buildContext(cls)
+        def classLoader = applicationContext.classLoader
+
+        def exprClassName = 'test.$Expr$Expr'
+        def startingIndex = EvaluatedExpressionReference.nextIndex(exprClassName) - expressions.length
+
+        List<Object> result = new ArrayList<>()
+        for (int i = startingIndex; i < startingIndex + expressions.size(); i++) {
+            String exprFullName = exprClassName + i
+            try {
+                def exprClass = (AbstractEvaluatedExpression) classLoader.loadClass(exprFullName).newInstance()
+                result.add(exprClass.evaluate(new DefaultExpressionEvaluationContext(null, null, applicationContext,
+                        null)))
+            } catch (ClassNotFoundException e) {
+                return null
+            }
+        }
+
+        return result
+    }
+
+
     Object evaluate(String expression) {
         return evaluateAgainstContext(expression, "")
     }

--- a/inject-java/src/test/groovy/io/micronaut/expressions/OperatorExpressionSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/expressions/OperatorExpressionSpec.groovy
@@ -590,6 +590,243 @@ class OperatorExpressionSpec extends AbstractEvaluatedExpressionsSpec {
         results[23] instanceof Boolean && results[23] == true
     }
 
+    void "test comparables"() {
+        given:
+        Object[] results = evaluateMultipleAgainstContext("""
+
+            record NonComparable(int value) {}
+
+            class Comp1 implements Comparable<Comp1> {
+
+                private final int value;
+
+                public Comp1(int value) {
+                    this.value = value;
+                }
+
+                @Override
+                public int compareTo(Comp1 o) {
+                    return value - o.value;
+                }
+            }
+
+            class InheritedComp extends Comp1 {
+                public InheritedComp(int value) {
+                    super(value);
+                }
+            }
+
+            class Comp2 implements Comparable<NonComparable> {
+                private final int value;
+
+                public Comp2(int value) {
+                    this.value = value;
+                }
+
+                @Override
+                public int compareTo(NonComparable o) {
+                    return value - o.value();
+                }
+
+            }
+
+            class Comp3 implements Comparable<Integer> {
+
+                private final int value;
+
+                public Comp3(int value) {
+                    this.value = value;
+                }
+
+                @Override
+                public int compareTo(Integer i) {
+                    return value - i;
+                }
+
+            }
+
+            class Comp4 implements Comparable {
+
+                private final int value;
+
+                public Comp4(int value) {
+                    this.value = value;
+                }
+
+                @Override
+                public int compareTo(Object i) {
+                    return value - (Integer) i;
+                }
+            }
+
+            @jakarta.inject.Singleton
+            class Context {
+
+                public NonComparable nonComp(int value) {
+                    return new NonComparable(value);
+                }
+
+                public InheritedComp inheritedComp(int value) {
+                    return new InheritedComp(value);
+                }
+
+                public Comparable<Comp1> compInterface(int value) {
+                    return new Comp1(value);
+                }
+
+                public Comp1 comp1(int value) {
+                    return new Comp1(value);
+                }
+
+                public Comp2 comp2(int value) {
+                    return new Comp2(value);
+                }
+
+                public Comp3 comp3(int value) {
+                    return new Comp3(value);
+                }
+
+                public Comp4 comp4(int value) {
+                    return new Comp4(value);
+                }
+            }
+
+        """,
+                // comparable to itself
+                "#{ comp1(10) > comp1(7) }", // 0
+                "#{ comp1(10) < comp1(7) }",            // 1
+                "#{ comp1(10) <= comp1(7) }",           // 2
+                "#{ comp1(7) >= comp1(7) }",            // 3
+                "#{ comp1(7) < comp1(8) }",             // 4
+                "#{ comp1(7) <= comp1(8) }",            // 5
+                "#{ comp1(7) > comp1(8) }",             // 6
+                "#{ comp1(7) >= comp1(8) }",            // 7
+
+                // left to right comparable
+                "#{ comp2(10) > nonComp(7) }",          // 8
+                "#{ comp2(10) < nonComp(7) }",          // 9
+                "#{ comp2(10) <= nonComp(7) }",         // 10
+                "#{ comp2(7) >= nonComp(7) }",          // 11
+                "#{ comp2(7) < nonComp(8) }",           // 12
+                "#{ comp2(7) <= nonComp(8) }",          // 13
+                "#{ comp2(7) > nonComp(8) }",           // 14
+                "#{ comp2(7) >= nonComp(8) }",          // 15
+
+                // right to left comparable
+                "#{ nonComp(10) > comp2(7) }",          // 16
+                "#{ nonComp(10) < comp2(7) }",          // 17
+                "#{ nonComp(10) <= comp2(7) }",         // 18
+                "#{ nonComp(7) >= comp2(7) }",          // 19
+                "#{ nonComp(7) < comp2(8) }",           // 20
+                "#{ nonComp(7) <= comp2(8) }",          // 21
+                "#{ nonComp(7) > comp2(8) }",           // 22
+                "#{ nonComp(7) >= comp2(8) }",          // 23
+
+                // comparable to primitive
+                "#{ comp3(10) > 7 }",                   // 24
+                "#{ comp3(10) < 7 }",                   // 25
+                "#{ comp3(10) <= 7 }",                  // 26
+                "#{ comp3(7) >= 7 }",                   // 27
+                "#{ comp3(7) < 8 }",                    // 28
+                "#{ comp3(7) <= 8 }",                   // 29
+                "#{ comp3(7) > 8 }",                    // 30
+                "#{ comp3(7) >= 8 }",                   // 31
+
+                // primitive to comparable
+                "#{ 10 > comp3(7) }",                   // 32
+                "#{ 10 < comp3(7) }",                   // 33
+                "#{ 10 <= comp3(7) }",                  // 34
+                "#{ 7 >= comp3(7) }",                   // 35
+                "#{ 7 < comp3(8) }",                    // 36
+                "#{ 7 <= comp3(8) }",                   // 37
+                "#{ 7 > comp3(8) }",                    // 38
+                "#{ 7 >= comp3(8) }",                   // 39
+
+                // inherited comparable
+                "#{ comp1(10) > inheritedComp(7) }",    // 40
+                "#{ comp1(10) < inheritedComp(7) }",    // 41
+                "#{ inheritedComp(10) > comp1(7) }",    // 42
+                "#{ inheritedComp(10) < comp1(7) }",    // 43
+
+                // interface comparable
+                "#{ compInterface(10) < comp1(7) }",    // 44
+                "#{ compInterface(10) > comp1(7) }",    // 45
+                "#{ comp1(10) < compInterface(7) }",    // 46
+                "#{ comp1(10) > compInterface(7) }",    // 47
+
+                // raw comparable
+                "#{ comp4(10) > 7 }",                   // 48
+                "#{ 7 > comp4(10) }"                    // 49
+        )
+
+        expect:
+        // comparable to itself
+        results[0] instanceof Boolean && results[0] == true
+        results[1] instanceof Boolean && results[1] == false
+        results[2] instanceof Boolean && results[2] == false
+        results[3] instanceof Boolean && results[3] == true
+        results[4] instanceof Boolean && results[4] == true
+        results[5] instanceof Boolean && results[5] == true
+        results[6] instanceof Boolean && results[6] == false
+        results[7] instanceof Boolean && results[7] == false
+
+        // left to right comparable
+        results[8] instanceof Boolean && results[8] == true
+        results[9] instanceof Boolean && results[9] == false
+        results[10] instanceof Boolean && results[10] == false
+        results[11] instanceof Boolean && results[11] == true
+        results[12] instanceof Boolean && results[12] == true
+        results[13] instanceof Boolean && results[13] == true
+        results[14] instanceof Boolean && results[14] == false
+        results[15] instanceof Boolean && results[15] == false
+
+        // right to left comparable
+        results[16] instanceof Boolean && results[16] == true
+        results[17] instanceof Boolean && results[17] == false
+        results[18] instanceof Boolean && results[18] == false
+        results[19] instanceof Boolean && results[19] == true
+        results[20] instanceof Boolean && results[20] == true
+        results[21] instanceof Boolean && results[21] == true
+        results[22] instanceof Boolean && results[22] == false
+        results[23] instanceof Boolean && results[23] == false
+
+        // comparable to primitive
+        results[24] instanceof Boolean && results[24] == true
+        results[25] instanceof Boolean && results[25] == false
+        results[26] instanceof Boolean && results[26] == false
+        results[27] instanceof Boolean && results[27] == true
+        results[28] instanceof Boolean && results[28] == true
+        results[29] instanceof Boolean && results[29] == true
+        results[30] instanceof Boolean && results[30] == false
+        results[31] instanceof Boolean && results[31] == false
+
+        // primitive to comparable
+        results[32] instanceof Boolean && results[32] == true
+        results[33] instanceof Boolean && results[33] == false
+        results[34] instanceof Boolean && results[34] == false
+        results[35] instanceof Boolean && results[35] == true
+        results[36] instanceof Boolean && results[36] == true
+        results[37] instanceof Boolean && results[37] == true
+        results[38] instanceof Boolean && results[38] == false
+        results[39] instanceof Boolean && results[39] == false
+
+        // inherited comparable
+        results[40] instanceof Boolean && results[40] == true
+        results[41] instanceof Boolean && results[41] == false
+        results[42] instanceof Boolean && results[42] == true
+        results[43] instanceof Boolean && results[43] == false
+
+        // comparable interface
+        results[44] instanceof Boolean && results[44] == false
+        results[45] instanceof Boolean && results[45] == true
+        results[46] instanceof Boolean && results[46] == false
+        results[47] instanceof Boolean && results[47] == true
+
+        // raw comparable
+        results[48] instanceof Boolean && results[48] == true
+        results[49] instanceof Boolean && results[49] == false
+    }
+
     void "test '==' operator"() {
         given:
         List<Object> results = evaluateMultiple(

--- a/src/main/docs/guide/config/evaluatedExpressions.adoc
+++ b/src/main/docs/guide/config/evaluatedExpressions.adoc
@@ -128,7 +128,8 @@ You can also change evaluation order by using brackets `()`.
 
 Equality check is supported for both primitive types and objects. It is performed using `Object.equals()` method.
 
-`>`, `<`, `>=`, `\<=` operations can only be applied to numeric types.
+`>`, `<`, `>=`, `\<=` operations can be applied to numeric types or types that implement `java.lang.Comparable`
+interface.
 
 `matches` keyword can be used to determine whether a string matches provided regular expression which has to
 be specified as string literal. The regular expression itself will be checked for validity at compilation time.
@@ -412,7 +413,7 @@ class ContextConsumer {
 }
 ----
 
-==== Retrieving Beans from Bean Context
+=== Retrieving Beans from Bean Context
 
 A predefined syntax construct `ctx[...]` can be used to retrieve beans from bean
 context. The argument inside square brackets has to be a fully qualified class name (note that `T(...)` wrapper is
@@ -425,7 +426,7 @@ optional and can be omitted for simplicity).
 #{ ctx[io.micronaut.example.ContextBean] }
 ----
 
-==== Retrieving Environment Properties
+=== Retrieving Environment Properties
 
 A syntax construct `env[...]` can be used to retrieve environment properties by name.
 The expression inside square brackets has to resolve to string value, otherwise compilation will fail. If property


### PR DESCRIPTION
Adds support for `Comparable` types in relational (>, <, >=, <=) operations in expressions. Also includes minor refactoring 
@graemerocher 