### PR TITLE
Reworked ability to disable initializing Slf4J

### DIFF
--- a/core/src/main/java/io/micronaut/core/io/scan/DefaultClassPathResourceLoader.java
+++ b/core/src/main/java/io/micronaut/core/io/scan/DefaultClassPathResourceLoader.java
@@ -89,7 +89,7 @@ public class DefaultClassPathResourceLoader implements ClassPathResourceLoader {
      * @param checkBase   If set to {@code true} an extended check for the base path is performed otherwise paths with relative URLs like {@code ../} are prohibited.
      */
     public DefaultClassPathResourceLoader(ClassLoader classLoader, String basePath, boolean checkBase) {
-        this(classLoader, basePath, false, true);
+        this(classLoader, basePath, checkBase, true);
     }
 
     /**

--- a/core/src/main/java/io/micronaut/core/io/scan/DefaultClassPathResourceLoader.java
+++ b/core/src/main/java/io/micronaut/core/io/scan/DefaultClassPathResourceLoader.java
@@ -27,9 +27,21 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.file.*;
-import java.util.*;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystemAlreadyExistsException;
+import java.nio.file.FileSystemNotFoundException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.ProviderNotFoundException;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
+
+import org.slf4j.helpers.NOPLogger;
 
 /**
  * Loads resources from the classpath.
@@ -40,7 +52,7 @@ import java.util.stream.Stream;
  */
 public class DefaultClassPathResourceLoader implements ClassPathResourceLoader {
 
-    private static final Logger LOG = LoggerFactory.getLogger(DefaultClassPathResourceLoader.class);
+    private final Logger log;
 
     private final ClassLoader classLoader;
     private final String basePath;
@@ -77,6 +89,21 @@ public class DefaultClassPathResourceLoader implements ClassPathResourceLoader {
      * @param checkBase   If set to {@code true} an extended check for the base path is performed otherwise paths with relative URLs like {@code ../} are prohibited.
      */
     public DefaultClassPathResourceLoader(ClassLoader classLoader, String basePath, boolean checkBase) {
+        this(classLoader, basePath, false, true);
+    }
+
+    /**
+     * Use when resources should have a standard base path.
+     *
+     * @param classLoader The class loader for loading resources
+     * @param basePath    The path to look for resources under
+     * @param checkBase   If set to {@code true} an extended check for the base path is performed otherwise paths with relative URLs like {@code ../} are prohibited.
+     * @param logEnabled flag to enable or disable logger
+     */
+    public DefaultClassPathResourceLoader(ClassLoader classLoader, String basePath, boolean checkBase, boolean logEnabled) {
+
+        log = logEnabled ? LoggerFactory.getLogger(getClass()) : NOPLogger.NOP_LOGGER;
+
         this.classLoader = classLoader;
         this.basePath = normalize(basePath);
         this.baseURL = checkBase && basePath != null ? classLoader.getResource(normalize(basePath)) : null;
@@ -129,9 +156,7 @@ public class DefaultClassPathResourceLoader implements ClassPathResourceLoader {
                                     try {
                                         fileSystem.close();
                                     } catch (IOException e) {
-                                        if (LOG.isDebugEnabled()) {
-                                            LOG.debug("Error shutting down JAR file system [" + fileSystem + "]: " + e.getMessage(), e);
-                                        }
+                                        log.debug("Error shutting down JAR file system [{}]: {}", fileSystem, e.getMessage(), e);
                                     }
                                 }
                             }
@@ -144,9 +169,7 @@ public class DefaultClassPathResourceLoader implements ClassPathResourceLoader {
                         return Optional.of(Files.newInputStream(pathObject));
                     }
                 } catch (URISyntaxException | IOException | ProviderNotFoundException e) {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Error establishing whether path is a directory: " + e.getMessage(), e);
-                    }
+                    log.debug("Error establishing whether path is a directory: {}", e.getMessage(), e);
                 }
             }
         }
@@ -253,6 +276,18 @@ public class DefaultClassPathResourceLoader implements ClassPathResourceLoader {
         return new DefaultClassPathResourceLoader(classLoader, basePath);
     }
 
