### PR TITLE
Move URI validation step back to RoutingInBoundHandler

### DIFF
--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyRequestLifecycle.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyRequestLifecycle.java
@@ -48,6 +48,7 @@ final class NettyRequestLifecycle extends RequestLifecycle {
 
     private final RoutingInBoundHandler rib;
     private final PipeliningServerHandler.OutboundAccess outboundAccess;
+    private final boolean validateUrl;
 
     /**
      * Should only be used where netty-specific stuff is needed, such as reading the body or
@@ -58,6 +59,7 @@ final class NettyRequestLifecycle extends RequestLifecycle {
     NettyRequestLifecycle(RoutingInBoundHandler rib, PipeliningServerHandler.OutboundAccess outboundAccess) {
         super(rib.routeExecutor);
         this.rib = rib;
+        this.validateUrl = rib.serverConfiguration.isValidateUrl();
         this.outboundAccess = outboundAccess;
     }
 


### PR DESCRIPTION
Still configurable though.

The reason for this is that with the previous logic, filters could still see an invalid `request.getPath()`. This is a potential security issue because proxy filters that are built as described [in the guide](https://docs.micronaut.io/latest/guide/index.html#proxyClient) may forward the invalid user-controlled path without checking.

This patch moves the uri check back to its original place. This ensures it's checked before filters. It also replaces the request with a fixed path ("/") so that the filters cannot see a malicious user-controlled path.