### PR TITLE
Fix O(n²) code size in dispatchOne generation

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/AptClassWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/AptClassWriter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.beans.visitor;
+
+import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.visitor.VisitorContext;
+import org.objectweb.asm.ClassWriter;
+
+/**
+ * ClassWriter implementation that uses the visitor context for {@link #getCommonSuperClass(String, String)}.
+ */
+final class AptClassWriter extends ClassWriter {
+    private final VisitorContext visitorContext;
+
+    public AptClassWriter(int flags, VisitorContext visitorContext) {
+        super(flags);
+        this.visitorContext = visitorContext;
+    }
+
+    @Override
+    protected String getCommonSuperClass(String type1, String type2) {
+        // this is basically the same as the supermethod, just with Class.forName replaced
+
+        ClassElement cl1 = loadClass(type1);
+        ClassElement cl2 = loadClass(type1);
+        if (cl2.isAssignable(cl1)) {
+            return type1;
+        }
+        if (cl1.isAssignable(cl2)) {
+            return type2;
+        }
+        if (cl1.isInterface() || cl2.isInterface()) {
+            return "java/lang/Object";
+        } else {
+            do {
+                // type2 should always be assignable to Object, the only type where this can be empty
+                cl1 = cl1.getSuperType().orElseThrow();
+            } while (!cl2.isAssignable(cl1));
+            return cl1.getName().replace('.', '/');
+        }
+    }
+
+    private ClassElement loadClass(String binaryName) {
+        return visitorContext.getClassElement(binaryName.replace('/', '.'))
+                .orElseThrow(() -> new TypeNotPresentException(binaryName, null));
+    }
+}

--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
@@ -101,6 +101,7 @@ final class BeanIntrospectionWriter extends AbstractAnnotationMetadataWriter {
             ReflectionUtils.getRequiredInternalMethod(Collections.class, "emptyList")
     );
 
+    private final VisitorContext visitorContext;
     private final ClassWriter referenceWriter;
     private final String introspectionName;
     private final Type introspectionType;
