### PR TITLE
docs: fix broken, stale, and deprecated links in user guide

### DIFF
--- a/src/main/docs/guide/aop/introductionAdvice.adoc
+++ b/src/main/docs/guide/aop/introductionAdvice.adoc
@@ -1,6 +1,6 @@
 Introduction advice is distinct from Around advice in that it involves providing an implementation instead of decorating.
 
-Examples of introduction advice include https://gorm.grails.org[GORM] and https://projects.spring.io/spring-data[Spring Data] which implement persistence logic for you.
+Examples of introduction advice include https://gorm.grails.org[GORM] and https://spring.io/projects/spring-data/[Spring Data] which implement persistence logic for you.
 
 Micronaut api:http.client.annotation.Client[] annotation is another example of introduction advice where the Micronaut framework implements HTTP client interfaces for you at compile time.
 

--- a/src/main/docs/guide/aop/scheduling.adoc
+++ b/src/main/docs/guide/aop/scheduling.adoc
@@ -53,7 +53,7 @@ The above example allows the task execution frequency to be configured with the 
 
 == Configuring the Scheduled Task Thread Pool
 
-Tasks executed by `@Scheduled` are run by default on a jdk:java.util.concurrent.ScheduledExecutorService[] configured to have twice the number of threads as available processors.
+Tasks executed by `@Scheduled` are run by default on a link:{jdkapi}/java.base/java/util/concurrent/ScheduledExecutorService.html[ScheduledExecutorService] configured to have twice the number of threads as available processors.
 
 You can configure this thread pool in your configuration file (e.g `application.yml`):
 

--- a/src/main/docs/guide/appendix/architecture/annotationArch.adoc
+++ b/src/main/docs/guide/appendix/architecture/annotationArch.adoc
@@ -4,7 +4,7 @@ Given this design decision, a compilation-time model was formulated to address t
 
 The api:core.annotation.AnnotationMetadata[] API is a construct that is used both a compilation time and at runtime by framework components. `AnnotationMetadata` represents the computed fusion of annotation information for a particular type, field, constructor, method or bean property and may include both annotations declared in the source code, but also synthetic meta-annotations that can be used at runtime to implement framework logic.
 
-When visiting source code within the <<compilerArch, Micronaut Compiler>> using the https://docs.micronaut.io/latest/api/io/micronaut/inject/ast/package-summary.html[Element API] for each api:inject.ast.ClassElement[], api:inject.ast.FieldElement[], api:inject.ast.MethodElement[], api:inject.ast.ConstructorElement[] and api:inject.ast.PropertyElement[] an instance of api:core.annotation.AnnotationMetadata[] is computed.
+When visiting source code within the <<compilerArch, Micronaut Compiler>> using the api:inject.ast.package-info[Element API] for each api:inject.ast.ClassElement[], api:inject.ast.FieldElement[], api:inject.ast.MethodElement[], api:inject.ast.ConstructorElement[] and api:inject.ast.PropertyElement[] an instance of api:core.annotation.AnnotationMetadata[] is computed.
 
 The `AnnotationMetadata` API tries to address the following challenges:
 
@@ -21,7 +21,7 @@ The basic flow is visualized below:
 
 image::arch/annotationmetadata.png[]
 
-Additionally, the api:inject.annotation.AbstractAnnotationMetadataBuilder[] will load via the https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/ServiceLoader.html[standard Java service loader mechanism] one or more instances of the following types that allow manipulating how an annotation is represented in the `AnnotationMetadata`:
+Additionally, the api:inject.annotation.AbstractAnnotationMetadataBuilder[] will load via the link:{jdkapi}/java.base/java/util/ServiceLoader.html[standard Java service loader mechanism] one or more instances of the following types that allow manipulating how an annotation is represented in the `AnnotationMetadata`:
 
 * api:inject.annotation.AnnotationMapper[] - A type that can map the value of one annotation to another, retaining the original annotation in the `AnnotationMetadata`
 * api:inject.annotation.AnnotationTransformer[] - A type that can transform the value of one annotation to another, eliminating the original annotation from the `AnnotationMetadata`

--- a/src/main/docs/guide/appendix/architecture/compilerArch.adoc
+++ b/src/main/docs/guide/appendix/architecture/compilerArch.adoc
@@ -1,17 +1,17 @@
 The Micronaut Compiler is a set of extensions to existing language compilers:
 
-* Java - the https://docs.oracle.com/en/java/javase/17/docs/api/java.compiler/javax/annotation/processing/package-summary.html[Java Annotation Processing (APT) API] is used for Java & Kotlin code (a future version of Micronaut will support KSP for Kotlin)
+* Java - the link:{jdkapi}/java.compiler/javax/annotation/processing/package-summary.html[Java Annotation Processing (APT) API] is used for Java & Kotlin code (a future version of Micronaut will support KSP for Kotlin)
 * Groovy - Groovy https://docs.groovy-lang.org/latest/html/api/org/codehaus/groovy/transform/ASTTransformation.html[AST Transformations] are used participate in the compilation of Groovy code.
 
-To keep this documentation simple, the remaining sections will describe the interaction with the Java compiler. 
+To keep this documentation simple, the remaining sections will describe the interaction with the Java compiler.
 
 The Micronaut Compiler visits end user code and generates additional bytecode that sits alongside the user code in the same package structure.
 
