### PR TITLE
Add Java 21

### DIFF
--- a/.github/workflows/graalvm-latest.yml
+++ b/.github/workflows/graalvm-latest.yml
@@ -34,7 +34,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 6
-      matrix: ${{ fromJson(needs.build_matrix.outputs.matrix) }}
+      matrix:
+        java: ['17', '21']
+        native_test_task: ${{ fromJson(needs.build_matrix.outputs.matrix).native_test_task }}
     env:
       GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
@@ -46,7 +48,7 @@ jobs:
         id: pre-build
         with:
           distribution: 'graalvm'
-          java: '17'
+          java: ${{ matrix.java }}
       - name: Build Steps
         uses: micronaut-projects/github-actions/graalvm/build@master
         id: build
@@ -60,4 +62,4 @@ jobs:
         uses: micronaut-projects/github-actions/graalvm/post-build@master
         id: post-build
         with:
-          java: '17'
+          java: ${{ matrix.java }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['17']
+        java: ['17', "21"]
     env:
       GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
@@ -64,7 +64,7 @@ jobs:
           ./gradlew check --no-daemon --continue
 
       - name: "🔎 Run static analysis"
-        if: env.SONAR_TOKEN != ''
+        if: env.SONAR_TOKEN != '' && matrix.java == '17'
         run: |
           ./gradlew sonar
 

--- a/config/accepted-api-changes.json
+++ b/config/accepted-api-changes.json
@@ -348,5 +348,20 @@
     "type": "io.micronaut.core.graal.AutomaticFeatureUtils",
     "member": "Constructor io.micronaut.core.graal.AutomaticFeatureUtils()",
     "reason": "Was deprecated"
+  },
+  {
+    "type": "io.micronaut.ast.groovy.TypeElementVisitorTransform$ElementVisitor$_visitNativeProperty_lambda1",
+    "member": "Constructor io.micronaut.ast.groovy.TypeElementVisitorTransform$ElementVisitor$_visitNativeProperty_lambda1(java.lang.Object,java.lang.Object,groovy.lang.Reference)",
+    "reason": "Under Java 21 the constructor is absent"
+  },
+  {
+    "type": "io.micronaut.ast.groovy.TypeElementVisitorTransform$ElementVisitor$_visitNativeProperty_lambda2",
+    "member": "Constructor io.micronaut.ast.groovy.TypeElementVisitorTransform$ElementVisitor$_visitNativeProperty_lambda2(java.lang.Object,java.lang.Object,groovy.lang.Reference)",
+    "reason": "Under Java 21 the constructor is absent"
+  },
+  {
+    "type": "io.micronaut.ast.groovy.TypeElementVisitorTransform$ElementVisitor$_visitNativeProperty_lambda3",
+    "member": "Constructor io.micronaut.ast.groovy.TypeElementVisitorTransform$ElementVisitor$_visitNativeProperty_lambda3(java.lang.Object,java.lang.Object,groovy.lang.Reference)",
+    "reason": "Under Java 21 the constructor is absent"
   }
 ]

--- a/context-propagation/build.gradle
+++ b/context-propagation/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "io.micronaut.build.internal.convention-library"
     id "org.jetbrains.kotlin.jvm"
-    id "org.jetbrains.kotlin.kapt"
+    id("com.google.devtools.ksp")
 }
 
 dependencies {
@@ -58,9 +58,7 @@ dependencies {
 
 // Kotlin
 dependencies {
-    kapt project(':inject-java')
-    kaptTest project(':inject-java')
-
+    kspTest projects.injectKotlin
     compileOnly libs.managed.kotlin.stdlib.jdk8
     compileOnly libs.managed.kotlinx.coroutines.core
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -68,9 +68,7 @@ include "test-suite-javax-inject"
 include "test-suite-jakarta-inject-bean-import"
 include "test-suite-http-server-tck-jdk"
 include "test-suite-http-server-tck-netty"
-if (JavaVersion.current() < JavaVersion.VERSION_21) {
-    include "test-suite-kotlin"
-}
+include "test-suite-kotlin"
 include "test-suite-kotlin-ksp"
 include "test-suite-groovy"
 include "test-suite-groovy"

--- a/settings.gradle
+++ b/settings.gradle
@@ -68,7 +68,9 @@ include "test-suite-javax-inject"
 include "test-suite-jakarta-inject-bean-import"
 include "test-suite-http-server-tck-jdk"
 include "test-suite-http-server-tck-netty"
-include "test-suite-kotlin"
+if (JavaVersion.current() < JavaVersion.VERSION_21) {
+    include "test-suite-kotlin"
+}
 include "test-suite-kotlin-ksp"
 include "test-suite-groovy"
 include "test-suite-groovy"

--- a/test-suite-kotlin/build.gradle
+++ b/test-suite-kotlin/build.gradle
@@ -82,21 +82,6 @@ configurations.testRuntimeClasspath {
     }
 }
 
-kotlin {
-    if (JavaVersion.current() > JavaVersion.VERSION_17) {
-        kotlinDaemonJvmArgs = ["--add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
-                               "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
-                               "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
-                               "--add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
-                               "--add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED",
-                               "--add-opens=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
-                               "--add-opens=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
-                               "--add-opens=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
-                               "--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
-                               "--add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"]
-    }
-}
-
 tasks.named("compileTestKotlin") {
     kotlinOptions.jvmTarget = "17"
 }

--- a/test-suite-kotlin/build.gradle
+++ b/test-suite-kotlin/build.gradle
@@ -82,6 +82,21 @@ configurations.testRuntimeClasspath {
     }
 }
 
+kotlin {
+    if (JavaVersion.current() > JavaVersion.VERSION_17) {
+        kotlinDaemonJvmArgs = ["--add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+                               "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+                               "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+                               "--add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+                               "--add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED",
+                               "--add-opens=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+                               "--add-opens=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+                               "--add-opens=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
+                               "--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+                               "--add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"]
+    }
+}
+
 tasks.named("compileTestKotlin") {
     kotlinOptions.jvmTarget = "17"
 }


### PR DESCRIPTION
- Exclude Kapt test-suite-kotlin under Java 21
- Switch to use Ksp for context-propagation tests
- Accept differences to generated classes caused by 21 (which we don't publish)