### PR TITLE
Update external Logback config documentation

### DIFF
--- a/src/main/docs/guide/logging/loggingConfiguration.adoc
+++ b/src/main/docs/guide/logging/loggingConfiguration.adoc
@@ -14,10 +14,10 @@ The same configuration can be achieved by setting the environment variable `LOGG
 [configuration]
 ----
 logger:
-  config: custom-logback.xml
+  config: /foo/custom-logback.xml
 ----
 
-You can also set a custom Logback XML configuration file to be used via `logger.config`. Be aware that **the referenced file should be an accessible resource on your classpath**!
+You can also set a custom Logback XML configuration file to be used via `logger.config`. The file is first checked on the class path and then on the filesystem.
 
 ==== Disabling a Logger with Properties
 

--- a/src/main/docs/guide/logging/loggingConfiguration.adoc
+++ b/src/main/docs/guide/logging/loggingConfiguration.adoc
@@ -17,7 +17,8 @@ logger:
   config: /foo/custom-logback.xml
 ----
 
-You can also set a custom Logback XML configuration file to be used via `logger.config`. The file is first checked on the class path and then on the filesystem.
+You can also set a custom Logback XML configuration file to be used via `logger.config`.
+The file is first checked on the classpath and then on the file system.
 
 ==== Disabling a Logger with Properties
 


### PR DESCRIPTION
An external config file can be set via `logger.confg` since 3.8.0 (probably done as a part of #9009).