### PR TITLE
Include space in cookie separator

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/NettyClientHttpRequest.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/NettyClientHttpRequest.java
@@ -115,7 +115,8 @@ public class NettyClientHttpRequest<B> implements MutableHttpRequest<B>, NettyHt
         cookies.put(cookie.getName(), value);
         String headerValue;
         if (cookies.size() > 1) {
-            headerValue = String.join(";", cookies.values());
+            // this has to include a space, the spec says so.
+            headerValue = String.join("; ", cookies.values());
         } else {
             headerValue = value;
         }

--- a/http-client/src/test/groovy/io/micronaut/http/client/CookieHeaderSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/CookieHeaderSpec.groovy
@@ -15,6 +15,6 @@ class CookieHeaderSpec extends Specification {
         request.cookie(Cookie.of("a", "3"))
 
         then:
-        request.headers.get(HttpHeaders.COOKIE) == "a=3;b=2"
+        request.headers.get(HttpHeaders.COOKIE) == "a=3; b=2"
     }
 }


### PR DESCRIPTION
The space is not optional. RFC 6265 4.2.1:

```
cookie-string = cookie-pair *( ";" SP cookie-pair )
```