### PR TITLE
fixes #9577

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,6 +41,7 @@ micronaut-validation = "4.0.0-M9"
 micronaut-rxjava2 = "2.0.0-M6"
 micronaut-rxjava3 = "3.0.0-M6"
 micronaut-reactor = "3.0.0-M7"
+micronaut-serde = "2.1.0"
 neo4j-java-driver = "1.4.5"
 selenium = "4.9.1"
 slf4j = "2.0.7"
@@ -83,6 +84,7 @@ test-boms-micronaut-validation = { module = "io.micronaut.validation:micronaut-v
 test-boms-micronaut-rxjava2 = { module = "io.micronaut.rxjava2:micronaut-rxjava2-bom", version.ref = "micronaut-rxjava2" }
 test-boms-micronaut-rxjava3 = { module = "io.micronaut.rxjava3:micronaut-rxjava3-bom", version.ref = "micronaut-rxjava3" }
 test-boms-micronaut-reactor = { module = "io.micronaut.reactor:micronaut-reactor-bom", version.ref = "micronaut-reactor" }
+test-boms-micronaut-serialisation = { module = "io.micronaut.serde:micronaut-serde-bom", version.ref = "micronaut-serde" }
 
 boms-groovy = { module = "org.apache.groovy:groovy-bom", version.ref = "managed-groovy" }
 boms-kotlin = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "managed-kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,7 +41,7 @@ micronaut-validation = "4.0.0-M9"
 micronaut-rxjava2 = "2.0.0-M6"
 micronaut-rxjava3 = "3.0.0-M6"
 micronaut-reactor = "3.0.0-M7"
-micronaut-serde = "2.1.0"
+micronaut-serde = "2.0.0"
 neo4j-java-driver = "1.4.5"
 selenium = "4.9.1"
 slf4j = "2.0.7"
@@ -84,7 +84,7 @@ test-boms-micronaut-validation = { module = "io.micronaut.validation:micronaut-v
 test-boms-micronaut-rxjava2 = { module = "io.micronaut.rxjava2:micronaut-rxjava2-bom", version.ref = "micronaut-rxjava2" }
 test-boms-micronaut-rxjava3 = { module = "io.micronaut.rxjava3:micronaut-rxjava3-bom", version.ref = "micronaut-rxjava3" }
 test-boms-micronaut-reactor = { module = "io.micronaut.reactor:micronaut-reactor-bom", version.ref = "micronaut-reactor" }
-test-boms-micronaut-serialisation = { module = "io.micronaut.serde:micronaut-serde-bom", version.ref = "micronaut-serde" }
+test-micronaut-serialisation-serde-jackson = { module = "io.micronaut.serde:micronaut-serde-jackson", version.ref = "micronaut-serde" }
 
 boms-groovy = { module = "org.apache.groovy:groovy-bom", version.ref = "managed-groovy" }
 boms-kotlin = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "managed-kotlin" }

--- a/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
+++ b/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
@@ -400,6 +400,7 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
                         }
 
                         if (log.isTraceEnabled()) {
+                            conversionContext.getLastError().ifPresent(x -> log.trace("There is error in conversion context:", x.getCause()));
                             if (converted.isPresent()) {
                                 log.trace("Resolved value [{}] for property: {}", converted.get(), name);
                             } else {

--- a/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
+++ b/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
@@ -21,6 +21,7 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.ConversionContext;
 import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.convert.exceptions.ConversionErrorException;
 import io.micronaut.core.convert.format.MapFormat;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.naming.conventions.StringConvention;
@@ -399,8 +400,11 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
                             converted = conversionService.convert(value, conversionContext);
                         }
 
+                        conversionContext.getLastError().ifPresent(error -> {
+                            throw new ConversionErrorException(conversionContext.getArgument(), error);
+                        });
+
                         if (log.isTraceEnabled()) {
-                            conversionContext.getLastError().ifPresent(x -> log.trace("There is error in conversion context:", x.getCause()));
                             if (converted.isPresent()) {
                                 log.trace("Resolved value [{}] for property: {}", converted.get(), name);
                             } else {

--- a/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
+++ b/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
@@ -21,7 +21,6 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.ConversionContext;
 import io.micronaut.core.convert.ConversionService;
-import io.micronaut.core.convert.exceptions.ConversionErrorException;
 import io.micronaut.core.convert.format.MapFormat;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.naming.conventions.StringConvention;
@@ -399,10 +398,6 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
                         } else {
                             converted = conversionService.convert(value, conversionContext);
                         }
-
-                        conversionContext.getLastError().ifPresent(error -> {
-                            throw new ConversionErrorException(conversionContext.getArgument(), error);
-                        });
 
                         if (log.isTraceEnabled()) {
                             if (converted.isPresent()) {

--- a/json-core/build.gradle
+++ b/json-core/build.gradle
@@ -13,8 +13,7 @@ dependencies {
     testImplementation project(":inject-java")
     testImplementation project(":inject-java-test")
     testImplementation project(":inject-groovy")
-    testImplementation platform(libs.test.boms.micronaut.serialisation)
-    testImplementation("io.micronaut.serde:micronaut-serde-jackson")
+    testImplementation libs.test.micronaut.serialisation.serde.jackson
     if (!JavaVersion.current().isJava9Compatible()) {
         testImplementation files(org.gradle.internal.jvm.Jvm.current().toolsJar)
     }

--- a/json-core/build.gradle
+++ b/json-core/build.gradle
@@ -13,6 +13,8 @@ dependencies {
     testImplementation project(":inject-java")
     testImplementation project(":inject-java-test")
     testImplementation project(":inject-groovy")
+    testImplementation platform(libs.test.boms.micronaut.serialisation)
+    testImplementation("io.micronaut.serde:micronaut-serde-jackson")
     if (!JavaVersion.current().isJava9Compatible()) {
         testImplementation files(org.gradle.internal.jvm.Jvm.current().toolsJar)
     }

--- a/json-core/src/main/java/io/micronaut/json/convert/JsonConverterRegistrar.java
+++ b/json-core/src/main/java/io/micronaut/json/convert/JsonConverterRegistrar.java
@@ -27,6 +27,7 @@ import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.MutableConversionService;
 import io.micronaut.core.convert.TypeConverter;
 import io.micronaut.core.convert.TypeConverterRegistrar;
+import io.micronaut.core.convert.exceptions.ConversionErrorException;
 import io.micronaut.core.convert.value.ConvertibleValues;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.type.Argument;
@@ -176,6 +177,9 @@ public final class JsonConverterRegistrar implements TypeConverterRegistrar {
             }
             ArgumentBinder binder = this.beanPropertyBinder.get();
             ArgumentBinder.BindingResult result = binder.bind(conversionContext, correctKeys(map));
+            conversionContext.getLastError().ifPresent(error -> {
+                throw new ConversionErrorException(conversionContext.getArgument(), error);
+            });
             return result.getValue();
         };
     }

--- a/json-core/src/test/groovy/io/micronaut/json/convert/JsonConverterRegistrarSpec.groovy
+++ b/json-core/src/test/groovy/io/micronaut/json/convert/JsonConverterRegistrarSpec.groovy
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.json.convert
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.core.convert.exceptions.ConversionErrorException
+import spock.lang.Specification
+
+class JsonConverterRegistrarSpec extends Specification {
+
+    void "throw ConversionErrorException when there is problem with serialisation"() {
+
+        given:
+        ApplicationContext ctx = ApplicationContext.run([
+                'micronaut.codec.json.additional-types': ['text/javascript', 'text/json']
+        ])
+
+        when:
+        JsonConverterRegistrar registrar = ctx.getBean(JsonConverterRegistrar)
+        def converter = registrar.mapToObjectConverter()
+        Map<String, Object> jsonMap = Map.of("firstName", "test", "constraint", Map.of("type", "age", "value", "18"))
+        converter.convert(jsonMap, OuterClass.class)
+
+        then:
+        def conversionError = thrown(ConversionErrorException.class)
+        conversionError.getMessage().contains("Ensure the class is annotated with io.micronaut.core.annotation.Introspected")
+    }
+
+    @Introspected
+    static class OuterClass {
+        String firstName
+        Constraint constraint
+    }
+
+    static record Constraint(Type type, String value) {
+        enum Type {
+            AGE,
+            SEX
+        }
+    }
+
+}


### PR DESCRIPTION
- If serialisation doesn't work a `ConversionErrorException` will be thrown.

Message from a provided example:

```
Failed to convert argument [E] for value [null] due to: No deserializable introspection present for type: Constraint constraint. Consider adding Serdeable.Deserializable annotate to type Constraint constraint. Alternatively if you are not in control of the project's source code, you can use @SerdeImport(Constraint.class) to enable deserialization of this type.
```


<img width="1430" alt="image" src="https://github.com/micronaut-projects/micronaut-core/assets/44323106/6f0e753b-f27f-43e0-a242-a4bbb3ab86e7">


