### PR TITLE
Replace chunked write API

### DIFF
--- a/http-netty/src/main/java/io/micronaut/http/netty/body/NettyWriteContext.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/body/NettyWriteContext.java
@@ -20,12 +20,12 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.handler.codec.http.FullHttpResponse;
-import io.netty.handler.codec.http.HttpChunkedInput;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpResponse;
 import org.reactivestreams.Publisher;
 
-import java.io.RandomAccessFile;
+import java.io.InputStream;
+import java.util.concurrent.ExecutorService;
 
 /**
  * This interface is used to write the different kinds of netty responses.
@@ -68,20 +68,11 @@ public interface NettyWriteContext {
     void writeStreamed(@NonNull HttpResponse response, @NonNull Publisher<HttpContent> content);
 
     /**
-     * Write a response with a {@link HttpChunkedInput} body.
+     * Write a response with a body that is a blocking stream.
      *
-     * @param response     The response. <b>Must not</b> be a {@link FullHttpResponse}
-     * @param chunkedInput The response body
+     * @param response        The response. <b>Must not</b> be a {@link FullHttpResponse}
+     * @param stream          The stream to read from
+     * @param executorService The executor for IO operations
      */
-    void writeChunked(@NonNull HttpResponse response, @NonNull HttpChunkedInput chunkedInput);
-
-    /**
-     * Write a response with a body that is a section of a {@link RandomAccessFile}.
-     *
-     * @param response         The response. <b>Must not</b> be a {@link FullHttpResponse}
-     * @param randomAccessFile File to read from
-     * @param position         Start position
-     * @param contentLength    Length of the section to send
-     */
-    void writeFile(@NonNull HttpResponse response, @NonNull RandomAccessFile randomAccessFile, long position, long contentLength);
+    void writeStream(@NonNull HttpResponse response, @NonNull InputStream stream, @NonNull ExecutorService executorService);
 }

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/body/SystemFileBodyWriter.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/body/SystemFileBodyWriter.java
@@ -48,7 +48,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.RandomAccessFile;
 import java.util.concurrent.ExecutorService;
 
 import static io.micronaut.http.HttpHeaders.CONTENT_RANGE;
@@ -171,24 +170,6 @@ public final class SystemFileBodyWriter extends AbstractFileBodyWriter implement
         IntRange(long firstPos, long lastPos) {
             this.firstPos = firstPos;
             this.lastPos = lastPos;
-        }
-    }
-
-    private static class RafInputStream extends InputStream {
-        private final RandomAccessFile raf;
-
-        RafInputStream(RandomAccessFile raf) {
-            this.raf = raf;
-        }
-
-        @Override
-        public int read() throws IOException {
-            return raf.read();
-        }
-
-        @Override
-        public int read(@NotNull byte[] b, int off, int len) throws IOException {
-            return raf.read(b, off, len);
         }
     }
 

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/PipeliningServerHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/PipeliningServerHandler.java
@@ -30,13 +30,11 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.EventLoop;
-import io.netty.channel.FileRegion;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
-import io.netty.handler.codec.http.HttpChunkedInput;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
@@ -303,24 +301,6 @@ public final class PipeliningServerHandler extends ChannelInboundHandlerAdapter 
          * @see #channelReadComplete
          */
         void readComplete() {
-        }
-    }
-
-    /**
-     * Wrapper class for a netty response with a special body type, like
-     * {@link HttpChunkedInput} or
-     * {@link FileRegion}.
-     *
-     * @param response The response
-     * @param body     The body, or {@code null} if there is no body
-     * @param needLast Whether to finish the response with a
-     *                 {@link LastHttpContent}
-     */
-    private record CustomResponse(HttpResponse response, @Nullable Object body, boolean needLast) {
-        CustomResponse {
-            if (response instanceof FullHttpResponse) {
-                throw new IllegalArgumentException("Response must not be a FullHttpResponse to send a special body");
-            }
         }
     }
 

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/PipeliningServerHandler.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/handler/PipeliningServerHandler.java
@@ -18,13 +18,10 @@ package io.micronaut.http.server.netty.handler;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
-import io.micronaut.core.util.SupplierUtil;
-import io.micronaut.http.exceptions.MessageBodyException;
 import io.micronaut.http.netty.body.NettyWriteContext;
 import io.micronaut.http.netty.stream.DelegateStreamedHttpRequest;
 import io.micronaut.http.netty.stream.EmptyHttpRequest;
 import io.micronaut.http.netty.stream.StreamedHttpResponse;
