### PR TITLE
Added ability to describe contentType to Part annotation

### DIFF
--- a/http/src/main/java/io/micronaut/http/annotation/Part.java
+++ b/http/src/main/java/io/micronaut/http/annotation/Part.java
@@ -35,7 +35,7 @@ import java.lang.annotation.Target;
  */
 @Documented
 @Retention(RUNTIME)
-@Target({ElementType.PARAMETER})
+@Target(ElementType.PARAMETER)
 @Bindable
 @Inherited
 public @interface Part {
@@ -45,4 +45,9 @@ public @interface Part {
      */
     @AliasFor(annotation = Bindable.class, member = "value")
     String value() default "";
+
+    /**
+     * @return The {@link io.micronaut.http.MediaType} value that this part is present
+     */
+    String contentType() default "";
 }


### PR DESCRIPTION
It would be nice to extend the Part annotation and allow the type content to be specified if required. I can't yet suggest how this can be handled at the controller level, but I can say for sure that this will help the micronaut-openapi generator, because now there is no way to correctly describe ,multipart form data without using swagger annotations