### PR TITLE
Update netty monorepo to v4.1.92.Final

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -127,7 +127,7 @@ managed-micronaut-views = "3.8.2"
 managed-micronaut-xml = "3.2.0"
 managed-neo4j = "3.5.35"
 managed-neo4j-java-driver = "4.4.9"
-managed-netty = "4.1.91.Final"
+managed-netty = "4.1.92.Final"
 managed-reactive-pg-client = "0.11.4"
 managed-reactive-streams = "1.0.4"
 # This should be kept aligned with https://github.com/micronaut-projects/micronaut-reactor/blob/master/gradle.properties from the BOM


### PR DESCRIPTION
see: https://netty.io/news/2023/04/25/4-1-92-Final.html