### PR TITLE
Possible bug in Factory and EachBean

### DIFF
--- a/inject-java/src/test/groovy/io/micronaut/inject/factory/FactoryEachBeanNamedSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/factory/FactoryEachBeanNamedSpec.groovy
@@ -1,0 +1,67 @@
+package io.micronaut.inject.factory
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.BeanContext
+import io.micronaut.context.annotation.EachBean
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Requires
+import io.micronaut.runtime.context.scope.Refreshable
+import jakarta.inject.Named
+import spock.lang.Specification
+
+class FactoryEachBeanNamedSpec extends Specification {
+
+    static final SPEC_NAME = "FactoryEachBeanNamedSpec"
+
+    void "check the factory"() {
+        given:
+        BeanContext beanContext = ApplicationContext.run(["spec.name": SPEC_NAME])
+
+        expect:
+        beanContext.getBeansOfType(IntegerReturnerWrapper).size() == 2
+
+        cleanup:
+        beanContext.close()
+    }
+
+    static interface IntegerReturner {
+        int getInteger()
+    }
+
+    @Refreshable
+    @Requires(property = "spec.name", value = SPEC_NAME)
+    static class One implements IntegerReturner {
+        @Override
+        int getInteger() {
+            1
+        }
+    }
+
+    @Refreshable
+    @Named("two")
+    @Requires(property = "spec.name", value = SPEC_NAME)
+    static class Two implements IntegerReturner {
+        @Override
+        int getInteger() {
+            2
+        }
+    }
+
+    static class IntegerReturnerWrapper {
+        final IntegerReturner inty
+
+        IntegerReturnerWrapper(IntegerReturner inty) {
+            this.inty = inty
+        }
+    }
+
+    @Factory
+    @Requires(property = "spec.name", value = SPEC_NAME)
+    static class IntegerReturnerFactory {
+
+        @EachBean(IntegerReturner)
+        IntegerReturnerWrapper buildWithFactory(IntegerReturner inty) {
+            new IntegerReturnerWrapper(inty)
+        }
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/factory/FactoryEachBeanNamedSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/factory/FactoryEachBeanNamedSpec.groovy
@@ -4,7 +4,6 @@ import io.micronaut.context.ApplicationContext
 import io.micronaut.context.BeanContext
 import io.micronaut.context.annotation.EachBean
 import io.micronaut.context.annotation.Factory
-import io.micronaut.context.annotation.Parameter
 import io.micronaut.context.annotation.Requires
 import io.micronaut.runtime.context.scope.Refreshable
 import jakarta.inject.Named
@@ -62,7 +61,7 @@ class FactoryEachBeanNamedSpec extends Specification {
     static class IntegerReturnerWrapper2 {
         final IntegerReturner inty
 
-        IntegerReturnerWrapper2(@Parameter IntegerReturner inty) {
+        IntegerReturnerWrapper2(IntegerReturner inty) {
             this.inty = inty
         }
     }
@@ -72,7 +71,7 @@ class FactoryEachBeanNamedSpec extends Specification {
     static class IntegerReturnerFactory {
 
         @EachBean(IntegerReturner)
-        IntegerReturnerWrapper buildWithFactory(@Parameter IntegerReturner inty) {
+        IntegerReturnerWrapper buildWithFactory(IntegerReturner inty) {
             new IntegerReturnerWrapper(inty)
         }
     }

--- a/inject-java/src/test/groovy/io/micronaut/inject/factory/FactoryEachBeanNamedSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/factory/FactoryEachBeanNamedSpec.groovy
@@ -4,6 +4,7 @@ import io.micronaut.context.ApplicationContext
 import io.micronaut.context.BeanContext
 import io.micronaut.context.annotation.EachBean
 import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Parameter
 import io.micronaut.context.annotation.Requires
 import io.micronaut.runtime.context.scope.Refreshable
 import jakarta.inject.Named
@@ -18,6 +19,7 @@ class FactoryEachBeanNamedSpec extends Specification {
         BeanContext beanContext = ApplicationContext.run(["spec.name": SPEC_NAME])
 
         expect:
+        beanContext.getBeansOfType(IntegerReturnerWrapper2).size() == 2
         beanContext.getBeansOfType(IntegerReturnerWrapper).size() == 2
 
         cleanup:
@@ -55,12 +57,22 @@ class FactoryEachBeanNamedSpec extends Specification {
         }
     }
 
+    @EachBean(IntegerReturner)
+    @Requires(property = "spec.name", value = SPEC_NAME)
+    static class IntegerReturnerWrapper2 {
+        final IntegerReturner inty
+
+        IntegerReturnerWrapper2(@Parameter IntegerReturner inty) {
+            this.inty = inty
+        }
+    }
+
     @Factory
     @Requires(property = "spec.name", value = SPEC_NAME)
     static class IntegerReturnerFactory {
 
         @EachBean(IntegerReturner)
-        IntegerReturnerWrapper buildWithFactory(IntegerReturner inty) {
+        IntegerReturnerWrapper buildWithFactory(@Parameter IntegerReturner inty) {
             new IntegerReturnerWrapper(inty)
         }
     }

--- a/inject/src/main/java/io/micronaut/context/BeanDefinitionDelegate.java
+++ b/inject/src/main/java/io/micronaut/context/BeanDefinitionDelegate.java
@@ -25,6 +25,7 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.naming.NameResolver;
 import io.micronaut.core.type.Argument;
+import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.ObjectUtils;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.DelegatingBeanDefinition;
@@ -39,7 +40,6 @@ import io.micronaut.inject.qualifiers.PrimaryQualifier;
 import io.micronaut.inject.qualifiers.Qualifiers;
 
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -62,7 +62,6 @@ sealed class BeanDefinitionDelegate<T> extends AbstractBeanContextConditional
 
     @Nullable
     private final ConfigurationPath configurationPath;
-
 
     private BeanDefinitionDelegate(BeanDefinition<T> definition, @Nullable Qualifier<T> qualifier, @Nullable ConfigurationPath configurationPath) {
         this.definition = definition;
@@ -172,7 +171,7 @@ sealed class BeanDefinitionDelegate<T> extends AbstractBeanContextConditional
         if (requiredArguments.length == 0) {
             return Collections.emptyMap();
         }
-        Map<String, Object> fulfilled = new LinkedHashMap<>(requiredArguments.length, 1);
+        Map<String, Object> fulfilled = CollectionUtils.newLinkedHashMap(requiredArguments.length);
         ConfigurationPath configurationPath = resolutionContext.getConfigurationPath();
         for (Argument<Object> argument : requiredArguments) {
             String argumentName = argument.getName();

--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
@@ -45,6 +45,7 @@ import io.micronaut.inject.BeanConfiguration;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.BeanDefinitionReference;
 import io.micronaut.inject.qualifiers.PrimaryQualifier;
+import io.micronaut.inject.qualifiers.Qualifiers;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -520,10 +521,15 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
                     createAndAddDelegate(resolutionContext, candidate, transformedCandidates, dependentPath);
                 } else {
                     Qualifier<?> qualifier = dependentCandidate.getDeclaredQualifier();
-                    if (qualifier == null && dependentCandidate.isPrimary()) {
-                        // Backwards compatibility, `getDeclaredQualifier` strips @Primary
-                        // This should be removed if @Primary is no longer qualifier
-                        qualifier = PrimaryQualifier.INSTANCE;
+                    if (qualifier == null) {
+                        if (dependentCandidate.isPrimary()) {
+                            // Backwards compatibility, `getDeclaredQualifier` strips @Primary
+                            // This should be removed if @Primary is no longer qualifier
+                            qualifier = PrimaryQualifier.INSTANCE;
+                        } else {
+                            // If the qualifier is null we cannot properly recognize the connected each bean
+                            qualifier = Qualifiers.byType(dependentCandidate.getBeanType());
+                        }
                     }
                     BeanDefinitionDelegate<?> delegate = BeanDefinitionDelegate.create(candidate, (Qualifier<T>) qualifier);
                     if (delegate.isEnabled(this, resolutionContext)) {


### PR DESCRIPTION
More likely to be me making a mistake, but we have the following pattern in the micronaut-security-keys-jwks guide, which is failing (as does this) with io.micronaut.context.exceptions.NonUniqueBeanException

Shouldn't this be handled by the EachBean annotation