### PR TITLE
fix: alias propagation / configuration builder  (#9919)

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -1017,7 +1017,7 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         if (!introducedAliasForAnnotations.isEmpty()) {
             newAnn = newAnn.withAnnotationValue(
                     newAnn.getAnnotationValue().mutate()
-                            .stereotypes(
+                            .stereotypesPrepend(
                                     introducedAliasForAnnotations.stream()
                                             .flatMap(a -> processAnnotation(context, a))
                                             .<AnnotationValue<?>>map(ProcessedAnnotation::getAnnotationValue)

--- a/core-processor/src/main/java/io/micronaut/inject/ast/PropertyElementQuery.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/PropertyElementQuery.java
@@ -16,8 +16,6 @@
 package io.micronaut.inject.ast;
 
 import io.micronaut.context.annotation.BeanProperties;
-import io.micronaut.context.annotation.ConfigurationBuilder;
-import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.core.annotation.AccessorsStyle;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationValue;
@@ -26,10 +24,8 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
@@ -67,8 +63,6 @@ public final class PropertyElementQuery {
      */
     public static @NonNull PropertyElementQuery of(@NonNull AnnotationMetadata annotationMetadata) {
         PropertyElementQuery conf = new PropertyElementQuery();
-        Set<String> includes = new HashSet<>();
-        Set<String> excludes = new HashSet<>();
 
         AnnotationValue<BeanProperties> annotation = annotationMetadata.getAnnotation(BeanProperties.class);
         if (annotation != null) {
@@ -84,21 +78,11 @@ public final class PropertyElementQuery {
             annotation.booleanValue(BeanProperties.MEMBER_ALLOW_WRITE_WITH_MULTIPLE_ARGS)
                 .ifPresent(conf::allowSetterWithMultipleArgs);
 
-            includes.addAll(Arrays.asList(annotation.stringValues(BeanProperties.MEMBER_INCLUDES)));
-            excludes.addAll(Arrays.asList(annotation.stringValues(BeanProperties.MEMBER_EXCLUDES)));
+            conf.includes(CollectionUtils.setOf(annotation.stringValues(BeanProperties.MEMBER_INCLUDES)));
+            conf.excludes(CollectionUtils.setOf(annotation.stringValues(BeanProperties.MEMBER_EXCLUDES)));
 
             conf.excludedAnnotations(CollectionUtils.setOf(annotation.stringValues(BeanProperties.MEMBER_EXCLUDED_ANNOTATIONS)));
         }
-
-        // TODO: investigate why aliases aren't propagated
-        includes.addAll(Arrays.asList(annotationMetadata.stringValues(ConfigurationProperties.class, BeanProperties.MEMBER_INCLUDES)));
-        excludes.addAll(Arrays.asList(annotationMetadata.stringValues(ConfigurationProperties.class, BeanProperties.MEMBER_EXCLUDES)));
-
-        includes.addAll(Arrays.asList(annotationMetadata.stringValues(ConfigurationBuilder.class, BeanProperties.MEMBER_INCLUDES)));
-        excludes.addAll(Arrays.asList(annotationMetadata.stringValues(ConfigurationBuilder.class, BeanProperties.MEMBER_EXCLUDES)));
-
-        conf.includes(includes);
-        conf.excludes(excludes);
 
         String[] readPrefixes = annotationMetadata.stringValues(AccessorsStyle.class, "readPrefixes");
         if (ArrayUtils.isNotEmpty(readPrefixes)) {

--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationValueBuilder.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationValueBuilder.java
@@ -178,6 +178,22 @@ public class AnnotationValueBuilder<T extends Annotation> {
     }
 
     /**
+     * Adds stereotypes of the annotation at the beginning.
+     *
+     * @param newStereotypes The stereotypes
+     * @return This builder
+     * @since 4.1.9
+     */
+    @NonNull
+    public AnnotationValueBuilder<T> stereotypesPrepend(@NonNull Collection<AnnotationValue<?>> newStereotypes) {
+        if (stereotypes == null) {
+            stereotypes = new ArrayList<>(10);
+        }
+        stereotypes.addAll(0, newStereotypes);
+        return this;
+    }
+
+    /**
      * Replaces stereotypes of the annotation.
      *
      * @param newStereotypes The stereotypes

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/configproperties/InheritedConfigurationReaderPrefixSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/configproperties/InheritedConfigurationReaderPrefixSpec.groovy
@@ -21,12 +21,12 @@ import io.micronaut.inject.BeanDefinition
 
 class InheritedConfigurationReaderPrefixSpec extends AbstractBeanDefinitionSpec {
 
-    void "property path is broken because alias is pointing to another alias"() {
+    void "property path is inherited because the alias for prefix was not specified without base prefix"() {
         given:
         BeanDefinition beanDefinition = buildBeanDefinition('io.micronaut.inject.configproperties.MyBean', """
 package io.micronaut.inject.configproperties;
 
-@TestEndpoint1("simple")
+@TestEndpoint1()
 class MyBean  {
     String myValue
 }
@@ -56,15 +56,15 @@ class MyBean  {
         beanDefinition.getInjectedMethods()[0].name == 'setMyValue'
         def metadata = beanDefinition.getInjectedMethods()[0].getAnnotationMetadata()
         metadata.hasAnnotation(Property)
-        metadata.getValue(Property, "name", String).get() == 'endpoints.my-value'
+        metadata.getValue(Property, "name", String).get() == 'simple.my-value'
     }
 
-    void "property path is broken because alias is pointing to another alias 2"() {
+    void "property path is inherited because the alias for prefix was not specified"() {
         given:
             BeanDefinition beanDefinition = buildBeanDefinition('io.micronaut.inject.configproperties.MyBean', """
 package io.micronaut.inject.configproperties;
 
-@TestEndpoint3("simple")
+@TestEndpoint3()
 class MyBean  {
     String myValue
 }
@@ -75,7 +75,7 @@ class MyBean  {
             beanDefinition.getInjectedMethods()[0].name == 'setMyValue'
             def metadata = beanDefinition.getInjectedMethods()[0].getAnnotationMetadata()
             metadata.hasAnnotation(Property)
-            metadata.getValue(Property, "name", String).get() == 'endpoints.simple.my-value'
+            metadata.getValue(Property, "name", String).get() == 'endpoints.my-value'
     }
 
     void "property path is overriding the existing one"() {

--- a/inject-java/src/test/groovy/io/micronaut/inject/annotation/JavaAnnotationMetadataBuilderSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/annotation/JavaAnnotationMetadataBuilderSpec.groovy
@@ -210,6 +210,23 @@ class Test {
         metadata.getValue(ConfigurationReader, String).get() == 'test'
     }
 
+    void "test alias for has correct value for aliased member with default value"() {
+        given:
+        AnnotationMetadata metadata = buildTypeAnnotationMetadata('''\
+package test;
+
+import io.micronaut.inject.annotation.*;
+
+@MyStereotypeWithDefaultValue("test")
+class Test {
+}
+''')
+        expect:
+        metadata != null
+        metadata.hasDeclaredStereotype(ConfigurationReader)
+        metadata.getValue(ConfigurationReader, String).get() == 'test'
+    }
+
     void "test read annotation with annotation value"() {
         given:
         AnnotationMetadata metadata = buildTypeAnnotationMetadata('''\

--- a/inject-java/src/test/groovy/io/micronaut/inject/annotation/MyStereotypeWithDefaultValue.java
+++ b/inject-java/src/test/groovy/io/micronaut/inject/annotation/MyStereotypeWithDefaultValue.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.annotation;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import io.micronaut.aop.Introduction;
+import io.micronaut.aop.introduction.StubIntroducer;
+import io.micronaut.context.annotation.AliasFor;
+import io.micronaut.context.annotation.ConfigurationReader;
+import io.micronaut.context.annotation.Type;
+import io.micronaut.retry.annotation.Recoverable;
+import jakarta.inject.Scope;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Recoverable
+@Introduction
+@Scope
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.TYPE})
+@Type(StubIntroducer.class)
+@ConfigurationReader("default")
+public @interface MyStereotypeWithDefaultValue {
+    /**
+     * @return The prefix to use to resolve the properties
+     */
+    @AliasFor(annotation = ConfigurationReader.class, member = "value")
+    String value() default "default";
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/inject/configproperties/ConfigurationPropertiesBuilderSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configproperties/ConfigurationPropertiesBuilderSpec.groovy
@@ -255,6 +255,55 @@ class Test {
         test.baz == null //deprecated properties not settable
     }
 
+    void "test with setters without arguments and do not allow zero args"() {
+        given:
+        BeanDefinition beanDefinition = buildBeanDefinition('test.MyProperties', '''
+package test;
+
+import io.micronaut.context.annotation.*;
+import java.lang.Deprecated;
+
+@ConfigurationProperties("test")
+class MyProperties {
+
+    @ConfigurationBuilder
+    Test test = new Test();
+
+
+}
+
+class Test {
+    private Boolean foo;
+    private Boolean bar;
+
+    public void setFoo() { this.foo = true;}
+    public Boolean getFoo() { return this.foo; }
+
+    public void setBar(Boolean bar) { this.bar = bar;}
+    public Boolean getBar() { return this.bar; }
+}
+''')
+
+        when:
+        InstantiatableBeanDefinition factory = beanDefinition
+        ApplicationContext applicationContext = ApplicationContext.run(
+                'test.foo':'true',
+                'test.bar':'true',
+        )
+        def bean = factory.instantiate(applicationContext)
+
+        then:
+        bean != null
+        bean.test != null
+
+        when:
+        def test = bean.test
+
+        then:
+        test.foo == null
+        test.bar == true
+    }
+
     void "test different inject types for config properties"() {
         when:
         BeanDefinition beanDefinition = buildBeanDefinition('test.Neo4jProperties', '''

--- a/inject-java/src/test/groovy/io/micronaut/inject/configproperties/InheritedConfigurationReaderPrefixSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configproperties/InheritedConfigurationReaderPrefixSpec.groovy
@@ -21,12 +21,12 @@ import io.micronaut.inject.BeanDefinition
 
 class InheritedConfigurationReaderPrefixSpec extends AbstractTypeElementSpec {
 
-    void "property path is broken because alias is pointing to another alias"() {
+    void "property path is inherited because the alias for prefix was not specified without base prefix"() {
         given:
             BeanDefinition beanDefinition = buildBeanDefinition('io.micronaut.inject.configproperties.MyBean', """
 package io.micronaut.inject.configproperties;
 
-@TestEndpoint1("simple")
+@TestEndpoint1()
 class MyBean  {
     String myValue;
 
@@ -72,15 +72,15 @@ class MyBean  {
             beanDefinition.getInjectedMethods()[0].name == 'setMyValue'
             def metadata = beanDefinition.getInjectedMethods()[0].getAnnotationMetadata()
             metadata.hasAnnotation(Property)
-            metadata.getValue(Property, "name", String).get() == 'endpoints.my-value'
+            metadata.getValue(Property, "name", String).get() == 'simple.my-value'
     }
 
-    void "property path is broken because alias is pointing to another alias 2"() {
+    void "property path is inherited because the alias for prefix was not specified"() {
         given:
             BeanDefinition beanDefinition = buildBeanDefinition('io.micronaut.inject.configproperties.MyBean', """
 package io.micronaut.inject.configproperties;
 
-@TestEndpoint3("simple")
+@TestEndpoint3()
 class MyBean  {
     String myValue;
 
@@ -99,7 +99,7 @@ class MyBean  {
             beanDefinition.getInjectedMethods()[0].name == 'setMyValue'
             def metadata = beanDefinition.getInjectedMethods()[0].getAnnotationMetadata()
             metadata.hasAnnotation(Property)
-            metadata.getValue(Property, "name", String).get() == 'endpoints.simple.my-value'
+            metadata.getValue(Property, "name", String).get() == 'endpoints.my-value'
     }
 
     void "property path is overriding the existing one"() {

--- a/inject/src/main/java/io/micronaut/context/annotation/ConfigurationBuilder.java
+++ b/inject/src/main/java/io/micronaut/context/annotation/ConfigurationBuilder.java
@@ -34,7 +34,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Documented
 @Retention(RUNTIME)
 @Target({ElementType.FIELD, ElementType.METHOD})
-@BeanProperties(accessKind = BeanProperties.AccessKind.METHOD, visibility = BeanProperties.Visibility.DEFAULT, allowWriteWithMultipleArgs = true, allowWriteWithZeroArgs = true)
+@BeanProperties(accessKind = BeanProperties.AccessKind.METHOD, visibility = BeanProperties.Visibility.DEFAULT, allowWriteWithMultipleArgs = true)
 public @interface ConfigurationBuilder {
 
     /**


### PR DESCRIPTION
This is an attempt to fix #9919.

**Aliases Propagation**
I had more time to dig into the problem and what I found is that the introduced aliases are added at the end of the annotation stereotypes and because of this they are the last to be processed and they do not override the annotations processed before. 

The fix consists in prepend the aliases so they are prioritized - no need to say that I'm not sure this has no unintended consequences as I'm not familiar with the framework internals, but the tests all passed.

I also added one new test and had to change some that didn't seem right to me (they seem to have been changed in the past to match what I consider to be incorrect behavior).

**Configuration Builder**
I changed the default to do not allow zero arguments as this behavior is very explicit in the documentation (although it might be a breaking change for those relying on the current behavior). 

I also added/corrected some tests.