### PR TITLE
imp: avoid name shadowning of result

### DIFF
--- a/aop/src/main/kotlin/io/micronaut/aop/util/KotlinInterceptedMethodHelper.kt
+++ b/aop/src/main/kotlin/io/micronaut/aop/util/KotlinInterceptedMethodHelper.kt
@@ -35,8 +35,8 @@ internal object KotlinInterceptedMethodHelper {
     suspend fun handleResult(result: CompletionStage<*>, isUnitValueType: Boolean): Any? = suspendCoroutine { continuation ->
         result.whenComplete { value: Any?, throwable: Throwable? ->
             if (throwable == null) {
-                val result = Result.success(value ?: if (isUnitValueType) Unit else null)
-                continuation.resumeWith(result)
+                val res = Result.success(value ?: if (isUnitValueType) Unit else null)
+                continuation.resumeWith(res)
             } else {
                 val exception = if (throwable is CompletionException) { throwable.cause ?: throwable } else throwable
                 continuation.resumeWithException(exception)


### PR DESCRIPTION
rename variable to avoid name shadowing of outer `result`

Originally suggested by @altro3 here: https://github.com/micronaut-projects/micronaut-core/pull/9596