### PR TITLE
processor finalization stacktrace

### DIFF
--- a/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/TypeElementVisitorProcessor.java
@@ -44,6 +44,8 @@ import javax.annotation.processing.SupportedOptions;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -278,7 +280,11 @@ public class TypeElementVisitorProcessor extends AbstractInjectAnnotationProcess
                 try {
                     loadedVisitor.getVisitor().finish(javaVisitorContext);
                 } catch (Throwable e) {
-                    error("Error finalizing type visitor [%s]: %s", loadedVisitor.getVisitor(), e.getMessage());
+                    StringWriter stackTraceWriter = new StringWriter();
+                    e.printStackTrace(new PrintWriter(stackTraceWriter));
+
+                    error("Error finalizing type visitor [%s]: %s\n%s",
+                        loadedVisitor.getVisitor(), e.getMessage(), stackTraceWriter);
                 }
             }
         }


### PR DESCRIPTION
The TypeElementVisitorProcessor calls the `.finish()` method on visitors and catches all exceptions if present. But the message might not be descriptive enough. For example a StackOverflowError does not have a message, so the logs would be:
```java
[ERROR] error: Error finalizing type visitor [...Visitor@5e67a490]: null
```
Since the visitors are not expected to fail frequently, printing stack trace should not hurt performance.