### PR TITLE
Remove managed logging dependencies

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.convention-base.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.convention-base.gradle
@@ -89,7 +89,7 @@ dependencies {
         transitive = false
     }
 
-    api libs.managed.slf4j.api
+    api libs.slf4j.api
     compileOnly libs.caffeine
     compileOnly libs.bundles.asm
 

--- a/context/build.gradle
+++ b/context/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     compileOnly project(':core-reactive')
     compileOnly project(':core-processor')
     compileOnly libs.log4j
-    compileOnly libs.managed.logback.classic
+    compileOnly libs.logback.classic
 
     // Support validation annotations
     compileOnly platform(libs.test.boms.micronaut.validation)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,7 +32,7 @@ jcache = "1.1.1"
 junit5 = "5.9.2"
 junit-platform="1.9.2"
 ktor = "1.6.8"
-managed-logback = "1.4.7"
+logback = "1.4.7"
 logbook-netty = "2.14.0"
 log4j = "2.19.0"
 micronaut-aws = "3.9.2"
@@ -46,6 +46,7 @@ micronaut-validation = "4.0.0-M3"
 micrometer = "1.10.2"
 neo4j-java-driver = "1.4.5"
 selenium = "4.7.2"
+slf4j = "2.0.7"
 smallrye = "5.5.0"
 spock = "2.3-groovy-4.0"
 spotbugs = "4.7.1"
@@ -72,7 +73,6 @@ managed-netty-http3 = "0.0.16.Final"
 managed-reactive-streams = "1.0.4"
 # This should be kept aligned with https://github.com/micronaut-projects/micronaut-reactor/blob/master/gradle.properties from the BOM
 managed-reactor = "3.5.5"
-managed-slf4j = "2.0.7"
 managed-snakeyaml = "2.0"
 managed-java-parser-core = "3.24.9"
 managed-ksp = "1.8.20-1.0.10"
@@ -147,10 +147,6 @@ managed-reactive-streams = { module = "org.reactivestreams:reactive-streams", ve
 managed-reactor = { module = "io.projectreactor:reactor-core", version.ref = "managed-reactor" }
 managed-reactor-test = { module = "io.projectreactor:reactor-test", version.ref = "managed-reactor" }
 
-managed-slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "managed-slf4j" }
-managed-slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "managed-slf4j" }
-managed-logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "managed-logback" }
-
 managed-snakeyaml = { module = "org.yaml:snakeyaml", version.ref = "managed-snakeyaml" }
 
 #
@@ -215,6 +211,8 @@ kotlin-kotest-junit5 = { module = "io.kotest:kotest-runner-junit5-jvm" }
 
 log4j = { module = "org.apache.logging.log4j:log4j-core", version.ref = "log4j" }
 
+logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
+
 logbook-netty = { module = "org.zalando:logbook-netty", version.ref = "logbook-netty" }
 
 micronaut-docs = { module = "io.micronaut.docs:micronaut-docs-asciidoc-config-props", version.ref = "micronaut-docs" }
@@ -246,6 +244,8 @@ selenium-support = { module = "org.seleniumhq.selenium:selenium-support", versio
 selenium-driver-chrome = { module = "org.seleniumhq.selenium:selenium-chrome-driver", version.ref = "selenium" }
 selenium-driver-firefox = { module = "org.seleniumhq.selenium:selenium-firefox-driver", version.ref = "selenium" }
 selenium-driver-htmlunit = { module = "org.seleniumhq.selenium:htmlunit-driver", version.ref = "selenium" }
+
+slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 
 smallrye = { module = "io.smallrye:smallrye-fault-tolerance", version.ref = "smallrye" }
 spock = { module = "org.spockframework:spock-core", version.ref = "spock" }

--- a/http-client/build.gradle
+++ b/http-client/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     testImplementation project(":jackson-databind")
     testImplementation project(":http-server-netty")
     testImplementation libs.wiremock
-    testImplementation libs.managed.logback.classic
+    testImplementation libs.logback.classic
 
     if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_15)) {
         testImplementation libs.bcpkix

--- a/http-server-netty/build.gradle
+++ b/http-server-netty/build.gradle
@@ -90,7 +90,7 @@ dependencies {
             classifier = Os.isArch("aarch64") ? "osx-aarch_64" : "osx-x86_64"
         }
     }
