### PR TITLE
imp: add default methods for writeValueAsString

### DIFF
--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/ErrorHandlerTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/ErrorHandlerTest.java
@@ -40,6 +40,7 @@ import io.micronaut.http.tck.AssertionUtils;
 import io.micronaut.http.tck.HttpResponseAssertion;
 import io.micronaut.http.tck.ServerUnderTest;
 import io.micronaut.http.tck.ServerUnderTestProviderUtils;
+import io.micronaut.json.JsonMapper;
 import jakarta.inject.Singleton;
 import org.junit.jupiter.api.Test;
 
@@ -99,7 +100,7 @@ public class ErrorHandlerTest {
             PROPERTY_MICRONAUT_SERVER_CORS_ENABLED, StringUtils.TRUE
         );
         try (ServerUnderTest server = ServerUnderTestProviderUtils.getServerUnderTestProvider().getServer(SPEC_NAME, configuration)) {
-            ObjectMapper objectMapper = server.getApplicationContext().getBean(ObjectMapper.class);
+            JsonMapper objectMapper = server.getApplicationContext().getBean(JsonMapper.class);
             HttpRequest<?> request = HttpRequest.POST("/json/errors/global", objectMapper.writeValueAsString(new RequestObject(101)))
                 .header(HttpHeaders.CONTENT_TYPE, io.micronaut.http.MediaType.APPLICATION_JSON);
             AssertionUtils.assertDoesNotThrow(server, request,

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/ErrorHandlerTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/ErrorHandlerTest.java
@@ -15,7 +15,6 @@
  */
 package io.micronaut.http.server.tck.tests;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.util.CollectionUtils;

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/ExpressionTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/ExpressionTest.java
@@ -19,7 +19,6 @@ import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpStatus;
-import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
 import io.micronaut.http.annotation.RouteCondition;

--- a/http/src/test/groovy/io/micronaut/http/hateoas/LinkSpec.groovy
+++ b/http/src/test/groovy/io/micronaut/http/hateoas/LinkSpec.groovy
@@ -2,6 +2,7 @@ package io.micronaut.http.hateoas
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.micronaut.context.ApplicationContext
+import io.micronaut.json.JsonMapper
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Specification
@@ -25,12 +26,12 @@ class LinkSpec extends Specification {
 
     void "test resource serde"() {
         given:
-        def objectMapper = context.getBean(ObjectMapper)
+        JsonMapper objectMapper = context.getBean(JsonMapper)
         def test = new Test(name: "Fred")
         test.link(Link.SELF, Link.build("/test/{name}").templated(true).build())
 
         when:
-        def json = objectMapper.writeValueAsString(test)
+        String json = objectMapper.writeValueAsString(test)
 
         then:
         json == '{"name":"Fred","_links":{"self":{"href":"/test/{name}","templated":true}}}'

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/BeanIntrospectionSpec.groovy
@@ -31,6 +31,7 @@ import io.micronaut.inject.annotation.EvaluatedAnnotationMetadata
 import io.micronaut.inject.beans.visitor.IntrospectedTypeElementVisitor
 import io.micronaut.inject.visitor.TypeElementVisitor
 import io.micronaut.jackson.modules.BeanIntrospectionModule
+import io.micronaut.json.JsonMapper
 import io.micronaut.validation.visitor.ValidationVisitor
 import jakarta.inject.Singleton
 import spock.lang.IgnoreIf
@@ -1055,9 +1056,9 @@ public record Foo(@JsonProperty("other") String name, @JsonIgnore int y) {
 ''')
         when:
         def obj = introspection.instantiate("test", 10)
-        def result = ApplicationContext.run('bean.introspection.test':'true').withCloseable {
+        String result = ApplicationContext.run('bean.introspection.test':'true').withCloseable {
             it.getBean(StaticBeanIntrospectionModule).introspectionMap[introspection.beanType] = introspection
-            it.getBean(ObjectMapper).writeValueAsString(obj)
+            it.getBean(JsonMapper).writeValueAsString(obj)
         }
         then:
         result == '{"other":"test"}'

--- a/jackson-databind/src/test/groovy/io/micronaut/jackson/modules/BeanIntrospectionModuleSpec.groovy
+++ b/jackson-databind/src/test/groovy/io/micronaut/jackson/modules/BeanIntrospectionModuleSpec.groovy
@@ -40,6 +40,7 @@ import io.micronaut.jackson.modules.wrappers.IntWrapper
 import io.micronaut.jackson.modules.wrappers.IntegerWrapper
 import io.micronaut.jackson.modules.wrappers.LongWrapper
 import io.micronaut.jackson.modules.wrappers.StringWrapper
+import io.micronaut.json.JsonMapper
 import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -55,12 +56,12 @@ class BeanIntrospectionModuleSpec extends Specification {
                 'jackson.deserialization.UNWRAP_ROOT_VALUE': true,
                 'jackson.serialization.WRAP_ROOT_VALUE': true
         )
-        ObjectMapper objectMapper = ctx.getBean(ObjectMapper)
+        JsonMapper objectMapper = ctx.getBean(JsonMapper)
 
         when:
         Author author = new Author(name:"Bob")
 
-        def result = objectMapper.writeValueAsString(author)
+        String result = objectMapper.writeValueAsString(author)
 
         then:
         result == '{"Author":{"name":"Bob"}}'
@@ -79,14 +80,14 @@ class BeanIntrospectionModuleSpec extends Specification {
                 'jackson.deserialization.UNWRAP_ROOT_VALUE': true,
                 'jackson.serialization.WRAP_ROOT_VALUE': true
         )
-        ObjectMapper objectMapper = ctx.getBean(ObjectMapper)
+        JsonMapper objectMapper = ctx.getBean(JsonMapper)
 
         when:
         HTTPCheck check = new HTTPCheck(headers:[
                 Accept:['application/json', 'application/xml']
         ] )
 
-        def result = objectMapper.writeValueAsString(check)
+        String result = objectMapper.writeValueAsString(check)
 
         then:
         result == '{"HTTPCheck":{"Header":{"Accept":["application/json","application/xml"]}}}'
@@ -105,12 +106,12 @@ class BeanIntrospectionModuleSpec extends Specification {
                 'jackson.deserialization.UNWRAP_ROOT_VALUE': true,
                 'jackson.serialization.WRAP_ROOT_VALUE': true
         )
-        ObjectMapper objectMapper = ctx.getBean(ObjectMapper)
+        JsonMapper objectMapper = ctx.getBean(JsonMapper)
 
         when:
         IntrospectionCreator check = new IntrospectionCreator("test")
 
-        def result = objectMapper.writeValueAsString(check)
+        String result = objectMapper.writeValueAsString(check)
 
         then:
         result == '{"IntrospectionCreator":{"label":"TEST"}}'
@@ -129,12 +130,12 @@ class BeanIntrospectionModuleSpec extends Specification {
                 'jackson.deserialization.UNWRAP_ROOT_VALUE': true,
                 'jackson.serialization.WRAP_ROOT_VALUE': true
         )
-        ObjectMapper objectMapper = ctx.getBean(ObjectMapper)
+        JsonMapper objectMapper = ctx.getBean(JsonMapper)
 
         when:
         InstanceInfo check = new InstanceInfo("test")
 
-        def result = objectMapper.writeValueAsString(check)
+        String result = objectMapper.writeValueAsString(check)
 
         then:
         result == '{"instance":{"hostName":"test"}}'
@@ -151,14 +152,14 @@ class BeanIntrospectionModuleSpec extends Specification {
     void "test serialize/deserialize convertible values"() {
         given:
         ApplicationContext ctx = ApplicationContext.run()
-        ObjectMapper objectMapper = ctx.getBean(ObjectMapper)
+        JsonMapper objectMapper = ctx.getBean(JsonMapper)
 
         when:
         HTTPCheck check = new HTTPCheck(headers:[
                 Accept:['application/json', 'application/xml']
         ] )
 
-        def result = objectMapper.writeValueAsString(check)
+        String result = objectMapper.writeValueAsString(check)
 
         then:
         result == '{"Header":{"Accept":["application/json","application/xml"]}}'
@@ -174,7 +175,7 @@ class BeanIntrospectionModuleSpec extends Specification {
     void "Bean introspection works with a bean without JsonIgnore annotations"() {
         given:
         ApplicationContext ctx = ApplicationContext.run()
-        ObjectMapper objectMapper = ctx.getBean(ObjectMapper)
+        JsonMapper objectMapper = ctx.getBean(JsonMapper)
 
         when:
         IgnoreTest guide = new IgnoreTest(name:"Test", code: 9999)
@@ -192,7 +193,7 @@ class BeanIntrospectionModuleSpec extends Specification {
         given:
         ApplicationContext ctx = ApplicationContext.run()
         ctx.getBean(BeanIntrospectionModule).ignoreReflectiveProperties = ignoreReflectiveProperties
-        ObjectMapper objectMapper = ctx.getBean(ObjectMapper)
+        JsonMapper objectMapper = ctx.getBean(JsonMapper)
 
         when:
         GuideWithoutJsonIncludeAnnotations guide = new GuideWithoutJsonIncludeAnnotations()
@@ -215,7 +216,7 @@ class BeanIntrospectionModuleSpec extends Specification {
         ApplicationContext ctx = ApplicationContext.run(
                 'jackson.serializationInclusion':'ALWAYS'
         )
-        ObjectMapper objectMapper = ctx.getBean(ObjectMapper)
+        JsonMapper objectMapper = ctx.getBean(JsonMapper)
 
         when:
         GuideWithoutJsonIncludeAnnotations guide = new GuideWithoutJsonIncludeAnnotations()
@@ -235,7 +236,7 @@ class BeanIntrospectionModuleSpec extends Specification {
         ApplicationContext ctx = ApplicationContext.run(
                 'jackson.serializationInclusion':'ALWAYS'
         )
-        ObjectMapper objectMapper = ctx.getBean(ObjectMapper)
+        JsonMapper objectMapper = ctx.getBean(JsonMapper)
 
         when:
         Guide guide = new Guide()
@@ -255,7 +256,7 @@ class BeanIntrospectionModuleSpec extends Specification {
         ApplicationContext ctx = ApplicationContext.run(
                 'jackson.serializationInclusion':'ALWAYS'
         )
-        ObjectMapper objectMapper = ctx.getBean(ObjectMapper)
+        JsonMapper objectMapper = ctx.getBean(JsonMapper)
 
         when:
         GuideWithNull guide = new GuideWithNull()
@@ -274,7 +275,7 @@ class BeanIntrospectionModuleSpec extends Specification {
         given:
         ApplicationContext ctx = ApplicationContext.run()
         ctx.getBean(BeanIntrospectionModule).ignoreReflectiveProperties = ignoreReflectiveProperties
-        ObjectMapper objectMapper = ctx.getBean(ObjectMapper)
+        JsonMapper objectMapper = ctx.getBean(JsonMapper)
 
         when:
         def value = new OptionalAuthor(name: Optional.<String>empty())
@@ -353,11 +354,11 @@ class BeanIntrospectionModuleSpec extends Specification {
     void "test that introspected serialization works with @JsonAnyGetter"() {
         given:
         ApplicationContext ctx = ApplicationContext.run()
-        ObjectMapper objectMapper = ctx.getBean(ObjectMapper)
+        JsonMapper objectMapper = ctx.getBean(JsonMapper)
 
         when:
         def plant = new PlantWithAnyGetter(name: "Rose", attributes: [color: "green", hasFlowers: true])
-        def str = objectMapper.writeValueAsString(plant)
+        String str = objectMapper.writeValueAsString(plant)
 
         then:
         str == '{"name":"Rose","color":"green","hasFlowers":true}'
@@ -611,7 +612,7 @@ class BeanIntrospectionModuleSpec extends Specification {
         given:
         ApplicationContext ctx = ApplicationContext.run()
         ctx.getBean(BeanIntrospectionModule).ignoreReflectiveProperties = ignoreReflectiveProperties
-        ObjectMapper objectMapper = ctx.getBean(ObjectMapper)
+        JsonMapper objectMapper = ctx.getBean(JsonMapper)
 
         expect:
         objectMapper.readValue('{"bar":"baz"}', JsonPropertyOnSetter.class).foo == 'baz'
@@ -629,7 +630,7 @@ class BeanIntrospectionModuleSpec extends Specification {
       given:
       ApplicationContext ctx = ApplicationContext.run()
       ctx.getBean(BeanIntrospectionModule).ignoreReflectiveProperties = ignoreReflectiveProperties
-      ObjectMapper objectMapper = ctx.getBean(ObjectMapper)
+      JsonMapper objectMapper = ctx.getBean(JsonMapper)
 
       expect:
       objectMapper.readValue('{"foo":"Bar"}', JsonSerializeAnnotated.class).foo == 'bar'
@@ -647,7 +648,7 @@ class BeanIntrospectionModuleSpec extends Specification {
         given:
         ApplicationContext ctx = ApplicationContext.run()
         ctx.getBean(BeanIntrospectionModule).ignoreReflectiveProperties = ignoreReflectiveProperties
-        ObjectMapper objectMapper = ctx.getBean(ObjectMapper)
+        JsonMapper objectMapper = ctx.getBean(JsonMapper)
 
         expect:
         objectMapper.writeValueAsString(new DifferentCreator('baz')) == '{"fooBar":"baz"}'
@@ -666,7 +667,7 @@ class BeanIntrospectionModuleSpec extends Specification {
         given:
         ApplicationContext ctx = ApplicationContext.run()
         ctx.getBean(BeanIntrospectionModule).ignoreReflectiveProperties = ignoreReflectiveProperties
-        ObjectMapper objectMapper = ctx.getBean(ObjectMapper)
+        JsonMapper objectMapper = ctx.getBean(JsonMapper)
 
         expect:
         objectMapper.writeValueAsString(new IntrospectionCreator('baz')) == '{"label":"BAZ"}'
@@ -974,8 +975,8 @@ class BeanIntrospectionModuleSpec extends Specification {
         given:
         ApplicationContext ctx = ApplicationContext.run()
         ctx.getBean(BeanIntrospectionModule).ignoreReflectiveProperties = ignoreReflectiveProperties
-        ObjectMapper objectMapper = ctx.getBean(ObjectMapper)
-        def ldt = LocalDateTime.of(2021, 11, 22, 10, 37)
+        JsonMapper objectMapper = ctx.getBean(JsonMapper)
+        LocalDateTime ldt = LocalDateTime.of(2021, 11, 22, 10, 37)
 
         expect:
         objectMapper.writeValueAsString(new FormatBean(ldt: ldt)) == '{"ldt":"2021-11-22 10:37:00"}'
@@ -1007,7 +1008,7 @@ class BeanIntrospectionModuleSpec extends Specification {
         given:
         ApplicationContext ctx = ApplicationContext.run()
         ctx.getBean(BeanIntrospectionModule).ignoreReflectiveProperties = ignoreReflectiveProperties
-        ObjectMapper objectMapper = ctx.getBean(ObjectMapper)
+        JsonMapper objectMapper = ctx.getBean(JsonMapper)
 
         expect:
         objectMapper.writeValueAsString(new IgnoreBean()) == '{"foo":"bar"}'
@@ -1054,7 +1055,7 @@ class BeanIntrospectionModuleSpec extends Specification {
         given:
         ApplicationContext ctx = ApplicationContext.run()
         ctx.getBean(BeanIntrospectionModule).ignoreReflectiveProperties = ignoreReflectiveProperties
-        ObjectMapper objectMapper = ctx.getBean(ObjectMapper)
+        JsonMapper objectMapper = ctx.getBean(JsonMapper)
 
         expect:
         objectMapper.writeValueAsString(new IgnoreBean2(foo: 'x', bar: 'y')) == '{"bar":"y"}'
@@ -1128,7 +1129,7 @@ class BeanIntrospectionModuleSpec extends Specification {
         given:
         ApplicationContext ctx = ApplicationContext.run()
         ctx.getBean(BeanIntrospectionModule).ignoreReflectiveProperties = ignoreReflectiveProperties
-        ObjectMapper objectMapper = ctx.getBean(ObjectMapper)
+        JsonMapper objectMapper = ctx.getBean(JsonMapper)
 
         expect:
         objectMapper.writeValueAsString(new JsonPropertyBean(foo: 'x')) == '{"bar":"x"}'
@@ -1161,7 +1162,7 @@ class BeanIntrospectionModuleSpec extends Specification {
         given:
         ApplicationContext ctx = ApplicationContext.run()
         ctx.getBean(BeanIntrospectionModule).ignoreReflectiveProperties = ignoreReflectiveProperties
-        ObjectMapper objectMapper = ctx.getBean(ObjectMapper)
+        JsonMapper objectMapper = ctx.getBean(JsonMapper)
 
         expect:
         objectMapper.writeValueAsString(new JsonNamingBean(fooBar: 'x')) == '{"foo_bar":"x"}'
@@ -1194,7 +1195,7 @@ class BeanIntrospectionModuleSpec extends Specification {
         given:
         ApplicationContext ctx = ApplicationContext.run(["jackson.property-naming-strategy": "SNAKE_CASE"])
         ctx.getBean(BeanIntrospectionModule).ignoreReflectiveProperties = ignoreReflectiveProperties
-        ObjectMapper objectMapper = ctx.getBean(ObjectMapper)
+        JsonMapper objectMapper = ctx.getBean(JsonMapper)
 
         expect:
         objectMapper.writeValueAsString(new JsonNamingBeanConfig(fooBar: 'x')) == '{"foo_bar":"x"}'

--- a/json-core/src/main/java/io/micronaut/json/JsonMapper.java
+++ b/json-core/src/main/java/io/micronaut/json/JsonMapper.java
@@ -91,6 +91,19 @@ public interface JsonMapper {
     <T> T readValue(@NonNull InputStream inputStream, @NonNull Argument<T> type) throws IOException;
 
     /**
+     * Parse and map json from the given stream.
+     *
+     * @param inputStream The input data.
+     * @param type        The type to deserialize to.
+     * @param <T>         Type variable of the return type.
+     * @return The deserialized object.
+     * @throws IOException IOException
+     */
+    default <T> T readValue(@NonNull InputStream inputStream, @NonNull Class<T> type) throws IOException {
+        return readValue(inputStream, Argument.of(type));
+    }
+
+    /**
      * Parse and map json from the given byte array.
      *
      * @param byteArray The input data.
@@ -125,6 +138,19 @@ public interface JsonMapper {
      */
     default <T> T readValue(@NonNull String string, @NonNull Argument<T> type) throws IOException {
         return readValue(string.getBytes(StandardCharsets.UTF_8), type);
+    }
+
+    /**
+     * Parse and map json from the given string.
+     *
+     * @param string The input data.
+     * @param type   The type to deserialize to.
+     * @param <T>    Type variable of the return type.
+     * @return The deserialized object.
+     * @throws IOException IOException
+     */
+    default <T> T readValue(@NonNull String string, @NonNull Class<T> type) throws IOException {
+        return readValue(string, Argument.of(type));
     }
 
     /**
@@ -210,19 +236,7 @@ public interface JsonMapper {
      * @throws IOException IOException
      */
     default String writeValueAsString(@Nullable Object object) throws IOException {
-        return writeValueAsString(object, StandardCharsets.UTF_8);
-    }
-
-    /**
-     * Write an object as String.
-     *
-     * @param object The object to serialize.
-     * @param  charset The {@linkplain java.nio.charset.Charset charset} to be used to decode the {@code bytes}.
-     * @return The serialized encoded json.
-     * @throws IOException IOException
-     */
-    default String writeValueAsString(@Nullable Object object, @NonNull Charset charset) throws IOException {
-        return new String(writeValueAsBytes(object), charset);
+        return new String(writeValueAsBytes(object), StandardCharsets.UTF_8);
     }
 
     /**

--- a/json-core/src/main/java/io/micronaut/json/JsonMapper.java
+++ b/json-core/src/main/java/io/micronaut/json/JsonMapper.java
@@ -28,6 +28,7 @@ import org.reactivestreams.Processor;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.ServiceLoader;
@@ -200,6 +201,29 @@ public interface JsonMapper {
      * @throws IOException IOException
      */
     <T> byte[] writeValueAsBytes(@NonNull Argument<T> type, @Nullable T object) throws IOException;
+
+    /**
+     * Write an object as String.
+     *
+     * @param object The object to serialize.
+     * @return The serialized encoded json.
+     * @throws IOException IOException
+     */
+    default String writeValueAsString(@Nullable Object object) throws IOException {
+        return writeValueAsString(object, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Write an object as String.
+     *
+     * @param object The object to serialize.
+     * @param  charset The {@linkplain java.nio.charset.Charset charset} to be used to decode the {@code bytes}.
+     * @return The serialized encoded json.
+     * @throws IOException IOException
+     */
+    default String writeValueAsString(@Nullable Object object, @NonNull Charset charset) throws IOException {
+        return new String(writeValueAsBytes(object), charset);
+    }
 
     /**
      * Update an object from json data.

--- a/json-core/src/main/java/io/micronaut/json/JsonMapper.java
+++ b/json-core/src/main/java/io/micronaut/json/JsonMapper.java
@@ -28,7 +28,6 @@ import org.reactivestreams.Processor;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.ServiceLoader;


### PR DESCRIPTION
To provide an API such as `com.fasterxml.jackson.databind.ObjectMapper::writeValueAsString`