### PR TITLE
Change to public so that java doc is generated for Configuration Reference link in manual.

### DIFF
--- a/buffer-netty/src/main/java/io/micronaut/buffer/netty/DefaultByteBufAllocatorConfiguration.java
+++ b/buffer-netty/src/main/java/io/micronaut/buffer/netty/DefaultByteBufAllocatorConfiguration.java
@@ -39,7 +39,7 @@ import io.micronaut.core.order.Ordered;
 @BootstrapContextCompatible
 @Internal
 @Order(Ordered.HIGHEST_PRECEDENCE)
-final class DefaultByteBufAllocatorConfiguration implements ByteBufAllocatorConfiguration {
+public final class DefaultByteBufAllocatorConfiguration implements ByteBufAllocatorConfiguration {
 
     private static final String PROP_PREFIX = "io.netty.allocator.";
 


### PR DESCRIPTION
closes #10202

Note: the `DefaultByteBufAllocatorConfiguration` class is still annotated `@Internal` and qualified `final`

I don't believe there are any other non-public classes annotated `@ConfigurationProperties` that will result in broken links for the manual.