### PR TITLE
Align build plugins versions used in `buildSrc`

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -9,7 +9,7 @@ repositories {
 
 dependencies {
     implementation "org.aim42:htmlSanityCheck:1.1.6"
-    implementation "io.micronaut.build.internal:micronaut-gradle-plugins:5.3.15"
+    implementation "io.micronaut.build.internal:micronaut-gradle-plugins:6.4.2"
 
     implementation "org.tomlj:tomlj:1.1.0"
     implementation "me.champeau.gradle:japicmp-gradle-plugin:0.4.1"


### PR DESCRIPTION
Apparently this causes some issues in some environements, probably an ordering problem, but they should always be aligned in any case.