### PR TITLE
Accept inetd-style FDs

### DIFF
--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/DefaultEventLoopGroupFactory.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/DefaultEventLoopGroupFactory.java
@@ -154,8 +154,8 @@ public class DefaultEventLoopGroupFactory implements EventLoopGroupFactory {
     }
 
     @Override
-    public Channel channelInstance(NettyChannelType type, EventLoopGroupConfiguration configuration, int fd) {
-        return getFactory(configuration).channelInstance(type, configuration, fd);
+    public Channel channelInstance(NettyChannelType type, EventLoopGroupConfiguration configuration, Channel parent, int fd) {
+        return getFactory(configuration).channelInstance(type, configuration, parent, fd);
     }
 
     @NonNull

--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/EpollEventLoopGroupFactory.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/EpollEventLoopGroupFactory.java
@@ -26,6 +26,7 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.ServerChannel;
 import io.netty.channel.epoll.Epoll;
 import io.netty.channel.epoll.EpollDatagramChannel;
+import io.netty.channel.epoll.EpollDomainSocketChannel;
 import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.epoll.EpollServerDomainSocketChannel;
 import io.netty.channel.epoll.EpollServerSocketChannel;
@@ -35,6 +36,8 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.unix.ServerDomainSocketChannel;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadFactory;
@@ -51,6 +54,7 @@ import java.util.concurrent.ThreadFactory;
 @BootstrapContextCompatible
 @Order(100)
 public class EpollEventLoopGroupFactory implements EventLoopGroupFactory {
+    private static final Logger LOG = LoggerFactory.getLogger(EpollEventLoopGroupFactory.class);
 
     /**
      * Creates an EpollEventLoopGroup.
@@ -133,6 +137,7 @@ public class EpollEventLoopGroupFactory implements EventLoopGroupFactory {
         return switch (type) {
             case SERVER_SOCKET -> EpollServerSocketChannel.class;
             case CLIENT_SOCKET -> EpollSocketChannel.class;
+            case DOMAIN_SOCKET -> EpollDomainSocketChannel.class;
             case DOMAIN_SERVER_SOCKET -> EpollServerDomainSocketChannel.class;
             case DATAGRAM_SOCKET -> EpollDatagramChannel.class;
         };
@@ -148,16 +153,21 @@ public class EpollEventLoopGroupFactory implements EventLoopGroupFactory {
         return switch (type) {
             case SERVER_SOCKET -> new EpollServerSocketChannel();
             case CLIENT_SOCKET -> new EpollSocketChannel();
+            case DOMAIN_SOCKET -> new EpollDomainSocketChannel();
             case DOMAIN_SERVER_SOCKET -> new EpollServerDomainSocketChannel();
             case DATAGRAM_SOCKET -> new EpollDatagramChannel();
         };
     }
 
     @Override
-    public Channel channelInstance(NettyChannelType type, EventLoopGroupConfiguration configuration, int fd) {
+    public Channel channelInstance(NettyChannelType type, EventLoopGroupConfiguration configuration, Channel parent, int fd) {
+        if (parent != null) {
+            LOG.warn("epoll does not support FD-based channels with a parent channel. This may cause issues with HTTP2.");
+        }
         return switch (type) {
             case SERVER_SOCKET -> new EpollServerSocketChannel(fd);
             case CLIENT_SOCKET -> new EpollSocketChannel(fd);
+            case DOMAIN_SOCKET -> new EpollDomainSocketChannel(fd);
             case DOMAIN_SERVER_SOCKET -> new EpollServerDomainSocketChannel(fd);
             case DATAGRAM_SOCKET -> new EpollDatagramChannel(fd);
         };

--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/EventLoopGroupFactory.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/EventLoopGroupFactory.java
@@ -232,7 +232,7 @@ public interface EventLoopGroupFactory {
      * @throws UnsupportedOperationException if domain sockets are not supported.
      * @deprecated Use {@link #channelInstance(NettyChannelType, EventLoopGroupConfiguration, Channel, int)} instead
      */
-    @Deprecated
+    @Deprecated(since = "4.4.0")
     default @NonNull Channel channelInstance(NettyChannelType type, @Nullable EventLoopGroupConfiguration configuration, int fd) {
         return channelInstance(type, configuration, null, fd);
     }

--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/EventLoopGroupFactory.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/EventLoopGroupFactory.java
@@ -242,6 +242,7 @@ public interface EventLoopGroupFactory {
      *
      * @param type Type of the channel to return
      * @param configuration The configuration
+     * @param parent The {@link Channel#parent() parent channel}
      * @param fd The pre-defined file descriptor
      * @return A channel implementation.
      * @throws UnsupportedOperationException if domain sockets are not supported.

--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/EventLoopGroupFactory.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/EventLoopGroupFactory.java
@@ -230,8 +230,23 @@ public interface EventLoopGroupFactory {
      * @param fd The pre-defined file descriptor
      * @return A channel implementation.
      * @throws UnsupportedOperationException if domain sockets are not supported.
+     * @deprecated Use {@link #channelInstance(NettyChannelType, EventLoopGroupConfiguration, Channel, int)} instead
      */
+    @Deprecated
     default @NonNull Channel channelInstance(NettyChannelType type, @Nullable EventLoopGroupConfiguration configuration, int fd) {
+        return channelInstance(type, configuration, null, fd);
+    }
+
+    /**
+     * Returns the channel instance.
+     *
+     * @param type Type of the channel to return
+     * @param configuration The configuration
+     * @param fd The pre-defined file descriptor
+     * @return A channel implementation.
+     * @throws UnsupportedOperationException if domain sockets are not supported.
+     */
+    default @NonNull Channel channelInstance(NettyChannelType type, @Nullable EventLoopGroupConfiguration configuration, @Nullable Channel parent, int fd) {
         throw new UnsupportedOperationException("This transport does not support creating channels from file descriptors. Please use kqueue or epoll.");
     }
 

--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/KQueueEventLoopGroupFactory.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/KQueueEventLoopGroupFactory.java
@@ -25,6 +25,7 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.ServerChannel;
 import io.netty.channel.kqueue.KQueue;
 import io.netty.channel.kqueue.KQueueDatagramChannel;
+import io.netty.channel.kqueue.KQueueDomainSocketChannel;
 import io.netty.channel.kqueue.KQueueEventLoopGroup;
 import io.netty.channel.kqueue.KQueueServerDomainSocketChannel;
 import io.netty.channel.kqueue.KQueueServerSocketChannel;
@@ -34,6 +35,8 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.unix.ServerDomainSocketChannel;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadFactory;
@@ -49,6 +52,7 @@ import java.util.concurrent.ThreadFactory;
 @Named(EventLoopGroupFactory.NATIVE)
 @BootstrapContextCompatible
 public class KQueueEventLoopGroupFactory implements EventLoopGroupFactory {
+    private static final Logger LOG = LoggerFactory.getLogger(KQueueEventLoopGroupFactory.class);
 
     /**
      * Creates a KQueueEventLoopGroup.
@@ -137,6 +141,7 @@ public class KQueueEventLoopGroupFactory implements EventLoopGroupFactory {
         return switch (type) {
             case SERVER_SOCKET -> KQueueServerSocketChannel.class;
             case CLIENT_SOCKET -> KQueueSocketChannel.class;
+            case DOMAIN_SOCKET -> KQueueDomainSocketChannel.class;
             case DOMAIN_SERVER_SOCKET -> KQueueServerDomainSocketChannel.class;
             case DATAGRAM_SOCKET -> KQueueDatagramChannel.class;
         };
@@ -152,16 +157,21 @@ public class KQueueEventLoopGroupFactory implements EventLoopGroupFactory {
         return switch (type) {
             case SERVER_SOCKET -> new KQueueServerSocketChannel();
             case CLIENT_SOCKET -> new KQueueSocketChannel();
+            case DOMAIN_SOCKET -> new KQueueDomainSocketChannel();
             case DOMAIN_SERVER_SOCKET -> new KQueueServerDomainSocketChannel();
             case DATAGRAM_SOCKET -> new KQueueDatagramChannel();
         };
     }
 
     @Override
-    public Channel channelInstance(NettyChannelType type, EventLoopGroupConfiguration configuration, int fd) {
+    public Channel channelInstance(NettyChannelType type, EventLoopGroupConfiguration configuration, Channel parent, int fd) {
+        if (parent != null) {
+            LOG.warn("kqueue does not support FD-based channels with a parent channel. This may cause issues with HTTP2.");
+        }
         return switch (type) {
             case SERVER_SOCKET -> new KQueueServerSocketChannel(fd);
             case CLIENT_SOCKET -> new KQueueSocketChannel(fd);
+            case DOMAIN_SOCKET -> new KQueueDomainSocketChannel(fd);
             case DOMAIN_SERVER_SOCKET -> new KQueueServerDomainSocketChannel(fd);
             case DATAGRAM_SOCKET -> new KQueueDatagramChannel(fd);
         };

--- a/http-netty/src/main/java/io/micronaut/http/netty/channel/NettyChannelType.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/channel/NettyChannelType.java
@@ -30,6 +30,10 @@ public enum NettyChannelType {
      */
     CLIENT_SOCKET,
     /**
+     * @see io.netty.channel.unix.DomainSocketChannel
+     */
+    DOMAIN_SOCKET,
+    /**
      * @see io.netty.channel.unix.ServerDomainSocketChannel
      */
     DOMAIN_SERVER_SOCKET,

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/DefaultNettyEmbeddedServerFactory.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/DefaultNettyEmbeddedServerFactory.java
@@ -303,8 +303,8 @@ public class DefaultNettyEmbeddedServerFactory
     }
 
     @Override
-    public Channel getChannelInstance(NettyChannelType type, EventLoopGroupConfiguration workerConfig, int fd) {
-        return eventLoopGroupFactory.channelInstance(type, workerConfig, fd);
+    public Channel getChannelInstance(NettyChannelType type, EventLoopGroupConfiguration workerConfig, Channel parent, int fd) {
+        return eventLoopGroupFactory.channelInstance(type, workerConfig, parent, fd);
     }
 
     @SuppressWarnings("unchecked")

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyEmbeddedServices.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/NettyEmbeddedServices.java
@@ -201,7 +201,7 @@ public interface NettyEmbeddedServices {
      * @return The channel
      * @throws UnsupportedOperationException if domain sockets are not supported.
      */
-    @NonNull default Channel getChannelInstance(NettyChannelType type, @NonNull EventLoopGroupConfiguration workerConfig, int fd) {
+    @NonNull default Channel getChannelInstance(NettyChannelType type, @NonNull EventLoopGroupConfiguration workerConfig, Channel parent, int fd) {
         throw new UnsupportedOperationException("File descriptor channels not supported");
     }
 

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/configuration/NettyHttpServerConfiguration.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/configuration/NettyHttpServerConfiguration.java
@@ -1325,7 +1325,9 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
         private String path;
         private boolean exposeDefaultRoutes = true;
         private Integer fd = null;
+        private Integer acceptedFd = null;
         private boolean bind = true;
+        private boolean serverSocket = true;
 
         /**
          * Create a TCP listener configuration.
@@ -1485,6 +1487,44 @@ public class NettyHttpServerConfiguration extends HttpServerConfiguration {
          */
         public void setBind(boolean bind) {
             this.bind = bind;
+        }
+
+        /**
+         * Whether to create a server socket. This is on by default. Turning it off only makes sense
+         * in combination with {@link #acceptedFd}.
+         *
+         * @return {@code true} iff a server socket should be created
+         */
+        public boolean isServerSocket() {
+            return serverSocket;
+        }
+
+        /**
+         * Whether to create a server socket. This is on by default. Turning it off only makes sense
+         * in combination with {@link #acceptedFd}.
+         *
+         * @param serverSocket {@code true} iff a server socket should be created
+         */
+        public void setServerSocket(boolean serverSocket) {
+            this.serverSocket = serverSocket;
+        }
+
+        /**
+         * An already accepted socket fd that should be registered to this listener.
+         *
+         * @return The fd to register
+         */
+        public Integer getAcceptedFd() {
+            return acceptedFd;
+        }
+
+        /**
+         * An already accepted socket fd that should be registered to this listener.
+         *
+         * @param acceptedFd The fd to register
+         */
+        public void setAcceptedFd(Integer acceptedFd) {
+            this.acceptedFd = acceptedFd;
         }
 
         /**

--- a/src/main/docs/guide/httpServer/serverConfiguration/listener.adoc
+++ b/src/main/docs/guide/httpServer/serverConfiguration/listener.adoc
@@ -46,7 +46,7 @@ NOTE: To use an abstract domain socket instead of a normal one, prefix the path 
 
 == systemd socket activation support
 
-When using the epoll transport, the HTTP server can be configured to use an existing file descriptor. With this feature, you can use socket created by systemd and passed to the micronaut process:
+The HTTP server can be configured to use an existing file descriptor. With this feature, you can use socket created by systemd and passed to the micronaut process:
 
 [configuration]
 ----
@@ -88,3 +88,36 @@ WantedBy=sockets.target
 ----
 
 Now your Micronaut application can be started by a client connecting to `http://127.0.0.1:8080`.
+
+NOTE: The nio transport only supports `fd: 0` ("inetd style"), through the JDK `System.inheritedChannel()` API. If you
+wish to use the default `fd: 3` recommended by systemd, you must use the epoll transport.
+
+=== inetd-style socket activation
+
+systemd also supports inetd-style socket activation. In that mode, instead of passing a listening socket fd
+(`ServerSocketChannel`), systemd will pass an already accepted fd (`SocketChannel`) representing an individual TCP
+connection. systemd will start a new instance of the service for each new TCP connection.
+
+The Micronaut HTTP server supports this mode through the `accepted-fd` config option. An `accepted-fd` will be
+registered with the listener it is declared on, and essentially treated like a connection that was accepted by the
+listener. The netty parent channel will be set to the listener server socket, which is important to avoid a
+https://github.com/netty/netty/pull/12546[netty bug] in connection with HTTP/2.
+
+WARNING: Epoll does not support setting the parent channel, so HTTP/2 may not work with `accepted-fd` and epoll.
+
+[configuration]
+----
+micronaut:
+  netty:
+    listeners:
+      systemd:
+        fd: 0 # inetd-style socket activation typically uses fd 0 (stdin)
+        bind: false # do not bind, we only use the server channel as the parent
+----
+
+By setting `server-socket: false`, you can disable the parent channel entirely. This may save some slight startup time,
+but may cause problems with HTTP/2.
+
+WARNING: Because inetd-style socket activation typically uses fd 0, it hijacks stdin and stdout. You must take care to
+never emit any output on stdout, as this may corrupt the HTTP response, or even show up for the user. In particular,
+you must configure logback to log to `System.err` instead, and disable the Micronaut startup banner.


### PR DESCRIPTION
In #10072, I implemented support for inheriting a ServerSocketChannel from a fixed file descriptor to support systemd socket activation. This PR extends that in two ways:

- Allow specifying an "accepted FD". That means an established *connection* (SocketChannel), not a listening socket (ServerSocketChannel). This allows for inetd-style socket activation which starts a process for each connection.
- Add support for nio when fd=0 or accepted-fd=0, using System.inheritedChannel().