### PR TITLE
Fix not supported error with type use annotations and expression

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -577,17 +577,21 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
                                                        @NonNull String memberName,
                                                        @NonNull Object initialAnnotationValue) {
         String originatingClassName = getOriginatingClassName(originatingElement);
+        if (originatingClassName != null) {
+            String packageName = NameUtils.getPackageName(originatingClassName);
+            String simpleClassName = NameUtils.getSimpleName(originatingClassName);
+            String exprClassName = "%s.$%s%s".formatted(packageName, simpleClassName, EXPR_SUFFIX);
 
-        String packageName = NameUtils.getPackageName(originatingClassName);
-        String simpleClassName = NameUtils.getSimpleName(originatingClassName);
-        String exprClassName = "%s.$%s%s".formatted(packageName, simpleClassName, EXPR_SUFFIX);
+            Integer expressionIndex = EvaluatedExpressionReference.nextIndex(exprClassName);
 
-        Integer expressionIndex = EvaluatedExpressionReference.nextIndex(exprClassName);
+            return new EvaluatedExpressionReference(initialAnnotationValue, annotationName, memberName, exprClassName + expressionIndex);
+        } else {
+            return initialAnnotationValue;
+        }
 
-        return new EvaluatedExpressionReference(initialAnnotationValue, annotationName, memberName, exprClassName + expressionIndex);
     }
 
-    @NonNull
+    @Nullable
     protected abstract String getOriginatingClassName(@NonNull T orginatingElement);
 
     /**

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/annotation/GroovyAnnotationMetadataBuilder.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/annotation/GroovyAnnotationMetadataBuilder.java
@@ -159,7 +159,12 @@ public class GroovyAnnotationMetadataBuilder extends AbstractAnnotationMetadataB
             return methodNode.getDeclaringClass().getName();
         }
 
-        return originatingElement.getDeclaringClass().getName();
+        ClassNode declaringClass = originatingElement.getDeclaringClass();
+        if (declaringClass != null) {
+            return declaringClass.getName();
+        } else {
+            return null;
+        }
     }
 
     @Override

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/AnnotationsElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/AnnotationsElement.java
@@ -25,6 +25,7 @@ import javax.lang.model.element.Modifier;
 import javax.lang.model.element.Name;
 import javax.lang.model.type.TypeMirror;
 import java.lang.annotation.Annotation;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -54,7 +55,7 @@ final class AnnotationsElement implements Element {
 
     @Override
     public Set<Modifier> getModifiers() {
-        throw notSupportedMethod();
+        return Collections.emptySet();
     }
 
     @Override
@@ -64,12 +65,12 @@ final class AnnotationsElement implements Element {
 
     @Override
     public Element getEnclosingElement() {
-        throw notSupportedMethod();
+        return null;
     }
 
     @Override
     public List<? extends Element> getEnclosedElements() {
-        throw notSupportedMethod();
+        return Collections.emptyList();
     }
 
     @Override
@@ -89,7 +90,7 @@ final class AnnotationsElement implements Element {
 
     @Override
     public <R, P> R accept(ElementVisitor<R, P> v, P p) {
-        throw notSupportedMethod();
+        return v.visit(this);
     }
 
     private static IllegalStateException notSupportedMethod() {

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/JavaAnnotationMetadataBuilder.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/JavaAnnotationMetadataBuilder.java
@@ -300,10 +300,17 @@ public class JavaAnnotationMetadataBuilder extends AbstractAnnotationMetadataBui
 
     @Override
     protected String getOriginatingClassName(Element orginatingElement) {
-        return JavaModelUtils.getClassName(getOriginatingTypeElement(orginatingElement));
+        TypeElement typeElement = getOriginatingTypeElement(orginatingElement);
+        if (typeElement != null) {
+            return JavaModelUtils.getClassName(typeElement);
+        }
+        return null;
     }
 
     private TypeElement getOriginatingTypeElement(Element element) {
+        if (element == null) {
+            return null;
+        }
         if (element instanceof TypeElement typeElement) {
             return typeElement;
         }

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/annotation/KotlinAnnotationMetadataBuilder.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/annotation/KotlinAnnotationMetadataBuilder.kt
@@ -378,12 +378,17 @@ internal class KotlinAnnotationMetadataBuilder(private val symbolProcessorEnviro
         }
     }
 
-    override fun getOriginatingClassName(orginatingElement: KSAnnotated): String {
-        return if (orginatingElement is KSClassDeclaration) {
+    override fun getOriginatingClassName(orginatingElement: KSAnnotated): String? {
+        val binaryName = if (orginatingElement is KSClassDeclaration) {
             orginatingElement.getBinaryName(resolver, visitorContext)
         } else {
             val classDeclaration = orginatingElement.getClassDeclaration(visitorContext)
             classDeclaration.getBinaryName(resolver, visitorContext)
+        }
+        return if (binaryName != Object::javaClass.name) {
+            binaryName
+        } else {
+            null
         }
     }
 

--- a/src/main/docs/guide/config/evaluatedExpressions.adoc
+++ b/src/main/docs/guide/config/evaluatedExpressions.adoc
@@ -10,6 +10,8 @@ double injectedValue;
 
 Expressions can be defined whenever an annotation member accepts a string or an array of strings.
 
+NOTE: Expressions are currently not supported for "type use" annotations (annotations that declare `ElementType.TYPE_USE`).
+
 .Evaluated Expression in array
 [source,java]
 ----


### PR DESCRIPTION
TYPE_USE annotations can't be used with expression at the moment because they fail to locate the originating class name, not sure how to fix this so for the moment improve the error and document that it is not supported.