### PR TITLE
Fix KSP nullability handling

### DIFF
--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/annotation/KotlinAnnotationMetadataBuilder.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/annotation/KotlinAnnotationMetadataBuilder.kt
@@ -182,23 +182,34 @@ internal class KotlinAnnotationMetadataBuilder(private val symbolProcessorEnviro
     }
 
     override fun postProcess(annotationMetadata: MutableAnnotationMetadata, element: KSAnnotated) {
-        if (element is KSValueParameter && element.type.resolve().isMarkedNullable) {
-            annotationMetadata.addDeclaredAnnotation(AnnotationUtil.NULLABLE, emptyMap())
+        if (element is KSValueParameter) {
+            handleNullability(element.type.resolve(), annotationMetadata)
         } else if (element is KSFunctionDeclaration) {
-            val markedNullable = element.returnType?.resolve()?.isMarkedNullable
-            if (markedNullable != null && markedNullable) {
-                annotationMetadata.addDeclaredAnnotation(AnnotationUtil.NULLABLE, emptyMap())
+            val ksType = element.returnType?.resolve()
+            if (ksType != null) {
+                handleNullability(ksType, annotationMetadata)
             }
         } else if (element is KSPropertyDeclaration) {
-            val markedNullable = element.type.resolve().isMarkedNullable
-            if (markedNullable) {
-                annotationMetadata.addDeclaredAnnotation(AnnotationUtil.NULLABLE, emptyMap())
-            }
+            handleNullability(element.type.resolve(), annotationMetadata)
         } else if (element is KSPropertySetter) {
             if (!annotationMetadata.hasAnnotation(JvmField::class.java) && (annotationMetadata.hasStereotype(AnnotationUtil.QUALIFIER) || annotationMetadata.hasAnnotation(Property::class.java))) {
                 // implicitly inject
                 annotationMetadata.addDeclaredAnnotation(AnnotationUtil.INJECT, emptyMap())
             }
+        }
+    }
+
+    private fun handleNullability(
+        ksType: KSType,
+        annotationMetadata: MutableAnnotationMetadata
+    ) {
+        if (ksType.isMarkedNullable) {
+            // explicitly allowed to be null so add nullable
+            annotationMetadata.addDeclaredAnnotation(AnnotationUtil.NULLABLE, emptyMap())
+        } else {
+            // with Kotlin the default is not null, so we must store in the metadata
+            // that the element is not nullable
+            annotationMetadata.addDeclaredAnnotation(AnnotationUtil.NON_NULL, emptyMap())
         }
     }
 

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/annotations/AnnotatePropertySpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/annotations/AnnotatePropertySpec.groovy
@@ -6,6 +6,8 @@ import io.micronaut.inject.ast.ClassElement
 import io.micronaut.inject.ast.MethodElement
 import io.micronaut.inject.visitor.TypeElementVisitor
 import io.micronaut.inject.visitor.VisitorContext
+import jakarta.annotation.Nonnull
+import jakarta.annotation.Nullable
 
 class AnnotatePropertySpec extends AbstractKotlinCompilerSpec {
 
@@ -18,7 +20,7 @@ import io.micronaut.core.annotation.Introspected
 
 
 @Introspected
-class AnnotatePropertyBean1(val firstName: String, val lastName: String)
+class AnnotatePropertyBean1(val firstName: String, val lastName: String?)
 
 ''')
         then:
@@ -34,7 +36,7 @@ import io.micronaut.core.annotation.Introspected
 
 
 @Introspected
-class AnnotatePropertyBean2(var firstName: String, var lastName: String)
+class AnnotatePropertyBean2(var firstName: String, var lastName: String?)
 
 ''')
         then:
@@ -65,19 +67,20 @@ class AnnotatePropertyBean2(var firstName: String, var lastName: String)
                 def property1 = properties[0]
                 assert property1.name == "firstName"
 
-                assert property1.getAnnotationMetadata().getAnnotationNames().isEmpty()
+                // Set comparison
+                assert property1.getAnnotationMetadata().getAnnotationNames() == [Nonnull.class.name] as Set<String>
                 assert property1.type.getAnnotationMetadata().getAnnotationNames().isEmpty()
                 assert property1.genericType.getAnnotationMetadata().getAnnotationNames().isEmpty()
 
                 property1.annotate(MyAnnotation)
 
-                assert property1.getAnnotationMetadata().getAnnotationNames().asList() == [MyAnnotation.class.name]
+                assert property1.getAnnotationMetadata().getAnnotationNames() == [MyAnnotation.class.name, Nonnull.class.name] as Set<String>
                 assert property1.type.getAnnotationMetadata().getAnnotationNames().isEmpty()
                 assert property1.genericType.getAnnotationMetadata().getAnnotationNames().isEmpty()
 
                 def field1 = property1.getField().orElse(null)
                 if (field1) {
-                    assert field1.getAnnotationNames().asList() == [MyAnnotation.class.name]
+                    assert field1.getAnnotationNames() == [MyAnnotation.class.name, Nonnull.class.name] as Set<String>
                     assert field1.type.getAnnotationMetadata().getAnnotationNames().isEmpty()
                     assert field1.genericType.getAnnotationMetadata().getAnnotationNames().isEmpty()
                 }
@@ -98,20 +101,20 @@ class AnnotatePropertyBean2(var firstName: String, var lastName: String)
                     def parameter = setter1.parameters[0]
                     // TODO: delegate to the parameter
 //                    assert parameter.getAnnotationNames().asList() == [MyAnnotation.class.name]
-                    assert parameter.getAnnotationNames().isEmpty()
+                    assert parameter.getAnnotationNames() == [Nonnull.class.name] as Set<String>
                     assert parameter.type.getAnnotationMetadata().getAnnotationNames().isEmpty()
                     assert parameter.genericType.getAnnotationMetadata().getAnnotationNames().isEmpty()
                 }
 
                 def property2 = properties[1]
                 assert property2.name == "lastName"
-                assert property2.getAnnotationMetadata().getAnnotationNames().isEmpty()
+                assert property2.getAnnotationMetadata().getAnnotationNames() == [Nullable.class.name] as Set<String>
                 assert property2.type.getAnnotationMetadata().getAnnotationNames().isEmpty()
                 assert property2.genericType.getAnnotationMetadata().getAnnotationNames().isEmpty()
 
                 def field2 = property2.getField().orElse(null)
                 if (field2) {
-                    assert field2.getAnnotationMetadata().getAnnotationNames().isEmpty()
+                    assert field2.getAnnotationMetadata().getAnnotationNames() == [Nullable.class.name] as Set<String>
                     assert field2.type.getAnnotationMetadata().getAnnotationNames().isEmpty()
                     assert field2.genericType.getAnnotationMetadata().getAnnotationNames().isEmpty()
                 }
@@ -128,7 +131,7 @@ class AnnotatePropertyBean2(var firstName: String, var lastName: String)
                     assert setter2.genericReturnType.getAnnotationMetadata().getAnnotationNames().isEmpty()
 
                     def parameter = setter2.parameters[0]
-                    assert parameter.getAnnotationNames().isEmpty()
+                    assert parameter.getAnnotationNames() == [Nullable.class.name] as Set<String>
                     assert parameter.type.getAnnotationMetadata().getAnnotationNames().isEmpty()
                     assert parameter.genericType.getAnnotationMetadata().getAnnotationNames().isEmpty()
                 }
