### PR TITLE
Implement JsonAnyGetter for BeanIntrospectionModule

### DIFF
--- a/jackson-databind/src/test/groovy/io/micronaut/jackson/modules/BeanIntrospectionModuleSpec.groovy
+++ b/jackson-databind/src/test/groovy/io/micronaut/jackson/modules/BeanIntrospectionModuleSpec.groovy
@@ -354,6 +354,7 @@ class BeanIntrospectionModuleSpec extends Specification {
     void "test that introspected serialization works with @JsonAnyGetter"() {
         given:
         ApplicationContext ctx = ApplicationContext.run()
+        ctx.getBean(BeanIntrospectionModule).ignoreReflectiveProperties = ignoreReflectiveProperties
         JsonMapper objectMapper = ctx.getBean(JsonMapper)
 
         when:
@@ -373,6 +374,9 @@ class BeanIntrospectionModuleSpec extends Specification {
 
         cleanup:
         ctx.close()
+
+        where:
+        ignoreReflectiveProperties << [true, false]
     }
 
     void "test that introspected serialization of errors works"() {


### PR DESCRIPTION
Normally this would be a feature I skip out on, because we can't support every jackson feature in BeanIntrospectionModule. However in this case, the BIM actually duplicated the AnyGetter as a normal property also, so a fix was necessary anyway, and implementing the full logic is not that difficult and a test case existed already.

A similar problem exists for JsonValue, but because there's no existing test case for it, I don't want to implement it fully. That means JsonValue will still not work with native image, likely. But JsonAnyGetter should.

Fixes #9870