### PR TITLE
Use Javac's `overrides` to determine if the method is overridden

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/ast/ConstructorElement.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/ConstructorElement.java
@@ -42,6 +42,11 @@ public interface ConstructorElement extends MethodElement {
     }
 
     @Override
+    default boolean hides(MethodElement hiddenMethod) {
+        return false;
+    }
+
+    @Override
     default boolean overrides(MethodElement overridden) {
         return false;
     }

--- a/inject-java/src/test/groovy/io/micronaut/visitors/ClassElementSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/ClassElementSpec.groovy
@@ -48,6 +48,27 @@ import java.util.function.Supplier
 
 class ClassElementSpec extends AbstractTypeElementSpec {
 
+    void "test package-private methods with broken different package"() {
+        when:
+        ClassElement classElement = buildClassElement('''
+package test.another;
+
+import test.Middle;
+
+class Test extends Middle {
+   private boolean testInjected;
+    void injectPackagePrivateMethod() {
+        testInjected = true;
+    }
+}
+
+''')
+
+            def elements = classElement.getEnclosedElements(ElementQuery.ALL_METHODS)
+        then: "A special case for the indentical methods with package-private access and broken package access in between"
+            elements.size() == 2
+    }
+
     void "test class element generics"() {
         given:
         ClassElement classElement = buildClassElement('''

--- a/inject-java/src/test/java/test/Middle.java
+++ b/inject-java/src/test/java/test/Middle.java
@@ -1,0 +1,12 @@
+package test;
+
+import jakarta.inject.Inject;
+import test.another.Base;
+
+public class Middle extends Base {
+    public boolean middle;
+    @Inject
+    void injectPackagePrivateMethod() {
+        middle = true;
+    }
+}

--- a/inject-java/src/test/java/test/another/Base.java
+++ b/inject-java/src/test/java/test/another/Base.java
@@ -1,0 +1,11 @@
+package test.another;
+
+import jakarta.inject.Inject;
+
+public class Base {
+    public boolean base;
+    @Inject
+    void injectPackagePrivateMethod() {
+        base = true;
+    }
+}

--- a/inject-java/src/test/java/test/another/BeanWithPackagePrivate.java
+++ b/inject-java/src/test/java/test/another/BeanWithPackagePrivate.java
@@ -1,0 +1,12 @@
+package test.another;
+
+import jakarta.inject.Singleton;
+import test.Middle;
+
+@Singleton
+public class BeanWithPackagePrivate extends Middle {
+    public boolean root;
+    void injectPackagePrivateMethod() {
+        root = true;
+    }
+}

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/AbstractKotlinMethodElement.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/AbstractKotlinMethodElement.kt
@@ -120,6 +120,10 @@ internal abstract class AbstractKotlinMethodElement<T : KotlinNativeElement>(
         // not sure how to implement this correctly for Kotlin
         false
 
+    override fun hides(hiddenMethod: MethodElement?) =
+        // not sure how to implement this correctly for Kotlin
+        false
+
     override fun getName() = name
 
     override fun getOwningType() = owningType

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/AbstractKotlinPropertyAccessorMethodElement.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/AbstractKotlinPropertyAccessorMethodElement.kt
@@ -62,4 +62,8 @@ internal abstract class AbstractKotlinPropertyAccessorMethodElement<T : KotlinNa
         // not sure how to implement this correctly for Kotlin
         false
 
+    override fun hides(hiddenMethod: MethodElement?) =
+        // not sure how to implement this correctly for Kotlin
+        false
+
 }

--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinConstructorElement.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/KotlinConstructorElement.kt
@@ -50,6 +50,10 @@ internal class KotlinConstructorElement(
         return false
     }
 
+    override fun hides(hiddenMethod: MethodElement?): Boolean {
+        return false
+    }
+
     override fun getName() = "<init>"
 
     override fun getReturnType(): ClassElement = declaringType


### PR DESCRIPTION
I investigated why we cannot use it by default, there is some limitation to the reflection invocation of the package-private methods. Added it as a note.