### PR TITLE
build: remove webdriver-binaries-gradle-plugin

### DIFF
--- a/gradle/webdriverbinaries.gradle
+++ b/gradle/webdriverbinaries.gradle
@@ -1,9 +1,0 @@
-if (System.getProperty('geb.env')) {
-    apply plugin:"com.energizedwork.webdriver-binaries"
-
-    webdriverBinaries {
-        chromedriver "${chromedriverVersion}"
-        geckodriver "${geckodriverVersion}"
-    }
-}
-

--- a/test-suite/build.gradle
+++ b/test-suite/build.gradle
@@ -4,9 +4,6 @@ buildscript {
     repositories {
         maven { url "https://plugins.gradle.org/m2/" }
     }
-    dependencies {
-        classpath "gradle.plugin.com.energizedwork.webdriver-binaries:webdriver-binaries-gradle-plugin:$webdriverBinariesVersion"
-    }
 }
 
 plugins {
@@ -23,7 +20,6 @@ micronautBuild {
 }
 
 apply from: "${rootProject.projectDir}/gradle/geb.gradle"
-apply from: "${rootProject.projectDir}/gradle/webdriverbinaries.gradle"
 
 dependencies {
     annotationProcessor project(":inject-java")


### PR DESCRIPTION
The [webdriver binary plugin ](https://github.com/erdi/webdriver-binaries-gradle-plugin) was useful to ease running the Web tests with real browser but we can get rid of it. 

It currently fails with: 

```
> Failed to apply plugin class 'io.micronaut.build.docs.JavadocAggregatorPlugin'.
   > A problem occurred configuring project ':test-suite'.
      > Could not resolve all files for configuration ':test-suite:classpath'.
         > Could not find org.ysb33r.gradle:grolifant:0.5.1.
           Searched in the following locations:
             - https://plugins.gradle.org/m2/org/ysb33r/gradle/grolifant/0.5.1/grolifant-0.5.1.pom
             - https://repo.maven.apache.org/maven2/org/ysb33r/gradle/grolifant/0.5.1/grolifant-0.5.1.pom
           Required by:
               project :test-suite > gradle.plugin.com.energizedwork.webdriver-binaries:webdriver-binaries-gradle-plugin:1.4
```