### PR TITLE
Change annotation-based CORS to match configuration-based defaults

### DIFF
--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/CrossOriginTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/cors/CrossOriginTest.java
@@ -87,6 +87,20 @@ public class CrossOriginTest {
     }
 
     @Test
+    void crossOriginAnnotationWithAnyOriginAnyHeaderAllowedByDefault() throws IOException {
+        asserts(SPECNAME,
+            preflight(UriBuilder.of("/foo").path("all"), "https://foo.com", HttpMethod.GET)
+                .header(HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS, "foo"),
+            (server, request) -> AssertionUtils.assertDoesNotThrow(server, request, HttpResponseAssertion.builder()
+                .status(HttpStatus.OK)
+                .assertResponse(response -> {
+                    assertCorsHeaders(response, "https://foo.com", HttpMethod.GET);
+                    assertTrue(response.getHeaders().names().contains(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS));
+                })
+                .build()));
+    }
+
+    @Test
     void verifyHttpMethodIsValidatedInACorsRequest() {
         assertAll(
             () -> asserts(SPECNAME,
@@ -300,6 +314,13 @@ public class CrossOriginTest {
         @Produces(MediaType.TEXT_PLAIN)
         @Get("/bar")
         String index() {
+            return "bar";
+        }
+
+        @CrossOrigin // allows all origins, all headers, by default
+        @Produces(MediaType.TEXT_PLAIN)
+        @Get("/all")
+        String defaults() {
             return "bar";
         }
     }

--- a/http-server/src/main/java/io/micronaut/http/server/cors/CrossOriginUtil.java
+++ b/http-server/src/main/java/io/micronaut/http/server/cors/CrossOriginUtil.java
@@ -23,7 +23,6 @@ import io.micronaut.http.HttpMethod;
 import io.micronaut.http.HttpRequest;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;

--- a/http-server/src/main/java/io/micronaut/http/server/cors/CrossOriginUtil.java
+++ b/http-server/src/main/java/io/micronaut/http/server/cors/CrossOriginUtil.java
@@ -63,16 +63,14 @@ public final class CrossOriginUtil {
         }
 
         CorsOriginConfiguration config = new CorsOriginConfiguration();
+        String[] allowedOrigins = annotationMetadata.stringValues(CrossOrigin.class, MEMBER_ALLOWED_ORIGINS);
         annotationMetadata.stringValue(CrossOrigin.class, MEMBER_ALLOWED_ORIGINS_REGEX).ifPresentOrElse(
             regex -> {
                 config.setAllowedOriginsRegex(regex);
-                config.setAllowedOrigins(Collections.emptyList());
+                // when allowed-origins-regex is set, don't default allowed-origins to ANY, use both iff set explicitly
+                config.setAllowedOrigins(Arrays.asList(allowedOrigins));
             },
-            () -> {
-                String[] allowedOrigins = annotationMetadata.stringValues(CrossOrigin.class, MEMBER_ALLOWED_ORIGINS);
-                List<String> allowedOriginsList = allowedOrigins.length == 0 ? CorsOriginConfiguration.ANY : Arrays.asList(allowedOrigins);
-                config.setAllowedOrigins(allowedOriginsList);
-            }
+            () -> config.setAllowedOrigins(allowedOrigins.length == 0 ? CorsOriginConfiguration.ANY : Arrays.asList(allowedOrigins))
         );
 
         String[] allowedHeaders = annotationMetadata.stringValues(CrossOrigin.class, MEMBER_ALLOWED_HEADERS);

--- a/src/main/docs/guide/appendix/breaks.adoc
+++ b/src/main/docs/guide/appendix/breaks.adoc
@@ -209,5 +209,5 @@ Since Micronaut 3.0 the `OncePerRequestHttpServerFilter` class was deprecated an
 
 ==== CORS support with the `@CrossOrigin` annotation
 
-In previous and current versions of Micronaut Framework, configuration-based CORS defaults to allow all origins when CORS is enabled and `allowed-origins` is not set otherwise. However, in previous versions of Micronaut Framework using the `@CrossOrigin` annotation defaults to no origins allowed, requiring the `allowedOrigins` attribute to be set. In Micronaut 4, `@CrossOrigin` is changed to match the behavior of configuration-based CORS. In other words, enabling CORS with `@CrossOrigin` without specifying any attributes means all origins are allowed.
+Micronaut Framework 4 changes `@CrossOrigin`  behavior to match configuration-based CORS behavior. A method annotated with `@CrossOrigin` allows any origin if you don't specify any value for the `allowedOrigins` and `allowedOriginsRegex` members.
 

--- a/src/main/docs/guide/appendix/breaks.adoc
+++ b/src/main/docs/guide/appendix/breaks.adoc
@@ -206,3 +206,8 @@ old behavior.
 ==== `OncePerRequestHttpServerFilter` removed
 
 Since Micronaut 3.0 the `OncePerRequestHttpServerFilter` class was deprecated and marked for removal. This class is now removed. Implement link:{api}/io/micronaut/http/filter/HttpServerFilter.html[HttpServerFilter] instead, and replace any usages of `micronaut.once` attributes with a custom attribute name.
+
+==== CORS support with the `@CrossOrigin` annotation
+
+In previous and current versions of Micronaut Framework, configuration-based CORS defaults to allow all origins when CORS is enabled and `allowed-origins` is not set otherwise. However, in previous versions of Micronaut Framework using the `@CrossOrigin` annotation defaults to no origins allowed, requiring the `allowedOrigins` attribute to be set. In Micronaut 4, `@CrossOrigin` is changed to match the behavior of configuration-based CORS. In other words, enabling CORS with `@CrossOrigin` without specifying any attributes means all origins are allowed.
+

--- a/src/main/docs/guide/httpServer/serverConfiguration/cors/annotationBasedCors.adoc
+++ b/src/main/docs/guide/httpServer/serverConfiguration/cors/annotationBasedCors.adoc
@@ -26,4 +26,4 @@ snippet::io.micronaut.docs.http.server.cors.CorsController[tags="imports,control
 <2> The `GET /hello` endpoint has "https://myui.com" as an allowed cross origin endpoint
 <3> The `GET /hello/nocors` endpoint cannot use "https://myui.com" as an origin, since it doesn't have a CORS configuration that allows it.
 
-NOTE: The `@CrossOrigin` annotation uses the same defaults as the application configuration alternative, when corresponding annotation attributes are not set. See  <<corsConfiguration, CORS configuration>> for details.
+NOTE: The `@CrossOrigin` annotation uses the same defaults as the application configuration alternative, when corresponding annotation attributes are not set. See <<corsConfiguration, CORS configuration>> for details.

--- a/src/main/docs/guide/httpServer/serverConfiguration/cors/annotationBasedCors.adoc
+++ b/src/main/docs/guide/httpServer/serverConfiguration/cors/annotationBasedCors.adoc
@@ -25,3 +25,5 @@ snippet::io.micronaut.docs.http.server.cors.CorsController[tags="imports,control
 <1> The ann:http.server.cors.CrossOrigin[] annotation is applied to a specific endpoint, making the CORS configuration fine-grained.
 <2> The `GET /hello` endpoint has "https://myui.com" as an allowed cross origin endpoint
 <3> The `GET /hello/nocors` endpoint cannot use "https://myui.com" as an origin, since it doesn't have a CORS configuration that allows it.
+
+NOTE: The `@CrossOrigin` annotation uses the same defaults as the application configuration alternative, when corresponding annotation attributes are not set. See  <<corsConfiguration, CORS configuration>> for details.

--- a/src/main/docs/guide/httpServer/serverConfiguration/cors/corsAllowedOrigins.adoc
+++ b/src/main/docs/guide/httpServer/serverConfiguration/cors/corsAllowedOrigins.adoc
@@ -18,4 +18,6 @@ micronaut:
             - http://foo.com
 ----
 
-WARNING: Use the `allowed-origins-regex` configuration judiciously. You may accidentally make an insecure configuration which could be targeted by an attacker registering domains targeting the regular expression. Note that if `allowed-origins-regex` is set then `allowed-origins` is ignored.
+WARNING: Use the `allowed-origins-regex` configuration judiciously. You may accidentally make an insecure configuration which could be targeted by an attacker registering domains targeting the regular expression.
+
+NOTE: `allowed-origins-regex` and `allowed-origins` can be combined. However, if using the former and the latter is not set explicitly then `allowed-origins` defaults to _none_ rather than _any_ to avoid unexpected allowed origins.

--- a/src/main/docs/guide/httpServer/serverConfiguration/cors/corsAllowedOrigins.adoc
+++ b/src/main/docs/guide/httpServer/serverConfiguration/cors/corsAllowedOrigins.adoc
@@ -18,4 +18,4 @@ micronaut:
             - http://foo.com
 ----
 
-WARNING: Use the `allowed-origins-regex` configuration judiciously. You may accidentally make an insecure configuration which could be targeted by an attacker registering domains targeting the regular expression.
+WARNING: Use the `allowed-origins-regex` configuration judiciously. You may accidentally make an insecure configuration which could be targeted by an attacker registering domains targeting the regular expression. Note that if `allowed-origins-regex` is set then `allowed-origins` is ignored.


### PR DESCRIPTION
Change CrossOrigin annotation-based CORS to match configuration-based CORS defaults so that enabling CORS allows all origins by default. This is a breaking change from Micronaut 3.9.x

closes #9504