### PR TITLE
Expression implementation improvements

### DIFF
--- a/core-processor/src/main/java/io/micronaut/expressions/EvaluatedExpressionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/EvaluatedExpressionWriter.java
@@ -19,7 +19,7 @@ import io.micronaut.context.expressions.AbstractEvaluatedExpression;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.expressions.ExpressionEvaluationContext;
 import io.micronaut.expressions.context.ExpressionWithContext;
-import io.micronaut.expressions.parser.CompoundEvaluatedEvaluatedExpressionParser;
+import io.micronaut.expressions.parser.CompoundEvaluatedExpressionParser;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
 import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
@@ -106,7 +106,7 @@ public final class EvaluatedExpressionWriter extends AbstractClassFileWriter {
         Object annotationValue = expressionMetadata.annotationValue();
 
         try {
-            ExpressionNode ast = new CompoundEvaluatedEvaluatedExpressionParser(annotationValue).parse();
+            ExpressionNode ast = new CompoundEvaluatedExpressionParser(annotationValue).parse();
             ast.compile(ctx);
             pushBoxPrimitiveIfNecessary(ast.resolveType(ctx), evaluateMethodVisitor);
         } catch (ExpressionParsingException | ExpressionCompilationException ex) {

--- a/core-processor/src/main/java/io/micronaut/expressions/EvaluatedExpressionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/EvaluatedExpressionWriter.java
@@ -21,6 +21,7 @@ import io.micronaut.core.expressions.ExpressionEvaluationContext;
 import io.micronaut.expressions.context.ExpressionWithContext;
 import io.micronaut.expressions.parser.CompoundEvaluatedEvaluatedExpressionParser;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
 import io.micronaut.expressions.parser.exception.ExpressionCompilationException;
 import io.micronaut.expressions.parser.exception.ExpressionParsingException;
@@ -90,7 +91,7 @@ public final class EvaluatedExpressionWriter extends AbstractClassFileWriter {
 
         cv.invokeConstructor(EVALUATED_EXPRESSION_TYPE, EVALUATED_EXPRESSIONS_CONSTRUCTOR);
         // RETURN
-        cv.visitInsn(RETURN);
+        cv.returnValue();
         // MAXSTACK = 2
         // MAXLOCALS = 1
         cv.visitMaxs(2, 1);
@@ -98,9 +99,8 @@ public final class EvaluatedExpressionWriter extends AbstractClassFileWriter {
         GeneratorAdapter evaluateMethodVisitor = startProtectedMethod(classWriter, "doEvaluate",
             Object.class.getName(), ExpressionEvaluationContext.class.getName());
 
-        ExpressionVisitorContext ctx = new ExpressionVisitorContext(
-            expressionMetadata.evaluationContext(),
-            visitorContext,
+        ExpressionCompilationContext ctx = new ExpressionCompilationContext(
+            new ExpressionVisitorContext(expressionMetadata.evaluationContext(), visitorContext),
             evaluateMethodVisitor);
 
         Object annotationValue = expressionMetadata.annotationValue();

--- a/core-processor/src/main/java/io/micronaut/expressions/context/DefaultExpressionCompilationContextFactory.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/context/DefaultExpressionCompilationContextFactory.java
@@ -41,7 +41,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public final class DefaultExpressionCompilationContextFactory implements ExpressionCompilationContextFactory {
 
     private static final Collection<ClassElement> CONTEXT_TYPES = ConcurrentHashMap.newKeySet();
-    private ExtensibleExpressionCompilationContext sharedContext;
+    private ExtensibleExpressionEvaluationContext sharedContext;
     private final VisitorContext visitorContext;
 
     public DefaultExpressionCompilationContextFactory(VisitorContext visitorContext) {
@@ -50,21 +50,21 @@ public final class DefaultExpressionCompilationContextFactory implements Express
     }
 
     @NotNull
-    private DefaultExpressionCompilationContext recreateContext() {
-        return new DefaultExpressionCompilationContext(CONTEXT_TYPES.toArray(ClassElement[]::new));
+    private DefaultExpressionEvaluationContext recreateContext() {
+        return new DefaultExpressionEvaluationContext(CONTEXT_TYPES.toArray(ClassElement[]::new));
     }
 
     @Override
     @NonNull
-    public ExpressionCompilationContext buildContextForMethod(@NonNull EvaluatedExpressionReference expression,
-                                                              @NonNull MethodElement methodElement) {
+    public ExpressionEvaluationContext buildContextForMethod(@NonNull EvaluatedExpressionReference expression,
+                                                             @NonNull MethodElement methodElement) {
         return buildForExpression(expression, null)
                  .extendWith(methodElement);
     }
 
     @Override
     @NonNull
-    public ExpressionCompilationContext buildContext(EvaluatedExpressionReference expression, ClassElement thisElement) {
+    public ExpressionEvaluationContext buildContext(EvaluatedExpressionReference expression, ClassElement thisElement) {
         return buildForExpression(expression, thisElement);
     }
 
@@ -75,13 +75,13 @@ public final class DefaultExpressionCompilationContextFactory implements Express
         return this;
     }
 
-    private ExtensibleExpressionCompilationContext buildForExpression(EvaluatedExpressionReference expression, ClassElement thisElement) {
+    private ExtensibleExpressionEvaluationContext buildForExpression(EvaluatedExpressionReference expression, ClassElement thisElement) {
         String annotationName = expression.annotationName();
         String memberName = expression.annotationMember();
 
         ClassElement annotation = visitorContext.getClassElement(annotationName).orElse(null);
 
-        ExtensibleExpressionCompilationContext evaluationContext = sharedContext;
+        ExtensibleExpressionEvaluationContext evaluationContext = sharedContext;
         if (annotation != null) {
             evaluationContext = addAnnotationEvaluationContext(evaluationContext, annotation);
             evaluationContext = addAnnotationMemberEvaluationContext(evaluationContext, annotation, memberName);
@@ -93,8 +93,8 @@ public final class DefaultExpressionCompilationContextFactory implements Express
         return evaluationContext;
     }
 
-    private ExtensibleExpressionCompilationContext addAnnotationEvaluationContext(
-        ExtensibleExpressionCompilationContext currentEvaluationContext,
+    private ExtensibleExpressionEvaluationContext addAnnotationEvaluationContext(
+        ExtensibleExpressionEvaluationContext currentEvaluationContext,
         ClassElement annotation) {
 
         return annotation.findAnnotation(AnnotationExpressionContext.class)
@@ -105,8 +105,8 @@ public final class DefaultExpressionCompilationContextFactory implements Express
                    .orElse(currentEvaluationContext);
     }
 
-    private ExtensibleExpressionCompilationContext addAnnotationMemberEvaluationContext(
-        ExtensibleExpressionCompilationContext currentEvaluationContext,
+    private ExtensibleExpressionEvaluationContext addAnnotationMemberEvaluationContext(
+        ExtensibleExpressionEvaluationContext currentEvaluationContext,
         ClassElement annotation,
         String annotationMember) {
 
@@ -121,7 +121,7 @@ public final class DefaultExpressionCompilationContextFactory implements Express
                    .flatMap(av -> av.annotationClassValue(AnnotationMetadata.VALUE_MEMBER).stream())
                    .map(AnnotationClassValue::getName)
                    .flatMap(className -> visitorContext.getClassElement(className).stream())
-                   .reduce(currentEvaluationContext, ExtensibleExpressionCompilationContext::extendWith, (a, b) -> a);
+                   .reduce(currentEvaluationContext, ExtensibleExpressionEvaluationContext::extendWith, (a, b) -> a);
     }
 
     /**

--- a/core-processor/src/main/java/io/micronaut/expressions/context/DefaultExpressionEvaluationContext.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/context/DefaultExpressionEvaluationContext.java
@@ -36,35 +36,35 @@ import static io.micronaut.inject.ast.ElementQuery.ALL_METHODS;
 import static java.util.function.Predicate.not;
 
 /**
- * Default implementation of {@link ExtensibleExpressionCompilationContext}. Extending
+ * Default implementation of {@link ExtensibleExpressionEvaluationContext}. Extending
  * this context will always return new instance instead of modifying the existing one.
  *
  * @since 4.0.0
  * @author Sergey Gavrilov
  */
 @Internal
-public class DefaultExpressionCompilationContext implements ExtensibleExpressionCompilationContext {
+public class DefaultExpressionEvaluationContext implements ExtensibleExpressionEvaluationContext {
 
     private final Collection<ClassElement> classElements;
     private final MethodElement methodElement;
 
     private final ClassElement thisType;
 
-    DefaultExpressionCompilationContext(ClassElement... classElements) {
+    DefaultExpressionEvaluationContext(ClassElement... classElements) {
         this(null, null, classElements);
     }
 
-    private DefaultExpressionCompilationContext(ClassElement thisType,
-                                                MethodElement methodElement,
-                                                ClassElement... classElements) {
+    private DefaultExpressionEvaluationContext(ClassElement thisType,
+                                               MethodElement methodElement,
+                                               ClassElement... classElements) {
         this.thisType = thisType;
         this.methodElement = methodElement;
         this.classElements = Arrays.asList(classElements);
     }
 
     @Override
-    public ExtensibleExpressionCompilationContext withThis(ClassElement classElement) {
-        return new DefaultExpressionCompilationContext(
+    public ExtensibleExpressionEvaluationContext withThis(ClassElement classElement) {
+        return new DefaultExpressionEvaluationContext(
             classElement,
             methodElement,
             classElements.toArray(ClassElement[]::new)
@@ -72,9 +72,9 @@ public class DefaultExpressionCompilationContext implements ExtensibleExpression
     }
 
     @Override
-    public DefaultExpressionCompilationContext extendWith(MethodElement methodElement) {
+    public DefaultExpressionEvaluationContext extendWith(MethodElement methodElement) {
         ClassElement resolvedThis = methodElement.isStatic() || methodElement instanceof ConstructorElement ? null : methodElement.getOwningType();
-        return new DefaultExpressionCompilationContext(
+        return new DefaultExpressionEvaluationContext(
             resolvedThis,
             methodElement,
             classElements.toArray(ClassElement[]::new)
@@ -82,8 +82,8 @@ public class DefaultExpressionCompilationContext implements ExtensibleExpression
     }
 
     @Override
-    public DefaultExpressionCompilationContext extendWith(ClassElement classElement) {
-        return new DefaultExpressionCompilationContext(
+    public DefaultExpressionEvaluationContext extendWith(ClassElement classElement) {
+        return new DefaultExpressionEvaluationContext(
             this.thisType,
             this.methodElement,
             ArrayUtils.concat(classElements.toArray(ClassElement[]::new), classElement)

--- a/core-processor/src/main/java/io/micronaut/expressions/context/ExpressionCompilationContextFactory.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/context/ExpressionCompilationContextFactory.java
@@ -37,8 +37,8 @@ public interface ExpressionCompilationContextFactory {
      * @return evaluation context for method
      */
     @NonNull
-    ExpressionCompilationContext buildContextForMethod(@NonNull EvaluatedExpressionReference expression,
-                                                       @NonNull MethodElement methodElement);
+    ExpressionEvaluationContext buildContextForMethod(@NonNull EvaluatedExpressionReference expression,
+                                                      @NonNull MethodElement methodElement);
 
     /**
      * Builds expression evaluation context for expression reference.
@@ -48,7 +48,7 @@ public interface ExpressionCompilationContextFactory {
      * @return evaluation context for method
      */
     @NonNull
-    ExpressionCompilationContext buildContext(EvaluatedExpressionReference expression, @Nullable ClassElement thisElement);
+    ExpressionEvaluationContext buildContext(EvaluatedExpressionReference expression, @Nullable ClassElement thisElement);
 
     /**
      * Adds evaluated expression context class element to context loader

--- a/core-processor/src/main/java/io/micronaut/expressions/context/ExpressionEvaluationContext.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/context/ExpressionEvaluationContext.java
@@ -33,7 +33,7 @@ import java.util.List;
  * @author Sergey Gavrilov
  */
 @Internal
-public interface ExpressionCompilationContext {
+public interface ExpressionEvaluationContext {
 
     /**
      * @return Find the type that represents this.

--- a/core-processor/src/main/java/io/micronaut/expressions/context/ExpressionWithContext.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/context/ExpressionWithContext.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  */
 @Internal
 public record ExpressionWithContext(@NonNull EvaluatedExpressionReference expressionReference,
-                                    @NonNull ExpressionCompilationContext evaluationContext) {
+                                    @NonNull ExpressionEvaluationContext evaluationContext) {
 
     /**
      * Provides initial annotation value treated as evaluated expression.

--- a/core-processor/src/main/java/io/micronaut/expressions/context/ExtensibleExpressionEvaluationContext.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/context/ExtensibleExpressionEvaluationContext.java
@@ -27,13 +27,13 @@ import io.micronaut.inject.ast.MethodElement;
  * @author Sergey Gavrilov
  */
 @Internal
-public interface ExtensibleExpressionCompilationContext extends ExpressionCompilationContext {
+public interface ExtensibleExpressionEvaluationContext extends ExpressionEvaluationContext {
 
     /**
      * @param classElement The type that represents this.
      * @return extended context
      */
-    ExtensibleExpressionCompilationContext withThis(@NonNull ClassElement classElement);
+    ExtensibleExpressionEvaluationContext withThis(@NonNull ClassElement classElement);
 
     /**
      * Extends compilation context with method element. Compilation context can only include
@@ -44,7 +44,7 @@ public interface ExtensibleExpressionCompilationContext extends ExpressionCompil
      * @return extended context
      */
     @NonNull
-    ExtensibleExpressionCompilationContext extendWith(@NonNull MethodElement methodElement);
+    ExtensibleExpressionEvaluationContext extendWith(@NonNull MethodElement methodElement);
 
     /**
      * Extends compilation context with class element. Compilation context can include
@@ -54,6 +54,6 @@ public interface ExtensibleExpressionCompilationContext extends ExpressionCompil
      * @return extended context
      */
     @NonNull
-    ExtensibleExpressionCompilationContext extendWith(@NonNull ClassElement classElement);
+    ExtensibleExpressionEvaluationContext extendWith(@NonNull ClassElement classElement);
 
 }

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/CompoundEvaluatedExpressionParser.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/CompoundEvaluatedExpressionParser.java
@@ -34,14 +34,14 @@ import static io.micronaut.expressions.EvaluatedExpressionConstants.EXPRESSION_P
 /**
  * This parser is used to split complex expression into multiple
  * single expressions if necessary and delegate each atomic expression
- * parsing to separate instance of {@link SingleEvaluatedEvaluatedExpressionParser},
+ * parsing to separate instance of {@link SingleEvaluatedExpressionParser},
  * then combining single expressions parsing results.
  *
  * @author Sergey Gavrilov
  * @since 4.0.0
  */
 @Internal
-public final class CompoundEvaluatedEvaluatedExpressionParser implements EvaluatedExpressionParser {
+public final class CompoundEvaluatedExpressionParser implements EvaluatedExpressionParser {
 
     private final Object expression;
 
@@ -50,7 +50,7 @@ public final class CompoundEvaluatedEvaluatedExpressionParser implements Evaluat
      *
      * @param expression either string or string[]
      */
-    public CompoundEvaluatedEvaluatedExpressionParser(@NonNull Object expression) {
+    public CompoundEvaluatedExpressionParser(@NonNull Object expression) {
         if (!(expression instanceof String || expression instanceof String[])) {
             throw new ExpressionParsingException("Can not parse expression: " + expression);
         }
@@ -62,7 +62,7 @@ public final class CompoundEvaluatedEvaluatedExpressionParser implements Evaluat
     public ExpressionNode parse() throws ExpressionParsingException {
         // if expression doesn't have prefix, the whole string is treated as expression
         if (expression instanceof String str && !str.contains(EXPRESSION_PREFIX)) {
-            return new SingleEvaluatedEvaluatedExpressionParser(str).parse();
+            return new SingleEvaluatedExpressionParser(str).parse();
         }
 
         return parseTemplateExpression(expression);
@@ -73,8 +73,8 @@ public final class CompoundEvaluatedEvaluatedExpressionParser implements Evaluat
             List<ExpressionNode> expressionParts =
                 splitExpressionParts(str).stream()
                     .map(this::prepareExpressionPart)
-                    .map(SingleEvaluatedEvaluatedExpressionParser::new)
-                    .map(SingleEvaluatedEvaluatedExpressionParser::parse)
+                    .map(SingleEvaluatedExpressionParser::new)
+                    .map(SingleEvaluatedExpressionParser::parse)
                     .toList();
 
             if (expressionParts.size() == 1) {

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/EvaluatedExpressionParser.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/EvaluatedExpressionParser.java
@@ -27,8 +27,8 @@ import io.micronaut.expressions.parser.exception.ExpressionParsingException;
  * @since 4.0.0
  */
 @Internal
-public sealed interface EvaluatedExpressionParser permits SingleEvaluatedEvaluatedExpressionParser,
-                                                          CompoundEvaluatedEvaluatedExpressionParser {
+public sealed interface EvaluatedExpressionParser permits SingleEvaluatedExpressionParser,
+    CompoundEvaluatedExpressionParser {
     /**
      * Parse expression into AST.
      *

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/SingleEvaluatedExpressionParser.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/SingleEvaluatedExpressionParser.java
@@ -74,7 +74,7 @@ import static io.micronaut.expressions.parser.token.TokenType.*;
  * @since 4.0.0
  */
 @Internal
-public final class SingleEvaluatedEvaluatedExpressionParser implements EvaluatedExpressionParser {
+public final class SingleEvaluatedExpressionParser implements EvaluatedExpressionParser {
     private final Tokenizer tokenizer;
     private Token lookahead;
 
@@ -84,7 +84,7 @@ public final class SingleEvaluatedEvaluatedExpressionParser implements Evaluated
      *
      * @param expression expression to parse
      */
-    public SingleEvaluatedEvaluatedExpressionParser(String expression) {
+    public SingleEvaluatedExpressionParser(String expression) {
         this.tokenizer = new Tokenizer(expression);
         this.lookahead = tokenizer.getNextToken();
     }

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/ExpressionNode.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/ExpressionNode.java
@@ -17,6 +17,7 @@ package io.micronaut.expressions.parser.ast;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.PrimitiveElement;
@@ -40,7 +41,7 @@ public abstract class ExpressionNode {
      *
      * @param ctx expression compilation context
      */
-    public final void compile(@NonNull ExpressionVisitorContext ctx) {
+    public final void compile(@NonNull ExpressionCompilationContext ctx) {
         resolveType(ctx);
         generateBytecode(ctx);
     }
@@ -50,7 +51,7 @@ public abstract class ExpressionNode {
      *
      * @param ctx expression compilation context
      */
-    protected abstract void generateBytecode(@NonNull ExpressionVisitorContext ctx);
+    protected abstract void generateBytecode(@NonNull ExpressionCompilationContext ctx);
 
     /**
      * On resolution stage type information is collected and node validity is checked. Once type
@@ -77,11 +78,37 @@ public abstract class ExpressionNode {
      * @return resolved type
      */
     @NonNull
+    public final Type resolveType(@NonNull ExpressionCompilationContext ctx) {
+        return resolveType(ctx.evaluationVisitorContext());
+    }
+
+    /**
+     * On resolution stage type information is collected and node validity is checked. Once type
+     * is resolved, type resolution result is cached.
+     *
+     * @param ctx expression compilation context
+     *
+     * @return resolved type
+     */
+    @NonNull
     public final ClassElement resolveClassElement(@NonNull ExpressionVisitorContext ctx) {
         if (classElement == null) {
             classElement = doResolveClassElement(ctx);
         }
         return classElement;
+    }
+
+    /**
+     * On resolution stage type information is collected and node validity is checked. Once type
+     * is resolved, type resolution result is cached.
+     *
+     * @param ctx expression compilation context
+     *
+     * @return resolved type
+     */
+    @NonNull
+    public final ClassElement resolveClassElement(@NonNull ExpressionCompilationContext ctx) {
+        return resolveClassElement(ctx.evaluationVisitorContext());
     }
 
     /**
@@ -96,6 +123,15 @@ public abstract class ExpressionNode {
         } catch (IllegalArgumentException e) {
             return ClassElement.of(type.getClassName());
         }
+    }
+
+    /**
+     * Resolves the class element for this node.
+     * @param ctx The expression compilation context
+     * @return The resolved type
+     */
+    protected ClassElement doResolveClassElement(ExpressionCompilationContext ctx) {
+        return doResolveClassElement(ctx.evaluationVisitorContext());
     }
 
     /**

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/access/AbstractMethodCall.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/access/AbstractMethodCall.java
@@ -21,6 +21,7 @@ import io.micronaut.expressions.parser.ast.ExpressionNode;
 import io.micronaut.expressions.parser.ast.collection.OneDimensionalArray;
 import io.micronaut.expressions.parser.ast.util.TypeDescriptors;
 import io.micronaut.expressions.parser.ast.types.TypeIdentifier;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.MethodElement;
@@ -59,7 +60,7 @@ public abstract sealed class AbstractMethodCall extends ExpressionNode permits C
     }
 
     @Override
-    protected Type doResolveType(ExpressionVisitorContext ctx) {
+    protected Type doResolveType(@NonNull ExpressionVisitorContext ctx) {
         if (usedMethod == null) {
             usedMethod = resolveUsedMethod(ctx);
         }
@@ -156,7 +157,7 @@ public abstract sealed class AbstractMethodCall extends ExpressionNode permits C
      *
      * @param ctx expression evaluation context
      */
-    protected void compileArguments(ExpressionVisitorContext ctx) {
+    protected void compileArguments(ExpressionCompilationContext ctx) {
         List<ExpressionNode> arguments = this.arguments;
         if (usedMethod.isVarArgs()) {
             arguments = prepareVarargsArguments();
@@ -174,7 +175,7 @@ public abstract sealed class AbstractMethodCall extends ExpressionNode permits C
      * @param argumentIndex argument index
      * @param argument      compiled argument
      */
-    private void compileArgument(ExpressionVisitorContext ctx,
+    private void compileArgument(ExpressionCompilationContext ctx,
                                  int argumentIndex,
                                  ExpressionNode argument) {
         GeneratorAdapter mv = ctx.methodVisitor();

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/access/BeanContextAccess.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/access/BeanContextAccess.java
@@ -16,8 +16,10 @@
 package io.micronaut.expressions.parser.ast.access;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
 import io.micronaut.expressions.parser.ast.types.TypeIdentifier;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
 import io.micronaut.inject.ast.ClassElement;
 import org.objectweb.asm.Type;
@@ -47,7 +49,7 @@ public class BeanContextAccess extends ExpressionNode {
     }
 
     @Override
-    protected void generateBytecode(ExpressionVisitorContext ctx) {
+    protected void generateBytecode(ExpressionCompilationContext ctx) {
         GeneratorAdapter mv = ctx.methodVisitor();
         mv.loadArg(0);
 
@@ -67,7 +69,7 @@ public class BeanContextAccess extends ExpressionNode {
     }
 
     @Override
-    protected Type doResolveType(ExpressionVisitorContext ctx) {
+    protected Type doResolveType(@NonNull ExpressionVisitorContext ctx) {
         return typeIdentifier.doResolveType(ctx);
     }
 }

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/access/ContextElementAccess.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/access/ContextElementAccess.java
@@ -16,8 +16,10 @@
 package io.micronaut.expressions.parser.ast.access;
 
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.expressions.context.ExpressionCompilationContext;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.expressions.context.ExpressionEvaluationContext;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
 import io.micronaut.expressions.parser.exception.ExpressionCompilationException;
 import io.micronaut.inject.ast.ClassElement;
@@ -53,7 +55,7 @@ public final class ContextElementAccess extends ExpressionNode {
     }
 
     @Override
-    protected void generateBytecode(ExpressionVisitorContext ctx) {
+    protected void generateBytecode(ExpressionCompilationContext ctx) {
         contextOperation.compile(ctx);
     }
 
@@ -63,7 +65,7 @@ public final class ContextElementAccess extends ExpressionNode {
     }
 
     @Override
-    public Type doResolveType(ExpressionVisitorContext ctx) {
+    public Type doResolveType(@NonNull ExpressionVisitorContext ctx) {
         return resolveContextOperation(ctx).resolveType(ctx);
     }
 
@@ -72,7 +74,7 @@ public final class ContextElementAccess extends ExpressionNode {
             return contextOperation;
         }
 
-        ExpressionCompilationContext evaluationContext = ctx.compilationContext();
+        ExpressionEvaluationContext evaluationContext = ctx.evaluationContext();
 
         List<PropertyElement> propertyElements = evaluationContext.findProperties(name);
         List<ParameterElement> parameterElements = evaluationContext.findParameters(name);

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/access/ContextMethodCall.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/access/ContextMethodCall.java
@@ -16,8 +16,9 @@
 package io.micronaut.expressions.parser.ast.access;
 
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.expressions.context.ExpressionCompilationContext;
+import io.micronaut.expressions.context.ExpressionEvaluationContext;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
 import io.micronaut.expressions.parser.exception.ExpressionCompilationException;
 import io.micronaut.inject.ast.ClassElement;
@@ -53,7 +54,7 @@ public final class ContextMethodCall extends AbstractMethodCall {
     protected CandidateMethod resolveUsedMethod(ExpressionVisitorContext ctx) {
         List<Type> argumentTypes = resolveArgumentTypes(ctx);
 
-        ExpressionCompilationContext evaluationContext = ctx.compilationContext();
+        ExpressionEvaluationContext evaluationContext = ctx.evaluationContext();
         List<CandidateMethod> candidateMethods =
             evaluationContext.findMethods(name)
                 .stream()
@@ -74,7 +75,7 @@ public final class ContextMethodCall extends AbstractMethodCall {
     }
 
     @Override
-    public void generateBytecode(ExpressionVisitorContext ctx) {
+    public void generateBytecode(ExpressionCompilationContext ctx) {
         GeneratorAdapter mv = ctx.methodVisitor();
         Type calleeType = usedMethod.getOwningType();
 

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/access/ContextMethodParameterAccess.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/access/ContextMethodParameterAccess.java
@@ -16,8 +16,10 @@
 package io.micronaut.expressions.parser.ast.access;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
 import io.micronaut.expressions.parser.ast.util.TypeDescriptors;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
 import io.micronaut.expressions.parser.exception.ExpressionCompilationException;
 import io.micronaut.inject.ast.ClassElement;
@@ -51,7 +53,7 @@ final class ContextMethodParameterAccess extends ExpressionNode {
     }
 
     @Override
-    protected void generateBytecode(ExpressionVisitorContext ctx) {
+    protected void generateBytecode(ExpressionCompilationContext ctx) {
         GeneratorAdapter mv = ctx.methodVisitor();
         mv.loadArg(0);
         mv.push(parameterIndex);
@@ -86,7 +88,7 @@ final class ContextMethodParameterAccess extends ExpressionNode {
     }
 
     @Override
-    protected Type doResolveType(ExpressionVisitorContext ctx) {
+    protected Type doResolveType(@NonNull ExpressionVisitorContext ctx) {
         doResolveClassElement(ctx);
         return getTypeReference(parameterElement.getType());
     }

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/access/ElementMethodCall.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/access/ElementMethodCall.java
@@ -19,6 +19,7 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
 import io.micronaut.expressions.parser.ast.types.TypeIdentifier;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
 import io.micronaut.expressions.parser.exception.ExpressionCompilationException;
 import io.micronaut.inject.ast.ClassElement;
@@ -69,7 +70,7 @@ public sealed class ElementMethodCall extends AbstractMethodCall permits Propert
     }
 
     @Override
-    protected void generateBytecode(ExpressionVisitorContext ctx) {
+    protected void generateBytecode(ExpressionCompilationContext ctx) {
         GeneratorAdapter mv = ctx.methodVisitor();
         ClassElement calleeClass = callee.resolveClassElement(ctx);
         Method method = usedMethod.toAsmMethod();
@@ -124,7 +125,6 @@ public sealed class ElementMethodCall extends AbstractMethodCall permits Propert
             // safe navigate optional
             classElement = classElement.getFirstTypeArgument().orElse(classElement);
         }
-
 
         ElementQuery<MethodElement> methodQuery = buildMethodQuery();
         List<CandidateMethod> candidateMethods = classElement.getEnclosedElements(methodQuery).stream()

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/access/EnvironmentAccess.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/access/EnvironmentAccess.java
@@ -16,7 +16,9 @@
 package io.micronaut.expressions.parser.ast.access;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
 import io.micronaut.expressions.parser.exception.ExpressionCompilationException;
 import io.micronaut.inject.ast.ClassElement;
@@ -49,7 +51,7 @@ public final class EnvironmentAccess extends ExpressionNode {
     }
 
     @Override
-    protected void generateBytecode(ExpressionVisitorContext ctx) {
+    protected void generateBytecode(ExpressionCompilationContext ctx) {
         GeneratorAdapter mv = ctx.methodVisitor();
         mv.loadArg(0);
         propertyName.compile(ctx);
@@ -64,7 +66,7 @@ public final class EnvironmentAccess extends ExpressionNode {
     }
 
     @Override
-    protected Type doResolveType(ExpressionVisitorContext ctx) {
+    protected Type doResolveType(@NonNull ExpressionVisitorContext ctx) {
         Type propertyNameType = propertyName.resolveType(ctx);
         if (!propertyNameType.equals(STRING)) {
             throw new ExpressionCompilationException("Invalid environment access operation. The expression inside environment " +

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/access/SubscriptOperator.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/access/SubscriptOperator.java
@@ -16,8 +16,10 @@
 package io.micronaut.expressions.parser.ast.access;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
 import io.micronaut.expressions.parser.exception.ExpressionCompilationException;
 import io.micronaut.inject.ast.ClassElement;
@@ -54,7 +56,7 @@ public class SubscriptOperator extends ExpressionNode {
     }
 
     @Override
-    protected void generateBytecode(ExpressionVisitorContext ctx) {
+    protected void generateBytecode(ExpressionCompilationContext ctx) {
         callee.compile(ctx);
         GeneratorAdapter methodVisitor = ctx.methodVisitor();
         ClassElement indexType = index.resolveClassElement(ctx);
@@ -111,7 +113,7 @@ public class SubscriptOperator extends ExpressionNode {
     }
 
     @Override
-    protected Type doResolveType(ExpressionVisitorContext ctx) {
+    protected Type doResolveType(@NonNull ExpressionVisitorContext ctx) {
         ClassElement valueElement = resolveClassElement(ctx);
         return JavaModelUtils.getTypeReference(valueElement);
     }

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/access/ThisAccess.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/access/ThisAccess.java
@@ -16,7 +16,9 @@
 package io.micronaut.expressions.parser.ast.access;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
 import io.micronaut.expressions.parser.exception.ExpressionCompilationException;
 import io.micronaut.inject.ast.ClassElement;
@@ -33,7 +35,7 @@ import static io.micronaut.expressions.parser.ast.util.TypeDescriptors.EVALUATIO
 @Internal
 public final class ThisAccess extends ExpressionNode {
     @Override
-    protected void generateBytecode(ExpressionVisitorContext ctx) {
+    protected void generateBytecode(ExpressionCompilationContext ctx) {
         GeneratorAdapter mv = ctx.methodVisitor();
         mv.loadArg(0);
         mv.invokeInterface(EVALUATION_CONTEXT_TYPE, new Method("getThis", Type.getType(Object.class), new Type[0]));
@@ -42,7 +44,7 @@ public final class ThisAccess extends ExpressionNode {
 
     @Override
     protected ClassElement doResolveClassElement(ExpressionVisitorContext ctx) {
-        ClassElement thisType = ctx.compilationContext().findThis();
+        ClassElement thisType = ctx.evaluationContext().findThis();
         if (thisType == null) {
             throw new ExpressionCompilationException(
                 "Cannot reference 'this' from the current context.");
@@ -52,7 +54,7 @@ public final class ThisAccess extends ExpressionNode {
     }
 
     @Override
-    protected Type doResolveType(ExpressionVisitorContext ctx) {
+    protected Type doResolveType(@NonNull ExpressionVisitorContext ctx) {
         return JavaModelUtils.getTypeReference(doResolveClassElement(ctx));
     }
 }

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/collection/OneDimensionalArray.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/collection/OneDimensionalArray.java
@@ -16,8 +16,10 @@
 package io.micronaut.expressions.parser.ast.collection;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
 import io.micronaut.expressions.parser.ast.types.TypeIdentifier;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
 import io.micronaut.inject.ast.ClassElement;
 import org.objectweb.asm.Type;
@@ -52,7 +54,7 @@ public final class OneDimensionalArray extends ExpressionNode {
     }
 
     @Override
-    public void generateBytecode(ExpressionVisitorContext ctx) {
+    public void generateBytecode(ExpressionCompilationContext ctx) {
         GeneratorAdapter mv = ctx.methodVisitor();
         int arraySize = initializer.size();
 
@@ -89,7 +91,7 @@ public final class OneDimensionalArray extends ExpressionNode {
     }
 
     @Override
-    protected Type doResolveType(ExpressionVisitorContext ctx) {
+    protected Type doResolveType(@NonNull ExpressionVisitorContext ctx) {
         return getTypeReference(doResolveClassElement(ctx));
     }
 }

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/conditional/TernaryExpression.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/conditional/TernaryExpression.java
@@ -16,9 +16,11 @@
 package io.micronaut.expressions.parser.ast.conditional;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.util.ObjectUtils;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
 import io.micronaut.expressions.parser.exception.ExpressionCompilationException;
 import io.micronaut.inject.ast.ClassElement;
@@ -65,7 +67,7 @@ public class TernaryExpression extends ExpressionNode {
     }
 
     @Override
-    public void generateBytecode(ExpressionVisitorContext ctx) {
+    public void generateBytecode(ExpressionCompilationContext ctx) {
         GeneratorAdapter mv = ctx.methodVisitor();
         Label falseLabel = new Label();
         Label returnLabel = new Label();
@@ -129,7 +131,7 @@ public class TernaryExpression extends ExpressionNode {
     }
 
     @Override
-    protected Type doResolveType(ExpressionVisitorContext ctx) {
+    protected Type doResolveType(@NonNull ExpressionVisitorContext ctx) {
         if (!shouldCoerceConditionToBoolean() && !isOneOf(condition.resolveType(ctx), BOOLEAN, BOOLEAN_WRAPPER)) {
             throw new ExpressionCompilationException("Invalid ternary operator. Condition should resolve to boolean type");
         }

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/literal/BoolLiteral.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/literal/BoolLiteral.java
@@ -16,7 +16,9 @@
 package io.micronaut.expressions.parser.ast.literal;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.PrimitiveElement;
@@ -39,7 +41,7 @@ public final class BoolLiteral extends ExpressionNode {
     }
 
     @Override
-    public void generateBytecode(ExpressionVisitorContext ctx) {
+    public void generateBytecode(ExpressionCompilationContext ctx) {
         ctx.methodVisitor().push(value);
     }
 
@@ -49,7 +51,7 @@ public final class BoolLiteral extends ExpressionNode {
     }
 
     @Override
-    protected Type doResolveType(ExpressionVisitorContext ctx) {
+    protected Type doResolveType(@NonNull ExpressionVisitorContext ctx) {
         return BOOLEAN;
     }
 }

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/literal/DoubleLiteral.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/literal/DoubleLiteral.java
@@ -16,7 +16,9 @@
 package io.micronaut.expressions.parser.ast.literal;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.PrimitiveElement;
@@ -39,7 +41,7 @@ public final class DoubleLiteral extends ExpressionNode {
     }
 
     @Override
-    public void generateBytecode(ExpressionVisitorContext ctx) {
+    public void generateBytecode(ExpressionCompilationContext ctx) {
         ctx.methodVisitor().push(value);
     }
 
@@ -49,7 +51,7 @@ public final class DoubleLiteral extends ExpressionNode {
     }
 
     @Override
-    protected Type doResolveType(ExpressionVisitorContext ctx) {
+    protected Type doResolveType(@NonNull ExpressionVisitorContext ctx) {
         return DOUBLE;
     }
 }

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/literal/FloatLiteral.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/literal/FloatLiteral.java
@@ -16,7 +16,9 @@
 package io.micronaut.expressions.parser.ast.literal;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.PrimitiveElement;
@@ -39,7 +41,7 @@ public final class FloatLiteral extends ExpressionNode {
     }
 
     @Override
-    public void generateBytecode(ExpressionVisitorContext ctx) {
+    public void generateBytecode(ExpressionCompilationContext ctx) {
         ctx.methodVisitor().push(value);
     }
 
@@ -49,7 +51,7 @@ public final class FloatLiteral extends ExpressionNode {
     }
 
     @Override
-    protected Type doResolveType(ExpressionVisitorContext ctx) {
+    protected Type doResolveType(@NonNull ExpressionVisitorContext ctx) {
         return FLOAT;
     }
 }

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/literal/IntLiteral.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/literal/IntLiteral.java
@@ -16,7 +16,9 @@
 package io.micronaut.expressions.parser.ast.literal;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.PrimitiveElement;
@@ -40,7 +42,7 @@ public final class IntLiteral extends ExpressionNode {
     }
 
     @Override
-    public void generateBytecode(ExpressionVisitorContext ctx) {
+    public void generateBytecode(ExpressionCompilationContext ctx) {
         ctx.methodVisitor().push(value);
     }
 
@@ -50,7 +52,7 @@ public final class IntLiteral extends ExpressionNode {
     }
 
     @Override
-    protected Type doResolveType(ExpressionVisitorContext ctx) {
+    protected Type doResolveType(@NonNull ExpressionVisitorContext ctx) {
         return INT;
     }
 

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/literal/LongLiteral.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/literal/LongLiteral.java
@@ -16,7 +16,9 @@
 package io.micronaut.expressions.parser.ast.literal;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.PrimitiveElement;
@@ -39,7 +41,7 @@ public final class LongLiteral extends ExpressionNode {
     }
 
     @Override
-    public void generateBytecode(ExpressionVisitorContext ctx) {
+    public void generateBytecode(ExpressionCompilationContext ctx) {
         ctx.methodVisitor().push(value);
     }
 
@@ -49,7 +51,7 @@ public final class LongLiteral extends ExpressionNode {
     }
 
     @Override
-    protected Type doResolveType(ExpressionVisitorContext ctx) {
+    protected Type doResolveType(@NonNull ExpressionVisitorContext ctx) {
         return LONG;
     }
 }

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/literal/NullLiteral.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/literal/NullLiteral.java
@@ -16,7 +16,9 @@
 package io.micronaut.expressions.parser.ast.literal;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
 import io.micronaut.inject.ast.ClassElement;
 import org.objectweb.asm.Type;
@@ -33,7 +35,7 @@ import static org.objectweb.asm.Opcodes.ACONST_NULL;
 @Internal
 public final class NullLiteral extends ExpressionNode {
     @Override
-    public void generateBytecode(ExpressionVisitorContext ctx) {
+    public void generateBytecode(ExpressionCompilationContext ctx) {
         ctx.methodVisitor().visitInsn(ACONST_NULL);
     }
 
@@ -43,7 +45,7 @@ public final class NullLiteral extends ExpressionNode {
     }
 
     @Override
-    protected Type doResolveType(ExpressionVisitorContext ctx) {
+    protected Type doResolveType(@NonNull ExpressionVisitorContext ctx) {
         return OBJECT;
     }
 }

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/literal/StringLiteral.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/literal/StringLiteral.java
@@ -16,7 +16,9 @@
 package io.micronaut.expressions.parser.ast.literal;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
 import io.micronaut.inject.ast.ClassElement;
 import org.objectweb.asm.Type;
@@ -44,7 +46,7 @@ public final class StringLiteral extends ExpressionNode {
     }
 
     @Override
-    public void generateBytecode(ExpressionVisitorContext ctx) {
+    public void generateBytecode(ExpressionCompilationContext ctx) {
         ctx.methodVisitor().push(value);
     }
 
@@ -54,7 +56,7 @@ public final class StringLiteral extends ExpressionNode {
     }
 
     @Override
-    protected Type doResolveType(ExpressionVisitorContext ctx) {
+    protected Type doResolveType(@NonNull ExpressionVisitorContext ctx) {
         return STRING;
     }
 }

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/binary/AddOperator.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/binary/AddOperator.java
@@ -18,7 +18,7 @@ package io.micronaut.expressions.parser.ast.operator.binary;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
 import io.micronaut.expressions.parser.ast.util.TypeDescriptors;
-import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import io.micronaut.expressions.parser.exception.ExpressionCompilationException;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.GeneratorAdapter;
@@ -86,7 +86,7 @@ public final class AddOperator extends BinaryOperator {
     }
 
     @Override
-    public void generateBytecode(ExpressionVisitorContext ctx) {
+    public void generateBytecode(ExpressionCompilationContext ctx) {
         Type leftType = leftOperand.resolveType(ctx);
         Type rightType = rightOperand.resolveType(ctx);
 
@@ -113,7 +113,7 @@ public final class AddOperator extends BinaryOperator {
         }
     }
 
-    private void concatStrings(ExpressionVisitorContext ctx) {
+    private void concatStrings(ExpressionCompilationContext ctx) {
         GeneratorAdapter mv = ctx.methodVisitor();
         initStringBuilder(mv);
         pushOperand(ctx, leftOperand);
@@ -127,7 +127,7 @@ public final class AddOperator extends BinaryOperator {
         mv.invokeConstructor(STRING_BUILDER_TYPE, STRING_BUILD_CONSTRUCTOR);
     }
 
-    private void pushOperand(ExpressionVisitorContext ctx, ExpressionNode operand) {
+    private void pushOperand(ExpressionCompilationContext ctx, ExpressionNode operand) {
         GeneratorAdapter mv = ctx.methodVisitor();
         if (operand instanceof AddOperator addOperator) {
             Type operatorType = addOperator.resolveType(ctx);

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/binary/AndOperator.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/binary/AndOperator.java
@@ -17,7 +17,7 @@ package io.micronaut.expressions.parser.ast.operator.binary;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
-import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.commons.GeneratorAdapter;
 
@@ -37,7 +37,7 @@ public final class AndOperator extends LogicalOperator {
     }
 
     @Override
-    public void generateBytecode(ExpressionVisitorContext ctx) {
+    public void generateBytecode(ExpressionCompilationContext ctx) {
         GeneratorAdapter mv = ctx.methodVisitor();
         Label falseLabel = new Label();
         Label trueLabel = new Label();
@@ -54,7 +54,7 @@ public final class AndOperator extends LogicalOperator {
         mv.visitLabel(trueLabel);
     }
 
-    private void pushOperand(ExpressionVisitorContext ctx, ExpressionNode operand, Label falseLabel) {
+    private void pushOperand(ExpressionCompilationContext ctx, ExpressionNode operand, Label falseLabel) {
         if (operand instanceof AndOperator andOperator) {
             pushOperand(ctx, andOperator.leftOperand, falseLabel);
             pushOperand(ctx, andOperator.rightOperand, falseLabel);

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/binary/BinaryOperator.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/binary/BinaryOperator.java
@@ -16,6 +16,7 @@
 package io.micronaut.expressions.parser.ast.operator.binary;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
 import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
 import org.objectweb.asm.Type;
@@ -41,7 +42,7 @@ public abstract sealed class BinaryOperator extends ExpressionNode permits AddOp
     }
 
     @Override
-    protected Type doResolveType(ExpressionVisitorContext ctx) {
+    protected Type doResolveType(@NonNull ExpressionVisitorContext ctx) {
         Type leftType = leftOperand.resolveType(ctx);
         Type rightType = rightOperand.resolveType(ctx);
         return resolveOperationType(leftType, rightType);

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/binary/ComparablesComparisonOperation.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/binary/ComparablesComparisonOperation.java
@@ -16,9 +16,11 @@
 package io.micronaut.expressions.parser.ast.operator.binary;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
 import io.micronaut.expressions.parser.ast.util.TypeDescriptors;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
 import io.micronaut.expressions.parser.exception.ExpressionCompilationException;
 import io.micronaut.inject.ast.ClassElement;
@@ -68,7 +70,7 @@ public final class ComparablesComparisonOperation extends ExpressionNode {
     }
 
     @Override
-    protected Type doResolveType(ExpressionVisitorContext ctx) {
+    protected Type doResolveType(@NonNull ExpressionVisitorContext ctx) {
         // resolving non-primitive class elements is necessary to handle cases
         // when one of expression nodes is of primitive type, but other expression node
         // is comparable to respective boxed type
@@ -119,7 +121,7 @@ public final class ComparablesComparisonOperation extends ExpressionNode {
     }
 
     @Override
-    public void generateBytecode(ExpressionVisitorContext ctx) {
+    public void generateBytecode(ExpressionCompilationContext ctx) {
         GeneratorAdapter mv = ctx.methodVisitor();
 
         Label elseLabel = new Label();
@@ -142,7 +144,7 @@ public final class ComparablesComparisonOperation extends ExpressionNode {
 
     private void pushCompareToMethodCall(ExpressionNode comparableNode,
                                          ExpressionNode comparedNode,
-                                         ExpressionVisitorContext ctx) {
+                                         ExpressionCompilationContext ctx) {
         GeneratorAdapter mv = ctx.methodVisitor();
         ClassElement comparableClass = comparableNode.resolveClassElement(ctx);
 

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/binary/DivOperator.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/binary/DivOperator.java
@@ -17,7 +17,7 @@ package io.micronaut.expressions.parser.ast.operator.binary;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
-import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import io.micronaut.expressions.parser.exception.ExpressionCompilationException;
 import org.objectweb.asm.Type;
 
@@ -48,7 +48,7 @@ public final class DivOperator extends MathOperator {
     }
 
     @Override
-    protected int getMathOperationOpcode(ExpressionVisitorContext ctx) {
+    protected int getMathOperationOpcode(ExpressionCompilationContext ctx) {
         Type type = resolveType(ctx);
         String typeDescriptor = type.getDescriptor();
         return Optional.ofNullable(DIV_OPERATION_OPCODES.get(typeDescriptor))

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/binary/EqOperator.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/binary/EqOperator.java
@@ -17,7 +17,7 @@ package io.micronaut.expressions.parser.ast.operator.binary;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
-import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.GeneratorAdapter;
 import org.objectweb.asm.commons.Method;
@@ -41,7 +41,7 @@ public sealed class EqOperator extends BinaryOperator permits NeqOperator {
     }
 
     @Override
-    public void generateBytecode(ExpressionVisitorContext ctx) {
+    public void generateBytecode(ExpressionCompilationContext ctx) {
         GeneratorAdapter mv = ctx.methodVisitor();
         Type lefType = leftOperand.resolveType(ctx);
         Type rightType = rightOperand.resolveType(ctx);

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/binary/InstanceofOperator.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/binary/InstanceofOperator.java
@@ -16,8 +16,10 @@
 package io.micronaut.expressions.parser.ast.operator.binary;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
 import io.micronaut.expressions.parser.ast.types.TypeIdentifier;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
 import io.micronaut.expressions.parser.exception.ExpressionCompilationException;
 import io.micronaut.inject.ast.ClassElement;
@@ -47,7 +49,7 @@ public final class InstanceofOperator extends ExpressionNode {
     }
 
     @Override
-    public void generateBytecode(ExpressionVisitorContext ctx) {
+    public void generateBytecode(ExpressionCompilationContext ctx) {
         Type targetType = typeIdentifier.resolveType(ctx);
         if (isPrimitive(targetType)) {
             throw new ExpressionCompilationException(
@@ -69,7 +71,7 @@ public final class InstanceofOperator extends ExpressionNode {
     }
 
     @Override
-    protected Type doResolveType(ExpressionVisitorContext ctx) {
+    protected Type doResolveType(@NonNull ExpressionVisitorContext ctx) {
         return BOOLEAN;
     }
 }

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/binary/MatchesOperator.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/binary/MatchesOperator.java
@@ -16,8 +16,10 @@
 package io.micronaut.expressions.parser.ast.operator.binary;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
 import io.micronaut.expressions.parser.ast.literal.StringLiteral;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
 import io.micronaut.expressions.parser.exception.ExpressionCompilationException;
 import io.micronaut.inject.ast.ClassElement;
@@ -52,7 +54,7 @@ public final class MatchesOperator extends ExpressionNode {
     }
 
     @Override
-    public void generateBytecode(ExpressionVisitorContext ctx) {
+    public void generateBytecode(ExpressionCompilationContext ctx) {
         GeneratorAdapter mv = ctx.methodVisitor();
         operand.compile(ctx);
         pattern.compile(ctx);
@@ -65,7 +67,7 @@ public final class MatchesOperator extends ExpressionNode {
     }
 
     @Override
-    protected Type doResolveType(ExpressionVisitorContext ctx) {
+    protected Type doResolveType(@NonNull ExpressionVisitorContext ctx) {
         if (!operand.resolveType(ctx).equals(STRING)) {
             throw new ExpressionCompilationException(
                 "Operator 'matches' can only be applied to String operand");

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/binary/MathOperator.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/binary/MathOperator.java
@@ -17,7 +17,7 @@ package io.micronaut.expressions.parser.ast.operator.binary;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
-import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.GeneratorAdapter;
 
@@ -42,7 +42,7 @@ public abstract sealed class MathOperator extends BinaryOperator permits DivOper
     }
 
     @Override
-    public void generateBytecode(ExpressionVisitorContext ctx) {
+    public void generateBytecode(ExpressionCompilationContext ctx) {
         GeneratorAdapter mv = ctx.methodVisitor();
         Type targetType = resolveType(ctx);
 
@@ -64,5 +64,5 @@ public abstract sealed class MathOperator extends BinaryOperator permits DivOper
         return computeNumericOperationTargetType(leftOperandType, rightOperandType);
     }
 
-    protected abstract int getMathOperationOpcode(ExpressionVisitorContext ctx);
+    protected abstract int getMathOperationOpcode(ExpressionCompilationContext ctx);
 }

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/binary/ModOperator.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/binary/ModOperator.java
@@ -17,7 +17,7 @@ package io.micronaut.expressions.parser.ast.operator.binary;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
-import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import io.micronaut.expressions.parser.exception.ExpressionCompilationException;
 import org.objectweb.asm.Type;
 
@@ -48,7 +48,7 @@ public final class ModOperator extends MathOperator {
     }
 
     @Override
-    protected int getMathOperationOpcode(ExpressionVisitorContext ctx) {
+    protected int getMathOperationOpcode(ExpressionCompilationContext ctx) {
         Type type = resolveType(ctx);
         String typeDescriptor = type.getDescriptor();
         return Optional.ofNullable(MOD_OPERATION_OPCODES.get(typeDescriptor))

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/binary/MulOperator.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/binary/MulOperator.java
@@ -17,7 +17,7 @@ package io.micronaut.expressions.parser.ast.operator.binary;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
-import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import io.micronaut.expressions.parser.exception.ExpressionCompilationException;
 import org.objectweb.asm.Type;
 
@@ -49,7 +49,7 @@ public final class MulOperator extends MathOperator {
     }
 
     @Override
-    protected int getMathOperationOpcode(ExpressionVisitorContext ctx) {
+    protected int getMathOperationOpcode(ExpressionCompilationContext ctx) {
         Type type = resolveType(ctx);
         String typeDescriptor = type.getDescriptor();
         return Optional.ofNullable(MUL_OPERATION_OPCODES.get(typeDescriptor))

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/binary/NeqOperator.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/binary/NeqOperator.java
@@ -17,7 +17,7 @@ package io.micronaut.expressions.parser.ast.operator.binary;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
-import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.GeneratorAdapter;
@@ -39,7 +39,7 @@ public final class NeqOperator extends EqOperator {
     }
 
     @Override
-    public void generateBytecode(ExpressionVisitorContext ctx) {
+    public void generateBytecode(ExpressionCompilationContext ctx) {
         super.generateBytecode(ctx);
 
         GeneratorAdapter mv = ctx.methodVisitor();

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/binary/NumericComparisonOperation.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/binary/NumericComparisonOperation.java
@@ -16,7 +16,9 @@
 package io.micronaut.expressions.parser.ast.operator.binary;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
 import io.micronaut.expressions.parser.exception.ExpressionCompilationException;
 import org.objectweb.asm.Label;
@@ -63,7 +65,7 @@ public final class NumericComparisonOperation extends ExpressionNode {
     }
 
     @Override
-    protected Type doResolveType(ExpressionVisitorContext ctx) {
+    protected Type doResolveType(@NonNull ExpressionVisitorContext ctx) {
         Type leftType = leftOperand.resolveType(ctx);
         Type rightType = rightOperand.resolveType(ctx);
 
@@ -76,7 +78,7 @@ public final class NumericComparisonOperation extends ExpressionNode {
     }
 
     @Override
-    public void generateBytecode(ExpressionVisitorContext ctx) {
+    public void generateBytecode(ExpressionCompilationContext ctx) {
         GeneratorAdapter mv = ctx.methodVisitor();
 
         Label elseLabel = new Label();

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/binary/OrOperator.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/binary/OrOperator.java
@@ -17,7 +17,7 @@ package io.micronaut.expressions.parser.ast.operator.binary;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
-import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.commons.GeneratorAdapter;
 
@@ -37,7 +37,7 @@ public final class OrOperator extends LogicalOperator {
     }
 
     @Override
-    public void generateBytecode(ExpressionVisitorContext ctx) {
+    public void generateBytecode(ExpressionCompilationContext ctx) {
         GeneratorAdapter mv = ctx.methodVisitor();
         Label falseLabel = new Label();
         Label returnLabel = new Label();

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/binary/PowOperator.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/binary/PowOperator.java
@@ -17,7 +17,7 @@ package io.micronaut.expressions.parser.ast.operator.binary;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
-import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import io.micronaut.expressions.parser.exception.ExpressionCompilationException;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.GeneratorAdapter;
@@ -50,7 +50,7 @@ public final class PowOperator extends BinaryOperator {
     }
 
     @Override
-    public void generateBytecode(ExpressionVisitorContext ctx) {
+    public void generateBytecode(ExpressionCompilationContext ctx) {
         GeneratorAdapter mv = ctx.methodVisitor();
 
         Type leftType = leftOperand.resolveType(ctx);

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/binary/RelationalOperator.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/binary/RelationalOperator.java
@@ -16,7 +16,9 @@
 package io.micronaut.expressions.parser.ast.operator.binary;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
 import org.objectweb.asm.Type;
 
@@ -53,7 +55,7 @@ public abstract sealed class RelationalOperator extends ExpressionNode permits G
     protected abstract Integer nonIntComparisonOpcode();
 
     @Override
-    protected Type doResolveType(ExpressionVisitorContext ctx) {
+    protected Type doResolveType(@NonNull ExpressionVisitorContext ctx) {
         Type leftType = leftOperand.resolveType(ctx);
         Type rightType = rightOperand.resolveType(ctx);
 
@@ -70,7 +72,7 @@ public abstract sealed class RelationalOperator extends ExpressionNode permits G
     }
 
     @Override
-    public void generateBytecode(ExpressionVisitorContext ctx) {
+    public void generateBytecode(ExpressionCompilationContext ctx) {
         comparisonOperation.compile(ctx);
     }
 }

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/binary/SubOperator.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/binary/SubOperator.java
@@ -17,7 +17,7 @@ package io.micronaut.expressions.parser.ast.operator.binary;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
-import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import io.micronaut.expressions.parser.exception.ExpressionCompilationException;
 import org.objectweb.asm.Type;
 
@@ -49,7 +49,7 @@ public final class SubOperator extends MathOperator {
     }
 
     @Override
-    protected int getMathOperationOpcode(ExpressionVisitorContext ctx) {
+    protected int getMathOperationOpcode(ExpressionCompilationContext ctx) {
         Type type = resolveType(ctx);
         String typeDescriptor = type.getDescriptor();
         return Optional.ofNullable(SUB_OPERATION_OPCODES.get(typeDescriptor))

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/unary/EmptyOperator.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/unary/EmptyOperator.java
@@ -16,11 +16,13 @@
 package io.micronaut.expressions.parser.ast.operator.unary;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.PrimitiveElement;
@@ -46,7 +48,7 @@ public final class EmptyOperator extends UnaryOperator {
     }
 
     @Override
-    protected void generateBytecode(ExpressionVisitorContext ctx) {
+    protected void generateBytecode(ExpressionCompilationContext ctx) {
         ClassElement type = operand.resolveClassElement(ctx);
 
         GeneratorAdapter mv = ctx.methodVisitor();
@@ -124,7 +126,7 @@ public final class EmptyOperator extends UnaryOperator {
     }
 
     @Override
-    public Type doResolveType(ExpressionVisitorContext ctx) {
+    public Type doResolveType(@NonNull ExpressionVisitorContext ctx) {
         return Type.BOOLEAN_TYPE;
     }
 

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/unary/NegOperator.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/unary/NegOperator.java
@@ -16,7 +16,9 @@
 package io.micronaut.expressions.parser.ast.operator.unary;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
 import io.micronaut.expressions.parser.exception.ExpressionCompilationException;
 import org.objectweb.asm.Type;
@@ -51,7 +53,7 @@ public final class NegOperator extends UnaryOperator {
     }
 
     @Override
-    public Type doResolveType(ExpressionVisitorContext ctx) {
+    public Type doResolveType(@NonNull ExpressionVisitorContext ctx) {
         Type nodeType = super.doResolveType(ctx);
         if (!isNumeric(nodeType)) {
             throw new ExpressionCompilationException(
@@ -61,7 +63,7 @@ public final class NegOperator extends UnaryOperator {
     }
 
     @Override
-    public void generateBytecode(ExpressionVisitorContext ctx) {
+    public void generateBytecode(ExpressionCompilationContext ctx) {
         GeneratorAdapter mv = ctx.methodVisitor();
 
         operand.compile(ctx);

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/unary/NotOperator.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/unary/NotOperator.java
@@ -16,7 +16,9 @@
 package io.micronaut.expressions.parser.ast.operator.unary;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
 import io.micronaut.expressions.parser.exception.ExpressionCompilationException;
 import org.objectweb.asm.Label;
@@ -40,7 +42,7 @@ public final class NotOperator extends UnaryOperator {
     }
 
     @Override
-    public Type doResolveType(ExpressionVisitorContext ctx) {
+    public Type doResolveType(@NonNull ExpressionVisitorContext ctx) {
         if (nodeType != null) {
             return nodeType;
         }
@@ -56,7 +58,7 @@ public final class NotOperator extends UnaryOperator {
     }
 
     @Override
-    public void generateBytecode(ExpressionVisitorContext ctx) {
+    public void generateBytecode(ExpressionCompilationContext ctx) {
         GeneratorAdapter mv = ctx.methodVisitor();
         Label falseLabel = new Label();
         Label returnLabel = new Label();

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/unary/PosOperator.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/unary/PosOperator.java
@@ -16,7 +16,9 @@
 package io.micronaut.expressions.parser.ast.operator.unary;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
 import io.micronaut.expressions.parser.exception.ExpressionCompilationException;
 import org.objectweb.asm.Type;
@@ -36,7 +38,7 @@ public final class PosOperator extends UnaryOperator {
     }
 
     @Override
-    public Type doResolveType(ExpressionVisitorContext ctx) {
+    public Type doResolveType(@NonNull ExpressionVisitorContext ctx) {
         Type nodeType = super.doResolveType(ctx);
 
         if (!isNumeric(nodeType)) {
@@ -47,7 +49,7 @@ public final class PosOperator extends UnaryOperator {
     }
 
     @Override
-    public void generateBytecode(ExpressionVisitorContext ctx) {
+    public void generateBytecode(ExpressionCompilationContext ctx) {
         operand.compile(ctx);
     }
 }

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/unary/UnaryOperator.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/operator/unary/UnaryOperator.java
@@ -16,6 +16,7 @@
 package io.micronaut.expressions.parser.ast.operator.unary;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
 import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
 import io.micronaut.inject.ast.ClassElement;
@@ -37,7 +38,7 @@ public abstract sealed class UnaryOperator extends ExpressionNode permits EmptyO
     }
 
     @Override
-    public Type doResolveType(ExpressionVisitorContext ctx) {
+    public Type doResolveType(@NonNull ExpressionVisitorContext ctx) {
         return operand.resolveType(ctx);
     }
 

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/ast/types/TypeIdentifier.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/ast/types/TypeIdentifier.java
@@ -16,8 +16,10 @@
 package io.micronaut.expressions.parser.ast.types;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.expressions.parser.ast.ExpressionNode;
 import io.micronaut.expressions.parser.ast.util.TypeDescriptors;
+import io.micronaut.expressions.parser.compilation.ExpressionCompilationContext;
 import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
 import io.micronaut.expressions.parser.exception.ExpressionCompilationException;
 import io.micronaut.inject.ast.ClassElement;
@@ -58,7 +60,7 @@ public final class TypeIdentifier extends ExpressionNode {
     }
 
     @Override
-    public void generateBytecode(ExpressionVisitorContext ctx) {
+    public void generateBytecode(ExpressionCompilationContext ctx) {
         ctx.methodVisitor().push(resolveType(ctx));
     }
 
@@ -77,7 +79,7 @@ public final class TypeIdentifier extends ExpressionNode {
     }
 
     @Override
-    public Type doResolveType(ExpressionVisitorContext ctx) {
+    public Type doResolveType(@NonNull ExpressionVisitorContext ctx) {
         String name = this.toString();
         if (PRIMITIVES.containsKey(name)) {
             return PRIMITIVES.get(name);

--- a/core-processor/src/main/java/io/micronaut/expressions/parser/compilation/ExpressionCompilationContext.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/parser/compilation/ExpressionCompilationContext.java
@@ -19,17 +19,31 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.expressions.context.ExpressionEvaluationContext;
 import io.micronaut.inject.visitor.VisitorContext;
+import org.objectweb.asm.commons.GeneratorAdapter;
 
 /**
  * Context class used for compiling expressions.
  *
- * @param evaluationContext expression compilation context
- * @param visitorContext     visitor context
- *
+ * @param evaluationVisitorContext evaluation visitor context
+ * @param methodVisitor            method visitor for compiled expression class
  * @author Sergey Gavrilov
  * @since 4.0.0
  */
 @Internal
-public record ExpressionVisitorContext(@NonNull ExpressionEvaluationContext evaluationContext,
-                                       @NonNull VisitorContext visitorContext) {
+public record ExpressionCompilationContext(@NonNull ExpressionVisitorContext evaluationVisitorContext,
+                                           @NonNull GeneratorAdapter methodVisitor) {
+
+    /**
+     * @return The evaluation context
+     */
+    public ExpressionEvaluationContext evaluationContext() {
+        return evaluationVisitorContext.evaluationContext();
+    }
+
+    /**
+     * @return The visitor context
+     */
+    public VisitorContext visitorContext() {
+        return evaluationVisitorContext.visitorContext();
+    }
 }

--- a/core-processor/src/main/java/io/micronaut/expressions/util/EvaluatedExpressionsUtils.java
+++ b/core-processor/src/main/java/io/micronaut/expressions/util/EvaluatedExpressionsUtils.java
@@ -15,10 +15,17 @@
  */
 package io.micronaut.expressions.util;
 
-import io.micronaut.core.expressions.EvaluatedExpressionReference;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.expressions.EvaluatedExpressionReference;
+import io.micronaut.expressions.context.DefaultExpressionCompilationContextFactory;
+import io.micronaut.expressions.context.ExpressionEvaluationContext;
+import io.micronaut.expressions.parser.CompoundEvaluatedExpressionParser;
+import io.micronaut.expressions.parser.compilation.ExpressionVisitorContext;
+import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.ast.MethodElement;
+import io.micronaut.inject.visitor.VisitorContext;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -37,6 +44,46 @@ import java.util.stream.Stream;
 public final class EvaluatedExpressionsUtils {
 
     /**
+     * Evaluates the expression return type.
+     *
+     * @param visitorContext The visitor context
+     * @param methodElement  The method element
+     * @param reference      The expression reference
+     * @return The resolved type
+     * @since 4.3.0
+     */
+    public static ClassElement evaluateExpressionType(VisitorContext visitorContext,
+                                                      MethodElement methodElement,
+                                                      EvaluatedExpressionReference reference) {
+        DefaultExpressionCompilationContextFactory factory = new DefaultExpressionCompilationContextFactory(visitorContext);
+        ExpressionEvaluationContext context = factory.buildContextForMethod(reference, methodElement);
+        String expression = (String) reference.annotationValue();
+        return new CompoundEvaluatedExpressionParser(expression)
+            .parse()
+            .resolveClassElement(new ExpressionVisitorContext(context, visitorContext));
+    }
+
+    /**
+     * Evaluates the expression return type.
+     *
+     * @param visitorContext The visitor context
+     * @param thisElement    The this element
+     * @param reference      The expression reference
+     * @return The resolved type
+     * @since 4.3.0
+     */
+    public static ClassElement evaluateExpressionType(VisitorContext visitorContext,
+                                                      ClassElement thisElement,
+                                                      EvaluatedExpressionReference reference) {
+        DefaultExpressionCompilationContextFactory factory = new DefaultExpressionCompilationContextFactory(visitorContext);
+        ExpressionEvaluationContext context = factory.buildContext(reference, thisElement);
+        String expression = (String) reference.annotationValue();
+        return new CompoundEvaluatedExpressionParser(expression)
+            .parse()
+            .resolveClassElement(new ExpressionVisitorContext(context, visitorContext));
+    }
+
+    /**
      * Finds evaluated expression references in provided annotation metadata,
      * including nested annotation values.
      *
@@ -47,39 +94,37 @@ public final class EvaluatedExpressionsUtils {
         return Stream.concat(
                 annotationMetadata.getAnnotationNames().stream(),
                 annotationMetadata.getStereotypeAnnotationNames().stream())
-                   .map(annotationMetadata::getAnnotation)
-                   .flatMap(annotation -> getNestedAnnotationValues(annotation).stream())
-                   .flatMap(av -> av.getValues().values().stream())
-                   .filter(EvaluatedExpressionReference.class::isInstance)
-                   .map(EvaluatedExpressionReference.class::cast)
-                   .distinct()
-                   .toList();
+            .map(annotationMetadata::getAnnotation)
+            .flatMap(annotation -> getNestedAnnotationValues(annotation).stream())
+            .flatMap(av -> av.getValues().values().stream())
+            .filter(EvaluatedExpressionReference.class::isInstance)
+            .map(EvaluatedExpressionReference.class::cast)
+            .distinct()
+            .toList();
     }
 
     private static Collection<AnnotationValue<?>> getNestedAnnotationValues(Object value) {
         List<AnnotationValue<?>> result = new ArrayList<>();
-        if (value instanceof AnnotationValue annotationValue) {
-            for (Object nestedValue: annotationValue.getValues().values()) {
+        if (value instanceof AnnotationValue<?> annotationValue) {
+            for (Object nestedValue : annotationValue.getValues().values()) {
                 result.addAll(getNestedAnnotationValues(nestedValue));
             }
             result.add(annotationValue);
         } else {
             Iterable<?> nestedValues = null;
-            if (value instanceof Iterable iterable) {
+            if (value instanceof Iterable<?> iterable) {
                 nestedValues = iterable;
             } else if (value instanceof AnnotationValue<?>[] values) {
                 nestedValues = Arrays.asList(values);
             }
-
             if (nestedValues != null) {
-                for (Object nextValue: nestedValues) {
+                for (Object nextValue : nestedValues) {
                     if (nextValue instanceof AnnotationValue) {
                         result.addAll(getNestedAnnotationValues(nextValue));
                     }
                 }
             }
         }
-
         return result;
     }
 }

--- a/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/AbstractAnnotationMetadataBuilder.java
@@ -57,7 +57,6 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
-import static io.micronaut.core.expressions.EvaluatedExpressionReference.EXPR_SUFFIX;
 import static io.micronaut.expressions.EvaluatedExpressionConstants.EXPRESSION_PATTERN;
 
 /**
@@ -627,9 +626,9 @@ public abstract class AbstractAnnotationMetadataBuilder<T, A> {
         if (originatingClassName != null) {
             String packageName = NameUtils.getPackageName(originatingClassName);
             String simpleClassName = NameUtils.getSimpleName(originatingClassName);
-            String exprClassName = "%s.$%s%s".formatted(packageName, simpleClassName, EXPR_SUFFIX);
+            String exprClassName = "%s.$%s%s".formatted(packageName, simpleClassName, EvaluatedExpressionReferenceCounter.EXPR_SUFFIX);
 
-            Integer expressionIndex = EvaluatedExpressionReference.nextIndex(exprClassName);
+            Integer expressionIndex = EvaluatedExpressionReferenceCounter.nextIndex(exprClassName);
 
             return new EvaluatedExpressionReference(initialAnnotationValue, annotationName, memberName, exprClassName + expressionIndex);
         } else {

--- a/core-processor/src/main/java/io/micronaut/inject/annotation/EvaluatedExpressionReferenceCounter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/annotation/EvaluatedExpressionReferenceCounter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.inject.annotation;
+
+import io.micronaut.core.annotation.Internal;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * A reference class writer counter.
+ * @author Denis Stepanov
+ * @since 4.3.0
+ */
+@Internal
+public class EvaluatedExpressionReferenceCounter {
+
+    public static final String EXPR_SUFFIX = "$Expr";
+
+    private static final Map<String, Integer> CLASS_NAME_INDEXES = new ConcurrentHashMap<>();
+
+    /**
+     * Provides next expression index for passed class name. In general indexes are needed only
+     * to make names of generated expression classes unique and avoid conflicts in cases when
+     * multiple expressions are defined in the same class. On each invocation with the same
+     * argument this method will return value incremented by 1. On first invocation it will return 0
+     *
+     * @param className name of class owning evaluated expression
+     * @return next index
+     */
+    public static Integer nextIndex(String className) {
+        if (CLASS_NAME_INDEXES.containsKey(className)) {
+            return CLASS_NAME_INDEXES.merge(className, 1, Integer::sum);
+        }
+
+        CLASS_NAME_INDEXES.put(className, 0);
+        return 0;
+    }
+
+}

--- a/core-processor/src/main/java/io/micronaut/inject/writer/EvaluatedExpressionProcessor.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/EvaluatedExpressionProcessor.java
@@ -21,7 +21,7 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.expressions.EvaluatedExpressionReference;
 import io.micronaut.expressions.EvaluatedExpressionWriter;
 import io.micronaut.expressions.context.DefaultExpressionCompilationContextFactory;
-import io.micronaut.expressions.context.ExpressionCompilationContext;
+import io.micronaut.expressions.context.ExpressionEvaluationContext;
 import io.micronaut.expressions.context.ExpressionWithContext;
 import io.micronaut.expressions.util.EvaluatedExpressionsUtils;
 import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
@@ -79,7 +79,7 @@ public final class EvaluatedExpressionProcessor {
 
         expressionReferences.stream()
             .map(expressionReference -> {
-                ExpressionCompilationContext evaluationContext = expressionCompilationContextFactory.buildContext(expressionReference, thisElement);
+                ExpressionEvaluationContext evaluationContext = expressionCompilationContextFactory.buildContext(expressionReference, thisElement);
                 return new ExpressionWithContext(expressionReference, evaluationContext);
             })
             .forEach(this::addExpression);
@@ -91,7 +91,7 @@ public final class EvaluatedExpressionProcessor {
 
         expressionReferences.stream()
             .map(expression -> {
-                ExpressionCompilationContext evaluationContext = expressionCompilationContextFactory.buildContextForMethod(expression, methodElement);
+                ExpressionEvaluationContext evaluationContext = expressionCompilationContextFactory.buildContextForMethod(expression, methodElement);
                 return new ExpressionWithContext(expression, evaluationContext);
             })
             .forEach(this::addExpression);

--- a/core/src/main/java/io/micronaut/core/expressions/EvaluatedExpressionReference.java
+++ b/core/src/main/java/io/micronaut/core/expressions/EvaluatedExpressionReference.java
@@ -18,9 +18,7 @@ package io.micronaut.core.expressions;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 
-import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Wrapper for annotation value, containing evaluated expressions and
@@ -40,28 +38,6 @@ public record EvaluatedExpressionReference(@NonNull Object annotationValue,
                                            @NonNull String annotationName,
                                            @NonNull String annotationMember,
                                            @NonNull String expressionClassName) {
-
-    public static final String EXPR_SUFFIX = "$Expr";
-
-    private static final Map<String, Integer> CLASS_NAME_INDEXES = new ConcurrentHashMap<>();
-
-    /**
-     * Provides next expression index for passed class name. In general indexes are needed only
-     * to make names of generated expression classes unique and avoid conflicts in cases when
-     * multiple expressions are defined in the same class. On each invocation with the same
-     * argument this method will return value incremented by 1. On first invocation it will return 0
-     *
-     * @param className name of class owning evaluated expression
-     * @return next index
-     */
-    public static Integer nextIndex(String className) {
-        if (CLASS_NAME_INDEXES.containsKey(className)) {
-            return CLASS_NAME_INDEXES.merge(className, 1, Integer::sum);
-        }
-
-        CLASS_NAME_INDEXES.put(className, 0);
-        return 0;
-    }
 
     @Override
     public boolean equals(Object o) {

--- a/inject-groovy-test/src/main/groovy/io/micronaut/ast/transform/test/AbstractEvaluatedExpressionsSpec.groovy
+++ b/inject-groovy-test/src/main/groovy/io/micronaut/ast/transform/test/AbstractEvaluatedExpressionsSpec.groovy
@@ -17,8 +17,8 @@ package io.micronaut.ast.transform.test
 
 import io.micronaut.context.expressions.AbstractEvaluatedExpression
 import io.micronaut.context.expressions.DefaultExpressionEvaluationContext
-import io.micronaut.core.expressions.EvaluatedExpressionReference
 import io.micronaut.core.naming.NameUtils
+import io.micronaut.inject.annotation.EvaluatedExpressionReferenceCounter
 import org.intellij.lang.annotations.Language
 
 class AbstractEvaluatedExpressionsSpec extends AbstractBeanDefinitionSpec {
@@ -48,7 +48,7 @@ class AbstractEvaluatedExpressionsSpec extends AbstractBeanDefinitionSpec {
         def classLoader = applicationContext.classLoader
 
         def exprClassName = 'test.$Expr$Expr'
-        def startingIndex = EvaluatedExpressionReference.nextIndex(exprClassName) - expressions.length
+        def startingIndex = EvaluatedExpressionReferenceCounter.nextIndex(exprClassName) - expressions.length
 
         List<Object> result = new ArrayList<>()
         for (int i = startingIndex; i < startingIndex + expressions.size(); i++) {
@@ -93,7 +93,7 @@ class AbstractEvaluatedExpressionsSpec extends AbstractBeanDefinitionSpec {
         def classLoader = applicationContext.classLoader
 
         def exprClassName = 'test.$Expr$Expr'
-        def startingIndex = EvaluatedExpressionReference.nextIndex(exprClassName) - expressions.length
+        def startingIndex = EvaluatedExpressionReferenceCounter.nextIndex(exprClassName) - expressions.length
 
         List<Object> result = new ArrayList<>()
         for (int i = startingIndex; i < startingIndex + expressions.size(); i++) {
@@ -135,7 +135,7 @@ class AbstractEvaluatedExpressionsSpec extends AbstractBeanDefinitionSpec {
         def classLoader = applicationContext.classLoader
 
         try {
-            def index = EvaluatedExpressionReference.nextIndex(exprClassName)
+            def index = EvaluatedExpressionReferenceCounter.nextIndex(exprClassName)
             def exprClass = (AbstractEvaluatedExpression) classLoader.loadClass(exprClassName + (index == 0 ? index : index - 1)).newInstance()
             return exprClass.evaluate(new DefaultExpressionEvaluationContext(null, null, applicationContext, null));
         } catch (ClassNotFoundException e) {
@@ -162,7 +162,7 @@ class AbstractEvaluatedExpressionsSpec extends AbstractBeanDefinitionSpec {
         def classLoader = applicationContext.classLoader
 
         try {
-            def index = EvaluatedExpressionReference.nextIndex(exprFullName)
+            def index = EvaluatedExpressionReferenceCounter.nextIndex(exprFullName)
             def exprClass = (AbstractEvaluatedExpression) classLoader.loadClass(exprFullName + (index == 0 ? index : index - 1)).newInstance()
             return exprClass.evaluate(new DefaultExpressionEvaluationContext(null, args, applicationContext, null));
         } catch (ClassNotFoundException e) {

--- a/inject-java-test/src/main/groovy/io/micronaut/annotation/processing/test/AbstractEvaluatedExpressionsSpec.groovy
+++ b/inject-java-test/src/main/groovy/io/micronaut/annotation/processing/test/AbstractEvaluatedExpressionsSpec.groovy
@@ -18,7 +18,7 @@ package io.micronaut.annotation.processing.test
 import io.micronaut.context.expressions.AbstractEvaluatedExpression
 import io.micronaut.context.expressions.DefaultExpressionEvaluationContext
 import io.micronaut.core.naming.NameUtils
-import io.micronaut.core.expressions.EvaluatedExpressionReference
+import io.micronaut.inject.annotation.EvaluatedExpressionReferenceCounter
 import io.micronaut.inject.visitor.TypeElementVisitor
 import io.micronaut.inject.visitor.VisitorContext
 import org.intellij.lang.annotations.Language
@@ -55,7 +55,7 @@ abstract class AbstractEvaluatedExpressionsSpec extends AbstractTypeElementSpec 
         def classLoader = applicationContext.classLoader
 
         def exprClassName = 'test.$Expr$Expr'
-        def startingIndex = EvaluatedExpressionReference.nextIndex(exprClassName) - expressions.length
+        def startingIndex = EvaluatedExpressionReferenceCounter.nextIndex(exprClassName) - expressions.length
 
         List<Object> result = new ArrayList<>()
         for (int i = startingIndex; i < startingIndex + expressions.size(); i++) {
@@ -96,7 +96,7 @@ abstract class AbstractEvaluatedExpressionsSpec extends AbstractTypeElementSpec 
         def classLoader = applicationContext.classLoader
 
         try {
-            def index = EvaluatedExpressionReference.nextIndex(exprFullName)
+            def index = EvaluatedExpressionReferenceCounter.nextIndex(exprFullName)
             def exprClass = (AbstractEvaluatedExpression) classLoader.loadClass(exprFullName + (index == 0 ? index : index - 1)).newInstance()
             exprClass.evaluate(new DefaultExpressionEvaluationContext(null, null, applicationContext, null))
         } catch (ClassNotFoundException e) {
@@ -133,7 +133,7 @@ abstract class AbstractEvaluatedExpressionsSpec extends AbstractTypeElementSpec 
         def classLoader = applicationContext.classLoader
 
         def exprClassName = 'test.$Expr$Expr'
-        def startingIndex = EvaluatedExpressionReference.nextIndex(exprClassName) - expressions.length
+        def startingIndex = EvaluatedExpressionReferenceCounter.nextIndex(exprClassName) - expressions.length
 
         List<Object> result = new ArrayList<>()
         for (int i = startingIndex; i < startingIndex + expressions.size(); i++) {
@@ -168,7 +168,7 @@ abstract class AbstractEvaluatedExpressionsSpec extends AbstractTypeElementSpec 
         def classLoader = applicationContext.classLoader
 
         try {
-            def index = EvaluatedExpressionReference.nextIndex(exprFullName)
+            def index = EvaluatedExpressionReferenceCounter.nextIndex(exprFullName)
             def exprClass = (AbstractEvaluatedExpression) classLoader.loadClass(exprFullName + (index == 0 ? index : index - 1)).newInstance()
             return exprClass.evaluate(new DefaultExpressionEvaluationContext(null, args, applicationContext, null))
         } catch (ClassNotFoundException e) {

--- a/inject-java/src/test/groovy/io/micronaut/expressions/TestExpressionsUsageSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/expressions/TestExpressionsUsageSpec.groovy
@@ -2,8 +2,6 @@ package io.micronaut.expressions
 
 import io.micronaut.annotation.processing.test.AbstractEvaluatedExpressionsSpec
 import io.micronaut.context.env.PropertySource
-import io.micronaut.context.exceptions.CircularDependencyException
-import io.micronaut.context.exceptions.ExpressionEvaluationException
 import io.micronaut.context.exceptions.NoSuchBeanException
 
 class TestExpressionsUsageSpec extends AbstractEvaluatedExpressionsSpec {

--- a/inject-java/src/test/groovy/io/micronaut/expressions/TypeExpressionsSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/expressions/TypeExpressionsSpec.groovy
@@ -1,0 +1,84 @@
+package io.micronaut.expressions
+
+import io.micronaut.annotation.processing.test.AbstractEvaluatedExpressionsSpec
+import io.micronaut.inject.ast.ClassElement
+import io.micronaut.inject.ast.PrimitiveElement
+
+class TypeExpressionsSpec extends AbstractEvaluatedExpressionsSpec {
+
+    void "test type of class annotation"() {
+        given:
+        Map<String, ClassElement> types =  ExpressionTypeCollector.TYPES
+        evaluateSingle("test.Expr", """
+
+            package exp;
+            import io.micronaut.context.annotation.AnnotationExpressionContext;
+            import io.micronaut.context.annotation.Executable;
+            import io.micronaut.context.annotation.Requires;
+            import jakarta.inject.Singleton;
+
+            @Singleton
+            @ExpAnnotation("#{ 1 }")
+            class Expr1 {
+            }
+
+            @Singleton
+            @ExpAnnotation("#{ 'str' }")
+            class Expr2 {
+            }
+
+            @interface ExpAnnotation {
+                String value();
+            }
+
+        """)
+
+        expect:
+        types['#{ 1 }'] == PrimitiveElement.INT
+        types['''#{ 'str' }'''].name == "java.lang.String"
+
+        cleanup:
+        types.clear()
+    }
+
+    void "test type of method annotation"() {
+        given:
+        Map<String, ClassElement> types =  ExpressionTypeCollector.TYPES
+        evaluateSingle("test.Expr", """
+
+            package exp;
+            import io.micronaut.context.annotation.AnnotationExpressionContext;
+            import io.micronaut.context.annotation.Executable;
+            import io.micronaut.context.annotation.Requires;
+            import jakarta.inject.Singleton;
+
+            @Singleton
+            class Expr1 {
+                @ExpAnnotation("#{ 1 }")
+                void myMethod() {
+                }
+
+            }
+
+            @Singleton
+            class Expr2 {
+                @ExpAnnotation("#{ 'strX' }")
+                void myMethod() {
+                }
+            }
+
+            @interface ExpAnnotation {
+                String value();
+            }
+
+        """)
+
+        expect:
+        types['#{ 1 }'] == PrimitiveElement.INT
+        types['''#{ 'strX' }'''].name == "java.lang.String"
+
+        cleanup:
+        types.clear()
+    }
+
+}


### PR DESCRIPTION
- Moved some of the code that is only used in the annotation processor.
- Naming improvements
- Introduced a new context that can be used for retrieving the expression type without providing the ASM writer (that is used in Micronaut Data) 