### PR TITLE
Micronaut 4 Groovy projects fail Intellij compilation

### DIFF
--- a/inject-groovy/src/functionalTest/groovy/io/micronaut/ast/groovy/GroovyCompilationSpec.groovy
+++ b/inject-groovy/src/functionalTest/groovy/io/micronaut/ast/groovy/GroovyCompilationSpec.groovy
@@ -1,0 +1,34 @@
+package io.micronaut.ast.groovy
+
+import io.micronaut.fixtures.context.MicronautApplicationTest
+import org.codehaus.groovy.tools.FileSystemCompiler
+import spock.lang.Issue
+
+class GroovyCompilationSpec extends MicronautApplicationTest {
+
+    @Issue("https://github.com/micronaut-projects/micronaut-core/issues/9915")
+    def "compilation with the Groovy compiler works as expected"() {
+        given:
+        groovySourceFile("Annotation.groovy", """
+import java.lang.annotation.ElementType
+import java.lang.annotation.Target
+
+@Target(ElementType.FIELD)
+@interface Annotation {
+}
+""")
+
+        groovySourceFile("Usage.groovy", """
+// Usage.groovy
+class Usage {
+    @Annotation
+    String field
+}
+""")
+        when:
+        FileSystemCompiler.commandLineCompile(testDirectory.resolve("src/main/java/Usage.groovy").toString())
+
+        then:
+        noExceptionThrown()
+    }
+}


### PR DESCRIPTION
Something in this PR has broken compilation with Groovyc and inject-groovy.

https://github.com/micronaut-projects/micronaut-core/pull/9232

when d273fdae71a75974a97528a552f665bd7f5e1f3c is reverted then this test passes.

I am not sure why