### PR TITLE
Move TCK tests for Client Filters to client TCK

### DIFF
--- a/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/filter/ClientRequestFilterTest.java
+++ b/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/filter/ClientRequestFilterTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.http.server.tck.tests.filter;
+package io.micronaut.http.client.tck.tests.filter;
 
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Nullable;

--- a/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/filter/ClientResponseFilterTest.java
+++ b/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/filter/ClientResponseFilterTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.http.server.tck.tests.filter;
+package io.micronaut.http.client.tck.tests.filter;
 
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Nullable;

--- a/test-suite-http-client-tck-jdk/src/test/java/io/micronaut/http/client/tck/jdk/tests/JdkHttpMethodTests.java
+++ b/test-suite-http-client-tck-jdk/src/test/java/io/micronaut/http/client/tck/jdk/tests/JdkHttpMethodTests.java
@@ -1,5 +1,6 @@
 package io.micronaut.http.client.tck.jdk.tests;
 
+import org.junit.platform.suite.api.ExcludeClassNamePatterns;
 import org.junit.platform.suite.api.SelectPackages;
 import org.junit.platform.suite.api.Suite;
 import org.junit.platform.suite.api.SuiteDisplayName;
@@ -11,6 +12,7 @@ import org.junit.platform.suite.api.SuiteDisplayName;
 @SelectPackages("io.micronaut.http.client.tck.tests")
 @SuiteDisplayName("HTTP Client TCK for the HTTP Client Implementation based on Java HTTP Client")
 @SuppressWarnings("java:S2187") // This runs a suite of tests, but has no tests of its own
+@ExcludeClassNamePatterns("io.micronaut.http.client.tck.tests.filter.Client.*FilterTest") // JDK client does not support client filters
 public class JdkHttpMethodTests {
 }
 

--- a/test-suite-http-server-tck-jdk/src/test/java/io/micronaut/http/server/tck/netty/tests/JdkHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-jdk/src/test/java/io/micronaut/http/server/tck/netty/tests/JdkHttpServerTestSuite.java
@@ -1,6 +1,5 @@
 package io.micronaut.http.server.tck.netty.tests;
 
-import org.junit.platform.suite.api.ExcludeClassNamePatterns;
 import org.junit.platform.suite.api.ExcludeTags;
 import org.junit.platform.suite.api.SelectPackages;
 import org.junit.platform.suite.api.Suite;
@@ -9,7 +8,6 @@ import org.junit.platform.suite.api.SuiteDisplayName;
 @Suite
 @SelectPackages("io.micronaut.http.server.tck.tests")
 @SuiteDisplayName("HTTP Server TCK for Javanet client")
-@ExcludeClassNamePatterns("io.micronaut.http.server.tck.tests.filter.Client.*FilterTest")
 @ExcludeTags("multipart") // Multipart not supported by HttpClient
 public class JdkHttpServerTestSuite {
 }


### PR DESCRIPTION
These test the client, not the server so I think it's better to have them in the Client TCK