### PR TITLE
refreshAndDiff() should handle array values and property placeholders

### DIFF
--- a/context/src/test/groovy/io/micronaut/runtime/context/scope/refresh/RefreshEventListenerSpec.groovy
+++ b/context/src/test/groovy/io/micronaut/runtime/context/scope/refresh/RefreshEventListenerSpec.groovy
@@ -10,13 +10,31 @@ import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Specification
 
+import java.nio.charset.StandardCharsets
+
 class RefreshEventListenerSpec extends Specification {
-    @Shared Map<String, Object> config = ['foo.bar': 'initial-value']
+    @Shared Map<String, Object> config = ['foo.bar': 'initial-value', 'secret.value': "foo".getBytes(StandardCharsets.UTF_8)]
     @Shared @AutoCleanup ApplicationContext context = ApplicationContext
             .builder()
             .propertySources(PropertySource.of(config))
             .start()
 
+    void "test refresh and diff"() {
+        given:
+        def env = context.getEnvironment()
+        when:
+        def result = env.refreshAndDiff()
+
+        then:
+        result.isEmpty()
+
+        when:
+        config.put("secret.value", "foo".getBytes(StandardCharsets.UTF_8))
+        result = env.refreshAndDiff()
+
+        then:
+        result.isEmpty()
+    }
     void 'test refresh event listener'() {
         given:
         def env = context.getEnvironment()

--- a/context/src/test/groovy/io/micronaut/runtime/context/scope/refresh/RefreshEventListenerSpec.groovy
+++ b/context/src/test/groovy/io/micronaut/runtime/context/scope/refresh/RefreshEventListenerSpec.groovy
@@ -13,7 +13,7 @@ import spock.lang.Specification
 import java.nio.charset.StandardCharsets
 
 class RefreshEventListenerSpec extends Specification {
-    @Shared Map<String, Object> config = ['foo.bar': 'initial-value', 'secret.value': "foo".getBytes(StandardCharsets.UTF_8)]
+    @Shared Map<String, Object> config = ['foo.bar': 'initial-value', 'secret.value': "foo".getBytes(StandardCharsets.UTF_8), 'other.config':'${secret.value}']
     @Shared @AutoCleanup ApplicationContext context = ApplicationContext
             .builder()
             .propertySources(PropertySource.of(config))
@@ -34,6 +34,17 @@ class RefreshEventListenerSpec extends Specification {
 
         then:
         result.isEmpty()
+
+        when:
+        config.put("secret.value", "bar".getBytes(StandardCharsets.UTF_8))
+        result = env.refreshAndDiff()
+
+        then:
+        !result.isEmpty()
+        result.size() == 2
+        result.containsKey("secret.value")
+        result.containsKey("other.config")
+
     }
     void 'test refresh event listener'() {
         given:

--- a/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
+++ b/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
@@ -816,6 +816,23 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
                 }
             }
         }
+        if (!changes.isEmpty()) {
+            Map<String, Object> placeholdersAltered = new LinkedHashMap<>();
+            for (Map<String, Object> map : newCatalog) {
+                if (map != null) {
+                    map.forEach((key, v) -> {
+                        if (v instanceof String val) {
+                            for (String changed : changes.keySet()) {
+                                if (val.contains(changed)) {
+                                    placeholdersAltered.put(key, v);
+                                }
+                            }
+                        }
+                    });
+                }
+            }
+            changes.putAll(placeholdersAltered);
+        }
         return changes;
     }
 

--- a/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
+++ b/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
@@ -57,6 +57,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -857,26 +858,8 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
         }
     }
 
-    @SuppressWarnings({"java:S1871", "java:S3776" })
     private static boolean hasChanged(Object newValue, Object oldValue) {
-        if (newValue instanceof byte[] a1 && oldValue instanceof byte[] a2) {
-            return !Arrays.equals(a1, a2);
-        } else if (newValue instanceof Object[] a1 && oldValue instanceof Object[] a2) {
-            return !Arrays.equals(a1, a2);
-        } else if (newValue instanceof int[] a1 && oldValue instanceof int[] a2) {
-            return !Arrays.equals(a1, a2);
-        } else if (newValue instanceof long[] a1 && oldValue instanceof long[] a2) {
-            return !Arrays.equals(a1, a2);
-        } else if (newValue instanceof char[] a1 && oldValue instanceof char[] a2) {
-            return !Arrays.equals(a1, a2);
-        } else if (newValue instanceof double[] a1 && oldValue instanceof double[] a2) {
-            return !Arrays.equals(a1, a2);
-        } else if (newValue instanceof float[] a1 && oldValue instanceof float[] a2) {
-            return !Arrays.equals(a1, a2);
-        } else if (newValue instanceof short[] a1 && oldValue instanceof short[] a2) {
-            return !Arrays.equals(a1, a2);
-        }
-        return !newValue.equals(oldValue);
+        return !Objects.deepEquals(newValue, oldValue);
     }
 
     private Map<String, Object>[] copyCatalog() {

--- a/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
+++ b/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
@@ -833,11 +833,33 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
                     changes.put(key, null);
                 } else if (hasOld && !hasNew) {
                     changes.put(key, oldValue);
-                } else if (hasNew && hasOld && !newValue.equals(oldValue)) {
+                } else if (hasNew && hasOld && hasChanged(newValue, oldValue)) {
                     changes.put(key, oldValue);
                 }
             }
         }
+    }
+
+    @SuppressWarnings({"java:S1871", "java:S3776" })
+    private static boolean hasChanged(Object newValue, Object oldValue) {
+        if (newValue instanceof byte[] a1 && oldValue instanceof byte[] a2) {
+            return !Arrays.equals(a1, a2);
+        } else if (newValue instanceof Object[] a1 && oldValue instanceof Object[] a2) {
+            return !Arrays.equals(a1, a2);
+        } else if (newValue instanceof int[] a1 && oldValue instanceof int[] a2) {
+            return !Arrays.equals(a1, a2);
+        } else if (newValue instanceof long[] a1 && oldValue instanceof long[] a2) {
+            return !Arrays.equals(a1, a2);
+        } else if (newValue instanceof char[] a1 && oldValue instanceof char[] a2) {
+            return !Arrays.equals(a1, a2);
+        } else if (newValue instanceof double[] a1 && oldValue instanceof double[] a2) {
+            return !Arrays.equals(a1, a2);
+        } else if (newValue instanceof float[] a1 && oldValue instanceof float[] a2) {
+            return !Arrays.equals(a1, a2);
+        } else if (newValue instanceof short[] a1 && oldValue instanceof short[] a2) {
+            return !Arrays.equals(a1, a2);
+        }
+        return !newValue.equals(oldValue);
     }
 
     private Map<String, Object>[] copyCatalog() {
@@ -931,7 +953,7 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
                 stdout.append(line);
             }
         } catch (IOException e) {
-
+            // ignore
         }
 
         return stdout;


### PR DESCRIPTION
Currently byte[] values (such as secrets) if they are re-read they are not correctly diffed