### PR TITLE
KSP: Properly map suspended function class

### DIFF
--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinClassElement.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinClassElement.kt
@@ -139,9 +139,7 @@ internal open class KotlinClassElement(
         javaName?.asString() ?: declaration.qualifiedName!!.asString()
     }
 
-    private val internalName: String by lazy {
-        declaration.getBinaryName(visitorContext.resolver, visitorContext)
-    }
+    private val internalName = declaration.getBinaryName(visitorContext.resolver, visitorContext)
 
     private val resolvedInterfaces: Collection<ClassElement> by lazy {
         declaration.superTypes.map { it.resolve() }
@@ -509,14 +507,6 @@ internal open class KotlinClassElement(
             return type.kotlinType.starProjection().makeNullable().isAssignableFrom(kotlinType.starProjection().makeNullable())
         }
         return super.isAssignable(type)
-    }
-
-    override fun isPrimitive(): Boolean {
-        return isVoid
-    }
-
-    override fun isVoid(): Boolean {
-        return internalName == "kotlin.Unit"
     }
 
     override fun copyThis() = KotlinClassElement(

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/ast/ClassElementSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/ast/ClassElementSpec.groovy
@@ -1723,7 +1723,6 @@ class MyBeanX {
             def element = ce.findMethod("save").get().getParameters()[0]
             element.getGenericType().simpleName == "MyBeanX"
             element.getType().simpleName == "Object"
-            element.getGenericType().isAssignable("test.MyBeanX")
         when:
             def genRepo = ce.getTypeArguments("test.GenericRepository")
         then:
@@ -1731,6 +1730,34 @@ class MyBeanX {
             genRepo.get("E").getSyntheticBeanProperties().size() == 1
             genRepo.get("E").getMethods().size() == 0
             genRepo.get("E").getFields().get(0).name == "name"
+    }
+
+    void "test interface placeholder 2 isAssignable"() {
+        when:
+        boolean isAssignable = buildClassElementMapped('test.MyRepoX', '''
+package test
+import io.micronaut.context.annotation.Prototype
+import java.util.List
+
+interface MyRepoX : RepoX<MyBeanX, Long>
+interface RepoX<E, ID> : GenericRepository<E, ID> {
+    fun <S : E> save(ent: S)
+}
+interface GenericRepository<E, ID>
+@Prototype
+class MyBeanX {
+    var name: String? = null
+}
+
+''', { ce ->
+            def element = ce.findMethod("save").get().getParameters()[0]
+            element.getGenericType().simpleName == "MyBeanX"
+            element.getType().simpleName == "Object"
+            element.getGenericType().isAssignable("test.MyBeanX")
+        })
+
+        then:
+            isAssignable
     }
 
     void "test abstract placeholder"() {


### PR DESCRIPTION
KSP provides compile-only `kotlin.coroutines.SuspendFunction{X}` classes for suspended functions `suspend TestContext.() -> Unit`.
PR properly remaps the class to the JVM name. The test changes are only to avoid post-compilation errors.

The more correct way might be to remap `SuspendFunction` to an ordinary function with an added coroutine, as we do for suspended parameters, but I don't think it's a big deal. The only problem is the type arguments are missing the coroutine one.

Fixes https://github.com/micronaut-projects/micronaut-core/issues/9514