### PR TITLE
Guard against FullHttpResponse in StreamingOutboundHandler

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/PipeliningServerHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/PipeliningServerHandler.java
@@ -788,6 +788,9 @@ public final class PipeliningServerHandler extends ChannelInboundHandlerAdapter 
 
         StreamingOutboundHandler(OutboundAccess outboundAccess, HttpResponse initialMessage) {
             super(outboundAccess);
+            if (initialMessage instanceof FullHttpResponse) {
+                throw new IllegalArgumentException("Cannot have a full response as the initial message of a streaming response");
+            }
             this.outboundAccess = outboundAccess;
             this.initialMessage = Objects.requireNonNull(initialMessage, "initialMessage");
         }


### PR DESCRIPTION
This is just defensive programming. I don't know if this can be hit.