### PR TITLE
Conversion service improvements

### DIFF
--- a/benchmarks/src/jmh/java/io/micronaut/core/convert/ConversionServiceBenchmark.java
+++ b/benchmarks/src/jmh/java/io/micronaut/core/convert/ConversionServiceBenchmark.java
@@ -37,13 +37,13 @@ public class ConversionServiceBenchmark {
     }
 
     @Benchmark
-    public void convertCacheHit() {
-        conversionService.convert("10", Integer.class);
+    public Object convertCacheHit() {
+        return conversionService.convert("10", Integer.class);
     }
 
     @Benchmark
-    public void convertCacheMiss() {
-        conversionService.convert(URI.create("http://test.com"), Integer.class);
+    public Object convertCacheMiss() {
+        return conversionService.convert(URI.create("http://test.com"), Integer.class);
     }
 
     public static void main(String[] args) throws RunnerException {

--- a/buffer-netty/src/main/java/io/micronaut/buffer/netty/NettyByteBufferFactory.java
+++ b/buffer-netty/src/main/java/io/micronaut/buffer/netty/NettyByteBufferFactory.java
@@ -18,12 +18,12 @@ package io.micronaut.buffer.netty;
 import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.convert.MutableConversionService;
+import io.micronaut.core.convert.TypeConverterRegistrar;
 import io.micronaut.core.io.buffer.ByteBuffer;
 import io.micronaut.core.io.buffer.ByteBufferFactory;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
-import jakarta.annotation.PostConstruct;
 import jakarta.inject.Singleton;
 
 import java.util.function.Supplier;
@@ -37,7 +37,7 @@ import java.util.function.Supplier;
 @Internal
 @Singleton
 @BootstrapContextCompatible
-public class NettyByteBufferFactory implements ByteBufferFactory<ByteBufAllocator, ByteBuf> {
+public final class NettyByteBufferFactory implements ByteBufferFactory<ByteBufAllocator, ByteBuf>, TypeConverterRegistrar {
 
     /**
      * Default Netty ByteBuffer Factory.
@@ -60,8 +60,8 @@ public class NettyByteBufferFactory implements ByteBufferFactory<ByteBufAllocato
         this.allocatorSupplier = () -> allocator;
     }
 
-    @PostConstruct
-    final void register(MutableConversionService conversionService) {
+    @Override
+    public void register(MutableConversionService conversionService) {
         conversionService.addConverter(ByteBuf.class, ByteBuffer.class, DEFAULT::wrap);
         conversionService.addConverter(ByteBuffer.class, ByteBuf.class, byteBuffer -> {
             if (byteBuffer instanceof NettyByteBuffer) {

--- a/context/src/main/java/io/micronaut/logging/LoggingConverterRegistrar.java
+++ b/context/src/main/java/io/micronaut/logging/LoggingConverterRegistrar.java
@@ -16,6 +16,7 @@
 package io.micronaut.logging;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.convert.CharSequenceToEnumConverter;
 import io.micronaut.core.convert.MutableConversionService;
 import io.micronaut.core.convert.TypeConverterRegistrar;
 
@@ -30,6 +31,6 @@ public final class LoggingConverterRegistrar implements TypeConverterRegistrar {
 
     @Override
     public void register(MutableConversionService conversionService) {
-        conversionService.addConverter(String.class, LogLevel.class, LogLevel::valueOf);
+        conversionService.addConverter(CharSequence.class, LogLevel.class, new CharSequenceToEnumConverter<>());
     }
 }

--- a/context/src/main/java/io/micronaut/logging/LoggingConverterRegistrar.java
+++ b/context/src/main/java/io/micronaut/logging/LoggingConverterRegistrar.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.logging;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.convert.MutableConversionService;
+import io.micronaut.core.convert.TypeConverterRegistrar;
+
+/**
+ * Logging converters.
+ *
+ * @author Denis Stepanov
+ * @since 4.2.0
+ */
+@Internal
+public final class LoggingConverterRegistrar implements TypeConverterRegistrar {
+
+    @Override
+    public void register(MutableConversionService conversionService) {
+        conversionService.addConverter(String.class, LogLevel.class, LogLevel::valueOf);
+    }
+}

--- a/context/src/main/resources/META-INF/services/io.micronaut.core.convert.TypeConverterRegistrar
+++ b/context/src/main/resources/META-INF/services/io.micronaut.core.convert.TypeConverterRegistrar
@@ -1,1 +1,2 @@
 io.micronaut.runtime.converters.time.TimeConverterRegistrar
+io.micronaut.logging.LoggingConverterRegistrar

--- a/core/src/main/java/io/micronaut/core/convert/CharSequenceToEnumConverter.java
+++ b/core/src/main/java/io/micronaut/core/convert/CharSequenceToEnumConverter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.core.convert;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.naming.NameUtils;
+import io.micronaut.core.util.StringUtils;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+/**
+ * The converter that converts {@link CharSequence} to an enum.
+ *
+ * @param <T> T The enum type
+ * @author Denis Stepanov
+ * @since 4.2.0
+ */
+@Internal
+public final class CharSequenceToEnumConverter<T extends Enum<T>> implements TypeConverter<CharSequence, T> {
+
+    @Override
+    public Optional<T> convert(CharSequence charSequence, Class<T> targetType, ConversionContext context) {
+        if (StringUtils.isEmpty(charSequence)) {
+            return Optional.empty();
+        }
+        String stringValue = charSequence.toString();
+        try {
+            T val = Enum.valueOf(targetType, stringValue);
+            return Optional.of(val);
+        } catch (IllegalArgumentException e) {
+            try {
+                T val = Enum.valueOf(targetType, NameUtils.environmentName(stringValue));
+                return Optional.of(val);
+            } catch (Exception e1) {
+                Optional<T> valOpt = Arrays.stream(targetType.getEnumConstants())
+                        .filter(val -> val.toString().equals(stringValue))
+                        .findFirst();
+                if (valOpt.isPresent()) {
+                    return valOpt;
+                }
+                context.reject(charSequence, e);
+                return Optional.empty();
+            }
+        }
+    }
+}

--- a/core/src/main/java/io/micronaut/core/convert/ConversionService.java
+++ b/core/src/main/java/io/micronaut/core/convert/ConversionService.java
@@ -40,10 +40,34 @@ public interface ConversionService {
      * @param object     The object to convert
      * @param targetType The target type
      * @param context    The conversion context
-     * @param <T>        The generic type
+     * @param <T>        The target type
      * @return The optional
      */
-    <T> Optional<T> convert(Object object, Class<T> targetType, ConversionContext context);
+    default <T> Optional<T> convert(Object object, Class<T> targetType, ConversionContext context) {
+        if (object == null || targetType == null || context == null) {
+            return Optional.empty();
+        }
+        if (targetType == Object.class) {
+            return Optional.of((T) object);
+        }
+        return convert(object, (Class<Object>) object.getClass(), targetType, context);
+    }
+
+    /**
+     * Attempts to convert the given object to the given target type from the given source type. If conversion fails or is not possible an empty {@link Optional} is returned.
+     *
+     * @param object     The object to convert
+     * @param sourceType The source type
+     * @param targetType The target type
+     * @param context    The conversion context
+     * @param <S>        The source type
+     * @param <T>        The target type
+     * @return The optional
+     * @since 4.2.0
+     */
+    default <S, T> Optional<T> convert(S object, Class<? super S> sourceType, Class<T> targetType, ConversionContext context) {
+        return convert(object, targetType, context);
+    }
 
     /**
      * Return whether the given source type is convertible to the given target type.
@@ -78,6 +102,21 @@ public interface ConversionService {
      */
     default <T> Optional<T> convert(Object object, Argument<T> targetType) {
         return convert(object, targetType.getType(), ConversionContext.of(targetType));
+    }
+
+    /**
+     * Attempts to convert the given object to the given target type from the given source type. If conversion fails or is not possible an empty {@link Optional} is returned.
+     *
+     * @param object     The object to convert
+     * @param sourceType The source type
+     * @param targetType The target type
+     * @param <S>        The source type
+     * @param <T>        The target type
+     * @return The optional
+     * @since 4.2.0
+     */
+    default <S, T> Optional<T> convert(S object, Class<? super S> sourceType, Argument<T> targetType) {
+        return convert(object, sourceType, targetType.getType(), ConversionContext.of(targetType));
     }
 
     /**

--- a/core/src/main/java/io/micronaut/core/convert/ConversionService.java
+++ b/core/src/main/java/io/micronaut/core/convert/ConversionService.java
@@ -44,6 +44,9 @@ public interface ConversionService {
      * @return The optional
      */
     default <T> Optional<T> convert(Object object, Class<T> targetType, ConversionContext context) {
+        if (object == null) {
+            return Optional.empty();
+        }
         return convert(object, (Class<Object>) object.getClass(), targetType, context);
     }
 

--- a/core/src/main/java/io/micronaut/core/convert/ConversionService.java
+++ b/core/src/main/java/io/micronaut/core/convert/ConversionService.java
@@ -44,12 +44,6 @@ public interface ConversionService {
      * @return The optional
      */
     default <T> Optional<T> convert(Object object, Class<T> targetType, ConversionContext context) {
-        if (object == null || targetType == null || context == null) {
-            return Optional.empty();
-        }
-        if (targetType == Object.class) {
-            return Optional.of((T) object);
-        }
         return convert(object, (Class<Object>) object.getClass(), targetType, context);
     }
 

--- a/core/src/main/java/io/micronaut/core/convert/DefaultMutableConversionService.java
+++ b/core/src/main/java/io/micronaut/core/convert/DefaultMutableConversionService.java
@@ -28,7 +28,6 @@ import io.micronaut.core.convert.value.ConvertibleValuesMap;
 import io.micronaut.core.io.IOUtils;
 import io.micronaut.core.io.buffer.ReferenceCounted;
 import io.micronaut.core.io.service.SoftServiceLoader;
-import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.type.Argument;
@@ -1252,32 +1251,4 @@ public class DefaultMutableConversionService implements MutableConversionService
         }
     }
 
-    private static final class CharSequenceToEnumConverter<T extends Enum<T>> implements TypeConverter<CharSequence, T> {
-
-        @Override
-        public Optional<T> convert(CharSequence charSequence, Class<T> targetType, ConversionContext context) {
-            if (StringUtils.isEmpty(charSequence)) {
-                return Optional.empty();
-            }
-            String stringValue = charSequence.toString();
-            try {
-                T val = Enum.valueOf(targetType, stringValue);
-                return Optional.of(val);
-            } catch (IllegalArgumentException e) {
-                try {
-                    T val = Enum.valueOf(targetType, NameUtils.environmentName(stringValue));
-                    return Optional.of(val);
-                } catch (Exception e1) {
-                    Optional<T> valOpt = Arrays.stream(targetType.getEnumConstants())
-                            .filter(val -> val.toString().equals(stringValue))
-                            .findFirst();
-                    if (valOpt.isPresent()) {
-                        return valOpt;
-                    }
-                    context.reject(charSequence, e);
-                    return Optional.empty();
-                }
-            }
-        }
-    }
 }

--- a/core/src/main/java/io/micronaut/core/convert/DefaultMutableConversionService.java
+++ b/core/src/main/java/io/micronaut/core/convert/DefaultMutableConversionService.java
@@ -200,8 +200,7 @@ public class DefaultMutableConversionService implements MutableConversionService
         final AnnotationMetadata annotationMetadata = context.getAnnotationMetadata();
         String formattingAnnotation;
         if (annotationMetadata.hasStereotypeNonRepeating(Format.class)) {
-            Optional<String> formattingAnn = annotationMetadata.getAnnotationNameByStereotype(Format.class);
-            formattingAnnotation = formattingAnn.orElse(null);
+            formattingAnnotation = annotationMetadata.getAnnotationNameByStereotype(Format.class).orElse(null);
         } else {
             formattingAnnotation = null;
         }

--- a/core/src/main/java/io/micronaut/core/convert/DefaultMutableConversionService.java
+++ b/core/src/main/java/io/micronaut/core/convert/DefaultMutableConversionService.java
@@ -106,6 +106,7 @@ public class DefaultMutableConversionService implements MutableConversionService
     private static final TypeConverter UNCONVERTIBLE = (object, targetType, context) -> Optional.empty();
 
     private static final Map<Class<?>, List<Class<?>>> COMMON_TYPE_HIERARCHY = CollectionUtils.newHashMap(30);
+
     static {
         // Optimize common hierarchy scenarios
         COMMON_TYPE_HIERARCHY.put(String.class, List.of(String.class, CharSequence.class, Object.class));

--- a/core/src/main/java/io/micronaut/core/convert/DefaultMutableConversionService.java
+++ b/core/src/main/java/io/micronaut/core/convert/DefaultMutableConversionService.java
@@ -856,10 +856,8 @@ public class DefaultMutableConversionService implements MutableConversionService
             return Optional.of(strings);
         });
 
-        TypeConverter<CharSequence, Enum> toEnumConverter = new CharSequenceToEnumConverter();
-
         // String -> Enum
-        addInternalConverter(CharSequence.class, Enum.class, toEnumConverter);
+        addInternalConverter(CharSequence.class, Enum.class, new CharSequenceToEnumConverter());
 
         // Object -> String
         addInternalConverter(Object.class, String.class, (Object object, Class<String> targetType, ConversionContext context) -> Optional.of(object.toString()));
@@ -1104,8 +1102,7 @@ public class DefaultMutableConversionService implements MutableConversionService
                 new MultiValuesConverterFactory.ObjectToMultiValuesConverter(this));
 
         // CharSequence -> java.net.Proxy.Type
-        CharSequenceToEnumConverter<Proxy.Type> toProxyType = new CharSequenceToEnumConverter<>();
-        addInternalConverter(CharSequence.class, Proxy.Type.class, (object, targetType, context) -> toProxyType.convert(object, targetType));
+        addInternalConverter(CharSequence.class, Proxy.Type.class, new CharSequenceToEnumConverter<>());
 
         Collection<TypeConverterRegistrar> registrars = new ArrayList<>();
         SoftServiceLoader.load(TypeConverterRegistrar.class)

--- a/core/src/main/java/io/micronaut/core/convert/DefaultMutableConversionService.java
+++ b/core/src/main/java/io/micronaut/core/convert/DefaultMutableConversionService.java
@@ -247,17 +247,12 @@ public class DefaultMutableConversionService implements MutableConversionService
                 return Optional.empty();
             } else {
                 addToConverterCache(pair, typeConverter);
-                if (typeConverter == UNCONVERTIBLE) {
-                    return Optional.empty();
-                } else {
-                    return typeConverter.convert(object, targetType, context);
-                }
             }
         }
