### PR TITLE
Use JsonNodeConvertibleValues when deserializing untyped ConvertibleValues

### DIFF
--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/BodyTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/BodyTest.java
@@ -58,6 +58,18 @@ public class BodyTest {
     }
 
     @Test
+    void testCustomBodyPOJOAsPart() throws IOException {
+        asserts(SPEC_NAME,
+            HttpRequest.POST("/response-body/part-pojo", "{\"point\":{\"x\":10,\"y\":20},\"foo\":\"bar\"}")
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON),
+            (server, request) -> AssertionUtils.assertDoesNotThrow(server, request,
+                HttpResponseAssertion.builder()
+                    .status(HttpStatus.CREATED)
+                    .body("{\"x\":10,\"y\":20}")
+                    .build()));
+    }
+
+    @Test
     void testCustomBodyPOJODefaultToJSON() throws IOException {
         asserts(SPEC_NAME,
             HttpRequest.POST("/response-body/pojo", "{\"x\":10,\"y\":20}"),
@@ -111,6 +123,12 @@ public class BodyTest {
         @Post(uri = "/pojo")
         @Status(HttpStatus.CREATED)
         Point post(@Body Point data) {
+            return data;
+        }
+
+        @Post(uri = "/part-pojo")
+        @Status(HttpStatus.CREATED)
+        Point postPart(@Body("point") Point data) {
             return data;
         }
 

--- a/jackson-databind/src/main/java/io/micronaut/jackson/serialize/ConvertibleValuesDeserializer.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/serialize/ConvertibleValuesDeserializer.java
@@ -67,6 +67,13 @@ final class ConvertibleValuesDeserializer<V> extends JsonDeserializer<Convertibl
     @Override
     public ConvertibleValues<V> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JacksonException {
         if (valueDeserializer == null) {
+            if (!p.hasCurrentToken()) {
+                p.nextToken();
+            }
+            if (p.getCurrentToken() != JsonToken.START_OBJECT) {
+                //noinspection unchecked
+                return (ConvertibleValues<V>) ctxt.handleUnexpectedToken(handledType(), p);
+            }
             JsonNode node = JSON_NODE_DESERIALIZER.deserialize(p, ctxt);
             return new JsonNodeConvertibleValues<>(node, conversionService);
         } else {

--- a/jackson-databind/src/main/java/io/micronaut/jackson/serialize/ConvertibleValuesDeserializer.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/serialize/ConvertibleValuesDeserializer.java
@@ -25,6 +25,8 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.value.ConvertibleValues;
 import io.micronaut.core.convert.value.MutableConvertibleValuesMap;
@@ -37,14 +39,16 @@ import java.io.IOException;
 final class ConvertibleValuesDeserializer<V> extends JsonDeserializer<ConvertibleValues<V>> implements ContextualDeserializer {
     private static final JsonNodeDeserializer JSON_NODE_DESERIALIZER = new JsonNodeDeserializer();
     private final ConversionService conversionService;
+    @Nullable
     private final JavaType valueType;
+    @Nullable
     private final JsonDeserializer<V> valueDeserializer;
 
-    ConvertibleValuesDeserializer(ConversionService conversionService, JavaType valueType) {
+    ConvertibleValuesDeserializer(@NonNull ConversionService conversionService, @Nullable JavaType valueType) {
         this(conversionService, valueType, null);
     }
 
-    ConvertibleValuesDeserializer(ConversionService conversionService, JavaType valueType, JsonDeserializer<V> valueDeserializer) {
+    private ConvertibleValuesDeserializer(@NonNull ConversionService conversionService, @Nullable JavaType valueType, @Nullable JsonDeserializer<V> valueDeserializer) {
         this.conversionService = conversionService;
         this.valueType = valueType;
         this.valueDeserializer = valueDeserializer;
@@ -52,6 +56,10 @@ final class ConvertibleValuesDeserializer<V> extends JsonDeserializer<Convertibl
 
     @Override
     public JsonDeserializer<?> createContextual(DeserializationContext ctxt, BeanProperty property) throws JsonMappingException {
+        if (valueType == null) {
+            // deserialize to JsonNodeConvertibleValues
+            return this;
+        }
         JsonDeserializer<Object> valueDeserializer = ctxt.findContextualValueDeserializer(valueType, property);
         return new ConvertibleValuesDeserializer<>(conversionService, valueType, valueDeserializer);
     }

--- a/jackson-databind/src/main/java/io/micronaut/jackson/serialize/MicronautDeserializers.java
+++ b/jackson-databind/src/main/java/io/micronaut/jackson/serialize/MicronautDeserializers.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.module.SimpleDeserializers;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.value.ConvertibleValues;
@@ -37,6 +38,9 @@ public class MicronautDeserializers extends SimpleDeserializers {
     public JsonDeserializer<?> findBeanDeserializer(JavaType type, DeserializationConfig config, BeanDescription beanDesc) throws JsonMappingException {
         if (type.getRawClass() == ConvertibleValues.class) {
             JavaType valueType = type.containedTypeOrUnknown(0);
+            if (valueType.equals(TypeFactory.unknownType())) {
+                valueType = null;
+            }
             return new ConvertibleValuesDeserializer<>(conversionService, valueType);
         }
 

--- a/jackson-databind/src/test/groovy/io/micronaut/jackson/serialize/ConvertibleValuesDeserializerSpec.groovy
+++ b/jackson-databind/src/test/groovy/io/micronaut/jackson/serialize/ConvertibleValuesDeserializerSpec.groovy
@@ -1,5 +1,6 @@
 package io.micronaut.jackson.serialize
 
+import com.fasterxml.jackson.databind.exc.MismatchedInputException
 import io.micronaut.context.ApplicationContext
 import io.micronaut.core.convert.value.ConvertibleValues
 import io.micronaut.core.type.Argument
@@ -22,6 +23,7 @@ class ConvertibleValuesDeserializerSpec extends Specification {
         cleanup:
         ctx.close()
     }
+
     def 'test with value type'() {
         given:
         def ctx = ApplicationContext.run()
@@ -34,6 +36,20 @@ class ConvertibleValuesDeserializerSpec extends Specification {
         // values should be int-typed
         values.get("foo", Object).get() == 4
         values.get("fizz", Object).get() == 5
+
+        cleanup:
+        ctx.close()
+    }
+
+    def 'test wrong format'() {
+        given:
+        def ctx = ApplicationContext.run()
+        def mapper = ctx.getBean(JsonMapper)
+
+        when:
+        mapper.readValue('[{"foo":"4","fizz":5},4]', Argument.of(ConvertibleValues))
+        then:
+        thrown MismatchedInputException
 
         cleanup:
         ctx.close()

--- a/management/src/test/groovy/io/micronaut/management/endpoint/loggers/LoggersEndpointSpec.groovy
+++ b/management/src/test/groovy/io/micronaut/management/endpoint/loggers/LoggersEndpointSpec.groovy
@@ -185,7 +185,7 @@ class LoggersEndpointSpec extends Specification {
 
         and:
         e.response.status == HttpStatus.BAD_REQUEST
-        e.response.getBody(Map).get()._embedded.errors[0].message.contains 'Failed to convert argument [configuredLevel] for value [FOO] due to: No enum constant io.micronaut.logging.LogLevel.FOO'
+        e.response.getBody(Map).get()._embedded.errors[0].message.contains 'Failed to convert argument [configuredLevel] for value [null] due to: Cannot deserialize value of type `io.micronaut.logging.LogLevel` from String "FOO": not one of the values accepted for Enum class: [ALL, DEBUG, NOT_SPECIFIED, TRACE, WARN, ERROR, INFO, OFF]'
     }
 
     void 'test that an attempt to set ROOT logger to NOT_SPECIFIED level will fail'() {


### PR DESCRIPTION
This should fix this failing test: https://github.com/micronaut-projects/micronaut-validation/pull/118/commits/a37ba8a7b4b191c457b0a1eea6cfe944458b3b78