### PR TITLE
Error handling for streaming reactive controllers

### DIFF
--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/stream/StreamingErrorHandlerSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/stream/StreamingErrorHandlerSpec.groovy
@@ -1,0 +1,199 @@
+package io.micronaut.http.server.netty.stream
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Error
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.http.client.exceptions.ResponseClosedException
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import reactor.core.publisher.Flux
+import spock.lang.Specification
+
+@MicronautTest
+@Property(name = "spec.name", value = "StreamingErrorHandlerSpec")
+@Property(name = "micronaut.http.client.read-timeout", value = "30s")
+class StreamingErrorHandlerSpec extends Specification{
+
+    @Inject
+    StreamingErrorClient client
+
+    @Inject
+    GlobalHandlerController globalHandler
+
+    @Inject
+    ErrorController controller
+
+    def setup() {
+        globalHandler.handlerInvoked = false
+        controller.handlerInvoked = false
+    }
+
+    void "global error handler is invoked on an immediate error for a chunked response"() {
+        when:
+        client.getFluxChunkedImmediateGlobalError()
+
+        then:
+        def e = thrown(HttpClientResponseException)
+        e.status == HttpStatus.I_AM_A_TEAPOT
+        e.response.getBody(String).get() == "Your request is globally erroneous: Cannot process request."
+        globalHandler.handlerInvoked
+        !controller.handlerInvoked
+    }
+
+    void "global error handler is not invoked on a delayed error for a chunked response"() {
+        when:
+        client.getFluxChunkedDelayedGlobalError()
+
+        then:
+        def e = thrown(ResponseClosedException)
+        !globalHandler.handlerInvoked
+        !controller.handlerInvoked
+    }
+
+    void "local error handler is invoked on an immediate error for a chunked response"() {
+        when:
+        client.getFluxChunkedImmediateLocalError()
+
+        then:
+        def e = thrown(HttpClientResponseException)
+        e.status == HttpStatus.I_AM_A_TEAPOT
+        e.response.getBody(String).get() == "Your request is locally erroneous: Cannot process request."
+        !globalHandler.handlerInvoked
+        controller.handlerInvoked
+    }
+
+    void "local error handler is not invoked on a delayed error for a chunked response"() {
+        when:
+        client.getFluxChunkedDelayedLocalError()
+
+        then:
+        def e = thrown(ResponseClosedException)
+        !globalHandler.handlerInvoked
+        !controller.handlerInvoked
+    }
+
+    void "error handlers are not invoked for an unspecified error for a chunked response"() {
+        when:
+        client.getFluxChunkedUnspecifiedError()
+
+        then:
+        def e = thrown(HttpClientResponseException)
+        e.status == HttpStatus.INTERNAL_SERVER_ERROR
+        e.response.getBody(String).get().contains("Cannot process request.")
+        !globalHandler.handlerInvoked
+        !controller.handlerInvoked
+    }
+
+    @Requires(property = "spec.name", value = "StreamingErrorHandlerSpec")
+    @Client("/streaming-errors")
+    static interface StreamingErrorClient {
+
+        @Get("/flux-chunked-immediate-global-error")
+        HttpResponse<?> getFluxChunkedImmediateGlobalError()
+
+        @Get("/flux-chunked-delayed-global-error")
+        HttpResponse<?> getFluxChunkedDelayedGlobalError()
+
+        @Get("/flux-chunked-immediate-local-error")
+        HttpResponse<?> getFluxChunkedImmediateLocalError()
+
+        @Get("/flux-chunked-delayed-local-error")
+        HttpResponse<?> getFluxChunkedDelayedLocalError()
+
+        @Get("/flux-chunked-immediate-unspecified-error")
+        HttpResponse<?> getFluxChunkedUnspecifiedError()
+    }
+
+    @Requires(property = "spec.name", value = "StreamingErrorHandlerSpec")
+    @Controller
+    static class GlobalHandlerController {
+        boolean handlerInvoked
+
+        @Error(global = true)
+        HttpResponse<String> handleMyGlobalTestException(HttpRequest<?> request, MyGlobalException exception) {
+            handlerInvoked = true
+            var error = "Your request is globally erroneous: " + exception.getMessage();
+            return HttpResponse.<String>status(HttpStatus.I_AM_A_TEAPOT, "Bad request")
+                    .body(error);
+        }
+    }
+
+    @Requires(property = "spec.name", value = "StreamingErrorHandlerSpec")
+    @Controller("/streaming-errors")
+    static class ErrorController {
+
+        boolean handlerInvoked
+
+        @Get("/flux-chunked-immediate-global-error")
+        Flux<String> fluxChunkedImmediateGlobalError() {
+            return Flux.error(new MyGlobalException("Cannot process request."))
+        }
+
+        @Get("/flux-chunked-delayed-global-error")
+        Flux<String> fluxChunkedDelayedGlobalError() {
+            return Flux.just("1", "2", "3").handle((data, sink) -> {
+                System.out.println("Handling %s".formatted(data))
+                if (data.equals("3")) {
+                    sink.error(new MyGlobalException("Cannot process request."))
+                } else {
+                    sink.next(data)
+                }
+            });
+        }
+
+        @Get("/flux-chunked-immediate-local-error")
+        Flux<String> fluxChunkedImmediateLocalError() {
+            return Flux.error(new MyLocalException("Cannot process request."))
+        }
+
+        @Get("/flux-chunked-delayed-local-error")
+        Flux<String> fluxChunkedDelayedLocalError() {
+            return Flux.just("1", "2", "3").handle((data, sink) -> {
+                System.out.println("Handling %s".formatted(data))
+                if (data.equals("3")) {
+                    sink.error(new MyLocalException("Cannot process request."))
+                } else {
+                    sink.next(data)
+                }
+            });
+        }
+
+        @Get("/flux-chunked-immediate-unspecified-error")
+        Flux<String> fluxChunkedImmediateUnspecifiedError() {
+            return Flux.error(new MyUnhandledException("Cannot process request."))
+        }
+
+        @Error
+        HttpResponse<String> handleMyLocalTestException(HttpRequest<?> request, MyLocalException exception) {
+            handlerInvoked = true
+            var error = "Your request is locally erroneous: " + exception.getMessage();
+            return HttpResponse.<String>status(HttpStatus.I_AM_A_TEAPOT, "Bad request")
+                    .body(error);
+        }
+    }
+
+    static class MyGlobalException extends RuntimeException {
+        MyGlobalException(String message) {
+            super(message)
+        }
+    }
+
+    static class MyLocalException extends RuntimeException {
+        MyLocalException(String message) {
+            super(message)
+        }
+    }
+
+    static class MyUnhandledException extends RuntimeException {
+        MyUnhandledException(String message) {
+            super(message)
+        }
+    }
+}

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/ErrorHandlerFluxTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/ErrorHandlerFluxTest.java
@@ -66,15 +66,11 @@ public class ErrorHandlerFluxTest {
 
     @Test
     void testErrorHandlerWithFluxChunkedSignaledImmediateError() throws IOException {
-        //NOTE - This demonstrates the current behavior of the error handler not getting invoked
-        //when writing a chunked response, even if the error is signaled before any data to be
-        //written to the response body. It would be ideal if in this case the error handler could
-        //still be invoked with the exception from the error signal.
         asserts(SPEC_NAME,
             HttpRequest.GET("/errors/flux-chunked-immediate-error"),
             (server, request) -> AssertionUtils.assertThrows(server, request, HttpResponseAssertion.builder()
-                .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body("Internal Server Error: Cannot process request.")
+                .status(HttpStatus.I_AM_A_TEAPOT)
+                .body("Your request is erroneous: Cannot process request.")
                 .build()));
     }
 

--- a/http-server/src/main/java/io/micronaut/http/server/RouteExecutor.java
+++ b/http-server/src/main/java/io/micronaut/http/server/RouteExecutor.java
@@ -757,7 +757,7 @@ public final class RouteExecutor {
                 }
                 bufferWritten = true;
                 bufferedFirstValue = null;
-                subscriber.request(Long.MAX_VALUE);
+                bodySink.onRequest(subscriber::request);
             }
         }
 

