### PR TITLE
Add support for inheriting method documentation

### DIFF
--- a/core-processor/src/main/java/io/micronaut/inject/utils/NativeElementsHelper.java
+++ b/core-processor/src/main/java/io/micronaut/inject/utils/NativeElementsHelper.java
@@ -201,11 +201,11 @@ public abstract class NativeElementsHelper<C, M> {
         if (excludeClass(classNode)) {
             return;
         }
+        reduce(owner, collectedMethods, getMethods(classNode), cache, false, false);
         C superClass = getSuperClass(classNode);
         if (superClass != null) {
             processClassHierarchy(owner, superClass, cache, collectedMethods, includeAbstract);
         }
-        reduce(owner, collectedMethods, getMethods(classNode), cache, false, false);
         for (C anInterface : getInterfaces(classNode)) {
             processInterfaceHierarchy(owner, anInterface, cache, collectedMethods, includeAbstract);
         }
@@ -219,10 +219,10 @@ public abstract class NativeElementsHelper<C, M> {
         if (excludeClass(classNode)) {
             return;
         }
+        reduce(owner, collectedMethods, getMethods(classNode), cache, true, includeAbstract);
         for (C anInterface : getInterfaces(classNode)) {
             processInterfaceHierarchy(owner, anInterface, cache, collectedMethods, includeAbstract);
         }
-        reduce(owner, collectedMethods, getMethods(classNode), cache, true, includeAbstract);
     }
 
     private void reduce(C owner,

--- a/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaMethodElement.java
+++ b/inject-java/src/main/java/io/micronaut/annotation/processing/visitor/JavaMethodElement.java
@@ -87,6 +87,24 @@ public class JavaMethodElement extends AbstractJavaElement implements MethodElem
     }
 
     @Override
+    public Optional<String> getDocumentation() {
+        Optional<String> doc = super.getDocumentation();
+        if (doc.isPresent()) {
+            return doc;
+        }
+
+        Collection<ExecutableElement> overriddenMethods = visitorContext.getNativeElementsHelper()
+                .findOverriddenMethods(owningType.classElement, executableElement);
+        for (ExecutableElement method: overriddenMethods) {
+            String methodDoc = visitorContext.getElements().getDocComment(method);
+            if (methodDoc != null) {
+                return Optional.of(methodDoc.trim());
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
     protected MutableAnnotationMetadataDelegate<?> getAnnotationMetadataToWrite() {
         return helper.getMethodAnnotationMetadata(presetAnnotationMetadata);
     }

--- a/inject-java/src/test/groovy/io/micronaut/visitors/DocumentationSpec.groovy
+++ b/inject-java/src/test/groovy/io/micronaut/visitors/DocumentationSpec.groovy
@@ -45,4 +45,61 @@ class Test {
         classElement.getEnclosedElements(ElementQuery.of(MethodElement.class).named("getTenant")).get(0).getDocumentation().get() == 'This is method level docs'
         classElement.getEnclosedElements(ElementQuery.of(MethodElement.class).named("setTenant")).get(0).getDocumentation().get() == 'This is method level docs'
     }
+
+    void "test read inherited documentation"() {
+        def classElement = buildClassElement("""
+package test;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * This is class level docs
+ */
+class Test implements TestInterface {
+    /**
+     * This is property level docs
+     */
+    @NotBlank
+    @NotNull
+    private String tenant;
+
+    @Override
+    public String getTenant() {
+        return tenant;
+    }
+
+    @Override
+    public void setTenant(String tenant) {
+        this.tenant = tenant;
+    }
+}
+
+interface TestInterface extends TestInterfaceB {
+    /**
+     * This is inherited method level docs
+     */
+    String getTenant();
+}
+
+interface TestInterfaceB {
+    /**
+     * This should be ignored
+     */
+    String getTenant();
+
+    /**
+     * This is deeply inherited method level docs
+     */
+    void setTenant(String tenant);
+
+}
+""")
+
+        expect:
+        classElement.getDocumentation().get() == 'This is class level docs'
+        classElement.getFields().get(0).getDocumentation().get() == 'This is property level docs'
+        classElement.getEnclosedElements(ElementQuery.of(MethodElement.class).named("getTenant")).get(0).getDocumentation().get() == 'This is inherited method level docs'
+        classElement.getEnclosedElements(ElementQuery.of(MethodElement.class).named("setTenant")).get(0).getDocumentation().get() == 'This is deeply inherited method level docs'
+    }
 }


### PR DESCRIPTION
Javadoc is able to inherit method documentation for overridden method: https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDFAGJH. Therefore, this behavior makes sense in processing, too. The order of overridden methods had to be changed for this to work correctly.