@@ -137,12 +140,12 @@ class AnnotatePropertyBean2(var firstName: String, var lastName: String)
 
                 def newClassElement = context.getClassElement(classElement.getName()).get()
                 def newProperty = newClassElement.getBeanProperties()[0]
-                assert newProperty.getAnnotationMetadata().getAnnotationNames().asList() == [MyAnnotation.class.name]
+                assert newProperty.getAnnotationMetadata().getAnnotationNames() == [Nonnull.class.name, MyAnnotation.class.name] as Set<String>
                 assert newProperty.type.getAnnotationMetadata().getAnnotationNames().isEmpty()
                 assert newProperty.genericType.getAnnotationMetadata().getAnnotationNames().isEmpty()
                 def field1new = newProperty.getField().orElse(null)
                 if (field1new) {
-                    assert field1new.getAnnotationMetadata().getAnnotationNames().asList() == [MyAnnotation.class.name]
+                    assert field1new.getAnnotationMetadata().getAnnotationNames() == [Nonnull.class.name, MyAnnotation.class.name] as Set<String>
                     assert field1new.type.getAnnotationMetadata().getAnnotationNames().isEmpty()
                     assert field1new.genericType.getAnnotationMetadata().getAnnotationNames().isEmpty()
                 }
@@ -163,7 +166,7 @@ class AnnotatePropertyBean2(var firstName: String, var lastName: String)
                     def parameter = setter1new.parameters[0]
                     // TODO: delegate to the parameter
 //                    assert parameter.getAnnotationNames().asList() == [MyAnnotation.class.name]
