### PR TITLE
Enable tcnative even when ALPN is not configured

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -66,6 +66,7 @@ managed-methvin-directory-watcher = "0.18.0"
 managed-netty = "4.1.93.Final"
 managed-netty-iouring = "0.0.21.Final"
 managed-netty-http3 = "0.0.16.Final"
+managed-netty-tcnative = "2.0.61.Final"
 managed-reactive-streams = "1.0.4"
 # This should be kept aligned with https://github.com/micronaut-projects/micronaut-reactor/blob/master/gradle.properties from the BOM
 managed-reactor = "3.5.6"
@@ -139,6 +140,7 @@ managed-netty-transport-native-epoll = { module = "io.netty:netty-transport-nati
 managed-netty-transport-native-kqueue = { module = "io.netty:netty-transport-native-kqueue", version.ref = "managed-netty" }
 managed-netty-transport-native-iouring = { module = "io.netty.incubator:netty-incubator-transport-native-io_uring", version.ref = "managed-netty-iouring" }
 managed-netty-transport-native-unix-common = { module = "io.netty:netty-transport-native-unix-common", version.ref = "managed-netty" }
+managed-netty-tcnative-boringssl-static = { module = "io.netty:netty-tcnative-boringssl-static", version.ref = "managed-netty-tcnative" }
 
 managed-reactive-streams = { module = "org.reactivestreams:reactive-streams", version.ref = "managed-reactive-streams" }
 

--- a/http-netty/src/main/java/io/micronaut/http/netty/NettyTlsUtils.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/NettyTlsUtils.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.netty;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.http.ssl.SslConfiguration;
+import io.netty.handler.ssl.OpenSslCachingX509KeyManagerFactory;
+import io.netty.handler.ssl.OpenSslX509KeyManagerFactory;
+import io.netty.handler.ssl.SslProvider;
+
+import javax.net.ssl.KeyManagerFactory;
+import java.security.KeyStore;
+import java.util.Optional;
+
+/**
+ * Common utilities for netty TLS support.
+ *
+ * @author Jonas Konrad
+ * @since 4.0.0
+ */
+@Internal
+public final class NettyTlsUtils {
+    private static boolean useOpenssl() {
+        return SslProvider.isAlpnSupported(SslProvider.OPENSSL_REFCNT);
+    }
+
+    /**
+     * The SSL provider to use.
+     *
+     * @return The provider
+     */
+    public static SslProvider sslProvider() {
+        return useOpenssl() ? SslProvider.OPENSSL_REFCNT : SslProvider.JDK;
+    }
+
+    /**
+     * Create a {@link KeyManagerFactory} from a {@link KeyStore}. This is basically like
+     * {@link io.micronaut.http.ssl.SslBuilder#getKeyManagerFactory(SslConfiguration)}, except it
+     * uses factories optimized for netty openssl if possible.
+     *
+     * @param ssl The ssl configuration
+     * @param keyStore The key store, i.e. the return value of
+     * {@link io.micronaut.http.ssl.SslBuilder#getKeyStore(SslConfiguration)}
+     * @return The {@link KeyManagerFactory} containing the key store
+     */
+    @NonNull
+    public static KeyManagerFactory storeToFactory(@NonNull SslConfiguration ssl, @Nullable KeyStore keyStore) throws Exception {
+        KeyManagerFactory keyManagerFactory;
+        if (useOpenssl()) {
+            // I don't understand why, but netty uses this logic, so we will too.
+            if (keyStore == null || keyStore.aliases().hasMoreElements()) {
+                keyManagerFactory = new OpenSslX509KeyManagerFactory();
+            } else {
+                keyManagerFactory = new OpenSslCachingX509KeyManagerFactory(KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm()));
+            }
+        } else {
+            keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        }
+        Optional<String> password = ssl.getKey().getPassword();
+        char[] keyPassword = password.map(String::toCharArray).orElse(null);
+        Optional<String> pwd = ssl.getKeyStore().getPassword();
+        if (keyPassword == null && pwd.isPresent()) {
+            keyPassword = pwd.get().toCharArray();
+        }
+        keyManagerFactory.init(keyStore, keyPassword);
+        return keyManagerFactory;
+    }
+}

--- a/http-server-netty/build.gradle
+++ b/http-server-netty/build.gradle
@@ -90,6 +90,11 @@ dependencies {
             classifier = Os.isArch("aarch64") ? "osx-aarch_64" : "osx-x86_64"
         }
     }
+    testImplementation(libs.managed.netty.tcnative.boringssl.static) {
+        artifact {
+            classifier = Os.isArch("aarch64") ? "osx-aarch_64" : "osx-x86_64"
+        }
+    }
     testImplementation libs.logback.classic
 
     // Adding these for now since micronaut-test isnt resolving correctly ... probably need to upgrade gradle there too


### PR DESCRIPTION
This PR enables tcnative support when available. Before this patch it would only be turned on if ALPN was necessary.

I also switched from OPENSSL to OPENSSL_REFCNT, which is more performant, and moved to the openssl-specific cached key manager factories from netty. To test this, I added tcnative to the http-server-netty tests, which also has leak detection.