### PR TITLE
Method binding with no @Body TCK tests, updated docs and docs examples.

### DIFF
--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/BodyTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/BodyTest.java
@@ -155,14 +155,14 @@ public class BodyTest {
         @Post(uri = "/args-no-body")
         @Status(HttpStatus.CREATED)
         Point postNoBody(Integer x, Integer y) {
-            return new Point(x,y);
+            return new Point(x, y);
         }
 
         @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
         @Post("/args-no-body-form")
         @Status(HttpStatus.CREATED)
         Point postNoBodyFormData(Integer x, Integer y) {
-            return new Point(x,y);
+            return new Point(x, y);
         }
 
         @Post(uri = "/part-pojo")

--- a/src/main/docs/guide/httpServer/binding.adoc
+++ b/src/main/docs/guide/httpServer/binding.adoc
@@ -130,5 +130,10 @@ The Micronaut framework tries to populate method arguments in the following orde
 . URI variables like `/{id}`.
 . From query parameters if the request is a `GET` request (e.g. `?foo=bar`).
 . If there is a `@Body` and request allows the body, bind the body to it.
-. If the request can have a body and no `@Body` is defined then try to parse the body (either JSON or form data) and bind the method arguments from the body.
+. If the request can have a body and no `@Body` is defined then try to parse the body (either JSON or form data) and bind the method arguments from the body (see the example).
 . Finally, if the method arguments cannot be populated return `400 BAD REQUEST`.
+
+snippet::io.micronaut.docs.server.binding.PointController[tags="class", indent=0, title="Binding Method Arguments From Body with no `@Body`"]
+
+<1> JSON request body binds to method controller arguments, e.g. '{"x":10,"y":20}' (with "application/json")
+<2> Form data also works, e.g. 'x=10&y=20' (with "application/x-www-form-urlencoded")

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/binding/Point.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/binding/Point.groovy
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.server.binding
+
+import io.micronaut.core.annotation.Introspected
+
+@Introspected
+class Point {
+
+    Integer x
+    Integer y
+
+    Point(Integer x, Integer y) {
+        this.x = x
+        this.y = y
+    }
+}

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/binding/PointController.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/binding/PointController.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.server.binding
+
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Consumes
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Post
+import io.micronaut.http.annotation.Status
+
+@Requires(property = 'spec.name', value = 'PointControllerSpec')
+// tag::class[]
+@Controller("/point")
+class PointController {
+
+    @Post(uri = "/no-body-json")
+    @Status(HttpStatus.CREATED)
+    Point noBodyJson(Integer x, Integer y) { // (1)
+        new Point(x,y)
+    }
+
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Post("/no-body-form")
+    @Status(HttpStatus.CREATED)
+    Point noBodyForm(Integer x, Integer y) {  // (2)
+        new Point(x,y)
+    }
+}
+// end::class[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/binding/PointControllerSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/binding/PointControllerSpec.groovy
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.server.binding
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.http.HttpHeaders
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MediaType
+import io.micronaut.http.client.HttpClient
+import io.micronaut.runtime.server.EmbeddedServer
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class PointControllerSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    EmbeddedServer embeddedServer = ApplicationContext.run(
+            EmbeddedServer, ['spec.name': 'PointControllerSpec'])
+    @Shared
+    @AutoCleanup
+    HttpClient client = embeddedServer.applicationContext.createBean(HttpClient, embeddedServer.getURL())
+
+    void "test JSON with no @Body endpoint"() {
+        given:
+        HttpRequest<String> httpRequest = HttpRequest
+                .POST("/point/no-body-json", '{"x":10,"y":20}')
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+
+        when:
+        HttpResponse<Point> response = client.toBlocking().exchange(httpRequest, Point)
+
+        then:
+        assertResult(response.body.orElse(null))
+    }
+
+    void "test Form data with no @Body endpoint"() {
+        given:
+        HttpRequest<String> httpRequest = HttpRequest
+                .POST("/point/no-body-form", 'x=10&y=20')
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED)
+
+        when:
+        HttpResponse<Point> response = client.toBlocking().exchange(httpRequest, Point)
+
+        then:
+        assertResult(response.body.orElse(null))
+    }
+
+    void assertResult(Point p) {
+        p
+        p.x == 10
+        p.y == 20
+    }
+}

