### PR TITLE
Reimplement `EnclosedElementsQuery` to improve performance

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/ast/DefaultElementQuery.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/DefaultElementQuery.java
@@ -49,6 +49,7 @@ final class DefaultElementQuery<T extends Element> implements ElementQuery<T>, E
     private final boolean includeOverriddenMethods;
     private final boolean includeHiddenElements;
     private final boolean excludePropertyElements;
+    private final int hashcode;
 
     DefaultElementQuery(Class<T> elementType) {
         this(elementType, null, false, false, false, false, false, false, false, false, false, false, null, null, null, null, null);
@@ -89,6 +90,7 @@ final class DefaultElementQuery<T extends Element> implements ElementQuery<T>, E
         this.includeHiddenElements = includeHiddenElements;
         this.excludePropertyElements = excludePropertyElements;
         this.typePredicates = typePredicates;
+        this.hashcode = Objects.hash(elementType, onlyAccessibleType, onlyDeclared, onlyAbstract, onlyConcrete, onlyInjected, namePredicates, annotationPredicates, modifiersPredicates, elementPredicates, typePredicates, onlyInstance, onlyStatic, includeEnumConstants, includeOverriddenMethods, includeHiddenElements, excludePropertyElements);
     }
 
     @Override
@@ -560,5 +562,22 @@ final class DefaultElementQuery<T extends Element> implements ElementQuery<T>, E
     @Override
     public Result<T> result() {
         return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DefaultElementQuery<?> that = (DefaultElementQuery<?>) o;
+        return onlyDeclared == that.onlyDeclared && onlyAbstract == that.onlyAbstract && onlyConcrete == that.onlyConcrete && onlyInjected == that.onlyInjected && onlyInstance == that.onlyInstance && onlyStatic == that.onlyStatic && includeEnumConstants == that.includeEnumConstants && includeOverriddenMethods == that.includeOverriddenMethods && includeHiddenElements == that.includeHiddenElements && excludePropertyElements == that.excludePropertyElements && Objects.equals(elementType, that.elementType) && Objects.equals(onlyAccessibleType, that.onlyAccessibleType) && Objects.equals(namePredicates, that.namePredicates) && Objects.equals(annotationPredicates, that.annotationPredicates) && Objects.equals(modifiersPredicates, that.modifiersPredicates) && Objects.equals(elementPredicates, that.elementPredicates) && Objects.equals(typePredicates, that.typePredicates);
+    }
+
+    @Override
+    public int hashCode() {
+        return hashcode;
     }
 }

--- a/core-processor/src/main/java/io/micronaut/inject/ast/MethodElement.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/MethodElement.java
@@ -329,6 +329,10 @@ public interface MethodElement extends MemberElement {
                     return false;
                 }
             }
+            if (!getDeclaringType().isAssignable(memberElement.getDeclaringType())) {
+                // not a parent class
+                return false;
+            }
             ClassElement existingReturnType = hidden.getReturnType().getGenericType();
             ClassElement newTypeReturn = newMethod.getReturnType().getGenericType();
             if (!newTypeReturn.isAssignable(existingReturnType)) {
@@ -337,7 +341,7 @@ public interface MethodElement extends MemberElement {
             if (hidden.isPackagePrivate()) {
                 return newMethod.getDeclaringType().getPackageName().equals(hidden.getDeclaringType().getPackageName());
             }
-            return true;
+            return memberElement.isAccessible(getDeclaringType());
         }
         return false;
     }

