### PR TITLE
use binary name to store annotation names in metadata for KSP

### DIFF
--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/annotation/KotlinAnnotationMetadataBuilder.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/annotation/KotlinAnnotationMetadataBuilder.kt
@@ -50,13 +50,9 @@ internal class KotlinAnnotationMetadataBuilder(private val symbolProcessorEnviro
         private fun getTypeForAnnotation(annotationMirror: KSAnnotation, visitorContext: KotlinVisitorContext): KSClassDeclaration {
             return annotationMirror.annotationType.resolve().declaration.getClassDeclaration(visitorContext)
         }
-        fun getAnnotationTypeName(annotationMirror: KSAnnotation, visitorContext: KotlinVisitorContext): String {
+        fun getAnnotationTypeName(resolver: Resolver, annotationMirror: KSAnnotation, visitorContext: KotlinVisitorContext): String {
             val type = getTypeForAnnotation(annotationMirror, visitorContext)
-            return if (type.qualifiedName != null) {
-                type.qualifiedName!!.asString()
-            } else {
-                annotationMirror.shortName.asString()
-            }
+            return type.getBinaryName(resolver, visitorContext)
         }
     }
 
@@ -86,7 +82,7 @@ internal class KotlinAnnotationMetadataBuilder(private val symbolProcessorEnviro
     }
 
     override fun getAnnotationTypeName(annotationMirror: KSAnnotation): String {
-        return Companion.getAnnotationTypeName(annotationMirror, visitorContext)
+        return Companion.getAnnotationTypeName(resolver, annotationMirror, visitorContext)
     }
 
     override fun getElementName(element: KSAnnotated): String {

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/extensions.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/extensions.kt
@@ -31,7 +31,7 @@ internal fun KSDeclaration.getBinaryName(resolver: Resolver, visitorContext: Kot
             declaration = parent
         }
     }
-    val binaryName = resolver.mapKotlinNameToJava(declaration.qualifiedName!!)?.asString()
+    val binaryName = if (declaration.qualifiedName != null) resolver.mapKotlinNameToJava(declaration.qualifiedName!!)?.asString() else null
     if (binaryName != null) {
         return binaryName
     }
@@ -43,13 +43,17 @@ internal fun KSDeclaration.getBinaryName(resolver: Resolver, visitorContext: Kot
             return asString;
         }
     }
-    if (declaration is KSClassDeclaration) {
+    if (declaration is KSClassDeclaration && declaration.origin != Origin.SYNTHETIC) {
         val signature = resolver.mapToJvmSignature(declaration)
         if (signature != null) {
             return Type.getType(signature).className
         }
     }
-    return computeName(declaration)
+    return if (declaration.origin != Origin.SYNTHETIC) {
+        computeName(declaration)
+    } else {
+        declaration.simpleName.asString()
+    }
 }
 
 private fun computeName(declaration: KSDeclaration): String {

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinVisitorContext.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinVisitorContext.kt
@@ -115,6 +115,7 @@ internal open class KotlinVisitorContext(
                 declaration.annotations.any { ann ->
                     stereotypes.contains(
                         KotlinAnnotationMetadataBuilder.getAnnotationTypeName(
+                            resolver,
                             ann,
                             this
                         )

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/visitor/BeanIntrospectionSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/visitor/BeanIntrospectionSpec.groovy
@@ -49,6 +49,35 @@ class Test
         introspection.instantiate().class.name == "test.Test"
     }
 
+    void 'test inner annotation'() {
+        when:
+        def introspection = buildBeanIntrospection("test.Test", """
+package test
+
+import io.micronaut.core.annotation.Introspected
+
+@MyAnn
+class Test
+
+@Introspected
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS)
+@MyAnn.InnerAnn
+annotation class MyAnn {
+    @Retention(AnnotationRetention.RUNTIME)
+    @Target(AnnotationTarget.CLASS)
+    annotation class InnerAnn
+}
+""")
+
+        then:
+        noExceptionThrown()
+        introspection != null
+        introspection.instantiate().class.name == "test.Test"
+        introspection.hasAnnotation('test.MyAnn')
+        introspection.hasStereotype('test.MyAnn$InnerAnn')
+    }
+
     void "test generics in arrays don't stack overflow"() {
         given:
         def introspection = buildBeanIntrospection('arraygenerics.Test', '''


### PR DESCRIPTION
KSP is currently using the canonical name to store annotation names in annotation metadata. This breaks for inner annotations since the binary name is the expected format produced by other languages. This PR changes the KSP implementation to use the binary name instead.