### PR TITLE
KSP: Visit synthetic properties in factories with advice

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataWriter.java
@@ -328,6 +328,10 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
             Map<String, GeneratorAdapter> loadTypeMethods,
             AnnotationMetadata annotationMetadata) {
         annotationMetadata = annotationMetadata.getTargetAnnotationMetadata();
+        if (annotationMetadata instanceof AnnotationMetadataHierarchy annotationMetadataHierarchy) {
+            // Synthetic property getters / setters can consist of field + (setter / getter) annotation hierarchy
+            annotationMetadata = MutableAnnotationMetadata.of(annotationMetadataHierarchy);
+        }
         if (annotationMetadata.isEmpty()) {
             generatorAdapter.getStatic(Type.getType(AnnotationMetadata.class), "EMPTY_METADATA", Type.getType(AnnotationMetadata.class));
         } else if (annotationMetadata instanceof MutableAnnotationMetadata mutableAnnotationMetadata) {

--- a/core-processor/src/main/java/io/micronaut/inject/processing/FactoryBeanElementCreator.java
+++ b/core-processor/src/main/java/io/micronaut/inject/processing/FactoryBeanElementCreator.java
@@ -244,6 +244,21 @@ final class FactoryBeanElementCreator extends DeclaredBeanElementCreator {
                 .filter(m -> m.isPublic() && !m.isFinal() && !m.isStatic()).toList();
             methodElements
                 .forEach(methodElement -> visitAroundMethod(aopProxyWriter, methodElement.getDeclaringType(), methodElement));
+            List<PropertyElement> syntheticBeanProperties = producedType.getSyntheticBeanProperties();
+            for (PropertyElement syntheticBeanProperty : syntheticBeanProperties) {
+                syntheticBeanProperty.getReadMethod().ifPresent(m -> {
+                        if (!m.isFinal()) {
+                            visitAroundMethod(aopProxyWriter, m.getDeclaringType(), m);
+                        }
+                    }
+                );
+                syntheticBeanProperty.getWriteMethod().ifPresent(m -> {
+                        if (!m.isFinal()) {
+                            visitAroundMethod(aopProxyWriter, m.getDeclaringType(), m);
+                        }
+                    }
+                );
+            }
 
         } else if (producedAnnotationMetadata.hasStereotype(Executable.class)) {
             if (producedType.isArray()) {

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/AbstractKotlinPropertyAccessorMethodElement.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/AbstractKotlinPropertyAccessorMethodElement.kt
@@ -45,7 +45,7 @@ internal abstract class AbstractKotlinPropertyAccessorMethodElement<T : KotlinNa
 
     override fun isSynthetic() = true
 
-    override fun isFinal() = true
+    override fun isFinal() = !accessor.receiver.isOpen()
 
     override fun isAbstract(): Boolean = accessor.receiver.isAbstract()
 

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinClassElement.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinClassElement.kt
@@ -714,7 +714,7 @@ internal open class KotlinClassElement(
                 }
 
                 MethodElement::class.java -> {
-                    val declaredFunctions = classNode.getDeclaredFunctions()
+                    classNode.getDeclaredFunctions()
                         .filter { func: KSFunctionDeclaration ->
                             !func.isConstructor() &&
                                     func.origin != Origin.SYNTHETIC &&
@@ -726,19 +726,6 @@ internal open class KotlinClassElement(
                                     ).contains(func.simpleName.asString())
                         }
                         .toList()
-                    val declaredProperties = classNode.getDeclaredProperties()
-                    val propertiesAndMethods = mutableListOf<KSNode>()
-                    propertiesAndMethods.addAll(declaredFunctions)
-                    declaredProperties.forEach { p ->
-                        if (p.setter != null) {
-                            propertiesAndMethods.add(p.setter!!)
-                        }
-                        if (p.getter != null){
-                            propertiesAndMethods.add(p.getter!!)
-                        }
-                    }
-
-                    return propertiesAndMethods
                 }
 
                 FieldElement::class.java -> {
@@ -786,22 +773,6 @@ internal open class KotlinClassElement(
             val elementFactory: KotlinElementFactory = visitorContext.elementFactory
             val owningClass = this@KotlinClassElement
             return when (nativeType) {
-                is KSPropertySetter -> {
-                    return KotlinPropertySetterMethodElement(
-                        owningClass,
-                        KotlinPropertyElement(owningClass, nativeType.receiver, elementAnnotationMetadataFactory, visitorContext),
-                        nativeType,
-                        elementAnnotationMetadataFactory, visitorContext
-                    )
-                }
-                is KSPropertyGetter -> {
-                    return KotlinPropertyGetterMethodElement(
-                        owningClass,
-                        nativeType,
-                        KotlinPropertyElement(owningClass, nativeType.receiver, elementAnnotationMetadataFactory, visitorContext),
-                        elementAnnotationMetadataFactory, visitorContext
-                    )
-                }
                 is KSFunctionDeclaration -> {
                     if (nativeType.isConstructor()) {
                         return elementFactory.newConstructorElement(

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinClassElement.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinClassElement.kt
@@ -714,7 +714,7 @@ internal open class KotlinClassElement(
                 }
 
                 MethodElement::class.java -> {
-                    classNode.getDeclaredFunctions()
+                    val declaredFunctions = classNode.getDeclaredFunctions()
                         .filter { func: KSFunctionDeclaration ->
                             !func.isConstructor() &&
                                     func.origin != Origin.SYNTHETIC &&
@@ -726,6 +726,19 @@ internal open class KotlinClassElement(
                                     ).contains(func.simpleName.asString())
                         }
                         .toList()
+                    val declaredProperties = classNode.getDeclaredProperties()
+                    val propertiesAndMethods = mutableListOf<KSNode>()
+                    propertiesAndMethods.addAll(declaredFunctions)
+                    declaredProperties.forEach { p ->
+                        if (p.setter != null) {
+                            propertiesAndMethods.add(p.setter!!)
+                        }
+                        if (p.getter != null){
+                            propertiesAndMethods.add(p.getter!!)
+                        }
+                    }
+
+                    return propertiesAndMethods
                 }
 
                 FieldElement::class.java -> {
@@ -773,6 +786,22 @@ internal open class KotlinClassElement(
             val elementFactory: KotlinElementFactory = visitorContext.elementFactory
             val owningClass = this@KotlinClassElement
             return when (nativeType) {
+                is KSPropertySetter -> {
+                    return KotlinPropertySetterMethodElement(
+                        owningClass,
+                        KotlinPropertyElement(owningClass, nativeType.receiver, elementAnnotationMetadataFactory, visitorContext),
+                        nativeType,
+                        elementAnnotationMetadataFactory, visitorContext
+                    )
+                }
+                is KSPropertyGetter -> {
+                    return KotlinPropertyGetterMethodElement(
+                        owningClass,
+                        nativeType,
+                        KotlinPropertyElement(owningClass, nativeType.receiver, elementAnnotationMetadataFactory, visitorContext),
+                        elementAnnotationMetadataFactory, visitorContext
+                    )
+                }
                 is KSFunctionDeclaration -> {
                     if (nativeType.isConstructor()) {
                         return elementFactory.newConstructorElement(

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinSimplePropertyElement.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinSimplePropertyElement.kt
@@ -16,6 +16,7 @@
 package io.micronaut.kotlin.processing.visitor
 
 import com.google.devtools.ksp.symbol.KSDeclaration
+import com.google.devtools.ksp.symbol.KSPropertyAccessor
 import io.micronaut.inject.ast.ArrayableClassElement
 import io.micronaut.inject.ast.ClassElement
 import io.micronaut.inject.ast.FieldElement
@@ -45,10 +46,18 @@ internal class KotlinSimplePropertyElement(
 
     override val declaration: KSDeclaration by lazy {
         val ksAnnotated = nativeType.element
-        if (ksAnnotated is KSDeclaration) {
-            ksAnnotated
-        } else {
-            throw IllegalStateException("Expected declaration got: $ksAnnotated")
+        when (ksAnnotated) {
+            is KSDeclaration -> {
+                ksAnnotated
+            }
+
+            is KSPropertyAccessor -> {
+                ksAnnotated.receiver
+            }
+
+            else -> {
+                throw IllegalStateException("Expected declaration got: $ksAnnotated")
+            }
         }
     }
 

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/aop/compile/IntroductionCompileSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/aop/compile/IntroductionCompileSpec.groovy
@@ -215,6 +215,7 @@ import jakarta.inject.Singleton
 @TestAnn
 interface MyBean {
     fun test(): Int
+    val test : Int
 }
 
 @Retention
@@ -241,5 +242,50 @@ class StubIntroduction: Interceptor<Any, Any> {
         instance instanceof Intercepted
         interceptor.invoked == 1
         result == 10
+
+        when:
+        result = instance.test
+
+        then:"the interceptor was invoked"
+        instance instanceof Intercepted
+        interceptor.invoked == 2
+        result == 10
+    }
+
+    void 'test intercept list property'() {
+        given:
+        ApplicationContext context = buildContext('''
+package introductiontest
+
+import io.micronaut.aop.*
+import jakarta.inject.Singleton
+
+@TestAnn
+interface MyBean {
+    val test : List<String>
+}
+
+@Retention
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
+@Introduction
+annotation class TestAnn
+
+@InterceptorBean(TestAnn::class)
+class StubIntroduction: Interceptor<Any, Any> {
+    override fun intercept(context: InvocationContext<Any, Any>): Any {
+        return emptyList()
+    }
+}
+''')
+        def instance = getBean(context, 'introductiontest.MyBean')
+        def interceptor = getBean(context, 'introductiontest.StubIntroduction')
+
+        when:
+        def result = instance.test
+
+        then:"the interceptor was invoked"
+        instance instanceof Intercepted
+        interceptor.invoked == 1
+        result == []
     }
 }

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/aop/compile/IntroductionCompileSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/aop/compile/IntroductionCompileSpec.groovy
@@ -271,8 +271,10 @@ interface MyBean {
 annotation class TestAnn
 
 @InterceptorBean(TestAnn::class)
-class StubIntroduction: Interceptor<Any, Any> {
-    override fun intercept(context: InvocationContext<Any, Any>): Any {
+class StubIntroduction: Interceptor<Any, List<Object>> {
+    var invoked : Boolean = false
+    override fun intercept(context: InvocationContext<Any, List<Object>>): List<Object> {
+        invoked = true
         return emptyList()
     }
 }
@@ -285,7 +287,7 @@ class StubIntroduction: Interceptor<Any, Any> {
 
         then:"the interceptor was invoked"
         instance instanceof Intercepted
-        interceptor.invoked == 1
+        interceptor.invoked
         result == []
     }
 }

--- a/inject-kotlin/src/test/kotlin/io/micronaut/kotlin/processing/aop/compile/MyClient.kt
+++ b/inject-kotlin/src/test/kotlin/io/micronaut/kotlin/processing/aop/compile/MyClient.kt
@@ -1,0 +1,17 @@
+package io.micronaut.kotlin.processing.aop.compile
+
+interface MyClient {
+    fun getUsersById(id: String): String
+
+    val users: List<String>
+}
+
+class MyClientImpl : MyClient {
+    override fun getUsersById(id: String): String {
+        return "bob"
+    }
+
+    override val users: List<String>
+        get() = listOf("Fred", "Bob")
+
+}

--- a/inject-kotlin/src/test/kotlin/io/micronaut/kotlin/processing/aop/simple/ArgMutatingInterceptor.kt
+++ b/inject-kotlin/src/test/kotlin/io/micronaut/kotlin/processing/aop/simple/ArgMutatingInterceptor.kt
@@ -12,13 +12,15 @@ class ArgMutatingInterceptor : Interceptor<Any?, Any?> {
         val m = context.synthesize(
             Mutating::class.java
         )
-        val arg = context.parameters[m.value] as MutableArgumentValue<Any>?
-        if (arg != null) {
-            val value = arg.value
-            if (value is Number) {
-                arg.setValue(value.toInt() * 2)
-            } else {
-                arg.setValue("changed")
+        if (!context.parameters.isEmpty()) {
+            val arg = context.parameters[m.value] as MutableArgumentValue<Any>?
+            if (arg != null) {
+                val value = arg.value
+                if (value is Number) {
+                    arg.setValue(value.toInt() * 2)
+                } else {
+                    arg.setValue("changed")
+                }
             }
         }
         return context.proceed()


### PR DESCRIPTION
In order for advice to apply to Groovy/Kotlin synthetic properties we need to visit these in the implementation of `@Factory`. This replicates the same logic as for introduction advice.