### PR TITLE
Handle errors in publisher responses in RoutingInBoundHandler

### DIFF
--- a/http-netty/src/main/java/io/micronaut/http/netty/body/NettyWriteContext.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/body/NettyWriteContext.java
@@ -18,11 +18,12 @@ package io.micronaut.http.netty.body;
 import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
-import io.micronaut.http.netty.stream.StreamedHttpResponse;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpChunkedInput;
+import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpResponse;
+import org.reactivestreams.Publisher;
 
 import java.io.RandomAccessFile;
 
@@ -48,12 +49,12 @@ public interface NettyWriteContext {
     void writeFull(@NonNull FullHttpResponse response);
 
     /**
-     * Write a streamed response. The actual response will only be written when the first item
-     * of the {@link org.reactivestreams.Publisher} is received, in order to handle errors.
+     * Write a streamed response.
      *
      * @param response The response to write
+     * @param content  The body
      */
-    void writeStreamed(@NonNull StreamedHttpResponse response);
+    void writeStreamed(@NonNull HttpResponse response, @NonNull Publisher<HttpContent> content);
 
     /**
      * Write a response with a {@link HttpChunkedInput} body.

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
@@ -573,9 +573,11 @@ public final class RoutingInBoundHandler implements RequestHandler {
             s.onSubscribe(new Subscription() {
                 @Override
                 public void request(long n) {
+                    HttpContent first = LazySendingSubscriber.this.first;
                     if (first != null) {
+                        LazySendingSubscriber.this.first = null;
+                        // onNext may trigger further request calls
                         s.onNext(first);
-                        first = null;
                         if (n != Long.MAX_VALUE) {
                             n--;
                             if (n == 0) {

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
@@ -627,7 +627,11 @@ public final class RoutingInBoundHandler implements RequestHandler {
                 MutableHttpResponse<?> response;
                 if (t instanceof HttpStatusException hse) {
                     response = HttpResponse.status(hse.getStatus());
-                    hse.getBody().ifPresent(response::body);
+                    if (hse.getBody().isPresent()) {
+                        response.body(hse.getBody().get());
+                    } else if (hse.getMessage() != null) {
+                        response.body(hse.getMessage());
+                    }
                 } else {
                     response = routeExecutor.createDefaultErrorResponse(request, t);
                 }

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/handler/PipeliningServerHandlerSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/handler/PipeliningServerHandlerSpec.groovy
@@ -1,8 +1,6 @@
 package io.micronaut.http.server.netty.handler
 
-
 import io.micronaut.http.netty.stream.StreamedHttpRequest
-import io.micronaut.http.server.netty.DelegateStreamedHttpResponse
 import io.netty.buffer.Unpooled
 import io.netty.channel.ChannelHandlerContext
 import io.netty.channel.ChannelOutboundHandlerAdapter
@@ -81,7 +79,7 @@ class PipeliningServerHandlerSpec extends Specification {
         def ch = new EmbeddedChannel(mon, new PipeliningServerHandler(new RequestHandler() {
             @Override
             void accept(ChannelHandlerContext ctx, HttpRequest request, PipeliningServerHandler.OutboundAccess outboundAccess) {
-                outboundAccess.writeStreamed(new DelegateStreamedHttpResponse(resp, sink.asFlux()))
+                outboundAccess.writeStreamed(resp, sink.asFlux())
             }
 
             @Override

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/stream/ErrorResponseSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/stream/ErrorResponseSpec.groovy
@@ -29,7 +29,7 @@ class ErrorResponseSpec extends Specification {
         def e = thrown(HttpClientResponseException)
         verifyAll {
             e.status == HttpStatus.BAD_REQUEST
-            e.message == "Client '/flowable': expected flowable error"
+            e.response.getBody(String).get() == "expected flowable error"
         }
     }
 

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/StreamTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/StreamTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.tck.tests;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.HttpHeaders;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.exceptions.HttpStatusException;
+import io.micronaut.http.tck.AssertionUtils;
+import io.micronaut.http.tck.HttpResponseAssertion;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+
+import java.io.IOException;
+
+import static io.micronaut.http.tck.TestScenario.asserts;
+
+@SuppressWarnings({
+    "java:S5960", // We're allowed assertions, as these are used in tests only
+    "checkstyle:MissingJavadocType",
+    "checkstyle:DesignForExtension"
+})
+public class StreamTest {
+    public static final String SPEC_NAME = "StreamTest";
+
+    @Test
+    void statusErrorAsFirstItem() throws IOException {
+        asserts(SPEC_NAME,
+            HttpRequest.GET("/stream/status-error-as-first-item").header(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_PLAIN),
+            (server, request) -> AssertionUtils.assertThrows(server, request, HttpResponseAssertion.builder()
+                .status(HttpStatus.NOT_FOUND)
+                .body("foo")
+                .build()));
+    }
+
+    @Test
+    void statusErrorImmediate() throws IOException {
+        asserts(SPEC_NAME,
+            HttpRequest.GET("/stream/status-error-immediate").header(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_PLAIN),
+            (server, request) -> AssertionUtils.assertThrows(server, request, HttpResponseAssertion.builder()
+                .status(HttpStatus.NOT_FOUND)
+                .body("foo")
+                .build()));
+    }
+
+    @Controller("/stream")
+    @Requires(property = "spec.name", value = SPEC_NAME)
+    static class StreamController {
+        @Get(uri = "/status-error-as-first-item", processes = MediaType.TEXT_PLAIN)
+        Publisher<String> statusErrorAsFirstItem() {
+            return Flux.error(new HttpStatusException(HttpStatus.NOT_FOUND, (Object) "foo"));
+        }
+
+        @Get(uri = "/status-error-immediate", processes = MediaType.TEXT_PLAIN)
+        Publisher<String> statusErrorImmediate() {
+            throw new HttpStatusException(HttpStatus.NOT_FOUND, (Object) "foo");
+        }
+    }
+}


### PR DESCRIPTION
This moves the handling logic from PipeliningServerHandler to RoutingInBoundHandler, because the latter can actually write the body properly.

This should fix https://github.com/micronaut-projects/micronaut-starter/pull/1764 .

Gradle is broken locally for me, so I'm not sure if the tests pass :)