### PR TITLE
Fix frequent CI failures of MDCReactorSpec

### DIFF
--- a/context-propagation/src/test/groovy/io/micronaut/context/propagation/MDCReactorSpec.groovy
+++ b/context-propagation/src/test/groovy/io/micronaut/context/propagation/MDCReactorSpec.groovy
@@ -17,6 +17,7 @@ import io.micronaut.http.annotation.Header
 import io.micronaut.http.annotation.Patch
 import io.micronaut.http.annotation.Post
 import io.micronaut.http.annotation.Put
+import io.micronaut.http.client.DefaultHttpClientConfiguration
 import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.http.filter.ClientFilterChain
@@ -55,7 +56,13 @@ class MDCReactorSpec extends Specification {
 
     @Shared
     @AutoCleanup
-    HttpClient client = HttpClient.create(embeddedServer.URL)
+    HttpClient client
+
+    def setup() {
+        def config = new DefaultHttpClientConfiguration()
+        config.setReadTimeout(Duration.ofMinutes(5))
+        client = HttpClient.create(embeddedServer.URL, config)
+    }
 
     void "test MDC propagates"() {
         expect:


### PR DESCRIPTION
This sets the read timeout of the main http client (which is manually instantiated) used in MDCReactorSpec to 5 
minutes, which is the same as what is set for the dependency-injected clients used elsewhere throughout the test.

This spec was frequently failing in CI with an HTTP read timeout error, likely due to resource starvation on the CI 
job runner causing slow responses from the embedded server that is used in the test.

This should fix #10026 
