### PR TITLE
Optimize cache usage in DefaultConversionService and fix race condition

### DIFF
--- a/core/src/main/java/io/micronaut/core/convert/DefaultConversionService.java
+++ b/core/src/main/java/io/micronaut/core/convert/DefaultConversionService.java
@@ -962,6 +962,20 @@ public class DefaultConversionService implements ConversionService<DefaultConver
             }
         }
 
+        boolean hasFormatting = formattingAnnotation != null;
+        if (hasFormatting) {
+            for (Class sourceSuperType : sourceHierarchy) {
+                for (Class targetSuperType : targetHierarchy) {
+                    ConvertiblePair pair = new ConvertiblePair(sourceSuperType, targetSuperType);
+                    typeConverter = typeConverters.get(pair);
+                    if (typeConverter != null) {
+                        converterCache.put(pair, typeConverter);
+                        return typeConverter;
+                    }
+                }
+            }
+        }
+
         return UNCONVERTIBLE;
     }
 

--- a/core/src/main/java/io/micronaut/core/convert/DefaultConversionService.java
+++ b/core/src/main/java/io/micronaut/core/convert/DefaultConversionService.java
@@ -125,42 +125,19 @@ public class DefaultConversionService implements ConversionService<DefaultConver
             ConvertiblePair pair = new ConvertiblePair(sourceType, targetType, formattingAnnotation);
             TypeConverter typeConverter = converterCache.get(pair);
             if (typeConverter == null) {
-                typeConverter = findTypeConverter(sourceType, targetType, formattingAnnotation);
-                if (typeConverter == null) {
-                    return Optional.empty();
-                } else {
-                    converterCache.put(pair, typeConverter);
-                    if (typeConverter == UNCONVERTIBLE) {
-                        return Optional.empty();
-                    } else {
-                        return typeConverter.convert(object, targetType, context);
-                    }
-                }
-            } else if (typeConverter != UNCONVERTIBLE) {
-                return typeConverter.convert(object, targetType, context);
+                typeConverter = findTypeConverter(pair.source, pair.target, pair.formattingAnnotation);
+                converterCache.put(pair, typeConverter);
             }
+           return typeConverter.convert(object, targetType, context);
         } else {
             ConvertiblePair pair = new ConvertiblePair(sourceType, targetType, null);
             TypeConverter typeConverter = converterCache.get(pair);
             if (typeConverter == null) {
-                typeConverter = findTypeConverter(sourceType, targetType, null);
-                if (typeConverter == null) {
-                    converterCache.put(pair, UNCONVERTIBLE);
-                    return Optional.empty();
-                } else {
-                    converterCache.put(pair, typeConverter);
-                    if (typeConverter == UNCONVERTIBLE) {
-                        return Optional.empty();
-                    } else {
-                        return typeConverter.convert(object, targetType, context);
-                    }
-                }
-            } else if (typeConverter != UNCONVERTIBLE) {
-                return typeConverter.convert(object, targetType, context);
+                typeConverter = findTypeConverter(pair.source, pair.target, pair.formattingAnnotation);
+                converterCache.put(pair, typeConverter);
             }
+            return typeConverter.convert(object, targetType, context);
         }
-
-        return Optional.empty();
     }
 
     @Override
@@ -168,12 +145,8 @@ public class DefaultConversionService implements ConversionService<DefaultConver
         ConvertiblePair pair = new ConvertiblePair(sourceType, targetType, null);
         TypeConverter typeConverter = converterCache.get(pair);
         if (typeConverter == null) {
-            typeConverter = findTypeConverter(sourceType, targetType, null);
-            if (typeConverter != null) {
-                converterCache.put(pair, typeConverter);
-                return typeConverter != UNCONVERTIBLE;
-            }
-            return false;
+            typeConverter = findTypeConverter(pair.source, pair.target, pair.formattingAnnotation);
+            converterCache.put(pair, typeConverter);
         }
         return typeConverter != UNCONVERTIBLE;
     }
@@ -202,7 +175,7 @@ public class DefaultConversionService implements ConversionService<DefaultConver
      * @since 3.5.3
      */
     @Internal
-    public void reset() {
+    public synchronized void reset() {
         typeConverters.clear();
         converterCache.clear();
         registerDefaultConverters();
@@ -212,7 +185,7 @@ public class DefaultConversionService implements ConversionService<DefaultConver
      * Default Converters.
      */
     @SuppressWarnings({"OptionalIsPresent", "unchecked"})
-    protected void registerDefaultConverters() {
+    protected synchronized void registerDefaultConverters() {
         // primitive array to wrapper array
         @SuppressWarnings("rawtypes")
         Function primitiveArrayToWrapperArray = ArrayUtils::toWrapperArray;
@@ -974,8 +947,8 @@ public class DefaultConversionService implements ConversionService<DefaultConver
      * @param <T> Generic type
      * @return type converter
      */
-    protected <T> TypeConverter findTypeConverter(Class<?> sourceType, Class<T> targetType, String formattingAnnotation) {
-        TypeConverter typeConverter = UNCONVERTIBLE;
+    protected synchronized  <T> TypeConverter findTypeConverter(Class<?> sourceType, Class<T> targetType, String formattingAnnotation) {
+        TypeConverter typeConverter = null;
         List<Class> sourceHierarchy = ClassUtils.resolveHierarchy(sourceType);
         List<Class> targetHierarchy = ClassUtils.resolveHierarchy(targetType);
         for (Class sourceSuperType : sourceHierarchy) {
@@ -988,20 +961,8 @@ public class DefaultConversionService implements ConversionService<DefaultConver
                 }
             }
         }
-        boolean hasFormatting = formattingAnnotation != null;
-        if (hasFormatting) {
-            for (Class sourceSuperType : sourceHierarchy) {
-                for (Class targetSuperType : targetHierarchy) {
-                    ConvertiblePair pair = new ConvertiblePair(sourceSuperType, targetSuperType);
-                    typeConverter = typeConverters.get(pair);
-                    if (typeConverter != null) {
-                        converterCache.put(pair, typeConverter);
-                        return typeConverter;
-                    }
-                }
-            }
-        }
-        return typeConverter;
+
+        return UNCONVERTIBLE;
     }
 
     private SimpleDateFormat resolveFormat(ConversionContext context) {


### PR DESCRIPTION
The usage of `typeConverters` and `converterCache` are optimized. 

1) Redundant operations are removed, which boosts the performance (according to the  `ConversionServiceBenchmark`) at ~ 2x.

2) The synchronized keyword is added to the critical methods that can be called from several threads. Now `typeConverters` and `converterCache` are consistent.

Here are the benchmark results that I've run on my Macbook 2,6 GHz 6-Core Intel Core i7, jdk-11.0.12.jdk:

```
Benchmark                                     Mode  Cnt         Score          Error  Units

Baseline:
ConversionServiceBenchmark.convertCacheHit   thrpt    5  27404123.384 ± 5692431.522  ops/s
ConversionServiceBenchmark.convertCacheMiss  thrpt    5   4923550.293 ±  461767.609  ops/s

Refactored (1):
ConversionServiceBenchmark.convertCacheHit   thrpt    5  48408342.853 ± 9369123.821  ops/s
ConversionServiceBenchmark.convertCacheMiss  thrpt    5   4842578.352 ±   34813.903  ops/s

Refactored + synchronized (1 + 2):
ConversionServiceBenchmark.convertCacheHit   thrpt    5  38918162.398 ± 10242478.879  ops/s
ConversionServiceBenchmark.convertCacheMiss  thrpt    5   4512350.735 ±   981537.261  ops/s
```