### PR TITLE
Ordering improvements

### DIFF
--- a/aop/src/main/java/io/micronaut/aop/chain/DefaultInterceptorRegistry.java
+++ b/aop/src/main/java/io/micronaut/aop/chain/DefaultInterceptorRegistry.java
@@ -124,7 +124,7 @@ public class DefaultInterceptorRegistry implements InterceptorRegistry {
                 selectedInterceptorRegistrations.add(beanRegistration);
             }
         }
-        selectedInterceptorRegistrations.sort(OrderUtil.COMPARATOR);
+        selectedInterceptorRegistrations.sort(OrderUtil.ORDERED_COMPARATOR);
 
         List<Interceptor<T, ?>> selectedInterceptors = new ArrayList<>(selectedInterceptorRegistrations.size());
         for (BeanRegistration<Interceptor<T, ?>> beanRegistration : selectedInterceptorRegistrations) {

--- a/context/src/main/java/io/micronaut/runtime/context/CompositeMessageSource.java
+++ b/context/src/main/java/io/micronaut/runtime/context/CompositeMessageSource.java
@@ -18,15 +18,14 @@ package io.micronaut.runtime.context;
 import io.micronaut.context.AbstractMessageSource;
 import io.micronaut.context.MessageSource;
 import io.micronaut.context.annotation.Primary;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.order.OrderUtil;
 import io.micronaut.core.util.ArgumentUtils;
 
-import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Composite message source that is the primary message source.
@@ -46,7 +45,7 @@ public final class CompositeMessageSource extends AbstractMessageSource {
      */
     public CompositeMessageSource(@Nullable Collection<MessageSource> messageSources) {
         if (messageSources != null) {
-            this.messageSources = OrderUtil.sort(messageSources.stream()).collect(Collectors.toList());
+            this.messageSources = OrderUtil.sortOrderedCollection(messageSources);
         } else {
             this.messageSources = Collections.emptyList();
         }

--- a/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
+++ b/core-processor/src/main/java/io/micronaut/inject/writer/BeanDefinitionWriter.java
@@ -48,6 +48,7 @@ import io.micronaut.core.annotation.AnnotationUtil;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.AnnotationValueBuilder;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NextMajorVersion;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.beans.BeanConstructor;
@@ -55,6 +56,7 @@ import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.ConversionServiceProvider;
 import io.micronaut.core.expressions.EvaluatedExpressionReference;
 import io.micronaut.core.naming.NameUtils;
+import io.micronaut.core.order.OrderUtil;
 import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.type.Argument;
@@ -160,6 +162,7 @@ import static io.micronaut.inject.visitor.BeanElementVisitor.VISITORS;
  */
 @Internal
 public class BeanDefinitionWriter extends AbstractClassFileWriter implements BeanDefinitionVisitor, BeanElement, Toggleable {
+    @NextMajorVersion("Inline as true")
     public static final String OMIT_CONFPROP_INJECTION_POINTS = "micronaut.processing.omit.confprop.injectpoints";
 
     public static final String CLASS_SUFFIX = "$Definition";
@@ -1176,6 +1179,7 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
             buildCheckIfShouldLoadMethod(checkIfShouldLoadMethodVisitor, annotationInjectionPoints);
             checkIfShouldLoadMethodVisitor.visitMaxs(DEFAULT_MAX_STACK, 10);
         }
+        addGetOrder();
 
         getInterceptedType().ifPresent(t -> implementInterceptedTypeMethod(t, this.classWriter));
 
@@ -1309,6 +1313,14 @@ public class BeanDefinitionWriter extends AbstractClassFileWriter implements Bea
                 getExposedTypesMethod.visitEnd();
             }
         }
+    }
+
+    private void addGetOrder() {
+        int order = OrderUtil.getOrder(annotationMetadata);
+        GeneratorAdapter getOrderMethod = startPublicMethod(classWriter, "getOrder", int.class.getName());
+        getOrderMethod.push(order);
+        getOrderMethod.returnValue();
+        getOrderMethod.endMethod();
     }
 
     private void pushStoreClassesAsSet(GeneratorAdapter writer, String[] classes) {

--- a/core/src/main/java/io/micronaut/core/beans/BeanInfo.java
+++ b/core/src/main/java/io/micronaut/core/beans/BeanInfo.java
@@ -17,6 +17,8 @@ package io.micronaut.core.beans;
 
 import io.micronaut.core.annotation.AnnotationMetadataProvider;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.order.OrderUtil;
+import io.micronaut.core.order.Ordered;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.type.ArgumentCoercible;
 
@@ -26,7 +28,7 @@ import io.micronaut.core.type.ArgumentCoercible;
  * @param <T> The type of the bean
  * @since 4.0.0
  */
-public interface BeanInfo<T> extends AnnotationMetadataProvider, ArgumentCoercible<T> {
+public interface BeanInfo<T> extends AnnotationMetadataProvider, ArgumentCoercible<T>, Ordered {
     /**
      * @return The bean type
      */
@@ -44,5 +46,10 @@ public interface BeanInfo<T> extends AnnotationMetadataProvider, ArgumentCoercib
     @Override
     default Argument<T> asArgument() {
         return getGenericBeanType();
+    }
+
+    @Override
+    default int getOrder() {
+        return OrderUtil.getOrder(getAnnotationMetadata());
     }
 }

--- a/http/src/main/java/io/micronaut/http/filter/FilterRunner.java
+++ b/http/src/main/java/io/micronaut/http/filter/FilterRunner.java
@@ -81,7 +81,7 @@ public class FilterRunner {
      */
     public static void sort(@NonNull List<GenericHttpFilter> filters) {
         checkOrdered(filters);
-        OrderUtil.sort(filters);
+        OrderUtil.sortOrdered((List) filters); // All filters are implementing ordered
     }
 
     /**
@@ -92,7 +92,7 @@ public class FilterRunner {
      */
     public static void sortReverse(@NonNull List<GenericHttpFilter> filters) {
         checkOrdered(filters);
-        OrderUtil.reverseSort(filters);
+        OrderUtil.reverseSortOrdered((List) filters); // All filters are implementing ordered
     }
 
     /**

--- a/inject/src/main/java/io/micronaut/context/BeanRegistration.java
+++ b/inject/src/main/java/io/micronaut/context/BeanRegistration.java
@@ -42,6 +42,7 @@ public class BeanRegistration<T> implements Ordered, CreatedBean<T>, BeanType<T>
     final BeanIdentifier identifier;
     final BeanDefinition<T> beanDefinition;
     final T bean;
+    private final int order;
 
     /**
      * @param identifier     The bean identifier
@@ -52,6 +53,11 @@ public class BeanRegistration<T> implements Ordered, CreatedBean<T>, BeanType<T>
         this.identifier = identifier;
         this.beanDefinition = beanDefinition;
         this.bean = bean;
+        if (bean == null) {
+            this.order = beanDefinition == null ? 0 : beanDefinition.getOrder();
+        } else {
+            this.order = beanDefinition == null ? OrderUtil.getOrder(bean) : OrderUtil.getOrder(beanDefinition, bean);
+        }
     }
 
     /**
@@ -103,7 +109,7 @@ public class BeanRegistration<T> implements Ordered, CreatedBean<T>, BeanType<T>
 
     @Override
     public int getOrder() {
-        return OrderUtil.getOrder(beanDefinition.getAnnotationMetadata(), bean);
+        return order;
     }
 
     /**

--- a/inject/src/main/java/io/micronaut/context/DefaultApplicationContextBuilder.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultApplicationContextBuilder.java
@@ -422,7 +422,7 @@ public class DefaultApplicationContextBuilder implements ApplicationContextBuild
         if (configurers.size() == 1) {
             return configurers.get(0);
         }
-        OrderUtil.sort(configurers);
+        OrderUtil.sortOrdered(configurers);
         return new ApplicationContextConfigurer() {
 
             @Override

--- a/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
+++ b/inject/src/main/java/io/micronaut/context/DefaultBeanContext.java
@@ -65,7 +65,6 @@ import io.micronaut.core.annotation.Indexes;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
-import io.micronaut.core.annotation.Order;
 import io.micronaut.core.annotation.UsedByGeneratedCode;
 import io.micronaut.core.convert.MutableConversionService;
 import io.micronaut.core.convert.TypeConverter;
@@ -78,7 +77,6 @@ import io.micronaut.core.naming.NameResolver;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.naming.Named;
 import io.micronaut.core.order.OrderUtil;
-import io.micronaut.core.order.Ordered;
 import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.type.ReturnType;
@@ -166,28 +164,9 @@ public class DefaultBeanContext implements InitializableBeanContext {
     private static final String PARALLEL_TYPE = Parallel.class.getName();
     private static final String INDEXES_TYPE = Indexes.class.getName();
     private static final String REPLACES_ANN = Replaces.class.getName();
-    private static final Comparator<BeanRegistration<?>> BEAN_REGISTRATION_COMPARATOR = new Comparator<>() {
-        // Keep anonymous class to avoid lambda overhead during the startup
-        @Override
-        public int compare(BeanRegistration<?> o1, BeanRegistration<?> o2) {
-            int order1 = OrderUtil.getOrder(o1.getBeanDefinition(), o1.getBean());
-            int order2 = OrderUtil.getOrder(o2.getBeanDefinition(), o2.getBean());
-            return Integer.compare(order1, order2);
-        }
-    };
-    private static final Comparator<BeanDefinition<?>> BEAN_DEFINITION_COMPARATOR = new Comparator<>() {
-        // Keep anonymous class to avoid lambda overhead during the startup
-        @Override
-        public int compare(BeanDefinition<?> bean1, BeanDefinition<?> bean2) {
-            int order1 = OrderUtil.getOrder(bean1.getAnnotationMetadata());
-            int order2 = OrderUtil.getOrder(bean2.getAnnotationMetadata());
-            return Integer.compare(order1, order2);
-        }
-    };
 
     private static final String MSG_COULD_NOT_BE_LOADED = "] could not be loaded: ";
     public static final String MSG_BEAN_DEFINITION = "Bean definition [";
-
 
     protected final AtomicBoolean running = new AtomicBoolean(false);
     protected final AtomicBoolean initializing = new AtomicBoolean(false);
@@ -1989,7 +1968,7 @@ public class DefaultBeanContext implements InitializableBeanContext {
                 }
             }
             filterReplacedBeans(null, eagerInit);
-            OrderUtil.sort(eagerInit);
+            OrderUtil.sortOrdered(eagerInit);
             for (BeanDefinition eagerInitDefinition : eagerInit) {
                 try {
                     initializeEagerBean(eagerInitDefinition);
@@ -3245,25 +3224,19 @@ public class DefaultBeanContext implements InitializableBeanContext {
         if (candidates.size() == 1) {
             return candidates.iterator().next();
         }
-        if (hasOrder(candidates)) {
-            // pick the bean with the highest priority
-            ArrayList<BeanDefinition<T>> listCandidates = new ArrayList<>(candidates);
-            listCandidates.sort(BEAN_DEFINITION_COMPARATOR);
-            final Iterator<BeanDefinition<T>> i = listCandidates.iterator();
-            if (i.hasNext()) {
-                final BeanDefinition<T> bean = i.next();
-                if (i.hasNext()) {
-                    // check there are not 2 beans with the same order
-                    final BeanDefinition<T> next = i.next();
-                    if (OrderUtil.getOrder(bean.getAnnotationMetadata()) == OrderUtil.getOrder(next.getAnnotationMetadata())) {
-                        throw new NonUniqueBeanException(beanType.getType(), candidates.iterator());
-                    }
-                }
-                LOG.debug("Picked bean {} with the highest precedence for type {} and qualifier {}", bean, beanType, null);
-                return bean;
-            }
-            throw new NonUniqueBeanException(beanType.getType(), candidates.iterator());
+        // pick the bean with the highest priority
+        ArrayList<BeanDefinition<T>> listCandidates = new ArrayList<>(candidates);
+        listCandidates.sort(OrderUtil.ORDERED_COMPARATOR);
+        Iterator<BeanDefinition<T>> iterator = listCandidates.iterator();
+        final BeanDefinition<T> bean = iterator.next();
+        final BeanDefinition<T> next = iterator.next();
+        // We should have at least two beans - no need for next checks
+        // Check there are not 2 beans with the same order
+        if (bean.getOrder() != next.getOrder()) {
+            LOG.debug("Picked bean {} with the highest precedence for type {} and qualifier {}", bean, beanType, null);
+            return bean;
         }
+
         Collection<BeanDefinition<T>> exactMatches = filterExactMatch(beanType.getType(), candidates);
         if (exactMatches.size() == 1) {
             return exactMatches.iterator().next();
@@ -3272,15 +3245,6 @@ public class DefaultBeanContext implements InitializableBeanContext {
             return findConcreteCandidate(beanType.getType(), qualifier, candidates);
         }
         return null;
-    }
-
-    private <T> boolean hasOrder(Collection<BeanDefinition<T>> candidates) {
-        for (BeanDefinition<T> candidate : candidates) {
-            if (candidate.hasAnnotation(Order.class)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     private void readAllBeanConfigurations() {
@@ -3505,22 +3469,11 @@ public class DefaultBeanContext implements InitializableBeanContext {
                                                                          Collection<BeanDefinition<T>> beanDefinitions,
                                                                          Argument<T> beanType,
                                                                          Qualifier<T> qualifier) {
-        boolean hasOrderAnnotation = false;
-        Set<BeanRegistration<T>> beansOfTypeList = new HashSet<>();
+        List<BeanRegistration<T>> beansOfTypeList = new ArrayList<>(beanDefinitions.size());
         for (BeanDefinition<T> definition : beanDefinitions) {
-            if (!hasOrderAnnotation && definition.hasAnnotation(Order.class)) {
-                hasOrderAnnotation = true;
-            }
             addCandidateToList(resolutionContext, definition, beanType, qualifier, beansOfTypeList);
         }
-        if (!beansOfTypeList.isEmpty()) {
-            if (Ordered.class.isAssignableFrom(beanType.getType())) {
-                return beansOfTypeList.stream().sorted(OrderUtil.COMPARATOR).toList();
-            }
-            if (hasOrderAnnotation) {
-                return beansOfTypeList.stream().sorted(BEAN_REGISTRATION_COMPARATOR).toList();
-            }
-        }
+        beansOfTypeList.sort(OrderUtil.ORDERED_COMPARATOR);
         return beansOfTypeList;
     }
 

--- a/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
+++ b/inject/src/main/java/io/micronaut/context/env/DefaultEnvironment.java
@@ -453,7 +453,7 @@ public class DefaultEnvironment extends PropertySourcePropertyResolver implement
         }
 
         propertySources.addAll(this.propertySources.values());
-        OrderUtil.sort(propertySources);
+        OrderUtil.sortOrdered(propertySources);
         for (PropertySource propertySource : propertySources) {
             log.debug("Processing property source: {}", propertySource.getName());
             processPropertySource(propertySource, propertySource.getConvention());

--- a/router/src/main/java/io/micronaut/web/router/BeanDefinitionFilterRoute.java
+++ b/router/src/main/java/io/micronaut/web/router/BeanDefinitionFilterRoute.java
@@ -19,7 +19,6 @@ import io.micronaut.context.BeanLocator;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.order.OrderUtil;
 import io.micronaut.http.filter.FilterOrder;
 import io.micronaut.http.filter.GenericHttpFilter;
 import io.micronaut.http.filter.HttpFilter;
@@ -45,7 +44,7 @@ class BeanDefinitionFilterRoute extends DefaultFilterRoute {
     BeanDefinitionFilterRoute(String pattern, BeanLocator beanLocator, BeanDefinition<? extends HttpFilter> definition) {
         super(pattern, () -> GenericHttpFilter.createLegacyFilter(
             beanLocator.getBean(definition),
-            new FilterOrder.Dynamic(OrderUtil.getOrder(definition))));
+            new FilterOrder.Dynamic(definition.getOrder())));
         this.definition = definition;
     }
 


### PR DESCRIPTION
- `BeanInfo` now implements `Ordered`
- Generated bean definition now has the order precalculated
- Introduced a new comparator that works with `Ordered` and avoids `instanceof`
- Improve logic in the bean context