-        if (typeConverter != UNCONVERTIBLE) {
-            return typeConverter.convert(object, targetType, context);
+        if (typeConverter == UNCONVERTIBLE) {
+            return Optional.empty();
         }
-        return Optional.empty();
+        return typeConverter.convert(object, targetType, context);
     }
 
     @Override

--- a/core/src/main/java/io/micronaut/core/convert/DefaultMutableConversionService.java
+++ b/core/src/main/java/io/micronaut/core/convert/DefaultMutableConversionService.java
@@ -342,6 +342,11 @@ public class DefaultMutableConversionService implements MutableConversionService
         }
     }
 
+    @Override
+    public <S, T> void addConverter(Class<S> sourceType, Class<T> targetType, Function<S, T> function) {
+        addConverter(sourceType, targetType, TypeConverter.of(sourceType, targetType, function));
+    }
+
     /**
      * Add internal converter.
      *
@@ -351,11 +356,6 @@ public class DefaultMutableConversionService implements MutableConversionService
      * @param <S> The source type
      * @param <T> The target type
      */
-    @Override
-    public <S, T> void addConverter(Class<S> sourceType, Class<T> targetType, Function<S, T> function) {
-        addConverter(sourceType, targetType, TypeConverter.of(sourceType, targetType, function));
-    }
-
     @Internal
     public <S, T> void addInternalConverter(Class<S> sourceType, Class<T> targetType, Function<S, T> function) {
         addInternalConverter(sourceType, targetType, TypeConverter.of(sourceType, targetType, function));

--- a/core/src/main/java/io/micronaut/core/convert/format/ReadableBytesTypeConverter.java
+++ b/core/src/main/java/io/micronaut/core/convert/format/ReadableBytesTypeConverter.java
@@ -44,19 +44,17 @@ public class ReadableBytesTypeConverter implements FormattingTypeConverter<CharS
         }
         String value = object.toString().toUpperCase(Locale.ENGLISH);
         try {
+            long numberPart = Long.parseLong(value.substring(0, value.length() - 2));
+            long size;
             if (value.endsWith("KB")) {
-                long size = Long.valueOf(value.substring(0, value.length() - 2)) * KB_UNIT;
-                return ConversionService.SHARED.convert(size, targetType);
+                size = numberPart * KB_UNIT;
+            } else if (value.endsWith("MB")) {
+                size = numberPart * KB_UNIT * KB_UNIT;
+            } else if (value.endsWith("GB")) {
+                size = numberPart * KB_UNIT * KB_UNIT * KB_UNIT;
+            } else {
+                size = Long.parseLong(value);
             }
-            if (value.endsWith("MB")) {
-                long size = Long.valueOf(value.substring(0, value.length() - 2)) * KB_UNIT * KB_UNIT;
-                return ConversionService.SHARED.convert(size, targetType);
-            }
-            if (value.endsWith("GB")) {
-                long size = Long.valueOf(value.substring(0, value.length() - 2)) * KB_UNIT * KB_UNIT * KB_UNIT;
-                return ConversionService.SHARED.convert(size, targetType);
-            }
-            Long size = Long.valueOf(value);
             return ConversionService.SHARED.convert(size, targetType);
         } catch (NumberFormatException e) {
             context.reject(value, e);

--- a/http-client-core/src/main/java/io/micronaut/http/client/loadbalance/LoadBalancerConverters.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/loadbalance/LoadBalancerConverters.java
@@ -17,6 +17,7 @@ package io.micronaut.http.client.loadbalance;
 
 import io.micronaut.core.convert.MutableConversionService;
 import io.micronaut.core.convert.TypeConverterRegistrar;
+import io.micronaut.http.client.HttpVersionSelection;
 import io.micronaut.http.client.LoadBalancer;
 
 import java.net.URI;
@@ -42,5 +43,6 @@ public class LoadBalancerConverters implements TypeConverterRegistrar {
                 return null;
             }
         });
