### PR TITLE
More detailed error messages

### DIFF
--- a/inject-groovy/src/test/groovy/io/micronaut/inject/failures/PropertyCircularDependencyFailureSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/failures/PropertyCircularDependencyFailureSpec.groovy
@@ -36,13 +36,14 @@ class PropertyCircularDependencyFailureSpec extends Specification {
         CircularDependencyException e = thrown()
         def lines = e.message.lines().toList()
         lines[0] == 'Failed to inject value for parameter [a] of method [setA] of class: io.micronaut.inject.failures.PropertyCircularDependencyFailureSpec$B'
-        lines[1] == 'Message: Circular dependency detected'
-        lines[2] == 'Path Taken: '
-        lines[3] == 'new B() --> B.setA([A a]) --> A.setB([B b])'
-        lines[4] == '^                                        |'
-        lines[5] == '|                                        |'
+        lines[1] == ''
+        lines[2] == 'Message: Circular dependency detected'
+        lines[3] == 'Path Taken: '
+        lines[4] == 'new B() --> B.setA([A a]) --> A.setB([B b])'
+        lines[5] == '^                                        |'
         lines[6] == '|                                        |'
-        lines[7] == '+----------------------------------------+'
+        lines[7] == '|                                        |'
+        lines[8] == '+----------------------------------------+'
         cleanup:
         context.close()
     }

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/failures/PropertyCircularDependencyFailureSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/failures/PropertyCircularDependencyFailureSpec.groovy
@@ -34,16 +34,15 @@ class PropertyCircularDependencyFailureSpec extends Specification {
 
         then:"The implementation is injected"
         CircularDependencyException e = thrown()
-        e.message.normalize() == '''\
-Failed to inject value for parameter [a] of method [setA] of class: io.micronaut.inject.failures.PropertyCircularDependencyFailureSpec$B
-
-Message: Circular dependency detected
-Path Taken: 
-new B() --> B.setA([A a]) --> A.setB([B b])
-^                                        |
-|                                        |
-|                                        |
-+----------------------------------------+'''
+        def lines = e.message.lines().toList()
+        lines[0] == 'Failed to inject value for parameter [a] of method [setA] of class: io.micronaut.inject.failures.PropertyCircularDependencyFailureSpec$B'
+        lines[1] == 'Message: Circular dependency detected'
+        lines[2] == 'Path Taken: '
+        lines[3] == 'new B() --> B.setA([A a]) --> A.setB([B b])'
+        lines[4] == '^                                        |'
+        lines[5] == '|                                        |'
+        lines[6] == '|                                        |'
+        lines[7] == '+----------------------------------------+'
         cleanup:
         context.close()
     }

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/failures/PropertyDependencyMissingSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/failures/PropertyDependencyMissingSpec.groovy
@@ -19,11 +19,11 @@ import io.micronaut.context.ApplicationContext
 import io.micronaut.context.exceptions.DependencyInjectionException
 import jakarta.inject.Inject
 import spock.lang.Specification
