### PR TITLE
docs: add reactor context propagation example

### DIFF
--- a/src/main/docs/guide/contextPropagation/reactorContextPropagation.adoc
+++ b/src/main/docs/guide/contextPropagation/reactorContextPropagation.adoc
@@ -22,7 +22,7 @@ To add the context in the middle of the reactive chain, do something like the fo
 
 snippet::io.micronaut.docs.propagation.reactor.PropagatedContextSpec[tags="example", indent=0]
 
-<1> Obtain the current context.
+<1> Obtain the current context that has been modified, e.g. with `PropagatedContext.get().plus(...)`, etc.
 <2> Add the context into the reactive chain.
 
 If you have Micrometer Context Propagation on the classpath but don't want to use it, apply the following configuration:

--- a/src/main/docs/guide/contextPropagation/reactorContextPropagation.adoc
+++ b/src/main/docs/guide/contextPropagation/reactorContextPropagation.adoc
@@ -20,7 +20,7 @@ NOTE: The thread-local values are read-only. To modify them, the `PropagatedCont
 
 To add the context in the middle of the reactive chain, do something like the following:
 
-snippet::io.micronaut.docs.propagation.reactor.PropagatedContextSpec[tags="example", indent=0]
+snippet::io.micronaut.docs.propagation.reactor.HelloController[tags="example", indent=0]
 
 <1> Obtain the current context that has been modified, e.g. with `PropagatedContext.get().plus(...)`, etc.
 <2> Add the context into the reactive chain.

--- a/src/main/docs/guide/contextPropagation/reactorContextPropagation.adoc
+++ b/src/main/docs/guide/contextPropagation/reactorContextPropagation.adoc
@@ -18,6 +18,13 @@ After that, all the thread-local propagated elements can restore their thread-lo
 
 NOTE: The thread-local values are read-only. To modify them, the `PropagatedContext` instance needs to be changed and put into the Reactor's context.
 
+To add the context in the middle of the reactive chain, do something like the following:
+
+snippet::io.micronaut.docs.propagation.reactor.PropagatedContextSpec[tags="example", indent=0]
+
+<1> Obtain the current context.
+<2> Add the context into the reactive chain.
+
 If you have Micrometer Context Propagation on the classpath but don't want to use it, apply the following configuration:
 
 .Disable Micrometer Context Propagation in Reactor

--- a/src/main/docs/guide/contextPropagation/reactorContextPropagation.adoc
+++ b/src/main/docs/guide/contextPropagation/reactorContextPropagation.adoc
@@ -20,7 +20,7 @@ NOTE: The thread-local values are read-only. To modify them, the `PropagatedCont
 
 To add the context in the middle of the reactive chain, do something like the following:
 
-snippet::io.micronaut.docs.propagation.reactor.HelloController[tags="example", indent=0]
+snippet::io.micronaut.docs.propagation.reactor.HelloController[tags="imports,example", indent=0]
 
 <1> Obtain the current context that has been modified, e.g. with `PropagatedContext.get().plus(...)`, etc.
 <2> Add the context into the reactive chain.

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/propagation/reactor/HelloController.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/propagation/reactor/HelloController.groovy
@@ -3,10 +3,9 @@ package io.micronaut.docs.propagation.reactor
 import io.micronaut.context.annotation.Requires
 import io.micronaut.core.async.propagation.ReactorPropagation
 import io.micronaut.core.propagation.PropagatedContext
-import io.micronaut.http.HttpRequest
+import io.micronaut.core.propagation.PropagatedContextElement
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
-import io.micronaut.http.context.ServerHttpRequestContext
 import reactor.core.publisher.Mono
 
 @Requires(property = 'spec.name', value = 'PropagatedContextSpec')
@@ -15,10 +14,12 @@ import reactor.core.publisher.Mono
 class HelloController {
 
     @Get('/hello')
-    Mono<String> hello(HttpRequest<?> httpRequest) {
-        PropagatedContext propagatedContext = PropagatedContext.get() + new ServerHttpRequestContext(httpRequest) // <1>
+    Mono<String> hello() {
+        PropagatedContext propagatedContext = PropagatedContext.get() + new MyContextElement() // <1>
         return Mono.just('Hello, World')
                 .contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, propagatedContext)) // <2>
     }
 }
