### PR TITLE
test: remove javax.persistence.Transient from Mapper

### DIFF
--- a/inject-kotlin/src/test/kotlin/io/micronaut/kotlin/processing/elementapi/EntityAnnotationMapper.kt
+++ b/inject-kotlin/src/test/kotlin/io/micronaut/kotlin/processing/elementapi/EntityAnnotationMapper.kt
@@ -33,9 +33,8 @@ class EntityAnnotationMapper : NamedAnnotationMapper {
     ): List<AnnotationValue<*>> {
         val builder = AnnotationValue.builder(
             Introspected::class.java
-        ) // don't bother with transients properties
-            .member("excludedAnnotations", "javax.persistence.Transient") // following are indexed for fast lookups
-            .member(
+        )
+            .member( // following are indexed for fast lookups
                 "indexed",
                 AnnotationValue.builder(
                     Introspected.IndexedAnnotation::class.java


### PR DESCRIPTION
@Transient exclusion was removed in @transient since https://github.com/micronaut-projects/micronaut-core/pull/8072/files