### PR TITLE
Fix property caching

### DIFF
--- a/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
+++ b/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
@@ -99,7 +99,7 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
      * Creates a new, initially empty, {@link PropertySourcePropertyResolver} for the given {@link ConversionService}.
      *
      * @param conversionService The {@link ConversionService}
-     * @param logEnabled        logEnabled flag to enable or disable logger
+     * @param logEnabled        flag to enable or disable logger
      */
     public PropertySourcePropertyResolver(ConversionService conversionService, boolean logEnabled) {
         this.log = logEnabled ? LoggerFactory.getLogger(getClass()) : NOPLogger.NOP_LOGGER;


### PR DESCRIPTION
This fixes the build broken by #9310. Basically:

https://github.com/micronaut-projects/micronaut-core/blob/94f458ac04b0180a989d0cf28984d5e3b5df592f/http-client/src/test/groovy/io/micronaut/http/client/filter/StaticClientFilterSpec.groovy#L24-L28

The resolution of micronaut.server.port used to request the value of test-port as String. With this patch, it requests the value as Object instead (`.getValue(Object.class)`). The caching in PropertySourcePropertyResolver depends on the requested type however, so the Object request (micronaut.server.port) and the String request (micronaut.http.services.a.url) are cached separately and have different computed ports. (Additionally Object request type is not cached at all, but this is not the core issue.)

This patch adds another cache *before* conversion that is independent of the requested type. This cache ensures that the value is not recomputed for different request types.