### PR TITLE
Fix goaway test

### DIFF
--- a/http-client/src/test/groovy/io/micronaut/http/client/netty/ConnectionManagerSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/netty/ConnectionManagerSpec.groovy
@@ -1034,7 +1034,8 @@ class ConnectionManagerSpec extends Specification {
         conn1.exchangeSettings()
         conn1.testExchangeResponse(future)
 
-        conn1.serverChannel.writeOutbound(new DefaultHttp2GoAwayFrame(Http2Error.INTERNAL_ERROR, Unpooled.copiedBuffer("foo", StandardCharsets.UTF_8)))
+        // use NO_ERROR so that netty doesn't close the channel
+        conn1.serverChannel.writeOutbound(new DefaultHttp2GoAwayFrame(Http2Error.NO_ERROR, Unpooled.copiedBuffer("foo", StandardCharsets.UTF_8)))
         conn1.advance()
 
         // after goaway, new requests should use a new connection


### PR DESCRIPTION
Seems the test was just broken. The internal error goaway frame made netty close the channel, which may send some bogus TLS and doesn't actually hit the code this test was supposed to test.

Please try on mac.