### PR TITLE
fix: remove duplicated ExitCode.OOM_ERROR

### DIFF
--- a/inject-kotlin-test/src/main/kotlin/io/micronaut/annotation/processing/test/support/AbstractKotlinCompilation.kt
+++ b/inject-kotlin-test/src/main/kotlin/io/micronaut/annotation/processing/test/support/AbstractKotlinCompilation.kt
@@ -293,7 +293,6 @@ abstract class AbstractKotlinCompilation<A : CommonCompilerArguments> internal c
 
 internal fun convertKotlinExitCode(code: ExitCode) = when(code) {
     ExitCode.OK -> KotlinCompilation.ExitCode.OK
-    ExitCode.OOM_ERROR,
     ExitCode.INTERNAL_ERROR -> KotlinCompilation.ExitCode.INTERNAL_ERROR
     ExitCode.COMPILATION_ERROR -> KotlinCompilation.ExitCode.COMPILATION_ERROR
     ExitCode.SCRIPT_EXECUTION_ERROR -> KotlinCompilation.ExitCode.SCRIPT_EXECUTION_ERROR


### PR DESCRIPTION
Cherry pick change by @altro3 in https://github.com/micronaut-projects/micronaut-core/pull/9596/files

It is already defined in line 299 `   ExitCode.OOM_ERROR -> throw OutOfMemoryError("Kotlin compiler ran out of memory")`