+        conversionService.addConverter(String.class, HttpVersionSelection.PlaintextMode.class, HttpVersionSelection.PlaintextMode::valueOf);
     }
 }

--- a/http-client-core/src/main/java/io/micronaut/http/client/loadbalance/LoadBalancerConverters.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/loadbalance/LoadBalancerConverters.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.http.client.loadbalance;
 
+import io.micronaut.core.convert.CharSequenceToEnumConverter;
 import io.micronaut.core.convert.MutableConversionService;
 import io.micronaut.core.convert.TypeConverterRegistrar;
 import io.micronaut.http.client.HttpVersionSelection;
@@ -43,6 +44,6 @@ public class LoadBalancerConverters implements TypeConverterRegistrar {
                 return null;
             }
         });
-        conversionService.addConverter(String.class, HttpVersionSelection.PlaintextMode.class, HttpVersionSelection.PlaintextMode::valueOf);
+        conversionService.addConverter(CharSequence.class, HttpVersionSelection.PlaintextMode.class, new CharSequenceToEnumConverter<>());
     }
 }

--- a/http-client/src/main/java/io/micronaut/http/client/netty/FullNettyClientHttpResponse.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/FullNettyClientHttpResponse.java
@@ -19,7 +19,6 @@ import io.micronaut.buffer.netty.NettyByteBufferFactory;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.async.subscriber.Completable;
-import io.micronaut.core.convert.ConversionContext;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.value.MutableConvertibleValues;
 import io.micronaut.core.convert.value.MutableConvertibleValuesMap;