+    /**
+     * Need this method to ability disable Slf4J initizalization.
+     *
+     * @param basePath The path to load resources
+     * @param logEnabled flag to enable or disable logger
+     *
+     * @return The resource loader
+     */
+    public ResourceLoader forBase(String basePath, boolean logEnabled) {
+        return new DefaultClassPathResourceLoader(classLoader, basePath, false, logEnabled);
+    }
+
     @SuppressWarnings("MagicNumber")
     private String normalize(String path) {
         if (path != null) {
@@ -297,9 +332,7 @@ public class DefaultClassPathResourceLoader implements ClassPathResourceLoader {
                                     try {
                                         fileSystem.close();
                                     } catch (IOException e) {
-                                        if (LOG.isDebugEnabled()) {
-                                            LOG.debug("Error shutting down JAR file system [" + fileSystem + "]: " + e.getMessage(), e);
-                                        }
+                                        log.debug("Error shutting down JAR file system [{}]: {}", fileSystem, e.getMessage(), e);
                                     }
                                 }
                             }
@@ -309,9 +342,7 @@ public class DefaultClassPathResourceLoader implements ClassPathResourceLoader {
                         return pathObject == null || Files.isDirectory(pathObject);
                     }
                 } catch (URISyntaxException | IOException | ProviderNotFoundException e) {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Error establishing whether path is a directory: " + e.getMessage(), e);
-                    }
+                    log.debug("Error establishing whether path is a directory: {}", e.getMessage(), e);
                 }
             }
             return path.indexOf('.') == -1; // fallback to less sophisticated approach

