### PR TITLE
Issue 6246 - UriBuilder/UriTemplate.PATTERN_FULL_URI: Query Parameters Parsed as Part of Path - simpler approach

### DIFF
--- a/http/src/main/java/io/micronaut/http/uri/DefaultUriBuilder.java
+++ b/http/src/main/java/io/micronaut/http/uri/DefaultUriBuilder.java
@@ -130,7 +130,7 @@ class DefaultUriBuilder implements UriBuilder {
                     this.path = new StringBuilder(path);
                 }
                 if (query != null) {
-                    final Map parameters = new QueryStringDecoder(query).parameters();
+                    final Map parameters = new QueryStringDecoder(uri.toString()).parameters();
                     this.queryParams = new MutableConvertibleMultiValuesMap<>(parameters);
                 } else {
                     this.queryParams = new MutableConvertibleMultiValuesMap<>();

--- a/http/src/main/java/io/micronaut/http/uri/UriTemplate.java
+++ b/http/src/main/java/io/micronaut/http/uri/UriTemplate.java
@@ -66,9 +66,8 @@ public class UriTemplate implements Comparable<UriTemplate> {
     private static final char DOT_OPERATOR = '.';
 
     // Regex patterns that matches URIs. See RFC 3986, appendix B
-    static final Pattern PATTERN_SCHEME = Pattern.compile("^" + STRING_PATTERN_SCHEME + "//.*");
-    static final Pattern PATTERN_FULL_PATH = Pattern.compile("^([^#\\?]*)(\\?([^#]*))?(\\#(.*))?$");
-    static final Pattern PATTERN_FULL_URI = Pattern.compile(
+    private static final Pattern PATTERN_SCHEME = Pattern.compile("^" + STRING_PATTERN_SCHEME + "//.*");
+    private static final Pattern PATTERN_FULL_URI = Pattern.compile(
             "^(" + STRING_PATTERN_SCHEME + ")?" + "(//(" + STRING_PATTERN_USER_INFO + "@)?" + STRING_PATTERN_HOST + "(:" + STRING_PATTERN_PORT +
                     ")?" + ")?" + STRING_PATTERN_PATH + "(\\?" + STRING_PATTERN_QUERY + ")?" + "(#" + STRING_PATTERN_REMAINING + ")?");
 

--- a/http/src/test/groovy/io/micronaut/http/uri/UriBuilderSpec.groovy
+++ b/http/src/test/groovy/io/micronaut/http/uri/UriBuilderSpec.groovy
@@ -183,4 +183,17 @@ class UriBuilderSpec extends Specification {
         expect:
         uri == 'myurl?%24top=10&%24filter=xyz'
     }
+    
+    @Issue("https://github.com/micronaut-projects/micronaut-core/issues/6246")
+    void "test uri build parse query param"() {
+        given:
+        String stringUri = "https://google.com/search?q1=v1"
+        UriBuilder builder = UriBuilder.of(stringUri)
+
+        when:
+        builder.queryParam("q2", "v2")
+
+        then:
+        builder.build().toString() == "https://google.com/search?q1=v1&q2=v2"
+    }
 }


### PR DESCRIPTION
- separated patterns of UriBuilder from UriTemplate
- added the '?' in the STRING_PATTERN_PATH for the UriBuilder