### PR TITLE
Fix buffer leak when proxying multipart requests

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/FormRouteCompleter.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/FormRouteCompleter.java
@@ -268,6 +268,8 @@ public final class FormRouteCompleter implements Subscriber<Object>, HttpBody {
                 unsentIncomplete = data;
                 return;
             }
+            // cancel can be called by the emitNext call, so prevent release there
+            unsentIncomplete = null;
 
             demand--;
             if (sink.tryEmitNext(data) != Sinks.EmitResult.OK) {

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/PipeliningServerHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/PipeliningServerHandler.java
@@ -901,6 +901,12 @@ public final class PipeliningServerHandler extends ChannelInboundHandlerAdapter 
 
         @Override
         void discard() {
+            // this is safe because:
+            // - onComplete/onError cannot have been called yet, because otherwise outboundHandler
+            //   would be null and discard couldn't have been called
+            // - while cancel() may trigger onComplete/onError, `removed` is true at this point, so
+            //   they won't call responseWritten in turn
+            requestHandler.responseWritten(outboundAccess.attachment);
             subscription.cancel();
             outboundHandler = null;
         }

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/ProxyStressTest.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/ProxyStressTest.groovy
@@ -1,0 +1,67 @@
+package io.micronaut.http.server.netty
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.MediaType
+import io.micronaut.http.MutableHttpResponse
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Part
+import io.micronaut.http.annotation.Post
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.ProxyHttpClient
+import io.micronaut.http.client.multipart.MultipartBody
+import io.micronaut.runtime.server.EmbeddedServer
+import jakarta.inject.Inject
+import org.reactivestreams.Publisher
+import spock.lang.Specification
+
+class ProxyStressTest extends Specification {
+    def 'proxy multipart stress test'() {
+        given:
+        def ctx = ApplicationContext.run(['spec.name': 'ProxyStressTest'])
+        def server = ctx.getBean(EmbeddedServer)
+        server.start()
+        def client = ctx.createBean(HttpClient, server.URI).toBlocking()
+
+        when:
+        for (var i = 0; i < 1000; i++) {
+            client.retrieve(HttpRequest.POST("/proxy", MultipartBody.builder()
+                    .addPart("data", "data")
+                    .addPart("testEventCode", "testEventCode"))
+                    .contentType(MediaType.MULTIPART_FORM_DATA_TYPE))
+        }
+        then:
+        true
+
+        cleanup:
+        ctx.close()
+    }
+
+    @Controller
+    @Requires(property = "spec.name", value = "ProxyStressTest")
+    static class MyController {
+        @Inject
+        ProxyHttpClient proxyHttpClient
+        @Inject
+        EmbeddedServer embeddedServer
+
+        @Post(value = "/proxy", consumes = MediaType.MULTIPART_FORM_DATA)
+        Publisher<MutableHttpResponse<?>> proxy(
+                @Part String data,
+                @Part String testEventCode,
+                HttpRequest<?> originRequest
+        ) {
+            return proxyHttpClient.proxy(originRequest.mutate()
+                    .uri(new URI(embeddedServer.URI.toString() + "/backend"))
+                    .body(MultipartBody.builder()
+                            .addPart("data", data)
+                            .addPart("accessToken", "foo")))
+        }
+
+        @Post(value = "/backend", consumes = MediaType.MULTIPART_FORM_DATA)
+        String backend() {
+            return "xyz"
+        }
+    }
+}


### PR DESCRIPTION
Two bugs here:
- The test client would close the connection after the LastHttpContent but before onComplete. This would lead to responseWritten not being called, causing a leak.
- The leak exposed a superfluous release call that happened only sometimes. When a FormRouteCompleter.Claimant is wrapped in a Mono, the Mono cancels the Claimant immediately on onNext. This caused the data to be released early.

Fixes #9677