--- a/core/src/test/groovy/io/micronaut/core/io/IOUtilsSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/io/IOUtilsSpec.groovy
@@ -136,7 +136,7 @@ class IOUtilsSpec extends Specification {
         URI uri = new URI(uriStr)
 
         expect:
-        expected == IOUtils.resolvePath(uri, path, toClose, (closeables, s) -> Paths.get("/")).toString()
+        expected == IOUtils.resolvePath(uri, path, toClose, (closeables, s) -> Paths.get("/")).toString().replaceAll("\\\\", "/")
 
         where:
         path                                                             | expected                                                          | uriStr

--- a/http-client/src/test/groovy/io/micronaut/http/client/ClientHostNameSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/ClientHostNameSpec.groovy
@@ -25,7 +25,8 @@ class ClientHostNameSpec extends Specification {
 
         then:
         def e = thrown(HttpClientException)
-        e.message.contains('Connect Error: foo_bar') || e.message.contains('Connect Error: No such host is known (foo_bar)')
+        // messages can be different for different locales in the OS, can't compare whole string
+        e.message.contains('Connect Error:') && e.message.contains('foo_bar')
 
         cleanup:
         client.close()

--- a/http-netty/src/main/java/io/micronaut/http/netty/AbstractCompositeCustomizer.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/AbstractCompositeCustomizer.java
@@ -53,6 +53,11 @@ public abstract class AbstractCompositeCustomizer<C, R> {
         this(new CopyOnWriteArrayList<>());
     }
 
+    /**
+     * Add customizer.
+     *
+     * @param customizer The customizer
+     */
     public synchronized void add(C customizer) {
         assert members instanceof CopyOnWriteArrayList : "only allow adding to root customizer";
         // do the insertion in one operation, so that concurrent readers don't see an inconsistent

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/FormDataHttpContentProcessor.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/FormDataHttpContentProcessor.java
@@ -45,7 +45,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * <p>Decodes {@link MediaType#MULTIPART_FORM_DATA} in a non-blocking manner.</p>
- * <p>
+ *
  * <p>Designed to be used by a single thread</p>
  *
  * @author Graeme Rocher

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/configuration/NettyHttpServerConfiguration.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/configuration/NettyHttpServerConfiguration.java
@@ -823,7 +823,7 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
      *
      * @author James Kleeh
      * @author graemerocher
-     * @since @since 3.1.0
+     * @since 3.1.0
      */
     @ConfigurationProperties("responses.file")
     public static class FileTypeHandlerConfiguration {

--- a/inject-java/src/test/groovy/io/micronaut/inject/failures/postconstruct/PostConstructExceptionSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/failures/postconstruct/PostConstructExceptionSpec.groovy
@@ -16,8 +16,7 @@
 package io.micronaut.inject.failures.postconstruct
 
 import io.micronaut.context.ApplicationContext
-import io.micronaut.context.BeanContext
-import io.micronaut.context.DefaultBeanContext
+import io.micronaut.context.env.CachedEnvironment
 import io.micronaut.context.exceptions.BeanInstantiationException
 import spock.lang.Specification
 
@@ -32,10 +31,10 @@ class PostConstructExceptionSpec extends Specification {
 
         then:"The implementation is injected"
         def e = thrown(BeanInstantiationException)
-        e.message == '''Error instantiating bean of type  [io.micronaut.inject.failures.postconstruct.B]
-
-Message: bad
-Path Taken: new B()'''
+        def ls = CachedEnvironment.getProperty("line.separator")
+        e.message == 'Error instantiating bean of type  [io.micronaut.inject.failures.postconstruct.B]' + ls + ls +
+                'Message: bad' + ls +
+                'Path Taken: new B()'
 
         cleanup:
         context.close()

--- a/inject/src/main/java/io/micronaut/context/env/AbstractPropertySourceLoader.java
+++ b/inject/src/main/java/io/micronaut/context/env/AbstractPropertySourceLoader.java
@@ -21,6 +21,7 @@ import io.micronaut.core.order.Ordered;
 import io.micronaut.core.util.Toggleable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.helpers.NOPLogger;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -43,12 +44,15 @@ public abstract class AbstractPropertySourceLoader implements PropertySourceLoad
      */
     public static final int DEFAULT_POSITION = EnvironmentPropertySource.POSITION - 100;
 
-    private static final Logger LOG = LoggerFactory.getLogger(AbstractPropertySourceLoader.class);
+    protected Logger log;
 
-    /**
-     * If you don't need to initialize SLF4J, set 'false'.
-     */
-    protected boolean logEnabled = true;
+    protected AbstractPropertySourceLoader() {
+        this(true);
+    }
+
+    protected AbstractPropertySourceLoader(boolean logEnabled) {
+        log = logEnabled ? LoggerFactory.getLogger(getClass()) : NOPLogger.NOP_LOGGER;
+    }
 
     @Override
     public int getOrder() {
@@ -100,18 +104,14 @@ public abstract class AbstractPropertySourceLoader implements PropertySourceLoad
     private Map<String, Object> loadProperties(ResourceLoader resourceLoader, String qualifiedName, String fileName) {
         Optional<InputStream> config = readInput(resourceLoader, fileName);
         if (config.isPresent()) {
-            if (logEnabled) {
-                LOG.debug("Found PropertySource for file name: {}", fileName);
-            }
+            log.debug("Found PropertySource for file name: {}", fileName);
             try (InputStream input = config.get()) {
                 return read(qualifiedName, input);
             } catch (IOException e) {
                 throw new ConfigurationException("I/O exception occurred reading [" + fileName + "]: " + e.getMessage(), e);
             }
         } else {
-            if (logEnabled) {
-                LOG.debug("No PropertySource found for file name: {}", fileName);
-            }
+            log.debug("No PropertySource found for file name: {}", fileName);
         }
         return Collections.emptyMap();
     }
@@ -156,27 +156,5 @@ public abstract class AbstractPropertySourceLoader implements PropertySourceLoad
                 finalMap.put(prefix + key, value);
             }
         }
-    }
-
-    /**
-     * Return logEnabled value.
-     *
-     * @return is log enabled
-     *
-     * @since 3.9.0
-     */
-    public boolean isLogEnabled() {
-        return logEnabled;
-    }
-
-    /**
-     * Setter for logEnabled.
-     *
-     * @param logEnabled is log enabled
-     *
-     * @since 3.9.0
-     */
-    public void setLogEnabled(boolean logEnabled) {
-        this.logEnabled = logEnabled;
     }
 }

--- a/inject/src/main/java/io/micronaut/context/env/AbstractPropertySourceLoader.java
+++ b/inject/src/main/java/io/micronaut/context/env/AbstractPropertySourceLoader.java
@@ -21,6 +21,7 @@ import io.micronaut.core.order.Ordered;
 import io.micronaut.core.util.Toggleable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.helpers.NOPLogger;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -43,12 +44,15 @@ public abstract class AbstractPropertySourceLoader implements PropertySourceLoad
      */
     public static final int DEFAULT_POSITION = EnvironmentPropertySource.POSITION - 100;
 
-    private static final Logger LOG = LoggerFactory.getLogger(AbstractPropertySourceLoader.class);
+    protected final Logger log;
 
-    /**
-     * If you don't need to initialize SLF4J, set 'false'.
-     */
-    protected boolean logEnabled = true;
+    protected AbstractPropertySourceLoader() {
+        this(true);
+    }
+
+    protected AbstractPropertySourceLoader(boolean logEnabled) {
+        log = logEnabled ? LoggerFactory.getLogger(getClass()) : NOPLogger.NOP_LOGGER;
+    }
 
     @Override
     public int getOrder() {
@@ -100,18 +104,14 @@ public abstract class AbstractPropertySourceLoader implements PropertySourceLoad
     private Map<String, Object> loadProperties(ResourceLoader resourceLoader, String qualifiedName, String fileName) {
         Optional<InputStream> config = readInput(resourceLoader, fileName);
         if (config.isPresent()) {
-            if (logEnabled) {
-                LOG.debug("Found PropertySource for file name: {}", fileName);
-            }
+            log.debug("Found PropertySource for file name: {}", fileName);
             try (InputStream input = config.get()) {
                 return read(qualifiedName, input);
             } catch (IOException e) {
                 throw new ConfigurationException("I/O exception occurred reading [" + fileName + "]: " + e.getMessage(), e);
             }
         } else {
-            if (logEnabled) {
-                LOG.debug("No PropertySource found for file name: {}", fileName);
-            }
+            log.debug("No PropertySource found for file name: {}", fileName);
         }
         return Collections.emptyMap();
     }
@@ -156,27 +156,5 @@ public abstract class AbstractPropertySourceLoader implements PropertySourceLoad
                 finalMap.put(prefix + key, value);
             }
         }
-    }
-
-    /**
-     * Return logEnabled value.
-     *
-     * @return is log enabled
-     *
-     * @since 3.9.0
-     */
-    public boolean isLogEnabled() {
-        return logEnabled;
-    }
-
-    /**
-     * Setter for logEnabled.
-     *
-     * @param logEnabled is log enabled
-     *
-     * @since 3.9.0
-     */
-    public void setLogEnabled(boolean logEnabled) {
-        this.logEnabled = logEnabled;
     }
 }