+
+class MyContextElement implements PropagatedContextElement { /*...*/ }
 // end::example[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/propagation/reactor/HelloController.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/propagation/reactor/HelloController.groovy
@@ -1,6 +1,6 @@
 package io.micronaut.docs.propagation.reactor
 
-import io.micronaut.context.annotation.Requires
+// tag::imports[]
 import io.micronaut.core.async.propagation.ReactorPropagation
 import io.micronaut.core.propagation.PropagatedContext
 import io.micronaut.core.propagation.PropagatedContextElement
@@ -8,6 +8,8 @@ import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.QueryValue
 import reactor.core.publisher.Mono
+// end::imports[]
+import io.micronaut.context.annotation.Requires
 
 @Requires(property = 'spec.name', value = 'PropagatedContextSpec')
 // tag::example[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/propagation/reactor/HelloController.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/propagation/reactor/HelloController.groovy
@@ -1,0 +1,24 @@
+package io.micronaut.docs.propagation.reactor
+
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.async.propagation.ReactorPropagation
+import io.micronaut.core.propagation.PropagatedContext
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.context.ServerHttpRequestContext
+import reactor.core.publisher.Mono
+
+@Requires(property = 'spec.name', value = 'PropagatedContextSpec')
+// tag::example[]
+@Controller
+class HelloController {
+
+    @Get('/hello')
+    Mono<String> hello(HttpRequest<?> httpRequest) {
+        PropagatedContext propagatedContext = PropagatedContext.get() + new ServerHttpRequestContext(httpRequest) // <1>
+        return Mono.just('Hello, World')
+                .contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, propagatedContext)) // <2>
+    }
+}
+// end::example[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/propagation/reactor/HelloController.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/propagation/reactor/HelloController.groovy
@@ -6,6 +6,7 @@ import io.micronaut.core.propagation.PropagatedContext
 import io.micronaut.core.propagation.PropagatedContextElement
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.QueryValue
 import reactor.core.publisher.Mono
 
 @Requires(property = 'spec.name', value = 'PropagatedContextSpec')
@@ -14,12 +15,12 @@ import reactor.core.publisher.Mono
 class HelloController {
 
     @Get('/hello')
-    Mono<String> hello() {
-        PropagatedContext propagatedContext = PropagatedContext.get() + new MyContextElement() // <1>
-        return Mono.just('Hello, World')
+    Mono<String> hello(@QueryValue('name') String name) {
+        PropagatedContext propagatedContext = PropagatedContext.get() + new MyContextElement(name) // <1>
+        return Mono.just("Hello, $name")
                 .contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, propagatedContext)) // <2>
     }
 }
 
-class MyContextElement implements PropagatedContextElement { /*...*/ }
+record MyContextElement(String value) implements PropagatedContextElement { }
 // end::example[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/propagation/reactor/PropagatedContextSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/propagation/reactor/PropagatedContextSpec.groovy
@@ -5,6 +5,7 @@ import io.micronaut.core.type.Argument
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.uri.UriBuilder
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
 import spock.lang.Specification
