### PR TITLE
DefaultApplicationContext should close an Environment that it created

### DIFF
--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
@@ -69,6 +69,11 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
     private final ClassPathResourceLoader resourceLoader;
     private final ApplicationContextConfiguration configuration;
     private Environment environment;
+    /**
+     * True if the {@link #environment} was created by this context,
+     * false if the {@link #environment} was provided by {@link #setEnvironment(Environment)}
+     */
+    private boolean environmentManaged;
 
     /**
      * Construct a new ApplicationContext for the given environment name.
@@ -172,6 +177,7 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
     public Environment getEnvironment() {
         if (environment == null) {
             environment = createEnvironment(configuration);
+            environmentManaged = true;
         }
         return environment;
     }
@@ -182,6 +188,7 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
     @Internal
     public void setEnvironment(Environment environment) {
         this.environment = environment;
+        this.environmentManaged = false;
     }
 
     @Override
@@ -200,7 +207,11 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
     public synchronized @NonNull
     ApplicationContext stop() {
         ApplicationContext stop = (ApplicationContext) super.stop();
+        if (environment != null && environmentManaged) {
+            environment.stop();
+        }
         environment = null;
+        environmentManaged = false;
         return stop;
     }
 

--- a/inject/src/test/java/io/micronaut/context/DefaultApplicationContextTest.java
+++ b/inject/src/test/java/io/micronaut/context/DefaultApplicationContextTest.java
@@ -1,0 +1,40 @@
+package io.micronaut.context;
+
+import io.micronaut.context.env.Environment;
+import org.junit.jupiter.api.Test;
+import spock.lang.Issue;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DefaultApplicationContextTest {
+    @Issue("https://github.com/micronaut-projects/micronaut-test/issues/615#issuecomment-1516355815")
+    @Test
+    public void applicationContextShouldShutDownTheEnvironmentItCreated() {
+        DefaultApplicationContext ctx = new DefaultApplicationContext();
+        ctx.start();
+        Environment env = ctx.getEnvironment();
+        assertTrue(env.isRunning());
+        ctx.stop();
+        assertFalse(env.isRunning(), "expected to be stopped");
+    }
+
+    @Test
+    public void applicationContextShouldNotStopTheEnvironmentItDidNotCreate() {
+        DefaultApplicationContext ctx = new DefaultApplicationContext();
+        // make DefaultApplicationContext create and stop it's managed environment,
+        // so it thinks it manages it
+        ctx.start();
+        ctx.stop();
+
+        // providing ctx with an external environment
+        ApplicationContext ctx2 = ApplicationContext.run();
+        ctx.setEnvironment(ctx2.getEnvironment());
+
+        ctx.start();
+        ctx.stop();
+        assertTrue(ctx2.getEnvironment().isRunning(), "shouldn't stop an external environment");
+
+        ctx2.stop(); //cleanup
+    }
+}


### PR DESCRIPTION
This PR fixes an issue with `DefaultApplicationContext` not closing an environment it created.
This addresses the problem that was attempted to be fixed by a [stale PR](https://github.com/micronaut-projects/micronaut-test/issues/615), but does it according to the advice in the PR review: https://github.com/micronaut-projects/micronaut-test/pull/582#issuecomment-1132715214