### PR TITLE
fix: JDK HTTP Client error logging on successful response

### DIFF
--- a/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/DefaultJdkHttpClient.java
+++ b/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/DefaultJdkHttpClient.java
@@ -149,9 +149,11 @@ public class DefaultJdkHttpClient extends AbstractJdkHttpClient implements JdkHt
             })
             .flatMap(Mono::fromCompletionStage)
             .map(netResponse -> {
-                log.error("Client {} Received HTTP Response: {} {}", clientId, netResponse.statusCode(), netResponse.uri());
                 boolean errorStatus = netResponse.statusCode() >= 400;
                 if (errorStatus && configuration.isExceptionOnErrorStatus()) {
+                    if (log.isErrorEnabled()) {
+                        log.error("Client {} Received HTTP Response: {} {}", clientId, netResponse.statusCode(), netResponse.uri());
+                    }
                     throw HttpClientExceptionUtils.populateServiceId(new HttpClientResponseException(HttpStatus.valueOf(netResponse.statusCode()).getReason(),
                         response(netResponse, bodyType)), clientId, configuration);
                 }

--- a/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/DefaultJdkHttpClient.java
+++ b/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/DefaultJdkHttpClient.java
@@ -149,11 +149,11 @@ public class DefaultJdkHttpClient extends AbstractJdkHttpClient implements JdkHt
             })
             .flatMap(Mono::fromCompletionStage)
             .map(netResponse -> {
+                if (log.isDebugEnabled()) {
+                    log.error("Client {} Received HTTP Response: {} {}", clientId, netResponse.statusCode(), netResponse.uri());
+                }
                 boolean errorStatus = netResponse.statusCode() >= 400;
                 if (errorStatus && configuration.isExceptionOnErrorStatus()) {
-                    if (log.isErrorEnabled()) {
-                        log.error("Client {} Received HTTP Response: {} {}", clientId, netResponse.statusCode(), netResponse.uri());
-                    }
                     throw HttpClientExceptionUtils.populateServiceId(new HttpClientResponseException(HttpStatus.valueOf(netResponse.statusCode()).getReason(),
                         response(netResponse, bodyType)), clientId, configuration);
                 }

--- a/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/DefaultJdkHttpClient.java
+++ b/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/DefaultJdkHttpClient.java
@@ -150,7 +150,7 @@ public class DefaultJdkHttpClient extends AbstractJdkHttpClient implements JdkHt
             .flatMap(Mono::fromCompletionStage)
             .map(netResponse -> {
                 if (log.isDebugEnabled()) {
-                    log.error("Client {} Received HTTP Response: {} {}", clientId, netResponse.statusCode(), netResponse.uri());
+                    log.debug("Client {} Received HTTP Response: {} {}", clientId, netResponse.statusCode(), netResponse.uri());
                 }
                 boolean errorStatus = netResponse.statusCode() >= 400;
                 if (errorStatus && configuration.isExceptionOnErrorStatus()) {

--- a/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/JdkBlockingHttpClient.java
+++ b/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/JdkBlockingHttpClient.java
@@ -81,11 +81,11 @@ public class JdkBlockingHttpClient extends AbstractJdkHttpClient implements Bloc
                 log.debug("Client {} Sending HTTP Request: {}", clientId, httpRequest);
             }
             HttpResponse<byte[]> httpResponse = client.send(httpRequest, HttpResponse.BodyHandlers.ofByteArray());
+            if (log.isDebugEnabled()) {
+                log.debug("Client {} Received HTTP Response: {} {}", clientId, httpResponse.statusCode(), httpResponse.uri());
+            }
             boolean errorStatus = httpResponse.statusCode() >= 400;
             if (errorStatus && configuration.isExceptionOnErrorStatus()) {
-                if (log.isErrorEnabled()) {
-                    log.error("Client {} Received HTTP Response: {} {}", clientId, httpResponse.statusCode(), httpResponse.uri());
-                }
                 throw HttpClientExceptionUtils.populateServiceId(new HttpClientResponseException(HttpStatus.valueOf(httpResponse.statusCode()).getReason(), response(httpResponse, bodyType)), clientId, configuration);
             }
             return response(httpResponse, bodyType);


### PR DESCRIPTION
Changed to do that same as with the blocking client call.