### PR TITLE
Fix NoSuchBean classcast exception when generating message

### DIFF
--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContext.java
@@ -51,6 +51,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -319,7 +320,7 @@ public class DefaultApplicationContext extends DefaultBeanContext implements App
         }
 
         Collection<BeanDefinition<T>> beanCandidates = findBeanCandidates(resolutionContext, beanType, false, definition -> !definition.isAbstract())
-            .stream().sorted().toList();
+            .stream().sorted(Comparator.comparing(BeanDefinition::getName)).toList();
         for (BeanDefinition<T> definition : beanCandidates) {
             if (definition != null && definition.isIterable()) {
                 if (definition.hasDeclaredAnnotation(EachProperty.class)) {

--- a/inject/src/test/groovy/io/micronaut/context/MultipleMatchingNoSuchBeanSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/MultipleMatchingNoSuchBeanSpec.groovy
@@ -5,10 +5,12 @@ import io.micronaut.context.annotation.Factory
 import io.micronaut.context.annotation.Requires
 import io.micronaut.context.exceptions.NoSuchBeanException
 import jakarta.inject.Singleton
+import spock.lang.Issue
 import spock.lang.Specification
 
 class MultipleMatchingNoSuchBeanSpec extends Specification {
 
+    @Issue("https://github.com/micronaut-projects/micronaut-core/pull/10429")
     def "multiple possible beans, but none matching failure message doesn't throw an exception"() {
         given:
         def ctx = ApplicationContext.run('spec.name': 'MultipleMatchingNoSuchBeanSpec')

--- a/inject/src/test/groovy/io/micronaut/context/MultipleMatchingNoSuchBeanSpec.groovy
+++ b/inject/src/test/groovy/io/micronaut/context/MultipleMatchingNoSuchBeanSpec.groovy
@@ -1,0 +1,63 @@
+package io.micronaut.context
+
+import io.micronaut.context.annotation.EachBean
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.exceptions.NoSuchBeanException
+import jakarta.inject.Singleton
+import spock.lang.Specification
+
+class MultipleMatchingNoSuchBeanSpec extends Specification {
+
+    def "multiple possible beans, but none matching failure message doesn't throw an exception"() {
+        given:
+        def ctx = ApplicationContext.run('spec.name': 'MultipleMatchingNoSuchBeanSpec')
+
+        when:
+        ctx.getBean(MyInterface)
+
+        then:
+        def ex = thrown(NoSuchBeanException)
+        ex.message.contains '''* [MyInterface] requires the presence of a bean of type [io.micronaut.context.MultipleMatchingNoSuchBeanSpec$BeanBConfig].
+                              | * [BeanBConfig] is disabled because:
+                              |  - Required property [excluded] with value [so ignored] not present'''.stripMargin()
+        ex.message.contains '''* [MyInterface] requires the presence of a bean of type [io.micronaut.context.MultipleMatchingNoSuchBeanSpec$BeanAConfig].
+                              | * [BeanAConfig] is disabled because:
+                              |  - Required property [excluded] with value [so ignored] not present'''.stripMargin()
+
+        cleanup:
+        ctx.close()
+    }
+
+    static interface MyInterface {}
+
+    static class BeanA implements MyInterface {}
+
+    static class BeanB implements MyInterface {}
+
+    @Factory
+    static class BeanAFactory {
+
+        @EachBean(BeanAConfig)
+        MyInterface make(BeanAConfig configuration) {
+            return new BeanA();
+        }
+    }
+
+    @Factory
+    static class BeanBFactory {
+
+        @EachBean(BeanBConfig)
+        MyInterface make(BeanBConfig configuration) {
+            return new BeanB();
+        }
+    }
+
+    @Singleton
+    @Requires(property = "excluded", value = "so ignored")
+    static class BeanAConfig {}
+
+    @Singleton
+    @Requires(property = "excluded", value = "so ignored")
+    static class BeanBConfig {}
+}


### PR DESCRIPTION
Prior to this, we would get a CCE as we tried to sort a stream of objects that were not comparable.

See https://github.com/micronaut-projects/micronaut-security/pull/1568/files