### PR TITLE
Delegate `isAbstract()` and `isSuspend()` to target executable method

### DIFF
--- a/inject/src/main/java/io/micronaut/inject/DelegatingExecutableMethod.java
+++ b/inject/src/main/java/io/micronaut/inject/DelegatingExecutableMethod.java
@@ -72,6 +72,16 @@ public interface DelegatingExecutableMethod<T, R> extends ExecutableMethod<T, R>
     }
 
     @Override
+    default boolean isAbstract(){
+        return getTarget().isAbstract();
+    }
+
+    @Override
+    default boolean isSuspend(){
+        return getTarget().isSuspend();
+    }
+
+    @Override
     default R invoke(T instance, Object... arguments) {
         return getTarget().invoke(instance, arguments);
     }

--- a/inject/src/test/groovy/io/micronaut/inject/DefaultBeanDefinitionMethodReferenceSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/inject/DefaultBeanDefinitionMethodReferenceSpec.groovy
@@ -1,0 +1,22 @@
+package io.micronaut.inject
+
+import spock.lang.Specification
+
+class DefaultBeanDefinitionMethodReferenceSpec extends Specification {
+
+    void "default bean definition method reference delegates isAbstract() to target method"() {
+        given:
+        final target = Mock(ExecutableMethod) { isAbstract() >> true }
+        final method = new DefaultBeanDefinitionMethodReference(null, target)
+        expect:
+        method.isAbstract() == true
+    }
+
+    void "default bean definition method reference delegates isSuspend() to target method"() {
+        given:
+        final target = Mock(ExecutableMethod) { isSuspend() >> true }
+        final method = new DefaultBeanDefinitionMethodReference(null, target)
+        expect:
+        method.isSuspend() == true
+    }
+}


### PR DESCRIPTION
Interface `ExecutableMethod` provides default implementations for `isAbstract()` and `isSuspend()` that always return `false`.

These changes make interface `DelegatingExecutableMethod` actually delegate to its target executable method to return appropriate results.

This issue is related to: https://github.com/micronaut-projects/micronaut-kafka/pull/874
