### PR TITLE
Tck: Tests for error handlers with flux controller methods

### DIFF
--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/ErrorHandlerFluxTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/ErrorHandlerFluxTest.java
@@ -8,7 +8,7 @@ import io.micronaut.http.HttpStatus;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Error;
 import io.micronaut.http.annotation.Get;
-import io.micronaut.http.client.exceptions.ResponseClosedException;
+import io.micronaut.http.client.exceptions.HttpClientException;
 import io.micronaut.http.tck.AssertionUtils;
 import io.micronaut.http.tck.HttpResponseAssertion;
 import org.junit.jupiter.api.Assertions;
@@ -65,7 +65,7 @@ public class ErrorHandlerFluxTest {
             HttpRequest.GET("/errors/flux-chunked-delayed-error"),
             (server, request) -> {
                 Executable e = () -> server.exchange(request);
-                Assertions.assertThrows(ResponseClosedException.class, e);
+                Assertions.assertThrows(HttpClientException.class, e);
             });
     }
 

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/ErrorHandlerFluxTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/ErrorHandlerFluxTest.java
@@ -49,7 +49,7 @@ public class ErrorHandlerFluxTest {
         asserts(SPEC_NAME,
             HttpRequest.GET("/errors/flux-exception"),
             (server, request) -> AssertionUtils.assertThrows(server, request, HttpResponseAssertion.builder()
-                .status(HttpStatus.BAD_REQUEST)
+                .status(HttpStatus.I_AM_A_TEAPOT)
                 .body("Your request is erroneous: Cannot process request.")
                 .build()));
     }
