### PR TITLE
Check for optional type in response adaptor

### DIFF
--- a/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/HttpResponseAdapter.java
+++ b/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/HttpResponseAdapter.java
@@ -111,6 +111,7 @@ public class HttpResponseAdapter<O> implements HttpResponse<O> {
             if (CharSequence.class.isAssignableFrom(finalArgument.getType())) {
                 Charset charset = contentType.getCharset().orElse(StandardCharsets.UTF_8);
                 var converted = Optional.of(new String(bytes, charset));
+                // If the requested type is an Optional, then we need to wrap the result again
                 return isOptional ? Optional.of(converted) : converted;
             } else if (finalArgument.getType() == byte[].class) {
                 var converted = Optional.of(bytes);

--- a/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/HttpResponseAdapter.java
+++ b/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/HttpResponseAdapter.java
@@ -114,6 +114,7 @@ public class HttpResponseAdapter<O> implements HttpResponse<O> {
                 return isOptional ? Optional.of(converted) : converted;
             } else if (finalArgument.getType() == byte[].class) {
                 var converted = Optional.of(bytes);
+                // If the requested type is an Optional, then we need to wrap the result again
                 return isOptional ? Optional.of(converted) : converted;
             } else {
                 Optional<MediaTypeCodec> foundCodec = mediaTypeCodecRegistry.findCodec(contentType);

--- a/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/HttpResponseAdapter.java
+++ b/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/HttpResponseAdapter.java
@@ -28,8 +28,11 @@ import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.MediaType;
+import io.micronaut.http.codec.CodecException;
 import io.micronaut.http.codec.MediaTypeCodec;
 import io.micronaut.http.codec.MediaTypeCodecRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -44,6 +47,8 @@ import java.util.Optional;
 @Internal
 @Experimental
 public class HttpResponseAdapter<O> implements HttpResponse<O> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HttpResponseAdapter.class);
 
     private final java.net.http.HttpResponse<byte[]> httpResponse;
     @NonNull
@@ -100,19 +105,58 @@ public class HttpResponseAdapter<O> implements HttpResponse<O> {
 
     private <T> Optional convertBytes(@Nullable MediaType contentType, byte[] bytes, Argument<T> type) {
         if (type != null && mediaTypeCodecRegistry != null && contentType != null) {
-            if (CharSequence.class.isAssignableFrom(type.getType())) {
+            if (isCharSequence(type)) {
                 Charset charset = contentType.getCharset().orElse(StandardCharsets.UTF_8);
-                return Optional.of(new String(bytes, charset));
-            } else if (type.getType() == byte[].class) {
-                return Optional.of(bytes);
+                return maybeWrap(Optional.of(new String(bytes, charset)), isOptional(type));
+            } else if (isByteArray(type)) {
+                return maybeWrap(Optional.of(bytes), isOptional(type));
             } else {
                 Optional<MediaTypeCodec> foundCodec = mediaTypeCodecRegistry.findCodec(contentType);
                 if (foundCodec.isPresent()) {
-                    return foundCodec.map(codec -> codec.decode(type, bytes));
+                    try {
+                        return foundCodec.map(codec -> codec.decode(type, bytes));
+                    } catch (CodecException e) {
+                        if (LOG.isDebugEnabled()) {
+                            var message = e.getMessage();
+                            LOG.debug("Error decoding body for type [{}] from '{}'. Attempting fallback.", type, contentType);
+                            LOG.debug("CodecException Message was: {}", message == null ? "null" : message.replace("\n", ""));
+                        }
+                        return fallback(bytes, type);
+                    }
                 }
             }
         }
         // last chance, try type conversion
-        return type != null ? conversionService.convert(bytes, ConversionContext.of(type)) : Optional.empty();
+        return fallback(bytes, type);
+    }
+
+    private boolean isOptional(Argument<?> type) {
+        return type != null && Optional.class.isAssignableFrom(type.getType());
+    }
+
+    private boolean isCharSequence(Argument<?> type) {
+        return type != null &&
+            (CharSequence.class.isAssignableFrom(type.getType())
+                || (isOptional(type) && CharSequence.class.isAssignableFrom(type.getWrappedType().getType())));
+    }
+
+    private boolean isByteArray(Argument<?> type) {
+        return type != null &&
+            (type.getType() == byte[].class
+                || (isOptional(type) && type.getWrappedType().getType() == byte[].class));
+    }
+
+    @SuppressWarnings({"rawtypes", "OptionalUsedAsFieldOrParameterType"})
+    private Optional maybeWrap(@NonNull Optional value, boolean wrap) {
+        return wrap ? Optional.of(value) : value;
+    }
+
+    @SuppressWarnings("rawtypes")
+    private <T> Optional fallback(byte[] bytes, Argument<T> type) {
+        if (type != null && Optional.class.isAssignableFrom(type.getType())) {
+            return Optional.of(conversionService.convert(bytes, ConversionContext.of(type.getWrappedType())));
+        } else {
+            return type != null ? conversionService.convert(bytes, ConversionContext.of(type)) : Optional.empty();
+        }
     }
 }

--- a/http-client-jdk/src/test/groovy/io/micronaut/http/client/jdk/RawStringHandlingSpec.groovy
+++ b/http-client-jdk/src/test/groovy/io/micronaut/http/client/jdk/RawStringHandlingSpec.groovy
@@ -1,0 +1,85 @@
+package io.micronaut.http.client.jdk
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.QueryValue
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Issue
+import spock.lang.Specification
+
+@MicronautTest
+@Property(name = "spec.name", value = "RawStringHandlingSpec")
+class RawStringHandlingSpec extends Specification {
+
+    @Inject
+    RawClient client
+
+    @Issue("https://github.com/micronaut-projects/micronaut-core/issues/9223")
+    void "test raw return type handling"() {
+        when:
+        def result = client.string()
+
+        then:
+        result.get() == "Hello World"
+
+        when:
+        result = client.noString()
+
+        then:
+        result.empty
+
+        when:
+        result = client.optional('present')
+
+        then:
+        result.get() == "Hello World"
+
+        when:
+        result = client.optional('absent')
+
+        then:
+        result.empty
+    }
+
+    @Controller("/raw")
+    @Requires(property = "spec.name", value = "RawStringHandlingSpec")
+    static class RawController {
+
+        @Get(value = "/string")
+        String string() {
+            "Hello World"
+        }
+
+        @Get(value = "/no-string")
+        String noString() {
+            null
+        }
+
+        @Get(value = "/optional")
+        Optional<String> optional(@QueryValue String name) {
+            if (name == 'present') {
+                return Optional.of("Hello World")
+            } else {
+                return Optional.empty()
+            }
+        }
+    }
+
+    @Client("/")
+    @Requires(property = "spec.name", value = "RawStringHandlingSpec")
+    static interface RawClient {
+
+        @Get("/raw/string")
+        Optional<String> string()
+
+        @Get("/raw/no-string")
+        Optional<String> noString()
+
+        @Get("/raw/optional")
+        Optional<String> optional(@QueryValue String name)
+    }
+}

--- a/test-suite-http-server-tck-jdk/src/test/java/io/micronaut/http/server/tck/netty/tests/JdkHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-jdk/src/test/java/io/micronaut/http/server/tck/netty/tests/JdkHttpServerTestSuite.java
@@ -1,6 +1,5 @@
 package io.micronaut.http.server.tck.netty.tests;
 
-import org.junit.platform.suite.api.ExcludeClassNamePatterns;
 import org.junit.platform.suite.api.ExcludeTags;
 import org.junit.platform.suite.api.SelectPackages;
 import org.junit.platform.suite.api.Suite;
@@ -10,9 +9,5 @@ import org.junit.platform.suite.api.SuiteDisplayName;
 @SelectPackages("io.micronaut.http.server.tck.tests")
 @SuiteDisplayName("HTTP Server TCK for Javanet client")
 @ExcludeTags("multipart") // Multipart not supported by HttpClient
-@ExcludeClassNamePatterns({
-    "io.micronaut.http.server.tck.tests.FilterErrorTest", // We expect Json as it's application/json, but it's text.
-    "io.micronaut.http.server.tck.tests.StreamTest", // We expect Json as it's application/json, but it's text.
-})
 public class JdkHttpServerTestSuite {
 }


### PR DESCRIPTION
And fallback if json decoding fails

This fixes the StreamTest and FilterErrorTest TCK tests that were failing in #9299

Closes #9223
Closes #9300