### PR TITLE
Only add content-length if the request type permits a body.

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -1301,7 +1301,7 @@ public class DefaultHttpClient implements
                 Object bodyValue = body.get();
                 if (bodyValue instanceof CharSequence sequence) {
                     ByteBuf byteBuf = charSequenceToByteBuf(sequence, requestContentType);
-                    FullHttpRequest nettyRequest = withBytes(nettyRequestBuilder.toHttpRequestWithoutBody(), byteBuf);
+                    FullHttpRequest nettyRequest = withBytes(nettyRequestBuilder.toHttpRequestWithoutBody(), byteBuf, true);
                     nettyRequest.setUri(newUri);
                     return new FullRequestWriter(nettyRequest);
                 } else {
@@ -1352,12 +1352,12 @@ public class DefaultHttpClient implements
                 } else {
                     bodyContent = Unpooled.EMPTY_BUFFER;
                 }
-                FullHttpRequest nettyRequest = withBytes(nettyRequestBuilder.toHttpRequestWithoutBody(), bodyContent);
+                FullHttpRequest nettyRequest = withBytes(nettyRequestBuilder.toHttpRequestWithoutBody(), bodyContent, true);
                 nettyRequest.setUri(newUri);
                 return new FullRequestWriter(nettyRequest);
             }
         } else {
-            FullHttpRequest nettyRequest = withBytes(nettyRequestBuilder.toHttpRequestWithoutBody(), Unpooled.EMPTY_BUFFER);
+            FullHttpRequest nettyRequest = withBytes(nettyRequestBuilder.toHttpRequestWithoutBody(), Unpooled.EMPTY_BUFFER, false);
             nettyRequest.setUri(newUri);
             return new FullRequestWriter(nettyRequest);
         }
@@ -1373,10 +1373,12 @@ public class DefaultHttpClient implements
         }
     }
 
-    private static FullHttpRequest withBytes(HttpRequest request, ByteBuf bytes) {
+    private static FullHttpRequest withBytes(HttpRequest request, ByteBuf bytes, boolean permitsBody) {
         HttpHeaders headers = request.headers();
         headers.remove(HttpHeaderNames.TRANSFER_ENCODING);
-        headers.set(HttpHeaderNames.CONTENT_LENGTH, bytes.readableBytes());
+        if(permitsBody) {
+            headers.set(HttpHeaderNames.CONTENT_LENGTH, bytes.readableBytes());
+        }
         return new DefaultFullHttpRequest(
             request.protocolVersion(),
             request.method(),


### PR DESCRIPTION
Currently, `DefaultHttpClient.java` sends a `Content-Length: 0` for GET requests. This can cause issues, for example in AWS ALBs, which will most often refuse the request.

For more info on the AWS ALB issue, see https://stackoverflow.com/questions/77288320/aws-application-load-balancer-rejecting-requests-with-content-length-0

The PR makes sure that the content-length header is not included for requests that do not permit a body, such as GET requests.