### PR TITLE
Initialize classes at build time that can deadlock graal compiler

### DIFF
--- a/core/src/main/resources/META-INF/native-image/io.micronaut/micronaut-core/native-image.properties
+++ b/core/src/main/resources/META-INF/native-image/io.micronaut/micronaut-core/native-image.properties
@@ -20,6 +20,8 @@ Args = --initialize-at-run-time=io.micronaut.core.io.socket.SocketUtils \
         --initialize-at-build-time=io.micronaut.core.optim \
         --initialize-at-build-time=io.micronaut.core.util \
         --initialize-at-build-time=io.micronaut.core.convert \
+        --initialize-at-build-time=io.micronaut.core.convert.ConversionContext \
+        --initialize-at-build-time=io.micronaut.core.convert.ImmutableArgumentConversionContext \
         --initialize-at-build-time=io.micronaut.core.type \
         --initialize-at-build-time=io.micronaut.core.annotation \
         --initialize-at-build-time=io.micronaut.core.annotation.AnnotationValue \

--- a/core/src/main/resources/META-INF/native-image/io.micronaut/micronaut-core/native-image.properties
+++ b/core/src/main/resources/META-INF/native-image/io.micronaut/micronaut-core/native-image.properties
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+# DO NOT REMOVE ConversionContext and ImmutableArgumentConversionContext. See https://github.com/micronaut-projects/micronaut-core/pull/10283
 Args = --initialize-at-run-time=io.micronaut.core.io.socket.SocketUtils \
         --initialize-at-run-time=io.micronaut.core.type.RuntimeTypeInformation$LazyTypeInfo \
         --initialize-at-build-time=io.micronaut.core.io \


### PR DESCRIPTION
A class loading deadlock can occur when `ConversionContext` is initialised concurrently since it has static final fields that are sub interfaces which are also initialised causing a loop.

This doesn't manifest on JIT likely because these classes are never initialised concurrently, but a deadlock can occur in the Graal compiler.

A real fix would to be alter the code but unfortunately there is no way to do this in a backwards compatible way. 

A workaround in Graal is to explicitly initialise these classes at build time which happens very early, avoiding the concurrent access that causes the deadlock.