### PR TITLE
Do not avoid processing enum methods

### DIFF
--- a/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
@@ -511,9 +511,6 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
                 executableElement,
                 javaVisitorContext.getElementAnnotationMetadataFactory()
             );
-            if (methodElement.getDeclaringType().isAssignable(Enum.class)) {
-                return null;
-            }
             for (LoadedVisitor visitor : visitors) {
                 if (visitor.matchesElement(methodElement)) {
                     visitor.getVisitor().visitMethod(methodElement, javaVisitorContext);

--- a/inject-java/src/test/groovy/io/micronaut/annotation/processing/visitor/JavaVisitorSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/annotation/processing/visitor/JavaVisitorSpec.groovy
@@ -1,0 +1,49 @@
+package io.micronaut.annotation.processing.visitor
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.inject.ast.ClassElement
+import io.micronaut.inject.ast.MethodElement
+import io.micronaut.inject.visitor.TypeElementVisitor
+import io.micronaut.inject.visitor.VisitorContext
+
+class JavaVisitorSpec extends AbstractTypeElementSpec {
+    private List<TypeElementVisitor> localTypeElementVisitors
+
+    def 'visit enum methods'() {
+        given:
+        List<MethodElement> methods = []
+
+        def enumVisitor = new TypeElementVisitor<Object, Object>() {
+            @Override
+            void visitMethod(MethodElement element, VisitorContext context) {
+                methods.add(element)
+            }
+        }
+        localTypeElementVisitors = [enumVisitor]
+
+        buildClassLoader('example.Foo', '''
+package example;
+enum Foo {A, B;
+    public String getValue() {
+        return this == A ? "AA" : "BB";
+    }
+}
+''')
+
+        methods = methods.sort{it.name}
+
+        expect:
+        methods.size() == 3
+        methods[0].name == "getValue"
+        methods[0].returnType.name == "java.lang.String"
+        methods[0].parameters.size() == 0
+
+        methods[1].name == "valueOf"
+        methods[2].name == "values"
+    }
+
+    @Override
+    protected Collection<TypeElementVisitor> getLocalTypeElementVisitors() {
+        return localTypeElementVisitors
+    }
+}


### PR DESCRIPTION
`TypeElementVisitors` currently skips visiting enum methods and I am not sure that this behavior is correct.

Enum methods may need visiting, just like bean methods, especially if annotated with `@Creator` and therefore present in the introspection.

For example, having this enum,
```java
@Serdeable
public enum TestStateEnum implements BmcEnum {
    Active,
    Inactive,
    Deleted,
    UnknownEnumValue;

    ....

    @JsonCreator
    public static TestStateEnum create(String value) {
        return valueMap.getOrDefault(value, UnknownEnumValue);
    }
}
```
micronaut serde will deserialize the class using the `create` method. If I want to make its parameter `@Nullable` with a type visitor, I could achieve this in the `visitClass` method with
```java
element.getMethods().stream()
      .filter(m -> m.getName().equals(OCI_SDK_ENUM_CREATOR_NAME))
      .findAny()
      .ifPresent(e -> e.getParameters()[0].annotate(Nullable.class));
```
but it seems more logical for the method to be processed in the `visitMethod` method.