### PR TITLE
Update OptionsFilter to not emit duplicate headers

### DIFF
--- a/http-client-jdk/src/test/groovy/io/micronaut/http/client/jdk/OptionsRequestAttributesSpec.groovy
+++ b/http-client-jdk/src/test/groovy/io/micronaut/http/client/jdk/OptionsRequestAttributesSpec.groovy
@@ -2,6 +2,7 @@ package io.micronaut.http.client.jdk
 
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Requires
+import io.micronaut.core.type.Argument
 import io.micronaut.core.util.StringUtils
 import io.micronaut.http.HttpAttributes
 import io.micronaut.http.HttpHeaders
@@ -52,11 +53,15 @@ class OptionsRequestAttributesSpec extends Specification {
         then:
         noExceptionThrown()
         response.status == HttpStatus.OK
-        response.getHeaders().getAll(HttpHeaders.ALLOW)
-        3 == response.getHeaders().getAll(HttpHeaders.ALLOW).size()
-        response.getHeaders().getAll(HttpHeaders.ALLOW).contains('GET')
-        response.getHeaders().getAll(HttpHeaders.ALLOW).contains('OPTIONS')
-        response.getHeaders().getAll(HttpHeaders.ALLOW).contains('HEAD')
+
+        when:
+        List<String> allowedMethods = response.getHeaders().get(HttpHeaders.ALLOW, Argument.of(List.class, Argument.of(String.class))).orElse(new ArrayList<>())
+
+        then:
+        3 == allowedMethods.size()
+        allowedMethods.contains('GET')
+        allowedMethods.contains('OPTIONS')
+        allowedMethods.contains('HEAD')
 
         cleanup:
         ctx.close()

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/OptionsRequestAttributesSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/OptionsRequestAttributesSpec.groovy
@@ -2,8 +2,14 @@ package io.micronaut.http.server.netty
 
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Requires
+import io.micronaut.core.type.Argument
 import io.micronaut.core.util.StringUtils
-import io.micronaut.http.*
+import io.micronaut.http.HttpAttributes
+import io.micronaut.http.HttpHeaders
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.MutableHttpResponse
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Filter
 import io.micronaut.http.annotation.Get
@@ -47,11 +53,15 @@ class OptionsRequestAttributesSpec extends Specification {
         then:
         noExceptionThrown()
         response.status == HttpStatus.OK
-        response.getHeaders().getAll(HttpHeaders.ALLOW)
-        3 == response.getHeaders().getAll(HttpHeaders.ALLOW).size()
-        response.getHeaders().getAll(HttpHeaders.ALLOW).contains('GET')
-        response.getHeaders().getAll(HttpHeaders.ALLOW).contains('OPTIONS')
-        response.getHeaders().getAll(HttpHeaders.ALLOW).contains('HEAD')
+
+        when:
+        List<String> allowedMethods = response.getHeaders().get(HttpHeaders.ALLOW, Argument.of(List.class, Argument.of(String.class))).orElse(new ArrayList<>())
+
+        then:
+        3 == allowedMethods.size()
+        allowedMethods.contains('GET')
+        allowedMethods.contains('OPTIONS')
+        allowedMethods.contains('HEAD')
 
         cleanup:
         ctx.close()

--- a/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/filter/options/OptionsFilterTest.java
+++ b/http-server-tck/src/main/java/io/micronaut/http/server/tck/tests/filter/options/OptionsFilterTest.java
@@ -21,7 +21,11 @@ import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.HttpMethod;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpStatus;
-import io.micronaut.http.annotation.*;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Options;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.annotation.Status;
 import io.micronaut.http.tck.AssertionUtils;
 import io.micronaut.http.tck.HttpResponseAssertion;
 import io.micronaut.http.tck.ServerUnderTest;
@@ -30,9 +34,12 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 import java.util.function.BiConsumer;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings({
     "java:S5960", // We're allowed assertions, as these are used in tests only
@@ -87,11 +94,12 @@ public class OptionsFilterTest {
                         .assertResponse(httpResponse -> {
                             assertNotNull(httpResponse.getHeaders().get(HttpHeaders.ALLOW));
                             assertNotNull(httpResponse.getHeaders().getAll(HttpHeaders.ALLOW));
-                            assertEquals(4, httpResponse.getHeaders().getAll(HttpHeaders.ALLOW).size());
-                            assertTrue(httpResponse.getHeaders().getAll(HttpHeaders.ALLOW).stream().anyMatch(v -> v.equals(HttpMethod.GET.toString())));
-                            assertTrue(httpResponse.getHeaders().getAll(HttpHeaders.ALLOW).stream().anyMatch(v -> v.equals(HttpMethod.POST.toString())));
-                            assertTrue(httpResponse.getHeaders().getAll(HttpHeaders.ALLOW).stream().anyMatch(v -> v.equals(HttpMethod.OPTIONS.toString())));
-                            assertTrue(httpResponse.getHeaders().getAll(HttpHeaders.ALLOW).stream().anyMatch(v -> v.equals(HttpMethod.HEAD.toString())));
+                            List<String> allowedMethods = httpResponse.getHeaders().get(HttpHeaders.ALLOW, List.class).orElseThrow();
+                            assertEquals(4, allowedMethods .size());
+                            assertTrue(allowedMethods.contains(HttpMethod.GET.toString()));
+                            assertTrue(allowedMethods.contains(HttpMethod.POST.toString()));
+                            assertTrue(allowedMethods.contains(HttpMethod.OPTIONS.toString()));
+                            assertTrue(allowedMethods.contains(HttpMethod.HEAD.toString()));
                         })
                     .build()));
     }

--- a/http-server/src/main/java/io/micronaut/http/server/OptionsFilter.java
+++ b/http-server/src/main/java/io/micronaut/http/server/OptionsFilter.java
@@ -20,20 +20,29 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.order.Ordered;
 import io.micronaut.core.util.StringUtils;
-import io.micronaut.http.*;
-import io.micronaut.http.annotation.RequestFilter;
+import io.micronaut.http.HttpAttributes;
+import io.micronaut.http.HttpHeaders;
+import io.micronaut.http.HttpMethod;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.MutableHttpResponse;
+import io.micronaut.http.annotation.ResponseFilter;
 import io.micronaut.http.annotation.ServerFilter;
 import io.micronaut.http.server.cors.CorsUtil;
-import io.micronaut.web.router.Router;
-import io.micronaut.web.router.UriRouteMatch;
 import io.micronaut.web.router.RouteMatch;
+import io.micronaut.web.router.UriRouteMatch;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import static io.micronaut.http.annotation.Filter.MATCH_ALL_PATTERN;
 import static io.micronaut.http.server.cors.CorsFilter.CORS_FILTER_ORDER;
 
 /**
  * This Filter intercepts HTTP OPTIONS requests which are not CORS Preflight requests.
- * It responds with a NO_CONTENT(204) response, and it populates the Allow HTTP Header with the supported HTTP methods for the request URI.
+ * It responds with an OK(200) response, and it populates the Allow HTTP Header with the supported HTTP methods for the request URI.
  * @author Sergio del Amo
  * @since 4.2.0
  */
@@ -45,20 +54,10 @@ public final class OptionsFilter implements Ordered {
     @SuppressWarnings("WeakerAccess")
     public static final String PREFIX = HttpServerConfiguration.PREFIX + ".dispatch-options-requests";
 
-    private final Router router;
-
-    /**
-     *
-     * @param router Router
-     */
-    public OptionsFilter(Router router) {
-        this.router = router;
-    }
-
-    @RequestFilter
+    @ResponseFilter
     @Nullable
     @Internal
-    public HttpResponse<?> filterRequest(HttpRequest<?> request) {
+    public HttpResponse<?> filterResponse(HttpRequest<?> request, MutableHttpResponse<?> response) {
         if (request.getMethod() != HttpMethod.OPTIONS) {
             return null; // proceed
         }
@@ -68,13 +67,15 @@ public final class OptionsFilter implements Ordered {
         if (hasOptionsRouteMatch(request)) {
             return null; // proceed
         }
-        MutableHttpResponse<?> mutableHttpResponse = HttpResponse.status(HttpStatus.OK);
-        router.findAny(request.getUri().toString(), request)
-            .map(UriRouteMatch::getHttpMethod)
-            .map(HttpMethod::toString)
-            .forEach(allow -> mutableHttpResponse.header(HttpHeaders.ALLOW, allow));
-        mutableHttpResponse.header(HttpHeaders.ALLOW, HttpMethod.OPTIONS.toString());
-        return mutableHttpResponse;
+        if (HttpStatus.METHOD_NOT_ALLOWED.equals(response.getStatus())) {
+            List<String> allowedMethods = response.getHeaders().get(HttpHeaders.ALLOW, String[].class)
+                .map(allow -> new ArrayList<>(Arrays.asList(allow))).orElse(new ArrayList<>());
+            allowedMethods.add(HttpMethod.OPTIONS.toString());
+            response.getHeaders().remove(HttpHeaders.ALLOW);
+            response.getHeaders().allowGeneric(allowedMethods);
+            response.status(HttpStatus.OK);
+        }
+        return response;
     }
 
     private boolean hasOptionsRouteMatch(HttpRequest<?> request) {

--- a/http-server/src/test/groovy/io/micronaut/http/server/OptionsFilterSpec.groovy
+++ b/http-server/src/test/groovy/io/micronaut/http/server/OptionsFilterSpec.groovy
@@ -4,14 +4,13 @@ import io.micronaut.core.order.OrderUtil
 import io.micronaut.core.order.Ordered
 import io.micronaut.http.server.cors.CorsFilter
 import io.micronaut.http.server.util.HttpHostResolver
-import io.micronaut.web.router.Router
 import spock.lang.Specification
 
 class OptionsFilterSpec extends Specification {
 
     void "OptionsFilter after CorsFilter"() {
         given:
-        OptionsFilter optionsFilter = new OptionsFilter(Mock(Router))
+        OptionsFilter optionsFilter = new OptionsFilter()
         CorsFilter corsFilter = new CorsFilter(Mock(HttpServerConfiguration.CorsConfiguration), Mock(HttpHostResolver))
 
         when:


### PR DESCRIPTION
OptionsFilter is updated to act upon the response and ensure that the `Allow` header is only written one time.

The filter was previously not working as expected with any of the Servlet implementations (including cloud 
functions). The problem being that an initial response has already been generated in the `onRouteMiss` method 
of `RequestLifecycle` and the `Allow` header has already been set using the same route lookup logic that was 
implemented in this filter. The result was that there would be multiple `Allow` headers emitted, containing mostly 
duplicate values.

The approach I've taken is to turn this filter into a `ResponseFilter` that relies on the fact that the allowed 
methods have already been set in the `RequestLifecycle` if there is not any explicit `Options` route implemented by 
the user.

Ultimately this simplifies things a bit, as we no longer need to look up the allowed routes here in the filter. 

Additionally, this ensures that the `Allow` header will only be emitted once, with a comma separated list of 
acceptable methods. The implementation was previously writing out multiple `Allow` headers each with a single method 
value. While this is technically allowed by the HTTP spec, I think single multi-valued header format is 
cleaner and less surprising.

This should clear the way further for being able to successfully update the Micronaut Core dependency to 4.2.x in Servlet, GCP, AWS, etc.