### PR TITLE
[bug] EL fails when using primitive method arguments in expression

### DIFF
--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/access/ContextMethodParameterAccess.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/access/ContextMethodParameterAccess.java
@@ -58,7 +58,11 @@ final class ContextMethodParameterAccess extends ExpressionNode {
         // invoke getArgument method
         mv.invokeInterface(EVALUATION_CONTEXT_TYPE, GET_ARGUMENT_METHOD);
         if (nodeType != null) {
-            mv.checkCast(nodeType);
+            if (TypeDescriptors.isPrimitive(nodeType)) {
+                mv.unbox(nodeType);
+            } else {
+                mv.checkCast(nodeType);
+            }
         }
     }
 

--- a/inject-java/src/test/groovy/io/micronaut/expressions/MethodArgumentEvaluationContextExpressionsSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/expressions/MethodArgumentEvaluationContextExpressionsSpec.groovy
@@ -29,4 +29,51 @@ class MethodArgumentEvaluationContextExpressionsSpec extends AbstractEvaluatedEx
         result instanceof String && result == 'arg1abc'
     }
 
+    void "test wrapped value method argument access"() {
+        given:
+        Object result = evaluateSingle("test.Expr", """
+            package test;
+            import io.micronaut.context.annotation.Executable;
+            import io.micronaut.context.annotation.Requires;
+            import jakarta.inject.Singleton;
+
+            @Singleton
+            class Expr {
+
+                @Executable
+                @Requires(value = "#{ #second + 'abc' }")
+                void test(String first, Integer second) {
+                }
+            }
+
+
+        """, ["arg0", 100] as Object[])
+
+        expect:
+        result instanceof String && result == '100abc'
+    }
+
+    void "test primitive value method argument access"() {
+        given:
+        Object result = evaluateSingle("test.Expr", """
+            package test;
+            import io.micronaut.context.annotation.Executable;
+            import io.micronaut.context.annotation.Requires;
+            import jakarta.inject.Singleton;
+
+            @Singleton
+            class Expr {
+
+                @Executable
+                @Requires(value = "#{ #second + 'abc' }")
+                void test(String first, int second) {
+                }
+            }
+
+
+        """, ["arg0", 100] as Object[])
+
+        expect:
+        result instanceof String && result == '100abc'
+    }
 }

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/expressions/MethodArgumentEvaluationContextExpressionsSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/expressions/MethodArgumentEvaluationContextExpressionsSpec.groovy
@@ -1,0 +1,48 @@
+package io.micronaut.kotlin.processing.expressions
+
+import io.micronaut.context.BeanContext
+import io.micronaut.context.expressions.AbstractEvaluatedExpression
+import io.micronaut.context.expressions.DefaultExpressionEvaluationContext
+import spock.lang.Specification;
+import static io.micronaut.annotation.processing.test.KotlinCompiler.buildContext
+
+class MethodArgumentEvaluationContextExpressionsSpec extends Specification {
+
+    String script(String secondParamType) {
+        """
+            package test
+
+            import io.micronaut.context.annotation.Executable
+            import io.micronaut.context.annotation.Requires
+            import jakarta.inject.Singleton
+
+            @Singleton
+            class ${secondParamType}Expr {
+
+                @Executable
+                @Requires(value = "#{ #second + 'abc' }")
+                fun test(first: String, second: $secondParamType) {
+                }
+            }
+        """
+    }
+
+    void "test method argument access with #type"() {
+        given:
+        def ctx = buildContext(script(type))
+
+        def exprClass = (AbstractEvaluatedExpression) ctx.classLoader.loadClass("test.\$${type}Expr\$Expr0").newInstance()
+        String result = exprClass.evaluate(new DefaultExpressionEvaluationContext(null, ["arg0", value] as Object[], ctx.getBean(BeanContext), null))
+
+        expect:
+        result == '100abc'
+
+        cleanup:
+        ctx.close()
+
+        where:
+        type     | value
+        'String' | '100'
+        'Int'    | 100
+    }
+}


### PR DESCRIPTION
The first test in this PR with `Integer` as the argument type works as expected:

```
                @Executable
                @Requires(value = "#{ #second + 'abc' }")
                void test(String first, Integer second) {
                }
```

However, when we use a primitive for the second argument (as in the second test):

```
                @Executable
                @Requires(value = "#{ #second + 'abc' }")
                void test(String first, int second) {
                }
```

We get a `VerifyError`

```
java.lang.VerifyError: Bad type on operand stack
Exception Details:
  Location:
    test/$Expr$Expr4.doEvaluate(Lio/micronaut/core/expressions/ExpressionEvaluationContext;)Ljava/lang/Object; @17: invokevirtual
  Reason:
    Type 'I' (current frame, stack[1]) is not assignable to integer
  Current Frame:
    bci: @17
    flags: { }
    locals: { 'test/$Expr$Expr4', 'io/micronaut/core/expressions/ExpressionEvaluationContext' }
    stack: { 'java/lang/StringBuilder', 'I' }
  Bytecode:
    0000000: bb00 0d59 b700 102b 04b9 0016 0200 c000
    0000010: 18b6 001c 121e b600 21b6 0025 b0       
```

Whilst this can be worked around in Java (by using the wrapper class), in Kotlin we need to introduce our own container class, as it also fails with `Int` as seen in the cache test here https://github.com/micronaut-projects/micronaut-cache/blob/master/test-suite-caffeine-kotlin/src/test/kotlin/io/micronaut/cache/ConditionalService.kt#L14