@@ -19,9 +20,10 @@ class PropagatedContextSpec extends Specification {
 
     void "test Mono Request"() {
         when:
-        String hello = client.toBlocking().retrieve(HttpRequest.GET('/hello'), Argument.of(String.class))
+        URI uri = UriBuilder.of('/hello').queryParam('name', 'Dean').build()
+        String hello = client.toBlocking().retrieve(HttpRequest.GET(uri), Argument.of(String))
 
         then:
-        'Hello, World' == hello
+        'Hello, Dean' == hello
     }
 }

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/propagation/reactor/PropagatedContextSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/propagation/reactor/PropagatedContextSpec.groovy
@@ -1,0 +1,43 @@
+package io.micronaut.docs.propagation.reactor
+
+import io.micronaut.core.async.propagation.ReactorPropagation
+import io.micronaut.core.propagation.PropagatedContext
+import io.micronaut.core.type.Argument
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import reactor.core.publisher.Mono
+import spock.lang.Specification
+
+@MicronautTest
+class PropagatedContextSpec extends Specification {
+
+    @Inject
+    @Client("/")
+    HttpClient client
+
+    void "test Mono Request"() {
+        when:
+        String hello = client.toBlocking().retrieve(HttpRequest.GET('/hello'), Argument.of(String.class))
+
+        then:
+        'Hello, World' == hello
+    }
+
+    // tag::example[]
+    @Controller
+    static class HelloController {
+
+        @Get('/hello')
+        Mono<String> hello() {
+            PropagatedContext propagatedContext = PropagatedContext.get() // <1>
+            return Mono.just('Hello, World')
+                .contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, propagatedContext)) // <2>
+        }
+    }
+    // end::example[]
+}

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/propagation/reactor/PropagatedContextSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/propagation/reactor/PropagatedContextSpec.groovy
@@ -1,5 +1,7 @@
 package io.micronaut.docs.propagation.reactor
 
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
 import io.micronaut.core.async.propagation.ReactorPropagation
 import io.micronaut.core.propagation.PropagatedContext
 import io.micronaut.core.type.Argument
@@ -13,6 +15,7 @@ import jakarta.inject.Inject
 import reactor.core.publisher.Mono
 import spock.lang.Specification
 
+@Property(name = 'spec.name', value = 'PropagatedContextSpec')
 @MicronautTest
 class PropagatedContextSpec extends Specification {
 
@@ -28,16 +31,18 @@ class PropagatedContextSpec extends Specification {
         'Hello, World' == hello
     }
 
-    // tag::example[]
-    @Controller
-    static class HelloController {
-
-        @Get('/hello')
-        Mono<String> hello() {
-            PropagatedContext propagatedContext = PropagatedContext.get() // <1>
-            return Mono.just('Hello, World')
-                .contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, propagatedContext)) // <2>
-        }
-    }
-    // end::example[]
 }
+
+@Requires(property = 'spec.name', value = 'PropagatedContextSpec')
+// tag::example[]
+@Controller
+class HelloController {
+
+    @Get('/hello')
+    Mono<String> hello() {
+        PropagatedContext propagatedContext = PropagatedContext.get() // <1>
+        return Mono.just('Hello, World')
+            .contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, propagatedContext)) // <2>
+    }
+}
+// end::example[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/propagation/reactor/PropagatedContextSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/propagation/reactor/PropagatedContextSpec.groovy
@@ -10,6 +10,7 @@ import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.context.ServerHttpRequestContext
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
 import reactor.core.publisher.Mono
@@ -39,8 +40,8 @@ class PropagatedContextSpec extends Specification {
 class HelloController {
 
     @Get('/hello')
-    Mono<String> hello() {
-        PropagatedContext propagatedContext = PropagatedContext.get() // <1>
+    Mono<String> hello(HttpRequest<?> httpRequest) {
+        PropagatedContext propagatedContext = PropagatedContext.get() + new ServerHttpRequestContext(httpRequest) // <1>
         return Mono.just('Hello, World')
             .contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, propagatedContext)) // <2>
     }

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/propagation/reactor/PropagatedContextSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/propagation/reactor/PropagatedContextSpec.groovy
@@ -1,19 +1,12 @@
 package io.micronaut.docs.propagation.reactor
 
 import io.micronaut.context.annotation.Property
-import io.micronaut.context.annotation.Requires
-import io.micronaut.core.async.propagation.ReactorPropagation
-import io.micronaut.core.propagation.PropagatedContext
 import io.micronaut.core.type.Argument
 import io.micronaut.http.HttpRequest
-import io.micronaut.http.annotation.Controller
-import io.micronaut.http.annotation.Get
 import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.annotation.Client
-import io.micronaut.http.context.ServerHttpRequestContext
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
-import reactor.core.publisher.Mono
 import spock.lang.Specification
 
 @Property(name = 'spec.name', value = 'PropagatedContextSpec')
@@ -31,19 +24,4 @@ class PropagatedContextSpec extends Specification {
         then:
         'Hello, World' == hello
     }
-
 }