--- a/inject/src/main/java/io/micronaut/context/env/AbstractPropertySourceLoader.java
+++ b/inject/src/main/java/io/micronaut/context/env/AbstractPropertySourceLoader.java
@@ -44,7 +44,7 @@ public abstract class AbstractPropertySourceLoader implements PropertySourceLoad
      */
     public static final int DEFAULT_POSITION = EnvironmentPropertySource.POSITION - 100;
 
-    protected final Logger log;
+    protected Logger log;
 
     protected AbstractPropertySourceLoader() {
         this(true);
@@ -157,4 +157,36 @@ public abstract class AbstractPropertySourceLoader implements PropertySourceLoad
             }
         }
     }
+
+    /**
+     * Return logEnabled value.
+     *
+     * @return is log enabled
+     * @deprecated don't need to have this method
+     *
+     * @since 3.9.0
+     */
+    @Deprecated
+    public boolean isLogEnabled() {
+        return !(log instanceof NOPLogger);
+    }
+
+    /**
+     * Setter for logEnabled.
+     *
+     * @param logEnabled is log enabled
+     *
+     * @deprecated set logEnabled value by constructor
+     *
+     * @since 3.9.0
+     */
+    @Deprecated
+    public void setLogEnabled(boolean logEnabled) {
+        if (logEnabled) {
+            log = LoggerFactory.getLogger(getClass());
+        } else {
+            log = NOPLogger.NOP_LOGGER;
+        }
+    }
+
 }

--- a/inject/src/main/java/io/micronaut/context/env/PropertiesPropertySourceLoader.java
+++ b/inject/src/main/java/io/micronaut/context/env/PropertiesPropertySourceLoader.java
@@ -35,6 +35,13 @@ public class PropertiesPropertySourceLoader extends AbstractPropertySourceLoader
      */
     public static final String PROPERTIES_EXTENSION = "properties";
 
