### PR TITLE
remove generic from JsonMapper::writeValueAsString

### DIFF
--- a/json-core/src/main/java/io/micronaut/json/JsonMapper.java
+++ b/json-core/src/main/java/io/micronaut/json/JsonMapper.java
@@ -252,7 +252,7 @@ public interface JsonMapper {
      * @since 4.0.0
      */
     @SuppressWarnings("unchecked")
-    default  @NonNull <T> String writeValueAsString(@NonNull Object object) throws IOException {
+    default  @NonNull String writeValueAsString(@NonNull Object object) throws IOException {
         Objects.requireNonNull(object, "Object cannot be null");
         return new String(writeValueAsBytes(object), StandardCharsets.UTF_8);
     }

--- a/json-core/src/main/java/io/micronaut/json/JsonMapper.java
+++ b/json-core/src/main/java/io/micronaut/json/JsonMapper.java
@@ -246,7 +246,6 @@ public interface JsonMapper {
     /**
      * Write the given value as a string.
      * @param object The object
-     * @param <T> The generic type
      * @return The string
      * @throws IOException If an unrecoverable error occurs
      * @since 4.0.0


### PR DESCRIPTION
I accidentally left this generic when addressing a PR feedback here

https://github.com/micronaut-projects/micronaut-core/pull/9424/commits/9ad2867fb38fd5a6dd346cf954e36fcbb750e4f4

