### PR TITLE
KSP: Allow to specify extra all-open annotations

### DIFF
--- a/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/AbstractKotlinElement.kt
+++ b/inject-kotlin/src/main/kotlin/io/micronaut/kotlin/processing/visitor/AbstractKotlinElement.kt
@@ -132,12 +132,17 @@ internal abstract class AbstractKotlinElement<T : KotlinNativeElement>(
         false
     }
 
-    private fun shouldBeOpen(annotationMetadata: AnnotationMetadata) = annotationMetadata.declaredMetadata.hasDeclaredStereotype(
-        Around::class.java,
-        Introduction::class.java,
-        InterceptorBinding::class.java,
-        InterceptorBindingDefinitions::class.java
-    )
+    private fun shouldBeOpen(annotationMetadata: AnnotationMetadata): Boolean {
+        if (extraOpenAnnotations != null && annotationMetadata.declaredMetadata.hasDeclaredStereotype(*extraOpenAnnotations)) {
+            return true
+        }
+        return annotationMetadata.declaredMetadata.hasDeclaredStereotype(
+            Around::class.java,
+            Introduction::class.java,
+            InterceptorBinding::class.java,
+            InterceptorBindingDefinitions::class.java
+        )
+    }
 
     override fun isAbstract(): Boolean {
         return if (annotatedInfo is KSModifierListOwner) {
@@ -605,6 +610,8 @@ internal abstract class AbstractKotlinElement<T : KotlinNativeElement>(
     }
 
     companion object {
+        val extraOpenAnnotations = System.getProperty("kotlin.allopen.annotations")?.split(",")?.toTypedArray()
+
         val primitives = mapOf(
             "kotlin.Boolean" to PrimitiveElement.BOOLEAN,
             "kotlin.Char" to PrimitiveElement.CHAR,

--- a/src/main/docs/guide/languageSupport/kotlin/ksp.adoc
+++ b/src/main/docs/guide/languageSupport/kotlin/ksp.adoc
@@ -90,3 +90,6 @@ tasks {
     }
 }
 ----
+
+Unfortunately, KSP doesn't see the changes in the classes made by other compiler plugins, which breaks integration with the `allopen` plugin.
+To make the integration work, we have introduced an experimental system property `kotlin.allopen.annotations` for the annotation processor. The property expects a list of annotations that are open, separated by `,`.


### PR DESCRIPTION
Workaround for https://github.com/micronaut-projects/micronaut-core/issues/9764