### PR TITLE
Deprecate some unused classes

### DIFF
--- a/http-netty/src/main/java/io/micronaut/http/netty/LastHttp2Content.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/LastHttp2Content.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.http.netty;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.http.netty.stream.Http2Content;
 import io.netty.handler.codec.http.LastHttpContent;
 
@@ -23,6 +24,9 @@ import io.netty.handler.codec.http.LastHttpContent;
  *
  * @author graemerocher
  * @since 2.1.3
+ * @deprecated Unused
  */
+@Internal
+@Deprecated
 public interface LastHttp2Content extends Http2Content, LastHttpContent {
 }

--- a/http-netty/src/main/java/io/micronaut/http/netty/stream/DefaultHttp2Content.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/stream/DefaultHttp2Content.java
@@ -24,6 +24,7 @@ import io.netty.handler.codec.http2.Http2Stream;
  * An {@link Http2Content} default implementation.
  */
 @Internal
+@Deprecated
 public final class DefaultHttp2Content extends DefaultHttpContent implements Http2Content {
     private final Http2Stream stream;
 

--- a/http-netty/src/main/java/io/micronaut/http/netty/stream/DefaultLastHttp2Content.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/stream/DefaultLastHttp2Content.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.http.netty.stream;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.http.netty.LastHttp2Content;
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
@@ -26,8 +27,10 @@ import io.netty.handler.codec.http2.Http2Stream;
  * @author graemerocher
  * @since 2.1.3
  */
+@Internal
+@Deprecated
 final class DefaultLastHttp2Content extends DefaultLastHttpContent implements LastHttp2Content {
-    
+
     private final Http2Stream stream;
 
     public DefaultLastHttp2Content(Http2Stream stream) {

--- a/http-netty/src/main/java/io/micronaut/http/netty/stream/Http2Content.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/stream/Http2Content.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.http.netty.stream;
 
+import io.micronaut.core.annotation.Internal;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http2.Http2Stream;
 
@@ -23,7 +24,10 @@ import io.netty.handler.codec.http2.Http2Stream;
  *
  * @author graemerocher
  * @since 2.1.3
+ * @deprecated Unused
  */
+@Internal
+@Deprecated
 public interface Http2Content extends HttpContent {
     /**
      * @return The stream the content is associated with.


### PR DESCRIPTION
Deprecate and make internal some unused classes. I will remove them in 4.1, this patch prepares for that without breaking compat.