-import io.micronaut.http.server.netty.SmartHttpContentCompressor;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.CompositeByteBuf;
@@ -32,11 +29,11 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
-import io.netty.channel.DefaultFileRegion;
 import io.netty.channel.EventLoop;
 import io.netty.channel.FileRegion;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpChunkedInput;
@@ -49,15 +46,8 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
-import io.netty.handler.stream.ChunkedFile;
-import io.netty.handler.stream.ChunkedInput;
 import io.netty.handler.timeout.IdleState;
 import io.netty.handler.timeout.IdleStateEvent;
-import io.netty.util.AttributeKey;
-import io.netty.util.ReferenceCountUtil;
-import io.netty.util.ResourceLeakDetector;
-import io.netty.util.ResourceLeakDetectorFactory;
-import io.netty.util.ResourceLeakTracker;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -67,15 +57,15 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Sinks;
 import reactor.util.concurrent.Queues;
 
-import java.io.IOException;
-import java.io.RandomAccessFile;
-import java.nio.channels.FileChannel;
+import java.io.InputStream;
+import java.io.InterruptedIOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Queue;
-import java.util.function.Supplier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 
 /**
  * Netty handler that handles incoming {@link HttpRequest}s and forwards them to a
@@ -86,9 +76,6 @@ import java.util.function.Supplier;
  */
 @Internal
 public final class PipeliningServerHandler extends ChannelInboundHandlerAdapter {
-    public static final Supplier<AttributeKey<SmartHttpContentCompressor>> ZERO_COPY_PREDICATE =
-        SupplierUtil.memoized(() -> AttributeKey.newInstance("zero-copy-predicate"));
-
     private static final int LENGTH_8K = 8192;
     private static final Logger LOG = LoggerFactory.getLogger(PipeliningServerHandler.class);
 
@@ -673,39 +660,10 @@ public final class PipeliningServerHandler extends ChannelInboundHandlerAdapter 
             content.subscribe(new StreamingOutboundHandler(this, response));
         }
 
-        /**
-         * Write a response with a special body
-         * ({@link io.netty.handler.codec.http.HttpChunkedInput},
-         * {@link io.micronaut.http.server.types.files.SystemFile}).
-         *
-         * @param response The response to write
-         */
-        private void writeStreamed(CustomResponse response) {
-            preprocess(response.response());
-            write(new ChunkedOutboundHandler(this, response));
-        }
-
         @Override
-        public void writeChunked(HttpResponse response, HttpChunkedInput chunkedInput) {
-            writeStreamed(new CustomResponse(response, chunkedInput, false));
-        }
-
-        @Override
-        public void writeFile(HttpResponse response, RandomAccessFile randomAccessFile, long position, long contentLength) {
-            SmartHttpContentCompressor predicate = ctx.channel().attr(ZERO_COPY_PREDICATE.get()).get();
-            if (predicate != null && predicate.shouldSkip(response)) {
-                // SSL not enabled - can use zero-copy file transfer.
-                writeStreamed(new CustomResponse(response, new TrackedDefaultFileRegion(randomAccessFile.getChannel(), position, contentLength), true));
-            } else {
-                // SSL enabled - cannot use zero-copy file transfer.
-                try {
-                    // HttpChunkedInput will write the end marker (LastHttpContent) for us.
-                    final HttpChunkedInput chunkedInput = new HttpChunkedInput(new TrackedChunkedFile(randomAccessFile, position, contentLength, LENGTH_8K));
-                    writeStreamed(new CustomResponse(response, chunkedInput, false));
-                } catch (IOException e) {
-                    throw new MessageBodyException("Could not read file", e);
-                }
-            }
+        public void writeStream(HttpResponse response, InputStream stream, ExecutorService executorService) {
+            preprocess(response);
+            write(new BlockingOutboundHandler(this, response, stream, executorService));
         }
     }
 