-
-@Requires(property = 'spec.name', value = 'PropagatedContextSpec')
-// tag::example[]
-@Controller
-class HelloController {
-
-    @Get('/hello')
-    Mono<String> hello(HttpRequest<?> httpRequest) {
-        PropagatedContext propagatedContext = PropagatedContext.get() + new ServerHttpRequestContext(httpRequest) // <1>
-        return Mono.just('Hello, World')
-            .contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, propagatedContext)) // <2>
-    }
-}
-// end::example[]

--- a/test-suite/src/test/java/io/micronaut/docs/propagation/reactor/HelloController.java
+++ b/test-suite/src/test/java/io/micronaut/docs/propagation/reactor/HelloController.java
@@ -3,10 +3,9 @@ package io.micronaut.docs.propagation.reactor;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.async.propagation.ReactorPropagation;
 import io.micronaut.core.propagation.PropagatedContext;
-import io.micronaut.http.HttpRequest;
+import io.micronaut.core.propagation.PropagatedContextElement;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
-import io.micronaut.http.context.ServerHttpRequestContext;
 import reactor.core.publisher.Mono;
 
 @Requires(property = "spec.name", value = "PropagatedContextSpec")
@@ -15,10 +14,12 @@ import reactor.core.publisher.Mono;
 class HelloController {
 
     @Get("/hello")
-    Mono<String> hello(HttpRequest<?> httpRequest) {
-        PropagatedContext propagatedContext = PropagatedContext.get().plus(new ServerHttpRequestContext(httpRequest)); // <1>
+    Mono<String> hello() {
+        PropagatedContext propagatedContext = PropagatedContext.get().plus(new MyContextElement()); // <1>
         return Mono.just("Hello, World")
             .contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, propagatedContext)); // <2>
     }
 }
+
+class MyContextElement implements PropagatedContextElement { /*...*/ }
 // end::example[]

--- a/test-suite/src/test/java/io/micronaut/docs/propagation/reactor/HelloController.java
+++ b/test-suite/src/test/java/io/micronaut/docs/propagation/reactor/HelloController.java
@@ -6,6 +6,7 @@ import io.micronaut.core.propagation.PropagatedContext;
 import io.micronaut.core.propagation.PropagatedContextElement;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.QueryValue;
 import reactor.core.publisher.Mono;
 
 @Requires(property = "spec.name", value = "PropagatedContextSpec")
@@ -14,12 +15,12 @@ import reactor.core.publisher.Mono;
 class HelloController {
 
     @Get("/hello")
-    Mono<String> hello() {
-        PropagatedContext propagatedContext = PropagatedContext.get().plus(new MyContextElement()); // <1>
-        return Mono.just("Hello, World")
+    Mono<String> hello(@QueryValue("name") String name) {
+        PropagatedContext propagatedContext = PropagatedContext.get().plus(new MyContextElement(name)); // <1>
+        return Mono.just("Hello, " + name)
             .contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, propagatedContext)); // <2>
     }
 }
 
-class MyContextElement implements PropagatedContextElement { /*...*/ }
+record MyContextElement(String value) implements PropagatedContextElement { }
 // end::example[]

--- a/test-suite/src/test/java/io/micronaut/docs/propagation/reactor/HelloController.java
+++ b/test-suite/src/test/java/io/micronaut/docs/propagation/reactor/HelloController.java
@@ -1,6 +1,6 @@
 package io.micronaut.docs.propagation.reactor;
 
-import io.micronaut.context.annotation.Requires;
+// tag::imports[]
 import io.micronaut.core.async.propagation.ReactorPropagation;
 import io.micronaut.core.propagation.PropagatedContext;
 import io.micronaut.core.propagation.PropagatedContextElement;
