### PR TITLE
reproducer: AOP Around advice cannot see local private fields in Groovy

### DIFF
--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/aop/around/PrivateFieldNotNullExample.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/aop/around/PrivateFieldNotNullExample.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.aop.around
+
+import jakarta.inject.Singleton
+
+import java.util.concurrent.CompletableFuture
+
+@Singleton
+class PrivateFieldNotNullExample {
+
+    private final String logPrefix = "Doing job: "
+
+    @NotNull
+    String doWork(String taskName) throws Exception {
+        return CompletableFuture.supplyAsync(() -> {
+            System.out.println(logPrefix + taskName)
+            return taskName
+        }).get()
+    }
+}

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/aop/around/PrivateFieldNotNullExampleSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/aop/around/PrivateFieldNotNullExampleSpec.groovy
@@ -1,0 +1,21 @@
+package io.micronaut.docs.aop.around
+
+import io.micronaut.context.ApplicationContext
+import spock.lang.Specification
+
+class PrivateFieldNotNullExampleSpec extends Specification {
+
+    void "test not null"() {
+        when:
+        def applicationContext = ApplicationContext.run()
+        def exampleBean = applicationContext.getBean(PrivateFieldNotNullExample)
+
+        def work = exampleBean.doWork('work')
+
+        then:
+        work == 'work'
+
+        cleanup:
+        applicationContext.close()
+    }
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/aop/around/PrivateFieldNotNullExample.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/aop/around/PrivateFieldNotNullExample.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.aop.around
+
+import jakarta.inject.Singleton
+import java.util.concurrent.CompletableFuture
+
+@Singleton
+open class PrivateFieldNotNullExample {
+
+    @NotNull
+    open fun doWork(taskName: String?) =
+        CompletableFuture.supplyAsync {
+            println("$prefix$taskName")
+            taskName
+        }.get()
+
+    companion object {
+        private val prefix = "Doing job: "
+    }
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/aop/around/PrivateFieldNotNullSpec.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/aop/around/PrivateFieldNotNullSpec.kt
@@ -1,0 +1,17 @@
+package io.micronaut.docs.aop.around
+
+import io.kotest.matchers.shouldBe
+import io.kotest.core.spec.style.AnnotationSpec
+import io.micronaut.context.ApplicationContext
+
+class PrivateFieldNotNullSpec: AnnotationSpec() {
+
+    @Test
+    fun testNotNull() {
+        val applicationContext = ApplicationContext.run()
+        val exampleBean = applicationContext.getBean(PrivateFieldNotNullExample::class.java)
+        val work = exampleBean.doWork("work")
+        work shouldBe "work"
+        applicationContext.close()
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/docs/aop/around/PrivateFieldNotNullExample.java
+++ b/test-suite/src/test/java/io/micronaut/docs/aop/around/PrivateFieldNotNullExample.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.aop.around;
+
+import jakarta.inject.Singleton;
+
+import java.util.concurrent.CompletableFuture;
+
+@Singleton
+public class PrivateFieldNotNullExample {
+
+    private final String logPrefix = "Doing job: ";
+
+    @NotNull
+    String doWork(String taskName) throws Exception {
+        return CompletableFuture.supplyAsync(() -> {
+            System.out.println(logPrefix + taskName);
+            return taskName;
+        }).get();
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/docs/aop/around/PrivateFieldNotNullTest.java
+++ b/test-suite/src/test/java/io/micronaut/docs/aop/around/PrivateFieldNotNullTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.docs.aop.around;
+
+import io.micronaut.context.ApplicationContext;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PrivateFieldNotNullTest {
+
+    @Test
+    void testNotNull() throws Exception {
+        try (ApplicationContext applicationContext = ApplicationContext.run()) {
+            var exampleBean = applicationContext.getBean(PrivateFieldNotNullExample.class);
+            String work = exampleBean.doWork("work");
+            assertEquals("work", work);
+        }
+    }
+}


### PR DESCRIPTION
We had an issue raised in micronaut-cache which showed that the @Slf4j private log variable could not be used within a closure or method inside a @Cacheable method

I moved the issue to core as it seems this is an issue solely with Groovy, which this reproducer demonstrates

See https://github.com/micronaut-projects/micronaut-core/issues/10503