### PR TITLE
missingBeans for EndpointsFilter

### DIFF
--- a/management/src/main/java/io/micronaut/management/endpoint/EndpointSensitivityHandler.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/EndpointSensitivityHandler.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.management.endpoint;
+
+/**
+ * If a bean of type {@link EndpointSensitivityHandler} is present the {@link EndpointsFilter} is not loaded.
+ * @author Sergio del Amo
+ * @since 4.0.0
+ */
+public interface EndpointSensitivityHandler {
+}

--- a/management/src/main/java/io/micronaut/management/endpoint/EndpointsFilter.java
+++ b/management/src/main/java/io/micronaut/management/endpoint/EndpointsFilter.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.management.endpoint;
 
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.order.Ordered;
@@ -40,6 +41,7 @@ import java.util.Optional;
  * @author Sergio del Amo
  * @since 1.0
  */
+@Requires(missingBeans = EndpointSensitivityHandler.class)
 @ServerFilter(Filter.MATCH_ALL_PATTERN)
 @Internal
 public class EndpointsFilter implements Ordered {

--- a/management/src/test/groovy/io/micronaut/management/endpoint/EndpointSensitivityHandlerSpec.groovy
+++ b/management/src/test/groovy/io/micronaut/management/endpoint/EndpointSensitivityHandlerSpec.groovy
@@ -1,0 +1,39 @@
+package io.micronaut.management.endpoint
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.env.Environment
+import io.micronaut.http.client.BlockingHttpClient
+import io.micronaut.http.client.HttpClient
+import io.micronaut.management.endpoint.env.EnvironmentEndpoint
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.management.endpoint.EndpointSensitivityHandler
+import jakarta.inject.Singleton
+import spock.lang.Specification
+
+class EndpointSensitivityHandlerSpec extends Specification {
+    void "when a bean of type EndpointSensitivityHandler is present then the EndpointsFilter id disabled"() {
+        given:
+        EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, ['spec.name': 'EndpointSensitivityHandlerSpec', 'endpoints.env.enabled': true], Environment.TEST)
+        HttpClient httpClient = embeddedServer.applicationContext.createBean(HttpClient, embeddedServer.getURL())
+        BlockingHttpClient client = httpClient.toBlocking()
+
+        when:
+        client.exchange("/${EnvironmentEndpoint.NAME}")
+
+        then:
+        noExceptionThrown()
+
+        cleanup:
+        client.close()
+        httpClient.close()
+        embeddedServer.close()
+    }
+
+    @Requires(property = 'spec.name', value = 'EndpointSensitivityHandlerSpec')
+    @Singleton
+    static class EndpointSensitivityHandlerImpl implements io.micronaut.management.endpoint.EndpointSensitivityHandler {
+
+    }
+
+}


### PR DESCRIPTION
[`EndpointsFilter`](https://github.com/micronaut-projects/micronaut-core/blob/4.0.x/management/src/main/java/io/micronaut/management/endpoint/EndpointsFilter.java#L44) was marked as @Internal  in [#9357](https://github.com/micronaut-projects/micronaut-core/pull/9357).

However, Micronaut Security needs to replace/disable that filter. The change to the new [filters API forced the replacement in security to be done using the new API](https://github.com/micronaut-projects/micronaut-security/blob/master/security/src/main/java/io/micronaut/security/filters/EndpointsFilterReplacement.java).

I think we should either remove the @Internal or what I think is a more elegant solution, create a marker API to convey Endpoints sensitivity is handled externally and thus the filter should not be loaded.

That it is what this PR proposes.