### PR TITLE
Fix NCDFE when snakeyaml is missing

### DIFF
--- a/inject/src/main/java/io/micronaut/context/env/yaml/YamlPropertySourceLoader.java
+++ b/inject/src/main/java/io/micronaut/context/env/yaml/YamlPropertySourceLoader.java
@@ -56,8 +56,7 @@ public class YamlPropertySourceLoader extends AbstractPropertySourceLoader {
             System.setProperty("java.runtime.name", "Unknown");
         }
 
-        Yaml yaml = new Yaml(new CustomSafeConstructor());
-        Iterable<Object> objects = yaml.loadAll(input);
+        Iterable<Object> objects = Wrapper.loadObjects(input);
         Iterator<Object> i = objects.iterator();
         if (i.hasNext()) {
             while (i.hasNext()) {
@@ -83,4 +82,12 @@ public class YamlPropertySourceLoader extends AbstractPropertySourceLoader {
         }
     }
 
+    private static class Wrapper {
+        // in nested class to prevent NCDFE
+
+        private static Iterable<Object> loadObjects(InputStream input) {
+            Yaml yaml = new Yaml(new CustomSafeConstructor());
+            return yaml.loadAll(input);
+        }
+    }
 }


### PR DESCRIPTION
I'm a bit confused about when NCDFEs happen and when they don't. From what I can tell, this NCDFE is caused by a Methodref in the constant pool, even though the method that uses the Methodref is never called.

This PR moves the method, and thus the Methodref, to a nested class. There is still a Class entry in the constant pool, but that seems to be fine in testing.

Fixes #9464