### PR TITLE
Fix reentrancy in PipeliningServerHandler#writeSome

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/PipeliningServerHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/PipeliningServerHandler.java
@@ -131,6 +131,10 @@ public final class PipeliningServerHandler extends ChannelInboundHandlerAdapter 
      * {@code true} iff we should flush on {@link #channelReadComplete}.
      */
     private boolean flushPending = false;
+    /**
+     * {@code true} inside {@link #writeSome()} to avoid reentrancy.
+     */
+    private boolean writing = false;
 
     public PipeliningServerHandler(RequestHandler requestHandler) {
         this.requestHandler = requestHandler;
@@ -265,23 +269,32 @@ public final class PipeliningServerHandler extends ChannelInboundHandlerAdapter 
      * Write some data if possible.
      */
     private void writeSome() {
-        while (ctx.channel().isWritable()) {
-            // if we have no outboundHandler, check whether the first queued response is ready
-            if (outboundHandler == null) {
-                OutboundAccess next = outboundQueue.peek();
-                if (next != null && next.handler != null) {
-                    outboundQueue.poll();
-                    outboundHandler = next.handler;
-                } else {
-                    return;
+        if (writing) {
+            // already inside writeSome
+            return;
+        }
+        writing = true;
+        try {
+            while (ctx.channel().isWritable()) {
+                // if we have no outboundHandler, check whether the first queued response is ready
+                if (outboundHandler == null) {
+                    OutboundAccess next = outboundQueue.peek();
+                    if (next != null && next.handler != null) {
+                        outboundQueue.poll();
+                        outboundHandler = next.handler;
+                    } else {
+                        return;
+                    }
+                }
+                OutboundHandler oldHandler = outboundHandler;
+                oldHandler.writeSome();
+                if (outboundHandler == oldHandler) {
+                    // handler is not done yet
+                    break;
                 }
             }
-            OutboundHandler oldHandler = outboundHandler;
-            oldHandler.writeSome();
-            if (outboundHandler == oldHandler) {
-                // handler is not done yet
-                break;
-            }
+        } finally {
+            writing = false;
         }
     }
 

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/handler/PipeliningServerHandlerSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/handler/PipeliningServerHandlerSpec.groovy
@@ -23,6 +23,7 @@ import io.netty.handler.codec.http.HttpResponseStatus
 import io.netty.handler.codec.http.HttpVersion
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Sinks
+import spock.lang.Issue
 import spock.lang.Specification
 
 import java.nio.charset.StandardCharsets
@@ -197,6 +198,7 @@ class PipeliningServerHandlerSpec extends Specification {
         ch.readOutbound() == null
     }
 
+    @Issue('https://github.com/micronaut-projects/micronaut-core/issues/9366')
     def 'nested write'() {
         given:
         def mon = new MonitorHandler()


### PR DESCRIPTION
writeSome is called when the channel writability changes, but it can in turn change the channel writability. This can lead to reentrancy (writeSome called inside writeSome), which can lead to duplicate responses.

This patch adds a simple flag to avoid reentrancy.

Fixes #9366
Fixes #9610