### PR TITLE
Another HTTP filters refactoring

### DIFF
--- a/http-client-core/src/main/java/io/micronaut/http/client/filter/DefaultHttpClientFilterResolver.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/filter/DefaultHttpClientFilterResolver.java
@@ -26,6 +26,7 @@ import io.micronaut.core.order.OrderUtil;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
+import io.micronaut.core.util.Toggleable;
 import io.micronaut.http.HttpMethod;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.annotation.ClientFilter;
@@ -94,7 +95,7 @@ public class DefaultHttpClientFilterResolver extends BaseFilterProcessor<ClientF
         List<GenericHttpFilter> filterList = new ArrayList<>(filterEntries.size());
         for (FilterEntry filterEntry : filterEntries) {
             final GenericHttpFilter filter = filterEntry.getFilter();
-            if (filter instanceof GenericHttpFilter.AroundLegacy al && !al.isEnabled()) {
+            if (filter instanceof Toggleable toggleable && !toggleable.isEnabled()) {
                 continue;
             }
             if (matchesFilterEntry(method, requestPath, filterEntry)) {
@@ -167,7 +168,7 @@ public class DefaultHttpClientFilterResolver extends BaseFilterProcessor<ClientF
         FilterPatternStyle patternStyle = annotationMetadata.enumValue(Filter.class,
             "patternStyle", FilterPatternStyle.class).orElse(FilterPatternStyle.ANT);
         return new ClientFilterEntry(
-            new GenericHttpFilter.AroundLegacy(httpClientFilter, new FilterOrder.Dynamic(OrderUtil.getOrder(annotationMetadata))),
+            GenericHttpFilter.createLegacyFilter(httpClientFilter, new FilterOrder.Dynamic(OrderUtil.getOrder(annotationMetadata))),
             annotationMetadata,
             methodsForFilter(annotationMetadata),
             patternStyle,

--- a/http-client-core/src/main/java/io/micronaut/http/client/filter/DefaultHttpClientFilterResolver.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/filter/DefaultHttpClientFilterResolver.java
@@ -26,7 +26,6 @@ import io.micronaut.core.order.OrderUtil;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
-import io.micronaut.core.util.Toggleable;
 import io.micronaut.http.HttpMethod;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.annotation.ClientFilter;
@@ -95,7 +94,7 @@ public class DefaultHttpClientFilterResolver extends BaseFilterProcessor<ClientF
         List<GenericHttpFilter> filterList = new ArrayList<>(filterEntries.size());
         for (FilterEntry filterEntry : filterEntries) {
             final GenericHttpFilter filter = filterEntry.getFilter();
-            if (filter instanceof Toggleable toggleable && !toggleable.isEnabled()) {
+            if (!GenericHttpFilter.isEnabled(filter)) {
                 continue;
             }
             if (matchesFilterEntry(method, requestPath, filterEntry)) {

--- a/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/AbstractJdkHttpClient.java
+++ b/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/AbstractJdkHttpClient.java
@@ -371,7 +371,7 @@ abstract class AbstractJdkHttpClient {
             filterResolver.resolveFilters(request, clientFilterEntries);
 
         FilterRunner.sortReverse(filters);
-        filters.add(GenericHttpFilter.terminalReactive(responsePublisher));
+        filters.add(GenericHttpFilter.terminalReactiveFilter(responsePublisher));
 
         FilterRunner runner = new FilterRunner(filters);
         return Mono.from(ReactiveExecutionFlow.fromFlow((ExecutionFlow<R>) runner.run(request)).toPublisher());

--- a/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/AbstractJdkHttpClient.java
+++ b/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/AbstractJdkHttpClient.java
@@ -371,7 +371,7 @@ abstract class AbstractJdkHttpClient {
             filterResolver.resolveFilters(request, clientFilterEntries);
 
         FilterRunner.sortReverse(filters);
-        filters.add(new GenericHttpFilter.TerminalReactive(responsePublisher));
+        filters.add(GenericHttpFilter.terminalReactive(responsePublisher));
 
         FilterRunner runner = new FilterRunner(filters);
         return Mono.from(ReactiveExecutionFlow.fromFlow((ExecutionFlow<R>) runner.run(request)).toPublisher());

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -1224,7 +1224,7 @@ public class DefaultHttpClient implements
         }
 
         FilterRunner.sortReverse(filters);
-        filters.add(GenericHttpFilter.terminalReactive(responsePublisher));
+        filters.add(GenericHttpFilter.terminalReactiveFilter(responsePublisher));
 
         FilterRunner runner = new FilterRunner(filters);
         Mono<R> responseMono = Mono.from(ReactiveExecutionFlow.fromFlow((ExecutionFlow<R>) runner.run(request)).toPublisher());

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -987,7 +987,7 @@ public class DefaultHttpClient implements
 
         // apply filters
         streamResponsePublisher = Flux.from(
-                applyFilterToResponsePublisher(parentRequest, request, requestURI, requestWrapper, streamResponsePublisher)
+                applyFilterToResponsePublisher(parentRequest, request, requestURI, streamResponsePublisher)
         );
 
         return streamResponsePublisher;
@@ -1018,7 +1018,6 @@ public class DefaultHttpClient implements
                                     request,
                                     requestWrapper.get(),
                                     requestURI,
-                                    requestWrapper,
                                     (Publisher) proxyResponsePublisher
                             )
                     );
@@ -1118,7 +1117,6 @@ public class DefaultHttpClient implements
             parentRequest,
             request,
             requestURI,
-            requestWrapper,
             responsePublisher
         );
         Flux<io.micronaut.http.HttpResponse<O>> finalReactiveSequence = Flux.from(finalPublisher);
@@ -1204,16 +1202,14 @@ public class DefaultHttpClient implements
             io.micronaut.http.HttpRequest<?> parentRequest,
             io.micronaut.http.HttpRequest<I> request,
             URI requestURI,
-            AtomicReference<MutableHttpRequest<?>> requestWrapper,
             Publisher<R> responsePublisher) {
 
-        if (!(request instanceof MutableHttpRequest mutRequest)) {
+        if (!(request instanceof MutableHttpRequest<?> mutRequest)) {
             return responsePublisher;
         }
 
         mutRequest.uri(requestURI);
-        if (informationalServiceId != null &&
-            !mutRequest.getAttribute(HttpAttributes.SERVICE_ID).isPresent()) {
+        if (informationalServiceId != null && mutRequest.getAttribute(HttpAttributes.SERVICE_ID).isEmpty()) {
 
             mutRequest.setAttribute(HttpAttributes.SERVICE_ID, informationalServiceId);
         }
@@ -1223,12 +1219,12 @@ public class DefaultHttpClient implements
         if (parentRequest != null) {
             // todo: migrate to new filter
             filters.add(
-                new GenericHttpFilter.AroundLegacy(new ClientServerContextFilter(parentRequest),
-                new FilterOrder.Fixed(Ordered.HIGHEST_PRECEDENCE)));
+                GenericHttpFilter.createLegacyFilter(new ClientServerContextFilter(parentRequest), new FilterOrder.Fixed(Ordered.HIGHEST_PRECEDENCE))
+            );
         }
 
         FilterRunner.sortReverse(filters);
-        filters.add(new GenericHttpFilter.TerminalReactive(responsePublisher));
+        filters.add(GenericHttpFilter.terminalReactive(responsePublisher));
 
         FilterRunner runner = new FilterRunner(filters);
         Mono<R> responseMono = Mono.from(ReactiveExecutionFlow.fromFlow((ExecutionFlow<R>) runner.run(request)).toPublisher());

--- a/http-server/src/main/java/io/micronaut/http/server/RequestLifecycle.java
+++ b/http-server/src/main/java/io/micronaut/http/server/RequestLifecycle.java
@@ -259,10 +259,10 @@ public class RequestLifecycle {
 
         List<GenericHttpFilter> filters = new ArrayList<>(httpFilters.size() + 1);
         filters.addAll(httpFilters);
-        filters.add((GenericHttpFilter.Terminal) (request) -> {
+        filters.add(GenericHttpFilter.terminal(request -> {
             this.request = request;
             return downstream.get();
-        });
+        }));
         FilterRunner filterRunner = new FilterRunner(filters) {
             @Override
             protected ExecutionFlow<? extends HttpResponse<?>> processResponse(HttpRequest<?> request, HttpResponse<?> response, PropagatedContext propagatedContext) {

--- a/http-server/src/main/java/io/micronaut/http/server/RequestLifecycle.java
+++ b/http-server/src/main/java/io/micronaut/http/server/RequestLifecycle.java
@@ -259,7 +259,7 @@ public class RequestLifecycle {
 
         List<GenericHttpFilter> filters = new ArrayList<>(httpFilters.size() + 1);
         filters.addAll(httpFilters);
-        filters.add(GenericHttpFilter.terminal(request -> {
+        filters.add(GenericHttpFilter.terminalFilter(request -> {
             this.request = request;
             return downstream.get();
         }));

--- a/http/src/main/java/io/micronaut/http/filter/AroundLegacyFilter.java
+++ b/http/src/main/java/io/micronaut/http/filter/AroundLegacyFilter.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.filter;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.async.propagation.ReactivePropagation;
+import io.micronaut.core.execution.ExecutionFlow;
+import io.micronaut.core.propagation.PropagatedContext;
+import io.micronaut.core.util.Toggleable;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.MutableHttpRequest;
+import io.micronaut.http.MutableHttpResponse;
+import io.micronaut.http.reactive.execution.ReactiveExecutionFlow;
+import org.reactivestreams.Publisher;
+
+import java.util.function.Function;
+
+/**
+ * "Legacy" filter, i.e. filter bean that implements {@link HttpFilter}.
+ *
+ * @param bean  The filter bean
+ * @param order The filter order
+ *
+ * @author Jonas Konrad
+ * @author Denis Stepanov
+ * @since 4.2.0
+ */
+@Internal
+record AroundLegacyFilter(HttpFilter bean, FilterOrder order) implements InternalHttpFilter, Toggleable {
+
+    @Override
+    public boolean isFiltersRequest() {
+        return true;
+    }
+
+    @Override
+    public boolean isFiltersResponse() {
+        return false;
+    }
+
+    @Override
+    public ExecutionFlow<FilterContext> processRequestFilter(FilterContext context,
+                                                             Function<FilterContext, ExecutionFlow<FilterContext>> downstream) {
+        // Legacy `Publisher<HttpResponse> proceed(..)` filters are always suspended
+        FilterChainImpl chainSuspensionPoint = new FilterChainImpl(downstream, context);
+        try (PropagatedContext.Scope ignore = context.propagatedContext().propagate()) {
+            return chainSuspensionPoint.processResult(
+                bean().doFilter(context.request(), chainSuspensionPoint),
+                context.propagatedContext()
+            );
+        } catch (Exception e) {
+            return ExecutionFlow.error(e);
+        }
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return !(bean instanceof Toggleable t) || t.isEnabled();
+    }
+
+    @Override
+    public int getOrder() {
+        return order.getOrder(bean);
+    }
+
+    /**
+     * A filter chain implementation that triggers the downstream on the proceed invocation.
+     */
+    private static final class FilterChainImpl implements ClientFilterChain, ServerFilterChain {
+
+        private final Function<FilterContext, ExecutionFlow<FilterContext>> downstream;
+        private FilterContext filterContext;
+
+        private FilterChainImpl(Function<FilterContext, ExecutionFlow<FilterContext>> downstream,
+                                FilterContext filterContext) {
+            this.downstream = downstream;
+            this.filterContext = filterContext;
+        }
+
+        @Override
+        public Publisher<? extends HttpResponse<?>> proceed(MutableHttpRequest<?> request) {
+            filterContext = filterContext.withRequest(request).withPropagatedContext(PropagatedContext.find().orElse(filterContext.propagatedContext()));
+            return ReactiveExecutionFlow.fromFlow(
+                downstream.apply(filterContext).<HttpResponse<?>>map(newFilterContext -> {
+                    filterContext = newFilterContext;
+                    return newFilterContext.response();
+                })
+            ).toPublisher();
+        }
+
+        @Override
+        public Publisher<MutableHttpResponse<?>> proceed(HttpRequest<?> request) {
+            filterContext = filterContext.withRequest(request).withPropagatedContext(PropagatedContext.find().orElse(filterContext.propagatedContext()));
+            return ReactiveExecutionFlow.fromFlow(
+                downstream.apply(filterContext).<MutableHttpResponse<?>>map(newFilterContext -> {
+                    filterContext = newFilterContext;
+                    return (MutableHttpResponse<?>) newFilterContext.response();
+                })
+            ).toPublisher();
+        }
+
+        private ExecutionFlow<FilterContext> processResult(Publisher<? extends HttpResponse<?>> publisher, PropagatedContext propagatedContext) {
+            return ReactiveExecutionFlow.fromPublisher(ReactivePropagation.propagate(propagatedContext, publisher))
+                .map(httpResponse -> filterContext.withResponse(httpResponse));
+        }
+
+    }
+}

--- a/http/src/main/java/io/micronaut/http/filter/AsyncFilter.java
+++ b/http/src/main/java/io/micronaut/http/filter/AsyncFilter.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.filter;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.execution.ExecutionFlow;
+
+import java.util.concurrent.Executor;
+import java.util.function.Function;
+
+/**
+ * Wrapper around a filter that signifies the filter should be run asynchronously on the given
+ * executor. Usually from an {@link io.micronaut.scheduling.annotation.ExecuteOn} annotation.
+ *
+ * @param actual   Actual filter
+ * @param executor Executor to run the filter on
+ * @author Jonas Konrad
+ * @author Denis Stepanov
+ * @since 4.2.0
+ */
+@Internal
+record AsyncFilter(InternalHttpFilter actual, Executor executor) implements InternalHttpFilter {
+
+    @Override
+    public boolean isFiltersRequest() {
+        return actual.isFiltersRequest();
+    }
+
+    @Override
+    public boolean isFiltersResponse() {
+        return actual.isFiltersResponse();
+    }
+
+    @Override
+    public ExecutionFlow<FilterContext> processRequestFilter(FilterContext context,
+                                                             Function<FilterContext, ExecutionFlow<FilterContext>> downstream) {
+        if (isFiltersRequest()) {
+            return ExecutionFlow.async(executor, () -> actual.processRequestFilter(context, downstream));
+        }
+        return InternalHttpFilter.super.processRequestFilter(context, downstream);
+    }
+
+    @Override
+    public ExecutionFlow<FilterContext> processResponseFilter(FilterContext context, Throwable exceptionToFilter) {
+        if (isFiltersResponse()) {
+            return ExecutionFlow.async(executor, () -> actual.processResponseFilter(context, exceptionToFilter));
+        }
+        return InternalHttpFilter.super.processResponseFilter(context, exceptionToFilter);
+    }
+
+    @Override
+    public int getOrder() {
+        return actual.getOrder();
+    }
+}

--- a/http/src/main/java/io/micronaut/http/filter/BaseFilterProcessor.java
+++ b/http/src/main/java/io/micronaut/http/filter/BaseFilterProcessor.java
@@ -133,19 +133,19 @@ public abstract class BaseFilterProcessor<A extends Annotation> implements Execu
             if (method.isAnnotationPresent(RequestFilter.class)) {
                 FilterMetadata methodLevel = metadata(method, RequestFilter.class);
                 FilterMetadata combined = combineMetadata(beanLevel, methodLevel);
-                addFilter(() -> withAsync(combined, FilterRunner.prepareFilterMethod(beanContext.getConversionService(), beanContext.getBean(beanDefinition), method, false, combined.order, argumentBinderRegistry)), method, combined);
+                addFilter(() -> withAsync(combined, MethodFilter.prepareFilterMethod(beanContext.getConversionService(), beanContext.getBean(beanDefinition), method, false, combined.order, argumentBinderRegistry)), method, combined);
             }
             if (method.isAnnotationPresent(ResponseFilter.class)) {
                 FilterMetadata methodLevel = metadata(method, ResponseFilter.class);
                 FilterMetadata combined = combineMetadata(beanLevel, methodLevel);
-                addFilter(() -> withAsync(combined, FilterRunner.prepareFilterMethod(beanContext.getConversionService(), beanContext.getBean(beanDefinition), method, true, combined.order, argumentBinderRegistry)), method, combined);
+                addFilter(() -> withAsync(combined, MethodFilter.prepareFilterMethod(beanContext.getConversionService(), beanContext.getBean(beanDefinition), method, true, combined.order, argumentBinderRegistry)), method, combined);
             }
         }
     }
 
     private GenericHttpFilter withAsync(FilterMetadata metadata, GenericHttpFilter filter) {
         if (metadata.executeOn != null) {
-            return new GenericHttpFilter.Async(filter, beanContext.getBean(Executor.class, Qualifiers.byName(metadata.executeOn)));
+            return new AsyncFilter((InternalHttpFilter) filter, beanContext.getBean(Executor.class, Qualifiers.byName(metadata.executeOn)));
         } else {
             return filter;
         }

--- a/http/src/main/java/io/micronaut/http/filter/FilterContext.java
+++ b/http/src/main/java/io/micronaut/http/filter/FilterContext.java
@@ -42,7 +42,7 @@ record FilterContext(@NonNull HttpRequest<?> request,
         this(request, null, propagatedContext);
     }
 
-    public FilterContext withRequest(@NonNull HttpRequest<?> request) {
+    FilterContext withRequest(@NonNull HttpRequest<?> request) {
         if (this.request == request) {
             return this;
         }
@@ -53,16 +53,15 @@ record FilterContext(@NonNull HttpRequest<?> request,
         return new FilterContext(request, response, propagatedContext);
     }
 
-    public FilterContext withResponse(@NonNull HttpResponse<?> response) {
+    FilterContext withResponse(@NonNull HttpResponse<?> response) {
         if (this.response == response) {
             return this;
         }
         Objects.requireNonNull(response);
-        // New response should remove the failure
         return new FilterContext(request, response, propagatedContext);
     }
 
-    public FilterContext withPropagatedContext(@NonNull PropagatedContext propagatedContext) {
+    FilterContext withPropagatedContext(@NonNull PropagatedContext propagatedContext) {
         if (this.propagatedContext == propagatedContext) {
             return this;
         }

--- a/http/src/main/java/io/micronaut/http/filter/FilterContext.java
+++ b/http/src/main/java/io/micronaut/http/filter/FilterContext.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.filter;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.propagation.PropagatedContext;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+
+import java.util.Objects;
+
+/**
+ * The filter context.
+ *
+ * @param request           The request
+ * @param response          The response
+ * @param propagatedContext The propagated context
+ * @author Denis Stepanov
+ * @since 4.2.0
+ */
+@Internal
+record FilterContext(@NonNull HttpRequest<?> request,
+                     @Nullable HttpResponse<?> response,
+                     @NonNull PropagatedContext propagatedContext) {
+
+    FilterContext(HttpRequest<?> request, PropagatedContext propagatedContext) {
+        this(request, null, propagatedContext);
+    }
+
+    public FilterContext withRequest(@NonNull HttpRequest<?> request) {
+        if (this.request == request) {
+            return this;
+        }
+        if (response != null) {
+            throw new IllegalStateException("Cannot modify the request after response is set!");
+        }
+        Objects.requireNonNull(request);
+        return new FilterContext(request, response, propagatedContext);
+    }
+
+    public FilterContext withResponse(@NonNull HttpResponse<?> response) {
+        if (this.response == response) {
+            return this;
+        }
+        Objects.requireNonNull(response);
+        // New response should remove the failure
+        return new FilterContext(request, response, propagatedContext);
+    }
+
+    public FilterContext withPropagatedContext(@NonNull PropagatedContext propagatedContext) {
+        if (this.propagatedContext == propagatedContext) {
+            return this;
+        }
+        Objects.requireNonNull(propagatedContext);
+        return new FilterContext(request, response, propagatedContext);
+    }
+
+}

--- a/http/src/main/java/io/micronaut/http/filter/FilterRunner.java
+++ b/http/src/main/java/io/micronaut/http/filter/FilterRunner.java
@@ -15,48 +15,20 @@
  */
 package io.micronaut.http.filter;
 
-import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
-import io.micronaut.core.async.propagation.ReactivePropagation;
-import io.micronaut.core.async.publisher.Publishers;
-import io.micronaut.core.bind.ArgumentBinder;
-import io.micronaut.core.bind.annotation.Bindable;
-import io.micronaut.core.convert.ArgumentConversionContext;
-import io.micronaut.core.convert.ConversionContext;
-import io.micronaut.core.convert.ConversionError;
-import io.micronaut.core.convert.ConversionService;
-import io.micronaut.core.convert.exceptions.ConversionErrorException;
-import io.micronaut.core.execution.CompletableFutureExecutionFlow;
 import io.micronaut.core.execution.ExecutionFlow;
-import io.micronaut.core.execution.ImperativeExecutionFlow;
 import io.micronaut.core.order.OrderUtil;
 import io.micronaut.core.order.Ordered;
-import io.micronaut.core.propagation.MutablePropagatedContext;
 import io.micronaut.core.propagation.PropagatedContext;
-import io.micronaut.core.type.Argument;
-import io.micronaut.core.type.Executable;
-import io.micronaut.core.type.UnsafeExecutable;
-import io.micronaut.http.FullHttpRequest;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
-import io.micronaut.http.MutableHttpRequest;
 import io.micronaut.http.MutableHttpResponse;
-import io.micronaut.http.bind.RequestBinderRegistry;
-import io.micronaut.http.reactive.execution.ReactiveExecutionFlow;
-import io.micronaut.inject.ExecutableMethod;
-import org.reactivestreams.Publisher;
 
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Objects;
-import java.util.Optional;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
-import java.util.function.Function;
-import java.util.function.Predicate;
 
 /**
  * The filter runner will start processing the filters in the forward order.
@@ -76,25 +48,29 @@ import java.util.function.Predicate;
  */
 @Internal
 public class FilterRunner {
-    private static final Predicate<FilterMethodContext> FILTER_CONDITION_ALWAYS_TRUE = runner -> true;
 
     /**
      * All filters to run. Request filters are executed in order from first to last, response
      * filters in the reverse order.
      */
-    private final List<GenericHttpFilter> filters;
+    private final List<InternalHttpFilter> filters;
     private final PropagatedContext initialPropagatedContext = PropagatedContext.getOrEmpty();
 
     /**
      * Create a new filter runner, to be used only once.
      *
-     * @param filters           The filters to run
+     * @param filters The filters to run
      */
     public FilterRunner(List<GenericHttpFilter> filters) {
-        this.filters = Objects.requireNonNull(filters, "filters");
+        this.filters = Objects.requireNonNull(filters, "filters").stream().map(f -> {
+            if (f instanceof InternalHttpFilter internalHttpFilter) {
+                return internalHttpFilter;
+            }
+            throw new IllegalStateException("Unrecognized filter implementation: " + f);
+        }).toList();
     }
 
-    private static void checkOrdered(List<GenericHttpFilter> filters) {
+    private static void checkOrdered(List<? extends GenericHttpFilter> filters) {
         if (!filters.stream().allMatch(f -> f instanceof Ordered)) {
             throw new IllegalStateException("Some filters cannot be ordered: " + filters);
         }
@@ -163,10 +139,10 @@ public class FilterRunner {
     }
 
     private ExecutionFlow<HttpResponse<?>> filterRequest(FilterContext context,
-                                                         ListIterator<GenericHttpFilter> iterator) {
+                                                         ListIterator<InternalHttpFilter> iterator) {
         return filterRequest0(context, iterator)
             .flatMap(newContext -> {
-                if (newContext.response != null) {
+                if (newContext.response() != null) {
                     return filterResponse(newContext, iterator, null);
                 }
                 return ExecutionFlow.error(new IllegalStateException("Request filters didn't produce any response!"));
@@ -174,15 +150,15 @@ public class FilterRunner {
     }
 
     private ExecutionFlow<FilterContext> filterRequest0(FilterContext context,
-                                                        ListIterator<GenericHttpFilter> iterator) {
-        if (context.response != null) {
+                                                        ListIterator<InternalHttpFilter> iterator) {
+        if (context.response() != null) {
             return ExecutionFlow.just(context);
         }
         if (iterator.hasNext()) {
-            GenericHttpFilter filter = iterator.next();
-            return processRequestFilter(filter, context, newContext -> filterRequest0(newContext, iterator))
+            InternalHttpFilter filter = iterator.next();
+            return (filter.isFiltersRequest() ? filter.processRequestFilter(context, newContext -> filterRequest0(newContext, iterator)) : filterRequest0(context, iterator))
                 .onErrorResume(throwable -> {
-                    return processFailure(context.request, throwable, context.propagatedContext).map(context::withResponse)
+                    return processFailure(context.request(), throwable, context.propagatedContext()).map(context::withResponse)
                         .onErrorResume(throwable2 -> {
                             // Exception filtering scenario of the http client
                             return filterResponse(context, iterator, throwable2).map(context::withResponse);
@@ -194,851 +170,29 @@ public class FilterRunner {
     }
 
     private ExecutionFlow<HttpResponse<?>> filterResponse(FilterContext context,
-                                                          ListIterator<GenericHttpFilter> iterator,
+                                                          ListIterator<InternalHttpFilter> iterator,
                                                           @Nullable
                                                           Throwable exception) {
         if (iterator.hasPrevious()) {
             // Walk backwards and execute response filters
-            GenericHttpFilter filter = iterator.previous();
-            return processResponseFilter(filter, context, exception)
+            InternalHttpFilter filter = iterator.previous();
+            return (filter.isFiltersResponse() ? filter.processResponseFilter(context, exception) : ExecutionFlow.just(context))
                 .flatMap(newContext -> {
                     if (context != newContext) {
-                        return processResponse(newContext.request, newContext.response, newContext.propagatedContext).map(newContext::withResponse);
+                        return processResponse(newContext.request(), newContext.response(), newContext.propagatedContext()).map(newContext::withResponse);
                     }
                     return ExecutionFlow.just(newContext);
                 })
-                .onErrorResume(throwable -> processFailure(context.request, throwable, context.propagatedContext).map(context::withResponse))
-                .flatMap(newContext -> filterResponse(newContext, iterator, newContext.response == null ? exception : null));
-        } else if (context.response != null) {
-            return ExecutionFlow.just(context.response);
+                .onErrorResume(throwable -> processFailure(context.request(), throwable, context.propagatedContext()).map(context::withResponse))
+                .flatMap(newContext -> filterResponse(newContext, iterator, newContext.response() == null ? exception : null));
+        } else if (context.response() != null) {
+            return ExecutionFlow.just(context.response());
         } else if (exception != null) {
             // This scenario only applies for client filters
             // Filters didn't remap the exception to any response
             return ExecutionFlow.error(exception);
         } else {
             return ExecutionFlow.error(new IllegalStateException("No response after response filters completed!"));
-        }
-    }
-
-    @SuppressWarnings({
-        "java:S3776", // performance
-        "java:S2259", // false positive
-        "java:S1181" // this is a framework not an application
-    })
-    private ExecutionFlow<FilterContext> processRequestFilter(GenericHttpFilter filter,
-                                                              FilterContext context,
-                                                              Function<FilterContext, ExecutionFlow<FilterContext>> downstream) {
-        Executor executeOn;
-        if (filter instanceof GenericHttpFilter.Async async) {
-            executeOn = async.executor();
-            filter = async.actual();
-        } else {
-            executeOn = null;
-        }
-
-        if (filter instanceof FilterMethod<?> before) {
-            if (before.isResponseFilter) {
-                // skip filter, only used for response
-                return downstream.apply(context);
-            }
-            MutablePropagatedContext mutablePropagatedContext = MutablePropagatedContext.of(context.propagatedContext);
-            ExecutionFlow<FilterContext> filterMethodFlow;
-            InternalFilterContinuation<?> continuation;
-            if (before.isSuspended()) {
-                continuation = before.createContinuation(downstream, context, mutablePropagatedContext);
-            } else {
-                continuation = null;
-            }
-            FilterMethodContext filterMethodContext = new FilterMethodContext(
-                mutablePropagatedContext,
-                context.request,
-                context.response,
-                null,
-                continuation);
-            if (executeOn == null) {
-                try (PropagatedContext.Scope ignore = context.propagatedContext.propagate()) {
-                    filterMethodFlow = before.filter(context, filterMethodContext);
-                }
-            } else {
-                filterMethodFlow = ExecutionFlow.async(executeOn, () -> {
-                    try (PropagatedContext.Scope ignore = context.propagatedContext.propagate()) {
-                        return before.filter(context, filterMethodContext);
-                    }
-                });
-            }
-            if (before.isSuspended()) {
-                return filterMethodFlow;
-            }
-            return filterMethodFlow.flatMap(downstream);
-        } else if (filter instanceof GenericHttpFilter.AroundLegacy around) {
-            FilterChainImpl chainSuspensionPoint = new FilterChainImpl(downstream, context);
-            // Legacy `Publisher<HttpResponse> proceed(..)` filters are always suspended
-            if (executeOn == null) {
-                try (PropagatedContext.Scope ignore = context.propagatedContext.propagate()) {
-                    return chainSuspensionPoint.processResult(
-                        around.bean().doFilter(context.request, chainSuspensionPoint),
-                        context.propagatedContext
-                    );
-                } catch (Exception e) {
-                    return ExecutionFlow.error(e);
-                }
-            } else {
-                return ExecutionFlow.async(executeOn, () -> {
-                    try (PropagatedContext.Scope ignore = context.propagatedContext.propagate()) {
-                        return chainSuspensionPoint.processResult(
-                            around.bean().doFilter(context.request, chainSuspensionPoint),
-                            context.propagatedContext
-                        );
-                    } catch (Exception e) {
-                        return ExecutionFlow.error(e);
-                    }
-                });
-            }
-        } else if (filter instanceof GenericHttpFilter.Terminal terminalFilter) {
-            if (executeOn != null) {
-                throw new IllegalStateException("Async terminal filters not supported");
-            }
-            if (filter.isSuspended()) {
-                throw new IllegalStateException("Terminal filters cannot be suspended");
-            }
-            try {
-                try (PropagatedContext.Scope ignore = context.propagatedContext.propagate()) {
-                    return terminalFilter.execute(context.request).map(context::withResponse).flatMap(downstream);
-                }
-            } catch (Throwable e) {
-                return ExecutionFlow.error(e);
-            }
-        } else {
-            throw new IllegalStateException("Unknown filter: " + filter);
-        }
-    }
-
-    private ExecutionFlow<FilterContext> processResponseFilter(GenericHttpFilter filter,
-                                                               FilterContext filterContext,
-                                                               Throwable exceptionToFilter) {
-        Executor executeOn;
-        if (filter instanceof GenericHttpFilter.Async async) {
-            executeOn = async.executor();
-            filter = async.actual();
-        } else {
-            executeOn = null;
-        }
-
-        if (exceptionToFilter != null && !filter.isFiltersException()) {
-            return ExecutionFlow.just(filterContext);
-        }
-
-        if (filter instanceof FilterMethod<?> after && after.isResponseFilter) {
-            if (after.isSuspended()) {
-                return ExecutionFlow.error(new IllegalStateException("Response filter cannot have a continuation!"));
-            }
-            PropagatedContext propagatedContext = filterContext.propagatedContext;
-            MutablePropagatedContext mutablePropagatedContext = MutablePropagatedContext.of(propagatedContext);
-            FilterMethodContext filterMethodContext = new FilterMethodContext(
-                mutablePropagatedContext,
-                filterContext.request,
-                filterContext.response,
-                exceptionToFilter,
-                null);
-            if (executeOn == null) {
-                try (PropagatedContext.Scope ignore = propagatedContext.propagate()) {
-                    return after.filter(filterContext, filterMethodContext);
-                }
-            } else {
-                return ExecutionFlow.async(executeOn, () -> {
-                    try (PropagatedContext.Scope ignore = propagatedContext.propagate()) {
-                        return after.filter(filterContext, filterMethodContext);
-                    }
-                });
-            }
-        }
-        return ExecutionFlow.just(filterContext);
-    }
-
-    @Internal
-    public static <T> FilterMethod<T> prepareFilterMethod(ConversionService conversionService,
-                                                          T bean,
-                                                          ExecutableMethod<T, ?> method,
-                                                          boolean isResponseFilter,
-                                                          FilterOrder order,
-                                                          RequestBinderRegistry argumentBinderRegistry) throws IllegalArgumentException {
-        return prepareFilterMethod(conversionService, bean, method, method.getArguments(), method.getReturnType().asArgument(), isResponseFilter, order, argumentBinderRegistry);
-    }
-
-    @Internal
-    @SuppressWarnings("java:S3776") // performance
-    private static <T> FilterMethod<T> prepareFilterMethod(ConversionService conversionService,
-                                                           @Nullable T bean,
-                                                           @Nullable ExecutableMethod<T, ?> method,
-                                                           Argument<?>[] arguments,
-                                                           Argument<?> returnType,
-                                                           boolean isResponseFilter,
-                                                           FilterOrder order,
-                                                           RequestBinderRegistry argumentBinderRegistry) throws IllegalArgumentException {
-        FilterArgBinder[] fulfilled = new FilterArgBinder[arguments.length];
-        Predicate<FilterMethodContext> filterCondition = FILTER_CONDITION_ALWAYS_TRUE;
-        boolean skipOnError = isResponseFilter;
-        boolean filtersException = false;
-        boolean waitForBody = false;
-        ContinuationCreator continuationCreator = null;
-        for (int i = 0; i < arguments.length; i++) {
-            Argument<?> argument = arguments[i];
-            Class<?> argumentType = argument.getType();
-            AnnotationMetadata annotationMetadata = argument.getAnnotationMetadata();
-            if (annotationMetadata.hasStereotype(Bindable.class)) {
-                ArgumentBinder<Object, HttpRequest<?>> argumentBinder = (ArgumentBinder<Object, HttpRequest<?>>) argumentBinderRegistry.findArgumentBinder(argument).orElse(null);
-                if (argumentBinder != null) {
-                    if (argumentBinder instanceof BaseFilterProcessor.RequiresRequestBodyBinder<?>) {
-                        if (isResponseFilter) {
-                            throw new IllegalArgumentException("Cannot bind @Body in response filter method [" + method.getDescription(true) + "]");
-                        }
-                        waitForBody = true;
-                    }
-                    fulfilled[i] = ctx -> {
-                        HttpRequest<?> request = ctx.request;
-                        ArgumentConversionContext<Object> conversionContext = (ArgumentConversionContext<Object>) ConversionContext.of(argument);
-                        ArgumentBinder.BindingResult<Object> result = argumentBinder.bind(conversionContext, request);
-                        if (result.isPresentAndSatisfied()) {
-                            return result.get();
-                        } else {
-                            List<ConversionError> conversionErrors = result.getConversionErrors();
-                            if (!conversionErrors.isEmpty()) {
-                                throw new ConversionErrorException(argument, conversionErrors.get(0));
-                            } else {
-                                throw new IllegalArgumentException("Unbindable argument [" + argument + "] to method [" + method.getDescription(true) + "]");
-                            }
-                        }
-                    };
-                } else {
-                    throw new IllegalArgumentException("Unsupported binding annotation in filter method [" + method.getDescription(true) + "]: " + annotationMetadata.getAnnotationNameByStereotype(Bindable.class).orElse(null));
-                }
-            } else if (argumentType.isAssignableFrom(HttpRequest.class)) {
-                fulfilled[i] = ctx -> ctx.request;
-            } else if (argumentType.isAssignableFrom(MutableHttpRequest.class)) {
-                fulfilled[i] = ctx -> {
-                    HttpRequest<?> request = ctx.request;
-                    if (!(ctx.request instanceof MutableHttpRequest<?>)) {
-                        request = ctx.request.mutate();
-                    }
-                    return request;
-                };
-            } else if (argumentType.isAssignableFrom(MutableHttpResponse.class)) {
-                if (!isResponseFilter) {
-                    throw new IllegalArgumentException("Filter is called before the response is known, can't have a response argument");
-                }
-                fulfilled[i] = ctx -> ctx.response;
-            } else if (Throwable.class.isAssignableFrom(argumentType)) {
-                if (!isResponseFilter) {
-                    throw new IllegalArgumentException("Request filters cannot handle exceptions");
-                }
-                if (!argument.isNullable()) {
-                    filterCondition = filterCondition.and(ctx -> ctx.failure != null && argument.isInstance(ctx.failure));
-                    fulfilled[i] = ctx -> ctx.failure;
-                } else {
-                    fulfilled[i] = ctx -> {
-                        if (ctx.failure != null && argument.isInstance(ctx.failure)) {
-                            return ctx.failure;
-                        }
-                        return null;
-                    };
-                }
-                filtersException = true;
-                skipOnError = false;
-            } else if (argumentType == FilterContinuation.class) {
-                if (isResponseFilter) {
-                    throw new IllegalArgumentException("Response filters cannot use filter continuations");
-                }
-                if (continuationCreator != null) {
-                    throw new IllegalArgumentException("Only one continuation per filter is allowed");
-                }
-                Argument<?> continuationReturnType = argument.getFirstTypeVariable().orElseThrow(() -> new IllegalArgumentException("Continuations must specify generic type"));
-                if (isReactive(continuationReturnType) && continuationReturnType.getWrappedType().isAssignableFrom(MutableHttpResponse.class)) {
-                    if (isReactive(returnType)) {
-                        continuationCreator = ResultAwareReactiveContinuationImpl::new;
-                    } else {
-                        continuationCreator = ReactiveContinuationImpl::new;
-                    }
-                    fulfilled[i] = ctx -> ctx.continuation;
-                } else if (continuationReturnType.getType().isAssignableFrom(MutableHttpResponse.class)) {
-                    continuationCreator = BlockingContinuationImpl::new;
-                    fulfilled[i] = ctx -> ctx.continuation;
-                } else {
-                    throw new IllegalArgumentException("Unsupported continuation type: " + continuationReturnType);
-                }
-            } else if (argumentType == MutablePropagatedContext.class) {
-                fulfilled[i] = ctx -> ctx.mutablePropagatedContext;
-            } else {
-                throw new IllegalArgumentException("Unsupported filter argument type: " + argument);
-            }
-        }
-        if (skipOnError) {
-            filterCondition = filterCondition.and(ctx -> ctx.failure == null);
-        } else if (filterCondition == FILTER_CONDITION_ALWAYS_TRUE) {
-            filterCondition = null;
-        }
-        FilterReturnHandler returnHandler = prepareReturnHandler(conversionService, returnType, isResponseFilter, continuationCreator != null, false);
-        return new FilterMethod<>(
-            order,
-            bean,
-            method,
-            isResponseFilter,
-            fulfilled,
-            filterCondition,
-            continuationCreator,
-            filtersException,
-            waitForBody,
-            returnHandler
-        );
-    }
-
-    private static boolean isReactive(Argument<?> continuationReturnType) {
-        // Argument.isReactive doesn't work in http-validation, this is a workaround
-        return continuationReturnType.isReactive() || continuationReturnType.getType() == Publisher.class;
-    }
-
-    @SuppressWarnings({"java:S3776", "java:S3740"}) // performance
-    private static FilterReturnHandler prepareReturnHandler(ConversionService conversionService,
-                                                            Argument<?> type,
-                                                            boolean isResponseFilter,
-                                                            boolean hasContinuation,
-                                                            boolean fromOptional) throws IllegalArgumentException {
-        if (type.isOptional()) {
-            FilterReturnHandler next = prepareReturnHandler(conversionService, type.getWrappedType(), isResponseFilter, hasContinuation, true);
-            return (r, o, c) -> next.handle(r, o == null ? null : ((Optional<?>) o).orElse(null), c);
-        }
-        if (type.isVoid()) {
-            if (hasContinuation) {
-                return FilterReturnHandler.VOID_WITH_CONTINUATION;
-            } else {
-                return FilterReturnHandler.VOID;
-            }
-        }
-        boolean nullable = type.isNullable() || fromOptional;
-        if (!isResponseFilter) {
-            if (type.getType() == HttpRequest.class || type.getType() == MutableHttpRequest.class) {
-                if (hasContinuation) {
-                    throw new IllegalArgumentException("Filter method that accepts a continuation cannot return an HttpRequest");
-                }
-                if (nullable) {
-                    return FilterReturnHandler.REQUEST_NULLABLE;
-                } else {
-                    return FilterReturnHandler.REQUEST;
-                }
-            } else if (type.getType() == HttpResponse.class || type.getType() == MutableHttpResponse.class) {
-                if (nullable) {
-                    return FilterReturnHandler.FROM_REQUEST_RESPONSE_NULLABLE;
-                } else {
-                    return FilterReturnHandler.FROM_REQUEST_RESPONSE;
-                }
-            }
-        } else {
-            if (hasContinuation) {
-                throw new AssertionError();
-            }
-            if (type.getType() == HttpResponse.class || type.getType() == MutableHttpResponse.class) {
-                if (nullable) {
-                    return FilterReturnHandler.FROM_RESPONSE_RESPONSE_NULLABLE;
-                } else {
-                    return FilterReturnHandler.FROM_RESPONSE_RESPONSE;
-                }
-            }
-        }
-        if (isReactive(type)) {
-            var next = prepareReturnHandler(conversionService, type.getWrappedType(), isResponseFilter, hasContinuation, false);
-            return (context, returnValue, continuation) -> {
-                if (returnValue == null && !nullable) {
-                    return next.handle(context, null, continuation);
-                }
-                Publisher<?> publisher = ReactivePropagation.propagate(
-                    context.propagatedContext,
-                    Publishers.convertPublisher(conversionService, returnValue, Publisher.class)
-                );
-                if (continuation instanceof ResultAwareContinuation resultAwareContinuation) {
-                    return resultAwareContinuation.processResult(publisher);
-                }
-                return ReactiveExecutionFlow.fromPublisher(publisher).flatMap(v -> {
-                    try {
-                        return next.handle(context, v, continuation);
-                    } catch (Throwable e) {
-                        return ExecutionFlow.error(e);
-                    }
-                });
-            };
-        } else if (type.isAsync()) {
-            var next = prepareReturnHandler(conversionService, type.getWrappedType(), isResponseFilter, hasContinuation, false);
-            return new DelayedFilterReturnHandler(isResponseFilter, next, nullable) {
-                @Override
-                protected ExecutionFlow<?> toFlow(FilterContext context, Object returnValue, InternalFilterContinuation<?> continuation) {
-                    //noinspection unchecked
-                    return CompletableFutureExecutionFlow.just(((CompletionStage<Object>) returnValue).toCompletableFuture());
-                }
-            };
-        } else {
-            throw new IllegalArgumentException("Unsupported filter return type " + type.getType().getName());
-        }
-    }
-
-    @SuppressWarnings("java:S6218") // equals/hashCode not used
-    record FilterMethod<T>(FilterOrder order,
-                           T bean,
-                           Executable<T, ?> method,
-                           boolean isResponseFilter,
-                           FilterArgBinder[] argBinders,
-                           @Nullable
-                           Predicate<FilterMethodContext> filterCondition,
-                           ContinuationCreator continuationCreator,
-                           boolean filtersException,
-                           boolean waitForBody,
-                           FilterReturnHandler returnHandler
-    ) implements GenericHttpFilter, Ordered {
-
-        @Override
-        public boolean isSuspended() {
-            return continuationCreator != null;
-        }
-
-        @Override
-        public boolean isFiltersException() {
-            return filtersException;
-        }
-
-        @Override
-        public int getOrder() {
-            return order.getOrder(bean);
-        }
-
-        @SuppressWarnings("java:S1452")
-        public InternalFilterContinuation<?> createContinuation(Function<FilterContext, ExecutionFlow<FilterContext>> downstream,
-                                                                FilterContext filterContext,
-                                                                MutablePropagatedContext mutablePropagatedContext) {
-            return continuationCreator.create(downstream, filterContext, mutablePropagatedContext);
-        }
-
-        private ExecutionFlow<FilterContext> filter(FilterContext filterContext,
-                                                    FilterMethodContext methodContext) {
-            try {
-                if (filterCondition != null && !filterCondition.test(methodContext)) {
-                    return ExecutionFlow.just(filterContext);
-                }
-                if (waitForBody && filterContext.request instanceof FullHttpRequest<?> fhr && !fhr.isFull()) {
-                    ExecutionFlow<?> buffered = fhr.bufferContents();
-                    if (buffered != null && buffered.tryComplete() == null) {
-                        return buffered.then(() -> filter0(filterContext, methodContext));
-                    }
-                }
-                return filter0(filterContext, methodContext);
-            } catch (Throwable e) {
-                return ExecutionFlow.error(e);
-            }
-        }
-
-        private ExecutionFlow<FilterContext> filter0(FilterContext filterContext, FilterMethodContext methodContext) {
-            try {
-                Object[] args = bindArgs(methodContext);
-                Object returnValue;
-                if (method instanceof UnsafeExecutable<T, ?> unsafeExecutable) {
-                    returnValue = unsafeExecutable.invokeUnsafe(bean, args);
-                } else {
-                    returnValue = method.invoke(bean, args);
-                }
-                ExecutionFlow<FilterContext> executionFlow = returnHandler.handle(filterContext, returnValue, methodContext.continuation);
-                PropagatedContext mutatedPropagatedContext = methodContext.mutablePropagatedContext.getContext();
-                if (mutatedPropagatedContext != filterContext.propagatedContext) {
-                    executionFlow = executionFlow.map(fc -> fc.withPropagatedContext(mutatedPropagatedContext));
-                }
-                return executionFlow;
-            } catch (Throwable e) {
-                return ExecutionFlow.error(e);
-            }
-        }
-
-        private Object[] bindArgs(FilterMethodContext context) {
-            Object[] args = new Object[argBinders.length];
-            for (int i = 0; i < args.length; i++) {
-                args[i] = argBinders[i].bind(context);
-            }
-            return args;
-        }
-
-    }
-
-    private record FilterMethodContext(
-        MutablePropagatedContext mutablePropagatedContext,
-        HttpRequest<?> request,
-        @Nullable HttpResponse<?> response,
-        @Nullable Throwable failure,
-        @Nullable InternalFilterContinuation<?> continuation) {
-    }
-
-    private interface FilterArgBinder {
-        Object bind(FilterMethodContext context);
-    }
-
-    private interface FilterReturnHandler {
-        /**
-         * Void method that accepts a continuation.
-         */
-        FilterReturnHandler VOID_WITH_CONTINUATION = (filterContext, returnValue, continuation) -> ExecutionFlow.just(continuation.afterMethodContext());
-        /**
-         * Void method.
-         */
-        FilterReturnHandler VOID = (filterContext, returnValue, continuation) -> ExecutionFlow.just(filterContext);
-        /**
-         * Request handler that returns a new request.
-         */
-        FilterReturnHandler REQUEST = (filterContext, returnValue, continuation) -> ExecutionFlow.just(
-            filterContext.withRequest(
-                (HttpRequest<?>) Objects.requireNonNull(returnValue, "Returned request must not be null, or mark the method as @Nullable")
-            )
-        );
-        /**
-         * Request handler that returns a new request (nullable).
-         */
-        FilterReturnHandler REQUEST_NULLABLE = (filterContext, returnValue, continuation) -> {
-            if (returnValue == null) {
-                return ExecutionFlow.just(filterContext);
-            }
-            return ExecutionFlow.just(
-                filterContext.withRequest((HttpRequest<?>) returnValue)
-            );
-        };
-        /**
-         * Request handler that returns a response.
-         */
-        FilterReturnHandler FROM_REQUEST_RESPONSE = (filterContext, returnValue, continuation) -> {
-            // cancel request pipeline, move immediately to response handling
-            return ExecutionFlow.just(
-                filterContext
-                    .withResponse(
-                        (HttpResponse<?>) Objects.requireNonNull(returnValue, "Returned response must not be null, or mark the method as @Nullable")
-                    )
-            );
-        };
-        /**
-         * Request handler that returns a response (nullable).
-         */
-        FilterReturnHandler FROM_REQUEST_RESPONSE_NULLABLE = (filterContext, returnValue, continuation) -> {
-            if (returnValue == null) {
-                return ExecutionFlow.just(filterContext);
-            }
-            // cancel request pipeline, move immediately to response handling
-            return ExecutionFlow.just(
-                filterContext.withResponse((HttpResponse<?>) returnValue)
-            );
-        };
-        /**
-         * Response handler that returns a new response.
-         */
-        FilterReturnHandler FROM_RESPONSE_RESPONSE = (filterContext, returnValue, continuation) -> {
-            // cancel request pipeline, move immediately to response handling
-            return ExecutionFlow.just(
-                filterContext
-                    .withResponse(
-                        (HttpResponse<?>) Objects.requireNonNull(returnValue, "Returned response must not be null, or mark the method as @Nullable")
-                    )
-            );
-        };
-        /**
-         * Response handler that returns a new response (nullable).
-         */
-        FilterReturnHandler FROM_RESPONSE_RESPONSE_NULLABLE = (filterContext, returnValue, continuation) -> {
-            if (returnValue == null) {
-                return ExecutionFlow.just(filterContext);
-            }
-            // cancel request pipeline, move immediately to response handling
-            return ExecutionFlow.just(
-                filterContext.withResponse((HttpResponse<?>) returnValue)
-            );
-        };
-
-        @SuppressWarnings("java:S112")
-            // internal interface
-        ExecutionFlow<FilterContext> handle(FilterContext context,
-                                            @Nullable Object returnValue,
-                                            @Nullable InternalFilterContinuation<?> passedOnContinuation) throws Throwable;
-    }
-
-    /**
-     * The continuation creator.
-     */
-    private interface ContinuationCreator {
-
-        InternalFilterContinuation<?> create(Function<FilterContext, ExecutionFlow<FilterContext>> downstream,
-                                             FilterContext filterContext,
-                                             MutablePropagatedContext mutablePropagatedContext);
-
-    }
-
-    private abstract static class DelayedFilterReturnHandler implements FilterReturnHandler {
-        final boolean isResponseFilter;
-        final FilterReturnHandler next;
-        final boolean nullable;
-
-        private DelayedFilterReturnHandler(boolean isResponseFilter, FilterReturnHandler next, boolean nullable) {
-            this.isResponseFilter = isResponseFilter;
-            this.next = next;
-            this.nullable = nullable;
-        }
-
-        @SuppressWarnings("java:S1452")
-        protected abstract ExecutionFlow<?> toFlow(FilterContext context,
-                                                   Object returnValue,
-                                                   @Nullable InternalFilterContinuation<?> continuation);
-
-        @Override
-        public ExecutionFlow<FilterContext> handle(FilterContext context,
-                                                   @Nullable Object returnValue,
-                                                   InternalFilterContinuation<?> continuation) throws Throwable {
-            if (returnValue == null && nullable) {
-                return next.handle(context, null, continuation);
-            }
-
-            ExecutionFlow<?> delayedFlow = toFlow(context,
-                Objects.requireNonNull(returnValue, "Returned value must not be null, or mark the method as @Nullable"),
-                continuation
-            );
-            ImperativeExecutionFlow<?> doneFlow = delayedFlow.tryComplete();
-            if (doneFlow != null) {
-                if (doneFlow.getError() != null) {
-                    throw doneFlow.getError();
-                }
-                return next.handle(context, doneFlow.getValue(), continuation);
-            } else {
-                return delayedFlow.flatMap(v -> {
-                    try {
-                        return next.handle(context, v, continuation);
-                    } catch (Throwable e) {
-                        return ExecutionFlow.error(e);
-                    }
-                });
-            }
-        }
-    }
-
-    /**
-     * The internal filter continuation implementation.
-     * @param <R> The response type
-     */
-    private sealed interface InternalFilterContinuation<R> extends FilterContinuation<R> {
-
-        FilterContext afterMethodContext();
-    }
-
-    private record FilterContext(@NonNull HttpRequest<?> request,
-                                 @Nullable HttpResponse<?> response,
-                                 @NonNull PropagatedContext propagatedContext) {
-
-        FilterContext(HttpRequest<?> request, PropagatedContext propagatedContext) {
-            this(request, null, propagatedContext);
-        }
-
-        public FilterContext withRequest(@NonNull HttpRequest<?> request) {
-            if (this.request == request) {
-                return this;
-            }
-            if (response != null) {
-                throw new IllegalStateException("Cannot modify the request after response is set!");
-            }
-            Objects.requireNonNull(request);
-            return new FilterContext(request, response, propagatedContext);
-        }
-
-        public FilterContext withResponse(@NonNull HttpResponse<?> response) {
-            if (this.response == response) {
-                return this;
-            }
-            Objects.requireNonNull(response);
-            // New response should remove the failure
-            return new FilterContext(request, response, propagatedContext);
-        }
-
-        public FilterContext withPropagatedContext(@NonNull PropagatedContext propagatedContext) {
-            if (this.propagatedContext == propagatedContext) {
-                return this;
-            }
-            Objects.requireNonNull(propagatedContext);
-            return new FilterContext(request, response, propagatedContext);
-        }
-
-    }
-
-    /**
-     * The reactive continuation that processes the method return value.
-     */
-    private static final class ResultAwareReactiveContinuationImpl extends ReactiveContinuationImpl
-        implements ResultAwareContinuation<Publisher<HttpResponse<?>>> {
-
-        private ResultAwareReactiveContinuationImpl(Function<FilterContext, ExecutionFlow<FilterContext>> next,
-                                                    FilterContext filterContext,
-                                                    MutablePropagatedContext mutablePropagatedContext) {
-            super(next, filterContext, mutablePropagatedContext);
-        }
-
-        @Override
-        public ExecutionFlow<FilterContext> processResult(Publisher<HttpResponse<?>> publisher) {
-            return ReactiveExecutionFlow.fromPublisher(publisher).map(httpResponse -> filterContext.withResponse(httpResponse));
-        }
-    }
-
-    /**
-     * Continuation implementation that yields a reactive type.<br>
-     * This class implements a bunch of interfaces that it would otherwise have to create lambdas
-     * for.
-     */
-    private static sealed class ReactiveContinuationImpl implements FilterContinuation<Publisher<HttpResponse<?>>>,
-        InternalFilterContinuation<Publisher<HttpResponse<?>>> {
-
-        protected FilterContext filterContext;
-        private final Function<FilterContext, ExecutionFlow<FilterContext>> downstream;
-        private final MutablePropagatedContext mutablePropagatedContext;
-
-        private ReactiveContinuationImpl(Function<FilterContext, ExecutionFlow<FilterContext>> downstream,
-                                         FilterContext filterContext,
-                                         MutablePropagatedContext mutablePropagatedContext) {
-            this.downstream = downstream;
-            this.filterContext = filterContext;
-            this.mutablePropagatedContext = mutablePropagatedContext;
-        }
-
-        @Override
-        public FilterContinuation<Publisher<HttpResponse<?>>> request(HttpRequest<?> request) {
-            return new ReactiveContinuationImpl(downstream, filterContext.withRequest(request), mutablePropagatedContext);
-        }
-
-        @Override
-        public Publisher<HttpResponse<?>> proceed() {
-            PropagatedContext propagatedContext = filterContext.propagatedContext;
-            PropagatedContext mutatedPropagatedContext = mutablePropagatedContext.getContext();
-            if (propagatedContext != mutatedPropagatedContext) {
-                filterContext = filterContext.withPropagatedContext(mutatedPropagatedContext);
-            } else {
-                filterContext = filterContext.withPropagatedContext(PropagatedContext.find().orElse(filterContext.propagatedContext));
-            }
-            return ReactiveExecutionFlow.fromFlow(
-                downstream.apply(filterContext).<HttpResponse<?>>map(newFilterContext -> {
-                    filterContext = newFilterContext;
-                    return newFilterContext.response;
-                })
-            ).toPublisher();
-        }
-
-        @Override
-        public FilterContext afterMethodContext() {
-            return filterContext;
-        }
-    }
-
-    /**
-     * The internal continuation that processes the method result.
-     * @param <T> The continuation result.
-     */
-    private sealed interface ResultAwareContinuation<T> extends InternalFilterContinuation<T> {
-
-        ExecutionFlow<FilterContext> processResult(T result);
-
-    }
-
-    /**
-     * A filter chain implementation that triggers the downstream on the proceed invocation.
-     */
-    private static final class FilterChainImpl implements ClientFilterChain, ServerFilterChain {
-
-        private final Function<FilterContext, ExecutionFlow<FilterContext>> downstream;
-        private FilterContext filterContext;
-
-        private FilterChainImpl(Function<FilterContext, ExecutionFlow<FilterContext>> downstream,
-                                FilterContext filterContext) {
-            this.downstream = downstream;
-            this.filterContext = filterContext;
-        }
-
-        @Override
-        public Publisher<? extends HttpResponse<?>> proceed(MutableHttpRequest<?> request) {
-            filterContext = filterContext.withRequest(request).withPropagatedContext(PropagatedContext.find().orElse(filterContext.propagatedContext));
-            return ReactiveExecutionFlow.fromFlow(
-                downstream.apply(filterContext).<HttpResponse<?>>map(newFilterContext -> {
-                    filterContext = newFilterContext;
-                    return newFilterContext.response;
-                })
-            ).toPublisher();
-        }
-
-        @Override
-        public Publisher<MutableHttpResponse<?>> proceed(HttpRequest<?> request) {
-            filterContext = filterContext.withRequest(request).withPropagatedContext(PropagatedContext.find().orElse(filterContext.propagatedContext));
-            return ReactiveExecutionFlow.fromFlow(
-                downstream.apply(filterContext).<MutableHttpResponse<?>>map(newFilterContext -> {
-                    filterContext = newFilterContext;
-                    return (MutableHttpResponse<?>) newFilterContext.response;
-                })
-            ).toPublisher();
-        }
-
-        public ExecutionFlow<FilterContext> processResult(Publisher<? extends HttpResponse<?>> publisher, PropagatedContext propagatedContext) {
-            return ReactiveExecutionFlow.fromPublisher(ReactivePropagation.propagate(propagatedContext, publisher))
-                .map(httpResponse -> filterContext.withResponse(httpResponse));
-        }
-
-    }
-
-    /**
-     * Implementation of {@link FilterContinuation} for blocking calls.
-     */
-    @SuppressWarnings("java:S112") // framework code
-    private static final class BlockingContinuationImpl implements FilterContinuation<HttpResponse<?>>, InternalFilterContinuation<HttpResponse<?>> {
-
-        private final Function<FilterContext, ExecutionFlow<FilterContext>> downstream;
-        private FilterContext filterContext;
-        private final MutablePropagatedContext mutablePropagatedContext;
-
-        private BlockingContinuationImpl(Function<FilterContext, ExecutionFlow<FilterContext>> downstream,
-                                         FilterContext filterContext, MutablePropagatedContext mutablePropagatedContext) {
-            this.downstream = downstream;
-            this.filterContext = filterContext;
-            this.mutablePropagatedContext = mutablePropagatedContext;
-        }
-
-        @Override
-        public FilterContinuation<HttpResponse<?>> request(HttpRequest<?> request) {
-            filterContext = filterContext.withRequest(request);
-            PropagatedContext propagatedContext = filterContext.propagatedContext;
-            PropagatedContext mutatedPropagatedContext = mutablePropagatedContext.getContext();
-            if (propagatedContext != mutatedPropagatedContext) {
-                filterContext = filterContext.withPropagatedContext(mutatedPropagatedContext);
-            } else {
-                filterContext = filterContext.withPropagatedContext(PropagatedContext.find().orElse(filterContext.propagatedContext));
-            }
-            return new BlockingContinuationImpl(downstream, filterContext, mutablePropagatedContext);
-        }
-
-        @Override
-        public HttpResponse<?> proceed() {
-            boolean interrupted = false;
-            while (true) {
-                try {
-                    // todo: detect event loop thread
-                    filterContext = downstream.apply(filterContext).toCompletableFuture().get();
-                    if (interrupted) {
-                        Thread.currentThread().interrupt();
-                    }
-                    return filterContext.response;
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    interrupted = true;
-                } catch (ExecutionException e) {
-                    Throwable cause = e.getCause();
-                    if (cause instanceof RuntimeException re) {
-                        throw re;
-                    } else {
-                        throw new RuntimeException(cause);
-                    }
-                }
-            }
-        }
-
-        @Override
-        public FilterContext afterMethodContext() {
-            return filterContext;
         }
     }
 

--- a/http/src/main/java/io/micronaut/http/filter/FilterRunner.java
+++ b/http/src/main/java/io/micronaut/http/filter/FilterRunner.java
@@ -28,7 +28,6 @@ import io.micronaut.http.MutableHttpResponse;
 
 import java.util.List;
 import java.util.ListIterator;
-import java.util.Objects;
 
 /**
  * The filter runner will start processing the filters in the forward order.
@@ -62,12 +61,7 @@ public class FilterRunner {
      * @param filters The filters to run
      */
     public FilterRunner(List<GenericHttpFilter> filters) {
-        this.filters = Objects.requireNonNull(filters, "filters").stream().map(f -> {
-            if (f instanceof InternalHttpFilter internalHttpFilter) {
-                return internalHttpFilter;
-            }
-            throw new IllegalStateException("Unrecognized filter implementation: " + f);
-        }).toList();
+        this.filters = (List) filters; // GenericHttpFilter is sealed and all implementations implement InternalHttpFilter
     }
 
     private static void checkOrdered(List<? extends GenericHttpFilter> filters) {

--- a/http/src/main/java/io/micronaut/http/filter/GenericHttpFilter.java
+++ b/http/src/main/java/io/micronaut/http/filter/GenericHttpFilter.java
@@ -15,141 +15,71 @@
  */
 package io.micronaut.http.filter;
 
-import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.execution.ExecutionFlow;
-import io.micronaut.core.order.Ordered;
-import io.micronaut.core.util.Toggleable;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
-import io.micronaut.http.reactive.execution.ReactiveExecutionFlow;
+import io.micronaut.http.MutableHttpResponse;
 import org.reactivestreams.Publisher;
 
-import java.util.concurrent.Executor;
+import java.util.function.Function;
 
 /**
  * Base interface for different filter types. Note that while the base interface is exposed, so you
  * can pass around instances of these filters, the different implementations are internal only.
- * Only the framework should construct or call instances of this interface. The exception is the
- * {@link Terminal terminal filter}.
  *
  * @author Jonas Konrad
  * @since 4.0.0
  */
-public sealed interface GenericHttpFilter
-    permits
-    FilterRunner.FilterMethod,
-    GenericHttpFilter.AroundLegacy,
-    GenericHttpFilter.Async,
-    GenericHttpFilter.Terminal {
+public sealed interface GenericHttpFilter permits InternalHttpFilter {
 
     /**
      * When the filter is using the continuation it needs to be suspended and wait for the response.
      * @return true if suspended
+     * @deprecated Not needed anymore
      */
+    @Deprecated(forRemoval = true)
     default boolean isSuspended() {
         return false;
     }
 
     /**
      * @return true if the filter can receive the processing exception.
+     * @deprecated Not needed anymore
      */
+    @Deprecated(forRemoval = true)
     default boolean isFiltersException() {
         return false;
     }
 
     /**
-     * Wrapper around a filter that signifies the filter should be run asynchronously on the given
-     * executor. Usually from an {@link io.micronaut.scheduling.annotation.ExecuteOn} annotation.
-     *
-     * @param actual Actual filter
-     * @param executor Executor to run the filter on
+     * Create a legacy filter.
+     * @param bean The {@link HttpFilter} bean.
+     * @param order The order
+     * @return new filter
+     * @since 4.2.0
      */
-    @Internal
-    record Async(
-        GenericHttpFilter actual,
-        Executor executor
-    ) implements GenericHttpFilter, Ordered {
-
-        @Override
-        public boolean isSuspended() {
-            return actual.isSuspended();
-        }
-
-        @Override
-        public boolean isFiltersException() {
-            return actual.isFiltersException();
-        }
-
-        @Override
-        public int getOrder() {
-            return ((Ordered) actual).getOrder();
-        }
+    static GenericHttpFilter createLegacyFilter(HttpFilter bean, FilterOrder order) {
+        return new AroundLegacyFilter(bean, order);
     }
 
     /**
-     * "Legacy" filter, i.e. filter bean that implements {@link HttpFilter}.
-     *
-     * @param bean The filter bean
-     * @param order The filter order
+     * Create a terminal filter.
+     * @param fn The function that supplier {@link MutableHttpResponse} from {@link HttpRequest}.
+     * @return new terminal filter
+     * @since 4.2.0
      */
-    @Internal
-    record AroundLegacy(
-        HttpFilter bean,
-        FilterOrder order
-    ) implements GenericHttpFilter, Ordered {
-
-        @Override
-        public boolean isSuspended() {
-            // Legacy filters are always suspended
-            return true;
-        }
-
-        @Override
-        public boolean isFiltersException() {
-            // Legacy filters can filter the exception using the publisher
-            return false;
-        }
-
-        public boolean isEnabled() {
-            return !(bean instanceof Toggleable t) || t.isEnabled();
-        }
-
-        @Override
-        public int getOrder() {
-            return order.getOrder(bean);
-        }
+    static GenericHttpFilter terminal(Function<HttpRequest<?>, ExecutionFlow<MutableHttpResponse<?>>> fn) {
+        return new TerminalFilter(fn);
     }
 
     /**
-     * Terminal filter that accepts a reactive type. Used as a temporary solution for the http
-     * client, until that is un-reactified.
-     *
+     * Create a terminal reactive filter.
+     * @param responsePublisher The response publisher
+     * @return new terminal filter
+     * @since 4.2.0
      */
-    @Internal
-    final class TerminalReactive implements Terminal {
-
-        private final Publisher<? extends HttpResponse<?>> responsePublisher;
-
-        /**
-         * @param responsePublisher The response publisher
-         */
-        public TerminalReactive(Publisher<? extends HttpResponse<?>> responsePublisher) {
-            this.responsePublisher = responsePublisher;
-        }
-
-        @Override
-        public ExecutionFlow<? extends HttpResponse<?>> execute(HttpRequest<?> request) throws Exception {
-            return ReactiveExecutionFlow.fromPublisher(responsePublisher);
-        }
+    static GenericHttpFilter terminalReactive(Publisher<? extends HttpResponse<?>> responsePublisher) {
+        return new TerminalReactiveFilter(responsePublisher);
     }
 
-    /**
-     * Last item in a filter chain, called when all other filters are done. Basically, this runs
-     * the actual request.
-     */
-    @Internal
-    @FunctionalInterface
-    non-sealed interface Terminal extends GenericHttpFilter {
-        ExecutionFlow<? extends HttpResponse<?>> execute(HttpRequest<?> request) throws Exception;
-    }
 }

--- a/http/src/main/java/io/micronaut/http/filter/GenericHttpFilter.java
+++ b/http/src/main/java/io/micronaut/http/filter/GenericHttpFilter.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.http.filter;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.execution.ExecutionFlow;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
@@ -58,6 +59,7 @@ public sealed interface GenericHttpFilter permits InternalHttpFilter {
      * @return new filter
      * @since 4.2.0
      */
+    @Internal
     static GenericHttpFilter createLegacyFilter(HttpFilter bean, FilterOrder order) {
         return new AroundLegacyFilter(bean, order);
     }
@@ -68,7 +70,8 @@ public sealed interface GenericHttpFilter permits InternalHttpFilter {
      * @return new terminal filter
      * @since 4.2.0
      */
-    static GenericHttpFilter terminal(Function<HttpRequest<?>, ExecutionFlow<MutableHttpResponse<?>>> fn) {
+    @Internal
+    static GenericHttpFilter terminalFilter(Function<HttpRequest<?>, ExecutionFlow<MutableHttpResponse<?>>> fn) {
         return new TerminalFilter(fn);
     }
 
@@ -78,8 +81,20 @@ public sealed interface GenericHttpFilter permits InternalHttpFilter {
      * @return new terminal filter
      * @since 4.2.0
      */
-    static GenericHttpFilter terminalReactive(Publisher<? extends HttpResponse<?>> responsePublisher) {
+    @Internal
+    static GenericHttpFilter terminalReactiveFilter(Publisher<? extends HttpResponse<?>> responsePublisher) {
         return new TerminalReactiveFilter(responsePublisher);
+    }
+
+    /**
+     * Check if the filter is enabled.
+     * @param filter The filter
+     * @return true if enabled
+     * @since 4.2.0
+     */
+    @Internal
+    static boolean isEnabled(GenericHttpFilter filter) {
+        return !(filter instanceof AroundLegacyFilter aroundLegacyFilter) || aroundLegacyFilter.isEnabled();
     }
 
 }

--- a/http/src/main/java/io/micronaut/http/filter/HttpFilterResolver.java
+++ b/http/src/main/java/io/micronaut/http/filter/HttpFilterResolver.java
@@ -113,7 +113,7 @@ public interface HttpFilterResolver<T extends AnnotationMetadataProvider> {
             @Nullable Set<HttpMethod> methods,
             @NonNull FilterPatternStyle patternStyle, String... patterns) {
             return new DefaultFilterEntry(
-                new GenericHttpFilter.AroundLegacy(
+                GenericHttpFilter.createLegacyFilter(
                     Objects.requireNonNull(filter, "Filter cannot be null"),
                     new FilterOrder.Dynamic(OrderUtil.getOrder(annotationMetadata))),
                 annotationMetadata != null ? annotationMetadata : AnnotationMetadata.EMPTY_METADATA,

--- a/http/src/main/java/io/micronaut/http/filter/InternalHttpFilter.java
+++ b/http/src/main/java/io/micronaut/http/filter/InternalHttpFilter.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.filter;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.execution.ExecutionFlow;
+import io.micronaut.core.order.Ordered;
+
+import java.util.function.Function;
+
+/**
+ * Base interface for different filter types. Note that while the base interface is exposed, so you
+ * can pass around instances of these filters, the different implementations are internal only.
+ *
+ * @author Denis Stepanov
+ * @since 4.2.0
+ */
+@Internal
+sealed interface InternalHttpFilter extends GenericHttpFilter, Ordered permits AroundLegacyFilter, AsyncFilter, MethodFilter, TerminalFilter, TerminalReactiveFilter {
+
+    /**
+     * If the filter supports filtering a request.
+     *
+     * @return true if filters request
+     * @since 4.2.0
+     */
+    boolean isFiltersRequest();
+
+    /**
+     * If the filter supports filtering a response.
+     *
+     * @return true if filters request
+     * @since 4.2.0
+     */
+    boolean isFiltersResponse();
+
+    /**
+     * Filter request.
+     *
+     * @param context    The filter context
+     * @param downstream The downstream
+     * @return The filter execution flow
+     */
+    @NonNull
+    default ExecutionFlow<FilterContext> processRequestFilter(@NonNull FilterContext context,
+                                                              @NonNull Function<FilterContext, ExecutionFlow<FilterContext>> downstream) {
+        if (!isFiltersRequest()) {
+            throw new IllegalStateException("Filtering request is not supported!");
+        }
+        return downstream.apply(context);
+    }
+
+    /**
+     * Filter response.
+     *
+     * @param context           The filter context
+     * @param exceptionToFilter The exception to filter
+     * @return The filter execution flow
+     */
+    @NonNull
+    default ExecutionFlow<FilterContext> processResponseFilter(@NonNull FilterContext context,
+                                                               @NonNull Throwable exceptionToFilter) {
+        if (!isFiltersResponse()) {
+            throw new IllegalStateException("Filtering response is not supported!");
+        }
+        return ExecutionFlow.just(context);
+    }
+
+}

--- a/http/src/main/java/io/micronaut/http/filter/MethodFilter.java
+++ b/http/src/main/java/io/micronaut/http/filter/MethodFilter.java
@@ -1,0 +1,727 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.filter;
+
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.async.propagation.ReactivePropagation;
+import io.micronaut.core.async.publisher.Publishers;
+import io.micronaut.core.bind.ArgumentBinder;
+import io.micronaut.core.bind.annotation.Bindable;
+import io.micronaut.core.convert.ArgumentConversionContext;
+import io.micronaut.core.convert.ConversionContext;
+import io.micronaut.core.convert.ConversionError;
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.convert.exceptions.ConversionErrorException;
+import io.micronaut.core.execution.CompletableFutureExecutionFlow;
+import io.micronaut.core.execution.ExecutionFlow;
+import io.micronaut.core.execution.ImperativeExecutionFlow;
+import io.micronaut.core.propagation.MutablePropagatedContext;
+import io.micronaut.core.propagation.PropagatedContext;
+import io.micronaut.core.type.Argument;
+import io.micronaut.core.type.Executable;
+import io.micronaut.core.type.UnsafeExecutable;
+import io.micronaut.http.FullHttpRequest;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.MutableHttpRequest;
+import io.micronaut.http.MutableHttpResponse;
+import io.micronaut.http.bind.RequestBinderRegistry;
+import io.micronaut.http.reactive.execution.ReactiveExecutionFlow;
+import io.micronaut.inject.ExecutableMethod;
+import org.reactivestreams.Publisher;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * Internal implementation of {@link io.micronaut.http.annotation.ServerFilter}.
+ *
+ * @param order               The order
+ * @param bean                The bean instance
+ * @param method              The method
+ * @param isResponseFilter    If it's a response filter
+ * @param argBinders          The argument binders
+ * @param filterCondition     The filter condition
+ * @param continuationCreator The continuation creator
+ * @param filtersException    The filter exception
+ * @param waitForBody         Should it wait for the body
+ * @param returnHandler       The return handler
+ * @param <T>                 The bean type
+ * @author Jonas Konrad
+ * @author Denis Stepanov
+ * @since 4.2.0
+ */
+@SuppressWarnings("java:S6218") // equals/hashCode not used
+@Internal
+record MethodFilter<T>(FilterOrder order,
+                       T bean,
+                       Executable<T, ?> method,
+                       boolean isResponseFilter,
+                       FilterArgBinder[] argBinders,
+                       @Nullable
+                       Predicate<FilterMethodContext> filterCondition,
+                       ContinuationCreator continuationCreator,
+                       boolean filtersException,
+                       boolean waitForBody,
+                       FilterReturnHandler returnHandler
+) implements InternalHttpFilter {
+
+    private static final Predicate<FilterMethodContext> FILTER_CONDITION_ALWAYS_TRUE = runner -> true;
+
+    static <T> MethodFilter<T> prepareFilterMethod(ConversionService conversionService,
+                                                   T bean,
+                                                   ExecutableMethod<T, ?> method,
+                                                   boolean isResponseFilter,
+                                                   FilterOrder order,
+                                                   RequestBinderRegistry argumentBinderRegistry) throws IllegalArgumentException {
+        return prepareFilterMethod(conversionService, bean, method, method.getArguments(), method.getReturnType().asArgument(), isResponseFilter, order, argumentBinderRegistry);
+    }
+
+    static <T> MethodFilter<T> prepareFilterMethod(ConversionService conversionService,
+                                                   @Nullable T bean,
+                                                   @Nullable ExecutableMethod<T, ?> method,
+                                                   Argument<?>[] arguments,
+                                                   Argument<?> returnType,
+                                                   boolean isResponseFilter,
+                                                   FilterOrder order,
+                                                   RequestBinderRegistry argumentBinderRegistry) throws IllegalArgumentException {
+
+        FilterArgBinder[] fulfilled = new FilterArgBinder[arguments.length];
+        Predicate<FilterMethodContext> filterCondition = FILTER_CONDITION_ALWAYS_TRUE;
+        boolean skipOnError = isResponseFilter;
+        boolean filtersException = false;
+        boolean waitForBody = false;
+        ContinuationCreator continuationCreator = null;
+        for (int i = 0; i < arguments.length; i++) {
+            Argument<?> argument = arguments[i];
+            Class<?> argumentType = argument.getType();
+            AnnotationMetadata annotationMetadata = argument.getAnnotationMetadata();
+            if (annotationMetadata.hasStereotype(Bindable.class)) {
+                ArgumentBinder<Object, HttpRequest<?>> argumentBinder = (ArgumentBinder<Object, HttpRequest<?>>) argumentBinderRegistry.findArgumentBinder(argument).orElse(null);
+                if (argumentBinder != null) {
+                    if (argumentBinder instanceof BaseFilterProcessor.RequiresRequestBodyBinder<?>) {
+                        if (isResponseFilter) {
+                            throw new IllegalArgumentException("Cannot bind @Body in response filter method [" + method.getDescription(true) + "]");
+                        }
+                        waitForBody = true;
+                    }
+                    fulfilled[i] = ctx -> {
+                        HttpRequest<?> request = ctx.request;
+                        ArgumentConversionContext<Object> conversionContext = (ArgumentConversionContext<Object>) ConversionContext.of(argument);
+                        ArgumentBinder.BindingResult<Object> result = argumentBinder.bind(conversionContext, request);
+                        if (result.isPresentAndSatisfied()) {
+                            return result.get();
+                        } else {
+                            List<ConversionError> conversionErrors = result.getConversionErrors();
+                            if (!conversionErrors.isEmpty()) {
+                                throw new ConversionErrorException(argument, conversionErrors.get(0));
+                            } else {
+                                throw new IllegalArgumentException("Unbindable argument [" + argument + "] to method [" + method.getDescription(true) + "]");
+                            }
+                        }
+                    };
+                } else {
+                    throw new IllegalArgumentException("Unsupported binding annotation in filter method [" + method.getDescription(true) + "]: " + annotationMetadata.getAnnotationNameByStereotype(Bindable.class).orElse(null));
+                }
+            } else if (argumentType.isAssignableFrom(HttpRequest.class)) {
+                fulfilled[i] = ctx -> ctx.request;
+            } else if (argumentType.isAssignableFrom(MutableHttpRequest.class)) {
+                fulfilled[i] = ctx -> {
+                    HttpRequest<?> request = ctx.request;
+                    if (!(ctx.request instanceof MutableHttpRequest<?>)) {
+                        request = ctx.request.mutate();
+                    }
+                    return request;
+                };
+            } else if (argumentType.isAssignableFrom(MutableHttpResponse.class)) {
+                if (!isResponseFilter) {
+                    throw new IllegalArgumentException("Filter is called before the response is known, can't have a response argument");
+                }
+                fulfilled[i] = ctx -> ctx.response;
+            } else if (Throwable.class.isAssignableFrom(argumentType)) {
+                if (!isResponseFilter) {
+                    throw new IllegalArgumentException("Request filters cannot handle exceptions");
+                }
+                if (!argument.isNullable()) {
+                    filterCondition = filterCondition.and(ctx -> ctx.failure != null && argument.isInstance(ctx.failure));
+                    fulfilled[i] = ctx -> ctx.failure;
+                } else {
+                    fulfilled[i] = ctx -> {
+                        if (ctx.failure != null && argument.isInstance(ctx.failure)) {
+                            return ctx.failure;
+                        }
+                        return null;
+                    };
+                }
+                filtersException = true;
+                skipOnError = false;
+            } else if (argumentType == FilterContinuation.class) {
+                if (isResponseFilter) {
+                    throw new IllegalArgumentException("Response filters cannot use filter continuations");
+                }
+                if (continuationCreator != null) {
+                    throw new IllegalArgumentException("Only one continuation per filter is allowed");
+                }
+                Argument<?> continuationReturnType = argument.getFirstTypeVariable().orElseThrow(() -> new IllegalArgumentException("Continuations must specify generic type"));
+                if (isReactive(continuationReturnType) && continuationReturnType.getWrappedType().isAssignableFrom(MutableHttpResponse.class)) {
+                    if (isReactive(returnType)) {
+                        continuationCreator = ResultAwareReactiveContinuationImpl::new;
+                    } else {
+                        continuationCreator = ReactiveContinuationImpl::new;
+                    }
+                    fulfilled[i] = ctx -> ctx.continuation;
+                } else if (continuationReturnType.getType().isAssignableFrom(MutableHttpResponse.class)) {
+                    continuationCreator = BlockingContinuationImpl::new;
+                    fulfilled[i] = ctx -> ctx.continuation;
+                } else {
+                    throw new IllegalArgumentException("Unsupported continuation type: " + continuationReturnType);
+                }
+            } else if (argumentType == MutablePropagatedContext.class) {
+                fulfilled[i] = ctx -> ctx.mutablePropagatedContext;
+            } else {
+                throw new IllegalArgumentException("Unsupported filter argument type: " + argument);
+            }
+        }
+        if (skipOnError) {
+            filterCondition = filterCondition.and(ctx -> ctx.failure == null);
+        } else if (filterCondition == FILTER_CONDITION_ALWAYS_TRUE) {
+            filterCondition = null;
+        }
+        FilterReturnHandler returnHandler = prepareReturnHandler(conversionService, returnType, isResponseFilter, continuationCreator != null, false);
+        return new MethodFilter<>(
+            order,
+            bean,
+            method,
+            isResponseFilter,
+            fulfilled,
+            filterCondition,
+            continuationCreator,
+            filtersException,
+            waitForBody,
+            returnHandler
+        );
+    }
+
+    private static boolean isReactive(Argument<?> continuationReturnType) {
+        // Argument.isReactive doesn't work in http-validation, this is a workaround
+        return continuationReturnType.isReactive() || continuationReturnType.getType() == Publisher.class;
+    }
+
+    @Override
+    public boolean isFiltersRequest() {
+        return !isResponseFilter;
+    }
+
+    @Override
+    public boolean isFiltersResponse() {
+        return isResponseFilter;
+    }
+
+    @Override
+    public ExecutionFlow<FilterContext> processRequestFilter(FilterContext context,
+                                                             Function<FilterContext, ExecutionFlow<FilterContext>> downstream) {
+        MutablePropagatedContext mutablePropagatedContext = MutablePropagatedContext.of(context.propagatedContext());
+        ExecutionFlow<FilterContext> filterMethodFlow;
+        InternalFilterContinuation<?> continuation;
+        if (continuationCreator != null) {
+            continuation = createContinuation(downstream, context, mutablePropagatedContext);
+        } else {
+            continuation = null;
+        }
+        FilterMethodContext filterMethodContext = new FilterMethodContext(
+            mutablePropagatedContext,
+            context.request(),
+            context.response(),
+            null,
+            continuation);
+        try (PropagatedContext.Scope ignore = context.propagatedContext().propagate()) {
+            filterMethodFlow = filter(context, filterMethodContext);
+        }
+        if (continuationCreator != null) {
+            return filterMethodFlow;
+        }
+        return filterMethodFlow.flatMap(downstream);
+    }
+
+    @Override
+    public ExecutionFlow<FilterContext> processResponseFilter(FilterContext context, Throwable exceptionToFilter) {
+        if (exceptionToFilter != null && !filtersException) {
+            return ExecutionFlow.just(context);
+        }
+        if (continuationCreator != null) {
+            return ExecutionFlow.error(new IllegalStateException("Response filter cannot have a continuation!"));
+        }
+        PropagatedContext propagatedContext = context.propagatedContext();
+        MutablePropagatedContext mutablePropagatedContext = MutablePropagatedContext.of(propagatedContext);
+        FilterMethodContext filterMethodContext = new FilterMethodContext(
+            mutablePropagatedContext,
+            context.request(),
+            context.response(),
+            exceptionToFilter,
+            null);
+        try (PropagatedContext.Scope ignore = propagatedContext.propagate()) {
+            return filter(context, filterMethodContext);
+        }
+    }
+
+    @Override
+    public int getOrder() {
+        return order.getOrder(bean);
+    }
+
+    private InternalFilterContinuation<?> createContinuation(Function<FilterContext, ExecutionFlow<FilterContext>> downstream,
+                                                             FilterContext filterContext,
+                                                             MutablePropagatedContext mutablePropagatedContext) {
+        return continuationCreator.create(downstream, filterContext, mutablePropagatedContext);
+    }
+
+    private ExecutionFlow<FilterContext> filter(FilterContext filterContext,
+                                                FilterMethodContext methodContext) {
+        try {
+            if (filterCondition != null && !filterCondition.test(methodContext)) {
+                return ExecutionFlow.just(filterContext);
+            }
+            if (waitForBody && filterContext.request() instanceof FullHttpRequest<?> fhr && !fhr.isFull()) {
+                ExecutionFlow<?> buffered = fhr.bufferContents();
+                if (buffered != null && buffered.tryComplete() == null) {
+                    return buffered.then(() -> filter0(filterContext, methodContext));
+                }
+            }
+            return filter0(filterContext, methodContext);
+        } catch (Throwable e) {
+            return ExecutionFlow.error(e);
+        }
+    }
+
+    private ExecutionFlow<FilterContext> filter0(FilterContext filterContext, FilterMethodContext methodContext) {
+        try {
+            Object[] args = bindArgs(methodContext);
+            Object returnValue;
+            if (method instanceof UnsafeExecutable<T, ?> unsafeExecutable) {
+                returnValue = unsafeExecutable.invokeUnsafe(bean, args);
+            } else {
+                returnValue = method.invoke(bean, args);
+            }
+            ExecutionFlow<FilterContext> executionFlow = returnHandler.handle(filterContext, returnValue, methodContext.continuation);
+            PropagatedContext mutatedPropagatedContext = methodContext.mutablePropagatedContext.getContext();
+            if (mutatedPropagatedContext != filterContext.propagatedContext()) {
+                executionFlow = executionFlow.map(fc -> fc.withPropagatedContext(mutatedPropagatedContext));
+            }
+            return executionFlow;
+        } catch (Throwable e) {
+            return ExecutionFlow.error(e);
+        }
+    }
+
+    private Object[] bindArgs(FilterMethodContext context) {
+        Object[] args = new Object[argBinders.length];
+        for (int i = 0; i < args.length; i++) {
+            args[i] = argBinders[i].bind(context);
+        }
+        return args;
+    }
+
+    private record FilterMethodContext(
+        MutablePropagatedContext mutablePropagatedContext,
+        HttpRequest<?> request,
+        @Nullable HttpResponse<?> response,
+        @Nullable Throwable failure,
+        @Nullable InternalFilterContinuation<?> continuation) {
+    }
+
+    private interface FilterArgBinder {
+        Object bind(FilterMethodContext context);
+    }
+
+    /**
+     * The continuation creator.
+     */
+    private interface ContinuationCreator {
+
+        InternalFilterContinuation<?> create(Function<FilterContext, ExecutionFlow<FilterContext>> downstream,
+                                             FilterContext filterContext,
+                                             MutablePropagatedContext mutablePropagatedContext);
+
+    }
+
+    @SuppressWarnings({"java:S3776", "java:S3740"}) // performance
+    private static FilterReturnHandler prepareReturnHandler(ConversionService conversionService,
+                                                            Argument<?> type,
+                                                            boolean isResponseFilter,
+                                                            boolean hasContinuation,
+                                                            boolean fromOptional) throws IllegalArgumentException {
+        if (type.isOptional()) {
+            FilterReturnHandler next = prepareReturnHandler(conversionService, type.getWrappedType(), isResponseFilter, hasContinuation, true);
+            return (r, o, c) -> next.handle(r, o == null ? null : ((Optional<?>) o).orElse(null), c);
+        }
+        if (type.isVoid()) {
+            if (hasContinuation) {
+                return FilterReturnHandler.VOID_WITH_CONTINUATION;
+            } else {
+                return FilterReturnHandler.VOID;
+            }
+        }
+        boolean nullable = type.isNullable() || fromOptional;
+        if (!isResponseFilter) {
+            if (type.getType() == HttpRequest.class || type.getType() == MutableHttpRequest.class) {
+                if (hasContinuation) {
+                    throw new IllegalArgumentException("Filter method that accepts a continuation cannot return an HttpRequest");
+                }
+                if (nullable) {
+                    return FilterReturnHandler.REQUEST_NULLABLE;
+                } else {
+                    return FilterReturnHandler.REQUEST;
+                }
+            } else if (type.getType() == HttpResponse.class || type.getType() == MutableHttpResponse.class) {
+                if (nullable) {
+                    return FilterReturnHandler.FROM_REQUEST_RESPONSE_NULLABLE;
+                } else {
+                    return FilterReturnHandler.FROM_REQUEST_RESPONSE;
+                }
+            }
+        } else {
+            if (hasContinuation) {
+                throw new AssertionError();
+            }
+            if (type.getType() == HttpResponse.class || type.getType() == MutableHttpResponse.class) {
+                if (nullable) {
+                    return FilterReturnHandler.FROM_RESPONSE_RESPONSE_NULLABLE;
+                } else {
+                    return FilterReturnHandler.FROM_RESPONSE_RESPONSE;
+                }
+            }
+        }
+        if (isReactive(type)) {
+            var next = prepareReturnHandler(conversionService, type.getWrappedType(), isResponseFilter, hasContinuation, false);
+            return (context, returnValue, continuation) -> {
+                if (returnValue == null && !nullable) {
+                    return next.handle(context, null, continuation);
+                }
+                Publisher<?> publisher = ReactivePropagation.propagate(
+                    context.propagatedContext(),
+                    Publishers.convertPublisher(conversionService, returnValue, Publisher.class)
+                );
+                if (continuation instanceof ResultAwareContinuation resultAwareContinuation) {
+                    return resultAwareContinuation.processResult(publisher);
+                }
+                return ReactiveExecutionFlow.fromPublisher(publisher).flatMap(v -> {
+                    try {
+                        return next.handle(context, v, continuation);
+                    } catch (Throwable e) {
+                        return ExecutionFlow.error(e);
+                    }
+                });
+            };
+        } else if (type.isAsync()) {
+            var next = prepareReturnHandler(conversionService, type.getWrappedType(), isResponseFilter, hasContinuation, false);
+            return new DelayedFilterReturnHandler(isResponseFilter, next, nullable) {
+                @Override
+                protected ExecutionFlow<?> toFlow(FilterContext context, Object returnValue, InternalFilterContinuation<?> continuation) {
+                    //noinspection unchecked
+                    return CompletableFutureExecutionFlow.just(((CompletionStage<Object>) returnValue).toCompletableFuture());
+                }
+            };
+        } else {
+            throw new IllegalArgumentException("Unsupported filter return type " + type.getType().getName());
+        }
+    }
+
+    private interface FilterReturnHandler {
+        /**
+         * Void method that accepts a continuation.
+         */
+        FilterReturnHandler VOID_WITH_CONTINUATION = (filterContext, returnValue, continuation) -> ExecutionFlow.just(continuation.afterMethodContext());
+        /**
+         * Void method.
+         */
+        FilterReturnHandler VOID = (filterContext, returnValue, continuation) -> ExecutionFlow.just(filterContext);
+        /**
+         * Request handler that returns a new request.
+         */
+        FilterReturnHandler REQUEST = (filterContext, returnValue, continuation) -> ExecutionFlow.just(
+            filterContext.withRequest(
+                (HttpRequest<?>) Objects.requireNonNull(returnValue, "Returned request must not be null, or mark the method as @Nullable")
+            )
+        );
+        /**
+         * Request handler that returns a new request (nullable).
+         */
+        FilterReturnHandler REQUEST_NULLABLE = (filterContext, returnValue, continuation) -> {
+            if (returnValue == null) {
+                return ExecutionFlow.just(filterContext);
+            }
+            return ExecutionFlow.just(
+                filterContext.withRequest((HttpRequest<?>) returnValue)
+            );
+        };
+        /**
+         * Request handler that returns a response.
+         */
+        FilterReturnHandler FROM_REQUEST_RESPONSE = (filterContext, returnValue, continuation) -> {
+            // cancel request pipeline, move immediately to response handling
+            return ExecutionFlow.just(
+                filterContext
+                    .withResponse(
+                        (HttpResponse<?>) Objects.requireNonNull(returnValue, "Returned response must not be null, or mark the method as @Nullable")
+                    )
+            );
+        };
+        /**
+         * Request handler that returns a response (nullable).
+         */
+        FilterReturnHandler FROM_REQUEST_RESPONSE_NULLABLE = (filterContext, returnValue, continuation) -> {
+            if (returnValue == null) {
+                return ExecutionFlow.just(filterContext);
+            }
+            // cancel request pipeline, move immediately to response handling
+            return ExecutionFlow.just(
+                filterContext.withResponse((HttpResponse<?>) returnValue)
+            );
+        };
+        /**
+         * Response handler that returns a new response.
+         */
+        FilterReturnHandler FROM_RESPONSE_RESPONSE = (filterContext, returnValue, continuation) -> {
+            // cancel request pipeline, move immediately to response handling
+            return ExecutionFlow.just(
+                filterContext
+                    .withResponse(
+                        (HttpResponse<?>) Objects.requireNonNull(returnValue, "Returned response must not be null, or mark the method as @Nullable")
+                    )
+            );
+        };
+        /**
+         * Response handler that returns a new response (nullable).
+         */
+        FilterReturnHandler FROM_RESPONSE_RESPONSE_NULLABLE = (filterContext, returnValue, continuation) -> {
+            if (returnValue == null) {
+                return ExecutionFlow.just(filterContext);
+            }
+            // cancel request pipeline, move immediately to response handling
+            return ExecutionFlow.just(
+                filterContext.withResponse((HttpResponse<?>) returnValue)
+            );
+        };
+
+        @SuppressWarnings("java:S112")
+            // internal interface
+        ExecutionFlow<FilterContext> handle(FilterContext context,
+                                            @Nullable Object returnValue,
+                                            @Nullable InternalFilterContinuation<?> passedOnContinuation) throws Throwable;
+    }
+
+    private abstract static class DelayedFilterReturnHandler implements FilterReturnHandler {
+        final boolean isResponseFilter;
+        final FilterReturnHandler next;
+        final boolean nullable;
+
+        private DelayedFilterReturnHandler(boolean isResponseFilter, FilterReturnHandler next, boolean nullable) {
+            this.isResponseFilter = isResponseFilter;
+            this.next = next;
+            this.nullable = nullable;
+        }
+
+        @SuppressWarnings("java:S1452")
+        protected abstract ExecutionFlow<?> toFlow(FilterContext context,
+                                                   Object returnValue,
+                                                   @Nullable InternalFilterContinuation<?> continuation);
+
+        @Override
+        public ExecutionFlow<FilterContext> handle(FilterContext context,
+                                                   @Nullable Object returnValue,
+                                                   InternalFilterContinuation<?> continuation) throws Throwable {
+            if (returnValue == null && nullable) {
+                return next.handle(context, null, continuation);
+            }
+
+            ExecutionFlow<?> delayedFlow = toFlow(context,
+                Objects.requireNonNull(returnValue, "Returned value must not be null, or mark the method as @Nullable"),
+                continuation
+            );
+            ImperativeExecutionFlow<?> doneFlow = delayedFlow.tryComplete();
+            if (doneFlow != null) {
+                if (doneFlow.getError() != null) {
+                    throw doneFlow.getError();
+                }
+                return next.handle(context, doneFlow.getValue(), continuation);
+            } else {
+                return delayedFlow.flatMap(v -> {
+                    try {
+                        return next.handle(context, v, continuation);
+                    } catch (Throwable e) {
+                        return ExecutionFlow.error(e);
+                    }
+                });
+            }
+        }
+    }
+
+    /**
+     * The internal filter continuation implementation.
+     *
+     * @param <R> The response type
+     */
+    private sealed interface InternalFilterContinuation<R> extends FilterContinuation<R> {
+
+        FilterContext afterMethodContext();
+    }
+
+    /**
+     * The reactive continuation that processes the method return value.
+     */
+    private static final class ResultAwareReactiveContinuationImpl extends ReactiveContinuationImpl
+        implements ResultAwareContinuation<Publisher<HttpResponse<?>>> {
+
+        private ResultAwareReactiveContinuationImpl(Function<FilterContext, ExecutionFlow<FilterContext>> next,
+                                                    FilterContext filterContext,
+                                                    MutablePropagatedContext mutablePropagatedContext) {
+            super(next, filterContext, mutablePropagatedContext);
+        }
+
+        @Override
+        public ExecutionFlow<FilterContext> processResult(Publisher<HttpResponse<?>> publisher) {
+            return ReactiveExecutionFlow.fromPublisher(publisher).map(httpResponse -> filterContext.withResponse(httpResponse));
+        }
+    }
+
+    /**
+     * Continuation implementation that yields a reactive type.<br>
+     * This class implements a bunch of interfaces that it would otherwise have to create lambdas
+     * for.
+     */
+    private static sealed class ReactiveContinuationImpl implements FilterContinuation<Publisher<HttpResponse<?>>>,
+        InternalFilterContinuation<Publisher<HttpResponse<?>>> {
+
+        protected FilterContext filterContext;
+        private final Function<FilterContext, ExecutionFlow<FilterContext>> downstream;
+        private final MutablePropagatedContext mutablePropagatedContext;
+
+        private ReactiveContinuationImpl(Function<FilterContext, ExecutionFlow<FilterContext>> downstream,
+                                         FilterContext filterContext,
+                                         MutablePropagatedContext mutablePropagatedContext) {
+            this.downstream = downstream;
+            this.filterContext = filterContext;
+            this.mutablePropagatedContext = mutablePropagatedContext;
+        }
+
+        @Override
+        public FilterContinuation<Publisher<HttpResponse<?>>> request(HttpRequest<?> request) {
+            return new ReactiveContinuationImpl(downstream, filterContext.withRequest(request), mutablePropagatedContext);
+        }
+
+        @Override
+        public Publisher<HttpResponse<?>> proceed() {
+            PropagatedContext propagatedContext = filterContext.propagatedContext();
+            PropagatedContext mutatedPropagatedContext = mutablePropagatedContext.getContext();
+            if (propagatedContext != mutatedPropagatedContext) {
+                filterContext = filterContext.withPropagatedContext(mutatedPropagatedContext);
+            } else {
+                filterContext = filterContext.withPropagatedContext(PropagatedContext.find().orElse(filterContext.propagatedContext()));
+            }
+            return ReactiveExecutionFlow.fromFlow(
+                downstream.apply(filterContext).<HttpResponse<?>>map(newFilterContext -> {
+                    filterContext = newFilterContext;
+                    return newFilterContext.response();
+                })
+            ).toPublisher();
+        }
+
+        @Override
+        public FilterContext afterMethodContext() {
+            return filterContext;
+        }
+    }
+
+    /**
+     * The internal continuation that processes the method result.
+     *
+     * @param <T> The continuation result.
+     */
+    private sealed interface ResultAwareContinuation<T> extends InternalFilterContinuation<T> {
+
+        ExecutionFlow<FilterContext> processResult(T result);
+
+    }
+
+    /**
+     * Implementation of {@link FilterContinuation} for blocking calls.
+     */
+    @SuppressWarnings("java:S112") // framework code
+    private static final class BlockingContinuationImpl implements FilterContinuation<HttpResponse<?>>, InternalFilterContinuation<HttpResponse<?>> {
+
+        private final Function<FilterContext, ExecutionFlow<FilterContext>> downstream;
+        private FilterContext filterContext;
+        private final MutablePropagatedContext mutablePropagatedContext;
+
+        private BlockingContinuationImpl(Function<FilterContext, ExecutionFlow<FilterContext>> downstream,
+                                         FilterContext filterContext, MutablePropagatedContext mutablePropagatedContext) {
+            this.downstream = downstream;
+            this.filterContext = filterContext;
+            this.mutablePropagatedContext = mutablePropagatedContext;
+        }
+
+        @Override
+        public FilterContinuation<HttpResponse<?>> request(HttpRequest<?> request) {
+            filterContext = filterContext.withRequest(request);
+            PropagatedContext propagatedContext = filterContext.propagatedContext();
+            PropagatedContext mutatedPropagatedContext = mutablePropagatedContext.getContext();
+            if (propagatedContext != mutatedPropagatedContext) {
+                filterContext = filterContext.withPropagatedContext(mutatedPropagatedContext);
+            } else {
+                filterContext = filterContext.withPropagatedContext(PropagatedContext.find().orElse(filterContext.propagatedContext()));
+            }
+            return new BlockingContinuationImpl(downstream, filterContext, mutablePropagatedContext);
+        }
+
+        @Override
+        public HttpResponse<?> proceed() {
+            boolean interrupted = false;
+            while (true) {
+                try {
+                    // todo: detect event loop thread
+                    filterContext = downstream.apply(filterContext).toCompletableFuture().get();
+                    if (interrupted) {
+                        Thread.currentThread().interrupt();
+                    }
+                    return filterContext.response();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    interrupted = true;
+                } catch (ExecutionException e) {
+                    Throwable cause = e.getCause();
+                    if (cause instanceof RuntimeException re) {
+                        throw re;
+                    } else {
+                        throw new RuntimeException(cause);
+                    }
+                }
+            }
+        }
+
+        @Override
+        public FilterContext afterMethodContext() {
+            return filterContext;
+        }
+    }
+
+}

--- a/http/src/main/java/io/micronaut/http/filter/TerminalFilter.java
+++ b/http/src/main/java/io/micronaut/http/filter/TerminalFilter.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.filter;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.execution.ExecutionFlow;
+import io.micronaut.core.propagation.PropagatedContext;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.MutableHttpResponse;
+
+import java.util.function.Function;
+
+/**
+ * Last item in a filter chain, called when all other filters are done. Basically, this runs
+ * the actual request.
+ *
+ * @author Jonas Konrad
+ * @author Denis Stepanov
+ * @since 4.2.0
+ */
+@Internal
+final class TerminalFilter implements InternalHttpFilter {
+
+    private final Function<HttpRequest<?>, ExecutionFlow<MutableHttpResponse<?>>> fn;
+
+    TerminalFilter(Function<HttpRequest<?>, ExecutionFlow<MutableHttpResponse<?>>> fn) {
+        this.fn = fn;
+    }
+
+    @Override
+    public boolean isFiltersRequest() {
+        return true;
+    }
+
+    @Override
+    public boolean isFiltersResponse() {
+        return false;
+    }
+
+    @Override
+    public ExecutionFlow<FilterContext> processRequestFilter(FilterContext context,
+                                                             Function<FilterContext, ExecutionFlow<FilterContext>> downstream) {
+        try {
+            try (PropagatedContext.Scope ignore = context.propagatedContext().propagate()) {
+                return fn.apply(context.request()).map(context::withResponse).flatMap(downstream);
+            }
+        } catch (Throwable e) {
+            return ExecutionFlow.error(e);
+        }
+    }
+}

--- a/http/src/main/java/io/micronaut/http/filter/TerminalReactiveFilter.java
+++ b/http/src/main/java/io/micronaut/http/filter/TerminalReactiveFilter.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.filter;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.execution.ExecutionFlow;
+import io.micronaut.core.propagation.PropagatedContext;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.reactive.execution.ReactiveExecutionFlow;
+import org.reactivestreams.Publisher;
+
+import java.util.function.Function;
+
+/**
+ * Terminal filter that accepts a reactive type. Used as a temporary solution for the http
+ * client, until that is un-reactified.
+ *
+ * @author Jonas Konrad
+ * @author Denis Stepanov
+ * @since 4.2.0
+ */
+@Internal
+final class TerminalReactiveFilter implements InternalHttpFilter {
+
+    private final Publisher<? extends HttpResponse<?>> responsePublisher;
+
+    /**
+     * @param responsePublisher The response publisher
+     */
+    public TerminalReactiveFilter(Publisher<? extends HttpResponse<?>> responsePublisher) {
+        this.responsePublisher = responsePublisher;
+    }
+
+    @Override
+    public boolean isFiltersRequest() {
+        return true;
+    }
+
+    @Override
+    public boolean isFiltersResponse() {
+        return false;
+    }
+
+    @Override
+    public ExecutionFlow<FilterContext> processRequestFilter(FilterContext context,
+                                                             Function<FilterContext, ExecutionFlow<FilterContext>> downstream) {
+        try {
+            try (PropagatedContext.Scope ignore = context.propagatedContext().propagate()) {
+                return ReactiveExecutionFlow.fromPublisher(responsePublisher).map(context::withResponse).flatMap(downstream);
+            }
+        } catch (Throwable e) {
+            return ExecutionFlow.error(e);
+        }
+    }
+
+}

--- a/http/src/test/groovy/io/micronaut/http/filter/FilterRunnerSpec.groovy
+++ b/http/src/test/groovy/io/micronaut/http/filter/FilterRunnerSpec.groovy
@@ -42,7 +42,7 @@ class FilterRunnerSpec extends Specification {
                     events.add("before")
                     null
                 },
-                GenericHttpFilter.terminal (req -> {
+                GenericHttpFilter.terminalFilter (req -> {
                     events.add("terminal")
                     ExecutionFlow.just(HttpResponse.ok())
                 })
@@ -72,7 +72,7 @@ class FilterRunnerSpec extends Specification {
                         return resp2
                     })
                 },
-                GenericHttpFilter.terminal (req -> {
+                GenericHttpFilter.terminalFilter (req -> {
                     assert req == req2
                     events.add("terminal")
                     ExecutionFlow.just(resp1)
@@ -107,7 +107,7 @@ class FilterRunnerSpec extends Specification {
                             .contextWrite { it.put('value', 'around 2') }
                     }
                 },
-                GenericHttpFilter.terminal (req -> {
+                GenericHttpFilter.terminalFilter (req -> {
                     return ReactiveExecutionFlow.fromPublisher(Mono.deferContextual(ctx -> {
                         events.add('terminal: ' + ctx.get('value'))
                         Mono.just(HttpResponse.ok("resp1"))
@@ -152,7 +152,7 @@ class FilterRunnerSpec extends Specification {
                                 .contextWrite { it.put('value', 'around 2') }
                     }
                 },
-                GenericHttpFilter.terminal (req -> {
+                GenericHttpFilter.terminalFilter (req -> {
                     return ReactiveExecutionFlow.fromPublisher(Mono.deferContextual(ctx -> {
                         events.add('terminal: ' + ctx.get('value'))
                         Mono.just(HttpResponse.ok("resp1"))
@@ -181,7 +181,7 @@ class FilterRunnerSpec extends Specification {
         def testExc = new Exception("Test exception")
         List<GenericHttpFilter> filters = [
                 before(ReturnType.of(void)) { throw testExc },
-                GenericHttpFilter.terminal (req -> {
+                GenericHttpFilter.terminalFilter (req -> {
                     events.add("terminal")
                     ExecutionFlow.just(HttpResponse.ok())
                 })
@@ -201,7 +201,7 @@ class FilterRunnerSpec extends Specification {
         def testExc = new Exception("Test exception")
         List<GenericHttpFilter> filters = [
                 after(ReturnType.of(void)) { req, resp -> throw testExc },
-                GenericHttpFilter.terminal (req -> {
+                GenericHttpFilter.terminalFilter (req -> {
                     events.add("terminal")
                     ExecutionFlow.just(HttpResponse.ok())
                 })
@@ -219,7 +219,7 @@ class FilterRunnerSpec extends Specification {
         given:
         def testExc = new RuntimeException("Test exception")
         List<GenericHttpFilter> filters = [
-            GenericHttpFilter.terminal (req -> {
+            GenericHttpFilter.terminalFilter (req -> {
                     throw testExc
                 })
         ]
@@ -235,7 +235,7 @@ class FilterRunnerSpec extends Specification {
         given:
         def testExc = new Exception("Test exception")
         List<GenericHttpFilter> filters = [
-            GenericHttpFilter.terminal (req -> {
+            GenericHttpFilter.terminalFilter (req -> {
                     return ExecutionFlow.error(testExc)
                 })
         ]
@@ -255,7 +255,7 @@ class FilterRunnerSpec extends Specification {
                 around(legacy) { request, chain ->
                     throw testExc
                 },
-                GenericHttpFilter.terminal (req -> {
+                GenericHttpFilter.terminalFilter (req -> {
                     events.add("terminal")
                     ExecutionFlow.just(HttpResponse.ok())
                 })
@@ -280,7 +280,7 @@ class FilterRunnerSpec extends Specification {
                 around(legacy) { request, chain ->
                     return Flux.from(chain.proceed(request)).map(r -> { throw testExc })
                 },
-                GenericHttpFilter.terminal (req -> {
+                GenericHttpFilter.terminalFilter (req -> {
                     events.add("terminal")
                     ExecutionFlow.just(HttpResponse.ok())
                 })
@@ -307,7 +307,7 @@ class FilterRunnerSpec extends Specification {
                     Flux.from(chain.proceed(request)).subscribe()
                     throw testExc
                 },
-                GenericHttpFilter.terminal (req -> {
+                GenericHttpFilter.terminalFilter (req -> {
                     events.add("terminal")
                     ExecutionFlow.just(HttpResponse.ok())
                 })
@@ -334,7 +334,7 @@ class FilterRunnerSpec extends Specification {
                     Flux.from(chain.proceed(request)).subscribe()
                     throw testExc
                 },
-                GenericHttpFilter.terminal (req -> {
+                GenericHttpFilter.terminalFilter (req -> {
                     CompletableFutureExecutionFlow.just(terminalFuture)
                 })
         ]
@@ -361,7 +361,7 @@ class FilterRunnerSpec extends Specification {
                     events.add("around")
                     Flux.just(HttpResponse.ok("foo"))
                 },
-                GenericHttpFilter.terminal (req -> {
+                GenericHttpFilter.terminalFilter (req -> {
                     events.add("terminal")
                     ExecutionFlow.just(HttpResponse.ok())
                 })
@@ -388,7 +388,7 @@ class FilterRunnerSpec extends Specification {
                     events.add("before")
                     req2
                 },
-                GenericHttpFilter.terminal (req -> {
+                GenericHttpFilter.terminalFilter (req -> {
                     assert req == req2
                     events.add("terminal")
                     ExecutionFlow.just(HttpResponse.ok())
@@ -409,7 +409,7 @@ class FilterRunnerSpec extends Specification {
                     events.add("before")
                     HttpResponse.ok()
                 },
-                GenericHttpFilter.terminal (req -> {
+                GenericHttpFilter.terminalFilter (req -> {
                     events.add("terminal")
                     ExecutionFlow.just(HttpResponse.ok())
                 })
@@ -432,7 +432,7 @@ class FilterRunnerSpec extends Specification {
                     events.add("before")
                     Flux.just(req2)
                 },
-                GenericHttpFilter.terminal (req -> {
+                GenericHttpFilter.terminalFilter (req -> {
                     assert req == req2
                     events.add("terminal")
                     ExecutionFlow.just(HttpResponse.ok())
@@ -456,7 +456,7 @@ class FilterRunnerSpec extends Specification {
                     events.add("before")
                     CompletableFuture.completedFuture(req2)
                 },
-                GenericHttpFilter.terminal (req -> {
+                GenericHttpFilter.terminalFilter (req -> {
                     assert req == req2
                     events.add("terminal")
                     ExecutionFlow.just(HttpResponse.ok())
@@ -477,7 +477,7 @@ class FilterRunnerSpec extends Specification {
                     events.add("before")
                     Flux.just(HttpResponse.ok())
                 },
-                GenericHttpFilter.terminal (req -> {
+                GenericHttpFilter.terminalFilter (req -> {
                     events.add("terminal")
                     ExecutionFlow.just(HttpResponse.ok())
                 })
@@ -500,7 +500,7 @@ class FilterRunnerSpec extends Specification {
                     events.add("after")
                     resp2
                 },
-                GenericHttpFilter.terminal (req -> {
+                GenericHttpFilter.terminalFilter (req -> {
                     events.add("terminal")
                     ExecutionFlow.just(resp1)
                 })
@@ -524,7 +524,7 @@ class FilterRunnerSpec extends Specification {
                     events.add("after")
                     Flux.just(resp2)
                 },
-                GenericHttpFilter.terminal (req -> {
+                GenericHttpFilter.terminalFilter (req -> {
                     events.add("terminal")
                     ExecutionFlow.just(resp1)
                 })
@@ -546,7 +546,7 @@ class FilterRunnerSpec extends Specification {
                     events.add("after")
                     null
                 },
-                GenericHttpFilter.terminal (req -> {
+                GenericHttpFilter.terminalFilter (req -> {
                     events.add("terminal")
                     ExecutionFlow.error(testExc)
                 })
@@ -571,7 +571,7 @@ class FilterRunnerSpec extends Specification {
                     events.add("after")
                     resp1
                 },
-                GenericHttpFilter.terminal (req -> {
+                GenericHttpFilter.terminalFilter (req -> {
                     events.add("terminal")
                     ExecutionFlow.error(testExc)
                 })
@@ -593,7 +593,7 @@ class FilterRunnerSpec extends Specification {
                     events.add("after")
                     null
                 },
-                GenericHttpFilter.terminal (req -> {
+                GenericHttpFilter.terminalFilter (req -> {
                     events.add("terminal")
                     ExecutionFlow.error(testExc)
                 })
@@ -645,7 +645,7 @@ class FilterRunnerSpec extends Specification {
                     events.add("after3 " + Thread.currentThread().name)
                     null
                 },
-                GenericHttpFilter.terminal (req -> {
+                GenericHttpFilter.terminalFilter (req -> {
                     events.add("terminal " + Thread.currentThread().name)
                     ExecutionFlow.just(HttpResponse.ok())
                 })
@@ -679,7 +679,7 @@ class FilterRunnerSpec extends Specification {
                     events.add("after")
                     return resp2
                 },
-                GenericHttpFilter.terminal (req -> {
+                GenericHttpFilter.terminalFilter (req -> {
                     assert req == req2
                     events.add("terminal")
                     ExecutionFlow.just(resp1)
@@ -703,7 +703,7 @@ class FilterRunnerSpec extends Specification {
 
     private def around(boolean legacy, Closure<Publisher<MutableHttpResponse<?>>> closure) {
         if (legacy) {
-            return new AroundLegacyFilter(
+            return GenericHttpFilter.createLegacyFilter(
                     new HttpServerFilter() {
                         @Override
                         Publisher<MutableHttpResponse<?>> doFilter(HttpRequest<?> request, ServerFilterChain chain) {

--- a/http/src/test/groovy/io/micronaut/http/filter/FilterRunnerSpec.groovy
+++ b/http/src/test/groovy/io/micronaut/http/filter/FilterRunnerSpec.groovy
@@ -42,7 +42,7 @@ class FilterRunnerSpec extends Specification {
                     events.add("before")
                     null
                 },
-                (GenericHttpFilter.Terminal) (req -> {
+                GenericHttpFilter.terminal (req -> {
                     events.add("terminal")
                     ExecutionFlow.just(HttpResponse.ok())
                 })
@@ -72,7 +72,7 @@ class FilterRunnerSpec extends Specification {
                         return resp2
                     })
                 },
-                (GenericHttpFilter.Terminal) (req -> {
+                GenericHttpFilter.terminal (req -> {
                     assert req == req2
                     events.add("terminal")
                     ExecutionFlow.just(resp1)
@@ -107,12 +107,12 @@ class FilterRunnerSpec extends Specification {
                             .contextWrite { it.put('value', 'around 2') }
                     }
                 },
-                (GenericHttpFilter.Terminal) (req) -> {
+                GenericHttpFilter.terminal (req -> {
                     return ReactiveExecutionFlow.fromPublisher(Mono.deferContextual(ctx -> {
                         events.add('terminal: ' + ctx.get('value'))
                         Mono.just(HttpResponse.ok("resp1"))
                     }))
-                }
+                })
         ]
 
         when:
@@ -152,12 +152,12 @@ class FilterRunnerSpec extends Specification {
                                 .contextWrite { it.put('value', 'around 2') }
                     }
                 },
-                (GenericHttpFilter.Terminal) (req) -> {
+                GenericHttpFilter.terminal (req -> {
                     return ReactiveExecutionFlow.fromPublisher(Mono.deferContextual(ctx -> {
                         events.add('terminal: ' + ctx.get('value'))
                         Mono.just(HttpResponse.ok("resp1"))
                     }))
-                }
+                })
         ]
 
         when:
@@ -181,7 +181,7 @@ class FilterRunnerSpec extends Specification {
         def testExc = new Exception("Test exception")
         List<GenericHttpFilter> filters = [
                 before(ReturnType.of(void)) { throw testExc },
-                (GenericHttpFilter.Terminal) (req -> {
+                GenericHttpFilter.terminal (req -> {
                     events.add("terminal")
                     ExecutionFlow.just(HttpResponse.ok())
                 })
@@ -201,7 +201,7 @@ class FilterRunnerSpec extends Specification {
         def testExc = new Exception("Test exception")
         List<GenericHttpFilter> filters = [
                 after(ReturnType.of(void)) { req, resp -> throw testExc },
-                (GenericHttpFilter.Terminal) (req -> {
+                GenericHttpFilter.terminal (req -> {
                     events.add("terminal")
                     ExecutionFlow.just(HttpResponse.ok())
                 })
@@ -219,7 +219,7 @@ class FilterRunnerSpec extends Specification {
         given:
         def testExc = new RuntimeException("Test exception")
         List<GenericHttpFilter> filters = [
-                (GenericHttpFilter.Terminal) (req -> {
+            GenericHttpFilter.terminal (req -> {
                     throw testExc
                 })
         ]
@@ -235,7 +235,7 @@ class FilterRunnerSpec extends Specification {
         given:
         def testExc = new Exception("Test exception")
         List<GenericHttpFilter> filters = [
-                (GenericHttpFilter.Terminal) (req -> {
+            GenericHttpFilter.terminal (req -> {
                     return ExecutionFlow.error(testExc)
                 })
         ]
@@ -255,7 +255,7 @@ class FilterRunnerSpec extends Specification {
                 around(legacy) { request, chain ->
                     throw testExc
                 },
-                (GenericHttpFilter.Terminal) (req -> {
+                GenericHttpFilter.terminal (req -> {
                     events.add("terminal")
                     ExecutionFlow.just(HttpResponse.ok())
                 })
@@ -280,7 +280,7 @@ class FilterRunnerSpec extends Specification {
                 around(legacy) { request, chain ->
                     return Flux.from(chain.proceed(request)).map(r -> { throw testExc })
                 },
-                (GenericHttpFilter.Terminal) (req -> {
+                GenericHttpFilter.terminal (req -> {
                     events.add("terminal")
                     ExecutionFlow.just(HttpResponse.ok())
                 })
@@ -307,7 +307,7 @@ class FilterRunnerSpec extends Specification {
                     Flux.from(chain.proceed(request)).subscribe()
                     throw testExc
                 },
-                (GenericHttpFilter.Terminal) (req -> {
+                GenericHttpFilter.terminal (req -> {
                     events.add("terminal")
                     ExecutionFlow.just(HttpResponse.ok())
                 })
@@ -334,7 +334,7 @@ class FilterRunnerSpec extends Specification {
                     Flux.from(chain.proceed(request)).subscribe()
                     throw testExc
                 },
-                (GenericHttpFilter.Terminal) (req -> {
+                GenericHttpFilter.terminal (req -> {
                     CompletableFutureExecutionFlow.just(terminalFuture)
                 })
         ]
@@ -361,7 +361,7 @@ class FilterRunnerSpec extends Specification {
                     events.add("around")
                     Flux.just(HttpResponse.ok("foo"))
                 },
-                (GenericHttpFilter.Terminal) (req -> {
+                GenericHttpFilter.terminal (req -> {
                     events.add("terminal")
                     ExecutionFlow.just(HttpResponse.ok())
                 })
@@ -388,7 +388,7 @@ class FilterRunnerSpec extends Specification {
                     events.add("before")
                     req2
                 },
-                (GenericHttpFilter.Terminal) (req -> {
+                GenericHttpFilter.terminal (req -> {
                     assert req == req2
                     events.add("terminal")
                     ExecutionFlow.just(HttpResponse.ok())
@@ -409,7 +409,7 @@ class FilterRunnerSpec extends Specification {
                     events.add("before")
                     HttpResponse.ok()
                 },
-                (GenericHttpFilter.Terminal) (req -> {
+                GenericHttpFilter.terminal (req -> {
                     events.add("terminal")
                     ExecutionFlow.just(HttpResponse.ok())
                 })
@@ -432,7 +432,7 @@ class FilterRunnerSpec extends Specification {
                     events.add("before")
                     Flux.just(req2)
                 },
-                (GenericHttpFilter.Terminal) (req -> {
+                GenericHttpFilter.terminal (req -> {
                     assert req == req2
                     events.add("terminal")
                     ExecutionFlow.just(HttpResponse.ok())
@@ -456,7 +456,7 @@ class FilterRunnerSpec extends Specification {
                     events.add("before")
                     CompletableFuture.completedFuture(req2)
                 },
-                (GenericHttpFilter.Terminal) (req -> {
+                GenericHttpFilter.terminal (req -> {
                     assert req == req2
                     events.add("terminal")
                     ExecutionFlow.just(HttpResponse.ok())
@@ -477,7 +477,7 @@ class FilterRunnerSpec extends Specification {
                     events.add("before")
                     Flux.just(HttpResponse.ok())
                 },
-                (GenericHttpFilter.Terminal) (req -> {
+                GenericHttpFilter.terminal (req -> {
                     events.add("terminal")
                     ExecutionFlow.just(HttpResponse.ok())
                 })
@@ -500,7 +500,7 @@ class FilterRunnerSpec extends Specification {
                     events.add("after")
                     resp2
                 },
-                (GenericHttpFilter.Terminal) (req -> {
+                GenericHttpFilter.terminal (req -> {
                     events.add("terminal")
                     ExecutionFlow.just(resp1)
                 })
@@ -524,7 +524,7 @@ class FilterRunnerSpec extends Specification {
                     events.add("after")
                     Flux.just(resp2)
                 },
-                (GenericHttpFilter.Terminal) (req -> {
+                GenericHttpFilter.terminal (req -> {
                     events.add("terminal")
                     ExecutionFlow.just(resp1)
                 })
@@ -546,7 +546,7 @@ class FilterRunnerSpec extends Specification {
                     events.add("after")
                     null
                 },
-                (GenericHttpFilter.Terminal) (req -> {
+                GenericHttpFilter.terminal (req -> {
                     events.add("terminal")
                     ExecutionFlow.error(testExc)
                 })
@@ -571,7 +571,7 @@ class FilterRunnerSpec extends Specification {
                     events.add("after")
                     resp1
                 },
-                (GenericHttpFilter.Terminal) (req -> {
+                GenericHttpFilter.terminal (req -> {
                     events.add("terminal")
                     ExecutionFlow.error(testExc)
                 })
@@ -593,7 +593,7 @@ class FilterRunnerSpec extends Specification {
                     events.add("after")
                     null
                 },
-                (GenericHttpFilter.Terminal) (req -> {
+                GenericHttpFilter.terminal (req -> {
                     events.add("terminal")
                     ExecutionFlow.error(testExc)
                 })
@@ -615,7 +615,7 @@ class FilterRunnerSpec extends Specification {
                     events.add("before1 " + Thread.currentThread().name)
                     null
                 },
-                new GenericHttpFilter.Async(before(ReturnType.of(void)) {
+                new AsyncFilter(before(ReturnType.of(void)) {
                     events.add("before2 " + Thread.currentThread().name)
                     null
                 }, Executors.newCachedThreadPool(new ThreadFactory() {
@@ -632,7 +632,7 @@ class FilterRunnerSpec extends Specification {
                     events.add("after1 " + Thread.currentThread().name)
                     null
                 },
-                new GenericHttpFilter.Async(after(ReturnType.of(void)) {
+                new AsyncFilter(after(ReturnType.of(void)) {
                     events.add("after2 " + Thread.currentThread().name)
                     null
                 }, Executors.newCachedThreadPool(new ThreadFactory() {
@@ -645,7 +645,7 @@ class FilterRunnerSpec extends Specification {
                     events.add("after3 " + Thread.currentThread().name)
                     null
                 },
-                (GenericHttpFilter.Terminal) (req -> {
+                GenericHttpFilter.terminal (req -> {
                     events.add("terminal " + Thread.currentThread().name)
                     ExecutionFlow.just(HttpResponse.ok())
                 })
@@ -679,7 +679,7 @@ class FilterRunnerSpec extends Specification {
                     events.add("after")
                     return resp2
                 },
-                (GenericHttpFilter.Terminal) (req -> {
+                GenericHttpFilter.terminal (req -> {
                     assert req == req2
                     events.add("terminal")
                     ExecutionFlow.just(resp1)
@@ -694,16 +694,16 @@ class FilterRunnerSpec extends Specification {
     }
 
     private def after(ReturnType returnType, List<Argument> arguments = closure.parameterTypes.collect { Argument.of(it) }, Closure<?> closure) {
-        return FilterRunner.prepareFilterMethod(ConversionService.SHARED, null, new LambdaExecutable(closure, arguments.toArray(new Argument[0]), returnType), true, new FilterOrder.Fixed(0), new DefaultRequestBinderRegistry(ConversionService.SHARED))
+        return MethodFilter.prepareFilterMethod(ConversionService.SHARED, null, new LambdaExecutable(closure, arguments.toArray(new Argument[0]), returnType), true, new FilterOrder.Fixed(0), new DefaultRequestBinderRegistry(ConversionService.SHARED))
     }
 
     private def before(ReturnType returnType, List<Argument> arguments = closure.parameterTypes.collect { Argument.of(it) }, Closure<?> closure) {
-        return FilterRunner.prepareFilterMethod(ConversionService.SHARED, null, new LambdaExecutable(closure, arguments.toArray(new Argument[0]), returnType), false, new FilterOrder.Fixed(0), new DefaultRequestBinderRegistry(ConversionService.SHARED))
+        return MethodFilter.prepareFilterMethod(ConversionService.SHARED, null, new LambdaExecutable(closure, arguments.toArray(new Argument[0]), returnType), false, new FilterOrder.Fixed(0), new DefaultRequestBinderRegistry(ConversionService.SHARED))
     }
 
     private def around(boolean legacy, Closure<Publisher<MutableHttpResponse<?>>> closure) {
         if (legacy) {
-            return new GenericHttpFilter.AroundLegacy(
+            return new AroundLegacyFilter(
                     new HttpServerFilter() {
                         @Override
                         Publisher<MutableHttpResponse<?>> doFilter(HttpRequest<?> request, ServerFilterChain chain) {

--- a/router/src/main/java/io/micronaut/web/router/BeanDefinitionFilterRoute.java
+++ b/router/src/main/java/io/micronaut/web/router/BeanDefinitionFilterRoute.java
@@ -43,7 +43,7 @@ class BeanDefinitionFilterRoute extends DefaultFilterRoute {
      * @param definition The definition
      */
     BeanDefinitionFilterRoute(String pattern, BeanLocator beanLocator, BeanDefinition<? extends HttpFilter> definition) {
-        super(pattern, () -> new GenericHttpFilter.AroundLegacy(
+        super(pattern, () -> GenericHttpFilter.createLegacyFilter(
             beanLocator.getBean(definition),
             new FilterOrder.Dynamic(OrderUtil.getOrder(definition))));
         this.definition = definition;

--- a/router/src/main/java/io/micronaut/web/router/DefaultFilterRoute.java
+++ b/router/src/main/java/io/micronaut/web/router/DefaultFilterRoute.java
@@ -21,6 +21,7 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.PathMatcher;
 import io.micronaut.core.util.StringUtils;
+import io.micronaut.core.util.Toggleable;
 import io.micronaut.http.HttpMethod;
 import io.micronaut.http.filter.FilterPatternStyle;
 import io.micronaut.http.filter.GenericHttpFilter;
@@ -134,7 +135,7 @@ class DefaultFilterRoute implements FilterRoute {
         for (String pattern : patterns) {
             if (matcher.matches(pattern, uriStr)) {
                 GenericHttpFilter filter = getFilter();
-                if (filter instanceof GenericHttpFilter.AroundLegacy al && !al.isEnabled()) {
+                if (filter instanceof Toggleable toggleable && !toggleable.isEnabled()) {
                     return Optional.empty();
                 }
                 return Optional.of(filter);

--- a/router/src/main/java/io/micronaut/web/router/DefaultFilterRoute.java
+++ b/router/src/main/java/io/micronaut/web/router/DefaultFilterRoute.java
@@ -21,7 +21,6 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.PathMatcher;
 import io.micronaut.core.util.StringUtils;
-import io.micronaut.core.util.Toggleable;
 import io.micronaut.http.HttpMethod;
 import io.micronaut.http.filter.FilterPatternStyle;
 import io.micronaut.http.filter.GenericHttpFilter;
@@ -135,7 +134,7 @@ class DefaultFilterRoute implements FilterRoute {
         for (String pattern : patterns) {
             if (matcher.matches(pattern, uriStr)) {
                 GenericHttpFilter filter = getFilter();
-                if (filter instanceof Toggleable toggleable && !toggleable.isEnabled()) {
+                if (!GenericHttpFilter.isEnabled(filter)) {
                     return Optional.empty();
                 }
                 return Optional.of(filter);

--- a/router/src/test/groovy/io/micronaut/web/router/DefaultFilterRouteSpec.groovy
+++ b/router/src/test/groovy/io/micronaut/web/router/DefaultFilterRouteSpec.groovy
@@ -33,7 +33,7 @@ class DefaultFilterRouteSpec extends Specification {
 
     void "test filter route matching with no methods specified"() {
         given:
-        def filter = new AroundLegacyFilter(new HttpFilter() {
+        def filter = GenericHttpFilter.createLegacyFilter(new HttpFilter() {
             @Override
             Publisher<? extends HttpResponse<?>> doFilter(HttpRequest<?> request, FilterChain chain) {
                 return null
@@ -56,7 +56,7 @@ class DefaultFilterRouteSpec extends Specification {
 
     void "test filter route matching with methods specified"() {
         given:
-        def filter = new AroundLegacyFilter(new HttpFilter() {
+        def filter = GenericHttpFilter.createLegacyFilter(new HttpFilter() {
             @Override
             Publisher<? extends HttpResponse<?>> doFilter(HttpRequest<?> request, FilterChain chain) {
                 return null
@@ -79,7 +79,7 @@ class DefaultFilterRouteSpec extends Specification {
 
     void "test filter route matching with regex pattern style specified"() {
         given:
-        def filter = new AroundLegacyFilter(new HttpFilter() {
+        def filter = GenericHttpFilter.createLegacyFilter(new HttpFilter() {
             @Override
             Publisher<? extends HttpResponse<?>> doFilter(HttpRequest<?> request, FilterChain chain) {
                 return null

--- a/router/src/test/groovy/io/micronaut/web/router/DefaultFilterRouteSpec.groovy
+++ b/router/src/test/groovy/io/micronaut/web/router/DefaultFilterRouteSpec.groovy
@@ -18,6 +18,7 @@ package io.micronaut.web.router
 import io.micronaut.http.HttpMethod
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponse
+import io.micronaut.http.filter.AroundLegacyFilter
 import io.micronaut.http.filter.FilterChain
 import io.micronaut.http.filter.FilterOrder
 import io.micronaut.http.filter.FilterPatternStyle
@@ -32,7 +33,7 @@ class DefaultFilterRouteSpec extends Specification {
 
     void "test filter route matching with no methods specified"() {
         given:
-        def filter = new GenericHttpFilter.AroundLegacy(new HttpFilter() {
+        def filter = new AroundLegacyFilter(new HttpFilter() {
             @Override
             Publisher<? extends HttpResponse<?>> doFilter(HttpRequest<?> request, FilterChain chain) {
                 return null
@@ -55,7 +56,7 @@ class DefaultFilterRouteSpec extends Specification {
 
     void "test filter route matching with methods specified"() {
         given:
-        def filter = new GenericHttpFilter.AroundLegacy(new HttpFilter() {
+        def filter = new AroundLegacyFilter(new HttpFilter() {
             @Override
             Publisher<? extends HttpResponse<?>> doFilter(HttpRequest<?> request, FilterChain chain) {
                 return null
@@ -78,7 +79,7 @@ class DefaultFilterRouteSpec extends Specification {
 
     void "test filter route matching with regex pattern style specified"() {
         given:
-        def filter = new GenericHttpFilter.AroundLegacy(new HttpFilter() {
+        def filter = new AroundLegacyFilter(new HttpFilter() {
             @Override
             Publisher<? extends HttpResponse<?>> doFilter(HttpRequest<?> request, FilterChain chain) {
                 return null


### PR DESCRIPTION
After https://github.com/micronaut-projects/micronaut-core/pull/9720 I found it's a bit complicated to maintain that code, refactoring to split the main filter runner into multiple classes. Avoid if-instanceof, converted most of the code to private, separate async execution.

Targeting 4.2