### PR TITLE
KSP: Resolved type arguments shouldn't be marked as a type variable

### DIFF
--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinTypeArgumentElement.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinTypeArgumentElement.kt
@@ -36,7 +36,7 @@ internal class KotlinTypeArgumentElement(
     resolved.resolvedTypeArguments,
     visitorContext,
     internalArrayDimensions,
-    true
+    false
 ), GenericElement {
 
     private val resolvedTypeAnnotationMetadata: ElementAnnotationMetadata by lazy {

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/beans/BeanDefinitionSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/beans/BeanDefinitionSpec.groovy
@@ -1116,13 +1116,13 @@ interface Deserializer<T> {
             def deserializerTypeParam = definition.getTypeArguments("test.Deserializer")[0]
 
         then: "The first is a placeholder"
-            serdeTypeParam.isTypeVariable() //
-            (serdeTypeParam instanceof GenericPlaceholder)
+            !serdeTypeParam.isTypeVariable()
+            !(serdeTypeParam instanceof GenericPlaceholder)
         and: "threat resolved placeholder as not a type variable"
-            serializerTypeParam.isTypeVariable()
-            (serializerTypeParam instanceof GenericPlaceholder)
-            deserializerTypeParam.isTypeVariable()
-            (deserializerTypeParam instanceof GenericPlaceholder)
+            !serializerTypeParam.isTypeVariable()
+            !(serializerTypeParam instanceof GenericPlaceholder)
+            !deserializerTypeParam.isTypeVariable()
+            !(deserializerTypeParam instanceof GenericPlaceholder)
     }
 
     void "test isTypeVariable array"() {
@@ -1156,15 +1156,15 @@ interface Deserializer<T> {
             // Arrays are not resolved as KotlinClassElements or placeholders
         then: "The first is a placeholder"
             serdeTypeParam.simpleName == "String[]"
-            serdeTypeParam.isTypeVariable()
-            (serdeTypeParam instanceof GenericPlaceholder)
+            !serdeTypeParam.isTypeVariable()
+            !(serdeTypeParam instanceof GenericPlaceholder)
         and: "threat resolved placeholder as not a type variable"
             serializerTypeParam.simpleName == "String[]"
-            serializerTypeParam.isTypeVariable()
-            (serializerTypeParam instanceof GenericPlaceholder)
+            !serializerTypeParam.isTypeVariable()
+            !(serializerTypeParam instanceof GenericPlaceholder)
             deserializerTypeParam.simpleName == "String[]"
-            deserializerTypeParam.isTypeVariable()
-            (deserializerTypeParam instanceof GenericPlaceholder)
+            !deserializerTypeParam.isTypeVariable()
+            !(deserializerTypeParam instanceof GenericPlaceholder)
     }
 
     void "test inline class return type"() {


### PR DESCRIPTION
The tests were corrected to match Java/Groovy equivalent test.

Fixes https://github.com/micronaut-projects/micronaut-core/issues/10117