--- a/test-suite-kotlin-ksp/src/test/kotlin/io/micronaut/docs/server/binding/Point.kt
+++ b/test-suite-kotlin-ksp/src/test/kotlin/io/micronaut/docs/server/binding/Point.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.server.binding
+
+import io.micronaut.core.annotation.Introspected
+
+@Introspected
+class Point {
+    var x: Int? = null
+    var y: Int? = null
+
+    constructor(x: Int?, y: Int?) {
+        this.x = x
+        this.y = y
+    }
+
+    override fun equals(o: Any?): Boolean {
+        if (this === o) {
+            return true
+        }
+        if (o == null || javaClass != o.javaClass) {
+            return false
+        }
+        val point = o as Point
+        return if (x != point.x) {
+            false
+        } else y == point.y
+    }
+
+    override fun hashCode(): Int {
+        var result = if (x != null) x.hashCode() else 0
+        result = 31 * result + if (y != null) y.hashCode() else 0
+        return result
+    }
+}
+

--- a/test-suite-kotlin-ksp/src/test/kotlin/io/micronaut/docs/server/binding/Point.kt
+++ b/test-suite-kotlin-ksp/src/test/kotlin/io/micronaut/docs/server/binding/Point.kt
@@ -18,32 +18,5 @@ package io.micronaut.docs.server.binding
 import io.micronaut.core.annotation.Introspected
 
 @Introspected
-class Point {
-    var x: Int? = null
-    var y: Int? = null
-
-    constructor(x: Int?, y: Int?) {
-        this.x = x
-        this.y = y
-    }
-
-    override fun equals(o: Any?): Boolean {
-        if (this === o) {
-            return true
-        }
-        if (o == null || javaClass != o.javaClass) {
-            return false
-        }
-        val point = o as Point
-        return if (x != point.x) {
-            false
-        } else y == point.y
-    }
-
-    override fun hashCode(): Int {
-        var result = if (x != null) x.hashCode() else 0
-        result = 31 * result + if (y != null) y.hashCode() else 0
-        return result
-    }
-}
+data class Point (val x: Int, val y: Int)
 

--- a/test-suite-kotlin-ksp/src/test/kotlin/io/micronaut/docs/server/binding/PointController.kt
+++ b/test-suite-kotlin-ksp/src/test/kotlin/io/micronaut/docs/server/binding/PointController.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.server.binding
+
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Consumes
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Post
+import io.micronaut.http.annotation.Status
+
+@Requires(property = "spec.name", value = "PointControllerTest")
+// tag::class[]
+@Controller("/point")
+class PointController {
+
+    @Post(uri = "/no-body-json")
+    @Status(HttpStatus.CREATED)
+    fun noBodyJson(x: Int?, y: Int?): Point { // (1)
+        return Point(x, y)
+    }
+
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Post("/no-body-form")
+    @Status(HttpStatus.CREATED)
+    fun noBodyForm(x: Int?, y: Int?): Point {  // (2)
+        return Point(x, y)
+    }
+}
+// end::class[]

