### PR TITLE
Fix for startup text not showing the context path

### DIFF
--- a/context/src/main/java/io/micronaut/runtime/Micronaut.java
+++ b/context/src/main/java/io/micronaut/runtime/Micronaut.java
@@ -94,7 +94,7 @@ public class Micronaut extends DefaultApplicationContextBuilder implements Appli
                             final EmbeddedServer embeddedServer = (EmbeddedServer) embeddedApplication;
                             if (LOG.isInfoEnabled()) {
                                 long took = elapsedMillis(start);
-                                URL url = embeddedServer.getURL();
+                                URL url = embeddedServer.getURLWithContextPath();
                                 LOG.info("Startup completed in {}ms. Server Running: {}", took, url);
                             }
                             keepAlive = embeddedServer.isKeepAlive();

--- a/context/src/main/java/io/micronaut/runtime/server/EmbeddedServer.java
+++ b/context/src/main/java/io/micronaut/runtime/server/EmbeddedServer.java
@@ -50,6 +50,11 @@ public interface EmbeddedServer extends EmbeddedApplication<EmbeddedServer> {
     URL getURL();
 
     /**
+     * @return The full URL to the server with the context path
+     */
+    URL getURLWithContextPath();
+
+    /**
      * @return The full URI to the server
      */
     URI getURI();

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
@@ -416,6 +416,19 @@ public class NettyHttpServer implements NettyEmbeddedServer {
     }
 
     @Override
+    public URL getURLWithContextPath() {
+        try {
+            String contextPath = serverConfiguration.getContextPath();
+            if (contextPath == null) {
+                return getURL();
+            }
+            return new URL(getScheme() + "://" + getHost() + ':' + getPort() + contextPath);
+        } catch (MalformedURLException e) {
+            throw new ConfigurationException("Invalid server URL: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
     public URI getURI() {
         try {
             return new URI(getScheme() + "://" + getHost() + ':' + getPort());


### PR DESCRIPTION
Fixed the terminal output at the startup not showing the context path in the url, issue [#9161](https://github.com/micronaut-projects/micronaut-core/issues/9161)