### PR TITLE
Allow context-path to be an empty String

### DIFF
--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/context/ContextURISpec.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/context/ContextURISpec.groovy
@@ -32,4 +32,18 @@ class ContextURISpec extends Specification {
         cleanup:
         embeddedServer.close()
     }
+
+    void "test getContextURI returns the base URI when context path is set to an empty string"() {
+        when:
+        EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
+                'micronaut.server.context-path': '',
+                'micronaut.server.port': 60006
+        ])
+
+        then:
+        embeddedServer.getContextURI().toString() == 'http://localhost:60006'
+
+        cleanup:
+        embeddedServer.close()
+    }
 }

--- a/router/src/main/java/io/micronaut/web/router/naming/ConfigurableUriNamingStrategy.java
+++ b/router/src/main/java/io/micronaut/web/router/naming/ConfigurableUriNamingStrategy.java
@@ -21,6 +21,7 @@ import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.annotation.Value;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.naming.conventions.PropertyConvention;
+import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.BeanDefinition;
 import jakarta.inject.Singleton;
 
@@ -69,11 +70,13 @@ public class ConfigurableUriNamingStrategy extends HyphenatedUriNamingStrategy {
     }
 
     private String normalizeContextPath(String contextPath) {
-        if (contextPath.charAt(0) != '/') {
-            contextPath = '/' + contextPath;
-        }
-        if (contextPath.charAt(contextPath.length() - 1) == '/') {
-            contextPath = contextPath.substring(0, contextPath.length() - 1);
+        if (StringUtils.isNotEmpty(contextPath)) {
+            if (contextPath.charAt(0) != '/') {
+                contextPath = '/' + contextPath;
+            }
+            if (contextPath.charAt(contextPath.length() - 1) == '/') {
+                contextPath = contextPath.substring(0, contextPath.length() - 1);
+            }
         }
         return contextPath;
     }

--- a/router/src/test/groovy/io/micronaut/web/router/ConfigurableUriNamingStrategySpec.groovy
+++ b/router/src/test/groovy/io/micronaut/web/router/ConfigurableUriNamingStrategySpec.groovy
@@ -59,6 +59,8 @@ class ConfigurableUriNamingStrategySpec extends Specification {
         applicationContext.close()
     }
 
+
+
     @Unroll
     void "Test 'micronaut.server.context-path' matches with #route"() {
         given:
@@ -161,6 +163,32 @@ class ConfigurableUriNamingStrategySpec extends Specification {
         GET    | '/test/city'               | 'Hello city'
         GET    | '/test/city/Madrid'        | 'City Madrid'
         GET    | '/test/city/country/Spain' | 'Country Spain'
+    }
+
+    @Unroll
+    void "Test 'micronaut.server.context-path' set to empty String matches with #route"() {
+        given:
+        def applicationContext = ApplicationContext.run(
+                PropertySource.of(
+                        'test',
+                        ['micronaut.server.context-path': '']
+                )
+        )
+                .start()
+        def router = applicationContext.getBean(Router)
+
+        expect:
+        router."$method"(route).isPresent()
+        router."$method"(route).get().invoke() == result
+
+        cleanup:
+        applicationContext.close()
+
+        where:
+        method | route                 | result
+        GET    | '/city'               | 'Hello city'
+        GET    | '/city/Madrid'        | 'City Madrid'
+        GET    | '/city/country/Spain' | 'Country Spain'
     }
 
     @Controller('/city')


### PR DESCRIPTION
`ConfigurableUriNamingStrategy` is updated to handle the case when `micronaut.server.context-path` is set to an empty 
String value, maintaining the same behavior as if the property were not explicitly set at all.

Resolves #10209 