### PR TITLE
graal: remove static final Logger from  DefaultHttpFactories

### DIFF
--- a/http/src/main/java/io/micronaut/http/DefaultHttpFactories.java
+++ b/http/src/main/java/io/micronaut/http/DefaultHttpFactories.java
@@ -34,8 +34,6 @@ import java.util.Optional;
 @Internal
 class DefaultHttpFactories {
 
-    private static final Logger LOG = LoggerFactory.getLogger(DefaultHttpFactories.class);
-
     /**
      * Resolves the default request factory.
      *
@@ -50,7 +48,9 @@ class DefaultHttpFactories {
             try {
                 return sd.load();
             } catch (Throwable e) {
-                LOG.warn("Unable to load default request factory for definition [" + definition + "]: " + e.getMessage(), e);
+                // I get the logger here intionally to avoid getting io.micronaut.http.DefaultHttpFactories unintentionally initialized at build time
+                Logger logger = LoggerFactory.getLogger(DefaultHttpFactories.class);
+                logger.warn("Unable to load default request factory for definition [" + definition + "]: " + e.getMessage(), e);
             }
         }
         return new SimpleHttpRequestFactory();
@@ -70,10 +70,11 @@ class DefaultHttpFactories {
             try {
                 return sd.load();
             } catch (Throwable e) {
-                LOG.warn("Unable to load default response factory for definition [" + definition + "]: " + e.getMessage(), e);
+                // I get the logger here intionally to avoid getting io.micronaut.http.DefaultHttpFactories unintentionally initialized at build time
+                Logger logger = LoggerFactory.getLogger(DefaultHttpFactories.class);
+                logger.warn("Unable to load default response factory for definition [" + definition + "]: " + e.getMessage(), e);
             }
         }
         return new SimpleHttpResponseFactory();
     }
-
 }


### PR DESCRIPTION
see: https://github.com/micronaut-projects/micronaut-starter/pull/1773

I assume this PR fixes: 


```
Error: Classes that should be initialized at run time got initialized during image building:
 org.slf4j.LoggerFactory was unintentionally initialized at build time. To see why org.slf4j.LoggerFactory got initialized use --trace-class-initialization=org.slf4j.LoggerFactory
io.micronaut.http.DefaultHttpFactories was unintentionally initialized at build time. To see why io.micronaut.http.DefaultHttpFactories got initialized use --trace-class-initialization=io.micronaut.http.DefaultHttpFactories
To see how the classes got initialized, use --trace-class-initialization=org.slf4j.LoggerFactory,io.micronaut.http.DefaultHttpFactories```
```
```
asses that should be initialized at run time got initialized during image building:
 io.micronaut.http.DefaultHttpFactories was unintentionally initialized at build time. io.micronaut.http.HttpResponseFactory caused initialization of this class with the following trace:
        at io.micronaut.http.DefaultHttpFactories.<clinit>(DefaultHttpFactories.java:37)
        at io.micronaut.http.HttpResponseFactory.<clinit>(HttpResponseFactory.java:29)

``