### PR TITLE
Support time zone in time format for access log

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/DateTimeElement.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/DateTimeElement.java
@@ -74,10 +74,10 @@ final class DateTimeElement implements LogElement {
         }
         this.dateFormat = dateFormat;
         String[] formatSplit = format.split(",");
-        switch (formatSplit.length) {
-            case 0, 1 -> formatter = DateTimeFormatter.ofPattern(format, Locale.US);
-            default ->
-                formatter = DateTimeFormatter.ofPattern(formatSplit[0], Locale.US).withZone(ZoneId.of(formatSplit[1].strip()));
+        if (formatSplit.length < 2) {
+            formatter = DateTimeFormatter.ofPattern(format, Locale.US);
+        } else {
+            formatter = DateTimeFormatter.ofPattern(formatSplit[0], Locale.US).withZone(ZoneId.of(formatSplit[1].strip()));
         }
         events = fromStart ? Event.REQUEST_HEADERS_EVENTS : LAST_RESPONSE_EVENTS;
     }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/DateTimeElement.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/DateTimeElement.java
@@ -18,6 +18,7 @@ package io.micronaut.http.server.netty.handler.accesslog.element;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.http.HttpHeaders;
 
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
@@ -72,7 +73,12 @@ final class DateTimeElement implements LogElement {
             }
         }
         this.dateFormat = dateFormat;
-        formatter = DateTimeFormatter.ofPattern(format, Locale.US);
+        String[] formatSplit = format.split(",");
+        switch (formatSplit.length) {
+            case 0, 1 -> formatter = DateTimeFormatter.ofPattern(format, Locale.US);
+            default ->
+                formatter = DateTimeFormatter.ofPattern(formatSplit[0], Locale.US).withZone(ZoneId.of(formatSplit[1].strip()));
+        }
         events = fromStart ? Event.REQUEST_HEADERS_EVENTS : LAST_RESPONSE_EVENTS;
     }
 

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/jackson/JsonViewServerFilter.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/jackson/JsonViewServerFilter.java
@@ -79,7 +79,7 @@ public class JsonViewServerFilter implements Ordered {
     }
 
     @ResponseFilter
-    public Publisher<? extends MutableHttpResponse<?>> doFilter(HttpRequest<?> request, MutableHttpResponse<?> response) {
+    public final Publisher<? extends MutableHttpResponse<?>> doFilter(HttpRequest<?> request, MutableHttpResponse<?> response) {
         final RouteInfo<?> routeInfo = request.getAttribute(HttpAttributes.ROUTE_INFO, RouteInfo.class).orElse(null);
         if (routeInfo != null) {
             final Optional<Class<?>> viewClass = routeInfo.findAnnotation(JsonView.class)

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/configuration/NettyHttpServerConfigurationSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/configuration/NettyHttpServerConfigurationSpec.groovy
@@ -406,6 +406,35 @@ class NettyHttpServerConfigurationSpec extends Specification {
         beanContext.close()
     }
 
+    void "test netty server access logger configuration with timezone"() {
+        given:
+        ApplicationContext beanContext = new DefaultApplicationContext("test")
+        beanContext.environment.addPropertySource(PropertySource.of("test",
+                ['micronaut.server.netty.access-logger.enabled': true,
+                 'micronaut.server.netty.access-logger.logger-name': 'mylogger',
+                 'micronaut.server.netty.access-logger.log-format': "%h %l %u [%{dd/MMM/yyyy:HH:mm:ss Z, UTC}t] \"%r\" %s %b \"%{Referer}i\" \"%{User-Agent}i\""]
+
+        ))
+        beanContext.start()
+
+        when:
+        NettyHttpServerConfiguration config = beanContext.getBean(NettyHttpServerConfiguration)
+
+        then:
+        config.accessLogger
+
+        when:
+        def accessLogConfig = config.accessLogger
+
+        then:
+        accessLogConfig.enabled
+        accessLogConfig.logFormat == "%h %l %u [%{dd/MMM/yyyy:HH:mm:ss Z, UTC}t] \"%r\" %s %b \"%{Referer}i\" \"%{User-Agent}i\""
+        accessLogConfig.loggerName == 'mylogger'
+
+        cleanup:
+        beanContext.close()
+    }
+
     void "test netty server http2 configuration"() {
         given:
         ApplicationContext beanContext = new DefaultApplicationContext("test")

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/handler/accesslog/element/AccessLogFormatParserSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/handler/accesslog/element/AccessLogFormatParserSpec.groovy
@@ -15,7 +15,10 @@
  */
 package io.micronaut.http.server.netty.handler.accesslog.element
 
+import io.micronaut.http.client.exceptions.HttpClientResponseException
 import spock.lang.Specification
+
+import java.time.DateTimeException
 
 class AccessLogFormatParserSpec extends Specification {
 
@@ -57,6 +60,13 @@ class AccessLogFormatParserSpec extends Specification {
 
         then:
         parser.toString() == "%h - - %t \"%r\" %s %b \"%{cookie1}C\" \"%{cookie2}c\""
+
+        when:
+        parser = new AccessLogFormatParser("%h %l %u [%{dd/MMM/yyyy:HH:mm:ss Z, UTC}t] \"%r\" %s %b \"%{cookie1}C\" \"%{cookie2}c\"")
+
+        then:
+        parser.toString() == "%h - - [%{dd/MMM/yyyy:HH:mm:ss Z, UTC}t] \"%r\" %s %b \"%{cookie1}C\" \"%{cookie2}c\""
+
     }
 
     def "test access log format parser for invalid formats"() {
@@ -71,6 +81,13 @@ class AccessLogFormatParserSpec extends Specification {
 
         then:
         parser.toString() == "%h - - %t \"%r\" - %b"
+
+        when:
+        new AccessLogFormatParser("%h %l %u [%{dd/MMM/yyyy:HH:mm:ss Z,Invalid zone}t] \"%r\" %s %b \"%{cookie1}C\" \"%{cookie2}c\"")
+
+        then:
+        def e = thrown(DateTimeException)
+        e.message == "Invalid ID for region-based ZoneId, invalid format: Invalid zone"
 
     }
 

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/handler/accesslog/element/AccessLogFormatParserSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/handler/accesslog/element/AccessLogFormatParserSpec.groovy
@@ -15,7 +15,6 @@
  */
 package io.micronaut.http.server.netty.handler.accesslog.element
 
-import io.micronaut.http.client.exceptions.HttpClientResponseException
 import spock.lang.Specification
 
 import java.time.DateTimeException
@@ -90,6 +89,5 @@ class AccessLogFormatParserSpec extends Specification {
         e.message == "Invalid ID for region-based ZoneId, invalid format: Invalid zone"
 
     }
-
 
 }


### PR DESCRIPTION
`DateTimeElement` now supports time zone as argument after `,` sign.

Example: `%{dd/MMM/yyyy:HH:mm:ss Z, UTC}t`