### PR TITLE
Reuse loaded native elements

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/ast/DefaultElementQuery.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/DefaultElementQuery.java
@@ -573,7 +573,10 @@ final class DefaultElementQuery<T extends Element> implements ElementQuery<T>, E
             includeOverriddenMethods,
             includeHiddenElements,
             false,
-            null, null, null, null,
+            null,
+            null,
+            null,
+            namePredicates, // Keep this to allow selecting only specific element
             null);
     }
 

--- a/core-processor/src/main/java/io/micronaut/inject/ast/DefaultElementQuery.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/DefaultElementQuery.java
@@ -558,6 +558,25 @@ final class DefaultElementQuery<T extends Element> implements ElementQuery<T>, E
             typePredicates);
     }
 
+    @Override
+    public Result<T> withoutPredicates() {
+        return new DefaultElementQuery<>(
+            elementType,
+            null,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            includeEnumConstants,
+            includeOverriddenMethods,
+            includeHiddenElements,
+            false,
+            null, null, null, null,
+            null);
+    }
+
     @NonNull
     @Override
     public Result<T> result() {

--- a/core-processor/src/main/java/io/micronaut/inject/ast/ElementQuery.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/ElementQuery.java
@@ -331,6 +331,7 @@ public interface ElementQuery<T extends Element> {
         /**
          * Creates a copy without the predicates.
          * @return a copy without the predicates.
+         * @since 4.3.0
          */
         Result<T> withoutPredicates();
     }

--- a/core-processor/src/main/java/io/micronaut/inject/ast/ElementQuery.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/ElementQuery.java
@@ -327,5 +327,11 @@ public interface ElementQuery<T extends Element> {
          * @return The element predicates
          */
         @NonNull List<Predicate<T>> getElementPredicates();
+
+        /**
+         * Creates a copy without the predicates.
+         * @return a copy without the predicates.
+         */
+        Result<T> withoutPredicates();
     }
 }

--- a/core-processor/src/main/java/io/micronaut/inject/ast/utils/EnclosedElementsQuery.java
+++ b/core-processor/src/main/java/io/micronaut/inject/ast/utils/EnclosedElementsQuery.java
@@ -172,18 +172,18 @@ public abstract class EnclosedElementsQuery<C, N> {
             return true;
         };
 
-        // Let's try to load the unfiltered result and apply the filter
-        QueryResultKey queryWithoutPredicatesResultKey = new QueryResultKey(result.withoutPredicates(), classElement.getNativeType());
-        List<T> valuesWithoutPredicates = (List<T>) resultsCache.get(queryWithoutPredicatesResultKey);
-        if (valuesWithoutPredicates != null) {
-            return valuesWithoutPredicates.stream().filter(filter).toList();
-        }
-
         C nativeClassType = getNativeClassType(classElement);
         List<T> elements;
         if (result.isOnlyDeclared() || classElement.getSuperType().isEmpty() && classElement.getInterfaces().isEmpty()) {
             elements = getElements(nativeClassType, result, filter);
         } else {
+            // Let's try to load the unfiltered result and apply the filter
+            QueryResultKey queryWithoutPredicatesResultKey = new QueryResultKey(result.withoutPredicates(), classElement.getNativeType());
+            List<T> valuesWithoutPredicates = (List<T>) resultsCache.get(queryWithoutPredicatesResultKey);
+            if (valuesWithoutPredicates != null) {
+                return valuesWithoutPredicates.stream().filter(filter).toList();
+            }
+
             elements = getAllElements(nativeClassType, (t1, t2) -> reduceElements(t1, t2, result), result);
             if (!queryWithoutPredicatesResultKey.equals(queryResultKey)) {
                 // This collection is before predicates are applied, we can store it and reuse


### PR DESCRIPTION
We can cache the elements extracted before the predicate filter is applied.