### PR TITLE
brotli compression

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ asm = "9.5"
 awaitility = "4.2.0"
 bcpkix = "1.70"
 blaze = "1.6.8"
+brotli4j = "1.12.0"
 caffeine = "2.9.3"
 compile-testing = "0.21.0"
 
@@ -163,6 +164,8 @@ aws-java-sdk-lambda = { module = "com.amazonaws:aws-java-sdk-lambda" }
 bcpkix = { module = "org.bouncycastle:bcpkix-jdk15on", version.ref = "bcpkix" }
 
 blaze-persistence-core = { module = "com.blazebit:blaze-persistence-core-impl", version.ref = "blaze" }
+
+brotli4j = { module = "com.aayushatharva.brotli4j:brotli4j", version.ref = "brotli4j" }
 
 caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version.ref = "caffeine" }
 

--- a/http-server-netty/build.gradle
+++ b/http-server-netty/build.gradle
@@ -53,6 +53,11 @@ dependencies {
         exclude group: 'io.micronaut'
     }
 
+    // Needed for Brotli compression
+    var brotli4jClassifier = Os.isFamily(Os.FAMILY_MAC) ? (Os.isArch("aarch64") ? "osx-aarch64" : "osx-x86_64") : 'linux-x86_64'
+    testImplementation libs.brotli4j
+    testRuntimeOnly "com.aayushatharva.brotli4j:native-${brotli4jClassifier}:${libs.versions.brotli4j.get()}"
+
     testImplementation project(":inject")
     testImplementation project(":inject-java-test")
     testImplementation project(":http-client")

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/java/ResponseController.java
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/java/ResponseController.java
@@ -31,6 +31,7 @@ import java.util.Optional;
  */
 @Controller("/java/response")
 public class ResponseController {
+    public static final String LARGE_BODY = "a".repeat(15_000);
 
     @Get("/disallow")
     public HttpResponse disallow() {
@@ -70,6 +71,11 @@ public class ResponseController {
     @Get(value = "/ok-with-body", produces = MediaType.TEXT_PLAIN)
     public HttpResponse okWithBody() {
         return HttpResponse.ok("some text");
+    }
+
+    @Get(value = "/ok-with-large-body", produces = MediaType.TEXT_PLAIN)
+    public HttpResponse okWithLargeBody() {
+        return HttpResponse.ok(LARGE_BODY);
     }
 
     @Get(value = "/error-with-body", produces = MediaType.TEXT_PLAIN)


### PR DESCRIPTION
This is a proof of concept for Brotli compression in Micronaut. 

Let me know what you think of this approach.


# Context

Netty 4.x supports Brotli compression.  Netty's content compressor checks for the presence of brotli4j on the runtime classpath.   If brotli4j is present, Netty can return Brotli compressed responses.

# Related work

I submitted a similar PR to the reactor-netty project.  reactor-netty server now supports Brotli compression:

https://github.com/reactor/reactor-netty/pull/2815