@@ -8,6 +8,8 @@ import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
 import io.micronaut.http.annotation.QueryValue;
 import reactor.core.publisher.Mono;
+// end::imports[]
+import io.micronaut.context.annotation.Requires;
 
 @Requires(property = "spec.name", value = "PropagatedContextSpec")
 // tag::example[]

--- a/test-suite/src/test/java/io/micronaut/docs/propagation/reactor/HelloController.java
+++ b/test-suite/src/test/java/io/micronaut/docs/propagation/reactor/HelloController.java
@@ -1,38 +1,13 @@
 package io.micronaut.docs.propagation.reactor;
 
-import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.async.propagation.ReactorPropagation;
 import io.micronaut.core.propagation.PropagatedContext;
-import io.micronaut.core.type.Argument;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
-import io.micronaut.http.client.HttpClient;
-import io.micronaut.http.client.annotation.Client;
 import io.micronaut.http.context.ServerHttpRequestContext;
-import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
-import jakarta.inject.Inject;
-import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-@Property(name = "spec.name", value = "PropagatedContextSpec")
-@MicronautTest
-class PropagatedContextSpec {
-
-    @Inject
-    @Client("/")
-    HttpClient client;
-
-    @Test
-    void testMonoRequest() {
-        String hello = client.toBlocking().retrieve(HttpRequest.GET("/hello"), Argument.of(String.class));
-        assertEquals("Hello, World", hello);
-    }
-
-}
 
 @Requires(property = "spec.name", value = "PropagatedContextSpec")
 // tag::example[]

--- a/test-suite/src/test/java/io/micronaut/docs/propagation/reactor/PropagatedContextSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/propagation/reactor/PropagatedContextSpec.java
@@ -4,7 +4,6 @@ import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.async.propagation.ReactorPropagation;
 import io.micronaut.core.propagation.PropagatedContext;
-import io.micronaut.core.propagation.PropagatedContextElement;
 import io.micronaut.core.type.Argument;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.annotation.Controller;
@@ -21,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Property(name = "spec.name", value = "PropagatedContextSpec")
 @MicronautTest
-public class PropagatedContextSpec {
+class PropagatedContextSpec {
 
     @Inject
     @Client("/")

--- a/test-suite/src/test/java/io/micronaut/docs/propagation/reactor/PropagatedContextSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/propagation/reactor/PropagatedContextSpec.java
@@ -1,0 +1,43 @@
+package io.micronaut.docs.propagation.reactor;
+
+import io.micronaut.core.async.propagation.ReactorPropagation;
+import io.micronaut.core.propagation.PropagatedContext;
+import io.micronaut.core.type.Argument;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@MicronautTest
+public class PropagatedContextSpec {
+
+    @Inject
+    @Client("/")
+    HttpClient client;
+
+    @Test
+    void testMonoRequest() {
+        String hello = client.toBlocking().retrieve(HttpRequest.GET("/hello"), Argument.of(String.class));
+        assertEquals("Hello, World", hello);
+    }
+
+    // tag::example[]
+    @Controller
+    static class HelloController {
+
+        @Get("/hello")
+        Mono<String> hello() {
+            PropagatedContext propagatedContext = PropagatedContext.get(); // <1>
+            return Mono.just("Hello, World")
+                .contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, propagatedContext)); // <2>
+        }
+    }
+    // end::example[]
+}

--- a/test-suite/src/test/java/io/micronaut/docs/propagation/reactor/PropagatedContextSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/propagation/reactor/PropagatedContextSpec.java
@@ -1,5 +1,7 @@
 package io.micronaut.docs.propagation.reactor;
 
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.async.propagation.ReactorPropagation;
 import io.micronaut.core.propagation.PropagatedContext;
 import io.micronaut.core.type.Argument;