@@ -73,7 +72,7 @@ public class FullNettyClientHttpResponse<B> implements HttpResponse<B>, Completa
 
     /**
      * @param fullHttpResponse       The full Http response
-     * @param mediaTypeCodecRegistry The media type codec registry
+     * @param handlerRegistry        The message body handler registry
      * @param bodyType               The body type
      * @param convertBody            Whether to auto convert the body to bodyType
      * @param conversionService      The conversion service
@@ -200,7 +199,7 @@ public class FullNettyClientHttpResponse<B> implements HttpResponse<B>, Completa
         return CharSequence.class.isAssignableFrom(rawBodyType) || Map.class.isAssignableFrom(rawBodyType);
     }
 
-    private <T> Optional convertByteBuf(ByteBuf content, Argument<T> type) {
+    private <T> Optional<T> convertByteBuf(ByteBuf content, Argument<T> type) {
         if (content.refCnt() == 0 || content.readableBytes() == 0) {
             if (LOG.isTraceEnabled()) {
                 LOG.trace("Full HTTP response received an empty body");
@@ -229,7 +228,7 @@ public class FullNettyClientHttpResponse<B> implements HttpResponse<B>, Completa
             LOG.trace("Missing or unknown Content-Type received from server.");
         }
         // last chance, try type conversion
-        return conversionService.convert(content, ConversionContext.of(type));
+        return conversionService.convert(content, ByteBuf.class, type);
     }
 
     @Override

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/body/ImmediateSingleObjectBody.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/body/ImmediateSingleObjectBody.java
@@ -85,7 +85,11 @@ public final class ImmediateSingleObjectBody extends ManagedBody<Object> impleme
         Object o = prepareClaim();
         Optional<?> converted;
         if (o instanceof io.netty.util.ReferenceCounted rc) {
-            converted = conversionService.convert(rc, context);
+            if (rc instanceof ByteBuf byteBuf) {
+                converted = conversionService.convert(byteBuf, ByteBuf.class, context.getArgument().getType(), context);
+            } else {
+                converted = conversionService.convert(rc, context);
+            }
             // stolen from NettyConverters.refCountAwareConvert. We don't need the isEmpty branch,
             // because we don't call next() in that case and don't transfer ownership.
             if (converted.isPresent()) {

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/converters/NettyConverters.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/converters/NettyConverters.java
@@ -52,7 +52,7 @@ import java.util.Optional;
  */
 @Prototype
 @Internal
