### PR TITLE
Wait for Netty shutdown when calling stopServerOnly

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyEmbeddedServer.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyEmbeddedServer.java
@@ -60,6 +60,7 @@ public interface NettyEmbeddedServer
     /**
      * Stops the Netty instance, but keeps the ApplicationContext running.
      * This for CRaC checkpointing purposes.
+     * This method will only return after waiting for netty to stop.
      *
      * @return The stopped NettyEmbeddedServer
      */

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
@@ -611,7 +611,7 @@ public class NettyHttpServer implements NettyEmbeddedServer {
     }
 
     private void stopInternal(boolean stopServerOnly) {
-        List<Future<?>> futures = new ArrayList<>();
+        List<Future<?>> futures = new ArrayList<>(2);
         try {
             if (shutdownParent) {
                 EventLoopGroupConfiguration parent = serverConfiguration.getParent();
@@ -656,7 +656,7 @@ public class NettyHttpServer implements NettyEmbeddedServer {
                     LOG.debug("Waiting for graceful shutdown to complete");
                 }
                 for (Future<?> future : futures) {
-                    future.await();
+                    future.awaitUninterruptibly();
                 }
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("Done...");

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
@@ -326,20 +326,20 @@ public class NettyHttpServer implements NettyEmbeddedServer {
     @Override
     @NonNull
     public synchronized NettyEmbeddedServer stop() {
-        return stop(true);
+        return stop(false);
     }
 
     @Override
     @NonNull
     public NettyEmbeddedServer stopServerOnly() {
-        return stop(false);
+        return stop(true);
     }
 
     @NonNull
-    private NettyEmbeddedServer stop(boolean stopApplicationContext) {
+    private NettyEmbeddedServer stop(boolean stopServerOnly) {
         if (isRunning() && workerGroup != null) {
             if (running.compareAndSet(true, false)) {
-                stopInternal(stopApplicationContext);
+                stopInternal(stopServerOnly);
             }
         }
         return this;
@@ -573,7 +573,7 @@ public class NettyHttpServer implements NettyEmbeddedServer {
                     LOG.error("Error starting Micronaut server: " + e.getMessage(), e);
                 }
             }
-            stopInternal(true);
+            stopInternal(false);
             throw new ServerStartupException("Unable to start Micronaut server on " + displayAddress(cfg), e);
         }
     }
@@ -604,35 +604,40 @@ public class NettyHttpServer implements NettyEmbeddedServer {
     }
 
     private void logShutdownErrorIfNecessary(Future<?> future) {
-        if (!future.isSuccess()) {
-            if (LOG.isWarnEnabled()) {
-                Throwable e = future.cause();
-                LOG.warn("Error stopping Micronaut server: " + e.getMessage(), e);
-            }
+        if (!future.isSuccess() && LOG.isWarnEnabled()) {
+            Throwable e = future.cause();
+            LOG.warn("Error stopping Micronaut server: " + e.getMessage(), e);
         }
     }
 
-    private void stopInternal(boolean stopApplicationContext) {
+    private void stopInternal(boolean stopServerOnly) {
+        List<Future<?>> futures = new ArrayList<>();
         try {
             if (shutdownParent) {
                 EventLoopGroupConfiguration parent = serverConfiguration.getParent();
                 if (parent != null) {
                     long quietPeriod = parent.getShutdownQuietPeriod().toMillis();
                     long timeout = parent.getShutdownTimeout().toMillis();
-                    parentGroup.shutdownGracefully(quietPeriod, timeout, TimeUnit.MILLISECONDS)
-                            .addListener(this::logShutdownErrorIfNecessary);
+                    futures.add(
+                        parentGroup.shutdownGracefully(quietPeriod, timeout, TimeUnit.MILLISECONDS)
+                            .addListener(this::logShutdownErrorIfNecessary)
+                    );
                 } else {
-                    parentGroup.shutdownGracefully()
-                            .addListener(this::logShutdownErrorIfNecessary);
+                    futures.add(
+                        parentGroup.shutdownGracefully()
+                            .addListener(this::logShutdownErrorIfNecessary)
+                    );
                 }
             }
             if (shutdownWorker) {
-                workerGroup.shutdownGracefully()
-                        .addListener(this::logShutdownErrorIfNecessary);
+                futures.add(
+                    workerGroup.shutdownGracefully()
+                        .addListener(this::logShutdownErrorIfNecessary)
+                );
             }
             webSocketSessions.close();
             applicationContext.getEventPublisher(ServerShutdownEvent.class).publishEvent(new ServerShutdownEvent(this));
-            if (isDefault && applicationContext.isRunning() && stopApplicationContext) {
+            if (isDefault && applicationContext.isRunning() && !stopServerOnly) {
                 applicationContext.stop();
             }
             serverConfiguration.getMultipart().getLocation().ifPresent(dir -> DiskFileUpload.baseDirectory = null);
@@ -643,6 +648,20 @@ public class NettyHttpServer implements NettyEmbeddedServer {
                 }
             }
             this.activeListeners = null;
+
+            // If we are only stopping the server, we need to wait for the futures to complete otherwise
+            // when CRaC is trying to take a snapshot it will capture objects in flow of shutting down.
+            if (stopServerOnly) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Waiting for graceful shutdown to complete");
+                }
+                for (Future<?> future : futures) {
+                    future.await();
+                }
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Done...");
+                }
+            }
         } catch (Throwable e) {
             if (LOG.isErrorEnabled()) {
                 LOG.error("Error stopping Micronaut server: " + e.getMessage(), e);


### PR DESCRIPTION
When running with CRaC, we encountered an error with Micronaut 4 running on Google Cloud Run.

Micronaut 3 apps worked as expected, but when a Micronaut 4 application was deployed to GCP it would fail to start with the error message:

```
free(): invalid pointer
```

Whilst trying to work out what was broken, I discovered that sleeping after calling `stopServerOnly` caused the deployment to pass.

I believe something has changed in Micronaut 4 that is either taking longer to close the ELG, or has some native code in it that is calling free in glibc on shutdown

The issue is that CRaC is snapshotting these objects in the process of shutting down, so on startup they continue and attempt to free memory that they no longer have ownership of.

I have no idea why the snapshotted image worked in a local docker installation, and only seemed to fail on GCP Cloud Run. I suspect the error was there in local docker, but was simply ignored by running it as --privileged

This PR fixes this by gathering the Netty promises when we shut down, and if we are calling `stopServerOnly` (ie: CRaC) then `await()` all the Futures in this list in turn before returning from `stopInternal`.

See: https://github.com/micronaut-projects/micronaut-crac/issues/156