@@ -128,9 +129,10 @@ final class BeanIntrospectionWriter extends AbstractAnnotationMetadataWriter {
     BeanIntrospectionWriter(String targetPackage, ClassElement classElement, AnnotationMetadata beanAnnotationMetadata,
                             VisitorContext visitorContext) {
         super(computeReferenceName(targetPackage, classElement.getName()), classElement, beanAnnotationMetadata, true, visitorContext);
+        this.visitorContext = visitorContext;
         final String name = classElement.getName();
         this.classElement = classElement;
-        this.referenceWriter = new ClassWriter(ClassWriter.COMPUTE_MAXS);
+        this.referenceWriter = new AptClassWriter(ClassWriter.COMPUTE_MAXS, visitorContext);
         this.introspectionName = computeShortIntrospectionName(targetPackage, name);
         this.introspectionType = getTypeReferenceForName(introspectionName);
         this.beanType = getTypeReferenceForName(name);
@@ -156,9 +158,10 @@ final class BeanIntrospectionWriter extends AbstractAnnotationMetadataWriter {
             AnnotationMetadata beanAnnotationMetadata,
             VisitorContext visitorContext) {
         super(computeReferenceName(targetPackage, generatingType) + index, originatingElement, beanAnnotationMetadata, true, visitorContext);
+        this.visitorContext = visitorContext;
         final String className = classElement.getName();
         this.classElement = classElement;
-        this.referenceWriter = new ClassWriter(ClassWriter.COMPUTE_MAXS);
+        this.referenceWriter = new AptClassWriter(ClassWriter.COMPUTE_MAXS, visitorContext);
         this.introspectionName = computeIntrospectionName(targetPackage, className);
         this.introspectionType = getTypeReferenceForName(introspectionName);
         this.beanType = getTypeReferenceForName(className);
@@ -493,7 +496,7 @@ final class BeanIntrospectionWriter extends AbstractAnnotationMetadataWriter {
     private void writeIntrospectionClass(ClassWriterOutputVisitor classWriterOutputVisitor) throws IOException {
         final Type superType = Type.getType(AbstractInitializableBeanIntrospection.class);
 
-        ClassWriter classWriter = new ClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES);
+        ClassWriter classWriter = new AptClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES, visitorContext);
         classWriter.visit(V17, ACC_SYNTHETIC | ACC_FINAL,
                 introspectionType.getInternalName(),
                 null,

--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/BeanIntrospectionWriter.java
@@ -980,7 +980,41 @@ final class BeanIntrospectionWriter extends AbstractAnnotationMetadataWriter {
         }
 
         @Override
-        public void writeDispatchOne(GeneratorAdapter writer, int index) {
+        public boolean writeDispatchOne(GeneratorAdapter writer, int methodIndex, Map<String, DispatchWriter.DispatchTargetState> stateMap) {
+            CopyConstructorDispatchState state = (CopyConstructorDispatchState) stateMap.computeIfAbsent(CopyConstructorDispatchState.KEY, k -> new CopyConstructorDispatchState(constructor, writer.newLabel()));
+            state.propertyNames.put(parameterName, methodIndex);
+            writer.goTo(state.label);
+            return false;
+        }
+    }
+
+    /**
+     * Shared implementation of {@link CopyConstructorDispatchTarget#writeDispatchOne}. <br>
+     *
+     * A non-shared copy constructor implementation would be O(n²) in the number of properties: For
+     * every property we generate a constructor call, and that constructor call has that many
+     * parameters too that all have to be loaded.<br>
+     *
+     * This shared implementation instead only generates one constructor call, and branches on each
+     * loaded property to figure out whether to copy it or to use the replacement from the
+     * {@code dispatchOne} parameter.
+     */
+    private class CopyConstructorDispatchState implements DispatchWriter.DispatchTargetState {
+        static final String KEY = CopyConstructorDispatchState.class.getName();
+
+        final MethodElement constructor;
+        final Label label;
+        final Map<String, Integer> propertyNames = new HashMap<>();
+
+        CopyConstructorDispatchState(MethodElement constructor, Label label) {
+            this.constructor = constructor;
+            this.label = label;
+        }
+
+        @Override
+        public void complete(GeneratorAdapter writer) {
+            writer.visitLabel(label);
+
             // In this case we have to do the copy constructor approach
             Set<BeanPropertyData> constructorProps = new HashSet<>();
 
@@ -993,14 +1027,9 @@ final class BeanIntrospectionWriter extends AbstractAnnotationMetadataWriter {
                 ParameterElement parameter = parameters[i];
                 String parameterName = parameter.getName();
 
-                if (this.parameterName.equals(parameterName)) {
-                    constructorArguments[i] = this;
-                    continue;
-                }
-
                 BeanPropertyData prop = beanProperties.stream()
-                        .filter(bp -> bp.name.equals(parameterName))
-                        .findAny().orElse(null);
+                    .filter(bp -> bp.name.equals(parameterName))
+                    .findAny().orElse(null);
 
                 int readDispatchIndex = prop == null ? -1 : prop.getDispatchIndex;
                 if (readDispatchIndex != -1) {
@@ -1043,26 +1072,68 @@ final class BeanIntrospectionWriter extends AbstractAnnotationMetadataWriter {
                     for (int i = 0; i < parameters.length; i++) {
                         ParameterElement parameter = parameters[i];
                         Object constructorArgument = constructorArguments[i];
+
                         boolean isPrimitive;
-                        if (constructorArgument == this) {
-                            constructorWriter.loadArg(2);
-                            isPrimitive = false;
-                        } else if (constructorArgument instanceof MethodElement readMethod) {
-                            constructorWriter.loadLocal(prevBeanTypeLocal, beanType);
-                            invokeMethod(constructorWriter, readMethod);
+                        if (constructorArgument instanceof MethodElement readMethod) {
                             isPrimitive = readMethod.getReturnType().isPrimitive();
                         } else if (constructorArgument instanceof FieldElement fieldElement) {
-                            constructorWriter.loadLocal(prevBeanTypeLocal, beanType);
-                            invokeGetField(constructorWriter, fieldElement);
                             isPrimitive = fieldElement.isPrimitive();
                         } else {
                             throw new IllegalStateException();
                         }
-                        if (isPrimitive) {
-                            if (!parameter.isPrimitive()) {
-                                pushBoxPrimitiveIfNecessary(parameter, constructorWriter);
+
+                        boolean writeNonReplaceBranch = true;
+
+                        Label endOfProperty = null;
+                        Integer target = propertyNames.get(parameter.getName());
+                        if (target != null) {
+                            // replace property with new value
+
+                            // if we're the only replaceable property, we can skip the second branch
+                            writeNonReplaceBranch = propertyNames.size() > 1;
+
+                            Label nonReplaceBranch = null;
+                            if (writeNonReplaceBranch) {
+                                nonReplaceBranch = constructorWriter.newLabel();
+                                constructorWriter.loadArg(0);
+                                constructorWriter.push(target);
+                                constructorWriter.ifICmp(GeneratorAdapter.NE, nonReplaceBranch);
                             }
-                        } else {
+
+                            constructorWriter.loadArg(2);
+                            // if the parameter is non-primitive, we share the cast with the non-replace branch
+                            if (isPrimitive) {
+                                pushCastToType(constructorWriter, parameter);
+                            }
+
+                            if (writeNonReplaceBranch) {
+                                endOfProperty = constructorWriter.newLabel();
+                                constructorWriter.goTo(endOfProperty);
+                                constructorWriter.visitLabel(nonReplaceBranch);
+                            }
+                        }
+
+                        if (writeNonReplaceBranch) {
+                            // non-replace branch
+                            if (constructorArgument instanceof MethodElement readMethod) {
+                                constructorWriter.loadLocal(prevBeanTypeLocal, beanType);
+                                invokeMethod(constructorWriter, readMethod);
+                            } else {
+                                constructorWriter.loadLocal(prevBeanTypeLocal, beanType);
+                                invokeGetField(constructorWriter, (FieldElement) constructorArgument);
+                            }
+                            if (isPrimitive) {
+                                if (!parameter.isPrimitive()) {
+                                    pushBoxPrimitiveIfNecessary(parameter, constructorWriter);
+                                }
+                            }
+                        }
+
+                        if (endOfProperty != null) {
+                            constructorWriter.visitLabel(endOfProperty);
+                        }
+
+                        if (!isPrimitive) {
                             pushCastToType(constructorWriter, parameter);
                         }
                     }
@@ -1108,21 +1179,11 @@ final class BeanIntrospectionWriter extends AbstractAnnotationMetadataWriter {
                     }
                     writer.loadLocal(beanTypeLocal, beanType);
                 }
+                writer.returnValue();
             } else {
                 // In this case the bean cannot be mutated via either copy constructor or setter so simply throw an exception
                 writer.throwException(Type.getType(UnsupportedOperationException.class), nonMutableMessage);
             }
-        }
-
-        @NonNull
-        private ClassElement invokeMethod(GeneratorAdapter mutateMethod, MethodElement method) {
-            ClassElement returnType = method.getReturnType();
-            if (classElement.isInterface()) {
-                mutateMethod.invokeInterface(beanType, new Method(method.getName(), getMethodDescriptor(returnType, Arrays.asList(method.getParameters()))));
-            } else {
-                mutateMethod.invokeVirtual(beanType, new Method(method.getName(), getMethodDescriptor(returnType, Arrays.asList(method.getParameters()))));
-            }
-            return returnType;
         }
 
         private void invokeGetField(GeneratorAdapter mutateMethod, FieldElement field) {


### PR DESCRIPTION
Copy constructor generation was O(n²) in the number of properties, which could easily hit method size limits for dispatchOne. This patch replaces the O(n²) implementation with O(n), at the cost of branching for each property.

Another alternative would be to load all properties into constants and then use a tableswitch to replace the one changed property. But in my opinion this is not worth the effort, since perf will be about the same for small copies and with large copies, the bottleneck will be elsewhere.

It may also be worth investigating other bytecode size reductions. Even after this patch, the class size of the `Massive` introspection is still around 64K bytes. For example, the static initializer seems to be calling `Argument.of` twice for each property.

Fixes #9651