### PR TITLE
Implement workaround for Eclipse JDT compiler

### DIFF
--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaVisitorContext.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaVisitorContext.java
@@ -185,13 +185,18 @@ public final class JavaVisitorContext implements VisitorContext, BeanElementVisi
 
     @Override
     public Optional<ClassElement> getClassElement(String name, ElementAnnotationMetadataFactory annotationMetadataFactory) {
-        TypeElement typeElement = elements.getTypeElement(name);
-        if (typeElement == null) {
-            // maybe inner class?
-            typeElement = elements.getTypeElement(name.replace('$', '.'));
+        try {
+            TypeElement typeElement = elements.getTypeElement(name);
+            if (typeElement == null) {
+                // maybe inner class?
+                typeElement = elements.getTypeElement(name.replace('$', '.'));
+            }
+            return Optional.ofNullable(typeElement)
+                .map(typeElement1 -> elementFactory.newClassElement(typeElement1, annotationMetadataFactory));
+        } catch (RuntimeException e) {
+            // can throw exception on Eclipse JDT which is braindead
+            return Optional.empty();
         }
-        return Optional.ofNullable(typeElement)
-            .map(typeElement1 -> elementFactory.newClassElement(typeElement1, annotationMetadataFactory));
     }
 
     @Override


### PR DESCRIPTION
The Eclipse JDT compiler still has issues with Micronaut's annotation processors and fails for some unknown reason throwing an AbortCompilation exception. See https://github.com/redhat-developer/vscode-java/issues/3223#issuecomment-1661641760 

This implements a workaround for the bug in the Eclipse JDT Compiler.