--- a/http-server/src/main/java/io/micronaut/http/server/RouteExecutor.java
+++ b/http-server/src/main/java/io/micronaut/http/server/RouteExecutor.java
@@ -62,10 +62,13 @@ import io.micronaut.web.router.UriRouteMatch;
 import io.micronaut.web.router.exceptions.UnsatisfiedRouteException;
 import jakarta.inject.Singleton;
 import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.CorePublisher;
+import reactor.core.publisher.BaseSubscriber;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxSink;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
@@ -79,6 +82,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
@@ -559,7 +563,7 @@ public final class RouteExecutor {
                             response = httpResponse.toMutableResponse();
                             final Argument<?> bodyArgument = routeInfo.getReturnType().getFirstTypeVariable().orElse(Argument.OBJECT_ARGUMENT);
                             if (bodyArgument.isAsyncOrReactive()) {
-                                return processPublisherBody(propagatedContext, request, response, routeInfo);
+                                return Mono.from(processPublisherBody(propagatedContext, request, response, routeInfo));
                             }
                         } else {
                             response = forStatus(routeInfo, null);
@@ -627,6 +631,11 @@ public final class RouteExecutor {
                 .switchIfEmpty(Mono.fromSupplier(emptyResponse))
                 .contextWrite(context -> ReactorPropagation.addPropagatedContext(context, propagatedContext).put(ServerRequestContext.KEY, request));
         }
+
+        return getStreamingResponsePublisher(propagatedContext, request, body, routeInfo);
+    }
+
+    private CorePublisher<MutableHttpResponse<?>> getStreamingResponsePublisher(PropagatedContext propagatedContext, HttpRequest<?> request, Object body, RouteInfo<?> routeInfo) {
         // streaming case
         Argument<?> typeArgument = routeInfo.getReturnType().getFirstTypeVariable().orElse(Argument.OBJECT_ARGUMENT);
         if (HttpResponse.class.isAssignableFrom(typeArgument.getType())) {
@@ -645,10 +654,10 @@ public final class RouteExecutor {
         return processPublisherBody(propagatedContext, request, response, routeInfo);
     }
 
-    private Mono<MutableHttpResponse<?>> processPublisherBody(PropagatedContext propagatedContext,
-                                                              HttpRequest<?> request,
-                                                              MutableHttpResponse<?> response,
-                                                              RouteInfo<?> routeInfo) {
+    private CorePublisher<MutableHttpResponse<?>> processPublisherBody(PropagatedContext propagatedContext,
+                                                                       HttpRequest<?> request,
+                                                                       MutableHttpResponse<?> response,
+                                                                       RouteInfo<?> routeInfo) {
         Object body = response.body();
         if (body == null) {
             return Mono.just(response);
@@ -667,11 +676,126 @@ public final class RouteExecutor {
             propagatedContext
         ).contextWrite(cv -> ReactorPropagation.addPropagatedContext(cv, propagatedContext).put(ServerRequestContext.KEY, request));
 
-        return Mono.<MutableHttpResponse<?>>just(response
-            .header(HttpHeaders.TRANSFER_ENCODING, "chunked")
-            .header(HttpHeaders.CONTENT_TYPE, mediaType)
-            .body(ReactivePropagation.propagate(propagatedContext, bodyPublisher)))
-            .contextWrite(context -> ReactorPropagation.addPropagatedContext(context, propagatedContext).put(ServerRequestContext.KEY, request));
+        return new StreamingDataProcessor(bodyPublisher).chunkedResponsePublisher(propagatedContext, request, response, routeInfo, mediaType);
+    }
+
+    /**
+     * Stateful processor for writing a streaming data HTTP response.
+     * <p>
+     * The first signal from the underlying body publisher is inspected before writing the response
+     * in order to check for potential errors and a matching error route. If the publisher signals
+     * an immediate error before writing any data and there is a matching error route, then the
+     * error will be propagated outward so that the error route will be invoked. Otherwise, an
+     * appropriate {@link MutableHttpResponse} will be published that is able to stream the body
+     * publisher as a chunked HTTP response.
+     */
+    private class StreamingDataProcessor implements Consumer<FluxSink<Object>> {
+
+        private final Flux<Object> bodyPublisher;
+
+        private boolean firstRequest = true;
+
+        private boolean bufferWritten = false;
+
+        private FluxSink<Object> bodySink;
+
+        private boolean subscribed = false;
+
+        private Object bufferedFirstValue = null;
+
+        private Throwable bufferedImmediateError = null;
+
+        private final StreamSubscriber subscriber = new StreamSubscriber();
+
+        private boolean isComplete;
+
+        private boolean isEmpty;
+
+        private StreamingDataProcessor(Flux<Object> bodyPublisher) {
+            this.bodyPublisher = bodyPublisher;
+        }
+
+        @SuppressWarnings("unchecked")
+        private CorePublisher<MutableHttpResponse<?>> chunkedResponsePublisher(PropagatedContext propagatedContext,
+                                                                               HttpRequest<?> request,
+                                                                               MutableHttpResponse<?> response,
+                                                                               RouteInfo<?> routeInfo,
+                                                                               MediaType mediaType) {
+            Flux<Object> outputStream = Flux.push(this);
+
+            response
+                .header(HttpHeaders.TRANSFER_ENCODING, "chunked")
+                .header(HttpHeaders.CONTENT_TYPE, mediaType)
+                .body(ReactivePropagation.propagate(propagatedContext, outputStream));
+
+            Mono<? extends MutableHttpResponse<?>> responsePublisher = Mono.just(response)
+                .contextWrite(context -> ReactorPropagation.addPropagatedContext(context, propagatedContext).put(ServerRequestContext.KEY, request));
+
+            return (CorePublisher<MutableHttpResponse<?>>) outputStream.take(1)
+                .switchIfEmpty(responsePublisher)
+                .onErrorReturn(throwable -> findErrorRoute(throwable, routeInfo.getDeclaringType(), request) == null, response)
+                .flatMap(data -> responsePublisher)
+                .contextWrite(cv -> ReactorPropagation.addPropagatedContext(cv, propagatedContext).put(ServerRequestContext.KEY, request));
+        }
+
+        @Override
+        public void accept(FluxSink<Object> bodySink) {
+            this.bodySink = bodySink;
+            if (!subscribed) {
+                subscribed = true;
+                bodyPublisher.subscribe(subscriber);
+            } else if (!firstRequest && !bufferWritten) {
+                if (bufferedImmediateError != null) {
+                    bodySink.error(bufferedImmediateError);
+                } if (isEmpty){
+                    bodySink.complete();
+                } else {
+                    bodySink.next(bufferedFirstValue);
+                    if (isComplete) {
+                        bodySink.complete();
+                    }
+                }
+                bufferWritten = true;
+                bufferedFirstValue = null;
+                subscriber.request(Long.MAX_VALUE);
+            }
+        }
+
+        private class StreamSubscriber extends BaseSubscriber<Object> {
+
+            @Override
+            protected void hookOnSubscribe(Subscription subscription) {
+                subscription.request(1L);
+            }
+
+            @Override
+            protected void hookOnNext(Object data) {
+                if(firstRequest) {
+                    bufferedFirstValue = data;
+                    firstRequest = false;
+                }
+                bodySink.next(data);
+            }
+
+            @Override
+            protected void hookOnComplete() {
+                if (firstRequest) {
+                    isEmpty = true;
+                    firstRequest = false;
+                }
+                isComplete = true;
+                bodySink.complete();
+            }
+
+            @Override
+            protected void hookOnError(Throwable throwable) {
+                if (firstRequest) {
+                    bufferedImmediateError = throwable;
+                    firstRequest = false;
+                }
+                bodySink.error(throwable);
+            }
+        }
     }
 
     private void applyConfiguredHeaders(MutableHttpHeaders headers) {


### PR DESCRIPTION
Error handling for streaming reactive controller methods, such as those that use a `Flux` as the return type, is 
improved such that immediate error signals in the stream that occur before any data has been written will be routed 
appropriately to any user-supplied `@Error` handler methods.

A new test specification is added to cover this scenario, and the TCK's `ErrorHandlerFluxTest` is improved to cover 
the enhanced error handling.

This resolves https://github.com/micronaut-projects/micronaut-reactor/issues/238
