### PR TITLE
Reduce test pollution with spec.name and requires in http-client tests

### DIFF
--- a/http-client/src/test/groovy/io/micronaut/http/client/BasicAuthSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/BasicAuthSpec.groovy
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017-2019 original authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.micronaut.http.client
 
 import io.micronaut.context.ApplicationContext
@@ -24,9 +9,19 @@ import io.micronaut.http.annotation.Get
 import io.micronaut.runtime.server.EmbeddedServer
 import org.reactivestreams.Publisher
 import reactor.core.publisher.Flux
+import spock.lang.AutoCleanup
+import spock.lang.Shared
 import spock.lang.Specification
 
 class BasicAuthSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
+            'spec.name': 'BasicAuthSpec'
+    ])
+
+    HttpClient httpClient = server.applicationContext.createBean(HttpClient, new URL("http://sherlock:password@localhost:${server.port}"))
 
     def "basicAuth() sets Authorization Header with Basic base64(username:password)"() {
         when:
@@ -40,23 +35,11 @@ class BasicAuthSpec extends Specification {
     }
 
     void "test user in absolute URL"() {
-        given:
-        EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
-                'spec.name': 'BasicAuthSpec'
-        ])
-        ApplicationContext ctx = server.applicationContext
-        HttpClient httpClient = ctx.createBean(HttpClient, new URL("http://sherlock:password@localhost:${server.port}"))
-
         when:
         String resp = httpClient.toBlocking().retrieve("/basicauth")
 
         then:
         resp == "sherlock:password"
-
-        cleanup:
-        httpClient.close()
-        ctx.close()
-        server.close()
     }
 
     @Requires(property = 'spec.name', value = 'BasicAuthSpec')

--- a/http-client/src/test/groovy/io/micronaut/http/client/BlockingDeadlockSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/BlockingDeadlockSpec.groovy
@@ -3,54 +3,51 @@ package io.micronaut.http.client
 import io.micronaut.context.ApplicationContext
 import io.micronaut.http.client.exceptions.HttpClientException
 import io.micronaut.http.netty.channel.EventLoopGroupRegistry
