### PR TITLE
allow access to the body from an annotation driven filter

### DIFF
--- a/core/src/main/java/io/micronaut/core/io/buffer/DelegateByteBuffer.java
+++ b/core/src/main/java/io/micronaut/core/io/buffer/DelegateByteBuffer.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.core.io.buffer;
+
+import io.micronaut.core.annotation.Internal;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+
+/**
+ * Delegate class for {@link ByteBuffer}.
+ *
+ * @param <T> The native buffer type
+ * @since 4.0.0
+ * @author Jonas Konrad
+ */
+@Internal
+public class DelegateByteBuffer<T> implements ByteBuffer<T> {
+    private final ByteBuffer<T> delegate;
+
+    public DelegateByteBuffer(ByteBuffer<T> delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public T asNativeBuffer() {
+        return delegate.asNativeBuffer();
+    }
+
+    @Override
+    public int readableBytes() {
+        return delegate.readableBytes();
+    }
+
+    @Override
+    public int writableBytes() {
+        return delegate.writableBytes();
+    }
+
+    @Override
+    public int maxCapacity() {
+        return delegate.maxCapacity();
+    }
+
+    @Override
+    public ByteBuffer capacity(int capacity) {
+        delegate.capacity(capacity);
+        return this;
+    }
+
+    @Override
+    public int readerIndex() {
+        return delegate.readerIndex();
+    }
+
+    @Override
+    public ByteBuffer readerIndex(int readPosition) {
+        delegate.readerIndex(readPosition);
+        return this;
+    }
+
+    @Override
+    public int writerIndex() {
+        return delegate.writerIndex();
+    }
+
+    @Override
+    public ByteBuffer writerIndex(int position) {
+        delegate.writerIndex(position);
+        return this;
+    }
+
+    @Override
+    public byte read() {
+        return delegate.read();
+    }
+
+    @Override
+    public CharSequence readCharSequence(int length, Charset charset) {
+        return delegate.readCharSequence(length, charset);
+    }
+
+    @Override
+    public ByteBuffer read(byte[] destination) {
+        delegate.read(destination);
+        return this;
+    }
+
+    @Override
+    public ByteBuffer read(byte[] destination, int offset, int length) {
+        delegate.read(destination, offset, length);
+        return this;
+    }
+
+    @Override
+    public ByteBuffer write(byte b) {
+        delegate.write(b);
+        return this;
+    }
+
+    @Override
+    public ByteBuffer write(byte[] source) {
+        delegate.write(source);
+        return this;
+    }
+
+    @Override
+    public ByteBuffer write(CharSequence source, Charset charset) {
+        delegate.write(source, charset);
+        return this;
+    }
+
+    @Override
+    public ByteBuffer write(byte[] source, int offset, int length) {
+        delegate.write(source, offset, length);
+        return this;
+    }
+
+    @Override
+    public ByteBuffer write(ByteBuffer... buffers) {
+        delegate.write(buffers);
+        return this;
+    }
+
+    @Override
+    public ByteBuffer write(java.nio.ByteBuffer... buffers) {
+        delegate.write(buffers);
+        return this;
+    }
+
+    @Override
+    public ByteBuffer slice(int index, int length) {
+        delegate.slice(index, length);
+        return this;
+    }
+
+    @Override
+    public java.nio.ByteBuffer asNioBuffer() {
+        return delegate.asNioBuffer();
+    }
+
+    @Override
+    public java.nio.ByteBuffer asNioBuffer(int index, int length) {
+        return delegate.asNioBuffer(index, length);
+    }
+
+    @Override
+    public InputStream toInputStream() {
+        return delegate.toInputStream();
+    }
+
+    @Override
+    public OutputStream toOutputStream() {
+        return delegate.toOutputStream();
+    }
+
+    @Override
+    public byte[] toByteArray() {
+        return delegate.toByteArray();
+    }
+
+    @Override
+    public String toString(Charset charset) {
+        return delegate.toString(charset);
+    }
+
+    @Override
+    public int indexOf(byte b) {
+        return delegate.indexOf(b);
+    }
+
+    @Override
+    public byte getByte(int index) {
+        return delegate.getByte(index);
+    }
+}

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpRequest.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpRequest.java
@@ -24,6 +24,7 @@ import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.value.MutableConvertibleValues;
 import io.micronaut.core.convert.value.MutableConvertibleValuesMap;
 import io.micronaut.core.execution.ExecutionFlow;
+import io.micronaut.core.io.buffer.ByteBuffer;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.HttpAttributes;
@@ -50,6 +51,7 @@ import io.micronaut.http.netty.stream.StreamedHttpRequest;
 import io.micronaut.http.server.HttpServerConfiguration;
 import io.micronaut.http.server.netty.body.ByteBody;
 import io.micronaut.http.server.netty.body.HttpBody;
+import io.micronaut.http.server.netty.body.ImmediateByteBody;
 import io.micronaut.http.server.netty.body.ImmediateMultiObjectBody;
 import io.micronaut.http.server.netty.body.ImmediateSingleObjectBody;
 import io.micronaut.http.server.netty.configuration.NettyHttpServerConfiguration;
@@ -101,7 +103,7 @@ import java.util.function.Supplier;
  * @since 1.0
  */
 @Internal
-public class NettyHttpRequest<T> extends AbstractNettyHttpRequest<T> implements HttpRequest<T>, PushCapableHttpRequest<T> {
+public class NettyHttpRequest<T> extends AbstractNettyHttpRequest<T> implements HttpRequest<T>, PushCapableHttpRequest<T>, io.micronaut.http.FullHttpRequest<T> {
     private static final Logger LOG = LoggerFactory.getLogger(NettyHttpRequest.class);
 
     /**
@@ -662,6 +664,19 @@ public class NettyHttpRequest<T> extends AbstractNettyHttpRequest<T> implements 
         } else {
             return contentLength;
         }
+    }
+
+    @Override
+    public boolean isFull() {
+        return body instanceof ImmediateByteBody;
+    }
+
+    @Override
+    public ByteBuffer<?> contents() {
+        if (body instanceof ImmediateByteBody immediateByteBody) {
+            return immediateByteBody;
+        }
+        return null;
     }
 
     /**

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyRequestLifecycle.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyRequestLifecycle.java
@@ -131,7 +131,7 @@ final class NettyRequestLifecycle extends RequestLifecycle {
         // the FormRouteCompleter can process data.
         if (nettyRequest.hasFormRouteCompleter()) {
             FormDataHttpContentProcessor processor = new FormDataHttpContentProcessor(nettyRequest, rib.serverConfiguration);
-            ByteBody rootBody = nettyRequest.rootBody();
+            ByteBody rootBody = nettyRequest.byteBody();
             FormRouteCompleter formRouteCompleter = nettyRequest.formRouteCompleter();
             try {
                 rootBody.processMulti(processor).handleForm(formRouteCompleter);

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/NettyBodyAnnotationBinder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/NettyBodyAnnotationBinder.java
@@ -82,11 +82,11 @@ final class NettyBodyAnnotationBinder<T> extends DefaultBodyAnnotationBinder<T> 
         if (!(source instanceof NettyHttpRequest<?> nhr)) {
             return super.bindFullBody(context, source);
         }
-        if (nhr.rootBody() instanceof ImmediateByteBody imm && imm.empty()) {
+        if (nhr.byteBody() instanceof ImmediateByteBody imm && imm.empty()) {
             return BindingResult.empty();
         }
 
-        ExecutionFlow<ImmediateByteBody> buffered = nhr.rootBody()
+        ExecutionFlow<ImmediateByteBody> buffered = nhr.byteBody()
             .buffer(nhr.getChannelHandlerContext().alloc());
 
         return new PendingRequestBindingResult<T>() {

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/NettyCompletableFutureBodyBinder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/NettyCompletableFutureBodyBinder.java
@@ -67,7 +67,7 @@ final class NettyCompletableFutureBodyBinder
     @Override
     public BindingResult<CompletableFuture<?>> bind(ArgumentConversionContext<CompletableFuture<?>> context, HttpRequest<?> source) {
         if (source instanceof NettyHttpRequest<?> nhr) {
-            ByteBody rootBody = nhr.rootBody();
+            ByteBody rootBody = nhr.byteBody();
             if (rootBody instanceof ImmediateByteBody immediate && immediate.empty()) {
                 return BindingResult.empty();
             }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/NettyInputStreamBodyBinder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/NettyInputStreamBodyBinder.java
@@ -60,11 +60,11 @@ final class NettyInputStreamBodyBinder implements NonBlockingBodyArgumentBinder<
     @Override
     public BindingResult<InputStream> bind(ArgumentConversionContext<InputStream> context, HttpRequest<?> source) {
         if (source instanceof NettyHttpRequest<?> nhr) {
-            if (nhr.rootBody() instanceof ImmediateByteBody imm && imm.empty()) {
+            if (nhr.byteBody() instanceof ImmediateByteBody imm && imm.empty()) {
                 return BindingResult.empty();
             }
             try {
-                InputStream s = nhr.rootBody().rawContent(httpServerConfiguration).coerceToInputStream(nhr.getChannelHandlerContext().alloc());
+                InputStream s = nhr.byteBody().rawContent(httpServerConfiguration).coerceToInputStream(nhr.getChannelHandlerContext().alloc());
                 return () -> Optional.of(s);
             } catch (ContentLengthExceededException t) {
                 if (LOG.isTraceEnabled()) {

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/NettyPublisherBodyBinder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/binders/NettyPublisherBodyBinder.java
@@ -76,7 +76,7 @@ final class NettyPublisherBodyBinder implements NonBlockingBodyArgumentBinder<Pu
     @Override
     public BindingResult<Publisher<?>> bind(ArgumentConversionContext<Publisher<?>> context, HttpRequest<?> source) {
         if (source instanceof NettyHttpRequest<?> nhr) {
-            ByteBody rootBody = nhr.rootBody();
+            ByteBody rootBody = nhr.byteBody();
             if (rootBody instanceof ImmediateByteBody imm && imm.empty()) {
                 return BindingResult.empty();
             }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/body/ImmediateByteBody.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/body/ImmediateByteBody.java
@@ -34,10 +34,7 @@ import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.LastHttpContent;
 
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -48,14 +45,12 @@ import java.util.List;
  * @author Jonas Konrad
  */
 @Internal
-public final class ImmediateByteBody extends ManagedBody<ByteBuf> implements ByteBody, ByteBuffer<ByteBuf> {
+public final class ImmediateByteBody extends ManagedBody<ByteBuf> implements ByteBody {
     private final boolean empty;
-    private final ByteBuffer<ByteBuf> byteBuffer;
 
     ImmediateByteBody(ByteBuf buf) {
         super(buf);
         this.empty = !buf.isReadable();
-        this.byteBuffer = NettyByteBufferFactory.DEFAULT.wrap(buf);
     }
 
     @Override
@@ -138,6 +133,11 @@ public final class ImmediateByteBody extends ManagedBody<ByteBuf> implements Byt
         return ExecutionFlow.just(this);
     }
 
+    public ByteBuf contentUnclaimed() {
+        checkUnclaimed();
+        return value();
+    }
+
     @Override
     public HttpRequest claimForReuse(HttpRequest request) {
         DefaultFullHttpRequest copy = new DefaultFullHttpRequest(
@@ -155,145 +155,5 @@ public final class ImmediateByteBody extends ManagedBody<ByteBuf> implements Byt
 
     public boolean empty() {
         return empty;
-    }
-
-    @Override
-    public ByteBuf asNativeBuffer() {
-        return byteBuffer.asNativeBuffer();
-    }
-
-    @Override
-    public int readableBytes() {
-        return byteBuffer.readableBytes();
-    }
-
-    @Override
-    public int writableBytes() {
-        return byteBuffer.writableBytes();
-    }
-
-    @Override
-    public int maxCapacity() {
-        return byteBuffer.maxCapacity();
-    }
-
-    @Override
-    public ByteBuffer capacity(int capacity) {
-        return byteBuffer.capacity(capacity);
-    }
-
-    @Override
-    public int readerIndex() {
-        return byteBuffer.readerIndex();
-    }
-
-    @Override
-    public ByteBuffer readerIndex(int readPosition) {
-        return byteBuffer.readerIndex(readPosition);
-    }
-
-    @Override
-    public int writerIndex() {
-        return byteBuffer.writerIndex();
-    }
-
-    @Override
-    public ByteBuffer writerIndex(int position) {
-        return byteBuffer.writerIndex(position);
-    }
-
-    @Override
-    public byte read() {
-        return byteBuffer.read();
-    }
-
-    @Override
-    public CharSequence readCharSequence(int length, Charset charset) {
-        return byteBuffer.readCharSequence(length, charset);
-    }
-
-    @Override
-    public ByteBuffer read(byte[] destination) {
-        return byteBuffer.read(destination);
-    }
-
-    @Override
-    public ByteBuffer read(byte[] destination, int offset, int length) {
-        return byteBuffer.read(destination, offset, length);
-    }
-
-    @Override
-    public ByteBuffer write(byte b) {
-        return byteBuffer.write(b);
-    }
-
-    @Override
-    public ByteBuffer write(byte[] source) {
-        return byteBuffer.write(source);
-    }
-
-    @Override
-    public ByteBuffer write(CharSequence source, Charset charset) {
-        return byteBuffer.write(source, charset);
-    }
-
-    @Override
-    public ByteBuffer write(byte[] source, int offset, int length) {
-        return byteBuffer.write(source, offset, length);
-    }
-
-    @Override
-    public ByteBuffer write(ByteBuffer... buffers) {
-        return byteBuffer.write(buffers);
-    }
-
-    @Override
-    public ByteBuffer write(java.nio.ByteBuffer... buffers) {
-        return byteBuffer.write(buffers);
-    }
-
-    @Override
-    public ByteBuffer slice(int index, int length) {
-        return byteBuffer.slice(index, length);
-    }
-
-    @Override
-    public java.nio.ByteBuffer asNioBuffer() {
-        return byteBuffer.asNioBuffer();
-    }
-
-    @Override
-    public java.nio.ByteBuffer asNioBuffer(int index, int length) {
-        return byteBuffer.asNioBuffer(index, length);
-    }
-
-    @Override
-    public InputStream toInputStream() {
-        return byteBuffer.toInputStream();
-    }
-
-    @Override
-    public OutputStream toOutputStream() {
-        return byteBuffer.toOutputStream();
-    }
-
-    @Override
-    public byte[] toByteArray() {
-        return byteBuffer.toByteArray();
-    }
-
-    @Override
-    public String toString(Charset charset) {
-        return byteBuffer.toString(StandardCharsets.UTF_8);
-    }
-
-    @Override
-    public int indexOf(byte b) {
-        return byteBuffer.indexOf(b);
-    }
-
-    @Override
-    public byte getByte(int index) {
-        return byteBuffer.getByte(index);
     }
 }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/body/ImmediateByteBody.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/body/ImmediateByteBody.java
@@ -34,7 +34,10 @@ import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.LastHttpContent;
 
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -45,12 +48,14 @@ import java.util.List;
  * @author Jonas Konrad
  */
 @Internal
-public final class ImmediateByteBody extends ManagedBody<ByteBuf> implements ByteBody {
+public final class ImmediateByteBody extends ManagedBody<ByteBuf> implements ByteBody, ByteBuffer<ByteBuf> {
     private final boolean empty;
+    private final ByteBuffer<ByteBuf> byteBuffer;
 
     ImmediateByteBody(ByteBuf buf) {
         super(buf);
         this.empty = !buf.isReadable();
+        this.byteBuffer = NettyByteBufferFactory.DEFAULT.wrap(buf);
     }
 
     @Override
@@ -150,5 +155,145 @@ public final class ImmediateByteBody extends ManagedBody<ByteBuf> implements Byt
 
     public boolean empty() {
         return empty;
+    }
+
+    @Override
+    public ByteBuf asNativeBuffer() {
+        return byteBuffer.asNativeBuffer();
+    }
+
+    @Override
+    public int readableBytes() {
+        return byteBuffer.readableBytes();
+    }
+
+    @Override
+    public int writableBytes() {
+        return byteBuffer.writableBytes();
+    }
+
+    @Override
+    public int maxCapacity() {
+        return byteBuffer.maxCapacity();
+    }
+
+    @Override
+    public ByteBuffer capacity(int capacity) {
+        return byteBuffer.capacity(capacity);
+    }
+
+    @Override
+    public int readerIndex() {
+        return byteBuffer.readerIndex();
+    }
+
+    @Override
+    public ByteBuffer readerIndex(int readPosition) {
+        return byteBuffer.readerIndex(readPosition);
+    }
+
+    @Override
+    public int writerIndex() {
+        return byteBuffer.writerIndex();
+    }
+
+    @Override
+    public ByteBuffer writerIndex(int position) {
+        return byteBuffer.writerIndex(position);
+    }
+
+    @Override
+    public byte read() {
+        return byteBuffer.read();
+    }
+
+    @Override
+    public CharSequence readCharSequence(int length, Charset charset) {
+        return byteBuffer.readCharSequence(length, charset);
+    }
+
+    @Override
+    public ByteBuffer read(byte[] destination) {
+        return byteBuffer.read(destination);
+    }
+
+    @Override
+    public ByteBuffer read(byte[] destination, int offset, int length) {
+        return byteBuffer.read(destination, offset, length);
+    }
+
+    @Override
+    public ByteBuffer write(byte b) {
+        return byteBuffer.write(b);
+    }
+
+    @Override
+    public ByteBuffer write(byte[] source) {
+        return byteBuffer.write(source);
+    }
+
+    @Override
+    public ByteBuffer write(CharSequence source, Charset charset) {
+        return byteBuffer.write(source, charset);
+    }
+
+    @Override
+    public ByteBuffer write(byte[] source, int offset, int length) {
+        return byteBuffer.write(source, offset, length);
+    }
+
+    @Override
+    public ByteBuffer write(ByteBuffer... buffers) {
+        return byteBuffer.write(buffers);
+    }
+
+    @Override
+    public ByteBuffer write(java.nio.ByteBuffer... buffers) {
+        return byteBuffer.write(buffers);
+    }
+
+    @Override
+    public ByteBuffer slice(int index, int length) {
+        return byteBuffer.slice(index, length);
+    }
+
+    @Override
+    public java.nio.ByteBuffer asNioBuffer() {
+        return byteBuffer.asNioBuffer();
+    }
+
+    @Override
+    public java.nio.ByteBuffer asNioBuffer(int index, int length) {
+        return byteBuffer.asNioBuffer(index, length);
+    }
+
+    @Override
+    public InputStream toInputStream() {
+        return byteBuffer.toInputStream();
+    }
+
+    @Override
+    public OutputStream toOutputStream() {
+        return byteBuffer.toOutputStream();
+    }
+
+    @Override
+    public byte[] toByteArray() {
+        return byteBuffer.toByteArray();
+    }
+
+    @Override
+    public String toString(Charset charset) {
+        return byteBuffer.toString(StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public int indexOf(byte b) {
+        return byteBuffer.indexOf(b);
+    }
+
+    @Override
+    public byte getByte(int index) {
+        return byteBuffer.getByte(index);
     }
 }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/body/ManagedBody.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/body/ManagedBody.java
@@ -54,9 +54,7 @@ abstract class ManagedBody<T> implements HttpBody {
      * @throws IllegalStateException if the value has already been claimed
      */
     final T claim() {
-        if (claimed) {
-            throw new IllegalStateException("Already claimed");
-        }
+        checkUnclaimed();
         claimed = true;
         return value;
     }
@@ -69,10 +67,14 @@ abstract class ManagedBody<T> implements HttpBody {
      * @return The value that will be claimed
      */
     final T prepareClaim() {
+        checkUnclaimed();
+        return value;
+    }
+
+    final void checkUnclaimed() {
         if (claimed) {
             throw new IllegalStateException("Already claimed");
         }
-        return value;
     }
 
     /**

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/multipart/MultipartBodyArgumentBinder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/multipart/MultipartBodyArgumentBinder.java
@@ -70,7 +70,7 @@ public class MultipartBodyArgumentBinder implements NonBlockingBodyArgumentBinde
             FormDataHttpContentProcessor processor = new FormDataHttpContentProcessor(nhr, httpServerConfiguration.get());
             MultiObjectBody multiObjectBody;
             try {
-                multiObjectBody = nhr.rootBody()
+                multiObjectBody = nhr.byteBody()
                     .processMulti(processor);
             } catch (Throwable e) {
                 return () -> Optional.of(Flux.<CompletedPart>error(e)::subscribe);

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/filter/RequestFilterTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/filter/RequestFilterTest.java
@@ -20,10 +20,14 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
+import io.micronaut.http.MediaType;
 import io.micronaut.http.MutableHttpRequest;
 import io.micronaut.http.MutableHttpResponse;
+import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Header;
+import io.micronaut.http.annotation.Post;
 import io.micronaut.http.annotation.RequestFilter;
 import io.micronaut.http.annotation.ServerFilter;
 import io.micronaut.http.filter.FilterContinuation;
@@ -40,6 +44,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -53,6 +58,25 @@ import java.util.concurrent.CompletionStage;
 })
 public class RequestFilterTest {
     public static final String SPEC_NAME = "RequestFilterTest";
+
+    @Test
+    public void requestFilterBinding() throws IOException {
+        TestScenario.builder()
+            .specName(SPEC_NAME)
+            .request(HttpRequest.POST("/request-filter/binding", "{\"foo\":10}").contentType(MediaType.APPLICATION_JSON_TYPE))
+            .assertion((server, request) -> {
+                AssertionUtils.assertDoesNotThrow(server, request, HttpResponseAssertion.builder()
+                    .status(HttpStatus.OK)
+                    .body("application/json {\"foo\":10}")
+                    .build());
+                Assertions.assertEquals(
+                    List.of("binding application/json {\"foo\":10}"),
+                    server.getApplicationContext().getBean(MyServerFilter.class).events
+                );
+            })
+
+            .run();
+    }
 
     @Test
     public void requestFilterImmediateRequestParameter() throws IOException {
@@ -352,6 +376,7 @@ public class RequestFilterTest {
             .run();
     }
 
+
     @ServerFilter
     @Singleton
     @Requires(property = "spec.name", value = SPEC_NAME)
@@ -361,6 +386,15 @@ public class RequestFilterTest {
         @RequestFilter("/request-filter/immediate-request-parameter")
         public void requestFilterImmediateRequestParameter(HttpRequest<?> request) {
             events.add("requestFilterImmediateRequestParameter " + request.getPath());
+        }
+
+        @RequestFilter("/request-filter/binding")
+        public void requestFilterBinding(
+            @Header String contentType,
+            @Body byte[] bytes,
+            FilterContinuation<HttpResponse<?>> continuation) {
+            events.add("binding " + contentType + " " + new String(bytes, StandardCharsets.UTF_8));
+            continuation.proceed();
         }
 
         @RequestFilter("/request-filter/immediate-mutable-request-parameter")
@@ -546,6 +580,11 @@ public class RequestFilterTest {
         @Get("/request-filter/empty-optional-response")
         public String requestFilterEmptyOptionalResponse(HttpRequest<?> request) {
             return "foo";
+        }
+
+        @Post("/request-filter/binding")
+        public String requestFilterBinding(@Header String contentType, @Body byte[] bytes) {
+            return contentType + " " + new String(bytes, StandardCharsets.UTF_8);
         }
     }
 }

--- a/http-validation/src/main/java/io/micronaut/validation/routes/FilterVisitor.java
+++ b/http-validation/src/main/java/io/micronaut/validation/routes/FilterVisitor.java
@@ -16,27 +16,30 @@
 package io.micronaut.validation.routes;
 
 import io.micronaut.core.annotation.AnnotationValue;
-import io.micronaut.core.async.publisher.Publishers;
-import io.micronaut.core.type.Argument;
+import io.micronaut.core.bind.annotation.Bindable;
+import io.micronaut.core.io.buffer.ByteBuffer;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.MutableHttpRequest;
 import io.micronaut.http.MutableHttpResponse;
+import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.ClientFilter;
+import io.micronaut.http.annotation.CookieValue;
+import io.micronaut.http.annotation.Header;
+import io.micronaut.http.annotation.PathVariable;
+import io.micronaut.http.annotation.QueryValue;
 import io.micronaut.http.annotation.RequestFilter;
 import io.micronaut.http.annotation.ResponseFilter;
 import io.micronaut.http.annotation.ServerFilter;
 import io.micronaut.http.filter.FilterContinuation;
-import io.micronaut.http.filter.FilterRunner;
 import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.ast.Element;
 import io.micronaut.inject.ast.MethodElement;
 import io.micronaut.inject.ast.ParameterElement;
 import io.micronaut.inject.visitor.TypeElementVisitor;
 import io.micronaut.inject.visitor.VisitorContext;
 import org.reactivestreams.Publisher;
 
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
@@ -52,12 +55,27 @@ public final class FilterVisitor implements TypeElementVisitor<Object, Object> {
         HttpResponse.class,
         MutableHttpResponse.class,
         FilterContinuation.class,
-        Optional.class
+        Optional.class,
+        Throwable.class
     );
+    private static final Set<String> PERMITTED_BINDING_ANNOTATIONS = Set.of(
+        Body.class.getName(),
+        Header.class.getName(),
+        QueryValue.class.getName(),
+        CookieValue.class.getName(),
+        PathVariable.class.getName()
+    );
+
+    @Override
+    public VisitorKind getVisitorKind() {
+        return VisitorKind.ISOLATING;
+    }
 
     @Override
     public Set<String> getSupportedAnnotationNames() {
         return Set.of(
+            ServerFilter.class.getName(),
+            ClientFilter.class.getName(),
             RequestFilter.class.getName(),
             ResponseFilter.class.getName()
         );
@@ -79,55 +97,106 @@ public final class FilterVisitor implements TypeElementVisitor<Object, Object> {
         }
 
         try {
-            Argument<?>[] args = toArguments(Arrays.stream(element.getParameters()).map(ParameterElement::getType).toList(), context);
-            Argument<?> ret = toArgument(element.getReturnType(), context);
+            ParameterElement[] parameters = element.getParameters();
+            boolean isResponseFilter = responseFilterAnnotation != null;
+            ParameterElement continuationCreator = null;
+            for (ParameterElement parameter : parameters) {
+                ClassElement parameterType = parameter.getGenericType();
+                if (parameter.hasStereotype(Bindable.class)) {
+                    String annotationName = parameter.getAnnotationNameByStereotype(Bindable.class).orElse(null);
+                    if (!PERMITTED_BINDING_ANNOTATIONS.contains(annotationName)) {
+                        context.fail("Unsupported binding annotation on filter method: " + annotationName, parameter);
+                        return;
+                    } else if (Body.class.getName().equals(annotationName) && !isPermittedRawType(parameterType)) {
+                        context.fail("The @Body to a filter method can only be a raw type (byte[], String, ByteBuffer etc.)", parameter);
+                        return;
+                    }
+                    continue;
+                }
+                if (isInvalidType(context, parameter, parameterType, "Unsupported filter method parameter type")) {
+                    return;
+                }
+                if (parameterType.isAssignable(HttpResponse.class)) {
+                    if (!isResponseFilter) {
+                        context.fail("Filter is called before the response is known, can't have a response argument", parameter);
+                        return;
+                    }
+                } else if (parameterType.isAssignable(Throwable.class)) {
+                    if (!isResponseFilter) {
+                        context.fail("Request filters cannot handle exceptions", parameter);
+                        return;
+                    }
+                } else if (parameterType.isAssignable(FilterContinuation.class)) {
+                    if (isResponseFilter) {
+                        context.fail("Response filters cannot use filter continuations", parameter);
+                        return;
+                    }
 
-            if (requestFilterAnnotation != null) {
-                // will throw on validation error
-                FilterRunner.validateFilterMethod(args, ret, false);
+                    if (continuationCreator != null) {
+                        context.fail("Only one continuation per filter is allowed", parameter);
+                        return;
+                    }
+                    continuationCreator = parameter;
+                    ClassElement continuationReturnType = resolveType(parameterType.getFirstTypeArgument().orElse(ClassElement.of(Object.class)));
+                    if (!continuationReturnType.isAssignable(HttpResponse.class) && !continuationReturnType.isAssignable(MutableHttpResponse.class)) {
+                        context.fail("Unsupported continuation type: " + continuationReturnType.getName(), parameter);
+                        return;
+                    }
+                }
             }
-            if (responseFilterAnnotation != null) {
-                // will throw on validation error
-                FilterRunner.validateFilterMethod(args, ret, true);
+            ClassElement returnType = resolveReturnType(element);
+            if (!returnType.isVoid()) {
+                if (isInvalidType(context, element, returnType, "Unsupported filter return type")) {
+                    return;
+                }
+                if (isResponseFilter) {
+                    if (!returnType.isAssignable(HttpResponse.class)) {
+                        context.fail("Unsupported filter return type: " + returnType.getName(), element);
+                    }
+                } else {
+                    if (continuationCreator != null && returnType.isAssignable(HttpRequest.class)) {
+                        context.fail("Filter method that accepts a continuation cannot return an HttpRequest", element);
+                        return;
+                    }
+                    if (!returnType.isAssignable(HttpRequest.class) && !returnType.isAssignable(HttpResponse.class)) {
+                        context.fail("Unsupported filter return type: " + returnType.getName(), element);
+                    }
+                }
             }
         } catch (IllegalArgumentException e) {
             context.fail(e.getMessage(), element);
         }
     }
 
-    private Argument<?>[] toArguments(Collection<ClassElement> classElements, VisitorContext context) {
-        return classElements.stream().map(arg -> toArgument(arg, context)).toArray(Argument[]::new);
+    private boolean isPermittedRawType(ClassElement parameterType) {
+        if (parameterType.isArray() && parameterType.isPrimitive() && parameterType.getName().equals("byte")) {
+            return true;
+        }
+        return parameterType.isAssignable(byte[].class) || parameterType.isAssignable(ByteBuffer.class) || parameterType.isAssignable(String.class);
     }
 
-    private Argument<?> toArgument(ClassElement classElement, VisitorContext context) {
-        Class<?> cl = toClass(classElement, context);
-        Argument<?>[] parameters;
-        try {
-            parameters = toArguments(classElement.getTypeArguments().values(), context);
-        } catch (IllegalArgumentException e) {
-            // we don't always need the type params, try the erased type
-            return Argument.of(cl);
-        }
-        return Argument.of(cl, parameters);
+    private static ClassElement resolveReturnType(MethodElement element) {
+        ClassElement returnType = element.getGenericReturnType();
+        return resolveType(returnType);
     }
 
-    private Class<?> toClass(ClassElement classElement, VisitorContext context) {
-        for (Class<?> permittedClass : PERMITTED_CLASSES) {
-            if (classElement.getName().equals(permittedClass.getName())) {
-                return permittedClass;
-            }
+    private static ClassElement resolveType(ClassElement returnType) {
+        if (returnType.isAssignable(Publisher.class) || returnType.isAssignable(CompletionStage.class) || returnType.isOptional()) {
+            returnType = returnType.getFirstTypeArgument().orElse(returnType);
         }
-        if (classElement.isAssignable(CompletionStage.class)) {
-            return CompletionStage.class;
-        }
-        if (classElement.isAssignable(Throwable.class)) {
-            return Throwable.class;
-        }
-        for (String reactiveTypeName : Publishers.getReactiveTypeNames()) {
-            if (classElement.isAssignable(reactiveTypeName)) {
-                return Publisher.class;
-            }
-        }
-        throw new IllegalArgumentException("Unsupported type for filter method: " + classElement.getName());
+        return returnType;
     }
+
+    private static boolean isInvalidType(VisitorContext context, Element parameter, ClassElement parameterType, String message) {
+        if (parameterType.isAssignable(Publisher.class) || parameterType.isAssignable(CompletionStage.class)) {
+            parameterType = parameterType.getFirstTypeArgument().orElse(parameterType);
+        }
+        boolean valid = PERMITTED_CLASSES.stream().anyMatch(parameterType::isAssignable);
+        if (!valid) {
+            context.fail(message + ": " + parameterType.getName(), parameter);
+            return true;
+        }
+        return false;
+    }
+
 }

--- a/http-validation/src/test/groovy/io/micronaut/validation/routes/FilterVisitorSpec.groovy
+++ b/http-validation/src/test/groovy/io/micronaut/validation/routes/FilterVisitorSpec.groovy
@@ -23,7 +23,28 @@ class Foo {
 
         then:
         def ex = thrown(RuntimeException)
-        ex.message.contains("Unsupported type for filter method: java.lang.String")
+        ex.message.contains("Unsupported filter method parameter type: java.lang.String")
+    }
+
+    def 'continuation parameter type'() {
+        expect:
+        buildTypeElement("""
+
+package test;
+
+import io.micronaut.http.*;
+import io.micronaut.http.annotation.*;
+import io.micronaut.http.filter.FilterContinuation;
+
+@ServerFilter
+class Foo {
+    @RequestFilter
+    public void requestFilterContinuationBlocking(HttpRequest<?> request, FilterContinuation<HttpResponse<?>> continuation) {
+    }
+}
+
+""")
+
     }
 
     def 'unknown return type'() {
@@ -46,7 +67,7 @@ class Foo {
 
         then:
         def ex = thrown(RuntimeException)
-        ex.message.contains("Unsupported type for filter method: java.lang.String")
+        ex.message.contains("Unsupported filter return type: java.lang.String")
     }
 
     def 'response on request filter'() {
@@ -94,6 +115,6 @@ class Foo {
 
         then:
         def ex = thrown(RuntimeException)
-        ex.message.contains("Unsupported filter return type io.micronaut.http.HttpRequest")
+        ex.message.contains("Unsupported filter return type: io.micronaut.http.HttpRequest")
     }
 }

--- a/http/src/main/java/io/micronaut/http/FullHttpRequest.java
+++ b/http/src/main/java/io/micronaut/http/FullHttpRequest.java
@@ -15,52 +15,29 @@
  */
 package io.micronaut.http;
 
-import io.micronaut.core.convert.ArgumentConversionContext;
-import io.micronaut.core.convert.ConversionContext;
-import io.micronaut.core.convert.ConversionError;
-import io.micronaut.core.convert.exceptions.ConversionErrorException;
-import io.micronaut.core.type.Argument;
-
-import java.util.Optional;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.io.buffer.ByteBuffer;
 
 /**
- * A request wrapper with knowledge of the body argument.
+ * Allows introspecting whether the request is a full http request.
  *
  * @param <B> The body type
  * @author James Kleeh
  * @since 1.1.0
  */
-public class FullHttpRequest<B> extends HttpRequestWrapper<B> {
-
-    private final Argument<B> bodyType;
+@Internal
+public interface FullHttpRequest<B> extends HttpRequest<B> {
+    /**
+     * @return Is the request full.
+     */
+    default boolean isFull() {
+        return false;
+    }
 
     /**
-     * @param delegate The Http Request
-     * @param bodyType The Body Type
+     * @return The body contents or null if there are none or they are not obtainable.
      */
-    public FullHttpRequest(HttpRequest<B> delegate,
-                           Argument<B> bodyType) {
-        super(delegate);
-        this.bodyType = bodyType;
-    }
-
-    @Override
-    public Optional<B> getBody() {
-        ArgumentConversionContext<B> conversionContext = ConversionContext.of(bodyType);
-        Optional<B> body = getBody(conversionContext);
-        if (conversionContext.hasErrors()) {
-            Exception cause = null;
-            Optional<ConversionError> lastError = conversionContext.getLastError();
-            if (lastError.isPresent()) {
-                ConversionError conversionError = lastError.get();
-                cause = conversionError.getCause();
-            }
-            if (cause instanceof RuntimeException runtimeException) {
-                throw runtimeException;
-            } else if (cause != null) {
-                throw new ConversionErrorException(bodyType, cause);
-            }
-        }
-        return body;
-    }
+    @Nullable
+    ByteBuffer<?> contents();
 }

--- a/http/src/main/java/io/micronaut/http/FullHttpRequest.java
+++ b/http/src/main/java/io/micronaut/http/FullHttpRequest.java
@@ -16,7 +16,9 @@
 package io.micronaut.http;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.execution.ExecutionFlow;
 import io.micronaut.core.io.buffer.ByteBuffer;
 
 /**
@@ -40,4 +42,13 @@ public interface FullHttpRequest<B> extends HttpRequest<B> {
      */
     @Nullable
     ByteBuffer<?> contents();
+
+    /**
+     * Get the contents of this request as a buffer. If this is a streaming request, the returned
+     * flow may be delayed.
+     *
+     * @return The request content
+     */
+    @NonNull
+    ExecutionFlow<ByteBuffer<?>> bufferContents();
 }

--- a/http/src/test/groovy/io/micronaut/http/filter/FilterRunnerSpec.groovy
+++ b/http/src/test/groovy/io/micronaut/http/filter/FilterRunnerSpec.groovy
@@ -11,6 +11,7 @@ import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus
 import io.micronaut.http.MutableHttpResponse
+import io.micronaut.http.bind.DefaultRequestBinderRegistry
 import io.micronaut.http.reactive.execution.ReactiveExecutionFlow
 import io.micronaut.inject.ExecutableMethod
 import org.reactivestreams.Publisher
@@ -693,11 +694,11 @@ class FilterRunnerSpec extends Specification {
     }
 
     private def after(ReturnType returnType, List<Argument> arguments = closure.parameterTypes.collect { Argument.of(it) }, Closure<?> closure) {
-        return FilterRunner.prepareFilterMethod(ConversionService.SHARED, null, new LambdaExecutable(closure, arguments.toArray(new Argument[0]), returnType), true, new FilterOrder.Fixed(0), argumentBinderRegistry)
+        return FilterRunner.prepareFilterMethod(ConversionService.SHARED, null, new LambdaExecutable(closure, arguments.toArray(new Argument[0]), returnType), true, new FilterOrder.Fixed(0), new DefaultRequestBinderRegistry(ConversionService.SHARED))
     }
 
     private def before(ReturnType returnType, List<Argument> arguments = closure.parameterTypes.collect { Argument.of(it) }, Closure<?> closure) {
-        return FilterRunner.prepareFilterMethod(ConversionService.SHARED, null, new LambdaExecutable(closure, arguments.toArray(new Argument[0]), returnType), false, new FilterOrder.Fixed(0), argumentBinderRegistry)
+        return FilterRunner.prepareFilterMethod(ConversionService.SHARED, null, new LambdaExecutable(closure, arguments.toArray(new Argument[0]), returnType), false, new FilterOrder.Fixed(0), new DefaultRequestBinderRegistry(ConversionService.SHARED))
     }
 
     private def around(boolean legacy, Closure<Publisher<MutableHttpResponse<?>>> closure) {

--- a/http/src/test/groovy/io/micronaut/http/filter/FilterRunnerSpec.groovy
+++ b/http/src/test/groovy/io/micronaut/http/filter/FilterRunnerSpec.groovy
@@ -693,11 +693,11 @@ class FilterRunnerSpec extends Specification {
     }
 
     private def after(ReturnType returnType, List<Argument> arguments = closure.parameterTypes.collect { Argument.of(it) }, Closure<?> closure) {
-        return FilterRunner.prepareFilterMethod(ConversionService.SHARED, null, new LambdaExecutable(closure, arguments.toArray(new Argument[0]), returnType), true, new FilterOrder.Fixed(0))
+        return FilterRunner.prepareFilterMethod(ConversionService.SHARED, null, new LambdaExecutable(closure, arguments.toArray(new Argument[0]), returnType), true, new FilterOrder.Fixed(0), argumentBinderRegistry)
     }
 
     private def before(ReturnType returnType, List<Argument> arguments = closure.parameterTypes.collect { Argument.of(it) }, Closure<?> closure) {
-        return FilterRunner.prepareFilterMethod(ConversionService.SHARED, null, new LambdaExecutable(closure, arguments.toArray(new Argument[0]), returnType), false, new FilterOrder.Fixed(0))
+        return FilterRunner.prepareFilterMethod(ConversionService.SHARED, null, new LambdaExecutable(closure, arguments.toArray(new Argument[0]), returnType), false, new FilterOrder.Fixed(0), argumentBinderRegistry)
     }
 
     private def around(boolean legacy, Closure<Publisher<MutableHttpResponse<?>>> closure) {

--- a/test-suite-http-server-tck-netty/src/test/java/io/micronaut/http/server/tck/netty/tests/NettyHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-netty/src/test/java/io/micronaut/http/server/tck/netty/tests/NettyHttpServerTestSuite.java
@@ -1,13 +1,11 @@
 package io.micronaut.http.server.tck.netty.tests;
 
-import org.junit.platform.suite.api.IncludeClassNamePatterns;
 import org.junit.platform.suite.api.SelectPackages;
 import org.junit.platform.suite.api.Suite;
 import org.junit.platform.suite.api.SuiteDisplayName;
 
 @Suite
 @SelectPackages("io.micronaut.http.server.tck.tests")
-@IncludeClassNamePatterns("io.micronaut.http.server.tck.tests.filter.RequestFilterTest")
 @SuiteDisplayName("HTTP Server TCK for Netty")
 public class NettyHttpServerTestSuite {
 }

--- a/test-suite-http-server-tck-netty/src/test/java/io/micronaut/http/server/tck/netty/tests/NettyHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-netty/src/test/java/io/micronaut/http/server/tck/netty/tests/NettyHttpServerTestSuite.java
@@ -1,11 +1,13 @@
 package io.micronaut.http.server.tck.netty.tests;
 
+import org.junit.platform.suite.api.IncludeClassNamePatterns;
 import org.junit.platform.suite.api.SelectPackages;
 import org.junit.platform.suite.api.Suite;
 import org.junit.platform.suite.api.SuiteDisplayName;
 
 @Suite
 @SelectPackages("io.micronaut.http.server.tck.tests")
+@IncludeClassNamePatterns("io.micronaut.http.server.tck.tests.filter.RequestFilterTest")
 @SuiteDisplayName("HTTP Server TCK for Netty")
 public class NettyHttpServerTestSuite {
 }


### PR DESCRIPTION
* allows using regular HTTP binding annotations in filters
* allows binding certain body types and fails otherwise