### PR TITLE
Fix processing order of introduced method in Java

### DIFF
--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/QueryParamClientWebSocket.java
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/websocket/QueryParamClientWebSocket.java
@@ -1,6 +1,7 @@
 package io.micronaut.http.server.netty.websocket;
 
 import io.micronaut.http.HttpRequest;
+import io.micronaut.http.annotation.QueryValue;
 import io.micronaut.websocket.WebSocketSession;
 import io.micronaut.websocket.annotation.ClientWebSocket;
 import io.micronaut.websocket.annotation.OnMessage;
@@ -14,7 +15,7 @@ public class QueryParamClientWebSocket {
     private String dinner;
 
     @OnOpen
-    public void onOpen(String dinner, WebSocketSession session, HttpRequest request) { // <3>
+    public void onOpen(@QueryValue String dinner, WebSocketSession session, HttpRequest request) { // <3>
         this.session = session;
         this.request = request;
         this.dinner = dinner;

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/PublicAbstractMethodVisitor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/PublicAbstractMethodVisitor.java
@@ -33,7 +33,9 @@ import java.util.Set;
  * @author graemerocher
  * @see javax.lang.model.util.AbstractTypeVisitor8
  * @since 1.0
+ * @deprecated No longer used
  */
+@Deprecated(forRemoval = true)
 public abstract class PublicAbstractMethodVisitor<R, P> extends PublicMethodVisitor<R, P> {
 
     private final TypeElement classElement;

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/PublicMethodVisitor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/PublicMethodVisitor.java
@@ -31,7 +31,9 @@ import java.util.Set;
  * @author graemerocher
  * @see javax.lang.model.util.AbstractTypeVisitor8
  * @since 1.0
+ * @deprecated No longer used
  */
+@Deprecated(forRemoval = true)
 public abstract class PublicMethodVisitor<R, P> extends SuperclassAwareTypeVisitor<R, P> {
 
     /**

--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/beans/IntroducedBeanVisitorSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/beans/IntroducedBeanVisitorSpec.groovy
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.introduction.beans
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+
+class IntroducedBeanVisitorSpec extends AbstractTypeElementSpec {
+
+    void "test introduced bean visitor"() {
+        given:
+            def context = buildContext("""
+package introducedbeanspec;
+
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.*;
+import io.micronaut.aop.Introduction;
+import io.micronaut.context.annotation.Type;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.aop.MethodInterceptor;
+import io.micronaut.aop.MethodInvocationContext;
+import io.micronaut.core.annotation.Nullable;
+import jakarta.inject.Singleton;
+import org.reactivestreams.Publisher;
+import java.util.Optional;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@Documented
+@Inherited
+@interface XMyDataMethod {
+}
+
+@Introduction
+@Type(MyRepoIntroducer.class)
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+@Inherited
+@interface RepoDef {
+}
+
+
+@Singleton
+class MyRepoIntroducer implements MethodInterceptor<Object, Object> {
+
+    @Nullable
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        return null;
+    }
+}
+
+interface Repo1 {
+    Publisher<MyBean> findAll();
+
+    Publisher<MyBean> method1();
+}
+
+interface Repo2<E> {
+    Publisher<E> findAll();
+
+    Publisher<E> method2();
+}
+
+@RepoDef
+interface Repo3 extends Repo2<MyBean>, Repo1 {
+
+    Publisher<MyBean> method3();
+
+}
+
+class MyBean {
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}
+
+
+""")
+
+        when:
+            def beanDef1 = context.getBeanDefinition(context.classLoader.loadClass("introducedbeanspec.Repo3"))
+            def findAllMethod = beanDef1.getRequiredMethod("findAll")
+            def method1 = beanDef1.getRequiredMethod("method1")
+            def method2 = beanDef1.getRequiredMethod("method2")
+            def method3 = beanDef1.getRequiredMethod("method3")
+        then:
+            findAllMethod.hasAnnotation("introducedbeanspec.XMyDataMethod")
+            method1.hasAnnotation("introducedbeanspec.XMyDataMethod")
+            method2.hasAnnotation("introducedbeanspec.XMyDataMethod")
+            method3.hasAnnotation("introducedbeanspec.XMyDataMethod")
+
+        cleanup:
+            context.close()
+    }
+
+    void "test introduced bean visitor 2"() {
+        given:
+            def context = buildContext("""
+package introducedbeanspec2;
+
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.*;
+import io.micronaut.aop.InterceptorBean;
+import io.micronaut.aop.Introduction;
+import io.micronaut.context.annotation.Type;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.aop.MethodInterceptor;
+import io.micronaut.aop.MethodInvocationContext;
+import io.micronaut.core.annotation.Nullable;
+import jakarta.inject.Singleton;
+import org.reactivestreams.Publisher;
+import java.util.Optional;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@Documented
+@Inherited
+@interface XMyDataMethod {
+}
+
+@Introduction
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+@Inherited
+@interface RepoDef {
+}
+
+
+@Singleton
+@InterceptorBean(RepoDef.class)
+class MyRepoIntroducer implements MethodInterceptor<Object, Object> {
+
+    @Nullable
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        return null;
+    }
+}
+
+interface Repo1 {
+    Publisher<MyBean> findAll();
+
+    Publisher<MyBean> method1();
+}
+
+interface Repo2<E> {
+    Publisher<E> findAll();
+
+    Publisher<E> method2();
+}
+
+@RepoDef
+interface Repo3 extends Repo2<MyBean>, Repo1 {
+
+    Publisher<MyBean> method3();
+
+}
+
+class MyBean {
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}
+
+
+""")
+
+        when:
+            def beanDef1 = context.getBeanDefinition(context.classLoader.loadClass("introducedbeanspec2.Repo3"))
+            def findAllMethod = beanDef1.getRequiredMethod("findAll")
+            def method1 = beanDef1.getRequiredMethod("method1")
+            def method2 = beanDef1.getRequiredMethod("method2")
+            def method3 = beanDef1.getRequiredMethod("method3")
+        then:
+            findAllMethod.hasAnnotation("introducedbeanspec2.XMyDataMethod")
+            method1.hasAnnotation("introducedbeanspec2.XMyDataMethod")
+            method2.hasAnnotation("introducedbeanspec2.XMyDataMethod")
+            method3.hasAnnotation("introducedbeanspec2.XMyDataMethod")
+
+        cleanup:
+            context.close()
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/introduction/beans/MyRepoVisitor2.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/introduction/beans/MyRepoVisitor2.java
@@ -1,0 +1,22 @@
+package io.micronaut.aop.introduction.beans;
+
+import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.ast.MethodElement;
+import io.micronaut.inject.visitor.TypeElementVisitor;
+import io.micronaut.inject.visitor.VisitorContext;
+
+public class MyRepoVisitor2 implements TypeElementVisitor<Object, Object> {
+
+    @Override
+    public void visitClass(ClassElement element, VisitorContext context) {
+    }
+
+    @Override
+    public void visitMethod(MethodElement element, VisitorContext context) {
+        if (element.getOwningType().getPackageName().equals("introducedbeanspec")) {
+            element.annotate("introducedbeanspec.XMyDataMethod");
+        } else if (element.getOwningType().getPackageName().equals("introducedbeanspec2")) {
+            element.annotate("introducedbeanspec2.XMyDataMethod");
+        }
+    }
+}

--- a/inject-java/src/test/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
+++ b/inject-java/src/test/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
@@ -18,3 +18,4 @@ io.micronaut.annotation.AnnotateMethodParameterSpec$AnnotateMethodParameterVisit
 io.micronaut.annotation.AnnotatePropertySpec$AnnotatePropertyVisitor
 io.micronaut.annotation.AnnotateClassSpec$AnnotateClassVisitor
 io.micronaut.annotation.AnnotateTypeArgSpec$AnnotateTypeArgVisitor
+io.micronaut.aop.introduction.beans.MyRepoVisitor2


### PR DESCRIPTION
Originally wanted to do this for 4.0 but didn't manage. Now the Java type element visitor is using the AST to process the hierarchy, in the same way as Groovy and Kotlin.

+ Groovy visitor improvement

Fixes https://github.com/micronaut-projects/micronaut-data/issues/2465