### PR TITLE
Update filterPatterns.adoc

### DIFF
--- a/src/main/docs/guide/httpServer/filters/filterPatterns.adoc
+++ b/src/main/docs/guide/httpServer/filters/filterPatterns.adoc
@@ -17,7 +17,7 @@ You can use different styles of pattern for path matching by setting `patternSty
 |customer/joy, customer/jay
 
 |`customer/*/id`
-|customer/adam/id, com/amy/id
+|customer/adam/id, customer/amy/id
 
 |`customer/**`
 |customer/adam, customer/adam/id, customer/adam/name


### PR DESCRIPTION
There is a minor typo in [6.23.1 Filter Patterns](https://docs.micronaut.io/latest/guide/#filterPatterns)
Filter pattern example `customer/*/id` matches `customer/amy/id`, not `com/amy/id`.
