### PR TITLE
Fix boxing a primitive value

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/writer/AbstractClassFileWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/AbstractClassFileWriter.java
@@ -833,7 +833,7 @@ public abstract class AbstractClassFileWriter implements Opcodes, OriginatingEle
      */
     protected static void pushBoxPrimitiveIfNecessary(Type fieldType, GeneratorAdapter injectMethodVisitor) {
         if (JavaModelUtils.isPrimitive(fieldType)) {
-            injectMethodVisitor.box(fieldType);
+            injectMethodVisitor.valueOf(fieldType);
         }
     }
 


### PR DESCRIPTION
Spotbugs detects that the boxing is done using the constructor invocations instead of using `valueOf`