### PR TITLE
move Async validation to processor module

### DIFF
--- a/context/build.gradle
+++ b/context/build.gradle
@@ -9,7 +9,6 @@ dependencies {
     api project(':aop')
 
     compileOnly project(':core-reactive')
-    compileOnly project(':core-processor')
     compileOnly libs.log4j
     compileOnly libs.logback.classic
 

--- a/context/src/main/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
+++ b/context/src/main/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
@@ -1,2 +1,0 @@
-io.micronaut.scheduling.async.validation.AsyncTypeElementVisitor
-

--- a/core-processor/build.gradle
+++ b/core-processor/build.gradle
@@ -12,7 +12,6 @@ dependencies {
         exclude group:'org.javassist', module:'javassist'
         exclude group:'com.google.guava', module:'guava'
     }
-    implementation project(":context")
     implementation project(":core-reactive")
 
     compileOnly libs.managed.kotlin.stdlib.jdk8

--- a/core-processor/build.gradle
+++ b/core-processor/build.gradle
@@ -3,6 +3,7 @@ plugins {
 }
 
 dependencies {
+
     api project(":inject")
     api project(":aop")
     api libs.asm.tree
@@ -11,6 +12,8 @@ dependencies {
         exclude group:'org.javassist', module:'javassist'
         exclude group:'com.google.guava', module:'guava'
     }
+    implementation project(":context")
+    implementation project(":core-reactive")
 
     compileOnly libs.managed.kotlin.stdlib.jdk8
 }

--- a/core-processor/src/main/java/io/micronaut/validation/visitor/AsyncTypeElementVisitor.java
+++ b/core-processor/src/main/java/io/micronaut/validation/visitor/AsyncTypeElementVisitor.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.scheduling.async.validation;
+package io.micronaut.validation.visitor.async;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;

--- a/core-processor/src/main/java/io/micronaut/validation/visitor/async/AsyncTypeElementVisitor.java
+++ b/core-processor/src/main/java/io/micronaut/validation/visitor/async/AsyncTypeElementVisitor.java
@@ -22,19 +22,26 @@ import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.MethodElement;
 import io.micronaut.inject.visitor.TypeElementVisitor;
 import io.micronaut.inject.visitor.VisitorContext;
-import io.micronaut.scheduling.annotation.Async;
 import org.reactivestreams.Publisher;
 
+import java.util.Set;
 import java.util.concurrent.CompletionStage;
 
 /**
- * A {@link TypeElementVisitor} that validates methods annotated with {@link Async} return void or futures.
+ * A {@link TypeElementVisitor} that validates methods annotated with {@code @˚Async} return void or futures.
  *
  * @author graemerocher
  * @since 1.0
  */
 @Internal
-public final class AsyncTypeElementVisitor implements TypeElementVisitor<Object, Async> {
+public final class AsyncTypeElementVisitor implements TypeElementVisitor<Object, Object> {
+
+    private static final String ANN = "io.micronaut.scheduling.annotation.Async";
+
+    @Override
+    public Set<String> getSupportedAnnotationNames() {
+        return Set.of(ANN);
+    }
 
     @NonNull
     @Override
@@ -44,14 +51,16 @@ public final class AsyncTypeElementVisitor implements TypeElementVisitor<Object,
 
     @Override
     public void visitMethod(MethodElement element, VisitorContext context) {
-        ClassElement returnType = element.getReturnType();
-        boolean isValid = returnType != null &&
+        if (element.hasDeclaredAnnotation(ANN)) {
+            ClassElement returnType = element.getReturnType();
+            boolean isValid = returnType != null &&
                 (returnType.isAssignable(CompletionStage.class) || returnType.isAssignable(void.class) ||
-                        returnType.isAssignable(Publisher.class) ||
-                        Publishers.getKnownReactiveTypes().stream().anyMatch(returnType::isAssignable));
+                    returnType.isAssignable(Publisher.class) ||
+                    Publishers.getKnownReactiveTypes().stream().anyMatch(returnType::isAssignable));
 
-        if (!isValid) {
-            context.fail("Method must return void, a Reactive Streams type or a subtype of CompletionStage", element);
+            if (!isValid) {
+                context.fail("Method must return void, a Reactive Streams type or a subtype of CompletionStage", element);
+            }
         }
     }
 }

--- a/core-processor/src/main/java/io/micronaut/validation/visitor/package-info.java
+++ b/core-processor/src/main/java/io/micronaut/validation/visitor/package-info.java
@@ -19,4 +19,4 @@
  * @author graemerocher
  * @since 1.0
  */
-package io.micronaut.scheduling.async.validation;
+package io.micronaut.validation.visitor.async;

--- a/core-processor/src/main/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
+++ b/core-processor/src/main/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
@@ -4,3 +4,4 @@ io.micronaut.context.visitor.ContextConfigurerVisitor
 io.micronaut.context.visitor.ExecutableVisitor
 io.micronaut.context.visitor.InternalApiTypeElementVisitor
 io.micronaut.context.visitor.ConfigurationReaderVisitor
+io.micronaut.validation.visitor.async.AsyncTypeElementVisitor


### PR DESCRIPTION
Micronaut is currently broken when using Eclipse or the VSCode Java tooling from Microsoft. See https://github.com/redhat-developer/vscode-java/issues/3223

It doesn't like that `AsyncTypeElementVisitor` is a compileOnly dependency of the processor and fails to compile/build the project.

Whilst this is a bug in Eclipse JDT, it may take a while to fix, so this provides a workaround