### PR TITLE
move default methods from serde ObjectMapper to JsonMapper

### DIFF
--- a/jackson-databind/src/test/groovy/io/micronaut/json/JsonMapperSpec.groovy
+++ b/jackson-databind/src/test/groovy/io/micronaut/json/JsonMapperSpec.groovy
@@ -1,0 +1,58 @@
+package io.micronaut.json
+
+import groovy.transform.EqualsAndHashCode
+import io.micronaut.core.type.Argument;
+import spock.lang.Specification
+
+import java.nio.charset.StandardCharsets;
+
+class JsonMapperSpec extends Specification {
+
+    void "test JsonMapper default methods"() {
+        given:
+        JsonMapper jsonMapper = JsonMapper.createDefault()
+        Book b = new Book(title: "Getting Things done")
+        String expected = '{"title":"Getting Things done"}'
+
+        when:
+        String result = jsonMapper.writeValueAsString(b)
+
+        then:
+        expected == result
+
+        when:
+        result = jsonMapper.writeValueAsString(Argument.of(Book), b)
+
+        then:
+        expected == result
+
+        when:
+        result = jsonMapper.writeValueAsString(Argument.of(Book), b, StandardCharsets.UTF_8)
+
+        then:
+        expected == result
+
+        when:
+        Book bookRead = jsonMapper.readValue(expected, Argument.of(Book))
+
+        then:
+        bookRead == b
+
+        when:
+        bookRead = jsonMapper.readValue(expected, Book)
+
+        then:
+        bookRead == b
+
+        when:
+        bookRead = jsonMapper.readValue(expected.bytes, Book)
+
+        then:
+        bookRead == b
+    }
+
+    @EqualsAndHashCode
+    static class Book {
+        String title
+    }
+}

