### PR TITLE
More efficient discard when request body is ignored

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/RoutingInBoundHandler.java
@@ -425,11 +425,6 @@ public final class RoutingInBoundHandler implements RequestHandler {
         // default Connection header if not set explicitly
         closeConnectionIfError(message, request, outboundAccess);
         io.netty.handler.codec.http.HttpResponse nettyResponse = NettyHttpResponseBuilder.toHttpResponse(message);
-        // close handled by HttpServerKeepAliveHandler
-        if (request.getNativeRequest() instanceof StreamedHttpRequest streamed && !streamed.isConsumed()) {
-            // consume incoming data
-            Flux.from(streamed).subscribe(HttpContent::release);
-        }
         if (nettyResponse instanceof StreamedHttpResponse streamed) {
             writeStreamedWithErrorHandling(request, outboundAccess, streamed);
         } else {

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/RequestCancelSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/RequestCancelSpec.groovy
@@ -1,0 +1,93 @@
+package io.micronaut.http.server.netty
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.RequestFilter
+import io.micronaut.http.annotation.ServerFilter
+import io.micronaut.runtime.server.EmbeddedServer
+import io.netty.buffer.Unpooled
+import io.netty.channel.embedded.EmbeddedChannel
+import io.netty.handler.codec.http.DefaultHttpRequest
+import io.netty.handler.codec.http.DefaultLastHttpContent
+import io.netty.handler.codec.http.FullHttpResponse
+import io.netty.handler.codec.http.HttpClientCodec
+import io.netty.handler.codec.http.HttpHeaderNames
+import io.netty.handler.codec.http.HttpMethod
+import io.netty.handler.codec.http.HttpObjectAggregator
+import io.netty.handler.codec.http.HttpResponseStatus
+import io.netty.handler.codec.http.HttpVersion
+import spock.lang.Specification
+
+import java.nio.charset.StandardCharsets
+
+class RequestCancelSpec extends Specification {
+    def 'filter returning early response'() {
+        given:
+        ApplicationContext ctx = ApplicationContext.run([
+                'spec.name': 'RequestCancelSpec',
+        ])
+        def embeddedServer = (NettyHttpServer) ctx.getBean(EmbeddedServer)
+
+        def serverEmbeddedChannel = embeddedServer.buildEmbeddedChannel(false)
+        def clientEmbeddedChannel = new EmbeddedChannel()
+        clientEmbeddedChannel.config().setAutoRead(true)
+
+        EmbeddedTestUtil.connect(serverEmbeddedChannel, clientEmbeddedChannel)
+
+        clientEmbeddedChannel.pipeline()
+                .addLast(new HttpClientCodec())
+                .addLast(new HttpObjectAggregator(1024))
+
+        def request1 = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/early-response")
+        request1.headers().set(HttpHeaderNames.CONTENT_LENGTH, 3)
+
+        when:
+        clientEmbeddedChannel.writeOneOutbound(request1)
+        clientEmbeddedChannel.flushOutbound()
+        EmbeddedTestUtil.advance(serverEmbeddedChannel, clientEmbeddedChannel)
+
+        then:
+        FullHttpResponse response1 = clientEmbeddedChannel.readInbound()
+        response1.status() == HttpResponseStatus.UNAUTHORIZED
+
+        when:
+        clientEmbeddedChannel.writeOneOutbound(new DefaultLastHttpContent(Unpooled.copiedBuffer("foo", StandardCharsets.UTF_8)))
+
+        def request2 = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/ok")
+        clientEmbeddedChannel.writeOneOutbound(request2)
+        clientEmbeddedChannel.flushOutbound()
+        EmbeddedTestUtil.advance(serverEmbeddedChannel, clientEmbeddedChannel)
+
+        then:
+        FullHttpResponse response2 = clientEmbeddedChannel.readInbound()
+        response2.status() == HttpResponseStatus.OK
+
+        cleanup:
+        response1.release()
+        response2.release()
+        clientEmbeddedChannel.close()
+        serverEmbeddedChannel.close()
+        ctx.close()
+    }
+
+    @ServerFilter
+    @Requires(property = "spec.name", value = "RequestCancelSpec")
+    static class MyFilter {
+        @RequestFilter("/early-response")
+        HttpResponse<?> earlyResponse() {
+            return HttpResponse.unauthorized()
+        }
+    }
+
+    @Controller
+    @Requires(property = "spec.name", value = "RequestCancelSpec")
+    static class MyController {
+        @Get("/ok")
+        String ok() {
+            return "ok"
+        }
+    }
+}


### PR DESCRIPTION
If the response is written before the request body is consumed, RIB would subscribe to the body to release the incoming data. This was not necessary, as PipeliningServerHandler already has more efficient discard logic triggered by closeIfNoSubscriber. This made no functional difference, but it's faster with this PR.