### PR TITLE
Fix identification getters / setters for properties with second upper case symbol. For example eTemperature

### DIFF
--- a/core/src/main/java/io/micronaut/core/naming/NameUtils.java
+++ b/core/src/main/java/io/micronaut/core/naming/NameUtils.java
@@ -290,8 +290,9 @@ public class NameUtils {
             int len = methodName.length();
             int prefixLength = writePrefix.length();
             if (len > prefixLength && methodName.startsWith(writePrefix)) {
-                char nextChar = methodName.charAt(prefixLength);
-                isValid = isValidCharacterAfterReaderWriterPrefix(nextChar);
+                char firstVarNameChar = methodName.charAt(prefixLength);
+                Character secondVarNameChar = len > prefixLength + 1 ? methodName.charAt(prefixLength + 1) : null;
+                isValid = isValidCharacterAfterReaderWriterPrefix(firstVarNameChar, secondVarNameChar);
             }
 
             if (isValid) {
@@ -426,7 +427,8 @@ public class NameUtils {
             int len = methodName.length();
             if (len > prefixLength) {
                 char firstVarNameChar = methodName.charAt(prefixLength);
-                isValid = isValidCharacterAfterReaderWriterPrefix(firstVarNameChar);
+                Character secondVarNameChar = len > prefixLength + 1 ? methodName.charAt(prefixLength + 1) : null;
+                isValid = isValidCharacterAfterReaderWriterPrefix(firstVarNameChar, secondVarNameChar);
             }
 
             if (isValid) {
@@ -437,8 +439,11 @@ public class NameUtils {
         return isValid;
     }
 
-    private static boolean isValidCharacterAfterReaderWriterPrefix(char c) {
-        return c == '_' || c == '$' || Character.isUpperCase(c);
+    private static boolean isValidCharacterAfterReaderWriterPrefix(char c, @Nullable Character nextChar) {
+        return c == '_' || c == '$' || Character.isUpperCase(c)
+                // case with properties with second uupercase letter. For example `eTemperature`
+                // valid getter name will be `geteTemperature`
+                || (nextChar != null && Character.isLowerCase(c) && Character.isUpperCase(nextChar));
     }
 
     /**
@@ -562,8 +567,14 @@ public class NameUtils {
                 return propertyName;
             case 1:
                 return prefix + propertyName.toUpperCase(Locale.ENGLISH);
-            default:
-                return prefix + Character.toUpperCase(propertyName.charAt(0)) + propertyName.substring(1);
+            default: {
+                var firstChar = propertyName.charAt(0);
+                var secondChar = propertyName.charAt(1);
+                if (Character.isLowerCase(firstChar) && Character.isUpperCase(secondChar)) {
+                    return prefix + propertyName;
+                }
+                return prefix + Character.toUpperCase(firstChar) + propertyName.substring(1);
+            }
         }
     }
 

--- a/core/src/test/groovy/io/micronaut/core/naming/NameUtilsSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/naming/NameUtilsSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -339,6 +339,12 @@ class NameUtilsSpec extends Specification {
         "getFoo"  | ["get"]         | true
         'get$foo' | ["get"]         | true
         'get_foo' | ["get"]         | true
+        'getfRo'  | ["get"]         | true
+        'get$__$A'| ["get"]         | true
+        'getf_A'  | ["get"]         | false
+        'getF_A'  | ["get"]         | true
+        'getF$A'  | ["get"]         | true
+        'getA'    | ["get"]         | true
         "getfoo"  | ["get"]         | false
         "a"       | ["get"]         | false
         "foo"     | ["with"]        | false
@@ -366,6 +372,12 @@ class NameUtilsSpec extends Specification {
         "setFoo"  | ["set"]         | true
         'set$foo' | ["set"]         | true
         'set_foo' | ["set"]         | true
+        'setfRo'  | ["set"]         | true
+        'set$__$A'| ["set"]         | true
+        'setf_A'  | ["set"]         | false
+        'setF_A'  | ["set"]         | true
+        'setF$A'  | ["set"]         | true
+        'setA'    | ["set"]         | true
         "setfoo"  | ["set"]         | false
         "a"       | ["set"]         | false
         "foo"     | ["with"]        | false
@@ -380,6 +392,7 @@ class NameUtilsSpec extends Specification {
         "setfoo"  | ["set", "with"] | false
         "withFoo" | ["set", "with"] | true
         "withfoo" | ["set", "with"] | false
+        "setorXyz"| ["set"]         | false
     }
 
     void "test getPropertyNameForGetter (#getter, #prefixes)"() {
@@ -397,6 +410,13 @@ class NameUtilsSpec extends Specification {
         "is"      | [""]            | "is"
         "getFoo"  | ["get", "with"] | "foo"
         "withFoo" | ["get", "with"] | "foo"
+        'get$foo' | ["get"]         | '$foo'
+        'get_foo' | ["get"]         | '_foo'
+        'getfRo'  | ["get"]         | 'fRo'
+        'get$__$A'| ["get"]         | '$__$A'
+        'getF_A'  | ["get"]         | 'f_A'
+        'getF$A'  | ["get"]         | 'f$A'
+        'getA'    | ["get"]         | 'a'
     }
 
     void "test getPropertyNameForSetter (#setter, #prefixes)"() {
@@ -414,6 +434,13 @@ class NameUtilsSpec extends Specification {
         "is"      | [""]            | "is"
         "setFoo"  | ["set", "with"] | "foo"
         "withFoo" | ["set", "with"] | "foo"
+        'set$foo' | ["set"]         | '$foo'
+        'set_foo' | ["set"]         | '_foo'
+        'setfRo'  | ["set"]         | 'fRo'
+        'set$__$A'| ["set"]         | '$__$A'
+        'setF_A'  | ["set"]         | 'f_A'
+        'setF$A'  | ["set"]         | 'f$A'
+        'setA'    | ["set"]         | 'a'
     }
 
     void "test getterNameFor (#name, #prefixes)"() {
@@ -429,6 +456,13 @@ class NameUtilsSpec extends Specification {
         "fooBar" | ["with"]        | "withFooBar"
         "fooBar" | ["set", "with"] | "setFooBar"
         "fooBar" | ["with", "set"] | "withFooBar"
+        '$foo'   | ["get"]         | 'get$foo'
+        '_foo'   | ["get"]         | 'get_foo'
+        'fRo'    | ["get"]         | 'getfRo'
+        '$__$A'  | ["get"]         | 'get$__$A'
+        'f_A'    | ["get"]         | 'getF_A'
+        'f$A'    | ["get"]         | 'getF$A'
+        'a'      | ["get"]         | 'getA'
     }
 
     void "test setterNameFor (#name, #prefixes)"() {
@@ -444,6 +478,13 @@ class NameUtilsSpec extends Specification {
         "fooBar" | ["with"]        | "withFooBar"
         "fooBar" | ["set", "with"] | "setFooBar"
         "fooBar" | ["with", "set"] | "withFooBar"
+        '$foo'   | ["set"]         | 'set$foo'
+        '_foo'   | ["set"]         | 'set_foo'
+        'fRo'    | ["set"]         | 'setfRo'
+        '$__$A'  | ["set"]         | 'set$__$A'
+        'f_A'    | ["set"]         | 'setF_A'
+        'f$A'    | ["set"]         | 'setF$A'
+        'a'      | ["set"]         | 'setA'
     }
 
 }


### PR DESCRIPTION
Related issue https://github.com/micronaut-projects/micronaut-openapi/issues/1226