### PR TITLE
doc: fix configuration properties

### DIFF
--- a/src/main/docs/guide/httpServer/transfers.adoc
+++ b/src/main/docs/guide/httpServer/transfers.adoc
@@ -42,6 +42,6 @@ TIP: To use a custom data source to send data through an input stream, construct
 
 By default, file responses include caching headers. The following options determine how the `Cache-Control` header is built.
 
-include::{includedir}configurationProperties/io.micronaut.http.server.netty.types.files.FileTypeHandlerConfiguration.adoc[]
+include::{includedir}configurationProperties/io.micronaut.http.server.netty.configuration.NettyHttpServerConfiguration$FileTypeHandlerConfiguration.adoc[]
 
-include::{includedir}configurationProperties/io.micronaut.http.server.netty.types.files.FileTypeHandlerConfiguration$CacheControlConfiguration.adoc[]
+include::{includedir}configurationProperties/io.micronaut.http.server.netty.configuration.NettyHttpServerConfiguration$FileTypeHandlerConfiguration$CacheControlConfiguration.adoc[]


### PR DESCRIPTION
documentation assemble failed with:

```
In file index.html
    <p>Unresolved directive in &lt;stdin&gt; - include::/Users/sdelamo/github/micronaut-projects/micronaut-core/build/working/01-includes/configurationProperties/io.micronaut.http.server.netty.types.files.FileTypeHandlerConfiguration.adoc[]</p>
    <p>Unresolved directive in &lt;stdin&gt; - include::/Users/sdelamo/github/micronaut-projects/micronaut-core/build/working/01-includes/configurationProperties/io.micronaut.http.server.netty.types.files.FileTypeHandlerConfiguration$CacheControlConfiguration.adoc[]</p>
``