### PR TITLE
Improve how AOP proxy target is generated

### DIFF
--- a/core-processor/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
+++ b/core-processor/src/main/java/io/micronaut/aop/writer/AopProxyWriter.java
@@ -97,17 +97,9 @@ import java.util.stream.Collectors;
  */
 @Internal
 public class AopProxyWriter extends AbstractClassFileWriter implements ProxyingBeanDefinitionVisitor, Toggleable {
-    public static final int MAX_LOCALS = 3;
+    private static final int MAX_LOCALS = 3;
 
-    public static final Method METHOD_GET_PROXY_TARGET_BEAN_WITH_CONTEXT = Method.getMethod(ReflectionUtils.getRequiredInternalMethod(
-            DefaultBeanContext.class,
-            "getProxyTargetBean",
-            BeanResolutionContext.class,
-            Argument.class,
-            Qualifier.class
-    ));
-
-    public static final Method METHOD_GET_PROXY_TARGET_BEAN_WITH_BEAN_DEFINITION_AND_CONTEXT = Method.getMethod(ReflectionUtils.getRequiredInternalMethod(
+    private static final Method METHOD_GET_PROXY_TARGET_BEAN_WITH_BEAN_DEFINITION_AND_CONTEXT = Method.getMethod(ReflectionUtils.getRequiredInternalMethod(
             DefaultBeanContext.class,
             "getProxyTargetBean",
             BeanResolutionContext.class,
@@ -116,39 +108,39 @@ public class AopProxyWriter extends AbstractClassFileWriter implements ProxyingB
             Qualifier.class
     ));
 
-    public static final Method METHOD_GET_PROXY_BEAN_DEFINITION = Method.getMethod(ReflectionUtils.getRequiredInternalMethod(
+    private static final Method METHOD_GET_PROXY_BEAN_DEFINITION = Method.getMethod(ReflectionUtils.getRequiredInternalMethod(
             BeanDefinitionRegistry.class,
             "getProxyTargetBeanDefinition",
             Argument.class,
             Qualifier.class
     ));
 
-    public static final Method METHOD_HAS_CACHED_INTERCEPTED_METHOD = Method.getMethod(ReflectionUtils.getRequiredInternalMethod(
+    private static final Method METHOD_HAS_CACHED_INTERCEPTED_METHOD = Method.getMethod(ReflectionUtils.getRequiredInternalMethod(
             InterceptedProxy.class,
             "hasCachedInterceptedTarget"
     ));
 
-    public static final Method METHOD_BEAN_DEFINITION_GET_REQUIRED_METHOD = Method.getMethod(ReflectionUtils.getRequiredInternalMethod(
+    private static final Method METHOD_BEAN_DEFINITION_GET_REQUIRED_METHOD = Method.getMethod(ReflectionUtils.getRequiredInternalMethod(
         BeanDefinition.class,
         "getRequiredMethod",
         String.class,
         Class[].class
     ));
 
-    public static final Type FIELD_TYPE_INTERCEPTORS = Type.getType(Interceptor[][].class);
-    public static final Type TYPE_INTERCEPTOR_CHAIN = Type.getType(InterceptorChain.class);
-    public static final Type TYPE_METHOD_INTERCEPTOR_CHAIN = Type.getType(MethodInterceptorChain.class);
-    public static final String FIELD_TARGET = "$target";
-    public static final String FIELD_BEAN_RESOLUTION_CONTEXT = "$beanResolutionContext";
-    public static final String FIELD_READ_WRITE_LOCK = "$target_rwl";
-    public static final Type TYPE_READ_WRITE_LOCK = Type.getType(ReentrantReadWriteLock.class);
-    public static final String FIELD_READ_LOCK = "$target_rl";
-    public static final String FIELD_WRITE_LOCK = "$target_wl";
-    public static final Type TYPE_LOCK = Type.getType(Lock.class);
-    public static final Type TYPE_BEAN_DEFINITION = Type.getType(BeanDefinition.class);
-    public static final Type TYPE_BEAN_LOCATOR = Type.getType(BeanLocator.class);
-    public static final Type TYPE_DEFAULT_BEAN_CONTEXT = Type.getType(DefaultBeanContext.class);
-    public static final Type TYPE_BEAN_DEFINITION_REGISTRY = Type.getType(BeanDefinitionRegistry.class);
+    private static final Type FIELD_TYPE_INTERCEPTORS = Type.getType(Interceptor[][].class);
+    private static final Type TYPE_INTERCEPTOR_CHAIN = Type.getType(InterceptorChain.class);
+    private static final Type TYPE_METHOD_INTERCEPTOR_CHAIN = Type.getType(MethodInterceptorChain.class);
+    private static final String FIELD_TARGET = "$target";
+    private static final String FIELD_BEAN_RESOLUTION_CONTEXT = "$beanResolutionContext";
+    private static final String FIELD_READ_WRITE_LOCK = "$target_rwl";
+    private static final Type TYPE_READ_WRITE_LOCK = Type.getType(ReentrantReadWriteLock.class);
+    private static final String FIELD_READ_LOCK = "$target_rl";
+    private static final String FIELD_WRITE_LOCK = "$target_wl";
+    private static final Type TYPE_LOCK = Type.getType(Lock.class);
+    private static final Type TYPE_BEAN_DEFINITION = Type.getType(BeanDefinition.class);
+    private static final Type TYPE_BEAN_LOCATOR = Type.getType(BeanLocator.class);
+    private static final Type TYPE_DEFAULT_BEAN_CONTEXT = Type.getType(DefaultBeanContext.class);
+    private static final Type TYPE_BEAN_DEFINITION_REGISTRY = Type.getType(BeanDefinitionRegistry.class);
 
     private static final Method METHOD_PROXY_TARGET_TYPE = Method.getMethod(ReflectionUtils.getRequiredInternalMethod(ProxyBeanDefinition.class, "getTargetDefinitionType"));
 
@@ -166,7 +158,7 @@ public class AopProxyWriter extends AbstractClassFileWriter implements ProxyingB
             new IllegalStateException("new MethodInterceptorChain(..) constructor not found. Incompatible version of Micronaut?")
     );
 
-    private final java.lang.reflect.Method METHOD_PROCEED = ReflectionUtils.getRequiredInternalMethod(InterceptorChain.class, "proceed");
+    private static final java.lang.reflect.Method METHOD_PROCEED = ReflectionUtils.getRequiredInternalMethod(InterceptorChain.class, "proceed");
 
     private static final String FIELD_INTERCEPTORS = "$interceptors";
     private static final String FIELD_BEAN_LOCATOR = "$beanLocator";

--- a/inject-java/src/test/groovy/io/micronaut/aop/lazyproxytarget/ArgMutatingInterceptor.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/lazyproxytarget/ArgMutatingInterceptor.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.lazyproxytarget;
+
+import io.micronaut.aop.Interceptor;
+import io.micronaut.aop.InvocationContext;
+import io.micronaut.core.type.MutableArgumentValue;
+import jakarta.inject.Singleton;
+
+/**
+ * @author Graeme Rocher
+ * @since 1.0
+ */
+@Singleton
+public class ArgMutatingInterceptor implements Interceptor {
+
+    @Override
+    public Object intercept(InvocationContext context) {
+        Mutating m = context.synthesize(Mutating.class);
+        MutableArgumentValue arg = (MutableArgumentValue) context.getParameters().get(m.value());
+        if(arg != null) {
+            Object value = arg.getValue();
+            if(value instanceof Number number) {
+                arg.setValue(number.intValue()*2);
+            }
+            else {
+                arg.setValue("changed");
+            }
+        }
+        return context.proceed();
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/lazyproxytarget/Mutating.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/lazyproxytarget/Mutating.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.lazyproxytarget;
+
+import io.micronaut.aop.Around;
+import io.micronaut.context.annotation.Type;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * @author Graeme Rocher
+ * @since 1.0
+ */
+
+@Around(proxyTarget = true, lazy = true)
+@Type(ArgMutatingInterceptor.class)
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface Mutating {
+    String value();
+}
+
+

--- a/inject-java/src/test/groovy/io/micronaut/aop/lazyproxytarget/ProxyingClass.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/lazyproxytarget/ProxyingClass.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.lazyproxytarget;
+
+import io.micronaut.aop.simple.Bar;
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Singleton;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author Graeme Rocher
+ * @since 1.0
+ */
+@Singleton
+public class ProxyingClass<A extends CharSequence> {
+
+
+    private Bar bar;
+
+    public int lifeCycleCount = 0;
+    public int invocationCount = 0;
+
+    public <T extends Bar> ProxyingClass(T bar) {
+        this.bar = bar;
+        assert bar != null;
+    }
+
+    @PostConstruct
+    void init() {
+        lifeCycleCount++;
+    }
+
+    @Mutating("name")
+    public String test(String name) {
+        invocationCount++;
+        return "Name is " + name;
+    }
+
+    @Mutating("age")
+    public String test(int age) {
+        return "Age is " + age;
+    }
+
+    @Mutating("name")
+    public String test(String name, int age) {
+        return "Name is "+name+" and age is " + age;
+    }
+
+    @Mutating("name")
+    public String test() {
+        return "noargs";
+    }
+
+    @Mutating("name")
+    public void testVoid(String name) {
+        assert name.equals("changed");
+    }
+
+    @Mutating("name")
+    public void testVoid(String name, int age) {
+        assert name.equals("changed");
+        assert age == 10;
+    }
+
+    @Mutating("name")
+    boolean testBoolean(String name) {
+        return name.equals("changed");
+    }
+
+    @Mutating("name")
+    boolean testBoolean(String name, int age) {
+        assert age == 10;
+        return name.equals("changed");
+    }
+
+    @Mutating("name")
+    int testInt(String name) {
+        return name.equals("changed") ? 1 : 0;
+    }
+
+    @Mutating("age")
+    int testInt(String name, int age) {
+        assert name.equals("test");
+        return age;
+    }
+
+    @Mutating("name")
+    long testLong(String name) {
+        return name.equals("changed") ? 1 : 0;
+    }
+
+    @Mutating("age")
+    long testLong(String name, int age) {
+        assert name.equals("test");
+        return age;
+    }
+
+    @Mutating("name")
+    short testShort(String name) {
+        return (short) (name.equals("changed") ? 1 : 0);
+    }
+
+    @Mutating("age")
+    short testShort(String name, int age) {
+        assert name.equals("test");
+        return (short) age;
+    }
+
+    @Mutating("name")
+    byte testByte(String name) {
+        return (byte) (name.equals("changed") ? 1 : 0);
+    }
+
+    @Mutating("age")
+    byte testByte(String name, int age) {
+        assert name.equals("test");
+        return (byte) age;
+    }
+
+    @Mutating("name")
+    double testDouble(String name) {
+        return name.equals("changed") ? 1 : 0;
+    }
+
+    @Mutating("age")
+    double testDouble(String name, int age) {
+        assert name.equals("test");
+        return age;
+    }
+
+    @Mutating("name")
+    float testFloat(String name) {
+        return name.equals("changed") ? 1 : 0;
+    }
+
+    @Mutating("age")
+    float testFloat(String name, int age) {
+        assert name.equals("test");
+        return age;
+    }
+
+    @Mutating("name")
+    char testChar(String name) {
+        return (char) (name.equals("changed") ? 1 : 0);
+    }
+
+    @Mutating("age")
+    char testChar(String name, int age) {
+        assert name.equals("test");
+        return (char) age;
+    }
+
+    @Mutating("name")
+    byte[] testByteArray(String name, byte[] data) {
+        assert name.equals("changed");
+        return data;
+    }
+
+    @Mutating("name")
+    <T extends CharSequence> T testGenericsWithExtends(T name, int age) {
+        return (T) ("Name is " + name);
+    }
+
+    @Mutating("name")
+    <T> List<? super String> testListWithWildCardSuper(T name, List<? super String> p2) {
+        return Collections.singletonList(name.toString());
+    }
+
+    @Mutating("name")
+    <T> List<? extends String> testListWithWildCardExtends(T name, List<? extends String> p2) {
+        return Collections.singletonList(name.toString());
+    }
+
+    @Mutating("name")
+    A testGenericsFromType(A name, int age) {
+        return (A) ("Name is " + name);
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/lazyproxytarget/ProxyingMethodLevelAopSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/lazyproxytarget/ProxyingMethodLevelAopSpec.groovy
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.lazyproxytarget
+
+import io.micronaut.aop.InterceptedProxy
+import io.micronaut.context.ApplicationContext
+import io.micronaut.inject.BeanDefinition
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ * @author Graeme Rocher
+ * @since 1.0
+ */
+class ProxyingMethodLevelAopSpec extends Specification {
+
+    @Unroll
+    void "test AOP method invocation for method #method"() {
+        given:
+        ApplicationContext context = ApplicationContext.run()
+        ProxyingClass foo = context.getBean(ProxyingClass)
+
+        expect:
+        args.isEmpty() ? foo."$method"() : foo."$method"(*args) == result
+        foo.lifeCycleCount == 0
+        foo instanceof InterceptedProxy
+        foo.interceptedTarget().lifeCycleCount == 1
+
+        cleanup:
+        context.close()
+
+        where:
+        method                        | args                   | result
+        'test'                        | ['test']               | "Name is changed"                   // test for single string arg
+        'test'                        | [10]                   | "Age is 20"                   // test for single primitive
+        'test'                        | ['test', 10]           | "Name is changed and age is 10"    // test for multiple args, one primitive
+        'test'                        | []                     | "noargs"                           // test for no args
+        'testVoid'                    | ['test']               | null                   // test for void return type
+        'testVoid'                    | ['test', 10]           | null                   // test for void return type
+        'testBoolean'                 | ['test']               | true                   // test for boolean return type
+        'testBoolean'                 | ['test', 10]           | true                  // test for boolean return type
+        'testInt'                     | ['test']               | 1                   // test for int return type
+        'testInt'                     | ['test', 10]           | 20                  // test for int return type
+        'testShort'                   | ['test']               | 1                   // test for short return type
+        'testShort'                   | ['test', 10]           | 20                  // test for short return type
+        'testChar'                    | ['test']               | 1                   // test for char return type
+        'testChar'                    | ['test', 10]           | 20                  // test for char return type
+        'testByte'                    | ['test']               | 1                   // test for byte return type
+        'testByte'                    | ['test', 10]           | 20                  // test for byte return type
+        'testFloat'                   | ['test']               | 1                   // test for float return type
+        'testFloat'                   | ['test', 10]           | 20                  // test for float return type
+        'testDouble'                  | ['test']               | 1                   // test for double return type
+        'testDouble'                  | ['test', 10]           | 20                  // test for double return type
+        'testByteArray'               | ['test', 'test'.bytes] | 'test'.bytes        // test for byte array
+        'testGenericsWithExtends'     | ['test', 10]           | 'Name is changed'        // test for generics
+        'testGenericsFromType'        | ['test', 10]           | 'Name is changed'        // test for generics
+        'testListWithWildCardSuper'   | ['test', []]           | ['changed']        // test for generics
+        'testListWithWildCardExtends' | ['test', []]           | ['changed']        // test for generics
+    }
+
+
+    void "test AOP setup"() {
+        given:
+        ApplicationContext context = ApplicationContext.run()
+
+        when: "the bean definition is obtained"
+        BeanDefinition<ProxyingClass> beanDefinition = context.findBeanDefinition(ProxyingClass).get()
+
+        then:
+        beanDefinition.findMethod("test", String).isPresent()
+        // should not be a reflection based method
+        !beanDefinition.findMethod("test", String).get().getClass().getName().contains("Reflection")
+
+        when:
+        ProxyingClass foo = context.getBean(ProxyingClass)
+
+
+        then:
+        foo instanceof InterceptedProxy
+        context.findExecutableMethod(ProxyingClass, "test", String).isPresent()
+        // should not be a reflection based method
+        !context.findExecutableMethod(ProxyingClass, "test", String).get().getClass().getName().contains("Reflection")
+        foo.test("test") == "Name is changed"
+
+        cleanup:
+        context.close()
+    }
+
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/proxytargethotswap/ArgMutatingInterceptor.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/proxytargethotswap/ArgMutatingInterceptor.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.proxytargethotswap;
+
+import io.micronaut.aop.Interceptor;
+import io.micronaut.aop.InvocationContext;
+import io.micronaut.core.type.MutableArgumentValue;
+import jakarta.inject.Singleton;
+
+/**
+ * @author Graeme Rocher
+ * @since 1.0
+ */
+@Singleton
+public class ArgMutatingInterceptor implements Interceptor {
+
+    @Override
+    public Object intercept(InvocationContext context) {
+        Mutating m = context.synthesize(Mutating.class);
+        MutableArgumentValue arg = (MutableArgumentValue) context.getParameters().get(m.value());
+        if(arg != null) {
+            Object value = arg.getValue();
+            if(value instanceof Number number) {
+                arg.setValue(number.intValue()*2);
+            }
+            else {
+                arg.setValue("changed");
+            }
+        }
+        return context.proceed();
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/proxytargethotswap/Mutating.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/proxytargethotswap/Mutating.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.proxytargethotswap;
+
+import io.micronaut.aop.Around;
+import io.micronaut.context.annotation.Type;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * @author Graeme Rocher
+ * @since 1.0
+ */
+
+@Around(proxyTarget = true, hotswap = true)
+@Type(ArgMutatingInterceptor.class)
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface Mutating {
+    String value();
+}
+
+

--- a/inject-java/src/test/groovy/io/micronaut/aop/proxytargethotswap/ProxyingClass.java
+++ b/inject-java/src/test/groovy/io/micronaut/aop/proxytargethotswap/ProxyingClass.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.proxytargethotswap;
+
+import io.micronaut.aop.simple.Bar;
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Singleton;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author Graeme Rocher
+ * @since 1.0
+ */
+@Singleton
+public class ProxyingClass<A extends CharSequence> {
+
+
+    private Bar bar;
+
+    public int lifeCycleCount = 0;
+    public int invocationCount = 0;
+
+    public <T extends Bar> ProxyingClass(T bar) {
+        this.bar = bar;
+        assert bar != null;
+    }
+
+    @PostConstruct
+    void init() {
+        lifeCycleCount++;
+    }
+
+    @Mutating("name")
+    public String test(String name) {
+        invocationCount++;
+        return "Name is " + name;
+    }
+
+    @Mutating("age")
+    public String test(int age) {
+        return "Age is " + age;
+    }
+
+    @Mutating("name")
+    public String test(String name, int age) {
+        return "Name is "+name+" and age is " + age;
+    }
+
+    @Mutating("name")
+    public String test() {
+        return "noargs";
+    }
+
+    @Mutating("name")
+    public void testVoid(String name) {
+        assert name.equals("changed");
+    }
+
+    @Mutating("name")
+    public void testVoid(String name, int age) {
+        assert name.equals("changed");
+        assert age == 10;
+    }
+
+    @Mutating("name")
+    boolean testBoolean(String name) {
+        return name.equals("changed");
+    }
+
+    @Mutating("name")
+    boolean testBoolean(String name, int age) {
+        assert age == 10;
+        return name.equals("changed");
+    }
+
+    @Mutating("name")
+    int testInt(String name) {
+        return name.equals("changed") ? 1 : 0;
+    }
+
+    @Mutating("age")
+    int testInt(String name, int age) {
+        assert name.equals("test");
+        return age;
+    }
+
+    @Mutating("name")
+    long testLong(String name) {
+        return name.equals("changed") ? 1 : 0;
+    }
+
+    @Mutating("age")
+    long testLong(String name, int age) {
+        assert name.equals("test");
+        return age;
+    }
+
+    @Mutating("name")
+    short testShort(String name) {
+        return (short) (name.equals("changed") ? 1 : 0);
+    }
+
+    @Mutating("age")
+    short testShort(String name, int age) {
+        assert name.equals("test");
+        return (short) age;
+    }
+
+    @Mutating("name")
+    byte testByte(String name) {
+        return (byte) (name.equals("changed") ? 1 : 0);
+    }
+
+    @Mutating("age")
+    byte testByte(String name, int age) {
+        assert name.equals("test");
+        return (byte) age;
+    }
+
+    @Mutating("name")
+    double testDouble(String name) {
+        return name.equals("changed") ? 1 : 0;
+    }
+
+    @Mutating("age")
+    double testDouble(String name, int age) {
+        assert name.equals("test");
+        return age;
+    }
+
+    @Mutating("name")
+    float testFloat(String name) {
+        return name.equals("changed") ? 1 : 0;
+    }
+
+    @Mutating("age")
+    float testFloat(String name, int age) {
+        assert name.equals("test");
+        return age;
+    }
+
+    @Mutating("name")
+    char testChar(String name) {
+        return (char) (name.equals("changed") ? 1 : 0);
+    }
+
+    @Mutating("age")
+    char testChar(String name, int age) {
+        assert name.equals("test");
+        return (char) age;
+    }
+
+    @Mutating("name")
+    byte[] testByteArray(String name, byte[] data) {
+        assert name.equals("changed");
+        return data;
+    }
+
+    @Mutating("name")
+    <T extends CharSequence> T testGenericsWithExtends(T name, int age) {
+        return (T) ("Name is " + name);
+    }
+
+    @Mutating("name")
+    <T> List<? super String> testListWithWildCardSuper(T name, List<? super String> p2) {
+        return Collections.singletonList(name.toString());
+    }
+
+    @Mutating("name")
+    <T> List<? extends String> testListWithWildCardExtends(T name, List<? extends String> p2) {
+        return Collections.singletonList(name.toString());
+    }
+
+    @Mutating("name")
+    A testGenericsFromType(A name, int age) {
+        return (A) ("Name is " + name);
+    }
+}

--- a/inject-java/src/test/groovy/io/micronaut/aop/proxytargethotswap/ProxyingMethodLevelAopSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/aop/proxytargethotswap/ProxyingMethodLevelAopSpec.groovy
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aop.proxytargethotswap
+
+import io.micronaut.aop.InterceptedProxy
+import io.micronaut.context.ApplicationContext
+import io.micronaut.inject.BeanDefinition
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ * @author Graeme Rocher
+ * @since 1.0
+ */
+class ProxyingMethodLevelAopSpec extends Specification {
+
+    @Unroll
+    void "test AOP method invocation for method #method"() {
+        given:
+        ApplicationContext context = ApplicationContext.run()
+        ProxyingClass foo = context.getBean(ProxyingClass)
+
+        expect:
+        args.isEmpty() ? foo."$method"() : foo."$method"(*args) == result
+        foo.lifeCycleCount == 0
+        foo instanceof InterceptedProxy
+        foo.interceptedTarget().lifeCycleCount == 1
+
+        cleanup:
+        context.close()
+
+        where:
+        method                        | args                   | result
+        'test'                        | ['test']               | "Name is changed"                   // test for single string arg
+        'test'                        | [10]                   | "Age is 20"                   // test for single primitive
+        'test'                        | ['test', 10]           | "Name is changed and age is 10"    // test for multiple args, one primitive
+        'test'                        | []                     | "noargs"                           // test for no args
+        'testVoid'                    | ['test']               | null                   // test for void return type
+        'testVoid'                    | ['test', 10]           | null                   // test for void return type
+        'testBoolean'                 | ['test']               | true                   // test for boolean return type
+        'testBoolean'                 | ['test', 10]           | true                  // test for boolean return type
+        'testInt'                     | ['test']               | 1                   // test for int return type
+        'testInt'                     | ['test', 10]           | 20                  // test for int return type
+        'testShort'                   | ['test']               | 1                   // test for short return type
+        'testShort'                   | ['test', 10]           | 20                  // test for short return type
+        'testChar'                    | ['test']               | 1                   // test for char return type
+        'testChar'                    | ['test', 10]           | 20                  // test for char return type
+        'testByte'                    | ['test']               | 1                   // test for byte return type
+        'testByte'                    | ['test', 10]           | 20                  // test for byte return type
+        'testFloat'                   | ['test']               | 1                   // test for float return type
+        'testFloat'                   | ['test', 10]           | 20                  // test for float return type
+        'testDouble'                  | ['test']               | 1                   // test for double return type
+        'testDouble'                  | ['test', 10]           | 20                  // test for double return type
+        'testByteArray'               | ['test', 'test'.bytes] | 'test'.bytes        // test for byte array
+        'testGenericsWithExtends'     | ['test', 10]           | 'Name is changed'        // test for generics
+        'testGenericsFromType'        | ['test', 10]           | 'Name is changed'        // test for generics
+        'testListWithWildCardSuper'   | ['test', []]           | ['changed']        // test for generics
+        'testListWithWildCardExtends' | ['test', []]           | ['changed']        // test for generics
+    }
+
+
+    void "test AOP setup"() {
+        given:
+        ApplicationContext context = ApplicationContext.run()
+
+        when: "the bean definition is obtained"
+        BeanDefinition<ProxyingClass> beanDefinition = context.findBeanDefinition(ProxyingClass).get()
+
+        then:
+        beanDefinition.findMethod("test", String).isPresent()
+        // should not be a reflection based method
+        !beanDefinition.findMethod("test", String).get().getClass().getName().contains("Reflection")
+
+        when:
+        ProxyingClass foo = context.getBean(ProxyingClass)
+
+
+        then:
+        foo instanceof InterceptedProxy
+        context.findExecutableMethod(ProxyingClass, "test", String).isPresent()
+        // should not be a reflection based method
+        !context.findExecutableMethod(ProxyingClass, "test", String).get().getClass().getName().contains("Reflection")
+        foo.test("test") == "Name is changed"
+
+        cleanup:
+        context.close()
+    }
+
+}

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -1489,6 +1489,27 @@ public class DefaultBeanContext implements InitializableBeanContext {
         return resolveBeanRegistration(resolutionContext, definition, beanType, qualifier).bean;
     }
 
+    /**
+     * Resolves the proxy target for a given proxy bean definition. If the bean has no proxy then the original bean is returned.
+     *
+     * @param resolutionContext The bean resolution context
+     * @param definition        The proxy bean definition
+     * @param beanType          The bean type
+     * @param qualifier         The bean qualifier
+     * @param <T>               The generic type
+     * @return The proxied instance
+     * @since 4.3.0
+     */
+    @Internal
+    @NonNull
+    @UsedByGeneratedCode
+    public <T> T getProxyTargetBean(@Nullable BeanResolutionContext resolutionContext,
+                                    @NonNull BeanDefinition<T> definition,
+                                    @NonNull Argument<T> beanType,
+                                    @Nullable Qualifier<T> qualifier) {
+        return resolveBeanRegistration(resolutionContext, definition, beanType, qualifier).bean;
+    }
+
     @NonNull
     @Override
     public <T, R> Optional<ExecutableMethod<T, R>> findProxyTargetMethod(@NonNull Class<T> beanType, @NonNull String method, @NonNull Class<?>[] arguments) {


### PR DESCRIPTION
I noticed that we would always call `getProxyTargetMethod` which would look for the bean definition all the time instead of reusing it.
Plus a few byte code improvements