+import io.netty.channel.EventLoopGroup
+import spock.lang.AutoCleanup
+import spock.lang.Shared
 import spock.lang.Specification
 
 import java.util.concurrent.ExecutionException
 
 class BlockingDeadlockSpec extends Specification {
-    def 'blocking on the same event loop should fail: connection already established'() {
-        given:
-        def ctx = ApplicationContext.run([
-                'micronaut.netty.event-loops.default.num-threads': 1
-        ])
-        def group = ctx.getBean(EventLoopGroupRegistry).getDefaultEventLoopGroup()
-        def client = ctx.createBean(HttpClient, 'https://micronaut.io').toBlocking()
 
+    @Shared
+    @AutoCleanup
+    ApplicationContext ctx = ApplicationContext.run([
+            'micronaut.netty.event-loops.default.num-threads': 1
+    ])
+
+    @Shared
+    EventLoopGroup group = ctx.getBean(EventLoopGroupRegistry).getDefaultEventLoopGroup()
+
+    @Shared
+    @AutoCleanup
+    BlockingHttpClient client = ctx.createBean(HttpClient, 'https://micronaut.io').toBlocking()
+
+    def 'blocking on the same event loop should fail: connection already established'() {
         when:
         // establish pool connection
         client.exchange('/')
         group.submit(() -> {
             client.exchange('/')
         }).get()
+
         then:
         def e = thrown ExecutionException
         e.cause instanceof HttpClientException
         e.cause.message.contains("deadlock")
-
-        cleanup:
-        client.close()
-        group.shutdownGracefully()
     }
 
     def 'blocking on the same event loop should fail: new connection'() {
-        given:
-        def ctx = ApplicationContext.run([
-                'micronaut.netty.event-loops.default.num-threads': 1
-        ])
-        def group = ctx.getBean(EventLoopGroupRegistry).getDefaultEventLoopGroup()
-        def client = ctx.createBean(HttpClient, 'https://micronaut.io').toBlocking()
-
         when:
         group.submit(() -> {
             client.exchange('/')
         }).get()
+
         then:
         def e = thrown ExecutionException
         e.cause instanceof HttpClientException
         e.cause.message.contains("deadlock")
-
-        cleanup:
-        client.close()
-        group.shutdownGracefully()
     }
 }

--- a/http-client/src/test/groovy/io/micronaut/http/client/ClientIntroductionAdviceSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/ClientIntroductionAdviceSpec.groovy
@@ -13,12 +13,10 @@ import io.micronaut.http.client.annotation.Client
 import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.runtime.server.EmbeddedServer
 import spock.lang.AutoCleanup
-import spock.lang.Shared
 import spock.lang.Specification
 
 class ClientIntroductionAdviceSpec extends Specification {
 
-    @Shared
     @AutoCleanup
     EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
             'spec.name': 'ClientIntroductionAdviceSpec',

--- a/http-client/src/test/groovy/io/micronaut/http/client/ClientRedirectSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/ClientRedirectSpec.groovy
@@ -22,48 +22,36 @@ import spock.lang.Specification
 
 class ClientRedirectSpec extends Specification {
 
-    @Shared @AutoCleanup EmbeddedServer embeddedServer =
-            ApplicationContext.run(EmbeddedServer, [
-                    'spec.name': 'ClientRedirectSpec',
-            ])
+    @Shared
+    @AutoCleanup
+    EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
+            'spec.name': 'ClientRedirectSpec',
+    ])
+
+    @Shared
+    @AutoCleanup
+    HttpClient client = embeddedServer.applicationContext.createBean(HttpClient, embeddedServer.getURL())
 
     void "test - client: full uri, direct"() {
-        given:
-        HttpClient client = embeddedServer.applicationContext.createBean(HttpClient, embeddedServer.getURL())
-
         when:
         HttpResponse<String> response = client.toBlocking().exchange('/test/direct', String)
 
         then:
         response.status() == HttpStatus.OK
         response.body() == "It works!"
-
-        cleanup:
-        client.stop()
-        client.close()
     }
 
     void "test - client: full uri, redirect: absolute - follows correctly"() {
-        given:
-        HttpClient client = embeddedServer.applicationContext.createBean(HttpClient, embeddedServer.getURL())
-
         when:
         HttpResponse<String> response = client.toBlocking().exchange('/test/redirect', String)
 
         then: "Micronaut Client follows the redirect to /test/direct"
         response.status() == HttpStatus.OK
         response.body() == "It works!"
-
-        cleanup:
-        client.stop()
-        client.close()
     }
 
     @NotYetImplemented
     void "test - client: full uri, redirect: relative"() {
-        given:
-        HttpClient client = embeddedServer.applicationContext.createBean(HttpClient, embeddedServer.getURL())
-
         when:
         HttpResponse<String> response = client.toBlocking().exchange('/test/redirect-relative', String)
 
@@ -71,9 +59,6 @@ class ClientRedirectSpec extends Specification {
         noExceptionThrown()
         response.status() == HttpStatus.OK
         response.body() == "It works!"
-
-        cleanup:
-        client.close()
     }
 
     void "test - client: relative uri, direct"() {
@@ -99,7 +84,6 @@ class ClientRedirectSpec extends Specification {
         response.body() == "It works!"
 
         cleanup:
-        client.stop()
         client.close()
     }
 
@@ -125,7 +109,6 @@ class ClientRedirectSpec extends Specification {
         response.body() == "It works!"
 
         cleanup:
-        client.stop()
         client.close()
     }
 
@@ -152,13 +135,12 @@ class ClientRedirectSpec extends Specification {
         response.body() == "It works!"
 
         cleanup:
-        client.stop()
         client.close()
     }
 
     void "test the host header is correct for redirect"() {
+        given:
         EmbeddedServer otherServer = ApplicationContext.run(EmbeddedServer, ['redirect.server': true, 'spec.name': 'ClientRedirectSpec'])
-        HttpClient client = embeddedServer.applicationContext.createBean(HttpClient, embeddedServer.getURL())
 
         when:
         String result = client.toBlocking().retrieve(HttpRequest.GET("/test/redirect-host").header("redirect", "http://localhost:${otherServer.getPort()}/test/host-header"))

--- a/http-client/src/test/groovy/io/micronaut/http/client/ClientSpecificLoggerSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/ClientSpecificLoggerSpec.groovy
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017-2019 original authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.micronaut.http.client
 
 import io.micronaut.context.ApplicationContext
@@ -24,37 +9,30 @@ import io.micronaut.runtime.ApplicationConfiguration
 import io.micronaut.runtime.server.EmbeddedServer
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
-import spock.lang.Retry
 import spock.lang.Specification
 
-// sometimes fails due to a port bind issue on Travis
-// this is because there is a timing issue between when an available port
-// is found and when the server is run with this port where within this window
-// the port could become available. To workaround this we add @Retry.
-@Retry
 class ClientSpecificLoggerSpec extends Specification {
 
     void "test client specific logger"() {
         given:
         int port = SocketUtils.findAvailableTcpPort()
-        EmbeddedServer server = ApplicationContext.run(EmbeddedServer,
-                ['micronaut.server.port': port,
-                 'spec.name': 'ClientSpecificLoggerSpec',
-                'micronaut.http.services.clientOne.url': "http://localhost:$port",
-                'micronaut.http.services.clientOne.logger-name': "${ClientSpecificLoggerSpec.class}.client.one",
-                'micronaut.http.services.clientOne.read-timeout': '500s']
-        )
-        ApplicationContext context = server.applicationContext
+        EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
+                'micronaut.server.port'                         : port,
+                'spec.name'                                     : 'ClientSpecificLoggerSpec',
+                'micronaut.http.services.clientOne.url'         : "http://localhost:$port",
+                'micronaut.http.services.clientOne.logger-name' : "${ClientSpecificLoggerSpec.class}.client.one",
+                'micronaut.http.services.clientOne.read-timeout': '500s'
+        ])
 
         when:
-        MyService myService = context.getBean(MyService)
+        MyService myService = server.applicationContext.getBean(MyService)
 
         then:
-        ((DefaultHttpClient) myService.client).log.name == "${ClientSpecificLoggerSpec.class}.client.one".toString()
-        ((DefaultHttpClient) myService.reactiveHttpClient).log.name == "${ClientSpecificLoggerSpec.class}.client.two".toString()
+        ((DefaultHttpClient) myService.client).log.name == "${ClientSpecificLoggerSpec.class}.client.one"
+        ((DefaultHttpClient) myService.reactiveHttpClient).log.name == "${ClientSpecificLoggerSpec.class}.client.two"
 
         cleanup:
-        context.close()
+        server.close()
     }
 
     @Requires(property = 'spec.name', value = 'ClientSpecificLoggerSpec')

--- a/http-client/src/test/groovy/io/micronaut/http/client/CompressedRequest.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/CompressedRequest.groovy
@@ -1,23 +1,8 @@
-/*
- * Copyright 2017-2020 original authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.micronaut.http.client
 
-import io.micronaut.core.async.annotation.SingleResult
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Requires
+import io.micronaut.core.async.annotation.SingleResult
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.MediaType
@@ -28,24 +13,23 @@ import io.micronaut.http.annotation.Post
 import io.micronaut.runtime.server.EmbeddedServer
 import io.netty.handler.codec.http.HttpHeaderValues
 import org.reactivestreams.Publisher
-import reactor.core.publisher.Flux
-import reactor.core.publisher.Mono
 import spock.lang.AutoCleanup
-import spock.lang.Shared
 import spock.lang.Specification
 
 import java.util.zip.GZIPOutputStream
 
 class CompressedRequest extends Specification {
 
-    @Shared @AutoCleanup EmbeddedServer embeddedServer =
-            ApplicationContext.run(EmbeddedServer, [
-                    'spec.name': 'CompressedRequest'
-            ])
+    @AutoCleanup
+    EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
+            'spec.name': 'CompressedRequest'
+    ])
+
+    @AutoCleanup
+    HttpClient client = embeddedServer.applicationContext.createBean(HttpClient, embeddedServer.getURL())
 
     void "test gzipped body in post request"() {
         given:
-        HttpClient client = HttpClient.create(embeddedServer.getURL())
         byte[] body = gzip("[0, 1, 2, 3, 4]")
 
         when:
@@ -58,10 +42,6 @@ class CompressedRequest extends Specification {
         then:
         result.body().size() == 5
         result.body() == [0, 1, 2, 3, 4]
-
-        cleanup:
-        client.stop()
-        client.close()
     }
 
     @Requires(property = 'spec.name', value = 'CompressedRequest')

--- a/http-client/src/test/groovy/io/micronaut/http/client/DefaultMethodClient.java
+++ b/http-client/src/test/groovy/io/micronaut/http/client/DefaultMethodClient.java
@@ -15,12 +15,14 @@
  */
 package io.micronaut.http.client;
 
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.Get;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.http.client.aop.Mutating;
 
 @Client("/aop")
+@Requires(property = "spec.name", value = "ClientIntroductionAdviceSpec")
 public interface DefaultMethodClient {
 
     @Get(produces = MediaType.TEXT_PLAIN, consumes = MediaType.TEXT_PLAIN)

--- a/http-client/src/test/groovy/io/micronaut/http/client/DefaultMethodClient2.java
+++ b/http-client/src/test/groovy/io/micronaut/http/client/DefaultMethodClient2.java
@@ -15,12 +15,14 @@
  */
 package io.micronaut.http.client;
 
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.Get;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.http.client.aop.Mutating;
 
 @Client("/aop")
+@Requires(property = "spec.name", value = "ClientIntroductionAdviceSpec")
 public interface DefaultMethodClient2 extends IDefaultMethodClient {
 
     @Get(produces = MediaType.TEXT_PLAIN, consumes = MediaType.TEXT_PLAIN)

--- a/http-client/src/test/groovy/io/micronaut/http/client/DefaultMethodClient3.java
+++ b/http-client/src/test/groovy/io/micronaut/http/client/DefaultMethodClient3.java
@@ -15,12 +15,14 @@
  */
 package io.micronaut.http.client;
 
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.Get;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.http.client.aop.Mutating;
 
 @Client("/aop")
+@Requires(property = "spec.name", value = "ClientIntroductionAdviceSpec")
 public abstract class DefaultMethodClient3 implements IDefaultMethodClient {
 
     @Get(produces = MediaType.TEXT_PLAIN, consumes = MediaType.TEXT_PLAIN)
@@ -30,5 +32,4 @@ public abstract class DefaultMethodClient3 implements IDefaultMethodClient {
     public String defaultMethod2(String zzz) {
         return index(zzz) + " 2";
     }
-
 }

--- a/http-client/src/test/groovy/io/micronaut/http/client/HttpGetSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/HttpGetSpec.groovy
@@ -61,7 +61,6 @@ class HttpGetSpec extends Specification {
 
     @Inject
     @Client("/")
-    @AutoCleanup
     HttpClient client
 
     @Inject

--- a/http-client/src/test/groovy/io/micronaut/http/client/NonMutableResponseSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/NonMutableResponseSpec.groovy
@@ -17,9 +17,14 @@ import java.util.concurrent.CompletableFuture
 
 class NonMutableResponseSpec extends Specification {
 
-    @Shared @AutoCleanup EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer,['micronaut.server.max-request-size': '10KB',
-                                                                                                'spec.name': 'NonMutableResponseSpec'])
-    @Shared HttpClient client = embeddedServer.applicationContext.createBean(HttpClient, embeddedServer.getURL())
+    @AutoCleanup
+    EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
+            'micronaut.server.max-request-size': '10KB',
+            'spec.name'                        : 'NonMutableResponseSpec'
+    ])
+
+    @AutoCleanup
+    HttpClient client = embeddedServer.applicationContext.createBean(HttpClient, embeddedServer.getURL())
 
     void "test returning a non mutable response from a controller"() {
         expect:
@@ -51,7 +56,8 @@ class NonMutableResponseSpec extends Specification {
     @Controller
     static class ResponseController {
 
-        @Inject ResponseClient responseClient
+        @Inject
+        ResponseClient responseClient
 
         @Get('/test/non-mutable')
         HttpResponse<String> go() {

--- a/http-client/src/test/groovy/io/micronaut/http/client/PoolTimeoutSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/PoolTimeoutSpec.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.http.client
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.client.exceptions.ReadTimeoutException
@@ -8,26 +9,29 @@ import io.micronaut.runtime.server.EmbeddedServer
 import io.micronaut.scheduling.TaskExecutors
 import io.micronaut.scheduling.annotation.ExecuteOn
 import reactor.core.publisher.Mono
+import spock.lang.AutoCleanup
 import spock.lang.Issue
 import spock.lang.Specification
 
 import java.util.concurrent.TimeUnit
 
 class PoolTimeoutSpec extends Specification {
+
+    @AutoCleanup
+    EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
+            "spec.name": "PoolTimeoutSpec",
+            "micronaut.http.client.pool.enabled": true,
+            "micronaut.http.client.pool.max-pending-connections": 1,
+            "micronaut.http.client.pool.max-concurrent-http1-connections": 1,
+            "micronaut.http.client.read-timeout": "1s",
+    ])
+
+    @AutoCleanup
+    HttpClient client = server.applicationContext.createBean(HttpClient, server.URI)
+
     @Issue('https://github.com/micronaut-projects/micronaut-core/issues/9448')
     def "cancelled pool acquire should not leak connection"() {
         given:
-        def ctx = ApplicationContext.run([
-                "spec.name": "PoolTimeoutSpec",
-                "micronaut.http.client.pool.enabled": true,
-                "micronaut.http.client.pool.max-pending-connections": 1,
-                "micronaut.http.client.pool.max-concurrent-http1-connections": 1,
-                "micronaut.http.client.read-timeout": "1s",
-        ])
-        def server = ctx.getBean(EmbeddedServer)
-        server.start()
-        def client = ctx.createBean(HttpClient, server.URI)
-
         def fut1 = Mono.from(client.retrieve("/slow-controller?req=1")).toFuture().thenApply {
             TimeUnit.SECONDS.sleep(3)
             it
@@ -35,27 +39,27 @@ class PoolTimeoutSpec extends Specification {
 
         when:
         client.toBlocking().retrieve("/slow-controller?req=2")
+
         then:
         thrown(ReadTimeoutException)
 
         when:
         def r1 = fut1.get()
+
         then:
         r1 == "foo"
 
         when:
         def r2 = client.toBlocking().retrieve("/slow-controller?req=3")
+
         then:
         r2 == "foo"
-
-        cleanup:
-        client.close()
-        server.stop()
-        ctx.close()
     }
 
+    @Requires(property = 'spec.name', value = 'PoolTimeoutSpec')
     @Controller("/slow-controller")
     static class SlowController {
+
         @Get
         @ExecuteOn(TaskExecutors.IO)
         String slow() {

--- a/http-client/src/test/groovy/io/micronaut/http/client/ServiceIdSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/ServiceIdSpec.groovy
@@ -16,21 +16,24 @@ import io.micronaut.http.filter.HttpClientFilter
 import io.micronaut.runtime.server.EmbeddedServer
 import jakarta.inject.Singleton
 import org.reactivestreams.Publisher
+import spock.lang.AutoCleanup
 import spock.lang.Specification
 
 class ServiceIdSpec extends Specification {
 
+    @AutoCleanup
+    EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
+            'spec.name': 'ServiceIdSpec',
+    ])
+
+    @AutoCleanup
+    ApplicationContext clientCtx = ApplicationContext.run([
+            'spec.name': 'ServiceIdSpec',
+            'micronaut.http.services.my-client-id.url': server.URI,
+    ])
+
     def 'service id set by declarative client'() {
         given:
-        def serverCtx = ApplicationContext.run([
-                'spec.name': 'ServiceIdSpec',
-        ])
-        def server = serverCtx.getBean(EmbeddedServer)
-        server.start()
-        def clientCtx = ApplicationContext.run([
-                'spec.name': 'ServiceIdSpec',
-                'micronaut.http.services.my-client-id.url': server.URI,
-        ])
         def client = clientCtx.getBean(DeclarativeClient)
         def filter = clientCtx.getBean(ServiceIdFilter)
 
@@ -38,24 +41,10 @@ class ServiceIdSpec extends Specification {
         filter.serviceId == null
         client.index() == "foo"
         filter.serviceId == "my-client-id"
-
-        cleanup:
-        server.close()
-        serverCtx.close()
-        clientCtx.close()
     }
 
     def 'service id set by normal client'() {
         given:
-        def serverCtx = ApplicationContext.run([
-                'spec.name': 'ServiceIdSpec',
-        ])
-        def server = serverCtx.getBean(EmbeddedServer)
-        server.start()
-        def clientCtx = ApplicationContext.run([
-                'spec.name': 'ServiceIdSpec',
-                'micronaut.http.services.my-client-id.url': server.URI,
-        ])
         def client = clientCtx.getBean(HttpClientRegistry).getClient(HttpVersion.HTTP_1_1, "my-client-id", null)
         def filter = clientCtx.getBean(ServiceIdFilter)
 
@@ -63,14 +52,10 @@ class ServiceIdSpec extends Specification {
         filter.serviceId == null
         client.toBlocking().exchange("/service-id", String).body() == "foo"
         filter.serviceId == "my-client-id"
-
-        cleanup:
-        server.close()
-        serverCtx.close()
-        clientCtx.close()
     }
 
     @Client(id = "my-client-id")
+    @Requires(property = "spec.name", value = "ServiceIdSpec")
     static interface DeclarativeClient {
         @Get("/service-id")
         String index()

--- a/http-client/src/test/groovy/io/micronaut/http/client/aop/BlockingFallbackSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/aop/BlockingFallbackSpec.groovy
@@ -16,6 +16,7 @@
 package io.micronaut.http.client.aop
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
 import io.micronaut.http.annotation.*
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.retry.annotation.Fallback
@@ -35,7 +36,9 @@ class BlockingFallbackSpec extends Specification {
 
     @Shared
     @AutoCleanup
-    ApplicationContext context = ApplicationContext.run()
+    ApplicationContext context = ApplicationContext.run([
+            'spec.name':'BlockingFallbackSpec',
+    ])
 
     @Shared
     EmbeddedServer embeddedServer = context.getBean(EmbeddedServer).start()
@@ -69,6 +72,7 @@ class BlockingFallbackSpec extends Specification {
 
     @Client('/blocking/fallback/books')
     @Recoverable
+    @Requires(property = 'spec.name', value = 'BlockingFallbackSpec')
     static interface BookClient extends BookApi {
         @Override
         @Recoverable(api = BookApi)
@@ -76,6 +80,7 @@ class BlockingFallbackSpec extends Specification {
     }
 
     @Fallback
+    @Requires(property = 'spec.name', value = 'BlockingFallbackSpec')
     static class BookFallback implements BookApi {
 
         Map<Long, Book> books = new LinkedHashMap<>()
@@ -114,6 +119,7 @@ class BlockingFallbackSpec extends Specification {
     }
 
     @Controller("/blocking/fallback/books")
+    @Requires(property = 'spec.name', value = 'BlockingFallbackSpec')
     static class BookController implements BookApi {
 
         @Override

--- a/http-client/src/test/groovy/io/micronaut/http/client/aop/BlockingPojoCrudSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/aop/BlockingPojoCrudSpec.groovy
@@ -16,6 +16,7 @@
 package io.micronaut.http.client.aop
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
 import io.micronaut.core.annotation.Introspected
 import io.micronaut.core.bind.BeanPropertyBinder
 import io.micronaut.http.annotation.*
@@ -34,7 +35,9 @@ class BlockingPojoCrudSpec extends Specification {
 
     @Shared
     @AutoCleanup
-    ApplicationContext context = ApplicationContext.run()
+    ApplicationContext context = ApplicationContext.run([
+            'spec.name':'BlockingPojoCrudSpec',
+    ])
 
     @Shared
     EmbeddedServer embeddedServer = context.getBean(EmbeddedServer).start()
@@ -84,10 +87,12 @@ class BlockingPojoCrudSpec extends Specification {
 
 
     @Client('/blocking/pojo/books')
+    @Requires(property = 'spec.name', value = 'BlockingPojoCrudSpec')
     static interface BookClient extends BookApi {
     }
 
     @Controller("/blocking/pojo/books")
+    @Requires(property = 'spec.name', value = 'BlockingPojoCrudSpec')
     static class BookController implements BookApi {
 
         Map<Long, Book> books = new LinkedHashMap<>()

--- a/http-client/src/test/groovy/io/micronaut/http/client/aop/CustomHttpMethodSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/aop/CustomHttpMethodSpec.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.http.client.aop
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.CustomHttpMethod
 import io.micronaut.http.annotation.Get
@@ -15,17 +16,38 @@ import spock.lang.Specification
  * @since 1.2.1
  */
 class CustomHttpMethodSpec extends Specification {
+
     @Shared
     @AutoCleanup
-    ApplicationContext context = ApplicationContext.run()
+    EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
+            'spec.name':'CustomHttpMethodSpec',
+    ])
 
     @Shared
-    EmbeddedServer embeddedServer = context.getBean(EmbeddedServer).start()
+    WebdavClient webdavClient = server.applicationContext.getBean(WebdavClient)
+
+    def "Lock method with uri parameter should run fine"() {
+        given:
+        String response = webdavClient.lock("John")
+
+        expect:
+        response == "LOCK John"
+    }
+
+    def "Get method with uri parameter should run fine"() {
+        given:
+        String response = webdavClient.get("John")
+
+        expect:
+        response == "GET John"
+    }
 
     @Client('/customHttpMethod')
+    @Requires(property = 'spec.name', value = 'CustomHttpMethodSpec')
     static interface WebdavClient extends MyApi {}
 
     @Controller("/customHttpMethod")
+    @Requires(property = 'spec.name', value = 'CustomHttpMethodSpec')
     static class MethodController {
         @CustomHttpMethod(method = "LOCK", value = "/{name}")
         String lock(String name) {
@@ -44,23 +66,5 @@ class CustomHttpMethodSpec extends Specification {
 
         @Get("/{name}")
         String get(String name)
-    }
-
-    def "Lock method with uri parameter should run fine"() {
-        given:
-        WebdavClient webdavClient = context.getBean(WebdavClient)
-        String response = webdavClient.lock("John")
-
-        expect:
-        response == "LOCK John"
-    }
-
-    def "Get method with uri parameter should run fine"() {
-        given:
-        WebdavClient webdavClient = context.getBean(WebdavClient)
-        String response = webdavClient.get("John")
-
-        expect:
-        response == "GET John"
     }
 }

--- a/http-client/src/test/groovy/io/micronaut/http/client/aop/HateosCrudSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/aop/HateosCrudSpec.groovy
@@ -1,21 +1,7 @@
-/*
- * Copyright 2017-2019 original authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.micronaut.http.client.aop
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
 import io.micronaut.http.MediaType
 import io.micronaut.http.annotation.*
 import io.micronaut.http.client.annotation.Client
@@ -23,7 +9,6 @@ import io.micronaut.http.hateoas.AbstractResource
 import io.micronaut.http.hateoas.Link
 import io.micronaut.runtime.server.EmbeddedServer
 import spock.lang.AutoCleanup
-import spock.lang.Shared
 import spock.lang.Specification
 
 import java.util.concurrent.atomic.AtomicLong
@@ -35,18 +20,14 @@ import java.util.concurrent.atomic.AtomicLong
 
 class HateoasCrudSpec extends Specification {
 
-    @Shared
     @AutoCleanup
-    ApplicationContext context = ApplicationContext.run()
+    EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
+            'spec.name':'HateoasCrudSpec',
+    ])
 
-    @Shared
-    EmbeddedServer embeddedServer = context.getBean(EmbeddedServer).start()
-
+    BookClient client = server.applicationContext.getBean(BookClient)
 
     void "test CRUD operations on generated client that returns blocking responses"() {
-        given:
-        BookClient client = context.getBean(BookClient)
-
         when:
         Book book = client.get(99)
         List<Book> books = client.list()
@@ -88,10 +69,12 @@ class HateoasCrudSpec extends Specification {
     }
 
     @Client('/hateoas/books')
+    @Requires(property = 'spec.name', value = 'HateoasCrudSpec')
     static interface BookClient extends BookApi {
     }
 
     @Controller("/hateoas/books")
+    @Requires(property = 'spec.name', value = 'HateoasCrudSpec')
     static class BookController implements BookApi {
 
         Map<Long, Book> books = new LinkedHashMap<>()

--- a/http-client/src/test/groovy/io/micronaut/http/client/aop/HeaderSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/aop/HeaderSpec.groovy
@@ -1,28 +1,13 @@
-/*
- * Copyright 2017-2019 original authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.micronaut.http.client.aop
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Header
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.runtime.server.EmbeddedServer
 import spock.lang.AutoCleanup
-import spock.lang.Shared
 import spock.lang.Specification
 
 /**
@@ -30,16 +15,16 @@ import spock.lang.Specification
  * @since 1.0
  */
 class HeaderSpec extends Specification {
-    @Shared
-    @AutoCleanup
-    ApplicationContext context = ApplicationContext.run()
 
-    @Shared
-    EmbeddedServer embeddedServer = context.getBean(EmbeddedServer).start()
+    @AutoCleanup
+    EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
+            'spec.name':'HeaderSpec',
+    ])
+
+    UserClient userClient = server.applicationContext.getBean(UserClient)
 
     void "test send and receive header"() {
         given:
-        UserClient userClient = context.getBean(UserClient)
         User user = userClient.get("Fred")
 
         expect:
@@ -49,11 +34,13 @@ class HeaderSpec extends Specification {
     }
 
     @Client('/headers')
+    @Requires(property = 'spec.name', value = 'HeaderSpec')
     static interface UserClient extends MyApi {
 
     }
 
     @Controller('/headers')
+    @Requires(property = 'spec.name', value = 'HeaderSpec')
     static class UserController implements MyApi {
 
         @Override

--- a/http-client/src/test/groovy/io/micronaut/http/client/aop/NotFoundSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/aop/NotFoundSpec.groovy
@@ -15,6 +15,7 @@
  */
 package io.micronaut.http.client.aop
 
+import io.micronaut.context.annotation.Requires
 import io.micronaut.core.async.annotation.SingleResult
 import io.micronaut.context.ApplicationContext
 import io.micronaut.http.MediaType
@@ -32,7 +33,9 @@ import spock.lang.Specification
 
 class NotFoundSpec extends Specification {
 
-    @Shared @AutoCleanup EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer)
+    @Shared @AutoCleanup EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
+            "spec.name": 'NotFoundSpec',
+    ])
 
     void "test 404 handling with Flowable"() {
         given:
@@ -56,6 +59,7 @@ class NotFoundSpec extends Specification {
     }
 
     @Client('/not-found')
+    @Requires(property = 'spec.name', value = 'NotFoundSpec')
     static interface InventoryClient {
         @Get('/maybe/{isbn}')
         @Consumes(MediaType.TEXT_PLAIN)
@@ -67,6 +71,7 @@ class NotFoundSpec extends Specification {
     }
 
     @Controller(value = "/not-found", produces = MediaType.TEXT_PLAIN)
+    @Requires(property = 'spec.name', value = 'NotFoundSpec')
     static class InventoryController {
         Map<String, Boolean> stock = [
                 '1234': true

--- a/http-client/src/test/groovy/io/micronaut/http/client/aop/PlaceholdersInClientSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/aop/PlaceholdersInClientSpec.groovy
@@ -1,26 +1,11 @@
-/*
- * Copyright 2017-2019 original authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.micronaut.http.client.aop
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.runtime.server.EmbeddedServer
 import spock.lang.AutoCleanup
-import spock.lang.Shared
 import spock.lang.Specification
 
 /**
@@ -29,20 +14,16 @@ import spock.lang.Specification
  */
 class PlaceholdersInClientSpec extends Specification {
 
-    @Shared
     @AutoCleanup
-    ApplicationContext context = ApplicationContext.run(
-            'books.uri':'/blocking',
-            'my.path':'{id}'
-    )
+    EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
+            'spec.name': 'BlockingCrudSpec',
+            'books.uri': '/blocking',
+            'my.path'  : '{id}'
+    ])
 
-    @Shared
-    EmbeddedServer embeddedServer = context.getBean(EmbeddedServer).start()
+    BookClient client = server.applicationContext.getBean(BookClient)
 
     void "test placeholder in @Client value"() {
-        given:
-        BookClient client = context.getBean(BookClient)
-
         when:
         BlockingCrudSpec.Book book = client.get(99)
         List<BlockingCrudSpec.Book> books = client.list()
@@ -59,15 +40,13 @@ class PlaceholdersInClientSpec extends Specification {
         book.title == "The Stand"
         book.id == 1
         client.getOther(book.id).title == book.title
-
     }
 
-
     @Client('${books.uri}/books')
+    @Requires(property = 'spec.name', value = 'BlockingCrudSpec')
     static interface BookClient extends BlockingCrudSpec.BookApi {
 
         @Get('/${my.path}')
         BlockingCrudSpec.Book getOther(Long id)
-
     }
 }

--- a/http-client/src/test/groovy/io/micronaut/http/client/aop/QueryParametersSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/aop/QueryParametersSpec.groovy
@@ -1,21 +1,7 @@
-/*
- * Copyright 2017-2019 original authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.micronaut.http.client.aop
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
 import io.micronaut.core.annotation.Introspected
 import io.micronaut.core.beans.exceptions.IntrospectionException
 import io.micronaut.http.HttpRequest
@@ -31,7 +17,6 @@ import spock.lang.AutoCleanup
 import spock.lang.Issue
 import spock.lang.Shared
 import spock.lang.Specification
-import spock.lang.Unroll
 
 import jakarta.annotation.Nullable
 
@@ -39,7 +24,9 @@ class QueryParametersSpec extends Specification {
 
     @Shared
     @AutoCleanup
-    EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer)
+    EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
+            'spec.name': 'QueryParametersSpec',
+    ])
 
     @Shared
     ItunesClient client = embeddedServer.getApplicationContext().getBean(ItunesClient)
@@ -54,7 +41,6 @@ class QueryParametersSpec extends Specification {
         client.searchTwo("Riverside").albums.size() == 2
     }
 
-    @Unroll
     void "test client mappping URL parameters appended through a Map (served through #flavour)"() {
         expect:
         client.searchExplodedMap(flavour, [term: "Riverside"]).albums.size() == 2
@@ -74,7 +60,6 @@ class QueryParametersSpec extends Specification {
         map.containsValue(null)
     }
 
-    @Unroll
     void "test client mappping multiple URL parameters appended through a Map (served through #flavour)"() {
         expect:
         client.searchExplodedMap(flavour, [term: ["Tool", 'Agnes Obel']]).albums.size() == 4
@@ -82,7 +67,6 @@ class QueryParametersSpec extends Specification {
         flavour << [ "pojo", "list", "map" ]
     }
 
-    @Unroll
     void "test client mappping URL parameters appended through a List (served through #flavour)"() {
         expect:
         client.searchExplodedList(flavour, ["Tool", 'Riverside']).albums.size() == 3
@@ -90,7 +74,6 @@ class QueryParametersSpec extends Specification {
         flavour << [ "pojo", "list", "map" ]
     }
 
-    @Unroll
     void "test client mappping URL parameters through singleton list (served through #flavour)"() {
         expect:
         client.searchExplodedList(flavour, ["Tool"]).albums.size() == 1
@@ -98,7 +81,6 @@ class QueryParametersSpec extends Specification {
         flavour << [ "pojo", "singlePojo", "list", "map" ]
     }
 
-    @Unroll
     void "test client mappping URL parameters appended through a POJO (served through #flavour)"() {
         expect:
         client.searchExplodedSinglePojo(flavour, new SearchParams(term: "Agnes Obel")).albums.size() == 3
@@ -106,7 +88,6 @@ class QueryParametersSpec extends Specification {
         flavour << [ "pojo", "singlePojo", "list", "map" ]
     }
 
-    @Unroll
     void "test client mappping URL parameters appended through a POJO with a list (served through #flavour)"() {
         when:
         client.searchExplodedPojo("list", new SearchParamsAsList(term: ["Tool", "Agnes Obel"]))
@@ -115,7 +96,6 @@ class QueryParametersSpec extends Specification {
         thrown(IntrospectionException)
     }
 
-    @Unroll
     void "test client mappping URL parameters appended through an introspected POJO with a list"() {
         expect:
         client.searchExplodedIntrospectedPojo(flavour, new IntrospectedSearchParamsAsList(term: ["Tool", "Agnes Obel"])).albums.size() == 4
@@ -194,6 +174,7 @@ class QueryParametersSpec extends Specification {
     }
 
     @Controller('/itunes')
+    @Requires(property = 'spec.name', value = 'QueryParametersSpec')
     static class ItunesController {
 
         Map<String, List<String>> artists = [
@@ -274,6 +255,7 @@ class QueryParametersSpec extends Specification {
 
 
     @Client("/itunes")
+    @Requires(property = 'spec.name', value = 'QueryParametersSpec')
     static interface ItunesClient {
 
         @Get("/search?limit=25&media=music&entity=album&term={term}")

--- a/http-client/src/test/groovy/io/micronaut/http/client/aop/ReactorJavaFallbackSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/aop/ReactorJavaFallbackSpec.groovy
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017-2019 original authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.micronaut.http.client.aop
 
 import io.micronaut.context.ApplicationContext
@@ -39,13 +24,9 @@ class ReactorJavaFallbackSpec extends Specification{
     @AutoCleanup
     EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, ['spec.name': 'ReactorJavaFallbackSpec'])
 
-    @Shared
-    @AutoCleanup
-    ApplicationContext context = embeddedServer.applicationContext
-
     void "test that fallbacks are called for RxJava responses"() {
         given:
-        BookClient client = context.getBean(BookClient)
+        BookClient client = embeddedServer.applicationContext.getBean(BookClient)
 
         when:
         Book book = Mono.from(client.get(99)).block()

--- a/http-client/src/test/groovy/io/micronaut/http/client/aop/RequestAttributeSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/aop/RequestAttributeSpec.groovy
@@ -1,22 +1,7 @@
-/*
- * Copyright 2017-2019 original authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package io.micronaut.http.client.aop
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.MutableHttpResponse
 import io.micronaut.http.annotation.Controller
@@ -37,14 +22,18 @@ class RequestAttributeSpec extends Specification {
 
     @Shared
     @AutoCleanup
-    ApplicationContext context = ApplicationContext.run()
+    EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
+            'spec.name': 'RequestAttributeSpec',
+    ])
 
     @Shared
-    EmbeddedServer embeddedServer = context.getBean(EmbeddedServer).start()
+    StoryClient storyClient = server.applicationContext.getBean(StoryClient)
+
+    @Shared
+    ReceiveClient receiveClient = server.applicationContext.getBean(ReceiveClient)
 
     void "test send and receive request attribute"() {
         given:
-        StoryClient storyClient = context.getBean(StoryClient)
         Story story = storyClient.get()
 
         expect:
@@ -52,13 +41,25 @@ class RequestAttributeSpec extends Specification {
         story.title == "The Hungry Caterpillar"
     }
 
+    @Issue('https://github.com/micronaut-projects/micronaut-core/issues/6717')
+    def 'request attributes should not be forwarded'() {
+        when:
+        def uri = receiveClient.get('foo')
+
+        then:
+        uri.path == '/request_attribute_not_forwarded'
+        uri.query == null
+    }
+
     @Client('/request_attribute')
+    @Requires(property = "spec.name", value = "RequestAttributeSpec")
     static interface StoryClient {
         @Get('/story')
         Story get()
     }
 
     @Controller('/request_attribute')
+    @Requires(property = "spec.name", value = "RequestAttributeSpec")
     static class StoryController {
 
         @Get("/story")
@@ -73,6 +74,7 @@ class RequestAttributeSpec extends Specification {
     }
 
     @Filter("/**")
+    @Requires(property = "spec.name", value = "RequestAttributeSpec")
     static class ServerFilter implements HttpServerFilter {
 
         @Override
@@ -82,25 +84,15 @@ class RequestAttributeSpec extends Specification {
         }
     }
 
-    @Issue('https://github.com/micronaut-projects/micronaut-core/issues/6717')
-    def 'request attributes should not be forwarded'() {
-        given:
-        def client = context.getBean(ReceiveClient)
-
-        when:
-        def uri = client.get('foo')
-        then:
-        uri.path == '/request_attribute_not_forwarded'
-        uri.query == null
-    }
-
     @Client('/request_attribute_not_forwarded')
+    @Requires(property = "spec.name", value = "RequestAttributeSpec")
     static interface ReceiveClient {
         @Get
         URI get(@RequestAttribute("example") String value)
     }
 
     @Controller('/request_attribute_not_forwarded')
+    @Requires(property = "spec.name", value = "RequestAttributeSpec")
     static class ReceiveController {
         @Get
         URI get(HttpRequest<?> request) {

--- a/http-client/src/test/groovy/io/micronaut/http/client/aop/StreamSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/aop/StreamSpec.groovy
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017-2019 original authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.micronaut.http.client.aop
 
 import io.micronaut.context.ApplicationContext
@@ -38,7 +23,6 @@ import spock.lang.AutoCleanup
 import spock.lang.PendingFeature
 import spock.lang.Shared
 import spock.lang.Specification
-import spock.lang.Unroll
 
 import jakarta.annotation.Nullable
 import java.nio.charset.StandardCharsets
@@ -56,13 +40,9 @@ class StreamSpec extends Specification {
             'spec.name': 'StreamSpec'
     ])
 
-    @Shared
-    @AutoCleanup
-    ApplicationContext context = embeddedServer.applicationContext
-
     void "test that the server can return a header value to us"() {
         given:
-        StreamEchoClient myClient = context.getBean(StreamEchoClient)
+        StreamEchoClient myClient = embeddedServer.applicationContext.getBean(StreamEchoClient)
 
         when:
         HttpResponse<String> response = myClient.echoWithHeaders(2, "Hello!")
@@ -75,7 +55,7 @@ class StreamSpec extends Specification {
 
     void "test that the server can return a header value to us with a single"() {
         given:
-        StreamEchoClient myClient = context.getBean(StreamEchoClient)
+        StreamEchoClient myClient = embeddedServer.applicationContext.getBean(StreamEchoClient)
 
         when:
         HttpResponse<String> response = myClient.echoWithHeadersSingle( "Hello!")
@@ -89,7 +69,7 @@ class StreamSpec extends Specification {
     void "test send and receive parameter"() {
         given:
         int n = 800// This can be as high as 806596 - if any higher, it will overflow the default aggregator buffer size
-        StreamEchoClient myClient = context.getBean(StreamEchoClient)
+        StreamEchoClient myClient = embeddedServer.applicationContext.getBean(StreamEchoClient)
 
         when:
         String result = myClient.echoAsString(n, "Hello, World!")
@@ -101,7 +81,8 @@ class StreamSpec extends Specification {
     void "test receive client using ByteBuffer"() {
         given:
         int n = 42376 // This may be higher than 806596, but the test takes forever, then.
-        StreamEchoClient myClient = context.getBean(StreamEchoClient)
+        StreamEchoClient myClient = embeddedServer.applicationContext.getBean(StreamEchoClient)
+
         when:
         Flux<ByteBuffer> reactiveSequence = myClient.echoAsByteBuffers(n, "Hello, World!")
         int sum = 0
@@ -117,7 +98,7 @@ class StreamSpec extends Specification {
 
     void "test that the client is unable to convert bytes to elephants"() {
         given:
-        StreamEchoClient myClient = context.getBean(StreamEchoClient)
+        StreamEchoClient myClient = embeddedServer.applicationContext.getBean(StreamEchoClient)
 
         when:
         Flux.from(myClient.echoAsElephant(42, "Hello, big grey animal!")).blockFirst()
@@ -128,12 +109,12 @@ class StreamSpec extends Specification {
                 'ByteBuffer to class io.micronaut.http.client.aop.StreamSpec$Elephant is registered'
     }
 
-    @Unroll
     void "JSON is still just text (variation #n)"() {
         given:
-        StreamEchoClient myClient = context.getBean(StreamEchoClient)
+        StreamEchoClient myClient = embeddedServer.applicationContext.getBean(StreamEchoClient)
         expect:
         myClient.someJson(n) == '{"key":"value"}'
+
         where:
         n << [1, 2]
     }
@@ -142,21 +123,21 @@ class StreamSpec extends Specification {
     void "JSON is still just text (variation 3)"() {
         // variation 3 uses ByteBuf, which is not supported anymore by RouteInfo.isResponseBodyJsonFormattable
         given:
-        StreamEchoClient myClient = context.getBean(StreamEchoClient)
+        StreamEchoClient myClient = embeddedServer.applicationContext.getBean(StreamEchoClient)
         expect:
         myClient.someJson(3) == '{"key":"value"}'
     }
 
     void "JSON can still be streamed using reactive sequence as container"() {
         given:
-        StreamEchoClient myClient = context.getBean(StreamEchoClient)
+        StreamEchoClient myClient = embeddedServer.applicationContext.getBean(StreamEchoClient)
         expect:
         myClient.someJsonCollection() == '[{"x":1},{"x":2}]'
     }
 
     void "JSON stream can still be streamed using reactive sequence as container"() {
         given:
-        StreamEchoClient myClient = context.getBean(StreamEchoClient)
+        StreamEchoClient myClient = embeddedServer.applicationContext.getBean(StreamEchoClient)
 
         expect:
         myClient.someJsonStreamCollection() == '{"x":1}{"x":2}'
@@ -164,7 +145,7 @@ class StreamSpec extends Specification {
 
     void "JSON error can still be streamed using reactive sequence as container"() {
         given:
-        StreamEchoClient myClient = context.getBean(StreamEchoClient)
+        StreamEchoClient myClient = embeddedServer.applicationContext.getBean(StreamEchoClient)
 
         when:
         myClient.someJsonErrorCollection()
@@ -176,7 +157,7 @@ class StreamSpec extends Specification {
 
     void "JSON stream error can still be streamed using reactive sequence as container"() {
         given:
-        StreamEchoClient myClient = context.getBean(StreamEchoClient)
+        StreamEchoClient myClient = embeddedServer.applicationContext.getBean(StreamEchoClient)
 
         when:
         myClient.someJsonStreamErrorCollection()
@@ -287,3 +268,4 @@ class StreamSpec extends Specification {
     }
 
 }
+

--- a/http-client/src/test/groovy/io/micronaut/http/client/convert/DateTimeConversionSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/convert/DateTimeConversionSpec.groovy
@@ -1,21 +1,7 @@
-/*
- * Copyright 2017-2019 original authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.micronaut.http.client.convert
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
 import io.micronaut.http.MediaType
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
@@ -23,7 +9,6 @@ import io.micronaut.http.annotation.QueryValue
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.runtime.server.EmbeddedServer
 import spock.lang.AutoCleanup
-import spock.lang.Shared
 import spock.lang.Specification
 
 import jakarta.validation.constraints.NotNull
@@ -32,12 +17,15 @@ import java.time.format.DateTimeFormatter
 
 class DateTimeConversionSpec extends Specification {
 
-    @Shared @AutoCleanup EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer)
+    @AutoCleanup
+    EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
+            "spec.name": 'DateTimeConversionSpec',
+    ])
 
     void "test offset date time conversion"() {
         given:
-        TimeController controller = embeddedServer.getApplicationContext().getBean(TimeController)
-        TimeClient client = embeddedServer.getApplicationContext().getBean(TimeClient)
+        TimeController controller = embeddedServer.applicationContext.getBean(TimeController)
+        TimeClient client = embeddedServer.applicationContext.getBean(TimeClient)
 
         def now = controller.target
         def result = OffsetDateTime.parse(client.time(now))
@@ -52,9 +40,11 @@ class DateTimeConversionSpec extends Specification {
     }
 
     @Client("/convert/time")
+    @Requires(property = 'spec.name', value = 'DateTimeConversionSpec')
     static interface TimeClient extends TimeApi {}
 
     @Controller("/convert/time")
+    @Requires(property = 'spec.name', value = 'DateTimeConversionSpec')
     static class TimeController implements TimeApi {
         def target = OffsetDateTime.parse("2007-12-03T10:15:30+01:00")
         @Override
@@ -63,6 +53,4 @@ class DateTimeConversionSpec extends Specification {
             return time.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
         }
     }
-
-
 }

--- a/http-client/src/test/groovy/io/micronaut/http/client/convert/FooBarController.java
+++ b/http-client/src/test/groovy/io/micronaut/http/client/convert/FooBarController.java
@@ -1,26 +1,12 @@
-/*
- * Copyright 2017-2020 original authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.micronaut.http.client.convert;
 
-
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
 import io.micronaut.http.annotation.PathVariable;
 
 @Controller("/convert")
+@Requires(property = "spec.name", value = "TypeConverterWithMethodReferenceSpec")
 public class FooBarController {
 
     @Get("/foo/{foo}")
@@ -32,6 +18,4 @@ public class FooBarController {
     public Bar bar(@PathVariable(name = "bar") Bar bar) {
         return bar;
     }
-
-
 }

--- a/http-client/src/test/groovy/io/micronaut/http/client/convert/TypeConverterWithMethodReferenceSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/convert/TypeConverterWithMethodReferenceSpec.groovy
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017-2019 original authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.micronaut.http.client.convert
 
 import io.micronaut.context.ApplicationContext
@@ -24,8 +9,15 @@ import spock.lang.Specification
 
 class TypeConverterWithMethodReferenceSpec extends Specification {
 
-    @Shared @AutoCleanup EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer)
-    @Shared HttpClient client = embeddedServer.applicationContext.createBean(HttpClient, embeddedServer.getURL())
+    @Shared
+    @AutoCleanup
+    EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
+            'spec.name': 'TypeConverterWithMethodReferenceSpec',
+    ])
+
+    @Shared
+    @AutoCleanup
+    HttpClient client = embeddedServer.applicationContext.createBean(HttpClient, embeddedServer.getURL())
 
     void "test type converters can be used with method references"() {
         when:


### PR DESCRIPTION
In an attempt to reduce (or remove) the flakiness in PoolTimeoutSpec, I've been through the http-client tests looking for places where we were not using spec.name and Requires.

I've tried to introduce some consistency on how the tests are run, with an embedded server created at field level (shared if multiple tests) and annotated with `@AutoCleanup` to ensure it's closed (instead of relying on each spec method to create and close the application)

Hopefully closes #9844 