### PR TITLE
doc: dont consider bean-introspection experimental

### DIFF
--- a/src/main/docs/guide/ioc/introspection/jacksonAndBeanIntrospection.adoc
+++ b/src/main/docs/guide/ioc/introspection/jacksonAndBeanIntrospection.adoc
@@ -3,5 +3,3 @@ Jackson is configured to use the api:core.beans.BeanIntrospection[] API to read 
 This feature is enabled by default; disable it by setting the `jackson.bean-introspection-module` configuration to `false`.
 
 NOTE: Currently only bean properties (private field with public getter/setter) are supported and usage of public fields is not supported.
-
-NOTE: This feature is currently experimental and may be subject to change in the future.


### PR DESCRIPTION
Today, I was doing a supporting company that wanted to upgrade to Micronaut Framework 4. They disabled `bean-introspection-module` in Micronaut Framework 3. When upgrading to 4 while keeping bean-introspection-module disabled, they hit [an issue in security](https://github.com/micronaut-projects/micronaut-security/pull/1580).

 I told them we encourage people to move to Micronaut Serialization or at least to Micronaut Jackson Databind with bean-introspection-module enabled and annotate any serializable POJO with `@Introspected`. 

They pointed to the fact that our documentation still considers `bean-introspection-module` as experimental, making them hesitate to enable it. 

The `bean-introspection-module `has been around for a while, and I think we should consider it no longer experimental. Thoughts? 