### PR TITLE
Include serdeable metadata to internal JSON objects

### DIFF
--- a/discovery-core/build.gradle
+++ b/discovery-core/build.gradle
@@ -5,9 +5,19 @@ plugins {
 dependencies {
     annotationProcessor project(":inject-java")
     annotationProcessor project(":graal")
+
+    annotationProcessor(platform(libs.test.boms.micronaut.serde))
+    annotationProcessor(libs.micronaut.serde.processor) {
+        exclude group: "io.micronaut", module: "json-core"
+    }
+
     api project(':context')
     implementation libs.managed.reactor
+
     compileOnly project(":jackson-databind")
-    testImplementation project(":jackson-databind")
-//    api project(":http")
+    compileOnly(platform(libs.test.boms.micronaut.serde))
+    compileOnly(libs.micronaut.serde.api) {
+        exclude group: "io.micronaut", module: "json-core"
+    }
+
 }

--- a/discovery-core/src/main/java/io/micronaut/health/HealthStatus.java
+++ b/discovery-core/src/main/java/io/micronaut/health/HealthStatus.java
@@ -17,6 +17,7 @@ package io.micronaut.health;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.ReflectiveAccess;
 import io.micronaut.serde.annotation.Serdeable;
 
 import java.util.Optional;
@@ -29,6 +30,7 @@ import java.util.Optional;
  * @since 1.0
  */
 @Serdeable
+@ReflectiveAccess
 public class HealthStatus implements Comparable<HealthStatus> {
 
     /**

--- a/discovery-core/src/main/java/io/micronaut/health/HealthStatus.java
+++ b/discovery-core/src/main/java/io/micronaut/health/HealthStatus.java
@@ -16,9 +16,8 @@
 package io.micronaut.health;
 
 import com.fasterxml.jackson.annotation.JsonValue;
-import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.annotation.ReflectiveAccess;
+import io.micronaut.serde.annotation.Serdeable;
 
 import java.util.Optional;
 
@@ -29,8 +28,7 @@ import java.util.Optional;
  * @author Graeme Rocher
  * @since 1.0
  */
-@Introspected
-@ReflectiveAccess
+@Serdeable
 public class HealthStatus implements Comparable<HealthStatus> {
 
     /**

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -77,6 +77,7 @@ managed-snakeyaml = "2.2"
 managed-java-parser-core = "3.25.8"
 managed-ksp = "1.9.22-1.0.17"
 micronaut-docs = "2.0.0"
+micronaut-serde = "2.8.1"
 
 [libraries]
 # Libraries prefixed with bom- are BOM files
@@ -86,6 +87,7 @@ test-boms-micronaut-validation = { module = "io.micronaut.validation:micronaut-v
 test-boms-micronaut-rxjava2 = { module = "io.micronaut.rxjava2:micronaut-rxjava2-bom", version.ref = "micronaut-rxjava2" }
 test-boms-micronaut-rxjava3 = { module = "io.micronaut.rxjava3:micronaut-rxjava3-bom", version.ref = "micronaut-rxjava3" }
 test-boms-micronaut-reactor = { module = "io.micronaut.reactor:micronaut-reactor-bom", version.ref = "micronaut-reactor" }
+test-boms-micronaut-serde = { module = "io.micronaut.serde:micronaut-serde-bom", version.ref = "micronaut-serde" }
 
 boms-groovy = { module = "org.apache.groovy:groovy-bom", version.ref = "managed-groovy" }
 boms-kotlin = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "managed-kotlin" }
@@ -261,6 +263,10 @@ micronaut-tracing-brave = { module = "io.micronaut.tracing:micronaut-tracing-bra
 
 micronaut-validation = { module = "io.micronaut.validation:micronaut-validation" }
 micronaut-validation-processor = { module = "io.micronaut.validation:micronaut-validation-processor" }
+
+micronaut-serde-api = { module = "io.micronaut.serde:micronaut-serde-api" }
+micronaut-serde-processor = { module = "io.micronaut.serde:micronaut-serde-processor" }
+micronaut-serde-jackson = { module = "io.micronaut.serde:micronaut-serde-jackson" }
 
 testcontainers-spock = { module = "org.testcontainers:spock", version.ref = "testcontainers" }
 

--- a/http/build.gradle
+++ b/http/build.gradle
@@ -6,12 +6,23 @@ plugins {
 dependencies {
     annotationProcessor project(":inject-java")
     annotationProcessor project(":graal")
+
+    annotationProcessor(platform(libs.test.boms.micronaut.serde))
+    annotationProcessor(libs.micronaut.serde.processor) {
+        exclude group: "io.micronaut", module: "json-core"
+    }
+
     api project(":context")
     api project(":core-reactive")
     implementation project(":context-propagation")
     implementation libs.managed.reactor
     compileOnly libs.managed.kotlinx.coroutines.core
     compileOnly libs.managed.kotlinx.coroutines.reactor
+
+    compileOnly(platform(libs.test.boms.micronaut.serde))
+    compileOnly(libs.micronaut.serde.api) {
+        exclude group: "io.micronaut", module: "json-core"
+    }
 
     compileOnly libs.managed.jackson.annotations
 

--- a/http/src/main/java/io/micronaut/http/hateoas/AbstractResource.java
+++ b/http/src/main/java/io/micronaut/http/hateoas/AbstractResource.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.annotation.ReflectiveAccess;
 import io.micronaut.core.convert.value.ConvertibleValues;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.core.value.OptionalMultiValues;
@@ -143,6 +144,7 @@ public abstract class AbstractResource<Impl extends AbstractResource<Impl>> impl
      */
     @SuppressWarnings("unchecked")
     @Internal
+    @ReflectiveAccess
     @JsonProperty(LINKS)
     public final void setLinks(Map<String, Object> links) {
         for (Map.Entry<String, Object> entry : links.entrySet()) {
@@ -169,6 +171,7 @@ public abstract class AbstractResource<Impl extends AbstractResource<Impl>> impl
      * @param embedded The links
      */
     @Internal
+    @ReflectiveAccess
     @JsonProperty(EMBEDDED)
     public final void setEmbedded(Map<String, List<Resource>> embedded) {
         this.embeddedMap.putAll(embedded);

--- a/http/src/main/java/io/micronaut/http/hateoas/GenericResource.java
+++ b/http/src/main/java/io/micronaut/http/hateoas/GenericResource.java
@@ -18,8 +18,8 @@ package io.micronaut.http.hateoas;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.util.ObjectUtils;
+import io.micronaut.serde.annotation.Serdeable;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -31,7 +31,7 @@ import java.util.Map;
  * @since 3.4.0
  * @author yawkat
  */
-@Introspected
+@Serdeable
 public final class GenericResource extends AbstractResource<GenericResource> {
     private final Map<String, Object> additionalProperties = new LinkedHashMap<>();
 

--- a/http/src/main/java/io/micronaut/http/hateoas/JsonError.java
+++ b/http/src/main/java/io/micronaut/http/hateoas/JsonError.java
@@ -22,6 +22,8 @@ import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.Produces;
 
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.serde.annotation.Serdeable;
+
 import java.util.Optional;
 
 /**
@@ -30,6 +32,7 @@ import java.util.Optional;
  * @author Graeme Rocher
  * @since 1.1
  */
+@Serdeable
 @Produces(MediaType.APPLICATION_JSON)
 public class JsonError extends AbstractResource<JsonError> {
 

--- a/http/src/main/java/io/micronaut/http/hateoas/Resource.java
+++ b/http/src/main/java/io/micronaut/http/hateoas/Resource.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.value.OptionalMultiValues;
+import io.micronaut.serde.annotation.Serdeable;
 
 /**
  * Represents a REST resource in a hateoas architecture.
@@ -27,6 +28,7 @@ import io.micronaut.core.value.OptionalMultiValues;
  * @author Graeme Rocher
  * @since 1.1
  */
+@Serdeable
 @Introspected
 public interface Resource {
 

--- a/http/src/main/java/io/micronaut/http/hateoas/VndError.java
+++ b/http/src/main/java/io/micronaut/http/hateoas/VndError.java
@@ -19,6 +19,7 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.Produces;
+import io.micronaut.serde.annotation.Serdeable;
 
 import java.util.List;
 
@@ -29,6 +30,7 @@ import java.util.List;
  * @since 1.1
  */
 @Produces(MediaType.APPLICATION_VND_ERROR)
+@Serdeable
 public class VndError extends JsonError {
 
     /**

--- a/management/build.gradle
+++ b/management/build.gradle
@@ -6,6 +6,11 @@ dependencies {
     annotationProcessor project(":inject-java")
     annotationProcessor project(":graal")
 
+    annotationProcessor(platform(libs.test.boms.micronaut.serde))
+    annotationProcessor(libs.micronaut.serde.processor) {
+        exclude group: "io.micronaut", module: "json-core"
+    }
+
     api project(":router")
     api project(":discovery-core")
     compileOnly project(":jackson-databind")
@@ -38,5 +43,10 @@ dependencies {
 
     compileOnly libs.logback.classic
     compileOnly libs.log4j
+
+    compileOnly(platform(libs.test.boms.micronaut.serde))
+    compileOnly(libs.micronaut.serde.api) {
+        exclude group: "io.micronaut", module: "json-core"
+    }
 
 }

--- a/management/src/main/java/io/micronaut/management/health/indicator/HealthResult.java
+++ b/management/src/main/java/io/micronaut/management/health/indicator/HealthResult.java
@@ -16,6 +16,7 @@
 package io.micronaut.management.health.indicator;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.micronaut.core.annotation.ReflectiveAccess;
 import io.micronaut.health.HealthStatus;
 import io.micronaut.serde.annotation.Serdeable;
 import jakarta.validation.constraints.NotNull;
@@ -33,6 +34,7 @@ import java.util.Map;
  */
 @Serdeable
 @JsonDeserialize(as = DefaultHealthResult.class)
+@ReflectiveAccess
 public interface HealthResult {
 
     /**

--- a/management/src/main/java/io/micronaut/management/health/indicator/HealthResult.java
+++ b/management/src/main/java/io/micronaut/management/health/indicator/HealthResult.java
@@ -16,9 +16,8 @@
 package io.micronaut.management.health.indicator;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import io.micronaut.core.annotation.Introspected;
-import io.micronaut.core.annotation.ReflectiveAccess;
 import io.micronaut.health.HealthStatus;
+import io.micronaut.serde.annotation.Serdeable;
 import jakarta.validation.constraints.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,8 +31,7 @@ import java.util.Map;
  * @author James Kleeh
  * @since 1.0
  */
-@Introspected
-@ReflectiveAccess
+@Serdeable
 @JsonDeserialize(as = DefaultHealthResult.class)
 public interface HealthResult {
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -76,6 +76,7 @@ include "test-suite-logback"
 include "test-suite-logback-external-configuration"
 include "test-suite-logback-graalvm"
 include "test-suite-netty-ssl-graalvm"
+include "test-suite-serde"
 include "test-utils"
 
 // benchmarks

--- a/test-suite-serde/build.gradle
+++ b/test-suite-serde/build.gradle
@@ -1,0 +1,18 @@
+plugins {
+    id "io.micronaut.build.internal.convention-test-library"
+}
+
+micronautBuild {
+    core {
+        usesMicronautTestSpock()
+    }
+}
+
+dependencies {
+    testAnnotationProcessor(projects.injectJava)
+    testImplementation(projects.http)
+    testImplementation(projects.management)
+    testImplementation(platform(libs.test.boms.micronaut.serde))
+    testImplementation libs.micronaut.serde.jackson
+    testImplementation(projects.micronaut.jacksonDatabind)
+}

--- a/test-suite-serde/src/test/groovy/io/micronaut/health/HealthSpec.groovy
+++ b/test-suite-serde/src/test/groovy/io/micronaut/health/HealthSpec.groovy
@@ -1,0 +1,36 @@
+package io.micronaut.health
+
+import io.micronaut.core.type.Argument
+import io.micronaut.jackson.databind.JacksonDatabindMapper
+import io.micronaut.json.JsonMapper
+import io.micronaut.management.health.indicator.HealthResult
+import io.micronaut.serde.ObjectMapper
+import spock.lang.Specification
+
+class HealthSpec extends Specification {
+
+    void "test HealthResult"(JsonMapper objectMapper) {
+        given:
+
+            HealthResult hr = HealthResult.builder("db", HealthStatus.DOWN)
+                    .details(Collections.singletonMap("foo", "bar"))
+                    .build()
+
+        when:
+            def result = objectMapper.writeValueAsString(hr)
+
+        then:
+            result == '{"name":"db","status":"DOWN","details":{"foo":"bar"}}'
+
+        when:
+            hr = objectMapper.readValue(result, Argument.of(HealthResult))
+
+        then:
+            hr.name == 'db'
+            hr.status == HealthStatus.DOWN
+
+        where:
+            objectMapper << [ObjectMapper.getDefault(), new JacksonDatabindMapper(new com.fasterxml.jackson.databind.ObjectMapper())]
+    }
+
+}

--- a/test-suite-serde/src/test/groovy/io/micronaut/http/hateoas/JsonErrorSpec.groovy
+++ b/test-suite-serde/src/test/groovy/io/micronaut/http/hateoas/JsonErrorSpec.groovy
@@ -1,0 +1,63 @@
+package io.micronaut.http.hateoas
+
+import io.micronaut.jackson.databind.JacksonDatabindMapper
+import io.micronaut.json.JsonMapper
+import io.micronaut.serde.ObjectMapper
+import spock.lang.PendingFeature
+import spock.lang.Specification
+
+class JsonErrorSpec extends Specification {
+
+    def jsonError = '{"_links":{"self":[{"href":"/resolve","templated":false}]},"_embedded":{"errors":[{"message":"Internal Server Error: Something bad happened"}]},"message":"Internal Server Error"}'
+
+    @PendingFeature
+    void "JsonError should be deserializable from a string - serde"() {
+        setup:
+            ObjectMapper objectMapper = ObjectMapper.getDefault()
+        when:
+            JsonError jsonError = objectMapper.readValue(this.jsonError, JsonError)
+
+        then:
+            jsonError.message == 'Internal Server Error'
+            jsonError.embedded.getFirst('errors').isPresent()
+            jsonError.links.getFirst("self").get().href == "/resolve"
+            !jsonError.links.getFirst("self").get().templated
+    }
+
+    @PendingFeature
+    void "can deserialize a Json error as a generic resource - serde"() {
+        setup:
+            ObjectMapper objectMapper = ObjectMapper.getDefault()
+        when:
+            GenericResource resource = objectMapper.readValue(jsonError, Resource)
+        then:
+            resource.embedded.getFirst('errors').isPresent()
+            resource.links.getFirst("self").get().href == "/resolve"
+            !resource.links.getFirst("self").get().templated
+    }
+
+    void "JsonError should be deserializable from a string - jackson databind"() {
+        setup:
+            JsonMapper objectMapper = new JacksonDatabindMapper(new com.fasterxml.jackson.databind.ObjectMapper())
+
+        when:
+            JsonError jsonError = objectMapper.readValue(this.jsonError, JsonError)
+
+        then:
+            jsonError.message == 'Internal Server Error'
+            jsonError.embedded.getFirst('errors').isPresent()
+            jsonError.links.getFirst("self").get().href == "/resolve"
+            !jsonError.links.getFirst("self").get().templated
+    }
+
+    void "can deserialize a Json error as a generic resource - jackson databind"() {
+        setup:
+            JsonMapper objectMapper = new JacksonDatabindMapper(new com.fasterxml.jackson.databind.ObjectMapper())
+        when:
+            GenericResource resource = objectMapper.readValue(jsonError, Resource)
+        then:
+            resource.embedded.getFirst('errors').isPresent()
+            resource.links.getFirst("self").get().href == "/resolve"
+            !resource.links.getFirst("self").get().templated
+    }
+}


### PR DESCRIPTION
This fixes one of the examples from https://github.com/micronaut-projects/micronaut-serialization/issues/691
And eliminates the need for a custom deserializer for HealthStatus in Micronaut Serialization