### PR TITLE
Don't error when a context class is not available

### DIFF
--- a/core-processor/src/main/java/io/micronaut/expressions/context/ExpressionEvaluationContextRegistrar.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/context/ExpressionEvaluationContextRegistrar.java
@@ -17,7 +17,6 @@ package io.micronaut.expressions.context;
 
 import io.micronaut.context.annotation.AnnotationExpressionContext;
 import io.micronaut.core.annotation.Experimental;
-import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.visitor.TypeElementVisitor;
 import io.micronaut.inject.visitor.VisitorContext;
 

--- a/core-processor/src/main/java/io/micronaut/expressions/context/ExpressionEvaluationContextRegistrar.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/context/ExpressionEvaluationContextRegistrar.java
@@ -32,14 +32,11 @@ import io.micronaut.inject.visitor.VisitorContext;
 public interface ExpressionEvaluationContextRegistrar extends TypeElementVisitor<AnnotationExpressionContext, AnnotationExpressionContext> {
     @Override
     default void start(VisitorContext visitorContext) {
-        ClassElement contextClass = visitorContext.getClassElement(getContextClassName())
-            .orElse(null);
-        if (contextClass == null) {
-            visitorContext.fail("Evaluation context class is not on the compilation classpath: " + getContextClassName(), null);
-        } else {
-            visitorContext.getExpressionCompilationContextFactory()
-                .registerContextClass(contextClass);
-        }
+        visitorContext.getClassElement(getContextClassName())
+            .ifPresent(contextClass ->
+                visitorContext.getExpressionCompilationContextFactory()
+                              .registerContextClass(contextClass)
+            );
     }
 
     String getContextClassName();

--- a/core-processor/src/main/java/io/micronaut/inject/writer/ClassWriterOutputVisitor.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/ClassWriterOutputVisitor.java
@@ -128,6 +128,7 @@ public interface ClassWriterOutputVisitor {
      * Visit a file that will be generated within the generated sources directory.
      *
      * @param path The path
+     * @param originatingElements  the originating elements
      * @return The file if it was possible to create it
      * @since 4.0.0
      */


### PR DESCRIPTION
In retrospect this error is unhelpful as it means you can't have an annotation processor without the module on the implementation class path which can be problematic. Since the compilation will fail anyway when any method or property is used from the context I don't think this error is necessary.