### PR TITLE
Fix bug with incorrect conversion strategy / add tests

### DIFF
--- a/context/src/main/java/io/micronaut/runtime/beans/MapperIntroduction.java
+++ b/context/src/main/java/io/micronaut/runtime/beans/MapperIntroduction.java
@@ -175,7 +175,7 @@ final class MapperIntroduction implements MethodInterceptor<Object, Object> {
                     MutableAnnotationMetadata annotationMetadata = new MutableAnnotationMetadata();
                     annotationMetadata.addAnnotation(Format.class.getName(), Map.of(AnnotationMetadata.VALUE_MEMBER, format));
                     conversionContext = conversionContext.with(new AnnotationMetadataHierarchy(argument.getAnnotationMetadata(), annotationMetadata));
-                } else if (conflictStrategy == Mapper.ConflictStrategy.CONVERT) {
+                } else if (conflictStrategy == Mapper.ConflictStrategy.CONVERT || conflictStrategy == null) {
                     conversionContext = ConversionContext.of(argument);
                 }
 

--- a/context/src/test/groovy/io/micronaut/runtime/beans/MapperAnnotationSpec.groovy
+++ b/context/src/test/groovy/io/micronaut/runtime/beans/MapperAnnotationSpec.groovy
@@ -72,6 +72,16 @@ class MapperAnnotationSpec extends Specification {
         result.parts == 10
     }
 
+    void "converting mapper test"() {
+        given:
+        SimpleRobotEntity result = testBean.toEntityConvert(new CreateRobot2("foo", "bar", "10"))
+
+        expect:
+        result.id == 'FOO'
+        result.companyId == 'bar'
+        result.parts == 10
+    }
+
     void "transform mapper test"() {
         when:
         SimpleRobotEntity result = testBean.toEntityTransform(new CreateRobot("foo", "bar", 10))
@@ -113,6 +123,10 @@ abstract class Test {
     abstract SimpleRobotEntity toEntity(CreateRobot createRobot)
 
     @Mapper.Mapping(to = "id", from = "#{createRobot.id.toUpperCase()}")
+    @Mapper.Mapping(to = "parts", from = "#{createRobot.parts}")
+    abstract SimpleRobotEntity toEntityConvert(CreateRobot2 createRobot)
+
+    @Mapper.Mapping(to = "id", from = "#{createRobot.id.toUpperCase()}")
     @Mapper.Mapping(to = "parts", from = "#{createRobot.parts * 2}", condition = "#{createRobot.parts < 50}", defaultValue = "10")
     @Mapper.Mapping(to = "companyId", from = "#{this.calcCompanyId(createRobot)}")
     abstract SimpleRobotEntity toEntityTransform(CreateRobot createRobot)
@@ -129,6 +143,19 @@ final class CreateRobot {
     final int parts
 
     CreateRobot(String id, String companyId, int parts) {
+        this.id = id
+        this.companyId = companyId
+        this.parts = parts
+    }
+}
+
+@Introspected
+final class CreateRobot2 {
+    final String id
+    final String companyId
+    final String parts
+
+    CreateRobot2(String id, String companyId, String parts) {
         this.id = id
         this.companyId = companyId
         this.parts = parts

--- a/inject/src/main/java/io/micronaut/context/annotation/Mapper.java
+++ b/inject/src/main/java/io/micronaut/context/annotation/Mapper.java
@@ -32,7 +32,7 @@ import java.lang.annotation.Target;
  * @since 4.1.0
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
+@Target({ ElementType.METHOD, ElementType.TYPE })
 @Experimental
 public @interface Mapper {
 
@@ -50,7 +50,7 @@ public @interface Mapper {
      * The mappings.
      */
     @Retention(RetentionPolicy.RUNTIME)
-    @Target(ElementType.METHOD)
+    @Target({ ElementType.METHOD, ElementType.TYPE })
     @Repeatable(value = Mapper.class)
     @interface Mapping {
         String MEMBER_TO = "to";

--- a/test-suite/src/test/java/io/micronaut/docs/ioc/mappers/MappersSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/ioc/mappers/MappersSpec.java
@@ -1,6 +1,7 @@
 package io.micronaut.docs.ioc.mappers;
 
 import io.micronaut.context.ApplicationContext;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -22,6 +23,21 @@ class MappersSpec {
             assertEquals("$1821.00", productDTO.price());
             assertEquals("Great Product Company", productDTO.distributor());
             // end::mappers[]
+        }
+    }
+
+    @Test
+    void tetError() {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            ProductMappers2 productMappers = context.getBean(ProductMappers2.class);
+
+            Assertions.assertThrows(IllegalArgumentException.class, () ->
+                productMappers.toProductDTO(new Product(
+                    "MacBook",
+                    910.50,
+                    "Apple"
+                ))
+            );
         }
     }
 }

--- a/test-suite/src/test/java/io/micronaut/docs/ioc/mappers/ProductMappers2.java
+++ b/test-suite/src/test/java/io/micronaut/docs/ioc/mappers/ProductMappers2.java
@@ -1,0 +1,24 @@
+package io.micronaut.docs.ioc.mappers;
+
+// tag::class[]
+import io.micronaut.context.annotation.Mapper;
+import io.micronaut.context.annotation.Mapper.Mapping;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Mapper(conflictStrategy = Mapper.ConflictStrategy.ERROR)
+public interface ProductMappers2 {
+    @Mapping(
+        to = "price",
+        from = "#{product.price * 2}")
+    @Mapping(
+        to = "distributor",
+        from = "#{this.getDistributor()}"
+    )
+    ProductDTO toProductDTO(Product product);
+
+    default String getDistributor() {
+        return "Great Product Company";
+    }
+}
+// tag::end[]


### PR DESCRIPTION
If a custom mapper is provided the error strategy is set to null instead of convert. Also there was no way to set the conflict strategy at the type level. This PR fixes both of those issues with the `Mapper/Mapping` annotations