### PR TITLE
AST: Support resolving the class element represented by `GenericElement`

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/ast/GenericElement.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/GenericElement.java
@@ -20,6 +20,8 @@ import io.micronaut.core.annotation.Experimental;
 import io.micronaut.inject.ast.annotation.MutableAnnotationMetadataDelegate;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Optional;
+
 /**
  * Represents a generic element that can appear as a type argument.
  *
@@ -53,6 +55,27 @@ public interface GenericElement extends ClassElement {
     @NotNull
     default MutableAnnotationMetadataDelegate<AnnotationMetadata> getGenericTypeAnnotationMetadata() {
         return (MutableAnnotationMetadataDelegate<AnnotationMetadata>) MutableAnnotationMetadataDelegate.EMPTY;
+    }
+
+    /**
+     * In some cases the class element can be a resolved as a generic element and this element should return the actual
+     * type that is generic element is representing.
+     *
+     * @return The resolved value of the generic element.
+     * @since 4.2.0
+     */
+    default Optional<ClassElement> getResolved() {
+        return Optional.empty();
+    }
+
+    /**
+     * Tries to resolve underneath type using {@link #getResolved()} or returns this type otherwise.
+     *
+     * @return The resolved value of the generic element or this type.
+     * @since 4.2.0
+     */
+    default ClassElement resolved() {
+        return getResolved().orElse(this);
     }
 
 }

--- a/core-processor/src/main/java/io/micronaut/inject/ast/GenericPlaceholderElement.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/GenericPlaceholderElement.java
@@ -16,6 +16,7 @@
 package io.micronaut.inject.ast;
 
 import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.annotation.NextMajorVersion;
 import io.micronaut.core.annotation.NonNull;
 
 import java.util.List;
