### PR TITLE
Javac: Extract type variable name using the element

### DIFF
--- a/inject-java/src/main/java/io/micronaut/annotation/processing/GenericUtils.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/GenericUtils.java
@@ -133,8 +133,9 @@ public class GenericUtils {
                     break;
                     case TYPEVAR:
                         TypeVariable tv = (TypeVariable) mirror;
-                        if (boundTypes.containsKey(tv.toString())) {
-                            resolvedParameters.put(parameterName, boundTypes.get(tv.toString()));
+                        String variableName = tv.asElement().getSimpleName().toString();
+                        if (boundTypes.containsKey(variableName)) {
+                            resolvedParameters.put(parameterName, boundTypes.get(variableName));
                         } else {
                             TypeMirror upperBound = tv.getUpperBound();
                             TypeMirror lowerBound = tv.getLowerBound();
@@ -195,7 +196,7 @@ public class GenericUtils {
         switch (kind) {
             case TYPEVAR:
                 TypeVariable tv = (TypeVariable) mirror;
-                String name = tv.toString();
+                String name = tv.asElement().getSimpleName().toString();
                 if (boundTypes.containsKey(name)) {
                     return boundTypes.get(name);
                 } else {
@@ -251,7 +252,7 @@ public class GenericUtils {
                     mirror
             );
         } else if (mirror instanceof TypeVariable tv) {
-            String variableName = tv.toString();
+            String variableName = tv.asElement().getSimpleName().toString();
             if (boundTypes.containsKey(variableName)) {
                 resolvedParameters.put(
                         parameterName,

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/AbstractJavaElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/AbstractJavaElement.java
@@ -385,7 +385,7 @@ public abstract class AbstractJavaElement extends AbstractAnnotationElement {
                                              Set<TypeMirror> visitedTypes,
                                              TypeVariable tv,
                                              boolean isRawType) {
-        String variableName = tv.toString();
+        String variableName = tv.asElement().getSimpleName().toString();
         ClassElement resolvedBound = parentTypeArguments.get(variableName);
         List<JavaClassElement> bounds = null;
         io.micronaut.inject.ast.Element declaredElement = this;


### PR DESCRIPTION
Graalvm dev build includes the annotations in the `TypeVariable`'s `toString` representation. It's better to correct its usage for the future.