### PR TITLE
fix: consider current package when generating bean imports

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/ast/utils/EnclosedElementsQuery.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/utils/EnclosedElementsQuery.java
@@ -137,7 +137,9 @@ public abstract class EnclosedElementsQuery<C, N> {
                 if (element.isPrivate() || element.getName().startsWith("$")) {
                     return false;
                 }
-                if (element instanceof MemberElement memberElement && !memberElement.isAccessible()) {
+                // exclude when not accessible from type
+                if (element instanceof MemberElement memberElement && !result.getOnlyAccessibleFromType()
+                    .filter(fromType -> memberElement.isAccessible(fromType)).isPresent()) {
                     return false;
                 }
             }

--- a/core-processor/src/main/java/io/micronaut/inject/writer/AbstractBeanDefinitionBuilder.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/AbstractBeanDefinitionBuilder.java
@@ -923,6 +923,16 @@ public abstract class AbstractBeanDefinitionBuilder implements BeanElementBuilde
             return element.isPublic();
         }
 
+        @Override
+        public boolean isPackagePrivate() {
+            return element.isPackagePrivate();
+        }
+
+        @Override
+        public boolean isPrivate() {
+            return element.isPrivate();
+        }
+
         @NonNull
         @Override
         public Object getNativeType() {


### PR DESCRIPTION
The internal bean element implementation didn't implement the methods for the determination of the visibility of the class, which resulted in the use of reflection for the bean definitions generated for the bean import.

By implementing the visibility methods the generated code for the imported bean definitions don't use reflection when the fields are visible.

I've tried to add a test to [inject-java-test/src/test/groovy/io/micronaut/inject/beanimport/BeanImportSpec.groovy](https://github.com/micronaut-projects/micronaut-core/blob/4.2.x/inject-java-test/src/test/groovy/io/micronaut/inject/beanimport/BeanImportSpec.groovy) but i'm unable to determine if reflection is used, this information isn't available in the BeanDefinition:

```java
    void "test bean import for current package"() {
        given:
        ApplicationContext context = buildContext('''
package io.micronaut.inject.beanimport;

import io.micronaut.context.annotation.*;
import jakarta.inject.Named;
import java.nio.charset.StandardCharsets;

@Import(classes=io.micronaut.inject.beanimport.BeanWithFields.class)
class Application {}
''')
        def bean = context.getBeanDefinition(BeanWithFields)

        expect:
        bean.getInjectedFields()[0].getName() == 'publicField' // How to determine that reflection isn't used?
        bean.getInjectedFields()[1].getName() == 'packageField' // How to determine that reflection isn't used?
        bean.getInjectedFields()[2].getName() == 'protectedField' // How to determine that reflection is used?
        bean.getInjectedFields()[3].getName() == 'privateField'  // How to determine that reflection is used?
    }

@Singleton
class BeanWithFields {
    public @Named("public") String publicField;
    @Named("package") String packageField;
    protected @Named("protected") String protectedField;
    private @Named("private") String privateField;
}
```