### PR TITLE
Allow setting of cloud deduction with probes via env vars or property

### DIFF
--- a/inject/src/main/java/io/micronaut/context/env/CachedEnvironment.java
+++ b/inject/src/main/java/io/micronaut/context/env/CachedEnvironment.java
@@ -23,6 +23,8 @@ import io.micronaut.core.optim.StaticOptimizations;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 /**
  * A "cached environment" is a performance optimization aimed at minimizing
@@ -44,6 +46,11 @@ public class CachedEnvironment {
     private static final boolean LOCKED = StaticOptimizations.isEnvironmentCached();
     private static final Map<String, String> CACHED_ENVIRONMENT;
     private static final Map<Object, String> CACHED_PROPERTIES;
+
+    /**
+     * Operator used to replace {@link System#getenv(String)} in testing.
+     */
+    private static UnaryOperator<String> getenv;
 
     static {
         if (LOCKED) {
@@ -67,7 +74,10 @@ public class CachedEnvironment {
      */
     @Nullable
     public static String getenv(String name) {
-        return LOCKED ? CACHED_ENVIRONMENT.get(name) : System.getenv(name);
+        if (LOCKED) {
+            return CACHED_ENVIRONMENT.get(name);
+        }
+        return getenv == null ? System.getenv(name) : getenv.apply(name);
     }
 
     /**

--- a/inject/src/main/java/io/micronaut/context/env/CachedEnvironment.java
+++ b/inject/src/main/java/io/micronaut/context/env/CachedEnvironment.java
@@ -23,7 +23,6 @@ import io.micronaut.core.optim.StaticOptimizations;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
 /**

--- a/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
+++ b/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2023 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -384,6 +384,25 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
     }
 
     /**
+     * @return Whether cloud environment should be deduced based on environment variable, system property or configuration
+     */
+    protected boolean shouldDeduceCloudEnvironment() {
+        String deduceProperty = CachedEnvironment.getProperty(Environment.DEDUCE_CLOUD_ENVIRONMENT_PROPERTY);
+        String deduceEnv = CachedEnvironment.getenv(Environment.DEDUCE_CLOUD_ENVIRONMENT_ENV);
+        if (StringUtils.isNotEmpty(deduceEnv)) {
+            boolean deduce = Boolean.parseBoolean(deduceEnv);
+            log.debug("Cloud environment deduction was set via environment variable to: {}", deduce);
+            return deduce;
+        } else if (StringUtils.isNotEmpty(deduceProperty)) {
+            boolean deduce = Boolean.parseBoolean(deduceProperty);
+            log.debug("Cloud environment deduction was set via system property to: {}", deduce);
+            return deduce;
+        } else {
+            return configuration.isDeduceCloudEnvironment();
+        }
+    }
+
+    /**
      * Creates the default annotation scanner.
      *
      * @param classLoader The class loader
@@ -640,7 +659,7 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
         EnvironmentsAndPackage environmentsAndPackage = this.environmentsAndPackage;
         boolean isNotFunction = !specifiedNames.contains(Environment.FUNCTION);
         final boolean deduceEnvironment = shouldDeduceEnvironments();
-        final boolean deduceCloudEnvironmentUsingProbes = isNotFunction && configuration.isDeduceCloudEnvironment();
+        final boolean deduceCloudEnvironmentUsingProbes = isNotFunction && shouldDeduceCloudEnvironment();
         if (environmentsAndPackage == null) {
             synchronized (EnvironmentsAndPackage.class) { // double check
                 environmentsAndPackage = this.environmentsAndPackage;

--- a/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
+++ b/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
@@ -387,19 +387,19 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
      * @return Whether cloud environment should be deduced based on environment variable, system property or configuration
      */
     protected boolean shouldDeduceCloudEnvironment() {
-        String deduceProperty = CachedEnvironment.getProperty(Environment.DEDUCE_CLOUD_ENVIRONMENT_PROPERTY);
         String deduceEnv = CachedEnvironment.getenv(Environment.DEDUCE_CLOUD_ENVIRONMENT_ENV);
         if (StringUtils.isNotEmpty(deduceEnv)) {
             boolean deduce = Boolean.parseBoolean(deduceEnv);
             log.debug("Cloud environment deduction was set via environment variable to: {}", deduce);
             return deduce;
-        } else if (StringUtils.isNotEmpty(deduceProperty)) {
+        }
+        String deduceProperty = CachedEnvironment.getProperty(Environment.DEDUCE_CLOUD_ENVIRONMENT_PROPERTY);
+        if (StringUtils.isNotEmpty(deduceProperty)) {
             boolean deduce = Boolean.parseBoolean(deduceProperty);
             log.debug("Cloud environment deduction was set via system property to: {}", deduce);
             return deduce;
-        } else {
-            return configuration.isDeduceCloudEnvironment();
         }
+        return configuration.isDeduceCloudEnvironment();
     }
 
     /**

--- a/inject/src/main/java/io/micronaut/context/env/Environment.java
+++ b/inject/src/main/java/io/micronaut/context/env/Environment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2023 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -199,6 +199,16 @@ public interface Environment extends PropertyResolver, LifeCycle<Environment>, M
      * Environment key for whether to deduce environments.
      */
     String DEDUCE_ENVIRONMENT_ENV = "MICRONAUT_ENV_DEDUCTION";
+
+    /**
+     * Property for whether to deduce cloud environments.
+     */
+    String DEDUCE_CLOUD_ENVIRONMENT_PROPERTY = "micronaut.env.cloud-deduction";
+
+    /**
+     * Environment key for whether to deduce cloud environments.
+     */
+    String DEDUCE_CLOUD_ENVIRONMENT_ENV = "MICRONAUT_ENV_CLOUD_DEDUCTION";
 
     /**
      * Should respect the order as provided.

--- a/src/main/docs/guide/appendix/breaks.adoc
+++ b/src/main/docs/guide/appendix/breaks.adoc
@@ -93,7 +93,7 @@ https://github.com/ben-manes/caffeine[Caffeine] is no longer shaded into the `io
 
 ==== Environment Deduction Disabled by Default
 
-In previous versions of the Micronaut framework probes were used to attempt to deduce the running environment and establish whether the application was running in the Cloud. These probes involved network calls resulting in issues with startup performance and security concerns. These probes are disabled by default and can be re-enabled as necessary by calling `ApplicationContextBuilder.deduceCloudEnvironment(true)` if your application still requires this functionality.
+In previous versions of the Micronaut framework, probes were used to attempt to deduce the running environment and establish whether the application was running in the Cloud. These probes involved network calls resulting in issues with startup performance and security concerns. These probes are disabled by default and can be re-enabled as necessary by calling `ApplicationContextBuilder.deduceCloudEnvironment(true)`, setting the system property `micronaut.env.cloud-deduction` to `true` or setting the environment `MICRONAUT_ENV_CLOUD_DEDUCTION` to `true` if your application still requires this functionality.
 
 ==== Update to Groovy 4
 

--- a/src/main/docs/guide/cloud/cloudConfiguration.adoc
+++ b/src/main/docs/guide/cloud/cloudConfiguration.adoc
@@ -2,8 +2,10 @@ Applications built for the Cloud often need to adapt to running in a Cloud envir
 
 Micronaut's <<environments, Environment>> concept can be configured to be Cloud platform-aware and makes a best effort to detect the underlying active Cloud environment.
 
-To enable this feature you can call `deduceCloudEnvironment(true)` on the api:context.ApplicationContextBuilder[] interface when starting Micronaut. For example:
+To enable this feature you can:
 
+1. call `deduceCloudEnvironment(true)` on the api:context.ApplicationContextBuilder[] interface when starting Micronaut. For example:
++
 .Enabling Cloud Environment Detection
 [source,java]
 ----
@@ -13,6 +15,9 @@ public static void main(String...args) {
              .start();
 }
 ----
+
+2. Set the `micronaut.env.cloud-deduction` property to `true` in your configuration.
+3. Provide an environment variable `MICRONAUT_ENV_CLOUD_DEDUCTION` set to `true`.
 
 You can then use the api:context.annotation.Requires[] annotation to <<conditionalBeans,conditionally load bean definitions>>.
 

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/context/env/DefaultEnvironmentSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/context/env/DefaultEnvironmentSpec.groovy
@@ -81,23 +81,13 @@ class DefaultEnvironmentSpec extends Specification {
         when:
         Field field = CachedEnvironment.class.getDeclaredField("getenv")
         field.setAccessible(true)
-        field.set(null, new UnaryOperator<String>() {
-            @Override
-            String apply(String s) {
-                return s == "MICRONAUT_ENV_CLOUD_DEDUCTION" ? StringUtils.TRUE : null
-            }
-        })
+        field.set(null, generateOperator(StringUtils.TRUE))
 
         then:
         env.shouldDeduceCloudEnvironment()
 
         when:
-        field.set(null, new UnaryOperator<String>() {
-            @Override
-            String apply(String s) {
-                return s == "MICRONAUT_ENV_CLOUD_DEDUCTION" ? StringUtils.FALSE : null
-            }
-        })
+        field.set(null, generateOperator(StringUtils.FALSE))
 
         then:
         !env.shouldDeduceCloudEnvironment()
@@ -105,5 +95,9 @@ class DefaultEnvironmentSpec extends Specification {
         cleanup:
         field.set(null, null)
         field.setAccessible(false)
+    }
+
+    UnaryOperator<String> generateOperator(String value) {
+        { String s -> s == "MICRONAUT_ENV_CLOUD_DEDUCTION" ? value : null }
     }
 }

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/context/env/DefaultEnvironmentSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/context/env/DefaultEnvironmentSpec.groovy
@@ -1,8 +1,16 @@
 package io.micronaut.docs.context.env
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.DefaultApplicationContextBuilder
+import io.micronaut.context.env.CachedEnvironment
+import io.micronaut.context.env.DefaultEnvironment
 import io.micronaut.context.env.Environment
+import io.micronaut.core.util.StringUtils
 import spock.lang.Specification
+import spock.util.environment.RestoreSystemProperties
+
+import java.lang.reflect.Field
+import java.util.function.UnaryOperator
 
 class DefaultEnvironmentSpec extends Specification {
 
@@ -19,4 +27,83 @@ class DefaultEnvironmentSpec extends Specification {
     }
     // end::disableEnvDeduction[]
 
+
+    void "shouldDeduceCloudEnvironment returns false by default"() {
+        given:
+        DefaultApplicationContextBuilder config = (DefaultApplicationContextBuilder) ApplicationContext.builder()
+        DefaultEnvironment env = new DefaultEnvironment(config)
+
+        expect:
+        !env.shouldDeduceCloudEnvironment()
+    }
+
+    void "shouldDeduceCloudEnvironment returns true if ApplicationContextBuilder deduceCloudEnvironment sets it to true"() {
+        when:
+        DefaultApplicationContextBuilder config = (DefaultApplicationContextBuilder) ApplicationContext.builder().deduceCloudEnvironment(true)
+        DefaultEnvironment env = new DefaultEnvironment(config)
+
+        then:
+        env.shouldDeduceCloudEnvironment()
+
+        when:
+        config = (DefaultApplicationContextBuilder) ApplicationContext.builder().deduceCloudEnvironment(false)
+        env = new DefaultEnvironment(config)
+
+        then:
+        !env.shouldDeduceCloudEnvironment()
+    }
+
+    @RestoreSystemProperties
+    void "shouldDeduceCloudEnvironment returns true if system property micronaut.env.cloud-deduction is set to true"() {
+        given:
+        System.setProperty("micronaut.env.cloud-deduction", StringUtils.TRUE)
+        DefaultApplicationContextBuilder config = (DefaultApplicationContextBuilder) ApplicationContext.builder()
+        DefaultEnvironment env = new DefaultEnvironment(config)
+
+        expect:
+        env.shouldDeduceCloudEnvironment()
+
+        when:
+        System.setProperty("micronaut.env.cloud-deduction", StringUtils.FALSE)
+
+        then:
+        !env.shouldDeduceCloudEnvironment()
+    }
+
+    void "shouldDeduceCloudEnvironment returns true if environment variable MICRONAUT_ENV_CLOUD_DEDUCTION is set to true"() {
+        given:
+        DefaultApplicationContextBuilder config = (DefaultApplicationContextBuilder) ApplicationContext.builder()
+        DefaultEnvironment env = new DefaultEnvironment(config)
+
+        expect:
+        !env.shouldDeduceCloudEnvironment()
+
+        when:
+        Field field = CachedEnvironment.class.getDeclaredField("getenv")
+        field.setAccessible(true)
+        field.set(null, new UnaryOperator<String>() {
+            @Override
+            String apply(String s) {
+                return s == "MICRONAUT_ENV_CLOUD_DEDUCTION" ? StringUtils.TRUE : null
+            }
+        })
+
+        then:
+        env.shouldDeduceCloudEnvironment()
+
+        when:
+        field.set(null, new UnaryOperator<String>() {
+            @Override
+            String apply(String s) {
+                return s == "MICRONAUT_ENV_CLOUD_DEDUCTION" ? StringUtils.FALSE : null
+            }
+        })
+
+        then:
+        !env.shouldDeduceCloudEnvironment()
+
+        cleanup:
+        field.set(null, null)
+        field.setAccessible(false)
+    }
 }


### PR DESCRIPTION
In https://github.com/micronaut-projects/micronaut-core/pull/8068 we disabled probing the OS/network to try and discover the cloud we were running on.

This PR adds an environment variable and property to allow it to be enabled.

Closes #9506