### PR TITLE
Allow fallback body conversion

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/body/ImmediateByteBody.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/body/ImmediateByteBody.java
@@ -123,7 +123,8 @@ public final class ImmediateByteBody extends ManagedBody<ByteBuf> implements Byt
     public <T> ImmediateSingleObjectBody processSingle(HttpServerConfiguration configuration, MessageBodyReader<T> reader, Argument<T> type, MediaType mediaType, Headers httpHeaders) {
         ByteBuf buf = prepareClaim();
         checkLength(configuration, buf.readableBytes());
-        ByteBuffer<ByteBuf> wrapped = NettyByteBufferFactory.DEFAULT.wrap(buf);
+        // use a slice here so that, in case of failure, our buffer positions remain unaffected
+        ByteBuffer<ByteBuf> wrapped = NettyByteBufferFactory.DEFAULT.wrap(buf.slice());
         T read = reader.read(type, mediaType, httpHeaders, wrapped);
         return next(new ImmediateSingleObjectBody(read));
     }

--- a/http-server-tck/build.gradle.kts
+++ b/http-server-tck/build.gradle.kts
@@ -25,3 +25,8 @@ dependencies {
     api(libs.junit.jupiter.params)
     api(libs.managed.reactor)
 }
+micronautBuild {
+    binaryCompatibility {
+        enabled.set(false)
+    }
+}

--- a/src/main/docs/guide/httpServer/errorHandling/localErrorHandling.adoc
+++ b/src/main/docs/guide/httpServer/errorHandling/localErrorHandling.adoc
@@ -11,3 +11,8 @@ snippet::io.micronaut.docs.server.json.PersonController[tags="statusError", inde
 <1> The api:http.annotation.Error[] declares which api:http.HttpStatus[] error code to handle (in this case 404)
 <2> A api:http.hateoas.JsonError[] instance is returned for all 404 responses
 <3> An api:http.HttpStatus#NOT_FOUND[] response is returned
+
+Similar to other controller methods, error handlers can use <<binding, request binding annotations>> on parameters e.g.
+to access header values. However, binding the request body comes with additional restrictions depending on the HTTP
+server implementation used. If the body has already been bound to a parameter of the original controller method, it may
+not be possible to bind the body to a different type, as the original bytes may already have been discarded.


### PR DESCRIPTION
When ImmediateByteBody.processSingle fails, e.g. because of a json syntax error, the body is not "claimed". This patch makes sure the buffer position is also unchanged. This allows binding the body in an error controller to a different type, e.g. `@Body String rawBody`.

It would also be simple to allow access to this body through request.getBody, simply by implementing support for ImmediateByteBody in that method, completely fixing #9583. However my concern with this is that it would also allow this access through getBody e.g. in filters, where the body is sometimes but not always available immediately. Requiring the use of the argument binder allows that binder to handle the streaming case properly by buffering the request body. This ensures the same code will work for both immediate and streaming requests, and won't just fail in production when the streaming case is hit.

Fixes #9583