### PR TITLE
Add a system property to prohibit dynamic service loading

### DIFF
--- a/core/src/main/java/io/micronaut/core/io/service/AotHelper.java
+++ b/core/src/main/java/io/micronaut/core/io/service/AotHelper.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.core.optim;
+package io.micronaut.core.io.service;
 
 import io.micronaut.core.annotation.Internal;
 
@@ -24,7 +24,7 @@ import io.micronaut.core.annotation.Internal;
  * @author Jonas Konrad
  */
 @Internal
-public final class AotHelper {
+final class AotHelper {
     /**
      * If this setting is enabled, any attempts to use {@link io.micronaut.core.io.service.SoftServiceLoader} on a
      * service type that is not optimized by aot will produce an exception.

--- a/core/src/main/java/io/micronaut/core/io/service/SoftServiceLoader.java
+++ b/core/src/main/java/io/micronaut/core/io/service/SoftServiceLoader.java
@@ -17,7 +17,6 @@ package io.micronaut.core.io.service;
 
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
-import io.micronaut.core.optim.AotHelper;
 import io.micronaut.core.optim.StaticOptimizations;
 import io.micronaut.core.reflect.ClassUtils;
 

--- a/core/src/main/java/io/micronaut/core/io/service/SoftServiceLoader.java
+++ b/core/src/main/java/io/micronaut/core/io/service/SoftServiceLoader.java
@@ -17,6 +17,7 @@ package io.micronaut.core.io.service;
 
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.optim.AotHelper;
 import io.micronaut.core.optim.StaticOptimizations;
 import io.micronaut.core.reflect.ClassUtils;
 
@@ -181,6 +182,8 @@ public final class SoftServiceLoader<S> implements Iterable<ServiceDefinition<S>
             Collection<S> values,
             Predicate<S> predicate,
             String name) {
+        AotHelper.checkDynamicServiceLoad(name);
+
         ServiceCollector<S> collector = newCollector(name, condition, classLoader, className -> {
             try {
                 @SuppressWarnings("unchecked") final Class<S> loadedClass =

--- a/core/src/main/java/io/micronaut/core/optim/AotHelper.java
+++ b/core/src/main/java/io/micronaut/core/optim/AotHelper.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.core.optim;
+
+import io.micronaut.core.annotation.Internal;
+
+/**
+ * AOT-specific helper.
+ *
+ * @since 4.2.0
+ * @author Jonas Konrad
+ */
+@Internal
+public final class AotHelper {
+    /**
+     * If this setting is enabled, any attempts to use {@link io.micronaut.core.io.service.SoftServiceLoader} on a
+     * service type that is not optimized by aot will produce an exception.
+     */
+    private static final String STRICT_SERVICE_LOADER_PROPERTY = "io.micronaut.aot.strict-service-loader";
+    private static final boolean STRICT_SERVICE_LOADER = Boolean.getBoolean(STRICT_SERVICE_LOADER_PROPERTY);
+
+    private AotHelper() {
+    }
+
+    /**
+     * Check whether loading a dynamic service is allowed. Will throw an exception otherwise.
+     *
+     * @param name The name of the service, for the exception error message
+     */
+    public static void checkDynamicServiceLoad(String name) {
+        if (STRICT_SERVICE_LOADER && !"buildtime".equals(System.getProperty("org.graalvm.nativeimage.imagecode"))) {
+            throw new UnsupportedOperationException("Dynamic service loading is forbidden, but there is no static service loader definition for " + name + ". Either add this service to the `service.types` micronaut-aot setting, or disable the `" + STRICT_SERVICE_LOADER_PROPERTY + "` system property.");
+        }
+    }
+}


### PR DESCRIPTION
This property can be used to confirm that all services are optimized by micronaut-aot and none are loaded dynamically.