### PR TITLE
Update corsAllowedMethods.adoc

### DIFF
--- a/src/main/docs/guide/httpServer/serverConfiguration/cors/corsAllowedMethods.adoc
+++ b/src/main/docs/guide/httpServer/serverConfiguration/cors/corsAllowedMethods.adoc
@@ -1,4 +1,4 @@
-To allow any request method for a given configuration, don't include the `allowed-methods` key in your configuration.
+To allow any request method for a given configuration, include the `allowed-methods` key in your configuration.
 
 For multiple allowed methods, set the `allowed-methods` key of the configuration to a list of strings.
 


### PR DESCRIPTION
It looks like the documentation means 'do' not "don't" for this case.