### PR TITLE
KSP: skip `ExecutableVisitor` warning for default parameters

### DIFF
--- a/core-processor/src/main/java/io/micronaut/context/visitor/ExecutableVisitor.java
+++ b/core-processor/src/main/java/io/micronaut/context/visitor/ExecutableVisitor.java
@@ -18,6 +18,7 @@ package io.micronaut.context.visitor;
 import io.micronaut.context.annotation.Executable;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.inject.ast.KotlinParameterElement;
 import io.micronaut.inject.ast.MethodElement;
 import io.micronaut.inject.ast.ParameterElement;
 import io.micronaut.inject.visitor.TypeElementVisitor;
@@ -41,7 +42,8 @@ public class ExecutableVisitor implements TypeElementVisitor<Object, Executable>
     @Override
     public void visitMethod(MethodElement element, VisitorContext context) {
         for (ParameterElement parameter : element.getParameters()) {
-            if (parameter.getType().isPrimitive() && parameter.isNullable()) {
+            if (parameter.getType().isPrimitive() && parameter.isNullable()
+                && !(parameter instanceof KotlinParameterElement kotlinParameterElement && kotlinParameterElement.hasDefault())) {
                 context.warn("@Nullable on primitive types will allow the method to be executed at runtime with null values, causing an exception", parameter);
             }
         }

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/ast/ClassElementSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/inject/ast/ClassElementSpec.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.kotlin.processing.inject.ast
 
 import io.micronaut.annotation.processing.test.AbstractKotlinCompilerSpec
+import io.micronaut.annotation.processing.test.KotlinCompiler
 import io.micronaut.core.annotation.AnnotationUtil
 import io.micronaut.core.annotation.Introspected
 import io.micronaut.core.util.CollectionUtils
@@ -62,10 +63,10 @@ class MyBean {}
         definition
 
         AllElementsVisitor.VISITED_CLASS_ELEMENTS.size() == 3
-        def enumEl = AllElementsVisitor.VISITED_CLASS_ELEMENTS.find { 
+        def enumEl = AllElementsVisitor.VISITED_CLASS_ELEMENTS.find {
             it.name == 'test.HelloController$Channel'
         }
-        
+
         enumEl
         def enmConsts = ((KotlinEnumElement) enumEl).elements()
         enmConsts
@@ -2362,6 +2363,45 @@ enum class MyType {
         expect:
             theType instanceof GenericElement
             (theType as GenericElement).resolved().isEnum()
+    }
+
+    void "test executable visitor"() {
+        def result = KotlinCompiler.compile("test.MyClass", '''
+package io.micronaut.core.beans
+
+import io.micronaut.context.annotation.Executable
+import io.micronaut.core.annotation.Introspected
+
+@Introspected
+data class TestEntity3(val firstName: String = "Denis",
+                       val lastName: String,
+                       val job: String? = "IT",
+                       val age: Int) {
+
+    @Executable
+    fun test4(i: Int? = 88) : String {
+        return "$i"
+    }
+
+    @Executable
+    fun test3(i: Int = 88) : String {
+        return "$i"
+    }
+
+    @Executable
+    fun test2(a: String = "A") : String {
+        return a
+    }
+
+    @Executable
+    fun test1(a: String = "A", b: String, i: Int = 99) : String {
+        return "$a $b $i"
+    }
+
+}
+''', {})
+        expect:
+            !result.component2().component2().messages.contains("@Nullable on primitive types")
     }
 
     private void assertListGenericArgument(ClassElement type, Closure cl) {


### PR DESCRIPTION
Fixes https://github.com/micronaut-projects/micronaut-core/issues/9825