### PR TITLE
Use the current JDK for testing, but 17 for building

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.convention-base.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.convention-base.gradle
@@ -39,6 +39,9 @@ tasks.withType(Test).configureEach {
     if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_15)) {
         jvmArgs "--enable-preview"
     }
+    javaLauncher.set(javaToolchains.launcherFor {
+        languageVersion.set(JavaLanguageVersion.of(JavaVersion.current().majorVersion))
+    })
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.convention-base.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.convention-base.gradle
@@ -39,9 +39,6 @@ tasks.withType(Test).configureEach {
     if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_15)) {
         jvmArgs "--enable-preview"
     }
-    javaLauncher.set(javaToolchains.launcherFor {
-        languageVersion.set(JavaLanguageVersion.of(JavaVersion.current().majorVersion))
-    })
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/config/accepted-api-changes.json
+++ b/config/accepted-api-changes.json
@@ -348,20 +348,5 @@
     "type": "io.micronaut.core.graal.AutomaticFeatureUtils",
     "member": "Constructor io.micronaut.core.graal.AutomaticFeatureUtils()",
     "reason": "Was deprecated"
-  },
-  {
-    "type": "io.micronaut.ast.groovy.TypeElementVisitorTransform$ElementVisitor$_visitNativeProperty_lambda1",
-    "member": "Constructor io.micronaut.ast.groovy.TypeElementVisitorTransform$ElementVisitor$_visitNativeProperty_lambda1(java.lang.Object,java.lang.Object,groovy.lang.Reference)",
-    "reason": "Under Java 21 the constructor is absent"
-  },
-  {
-    "type": "io.micronaut.ast.groovy.TypeElementVisitorTransform$ElementVisitor$_visitNativeProperty_lambda2",
-    "member": "Constructor io.micronaut.ast.groovy.TypeElementVisitorTransform$ElementVisitor$_visitNativeProperty_lambda2(java.lang.Object,java.lang.Object,groovy.lang.Reference)",
-    "reason": "Under Java 21 the constructor is absent"
-  },
-  {
-    "type": "io.micronaut.ast.groovy.TypeElementVisitorTransform$ElementVisitor$_visitNativeProperty_lambda3",
-    "member": "Constructor io.micronaut.ast.groovy.TypeElementVisitorTransform$ElementVisitor$_visitNativeProperty_lambda3(java.lang.Object,java.lang.Object,groovy.lang.Reference)",
-    "reason": "Under Java 21 the constructor is absent"
   }
 ]

--- a/context-propagation/build.gradle
+++ b/context-propagation/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "io.micronaut.build.internal.convention-library"
     id "org.jetbrains.kotlin.jvm"