@@ -912,89 +870,154 @@ public final class PipeliningServerHandler extends ChannelInboundHandlerAdapter 
         }
     }
 
-    /**
-     * Handler that writes a files etc.
-     */
-    private final class ChunkedOutboundHandler extends OutboundHandler {
-        private final CustomResponse message;
+    private final class BlockingOutboundHandler extends OutboundHandler {
+        private static final int QUEUE_SIZE = 2;
 
-        ChunkedOutboundHandler(OutboundAccess outboundAccess, CustomResponse message) {
+        private final HttpResponse response;
+        private final InputStream stream;
+        private final ExecutorService blockingExecutor;
+
+        private final Queue<ByteBuf> queue = new ArrayDeque<>(QUEUE_SIZE);
+        private Future<?> worker = null;
+        private boolean workerReady = false;
+        private boolean discard = false;
+        private boolean done = false;
+        private boolean producerWaiting = false;
+        private boolean consumerWaiting = false;
+
+        BlockingOutboundHandler(
+            OutboundAccess outboundAccess,
+            HttpResponse response,
+            InputStream stream,
+            ExecutorService blockingExecutor) {
             super(outboundAccess);
-            this.message = message;
+            this.response = response;
+            this.stream = stream;
+            this.blockingExecutor = blockingExecutor;
         }
 
         @Override
         void writeSome() {
-            boolean responseIsLast = message.body() == null && !message.needLast();
-            write(message.response(), responseIsLast, responseIsLast && outboundAccess.closeAfterWrite);
-            if (message.body() != null) {
-                boolean bodyIsLast = !message.needLast();
-                write(message.body(), bodyIsLast, bodyIsLast && outboundAccess.closeAfterWrite);
+            if (worker == null) {
+                write(response, false, false);
+                worker = blockingExecutor.submit(this::work);
             }
-            if (message.needLast()) {
-                write(LastHttpContent.EMPTY_LAST_CONTENT, true, outboundAccess.closeAfterWrite);
-            }
-            outboundHandler = null;
-            requestHandler.responseWritten(outboundAccess.attachment);
-            PipeliningServerHandler.this.writeSome();
+            do {
+                ByteBuf msg;
+                synchronized (this) {
+                    if (producerWaiting) {
+                        producerWaiting = false;
+                        notifyAll();
+                    }
+                    msg = queue.poll();
+                    if (msg == null && !this.done) {
+                        consumerWaiting = true;
+                        break;
+                    }
+                }
+                if (msg == null) {
+                    // this.done == true inside the synchronized block
+                    write(LastHttpContent.EMPTY_LAST_CONTENT, true, false);
+
+                    outboundHandler = null;
+                    requestHandler.responseWritten(outboundAccess.attachment);
+                    PipeliningServerHandler.this.writeSome();
+                    break;
+                } else {
+                    write(new DefaultHttpContent(msg), true, false);
+                }
+            } while (ctx.channel().isWritable());
         }
 
         @Override
         void discard() {
-            ReferenceCountUtil.release(message.response());
-            if (message.body() instanceof ChunkedInput<?> ci) {
-                try {
-                    ci.close();
-                } catch (Exception e) {
-                    if (LOG.isWarnEnabled()) {
-                        LOG.warn("Failed to close ChunkedInput", e);
+            discard = true;
+            if (worker == null) {
+                worker = blockingExecutor.submit(this::work);
+            } else {
+                synchronized (this) {
+                    if (workerReady) {
+                        worker.cancel(true);
+                        // in case the worker was already done, drain buffers
+                        drain();
+                    } // else worker is still setting up and will see the discard flag in due time
+                }
+            }
+        }
+
+        private void work() {
+            ByteBuf buf = null;
+            try (InputStream stream = this.stream) {
+                synchronized (this) {
+                    this.workerReady = true;
+                    if (this.discard) {
+                        // don't read
+                        return;
                     }
                 }
-            } else if (message.body() instanceof FileRegion fr) {
-                fr.release();
+                while (true) {
+                    buf = ctx.alloc().heapBuffer(LENGTH_8K);
+                    int n = buf.writeBytes(stream, LENGTH_8K);
+                    synchronized (this) {
+                        if (n == -1) {
+                            done = true;
+                            wakeConsumer();
+                            break;
+                        }
+                        while (queue.size() >= QUEUE_SIZE && !discard) {
+                            producerWaiting = true;
+                            wait();
+                        }
+                        if (discard) {
+                            break;
+                        }
+                        queue.add(buf);
+                        // buf is now owned by the queue
+                        buf = null;
+
+                        wakeConsumer();
+                    }
+                }
+            } catch (InterruptedException | InterruptedIOException ignored) {
+            } catch (Exception e) {
+                if (LOG.isWarnEnabled()) {
+                    LOG.warn("InputStream threw an error during read. This error cannot be forwarded to the client. Please make sure any errors are thrown by the controller instead.", e);
+                }
+            } finally {
+                // if we failed to add a buffer to the queue, release it
+                if (buf != null) {
+                    buf.release();
+                }
+                synchronized (this) {
+                    done = true;
+
+                    if (discard) {
+                        drain();
+                    }
+                }
             }
-            outboundHandler = null;
-        }
-    }
-
-    private static class TrackedDefaultFileRegion extends DefaultFileRegion {
-        //to avoid initializing Netty at build time
-        private static final Supplier<ResourceLeakDetector<TrackedDefaultFileRegion>> LEAK_DETECTOR = SupplierUtil.memoized(() ->
-            ResourceLeakDetectorFactory.instance().newResourceLeakDetector(TrackedDefaultFileRegion.class));
-
-        private final ResourceLeakTracker<TrackedDefaultFileRegion> tracker;
-
-        public TrackedDefaultFileRegion(FileChannel fileChannel, long position, long count) {
-            super(fileChannel, position, count);
-            this.tracker = LEAK_DETECTOR.get().track(this);
         }
 
-        @Override
-        protected void deallocate() {
-            super.deallocate();
-            if (tracker != null) {
-                tracker.close(this);
+        private void wakeConsumer() {
+            assert Thread.holdsLock(this);
+
+            if (!discard && consumerWaiting) {
+                consumerWaiting = false;
+                ctx.executor().execute(PipeliningServerHandler.this::writeSome);
             }
         }
-    }
 
-    private static class TrackedChunkedFile extends ChunkedFile {
-        //to avoid initializing Netty at build time
-        private static final Supplier<ResourceLeakDetector<TrackedChunkedFile>> LEAK_DETECTOR = SupplierUtil.memoized(() ->
-            ResourceLeakDetectorFactory.instance().newResourceLeakDetector(TrackedChunkedFile.class));
+        private void drain() {
+            assert Thread.holdsLock(this);
 
-        private final ResourceLeakTracker<TrackedChunkedFile> tracker;
-
-        public TrackedChunkedFile(RandomAccessFile file, long offset, long length, int chunkSize) throws IOException {
-            super(file, offset, length, chunkSize);
-            this.tracker = LEAK_DETECTOR.get().track(this);
-        }
-
-        @Override
-        public void close() throws Exception {
-            super.close();
-            if (tracker != null) {
-                tracker.close(this);
+            ByteBuf buf;
+            while (true) {
+                buf = queue.poll();
+                if (buf != null) {
+                    buf.release();
+                } else {
+                    break;
+                }
             }
         }
     }

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/stream/StreamPressureSpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/stream/StreamPressureSpec.groovy
@@ -1,0 +1,101 @@
+package io.micronaut.http.server.netty.stream
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.io.buffer.ByteBuffer
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.StreamingHttpClient
+import io.micronaut.runtime.server.EmbeddedServer
+import reactor.core.publisher.Flux
+import spock.lang.Specification
+
+import java.util.concurrent.ThreadLocalRandom
+
+class StreamPressureSpec extends Specification {
+    def 'producer pressure'() {
+        given:
+        def data = new byte[1024 * 1024 * 4]
+        ThreadLocalRandom.current().nextBytes(data)
+
+        def ctx = ApplicationContext.run(['spec.name': 'StreamPressureSpec'])
+        ctx.getBean(MyController).stream = new ByteArrayInputStream(data)
+
+        def server = ctx.getBean(EmbeddedServer)
+        server.start()
+        def client = ctx.createBean(HttpClient, server.URI).toBlocking()
+
+        expect:
+        client.retrieve("/stream-pressure", byte[]) == data
+
+        cleanup:
+        server.stop()
+        client.close()
+        ctx.close()
+    }
+
+    def 'consumer pressure'() {
+        given:
+        def ctx = ApplicationContext.run(['spec.name': 'StreamPressureSpec'])
+
+        byte[] data = new byte[1024 * 1024]
+        ThreadLocalRandom.current().nextBytes(data)
+        def serverStream = new PipedOutputStream()
+        ctx.getBean(MyController).stream = new PipedInputStream(serverStream)
+
+        def clientOStream = new PipedOutputStream()
+        def clientIStream = new PipedInputStream(clientOStream)
+
+        def server = ctx.getBean(EmbeddedServer)
+        server.start()
+        def client = ctx.createBean(StreamingHttpClient, server.URI)
+
+        when:
+        Flux.from(client.dataStream(HttpRequest.GET("/stream-pressure"))).subscribe {
+            clientOStream.write(it.toByteArray())
+        }
+        serverStream.write(data)
+        serverStream.flush()
+        then:
+        clientIStream.readNBytes(data.length) == data
+
+        when:
+        serverStream.write(data)
+        serverStream.flush()
+        then:
+        clientIStream.readNBytes(data.length) == data
+
+        cleanup:
+        serverStream.close()
+        clientIStream.close()
+        server.stop()
+        client.close()
+        ctx.close()
+    }
+
+    private byte[] read(Iterator<ByteBuffer<?>> itr, int n) {
+        byte[] out = new byte[n]
+        int off = 0
+        while (n > 0) {
+            def buf = itr.next()
+            def chunkN = buf.readableBytes()
+            buf.read(out, off, chunkN)
+            off += chunkN
+            n -= chunkN
+        }
+        return out
+    }
+
+    @Requires(property = "spec.name", value = "StreamPressureSpec")
+    @Controller
+    static class MyController {
+        InputStream stream
+
+        @Get("/stream-pressure")
+        InputStream get() {
+            return this.stream
+        }
+    }
+}


### PR DESCRIPTION
This PR replaces the writeChunked and writeFile APIs with a new writeStream API that takes an InputStream. This removes the need for the ChunkedWriteHandler.

Chunked writes were used for two purposes: Sending file regions and sending InputStreams. This has always complicated the HTTP pipeline somewhat as the pipeline had to deal with not just HttpContent objects but also ChunkedInput and FileRegion objects.

This PR replaces the machinery for InputStream writing with a more straight-forward solution that reads the data on the IO thread and then sends it down the channel.

Additionally, the file-specific APIs based on RandomAccessFile are removed. The body writer now just creates an InputStream for the file region in question and sends that. This removes support for zero-copy transfers, however that is a niche feature anyway because it doesn't work with TLS or HTTP/2. If someone wants a performant HTTP server, HTTP/2 takes priority over zero-copy so it makes little sense.

This PR may have small conflicts with #10131 as that PR changed the PipeliningServerHandler body handling a little bit. Otherwise this PR should have no visible impact on users.