### PR TITLE
Skip calling `containsBean` for `io.micronaut.context.BeanProvider`

### DIFF
--- a/inject/src/main/java/io/micronaut/inject/provider/AbstractProviderDefinition.java
+++ b/inject/src/main/java/io/micronaut/inject/provider/AbstractProviderDefinition.java
@@ -147,8 +147,7 @@ public abstract class AbstractProviderDefinition<T> implements InstantiatableBea
                             qualifier = Qualifiers.byName(n.toString());
                         }
                     }
-                    boolean allowEmptyProviders = isAllowEmptyProviders(context);
-                    if (isNullableProvider || isOptionalProvider || !allowEmptyProviders && !(qualifier instanceof AnyQualifier)) {
+                    if (isNullableProvider || isOptionalProvider || !(isAllowEmptyProviders(context) || qualifier instanceof AnyQualifier)) {
                         // Skip the contains bean for the providers that support an empty value and aren't nullable or optional
                         boolean hasBean = context.containsBean(argument, qualifier);
                         if (!hasBean) {

--- a/inject/src/main/java/io/micronaut/inject/provider/AbstractProviderDefinition.java
+++ b/inject/src/main/java/io/micronaut/inject/provider/AbstractProviderDefinition.java
@@ -21,6 +21,7 @@ import io.micronaut.context.Qualifier;
 import io.micronaut.context.annotation.Any;
 import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.context.exceptions.BeanInstantiationException;
+import io.micronaut.context.exceptions.DisabledBeanException;
 import io.micronaut.context.exceptions.NoSuchBeanException;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationUtil;
@@ -40,6 +41,7 @@ import io.micronaut.inject.qualifiers.Qualifiers;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Abstract bean definition for other providers to extend from.
@@ -150,6 +152,12 @@ public abstract class AbstractProviderDefinition<T> implements InstantiatableBea
                         // Skip the contains bean for the providers that support an empty value and aren't nullable or optional
                         boolean hasBean = context.containsBean(argument, qualifier);
                         if (!hasBean) {
+                            if (isNullableProvider) {
+                                throw new DisabledBeanException("Nullable bean doesn't exist");
+                            }
+                            if (isOptionalProvider) {
+                                return (T) Optional.empty();
+                            }
                             throw new NoSuchBeanException(argument, qualifier);
                         }
                     }

--- a/inject/src/main/java/io/micronaut/inject/provider/BeanProviderDefinition.java
+++ b/inject/src/main/java/io/micronaut/inject/provider/BeanProviderDefinition.java
@@ -60,8 +60,9 @@ public final class BeanProviderDefinition extends AbstractProviderDefinition<Bea
             @NonNull Argument<Object> argument,
             @Nullable Qualifier<Object> qualifier,
             boolean singleton) {
-        return new BeanProvider<Object>() {
+        return new BeanProvider<>() {
 
+            private final DefaultBeanContext defaultBeanContext = (DefaultBeanContext) context;
             private final Qualifier<Object> finalQualifier =
                     qualifier instanceof AnyQualifier ? null : qualifier;
 
@@ -78,12 +79,12 @@ public final class BeanProviderDefinition extends AbstractProviderDefinition<Bea
 
             @Override
             public Object get() {
-                return ((DefaultBeanContext) context).getBean(resolutionContext.copy(), argument, finalQualifier);
+                return defaultBeanContext.getBean(resolutionContext.copy(), argument, finalQualifier);
             }
 
             @Override
             public Optional<Object> find(Qualifier<Object> qualifier) {
-                return ((DefaultBeanContext) context).findBean(resolutionContext.copy(), argument, qualify(qualifier));
+                return defaultBeanContext.findBean(resolutionContext.copy(), argument, qualify(qualifier));
             }
 
             @Override
@@ -93,7 +94,7 @@ public final class BeanProviderDefinition extends AbstractProviderDefinition<Bea
 
             @Override
             public Object get(Qualifier<Object> qualifier) {
-                return ((DefaultBeanContext) context).getBean(resolutionContext.copy(), argument, qualify(qualifier));
+                return defaultBeanContext.getBean(resolutionContext.copy(), argument, qualify(qualifier));
             }
 
             @Override
@@ -113,12 +114,12 @@ public final class BeanProviderDefinition extends AbstractProviderDefinition<Bea
             @NonNull
             @Override
             public Iterator<Object> iterator() {
-                return ((DefaultBeanContext) context).getBeansOfType(resolutionContext.copy(), argument, finalQualifier).iterator();
+                return defaultBeanContext.getBeansOfType(resolutionContext.copy(), argument, finalQualifier).iterator();
             }
 
             @Override
             public Stream<Object> stream() {
-                return ((DefaultBeanContext) context).streamOfType(resolutionContext.copy(), argument, finalQualifier);
+                return defaultBeanContext.streamOfType(resolutionContext.copy(), argument, finalQualifier);
             }
         };
     }

--- a/inject/src/main/java/io/micronaut/inject/provider/JakartaProviderBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/inject/provider/JakartaProviderBeanDefinition.java
@@ -49,19 +49,20 @@ public final class JakartaProviderBeanDefinition extends AbstractProviderDefinit
 
     @Override
     protected Provider<Object> buildProvider(BeanResolutionContext resolutionContext, BeanContext context, Argument<Object> argument, Qualifier<Object> qualifier, boolean singleton) {
+        DefaultBeanContext defaultBeanContext = (DefaultBeanContext) context;
         if (singleton) {
-            return new Provider<Object>() {
+            return new Provider<>() {
                 Object bean;
                 @Override
                 public Object get() {
                     if (bean == null) {
-                        bean = ((DefaultBeanContext) context).getBean(resolutionContext.copy(), argument, qualifier);
+                        bean = defaultBeanContext.getBean(resolutionContext.copy(), argument, qualifier);
                     }
                     return bean;
                 }
             };
         }
-        return () -> ((DefaultBeanContext) context).getBean(resolutionContext.copy(), argument, qualifier);
+        return () -> defaultBeanContext.getBean(resolutionContext.copy(), argument, qualifier);
     }
 
     static boolean isTypePresent() {

--- a/inject/src/main/java/io/micronaut/inject/provider/JavaxProviderBeanDefinition.java
+++ b/inject/src/main/java/io/micronaut/inject/provider/JavaxProviderBeanDefinition.java
@@ -51,20 +51,21 @@ public final class JavaxProviderBeanDefinition extends AbstractProviderDefinitio
 
     @Override
     protected Provider<Object> buildProvider(BeanResolutionContext resolutionContext, BeanContext context, Argument<Object> argument, Qualifier<Object> qualifier, boolean singleton) {
+        DefaultBeanContext defaultBeanContext = (DefaultBeanContext) context;
         if (singleton) {
-            return new Provider<Object>() {
+            return new Provider<>() {
                 Object bean;
 
                 @Override
                 public Object get() {
                     if (bean == null) {
-                        bean = ((DefaultBeanContext) context).getBean(resolutionContext.copy(), argument, qualifier);
+                        bean = defaultBeanContext.getBean(resolutionContext.copy(), argument, qualifier);
                     }
                     return bean;
                 }
             };
         }
-        return () -> ((DefaultBeanContext) context).getBean(resolutionContext.copy(), argument, qualifier);
+        return () -> defaultBeanContext.getBean(resolutionContext.copy(), argument, qualifier);
     }
 
     private static boolean isTypePresent() {


### PR DESCRIPTION
The result is not important as BeanProvider allows empty values