### PR TITLE
test. ThreadSelection accept event loop in the handler in blocking and auto scenarios

### DIFF
--- a/test-suite-helper/src/main/java/io/micronaut/testsuitehelper/TestGeneratingAnnotationProcessor.java
+++ b/test-suite-helper/src/main/java/io/micronaut/testsuitehelper/TestGeneratingAnnotationProcessor.java
@@ -81,7 +81,7 @@ public class TestGeneratingAnnotationProcessor extends AbstractProcessor {
     }
 
     private String determineOutputPath() throws IOException {
-        // go write a file so as to figure out where we're running
+        // go write a file to figure out where we're running
         final FileObject resource = processingEnv
             .getFiler()
             .createResource(StandardLocation.CLASS_OUTPUT, "", "tmp" + System.currentTimeMillis(), (Element[]) null);


### PR DESCRIPTION
The test is really flaky:

https://ge.micronaut.io/scans/tests?search.timeZoneId=Europe%2FMadrid&tests.container=io.micronaut.http.server.netty.threading.ThreadSelectionSpec

I am not sure why but it seems sometime the handler uses the event loop. I don't know if it is a bug that the sometimes run in the event loop or if we just need to adjust the test as in this pull request. .  