@@ -59,13 +59,17 @@ public class ErrorHandlerFluxTest {
         asserts(SPEC_NAME,
             HttpRequest.GET("/errors/flux-single-exception"),
             (server, request) -> AssertionUtils.assertThrows(server, request, HttpResponseAssertion.builder()
-                .status(HttpStatus.BAD_REQUEST)
+                .status(HttpStatus.I_AM_A_TEAPOT)
                 .body("Your request is erroneous: Cannot process request.")
                 .build()));
     }
 
     @Test
     void testErrorHandlerWithFluxChunkedSignaledImmediateError() throws IOException {
+        //NOTE - This demonstrates the current behavior of the error handler not getting invoked
+        //when writing a chunked response, even if the error is signaled before any data to be
+        //written to the response body. It would be ideal if in this case the error handler could
+        //still be invoked with the exception from the error signal.
         asserts(SPEC_NAME,
             HttpRequest.GET("/errors/flux-chunked-immediate-error"),
             (server, request) -> AssertionUtils.assertThrows(server, request, HttpResponseAssertion.builder()
@@ -89,7 +93,7 @@ public class ErrorHandlerFluxTest {
         asserts(SPEC_NAME,
             HttpRequest.GET("/errors/flux-single-error"),
             (server, request) -> AssertionUtils.assertThrows(server, request, HttpResponseAssertion.builder()
-                .status(HttpStatus.BAD_REQUEST)
+                .status(HttpStatus.I_AM_A_TEAPOT)
                 .body("Your request is erroneous: Cannot process request.")
                 .build()));
     }
@@ -134,7 +138,7 @@ public class ErrorHandlerFluxTest {
         @Error(global = true)
         public HttpResponse<String> handleMyTestException(HttpRequest<?> request, MyTestException exception) {
             var error = "Your request is erroneous: " + exception.getMessage();
-            return HttpResponse.<String>status(HttpStatus.BAD_REQUEST, "Bad request")
+            return HttpResponse.<String>status(HttpStatus.I_AM_A_TEAPOT, "Bad request")
                 .body(error);
         }
 

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/ErrorHandlerFluxTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/ErrorHandlerFluxTest.java
@@ -1,0 +1,2 @@
+package io.micronaut.http.server.tck.tests;public class ErrorHandlerFluxTest {
+}

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/ErrorHandlerFluxTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/ErrorHandlerFluxTest.java
@@ -1,2 +1,134 @@
-package io.micronaut.http.server.tck.tests;public class ErrorHandlerFluxTest {
+package io.micronaut.http.server.tck.tests;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.async.annotation.SingleResult;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Error;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.client.exceptions.ResponseClosedException;
+import io.micronaut.http.tck.AssertionUtils;
+import io.micronaut.http.tck.HttpResponseAssertion;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import reactor.core.publisher.Flux;
+
+import java.io.IOException;
+
+import static io.micronaut.http.tck.TestScenario.asserts;
+
+@SuppressWarnings({
+    "java:S5960", // We're allowed assertions, as these are used in tests only
+    "checkstyle:MissingJavadocType",
+    "checkstyle:DesignForExtension"
+})
+public class ErrorHandlerFluxTest {
+
+    public static final String SPEC_NAME = "ErrorHandlerFluxTest";
+
+    @Test
+    void testErrorHandlerWithFluxThrownException() throws IOException {
+        asserts(SPEC_NAME,
+            HttpRequest.GET("/errors/flux-exception"),
+            (server, request) -> AssertionUtils.assertThrows(server, request, HttpResponseAssertion.builder()
+                .status(HttpStatus.BAD_REQUEST)
+                .body("Your request is erroneous: Cannot process request.")
+                .build()));
+    }
+
+    @Test
+    void testErrorHandlerWithFluxSingleResultThrownException() throws IOException {
+        asserts(SPEC_NAME,
+            HttpRequest.GET("/errors/flux-single-exception"),
+            (server, request) -> AssertionUtils.assertThrows(server, request, HttpResponseAssertion.builder()
+                .status(HttpStatus.BAD_REQUEST)
+                .body("Your request is erroneous: Cannot process request.")
+                .build()));
+    }
+
+    @Test
+    void testErrorHandlerWithFluxChunkedSignaledImmediateError() throws IOException {
+        asserts(SPEC_NAME,
+            HttpRequest.GET("/errors/flux-chunked-immediate-error"),
+            (server, request) -> AssertionUtils.assertThrows(server, request, HttpResponseAssertion.builder()
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body("Internal Server Error: Cannot process request.")
+                .build()));
+    }
+
+    @Test
+    void testErrorHandlerWithFluxChunkedSignaledDelayedError() throws IOException {
+        asserts(SPEC_NAME,
+            HttpRequest.GET("/errors/flux-chunked-delayed-error"),
+            (server, request) -> {
+                Executable e = () -> server.exchange(request);
+                Assertions.assertThrows(ResponseClosedException.class, e);
+            });
+    }
+
+    @Test
+    void testErrorHandlerWithFluxSingleResultSignaledError() throws IOException {
+        asserts(SPEC_NAME,
+            HttpRequest.GET("/errors/flux-single-error"),
+            (server, request) -> AssertionUtils.assertThrows(server, request, HttpResponseAssertion.builder()
+                .status(HttpStatus.BAD_REQUEST)
+                .body("Your request is erroneous: Cannot process request.")
+                .build()));
+    }
+
+    @Requires(property = "spec.name", value = SPEC_NAME)
+    @Controller("/errors")
+    static class ErrorController {
+
+        @Get("/flux-exception")
+        Flux<String> fluxException() {
+            throw new MyTestException("Cannot process request.");
+        }
+
+        @Get("/flux-single-exception")
+        @SingleResult
+        Flux<String> fluxSingleException() {
+            throw new MyTestException("Cannot process request.");
+        }
+
+        @Get("/flux-single-error")
+        @SingleResult
+        Flux<String> fluxSingleError() {
+            return Flux.error(new MyTestException("Cannot process request."));
+        }
+
+        @Get("/flux-chunked-immediate-error")
+        Flux<String> fluxChunkedImmediateError() {
+            return Flux.error(new MyTestException("Cannot process request."));
+        }
+
+        @Get("/flux-chunked-delayed-error")
+        Flux<String> fluxChunkedDelayedError() {
+            return Flux.just("1", "2", "3").handle((data, sink) -> {
+                if (data.equals("3")) {
+                    sink.error(new MyTestException("Cannot process request."));
+                } else {
+                    sink.next(data);
+                }
+            });
+        }
+
+        @Error(global = true)
+        public HttpResponse<String> entityNotFoundHandler(HttpRequest<?> request, MyTestException exception) {
+            var error = "Your request is erroneous: " + exception.getMessage();
+            return HttpResponse.<String>status(HttpStatus.BAD_REQUEST, "Bad request")
+                .body(error);
+        }
+
+    }
+
+    static class MyTestException extends RuntimeException {
+
+        public MyTestException(String message) {
+            super(message);
+        }
+    }
 }

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/ErrorHandlerFluxTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/ErrorHandlerFluxTest.java
@@ -117,7 +117,7 @@ public class ErrorHandlerFluxTest {
         }
 
         @Error(global = true)
-        public HttpResponse<String> entityNotFoundHandler(HttpRequest<?> request, MyTestException exception) {
+        public HttpResponse<String> handleMyTestException(HttpRequest<?> request, MyTestException exception) {
             var error = "Your request is erroneous: " + exception.getMessage();
             return HttpResponse.<String>status(HttpStatus.BAD_REQUEST, "Bad request")
                 .body(error);

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/ErrorHandlerFluxTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/ErrorHandlerFluxTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.http.server.tck.tests;
 
 import io.micronaut.context.annotation.Requires;


### PR DESCRIPTION
After investigating https://github.com/micronaut-projects/micronaut-reactor/issues/238, I've got some questions to improve my understanding of how `@Error` handlers work in conjunction with `@Controller` methods that return a `Flux`, and try to figure out if there are any actual issues we need to address.

The test added by this PR exercises the existing behavior in various combinations of a `Flux` returning controller method in conjunction with an `@Error` handler method. It demonstrates the following:

A) A `Flux` returning controller method that is annotated with `@SingleResult` results in the `@Error` handler getting invoked as expected if the Flux signals an error - i.e., `return Flux.error(new MyException())`

B) A `Flux` returning controller method that throws an exception results in the `@Error` handler getting invoked regardless of whether or not the method is annotated with `@SingleResult`.

C) A `Flux` returning controller method that is not annotated with `@SingleResult` results in the `@Error` handler not getting invoked if the Flux signals an error as in scenario A.

D) A `Flux` returning controller method that is not annotated with `@SingleResult` that has an error signaled after the body has already begun to be written in the chunked response causes the connection to be closed and a warning logged without invoking the `@Error` handler as expected.

My questions:

1) I would guess that the behavior of scenario C is intentional because it is a chunked response and it is possible that the headers have already been written. Is that guess correct?

2) If so, would it be possible for us to treat a Flux that immediately signals an error (without any data events) differently? Could we invoke the error handler at that point, or is it too difficult because status and headers have already been written? 

3) Is the behavior in the B scenario also intentional? It seems inconsistent to me that throwing an exception results in different behavior than signaling an error. 