### PR TITLE
Fix all-opens support in ksp

### DIFF
--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/AbstractKotlinElement.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/AbstractKotlinElement.kt
@@ -40,6 +40,7 @@ import io.micronaut.core.annotation.AnnotationMetadata
 import io.micronaut.inject.ast.ClassElement
 import io.micronaut.inject.ast.Element
 import io.micronaut.inject.ast.ElementModifier
+import io.micronaut.inject.ast.MemberElement
 import io.micronaut.inject.ast.PrimitiveElement
 import io.micronaut.inject.ast.WildcardElement
 import io.micronaut.inject.ast.annotation.AbstractAnnotationElement
@@ -121,13 +122,22 @@ internal abstract class AbstractKotlinElement<T : KotlinNativeElement>(
             // ksp does not see when all-open opens up these classes
             // https://github.com/micronaut-projects/micronaut-core/issues/9426
             // this logic is similar to what all-opens does.
-            val cl = annotatedInfo as? KSClassDeclaration ?: annotatedInfo.parentDeclaration as? KSClassDeclaration
-            cl == null || !visitorContext.elementFactory.newClassElement(cl)
-                .hasDeclaredStereotype(Around::class.java, Introduction::class.java, InterceptorBinding::class.java, InterceptorBindingDefinitions::class.java)
+            if (this is MemberElement) {
+                !shouldBeOpen(owningType)
+            } else {
+                !shouldBeOpen(this)
+            }
         }
     } else {
         false
     }
+
+    private fun shouldBeOpen(annotationMetadata: AnnotationMetadata) = annotationMetadata.declaredMetadata.hasDeclaredStereotype(
+        Around::class.java,
+        Introduction::class.java,
+        InterceptorBinding::class.java,
+        InterceptorBindingDefinitions::class.java
+    )
 
     override fun isAbstract(): Boolean {
         return if (annotatedInfo is KSModifierListOwner) {

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/aop/compile/FinalModifierSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/aop/compile/FinalModifierSpec.groovy
@@ -20,9 +20,11 @@ import io.micronaut.aop.Intercepted
 import io.micronaut.inject.qualifiers.Qualifiers
 import io.micronaut.inject.writer.BeanDefinitionWriter
 import spock.lang.Issue
+import spock.lang.PendingFeature
 import spock.lang.Specification
 
-import static io.micronaut.annotation.processing.test.KotlinCompiler.*
+import static io.micronaut.annotation.processing.test.KotlinCompiler.buildBeanDefinition
+import static io.micronaut.annotation.processing.test.KotlinCompiler.buildContext
 
 class FinalModifierSpec extends Specification {
 
@@ -175,6 +177,7 @@ class MyBean
         e.message.contains 'Cannot apply AOP advice to final class. Class must be made non-final to support proxying: test.MyBean'
     }
 
+    @PendingFeature(reason = "active workaround for https://github.com/micronaut-projects/micronaut-core/issues/9426")
     void "test final modifier on class with AOP advice doesn't compile"() {
         when:
         buildBeanDefinition('test.$MyBean' + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionWriter.PROXY_SUFFIX, '''
@@ -197,6 +200,7 @@ class MyBean(@Value("\\${foo.bar}") private val myValue: String) {
         e.message.contains 'Cannot apply AOP advice to final class. Class must be made non-final to support proxying: test.MyBean'
     }
 
+    @PendingFeature(reason = "active workaround for https://github.com/micronaut-projects/micronaut-core/issues/9426")
     void "test final modifier on method with AOP advice doesn't compile"() {
         when:
         buildBeanDefinition('test.$MyBean' + BeanDefinitionWriter.CLASS_SUFFIX + BeanDefinitionWriter.PROXY_SUFFIX, '''


### PR DESCRIPTION
ksp does not currently see when classes or methods are opened by the all-opens plugin. This patch assumes these elements are open if the annotations that all-opens considers by default are present.

There's no test in this PR, I have one in micronaut-starter. However from the tests that I had to disable in FinalModifierSpec, I'm pretty sure this will work.

Fixes #9426