### PR TITLE
Wait for request body if necessary in filter

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpRequest.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpRequest.java
@@ -258,10 +258,10 @@ public class NettyHttpRequest<T> extends AbstractNettyHttpRequest<T> implements 
             if (next == null) {
                 break;
             }
+            httpBody = next;
             if (httpBody instanceof ByteBody bb) {
                 byteBody = bb;
             }
-            httpBody = next;
         }
         return byteBody;
     }
@@ -712,7 +712,7 @@ public class NettyHttpRequest<T> extends AbstractNettyHttpRequest<T> implements 
 
     @Override
     public boolean isFull() {
-        return body instanceof ImmediateByteBody;
+        return byteBody() instanceof ImmediateByteBody;
     }
 
     @Override

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/filters/FilterBodySpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/filters/FilterBodySpec.groovy
@@ -1,0 +1,61 @@
+package io.micronaut.http.server.netty.filters
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.annotation.Order
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.RequestFilter
+import io.micronaut.http.annotation.ServerFilter
+import io.micronaut.http.client.HttpClient
+import io.micronaut.runtime.server.EmbeddedServer
+import jakarta.inject.Singleton
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Sinks
+import spock.lang.Specification
+
+class FilterBodySpec extends Specification {
+    def "delayed body"() {
+        given:
+        def ctx = ApplicationContext.run(["spec.name":"FilterBodySpec"])
+        def server = ctx.getBean(EmbeddedServer)
+        server.start()
+        def client = ctx.createBean(HttpClient, server.URI)
+        def filter = ctx.getBean(MyFilter)
+
+        when:
+        filter.secondBodyPartSink = Sinks.one()
+        def resp = client.toBlocking().exchange(HttpRequest.POST("/foo", Flux.concat(
+                Flux.just("foo"),
+                filter.secondBodyPartSink.asMono()
+        )).contentType(MediaType.TEXT_PLAIN_TYPE), String)
+        then:
+        resp.body() == "foobar"
+
+        cleanup:
+        client.close()
+        server.stop()
+        ctx.close()
+    }
+
+    @Requires(property = 'spec.name', value = 'FilterBodySpec')
+    @ServerFilter("/foo")
+    @Singleton
+    static class MyFilter {
+        Sinks.One<String> secondBodyPartSink
+
+        @RequestFilter
+        @Order(-1)
+        void signal() {
+            secondBodyPartSink.emitValue("bar", Sinks.EmitFailureHandler.FAIL_FAST)
+        }
+
+        @RequestFilter
+        @Order(0)
+        HttpResponse<String> await(@Body String body) {
+            return HttpResponse.ok(body)
+        }
+    }
+}

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/filters/FilterBodySpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/filters/FilterBodySpec.groovy
@@ -7,6 +7,10 @@ import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.MediaType
 import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.Consumes
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Post
+import io.micronaut.http.annotation.Produces
 import io.micronaut.http.annotation.RequestFilter
 import io.micronaut.http.annotation.ServerFilter
 import io.micronaut.http.client.HttpClient