@@ -15,6 +17,7 @@ import reactor.core.publisher.Mono;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@Property(name = "spec.name", value = "PropagatedContextSpec")
 @MicronautTest
 public class PropagatedContextSpec {
 
@@ -28,16 +31,18 @@ public class PropagatedContextSpec {
         assertEquals("Hello, World", hello);
     }
 
-    // tag::example[]
-    @Controller
-    static class HelloController {
-
-        @Get("/hello")
-        Mono<String> hello() {
-            PropagatedContext propagatedContext = PropagatedContext.get(); // <1>
-            return Mono.just("Hello, World")
-                .contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, propagatedContext)); // <2>
-        }
-    }
-    // end::example[]
 }
+
+@Requires(property = "spec.name", value = "PropagatedContextSpec")
+// tag::example[]
+@Controller
+class HelloController {
+
+    @Get("/hello")
+    Mono<String> hello() {
+        PropagatedContext propagatedContext = PropagatedContext.get(); // <1>
+        return Mono.just("Hello, World")
+            .contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, propagatedContext)); // <2>
+    }
+}
+// end::example[]

--- a/test-suite/src/test/java/io/micronaut/docs/propagation/reactor/PropagatedContextSpec.java
+++ b/test-suite/src/test/java/io/micronaut/docs/propagation/reactor/PropagatedContextSpec.java
@@ -4,12 +4,14 @@ import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.async.propagation.ReactorPropagation;
 import io.micronaut.core.propagation.PropagatedContext;
+import io.micronaut.core.propagation.PropagatedContextElement;
 import io.micronaut.core.type.Argument;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
 import io.micronaut.http.client.HttpClient;
 import io.micronaut.http.client.annotation.Client;
+import io.micronaut.http.context.ServerHttpRequestContext;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
@@ -39,8 +41,8 @@ public class PropagatedContextSpec {
 class HelloController {
 
     @Get("/hello")
-    Mono<String> hello() {
-        PropagatedContext propagatedContext = PropagatedContext.get(); // <1>
+    Mono<String> hello(HttpRequest<?> httpRequest) {
+        PropagatedContext propagatedContext = PropagatedContext.get().plus(new ServerHttpRequestContext(httpRequest)); // <1>
         return Mono.just("Hello, World")
             .contextWrite(ctx -> ReactorPropagation.addPropagatedContext(ctx, propagatedContext)); // <2>
     }

--- a/test-suite/src/test/java/io/micronaut/docs/propagation/reactor/PropagatedContextTest.java
+++ b/test-suite/src/test/java/io/micronaut/docs/propagation/reactor/PropagatedContextTest.java
@@ -1,0 +1,28 @@
+package io.micronaut.docs.propagation.reactor;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.core.type.Argument;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Property(name = "spec.name", value = "PropagatedContextSpec")
+@MicronautTest
+class PropagatedContextTest {
+
+    @Inject
+    @Client("/")
+    HttpClient client;
+
+    @Test
+    void testMonoRequest() {
+        String hello = client.toBlocking().retrieve(HttpRequest.GET("/hello"), Argument.of(String.class));
+        assertEquals("Hello, World", hello);
+    }
+
+}

--- a/test-suite/src/test/java/io/micronaut/docs/propagation/reactor/PropagatedContextTest.java
+++ b/test-suite/src/test/java/io/micronaut/docs/propagation/reactor/PropagatedContextTest.java
@@ -5,9 +5,12 @@ import io.micronaut.core.type.Argument;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.client.HttpClient;
 import io.micronaut.http.client.annotation.Client;
+import io.micronaut.http.uri.UriBuilder;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
+
+import java.net.URI;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -21,8 +24,8 @@ class PropagatedContextTest {
 
     @Test
     void testMonoRequest() {
-        String hello = client.toBlocking().retrieve(HttpRequest.GET("/hello"), Argument.of(String.class));
-        assertEquals("Hello, World", hello);
+        URI uri = UriBuilder.of("/hello").queryParam("name", "Dean").build();
+        String hello = client.toBlocking().retrieve(HttpRequest.GET(uri), Argument.of(String.class));
+        assertEquals("Hello, Dean", hello);
     }
-
 }


### PR DESCRIPTION
closes #10219

I believe we agreed in the meeting that a kotlin example is not necessary (nor appropriate).