### PR TITLE
regression: support JSON Patch

### DIFF
--- a/http-netty/src/main/java/io/micronaut/http/netty/body/NettyJsonHandler.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/body/NettyJsonHandler.java
@@ -57,6 +57,7 @@ import java.io.OutputStream;
     MediaType.APPLICATION_HAL_JSON,
     MediaType.APPLICATION_JSON_GITHUB,
     MediaType.APPLICATION_JSON_FEED,
+    MediaType.APPLICATION_JSON_PATCH,
     MediaType.APPLICATION_JSON_PROBLEM
 })
 @Consumes({
@@ -65,6 +66,7 @@ import java.io.OutputStream;
     MediaType.APPLICATION_HAL_JSON,
     MediaType.APPLICATION_JSON_GITHUB,
     MediaType.APPLICATION_JSON_FEED,
+    MediaType.APPLICATION_JSON_PATCH,
     MediaType.APPLICATION_JSON_PROBLEM
 })
 @BootstrapContextCompatible

--- a/http/src/main/java/io/micronaut/http/MediaType.java
+++ b/http/src/main/java/io/micronaut/http/MediaType.java
@@ -183,6 +183,18 @@ public class MediaType implements CharSequence {
     public static final MediaType APPLICATION_JSON_FEED_TYPE = new MediaType(MediaType.APPLICATION_JSON_FEED);
 
     /**
+     * @see <a href="https://datatracker.ietf.org/doc/html/rfc6902/">JSON Patch</a>
+     * JSON Patch: application/json-patch+json.
+     */
+    public static final String APPLICATION_JSON_PATCH = "application/json-patch+json";
+
+    /**
+     * JSON Patch: application/json-patch+json.
+     */
+    public static final MediaType APPLICATION_JSON_PATCH_TYPE = new MediaType(MediaType.APPLICATION_JSON_PATCH);
+
+
+    /**
      * JSON Feed: application/problem+json.
      */
     public static final String APPLICATION_JSON_PROBLEM = "application/problem+json";
@@ -571,6 +583,8 @@ public class MediaType implements CharSequence {
                 return APPLICATION_JSON_FEED_TYPE;
             case APPLICATION_JSON_GITHUB:
                 return APPLICATION_JSON_GITHUB_TYPE;
+            case APPLICATION_JSON_PATCH:
+                return APPLICATION_JSON_PATCH_TYPE;
             case APPLICATION_JSON_PROBLEM:
                 return APPLICATION_JSON_PROBLEM_TYPE;
             case APPLICATION_YAML:

--- a/http/src/test/groovy/io/micronaut/http/MediaTypeSpec.groovy
+++ b/http/src/test/groovy/io/micronaut/http/MediaTypeSpec.groovy
@@ -33,6 +33,7 @@ class MediaTypeSpec extends Specification {
         MediaType.of('application/vnd.github+json') == MediaType.APPLICATION_JSON_GITHUB_TYPE
         MediaType.of('application/feed+json') == MediaType.APPLICATION_JSON_FEED_TYPE
         MediaType.of('application/problem+json') == MediaType.APPLICATION_JSON_PROBLEM_TYPE
+        MediaType.of('application/json-patch+json') == MediaType.APPLICATION_JSON_PATCH_TYPE
     }
 
     void "test media type"() {

--- a/json-core/src/main/java/io/micronaut/json/body/JsonMessageHandler.java
+++ b/json-core/src/main/java/io/micronaut/json/body/JsonMessageHandler.java
@@ -53,7 +53,8 @@ import java.io.OutputStream;
     MediaType.APPLICATION_HAL_JSON,
     MediaType.APPLICATION_JSON_GITHUB,
     MediaType.APPLICATION_JSON_FEED,
-    MediaType.APPLICATION_JSON_PROBLEM
+    MediaType.APPLICATION_JSON_PROBLEM,
+    MediaType.APPLICATION_JSON_PATCH
 })
 @Consumes({
     MediaType.APPLICATION_JSON,
@@ -61,7 +62,8 @@ import java.io.OutputStream;
     MediaType.APPLICATION_HAL_JSON,
     MediaType.APPLICATION_JSON_GITHUB,
     MediaType.APPLICATION_JSON_FEED,
-    MediaType.APPLICATION_JSON_PROBLEM
+    MediaType.APPLICATION_JSON_PROBLEM,
+    MediaType.APPLICATION_JSON_PATCH
 })
 @BootstrapContextCompatible
 public final class JsonMessageHandler<T> implements MessageBodyHandler<T> {

--- a/json-core/src/main/java/io/micronaut/json/codec/JsonMediaTypeCodec.java
+++ b/json-core/src/main/java/io/micronaut/json/codec/JsonMediaTypeCodec.java
@@ -49,6 +49,7 @@ public class JsonMediaTypeCodec extends MapperMediaTypeCodec {
         MediaType.APPLICATION_HAL_JSON_TYPE,
         MediaType.APPLICATION_JSON_GITHUB_TYPE,
         MediaType.APPLICATION_JSON_FEED_TYPE,
+        MediaType.APPLICATION_JSON_PATCH_TYPE,
         MediaType.APPLICATION_JSON_PROBLEM_TYPE
     );
 

--- a/test-suite/src/test/java/io/micronaut/docs/jsonpatch/JsonPatchTest.java
+++ b/test-suite/src/test/java/io/micronaut/docs/jsonpatch/JsonPatchTest.java
@@ -1,0 +1,47 @@
+package io.micronaut.docs.jsonpatch;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.*;
+import io.micronaut.http.client.BlockingHttpClient;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Property(name = "spec.name", value = "JsonPatchTest")
+@MicronautTest
+class JsonPatchTest {
+    @Test
+    void testJsonPatch(@Client("/") HttpClient httpClient) {
+        BlockingHttpClient client = httpClient.toBlocking();
+        String expected = "{\"op\":\"replace\",\"path\":\"/baz\",\"value\":\"boo\"}";
+        String json = assertDoesNotThrow(() -> client.retrieve(
+            HttpRequest.PATCH("/jsonpatch", "{\"op\":\"replace\",\"path\":\"/baz\",\"value\":\"boo\"}")
+                .contentType("application/json-patch+json")
+                .accept("application/json-patch+json")
+        ));
+        assertNotNull(json);
+        assertEquals(expected, json);
+    }
+
+    @Requires(property = "spec.name", value = "JsonPatchTest")
+    @Controller("/jsonpatch")
+    static class JsonPatchController {
+        @Consumes(MediaType.APPLICATION_JSON_PATCH)
+        @Produces(MediaType.APPLICATION_JSON_PATCH)
+        @Patch
+        PatchOperation patch(@Body PatchOperation patch) {
+            return patch;
+        }
+    }
+
+    @Introspected
+    record PatchOperation(String op, String path, String value) {
+    }
+}


### PR DESCRIPTION
I confirmed this used to work in Micronaut Framework 3. 

> I'm migrating from Micronaut 3.x to 4.x, and I have this endpoint:
> 
>     @Patch(value = "/{id}", consumes = "application/json-patch+json")
>     public Mono<AbstractAttachmentDto> updateByAttachmentId(@Body @Valid AttachmentPatch dto, @PathVariable UUID id) {
>         return service.patch(dto, id);
>     }
> 
> 
> Which now when called throws an error (400 bad request):
> 
>         "errors": [
>             {
>                 "message": "Required Body [dto] not specified",
>                 "path": "/dto"
>             }
>         ]
> 
> 
> If I switch to application/json the error goes away. But this was working in Micronaut 3. And I can't find any solution in the docs, or in the migration guide.