-public class NettyConverters implements TypeConverterRegistrar {
+public final class NettyConverters implements TypeConverterRegistrar {
 
     private final ConversionService conversionService;
     private final BeanProvider<MediaTypeCodecRegistry> decoderRegistryProvider;
@@ -157,7 +157,7 @@ public class NettyConverters implements TypeConverterRegistrar {
     /**
      * @return A FileUpload to CompletedFileUpload converter
      */
-    protected TypeConverter<FileUpload, Object> fileUploadToObjectConverter() {
+    private TypeConverter<FileUpload, Object> fileUploadToObjectConverter() {
         return (object, targetType, context) -> {
             try {
                 if (!object.isCompleted()) {
@@ -188,7 +188,7 @@ public class NettyConverters implements TypeConverterRegistrar {
     /**
      * @return A converter that returns bytebufs to objects
      */
-    protected TypeConverter<ByteBuf, Object> byteBufToObjectConverter() {
+    private TypeConverter<ByteBuf, Object> byteBufToObjectConverter() {
         return (object, targetType, context) -> conversionService.convert(object.toString(context.getCharset()), targetType, context);
     }
 

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/converters/NettyConverters.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/converters/NettyConverters.java
@@ -22,7 +22,6 @@ import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.ConversionContext;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.MutableConversionService;
-import io.micronaut.core.convert.TypeConverter;
 import io.micronaut.core.convert.TypeConverterRegistrar;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.util.StringUtils;
@@ -60,9 +59,10 @@ public final class NettyConverters implements TypeConverterRegistrar {
 
     /**
      * Default constructor.
-     * @param conversionService The conversion service
+     *
+     * @param conversionService       The conversion service
      * @param decoderRegistryProvider The decoder registry provider
-     * @param channelOptionFactory The decoder channel option factory
+     * @param channelOptionFactory    The decoder channel option factory
      */
     public NettyConverters(ConversionService conversionService,
                            //Prevent early initialization of the codecs
@@ -88,25 +88,78 @@ public final class NettyConverters implements TypeConverterRegistrar {
         conversionService.addConverter(
                 ByteBuf.class,
                 Object.class,
-                byteBufToObjectConverter()
+                (object, targetType, context) -> conversionService.convert(object.toString(context.getCharset()), targetType, context)
         );
 
         conversionService.addConverter(
                 FileUpload.class,
                 Object.class,
-                fileUploadToObjectConverter()
+                (object, targetType, context) -> {
+                    try {
+                        if (!object.isCompleted()) {
+                            return Optional.empty();
+                        }
+                        String contentType = object.getContentType();
+                        ByteBuf byteBuf = object.getByteBuf();
+                        if (StringUtils.isNotEmpty(contentType)) {
+                            MediaType mediaType = MediaType.of(contentType);
+                            Optional<MediaTypeCodec> registered = decoderRegistryProvider.get().findCodec(mediaType);
+                            if (registered.isPresent()) {
+                                MediaTypeCodec decoder = registered.get();
+                                Object val = decoder.decode(targetType, new ByteBufInputStream(byteBuf));
+                                return Optional.of(val);
+                            } else {
+                                return this.conversionService.convert(byteBuf, targetType, context);
+                            }
+                        }
+                        return this.conversionService.convert(byteBuf, targetType, context);
+                    } catch (Exception e) {
+                        context.reject(e);
+                        return Optional.empty();
+                    }
+                }
         );
 
         conversionService.addConverter(
                 NettyPartData.class,
                 Object.class,
-                nettyPartDataToObjectConverter()
+                (object, targetType, context) -> {
+                    try {
+                        if (targetType.isAssignableFrom(ByteBuffer.class)) {
+                            return Optional.of(object.getByteBuffer());
+                        } else if (targetType.isAssignableFrom(InputStream.class)) {
+                            return Optional.of(object.getInputStream());
+                        } else {
+                            ByteBuf byteBuf = object.getByteBuf();
+                            try {
+                                return this.conversionService.convert(byteBuf, targetType, context);
+                            } finally {
+                                byteBuf.release();
+                            }
+                        }
+                    } catch (IOException e) {
+                        context.reject(e);
+                        return Optional.empty();
+                    }
+                }
         );
 
         conversionService.addConverter(
                 Attribute.class,
                 Object.class,
-                nettyAttributeToObjectConverter()
+                (object, targetType, context) -> {
+                    try {
+                        final String value = object.getValue();
+                        if (targetType.isInstance(value)) {
+                            return Optional.of(value);
+                        } else {
+                            return this.conversionService.convert(value, targetType, context);
+                        }
+                    } catch (IOException e) {
+                        context.reject(e);
+                        return Optional.empty();
+                    }
+                }
         );
 
         conversionService.addConverter(
@@ -116,82 +169,6 @@ public final class NettyConverters implements TypeConverterRegistrar {
         );
     }
 
-    private TypeConverter<Attribute, Object> nettyAttributeToObjectConverter() {
-        return (object, targetType, context) -> {
-            try {
-                final String value = object.getValue();
-                if (targetType.isInstance(value)) {
-                    return Optional.of(value);
-                } else {
-                    return conversionService.convert(value, targetType, context);
-                }
-            } catch (IOException e) {
-                context.reject(e);
-                return Optional.empty();
-            }
-        };
-    }
-
-    private TypeConverter<NettyPartData, Object> nettyPartDataToObjectConverter() {
-        return (object, targetType, context) -> {
-            try {
-                if (targetType.isAssignableFrom(ByteBuffer.class)) {
-                    return Optional.of(object.getByteBuffer());
-                } else if (targetType.isAssignableFrom(InputStream.class)) {
-                    return Optional.of(object.getInputStream());
-                } else {
-                    ByteBuf byteBuf = object.getByteBuf();
-                    try {
-                        return conversionService.convert(byteBuf, targetType, context);
-                    } finally {
-                        byteBuf.release();
-                    }
-                }
-            } catch (IOException e) {
-                context.reject(e);
-                return Optional.empty();
-            }
-        };
-    }
-
-    /**
-     * @return A FileUpload to CompletedFileUpload converter
-     */
-    private TypeConverter<FileUpload, Object> fileUploadToObjectConverter() {
-        return (object, targetType, context) -> {
-            try {
-                if (!object.isCompleted()) {
-                    return Optional.empty();
-                }
-
-                String contentType = object.getContentType();
-                ByteBuf byteBuf = object.getByteBuf();
-                if (StringUtils.isNotEmpty(contentType)) {
-                    MediaType mediaType = MediaType.of(contentType);
-                    Optional<MediaTypeCodec> registered = decoderRegistryProvider.get().findCodec(mediaType);
-                    if (registered.isPresent()) {
-                        MediaTypeCodec decoder = registered.get();
-                        Object val = decoder.decode(targetType, new ByteBufInputStream(byteBuf));
-                        return Optional.of(val);
-                    } else {
-                        return conversionService.convert(byteBuf, targetType, context);
-                    }
-                }
-                return conversionService.convert(byteBuf, targetType, context);
-            } catch (Exception e) {
-                context.reject(e);
-                return Optional.empty();
-            }
-        };
-    }
-
-    /**
-     * @return A converter that returns bytebufs to objects
-     */
-    private TypeConverter<ByteBuf, Object> byteBufToObjectConverter() {
-        return (object, targetType, context) -> conversionService.convert(object.toString(context.getCharset()), targetType, context);
-    }
-
     /**
      * This method converts a
      * {@link io.netty.util.ReferenceCounted netty reference counted object} and transfers release
@@ -199,8 +176,8 @@ public final class NettyConverters implements TypeConverterRegistrar {
      *
      * @param service The conversion service
      * @param context The context to convert to
-     * @param input The object to convert
-     * @param <T> Target type
+     * @param input   The object to convert
+     * @param <T>     Target type
      * @return The converted object
      */
     public static <T> Optional<T> refCountAwareConvert(ConversionService service, ReferenceCounted input, ArgumentConversionContext<T> context) {
@@ -214,11 +191,11 @@ public final class NettyConverters implements TypeConverterRegistrar {
      * {@link io.netty.util.ReferenceCounted netty reference counted object} and transfers release
      * ownership to the new object.
      *
-     * @param service The conversion service
-     * @param input The object to convert
+     * @param service    The conversion service
+     * @param input      The object to convert
      * @param targetType The type to convert to
-     * @param context The context to convert with
-     * @param <T> Target type
+     * @param context    The context to convert with
+     * @param <T>        Target type
      * @return The converted object
      */
     public static <T> Optional<T> refCountAwareConvert(ConversionService service, ReferenceCounted input, Class<T> targetType, ConversionContext context) {

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/converters/NettyConvertersSpi.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/converters/NettyConvertersSpi.java
@@ -21,6 +21,7 @@ import io.micronaut.core.convert.TypeConverter;
 import io.micronaut.core.convert.TypeConverterRegistrar;
 import io.micronaut.http.multipart.CompletedFileUpload;
 import io.micronaut.http.multipart.CompletedPart;
+import io.micronaut.http.server.netty.configuration.NettyHttpServerConfiguration;
 import io.micronaut.http.server.netty.multipart.NettyCompletedAttribute;
 import io.micronaut.http.server.netty.multipart.NettyCompletedFileUpload;
 import io.micronaut.http.server.netty.multipart.NettyPartData;
@@ -32,6 +33,7 @@ import io.netty.channel.WriteBufferWaterMark;
 import io.netty.handler.codec.http.multipart.Attribute;
 import io.netty.handler.codec.http.multipart.FileUpload;
 import io.netty.handler.codec.http.multipart.HttpData;
+import io.netty.handler.logging.LogLevel;
 
 import java.io.IOException;
 import java.util.Map;
@@ -48,6 +50,12 @@ import java.util.Optional;
 public final class NettyConvertersSpi implements TypeConverterRegistrar {
     @Override
     public void register(MutableConversionService conversionService) {
+        conversionService.addConverter(String.class, LogLevel.class, LogLevel::valueOf);
+        conversionService.addConverter(
+                String.class,
+                NettyHttpServerConfiguration.NettyListenerConfiguration.Family.class,
+                NettyHttpServerConfiguration.NettyListenerConfiguration.Family::valueOf
+        );
         conversionService.addConverter(
             ByteBuf.class,
             CharSequence.class,

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/converters/NettyConvertersSpi.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/converters/NettyConvertersSpi.java
@@ -16,6 +16,7 @@
 package io.micronaut.http.server.netty.converters;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.convert.CharSequenceToEnumConverter;
 import io.micronaut.core.convert.MutableConversionService;
 import io.micronaut.core.convert.TypeConverter;
 import io.micronaut.core.convert.TypeConverterRegistrar;
@@ -50,11 +51,11 @@ import java.util.Optional;
 public final class NettyConvertersSpi implements TypeConverterRegistrar {
     @Override
     public void register(MutableConversionService conversionService) {
-        conversionService.addConverter(String.class, LogLevel.class, LogLevel::valueOf);
+        conversionService.addConverter(CharSequence.class, LogLevel.class, new CharSequenceToEnumConverter<>());
         conversionService.addConverter(
-                String.class,
+                CharSequence.class,
                 NettyHttpServerConfiguration.NettyListenerConfiguration.Family.class,
-                NettyHttpServerConfiguration.NettyListenerConfiguration.Family::valueOf
+                new CharSequenceToEnumConverter<>()
         );
         conversionService.addConverter(
             ByteBuf.class,

--- a/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
+++ b/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
@@ -311,6 +311,11 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
     }
 
     @Override
+    public <S, T> Optional<T> convert(S object, Class<? super S> sourceType, Class<T> targetType, ConversionContext context) {
+        return mutableConversionService.convert(object, sourceType, targetType, context);
+    }
+
+    @Override
     public <S, T> boolean canConvert(Class<S> sourceType, Class<T> targetType) {
         return mutableConversionService.canConvert(sourceType, targetType);
     }

--- a/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
+++ b/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
@@ -17,6 +17,7 @@ package io.micronaut.context.env;
 
 import io.micronaut.context.ApplicationContextConfiguration;
 import io.micronaut.context.exceptions.ConfigurationException;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.convert.ConversionContext;
@@ -64,7 +65,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -139,7 +139,6 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
         this.configuration = configuration;
         this.resourceLoader = configuration.getResourceLoader();
 
-        Set<String> environments = new LinkedHashSet<>(3);
         List<String> specifiedNames = new ArrayList<>(configuration.getEnvironments());
 
         specifiedNames.addAll(0, Stream.of(CachedEnvironment.getProperty(ENVIRONMENTS_PROPERTY),
@@ -147,14 +146,14 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
                 .filter(StringUtils::isNotEmpty)
                 .flatMap(s -> Arrays.stream(s.split(",")))
                 .map(String::trim)
-                .collect(Collectors.toList()));
+                .toList());
 
         this.deduceEnvironments = configuration.getDeduceEnvironments().orElse(null);
         EnvironmentsAndPackage environmentsAndPackage = getEnvironmentsAndPackage(specifiedNames);
         if (environmentsAndPackage.enviroments.isEmpty() && specifiedNames.isEmpty()) {
             specifiedNames = configuration.getDefaultEnvironments();
         }
-        environments.addAll(environmentsAndPackage.enviroments);
+        Set<String> environments = new LinkedHashSet<>(environmentsAndPackage.enviroments);
         String aPackage = environmentsAndPackage.aPackage;
         if (aPackage != null) {
             packages.add(aPackage);
@@ -293,9 +292,7 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
         reading.set(false);
         this.propertySources.values().removeAll(refreshablePropertySources);
         synchronized (catalog) {
-            for (int i = 0; i < catalog.length; i++) {
-                catalog[i] = null;
-            }
+            Arrays.fill(catalog, null);
             resetCaches();
         }
         return this;
@@ -326,6 +323,14 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
     @Override
     public <S, T> void addConverter(Class<S> sourceType, Class<T> targetType, Function<S, T> typeConverter) {
         mutableConversionService.addConverter(sourceType, targetType, typeConverter);
+    }
+
+    /**
+     * @return The mutable conversion service.
+     */
+    @Internal
+    public MutableConversionService getMutableConversionService() {
+        return mutableConversionService;
     }
 
     @Override

--- a/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
+++ b/inject/src/main/java/io/micronaut/context/env/PropertySourcePropertyResolver.java
@@ -415,7 +415,7 @@ public class PropertySourcePropertyResolver implements PropertyResolver, AutoClo
             } else if (Map.class.isAssignableFrom(requiredType)) {
                 Map<String, Object> subMap = resolveSubMap(name, entries, conversionContext);
                 if (!subMap.isEmpty()) {
-                    return conversionService.convert(subMap, requiredType, conversionContext);
+                    return conversionService.convert(subMap, Map.class, requiredType, conversionContext);
                 } else {
                     return (Optional<T>) Optional.of(subMap);
                 }

--- a/json-core/src/main/java/io/micronaut/json/convert/JsonConverterRegistrar.java
+++ b/json-core/src/main/java/io/micronaut/json/convert/JsonConverterRegistrar.java
@@ -36,6 +36,8 @@ import io.micronaut.json.tree.JsonNode;
 import jakarta.inject.Inject;
 
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -94,6 +96,16 @@ public final class JsonConverterRegistrar implements TypeConverterRegistrar {
                 Object.class,
                 jsonNodeToObjectConverter()
         );
+        conversionService.addConverter(JsonNode.class, String.class, JsonNode::getStringValue);
+        conversionService.addConverter(JsonNode.class, Integer.class, JsonNode::getIntValue);
+        conversionService.addConverter(JsonNode.class, Double.class, JsonNode::getDoubleValue);
+        conversionService.addConverter(JsonNode.class, BigDecimal.class, JsonNode::getBigDecimalValue);
+        conversionService.addConverter(JsonNode.class, BigInteger.class, JsonNode::getBigIntegerValue);
+        conversionService.addConverter(JsonNode.class, Boolean.class, JsonNode::getBooleanValue);
+        conversionService.addConverter(JsonNode.class, Double.class, JsonNode::getDoubleValue);
+        conversionService.addConverter(JsonNode.class, Float.class, JsonNode::getFloatValue);
+        conversionService.addConverter(JsonNode.class, Number.class, JsonNode::getNumberValue);
+
         conversionService.addConverter(
                 LazyJsonNode.class,
                 Object.class,


### PR DESCRIPTION
- Introduced internal not-concurrent map
- Added common source type implementation converter variations
- Added missing converters to avoid runtime creation
- Created a way to convert an object from a specific type, allowing to bypass looking for the implementation converter
- Added a common preset class hierarchy, avoiding reflection call