@@ -68,6 +69,8 @@ public interface GenericPlaceholderElement extends GenericElement {
      * @return The resolved value of the placeholder.
      * @since 4.0.0
      */
+    @NextMajorVersion("Remove this method. There is an equivalent in the super class.")
+    @Override
     default Optional<ClassElement> getResolved() {
         return Optional.empty();
     }

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyWildcardElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyWildcardElement.java
@@ -30,6 +30,7 @@ import io.micronaut.inject.ast.annotation.WildcardElementAnnotationMetadata;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -66,6 +67,11 @@ final class GroovyWildcardElement extends GroovyClassElement implements Wildcard
         this.upperBounds = upperBounds;
         this.lowerBounds = lowerBounds;
         typeAnnotationMetadata = new WildcardElementAnnotationMetadata(this, upperType);
+    }
+
+    @Override
+    public Optional<ClassElement> getResolved() {
+        return Optional.of(upperType);
     }
 
     @Override

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaWildcardElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaWildcardElement.java
@@ -31,6 +31,7 @@ import io.micronaut.inject.ast.annotation.WildcardElementAnnotationMetadata;
 import javax.lang.model.type.WildcardType;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 
 /**
@@ -66,6 +67,11 @@ final class JavaWildcardElement extends JavaClassElement implements WildcardElem
         this.upperBounds = upperBounds;
         this.lowerBounds = lowerBounds;
         typeAnnotationMetadata = new WildcardElementAnnotationMetadata(this, upperBound);
+    }
+
+    @Override
+    public Optional<ClassElement> getResolved() {
+        return Optional.of(upperBound);
     }
 
     @Override

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinTypeArgumentElement.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinTypeArgumentElement.kt
@@ -22,6 +22,8 @@ import io.micronaut.inject.ast.GenericElement
 import io.micronaut.inject.ast.annotation.AbstractElementAnnotationMetadata
 import io.micronaut.inject.ast.annotation.ElementAnnotationMetadata
 import io.micronaut.inject.ast.annotation.MutableAnnotationMetadataDelegate
+import java.util.*
+import kotlin.collections.ArrayList
 
 internal class KotlinTypeArgumentElement(
     private var internalGenericNativeType: KotlinTypeArgumentNativeElement,
@@ -64,6 +66,7 @@ internal class KotlinTypeArgumentElement(
         }
         KotlinTypeArgumentElementAnnotationMetadata(this, resolved)
     }
+
     private val resolvedAnnotationMetadata: AnnotationMetadata by lazy {
         AnnotationMetadataHierarchy(
             true,
@@ -71,9 +74,12 @@ internal class KotlinTypeArgumentElement(
             resolvedGenericTypeAnnotationMetadata
         )
     }
+
     private val resolvedGenericTypeAnnotationMetadata: ElementAnnotationMetadata by lazy {
         elementAnnotationMetadataFactory.buildGenericTypeAnnotations(this)
     }
+
+    override fun getResolved(): Optional<ClassElement> = Optional.of(resolved)
 
     override fun getGenericNativeType() = internalGenericNativeType
 

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinWildcardElement.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinWildcardElement.kt
@@ -24,6 +24,7 @@ import io.micronaut.inject.ast.WildcardElement
 import io.micronaut.inject.ast.annotation.ElementAnnotationMetadata
 import io.micronaut.inject.ast.annotation.ElementAnnotationMetadataFactory
 import io.micronaut.inject.ast.annotation.WildcardElementAnnotationMetadata
+import java.util.*
 import java.util.function.Function
 
 internal class KotlinWildcardElement(
@@ -47,6 +48,7 @@ internal class KotlinWildcardElement(
     private val resolvedTypeAnnotationMetadata: ElementAnnotationMetadata by lazy {
         WildcardElementAnnotationMetadata(this, upper)
     }
+
     private val resolvedAnnotationMetadata: AnnotationMetadata by lazy {
         AnnotationMetadataHierarchy(
             true,
@@ -54,9 +56,12 @@ internal class KotlinWildcardElement(
             resolvedGenericTypeAnnotationMetadata
         )
     }
+
     private val resolvedGenericTypeAnnotationMetadata: ElementAnnotationMetadata by lazy {
         elementAnnotationMetadataFactory.buildGenericTypeAnnotations(this)
     }
+
+    override fun getResolved(): Optional<ClassElement> = Optional.of(upper)
 
     override fun getAnnotationMetadataToWrite() = resolvedGenericTypeAnnotationMetadata
 

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/ast/ClassElementSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/ast/ClassElementSpec.groovy
@@ -10,6 +10,7 @@ import io.micronaut.inject.ast.Element
 import io.micronaut.inject.ast.ElementModifier
 import io.micronaut.inject.ast.ElementQuery
 import io.micronaut.inject.ast.FieldElement
+import io.micronaut.inject.ast.GenericElement
 import io.micronaut.inject.ast.GenericPlaceholderElement
 import io.micronaut.inject.ast.MemberElement
 import io.micronaut.inject.ast.MethodElement
@@ -2275,6 +2276,36 @@ class StripeConfig {
 ''')
         then:
             noExceptionThrown()
+    }
+
+    void "test enum collection"() {
+        def ce = buildClassElement('test.TestNamed', '''
+package test
+import io.micronaut.context.annotation.Executable
+import io.micronaut.context.annotation.Prototype
+import jakarta.inject.Singleton
+import java.util.List
+
+@Prototype
+class TestNamed {
+    @Executable
+    fun method1(coll: Collection<MyType>) : kotlin.Int {
+        return 111
+    }
+
+}
+
+
+enum class MyType {
+    A, B
+}
+
+''')
+
+        def theType = ce.findMethod("method1").get().getParameters()[0].type.firstTypeArgument.get()
+        expect:
+            theType instanceof GenericElement
+            (theType as GenericElement).resolved().isEnum()
     }
 
     private void assertListGenericArgument(ClassElement type, Closure cl) {


### PR DESCRIPTION
To support https://github.com/micronaut-projects/micronaut-core/issues/9754

@altro3 I'm extending `getResolved/resolve` to all generic elements in 4.2.