### PR TITLE
test: set explicitely WRITE_IN_METAINF=false

### DIFF
--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/ast/ClassElementSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/ast/ClassElementSpec.groovy
@@ -84,6 +84,7 @@ class MyBean {}
         AllElementsVisitor.VISITED_ELEMENTS.clear()
         AllElementsVisitor.VISITED_METHOD_ELEMENTS.clear()
         AllElementsVisitor.WRITE_FILE = true
+        AllElementsVisitor.WRITE_IN_METAINF = false
 
         when:
         def definition = buildBeanDefinition('test.visit.Test', '''


### PR DESCRIPTION
This test fails when run in a suite without this fix. 