### PR TITLE
Remove chatbots from 3.9.x micronaut-bom

### DIFF
--- a/bom/build.gradle
+++ b/bom/build.gradle
@@ -24,6 +24,28 @@ micronautBom {
         // https://github.com/micronaut-projects/micronaut-serialization/issues/167
         dependencies.add("io.micronaut.serde:micronaut-serde-tck:1.0.0")
 
+        // ChatBots module removed from 3.9.8, this can be removed after it's released
+        acceptedVersionRegressions.add("micronaut-chatbots")
+        acceptedLibraryRegressions.addAll(
+                "micronaut-chatbots-basecamp-api",
+                "micronaut-chatbots-basecamp-lambda",
+                "micronaut-chatbots-telegram-gcp-function",
+                "micronaut-chatbots-telegram-lambda",
+                "micronaut-chatbots-telegram-http",
+                "micronaut-chatbots-basecamp-azure-function",
+                "micronaut-chatbots-basecamp-http",
+                "micronaut-chatbots-http",
+                "micronaut-chatbots-basecamp-core",
+                "micronaut-chatbots-core",
+                "micronaut-chatbots-telegram-azure-function",
+                "micronaut-chatbots-bom",
+                "micronaut-chatbots-google-api",
+                "micronaut-chatbots-telegram-api",
+                "micronaut-chatbots-lambda",
+                "micronaut-chatbots-telegram-core",
+                "micronaut-chatbots-basecamp-gcp-function"
+        )
+
         // https://github.com/micronaut-projects/micronaut-oracle-cloud/issues/359
         dependencies.add("io.micronaut.oraclecloud:micronaut-oraclecloud-sdk-processor:2.1.1")
         dependencies.add("io.micronaut.oraclecloud:micronaut-oraclecloud-atp-hikari-test:2.1.1")
@@ -55,7 +77,7 @@ micronautBom {
 
         // The R2DBC bom that we include mentions dependencies which do not belong to io.r2dbc group
         bomAuthorizedGroupIds.put("io.r2dbc:r2dbc-bom", ["com.google.cloud", "com.oracle.database.r2dbc", "org.mariadb", "dev.miku"] as Set)
-        
+
         // Tracing
         bomAuthorizedGroupIds.put(
                 "io.zipkin.brave:brave-bom",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -70,7 +70,6 @@ managed-micronaut-aot = "1.1.2"
 managed-micronaut-aws = "3.17.3"
 managed-micronaut-azure = "4.1.1"
 managed-micronaut-cache = "3.5.0"
-managed-micronaut-chatbots = "1.0.0-M1"
 managed-micronaut-cassandra = "5.1.1"
 managed-micronaut-coherence = "3.7.2"
 managed-micronaut-crac = "1.2.3"
@@ -151,7 +150,6 @@ micronaut-docs = "2.0.0"
 boms-micronaut-aws = { module = "io.micronaut.aws:micronaut-aws-bom", version.ref = "managed-micronaut-aws" }
 boms-micronaut-azure = { module = "io.micronaut.azure:micronaut-azure-bom", version.ref = "managed-micronaut-azure" }
 boms-micronaut-cache = { module = "io.micronaut.cache:micronaut-cache-bom", version.ref = "managed-micronaut-cache" }
-boms-micronaut-chatbots = { module = "io.micronaut.chatbots:micronaut-chatbots-bom", version.ref = "managed-micronaut-chatbots" }
 boms-micronaut-coherence = { module = "io.micronaut.coherence:micronaut-coherence-bom", version.ref = "managed-micronaut-coherence" }
 boms-micronaut-crac = { module = "io.micronaut.crac:micronaut-crac-bom", version.ref = "managed-micronaut-crac" }
 boms-micronaut-email = { module = "io.micronaut.email:micronaut-email-bom", version.ref = "managed-micronaut-email" }


### PR DESCRIPTION
It didn't make it into the 3.x branch, and v1.0.0 of chatbots is for Micronaut 4