### PR TITLE
TCK tests for boolean textplain

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -127,7 +127,7 @@ managed-micronaut-views = "3.8.2"
 managed-micronaut-xml = "3.2.0"
 managed-neo4j = "3.5.35"
 managed-neo4j-java-driver = "4.4.9"
-managed-netty = "4.1.91.Final"
+managed-netty = "4.1.92.Final"
 managed-reactive-pg-client = "0.11.4"
 managed-reactive-streams = "1.0.4"
 # This should be kept aligned with https://github.com/micronaut-projects/micronaut-reactor/blob/master/gradle.properties from the BOM

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/AssertionUtils.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/AssertionUtils.java
@@ -18,6 +18,7 @@ package io.micronaut.http.server.tck;
 import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.type.Argument;
 import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
@@ -88,8 +89,15 @@ public final class AssertionUtils {
     public static <T> void assertDoesNotThrow(@NonNull ServerUnderTest server,
                                               @NonNull HttpRequest<T> request,
                                               @NonNull HttpResponseAssertion assertion) {
-        ThrowingSupplier<HttpResponse<?>> executable = assertion.getBody() != null ?
-            () -> server.exchange(request, String.class) :
+        assertDoesNotThrow(server, request, assertion.getBody() != null ? Argument.of(String.class) : null, assertion);
+    }
+
+    public static <T, B> void assertDoesNotThrow(@NonNull ServerUnderTest server,
+                                              @NonNull HttpRequest<T> request,
+                                              @Nullable Argument<B> bodyType,
+                                              @NonNull HttpResponseAssertion assertion) {
+        ThrowingSupplier<HttpResponse<?>> executable = bodyType != null ?
+            () -> server.exchange(request, bodyType) :
             () -> server.exchange(request);
         HttpResponse<?> response = Assertions.assertDoesNotThrow(executable);
         assertEquals(assertion.getHttpStatus(), response.getStatus());

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/bodywritable/HtmlBodyWritableTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/bodywritable/HtmlBodyWritableTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.tck.tests.bodywritable;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.io.Writable;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.MutableHttpResponse;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Filter;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Produces;
+import io.micronaut.http.filter.HttpServerFilter;
+import io.micronaut.http.filter.ServerFilterChain;
+import io.micronaut.http.server.tck.AssertionUtils;
+import io.micronaut.http.server.tck.BodyAssertion;
+import io.micronaut.http.server.tck.HttpResponseAssertion;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+import static io.micronaut.http.server.tck.TestScenario.asserts;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings({
+    "java:S5960", // We're allowed assertions, as these are used in tests only
+    "checkstyle:MissingJavadocType",
+    "checkstyle:DesignForExtension"
+})
+public class HtmlBodyWritableTest {
+    public static final String SPEC_NAME = "ControllerConstraintHandlerTest";
+    private static final HttpResponseAssertion ASSERTION = HttpResponseAssertion.builder()
+        .status(HttpStatus.OK)
+        .body(BodyAssertion.builder().body("<!DOCTYPE html><html></html>").equals())
+        .assertResponse(response -> {
+            assertTrue(response.getContentType().isPresent());
+            assertEquals(MediaType.TEXT_HTML_TYPE, response.getContentType().get());
+        }).build();
+
+    @Test
+    void htmlWritable() throws IOException {
+        asserts(SPEC_NAME,
+            HttpRequest.GET("/html/writable"),
+            (server, request) -> AssertionUtils.assertDoesNotThrow(server, request, ASSERTION));
+    }
+
+    @Test
+    void htmlWritableMono() throws IOException {
+        asserts(SPEC_NAME,
+            HttpRequest.GET("/html/writablemono"),
+            (server, request) -> AssertionUtils.assertDoesNotThrow(server, request, ASSERTION));
+    }
+
+    @Test
+    void htmlWritableFluxFilter() throws IOException {
+        asserts(SPEC_NAME,
+            HttpRequest.GET("/html/writablefluxfilter"),
+            (server, request) -> AssertionUtils.assertDoesNotThrow(server, request, ASSERTION));
+    }
+
+    @Controller("/html")
+    @Requires(property = "spec.name", value = SPEC_NAME)
+    static class OnErrorMethodController {
+        @Get("/writable")
+        @Produces(MediaType.TEXT_HTML)
+        Writable index() {
+            return out -> out.write("<!DOCTYPE html><html></html>");
+        }
+
+        @Get("/writablemono")
+        @Produces(MediaType.TEXT_HTML)
+        Mono<Writable> indexmono() {
+            Writable writable = out -> out.write("<!DOCTYPE html><html></html>");
+            return Mono.just(writable);
+        }
+
+        @Get("/writablefluxfilter")
+        Map<String, Object> indexfluxfilter() {
+            return Collections.emptyMap();
+        }
+    }
+
+    @Requires(property = "spec.name", value = SPEC_NAME)
+    @Filter("/html/writablefluxfilter")
+    static class MockFilter implements HttpServerFilter {
+        @Override
+        public Publisher<MutableHttpResponse<?>> doFilter(HttpRequest<?> request, ServerFilterChain chain) {
+            return Flux.from(chain.proceed(request))
+                .switchMap(response -> {
+                    Writable writable = out -> out.write("<!DOCTYPE html><html></html>");
+                    response.body(writable);
+                    response.contentType(MediaType.TEXT_HTML);
+                    return Flux.just(response);
+                });
+        }
+    }
+}

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/codec/JsonCodeAdditionalTypeTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/codec/JsonCodeAdditionalTypeTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.tck.tests.codec;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.type.Argument;
+import io.micronaut.http.HttpHeaders;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Produces;
+import io.micronaut.http.server.tck.AssertionUtils;
+import io.micronaut.http.server.tck.BodyAssertion;
+import io.micronaut.http.server.tck.HttpResponseAssertion;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+import static io.micronaut.http.server.tck.TestScenario.asserts;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+@SuppressWarnings({
+    "java:S5960", // We're allowed assertions, as these are used in tests only
+    "checkstyle:MissingJavadocType",
+    "checkstyle:DesignForExtension"
+})
+public class JsonCodeAdditionalTypeTest {
+    public static final String SPEC_NAME = "JsonCodeAdditionalTypeTest";
+    public static final String APPLICATION_JSON_FEED = "application/json+feed";
+
+    @Test
+    void itIsPossibleToCanRegisterAdditionTypesForJsonCodec() throws IOException {
+        HttpResponseAssertion assertion = HttpResponseAssertion.builder()
+            .body(BodyAssertion.builder().body("https://jsonfeed.org").contains())
+            .status(HttpStatus.OK)
+            .assertResponse(response -> assertEquals(APPLICATION_JSON_FEED, response.header("Content-Type"))).build();
+
+        Map<String, Object> config = Collections.singletonMap("micronaut.codec.json.additional-types", Collections.singletonList(APPLICATION_JSON_FEED));
+        asserts(SPEC_NAME,
+            config,
+            HttpRequest.GET("/json-additional-codec").header(HttpHeaders.ACCEPT, APPLICATION_JSON_FEED),
+            (server, request) -> AssertionUtils.assertDoesNotThrow(server, request, assertion));
+
+        asserts(SPEC_NAME,
+            config,
+            HttpRequest.GET("/json-additional-codec/pojo").header(HttpHeaders.ACCEPT, APPLICATION_JSON_FEED),
+            (server, request) -> AssertionUtils.assertDoesNotThrow(server, request, assertion));
+    }
+
+    @Requires(property = "spec.name", value = SPEC_NAME)
+    @Controller
+    static class JsonFeedController {
+
+        @Produces(APPLICATION_JSON_FEED)
+        @Get("/json-additional-codec")
+        String index() {
+            return "{\n" +
+                "    \"version\": \"https://jsonfeed.org/version/1\",\n" +
+                "    \"title\": \"My Example Feed\",\n" +
+                "    \"home_page_url\": \"https://example.org/\",\n" +
+                "    \"feed_url\": \"https://example.org/feed.json\",\n" +
+                "    ]\n" +
+                "}";
+        }
+
+        @Produces(APPLICATION_JSON_FEED)
+        @Get("/json-additional-codec/pojo")
+        JsonFeed pojo() {
+            return new JsonFeed("https://jsonfeed.org/version/1", "My Example Feed", "https://example.org/", "https://example.org/feed.json");
+        }
+    }
+
+    @Introspected
+    static class JsonFeed {
+        private final String version;
+        private final String title;
+        @JsonProperty("home_page_url")
+        private final String homePageUrl;
+        @JsonProperty("feed_url")
+        private final String feedUrl;
+
+        public JsonFeed(String version, String title, String homePageUrl, String feedUrl) {
+            this.version = version;
+            this.title = title;
+            this.homePageUrl = homePageUrl;
+            this.feedUrl = feedUrl;
+        }
+
+        public String getVersion() {
+            return version;
+        }
+
+        public String getTitle() {
+            return title;
+        }
+
+        public String getHomePageUrl() {
+            return homePageUrl;
+        }
+
+        public String getFeedUrl() {
+            return feedUrl;
+        }
+    }
+}

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/constraintshandler/ControllerConstraintHandlerTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/constraintshandler/ControllerConstraintHandlerTest.java
@@ -63,9 +63,6 @@ public class ControllerConstraintHandlerTest {
         })
         .build();
 
-    /**
-     * @see <a href="https://github.com/micronaut-projects/micronaut-aws/issues/1164">micronaut-aws #1164</a>
-     */
     @Test
     void testPojoConstraintViolationExceptionIsHandledViaHandler() throws IOException {
         asserts(SPEC_NAME,

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/textplain/TxtPlainBooleanTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/textplain/TxtPlainBooleanTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.tck.tests.textplain;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Produces;
+import io.micronaut.http.server.tck.AssertionUtils;
+import io.micronaut.http.server.tck.BodyAssertion;
+import io.micronaut.http.server.tck.HttpResponseAssertion;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static io.micronaut.http.server.tck.TestScenario.asserts;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings({
+    "java:S5960", // We're allowed assertions, as these are used in tests only
+    "checkstyle:MissingJavadocType",
+    "checkstyle:DesignForExtension"
+})
+public class TxtPlainBooleanTest {
+    public static final String SPEC_NAME = "ControllerConstraintHandlerTest";
+    private static final HttpResponseAssertion ASSERTION = HttpResponseAssertion.builder()
+        .status(HttpStatus.OK)
+        .body(BodyAssertion.builder().body("true").equals())
+        .assertResponse(response -> {
+            assertTrue(response.getContentType().isPresent());
+            assertEquals(MediaType.TEXT_PLAIN_TYPE, response.getContentType().get());
+        }).build();
+
+    @Test
+    void txtBoolean() throws IOException {
+        asserts(SPEC_NAME,
+            HttpRequest.GET("/txt/boolean"),
+            (server, request) -> AssertionUtils.assertDoesNotThrow(server, request, ASSERTION));
+    }
+
+    @Controller("/txt")
+    @Requires(property = "spec.name", value = SPEC_NAME)
+    static class OnErrorMethodController {
+        @Get("/boolean")
+        @Produces(MediaType.TEXT_PLAIN)
+        Boolean index() {
+            return Boolean.TRUE;
+        }
+    }
+}

--- a/json-core/src/test/groovy/io/micronaut/json/codec/JsonMediaTypeCodecSpec.groovy
+++ b/json-core/src/test/groovy/io/micronaut/json/codec/JsonMediaTypeCodecSpec.groovy
@@ -24,7 +24,7 @@ class JsonMediaTypeCodecSpec extends Specification {
     void "test additional type configuration"() {
         given:
         ApplicationContext ctx = ApplicationContext.run([
-                'micronaut.codec.json.additionalTypes': ['text/javascript']
+                'micronaut.codec.json.additional-types': ['text/javascript']
         ])
 
         when:

--- a/runtime/src/test/groovy/io/micronaut/runtime/http/codec/TextPlainCodecSpec.groovy
+++ b/runtime/src/test/groovy/io/micronaut/runtime/http/codec/TextPlainCodecSpec.groovy
@@ -43,8 +43,8 @@ class TextPlainCodecSpec extends Specification {
     void "test additional type configuration"() {
         given:
         ApplicationContext ctx = ApplicationContext.run([
-                'micronaut.codec.text.additionalTypes': ['text/html'],
-                'micronaut.codec.json.additionalTypes': ['foo/javascript']
+                'micronaut.codec.text.additional-types': ['text/html'],
+                'micronaut.codec.json.additional-types': ['foo/javascript']
         ])
 
         when:
@@ -63,7 +63,7 @@ class TextPlainCodecSpec extends Specification {
     void "test additional type configuration 2"() {
         given:
         ApplicationContext ctx = ApplicationContext.run([
-                'micronaut.codec.json.additionalTypes': ['foo/javascript']
+                'micronaut.codec.json.additional-types': ['foo/javascript']
         ])
 
         when:

--- a/src/main/docs/guide/httpServer/consumesAnnotation.adoc
+++ b/src/main/docs/guide/httpServer/consumesAnnotation.adoc
@@ -15,7 +15,7 @@ Normally JSON parsing only happens if the content type is `application/json`. Th
 micronaut:
   codec:
     json:
-      additionalTypes:
+      additional-types:
         - text/javascript
         - ...
 ----

--- a/test-suite-http-server-tck-netty/src/test/java/io/micronaut/http/server/tck/netty/tests/NettyHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-netty/src/test/java/io/micronaut/http/server/tck/netty/tests/NettyHttpServerTestSuite.java
@@ -1,11 +1,13 @@
 package io.micronaut.http.server.tck.netty.tests;
 
+import org.junit.platform.suite.api.IncludeClassNamePatterns;
 import org.junit.platform.suite.api.SelectPackages;
 import org.junit.platform.suite.api.Suite;
 import org.junit.platform.suite.api.SuiteDisplayName;
 
 @Suite
 @SelectPackages("io.micronaut.http.server.tck.tests")
+@IncludeClassNamePatterns("io.micronaut.http.server.tck.tests.codec.JsonCodeAdditionalTypeTest")
 @SuiteDisplayName("HTTP Server TCK for Netty")
 public class NettyHttpServerTestSuite {
 }


### PR DESCRIPTION
The tests passes for Http Client JDK both manual and declarative. 

for Netty HTP Client , it fails for declarative passes for manual. 

This bug was first spotted in servlet. 

Conversation: 

@yawkat 
> can't deserialize boolean from text/plain

@graemerocher 
> why?


@yawkat
because it has no specified structure. we could parse it as json, but that could be wrong

@graemerocher 

> shouldn't it go through the normal conversion infrastructure for text/plain? We already have a String -> Boolean converter

@yawkat 
> this is what TextPlainCodec did, toString for serialization and conversion for deserialization. but going through conversion kind of defeats the point of the message handlers.

> On the write side, there is this workaround: https://github.com/micronaut-projects/micronaut-core/blob/37874c634202233f35b7c9376a5edfd5d49861f2/http/src/main/java/io/micronaut/http/body/DynamicMessageBodyWriter.java#L64-L69 – it's restricted to java.lang types, and just calls toString. but this does not work on the read side since there is no real inverse of toString, only conversion. it's in breaks.adoc here: https://github.com/micronaut-projects/micronaut-core/blob/37874c634202233f35b7c9376a5edfd5d49861f2/src/main/docs/guide/appendix/breaks.adoc#L186