--- a/core-processor/src/main/java/io/micronaut/inject/ast/utils/EnclosedElementsQuery.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/utils/EnclosedElementsQuery.java
@@ -34,7 +34,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -54,7 +54,9 @@ import java.util.function.Predicate;
 public abstract class EnclosedElementsQuery<C, N> {
 
     private static final int MAX_ITEMS_IN_CACHE = 200;
+    private static final int MAX_RESULTS = 20;
     private final Map<CacheKey, Element> elementsCache = new LinkedHashMap<>();
+    private final Map<QueryResultKey, List<?>> resultsCache = new LinkedHashMap<>();
 
     /**
      * Get native class element.
@@ -87,6 +89,13 @@ public abstract class EnclosedElementsQuery<C, N> {
     public <T extends io.micronaut.inject.ast.Element> List<T> getEnclosedElements(ClassElement classElement, @NonNull ElementQuery<T> query) {
         Objects.requireNonNull(query, "Query cannot be null");
         ElementQuery.Result<T> result = query.result();
+
+        QueryResultKey queryResultKey = new QueryResultKey(result, classElement.getNativeType());
+        List<T> values = (List<T>) resultsCache.get(queryResultKey);
+        if (values != null) {
+            return values;
+        }
+
         Set<N> excludeElements = getExcludedNativeElements(result);
         Predicate<T> filter = element -> {
             if (excludeElements.contains(getNativeType(element))) {
@@ -153,19 +162,8 @@ public abstract class EnclosedElementsQuery<C, N> {
                 }
             }
             if (!result.getTypePredicates().isEmpty()) {
+                ClassElement ce = memberType(classElement, element);
                 for (Predicate<ClassElement> typePredicate : result.getTypePredicates()) {
-                    ClassElement ce;
-                    if (element instanceof ConstructorElement) {
-                        ce = classElement;
-                    } else if (element instanceof MethodElement methodElement) {
-                        ce = methodElement.getGenericReturnType();
-                    } else if (element instanceof ClassElement theClass) {
-                        ce = theClass;
-                    } else if (element instanceof FieldElement fieldElement) {
-                        ce = fieldElement.getGenericField();
-                    } else {
-                        throw new IllegalStateException("Unknown element: " + element);
-                    }
                     if (!typePredicate.test(ce)) {
                         return false;
                     }
@@ -173,11 +171,31 @@ public abstract class EnclosedElementsQuery<C, N> {
             }
             return true;
         };
-        Collection<T> allElements = getAllElements(getNativeClassType(classElement), result.isOnlyDeclared(), (t1, t2) -> reduceElements(t1, t2, result), result);
-        return allElements
-                .stream()
-                .filter(filter)
-                .toList();
+
+        C nativeClassType = getNativeClassType(classElement);
+        List<T> elements;
+        if (result.isOnlyDeclared() || classElement.getSuperType().isEmpty() && classElement.getInterfaces().isEmpty()) {
+            elements = getElements(nativeClassType, result, filter);
+        } else {
+            elements = getAllElements(nativeClassType, (t1, t2) -> reduceElements(t1, t2, result), result, filter);
+        }
+        resultsCache.put(queryResultKey, elements);
+        adjustMapCapacity(resultsCache, MAX_RESULTS);
+        return elements;
+    }
+
+    private <T extends Element> ClassElement memberType(ClassElement classElement, T element) {
+        if (element instanceof ConstructorElement) {
+            return classElement;
+        } else if (element instanceof MethodElement methodElement) {
+            return methodElement.getGenericReturnType();
+        } else if (element instanceof ClassElement theClass) {
+            return theClass;
+        } else if (element instanceof FieldElement fieldElement) {
+            return fieldElement.getGenericField();
+        } else {
+            throw new IllegalStateException("Unknown element: " + element);
+        }
     }
 
     private boolean reduceElements(io.micronaut.inject.ast.Element newElement,
@@ -203,76 +221,177 @@ public abstract class EnclosedElementsQuery<C, N> {
         return false;
     }
 
-    private <T extends io.micronaut.inject.ast.Element> Collection<T> getAllElements(C classNode,
-                                                                                     boolean onlyDeclared,
-                                                                                     BiPredicate<T, T> reduce,
-                                                                                     ElementQuery.Result<?> result) {
-        Set<T> elements = new LinkedHashSet<>();
-        List<List<N>> hierarchy = new ArrayList<>();
-        collectHierarchy(classNode, onlyDeclared, hierarchy, result);
-        for (List<N> classElements : hierarchy) {
-            Set<T> addedFromClassElements = new LinkedHashSet<>();
-            classElements:
-            for (N element : classElements) {
-                List<Predicate<String>> namePredicates = result.getNamePredicates();
-                if (!namePredicates.isEmpty()) {
-                    String elementName = getElementName(element);
-                    for (Predicate<String> namePredicate : namePredicates) {
-                        if (!namePredicate.test(elementName)) {
-                            continue classElements;
-                        }
-                    }
-                }
+    private <T extends io.micronaut.inject.ast.Element> List<T> getAllElements(C classNode,
+                                                                               BiPredicate<T, T> reduce,
+                                                                               ElementQuery.Result<?> result,
+                                                                               Predicate<T> filter) {
 
-                N nativeType = getCacheKey(element);
-                CacheKey cacheKey = new CacheKey(result.getElementType(), nativeType);
-                T newElement = (T) elementsCache.computeIfAbsent(cacheKey, ck -> toAstElement(nativeType, result.getElementType()));
-                if (result.getElementType() == MemberElement.class) {
-                    // Also cache members query results as it's original element type
-                    if (newElement instanceof FieldElement) {
-                        elementsCache.putIfAbsent(new CacheKey(FieldElement.class, nativeType), newElement);
-                    } else if (newElement instanceof ConstructorElement) {
-                        elementsCache.putIfAbsent(new CacheKey(ConstructorElement.class, nativeType), newElement);
-                        elementsCache.putIfAbsent(new CacheKey(MethodElement.class, nativeType), newElement);
-                    } else if (newElement instanceof MethodElement) {
-                        elementsCache.putIfAbsent(new CacheKey(MethodElement.class, nativeType), newElement);
-                    } else if (newElement instanceof PropertyElement) {
-                        elementsCache.putIfAbsent(new CacheKey(PropertyElement.class, nativeType), newElement);
-                    }
-                } else if (MemberElement.class.isAssignableFrom(result.getElementType())) {
-                    elementsCache.putIfAbsent(new CacheKey(MemberElement.class, nativeType), newElement);
-                }
-                if (elementsCache.size() == MAX_ITEMS_IN_CACHE) {
-                    Iterator<Map.Entry<CacheKey, Element>> iterator = elementsCache.entrySet().iterator();
-                    iterator.next();
-                    iterator.remove();
-                }
-                if (!result.getElementType().isInstance(newElement)) {
-                    // dirty cache
-                    elementsCache.remove(cacheKey);
-                    newElement = (T) elementsCache.computeIfAbsent(cacheKey, ck -> toAstElement(nativeType, result.getElementType()));
-                }
-                for (Iterator<T> iterator = elements.iterator(); iterator.hasNext(); ) {
-                    T existingElement = iterator.next();
-                    if (newElement.equals(existingElement)) {
-                        continue;
-                    }
-                    if (reduce.test(newElement, existingElement)) {
-                        iterator.remove();
-                        addedFromClassElements.add(newElement);
-                    } else if (reduce.test(existingElement, newElement)) {
-                        continue classElements;
-                    }
-                }
-                addedFromClassElements.add(newElement);
+        List<T> elements = new LinkedList<>();
+        List<T> addedFromClassElements = new ArrayList<>(20);
+        if (isInterface(classNode)) {
+            processInterfaceHierarchy(classNode, reduce, result, addedFromClassElements, elements, true);
+        } else {
+            boolean includeAbstract = isAbstractClass(classNode) || result.isIncludeOverriddenMethods();
+            processClassHierarchy(classNode, reduce, result, addedFromClassElements, elements, includeAbstract);
+        }
+        Iterator<T> iterator = elements.iterator();
+        while (iterator.hasNext()) {
+            T element = iterator.next();
+            if (!filter.test(element)) {
+                iterator.remove();
             }
-            elements.addAll(addedFromClassElements);
         }
         return elements;
     }
 
+    private <T extends Element> void processClassHierarchy(C classNode,
+                                                           BiPredicate<T, T> reduce,
+                                                           ElementQuery.Result<?> result,
+                                                           List<T> addedFromClassElements,
+                                                           List<T> collectedElements,
+                                                           boolean includeAbstract) {
+        if (excludeClass(classNode)) {
+            return;
+        }
+        C superClass = getSuperClass(classNode);
+        if (superClass != null) {
+            processClassHierarchy(superClass, reduce, result, addedFromClassElements, collectedElements, includeAbstract);
+        }
+        reduce(collectedElements, getEnclosedElements(classNode, result, includeAbstract), reduce, result, addedFromClassElements, false, false);
+        for (C anInterface : getInterfaces(classNode)) {
+            processInterfaceHierarchy(anInterface, reduce, result, addedFromClassElements, collectedElements, includeAbstract);
+        }
+    }
+
+    private <T extends Element> void processInterfaceHierarchy(C classNode,
+                                                               BiPredicate<T, T> reduce,
+                                                               ElementQuery.Result<?> result,
+                                                               List<T> addedFromClassElements,
+                                                               Collection<T> collectedElements,
+                                                               boolean includeAbstract) {
+        if (excludeClass(classNode)) {
+            return;
+        }
+        for (C anInterface : getInterfaces(classNode)) {
+            processInterfaceHierarchy(anInterface, reduce, result, addedFromClassElements, collectedElements, includeAbstract);
+        }
+        reduce(collectedElements, getEnclosedElements(classNode, result, includeAbstract), reduce, result, addedFromClassElements, true, includeAbstract);
+    }
+
+    private <T extends Element> void reduce(Collection<T> collectedElements,
+                                            List<N> classElements,
+                                            BiPredicate<T, T> reduce,
+                                            ElementQuery.Result<?> result,
+                                            List<T> addedFromClassElements,
+                                            boolean isInterface,
+                                            boolean includesAbstract) {
+        List<Predicate<String>> namePredicates = result.getNamePredicates();
+        boolean hasNamePredicates = !namePredicates.isEmpty();
+        addedFromClassElements.clear(); // Reusing this collection for all the calls
+        classElements:
+        for (N element : classElements) {
+            if (hasNamePredicates) {
+                String elementName = getElementName(element);
+                for (Predicate<String> namePredicate : namePredicates) {
+                    if (!namePredicate.test(elementName)) {
+                        continue classElements;
+                    }
+                }
+            }
+            T newElement = convertElement(result, element);
+
+            for (Iterator<T> iterator = collectedElements.iterator(); iterator.hasNext(); ) {
+                T existingElement = iterator.next();
+                if (!existingElement.getName().equals(newElement.getName())) {
+                    continue;
+                }
+                if (isInterface) {
+                    if (existingElement == newElement) {
+                        continue classElements;
+                    }
+                    if (reduce.test(existingElement, newElement)) {
+                        continue classElements;
+                    } else if (includesAbstract && reduce.test(newElement, existingElement)) {
+                        iterator.remove();
+                        addedFromClassElements.add(newElement);
+                        continue classElements;
+                    }
+                } else if (reduce.test(newElement, existingElement)) {
+                    iterator.remove();
+                    addedFromClassElements.add(newElement);
+                    continue classElements;
+                }
+
+            }
+            addedFromClassElements.add(newElement);
+        }
+        collectedElements.addAll(addedFromClassElements);
+    }
+
+    private <T extends io.micronaut.inject.ast.Element> List<T> getElements(C classNode,
+                                                                            ElementQuery.Result<?> result,
+                                                                            Predicate<T> filter) {
+        List<N> enclosedElements = getEnclosedElements(classNode, result, true);
+        List<T> elements = new ArrayList<>(enclosedElements.size());
+        List<Predicate<String>> namePredicates = result.getNamePredicates();
+        boolean hasNamePredicates = !namePredicates.isEmpty();
+        enclosedElementsLoop:
+        for (N enclosedElement : enclosedElements) {
+            if (hasNamePredicates) {
+                String elementName = getElementName(enclosedElement);
+                for (Predicate<String> namePredicate : namePredicates) {
+                    if (!namePredicate.test(elementName)) {
+                        continue enclosedElementsLoop;
+                    }
+                }
+            }
+            T element = convertElement(result, enclosedElement);
+            if (filter.test(element)) {
+                elements.add(element);
+            }
+        }
+        return elements;
+    }
+
+    private <T extends Element> T convertElement(ElementQuery.Result<?> result, N element) {
+        N nativeType = getCacheKey(element);
+        CacheKey cacheKey = new CacheKey(result.getElementType(), nativeType);
+        T newElement = (T) elementsCache.computeIfAbsent(cacheKey, ck -> toAstElement(nativeType, result.getElementType()));
+        if (result.getElementType() == MemberElement.class) {
+            // Also cache members query results as it's original element type
+            if (newElement instanceof FieldElement) {
+                elementsCache.putIfAbsent(new CacheKey(FieldElement.class, nativeType), newElement);
+            } else if (newElement instanceof ConstructorElement) {
+                elementsCache.putIfAbsent(new CacheKey(ConstructorElement.class, nativeType), newElement);
+                elementsCache.putIfAbsent(new CacheKey(MethodElement.class, nativeType), newElement);
+            } else if (newElement instanceof MethodElement) {
+                elementsCache.putIfAbsent(new CacheKey(MethodElement.class, nativeType), newElement);
+            } else if (newElement instanceof PropertyElement) {
+                elementsCache.putIfAbsent(new CacheKey(PropertyElement.class, nativeType), newElement);
+            }
+        } else if (MemberElement.class.isAssignableFrom(result.getElementType())) {
+            elementsCache.putIfAbsent(new CacheKey(MemberElement.class, nativeType), newElement);
+        }
+        adjustMapCapacity(elementsCache, MAX_ITEMS_IN_CACHE);
+        if (!result.getElementType().isInstance(newElement)) {
+            // dirty cache
+            elementsCache.remove(cacheKey);
+            newElement = (T) elementsCache.computeIfAbsent(cacheKey, ck -> toAstElement(nativeType, result.getElementType()));
+        }
+        return newElement;
+    }
+
+    private void adjustMapCapacity(Map<?, ?> map, int size) {
+        if (map.size() == size) {
+            Iterator<?> iterator = map.entrySet().iterator();
+            iterator.next();
+            iterator.remove();
+        }
+    }
+
     /**
      * Gets the element name.
+     *
      * @param element The element
      * @return The name
      */
@@ -286,27 +405,6 @@ public abstract class EnclosedElementsQuery<C, N> {
      */
     protected N getCacheKey(N element) {
         return element;
-    }
-
-    private void collectHierarchy(C classNode,
-                                  boolean onlyDeclared,
-                                  List<List<N>> hierarchy,
-                                  ElementQuery.Result<?> result) {
-        if (excludeClass(classNode)) {
-            return;
-        }
-        if (!onlyDeclared) {
-            C superclass = getSuperClass(classNode);
-            if (superclass != null) {
-                collectHierarchy(superclass, false, hierarchy, result);
-            }
-            for (C interfaceNode : getInterfaces(classNode)) {
-                List<List<N>> interfaceElements = new ArrayList<>();
-                collectHierarchy(interfaceNode, false, interfaceElements, result);
-                hierarchy.addAll(interfaceElements);
-            }
-        }
-        hierarchy.add(getEnclosedElements(classNode, result));
     }
 
     /**
@@ -340,12 +438,25 @@ public abstract class EnclosedElementsQuery<C, N> {
     /**
      * Extracts the enclosed elements of the class.
      *
+     * @param classNode       The class
+     * @param result          The query result
+     * @param includeAbstract If abstract/non-default elements should be included
+     * @return The enclosed elements
+     */
+    @NonNull
+    protected abstract List<N> getEnclosedElements(C classNode, ElementQuery.Result<?> result, boolean includeAbstract);
+
+    /**
+     * Extracts the enclosed elements of the class.
+     *
      * @param classNode The class
      * @param result    The query result
      * @return The enclosed elements
      */
     @NonNull
-    protected abstract List<N> getEnclosedElements(C classNode, ElementQuery.Result<?> result);
+    protected List<N> getEnclosedElements(C classNode, ElementQuery.Result<?> result) {
+        return getEnclosedElements(classNode, result, true);
+    }
 
     /**
      * Checks if the class needs to be excluded.
@@ -356,15 +467,36 @@ public abstract class EnclosedElementsQuery<C, N> {
     protected abstract boolean excludeClass(C classNode);
 
     /**
+     * Is abstract class.
+     *
+     * @param classNode The class node
+     * @return true if abstract
+     * @since 4.3.0
+     */
+    protected abstract boolean isAbstractClass(C classNode);
+
+    /**
+     * Is interface.
+     *
+     * @param classNode The class node
+     * @return true if interface
+     * @since 4.3.0
+     */
+    protected abstract boolean isInterface(C classNode);
+
+    /**
      * Converts the native element to the AST element.
      *
-     * @param nativeType The native element.
-     * @param elementType     The result type
+     * @param nativeType  The native element.
+     * @param elementType The result type
      * @return The AST element
      */
     @NonNull
     protected abstract io.micronaut.inject.ast.Element toAstElement(N nativeType, Class<?> elementType);
 
     private record CacheKey(Class<?> elementType, Object nativeType) {
+    }
+
+    private record QueryResultKey(ElementQuery.Result<?> result, Object nativeType) {
     }
 }

--- a/core-processor/src/main/java/io/micronaut/inject/ast/utils/EnclosedElementsQuery.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/utils/EnclosedElementsQuery.java
@@ -234,13 +234,7 @@ public abstract class EnclosedElementsQuery<C, N> {
             boolean includeAbstract = isAbstractClass(classNode) || result.isIncludeOverriddenMethods();
             processClassHierarchy(classNode, reduce, result, addedFromClassElements, elements, includeAbstract);
         }
-        Iterator<T> iterator = elements.iterator();
-        while (iterator.hasNext()) {
-            T element = iterator.next();
-            if (!filter.test(element)) {
-                iterator.remove();
-            }
-        }
+        elements.removeIf(element -> !filter.test(element));
         return elements;
     }
 

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyClassElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyClassElement.java
@@ -771,7 +771,7 @@ public class GroovyClassElement extends AbstractGroovyElement implements Arrayab
                 return false;
             }
             if (methodNode.isPrivate() && classNode.isInterface()) {
-                return false;
+                return true;
             }
             if (!methodNode.isAbstract() && classNode.isInterface()) {
                 return false;

--- a/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyClassElement.java
+++ b/inject-groovy/src/main/groovy/io/micronaut/ast/groovy/visitor/GroovyClassElement.java
@@ -51,6 +51,7 @@ import io.micronaut.inject.ast.annotation.MutableAnnotationMetadataDelegate;
 import io.micronaut.inject.ast.utils.AstBeanPropertiesUtils;
 import io.micronaut.inject.ast.utils.EnclosedElementsQuery;
 import org.codehaus.groovy.ast.AnnotatedNode;
+import org.codehaus.groovy.ast.AnnotationNode;
 import org.codehaus.groovy.ast.ClassHelper;
 import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.ConstructorNode;
@@ -720,21 +721,25 @@ public class GroovyClassElement extends AbstractGroovyElement implements Arrayab
 
         @Override
         protected List<AnnotatedNode> getEnclosedElements(ClassNode classNode,
-                                                          ElementQuery.Result<?> result) {
+                                                          ElementQuery.Result<?> result,
+                                                          boolean includeAbstract) {
             Class<?> elementType = result.getElementType();
-            return getEnclosedElements(classNode, result, elementType);
+            return getEnclosedElements(classNode, result, elementType, includeAbstract);
         }
 
-        private List<AnnotatedNode> getEnclosedElements(ClassNode classNode, ElementQuery.Result<?> result, Class<?> elementType) {
+        private List<AnnotatedNode> getEnclosedElements(ClassNode classNode,
+                                                        ElementQuery.Result<?> result,
+                                                        Class<?> elementType,
+                                                        boolean includeAbstract) {
             if (elementType == MemberElement.class) {
                 return Stream.concat(
-                        getEnclosedElements(classNode, result, FieldElement.class).stream(),
-                        getEnclosedElements(classNode, result, MethodElement.class).stream()
+                        getEnclosedElements(classNode, result, FieldElement.class, includeAbstract).stream(),
+                        getEnclosedElements(classNode, result, MethodElement.class, includeAbstract).stream()
                 ).toList();
             } else if (elementType == MethodElement.class) {
                 return classNode.getMethods()
                         .stream()
-                        .filter(methodNode -> !JUNK_METHOD_FILTER.test(methodNode) && (methodNode.getModifiers() & Opcodes.ACC_SYNTHETIC) == 0)
+                        .filter(methodNode -> !JUNK_METHOD_FILTER.test(methodNode) && (methodNode.getModifiers() & Opcodes.ACC_SYNTHETIC) == 0 && (includeAbstract || isNonAbstract(classNode, methodNode)))
                         .<AnnotatedNode>map(m -> m)
                         .toList();
             } else if (elementType == FieldElement.class) {
@@ -761,6 +766,19 @@ public class GroovyClassElement extends AbstractGroovyElement implements Arrayab
             }
         }
 
+        private boolean isNonAbstract(ClassNode classNode, MethodNode methodNode) {
+            if (methodNode.isDefault()) {
+                return false;
+            }
+            if (methodNode.isPrivate() && classNode.isInterface()) {
+                return false;
+            }
+            if (!methodNode.isAbstract() && classNode.isInterface()) {
+                return false;
+            }
+            return !methodNode.isAbstract();
+        }
+
         @Override
         protected boolean excludeClass(ClassNode classNode) {
             String packageName = Objects.requireNonNullElse(classNode.getPackageName(), "");
@@ -773,6 +791,23 @@ public class GroovyClassElement extends AbstractGroovyElement implements Arrayab
                     || Enum.class.getName().equals(className)
                     || GroovyObjectSupport.class.getName().equals(className)
                     || Script.class.getName().equals(className);
+        }
+
+        @Override
+        protected boolean isAbstractClass(ClassNode classNode) {
+            return classNode.isAbstract();
+        }
+
+        @Override
+        protected boolean isInterface(ClassNode classNode) {
+            if (classNode.isInterface()) {
+                return true;
+            }
+            List<AnnotationNode> annotations = classNode.getAnnotations();
+            if (annotations != null) {
+                return annotations.stream().anyMatch(a -> a.getClassNode().getName().equals(groovy.transform.Trait.class.getName()));
+            }
+            return false;
         }
 
         @Override

--- a/inject-groovy/src/test/groovy/io/micronaut/aop/introduction/IntroductionAdviceWithNewInterfaceSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/aop/introduction/IntroductionAdviceWithNewInterfaceSpec.groovy
@@ -17,7 +17,6 @@ package io.micronaut.aop.introduction
 
 import io.micronaut.ast.transform.test.AbstractBeanDefinitionSpec
 import io.micronaut.context.ApplicationContext
-import io.micronaut.context.DefaultBeanContext
 import io.micronaut.context.event.ApplicationEventListener
 import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.InstantiatableBeanDefinition
@@ -193,7 +192,7 @@ interface SpecificInterface {
         then:
         //I ended up going this route because actually calling the methods here would be relying on
         //having the target interface in the bytecode of the test
-        instance.$proxyMethods.length == 1
+        instance.$proxyMethods.length == 2
 
         cleanup:
         context.close()

--- a/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/ClassElementSpec.groovy
+++ b/inject-groovy/src/test/groovy/io/micronaut/inject/visitor/ClassElementSpec.groovy
@@ -815,7 +815,7 @@ interface MyBean extends GenericInterface, SpecificInterface {
         when:
             def allMethods = classElement.getEnclosedElements(ElementQuery.ALL_METHODS)
         then:
-            allMethods.size() == 1
+            allMethods.size() == 2
         when:
             def declaredMethods = classElement.getEnclosedElements(ElementQuery.ALL_METHODS.onlyDeclared())
         then:

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
@@ -809,7 +809,7 @@ public class JavaClassElement extends AbstractJavaElement implements ArrayableCl
                 ee = classNode.getEnclosedElements();
             }
             EnumSet<ElementKind> elementKinds = getElementKind(result);
-            List<Element> list = new ArrayList<>(elementKinds.size());
+            List<Element> list = new ArrayList<>(ee.size());
             for (Element element : ee) {
                 Set<Modifier> modifiers = element.getModifiers();
                 if (elementKinds.contains(element.getKind()) && (includeAbstract || isNonAbstractMethod(modifiers, classNode))) {

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaClassElement.java
@@ -812,18 +812,18 @@ public class JavaClassElement extends AbstractJavaElement implements ArrayableCl
             List<Element> list = new ArrayList<>(ee.size());
             for (Element element : ee) {
                 Set<Modifier> modifiers = element.getModifiers();
-                if (elementKinds.contains(element.getKind()) && (includeAbstract || isNonAbstractMethod(modifiers, classNode))) {
+                if (elementKinds.contains(element.getKind()) && (includeAbstract || isNonAbstractMethod(modifiers))) {
                     list.add(element);
                 }
             }
             return list;
         }
 
-        private boolean isNonAbstractMethod(Set<Modifier> modifiers, TypeElement classNode) {
+        private boolean isNonAbstractMethod(Set<Modifier> modifiers) {
             if (modifiers.contains(Modifier.DEFAULT)) {
                 return true;
             }
-            if (modifiers.contains(Modifier.PRIVATE) && isInterface(classNode)) {
+            if (modifiers.contains(Modifier.PRIVATE)) {
                 return true;
             }
             return !modifiers.contains(Modifier.ABSTRACT);

--- a/inject-java/src/test/groovy/io/micronaut/visitors/ClassElementSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/ClassElementSpec.groovy
@@ -3319,6 +3319,42 @@ interface MyInterface {
         methods.size() == 4
     }
 
+    void "test unrecognized default method"() {
+        given:
+            ClassElement classElement = buildClassElement('''
+package elementquery;
+
+interface MyBean extends GenericInterface, SpecificInterface {
+
+    default Specific getObject() {
+        return null;
+    }
+
+}
+
+class Generic {
+}
+class Specific extends Generic {
+}
+interface GenericInterface {
+    Generic getObject();
+}
+interface SpecificInterface {
+    Specific getObject();
+}
+
+''')
+        when:
+            def allMethods = classElement.getEnclosedElements(ElementQuery.ALL_METHODS)
+        then:
+            allMethods.size() == 2
+        when:
+            def declaredMethods = classElement.getEnclosedElements(ElementQuery.ALL_METHODS.onlyDeclared())
+        then:
+            declaredMethods.size() == 1
+            declaredMethods.get(0).isDefault() == true
+    }
+
     private void assertListGenericArgument(ClassElement type, Closure cl) {
         def arg1 = type.getAllTypeArguments().get(List.class.name).get("E")
         def arg2 = type.getAllTypeArguments().get(Collection.class.name).get("E")


### PR DESCRIPTION
- Querieng now avoids processing abstract interface methods for non-abstract classes
- Added caching for query requests
- Fixed `hides` method

Should fix https://github.com/micronaut-projects/micronaut-core/issues/10145 and also improve KSP performance.