### PR TITLE
Fix status route resolution

### DIFF
--- a/http-client/src/test/groovy/io/micronaut/http/client/InvalidStatusSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/InvalidStatusSpec.groovy
@@ -1,53 +1,57 @@
 package io.micronaut.http.client
 
-
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Requires
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.runtime.server.EmbeddedServer
-import spock.lang.AutoCleanup
-import spock.lang.Shared
 import spock.lang.Specification
 
 class InvalidStatusSpec extends Specification {
 
-    @Shared
-    @AutoCleanup
-    ApplicationContext context = ApplicationContext.run([
-            'spec.name': 'InvalidStatusSpec'
-    ])
-
-    void "test receiving an invalid status code"() {
+    void "test receiving an invalid status code"(int status) {
         given:
+        ApplicationContext context = ApplicationContext.run([
+                'spec.name': 'InvalidStatusSpec',
+                'micronaut.http.client.exception-on-error-status': false
+        ])
         EmbeddedServer server = context.getBean(EmbeddedServer)
         server.start()
         StreamingHttpClient client = context.createBean(StreamingHttpClient, server.URL)
 
         when:
-        def response = client.toBlocking().exchange("/invalid-status", String)
+        def response = client.toBlocking().exchange("/invalid-status/$status", String, String)
 
         then:
-        response.code() == 290
+        response.code() == status
 
         when:
         response.status()
         then:
         def ex = thrown(IllegalArgumentException)
-        ex.message == "Invalid HTTP status code: 290"
+        ex.message == "Invalid HTTP status code: $status"
 
         cleanup:
         client.close()
         server.stop()
+        context.close()
+
+        where:
+        status << [290, 700]
     }
 
     @Controller('/invalid-status')
     @Requires(property = 'spec.name', value = 'InvalidStatusSpec')
     static class InvalidStatusController {
-        @Get
-        HttpResponse<?> status() {
+        @Get("/290")
+        HttpResponse<?> status290() {
             return HttpResponse.ok().status(290)
+        }
+
+        @Get("/700")
+        HttpResponse<?> status700() {
+            return HttpResponse.ok().status(700)
         }
     }
 }

--- a/http-server/src/main/java/io/micronaut/http/server/RequestLifecycle.java
+++ b/http-server/src/main/java/io/micronaut/http/server/RequestLifecycle.java
@@ -288,7 +288,7 @@ public class RequestLifecycle {
 
     private ExecutionFlow<MutableHttpResponse<?>> handleStatusException(MutableHttpResponse<?> response, RouteInfo<?> routeInfo, PropagatedContext propagatedContext) {
         if (response.code() >= 400 && routeInfo != null && !routeInfo.isErrorRoute()) {
-            RouteMatch<Object> statusRoute = routeExecutor.findStatusRoute(request, response.status(), routeInfo);
+            RouteMatch<Object> statusRoute = routeExecutor.findStatusRoute(request, response.code(), routeInfo);
             if (statusRoute != null) {
                 return fulfillArguments(statusRoute)
                     .flatMap(rm -> routeExecutor.callRoute(propagatedContext, rm, request).flatMap(res -> handleStatusException(res, rm, propagatedContext)))

--- a/http-server/src/main/java/io/micronaut/http/server/RouteExecutor.java
+++ b/http-server/src/main/java/io/micronaut/http/server/RouteExecutor.java
@@ -345,7 +345,7 @@ public final class RouteExecutor {
         return errorRoute;
     }
 
-    RouteMatch<Object> findStatusRoute(HttpRequest<?> incomingRequest, HttpStatus status, RouteInfo<?> finalRoute) {
+    RouteMatch<Object> findStatusRoute(HttpRequest<?> incomingRequest, int status, RouteInfo<?> finalRoute) {
         Class<?> declaringType = finalRoute.getDeclaringType();
         // handle re-mapping of errors
         RouteMatch<Object> statusRoute = null;

--- a/router/src/main/java/io/micronaut/web/router/DefaultRouteBuilder.java
+++ b/router/src/main/java/io/micronaut/web/router/DefaultRouteBuilder.java
@@ -657,7 +657,7 @@ public abstract class DefaultRouteBuilder implements RouteBuilder {
      */
     final class DefaultStatusRoute extends AbstractRoute implements StatusRoute {
 
-        private final HttpStatus status;
+        private final int statusCode;
         private final Class<?> originatingClass;
 
         /**
@@ -678,14 +678,14 @@ public abstract class DefaultRouteBuilder implements RouteBuilder {
         public DefaultStatusRoute(Class<?> originatingClass, HttpStatus status, MethodExecutionHandle<Object, Object> targetMethod, ConversionService conversionService) {
             super(targetMethod, conversionService, Collections.emptyList());
             this.originatingClass = originatingClass;
-            this.status = status;
+            this.statusCode = status.getCode();
         }
 
         @Override
         public StatusRouteInfo<Object, Object> toRouteInfo() {
             return new DefaultStatusRouteInfo<>(
                     originatingClass,
-                    status,
+                    statusCode,
                     targetMethod,
                     bodyArgumentName,
                     bodyArgument,
@@ -705,7 +705,12 @@ public abstract class DefaultRouteBuilder implements RouteBuilder {
 
         @Override
         public HttpStatus status() {
-            return status;
+            return HttpStatus.valueOf(statusCode);
+        }
+
+        @Override
+        public int statusCode() {
+            return statusCode;
         }
 
         @Override
@@ -728,13 +733,6 @@ public abstract class DefaultRouteBuilder implements RouteBuilder {
             return (StatusRoute) super.where(condition);
         }
 
-        /**
-         * @return The {@link io.micronaut.http.HttpStatus}
-         */
-        public HttpStatus getStatus() {
-            return status;
-        }
-
         @Override
         public boolean equals(Object o) {
             if (this == o) {
@@ -746,13 +744,13 @@ public abstract class DefaultRouteBuilder implements RouteBuilder {
             if (!super.equals(o)) {
                 return false;
             }
-            return status == that.status &&
+            return statusCode == that.statusCode &&
                     Objects.equals(originatingClass, that.originatingClass);
         }
 
         @Override
         public int hashCode() {
-            return ObjectUtils.hash(super.hashCode(), status, originatingClass);
+            return ObjectUtils.hash(super.hashCode(), statusCode, originatingClass);
         }
     }
 

--- a/router/src/main/java/io/micronaut/web/router/DefaultRouter.java
+++ b/router/src/main/java/io/micronaut/web/router/DefaultRouter.java
@@ -117,7 +117,7 @@ public class DefaultRouter implements Router, HttpServerFilterResolver<RouteMatc
                 StatusRouteInfo<Object, Object> routeInfo = statusRoute.toRouteInfo();
                 if (statusRoutes.contains(routeInfo)) {
                     final StatusRouteInfo<Object, Object> existing = statusRoutes.stream().filter(r -> r.equals(routeInfo)).findFirst().orElse(null);
-                    throw new RoutingException("Attempted to register multiple local routes for http status [" + statusRoute.status() + "]. New route: " + statusRoute + ". Existing: " + existing);
+                    throw new RoutingException("Attempted to register multiple local routes for http status [" + statusRoute.statusCode() + "]. New route: " + statusRoute + ". Existing: " + existing);
                 }
                 statusRoutes.add(routeInfo);
             }
@@ -435,15 +435,25 @@ public class DefaultRouter implements Router, HttpServerFilterResolver<RouteMatc
             @NonNull Class<?> originatingClass,
             @NonNull HttpStatus status,
             HttpRequest<?> request) {
-        return findStatusInternal(originatingClass, status, request);
+        return findStatusInternal(originatingClass, status.getCode(), request);
     }
 
     @Override
     public <R> Optional<RouteMatch<R>> findStatusRoute(@NonNull HttpStatus status, HttpRequest<?> request) {
-        return findStatusInternal(null, status, request);
+        return findStatusInternal(null, status.getCode(), request);
     }
 
-    private <R> Optional<RouteMatch<R>> findStatusInternal(@Nullable Class<?> originatingClass, @NonNull HttpStatus status, HttpRequest<?> request) {
+    @Override
+    public <R> Optional<RouteMatch<R>> findStatusRoute(Class<?> originatingClass, int statusCode, HttpRequest<?> request) {
+        return findStatusInternal(originatingClass, statusCode, request);
+    }
+
+    @Override
+    public <R> Optional<RouteMatch<R>> findStatusRoute(int statusCode, HttpRequest<?> request) {
+        return findStatusInternal(null, statusCode, request);
+    }
+
+    private <R> Optional<RouteMatch<R>> findStatusInternal(@Nullable Class<?> originatingClass, int status, HttpRequest<?> request) {
         Collection<MediaType> accept =
                 request.accept();
         final boolean hasAcceptHeader = CollectionUtils.isNotEmpty(accept);

--- a/router/src/main/java/io/micronaut/web/router/Router.java
+++ b/router/src/main/java/io/micronaut/web/router/Router.java
@@ -259,6 +259,29 @@ public interface Router {
             HttpRequest<?> request);
 
     /**
+     * Found a {@link RouteMatch} for the given status code.
+     *
+     * @param originatingClass The class the error originates from
+     * @param statusCode       The HTTP status
+     * @param request          The request
+     * @param <R>              The matched route
+     * @return The {@link RouteMatch}
+     */
+    default <R> Optional<RouteMatch<R>> findStatusRoute(
+            @NonNull Class<?> originatingClass,
+            int statusCode,
+            HttpRequest<?> request) {
+        HttpStatus status;
+        try {
+            status = HttpStatus.valueOf(statusCode);
+        } catch (IllegalArgumentException iae) {
+            // custom status code
+            return Optional.empty();
+        }
+        return findStatusRoute(originatingClass, status, request);
+    }
+
+    /**
      * Found a {@link RouteMatch} for the given {@link io.micronaut.http.HttpStatus} code.
      *
      * @param status           The HTTP status
@@ -269,6 +292,27 @@ public interface Router {
     <R> Optional<RouteMatch<R>> findStatusRoute(
             @NonNull HttpStatus status,
             HttpRequest<?> request);
+
+    /**
+     * Found a {@link RouteMatch} for the given status code.
+     *
+     * @param statusCode       The HTTP status code
+     * @param request          The request
+     * @param <R>              The matched route
+     * @return The {@link RouteMatch}
+     */
+    default <R> Optional<RouteMatch<R>> findStatusRoute(
+            int statusCode,
+            HttpRequest<?> request) {
+        HttpStatus status;
+        try {
+            status = HttpStatus.valueOf(statusCode);
+        } catch (IllegalArgumentException iae) {
+            // custom status code
+            return Optional.empty();
+        }
+        return findStatusRoute(status, request);
+    }
 
     /**
      * Build a filtered {@link org.reactivestreams.Publisher} for an action.

--- a/router/src/main/java/io/micronaut/web/router/StatusRoute.java
+++ b/router/src/main/java/io/micronaut/web/router/StatusRoute.java
@@ -44,6 +44,13 @@ public interface StatusRoute extends Route {
      */
     HttpStatus status();
 
+    /**
+     * @return The status
+     */
+    default int statusCode() {
+        return status().getCode();
+    }
+
     @Override
     StatusRoute consumes(MediaType... mediaType);
 

--- a/router/src/main/java/io/micronaut/web/router/StatusRouteInfo.java
+++ b/router/src/main/java/io/micronaut/web/router/StatusRouteInfo.java
@@ -41,6 +41,13 @@ public interface StatusRouteInfo<T, R> extends MethodBasedRouteInfo<T, R>, Reque
     HttpStatus status();
 
     /**
+     * @return The status
+     */
+    default int statusCode() {
+        return status().getCode();
+    }
+
+    /**
      * Match the given HTTP status.
      *
      * @param status The status to match
@@ -51,10 +58,45 @@ public interface StatusRouteInfo<T, R> extends MethodBasedRouteInfo<T, R>, Reque
     /**
      * Match the given HTTP status.
      *
+     * @param statusCode The status to match
+     * @return The route match
+     */
+    default Optional<RouteMatch<R>> match(int statusCode) {
+        HttpStatus status;
+        try {
+            status = HttpStatus.valueOf(statusCode);
+        } catch (IllegalArgumentException iae) {
+            // custom status code
+            return Optional.empty();
+        }
+        return match(status);
+    }
+
+    /**
+     * Match the given HTTP status.
+     *
      * @param originatingClass The class where the error originates from
      * @param status The status to match
      * @return The route match
      */
     Optional<RouteMatch<R>> match(Class<?> originatingClass, HttpStatus status);
+
+    /**
+     * Match the given HTTP status.
+     *
+     * @param originatingClass The class where the error originates from
+     * @param statusCode The status to match
+     * @return The route match
+     */
+    default Optional<RouteMatch<R>> match(Class<?> originatingClass, int statusCode) {
+        HttpStatus status;
+        try {
+            status = HttpStatus.valueOf(statusCode);
+        } catch (IllegalArgumentException iae) {
+            // custom status code
+            return Optional.empty();
+        }
+        return match(originatingClass, status);
+    }
 
 }

--- a/router/src/main/java/io/micronaut/web/router/filter/FilteredRouter.java
+++ b/router/src/main/java/io/micronaut/web/router/filter/FilteredRouter.java
@@ -158,8 +158,18 @@ public class FilteredRouter implements Router {
     }
 
     @Override
+    public <R> Optional<RouteMatch<R>> findStatusRoute(Class<?> originatingClass, int statusCode, HttpRequest<?> request) {
+        return router.findStatusRoute(originatingClass, statusCode, request);
+    }
+
+    @Override
     public <R> Optional<RouteMatch<R>> findStatusRoute(@NonNull HttpStatus status, HttpRequest<?> request) {
         return router.findStatusRoute(status, request);
+    }
+
+    @Override
+    public <R> Optional<RouteMatch<R>> findStatusRoute(int statusCode, HttpRequest<?> request) {
+        return router.findStatusRoute(statusCode, request);
     }
 
     @NonNull


### PR DESCRIPTION
This patch fixes an error with a >400 status returned by a controller.

I moved a bunch of API to int-based status handling. However, this PR does not go all the way: We may want to add int-based parameters to `@Status` and `@Error`. But that is more work especially to test so I left it out of this PR. It's a bit much for a patch release and for such an obscure feature.

Fixes #9824