### PR TITLE
Update to netty 4.1.94.Final

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -127,7 +127,7 @@ managed-micronaut-views = "3.8.2"
 managed-micronaut-xml = "3.2.0"
 managed-neo4j = "3.5.35"
 managed-neo4j-java-driver = "4.4.9"
-managed-netty = "4.1.93.Final"
+managed-netty = "4.1.94.Final"
 managed-reactive-pg-client = "0.11.4"
 managed-reactive-streams = "1.0.4"
 # This should be kept aligned with https://github.com/micronaut-projects/micronaut-reactor/blob/master/gradle.properties from the BOM


### PR DESCRIPTION
Apparently includes a fix for CVE-2023-34462. Details aren't public yet, though the changelog mentions SniHandler which we don't use, so we are probably not affected.