### PR TITLE
Escape header values correctly for access log

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/AbstractHttpMessageLogElement.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/AbstractHttpMessageLogElement.java
@@ -29,6 +29,15 @@ import java.util.Set;
  * @since 2.0
  */
 abstract class AbstractHttpMessageLogElement implements LogElement {
+    private static final Set<Character> CHARACTERS_TO_ESCAPE = new HashSet<>(){{
+        add('\b');
+        add('\n');
+        add('\t');
+        add('\r');
+        add('\\');
+        add('"');
+    }};
+
     protected Set<Event> events;
 
     /**
@@ -37,15 +46,6 @@ abstract class AbstractHttpMessageLogElement implements LogElement {
      * @return The value.
      */
     protected abstract String value(HttpHeaders headers);
-
-    private static final Set<Character> keysToEscape = new HashSet<>(){{
-        add('\b');
-        add('\n');
-        add('\t');
-        add('\r');
-        add('\\');
-        add('"');
-    }};
 
     private static String wrapValue(String value) {
         // Does the value contain a " ? If so must encode it
@@ -58,7 +58,7 @@ abstract class AbstractHttpMessageLogElement implements LogElement {
         int i = 0;
         while (i < value.length()) {
             char currentChar = value.charAt(i);
-            if (keysToEscape.contains(currentChar)) {
+            if (CHARACTERS_TO_ESCAPE.contains(currentChar)) {
                 buffer.append('\\');
                 switch (currentChar) {
                     case '\b' -> buffer.append('b');

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/AbstractHttpMessageLogElement.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/AbstractHttpMessageLogElement.java
@@ -29,14 +29,7 @@ import java.util.Set;
  * @since 2.0
  */
 abstract class AbstractHttpMessageLogElement implements LogElement {
-    private static final Set<Character> CHARACTERS_TO_ESCAPE = new HashSet<>(){{
-        add('\b');
-        add('\n');
-        add('\t');
-        add('\r');
-        add('\\');
-        add('"');
-    }};
+    private static final Set<Character> CHARACTERS_TO_ESCAPE = Set.of('\b', '\n', '\t', '\r', '\\', '"');
 
     protected Set<Event> events;
 

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/AbstractHttpMessageLogElement.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/accesslog/element/AbstractHttpMessageLogElement.java
@@ -19,7 +19,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.http.HttpHeaders;
 
-import java.util.HashSet;
 import java.util.Set;
 
 /**

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/handler/accesslog/element/AccessLogFormatParserSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/handler/accesslog/element/AccessLogFormatParserSpec.groovy
@@ -15,6 +15,8 @@
  */
 package io.micronaut.http.server.netty.handler.accesslog.element
 
+import io.netty.channel.socket.SocketChannel
+import io.netty.handler.codec.http.DefaultHttpHeaders
 import spock.lang.Specification
 
 import java.time.DateTimeException
@@ -88,6 +90,19 @@ class AccessLogFormatParserSpec extends Specification {
         def e = thrown(DateTimeException)
         e.message == "Invalid ID for region-based ZoneId, invalid format: Invalid zone"
 
+    }
+
+    def 'Test string escaping from header value'() {
+        def headers = new DefaultHttpHeaders()
+        headers.add("User-Agent", "test string  \" \\")
+        def element = new HeaderElement(true, "User-Agent")
+
+        when:
+        def headerVal = element.onRequestHeaders(Mock(SocketChannel.class), "POST", headers, "/test", "http")
+
+        then:
+        headers.contains("User-Agent")
+        headerVal == "test string  \\\" \\\\"
     }
 
 }


### PR DESCRIPTION
- This PR correctly escaping header value for access log.
- Current pattern now makes more sense:
```
public static final String COMBINED_LOG_FORMAT = "%h %l %u %t \"%r\" %s %b \"%{Referer}i\" \"%{User-Agent}i\"";
```
and it will put Referer and  User-Agent between double quotes without single one.

Earlier behaviour:
```
localhost - - [08/Jun/2023:16:34:40 +0200] "GET /tet12313 HTTP/1.1" 401 - "'Referer-Header-Value'" "'User-Agent-Value'"
```
