### PR TITLE
Support GraalVM JDK 21+ --strict-image-heap flag

### DIFF
--- a/core/src/main/resources/META-INF/native-image/io.micronaut/micronaut-core/native-image.properties
+++ b/core/src/main/resources/META-INF/native-image/io.micronaut/micronaut-core/native-image.properties
@@ -15,6 +15,7 @@
 #
 
 Args = --initialize-at-run-time=io.micronaut.core.io.socket.SocketUtils \
+        --initialize-at-run-time=io.micronaut.core.type.RuntimeTypeInformation$LazyTypeInfo \
         --initialize-at-build-time=io.micronaut.core.io \
         --initialize-at-build-time=io.micronaut.core.optim \
         --initialize-at-build-time=io.micronaut.core.util \

--- a/test-suite-http-server-tck-netty/build.gradle
+++ b/test-suite-http-server-tck-netty/build.gradle
@@ -42,12 +42,6 @@ tasks.named("test") {
     useJUnitPlatform()
 }
 
-def openGraalModules = [
-        "org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk",
-        "org.graalvm.nativeimage.builder/com.oracle.svm.core.configure",
-        "org.graalvm.sdk/org.graalvm.nativeimage.impl"
-]
-
 graalvmNative {
     toolchainDetection = false
     metadataRepository {
@@ -56,9 +50,6 @@ graalvmNative {
     binaries {
         all {
             resources.autodetect()
-            openGraalModules.each { module ->
-                jvmArgs.add("--add-exports=" + module + "=ALL-UNNAMED")
-            }
         }
     }
 }


### PR DESCRIPTION
In the next version of GraalVM `--strict-image-heap` will be the default which means that any objects stored in the image heap that are not primitive needs to be initialised at build time.

Currently the only objects Micronaut initialises are build time is the annotation metadata. These can potentially have instantiated conditions (types that implement `io.micronaut.context.condition.Condition`) inside the annotation metadata. This is because `@Requires(condition=..)` member is annotated with `@InstantiatedMember` so that these instances are instantiated and stored in the metadata.

This change alters our GraalVM feature so that these condition objects are marked for initialisation at build time and fixes GraalVM compilation when `--strict-image-heap` is specified. We already had restrictions in place that conditions cannot have constructor arguments. So another restriction that they can't have weird static initialisers that do IO/start threads etc. is not going to be an issue.

A cursory search through existing conditions shows they none of them have any static initialisers so IMO this is a safe change to make in preparation for the next release of GraalVM.