### PR TITLE
imp: don't send Content-length header for GET requests

### DIFF
--- a/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/HttpRequestFactory.java
+++ b/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/HttpRequestFactory.java
@@ -21,6 +21,7 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.core.type.Argument;
 import io.micronaut.http.HttpHeaders;
+import io.micronaut.http.HttpMethod;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.client.HttpClientConfiguration;
 import io.micronaut.http.codec.MediaTypeCodec;
@@ -56,8 +57,12 @@ public final class HttpRequestFactory {
     ) {
         final HttpRequest.Builder builder = HttpRequest.newBuilder().uri(uri);
         configuration.getReadTimeout().ifPresent(builder::timeout);
-        HttpRequest.BodyPublisher bodyPublisher = publisherForRequest(request, bodyType, mediaTypeCodecRegistry);
-        builder.method(request.getMethod().toString(), bodyPublisher);
+        if (request.getMethod() == HttpMethod.GET) {
+            builder.GET();
+        } else {
+            HttpRequest.BodyPublisher bodyPublisher = publisherForRequest(request, bodyType, mediaTypeCodecRegistry);
+            builder.method(request.getMethod().toString(), bodyPublisher);
+        }
         request.getHeaders().forEach((name, values) -> values.forEach(value -> builder.header(name, value)));
         if (request.getContentType().isEmpty()) {
             builder.header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);

--- a/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/HttpRequestFactory.java
+++ b/http-client-jdk/src/main/java/io/micronaut/http/client/jdk/HttpRequestFactory.java
@@ -59,6 +59,8 @@ public final class HttpRequestFactory {
         configuration.getReadTimeout().ifPresent(builder::timeout);
         if (request.getMethod() == HttpMethod.GET) {
             builder.GET();
+        } else if (request.getMethod() == HttpMethod.DELETE) {
+            builder.DELETE();
         } else {
             HttpRequest.BodyPublisher bodyPublisher = publisherForRequest(request, bodyType, mediaTypeCodecRegistry);
             builder.method(request.getMethod().toString(), bodyPublisher);

--- a/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/ClientDisabledCondition.java
+++ b/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/ClientDisabledCondition.java
@@ -1,0 +1,57 @@
+package io.micronaut.http.client.tck.tests;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
+import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
+
+public class ClientDisabledCondition implements ExecutionCondition {
+
+    private static final ConditionEvaluationResult ENABLED_BY_DEFAULT = enabled("@ClientDisabled is not present");
+
+    private static final ConditionEvaluationResult ENABLED = enabled("Enabled");
+
+    private static final ConditionEvaluationResult DISABLED = disabled("Disabled");
+
+    public static final String JDK = "jdk";
+    public static final String NETTY = "netty";
+    public static final String HTTP_CLIENT_CONFIGURATION = "httpClient";
+
+    private static boolean jdkMajorVersionMatches(ClientDisabled d) {
+        return Integer.toString(Runtime.version().feature()).equals(d.jdk());
+    }
+
+    private static boolean clientParameterMatches(ExtensionContext context, ClientDisabled d) {
+        return context.getConfigurationParameter(HTTP_CLIENT_CONFIGURATION).orElse("").equalsIgnoreCase(d.httpClient());
+    }
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+        return findAnnotation(context.getElement(), ClientDisabled.class)
+            .map(d -> clientParameterMatches(context, d) && jdkMajorVersionMatches(d)
+                ? DISABLED
+                : ENABLED)
+            .orElse(ENABLED_BY_DEFAULT);
+    }
+
+    @Documented
+    @Target({ElementType.TYPE, ElementType.METHOD})
+    @Retention(RetentionPolicy.RUNTIME)
+    @ExtendWith(ClientDisabledCondition.class)
+    public @interface ClientDisabled {
+
+        String httpClient() default "";
+
+        String jdk() default "";
+    }
+}

--- a/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/ClientDisabledCondition.java
+++ b/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/ClientDisabledCondition.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.http.client.tck.tests;
 
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
@@ -15,6 +30,13 @@ import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled
 import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
 import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
 
+/**
+ * A condition that enables or disables a test based on the presence of the {@link ClientDisabled} annotation.
+ * <p>
+ * The condition is enabled by default, unless the annotation is present and the {@link ClientDisabled#jdk()} or
+ * {@link ClientDisabled#httpClient()} parameters match the current JDK version and the HTTP client configuration
+ * parameter.
+ */
 public class ClientDisabledCondition implements ExecutionCondition {
 
     private static final ConditionEvaluationResult ENABLED_BY_DEFAULT = enabled("@ClientDisabled is not present");
@@ -44,6 +66,9 @@ public class ClientDisabledCondition implements ExecutionCondition {
             .orElse(ENABLED_BY_DEFAULT);
     }
 
+    /**
+     * Annotation that can be used to disable a test based on the JDK version and the HTTP client configuration.
+     */
     @Documented
     @Target({ElementType.TYPE, ElementType.METHOD})
     @Retention(RetentionPolicy.RUNTIME)

--- a/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/ClientDisabledCondition.java
+++ b/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/ClientDisabledCondition.java
@@ -39,16 +39,14 @@ import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
  */
 public class ClientDisabledCondition implements ExecutionCondition {
 
-    private static final ConditionEvaluationResult ENABLED_BY_DEFAULT = enabled("@ClientDisabled is not present");
-
-    private static final ConditionEvaluationResult ENABLED = enabled("Enabled");
-
-    private static final ConditionEvaluationResult DISABLED = disabled("Disabled");
-
     public static final String JDK = "jdk";
     public static final String NETTY = "netty";
     public static final String HTTP_CLIENT_CONFIGURATION = "httpClient";
 
+    private static final ConditionEvaluationResult ENABLED_BY_DEFAULT = enabled("@ClientDisabled is not present");
+    private static final ConditionEvaluationResult ENABLED = enabled("Enabled");
+    private static final ConditionEvaluationResult DISABLED = disabled("Disabled");
+    
     private static boolean jdkMajorVersionMatches(ClientDisabled d) {
         return Integer.toString(Runtime.version().feature()).equals(d.jdk());
     }

--- a/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/ContentLengthHeaderTest.java
+++ b/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/ContentLengthHeaderTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.client.tck.tests;
+
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.core.io.socket.SocketUtils;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.MutableHttpRequest;
+import io.micronaut.http.client.HttpClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import reactor.core.publisher.Flux;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URL;
+
+import static io.micronaut.http.HttpHeaders.CONTENT_LENGTH;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ContentLengthHeaderTest {
+
+    private static final String PATH = "/content-length";
+
+    private HttpServer server;
+
+    private ApplicationContext applicationContext;
+    private HttpClient httpClient;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = HttpServer.create(new InetSocketAddress(SocketUtils.findAvailableTcpPort()), 0);
+        server.setExecutor(java.util.concurrent.Executors.newCachedThreadPool());
+        server.createContext(PATH, new MyHandler());
+        server.start();
+
+        applicationContext = ApplicationContext.run();
+        httpClient = applicationContext.createBean(HttpClient.class, new URL("http://localhost:" + server.getAddress().getPort()));
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.stop(0);
+        }
+        applicationContext.stop();
+    }
+
+    @ParameterizedTest(name = "blocking={0}")
+    @ValueSource(booleans = {true, false})
+    @Disabled
+    void postContainsHeader(boolean blocking) {
+        MutableHttpRequest<String> post = HttpRequest.POST(PATH, "tim");
+        String retrieve = blocking
+            ? httpClient.toBlocking().retrieve(post)
+            : Flux.from(httpClient.retrieve(post)).blockFirst();
+        assertEquals("POST:3", retrieve);
+    }
+
+    @ParameterizedTest(name = "blocking={0}")
+    @ValueSource(booleans = {true})
+    void getContainsHeader(boolean blocking) {
+        MutableHttpRequest<String> get = HttpRequest.GET(PATH);
+        String retrieve = blocking
+            ? httpClient.toBlocking().retrieve(get)
+            : Flux.from(httpClient.retrieve(get)).blockFirst();
+
+        assertEquals("GET:", retrieve);
+    }
+
+    static class MyHandler implements HttpHandler {
+
+        private String header(Headers requestHeaders, String name) {
+            if (requestHeaders.containsKey(name)) {
+                return String.join(", ", requestHeaders.get(name));
+            } else {
+                return "";
+            }
+        }
+
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            String method = exchange.getRequestMethod();
+            String contentLength = header(exchange.getRequestHeaders(), CONTENT_LENGTH);
+            exchange.sendResponseHeaders(200, 0);
+            try (var os = exchange.getResponseBody()) {
+                os.write("%s:%s".formatted(method, contentLength).getBytes());
+            }
+            exchange.close();
+        }
+    }
+}

--- a/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/ContentLengthHeaderTest.java
+++ b/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/ContentLengthHeaderTest.java
@@ -77,15 +77,13 @@ class ContentLengthHeaderTest {
 
     @ParameterizedTest(name = "blocking={0}")
     @ValueSource(booleans = {true, false})
-    @ClientDisabledCondition.ClientDisabled(httpClient = ClientDisabledCondition.JDK, jdk = "21") // The bug is fixed in the JDK HttpClient 21, so we disable the test for that version
+    @ClientDisabledCondition.ClientDisabled(httpClient = ClientDisabledCondition.JDK, jdk = "17") // The bug is fixed in the JDK HttpClient 21, so we disable the test for prior versions
     void getContainsHeader(boolean blocking) {
         MutableHttpRequest<String> get = HttpRequest.GET(PATH);
         String retrieve = blocking
             ? httpClient.toBlocking().retrieve(get)
             : Flux.from(httpClient.retrieve(get)).blockFirst();
-
-        // This should fail as we shouldn't be sending a Content-Length header for GET requests
-        assertEquals("GET:0", retrieve);
+        assertEquals("GET:", retrieve);
     }
 
     static class MyHandler implements HttpHandler {

--- a/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/ContentLengthHeaderTest.java
+++ b/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/ContentLengthHeaderTest.java
@@ -77,13 +77,15 @@ class ContentLengthHeaderTest {
 
     @ParameterizedTest(name = "blocking={0}")
     @ValueSource(booleans = {true, false})
+    @ClientDisabledCondition.ClientDisabled(httpClient = ClientDisabledCondition.JDK, jdk = "21") // The bug is fixed in the JDK HttpClient 21, so we disable the test for that version
     void getContainsHeader(boolean blocking) {
         MutableHttpRequest<String> get = HttpRequest.GET(PATH);
         String retrieve = blocking
             ? httpClient.toBlocking().retrieve(get)
             : Flux.from(httpClient.retrieve(get)).blockFirst();
 
-        assertEquals("GET:", retrieve);
+        // This should fail as we shouldn't be sending a Content-Length header for GET requests
+        assertEquals("GET:0", retrieve);
     }
 
     static class MyHandler implements HttpHandler {

--- a/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/ContentLengthHeaderTest.java
+++ b/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/ContentLengthHeaderTest.java
@@ -26,7 +26,6 @@ import io.micronaut.http.MutableHttpRequest;
 import io.micronaut.http.client.HttpClient;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import reactor.core.publisher.Flux;

--- a/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/ContentLengthHeaderTest.java
+++ b/http-client-tck/src/main/java/io/micronaut/http/client/tck/tests/ContentLengthHeaderTest.java
@@ -68,7 +68,6 @@ class ContentLengthHeaderTest {
 
     @ParameterizedTest(name = "blocking={0}")
     @ValueSource(booleans = {true, false})
-    @Disabled
     void postContainsHeader(boolean blocking) {
         MutableHttpRequest<String> post = HttpRequest.POST(PATH, "tim");
         String retrieve = blocking
@@ -78,7 +77,7 @@ class ContentLengthHeaderTest {
     }
 
     @ParameterizedTest(name = "blocking={0}")
-    @ValueSource(booleans = {true})
+    @ValueSource(booleans = {true, false})
     void getContainsHeader(boolean blocking) {
         MutableHttpRequest<String> get = HttpRequest.GET(PATH);
         String retrieve = blocking

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -1376,7 +1376,7 @@ public class DefaultHttpClient implements
     private static FullHttpRequest withBytes(HttpRequest request, ByteBuf bytes) {
         HttpHeaders headers = request.headers();
         headers.remove(HttpHeaderNames.TRANSFER_ENCODING);
-        if(permitsRequestBody(request.method())) {
+        if (permitsRequestBody(request.method())) {
             headers.set(HttpHeaderNames.CONTENT_LENGTH, bytes.readableBytes());
         }
         return new DefaultFullHttpRequest(

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -1390,14 +1390,13 @@ public class DefaultHttpClient implements
     }
 
     private static boolean requiresRequestBody(io.netty.handler.codec.http.HttpMethod method) {
-        return method != null && (method.equals(HttpMethod.POST) || method.equals(HttpMethod.PUT) || method.equals(HttpMethod.PATCH));
+        return method != null && (method.equals(io.netty.handler.codec.http.HttpMethod.POST) || method.equals(io.netty.handler.codec.http.HttpMethod.PUT) || method.equals(io.netty.handler.codec.http.HttpMethod.PATCH));
     }
 
     private static boolean permitsRequestBody(io.netty.handler.codec.http.HttpMethod method) {
         return method != null && (requiresRequestBody(method)
-            || method.equals(HttpMethod.OPTIONS)
-            || method.equals(HttpMethod.DELETE)
-            || method.equals(HttpMethod.CUSTOM)
+            || method.equals(io.netty.handler.codec.http.HttpMethod.OPTIONS)
+            || method.equals(io.netty.handler.codec.http.HttpMethod.DELETE)
         );
     }
 

--- a/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/DefaultHttpClient.java
@@ -1301,7 +1301,7 @@ public class DefaultHttpClient implements
                 Object bodyValue = body.get();
                 if (bodyValue instanceof CharSequence sequence) {
                     ByteBuf byteBuf = charSequenceToByteBuf(sequence, requestContentType);
-                    FullHttpRequest nettyRequest = withBytes(nettyRequestBuilder.toHttpRequestWithoutBody(), byteBuf);
+                    FullHttpRequest nettyRequest = withBytes(nettyRequestBuilder.toHttpRequestWithoutBody(), byteBuf, true);
                     nettyRequest.setUri(newUri);
                     return new FullRequestWriter(nettyRequest);
                 } else {
@@ -1352,12 +1352,12 @@ public class DefaultHttpClient implements
                 } else {
                     bodyContent = Unpooled.EMPTY_BUFFER;
                 }
-                FullHttpRequest nettyRequest = withBytes(nettyRequestBuilder.toHttpRequestWithoutBody(), bodyContent);
+                FullHttpRequest nettyRequest = withBytes(nettyRequestBuilder.toHttpRequestWithoutBody(), bodyContent, true);
                 nettyRequest.setUri(newUri);
                 return new FullRequestWriter(nettyRequest);
             }
         } else {
-            FullHttpRequest nettyRequest = withBytes(nettyRequestBuilder.toHttpRequestWithoutBody(), Unpooled.EMPTY_BUFFER);
+            FullHttpRequest nettyRequest = withBytes(nettyRequestBuilder.toHttpRequestWithoutBody(), Unpooled.EMPTY_BUFFER, false);
             nettyRequest.setUri(newUri);
             return new FullRequestWriter(nettyRequest);
         }
@@ -1373,10 +1373,12 @@ public class DefaultHttpClient implements
         }
     }
 
-    private static FullHttpRequest withBytes(HttpRequest request, ByteBuf bytes) {
+    private static FullHttpRequest withBytes(HttpRequest request, ByteBuf bytes, boolean permitsBody) {
         HttpHeaders headers = request.headers();
         headers.remove(HttpHeaderNames.TRANSFER_ENCODING);
-        headers.set(HttpHeaderNames.CONTENT_LENGTH, bytes.readableBytes());
+        if(permitsBody) {
+            headers.set(HttpHeaderNames.CONTENT_LENGTH, bytes.readableBytes());
+        }
         return new DefaultFullHttpRequest(
             request.protocolVersion(),
             request.method(),

--- a/test-suite-http-client-tck-jdk/src/test/java/io/micronaut/http/client/tck/jdk/tests/JdkHttpMethodTests.java
+++ b/test-suite-http-client-tck-jdk/src/test/java/io/micronaut/http/client/tck/jdk/tests/JdkHttpMethodTests.java
@@ -14,6 +14,7 @@ import org.junit.platform.suite.api.SuiteDisplayName;
 @SuppressWarnings("java:S2187") // This runs a suite of tests, but has no tests of its own
 @ExcludeClassNamePatterns({
     "io.micronaut.http.client.tck.tests.ContinueTest", // Unsupported body type errors
+    "io.micronaut.http.client.tck.tests.ContentLengthHeaderTest", // GET requests add content-length header until https://github.com/openjdk/jdk/commit/6a7709320d28d8e1593b113fdf39ab583fca3687
 })
 public class JdkHttpMethodTests {
 }

--- a/test-suite-http-client-tck-jdk/src/test/java/io/micronaut/http/client/tck/jdk/tests/JdkHttpMethodTests.java
+++ b/test-suite-http-client-tck-jdk/src/test/java/io/micronaut/http/client/tck/jdk/tests/JdkHttpMethodTests.java
@@ -1,5 +1,7 @@
 package io.micronaut.http.client.tck.jdk.tests;
 
+import io.micronaut.http.client.tck.tests.ClientDisabledCondition;
+import org.junit.platform.suite.api.ConfigurationParameter;
 import org.junit.platform.suite.api.ExcludeClassNamePatterns;
 import org.junit.platform.suite.api.SelectPackages;
 import org.junit.platform.suite.api.Suite;
@@ -11,10 +13,10 @@ import org.junit.platform.suite.api.SuiteDisplayName;
 @Suite
 @SelectPackages("io.micronaut.http.client.tck.tests")
 @SuiteDisplayName("HTTP Client TCK for the HTTP Client Implementation based on Java HTTP Client")
+@ConfigurationParameter(key = ClientDisabledCondition.HTTP_CLIENT_CONFIGURATION, value = ClientDisabledCondition.JDK)
 @SuppressWarnings("java:S2187") // This runs a suite of tests, but has no tests of its own
 @ExcludeClassNamePatterns({
     "io.micronaut.http.client.tck.tests.ContinueTest", // Unsupported body type errors
-    "io.micronaut.http.client.tck.tests.ContentLengthHeaderTest", // GET requests add content-length header until https://github.com/openjdk/jdk/commit/6a7709320d28d8e1593b113fdf39ab583fca3687
 })
 public class JdkHttpMethodTests {
 }

--- a/test-suite-http-client-tck-netty/src/test/java/io/micronaut/http/client/tck/netty/tests/NettyHttpMethodTests.java
+++ b/test-suite-http-client-tck-netty/src/test/java/io/micronaut/http/client/tck/netty/tests/NettyHttpMethodTests.java
@@ -1,5 +1,7 @@
 package io.micronaut.http.client.tck.netty.tests;
 
+import io.micronaut.http.client.tck.tests.ClientDisabledCondition;
+import org.junit.platform.suite.api.ConfigurationParameter;
 import org.junit.platform.suite.api.SelectPackages;
 import org.junit.platform.suite.api.Suite;
 import org.junit.platform.suite.api.SuiteDisplayName;
@@ -7,6 +9,7 @@ import org.junit.platform.suite.api.SuiteDisplayName;
 @Suite
 @SelectPackages("io.micronaut.http.client.tck.tests")
 @SuiteDisplayName("HTTP Client TCK for the HTTP Client Implementation based on Netty")
+@ConfigurationParameter(key = ClientDisabledCondition.HTTP_CLIENT_CONFIGURATION, value = ClientDisabledCondition.NETTY)
 @SuppressWarnings("java:S2187") // This runs a suite of tests, but has no tests of its own
 public class NettyHttpMethodTests {
 }


### PR DESCRIPTION
See https://github.com/micronaut-projects/micronaut-core/pull/10211

Disabled for the JDK client tests as this is broken in the JDK for 17

[The issue shows it as fixed in 19](https://bugs.openjdk.org/browse/JDK-8283544)