-The AST of user source is visited using implementations of api:inject.visitor.TypeElementVisitor[] which are loaded via the https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/ServiceLoader.html[standard Java service loader mechanism].
+The AST of user source is visited using implementations of api:inject.visitor.TypeElementVisitor[] which are loaded via the link:{jdkapi}/java.base/java/util/ServiceLoader.html[standard Java service loader mechanism].
 
 Each api:inject.visitor.TypeElementVisitor[] implementation can override one or more of the `visit*` methods which receive an instance of api:inject.ast.Element[].
 
-The https://docs.micronaut.io/latest/api/io/micronaut/inject/ast/package-summary.html[Element API] provides a language-neutral abstraction over the AST and computation of the api:core.annotation.AnnotationMetadata[] for a given element (class, method, field etc.).
+The api:inject.ast.package-info[Element API] provides a language-neutral abstraction over the AST and computation of the api:core.annotation.AnnotationMetadata[] for a given element (class, method, field etc.).
 
 
 

--- a/src/main/docs/guide/appendix/architecture/containerArch.adoc
+++ b/src/main/docs/guide/appendix/architecture/containerArch.adoc
@@ -1,6 +1,6 @@
 Once the job of the <<compilerArch, Micronaut Compiler>> is complete and the required classes generated, it is up to the api:context.BeanContext[] to load the classes for runtime execution.
 
-Whilst the https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/ServiceLoader.html[standard Java service loader mechanism] is used to define instances of api:inject.BeanDefinitionReference[], the instances themselves are instead loaded with api:core.io.service.SoftServiceLoader[] which is a more lenient implementation that allows checking if the service is actually present before loading and also allows parallel loading of services.
+Whilst the link:{jdkapi}/java.base/java/util/ServiceLoader.html[standard Java service loader mechanism] is used to define instances of api:inject.BeanDefinitionReference[], the instances themselves are instead loaded with api:core.io.service.SoftServiceLoader[] which is a more lenient implementation that allows checking if the service is actually present before loading and also allows parallel loading of services.
 
 The api:context.BeanContext[] performs the following steps:
 
@@ -15,7 +15,7 @@ image::arch/beancontext.png[]
 
 The api:context.ApplicationContext[] is a specialized version of the api:context.BeanContext[] that adds the notion of one or more active environments (encapsulated by api:context.env.Environment[]) and <<conditionalBeans, conditional bean loading>> based on this environment.
 
-The api:context.env.Environment[] is loaded from one or more defined api:context.env.PropertySource[] instances that are discovered via the https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/ServiceLoader.html[standard Java service loader mechanism] by loading instances of api:context.env.PropertySourceLoader[].
+The api:context.env.Environment[] is loaded from one or more defined api:context.env.PropertySource[] instances that are discovered via the link:{jdkapi}/java.base/java/util/ServiceLoader.html[standard Java service loader mechanism] by loading instances of api:context.env.PropertySourceLoader[].
 
 A developer can extend Micronaut to load a api:context.env.PropertySource[] through an entirely custom mechanism by adding another implementation and the associated `META-INF/services/io.micronaut.context.env.PropertySourceLoader` file referencing this class.
 

--- a/src/main/docs/guide/appendix/architecture/httpServerArch.adoc
+++ b/src/main/docs/guide/appendix/architecture/httpServerArch.adoc
@@ -71,7 +71,7 @@ Adding a `ChannelHandler` allows performing tasks such as wire-level logging of 
 
 === Netty Server Routing
 
-Micronaut defines a set of https://docs.micronaut.io/latest/api/io/micronaut/http/annotation/package-summary.html[HTTP annotations] that allow binding user code to incoming api:http.HttpRequest[] instances and customizing the resulting api:http.HttpResponse[].
+Micronaut defines a set of api:http.annotation.package-info[HTTP annotations] that allow binding user code to incoming api:http.HttpRequest[] instances and customizing the resulting api:http.HttpResponse[].
 
 One or many configured api:web.router.RouteBuilder[] implementations construct instances of api:web.router.UriRoute[] which is used by the api:web.router.Router[] components to route incoming requests methods of annotated classes such as:
 

--- a/src/main/docs/guide/appendix/architecture/introspectionArch.adoc
+++ b/src/main/docs/guide/appendix/architecture/introspectionArch.adoc
@@ -1,4 +1,4 @@
-The goal of <<introspection, Bean Introspections>> is to provide an alternative to reflection and the JDK's https://docs.oracle.com/en/java/javase/17/docs/api/java.desktop/java/beans/Introspector.html[Introspector API] that is coupled to the `java.desktop` module in recent versions of Java.
+The goal of <<introspection, Bean Introspections>> is to provide an alternative to reflection and the JDK's link:{jdkapi}/java.desktop/java/beans/Introspector.html[Introspector API] that is coupled to the `java.desktop` module in recent versions of Java.
 
 Many libraries in Java need to programmatically discover what methods represent properties of a class in some way and whilst the https://en.wikipedia.org/wiki/JavaBeans[JavaBeans specification] tried to establish a standard convention, the language itself has evolved to include other constructs like Records that represent properties as components.
 

--- a/src/main/docs/guide/appendix/architecture/iocArch.adoc
+++ b/src/main/docs/guide/appendix/architecture/iocArch.adoc
@@ -2,13 +2,13 @@ Micronaut framework is an implementation of the JSR-330 specification for Depend
 
 Dependency Injection (or Inversion of Control) is a widely adopted and common pattern in Java that allows loosely decoupling components to allow applications to be easily extended and tested.
 
