### PR TITLE
test: Ignore SSL tests in MacOS because they fail most of the time

### DIFF
--- a/http-client/src/test/groovy/io/micronaut/http/client/SslRefreshSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/SslRefreshSpec.groovy
@@ -15,6 +15,7 @@ import io.micronaut.runtime.context.scope.refresh.RefreshEvent
 import io.micronaut.runtime.server.EmbeddedServer
 import io.netty.handler.ssl.SslHandler
 import io.netty.handler.ssl.util.SelfSignedCertificate
+import spock.lang.IgnoreIf
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -24,6 +25,7 @@ import java.security.KeyStore
 import java.security.cert.Certificate
 import java.security.cert.X509Certificate
 
+@IgnoreIf({ os.isMacOs() })
 class SslRefreshSpec extends Specification {
 
     @Shared List<String> ciphers = ['TLS_RSA_WITH_AES_128_CBC_SHA',

--- a/http-client/src/test/groovy/io/micronaut/http/client/SslStaticCertSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/SslStaticCertSpec.groovy
@@ -26,10 +26,12 @@ import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.runtime.server.EmbeddedServer
 import reactor.core.publisher.Flux
+import spock.lang.IgnoreIf
 import spock.lang.Retry
 import spock.lang.Shared
 import spock.lang.Specification
 
+@IgnoreIf({ os.isMacOs() })
 @Retry(mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class SslStaticCertSpec extends Specification {
 


### PR DESCRIPTION
Close: https://github.com/micronaut-projects/micronaut-core/issues/9728

see: https://ge.micronaut.io/scans/tests?search.query=tag:%22Mac%20OS%20X%22&search.relativeStartTime=P90D&search.timeZoneId=Europe/Madrid&tests.container=io.micronaut.http.client.SslRefreshSpec&tests.test=test%20client%20ssl%20refresh

see: https://ge.micronaut.io/scans/tests?search.query=tag:%22Mac%20OS%20X%22&search.relativeStartTime=P90D&search.timeZoneId=Europe/Madrid&tests.container=io.micronaut.http.client.SslStaticCertSpec