### PR TITLE
fix: JsonMapperSupplier could throw an exception and the next should be consider

### DIFF
--- a/json-core/src/main/java/io/micronaut/json/JsonMapper.java
+++ b/json-core/src/main/java/io/micronaut/json/JsonMapper.java
@@ -356,8 +356,15 @@ public interface JsonMapper {
                     return Stream.empty();
                 }
             })
-            .min(OrderUtil.COMPARATOR)
-            .orElseThrow(() -> new IllegalStateException("No JsonMapper implementation found"))
-            .get();
+            .sorted(OrderUtil.COMPARATOR)
+            .flatMap(jsonMapperSupplier -> {
+                try {
+                    return Stream.of(jsonMapperSupplier.get());
+                } catch(Exception e) {
+                    return Stream.empty();
+                }
+            })
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException("No JsonMapper implementation found"));
     }
 }

--- a/json-core/src/main/java/io/micronaut/json/JsonMapper.java
+++ b/json-core/src/main/java/io/micronaut/json/JsonMapper.java
@@ -360,7 +360,7 @@ public interface JsonMapper {
             .flatMap(jsonMapperSupplier -> {
                 try {
                     return Stream.of(jsonMapperSupplier.get());
-                } catch(Exception e) {
+                } catch (Exception e) {
                     return Stream.empty();
                 }
             })


### PR DESCRIPTION
For example, you could have `SerdeJsonMapperSupplier`which is in serde-api in your classpath serde.jackson. And thus no  Serde ObjectMapper implementation. You will get: 

```
io.micronaut.context.exceptions.NoSuchBeanException: No bean of type [io.micronaut.serde.ObjectMapper] exists. Make sure the bean is not disabled by bean requirements (enable trace logging for 'io.micronaut.context.condition' to check) and if the bean is enabled then ensure the class is declared a bean and annotation processing is enabled (for Java and Kotlin the 'micronaut-inject-java' dependency should be configured as an annotation processor).
```