### PR TITLE
Allow suppressing internal warnings

### DIFF
--- a/core-processor/src/main/java/io/micronaut/context/visitor/InternalApiTypeElementVisitor.java
+++ b/core-processor/src/main/java/io/micronaut/context/visitor/InternalApiTypeElementVisitor.java
@@ -40,7 +40,7 @@ public class InternalApiTypeElementVisitor implements TypeElementVisitor<Object,
 
     private static final String IO_MICRONAUT = "io.micronaut";
 
-    private static final String MICRONAUT_PROCESSING_INTERNAL_WARNINGS = "micronaut.processing.internal-warnings";
+    private static final String MICRONAUT_PROCESSING_INTERNAL_WARNINGS = "micronaut.processing.internal.warnings";
 
     private boolean warned = false;
 

--- a/core/src/main/java/io/micronaut/core/annotation/AnnotationValue.java
+++ b/core/src/main/java/io/micronaut/core/annotation/AnnotationValue.java
@@ -21,7 +21,6 @@ import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.value.ConvertibleValues;
 import io.micronaut.core.expressions.EvaluatedExpression;
 import io.micronaut.core.reflect.ClassUtils;
-import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.core.util.ArrayUtils;

--- a/core/src/main/java/io/micronaut/core/annotation/Experimental.java
+++ b/core/src/main/java/io/micronaut/core/annotation/Experimental.java
@@ -19,7 +19,11 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 /**
- * Annotates a class or method as being experimental and subject to change or removal.
+ * <p>Annotates a class or method as being experimental and subject to change or removal.</p?
+ *
+ * <p>Overriding an experimental element will produce a compilation warning. These warnings can be
+ * suppressed by setting an annotation processing argument:
+ * <code>-Amicronaut.processing.internal-warnings=false</code></p>
  *
  * @author Graeme Rocher
  * @since 1.0

--- a/core/src/main/java/io/micronaut/core/annotation/Experimental.java
+++ b/core/src/main/java/io/micronaut/core/annotation/Experimental.java
@@ -23,7 +23,7 @@ import java.lang.annotation.RetentionPolicy;
  *
  * <p>Overriding an experimental element will produce a compilation warning. These warnings can be
  * suppressed by setting an annotation processing argument:
- * <code>-Amicronaut.processing.internal-warnings=false</code></p>
+ * <code>-Amicronaut.processing.internal.warnings=false</code></p>
  *
  * @author Graeme Rocher
  * @since 1.0

--- a/core/src/main/java/io/micronaut/core/annotation/Experimental.java
+++ b/core/src/main/java/io/micronaut/core/annotation/Experimental.java
@@ -19,7 +19,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 /**
- * <p>Annotates a class or method as being experimental and subject to change or removal.</p?
+ * <p>Annotates a class or method as being experimental and subject to change or removal.</p>
  *
  * <p>Overriding an experimental element will produce a compilation warning. These warnings can be
  * suppressed by setting an annotation processing argument:

--- a/core/src/main/java/io/micronaut/core/annotation/Internal.java
+++ b/core/src/main/java/io/micronaut/core/annotation/Internal.java
@@ -25,7 +25,7 @@ import java.lang.annotation.RetentionPolicy;
  *
  * <p>Overriding an internal element will produce a compilation warning. These warnings can be
  * suppressed by setting an annotation processing argument:
- * <code>-Amicronaut.processing.internal-warnings=false</code></p>
+ * <code>-Amicronaut.processing.internal.warnings=false</code></p>
  *
  * @author Graeme Rocher
  * @since 1.0

--- a/core/src/main/java/io/micronaut/core/annotation/Internal.java
+++ b/core/src/main/java/io/micronaut/core/annotation/Internal.java
@@ -21,7 +21,11 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 /**
- * Annotates a class or method regarded as internal and not for public consumption.
+ * <p>Annotates a class or method regarded as internal and not for public consumption.</p>
+ *
+ * <p>Overriding an internal element will produce a compilation warning. These warnings can be
+ * suppressed by setting an annotation processing argument:
+ * <code>-Amicronaut.processing.internal-warnings=false</code></p>
  *
  * @author Graeme Rocher
  * @since 1.0


### PR DESCRIPTION
This PR allows suppressing internal/experimental warnings. In an internal project, this output accounts for more than 20% of the whole log, and when you know what you're doing, it's unnecessary.