### PR TITLE
Correct cache key of overridden method lookup

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/utils/NativeElementsHelper.java
+++ b/core-processor/src/main/java/io/micronaut/inject/utils/NativeElementsHelper.java
@@ -153,16 +153,16 @@ public abstract class NativeElementsHelper<C, M> {
      * @return the overridden methods
      */
     public final Collection<M> findOverriddenMethods(C classNode, M methodElement) {
-        Object classKey = getClassCacheKey(classNode);
-        MethodCacheKey cacheKey = new MethodCacheKey(
-            classKey,
+        Object classCacheKey = getClassCacheKey(classNode);
+        MethodCacheKey methodCacheKey = new MethodCacheKey(
+            classCacheKey,
             getMethodCacheKey(methodElement)
         );
-        Collection<M> overriddenMethods = overridesCache.get(cacheKey);
+        Collection<M> overriddenMethods = overridesCache.get(methodCacheKey);
         if (overriddenMethods != null) {
             return overriddenMethods;
         }
-        if (processedClasses.contains(classKey)) {
+        if (processedClasses.contains(classCacheKey)) {
             return List.of();
         }
         List<MethodElement<M>> allElements = getAllElements(classNode);
@@ -171,15 +171,12 @@ public abstract class NativeElementsHelper<C, M> {
                 continue;
             }
             overridesCache.put(
-                new MethodCacheKey(
-                    classKey,
-                    getMethodCacheKey(method.methodElement)
-                ),
+                methodCacheKey,
                 method.overridden
             );
         }
-        processedClasses.add(classKey);
-        return overridesCache.getOrDefault(cacheKey, List.of());
+        processedClasses.add(classCacheKey);
+        return overridesCache.getOrDefault(methodCacheKey, List.of());
     }
 
     private List<MethodElement<M>> getAllElements(C classNode) {

--- a/core-processor/src/main/java/io/micronaut/inject/utils/NativeElementsHelper.java
+++ b/core-processor/src/main/java/io/micronaut/inject/utils/NativeElementsHelper.java
@@ -178,7 +178,7 @@ public abstract class NativeElementsHelper<C, M> {
                 method.overridden
             );
         }
-        processedClasses.add(classNode);
+        processedClasses.add(classKey);
         return overridesCache.getOrDefault(cacheKey, List.of());
     }
 

--- a/core-processor/src/main/java/io/micronaut/inject/utils/NativeElementsHelper.java
+++ b/core-processor/src/main/java/io/micronaut/inject/utils/NativeElementsHelper.java
@@ -171,7 +171,10 @@ public abstract class NativeElementsHelper<C, M> {
                 continue;
             }
             overridesCache.put(
-                methodCacheKey,
+                new MethodCacheKey(
+                    classCacheKey,
+                    getMethodCacheKey(method.methodElement)
+                ),
                 method.overridden
             );
         }


### PR DESCRIPTION
Found a mistake identified by https://github.com/micronaut-projects/micronaut-core/issues/9750