### PR TITLE
fix health monitor task

### DIFF
--- a/management/src/main/java/io/micronaut/management/health/monitor/HealthMonitorTask.java
+++ b/management/src/main/java/io/micronaut/management/health/monitor/HealthMonitorTask.java
@@ -27,8 +27,6 @@ import io.micronaut.scheduling.annotation.Scheduled;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import org.reactivestreams.Publisher;
-import org.reactivestreams.Subscriber;
-import org.reactivestreams.Subscription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
@@ -82,51 +80,29 @@ public class HealthMonitorTask {
         if (LOG.isDebugEnabled()) {
             LOG.debug("Starting health monitor check");
         }
-        List<Publisher<HealthResult>> healthResults = healthIndicators
+        List<Publisher<HealthResult>> resultPublishers = healthIndicators
             .stream()
             .map(HealthIndicator::getResult)
             .collect(Collectors.toList());
 
-        Flux<HealthResult> reactiveSequence = Flux
-            .merge(healthResults)
-            .filter(healthResult -> {
-                    HealthStatus status = healthResult.getStatus();
-                    return status.equals(HealthStatus.DOWN) || !status.getOperational().orElse(true);
-                }
-            );
-
-        reactiveSequence.next().subscribe(new Subscriber<HealthResult>() {
-            @Override
-            public void onSubscribe(Subscription s) {
-
-            }
-
-            @Override
-            public void onNext(HealthResult healthResult) {
-                HealthStatus status = healthResult.getStatus();
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Health monitor check with status {}", status);
-                }
-                currentHealthStatus.update(status);
-            }
-
-            @Override
-            public void onError(Throwable e) {
+        Flux
+            .merge(resultPublishers)
+            .collectList()
+            .doOnError((e) -> {
                 if (LOG.isErrorEnabled()) {
                     LOG.error("Health monitor check failed with exception: " + e.getMessage(), e);
                 }
-
                 currentHealthStatus.update(HealthStatus.DOWN.describe("Error occurred running health check: " + e.getMessage()));
-            }
-
-            @Override
-            public void onComplete() {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Health monitor check passed.");
+            })
+            .subscribe(healthResults -> {
+                java.util.Optional<HealthResult> firstDown = healthResults.stream().filter(r -> r.getStatus().equals(io.micronaut.health.HealthStatus.DOWN) || !r.getStatus().getOperational().orElse(true))
+                    .findFirst();
+                if (firstDown.isPresent()) {
+                    currentHealthStatus.update(firstDown.get().getStatus());
+                } else {
+                    currentHealthStatus.update(HealthStatus.UP);
                 }
+            });
 
-                currentHealthStatus.update(HealthStatus.UP);
-            }
-        });
     }
 }

--- a/management/src/test/groovy/io/micronaut/management/endpoint/health/HealthMonitorTaskSpec.groovy
+++ b/management/src/test/groovy/io/micronaut/management/endpoint/health/HealthMonitorTaskSpec.groovy
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.management.endpoint.health
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.health.CurrentHealthStatus
+import io.micronaut.health.HealthStatus
+import spock.lang.Specification
+
+class HealthMonitorTaskSpec extends Specification {
+
+    void "test CurrentHealthStatus is updated when check is down"() {
+        given:
+        ApplicationContext context = ApplicationContext.builder(['micronaut.health.monitor.enabled': true,
+                                                                 'endpoints.health.disk-space.threshold': 999999999999999999,
+                                                                 'micronaut.health.monitor.initial-delay': '0ms',
+                                                                 'micronaut.application.name': 'health-monitor-task-test']).build()
+        context.start()
+        Thread.sleep(1000)
+
+        expect:
+        context.getBean(CurrentHealthStatus).current().name == HealthStatus.NAME_DOWN
+
+        cleanup:
+        context.close()
+    }
+
+}


### PR DESCRIPTION
I discovered that HealthMonitoringTask is currently broken. While the periodic task is scheduled according to config, the logic fails to update the CurrentHealthStatus bean.

See example in the added test HealthMonitorTaskSpec.groovy


I found out that the subscriber to reactiveSequence is not getting triggered. It looks like in the  `onSubscribe` we have to explicitly call `request` method so that HealthIndicators would emit HealthResults

If we fix the above problem with use of `request` we run into another problem. `onComplete` in the subscriber reports that the status is UP, even though some checks might be DOWN, and the web endpoints report DOWN. So it looks like incorrect behaviour.

This PR proposes a rewrite in a more clear way and fixing the above problems:
- first, collect all publishers in a List
- use Flux.collectList to subscribe to all publishers and collect all results in one list
- Then we can operate on the final result list in a simple way to check if any status is down and report that. Only if all statuses are up then we report UP 
