### PR TITLE
Fix logged error when using form fields with blocking filter

### DIFF
--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/filters/FilterFormSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/filters/FilterFormSpec.groovy
@@ -1,0 +1,55 @@
+package io.micronaut.http.server.netty.filters
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Post
+import io.micronaut.http.annotation.RequestFilter
+import io.micronaut.http.annotation.ServerFilter
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.multipart.MultipartBody
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.annotation.ExecuteOn
+import spock.lang.Issue
+import spock.lang.Specification
+
+class FilterFormSpec extends Specification {
+    @Issue('https://github.com/micronaut-projects/micronaut-core/issues/9917')
+    def "exception in form parameter"() {
+        given:
+        def ctx = ApplicationContext.run(["spec.name": "FilterFormSpec"])
+        def server = ctx.getBean(EmbeddedServer)
+        server.start()
+        def client = ctx.createBean(HttpClient, server.URI).toBlocking()
+
+        when:
+        def resp = client.exchange(HttpRequest.POST("/form-error", MultipartBody.builder().addPart("file", "foo").build()).contentType(MediaType.MULTIPART_FORM_DATA_TYPE), String)
+        then:
+        resp.body() == "Ok 3"
+
+        cleanup:
+        client.close()
+        server.close()
+        ctx.close()
+    }
+
+    @Controller
+    @Requires(property = "spec.name", value = "FilterFormSpec")
+    static class Ctrl {
+        @Post(value = "/form-error", consumes = MediaType.MULTIPART_FORM_DATA, produces = MediaType.TEXT_PLAIN)
+        def upload(byte[] file) {
+            return "Ok $file.length"
+        }
+    }
+
+    @ServerFilter("/form-error")
+    static class Fltr {
+        @RequestFilter
+        @ExecuteOn(TaskExecutors.BLOCKING)
+        void filterRequest() {
+        }
+    }
+}


### PR DESCRIPTION
The blocking filter would cause onSubscribe to be delayed, leading to a logged exception when trying to request from upstream. This patch simply skips the request call in that case. The request will be done in onSubscribe later.

Also make sure the subscriber methods are only called on the event loop to avoid concurrency issues.

Fixes #9917