-                    assert parameter.getAnnotationNames().isEmpty()
+                    assert parameter.getAnnotationNames() == [Nonnull.class.name] as Set<String>
                     assert parameter.type.getAnnotationMetadata().getAnnotationNames().isEmpty()
                     assert parameter.genericType.getAnnotationMetadata().getAnnotationNames().isEmpty()
                 }

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/beans/executable/ExecutableBeanSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/beans/executable/ExecutableBeanSpec.groovy
@@ -22,6 +22,7 @@ import io.micronaut.core.annotation.Introspected
 import io.micronaut.core.type.Argument
 import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.validation.RequiresValidation
+import jakarta.annotation.Nonnull
 import spock.lang.Issue
 import spock.lang.PendingFeature
 import spock.lang.Specification
@@ -534,9 +535,17 @@ class MyBean {
 
 ''')
         when:
+            def saveAllList = bd.findMethod("saveAll", List).get()
+            def saveAllListArgument = saveAllList.getArguments()[0]
+        then:
+            // The list itself should be marked as Nonnull
+            saveAllListArgument.getAnnotationMetadata().getAnnotationNames() == [Nonnull.class.name] as Set<String>
+
+        when:
             def saveAll = bd.findMethod("saveAll", List).get()
             def listTypeArgument = saveAll.getArguments()[0].getTypeParameters()[0]
         then:
+            // this is not Nonnull as we are checking the list content type, not the list itself
             validateMyBookArgument(listTypeArgument)
 
         when:
@@ -567,19 +576,19 @@ class MyBean {
             def save2 = bd.findMethod("save2", MyBook).get()
             def parameter2 = save2.getArguments()[0]
         then:
-            validateMyBookArgument(parameter2)
+            validateMyBookArgument(parameter2, true)
 
         when:
             def save3 = bd.findMethod("save3", MyBook).get()
             def parameter3 = save3.getArguments()[0]
         then:
-            validateMyBookArgument(parameter3)
+            validateMyBookArgument(parameter3, true)
 
         when:
             def save4 = bd.findMethod("save4", MyBook).get()
             def parameter4 = save4.getArguments()[0]
         then:
-            validateMyBookArgument(parameter4)
+            validateMyBookArgument(parameter4, true)
 
 //        when:
 //            def save5 = bd.findMethod("save5", MyBook).get()
@@ -659,13 +668,18 @@ class MyBean {
             validateMyBookArgument(parameter5)
     }
 
-    void validateMyBookArgument(Argument argument) {
-        // The argument should only have type annotations
+    void validateMyBookArgument(Argument argument, boolean shouldBeNonnull = false) {
+        // The argument should only have type annotations and potentially Nonnull
         def am = argument.getAnnotationMetadata()
         assert am.hasAnnotation(TypeUseRuntimeAnn.class)
         assert !am.hasAnnotation(MyEntity.class)
         assert !am.hasAnnotation(Introspected.class)
-        assert am.getAnnotationNames().size() == 1
+        if (shouldBeNonnull) {
+            assert am.hasAnnotation(Nonnull.class)
+            assert am.getAnnotationNames() == [Nonnull.class.name, TypeUseRuntimeAnn.class.name] as Set<String>
+        } else {
+            assert am.getAnnotationNames() == [TypeUseRuntimeAnn.class.name] as Set<String>
+        }
     }
 }
 

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/visitor/BeanIntrospectionSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/visitor/BeanIntrospectionSpec.groovy
@@ -49,6 +49,27 @@ class Test
         introspection.instantiate().class.name == "test.Test"
     }
 
+    void "test non-null and null introspection"() {
+        when:
+        def introspection = buildBeanIntrospection("test.Test", """
+package test
+
+import io.micronaut.core.annotation.Introspected
+
+@Introspected
+data class Test(
+    val name: String,
+    val description: String? = null)
+""")
+
+        then:
+        noExceptionThrown()
+        introspection != null
+        introspection.constructorArguments.size() == 2
+        introspection.constructorArguments[0].isNonNull()
+        introspection.constructorArguments[1].isNullable()
+    }
+
     void 'test inner annotation'() {
         when:
         def introspection = buildBeanIntrospection("test.Test", """


### PR DESCRIPTION
With Kotlin it is not enough to just add `Nullable` to elements marked as nullable, we also have to store the fact that elements not marked as such as `NonNull`. This PR stores `NonNull` in the annotation metadata for Kotlin elements that cannot be null.