### PR TITLE
Improve default annotation values

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataWriter.java
@@ -19,6 +19,7 @@ import io.micronaut.context.expressions.AbstractEvaluatedExpression;
 import io.micronaut.core.annotation.AnnotationClassValue;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationMetadataDelegate;
+import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.UsedByGeneratedCode;
 import io.micronaut.core.expressions.EvaluatedExpressionReference;
@@ -44,6 +45,7 @@ import java.lang.reflect.Array;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -395,33 +397,81 @@ public class AnnotationMetadataWriter extends AbstractClassFileWriter {
             Map<String, GeneratorAdapter> loadTypeMethods) {
             final Map<String, Map<CharSequence, Object>> annotationDefaultValues = annotationMetadata.annotationDefaultValues;
         if (CollectionUtils.isNotEmpty(annotationDefaultValues)) {
-            for (Map.Entry<String, Map<CharSequence, Object>> entry : annotationDefaultValues.entrySet()) {
-                final Map<CharSequence, Object> annotationValues = entry.getValue();
-                final boolean typeOnly = CollectionUtils.isEmpty(annotationValues);
-                String annotationName = entry.getKey();
-
-                // skip already registered
-                if (typeOnly && AnnotationMetadataSupport.getRegisteredAnnotationType(annotationName).isPresent()) {
-                    continue;
-                }
-
-                invokeLoadClassValueMethod(owningType, classWriter, staticInit, loadTypeMethods, new AnnotationClassValue(annotationName));
-
-                if (!typeOnly) {
-                    pushStringMapOf(staticInit, annotationValues, true, null, v -> pushValue(owningType, classWriter, staticInit, v, defaultsStorage, loadTypeMethods, true));
-                    staticInit.invokeStatic(TYPE_DEFAULT_ANNOTATION_METADATA, METHOD_REGISTER_ANNOTATION_DEFAULTS);
-                } else {
-                    staticInit.invokeStatic(TYPE_DEFAULT_ANNOTATION_METADATA, METHOD_REGISTER_ANNOTATION_TYPE);
-                }
-            }
+            writeAnnotationDefaultsInternal(owningType, classWriter, staticInit, defaultsStorage, loadTypeMethods, annotationDefaultValues, new HashSet<>());
         }
         if (annotationMetadata.annotationRepeatableContainer != null && !annotationMetadata.annotationRepeatableContainer.isEmpty()) {
-            AnnotationMetadataSupport.registerRepeatableAnnotations(annotationMetadata.annotationRepeatableContainer);
-            if (!annotationMetadata.annotationRepeatableContainer.isEmpty()) {
+            Map<String, String> annotationRepeatableContainer = new LinkedHashMap<>(annotationMetadata.annotationRepeatableContainer);
+            AnnotationMetadataSupport.getCoreRepeatableAnnotationsContainers().forEach(annotationRepeatableContainer::remove);
+            AnnotationMetadataSupport.registerRepeatableAnnotations(annotationRepeatableContainer);
+            if (!annotationRepeatableContainer.isEmpty()) {
                 pushStringMapOf(staticInit, annotationMetadata.annotationRepeatableContainer, true, null, v -> pushValue(owningType, classWriter, staticInit, v, defaultsStorage, loadTypeMethods, true));
                 staticInit.invokeStatic(TYPE_DEFAULT_ANNOTATION_METADATA, METHOD_REGISTER_REPEATABLE_ANNOTATIONS);
             }
         }
+    }
+
+    private static void writeAnnotationDefaultsInternal(Type owningType,
+                                                        ClassWriter classWriter,
+                                                        GeneratorAdapter staticInit,
+                                                        Map<String, Integer> defaultsStorage,
+                                                        Map<String, GeneratorAdapter> loadTypeMethods,
+                                                        Map<String, Map<CharSequence, Object>> annotationDefaultValues,
+                                                        Set<String> writtenAnnotations) {
+        for (Map.Entry<String, Map<CharSequence, Object>> entry : annotationDefaultValues.entrySet()) {
+            writeAnnotationDefaultsInternal(owningType,
+                classWriter,
+                staticInit,
+                defaultsStorage,
+                loadTypeMethods,
+                writtenAnnotations,
+                entry.getKey(),
+                entry.getValue());
+        }
+    }
+
+    private static void writeAnnotationDefaultsInternal(Type owningType,
+                                                        ClassWriter classWriter,
+                                                        GeneratorAdapter staticInit,
+                                                        Map<String, Integer> defaultsStorage,
+                                                        Map<String, GeneratorAdapter> loadTypeMethods,
+                                                        Set<String> writtenAnnotations,
+                                                        String annotationName,
+                                                        Map<CharSequence, Object> annotationValues) {
+        final boolean typeOnly = CollectionUtils.isEmpty(annotationValues);
+
+        // skip already registered
+        if (typeOnly && AnnotationMetadataSupport.getRegisteredAnnotationType(annotationName).isPresent() || AnnotationMetadataSupport.getCoreAnnotationDefaults().containsKey(annotationName)) {
+            return;
+        }
+
+        if (!writtenAnnotations.add(annotationName)) {
+            return;
+        }
+
+        for (Map.Entry<CharSequence, Object> values : annotationValues.entrySet()) {
+            Object value = values.getValue();
+            if (value instanceof AnnotationValue<?> annotationValue && CollectionUtils.isNotEmpty(annotationValue.getDefaultValues())) {
+                writeAnnotationDefaultsInternal(owningType,
+                    classWriter,
+                    staticInit,
+                    defaultsStorage,
+                    loadTypeMethods,
+                    writtenAnnotations,
+                    annotationValue.getAnnotationName(),
+                    annotationValue.getDefaultValues());
+            }
+        }
+
+        invokeLoadClassValueMethod(owningType, classWriter, staticInit, loadTypeMethods, new AnnotationClassValue<>(annotationName));
+
+        if (!typeOnly) {
+            pushStringMapOf(staticInit, annotationValues, true, null, v -> pushValue(owningType, classWriter, staticInit, v, defaultsStorage, loadTypeMethods, true));
+            staticInit.invokeStatic(TYPE_DEFAULT_ANNOTATION_METADATA, METHOD_REGISTER_ANNOTATION_DEFAULTS);
+        } else {
+            staticInit.invokeStatic(TYPE_DEFAULT_ANNOTATION_METADATA, METHOD_REGISTER_ANNOTATION_TYPE);
+        }
+
+        writtenAnnotations.add(annotationName);
     }
 
     private static void instantiateInternal(

--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationDefaultValuesProvider.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationDefaultValuesProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.core.annotation;
+
+import java.util.Map;
+
+/**
+ * The annotation default values provider.
+ *
+ * @author Denis Stepanov
+ * @since 4.3.0
+ */
+public interface AnnotationDefaultValuesProvider {
+
+    /**
+     * @param annotationName The annotation name
+     * @return The annotation default values
+     */
+    @NonNull
+    Map<CharSequence, Object> provide(String annotationName);
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/annotation/AnnotationMetadataWriterSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/annotation/AnnotationMetadataWriterSpec.groovy
@@ -634,6 +634,28 @@ class Test {
         properties[2].get("name", String).get() == "prop4"
     }
 
+    void "test read beandef annotation with a default annotation value"() {
+        when:
+            BeanDefinition definition = buildBeanDefinition('test.Test', '''\
+package test;
+
+import io.micronaut.inject.annotation.*;
+import jakarta.inject.Singleton;
+
+@Singleton
+@TopLevel2
+class Test {
+}
+''')
+            AnnotationMetadata metadata = definition.getAnnotationMetadata()
+
+        then:
+            AnnotationValue nestedAnnotation = metadata.getAnnotation(TopLevel2).getDefaultValues().get("nested")
+            nestedAnnotation.annotationName == "io.micronaut.inject.annotation.Nested"
+            nestedAnnotation.getDefaultValues().get("num") == 10
+
+    }
+
     void "test annotation metadata string value array types"() {
         given:
         AnnotationMetadata metadata = buildTypeAnnotationMetadata('''

--- a/inject-java/src/test/groovy/io/micronaut/inject/annotation/MyBean.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/annotation/MyBean.java
@@ -1,0 +1,8 @@
+package io.micronaut.inject.annotation;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+@TopLevel2
+public class MyBean {
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/annotation/TopLevel2.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/annotation/TopLevel2.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * @author graemerocher
+ * @since 1.0
+ */
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.TYPE})
+public @interface TopLevel2 {
+
+    Nested nested() default @Nested();
+}

--- a/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataSupport.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/AnnotationMetadataSupport.java
@@ -44,7 +44,9 @@ import io.micronaut.context.annotation.Secondary;
 import io.micronaut.context.annotation.Type;
 import io.micronaut.context.annotation.Value;
 import io.micronaut.context.condition.TrueCondition;
+import io.micronaut.core.annotation.AccessorsStyle;
 import io.micronaut.core.annotation.AnnotationClassValue;
+import io.micronaut.core.annotation.AnnotationDefaultValuesProvider;
 import io.micronaut.core.annotation.AnnotationUtil;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.AnnotationValueProvider;
@@ -105,6 +107,17 @@ public final class AnnotationMetadataSupport {
 
     private static final Map<Class<? extends Annotation>, Optional<Constructor<InvocationHandler>>> ANNOTATION_PROXY_CACHE = new ConcurrentHashMap<>(20);
     private static final Map<String, Class<? extends Annotation>> ANNOTATION_TYPES = new ConcurrentHashMap<>(20);
+
+    /**
+     * The annotation default values provider.
+     * @since 4.3.0
+     */
+    public static final AnnotationDefaultValuesProvider ANNOTATION_DEFAULT_VALUES_PROVIDER = new AnnotationDefaultValuesProvider() {
+        @Override
+        public Map<CharSequence, Object> provide(String annotationName) {
+            return AnnotationMetadataSupport.getDefaultValues(annotationName);
+        }
+    };
 
     static {
         // some common ones for startup optimization
@@ -189,14 +202,13 @@ public final class AnnotationMetadataSupport {
             Map.of("qualifier", Annotation.class)
         );
 
-        Map<CharSequence, Object> builderDefaults = Map.of("accessorStyle", new AnnotationValue("io.micronaut.core.annotation.AccessorsStyle", Map.of("writePrefixes", new String[]{""}), AnnotationMetadataSupport.getDefaultValues("io.micronaut.core.annotation.AccessorsStyle")), "creatorMethod", "build");
         coreAnnotationsDefaults.put(
             Introspected.IntrospectionBuilder.class.getName(),
-            builderDefaults
+            Map.of("accessorStyle", new AnnotationValue("io.micronaut.core.annotation.AccessorsStyle", Map.of("writePrefixes", new String[]{""}), AnnotationMetadataSupport.ANNOTATION_DEFAULT_VALUES_PROVIDER), "creatorMethod", "build")
         );
         coreAnnotationsDefaults.put(
             Introspected.class.getName(),
-            Map.ofEntries(Map.entry("accessKind", new String[]{"METHOD"}), Map.entry("annotationMetadata", true), Map.entry("builder", new AnnotationValue("io.micronaut.core.annotation.Introspected$IntrospectionBuilder", Map.of(), builderDefaults)), Map.entry("classNames", new String[0]), Map.entry("classes", new AnnotationClassValue[0]), Map.entry("excludedAnnotations", new AnnotationClassValue[0]), Map.entry("excludes", new String[0]), Map.entry("includedAnnotations", new AnnotationClassValue[0]), Map.entry("includes", new String[0]), Map.entry("indexed", new AnnotationValue[0]), Map.entry("packages", new String[0]), Map.entry("visibility", new String[]{"DEFAULT"}), Map.entry("withPrefix", "with"))
+            Map.ofEntries(Map.entry("accessKind", new String[]{"METHOD"}), Map.entry("annotationMetadata", true), Map.entry("builder", new AnnotationValue("io.micronaut.core.annotation.Introspected$IntrospectionBuilder", Map.of(), AnnotationMetadataSupport.ANNOTATION_DEFAULT_VALUES_PROVIDER)), Map.entry("classNames", new String[0]), Map.entry("classes", new AnnotationClassValue[0]), Map.entry("excludedAnnotations", new AnnotationClassValue[0]), Map.entry("excludes", new String[0]), Map.entry("includedAnnotations", new AnnotationClassValue[0]), Map.entry("includes", new String[0]), Map.entry("indexed", new AnnotationValue[0]), Map.entry("packages", new String[0]), Map.entry("visibility", new String[]{"DEFAULT"}), Map.entry("withPrefix", "with"))
         );
         coreAnnotationsDefaults.put(
             MapFormat.class.getName(),
@@ -231,8 +243,16 @@ public final class AnnotationMetadataSupport {
             Map.of("interfaces", new AnnotationClassValue[0])
         );
         coreAnnotationsDefaults.put(
+            "io.micronaut.aop.Adapter",
+            Map.of()
+        );
+        coreAnnotationsDefaults.put(
             "io.micronaut.validation.annotation.ValidatedElement",
             Map.of()
+        );
+        coreAnnotationsDefaults.put(
+            AccessorsStyle.class.getName(),
+            Map.of("readPrefixes", new String[]{"get"}, "writePrefixes", new String[]{"set"})
         );
 
         CORE_ANNOTATION_DEFAULTS = Collections.unmodifiableMap(coreAnnotationsDefaults);

--- a/inject/src/main/java/io/micronaut/inject/annotation/DefaultAnnotationMetadata.java
+++ b/inject/src/main/java/io/micronaut/inject/annotation/DefaultAnnotationMetadata.java
@@ -1015,7 +1015,7 @@ public class DefaultAnnotationMetadata extends AbstractAnnotationMetadata implem
     }
 
     @NonNull
-    protected  <T extends Annotation> AnnotationValue<T> newAnnotationValue(String annotationType, Map<CharSequence, Object> values) {
+    protected <T extends Annotation> AnnotationValue<T> newAnnotationValue(String annotationType, Map<CharSequence, Object> values) {
         return new AnnotationValue<>(annotationType, values, AnnotationMetadataSupport.getDefaultValuesOrNull(annotationType));
     }
 


### PR DESCRIPTION
Added Core annotations default values to prevent repeating them in bean definitions.
Fixed a bug with missing defaults for nested annotations.
Changed for `AnnotationValues` to have default values fetched lazily, preventing additional calls to the concurrent map during the class init.

We might want to remove additional calls to fill `Map<String, Class<? extends Annotation>> ANNOTATION_TYPES` and make that resolution at the runtime. In don't think `AnnotationMetadata` `Optional<Class<? extends Annotation>> getAnnotationType(@NonNull String name)` is very much used.