### PR TITLE
Fix special case of NameUtils.underscoreSeparate where the first char is the separator char

### DIFF
--- a/core/src/main/java/io/micronaut/core/naming/NameUtils.java
+++ b/core/src/main/java/io/micronaut/core/naming/NameUtils.java
@@ -167,7 +167,18 @@ public class NameUtils {
      * @return The underscore separated version
      */
     public static String underscoreSeparate(String camelCase) {
-        return separateCamelCase(camelCase.replace('-', '_'), false, '_');
+        return underscoreSeparate(camelCase, false);
+    }
+
+    /**
+     * Returns the underscore separated version of the given camel case string, optionally with lowercase result.
+     *
+     * @param camelCase The camel case name
+     * @param lowercase true to lowercase the result
+     * @return The underscore separated version
+     */
+    public static String underscoreSeparate(String camelCase, boolean lowercase) {
+        return separateCamelCase(camelCase.replace('-', '_'), lowercase, '_');
     }
 
     /**
@@ -555,13 +566,19 @@ public class NameUtils {
     }
 
     private static String separateCamelCase(String name, boolean lowerCase, char separatorChar) {
+        StringBuilder newName = new StringBuilder();
         if (!lowerCase) {
-            StringBuilder newName = new StringBuilder();
             boolean first = true;
             char last = '0';
             for (char c : name.toCharArray()) {
                 if (first) {
-                    newName.append(c);
+                    if (c == separatorChar) {
+                        // special case where first char == separatorChar, don't double it
+                        // https://github.com/micronaut-projects/micronaut-core/issues/10140
+                        last = separatorChar;
+                    } else {
+                        newName.append(c);
+                    }
                     first = false;
                 } else {
                     if (Character.isUpperCase(c) && !Character.isUpperCase(last)) {
@@ -583,9 +600,7 @@ public class NameUtils {
                 }
                 last = c;
             }
-            return newName.toString();
         } else {
-            StringBuilder newName = new StringBuilder();
             char[] chars = name.toCharArray();
             boolean first = true;
             char last = '0';
@@ -619,8 +634,8 @@ public class NameUtils {
                 last = c;
             }
 
-            return newName.toString();
         }
+        return newName.toString();
     }
 
     /**

--- a/core/src/main/java/io/micronaut/core/naming/NameUtils.java
+++ b/core/src/main/java/io/micronaut/core/naming/NameUtils.java
@@ -572,11 +572,9 @@ public class NameUtils {
             char last = '0';
             for (char c : name.toCharArray()) {
                 if (first) {
-                    if (c == separatorChar) {
+                    if (c != separatorChar) {
                         // special case where first char == separatorChar, don't double it
                         // https://github.com/micronaut-projects/micronaut-core/issues/10140
-                        last = separatorChar;
-                    } else {
                         newName.append(c);
                     }
                     first = false;

--- a/core/src/test/groovy/io/micronaut/core/naming/NameUtilsSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/naming/NameUtilsSpec.groovy
@@ -15,6 +15,7 @@
  */
 package io.micronaut.core.naming
 
+import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -126,6 +127,34 @@ class NameUtilsSpec extends Specification {
         "FOO-BAR"           | 'FOO_BAR'
         "foo-bar-baz"       | 'FOO_BAR_BAZ'
         "fooBBar"           | 'FOO_BBAR'
+    }
+
+    @Issue('https://github.com/micronaut-projects/micronaut-core/issues/10140')
+    @Unroll
+    void "test underscore separated #value with lowercase = #lowercase"() {
+        expect:
+        NameUtils.underscoreSeparate(value, lowercase) == result
+
+        where:
+        value               | result                    | lowercase
+        // the fix handles this case, where previously it resulted in '__name_Of_Thing'
+        "_nameOfThing"      | '_name_Of_Thing'          | false
+        "__nameOfThing"      | '_name_Of_Thing'         | false
+        "_nameOfThing"      | '_name_of_thing'          | true
+        "__nameOfThing"      | '_name_of_thing'         | true
+        // the following are passing cases from prior to fix
+        "com.fooBar.FooBar" | "com.foo_bar.foo_bar"     | true
+        "FooBar"            | "foo_bar"                 | true
+        "com.bar.FooBar"    | "com.bar.foo_bar"         | true
+        "Foo"               | 'foo'                     | true
+        "FOO__BAR"          | 'foo_bar'                 | true
+        "FooBBar"           | 'foo_bbar'                | true
+        "com.fooBar.FooBar" | "com.foo_Bar.Foo_Bar"     | false
+        "FooBar"            | "Foo_Bar"                 | false
+        "com.bar.FooBar"    | "com.bar.Foo_Bar"         | false
+        "Foo"               | 'Foo'                     | false
+        "FOO__BAR"          | 'FOO_BAR'                 | false
+        "FooBBar"           | 'Foo_BBar'                | false
     }
 
     void "test decapitalize"() {

--- a/core/src/test/groovy/io/micronaut/core/naming/NameUtilsSpec.groovy
+++ b/core/src/test/groovy/io/micronaut/core/naming/NameUtilsSpec.groovy
@@ -139,9 +139,9 @@ class NameUtilsSpec extends Specification {
         value               | result                    | lowercase
         // the fix handles this case, where previously it resulted in '__name_Of_Thing'
         "_nameOfThing"      | '_name_Of_Thing'          | false
-        "__nameOfThing"      | '_name_Of_Thing'         | false
+        "__nameOfThing"     | '_name_Of_Thing'          | false
         "_nameOfThing"      | '_name_of_thing'          | true
-        "__nameOfThing"      | '_name_of_thing'         | true
+        "__nameOfThing"     | '_name_of_thing'          | true
         // the following are passing cases from prior to fix
         "com.fooBar.FooBar" | "com.foo_bar.foo_bar"     | true
         "FooBar"            | "foo_bar"                 | true


### PR DESCRIPTION
Fix special case of `NameUtils.underscoreSeparate()` where the first char is the separator char results in a double separator char prefix. 

Also overload `underscoreSeparate()` to support a lowercase result.

fixes #10140