### PR TITLE
Add values back to config metadata

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/configuration/ConfigurationMetadataBuilder.java
+++ b/core-processor/src/main/java/io/micronaut/inject/configuration/ConfigurationMetadataBuilder.java
@@ -20,6 +20,7 @@ import com.github.javaparser.javadoc.Javadoc;
 import com.github.javaparser.javadoc.JavadocBlockTag;
 import com.github.javaparser.javadoc.description.JavadocDescription;
 import com.github.javaparser.javadoc.description.JavadocDescriptionElement;
+import com.github.javaparser.javadoc.description.JavadocInlineTag;
 import com.github.javaparser.javadoc.description.JavadocSnippet;
 import io.micronaut.context.annotation.ConfigurationReader;
 import io.micronaut.core.annotation.Internal;
@@ -130,6 +131,8 @@ public class ConfigurationMetadataBuilder {
                     for (JavadocDescriptionElement jde : elements) {
                         if (jde instanceof JavadocSnippet snippet) {
                             builder.append(snippet.toText());
+                        } else if (jde instanceof JavadocInlineTag tag) {
+                            builder.append(tag.toText());
                         }
                     }
                 } else if (element instanceof MethodElement) {

--- a/inject-java/src/test/groovy/io/micronaut/inject/configuration/ConfigurationMetadataSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configuration/ConfigurationMetadataSpec.groovy
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017-2019 original authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.micronaut.inject.configuration
 
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -133,7 +118,6 @@ import io.micronaut.context.annotation.*;
 
 /**
 *  My Configuration description.
-*
 */
 @ConfigurationProperties("test")
 interface MyProperties {
@@ -156,12 +140,62 @@ interface MyProperties {
 
         then:
         jsonEquals(metadataJson, [
-                groups: [
+                groups    : [
                         [name: 'test', type: "test.MyProperties", description: "My Configuration description."],
                 ],
                 properties: [
                         [name: 'test.name', type: "java.lang.String", sourceType: "test.MyProperties", description: "Get the name, default value {@value #DEFAULT_NAME}."],
                         [name: 'test.age', type: "int", sourceType: "test.MyProperties", description: "The age"]
+                ]
+
+        ])
+    }
+
+    void "test setter descriptions"() {
+        when:
+        String metadataJson = buildConfigurationMetadata('''
+package test;
+
+import io.micronaut.context.annotation.*;
+import io.micronaut.core.util.Toggleable;
+
+interface BaseConfig extends Toggleable {
+
+    /**
+     * @return The name
+     */
+    String getName();
+}
+
+@ConfigurationProperties("test")
+class Config implements BaseConfig {
+
+    public static final String DEFAULT_NAME = "test";
+
+    private String name = DEFAULT_NAME;
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Sets the name (default {@value #DEFAULT_NAME}).
+     * @param name the name to use
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+}
+''')
+
+        then:
+        jsonEquals(metadataJson, [
+                groups    : [
+                        [name: 'test', type: "test.Config"],
+                ],
+                properties: [
+                        [name: 'test.name', type: "java.lang.String", sourceType: "test.Config", description: "Sets the name (default {@value #DEFAULT_NAME})."],
                 ]
 
         ])


### PR DESCRIPTION
We were skipping them as they are instances of JavadocInlineTag

Also add a method of testing json without requiring big confusing json strings

Fixes #9735