### PR TITLE
Fix empty header value validation

### DIFF
--- a/http/src/main/java/io/micronaut/http/CaseInsensitiveMutableHttpHeaders.java
+++ b/http/src/main/java/io/micronaut/http/CaseInsensitiveMutableHttpHeaders.java
@@ -193,6 +193,9 @@ public final class CaseInsensitiveMutableHttpHeaders implements MutableHttpHeade
         //  HTAB           = %x09 ; horizontal tab
         //  See: https://datatracker.ietf.org/doc/html/rfc7230#section-3.2
         //  And: https://datatracker.ietf.org/doc/html/rfc5234#appendix-B.1
+        if (value.isEmpty()) {
+            return -1;
+        }
         int b = value.charAt(0);
         if (b < 0x21 || b == 0x7F) {
             return 0;

--- a/http/src/test/groovy/io/micronaut/http/CaseInsensitiveMutableHttpHeadersSpec.groovy
+++ b/http/src/test/groovy/io/micronaut/http/CaseInsensitiveMutableHttpHeadersSpec.groovy
@@ -117,6 +117,17 @@ class CaseInsensitiveMutableHttpHeadersSpec extends Specification {
         headers.get("foo") == null
     }
 
+    void "empty header value"() {
+        given:
+        CaseInsensitiveMutableHttpHeaders headers = new CaseInsensitiveMutableHttpHeaders(ConversionService.SHARED)
+
+        when:
+        headers.add("foo", "")
+
+        then:
+        headers.get("foo") == ""
+    }
+
     void "cannot add invalid or insecure header names"() {
         given:
         CaseInsensitiveMutableHttpHeaders headers = new CaseInsensitiveMutableHttpHeaders(ConversionService.SHARED)


### PR DESCRIPTION
Field values can be empty according to https://httpwg.org/specs/rfc9110.html#fields.values . 

Fixes #9907