-The way in which objects are wired together is decoupled from the objects themselves in this model by a separate programming model. In the case of Micronaut this model is based on annotations defined within the JSR-330 specification plus an extended set of annotations located within the https://docs.micronaut.io/latest/api/io/micronaut/context/annotation/package-summary.html[io.micronaut.context.annotation] package.
+The way in which objects are wired together is decoupled from the objects themselves in this model by a separate programming model. In the case of Micronaut this model is based on annotations defined within the JSR-330 specification plus an extended set of annotations located within the api:inject.context.annotation.package-info[io.micronaut.context.annotation] package.
 
 These annotations are visited by the <<compilerArch, Micronaut Compiler>> which traverses the source code language AST and builds a model used to wire objects together at runtime.
 
 NOTE: It is important to note that the actual object wiring is deferred until runtime.
 
-For Java code api:annotation.processing.BeanDefinitionInjectProcessor[] (which is a Java Annotation https://docs.oracle.com/en/java/javase/17/docs/api/java.compiler/javax/annotation/processing/Processor.html[Processor]) is invoked from the Java compiler for each class annotated with a bean definition annotation.
+For Java code api:annotation.processing.BeanDefinitionInjectProcessor[] (which is a Java Annotation link:{jdkapi}/java.compiler/javax/annotation/processing/Processor.html[Processor]) is invoked from the Java compiler for each class annotated with a bean definition annotation.
 
 NOTE: What constitutes a bean defining annotation is complex as it takes into account meta-annotations, but in general it is any annotation annotated with a JSR-330 bean `@Scope`
 

--- a/src/main/docs/guide/cloud/cloudConfiguration/distributedConfigurationConsul.adoc
+++ b/src/main/docs/guide/cloud/cloudConfiguration/distributedConfigurationConsul.adoc
@@ -10,7 +10,7 @@ The quickest way to start using Consul is via Docker:
 docker run -p 8500:8500 consul
 ----
 
-Alternatively you can https://www.consul.io/docs/install[install and run a local Consul instance].
+Alternatively you can https://developer.hashicorp.com/consul/docs/install[install and run a local Consul instance].
 
 == Enabling Distributed Configuration with Consul
 

--- a/src/main/docs/guide/cloud/cloudConfiguration/distributedConfigurationSpringCloud.adoc
+++ b/src/main/docs/guide/cloud/cloudConfiguration/distributedConfigurationSpringCloud.adoc
@@ -1,4 +1,4 @@
-Since 1.1, the Micronaut framework features a native https://spring.io/projects/spring-cloud-config[Spring Cloud Configuration] for those who have not switched to a dedicated more complete solution like Consul.
+Since 1.1, the Micronaut framework features a native https://spring.io/projects/spring-cloud-config/[Spring Cloud Configuration] for those who have not switched to a dedicated more complete solution like Consul.
 
 To enable distributed configuration make sure <<bootstrap>> is enabled and create a `src/main/resources/bootstrap.[yml/toml/properties]` file with the following configuration:
 
@@ -24,4 +24,4 @@ spring:
 
 The Micronaut framework uses the configured `micronaut.application.name` to look up property sources for the application from Spring Cloud config server configured via `spring.cloud.config.uri`.
 
-See the https://spring.io/projects/spring-cloud-config#learn[Documentation for Spring Cloud Config Server] for more information on how to set up the server.
+See the https://spring.io/projects/spring-cloud-config/[Documentation for Spring Cloud Config Server] for more information on how to set up the server.

--- a/src/main/docs/guide/cloud/cloudConfiguration/distributedConfigurationVault.adoc
+++ b/src/main/docs/guide/cloud/cloudConfiguration/distributedConfigurationVault.adoc
@@ -39,4 +39,4 @@ The Micronaut framework uses the configured `micronaut.application.name` to look
 
 |===
 
-See the https://www.vaultproject.io/api-docs/secret/kv[Documentation for HashiCorp Vault] for more information on how to set up the server.
+See the https://developer.hashicorp.com/vault/api-docs/secret/kv[Documentation for HashiCorp Vault] for more information on how to set up the server.

--- a/src/main/docs/guide/config/customTypeConverter.adoc
+++ b/src/main/docs/guide/config/customTypeConverter.adoc
@@ -6,7 +6,7 @@ Consider the following api:context.annotation.ConfigurationProperties[]:
 
 snippet::io.micronaut.docs.config.converters.MyConfigurationProperties[tags="class", indent=0]
 
-The type `MyConfigurationProperties` has a property named `updatedAt` of type jdk:java.time.LocalDate[].
+The type `MyConfigurationProperties` has a property named `updatedAt` of type link:{jdkapi}/java.base/java/time/LocalDate.html[LocalDate].
 
 To bind this property from a map via configuration:
 

--- a/src/main/docs/guide/config/propertySource.adoc
+++ b/src/main/docs/guide/config/propertySource.adoc
@@ -77,7 +77,7 @@ To securely externalize configuration consider using a secrets manager system su
 
 * https://micronaut-projects.github.io/micronaut-aws/latest/guide/#secretsmanager[AWS Secrets Manager].
 * https://micronaut-projects.github.io/micronaut-gcp/latest/guide/#secretManager[Google Cloud Secrets Manager].
-* https://docs.micronaut.io/latest/guide/#distributedConfigurationVault[HashiCorp Vault].
+* <<distributedConfigurationVault, HashiCorp Vault>>
 * https://micronaut-projects.github.io/micronaut-kubernetes/latest/guide/index.html#config-client[Kubernetes Secrets].
 * https://micronaut-projects.github.io/micronaut-oracle-cloud/latest/guide/#vault[Oracle Cloud Vault].
 

--- a/src/main/docs/guide/configurations/dataAccess.adoc
+++ b/src/main/docs/guide/configurations/dataAccess.adoc
@@ -5,13 +5,13 @@ This table summarizes the configuration modules and dependencies to add to your 
 |Dependency|Description
 
 |`io.micronaut.sql:micronaut-jdbc-dbcp`
-|Configures SQL jdk:javax.sql.DataSource[]s using https://commons.apache.org/proper/commons-dbcp/[Commons DBCP]
+|Configures SQL link:{jdkapi}/java.sql/javax/sql/DataSource.html[DataSource]s using https://commons.apache.org/proper/commons-dbcp/[Commons DBCP]
 
 |`io.micronaut.sql:micronaut-jdbc-hikari`
-|Configures SQL jdk:javax.sql.DataSource[]s using https://github.com/brettwooldridge/HikariCP[Hikari Connection Pool]
+|Configures SQL link:{jdkapi}/java.sql/javax/sql/DataSource.html[DataSource]s using https://github.com/brettwooldridge/HikariCP[Hikari Connection Pool]
 
 |`io.micronaut.sql:micronaut-jdbc-tomcat`
-|Configures SQL jdk:javax.sql.DataSource[]s using https://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html[Tomcat Connection Pool]
+|Configures SQL link:{jdkapi}/java.sql/javax/sql/DataSource.html[DataSource]s using https://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html[Tomcat Connection Pool]
 
 |`io.micronaut.sql:micronaut-hibernate-jpa`
 |Configures Hibernate/JPA `EntityManagerFactory` beans

--- a/src/main/docs/guide/contextPropagation/reactorContextPropagation.adoc
+++ b/src/main/docs/guide/contextPropagation/reactorContextPropagation.adoc
@@ -2,7 +2,7 @@ Since Micronaut Framework version 4, https://projectreactor.io[Project Reactor] 
 
 Before version 4, Micronaut Framework required the instrumentation of every reactive operator to capture the current state to propagate it. It added an unwanted overhead and forced us to maintain complicated Reactor operators' instrumentation.
 
-Since 3.5.0, Reactor-Core embeds support for the `io.micrometer:context-propagation` SPI. This allows to achieve the same thread-local propagation by including the  https://micrometer.io/docs/contextPropagation[Micrometer Context Propagation] dependency.
+Since 3.5.0, Reactor-Core embeds support for the `io.micrometer:context-propagation` SPI. This allows to achieve the same thread-local propagation by including the https://micrometer.io/docs/contextPropagation[Micrometer Context Propagation] dependency.
 
 The framework automatically adds the `PropagatedContext` to Project Reactor's context for interceptors and the HTTP filters. You can access it via the utility class api:core.async.propagation.ReactorPropagation[].
 

--- a/src/main/docs/guide/httpClient/clientAnnotation.adoc
+++ b/src/main/docs/guide/httpClient/clientAnnotation.adoc
@@ -30,7 +30,7 @@ snippet::io.micronaut.docs.annotation.PetClient[tags="imports, class", indent=0,
 <2> The interface extends from `PetOperations`
 <3> The `save` method is overridden. See the warning below.
 
-WARNING: Notice in the above example we override the `save` method. This is necessary if you compile without the `-parameters` option since Java does not retain parameters names in bytecode otherwise. Overriding is not necessary if you compile with `-parameters`. In addition, when overriding methods you should ensure any validation annotations are declared again since these are not jdk:java.lang.annotation.Inherited[] annotations.
+WARNING: Notice in the above example we override the `save` method. This is necessary if you compile without the `-parameters` option since Java does not retain parameters names in bytecode otherwise. Overriding is not necessary if you compile with `-parameters`. In addition, when overriding methods you should ensure any validation annotations are declared again since these are not link:{jdkapi}/java.base/java/lang/annotation/Inherited.html[Inherited] annotations.
 
 Once you have defined a client you can `@Inject` it wherever you need it.
 
@@ -64,11 +64,11 @@ The following table illustrates common return types usable with ann:http.client.
 |A rs:Publisher[] implementation that emits a POJO
 |`Mono<Book> hello()`
 
-|jdk:java.util.concurrent.CompletableFuture[]
+|link:{jdkapi}/java.base/java/util/concurrent/CompletableFuture.html[CompletableFuture]
 |A Java `CompletableFuture` instance
 |`CompletableFuture<String> hello()`
 
-|jdk:java.lang.CharSequence[]
+|link:{jdkapi}/java.base/java/lang/CharSequence.html[CharSequence]
 |A blocking native type. Such as `String`
 |`String hello()`
 
@@ -79,4 +79,4 @@ The following table illustrates common return types usable with ann:http.client.
 
 Generally, any reactive type that can be converted to the rs:Publisher[] interface is supported as a return type, including (but not limited to) the reactive types defined by RxJava 1.x, RxJava 2.x, and Reactor 3.x.
 
-Returning jdk:java.util.concurrent.CompletableFuture[] instances is also supported. Note that returning any other type _results in a blocking request_ and is not recommended other than for testing.
+Returning link:{jdkapi}/java.base/java/util/concurrent/CompletableFuture.html[CompletableFuture] instances is also supported. Note that returning any other type _results in a blocking request_ and is not recommended other than for testing.

--- a/src/main/docs/guide/httpClient/lowLevelHttpClient/clientBasics.adoc
+++ b/src/main/docs/guide/httpClient/lowLevelHttpClient/clientBasics.adoc
@@ -108,7 +108,7 @@ On the client you can call this endpoint and decode the JSON into a map using th
 
 snippet::io.micronaut.docs.basics.HelloControllerSpec[tags="jsonmap", indent=0, title="Decoding the response body to a Map"]
 
-The above example decodes the response into a jdk:java.util.Map[] representing the JSON. You can use the `Argument.of(..)` method to customize the type of the key and value:
+The above example decodes the response into a link:{jdkapi}/java.base/java/util/Map.html[Map] representing the JSON. You can use the `Argument.of(..)` method to customize the type of the key and value:
 
 snippet::io.micronaut.docs.basics.HelloControllerSpec[tags="jsonmaptypes", indent=0, title="Decoding the response body to a Map"]
 

--- a/src/main/docs/guide/httpServer/formData.adoc
+++ b/src/main/docs/guide/httpServer/formData.adoc
@@ -12,4 +12,4 @@ Alternatively, instead of using a POJO you can bind form data directly to method
 
 snippet::io.micronaut.docs.server.json.PersonController[tags="class,args,endclass", indent=0, title="Binding Form Data to Parameters"]
 
-As you can see from the example above, this approach lets you use features such as support for jdk:java.util.Optional[] types and restrict the parameters to be bound. When using POJOs you must be careful to use Jackson annotations to exclude properties that should not be bound.
+As you can see from the example above, this approach lets you use features such as support for link:{jdkapi}/java.base/java/util/Optional.html[Optional] types and restrict the parameters to be bound. When using POJOs you must be careful to use Jackson annotations to exclude properties that should not be bound.

--- a/src/main/docs/guide/httpServer/jsonBinding.adoc
+++ b/src/main/docs/guide/httpServer/jsonBinding.adoc
@@ -48,7 +48,7 @@ $ curl -X POST localhost:8080/people -d '{"firstName":"Fred","lastName":"Flintst
 
 == Binding Using CompletableFuture
 
-The same method as the previous example can also be written with the jdk:java.util.concurrent.CompletableFuture[] API instead:
+The same method as the previous example can also be written with the link:{jdkapi}/java.base/java/util/concurrent/CompletableFuture.html[CompletableFuture] API instead:
 
 snippet::io.micronaut.docs.server.json.PersonController[tags="class,future,endclass", indent=0, title="Using CompletableFuture to Read the JSON"]
 
@@ -72,8 +72,8 @@ All Jackson configuration keys start with `jackson`.
 
 |=======
 | dateFormat | String | The date format
-| locale     | String | Uses link:{javase}java/util/Locale.html#forLanguageTag-java.lang.String-[Locale.forLanguageTag]. Example: `en-US`
-| timeZone   | String |Uses link:{javase}java/util/TimeZone.html#getTimeZone-java.lang.String-[TimeZone.getTimeZone]. Example: `PST`
+| locale     | String | Uses link:{jdkapi}/java.base/java/util/Locale.html#forLanguageTag-java.lang.String-[Locale.forLanguageTag]. Example: `en-US`
+| timeZone   | String |Uses link:{jdkapi}/java.base/java/util/TimeZone.html#getTimeZone-java.lang.String-[TimeZone.getTimeZone]. Example: `PST`
 | serializationInclusion | String | One of link:{jackson-annotations}com/fasterxml/jackson/annotation/JsonInclude.Include.html[JsonInclude.Include]. Example: `ALWAYS`
 | propertyNamingStrategy | String | Name of an instance of link:{jackson-databind}com/fasterxml/jackson/databind/PropertyNamingStrategy.html[PropertyNamingStrategy]. Example: `SNAKE_CASE`
 | defaultTyping          | String | The global defaultTyping for polymorphic type handling from enum link:{jackson-databind}com/fasterxml/jackson/databind/ObjectMapper.DefaultTyping.html[ObjectMapper.DefaultTyping]. Example: `NON_FINAL`

--- a/src/main/docs/guide/httpServer/reactiveServer/reactiveResponses.adoc
+++ b/src/main/docs/guide/httpServer/reactiveServer/reactiveResponses.adoc
@@ -1,12 +1,12 @@
 The previous section introduced the notion of Reactive programming using https://projectreactor.io[Project Reactor] and Micronaut.
 
-The Micronaut framework supports returning common reactive types such as reactor:Mono[] (or rx:Single[] rx:Maybe[] rx:Observable[] types from RxJava), an instance of rs:Publisher[] or jdk:java.util.concurrent.CompletableFuture[] from any controller method.
+The Micronaut framework supports returning common reactive types such as reactor:Mono[] (or rx:Single[] rx:Maybe[] rx:Observable[] types from RxJava), an instance of rs:Publisher[] or link:{jdkapi}/java.base/java/util/concurrent/CompletableFuture.html[CompletableFuture] from any controller method.
 
 NOTE: To use https://projectreactor.io[Project Reactor]'s `Flux` or `Mono` you need to add the Micronaut Reactor dependency to your project to include the necessary converters.
 
 NOTE: To use https://github.com/ReactiveX/RxJava[RxJava]'s `Flowable`, `Single` or `Maybe` you need to add the Micronaut RxJava dependency to your project to include the necessary converters.
 
-The argument designated as the body of the request using the api:http.annotation.Body[] annotation can also be a reactive type or a jdk:java.util.concurrent.CompletableFuture[].
+The argument designated as the body of the request using the api:http.annotation.Body[] annotation can also be a reactive type or a link:{jdkapi}/java.base/java/util/concurrent/CompletableFuture.html[CompletableFuture].
 
 When returning a reactive type, The Micronaut framework subscribes to the returned reactive type on the same thread as the request (a Netty Event Loop thread). It is therefore important that if you perform any blocking operations, you offload those operations to an appropriately configured thread pool, for example using the https://projectreactor.io[Project Reactor] or https://github.com/ReactiveX/RxJava[RxJava] `subscribeOn(..)` facility or ann:scheduling.annotation.ExecuteOn[].
 
@@ -22,7 +22,7 @@ To summarize, the following table illustrates some common response types and the
 |Any type that implements the rs:Publisher[] interface
 |`Publisher<String> hello()`
 
-|jdk:java.util.concurrent.CompletableFuture[]
+|link:{jdkapi}/java.base/java/util/concurrent/CompletableFuture.html[CompletableFuture]
 |A Java `CompletableFuture` instance
 |`CompletableFuture<String> hello()`
 
@@ -30,7 +30,7 @@ To summarize, the following table illustrates some common response types and the
 |An api:http.HttpResponse[] and optional response body
 |`HttpResponse<Publisher<String>> hello()`
 
-|jdk:java.lang.CharSequence[]
+|link:{jdkapi}/java.base/java/lang/CharSequence.html[CharSequence]
 |Any implementation of `CharSequence`
 |`String hello()`
 

--- a/src/main/docs/guide/httpServer/serverConfiguration/cors/corsAllowedOrigins.adoc
+++ b/src/main/docs/guide/httpServer/serverConfiguration/cors/corsAllowedOrigins.adoc
@@ -2,7 +2,7 @@ Don't define `allowed-origins` or `allowed-origins-regex` to allow any origin fo
 
 For multiple valid origins, set the `allowed-origins` key of the configuration to a list of strings.
 
-You can also define via `allowed-origins-regex` a regular expression (`^http(|s)://www\.google\.com$`). The Regular expression is passed to link:{javase}java/util/regex/Pattern.html#compile-java.lang.String-[Pattern#compile] and compared to the request origin with link:{javase}java/util/regex/Matcher.html#matches--[Matcher#matches].
+You can also define via `allowed-origins-regex` a regular expression (`^http(|s)://www\.google\.com$`). The Regular expression is passed to link:{jdkapi}/java.base/java/util/regex/Pattern.html#compile-java.lang.String-[Pattern#compile] and compared to the request origin with link:{jdkapi}/java.base/java/util/regex/Matcher.html#matches--[Matcher#matches].
 
 .Example CORS Configuration
 [configuration]

--- a/src/main/docs/guide/httpServer/serverIO.adoc
+++ b/src/main/docs/guide/httpServer/serverIO.adoc
@@ -41,7 +41,7 @@ In some cases you may wish to integrate a library that does not support non-bloc
 
 ==== Writable
 
-In this case you can return a api:core.io.Writable[] object from any controller method. The api:core.io.Writable[] interface has various signatures that allow writing to traditional blocking streams like jdk:java.io.Writer[] or jdk:java.io.OutputStream[].
+In this case you can return a api:core.io.Writable[] object from any controller method. The api:core.io.Writable[] interface has various signatures that allow writing to traditional blocking streams like link:{jdkapi}/java.base/java/io/Writer.html[Writer] or link:{jdkapi}/java.base/java/io/OutputStream.html[OutputStream].
 
 When returning a api:core.io.Writable[], the blocking I/O operation is shifted to the I/O thread pool so the Netty event loop is not blocked.
 
@@ -53,7 +53,7 @@ snippet::io.micronaut.docs.writable.TemplateController[tags="imports,clazz", ind
 
 <1> The controller creates a simple template
 <2> The controller method returns a api:core.io.Writable[]
-<3> The returned function receives a jdk:java.io.Writer[] and calls `writeTo` on the template.
+<3> The returned function receives a link:{jdkapi}/java.base/java/io/Writer.html[Writer] and calls `writeTo` on the template.
 
 ==== InputStream
 

--- a/src/main/docs/guide/httpServer/transfers.adoc
+++ b/src/main/docs/guide/httpServer/transfers.adoc
@@ -2,7 +2,7 @@ The Micronaut framework supports sending files to the client in a couple of easy
 
 == Sending File Objects
 
-It is possible to return a jdk:java.io.File[] object from your controller method, and the data will be returned to the client. The `Content-Type` header of file responses is calculated based on the name of the file.
+It is possible to return a link:{jdkapi}/java.base/java/io/File.html[File] object from your controller method, and the data will be returned to the client. The `Content-Type` header of file responses is calculated based on the name of the file.
 
 To control either the media type of the file being sent, or to set the file to be downloaded (i.e. using the `Content-Disposition` header), instead construct a api:http.server.types.files.SystemFile[] with the file to use. For example:
 
@@ -36,7 +36,7 @@ public StreamedFile download() {
 
 The server supports returning `304` (Not Modified) responses if the files being transferred have not changed, and the request contains the appropriate header. In addition, if the client accepts encoded responses, the Micronaut framework encodes the file if appropriate. Encoding happens if the file is text-based and larger than 1KB by default. The threshold at which data is encoded is configurable. See the server configuration reference for details.
 
-TIP: To use a custom data source to send data through an input stream, construct a link:{javase}java/io/PipedInputStream.html[PipedInputStream] and link:{javase}java/io/PipedOutputStream.html[PipedOutputStream] to write data from the output stream to the input. Make sure to do the work on a separate thread so the file can be returned immediately.
+TIP: To use a custom data source to send data through an input stream, construct a link:{jdkapi}/java.base/java/io/PipedInputStream.html[PipedInputStream] and link:{jdkapi}/java.base/java/io/PipedOutputStream.html[PipedOutputStream] to write data from the output stream to the input. Make sure to do the work on a separate thread so the file can be returned immediately.
 
 == Cache Configuration
 

--- a/src/main/docs/guide/httpServer/uploads.adoc
+++ b/src/main/docs/guide/httpServer/uploads.adoc
@@ -16,7 +16,7 @@ TIP: If the route argument name cannot or should not match the name of the part 
 
 === Chunk Data Types
 
-api:io.micronaut.http.multipart.PartData[] represents a chunk of data received in a multipart request. api:io.micronaut.http.multipart.PartData[] interface methods convert the data to a `byte[]`, link:{javase}java/io/InputStream.html[InputStream], or a link:{javase}java/nio/ByteBuffer.html[ByteBuffer].
+api:io.micronaut.http.multipart.PartData[] represents a chunk of data received in a multipart request. api:io.micronaut.http.multipart.PartData[] interface methods convert the data to a `byte[]`, link:{jdkapi}/java.base/java/io/InputStream.html[InputStream], or a link:{jdkapi}/java.base/java/nio/ByteBuffer.html[ByteBuffer].
 
 NOTE: Data can only be retrieved from a api:io.micronaut.http.multipart.PartData[] once. The underlying buffer is released, causing further attempts to fail.
 

--- a/src/main/docs/guide/httpServer/websocket/websocketClient.adoc
+++ b/src/main/docs/guide/httpServer/websocket/websocketClient.adoc
@@ -46,7 +46,7 @@ The above example defines a send method that returns a reactor:Mono[].
 public abstract java.util.concurrent.Future<String> sendAsync(String message);
 ----
 
-The above example defines a send method that executes asynchronously and returns a jdk:java.util.concurrent.Future[] to access the results.
+The above example defines a send method that executes asynchronously and returns a link:{jdkapi}/java.base/java/util/concurrent/Future.html[Future] to access the results.
 
 Once you have defined a client class you can connect to the client socket and start sending messages:
 

--- a/src/main/docs/guide/httpServer/websocket/websocketServer.adoc
+++ b/src/main/docs/guide/httpServer/websocket/websocketServer.adoc
@@ -35,7 +35,7 @@ A method annotated with ann:websocket.annotation.OnError[] can be added to imple
 
 === Non-Blocking Message Handling
 
-The previous example uses the `broadcastSync` method of the api:websocket.WebSocketBroadcaster[] interface which blocks until the broadcast is complete. A similar `sendSync` method exists in api:websocket.WebSocketSession[] to send a message to a single receiver in a blocking manner. You can however implement non-blocking WebSocket servers by instead returning a rs:Publisher[] or a jdk:java.util.concurrent.Future[] from each WebSocket handler method. For example:
+The previous example uses the `broadcastSync` method of the api:websocket.WebSocketBroadcaster[] interface which blocks until the broadcast is complete. A similar `sendSync` method exists in api:websocket.WebSocketSession[] to send a message to a single receiver in a blocking manner. You can however implement non-blocking WebSocket servers by instead returning a rs:Publisher[] or a link:{jdkapi}/java.base/java/util/concurrent/Future.html[Future] from each WebSocket handler method. For example:
 
 snippet::io.micronaut.docs.http.server.netty.websocket.ReactivePojoChatServerWebSocket[tags="onmessage", indent=0,title="WebSocket Chat Example"]
 

--- a/src/main/docs/guide/i18n/bundle.adoc
+++ b/src/main/docs/guide/i18n/bundle.adoc
@@ -14,7 +14,7 @@ include::test-suite/src/test/resources/io/micronaut/docs/i18n/messages_en.proper
 include::test-suite/src/test/resources/io/micronaut/docs/i18n/messages_es.properties[]
 ----
 
-You can use api:context.i18n.ResourceBundleMessageSource[], an implementation of api:context.MessageSource[] which eases accessing link:{javase}/java/util/ResourceBundle.html[Resource Bundles] and provides cache functionality, to access the previous messages.
+You can use api:context.i18n.ResourceBundleMessageSource[], an implementation of api:context.MessageSource[] which eases accessing link:{jdkapi}/java.base/java/util/ResourceBundle.html[Resource Bundles] and provides cache functionality, to access the previous messages.
 
 WARNING: Do not instantiate a new `ResourceBundleMessageSource` each time you retrieve a message. Instantiate it once, for example in a factory.
 

--- a/src/main/docs/guide/ioc/annotationMetadata.adoc
+++ b/src/main/docs/guide/ioc/annotationMetadata.adoc
@@ -37,15 +37,15 @@ This approach is not recommended however, as it requires reflection and increase
 
 === Annotation Inheritance
 
-The Micronaut framework will respect the rules defined in Java's jdk:java.lang.reflect.AnnotatedElement[] API with regard to annotation inheritance:
+The Micronaut framework will respect the rules defined in Java's link:{jdkapi}/java.base/java/lang/reflect/AnnotatedElement.html[AnnotatedElement] API with regard to annotation inheritance:
 
-* Annotations meta-annotated with jdk:java.lang.annotation.Inherited[] will be available via the `getAnnotation*` methods of the api:core.annotation.AnnotationMetadata[] API whilst those directly declared are available via the `getDeclaredAnnotation*` methods.
-* Annotations not meta-annotated with jdk:java.lang.annotation.Inherited[] will not be included in the metadata
+* Annotations meta-annotated with link:{jdkapi}/java.base/java/lang/annotation/Inherited.html[Inherited] will be available via the `getAnnotation*` methods of the api:core.annotation.AnnotationMetadata[] API whilst those directly declared are available via the `getDeclaredAnnotation*` methods.
+* Annotations not meta-annotated with link:{jdkapi}/java.base/java/lang/annotation/Inherited.html[Inherited] will not be included in the metadata
 
-The Micronaut framework differs from the jdk:java.lang.reflect.AnnotatedElement[] API in that it extends these rules to methods and method parameters such that:
+The Micronaut framework differs from the link:{jdkapi}/java.base/java/lang/reflect/AnnotatedElement.html[AnnotatedElement] API in that it extends these rules to methods and method parameters such that:
 
-* Any annotations annotated with jdk:java.lang.annotation.Inherited[] and present on a method of interface or super class `A` that is overridden by child interface or class `B` will be inherited into the api:core.annotation.AnnotationMetadata[] retrievable via the api:inject.ExecutableMethod[] API from a api:inject.BeanDefinition[] or an <<aop, AOP interceptor>>.
-* Any annotations annotated with jdk:java.lang.annotation.Inherited[] and present on a method parameter of interface or super class `A` that is overridden by child interface or class `B` will be inherited into the api:core.annotation.AnnotationMetadata[] retrievable via the api:core.type.Argument[] interface from the `getArguments` method of the api:inject.ExecutableMethod[] API.
+* Any annotations annotated with link:{jdkapi}/java.base/java/lang/reflect/AnnotatedElement.html[AnnotatedElement] and present on a method of interface or super class `A` that is overridden by child interface or class `B` will be inherited into the api:core.annotation.AnnotationMetadata[] retrievable via the api:inject.ExecutableMethod[] API from a api:inject.BeanDefinition[] or an <<aop, AOP interceptor>>.
+* Any annotations annotated with link:{jdkapi}/java.base/java/lang/annotation/Inherited.html[Inherited] and present on a method parameter of interface or super class `A` that is overridden by child interface or class `B` will be inherited into the api:core.annotation.AnnotationMetadata[] retrievable via the api:core.type.Argument[] interface from the `getArguments` method of the api:inject.ExecutableMethod[] API.
 
 In general behaviour which you may wish to override is not inherited by default including <<scopes, Bean Scopes>>, <<qualifiers, Bean Qualifiers>>, <<conditionalBeans, Bean Conditions>>, <<validation, Validation Rules>> and so on.
 

--- a/src/main/docs/guide/ioc/introspection.adoc
+++ b/src/main/docs/guide/ioc/introspection.adoc
@@ -1,3 +1,3 @@
-Since Micronaut framework 1.1, a compile-time replacement for the JDK's jdk:java.beans.Introspector[] class has been included.
+Since Micronaut framework 1.1, a compile-time replacement for the JDK's link:{jdkapi}/java.desktop/java/beans/Introspector.html[Introspector] class has been included.
 
 The api:core.beans.BeanIntrospector[] and api:core.beans.BeanIntrospection[] interfaces allow looking up bean introspections to instantiate and read/write bean properties without using reflection or caching reflective metadata, which consume excessive memory for large beans.

--- a/src/main/docs/guide/ioc/introspection/makingABeanAvailableForIntrospection.adoc
+++ b/src/main/docs/guide/ioc/introspection/makingABeanAvailableForIntrospection.adoc
@@ -1,4 +1,4 @@
-Unlike the JDK's jdk:java.beans.Introspector[], every class is not automatically available for introspection. To make a class available for introspection you must at a minimum enable Micronaut's annotation processor (`micronaut-inject-java` for Java and Kotlin and `micronaut-inject-groovy` for Groovy) in your build and ensure you have a runtime time dependency on `micronaut-core`.
+Unlike the JDK's link:{jdkapi}/java.desktop/java/beans/Introspector.html[Introspector], every class is not automatically available for introspection. To make a class available for introspection you must at a minimum enable Micronaut's annotation processor (`micronaut-inject-java` for Java and Kotlin and `micronaut-inject-groovy` for Groovy) in your build and ensure you have a runtime time dependency on `micronaut-core`.
 
 dependency::micronaut-inject-java[scope="annotationProcessor"]
 


### PR DESCRIPTION
All the guide self-references to '/latest/' have been eliminated.

closes #9566