### PR TITLE
Workaround for recognizing "javax.inject.Named"

### DIFF
--- a/inject/src/main/java/io/micronaut/inject/BeanType.java
+++ b/inject/src/main/java/io/micronaut/inject/BeanType.java
@@ -69,7 +69,7 @@ public interface BeanType<T> extends AnnotationMetadataProvider, BeanContextCond
         AnnotationMetadata annotationMetadata = getAnnotationMetadata();
         // here we resolved the declared Qualifier of the bean
         return annotationMetadata
-            .findDeclaredAnnotation(AnnotationUtil.NAMED)
+            .findDeclaredAnnotation(AnnotationUtil.NAMED).or(() -> annotationMetadata.findDeclaredAnnotation("javax.inject.Named"))
             .flatMap(AnnotationValue::stringValue);
     }
 

--- a/inject/src/main/java/io/micronaut/inject/QualifiedBeanType.java
+++ b/inject/src/main/java/io/micronaut/inject/QualifiedBeanType.java
@@ -21,13 +21,11 @@ import io.micronaut.core.annotation.AnnotationMetadataDelegate;
 import io.micronaut.core.annotation.AnnotationUtil;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Nullable;
-import io.micronaut.core.naming.NameResolver;
 import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
 import io.micronaut.inject.qualifiers.Qualifiers;
 
 import java.lang.annotation.Annotation;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * An interface for a {@link BeanType} that allows qualifiers.
@@ -70,6 +68,9 @@ public interface QualifiedBeanType<T> extends BeanType<T>, AnnotationMetadataDel
             Qualifier<T> qualifier = resolveDynamicQualifier();
             if (qualifier == null) {
                 String name = annotationMetadata.stringValue(AnnotationUtil.NAMED).orElse(null);
+                if (name == null) {
+                    name = annotationMetadata.stringValue("javax.inject.Named").orElse(null);
+                }
                 qualifier = name != null ? Qualifiers.byAnnotation(annotationMetadata, name) : null;
             }
             return qualifier;

--- a/inject/src/main/java/io/micronaut/inject/qualifiers/NameQualifier.java
+++ b/inject/src/main/java/io/micronaut/inject/qualifiers/NameQualifier.java
@@ -68,7 +68,7 @@ class NameQualifier<T> implements Qualifier<T>, io.micronaut.core.naming.Named {
             AnnotationMetadata annotationMetadata = candidate.getAnnotationMetadata();
             // here we resolved the declared Qualifier of the bean
             String thisName = annotationMetadata
-                    .findDeclaredAnnotation(AnnotationUtil.NAMED)
+                    .findDeclaredAnnotation(AnnotationUtil.NAMED).or(() -> annotationMetadata.findDeclaredAnnotation("javax.inject.Named"))
                     .flatMap(AnnotationValue::stringValue)
                     .orElse(null);
 

--- a/inject/src/main/java/io/micronaut/inject/qualifiers/Qualifiers.java
+++ b/inject/src/main/java/io/micronaut/inject/qualifiers/Qualifiers.java
@@ -383,8 +383,8 @@ public class Qualifiers {
             if (aClass.isPresent()) {
                 return byType(aClass.get());
             }
-        } else if (Named.class == type || AnnotationUtil.NAMED.equals(type.getName())) {
-            Optional<String> value = metadata.stringValue(type);
+        } else if (Named.class == type) {
+            Optional<String> value = metadata.stringValue(type).or(() -> metadata.stringValue("javax.inject.Named"));
             if (value.isPresent()) {
                 return byName(value.get());
             }
@@ -405,8 +405,8 @@ public class Qualifiers {
         } else if (Qualifier.PRIMARY.equals(type)) {
             //noinspection unchecked
             return PrimaryQualifier.INSTANCE;
-        } else if (Named.class.getName().equals(type) || AnnotationUtil.NAMED.equals(type)) {
-            String n = metadata.stringValue(type).orElse(null);
+        } else if (Named.class.getName().equals(type)) {
+            String n = metadata.stringValue(type).or(() -> metadata.stringValue("javax.inject.Named")).orElse(null);
             if (n != null) {
                 return byName(n);
             }


### PR DESCRIPTION
This can be removed after the platform is recompiled with the latest Core.