### PR TITLE
Retain client response content on parsing failure

### DIFF
--- a/http-client/src/main/java/io/micronaut/http/client/netty/FullNettyClientHttpResponse.java
+++ b/http-client/src/main/java/io/micronaut/http/client/netty/FullNettyClientHttpResponse.java
@@ -90,7 +90,7 @@ public class FullNettyClientHttpResponse<B> implements HttpResponse<B>, Completa
         // this class doesn't really have lifecycle management (we don't make the user release()
         // it), so we have to copy the data to a non-refcounted buffer.
         this.unpooledContent = Unpooled.buffer(fullHttpResponse.content().readableBytes());
-        unpooledContent.writeBytes(fullHttpResponse.content());
+        unpooledContent.writeBytes(fullHttpResponse.content(), 0, fullHttpResponse.content().readableBytes());
         this.handlerRegistry = handlerRegistry;
         this.nettyCookies = new NettyCookies(fullHttpResponse.headers(), conversionService);
         Class<?> rawBodyType = bodyType != null ? bodyType.getType() : null;

--- a/http-client/src/test/groovy/io/micronaut/http/client/netty/FullNettyClientHttpResponseSpec.groovy
+++ b/http-client/src/test/groovy/io/micronaut/http/client/netty/FullNettyClientHttpResponseSpec.groovy
@@ -3,6 +3,8 @@ package io.micronaut.http.client.netty
 import io.micronaut.core.convert.ConversionService
 import io.micronaut.http.cookie.Cookie
 import io.micronaut.http.cookie.Cookies
+import io.netty.buffer.ByteBuf
+import io.netty.buffer.Unpooled
 import io.netty.handler.codec.http.DefaultFullHttpResponse
 import io.netty.handler.codec.http.DefaultHttpHeaders
 import io.netty.handler.codec.http.FullHttpResponse
@@ -11,6 +13,8 @@ import io.netty.handler.codec.http.HttpHeaders
 import io.netty.handler.codec.http.HttpResponseStatus
 import io.netty.handler.codec.http.HttpVersion
 import spock.lang.Specification
+
+import java.nio.charset.Charset
 
 class FullNettyClientHttpResponseSpec extends Specification {
 
@@ -60,6 +64,20 @@ class FullNettyClientHttpResponseSpec extends Specification {
         cookies.get("SES").path == "/"
         cookies.get("JKL").secure
         cookies.get("JKL").domain == ".xxx.com"
+    }
+
+    void "test multiple responses can be created with the same body content"() {
+        given:
+        ByteBuf content = Unpooled.copiedBuffer("foo bar", Charset.defaultCharset())
+        FullHttpResponse fullHttpResponse = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, content)
+
+        when:
+        FullNettyClientHttpResponse response1 = new FullNettyClientHttpResponse(fullHttpResponse, null, null, false, ConversionService.SHARED)
+        FullNettyClientHttpResponse response2 = new FullNettyClientHttpResponse(fullHttpResponse, null, null, false, ConversionService.SHARED)
+
+        then:
+        response1.getBody(String.class).get() == "foo bar"
+        response2.getBody(String.class).get() == "foo bar"
     }
 
 }


### PR DESCRIPTION
`FullNettyHttpClientResponse` is modified to copy the source `ByteBuf` content from the `FullHttpResponse` passed to its constructor without increasing the `readerIndex` of the source buffer so that it may be re-read upon a creation of a new instance of `FullNettyHttpClientResponse` from the same source `FullHttpResponse` as happens in the case of a non-error response that fails upon deserialization of the body content. This ensures that the original body content can still be obtained by calling `HttpClientResponseException.getResponse().getBody(...)`.

This potentially resolves #10458