@@ -17,9 +21,9 @@ import reactor.core.publisher.Sinks
 import spock.lang.Specification
 
 class FilterBodySpec extends Specification {
-    def "delayed body"() {
+    def "delayed body"(String uri, String response) {
         given:
-        def ctx = ApplicationContext.run(["spec.name":"FilterBodySpec"])
+        def ctx = ApplicationContext.run(["spec.name": "FilterBodySpec"])
         def server = ctx.getBean(EmbeddedServer)
         server.start()
         def client = ctx.createBean(HttpClient, server.URI)
@@ -27,35 +31,55 @@ class FilterBodySpec extends Specification {
 
         when:
         filter.secondBodyPartSink = Sinks.one()
-        def resp = client.toBlocking().exchange(HttpRequest.POST("/foo", Flux.concat(
+        def resp = client.toBlocking().exchange(HttpRequest.POST(uri, Flux.concat(
                 Flux.just("foo"),
                 filter.secondBodyPartSink.asMono()
         )).contentType(MediaType.TEXT_PLAIN_TYPE), String)
         then:
-        resp.body() == "foobar"
+        resp.body() == response
 
         cleanup:
         client.close()
         server.stop()
         ctx.close()
+
+        where:
+        uri                                    | response
+        "/filter-body/delayed-body"            | "filter: foobar"
+        "/filter-body/delayed-body-controller" | "controller: foobar"
     }
 
     @Requires(property = 'spec.name', value = 'FilterBodySpec')
-    @ServerFilter("/foo")
+    @ServerFilter("/filter-body")
     @Singleton
     static class MyFilter {
         Sinks.One<String> secondBodyPartSink
 
-        @RequestFilter
+        @RequestFilter("/**")
         @Order(-1)
         void signal() {
             secondBodyPartSink.emitValue("bar", Sinks.EmitFailureHandler.FAIL_FAST)
         }
 
-        @RequestFilter
+        @RequestFilter("/delayed-body")
         @Order(0)
         HttpResponse<String> await(@Body String body) {
-            return HttpResponse.ok(body)
+            return HttpResponse.ok("filter: " + body)
+        }
+
+        @RequestFilter("/delayed-body-controller")
+        @Order(0)
+        void awaitController(@Body String body) {
+        }
+    }
+
+    @Controller("/filter-body")
+    static class MyController {
+        @Post("/delayed-body-controller")
+        @Produces(MediaType.TEXT_PLAIN)
+        @Consumes(MediaType.TEXT_PLAIN)
+        String controller(@Body String body) {
+            return "controller: " + body
         }
     }
 }

--- a/http/src/main/java/io/micronaut/http/FullHttpRequest.java
+++ b/http/src/main/java/io/micronaut/http/FullHttpRequest.java
@@ -16,7 +16,6 @@
 package io.micronaut.http;
 
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.execution.ExecutionFlow;
 import io.micronaut.core.io.buffer.ByteBuffer;
@@ -31,6 +30,8 @@ import io.micronaut.core.io.buffer.ByteBuffer;
 @Internal
 public interface FullHttpRequest<B> extends HttpRequest<B> {
     /**
+     * Shortcut for {@code contents() != null}.
+     *
      * @return Is the request full.
      */
     default boolean isFull() {
@@ -38,6 +39,9 @@ public interface FullHttpRequest<B> extends HttpRequest<B> {
     }
 
     /**
+     * Get the raw body of this request. May be called multiple times. Buffer ownership is not
+     * transferred to the caller.
+     *
      * @return The body contents or null if there are none or they are not obtainable.
      */
     @Nullable
@@ -45,10 +49,12 @@ public interface FullHttpRequest<B> extends HttpRequest<B> {
 
     /**
      * Get the contents of this request as a buffer. If this is a streaming request, the returned
-     * flow may be delayed.
+     * flow may be delayed. If buffering is not supported for this request, this may return
+     * {@code null}. Once the returned flow completes, {@link #contents()} must return the same
+     * value.
      *
-     * @return The request content
+     * @return The request content, or {@code null} if buffering is not supported
      */
-    @NonNull
+    @Nullable
     ExecutionFlow<ByteBuffer<?>> bufferContents();
 }

--- a/http/src/main/java/io/micronaut/http/filter/BaseFilterProcessor.java
+++ b/http/src/main/java/io/micronaut/http/filter/BaseFilterProcessor.java
@@ -87,8 +87,8 @@ public abstract class BaseFilterProcessor<A extends Annotation> implements Execu
                 Class<? extends Annotation> annotation = argument.getAnnotationMetadata().getAnnotationTypeByStereotype(Bindable.class).orElse(null);
                 if (annotation != null && PERMITTED_BINDING_ANNOTATIONS.contains(annotation.getName())) {
                     if (annotation == Body.class) {
-                        return Optional.of((context, source) -> {
-                            if (source instanceof FullHttpRequest<?> fullHttpRequest && fullHttpRequest.isFull()) {
+                        return Optional.of((RequiresRequestBodyBinder<T>) (context, source) -> {
+                            if (source instanceof FullHttpRequest<?> fullHttpRequest) {
                                 ByteBuffer<?> contents = fullHttpRequest.contents();
                                 if (contents != null) {
                                     Argument<T> t = context.getArgument();
@@ -246,5 +246,14 @@ public abstract class BaseFilterProcessor<A extends Annotation> implements Execu
         @Nullable List<String> serviceId,
         @Nullable List<String> excludeServiceId
     ) {
+    }
+
+    /**
+     * Interface that signals to {@link FilterRunner} that we should wait for the request body to
+     * arrive before running this binder.
+     *
+     * @param <T> Arg type
+     */
+    public interface RequiresRequestBodyBinder<T> extends ArgumentBinder<T, HttpRequest<?>> {
     }
 }


### PR DESCRIPTION
Use FullHttpRequest.bufferContents to wait for the request body if it is needed for a filter method but isn't immediately available.

Also changed the bufferContents contract a bit so that this will fail more gracefully in servlet.