-    testImplementation libs.managed.logback.classic
+    testImplementation libs.logback.classic
 
     // Adding these for now since micronaut-test isnt resolving correctly ... probably need to upgrade gradle there too
     testImplementation libs.junit.jupiter.api

--- a/http/build.gradle
+++ b/http/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     testImplementation project(":jackson-databind")
     testImplementation project(":inject")
     testImplementation project(":runtime")
-    testImplementation(libs.managed.logback.classic)
+    testImplementation(libs.logback.classic)
 }
 
 tasks.named("compileKotlin") {

--- a/management/build.gradle
+++ b/management/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     testRuntimeOnly libs.h2
     testRuntimeOnly libs.mysql.driver
 
-    compileOnly libs.managed.logback.classic
+    compileOnly libs.logback.classic
     compileOnly libs.log4j
 
 }

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     compileOnly libs.caffeine
     compileOnly libs.managed.kotlinx.coroutines.core
     compileOnly libs.managed.kotlinx.coroutines.reactive
-    testImplementation libs.managed.logback.classic
+    testImplementation libs.logback.classic
     testImplementation libs.managed.snakeyaml
     testAnnotationProcessor project(":inject-java")
     testImplementation libs.jsr107

--- a/test-suite-geb/build.gradle
+++ b/test-suite-geb/build.gradle
@@ -38,5 +38,5 @@ dependencies {
     testImplementation project(':http-server-netty')
     testImplementation project(":jackson-databind")
 
-    testRuntimeOnly libs.managed.logback.classic
+    testRuntimeOnly libs.logback.classic
 }

--- a/test-suite-http-server-tck-netty/build.gradle
+++ b/test-suite-http-server-tck-netty/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     testImplementation(projects.httpServerNetty)
     testImplementation(projects.httpClient)
     testImplementation(libs.junit.platform.engine)
-    testImplementation(libs.managed.logback.classic)
+    testImplementation(libs.logback.classic)
     testImplementation(platform(libs.test.boms.micronaut.validation))
     testImplementation(libs.micronaut.validation) {
         exclude(group: "io.micronaut")

--- a/test-suite-logback-external-configuration/build.gradle.kts
+++ b/test-suite-logback-external-configuration/build.gradle.kts
@@ -7,7 +7,7 @@ dependencies {
     testImplementation(libs.spock)
     testImplementation(projects.context)
     testImplementation(projects.injectGroovy)
-    testImplementation(libs.managed.logback.classic)
+    testImplementation(libs.logback.classic)
     testImplementation(projects.management)
     testImplementation(projects.httpClient)
     testImplementation(projects.jacksonDatabind)

--- a/test-suite-logback/build.gradle
+++ b/test-suite-logback/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     testImplementation(projects.context)
 
     testImplementation(projects.injectGroovy)
-    testImplementation(libs.managed.logback.classic)
+    testImplementation(libs.logback.classic)
 
     testImplementation(projects.management)
     testImplementation(projects.httpClient)

--- a/test-suite/build.gradle
+++ b/test-suite/build.gradle
@@ -89,7 +89,7 @@ dependencies {
     testRuntimeOnly(platform(libs.test.boms.micronaut.aws))
     testRuntimeOnly libs.h2
     testRuntimeOnly libs.junit.vintage
-    testRuntimeOnly libs.managed.logback.classic
+    testRuntimeOnly libs.logback.classic
     testRuntimeOnly libs.aws.java.sdk.lambda
 
     // needed for HTTP/2 tests
@@ -103,7 +103,7 @@ dependencies {
     }
     testImplementation libs.managed.netty.incubator.codec.http3
     testImplementation libs.logbook.netty
-    testImplementation libs.managed.logback.classic
+    testImplementation libs.logback.classic
 
     if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_15)) {
         testImplementation libs.bcpkix


### PR DESCRIPTION
These are already defined in `micronaut-logging`. This will fix the warnings about duplicate logging entries when building the platform.