### PR TITLE
doc: Kotlin inline value classes No @Introspected

### DIFF
--- a/src/main/docs/guide/ioc/introspection/kotlinAndBeanIntrospection.adoc
+++ b/src/main/docs/guide/ioc/introspection/kotlinAndBeanIntrospection.adoc
@@ -1,0 +1,17 @@
+You can annotate a https://kotlinlang.org/docs/data-classes.html[Kotlin Data Class] with ann:core.annotation.Introspected[]:
+
+.Kotlin Data Class annotated with @Introspected
+[source, kotlin]
+----
+include::{testsuitekotlin}/core/beans/UserDataClass.kt[tags="dataclass", indent=0]
+----
+
+and instantiate it with the BeanIntrospection API:
+
+.Kotlin Data Class instantiated via BeanIntrospection API
+[source, kotlin]
+----
+include::{testsuitekotlin}/core/beans/UserDataClassTest.kt[tags="dataclassbeanintrospectioninstantiate", indent=0]
+----
+
+WARNING: https://kotlinlang.org/docs/inline-classes.html[Kotlin Inline Value Classes] are not supported yet by the api:core.beans.BeanIntrospection[] API.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -50,6 +50,7 @@ ioc:
     introspectExistingAnnotations: Write an AnnotationMapper to Introspect Existing Annotations
     beanWrapperApi: The BeanWrapper API
     jacksonAndBeanIntrospection: Jackson and Bean Introspection
+    kotlinAndBeanIntrospection: Kotlin and Bean Introspection
   beanMappers: Bean Mappers
   beanValidation: Bean Validation
   annotationMetadata: Bean Annotation Metadata

--- a/test-suite-kotlin-ksp/src/test/kotlin/io/micronaut/docs/core/beans/UserDataClass.kt
+++ b/test-suite-kotlin-ksp/src/test/kotlin/io/micronaut/docs/core/beans/UserDataClass.kt
@@ -1,0 +1,11 @@
+package io.micronaut.docs.core.beans
+
+import io.micronaut.core.annotation.Introspected
+
+/**
+ * https://kotlinlang.org/docs/data-classes.html
+ */
+//tag::dataclass[]
+@Introspected
+data class UserDataClass(val name: String)
+//end::dataclass[]

--- a/test-suite-kotlin-ksp/src/test/kotlin/io/micronaut/docs/core/beans/UserDataClassTest.kt
+++ b/test-suite-kotlin-ksp/src/test/kotlin/io/micronaut/docs/core/beans/UserDataClassTest.kt
@@ -1,0 +1,16 @@
+package io.micronaut.docs.core.beans
+
+import io.micronaut.core.beans.BeanIntrospection
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+
+class UserDataClassTest {
+
+    @Test
+    fun aDataClassCanBeInstantiatedViaBeanIntrospection() {
+        val introspection: BeanIntrospection<UserDataClass> = assertDoesNotThrow { BeanIntrospection.getIntrospection(UserDataClass::class.java) }
+        val user: UserDataClass = introspection.instantiate("John")
+        assertEquals("John", user.name)
+    }
+}

--- a/test-suite-kotlin-ksp/src/test/kotlin/io/micronaut/docs/core/beans/UserInlineValueClass.kt
+++ b/test-suite-kotlin-ksp/src/test/kotlin/io/micronaut/docs/core/beans/UserInlineValueClass.kt
@@ -1,0 +1,11 @@
+package io.micronaut.docs.core.beans
+
+import io.micronaut.core.annotation.Introspected
+
+/**
+ * https://kotlinlang.org/docs/inline-classes.html
+ */
+@JvmInline
+@Introspected
+value class UserInlineValueClass(val name: String) {
+}

--- a/test-suite-kotlin-ksp/src/test/kotlin/io/micronaut/docs/core/beans/UserInlineValueClassTest.kt
+++ b/test-suite-kotlin-ksp/src/test/kotlin/io/micronaut/docs/core/beans/UserInlineValueClassTest.kt
@@ -1,0 +1,18 @@
+package io.micronaut.docs.core.beans
+
+import io.micronaut.core.beans.BeanIntrospection
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+
+class UserInlineValueClassTest {
+
+    @Disabled("Kotline inline value classes not yet supported via Bean Introspection")
+    @Test
+    fun anInlineValueClassNotYetSupportedViaBeanIntrospection() {
+        val introspection: BeanIntrospection<UserInlineValueClass> = assertDoesNotThrow { BeanIntrospection.getIntrospection(UserInlineValueClass::class.java) }
+        val user: UserInlineValueClass = introspection.instantiate("John")
+        assertEquals("John", user.name)
+    }
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/core/beans/UserDataClass.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/core/beans/UserDataClass.kt
@@ -1,0 +1,11 @@
+package io.micronaut.docs.core.beans
+
+import io.micronaut.core.annotation.Introspected
+
+/**
+ * https://kotlinlang.org/docs/data-classes.html
+ */
+//tag::dataclass[]
+@Introspected
+data class UserDataClass(val name: String)
+//end::dataclass[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/core/beans/UserDataClassTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/core/beans/UserDataClassTest.kt
@@ -1,0 +1,17 @@
+package io.micronaut.docs.core.beans
+
+import io.micronaut.core.beans.BeanIntrospection
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class UserDataClassTest {
+
+    @Test
+    fun aDataClassCanBeInstantiatedViaBeanIntrospection() {
+//tag::dataclassbeanintrospectioninstantiate[]
+        val introspection: BeanIntrospection<UserDataClass> = BeanIntrospection.getIntrospection(UserDataClass::class.java)
+        val user: UserDataClass = introspection.instantiate("John")
+//end::dataclassbeanintrospectioninstantiate[]
+        assertEquals("John", user.name)
+    }
+}


### PR DESCRIPTION
This PR adds a section to the documentation mentioning that the BeanIntrospectionAPI supports Kotlin Data classes, while Kotlin inline value classes still need support.