### PR TITLE
protect against activeListeners NPE

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyHttpServer.java
@@ -641,10 +641,12 @@ public class NettyHttpServer implements NettyEmbeddedServer {
                 applicationContext.stop();
             }
             serverConfiguration.getMultipart().getLocation().ifPresent(dir -> DiskFileUpload.baseDirectory = null);
-            for (Listener listener : activeListeners) {
-                if (listener.httpPipelineBuilder != null) {
-                    listener.httpPipelineBuilder.close();
-                    listener.httpPipelineBuilder = null;
+            if (activeListeners != null) {
+                for (Listener listener : activeListeners) {
+                    if (listener.httpPipelineBuilder != null) {
+                        listener.httpPipelineBuilder.close();
+                        listener.httpPipelineBuilder = null;
+                    }
                 }
             }
             this.activeListeners = null;


### PR DESCRIPTION
see: https://ge.micronaut.io/s/bixblaqnbdlek/tests/task/:test-suite-netty-ssl-graalvm:test/details/example.micronaut.HelloControllerTest?top-execution=1

```
java.lang.NullPointerException: Cannot invoke "java.util.List.iterator()" because "this.activeListeners" is null
	at io.micronaut.http.server.netty.NettyHttpServer.stopInternal(NettyHttpServer.java:644)
	at io.micronaut.http.server.netty.NettyHttpServer.bind(NettyHttpServer.java:576)
	at io.micronaut.http.server.netty.NettyHttpServer.start(NettyHttpServer.java:287)
	at io.micronaut.http.server.netty.NettyHttpServer.start(NettyHttpServer.java:104)
	at io.micronaut.test.extensions.AbstractMicronautExtension.beforeClass(AbstractMicronautExtension.java:331)
	at io.micronaut.test.extensions.junit5.MicronautJunit5Extension.befo
```	