### PR TITLE
Allow specifying inheritance handling on core nullable annotations

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/annotation/internal/CoreNonNullTransformer.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/internal/CoreNonNullTransformer.java
@@ -17,11 +17,13 @@ package io.micronaut.inject.annotation.internal;
 
 import io.micronaut.core.annotation.AnnotationUtil;
 import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.AnnotationValueBuilder;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.inject.annotation.NamedAnnotationTransformer;
 import io.micronaut.inject.visitor.VisitorContext;
 
 import java.lang.annotation.Annotation;
+import java.lang.annotation.Inherited;
 import java.util.Collections;
 import java.util.List;
 
@@ -41,8 +43,14 @@ public class CoreNonNullTransformer implements NamedAnnotationTransformer {
 
     @Override
     public List<AnnotationValue<?>> transform(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
+        AnnotationValueBuilder<Annotation> builder = AnnotationValue.builder(AnnotationUtil.NON_NULL);
+        annotation.booleanValue("inherited").ifPresent(b -> {
+            if (Boolean.TRUE.equals(b)) {
+                builder.stereotype(AnnotationValue.builder(Inherited.class).build());
+            }
+        });
         return Collections.singletonList(
-                AnnotationValue.builder(AnnotationUtil.NON_NULL).build()
+                builder.build()
         );
     }
 }

--- a/core-processor/src/main/java/io/micronaut/inject/annotation/internal/CoreNullableTransformer.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/internal/CoreNullableTransformer.java
@@ -17,11 +17,13 @@ package io.micronaut.inject.annotation.internal;
 
 import io.micronaut.core.annotation.AnnotationUtil;
 import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.AnnotationValueBuilder;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.inject.annotation.NamedAnnotationTransformer;
 import io.micronaut.inject.visitor.VisitorContext;
 
 import java.lang.annotation.Annotation;
+import java.lang.annotation.Inherited;
 import java.util.Collections;
 import java.util.List;
 
@@ -41,8 +43,14 @@ public class CoreNullableTransformer implements NamedAnnotationTransformer {
 
     @Override
     public List<AnnotationValue<?>> transform(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
+        AnnotationValueBuilder<Annotation> builder = AnnotationValue.builder(AnnotationUtil.NULLABLE);
+        annotation.booleanValue("inherited").ifPresent(b -> {
+            if (Boolean.TRUE.equals(b)) {
+                builder.stereotype(AnnotationValue.builder(Inherited.class).build());
+            }
+        });
         return Collections.singletonList(
-                AnnotationValue.builder(AnnotationUtil.NULLABLE).build()
+                builder.build()
         );
     }
 }

--- a/core/src/main/java/io/micronaut/core/annotation/NonNull.java
+++ b/core/src/main/java/io/micronaut/core/annotation/NonNull.java
@@ -41,4 +41,10 @@ import java.lang.annotation.Target;
 @Documented
 @Nonnull
 public @interface NonNull {
+    /**
+     * Whether the nullable behaviour is inherited by subclasses or implementors in interfaces.
+     * @return True if it should be inherited (defaults to false)
+     * @since 4.1.0
+     */
+    boolean inherited() default false;
 }

--- a/core/src/main/java/io/micronaut/core/annotation/Nullable.java
+++ b/core/src/main/java/io/micronaut/core/annotation/Nullable.java
@@ -37,4 +37,10 @@ import java.lang.annotation.Target;
 @Documented
 @jakarta.annotation.Nullable
 public @interface Nullable {
+    /**
+     * Whether the nullable behaviour is inherited by subclasses or implementors in interfaces.
+     * @return True if it should be inherited (defaults to false)
+     * @since 4.1.0
+     */
+    boolean inherited() default false;
 }

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/annotation/InheritedNullableAnnotationSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/annotation/InheritedNullableAnnotationSpec.groovy
@@ -4,6 +4,65 @@ import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 
 class InheritedNullableAnnotationSpec extends AbstractTypeElementSpec {
 
+    def "setting inherited on nullable annotation"() {
+        given:
+        def introspection = buildBeanDefinition('test.ControllerImplementation', '''
+package test;
+
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Header;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.annotation.NonNull;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Controller
+class ControllerImplementation implements ControllerInterface {
+    @Get("/defined")
+    public String defined(@Nullable @Header(value = "header1") String header1) {
+        return header1;
+    }
+
+    @Override
+    public String inherited(String header1) {
+        return header1;
+    }
+
+     @Override
+    public String inherited2(String header1) {
+        return header1;
+    }
+}
+
+@Controller
+interface ControllerInterface {
+
+    @Get(value = "/inherited", produces = { "application/json" })
+    default String inherited(@Nullable(inherited=true) @Header(value = "header1") String header1) {
+        return header1;
+    }
+
+     @Get(value = "/inherited", produces = { "application/json" })
+    default String inherited2(@NonNull(inherited=true) @Header(value = "header1") String header1) {
+        return header1;
+    }
+}
+''')
+        def definedArgument = introspection.findMethod('defined', String).get().arguments.first()
+        def inheritedArgument = introspection.findMethod('inherited', String).get().arguments.first()
+        def inheritedArgument2 = introspection.findMethod('inherited2', String).get().arguments.first()
+
+        expect:
+        definedArgument.isNullable()
+        inheritedArgument.isNullable()
+        inheritedArgument2.isNonNull()
+    }
+
     def "custom inherited nullable annotations can be defined and used"() {
         given:
         def introspection = buildBeanDefinition('test.ControllerImplementation', '''


### PR DESCRIPTION
Currently there is no way to control if our core nullable / non-null annotations are inherited when implementing interfaces / subclassing. This means that in the OpenAPI generator gradle/maven plugins require a custom `HardNullable` annotation to be generated. This PR adds a new member `inherited` that allows specifying whether the annotation should be inherited, removing the need for a custom annotation.