### PR TITLE
Improve MessageBodyHandler selection

### DIFF
--- a/http-netty/build.gradle
+++ b/http-netty/build.gradle
@@ -2,6 +2,12 @@ plugins {
     id "io.micronaut.build.internal.convention-library"
 }
 
+micronautBuild {
+    core {
+        usesMicronautTestSpock()
+    }
+}
+
 dependencies {
     annotationProcessor project(":inject-java")
     annotationProcessor project(":graal")
@@ -23,6 +29,11 @@ dependencies {
     testImplementation project(":runtime")
     testImplementation project(":websocket")
     testImplementation project(":jackson-databind")
+
+    testAnnotationProcessor project(":inject-java")
+    testImplementation project(":inject")
+    testImplementation project(":inject-java-test")
+    testCompileOnly project(":inject-groovy")
 }
 
 spotless {

--- a/http-netty/src/test/groovy/io/micronaut/http/netty/body/CustomBodyReaderSpec.groovy
+++ b/http-netty/src/test/groovy/io/micronaut/http/netty/body/CustomBodyReaderSpec.groovy
@@ -2,6 +2,7 @@ package io.micronaut.http.netty.body
 
 import io.micronaut.core.annotation.NonNull
 import io.micronaut.core.annotation.Nullable
+import io.micronaut.core.annotation.Order
 import io.micronaut.core.type.Argument
 import io.micronaut.core.type.Headers
 import io.micronaut.http.MediaType
@@ -62,10 +63,8 @@ class CustomBodyReaderSpec extends Specification {
 
     @Singleton
     @Produces(MediaType.APPLICATION_JSON)
+    @Order(2)
     static class ABodyReader implements MessageBodyReader<A> {
-
-        // Higher than NettyJsonHandler
-        int order = 2
 
         @Override
         A read(@NonNull Argument<A> type, @Nullable MediaType mediaType, @NonNull Headers httpHeaders, @NonNull InputStream inputStream) throws CodecException {
@@ -75,10 +74,9 @@ class CustomBodyReaderSpec extends Specification {
 
     @Singleton
     @Produces(MediaType.APPLICATION_JSON)
+    // Higher than ABodyWriter
+    @Order(1)
     static class CBodyReader implements MessageBodyReader<C> {
-
-        // Higher than ABodyWriter
-        int order = 1
 
         @Override
         C read(@NonNull Argument<C> type, @Nullable MediaType mediaType, @NonNull Headers httpHeaders, @NonNull InputStream inputStream) throws CodecException {

--- a/http-netty/src/test/groovy/io/micronaut/http/netty/body/CustomBodyReaderSpec.groovy
+++ b/http-netty/src/test/groovy/io/micronaut/http/netty/body/CustomBodyReaderSpec.groovy
@@ -63,7 +63,8 @@ class CustomBodyReaderSpec extends Specification {
 
     @Singleton
     @Produces(MediaType.APPLICATION_JSON)
-    @Order(2)
+    // Higher than NettyJsonHandler
+    @Order(-1)
     static class ABodyReader implements MessageBodyReader<A> {
 
         @Override
@@ -75,7 +76,7 @@ class CustomBodyReaderSpec extends Specification {
     @Singleton
     @Produces(MediaType.APPLICATION_JSON)
     // Higher than ABodyWriter
-    @Order(1)
+    @Order(-2)
     static class CBodyReader implements MessageBodyReader<C> {
 
         @Override

--- a/http-netty/src/test/groovy/io/micronaut/http/netty/body/CustomBodyWriterSpec.groovy
+++ b/http-netty/src/test/groovy/io/micronaut/http/netty/body/CustomBodyWriterSpec.groovy
@@ -1,0 +1,48 @@
+package io.micronaut.http.netty.body
+
+import io.micronaut.core.annotation.NonNull
+import io.micronaut.core.type.Argument
+import io.micronaut.core.type.MutableHeaders
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Produces
+import io.micronaut.http.body.DefaultMessageBodyHandlerRegistry
+import io.micronaut.http.body.MessageBodyWriter
+import io.micronaut.http.codec.CodecException
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import spock.lang.Specification
+
+@MicronautTest
+class CustomBodyWriterSpec extends Specification {
+
+    @Inject
+    DefaultMessageBodyHandlerRegistry bodyHandlerRegistry
+
+    void "test message writer ordering works correctly"() {
+        when:
+        def writer = bodyHandlerRegistry.findWriter(Argument.of(A), List.of(MediaType.APPLICATION_JSON_TYPE))
+
+        then:
+        writer.isPresent()
+        writer.get() instanceof ABodyWriter
+    }
+
+    class A {
+        String myHeader
+    }
+
+    @Singleton
+    @Produces(MediaType.APPLICATION_JSON)
+    static class ABodyWriter implements MessageBodyWriter<A> {
+
+        // Higher than NettyJsonHandler
+        int order = 1
+
+        @Override
+        void writeTo(@NonNull Argument<A> type, @NonNull MediaType mediaType, A object, @NonNull MutableHeaders outgoingHeaders, @NonNull OutputStream outputStream) throws CodecException {
+            outgoingHeaders.add("my-header", object.myHeader)
+        }
+    }
+
+}

--- a/http-netty/src/test/groovy/io/micronaut/http/netty/body/CustomBodyWriterSpec.groovy
+++ b/http-netty/src/test/groovy/io/micronaut/http/netty/body/CustomBodyWriterSpec.groovy
@@ -25,12 +25,51 @@ class CustomBodyWriterSpec extends Specification {
 
         then:
         writer.isPresent()
+        // ABodyWriter is chosen since it has higher order than JSONMessageHandler
         writer.get() instanceof ABodyWriter
     }
 
-    class A {
+    void "test do not select un-assignable message body writer"() {
+        when:
+        def writer = bodyHandlerRegistry.findWriter(Argument.of(B), List.of(MediaType.APPLICATION_JSON_TYPE))
+
+        then:
+        writer.isPresent()
+        // ABodyWriter is chosen since CBodyWriter cannot consume instances of B
+        writer.get() instanceof ABodyWriter
+    }
+
+    void "test writer order works correctly for subtypes"() {
+        when:
+        def writer = bodyHandlerRegistry.findWriter(Argument.of(C), List.of(MediaType.APPLICATION_JSON_TYPE))
+
+        then:
+        writer.isPresent()
+        // CBodyWriter is chosen since it has the highest order
+        writer.get() instanceof CBodyWriter
+    }
+
+    void "test writer is selected if it has generic type argument"() {
+        when:
+        def writer = bodyHandlerRegistry.findWriter(Argument.of(K), List.of(MediaType.APPLICATION_JSON_TYPE))
+
+        then:
+        writer.isPresent()
+        // NettyJsonHandler allows any type, since the argument is generic, so it is chosen in this case
+        writer.get() instanceof NettyJsonHandler
+    }
+
+    static class A {
         String myHeader
     }
+
+    static class B extends A {}
+
+    static class C extends B {
+        String anotherHeader
+    }
+
+    static class K {}
 
     @Singleton
     @Produces(MediaType.APPLICATION_JSON)
@@ -42,6 +81,19 @@ class CustomBodyWriterSpec extends Specification {
         @Override
         void writeTo(@NonNull Argument<A> type, @NonNull MediaType mediaType, A object, @NonNull MutableHeaders outgoingHeaders, @NonNull OutputStream outputStream) throws CodecException {
             outgoingHeaders.add("my-header", object.myHeader)
+        }
+    }
+
+    @Singleton
+    @Produces(MediaType.APPLICATION_JSON)
+    static class CBodyWriter implements MessageBodyWriter<C> {
+
+        // Higher than ABodyWriter
+        int order = 2
+
+        @Override
+        void writeTo(@NonNull Argument<C> type, @NonNull MediaType mediaType, C object, @NonNull MutableHeaders outgoingHeaders, @NonNull OutputStream outputStream) throws CodecException {
+            outgoingHeaders.add("my-header", object.myHeader).add("another-header", object.anotherHeader)
         }
     }
 

--- a/http-netty/src/test/groovy/io/micronaut/http/netty/body/CustomBodyWriterSpec.groovy
+++ b/http-netty/src/test/groovy/io/micronaut/http/netty/body/CustomBodyWriterSpec.groovy
@@ -75,7 +75,7 @@ class CustomBodyWriterSpec extends Specification {
     @Singleton
     @Produces(MediaType.APPLICATION_JSON)
     // Higher than NettyJsonHandler
-    @Order(1)
+    @Order(-1)
     static class ABodyWriter implements MessageBodyWriter<A> {
 
         @Override
@@ -87,7 +87,7 @@ class CustomBodyWriterSpec extends Specification {
     @Singleton
     @Produces(MediaType.APPLICATION_JSON)
     // Higher than ABodyWriter
-    @Order(2)
+    @Order(-2)
     static class CBodyWriter implements MessageBodyWriter<C> {
 
         @Override

--- a/http-netty/src/test/groovy/io/micronaut/http/netty/body/CustomBodyWriterSpec.groovy
+++ b/http-netty/src/test/groovy/io/micronaut/http/netty/body/CustomBodyWriterSpec.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.http.netty.body
 
 import io.micronaut.core.annotation.NonNull
+import io.micronaut.core.annotation.Order
 import io.micronaut.core.type.Argument
 import io.micronaut.core.type.MutableHeaders
 import io.micronaut.http.MediaType
@@ -73,10 +74,9 @@ class CustomBodyWriterSpec extends Specification {
 
     @Singleton
     @Produces(MediaType.APPLICATION_JSON)
+    // Higher than NettyJsonHandler
+    @Order(1)
     static class ABodyWriter implements MessageBodyWriter<A> {
-
-        // Higher than NettyJsonHandler
-        int order = 1
 
         @Override
         void writeTo(@NonNull Argument<A> type, @NonNull MediaType mediaType, A object, @NonNull MutableHeaders outgoingHeaders, @NonNull OutputStream outputStream) throws CodecException {
@@ -86,10 +86,9 @@ class CustomBodyWriterSpec extends Specification {
 
     @Singleton
     @Produces(MediaType.APPLICATION_JSON)
+    // Higher than ABodyWriter
+    @Order(2)
     static class CBodyWriter implements MessageBodyWriter<C> {
-
-        // Higher than ABodyWriter
-        int order = 2
 
         @Override
         void writeTo(@NonNull Argument<C> type, @NonNull MediaType mediaType, C object, @NonNull MutableHeaders outgoingHeaders, @NonNull OutputStream outputStream) throws CodecException {

--- a/http/src/main/java/io/micronaut/http/body/DefaultMessageBodyHandlerRegistry.java
+++ b/http/src/main/java/io/micronaut/http/body/DefaultMessageBodyHandlerRegistry.java
@@ -96,7 +96,7 @@ public final class DefaultMessageBodyHandlerRegistry extends RawMessageBodyHandl
             } else {
                 // Pick the highest priority
                 return beanDefinitions.stream()
-                    .max(OrderUtil.COMPARATOR)
+                    .max(OrderUtil.REVERSE_COMPARATOR)
                     .map(beanLocator::getBean)
                     .orElse(null);
             }
@@ -156,7 +156,7 @@ public final class DefaultMessageBodyHandlerRegistry extends RawMessageBodyHandl
             } else {
                 // Pick the highest priority
                 return beanDefinitions.stream()
-                    .max(OrderUtil.COMPARATOR)
+                    .max(OrderUtil.REVERSE_COMPARATOR)
                     .map(beanLocator::getBean)
                     .orElse(null);
             }

--- a/http/src/main/java/io/micronaut/http/body/DefaultMessageBodyHandlerRegistry.java
+++ b/http/src/main/java/io/micronaut/http/body/DefaultMessageBodyHandlerRegistry.java
@@ -156,8 +156,8 @@ public final class DefaultMessageBodyHandlerRegistry extends RawMessageBodyHandl
             } else {
                 // Pick the highest priority
                 return beanDefinitions.stream()
-                    .map(beanLocator::getBean)
                     .max(OrderUtil.COMPARATOR)
+                    .map(beanLocator::getBean)
                     .orElse(null);
             }
         }

--- a/http/src/main/java/io/micronaut/http/body/DefaultMessageBodyHandlerRegistry.java
+++ b/http/src/main/java/io/micronaut/http/body/DefaultMessageBodyHandlerRegistry.java
@@ -22,6 +22,7 @@ import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.order.OrderUtil;
 import io.micronaut.core.type.Argument;
+import io.micronaut.core.type.GenericPlaceholder;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.Consumes;
 import io.micronaut.http.annotation.Produces;
@@ -172,7 +173,9 @@ public final class DefaultMessageBodyHandlerRegistry extends RawMessageBodyHandl
                 if (type.getType() == MessageBodyWriter.class && c instanceof BeanDefinition<?> definition) {
                     List<Argument<?>> consumedType = definition.getTypeArguments(type.getType());
                     Argument<?> requiredType = type.getTypeParameters()[0];
-                    if (consumedType.isEmpty() || !consumedType.get(0).isAssignableFrom(requiredType)){
+                    if (consumedType.isEmpty() ||
+                        !(consumedType.get(0).isTypeVariable() || consumedType.get(0).isAssignableFrom(requiredType.getType()))
+                    ){
                         return false;
                     }
                 }

--- a/http/src/main/java/io/micronaut/http/body/DefaultMessageBodyHandlerRegistry.java
+++ b/http/src/main/java/io/micronaut/http/body/DefaultMessageBodyHandlerRegistry.java
@@ -92,10 +92,10 @@ public final class DefaultMessageBodyHandlerRegistry extends RawMessageBodyHandl
             if (exactMatch.size() == 1) {
                 return beanLocator.getBean(exactMatch.iterator().next());
             } else {
-                // pick highest priority
-                return OrderUtil.sort(beanDefinitions.stream())
-                    .findFirst()
+                // Pick the highest priority
+                return beanDefinitions.stream()
                     .map(beanLocator::getBean)
+                    .max(OrderUtil.COMPARATOR)
                     .orElse(null);
             }
         }
@@ -150,10 +150,10 @@ public final class DefaultMessageBodyHandlerRegistry extends RawMessageBodyHandl
             if (exactMatch.size() == 1) {
                 return beanLocator.getBean(exactMatch.iterator().next());
             } else {
-                // pick highest priority
-                return OrderUtil.sort(beanDefinitions.stream())
-                    .findFirst()
+                // Pick the highest priority
+                return beanDefinitions.stream()
                     .map(beanLocator::getBean)
+                    .max(OrderUtil.COMPARATOR)
                     .orElse(null);
             }
         }

--- a/http/src/main/java/io/micronaut/http/body/MessageBodyReader.java
+++ b/http/src/main/java/io/micronaut/http/body/MessageBodyReader.java
@@ -33,6 +33,7 @@ import java.io.InputStream;
  * An interface that allows reading a message body from the client or the server.
  *
  * <p>Implementors can defined beans that are annotated with {@link io.micronaut.http.annotation.Consumes} to restrict the applicable content types.</p>
+ * <p>Use {@link io.micronaut.core.annotation.Order} to specify the precedence of the reader with lower order corresponding to higher precedence.</p>
  *
  * @see io.micronaut.http.annotation.Consumes
  * @param <T> The generic type.

--- a/http/src/main/java/io/micronaut/http/body/MessageBodyReader.java
+++ b/http/src/main/java/io/micronaut/http/body/MessageBodyReader.java
@@ -21,7 +21,6 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.io.buffer.ByteBuffer;
 import io.micronaut.core.io.buffer.ReferenceCounted;
-import io.micronaut.core.order.Ordered;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.type.Headers;
 import io.micronaut.http.MediaType;
@@ -41,7 +40,7 @@ import java.io.InputStream;
  */
 @Experimental
 @Indexed(MessageBodyReader.class)
-public interface MessageBodyReader<T> extends Ordered {
+public interface MessageBodyReader<T> {
     /**
      * Is the type readable.
      * @param type The type

--- a/http/src/main/java/io/micronaut/http/body/MessageBodyWriter.java
+++ b/http/src/main/java/io/micronaut/http/body/MessageBodyWriter.java
@@ -22,7 +22,6 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.io.buffer.ByteBuffer;
 import io.micronaut.core.io.buffer.ByteBufferFactory;
 import io.micronaut.core.io.buffer.ReferenceCounted;
-import io.micronaut.core.order.Ordered;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.type.Headers;
 import io.micronaut.core.type.MutableHeaders;
@@ -45,7 +44,7 @@ import java.nio.charset.StandardCharsets;
  */
 @Experimental
 @Indexed(MessageBodyWriter.class)
-public interface MessageBodyWriter<T> extends Ordered {
+public interface MessageBodyWriter<T> {
     /**
      * Is the type writeable.
      *

--- a/http/src/main/java/io/micronaut/http/body/MessageBodyWriter.java
+++ b/http/src/main/java/io/micronaut/http/body/MessageBodyWriter.java
@@ -37,6 +37,7 @@ import java.nio.charset.StandardCharsets;
  * An interface that allows writing a message body for the client or the server.
  *
  * <p>Implementors can define beans that use {@link io.micronaut.http.annotation.Produces} to restrict the applicable content types.</p>
+ * <p>Use {@link io.micronaut.core.annotation.Order} to specify the precedence of the writer with lower order corresponding to higher precedence.</p>
  *
  * @param <T> The generic type.
  * @see io.micronaut.http.annotation.Produces


### PR DESCRIPTION
* Use the message body writer and reader order in selection
* For writers, only select those that can consume a particular type