-    id("com.google.devtools.ksp")
+    id "org.jetbrains.kotlin.kapt"
 }
 
 dependencies {
@@ -58,7 +58,9 @@ dependencies {
 
 // Kotlin
 dependencies {
-    kspTest projects.injectKotlin
+    kapt project(':inject-java')
+    kaptTest project(':inject-java')
+
     compileOnly libs.managed.kotlin.stdlib.jdk8
     compileOnly libs.managed.kotlinx.coroutines.core
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -57,3 +57,5 @@ org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx1g
 systemProp.predictiveTestSelection=false
 predictiveTestSelection=false
+
+kotlin.daemon.jvmargs= --add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/gradle.properties
+++ b/gradle.properties
@@ -61,12 +61,12 @@ predictiveTestSelection=false
 # No matter which Java toolchain we use, the Kotlin Daemon is always invoked by the current JDK.
 # Therefor to fix Kapt errors when running tests under Java 21, we need to open up some modules for the Kotlin Daemon.
 kotlin.daemon.jvmargs=--add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED\
- --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED\
- --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED\
- --add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED\
- --add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED\
- --add-opens=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED\
- --add-opens=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED\
- --add-opens=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED\
- --add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED\
+ --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED \
+ --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED \
+ --add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+ --add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED \
+ --add-opens=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED \
+ --add-opens=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+ --add-opens=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED \
+ --add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
  --add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/gradle.properties
+++ b/gradle.properties
@@ -58,4 +58,15 @@ org.gradle.jvmargs=-Xmx1g
 systemProp.predictiveTestSelection=false
 predictiveTestSelection=false
 
-kotlin.daemon.jvmargs= --add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+# No matter which Java toolchain we use, the Kotlin Daemon is always invoked by the current JDK.
+# Therefor to fix Kapt errors when running tests under Java 21, we need to open up some modules for the Kotlin Daemon.
+kotlin.daemon.jvmargs=--add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED\
+ --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED\
+ --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED\
+ --add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED\
+ --add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED\
+ --add-opens=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED\
+ --add-opens=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED\
+ --add-opens=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED\
+ --add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED\
+ --add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/threading/ThreadSelectionSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/threading/ThreadSelectionSpec.groovy
@@ -29,16 +29,19 @@ import reactor.core.publisher.Flux
 import reactor.core.publisher.FluxSink
 import reactor.core.publisher.Mono
 import spock.lang.Specification
-import spock.lang.Unroll
 
 import java.util.concurrent.ExecutorService
 
 class ThreadSelectionSpec extends Specification {
 
     static final String IO = "io-executor-thread-"
+    static final String VIRTUAL = "virtual-executor"
     static final String LOOP = "default-nioEventLoopGroup"
 
-    @Unroll
+    private String jdkSwitch(String java17, String other) {
+        System.getProperty("java.version").startsWith("17") ? java17 : other
+    }
+
     void "test thread selection strategy #strategy"() {
         given:
         EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, ['micronaut.server.thread-selection': strategy])
@@ -54,13 +57,13 @@ class ThreadSelectionSpec extends Specification {
         embeddedServer.close()
 
         where:
-        strategy               | blocking | nonBlocking | scheduleBlocking
-        ThreadSelection.AUTO   | IO       | LOOP        | IO
-        ThreadSelection.IO     | IO       | IO          | IO
-        ThreadSelection.MANUAL | LOOP     | LOOP        | IO
+        strategy                 | blocking               | nonBlocking              | scheduleBlocking
+        ThreadSelection.AUTO     | jdkSwitch(IO, VIRTUAL) | LOOP                     | IO
+        ThreadSelection.BLOCKING | jdkSwitch(IO, VIRTUAL) | jdkSwitch(LOOP, VIRTUAL) | IO
+        ThreadSelection.IO       | IO                     | IO                       | IO
+        ThreadSelection.MANUAL   | LOOP                   | LOOP                     | IO
     }
 
-    @Unroll
     void "test thread selection strategy for reactive types #strategy"() {
         given:
         EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, ['micronaut.server.thread-selection': strategy])
@@ -77,10 +80,11 @@ class ThreadSelectionSpec extends Specification {
         embeddedServer.close()
 
         where:
-        strategy               |  reactive | blockingReactive | scheduleSse | scheduleReactive
-        ThreadSelection.AUTO   |  LOOP     | IO               | IO          | IO
-        ThreadSelection.IO     |  IO       | IO               | IO          | IO
-        ThreadSelection.MANUAL |  LOOP     | LOOP             | IO          | IO
+        strategy                 | reactive               | blockingReactive         | scheduleSse | scheduleReactive
+        ThreadSelection.AUTO     | LOOP                   | jdkSwitch(IO, VIRTUAL)   | IO          | IO
+        ThreadSelection.BLOCKING | jdkSwitch(IO, VIRTUAL) | jdkSwitch(LOOP, VIRTUAL) | IO          | IO
+        ThreadSelection.IO       | IO                     | IO                       | IO          | IO
+        ThreadSelection.MANUAL   | LOOP                   | LOOP                     | IO          | IO
     }
 
     void "test thread selection for exception handlers"() {
@@ -102,10 +106,11 @@ class ThreadSelectionSpec extends Specification {
         embeddedServer.close()
 
         where:
-        strategy               |  controller          | handler          | scheduledHandler
-        ThreadSelection.AUTO   |  "controller: $IO"   | "handler: $IO"   | "handler: $IO"
-        ThreadSelection.IO     |  "controller: $IO"   | "handler: $IO"   | "handler: $IO"
-        ThreadSelection.MANUAL |  "controller: $LOOP" | "handler: $LOOP" | "handler: $IO"
+        strategy                 | controller                              | handler                              | scheduledHandler
+        ThreadSelection.AUTO     | "controller: ${jdkSwitch(IO, VIRTUAL)}" | "handler: ${jdkSwitch(IO, VIRTUAL)}" | "handler: $IO"
+        ThreadSelection.BLOCKING | "controller: ${jdkSwitch(IO, VIRTUAL)}" | "handler: ${jdkSwitch(IO, VIRTUAL)}" | "handler: $IO"
+        ThreadSelection.IO       | "controller: $IO"                       | "handler: $IO"                       | "handler: $IO"
+        ThreadSelection.MANUAL   | "controller: $LOOP"                     | "handler: $LOOP"                     | "handler: $IO"
     }
 
     void "test thread selection for error route"() {
@@ -124,10 +129,11 @@ class ThreadSelectionSpec extends Specification {
         embeddedServer.close()
 
         where:
-        strategy               |  controller          | handler
-        ThreadSelection.AUTO   |  "controller: $IO"   | "handler: $IO"
-        ThreadSelection.IO     |  "controller: $IO"   | "handler: $IO"
-        ThreadSelection.MANUAL |  "controller: $LOOP" | "handler: $LOOP"
+        strategy                 | controller          | handler
+        ThreadSelection.AUTO     | "controller: $IO"   | "handler: $IO"
+        ThreadSelection.BLOCKING | "controller: $IO"   | "handler: $IO"
+        ThreadSelection.IO       | "controller: $IO"   | "handler: $IO"
+        ThreadSelection.MANUAL   | "controller: $LOOP" | "handler: $LOOP"
     }
 
     void "test injecting an executor service does not inject the Netty event loop"() {
@@ -232,10 +238,10 @@ class ThreadSelectionSpec extends Specification {
         @ExecuteOn(TaskExecutors.IO)
         @Get(uri = "/scheduleSse", produces = MediaType.TEXT_EVENT_STREAM)
         Flux<Event<String>> scheduleSse() {
-            return Flux.<Event<String>>create(emitter -> {
-                        emitter.next( Event.of("thread: ${Thread.currentThread().name}".toString()))
-                        emitter.complete()
-                    }, FluxSink.OverflowStrategy.BUFFER)
+            return Flux.<Event<String>> create(emitter -> {
+                emitter.next(Event.of("thread: ${Thread.currentThread().name}".toString()))
+                emitter.complete()
+            }, FluxSink.OverflowStrategy.BUFFER)
         }
 
         @Get("/exception")
@@ -265,8 +271,8 @@ class ThreadSelectionSpec extends Specification {
         @Override
         Publisher<MutableHttpResponse<?>> doFilter(HttpRequest<?> request, ServerFilterChain chain) {
             return Flux.create(emitter -> {
-                    emitter.next("Good")
-                    emitter.complete()
+                emitter.next("Good")
+                emitter.complete()
             }, FluxSink.OverflowStrategy.LATEST).switchMap({ String it ->
                 return chain.proceed(request)
             })

--- a/inject-java/src/test/groovy/io/micronaut/inject/requires/RequiresSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/requires/RequiresSpec.groovy
@@ -53,7 +53,7 @@ class MyBean {
         def lines = e.message.readLines().collect { it.trim() }
         lines[0] == 'No bean of type [test.MyBean] exists. The following matching beans are disabled by bean requirements:'
         lines[1] == '* Bean of type [test.MyBean] is disabled because:'
-        lines[2] == '- Java major version [17] must be at least 800'
+        lines[2] == "- Java major version [${Runtime.version().feature()}] must be at least 800"
 
         cleanup:
         context.close()

--- a/runtime/src/test/groovy/io/micronaut/runtime/executor/ExecutorServiceConfigSpec.groovy
+++ b/runtime/src/test/groovy/io/micronaut/runtime/executor/ExecutorServiceConfigSpec.groovy
@@ -33,7 +33,7 @@ class ExecutorServiceConfigSpec extends Specification {
         def configs = ctx.getBeansOfType(ExecutorConfiguration)
 
         then:
-        configs.name ==~ ['one', 'two', 'io', 'scheduled'] + (System.getProperty("java.version").startsWith("17") ? [] : ['virtual'])
+        configs.name ==~ ['one', 'two', 'io', 'scheduled'] + (Runtime.version().feature() == 17 ? [] : ['virtual'])
 
         when:
         Collection<ExecutorService> executorServices = ctx.getBeansOfType(ExecutorService.class)
@@ -135,7 +135,7 @@ class ExecutorServiceConfigSpec extends Specification {
 
         then:
         executorServices.size() == expectedExecutorCount
-        moreConfigs.name ==~ ['one', 'two', 'io', 'scheduled'] + (System.getProperty("java.version").startsWith("17") ? [] : ['virtual'])
+        moreConfigs.name ==~ ['one', 'two', 'io', 'scheduled'] + (Runtime.version().feature() == 17 ? [] : ['virtual'])
         configs.size() == 2
 
         when:
@@ -187,7 +187,7 @@ class ExecutorServiceConfigSpec extends Specification {
 
         then:
         executorServices.size() == expectedExecutorCount - 1
-        moreConfigs.name ==~ ['two', 'io', 'scheduled'] + (System.getProperty("java.version").startsWith("17") ? [] : ['virtual'])
+        moreConfigs.name ==~ ['two', 'io', 'scheduled'] + (Runtime.version().feature() == 17 ? [] : ['virtual'])
         configs.size() == 2
 
         where:

--- a/runtime/src/test/groovy/io/micronaut/runtime/executor/ExecutorServiceConfigSpec.groovy
+++ b/runtime/src/test/groovy/io/micronaut/runtime/executor/ExecutorServiceConfigSpec.groovy
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017-2019 original authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.micronaut.runtime.executor
 
 import io.micronaut.context.ApplicationContext
@@ -23,12 +8,12 @@ import io.micronaut.scheduling.executor.ExecutorConfiguration
 import io.micronaut.scheduling.executor.UserExecutorConfiguration
 import io.micronaut.scheduling.instrument.InstrumentedExecutor
 import spock.lang.Specification
-import spock.lang.Unroll
 
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.ForkJoinPool
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ThreadPoolExecutor
+
 /**
  * @author Graeme Rocher
  * @since 1.0
@@ -36,7 +21,6 @@ import java.util.concurrent.ThreadPoolExecutor
 class ExecutorServiceConfigSpec extends Specification {
     static final int expectedExecutorCount = LoomSupport.isSupported() ? 6 : 5
 
-    @Unroll
     void "test configure custom executor with invalidate cache: #invalidateCache"() {
         given:
         ApplicationContext ctx = ApplicationContext.run(
@@ -49,7 +33,7 @@ class ExecutorServiceConfigSpec extends Specification {
         def configs = ctx.getBeansOfType(ExecutorConfiguration)
 
         then:
-        configs.size() == 4
+        configs.name ==~ ['one', 'two', 'io', 'scheduled'] + (System.getProperty("java.version").startsWith("17") ? [] : ['virtual'])
 
         when:
         Collection<ExecutorService> executorServices = ctx.getBeansOfType(ExecutorService.class)
@@ -106,7 +90,6 @@ class ExecutorServiceConfigSpec extends Specification {
     }
 
 
-    @Unroll
     void "test configure custom executor - distinct initialization order with invalidate cache: #invalidateCache"() {
         given:
         ApplicationContext ctx = ApplicationContext.run(
@@ -152,7 +135,7 @@ class ExecutorServiceConfigSpec extends Specification {
 
         then:
         executorServices.size() == expectedExecutorCount
-        moreConfigs.size() == 4
+        moreConfigs.name ==~ ['one', 'two', 'io', 'scheduled'] + (System.getProperty("java.version").startsWith("17") ? [] : ['virtual'])
         configs.size() == 2
 
         when:
@@ -175,7 +158,6 @@ class ExecutorServiceConfigSpec extends Specification {
         false           | "test"
     }
 
-    @Unroll
     void "test configure existing IO executor - distinct initialization order with invalidate cache: #invalidateCache"() {
         given:
         ApplicationContext ctx = ApplicationContext.run(
@@ -205,7 +187,7 @@ class ExecutorServiceConfigSpec extends Specification {
 
         then:
         executorServices.size() == expectedExecutorCount - 1
-        moreConfigs.size() == 3
+        moreConfigs.name ==~ ['two', 'io', 'scheduled'] + (System.getProperty("java.version").startsWith("17") ? [] : ['virtual'])
         configs.size() == 2
 
         where:

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'io.micronaut.build.shared.settings' version '6.5.7'
+    id 'io.micronaut.build.shared.settings' version '6.6.0'
 }
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -68,9 +68,7 @@ include "test-suite-javax-inject"
 include "test-suite-jakarta-inject-bean-import"
 include "test-suite-http-server-tck-jdk"
 include "test-suite-http-server-tck-netty"
-if (JavaVersion.current() < JavaVersion.VERSION_21) {
-    include "test-suite-kotlin"
-}
+include "test-suite-kotlin"
 include "test-suite-kotlin-ksp"
 include "test-suite-groovy"
 include "test-suite-groovy"


### PR DESCRIPTION
Previously we added a PR to run (and compile) under Java 21

https://github.com/micronaut-projects/micronaut-core/pull/9978

This did not work as expected, as in reality this is configuring under the current JDK, but compilation is being done by Java 17 from the ToolChain set up by the micronaut-build plugin.

This PR modifies the test tasks to run on the JDK that is used to start the build.

But all compilation will be done via Java 17 from the toolchain.

I believe this supersedes both https://github.com/micronaut-projects/micronaut-core/pull/9978 and https://github.com/micronaut-projects/micronaut-core/pull/9985