+    public PropertiesPropertySourceLoader() {
+    }
+
+    public PropertiesPropertySourceLoader(boolean logEnabled) {
+        super(logEnabled);
+    }
+
     @Override
     public Set<String> getExtensions() {
         return Collections.singleton(PROPERTIES_EXTENSION);

--- a/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
+++ b/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
@@ -88,7 +88,7 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
     protected final Map<String, Object>[] rawCatalog = new Map[58];
     protected final Map<String, Object>[] nonGenerated = new Map[58];
 
-    protected final Logger log;
+    protected Logger log;
 
     private final SecureRandom random = new SecureRandom();
     private final Map<String, Boolean> containsCache = new ConcurrentHashMap<>(20);
@@ -110,10 +110,19 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
     }
 
     /**
+     * Creates a new, initially empty, {@link PropertySourcePropertyResolver} for the given {@link ConversionService}.
+     *
+     * @param conversionService The {@link ConversionService}
+     */
+    public PropertySourcePropertyResolver(ConversionService<?> conversionService) {
+        this(conversionService, true);
+    }
+
+    /**
      * Creates a new, initially empty, {@link PropertySourcePropertyResolver}.
      */
     public PropertySourcePropertyResolver() {
-        this(ConversionService.SHARED, true);
+        this(ConversionService.SHARED);
     }
 
     /**
@@ -122,7 +131,7 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
      * @param propertySources The {@link PropertySource} instances
      */
     public PropertySourcePropertyResolver(PropertySource... propertySources) {
-        this(ConversionService.SHARED, true);
+        this(ConversionService.SHARED);
         if (propertySources != null) {
             for (PropertySource propertySource : propertySources) {
                 addPropertySource(propertySource);
@@ -904,6 +913,37 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
     public void close() throws Exception {
         if (propertyPlaceholderResolver instanceof AutoCloseable) {
             ((AutoCloseable) propertyPlaceholderResolver).close();
+        }
+    }
+
+    /**
+     * Return logEnabled value.
+     *
+     * @return is log enabled
+     * @deprecated don't need to have this method
+     *
+     * @since 3.9.0
+     */
+    @Deprecated
+    public boolean isLogEnabled() {
+        return !(log instanceof NOPLogger);
+    }
+
+    /**
+     * Setter for logEnabled.
+     *
+     * @param logEnabled is log enabled
+     *
+     * @deprecated set logEnabled value by constructor
+     *
+     * @since 3.9.0
+     */
+    @Deprecated
+    public void setLogEnabled(boolean logEnabled) {
+        if (logEnabled) {
+            log = LoggerFactory.getLogger(getClass());
+        } else {
+            log = NOPLogger.NOP_LOGGER;
         }
     }
 

--- a/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
+++ b/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
@@ -35,7 +35,10 @@ import io.micronaut.core.util.StringUtils;
 import io.micronaut.core.value.MapPropertyResolver;
 import io.micronaut.core.value.PropertyResolver;
 import io.micronaut.core.value.ValueException;
+
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.helpers.NOPLogger;
 
 import java.security.SecureRandom;
 import java.util.ArrayList;
@@ -66,8 +69,6 @@ import java.util.stream.Collectors;
  */
 public class PropertySourcePropertyResolver implements PropertyResolver, AutoCloseable {
 
-    private static final Logger LOG = ClassUtils.getLogger(PropertySourcePropertyResolver.class);
-
     private static final EnvironmentProperties CURRENT_ENV = StaticOptimizations.get(EnvironmentProperties.class)
             .orElseGet(EnvironmentProperties::empty);
     private static final Pattern DOT_PATTERN = Pattern.compile("\\.");
@@ -87,10 +88,7 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
     protected final Map<String, Object>[] rawCatalog = new Map[58];
     protected final Map<String, Object>[] nonGenerated = new Map[58];
 
-    /**
-     * If you don't need to initialize SLF4J, set 'false'.
-     */
-    protected boolean logEnabled = true;
+    protected final Logger log;
 
     private final SecureRandom random = new SecureRandom();
     private final Map<String, Boolean> containsCache = new ConcurrentHashMap<>(20);
@@ -101,8 +99,12 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
      * Creates a new, initially empty, {@link PropertySourcePropertyResolver} for the given {@link ConversionService}.
      *
      * @param conversionService The {@link ConversionService}
+     * @param logEnabled logEnabled flag to enable or disable logger
      */
-    public PropertySourcePropertyResolver(ConversionService<?> conversionService) {
+    public PropertySourcePropertyResolver(ConversionService<?> conversionService, boolean logEnabled) {
+
+        log = logEnabled ? LoggerFactory.getLogger(getClass()) : NOPLogger.NOP_LOGGER;
+
         this.conversionService = conversionService;
         this.propertyPlaceholderResolver = new DefaultPropertyPlaceholderResolver(this, conversionService);
     }
@@ -111,7 +113,7 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
      * Creates a new, initially empty, {@link PropertySourcePropertyResolver}.
      */
     public PropertySourcePropertyResolver() {
-        this(ConversionService.SHARED);
+        this(ConversionService.SHARED, true);
     }
 
     /**
@@ -120,7 +122,7 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
      * @param propertySources The {@link PropertySource} instances
      */
     public PropertySourcePropertyResolver(PropertySource... propertySources) {
-        this(ConversionService.SHARED);
+        this(ConversionService.SHARED, true);
         if (propertySources != null) {
             for (PropertySource propertySource : propertySources) {
                 addPropertySource(propertySource);
@@ -330,11 +332,11 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
                             converted = conversionService.convert(value, conversionContext);
                         }
 
-                        if (logEnabled && LOG.isTraceEnabled()) {
+                        if (log.isTraceEnabled()) {
                             if (converted.isPresent()) {
-                                LOG.trace("Resolved value [{}] for property: {}", converted.get(), name);
+                                log.trace("Resolved value [{}] for property: {}", converted.get(), name);
                             } else {
-                                LOG.trace("Resolved value [{}] cannot be converted to type [{}] for property: {}", value, conversionContext.getArgument(), name);
+                                log.trace("Resolved value [{}] cannot be converted to type [{}] for property: {}", value, conversionContext.getArgument(), name);
                             }
                         }
 
@@ -363,9 +365,7 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
             }
 
         }
-        if (logEnabled) {
-            LOG.trace("No value found for property: {}", name);
-        }
+        log.trace("No value found for property: {}", name);
 
         Class<T> requiredType = conversionContext.getArgument().getType();
         if (Properties.class.isAssignableFrom(requiredType)) {
@@ -533,9 +533,7 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
         synchronized (catalog) {
             for (String property : properties) {
 
-                if (logEnabled) {
-                    LOG.trace("Processing property key {}", property);
-                }
+                log.trace("Processing property key {}", property);
 
                 Object value = properties.get(property);
 
@@ -907,28 +905,6 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
         if (propertyPlaceholderResolver instanceof AutoCloseable) {
             ((AutoCloseable) propertyPlaceholderResolver).close();
         }
-    }
-
-    /**
-     * Return logEnabled value.
-     *
-     * @return is log enabled
-     *
-     * @since 3.9.0
-     */
-    public boolean isLogEnabled() {
-        return logEnabled;
-    }
-
-    /**
-     * Setter for logEnabled.
-     *
-     * @param logEnabled is log enabled
-     *
-     * @since 3.9.0
-     */
-    public void setLogEnabled(boolean logEnabled) {
-        this.logEnabled = logEnabled;
     }
 
     /**

--- a/inject/src/main/java/io/micronaut/context/env/yaml/YamlPropertySourceLoader.java
+++ b/inject/src/main/java/io/micronaut/context/env/yaml/YamlPropertySourceLoader.java
@@ -17,8 +17,6 @@ package io.micronaut.context.env.yaml;
 
 import io.micronaut.context.env.AbstractPropertySourceLoader;
 import io.micronaut.core.util.CollectionUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
 
 import java.io.InputStream;
@@ -34,7 +32,12 @@ import java.util.Set;
  */
 public class YamlPropertySourceLoader extends AbstractPropertySourceLoader {
 
-    private static final Logger LOG = LoggerFactory.getLogger(YamlPropertySourceLoader.class);
+    public YamlPropertySourceLoader() {
+    }
+
+    public YamlPropertySourceLoader(boolean logEnabled) {
+        super(logEnabled);
+    }
 
     @Override
     public boolean isEnabled() {
@@ -61,17 +64,13 @@ public class YamlPropertySourceLoader extends AbstractPropertySourceLoader {
                 Object object = i.next();
                 if (object instanceof Map) {
                     Map map = (Map) object;
-                    if (logEnabled) {
-                        LOG.trace("Processing YAML: {}", map);
-                    }
+                    log.trace("Processing YAML: {}", map);
                     String prefix = "";
                     processMap(finalMap, map, prefix);
                 }
             }
         } else {
-            if (logEnabled) {
-                LOG.trace("PropertySource [{}] produced no YAML content", name);
-            }
+            log.trace("PropertySource [{}] produced no YAML content", name);
         }
     }
 

--- a/jackson-core/src/main/java/io/micronaut/jackson/core/env/CloudFoundryVcapApplicationPropertySourceLoader.java
+++ b/jackson-core/src/main/java/io/micronaut/jackson/core/env/CloudFoundryVcapApplicationPropertySourceLoader.java
@@ -46,6 +46,13 @@ public class CloudFoundryVcapApplicationPropertySourceLoader extends EnvJsonProp
 
     private static final String VCAP_APPLICATION = "VCAP_APPLICATION";
 
+    public CloudFoundryVcapApplicationPropertySourceLoader() {
+    }
+
+    public CloudFoundryVcapApplicationPropertySourceLoader(boolean logEnabled) {
+        super(logEnabled);
+    }
+
     @Override
     public int getOrder() {
         return POSITION;

--- a/jackson-core/src/main/java/io/micronaut/jackson/core/env/CloudFoundryVcapServicesPropertySourceLoader.java
+++ b/jackson-core/src/main/java/io/micronaut/jackson/core/env/CloudFoundryVcapServicesPropertySourceLoader.java
@@ -47,6 +47,13 @@ public class CloudFoundryVcapServicesPropertySourceLoader extends EnvJsonPropert
 
     private static final String VCAP_SERVICES = "VCAP_SERVICES";
 
+    public CloudFoundryVcapServicesPropertySourceLoader() {
+    }
+
+    public CloudFoundryVcapServicesPropertySourceLoader(boolean logEnabled) {
+        super(logEnabled);
+    }
+
     @Override
     public int getOrder() {
         return POSITION;

--- a/jackson-core/src/main/java/io/micronaut/jackson/core/env/EnvJsonPropertySourceLoader.java
+++ b/jackson-core/src/main/java/io/micronaut/jackson/core/env/EnvJsonPropertySourceLoader.java
@@ -43,6 +43,13 @@ public class EnvJsonPropertySourceLoader extends JsonPropertySourceLoader {
     private static final String SPRING_APPLICATION_JSON = "SPRING_APPLICATION_JSON";
     private static final String MICRONAUT_APPLICATION_JSON = "MICRONAUT_APPLICATION_JSON";
 
+    public EnvJsonPropertySourceLoader() {
+    }
+
+    public EnvJsonPropertySourceLoader(boolean logEnabled) {
+        super(logEnabled);
+    }
+
     @Override
     public int getOrder() {
         return POSITION;

--- a/jackson-core/src/main/java/io/micronaut/jackson/core/env/JsonPropertySourceLoader.java
+++ b/jackson-core/src/main/java/io/micronaut/jackson/core/env/JsonPropertySourceLoader.java
@@ -45,6 +45,13 @@ public class JsonPropertySourceLoader extends AbstractPropertySourceLoader {
      */
     public static final String FILE_EXTENSION = "json";
 
+    public JsonPropertySourceLoader() {
+    }
+
+    public JsonPropertySourceLoader(boolean logEnabled) {
+        super(logEnabled);
+    }
+
     @Override
     public Set<String> getExtensions() {
         return Collections.singleton(FILE_EXTENSION);

--- a/jackson-databind/src/main/java/io/micronaut/jackson/env/JsonPropertySourceLoader.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/env/JsonPropertySourceLoader.java
@@ -41,6 +41,13 @@ public class JsonPropertySourceLoader extends AbstractPropertySourceLoader {
      */
     public static final String FILE_EXTENSION = "json";
 
+    public JsonPropertySourceLoader() {
+    }
+
+    public JsonPropertySourceLoader(boolean logEnabled) {
+        super(logEnabled);
+    }
+
     @Override
     public Set<String> getExtensions() {
         return Collections.singleton(FILE_EXTENSION);

--- a/session/src/main/java/io/micronaut/session/Session.java
+++ b/session/src/main/java/io/micronaut/session/Session.java
@@ -49,7 +49,7 @@ public interface Session extends MutableConvertibleValues<Object> {
 
     /**
      * Returns the last time the client sent a request associated with this session as an {@link Instant}.
-     * <p>
+     *
      * <p>Actions that your application takes, such as getting or setting a value associated with the session, do not
      * affect the access time.
      *


### PR DESCRIPTION
Unfortunately, the previous solution didn't work because the static fields were still initialized regardless of usage.

This solution is much more efficient and works 100% because I tested it several times :). Now, if necessary, the logEnabled flag is set in the constructor and the logger is not static, but is created through the factory only if necessary. Otherwise, a dummy logger is created.

Thus, the code remains as it was and we have the opportunity to turn off the initialization of slf4j in micronaut-openapi.

This solution also corrects the names of loggers when inheriting. Now the child and parent methods use a single logger with the name of the child class (this cannot be done when you have a static logger)