--- a/json-core/src/main/java/io/micronaut/json/JsonMapper.java
+++ b/json-core/src/main/java/io/micronaut/json/JsonMapper.java
@@ -148,6 +148,7 @@ public interface JsonMapper {
      * @param <T> The generic type
      * @return The value or {@code null} if it decodes to null
      * @throws IOException If an unrecoverable error occurs
+     * @since 4.0.0
      */
     default @Nullable <T> T readValue(@NonNull byte[] byteArray, @NonNull Class<T> type) throws IOException {
         Objects.requireNonNull(type, "Type cannot be null");
@@ -248,6 +249,7 @@ public interface JsonMapper {
      * @param <T> The generic type
      * @return The string
      * @throws IOException If an unrecoverable error occurs
+     * @since 4.0.0
      */
     @SuppressWarnings("unchecked")
     default  @NonNull <T> String writeValueAsString(@NonNull T object) throws IOException {
@@ -262,6 +264,7 @@ public interface JsonMapper {
      * @param <T> The generic type
      * @return The string
      * @throws IOException If an unrecoverable error occurs
+     * @since 4.0.0
      */
     default  @NonNull <T> String writeValueAsString(@NonNull Argument<T> type, @Nullable T object) throws IOException {
         return writeValueAsString(type, object, StandardCharsets.UTF_8);
@@ -275,6 +278,7 @@ public interface JsonMapper {
      * @param <T> The generic type
      * @return The string
      * @throws IOException If an unrecoverable error occurs
+     * @since 4.0.0
      */
     default  @NonNull <T> String writeValueAsString(@NonNull Argument<T> type, @Nullable T object, Charset charset) throws IOException {
         Objects.requireNonNull(charset, "Charset cannot be null");

--- a/json-core/src/main/java/io/micronaut/json/JsonMapper.java
+++ b/json-core/src/main/java/io/micronaut/json/JsonMapper.java
@@ -252,9 +252,9 @@ public interface JsonMapper {
      * @since 4.0.0
      */
     @SuppressWarnings("unchecked")
-    default  @NonNull <T> String writeValueAsString(@NonNull T object) throws IOException {
+    default  @NonNull <T> String writeValueAsString(@NonNull Object object) throws IOException {
         Objects.requireNonNull(object, "Object cannot be null");
-        return writeValueAsString((Argument<T>) Argument.of(object.getClass()), object, StandardCharsets.UTF_8);
+        return new String(writeValueAsBytes(object), StandardCharsets.UTF_8);
     }
 
     /**

--- a/json-core/src/main/java/io/micronaut/json/JsonMapper.java
+++ b/json-core/src/main/java/io/micronaut/json/JsonMapper.java
@@ -28,7 +28,9 @@ import org.reactivestreams.Processor;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.function.Consumer;
@@ -90,15 +92,15 @@ public interface JsonMapper {
     <T> T readValue(@NonNull InputStream inputStream, @NonNull Argument<T> type) throws IOException;
 
     /**
-     * Parse and map json from the given stream.
-     *
-     * @param inputStream The input data.
-     * @param type        The type to deserialize to.
-     * @param <T>         Type variable of the return type.
-     * @return The deserialized object.
-     * @throws IOException IOException
+     * Read a value from the given input stream for the given type.
+     * @param inputStream The input stream
+     * @param type The type
+     * @param <T> The generic type
+     * @return The value or {@code null} if it decodes to null
+     * @throws IOException If an unrecoverable error occurs
      */
-    default <T> T readValue(@NonNull InputStream inputStream, @NonNull Class<T> type) throws IOException {
+    default @Nullable <T> T readValue(@NonNull InputStream inputStream, @NonNull Class<T> type) throws IOException {
+        Objects.requireNonNull(type, "Type cannot be null");
         return readValue(inputStream, Argument.of(type));
     }
 
@@ -140,15 +142,28 @@ public interface JsonMapper {
     }
 
     /**
-     * Parse and map json from the given string.
-     *
-     * @param string The input data.
-     * @param type   The type to deserialize to.
-     * @param <T>    Type variable of the return type.
-     * @return The deserialized object.
-     * @throws IOException IOException
+     * Read a value from the byte array for the given type.
+     * @param byteArray The byte array
+     * @param type The type
+     * @param <T> The generic type
+     * @return The value or {@code null} if it decodes to null
+     * @throws IOException If an unrecoverable error occurs
      */
-    default <T> T readValue(@NonNull String string, @NonNull Class<T> type) throws IOException {
+    default @Nullable <T> T readValue(@NonNull byte[] byteArray, @NonNull Class<T> type) throws IOException {
+        Objects.requireNonNull(type, "Type cannot be null");
+        return readValue(byteArray, Argument.of(type));
+    }
+
+    /**
+     * Read a value from the given string for the given type.
+     * @param string The string
+     * @param type The type
+     * @param <T> The generic type
+     * @return The value or {@code null} if it decodes to null
+     * @throws IOException If an unrecoverable error occurs
+     */
+    default @Nullable <T> T readValue(@NonNull String string, @NonNull Class<T> type) throws IOException {
+        Objects.requireNonNull(type, "Type cannot be null");
         return readValue(string, Argument.of(type));
     }
 
@@ -228,14 +243,43 @@ public interface JsonMapper {
     <T> byte[] writeValueAsBytes(@NonNull Argument<T> type, @Nullable T object) throws IOException;
 
     /**
-     * Write an object as String.
-     *
-     * @param object The object to serialize.
-     * @return The serialized encoded json.
-     * @throws IOException IOException
+     * Write the given value as a string.
+     * @param object The object
+     * @param <T> The generic type
+     * @return The string
+     * @throws IOException If an unrecoverable error occurs
      */
-    default String writeValueAsString(@Nullable Object object) throws IOException {
-        return new String(writeValueAsBytes(object), StandardCharsets.UTF_8);
+    @SuppressWarnings("unchecked")
+    default  @NonNull <T> String writeValueAsString(@NonNull T object) throws IOException {
+        Objects.requireNonNull(object, "Object cannot be null");
+        return writeValueAsString((Argument<T>) Argument.of(object.getClass()), object, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Write the given value as a string.
+     * @param type The type, never {@code null}
+     * @param object The object
+     * @param <T> The generic type
+     * @return The string
+     * @throws IOException If an unrecoverable error occurs
+     */
+    default  @NonNull <T> String writeValueAsString(@NonNull Argument<T> type, @Nullable T object) throws IOException {
+        return writeValueAsString(type, object, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Write the given value as a string.
+     * @param type The type, never {@code null}
+     * @param object The object
+     * @param charset The charset, never {@code null}
+     * @param <T> The generic type
+     * @return The string
+     * @throws IOException If an unrecoverable error occurs
+     */
+    default  @NonNull <T> String writeValueAsString(@NonNull Argument<T> type, @Nullable T object, Charset charset) throws IOException {
+        Objects.requireNonNull(charset, "Charset cannot be null");
+        byte[] bytes = writeValueAsBytes(type, object);
+        return new String(bytes, charset);
     }
 
     /**


### PR DESCRIPTION
This PR moves the default methods in Serde's Object Mapper to core JsonMapper. 

I have created to remove [these methods will be removed in serde](https://github.com/micronaut-projects/micronaut-serialization/pull/482/) once M8 of core is released.  