### PR TITLE
Change default connection pool idle timeout from 0 to null

### DIFF
--- a/http-client-core/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
+++ b/http-client-core/src/main/java/io/micronaut/http/client/HttpClientConfiguration.java
@@ -118,7 +118,7 @@ public abstract class HttpClientConfiguration {
 
     private Duration readIdleTimeout = Duration.of(DEFAULT_READ_IDLE_TIMEOUT_MINUTES, ChronoUnit.MINUTES);
 
-    private Duration connectionPoolIdleTimeout = Duration.ofSeconds(DEFAULT_CONNECTION_POOL_IDLE_TIMEOUT_SECONDS);
+    private Duration connectionPoolIdleTimeout = DEFAULT_CONNECTION_POOL_IDLE_TIMEOUT_SECONDS == 0 ? null : Duration.ofSeconds(DEFAULT_CONNECTION_POOL_IDLE_TIMEOUT_SECONDS);
 
     private Duration shutdownQuietPeriod = Duration.ofMillis(DEFAULT_SHUTDOWN_QUIET_PERIOD_MILLISECONDS);
 

--- a/http-client/src/test/groovy/io/micronaut/http/client/config/DefaultHttpClientConfigurationSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/config/DefaultHttpClientConfigurationSpec.groovy
@@ -18,6 +18,7 @@ package io.micronaut.http.client.config
 import io.micronaut.context.ApplicationContext
 import io.micronaut.http.client.DefaultHttpClientConfiguration
 import io.micronaut.http.client.HttpClientConfiguration
+import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -119,5 +120,13 @@ class DefaultHttpClientConfigurationSpec extends Specification {
         proxyOne.address().port == 8080
 
         config.resolveProxy(false, "b", 80) == Proxy.NO_PROXY
+    }
+
+    @Issue('https://github.com/micronaut-projects/micronaut-core/pull/10013')
+    void "default connection pool idle timeout"() {
+        given:
+        def cfg = new DefaultHttpClientConfiguration()
+        expect:
+        cfg.connectionPoolIdleTimeout.isEmpty()
     }
 }


### PR DESCRIPTION
This was an oversight, but I think 0 should be handled the same way so not sure this PR changes anything in practice.