### PR TITLE
Fix logging with logger.config and no levels

### DIFF
--- a/context/src/main/java/io/micronaut/logging/PropertiesLoggingLevelsConfigurer.java
+++ b/context/src/main/java/io/micronaut/logging/PropertiesLoggingLevelsConfigurer.java
@@ -45,11 +45,12 @@ import java.util.Map;
 @Context
 @Requires(beans = LoggingSystem.class)
 @Requires(beans = Environment.class)
-@Requires(property = PropertiesLoggingLevelsConfigurer.LOGGER_LEVELS_PROPERTY_PREFIX)
+@Requires(property = PropertiesLoggingLevelsConfigurer.LOGGER_PROPERTY_PREFIX)
 @Internal
 final class PropertiesLoggingLevelsConfigurer implements ApplicationEventListener<RefreshEvent> {
 
-    static final String LOGGER_LEVELS_PROPERTY_PREFIX = "logger.levels";
+    static final String LOGGER_PROPERTY_PREFIX = "logger";
+    static final String LOGGER_LEVELS_PROPERTY_PREFIX = LOGGER_PROPERTY_PREFIX + ".levels";
     private static final Logger LOGGER = LoggerFactory.getLogger(PropertiesLoggingLevelsConfigurer.class);
 
     private final Environment environment;

--- a/management/src/test/groovy/io/micronaut/management/endpoint/beans/BeansEndpointSpec.groovy
+++ b/management/src/test/groovy/io/micronaut/management/endpoint/beans/BeansEndpointSpec.groovy
@@ -48,7 +48,7 @@ class BeansEndpointSpec extends Specification {
         beans["io.micronaut.management.endpoint.beans.\$BeansEndpoint" + BeanDefinitionWriter.CLASS_SUFFIX].type == "io.micronaut.management.endpoint.beans.BeansEndpoint"
         result.disabled.find {
             it.type == 'io.micronaut.logging.PropertiesLoggingLevelsConfigurer'
-        }.reasons == ["Required property [logger.levels] with value [null] not present"]
+        }.reasons == ["Required property [logger] with value [null] not present"]
 
         cleanup:
         rxClient.close()

--- a/test-suite-logback-external-configuration/src/test/groovy/io/micronaut/logback/ExternalConfigurationSpec.groovy
+++ b/test-suite-logback-external-configuration/src/test/groovy/io/micronaut/logback/ExternalConfigurationSpec.groovy
@@ -53,4 +53,22 @@ class ExternalConfigurationSpec extends Specification {
         cleanup:
         server.stop()
     }
+
+    def "configuration via logger.config should work without configuring levels"() {
+        when:
+        def server = ApplicationContext.run(EmbeddedServer, [
+                "logger.config": "src/external/external-logback.xml",
+        ])
+        Logger fromXml = (Logger) LoggerFactory.getLogger("i.should.not.exist")
+        Logger external = (Logger) LoggerFactory.getLogger("external.logging")
+
+        then: 'logback.xml is ignored as we have set a configurationFile'
+        fromXml.level == null
+
+        and: 'external configuration is used'
+        external.level == Level.TRACE
+
+        cleanup:
+        server.stop()
+    }
 }


### PR DESCRIPTION
When we configure logger.config as per the docs:

https://docs.micronaut.io/latest/guide/#loggingConfiguration

It is not used unless we also configure logger.levels.xxx

This PR fixes that by relaxing the property required for PropertiesLoggingLevelsConfigurer so the logging system gets initialized if this config is defined

Closes #8918