+
 /**
  * Created by graemerocher on 12/05/2017.
  */
 class PropertyDependencyMissingSpec  extends Specification {
-
 
     void "test a useful exception is thrown when a dependency injection failure occurs"() {
         given:
@@ -34,9 +34,10 @@ class PropertyDependencyMissingSpec  extends Specification {
 
         then:"The correct error is thrown"
         DependencyInjectionException e = thrown()
-        e.message.normalize().contains 'Failed to inject value for parameter [a] of method [setA] of class: io.micronaut.inject.failures.PropertyDependencyMissingSpec$B'
-        e.message.normalize().contains '''Message: No bean of type [io.micronaut.inject.failures.PropertyDependencyMissingSpec$A] exists. Make sure the bean is not disabled by bean requirements (enable trace logging for 'io.micronaut.context.condition' to check) and if the bean is enabled then ensure the class is declared a bean and annotation processing is enabled (for Java and Kotlin the 'micronaut-inject-java' dependency should be configured as an annotation processor).'''
-        e.message.normalize().contains '''Path Taken: new B() --> B.setA([A a])'''
+        def lines = e.message.lines().toList()
+        lines[0] == 'Failed to inject value for parameter [a] of method [setA] of class: io.micronaut.inject.failures.PropertyDependencyMissingSpec$B'
+        lines[1] == 'Message: No bean of type [io.micronaut.inject.failures.PropertyDependencyMissingSpec$A] exists. '
+        lines[2] == 'Path Taken: new B() --> B.setA([A a])'
 
         cleanup:
         context.close()

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/failures/PropertyDependencyMissingSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/failures/PropertyDependencyMissingSpec.groovy
@@ -36,8 +36,9 @@ class PropertyDependencyMissingSpec  extends Specification {
         DependencyInjectionException e = thrown()
         def lines = e.message.lines().toList()
         lines[0] == 'Failed to inject value for parameter [a] of method [setA] of class: io.micronaut.inject.failures.PropertyDependencyMissingSpec$B'
-        lines[1] == 'Message: No bean of type [io.micronaut.inject.failures.PropertyDependencyMissingSpec$A] exists. '
-        lines[2] == 'Path Taken: new B() --> B.setA([A a])'
+        lines[1] == ''
+        lines[2] == 'Message: No bean of type [io.micronaut.inject.failures.PropertyDependencyMissingSpec$A] exists. '
+        lines[3] == 'Path Taken: new B() --> B.setA([A a])'
 
         cleanup:
         context.close()

--- a/inject-java/src/test/groovy/io/micronaut/inject/configproperties/nesting/EachPropertyNestingSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configproperties/nesting/EachPropertyNestingSpec.groovy
@@ -1,12 +1,9 @@
 package io.micronaut.inject.configproperties.nesting
 
 import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
-import io.micronaut.context.ApplicationContext
 import io.micronaut.context.ApplicationContextBuilder
-import io.micronaut.context.exceptions.DependencyInjectionException
 import io.micronaut.context.exceptions.NoSuchBeanException
 import io.micronaut.inject.qualifiers.Qualifiers
-import spock.lang.Specification
 
 class EachPropertyNestingSpec extends AbstractTypeElementSpec {
 
@@ -127,11 +124,14 @@ class ClassOuterConfig {
         config2.inner.inners.find { it.name == '2nd' }.count == 40
 
         when:"A unresolvable bean is queried"
-        def inner = getBean(context, 'test.ClassOuterConfig$ClassInnerConfig$ClassInnerEachConfig', Qualifiers.byName("foo-bar"))
+        getBean(context, 'test.ClassOuterConfig$ClassInnerConfig$ClassInnerEachConfig', Qualifiers.byName("foo-bar"))
 
         then:
         def e = thrown(NoSuchBeanException)
-        e.message == 'No bean of type [test.ClassOuterConfig$ClassInnerConfig$ClassInnerEachConfig] exists for the given qualifier: @Named(\'foo-bar\'). No configuration entries found under the prefix: [test.*.inner.inners.*]. Provide the necessary configuration to resolve this issue.'
+        def lines = e.message.lines().toList()
+        lines[0] == 'No bean of type [test.ClassOuterConfig$ClassInnerConfig$ClassInnerEachConfig] exists for the given qualifier: @Named(\'foo-bar\'). '
+        lines[1] == '* [ClassInnerEachConfig] is disabled because:'
+        lines[2] == ' - Configuration requires entries under the prefix: [test.*.inner.inners.*]'
     }
 
     @Override

--- a/inject-java/src/test/groovy/io/micronaut/inject/configurations/RequiresBeanSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/configurations/RequiresBeanSpec.groovy
@@ -16,10 +16,6 @@
 package io.micronaut.inject.configurations
 
 import io.micronaut.context.ApplicationContext
-import io.micronaut.context.BeanContext
-import io.micronaut.context.DefaultApplicationContext
-import io.micronaut.context.DefaultBeanContext
-import io.micronaut.context.env.PropertySource
 import io.micronaut.context.exceptions.NoSuchBeanException
 import io.micronaut.inject.configurations.requiresbean.RequiresBean
 import io.micronaut.inject.configurations.requiresconditionfalse.GitHubActionsBean
@@ -85,9 +81,10 @@ class RequiresBeanSpec extends Specification {
 
         then:
         NoSuchBeanException e = thrown()
-        def list = e.message.readLines().collect { it.trim()}
-        list[0] == 'No bean of type [io.micronaut.inject.configurations.requiresproperty.RequiresProperty] exists. The bean [RequiresProperty] is disabled because it is within the package [io.micronaut.inject.configurations.requiresproperty] which is disabled due to bean requirements:'
-        list[1] == '* Required property [data-source.url] with value [null] not present'
+        def list = e.message.readLines().toList()
+        list[0] == 'No bean of type [io.micronaut.inject.configurations.requiresproperty.RequiresProperty] exists. '
+        list[1] == '* [RequiresProperty] is disabled because it is within the package [io.micronaut.inject.configurations.requiresproperty] which is disabled due to bean requirements: '
+        list[2] == ' - Required property [data-source.url] with value [null] not present'
 
         cleanup:
         context.close()

--- a/inject-java/src/test/groovy/io/micronaut/inject/foreach/EachPropertySpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/foreach/EachPropertySpec.groovy
@@ -17,15 +17,14 @@ package io.micronaut.inject.foreach
 
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.DefaultApplicationContext
-import io.micronaut.context.Qualifier
 import io.micronaut.context.env.MapPropertySource
 import io.micronaut.context.env.PropertySource
 import io.micronaut.context.exceptions.NoSuchBeanException
 import io.micronaut.context.exceptions.NonUniqueBeanException
-import io.micronaut.inject.foreach.nested.A
 import io.micronaut.inject.foreach.nested.C
 import io.micronaut.inject.qualifiers.Qualifiers
 import spock.lang.Specification
+
 /**
  * @author Graeme Rocher
  * @since 1.0
@@ -41,14 +40,20 @@ class EachPropertySpec extends Specification {
 
         then:
         def error = thrown(NoSuchBeanException)
-        error.message == 'No bean of type [io.micronaut.inject.foreach.MyConfiguration] exists. No configuration entries found under the prefix: [foo.bar.*]. Provide the necessary configuration to resolve this issue.'
+        def lines = error.message.lines().toList()
+        lines[0] == "No bean of type [io.micronaut.inject.foreach.MyConfiguration] exists. "
+        lines[1] == "* [MyConfiguration] is disabled because:"
+        lines[2] == " - Configuration requires entries under the prefix: [foo.bar.*]"
 
         when:
         context.getBean(MyConfiguration, Qualifiers.byName("baz"))
 
         then:
         error = thrown(NoSuchBeanException)
-        error.message == 'No bean of type [io.micronaut.inject.foreach.MyConfiguration] exists for the given qualifier: @Named(\'baz\'). No configuration entries found under the prefix: [foo.bar.baz]. Provide the necessary configuration to resolve this issue.'
+        def lines2 = error.message.lines().toList()
+        lines2[0] == "No bean of type [io.micronaut.inject.foreach.MyConfiguration] exists for the given qualifier: @Named('baz'). "
+        lines2[1] == "* [MyConfiguration] is disabled because:"
+        lines2[2] == " - Configuration requires entries under the prefix: [foo.bar.baz]"
 
         cleanup:
         context.close()
@@ -63,18 +68,23 @@ class EachPropertySpec extends Specification {
 
         then:
         def error = thrown(NoSuchBeanException)
-        error.message.startsWith("No bean of type [io.micronaut.inject.foreach.MyBean] exists.")
-        error.message.contains("* [MyBean] requires the presence of a bean of type [io.micronaut.inject.foreach.MyConfiguration] which does not exist.")
-        error.message.endsWith("* [MyConfiguration] requires the presence of configuration. No configuration entries found under the prefix: [foo.bar.*]. Provide the necessary configuration to resolve this issue.")
+        def lines = error.message.lines().toList()
+        lines[0] == "No bean of type [io.micronaut.inject.foreach.MyBean] exists. "
+        lines[1] == "* [MyBean] requires the presence of a bean of type [io.micronaut.inject.foreach.MyConfiguration]."
+        lines[2] == " * [MyConfiguration] is disabled because:"
+        lines[3] == "  - Configuration requires entries under the prefix: [foo.bar.*]"
 
         when:
         context.getBean(C.class, Qualifiers.byName("test"))
 
         then:
         error = thrown(NoSuchBeanException)
-        error.message.contains('* [C] requires the presence of a bean of type [io.micronaut.inject.foreach.nested.B] with qualifier [@Named(\'test\')] which does not exist.')
-        error.message.contains("* [B] requires the presence of a bean of type [io.micronaut.inject.foreach.nested.A] with qualifier [@Named('test')] which does not exist.")
-        error.message.endsWith('* [A] requires the presence of configuration. No configuration entries found under the prefix: [foo.test]. Provide the necessary configuration to resolve this issue.')
+        def lines2 = error.message.lines().toList()
+        lines2[0] == "No bean of type [io.micronaut.inject.foreach.nested.C] exists for the given qualifier: @Named('test'). "
+        lines2[1] == "* [C] requires the presence of a bean of type [io.micronaut.inject.foreach.nested.B] with qualifier [@Named('test')]."
+        lines2[2] == " * [B] requires the presence of a bean of type [io.micronaut.inject.foreach.nested.A] with qualifier [@Named('test')]."
+        lines2[3] == "  * [A] is disabled because:"
+        lines2[4] == "   - Configuration requires entries under the prefix: [foo.test]"
 
         cleanup:
         context.close()

--- a/inject-java/src/test/groovy/io/micronaut/inject/requires/RequiresSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/inject/requires/RequiresSpec.groovy
@@ -14,6 +14,143 @@ import spock.util.environment.RestoreSystemProperties
 
 class RequiresSpec extends AbstractTypeElementSpec{
 
+    void "test requires eachbean simple"() {
+        given:
+            ApplicationContext context = buildContext( '''
+package test;
+
+import io.micronaut.context.annotation.*;
+
+@Requires(property = "myconf")
+@ConfigurationProperties("myconf")
+class MyConfiguration {
+}
+
+@EachBean(MyConfiguration.class)
+class MyClient {
+}
+
+@EachBean(MyClient.class)
+class MyBean {
+}
+''')
+        when:"the bean doesn't exist"
+            getBean(context, 'test.MyBean')
+
+        then:
+            def e = thrown(NoSuchBeanException)
+            def lines = e.message.readLines()
+            lines[0] == "No bean of type [test.MyBean] exists. "
+            lines[1] == "* [MyBean] requires the presence of a bean of type [test.MyClient]."
+            lines[2] == " * [MyClient] requires the presence of a bean of type [test.MyConfiguration]."
+            lines[3] == "  * [MyConfiguration] is disabled because:"
+            lines[4] == "   - Required property [myconf] with value [null] not present"
+        cleanup:
+            context.close()
+    }
+
+    void "test requires eachbean multiple"() {
+        given:
+            ApplicationContext context = buildContext( '''
+package test;
+
+import io.micronaut.context.annotation.*;
+
+@Requires(property = "myconf")
+@Requires(missingProperty = "myconf2.multiple")
+@ConfigurationProperties("myconf")
+class MyDefaultConfiguration implements MyConfiguration {
+}
+
+@EachProperty(value = "myconf2.multiple", primary = "default")
+class MyMultiConfiguration implements MyConfiguration {
+}
+
+interface MyConfiguration {
+}
+
+@EachBean(MyConfiguration.class)
+class MyClient {
+}
+
+@EachBean(MyClient.class)
+class MyBean {
+}
+''')
+        when:"the bean doesn't exist"
+            getBean(context, 'test.MyBean')
+
+        then:
+            def e = thrown(NoSuchBeanException)
+            def lines = e.message.readLines()
+            lines[0] == "No bean of type [test.MyBean] exists. "
+            lines[1] == "* [MyBean] requires the presence of a bean of type [test.MyClient]."
+            lines[2] == " * [MyClient] requires the presence of a bean of type [test.MyConfiguration]."
+            lines[3] == "  * [MyMultiConfiguration] a candidate of [MyConfiguration] is disabled because:"
+            lines[4] == "   - Configuration requires entries under the prefix: [myconf2.multiple.default]"
+            lines[5] == "  * [MyDefaultConfiguration] a candidate of [MyConfiguration] is disabled because:"
+            lines[6] == "   - Required property [myconf] with value [null] not present"
+            lines.size() == 7
+        cleanup:
+            context.close()
+    }
+
+    void "test requires eachbean multiple 2"() {
+        given:
+            ApplicationContext context = buildContext( '''
+package test;
+
+import io.micronaut.context.annotation.*;
+import jakarta.inject.Singleton;
+
+@Requires(property = "myconf.helper", pattern = "abc")
+@Singleton
+class MyHelper {
+}
+
+@Requires(property = "myconf")
+@Requires(missingProperty = "myconf2.multiple")
+@ConfigurationProperties("myconf")
+class MyDefaultConfiguration implements MyConfiguration {
+}
+
+@Requires(bean = MyHelper.class)
+@EachProperty(value = "myconf2.multiple", primary = "default")
+class MyMultiConfiguration implements MyConfiguration {
+}
+
+interface MyConfiguration {
+}
+
+@EachBean(MyConfiguration.class)
+class MyClient {
+}
+
+@EachBean(MyClient.class)
+class MyBean {
+}
+''')
+        when:"the bean doesn't exist"
+            getBean(context, 'test.MyBean')
+
+        then:
+            def e = thrown(NoSuchBeanException)
+            def lines = e.message.readLines()
+            lines[0] == "No bean of type [test.MyBean] exists. "
+            lines[1] == "* [MyBean] requires the presence of a bean of type [test.MyClient]."
+            lines[2] == " * [MyClient] requires the presence of a bean of type [test.MyConfiguration]."
+            lines[3] == "  * [MyDefaultConfiguration] a candidate of [MyConfiguration] is disabled because:"
+            lines[4] == "   - Required property [myconf] with value [null] not present"
+            lines[5] == "  * [MyMultiConfiguration] a candidate of [MyConfiguration] is disabled because:"
+            lines[6] == "   - No bean of type [test.MyHelper] present within context"
+            lines[7] == "   * [MyHelper] is disabled because:"
+            lines[8] == "    - Required property [myconf.helper] with value [null] not present"
+
+            lines.size() == 9
+        cleanup:
+            context.close()
+    }
+
     void "test requires java sdk - success"() {
         given:
         ApplicationContext context = buildContext( '''
@@ -50,10 +187,10 @@ class MyBean {
 
         then:
         def e = thrown(NoSuchBeanException)
-        def lines = e.message.readLines().collect { it.trim() }
-        lines[0] == 'No bean of type [test.MyBean] exists. The following matching beans are disabled by bean requirements:'
-        lines[1] == '* Bean of type [test.MyBean] is disabled because:'
-        lines[2] == "- Java major version [${Runtime.version().feature()}] must be at least 800"
+        def lines = e.message.readLines()
+        lines[0] == 'No bean of type [test.MyBean] exists. '
+        lines[1] == '* [MyBean] is disabled because:'
+        lines[2] == " - Java major version [${Runtime.version().feature()}] must be at least 800"
 
         cleanup:
         context.close()
@@ -77,10 +214,10 @@ class MyBean {
 
         then:
         def e = thrown(NoSuchBeanException)
-        def lines = e.message.readLines().collect { it.trim() }
-        lines[0] == 'No bean of type [test.MyBean] exists. The following matching beans are disabled by bean requirements:'
-        lines[1] == '* Bean of type [test.MyBean] is disabled because:'
-        lines[2] == '- Required property [foo] with value [bar] not present'
+        def lines = e.message.readLines()
+        lines[0] == 'No bean of type [test.MyBean] exists. '
+        lines[1] == '* [MyBean] is disabled because:'
+        lines[2] == ' - Required property [foo] with value [bar] not present'
 
         cleanup:
         context.close()

--- a/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/beans/BeanDefinitionSpec.groovy
+++ b/inject-kotlin/src/test/groovy/io/micronaut/kotlin/processing/beans/BeanDefinitionSpec.groovy
@@ -99,7 +99,10 @@ class ExampleTest(private val application: EmbeddedApplication<*>): StringSpec({
 
         then:
         def e = thrown(NoSuchBeanException)
-        e.message.contains("Bean of type [test.ExampleTest] is disabled")
+        def lines = e.message.lines().toList()
+        lines[0] == 'No bean of type [test.ExampleTest] exists. '
+        lines[1] == '* [ExampleTest] is disabled because:'
+        lines[2] == ' - Custom condition [class io.micronaut.test.condition.TestActiveCondition] failed evaluation'
     }
 
     void "test jvm field"() {

--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
@@ -292,65 +292,73 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
     }
 
     @Override
-    protected <T> NoSuchBeanException newNoSuchBeanException(@Nullable BeanResolutionContext resolutionContext, Argument<T> beanType, Qualifier<T> qualifier, String message) {
+    protected <T> NoSuchBeanException newNoSuchBeanException(@Nullable BeanResolutionContext resolutionContext,
+                                                             Argument<T> beanType,
+                                                             @Nullable Qualifier<T> qualifier,
+                                                             @Nullable String message) {
         if (message == null) {
-            message = super.resolveDisabledBeanMessage(resolutionContext, beanType, qualifier);
-        }
-
-        if (message == null) {
-            message = resolveIterableBeanMissingMessage(resolutionContext, beanType, qualifier, message);
+            StringBuilder stringBuilder = new StringBuilder();
+            String ls = CachedEnvironment.getProperty("line.separator");
+            appendBeanMissingMessage("", stringBuilder, ls, resolutionContext, beanType, qualifier);
+            message = stringBuilder.toString();
         }
 
         return super.newNoSuchBeanException(resolutionContext, beanType, qualifier, message);
     }
 
-    private <T> String resolveIterableBeanMissingMessage(BeanResolutionContext resolutionContext, Argument<T> beanType, Qualifier<T> qualifier, String message) {
-        BeanDefinition<T> definition = findAnyBeanDefinition(resolutionContext, beanType);
-        if (definition != null && definition.isIterable()) {
-            if (definition.hasDeclaredAnnotation(EachProperty.class)) {
-                message = resolveEachPropertyMissingBeanMessage(resolutionContext, qualifier, definition);
-            } else if (definition.hasDeclaredAnnotation(EachBean.class)) {
-                message = resolveEachBeanMissingMessage(resolutionContext, beanType, qualifier, definition);
+    private <T> void appendBeanMissingMessage(String linePrefix,
+                                              StringBuilder messageBuilder,
+                                              String lineSeparator,
+                                              @Nullable BeanResolutionContext resolutionContext,
+                                              Argument<T> beanType,
+                                              @Nullable Qualifier<T> qualifier) {
+
+        if (linePrefix.length() == 10) {
+            // Break possible cyclic dependencies
+            return;
+        }
+
+        Collection<BeanDefinition<T>> beanCandidates = findBeanCandidates(resolutionContext, beanType, false, definition -> !definition.isAbstract())
+            .stream().sorted().toList();
+        for (BeanDefinition<T> definition : beanCandidates) {
+            if (definition != null && definition.isIterable()) {
+                if (definition.hasDeclaredAnnotation(EachProperty.class)) {
+                    appendEachPropertyMissingBeanMessage(linePrefix, messageBuilder, lineSeparator, resolutionContext, beanType, qualifier, definition);
+                } else if (definition.hasDeclaredAnnotation(EachBean.class)) {
+                    appendMissingEachBeanMessage(linePrefix, messageBuilder, lineSeparator, resolutionContext, beanType, qualifier, definition);
+                }
             }
         }
-        return message;
+        resolveDisabledBeanMessage(linePrefix, messageBuilder, lineSeparator, resolutionContext, beanType, qualifier);
     }
 
-    @NonNull
-    private <T> String resolveEachBeanMissingMessage(BeanResolutionContext resolutionContext, Argument<T> beanType, Qualifier<T> qualifier, BeanDefinition<T> definition) {
-        String message;
-        List<BeanDefinition<?>> dependencyChain = calculateEachBeanChain(resolutionContext, definition);
-        StringBuilder messageBuilder = new StringBuilder();
-        Argument<?> requiredBeanType = beanType;
-        Iterator<BeanDefinition<?>> i = dependencyChain.iterator();
-        String ls = CachedEnvironment.getProperty("line.separator");
-        while (i.hasNext()) {
-            messageBuilder.append(ls);
-            BeanDefinition<?> beanDefinition = i.next();
-            Argument<?> nextBeanType = beanDefinition.asArgument();
-            messageBuilder.append("* [").append(requiredBeanType.getTypeString(true))
-                .append("] requires the presence of a bean of type [")
-                .append(nextBeanType.getTypeString(false))
-                .append("]");
-            if (qualifier != null) {
-                messageBuilder.append(" with qualifier [").append(qualifier).append("]");
-            }
-            messageBuilder.append(" which does not exist.");
-            if (beanDefinition.hasDeclaredAnnotation(EachProperty.class)) {
-                messageBuilder.append(ls);
-                String propertyMissingMessage = resolveEachPropertyMissingBeanMessage(resolutionContext, qualifier, beanDefinition);
-                messageBuilder.append("* ")
-                    .append("[")
-                    .append(nextBeanType.getTypeString(true))
-                    .append("] requires the presence of configuration. ")
-                    .append(propertyMissingMessage);
-                break;
-            }
-            requiredBeanType = nextBeanType;
-        }
+    private <T> void appendMissingEachBeanMessage(String linePrefix,
+                                                  StringBuilder messageBuilder,
+                                                  String lineSeparator,
+                                                  @Nullable BeanResolutionContext resolutionContext,
+                                                  Argument<T> beanType,
+                                                  @Nullable Qualifier<T> qualifier,
+                                                  BeanDefinition<T> definition) {
+        Class<?> dependentBean = definition.classValue(EachBean.class).orElseThrow();
 
-        message = messageBuilder.toString();
-        return message;
+        messageBuilder
+            .append(lineSeparator)
+            .append(linePrefix)
+            .append("* [").append(beanType.getTypeString(true))
+            .append("] requires the presence of a bean of type [")
+            .append(dependentBean.getName())
+            .append("]");
+        if (qualifier != null) {
+            messageBuilder.append(" with qualifier [").append(qualifier).append("]");
+        }
+        messageBuilder.append(".");
+
+        appendBeanMissingMessage(linePrefix + " ",
+            messageBuilder,
+            lineSeparator,
+            resolutionContext,
+            Argument.of(dependentBean),
+            (Qualifier) qualifier);
     }
 
     @Nullable
@@ -361,23 +369,6 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
             definition = existing.iterator().next();
         }
         return definition;
-    }
-
-    private <T> List<BeanDefinition<?>> calculateEachBeanChain(
-        BeanResolutionContext resolutionContext,
-        BeanDefinition<T> definition) {
-        Class<?> dependentBean = definition.classValue(EachBean.class).orElse(null);
-        List<BeanDefinition<?>> chain = new ArrayList<>();
-        while (dependentBean != null) {
-            BeanDefinition<?> dependent = findAnyBeanDefinition(resolutionContext, Argument.of(dependentBean));
-            if (dependent == null) {
-                break;
-            }
-            chain.add(dependent);
-            dependentBean = dependent.classValue(EachBean.class).orElse(null);
-        }
-
-        return chain;
     }
 
     private List<BeanDefinition<?>> calculateEachPropertyChain(
@@ -400,9 +391,36 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
         return chain;
     }
 
-
     @NonNull
-    private String resolveEachPropertyMissingBeanMessage(BeanResolutionContext resolutionContext, Qualifier<?> qualifier, BeanDefinition<?> definition) {
+    private <T> void appendEachPropertyMissingBeanMessage(String linePrefix,
+                                                          StringBuilder messageBuilder,
+                                                          String lineSeparator,
+                                                          @Nullable BeanResolutionContext resolutionContext,
+                                                          Argument<T> beanType,
+                                                          @Nullable Qualifier<T> qualifier,
+                                                          BeanDefinition<?> definition) {
+        String prefix = calculatePrefix(resolutionContext, qualifier, definition);
+
+        messageBuilder
+            .append(lineSeparator)
+            .append(linePrefix)
+            .append("* [")
+            .append(definition.asArgument().getTypeString(true));
+        if (!definition.getBeanType().equals(beanType.getType())) {
+            messageBuilder.append("] a candidate of [")
+                .append(beanType.getTypeString(true));
+        }
+        messageBuilder.append("] is disabled because:")
+            .append(lineSeparator);
+        messageBuilder
+            .append(linePrefix)
+            .append(" - ")
+            .append("Configuration requires entries under the prefix: [")
+            .append(prefix)
+            .append("]");
+    }
+
+    private <T> String calculatePrefix(BeanResolutionContext resolutionContext, Qualifier<T> qualifier, BeanDefinition<?> definition) {
         List<BeanDefinition<?>> chain = calculateEachPropertyChain(resolutionContext, definition);
         String prefix;
         if (chain.size() > 1) {
@@ -410,7 +428,6 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
             ConfigurationPath path = ConfigurationPath.of(chain.toArray(BeanDefinition[]::new));
             prefix = path.path();
         } else {
-
             prefix = definition.stringValue(EachProperty.class).orElse("");
             if (qualifier != null) {
                 if (qualifier instanceof Named named) {
@@ -422,14 +439,12 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
                 prefix += "." + definition.stringValue(EachProperty.class, "primary").orElse("*");
             }
         }
-
-
-        return "No configuration entries found under the prefix: [" + prefix + "]. Provide the necessary configuration to resolve this issue.";
+        return prefix;
     }
 
     @Override
     protected <T> void collectIterableBeans(BeanResolutionContext resolutionContext, BeanDefinition<T> iterableBean, Set<BeanDefinition<T>> targetSet) {
-        try(BeanResolutionContext rc = newResolutionContext(iterableBean, resolutionContext)) {
+        try (BeanResolutionContext rc = newResolutionContext(iterableBean, resolutionContext)) {
             if (iterableBean.hasDeclaredStereotype(EachProperty.class)) {
                 transformEachPropertyBeanDefinition(rc, iterableBean, targetSet);
             } else if (iterableBean.hasDeclaredStereotype(EachBean.class)) {

--- a/inject/src/main/java/io/micronaut/context/RequiresCondition.java
+++ b/inject/src/main/java/io/micronaut/context/RequiresCondition.java
@@ -570,7 +570,7 @@ public class RequiresCondition implements Condition {
                 BeanContext beanContext = context.getBeanContext();
                 for (Class<?> type : beans) {
                     if (!beanContext.containsBean(type)) {
-                        context.fail("No bean of type [" + type + "] present within context");
+                        context.fail("No bean of type [" + type.getName() + "] present within context");
                         return false;
                     }
                 }
@@ -595,7 +595,7 @@ public class RequiresCondition implements Condition {
                     );
                     for (BeanDefinition<?> beanDefinition : beanDefinitions) {
                         if (!beanDefinition.isAbstract()) {
-                            context.fail("Existing bean [" + beanDefinition.getName() + "] of type [" + type + "] registered in context");
+                            context.fail("Existing bean [" + beanDefinition.getName() + "] of type [" + type.getName() + "] registered in context");
                             return false;
                         }
                     }

--- a/inject/src/main/java/io/micronaut/context/exceptions/MessageUtils.java
+++ b/inject/src/main/java/io/micronaut/context/exceptions/MessageUtils.java
@@ -105,6 +105,7 @@ class MessageUtils {
                 .append(methodName)
                 .append("] of class: ")
                 .append(declaringTypeName)
+                .append(ls)
                 .append(ls);
 
         if (message != null) {

--- a/inject/src/main/java/io/micronaut/context/exceptions/MessageUtils.java
+++ b/inject/src/main/java/io/micronaut/context/exceptions/MessageUtils.java
@@ -105,7 +105,6 @@ class MessageUtils {
                 .append(methodName)
                 .append("] of class: ")
                 .append(declaringTypeName)
-                .append(ls)
                 .append(ls);
 
         if (message != null) {


### PR DESCRIPTION
Previously new detailed messages introduced in v4 only included one level of information about why the bean was disabled. That doesn't help much for more complicated configuration beans like MongoDB, JDBC etc. Now it should be more detailed.