--- a/test-suite-kotlin-ksp/src/test/kotlin/io/micronaut/docs/server/binding/PointController.kt
+++ b/test-suite-kotlin-ksp/src/test/kotlin/io/micronaut/docs/server/binding/PointController.kt
@@ -30,14 +30,14 @@ class PointController {
 
     @Post(uri = "/no-body-json")
     @Status(HttpStatus.CREATED)
-    fun noBodyJson(x: Int?, y: Int?): Point { // (1)
+    fun noBodyJson(x: Int, y: Int): Point { // (1)
         return Point(x, y)
     }
 
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Post("/no-body-form")
     @Status(HttpStatus.CREATED)
-    fun noBodyForm(x: Int?, y: Int?): Point {  // (2)
+    fun noBodyForm(x: Int, y: Int): Point {  // (2)
         return Point(x, y)
     }
 }

--- a/test-suite-kotlin-ksp/src/test/kotlin/io/micronaut/docs/server/binding/PointController.kt
+++ b/test-suite-kotlin-ksp/src/test/kotlin/io/micronaut/docs/server/binding/PointController.kt
@@ -30,15 +30,11 @@ class PointController {
 
     @Post(uri = "/no-body-json")
     @Status(HttpStatus.CREATED)
-    fun noBodyJson(x: Int, y: Int): Point { // (1)
-        return Point(x, y)
-    }
+    fun noBodyJson(x: Int, y: Int) = Point(x,y) // (1)
 
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Post("/no-body-form")
     @Status(HttpStatus.CREATED)
-    fun noBodyForm(x: Int, y: Int): Point {  // (2)
-        return Point(x, y)
-    }
+    fun noBodyForm(x: Int, y: Int) = Point(x,y)  // (2)
 }
 // end::class[]

--- a/test-suite-kotlin-ksp/src/test/kotlin/io/micronaut/docs/server/binding/PointControllerTest.kt
+++ b/test-suite-kotlin-ksp/src/test/kotlin/io/micronaut/docs/server/binding/PointControllerTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.server.binding
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.micronaut.context.ApplicationContext
+import io.micronaut.http.HttpHeaders
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.MediaType
+import io.micronaut.http.client.HttpClient
+import io.micronaut.runtime.server.EmbeddedServer
+import java.util.Map
+
+class PointControllerTest : StringSpec() {
+
+    val embeddedServer = autoClose(
+        ApplicationContext.run(EmbeddedServer::class.java, Map.of<String, Any>("spec.name", "PointControllerTest"))
+    )
+
+    val client = autoClose(
+        embeddedServer.applicationContext.createBean(HttpClient::class.java, embeddedServer.getURL())
+    )
+
+    init {
+        "test JSON with no @Body endpoint"() {
+            val httpRequest: HttpRequest<String> = HttpRequest
+                .POST("/point/no-body-json", "{\"x\":10,\"y\":20}")
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+            val response = client!!.toBlocking().exchange(httpRequest, Point::class.java)
+
+            assertResult(response.body.orElse(null))
+        }
+
+        "test Form data with no @Body endpoint"() {
+            val httpRequest: HttpRequest<String> = HttpRequest
+                .POST("/point/no-body-form", "x=10&y=20")
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED)
+            val response = client!!.toBlocking().exchange(httpRequest, Point::class.java)
+
+            assertResult(response.body.orElse(null))
+        }
+    }
+
+    private fun assertResult(p: Point) {
+        p shouldNotBe null
+        p.x shouldBe 10
+        p.y shouldBe 20
+    }
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/binding/Point.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/binding/Point.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.server.binding
+
+import io.micronaut.core.annotation.Introspected
+
+@Introspected
+class Point {
+    var x: Int? = null
+    var y: Int? = null
+
+    constructor(x: Int?, y: Int?) {
+        this.x = x
+        this.y = y
+    }
+
+    override fun equals(o: Any?): Boolean {
+        if (this === o) {
+            return true
+        }
+        if (o == null || javaClass != o.javaClass) {
+            return false
+        }
+        val point = o as Point
+        return if (x != point.x) {
+            false
+        } else y == point.y
+    }
+
+    override fun hashCode(): Int {
+        var result = if (x != null) x.hashCode() else 0
+        result = 31 * result + if (y != null) y.hashCode() else 0
+        return result
+    }
+}
+

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/binding/Point.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/binding/Point.kt
@@ -18,32 +18,5 @@ package io.micronaut.docs.server.binding
 import io.micronaut.core.annotation.Introspected
 
 @Introspected
-class Point {
-    var x: Int? = null
-    var y: Int? = null
-
-    constructor(x: Int?, y: Int?) {
-        this.x = x
-        this.y = y
-    }
-
-    override fun equals(o: Any?): Boolean {
-        if (this === o) {
-            return true
-        }
-        if (o == null || javaClass != o.javaClass) {
-            return false
-        }
-        val point = o as Point
-        return if (x != point.x) {
-            false
-        } else y == point.y
-    }
-
-    override fun hashCode(): Int {
-        var result = if (x != null) x.hashCode() else 0
-        result = 31 * result + if (y != null) y.hashCode() else 0
-        return result
-    }
-}
+data class Point (val x: Int, val y: Int)
 

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/binding/PointController.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/binding/PointController.kt
@@ -31,14 +31,14 @@ class PointController {
 
     @Post(uri = "/no-body-json")
     @Status(HttpStatus.CREATED)
-    fun noBodyJson(x: Int?, y: Int?): Point { // (1)
+    fun noBodyJson(x: Int, y: Int): Point { // (1)
         return Point(x, y)
     }
 
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Post("/no-body-form")
     @Status(HttpStatus.CREATED)
-    fun noBodyForm(x: Int?, y: Int?): Point {  // (2)
+    fun noBodyForm(x: Int, y: Int): Point {  // (2)
         return Point(x, y)
     }
 }

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/binding/PointController.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/binding/PointController.kt
@@ -31,15 +31,11 @@ class PointController {
 
     @Post(uri = "/no-body-json")
     @Status(HttpStatus.CREATED)
-    fun noBodyJson(x: Int, y: Int): Point { // (1)
-        return Point(x, y)
-    }
+    fun noBodyJson(x: Int, y: Int) = Point(x,y) // (1)
 
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Post("/no-body-form")
     @Status(HttpStatus.CREATED)
-    fun noBodyForm(x: Int, y: Int): Point {  // (2)
-        return Point(x, y)
-    }
+    fun noBodyForm(x: Int, y: Int) = Point(x,y)  // (2)
 }
 // end::class[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/binding/PointController.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/binding/PointController.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.server.binding
+
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Consumes
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Post
+import io.micronaut.http.annotation.Status
+
+
+@Requires(property = "spec.name", value = "PointControllerTest")
+// tag::class[]
+@Controller("/point")
+class PointController {
+
+    @Post(uri = "/no-body-json")
+    @Status(HttpStatus.CREATED)
+    fun noBodyJson(x: Int?, y: Int?): Point { // (1)
+        return Point(x, y)
+    }
+
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Post("/no-body-form")
+    @Status(HttpStatus.CREATED)
+    fun noBodyForm(x: Int?, y: Int?): Point {  // (2)
+        return Point(x, y)
+    }
+}
+// end::class[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/binding/PointControllerTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/server/binding/PointControllerTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.server.binding
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.micronaut.context.ApplicationContext
+import io.micronaut.http.HttpHeaders
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.MediaType
+import io.micronaut.http.client.HttpClient
+import io.micronaut.runtime.server.EmbeddedServer
+import java.util.Map
+
+class PointControllerTest : StringSpec() {
+
+    val embeddedServer = autoClose(
+        ApplicationContext.run(EmbeddedServer::class.java, Map.of<String, Any>("spec.name", "PointControllerTest"))
+    )
+
+    val client = autoClose(
+        embeddedServer.applicationContext.createBean(HttpClient::class.java, embeddedServer.getURL())
+    )
+
+    init {
+        "test JSON with no @Body endpoint"() {
+            val httpRequest: HttpRequest<String> = HttpRequest
+                .POST("/point/no-body-json", "{\"x\":10,\"y\":20}")
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+            val response = client!!.toBlocking().exchange(httpRequest, Point::class.java)
+
+            assertResult(response.body.orElse(null))
+        }
+
+        "test Form data with no @Body endpoint"() {
+            val httpRequest: HttpRequest<String> = HttpRequest
+                .POST("/point/no-body-form", "x=10&y=20")
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED)
+            val response = client!!.toBlocking().exchange(httpRequest, Point::class.java)
+
+            assertResult(response.body.orElse(null))
+        }
+    }
+
+    private fun assertResult(p: Point) {
+        p shouldNotBe null
+        p.x shouldBe 10
+        p.y shouldBe 20
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/docs/server/binding/Point.java
+++ b/test-suite/src/test/java/io/micronaut/docs/server/binding/Point.java
@@ -1,0 +1,56 @@
+package io.micronaut.docs.server.binding;
+
+import io.micronaut.core.annotation.Introspected;
+
+import java.util.Objects;
+
+@Introspected
+public class Point {
+    private Integer x;
+    private Integer y;
+
+    public Point(Integer x, Integer y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    public Integer getX() {
+        return x;
+    }
+
+    public void setX(Integer x) {
+        this.x = x;
+    }
+
+    public Integer getY() {
+        return y;
+    }
+
+    public void setY(Integer y) {
+        this.y = y;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Point point = (Point) o;
+
+        if (!Objects.equals(x, point.x)) {
+            return false;
+        }
+        return Objects.equals(y, point.y);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = x != null ? x.hashCode() : 0;
+        result = 31 * result + (y != null ? y.hashCode() : 0);
+        return result;
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/docs/server/binding/PointController.java
+++ b/test-suite/src/test/java/io/micronaut/docs/server/binding/PointController.java
@@ -1,0 +1,29 @@
+package io.micronaut.docs.server.binding;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Consumes;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.annotation.Status;
+
+@Requires(property = "spec.name", value = "PointControllerTest")
+// tag::class[]
+@Controller("/point")
+public class PointController {
+
+    @Post(uri = "/no-body-json")
+    @Status(HttpStatus.CREATED)
+    Point noBodyJson(Integer x, Integer y) { // (1)
+        return new Point(x,y);
+    }
+
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Post("/no-body-form")
+    @Status(HttpStatus.CREATED)
+    Point noBodyForm(Integer x, Integer y) {  // (2)
+        return new Point(x,y);
+    }
+}
+// end::class[]

--- a/test-suite/src/test/java/io/micronaut/docs/server/binding/PointControllerTest.java
+++ b/test-suite/src/test/java/io/micronaut/docs/server/binding/PointControllerTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.server.binding;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.http.HttpHeaders;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.runtime.server.EmbeddedServer;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class PointControllerTest {
+    private static EmbeddedServer server;
+    private static HttpClient client;
+
+    @BeforeClass
+    public static void setupServer() {
+        server = ApplicationContext.run(EmbeddedServer.class, Map.of("spec.name", "PointControllerTest"));
+        client = server
+            .getApplicationContext()
+            .createBean(HttpClient.class, server.getURL());
+    }
+
+    @AfterClass
+    public static void stopServer() {
+        if(server != null) {
+            server.stop();
+        }
+        if(client != null) {
+            client.stop();
+        }
+    }
+
+    @Test
+    public void testJsonWithNoAtBodyEndpoint() {
+        HttpRequest<String> httpRequest = HttpRequest
+            .POST("/point/no-body-json", "{\"x\":10,\"y\":20}")
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+        HttpResponse<Point> response = client.toBlocking().exchange(httpRequest, Point.class);
+
+        assertResult(response.getBody().orElse(null));
+    }
+
+    @Test
+    public void testFormWithNoAtBodyEndpoint() {
+        HttpRequest<String> httpRequest = HttpRequest
+            .POST("/point/no-body-form", "x=10&y=20")
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED);
+        HttpResponse<Point> response = client.toBlocking().exchange(httpRequest, Point.class);
+
+        assertResult(response.getBody().orElse(null));
+    }
+
+    private void assertResult(Point p) {
+        assertNotNull(p);
+        assertEquals(Integer.valueOf(10), p.getX());
+        assertEquals(Integer.valueOf(20), p.getY());
+    }
+}


### PR DESCRIPTION
Add http-tck tests for json and form data body and controller with no `@Body` annotation.
Update binding docs, and add docs examples for java, groovy, kotlin.

closes #9388