### PR TITLE
Add prefer-openssl config option

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/ssl/NettyClientSslBuilder.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/ssl/NettyClientSslBuilder.java
@@ -92,7 +92,7 @@ public class NettyClientSslBuilder extends SslBuilder<SslContext> implements Cli
             .forClient()
             .keyManager(getKeyManagerFactory(ssl))
             .trustManager(getTrustManagerFactory(ssl))
-            .sslProvider(NettyTlsUtils.sslProvider());
+            .sslProvider(NettyTlsUtils.sslProvider(ssl));
         Optional<String[]> protocols = ssl.getProtocols();
         if (protocols.isPresent()) {
             sslBuilder.protocols(protocols.get());

--- a/http-netty/src/main/java/io/micronaut/http/netty/NettyTlsUtils.java
+++ b/http-netty/src/main/java/io/micronaut/http/netty/NettyTlsUtils.java
@@ -35,8 +35,8 @@ import java.util.Optional;
  */
 @Internal
 public final class NettyTlsUtils {
-    private static boolean useOpenssl() {
-        return SslProvider.isAlpnSupported(SslProvider.OPENSSL_REFCNT);
+    private static boolean useOpenssl(SslConfiguration sslConfiguration) {
+        return sslConfiguration.isPreferOpenssl() && SslProvider.isAlpnSupported(SslProvider.OPENSSL_REFCNT);
     }
 
     /**
@@ -44,8 +44,8 @@ public final class NettyTlsUtils {
      *
      * @return The provider
      */
-    public static SslProvider sslProvider() {
-        return useOpenssl() ? SslProvider.OPENSSL_REFCNT : SslProvider.JDK;
+    public static SslProvider sslProvider(SslConfiguration sslConfiguration) {
+        return useOpenssl(sslConfiguration) ? SslProvider.OPENSSL_REFCNT : SslProvider.JDK;
     }
 
     /**
@@ -61,7 +61,7 @@ public final class NettyTlsUtils {
     @NonNull
     public static KeyManagerFactory storeToFactory(@NonNull SslConfiguration ssl, @Nullable KeyStore keyStore) throws Exception {
         KeyManagerFactory keyManagerFactory;
-        if (useOpenssl()) {
+        if (useOpenssl(ssl)) {
             // I don't understand why, but netty uses this logic, so we will too.
             if (keyStore == null || keyStore.aliases().hasMoreElements()) {
                 keyManagerFactory = new OpenSslX509KeyManagerFactory();

--- a/http-server-netty/build.gradle
+++ b/http-server-netty/build.gradle
@@ -91,7 +91,11 @@ dependencies {
     }
     testImplementation(libs.managed.netty.tcnative.boringssl.static) {
         artifact {
-            classifier = Os.isArch("aarch64") ? "osx-aarch_64" : "osx-x86_64"
+            if (Os.isFamily("mac")) {
+                classifier = Os.isArch("aarch64") ? "osx-aarch_64" : "osx-x86_64"
+            } else {
+                classifier = "linux-x86_64"
+            }
         }
     }
     testImplementation libs.logback.classic

--- a/http-server-netty/src/main/java/io/micronaut/http/server/netty/ssl/AbstractServerSslBuilder.java
+++ b/http-server-netty/src/main/java/io/micronaut/http/server/netty/ssl/AbstractServerSslBuilder.java
@@ -104,7 +104,7 @@ public abstract class AbstractServerSslBuilder extends SslBuilder<SslContext> im
     }
 
     private static void setupSslBuilder(SslContextBuilder sslBuilder, SslConfiguration ssl, HttpVersion httpVersion) {
-        sslBuilder.sslProvider(NettyTlsUtils.sslProvider());
+        sslBuilder.sslProvider(NettyTlsUtils.sslProvider(ssl));
         Optional<String[]> protocols = ssl.getProtocols();
         if (protocols.isPresent()) {
             sslBuilder.protocols(protocols.get());

--- a/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/ssl/RequestCertificateSpec2.groovy
+++ b/http-server-netty/src/test/groovy/io/micronaut/http/server/netty/ssl/RequestCertificateSpec2.groovy
@@ -146,6 +146,7 @@ class RequestCertificateSpec2 extends Specification {
                 'micronaut.ssl.trust-store.path'      : 'file://' + trustStorePath.toString(),
                 'micronaut.ssl.trust-store.type'      : 'JKS',
                 'micronaut.ssl.trust-store.password'  : '123456',
+                'micronaut.ssl.prefer-openssl'        : false, // openssl impl just closes the connection, different error
         ])
 
         def server = ctx.getBean(EmbeddedServer)

--- a/http/src/main/java/io/micronaut/http/ssl/SslConfiguration.java
+++ b/http/src/main/java/io/micronaut/http/ssl/SslConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.http.ssl;
 
+import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.core.util.Toggleable;
@@ -74,6 +75,7 @@ public class SslConfiguration implements Toggleable {
     private String[] protocols;
     private String protocol = DEFAULT_PROTOCOL;
     private Duration handshakeTimeout = Duration.ofSeconds(10);
+    private boolean preferOpenssl = true;
 
     /**
      * @return Whether SSL is enabled.
@@ -265,6 +267,28 @@ public class SslConfiguration implements Toggleable {
     }
 
     /**
+     * Whether an OpenSSL-backed TLS implementation should be preferred if it's on the classpath.
+     * {@code true} by default.
+     *
+     * @return Whether OpenSSL should be preferred
+     */
+    @Experimental
+    public boolean isPreferOpenssl() {
+        return preferOpenssl;
+    }
+
+    /**
+     * Whether an OpenSSL-backed TLS implementation should be preferred if it's on the classpath.
+     * {@code true} by default.
+     *
+     * @param preferOpenssl Whether OpenSSL should be preferred
+     */
+    @Experimental
+    public void setPreferOpenssl(boolean preferOpenssl) {
+        this.preferOpenssl = preferOpenssl;
+    }
+
+    /**
      * Reads an existing config.
      *
      * @param defaultSslConfiguration The default SSL config
@@ -295,6 +319,7 @@ public class SslConfiguration implements Toggleable {
             defaultSslConfiguration.getCiphers().ifPresent(ciphers -> this.ciphers = ciphers);
             defaultSslConfiguration.getClientAuthentication().ifPresent(ca -> this.clientAuthentication = ca);
             this.handshakeTimeout = defaultSslConfiguration.getHandshakeTimeout();
+            this.preferOpenssl = defaultSslConfiguration.isPreferOpenssl();
         }
     }
 


### PR DESCRIPTION
RequestCertificateSpec2.untrusted does not work with tcnative because boringssl does not appear to return the cert error. This patch adds and uses a config option to disable the openssl impl for this test.