### PR TITLE
Do not include malformed URI in error message

### DIFF
--- a/http-server/src/main/java/io/micronaut/http/server/exceptions/URISyntaxHandler.java
+++ b/http-server/src/main/java/io/micronaut/http/server/exceptions/URISyntaxHandler.java
@@ -55,7 +55,7 @@ public class URISyntaxHandler implements ExceptionHandler<URISyntaxException, Ht
                 .error(new Error() {
                     @Override
                     public String getMessage() {
-                        return "Malformed URI: " + exception.getMessage();
+                        return "Malformed URI";
                     }
 
                     @Override

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/urisyntax/MalformedUriSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/urisyntax/MalformedUriSpec.groovy
@@ -22,6 +22,6 @@ class MalformedUriSpec extends Specification {
         then:
         connection.getResponseCode() == 400
         connection.getResponseMessage() == HttpStatus.BAD_REQUEST.reason
-        connection.getErrorStream().getText().contains('"message":"Malformed URI')
+        connection.getErrorStream().getText().contains('"message":"Malformed URI"')
     }
 }

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/urisyntax/MalformedUriSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/server/urisyntax/MalformedUriSpec.groovy
@@ -14,14 +14,14 @@ class MalformedUriSpec extends Specification {
     @AutoCleanup
     EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer);
 
-    void testMalformedUriReturns400() {
+    void testMalformedUriReturns400AndUserInputNotPrintedInLogs() {
         when:
-        HttpURLConnection connection = (HttpURLConnection) new URL("$embeddedServer.URL/malformed/[]").openConnection()
+        HttpURLConnection connection = (HttpURLConnection) new URL("$embeddedServer.URL?\"><tag>=/malformed[]").openConnection()
         connection.connect()
 
         then:
         connection.getResponseCode() == 400
         connection.getResponseMessage() == HttpStatus.BAD_REQUEST.reason
-        connection.getErrorStream().getText().contains('"message":"Malformed URI:')
+        connection.getErrorStream().getText().contains('"message":"Malformed URI')
     }
 }


### PR DESCRIPTION
For a malformed uri filter out user input when printing error messages

Fixes #10147 