### PR TITLE
Fix bean imports in combination with builders

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
+++ b/core-processor/src/main/java/io/micronaut/inject/beans/visitor/IntrospectedTypeElementVisitor.java
@@ -105,7 +105,7 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                     return;
                 }
                 int introspectionIndex = index.getAndIncrement();
-                processBuilderDefinition(ce, context, introspected, introspectionIndex);
+                processBuilderDefinition(ce, context, ce.findAnnotation(Introspected.class).orElse(introspected), introspectionIndex, targetPackage);
                 final BeanIntrospectionWriter writer = new BeanIntrospectionWriter(
                     targetPackage,
                     element.getName(),
@@ -136,7 +136,7 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                             continue;
                         }
                         int introspectionIndex = j++;
-                        processBuilderDefinition(classElement, context, introspected, introspectionIndex);
+                        processBuilderDefinition(classElement, context, classElement.findAnnotation(Introspected.class).orElse(introspected), introspectionIndex, targetPackage);
                         final BeanIntrospectionWriter writer = new BeanIntrospectionWriter(
                             targetPackage,
                             element.getName(),
@@ -157,7 +157,7 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                 }
             }
         } else {
-            processBuilderDefinition(element, context, introspected, 0);
+            processBuilderDefinition(element, context, introspected, 0, targetPackage);
             final BeanIntrospectionWriter writer = new BeanIntrospectionWriter(
                 targetPackage,
                 element,
@@ -168,7 +168,7 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
         }
     }
 
-    private void processBuilderDefinition(ClassElement element, VisitorContext context, AnnotationValue<Introspected> introspected, int index) {
+    private void processBuilderDefinition(ClassElement element, VisitorContext context, AnnotationValue<Introspected> introspected, int index, String targetPackage) {
         AnnotationValue<Introspected.IntrospectionBuilder> builder = introspected.getAnnotation("builder", Introspected.IntrospectionBuilder.class).orElse(null);
         if (builder != null) {
             String builderMethod = builder.stringValue("builderMethod").orElse(null);
@@ -200,7 +200,8 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                             null,
                             returnType,
                             methodMetadata,
-                            index
+                            index,
+                            targetPackage
                         );
                     } else {
                         context.fail("Builder return type is not public. The method must be static and accessible.", methodElement);
@@ -224,8 +225,8 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
                         builderClassElement.getDefaultConstructor().orElse(null),
                         builderClassElement,
                         builderClassElement.getTargetAnnotationMetadata(),
-                        index
-                    );
+                        index,
+                        targetPackage);
                 } else {
                     context.fail("Builder class not found on compilation classpath: " + builderClass.getName(), element);
                 }
@@ -286,7 +287,7 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
         MethodElement defaultConstructor,
         ClassElement builderType,
         AnnotationMetadata builderMetadata,
-        int index) {
+        int index, String targetPackage) {
         if (builderMetadata == null) {
             builderMetadata = AnnotationMetadata.EMPTY_METADATA;
         }
@@ -303,7 +304,7 @@ public class IntrospectedTypeElementVisitor implements TypeElementVisitor<Object
             MethodElement creatorMethodElement = builderType.getEnclosedElement(buildMethodQuery).orElse(null);
             if (creatorMethodElement != null) {
                 final BeanIntrospectionWriter builderWriter = new BeanIntrospectionWriter(
-                    classToBuild.getPackageName(),
+                    targetPackage,
                     builderType.getName(),
                     index,
                     classToBuild,

--- a/inject-java-test/build.gradle
+++ b/inject-java-test/build.gradle
@@ -7,9 +7,6 @@ dependencies {
 
     api project(":inject-java")
     api project(":context")
-//    api "com.google.testing.compile:compile-testing:0.19", {
-//        exclude group:'com.google.truth', module:'truth'
-//    }
     api libs.managed.groovy
     api(libs.spock) {
         exclude module:'groovy-all'

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/builder/BeanIntrospectionBuilderSpec.groovy
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/builder/BeanIntrospectionBuilderSpec.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.inject.visitor.beans.builder
 
 import io.micronaut.core.beans.BeanIntrospection
+import io.micronaut.core.beans.exceptions.IntrospectionException
 import spock.lang.Specification
 
 class BeanIntrospectionBuilderSpec extends Specification {
@@ -57,6 +58,31 @@ class BeanIntrospectionBuilderSpec extends Specification {
         introspection.isBuildable()
         result.name == "Fred"
         result.age == 20
+    }
+
+    void 'test build type with import'() {
+        given:
+        def introspection = BeanIntrospection.getIntrospection(TestBuildMe5)
+        def builder = introspection.builder()
+        def result = builder.with("name", "Fred").with("age", 20).build()
+
+
+        expect:
+        introspection.hasBuilder()
+        introspection.isBuildable()
+        result.name == "Fred"
+        result.age == 20
+    }
+
+    void 'test build type with import, no builder declaration'() {
+        when:
+        def introspection = BeanIntrospection.getIntrospection(TestBuildMe6)
+        def builder = introspection.builder()
+        def result = builder.with("name", "Fred").with("age", 20).build()
+
+
+        then:
+        thrown(IntrospectionException)
     }
 
     void 'test build type with builder method'() {

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/builder/ImportTest.java
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/builder/ImportTest.java
@@ -1,0 +1,7 @@
+package io.micronaut.inject.visitor.beans.builder;
+
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected(classes = TestBuildMe5.class, builder = @Introspected.IntrospectionBuilder(builderMethod = "builder"))
+public class ImportTest {
+}

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/builder/ImportTest2.java
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/builder/ImportTest2.java
@@ -1,0 +1,7 @@
+package io.micronaut.inject.visitor.beans.builder;
+
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected(classes = TestBuildMe6.class)
+public class ImportTest2 {
+}

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/builder/TestBuildMe5.java
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/builder/TestBuildMe5.java
@@ -1,0 +1,46 @@
+package io.micronaut.inject.visitor.beans.builder;
+
+
+public class TestBuildMe5 {
+    private final String name;
+    private final int age;
+
+    private TestBuildMe5(String name, int age) {
+        this.name = name;
+        this.age = age;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private String name;
+        private int age;
+
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder age(int age) {
+            this.age = age;
+            return this;
+        }
+
+        public TestBuildMe5 build() {
+            return new TestBuildMe5(
+                name,
+                age
+            );
+        }
+    }
+}

--- a/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/builder/TestBuildMe6.java
+++ b/inject-java-test/src/test/groovy/io/micronaut/inject/visitor/beans/builder/TestBuildMe6.java
@@ -1,0 +1,49 @@
+package io.micronaut.inject.visitor.beans.builder;
+
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+@JsonDeserialize(builder = TestBuildMe6.Builder.class)
+public class TestBuildMe6 {
+    private final String name;
+    private final int age;
+
+    private TestBuildMe6(String name, int age) {
+        this.name = name;
+        this.age = age;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private String name;
+        private int age;
+
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder age(int age) {
+            this.age = age;
+            return this;
+        }
+
+        public TestBuildMe6 build() {
+            return new TestBuildMe6(
+                name,
+                age
+            );
+        }
+    }
+}


### PR DESCRIPTION
Using imported introspections with builders currently doesn't work because the package name is incorrect and annotation metadata can't be read from the element. This PR fixes these two issues.