### PR TITLE
Update test to correctly assert error with Servlet

### DIFF
--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/ErrorHandlerFluxTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/ErrorHandlerFluxTest.java
@@ -83,7 +83,7 @@ public class ErrorHandlerFluxTest {
         asserts(SPEC_NAME,
             HttpRequest.GET("/errors/flux-chunked-delayed-error"),
             (server, request) -> {
-                Executable e = () -> server.exchange(request);
+                Executable e = () -> server.exchange(request, String[].class);
                 Assertions.assertThrows(HttpClientException.class, e);
             });
     }


### PR DESCRIPTION
`ErrorHandlerFluxTest` in the TCK is updated to correctly detect failures that arise from mid-stream errors in a 
streaming servlet response.

When an error happens mid-stream, Servlet simply ends the response, therefore still returning the 200 OK status code. 
Attempting to deserialize the malformed response results in the client throwing the expected exception.

https://github.com/micronaut-projects/micronaut-servlet/pull/595 will need to be merged in order for Servlet to 
completely satisfy this test.
