### PR TITLE
avoid unnecessary calls to ConcurrentLinkedDeque.size() 

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/PoolResizer.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/PoolResizer.java
@@ -225,7 +225,8 @@ abstract class PoolResizer {
     }
 
     final void addPendingRequest(PoolSink<ConnectionManager.PoolHandle> sink) {
-        if (pendingRequests.size() >= connectionPoolConfiguration.getMaxPendingAcquires()) {
+        int maxPendingAcquires = connectionPoolConfiguration.getMaxPendingAcquires();
+        if (maxPendingAcquires != Integer.MAX_VALUE && pendingRequests.size() >= maxPendingAcquires) {
             sink.tryEmitError(new HttpClientException("Cannot acquire connection, exceeded max pending acquires configuration"));
             return;
         }


### PR DESCRIPTION
because it's a non-constant-time operation