### PR TITLE
Allow Refreshable scope under test for Env.FUNCTION and ANDROID

### DIFF
--- a/context/src/main/java/io/micronaut/runtime/context/scope/refresh/RefreshScope.java
+++ b/context/src/main/java/io/micronaut/runtime/context/scope/refresh/RefreshScope.java
@@ -54,7 +54,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * @since 1.0
  */
 @Singleton
-@Requires(notEnv = {Environment.FUNCTION, Environment.ANDROID})
+@Requires(condition = RefreshScopeCondition.class)
 public class RefreshScope implements CustomScope<Refreshable>, LifeCycle<RefreshScope>, ApplicationEventListener<RefreshEvent>, Ordered {
 
     public static final int POSITION = RefreshEventListener.DEFAULT_POSITION - 100;

--- a/context/src/main/java/io/micronaut/runtime/context/scope/refresh/RefreshScopeCondition.java
+++ b/context/src/main/java/io/micronaut/runtime/context/scope/refresh/RefreshScopeCondition.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.runtime.context.scope.refresh;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.condition.Condition;
+import io.micronaut.context.condition.ConditionContext;
+import io.micronaut.context.env.Environment;
+
+import java.util.Arrays;
+import java.util.Set;
+
+/**
+ * As an optimization, RefreshScope is disabled for function and android environments when not under test.
+ *
+ * @author Tim Yates
+ * @since 4.2.2
+ */
+public class RefreshScopeCondition implements Condition {
+
+    private static final String[] DISABLED_ENVIRONMENTS = new String[]{Environment.FUNCTION, Environment.ANDROID};
+
+    @Override
+    public boolean matches(ConditionContext context) {
+        BeanContext beanContext = context.getBeanContext();
+
+        if (beanContext instanceof ApplicationContext applicationContext) {
+            Environment environment = applicationContext.getEnvironment();
+            Set<String> activeNames = environment.getActiveNames();
+
+            boolean disabledEnvironment = Arrays.stream(DISABLED_ENVIRONMENTS).anyMatch(activeNames::contains);
+            boolean isUnderTest = activeNames.contains(Environment.TEST);
+
+            if (disabledEnvironment && !isUnderTest) {
+                context.fail("Refresh scope is disabled for " + Environment.FUNCTION + " and " + Environment.ANDROID + " environments when not under test.");
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/runtime/src/test/groovy/io/micronaut/runtime/context/scope/RefreshScopeSpec.groovy
+++ b/runtime/src/test/groovy/io/micronaut/runtime/context/scope/RefreshScopeSpec.groovy
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017-2019 original authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.micronaut.runtime.context.scope
 
 import io.micronaut.context.ApplicationContext
@@ -47,6 +32,17 @@ class RefreshScopeSpec extends Specification {
         ctx.close()
     }
 
+    void "RefreshScope bean is loaded for function environment under test"() {
+        when:
+        ApplicationContext ctx = ApplicationContext.run(Environment.FUNCTION, Environment.TEST)
+
+        then:
+        ctx.containsBean(RefreshScope)
+
+        cleanup:
+        ctx.close()
+    }
+
     void "RefreshScope bean is loaded by default"() {
         when:
         ApplicationContext ctx = ApplicationContext.run()
@@ -60,10 +56,21 @@ class RefreshScopeSpec extends Specification {
 
     void "RefreshScope bean is not loaded for android environment"() {
         when:
-        ApplicationContext ctx = ApplicationContext.run(Environment.ANDROID)
+        ApplicationContext ctx = ApplicationContext.builder().deduceEnvironment(false).environments(Environment.ANDROID).start()
 
         then:
         !ctx.containsBean(RefreshScope)
+
+        cleanup:
+        ctx.close()
+    }
+
+    void "RefreshScope bean is loaded for android test environment"() {
+        when: 'we specify android, but test is deduced via stack trace inspection'
+        ApplicationContext ctx = ApplicationContext.run(Environment.ANDROID)
+
+        then:
+        ctx.containsBean(RefreshScope)
 
         cleanup:
         ctx.close()


### PR DESCRIPTION
It was seen in the Aws module that `@MockLambdaTest` and `@MockBean` did not work as expected.

https://github.com/micronaut-projects/micronaut-aws/issues/1870

This is because:

1. `@MockBean` uses the Refreshable scope
2. `@MockLambdaTest` adds Environment.FUNCTION to the test context
3. The Refresh scope is disabled for the FUNCTION environment

After this PR, RefreshScope is still disabled for Environment.FUNCTION...

...*UNLESS* Environment.TEST is also enabled.